### PR TITLE
feat(rules): add Codex model-selection routing rule + migrate RALF-IT to plugin

### DIFF
--- a/src/user/.agents/skills/ralf-it/SKILL.md
+++ b/src/user/.agents/skills/ralf-it/SKILL.md
@@ -148,10 +148,14 @@ Prepare the `.ralf/` directory for foreign agent artifacts. This runs once, afte
 
 | Agent | Command |
 |-------|---------|
-| Codex | `codex exec -s read-only - < {prompt_file} > {review_file} 2>{error_file}` |
+| Codex | `CODEX_HOME="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"; node "$CODEX_HOME/scripts/codex-companion.mjs" task --model gpt-5.4 < {prompt_file} > {review_file} 2>{error_file}` |
 | Gemini | `gemini -p "" --approval-mode plan -o text < {prompt_file} > {review_file} 2>{error_file}` |
 
-Both use a 10-minute timeout (600000ms) and run in read-only/plan mode (cannot modify source files).
+Both use a 10-minute timeout (600000ms) and run read-only — neither can modify source files.
+
+**Codex model:** pass `--model gpt-5.4` (primary reviewer default). See `~/.claude/rules/codex-routing.md` for alternatives.
+
+**Plugin prerequisite:** install the Claude Code Codex plugin and run `/codex:setup` once per environment. If the plugin is absent, the Codex path degrades cleanly to pure fresh-eyes.
 
 ### Step 4: Dispatch Implementation Subagent(s)
 
@@ -353,7 +357,7 @@ After reporting, use **superpowers:finishing-a-development-branch** to present m
 - **superpowers:test-driven-development** — TDD for implementation
 
 **Foreign agent CLIs (iterations 1-2 only):**
-- **Codex CLI** — `codex exec -s read-only` (read-only sandbox)
+- **Codex** — Claude Code Codex plugin via `codex-companion.mjs task` (read-only sandbox; see `~/.claude/rules/codex-routing.md`)
 - **Gemini CLI** — `gemini --approval-mode plan` (read-only plan mode)
 
 **RALF-IT replaces these for complex work:**

--- a/src/user/.agents/skills/ralf-it/foreign-agent-prompt.md
+++ b/src/user/.agents/skills/ralf-it/foreign-agent-prompt.md
@@ -8,8 +8,8 @@ the file.
 **Written to:** `.ralf/{session_id}/prompt-{agent}-{timestamp}.md`
 
 **Consumed by:**
-- **Codex:** `codex-companion.mjs task < <path>` (read-only sandbox)
-- **Gemini:** `gemini -p "" --approval-mode plan -o text < <path>` (plan mode)
+- **Codex:** `codex-companion.mjs task < path` (read-only sandbox)
+- **Gemini:** `gemini -p "" --approval-mode plan -o text < path` (plan mode)
 
 **Critical:** This file is written BEFORE the subagent does any implementation work,
 so it reflects the clean spec/DoD without implementation bias.

--- a/src/user/.agents/skills/ralf-it/foreign-agent-prompt.md
+++ b/src/user/.agents/skills/ralf-it/foreign-agent-prompt.md
@@ -1,11 +1,15 @@
 # RALF-IT Foreign Agent Instruction File Template
 
-This template is used by the foreign-eyes subagent to create the instruction file that gets
-piped to a foreign CLI (Codex/Gemini) via stdin. The subagent fills in `{dod}` and `{spec}`
-from the original task before writing the file.
+This template is used by the foreign-eyes subagent to create the instruction file handed
+to a foreign CLI (Codex via the Claude Code Codex plugin, or Gemini via the `gemini`
+binary). The subagent fills in `{dod}` and `{spec}` from the original task before writing
+the file.
 
 **Written to:** `.ralf/{session_id}/prompt-{agent}-{timestamp}.md`
-**Consumed by:** Foreign CLI via stdin redirect
+
+**Consumed by:**
+- **Codex:** `codex-companion.mjs task < <path>` (read-only sandbox)
+- **Gemini:** `gemini -p "" --approval-mode plan -o text < <path>` (plan mode)
 
 **Critical:** This file is written BEFORE the subagent does any implementation work,
 so it reflects the clean spec/DoD without implementation bias.

--- a/src/user/.agents/skills/ralf-it/foreign-eyes-prompt.md
+++ b/src/user/.agents/skills/ralf-it/foreign-eyes-prompt.md
@@ -52,7 +52,8 @@ Agent tool (general-purpose, mode: "auto"):
     ## Foreign Agent Configuration
 
     - Agent: {agent_name}
-    - CLI invocation (codex): codex exec -s read-only - < {prompt_file} > {review_file} 2>{error_file}
+    - CLI invocation (codex): CODEX_HOME="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"; node "$CODEX_HOME/scripts/codex-companion.mjs" task --model gpt-5.4 < {prompt_file} > {review_file} 2>{error_file}
+      (model selection: `~/.claude/rules/codex-routing.md`)
     - CLI invocation (gemini): gemini -p "" --approval-mode plan -o text < {prompt_file} > {review_file} 2>{error_file}
     - Timeout: 600000ms (10 minutes)
     - Session directory: .ralf/{session_id}/
@@ -104,7 +105,8 @@ Agent tool (general-purpose, mode: "auto"):
 
        For codex:
        ```bash
-       codex exec -s read-only - < .ralf/{session_id}/prompt-{agent_lower}-{timestamp}.md > .ralf/{session_id}/{agent_lower}-review-{timestamp}.md 2>.ralf/{session_id}/{agent_lower}-errors-{timestamp}.log
+       CODEX_HOME="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"
+       node "$CODEX_HOME/scripts/codex-companion.mjs" task --model gpt-5.4 < .ralf/{session_id}/prompt-{agent_lower}-{timestamp}.md > .ralf/{session_id}/{agent_lower}-review-{timestamp}.md 2>.ralf/{session_id}/{agent_lower}-errors-{timestamp}.log
        ```
 
        For gemini:
@@ -118,12 +120,13 @@ Agent tool (general-purpose, mode: "auto"):
 
         **Detect these failures and degrade to pure fresh-eyes (skip Phase 4):**
 
-        a. CLI not found — stderr contains "command not found"
+        a. Runtime not found — stderr contains "command not found", or (for Codex) the companion script path resolved from `$CODEX_HOME` does not exist (plugin not installed at either `$CLAUDE_PLUGIN_ROOT` or the marketplace fallback)
         b. Timeout — Bash timeout exceeded
         c. Token quota exhausted — stderr contains any of: "quota", "rate limit",
            "rate_limit", "exceeded", "429", "resource_exhausted", "too many requests"
-        d. No review output — review file is empty or does not exist
-        e. Unparseable output — review file exists but cannot be meaningfully interpreted
+        d. Auth failure (Codex) — stderr mentions missing or unauthenticated Codex; remediation is `/codex:setup`
+        e. No review output — review file is empty or does not exist
+        f. Unparseable output — review file exists but cannot be meaningfully interpreted
 
         If any failure is detected: record the failure status, skip Phase 4 entirely,
         and proceed to Phase 5 with the foreign agent status set appropriately.

--- a/src/user/.claude/rules/codex-routing.md
+++ b/src/user/.claude/rules/codex-routing.md
@@ -1,0 +1,21 @@
+# Codex Routing
+
+When delegating to Codex, always go through the Claude Code Codex plugin — never the raw `codex` binary.
+
+**Invocation (from a skill or subagent):**
+```
+CODEX_HOME="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"
+node "$CODEX_HOME/scripts/codex-companion.mjs" task [--model <name|spark>] [--write] < prompt.md
+```
+`CLAUDE_PLUGIN_ROOT` is only set for plugin-owned code; fall back to the marketplace install path. Omit `--write` for read-only (the sandbox enforces it); add `--write` only when Codex must edit files. Pipe the prompt on stdin — `--prompt-file` works today but lives in the plugin's internal `codex-cli-runtime` contract, so prefer stdin for forward-compat.
+
+**Model selection** (leave `--model` unset to accept the plugin default; set explicitly when a task profile matches):
+- Architecture, cross-subsystem, security, final pre-merge pass → `gpt-5.4`
+- First-pass triage, diff summary, per-file parallel review, cost-sensitive runs → `gpt-5.4-mini`
+- Deeply code-centric, Codex-tuned agentic work → `gpt-5.3-codex-spark` (alias: `spark`)
+
+**Cost:** `mini` ≈ 30% of `gpt-5.4`; `spark` ≈ 70–93% of `gpt-5.4`. Parallelize with `mini`, decide with `gpt-5.4`.
+
+**Prompt format:** follow the plugin's `codex:gpt-5-4-prompting` skill — XML-tagged blocks, one task per run, explicit completion contract.
+
+**Slash commands** (`/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, `/codex:status`, `/codex:result`, `/codex:cancel`) are user-initiated only; the model cannot fire them. Suggest them to the user instead.

--- a/src/user/.claude/rules/completion-gate.md
+++ b/src/user/.claude/rules/completion-gate.md
@@ -14,5 +14,7 @@ No exceptions. No partial runs. Each step feeds the next.
 
 **Subagents**: When dispatching subagents to do implementation work, always include the full completion gate workflow (review, simplify, verify) in their instructions. Subagent work that skips the gate is incomplete work.
 
+**Optional adversarial pass** (operator-initiated): For high-stakes changes (architecture shifts, security-sensitive code, final pre-merge), add `/codex:adversarial-review --wait --model gpt-5.4` as defense-in-depth after the in-house review steps.
+
 **HARD STOP**: After this gate, you MUST run delivery steps before calling work complete.
 DO NOT commit to main. DO NOT push directly. `finishing-a-development-branch` is NEXT.

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -5,3 +5,5 @@ MANDATORY delegation for non-trivial work (skip for obvious one-liners, config c
 - Planning → `brainstorming` skill
 - Implementation → `test-driven-development` skill first, then domain skills (e.g. `typescript-developer`)
 - Tests → `writing-unit-tests` + `testing-anti-patterns` skills
+
+**Cross-tool delegation:** see `rules/codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -6,4 +6,4 @@ MANDATORY delegation for non-trivial work (skip for obvious one-liners, config c
 - Implementation → `test-driven-development` skill first, then domain skills (e.g. `typescript-developer`)
 - Tests → `writing-unit-tests` + `testing-anti-patterns` skills
 
-**Cross-tool delegation:** see `rules/codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.
+**Cross-tool delegation:** see `codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.


### PR DESCRIPTION
## Summary
- Adds `src/user/.claude/rules/codex-routing.md` defining when to pick `gpt-5.4` vs `gpt-5.4-mini` vs `gpt-5.3-codex-spark` when delegating review/coding work to the Claude Code Codex plugin.
- Cross-referenced from `rules/delegation.md` (cross-tool delegation pointer) and `rules/completion-gate.md` (operator-initiated adversarial-review note).
- Migrates RALF-IT iter-1 Codex foreign-eyes from the raw `codex exec -s read-only` binary to `codex-companion.mjs task` via the Claude Code Codex plugin. Uses stdin redirection (stable) rather than the `--prompt-file` flag (internal contract). Resolves plugin root with `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}` fallback since the env var is only set inside plugin-owned code.
- Gemini iter-2 path untouched.

## Why
- Scott drafted a model-selection routing policy; no home existed for it. The delegating agent (Claude) needed a decision rule.
- Scott just installed the Claude Code Codex plugin, so skills that previously shelled to the raw `codex` binary needed to migrate.
- RALF-IT was the only Codex caller in the repo; migrating it validates the plugin path end-to-end.

## Test plan
- [ ] `bash scripts/install.sh --dry-run --tools=claude` places `codex-routing.md` under `~/.claude/rules/` alongside peer rules
- [ ] Fresh Claude session loads `~/.claude/rules/codex-routing.md` in context the same way other rules appear (confirms @include plumbing)
- [ ] `/codex:setup` reports Codex plugin ready
- [ ] `CODEX_HOME=\"${CLAUDE_PLUGIN_ROOT:-\$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}\"` resolves to an existing `scripts/codex-companion.mjs` from a non-plugin bash context
- [ ] RALF-IT smoke test with `MAX_ITERATIONS=1` against a trivial spec: iter-1 dispatches the companion script, review comes back structured, Codex does not modify source files (read-only sandbox holds), `.ralf/\{session_id\}/` contains prompt+review+error files
- [ ] Gemini iter-2 path unchanged (run iter-2 smoke test)
- [ ] Intentional failure (bogus `--model`) degrades cleanly to pure fresh-eyes per the expanded failure-detection list