### PR TITLE
fix(beads): harden bead-driven workflow boundaries (epic lu3)

### DIFF
--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -150,3 +150,11 @@ and is handled separately via the `merge-and-cleanup` formula.
 **Discovered work:**
 If a subagent reports discovered work, create new beads immediately.
 Do NOT add them to the current molecule or fix them inline.
+
+## Red Flags
+
+| Thought | Reality |
+|---------|---------|
+| "I'll just invoke `ralf-it` / `subagent-driven-development` / `executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE formula steps, not as peers. |
+| "The formula step is simple — I'll do the work in the main agent" | No. Main agent orchestrates. Dispatch a subagent even for small steps. |
+| "I'll skip the formula and just run the work" | The formula IS the workflow. Skipping it skips the gate. |

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -140,7 +140,7 @@ The main agent MUST NOT:
 - Push branches
 - Make git commits
 
-All of these happen inside subagents executing formula step beads.
+All of these happen inside subagents executing molecule step beads (the runtime instances of the formula's step definitions).
 
 **No unauthorized merges.**
 The implement-feature and fix-bug formulas end at `await-review`.
@@ -155,6 +155,6 @@ Do NOT add them to the current molecule or fix them inline.
 
 | Thought | Reality |
 |---------|---------|
-| "I'll just invoke `ralf-it` / `superpowers:subagent-driven-development` / `superpowers:executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE formula steps, not as peers. |
+| "I'll just invoke `ralf-it` / `superpowers:subagent-driven-development` / `superpowers:executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE molecule steps, not as peers. |
 | "The step is small — I'll skip the subagent and do it in the main agent" | No. Main agent orchestrates, subagents implement. Dispatch even for small steps. |
 | "I'll skip the formula and just run the work directly" | The formula IS the workflow. Skipping it skips the gate. |

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -156,5 +156,5 @@ Do NOT add them to the current molecule or fix them inline.
 | Thought | Reality |
 |---------|---------|
 | "I'll just invoke `ralf-it` / `subagent-driven-development` / `executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE formula steps, not as peers. |
-| "The formula step is simple — I'll do the work in the main agent" | No. Main agent orchestrates. Dispatch a subagent even for small steps. |
-| "I'll skip the formula and just run the work" | The formula IS the workflow. Skipping it skips the gate. |
+| "The step is small — I'll skip the subagent and do it in the main agent" | No. Main agent orchestrates, subagents implement. Dispatch even for small steps. |
+| "I'll skip the formula and just run the work directly" | The formula IS the workflow. Skipping it skips the gate. |

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -155,6 +155,6 @@ Do NOT add them to the current molecule or fix them inline.
 
 | Thought | Reality |
 |---------|---------|
-| "I'll just invoke `ralf-it` / `subagent-driven-development` / `executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE formula steps, not as peers. |
+| "I'll just invoke `ralf-it` / `superpowers:subagent-driven-development` / `superpowers:executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE formula steps, not as peers. |
 | "The step is small — I'll skip the subagent and do it in the main agent" | No. Main agent orchestrates, subagents implement. Dispatch even for small steps. |
 | "I'll skip the formula and just run the work directly" | The formula IS the workflow. Skipping it skips the gate. |

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -111,14 +111,16 @@ Tell the user it is a formula bug (child step beads were not materialized).
 Do NOT fall back to invoking the brainstorming skill inline — that bypasses
 the state tracking the molecule exists to provide.
 
-For other mid-run abandonment (real progress was made, but the molecule
-needs to stop), prefer:
+For mid-run abandonment of a **poured** molecule (real progress was made,
+but the molecule needs to stop), prefer:
 
 ```bash
-bd mol squash <wisp-id> --summary "Aborted: <reason>"
+bd mol squash <mol-id> --summary "Aborted: <reason>"
 ```
 
-to preserve history for debugging.
+to preserve history for debugging. Squash is only for poured molecules —
+wisps (including `brainstorm-bead`) have ephemeral state, so `bd mol burn`
+is the right recovery for any wisp abandonment.
 
 ---
 

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -150,9 +150,9 @@ Exception: if it's obviously trivial, just do it without announcing.
 | "I'll make up step IDs — they look like `<root>.<step>`" | No. Use IDs from `bd mol current` output. |
 | "After brainstorming, I should invoke `writing-plans` next" | No. The bead is the plan. Next is `implement-bead`. |
 
-### Recovery: if you land in superpowers:writing-plans
+### Recovery: if you land in `superpowers:writing-plans`
 
-If you hit `writing-plans`' execute-plan vs subagent-driven-development menu
-while on a bead, STOP. The bead is the plan. Ensure `brainstormed` +
-`implementation-ready` labels exist, then invoke `implement-bead`. Pick neither
-menu option.
+If you hit `superpowers:writing-plans` and see its execute-plan vs
+`superpowers:subagent-driven-development` menu while on a bead, STOP. The
+bead is the plan. Ensure `brainstormed` + `implementation-ready` labels
+exist, then invoke `implement-bead`. Pick neither menu option.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -148,3 +148,12 @@ Exception: if it's obviously trivial, just do it without announcing.
 | "This molecule looks incomplete, I'll create a new one" | Resume the existing molecule first. |
 | "The molecule looks empty, I'll just do the work inline" | STOP. 0/0 = formula bug. Burn + report, do not bypass. |
 | "I'll make up step IDs — they look like `<root>.<step>`" | No. Use IDs from `bd mol current` output. |
+| "After brainstorming, I should invoke `writing-plans` next" | No. The bead is the plan. Next is `implement-bead`. |
+
+### Recovery: if you land in superpowers:writing-plans
+
+If, while working a bead, you find yourself at `writing-plans`' two-options
+menu (execute-plan vs. subagent-driven-development), STOP. The bead is the
+plan — you do not need another one. Confirm the bead has the
+`brainstormed` and `implementation-ready` labels (add them if missing) and
+then invoke `implement-bead`. Do not pick either menu option.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -152,8 +152,7 @@ Exception: if it's obviously trivial, just do it without announcing.
 
 ### Recovery: if you land in superpowers:writing-plans
 
-If, while working a bead, you find yourself at `writing-plans`' two-options
-menu (execute-plan vs. subagent-driven-development), STOP. The bead is the
-plan — you do not need another one. Confirm the bead has the
-`brainstormed` and `implementation-ready` labels (add them if missing) and
-then invoke `implement-bead`. Do not pick either menu option.
+If you hit `writing-plans`' execute-plan vs subagent-driven-development menu
+while on a bead, STOP. The bead is the plan. Ensure `brainstormed` +
+`implementation-ready` labels exist, then invoke `implement-bead`. Pick neither
+menu option.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -146,7 +146,7 @@ Exception: if it's obviously trivial, just do it without announcing.
 | "The bead has some AC, close enough" | Has `implementation-ready` label? No? Then Route C. |
 | "I'll do a quick brainstorm in-line without the formula" | No. The formula provides state tracking and spec review. |
 | "This molecule looks incomplete, I'll create a new one" | Resume the existing molecule first. |
-| "The molecule looks empty, I'll just do the work inline" | STOP. 0/0 = formula bug. Burn + report, do not bypass. |
+| "The molecule looks empty, I'll just do the work inline" | STOP. 0/0 = formula bug. Burn (`bd mol burn <wisp-id>`) + report, do not bypass. |
 | "I'll make up step IDs — they look like `<root>.<step>`" | No. Use IDs from `bd mol current` output. |
 | "After brainstorming, I should invoke `writing-plans` next" | No. The bead is the plan. Next is `implement-bead`. |
 

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -80,12 +80,45 @@ Action: wisp the brainstorm-bead formula:
 bd mol wisp create brainstorm-bead --var bead-id=<id>
 ```
 
-Then execute the formula as the MAIN AGENT (brainstorming requires
-interactive conversation with the user — do NOT dispatch a subagent).
+Then drive the molecule as the MAIN AGENT (brainstorming requires
+interactive conversation with the user — do NOT dispatch a subagent):
+
+1. `bd mol current <wisp-id>` — shows all steps with status markers
+2. For the first `[ready]` step:
+   - `bd update <step-id> --claim` — lock as in_progress
+   - `bd show <step-id>` — read the step's instructions
+   - Execute the step (interactive conversation for the discuss step)
+   - `bd close <step-id> --continue` — closes and auto-claims the next step
+3. Repeat until all steps show `[done]`.
+
+Use the step IDs reported by `bd mol current` — do NOT synthesize
+`<root>.<step>` patterns. Step IDs are independent hash-based identifiers.
 
 After the formula completes, the bead will have the `implementation-ready`
 label and will be picked up by `run-queue`, or the user can invoke
 `implement-bead` directly.
+
+### Failure mode: 0/0 steps after wisp creation
+
+If `bd mol current <wisp-id>` shows "0/0 steps complete" with no step
+list, the formula is missing `pour = true`. Recover with:
+
+```bash
+bd mol burn <wisp-id>
+```
+
+Tell the user it is a formula bug (child step beads were not materialized).
+Do NOT fall back to invoking the brainstorming skill inline — that bypasses
+the state tracking the molecule exists to provide.
+
+For other mid-run abandonment (real progress was made, but the molecule
+needs to stop), prefer:
+
+```bash
+bd mol squash <wisp-id> --summary "Aborted: <reason>"
+```
+
+to preserve history for debugging.
 
 ---
 
@@ -113,3 +146,5 @@ Exception: if it's obviously trivial, just do it without announcing.
 | "The bead has some AC, close enough" | Has `implementation-ready` label? No? Then Route C. |
 | "I'll do a quick brainstorm in-line without the formula" | No. The formula provides state tracking and spec review. |
 | "This molecule looks incomplete, I'll create a new one" | Resume the existing molecule first. |
+| "The molecule looks empty, I'll just do the work inline" | STOP. 0/0 = formula bug. Burn + report, do not bypass. |
+| "I'll make up step IDs — they look like `<root>.<step>`" | No. Use IDs from `bd mol current` output. |

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -16,11 +16,13 @@
 #
 # Usage:
 #   bd mol wisp create brainstorm-bead --var bead-id=proj-42
+#   bd mol current <wisp-id>   # shows steps with status
 
 formula     = "brainstorm-bead"
 description = "Interactive spec-writing: assess gaps → discuss with user → write spec → RALF spec review → mark implementation-ready"
 type        = "workflow"
 phase       = "vapor"
+pour        = true
 version     = 1
 
 [vars.bead-id]

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -21,6 +21,7 @@ formula     = "fix-bug"
 description = "Bug fix: diagnose root cause → regression test → fix → completion gate → PR → close"
 type        = "workflow"
 phase       = "liquid"  # persistent across sessions — steps tracked as beads, synced to git
+pour        = true
 version     = 1
 
 [vars.bug]

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -64,7 +64,7 @@ needs = ["reproduce"]
 description = """
 Trace the failure backward to the original invalid state or wrong assumption.
 
-Skill: superpowers:root-cause-tracing (if the call stack is deep or unclear)
+Skill: superpowers:root-cause-tracing
 
 Rules:
 - A symptom is WHERE it breaks. A root cause is WHY it breaks.
@@ -139,6 +139,8 @@ title = "Implement the fix (green phase)"
 needs = ["write-regression-test"]
 description = """
 Fix the root cause identified in the diagnose phase.
+
+Skill: superpowers:test-driven-development
 
 Rules:
 - Fix the ROOT CAUSE, not the symptom

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -25,6 +25,7 @@ formula      = "implement-feature"
 description  = "TDD feature implementation: brainstorm → worktree → red/green/refactor → completion gate → PR → close"
 type         = "workflow"
 phase        = "liquid"  # persistent across sessions — steps tracked as beads, synced to git
+pour         = true
 version      = 1
 
 [vars.feature]

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -101,7 +101,7 @@ needs = ["worktree"]
 description = """
 Write tests FIRST. No implementation code at this step.
 
-Skills: superpowers:writing-unit-tests, superpowers:testing-anti-patterns
+Skills: superpowers:test-driven-development, superpowers:writing-unit-tests, superpowers:testing-anti-patterns
 
 Rules:
 - Tests must be written against the acceptance criteria from the brainstorm step

--- a/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
+++ b/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
@@ -20,11 +20,13 @@
 #   bd mol wisp create merge-and-cleanup \
 #     --var pr="123" \
 #     --var bead-id=proj-42
+#   bd mol current <wisp-id>   # shows steps with status
 
 formula     = "merge-and-cleanup"
 description = "PR merge: verify completion gate → check all comments → explicit merge auth → merge → cleanup"
 type        = "workflow"
 phase       = "vapor"
+pour        = true
 version     = 1
 
 [vars.pr]

--- a/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
+++ b/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
@@ -49,6 +49,8 @@ Before touching this PR, verify that the mandatory completion gate
 was run. Do not take the implementing agent's word for it — look for
 evidence in the PR activity and git history.
 
+Skill: superpowers:requesting-code-review (when dispatching the retroactive review)
+
 1. Find the branch for this PR:
      gh pr view {{pr}} --json headRefName | jq -r '.headRefName'
 
@@ -88,6 +90,8 @@ description = """
 Retrieve ALL comments on this PR. Both sources are required — do not
 rely on memory or assumption about what comments exist.
 
+Skill: superpowers:wait-for-pr-comments
+
 Run these commands and record their full output:
 
   # Top-level review comments and summary comments
@@ -117,6 +121,8 @@ title = "Address all blocking feedback"
 needs = ["check-pr-comments"]
 description = """
 Fix all comments triaged as Blocking in the previous step.
+
+Skill: superpowers:receiving-code-review
 
 For each blocking comment:
   - If fix is clear and unambiguous: implement, commit, push

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -104,12 +104,13 @@ The polling loop and background subagents will interrupt interactive conversatio
 Beads and superpowers are partners with distinct roles. Do not confuse them.
 
 - **Beads = OUTER lifecycle** — what work exists, its state, dependencies, and
-  multi-session persistence. The bead is the plan. Formulas drive the workflow.
+  multi-session persistence. The bead is the plan. Formulas define the workflow
+  at authoring time; at runtime the agent drives the resulting molecule.
 - **Superpowers = INNER methodology** — *how* to actually do the work at each
-  step. Skills are invoked *inside* formula steps, not as peers of the bead
+  step. Skills are invoked *inside* molecule steps, not as peers of the bead
   workflow.
 
-### Inner methodology skills (partners — use freely inside formula steps)
+### Inner methodology skills (partners — use freely inside molecule steps)
 
 - `superpowers:brainstorming`
 - `superpowers:systematic-debugging`

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -128,6 +128,6 @@ Beads and superpowers are partners with distinct roles. Do not confuse them.
 - `superpowers:executing-plans` — `implement-bead` is the executor
 - `superpowers:subagent-driven-development` — `implement-bead` orchestrates via the formula DAG
 
-**Rule:** if you find yourself matching one of the off-limits skills while on a
-bead, STOP. The right path is `start-bead` → `brainstorm-bead` → `implement-bead`.
-Off-limits skills remain available for non-bead work.
+**Rule:** off-limits skills compete with the bead lifecycle. On a bead, use
+`start-bead` → `brainstorm-bead` → `implement-bead` instead. Off-limits skills
+remain available for non-bead work.

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -121,6 +121,7 @@ Beads and superpowers are partners with distinct roles. Do not confuse them.
 - `superpowers:finishing-a-development-branch`
 - `superpowers:requesting-code-review`
 - `superpowers:receiving-code-review`
+- `superpowers:wait-for-pr-comments`
 - `superpowers:dispatching-parallel-agents`
 
 ### Off-limits for bead-tracked work (compete with bead lifecycle)

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -96,3 +96,38 @@ The polling loop and background subagents will interrupt interactive conversatio
 
 - Brainstorming session: interactive, user present, no background work
 - run-queue session: autonomous, separate window/terminal, no brainstorming
+
+---
+
+## Skill Partnership
+
+Beads and superpowers are partners with distinct roles. Do not confuse them.
+
+- **Beads = OUTER lifecycle** — what work exists, its state, dependencies, and
+  multi-session persistence. The bead is the plan. Formulas drive the workflow.
+- **Superpowers = INNER methodology** — *how* to actually do the work at each
+  step. Skills are invoked *inside* formula steps, not as peers of the bead
+  workflow.
+
+### Inner methodology skills (partners — use freely inside formula steps)
+
+- `superpowers:brainstorming`
+- `superpowers:systematic-debugging`
+- `superpowers:root-cause-tracing`
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `superpowers:using-git-worktrees`
+- `superpowers:finishing-a-development-branch`
+- `superpowers:requesting-code-review`
+- `superpowers:receiving-code-review`
+- `superpowers:dispatching-parallel-agents`
+
+### Off-limits for bead-tracked work (compete with bead lifecycle)
+
+- `superpowers:writing-plans` — the bead description IS the plan
+- `superpowers:executing-plans` — `implement-bead` is the executor
+- `superpowers:subagent-driven-development` — `implement-bead` orchestrates via the formula DAG
+
+**Rule:** if you find yourself matching one of the off-limits skills while on a
+bead, STOP. The right path is `start-bead` → `brainstorm-bead` → `implement-bead`.
+Off-limits skills remain available for non-bead work.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -8,6 +8,6 @@ For bead-tracked work, delivery runs inside formula steps, not as a peer workflo
 
 **Do NOT** invoke `finishing-a-development-branch` or `wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
 
-When the formula's current step is `create-pr`, execute it immediately — do not pause for authorization. The core `delivery.md` AUTOMATIC category applies: pause only at merge.
+When the formula's current step is `create-pr`, execute it immediately — the AUTOMATIC category in core `delivery.md` applies.
 
 If you arrive at the end of a formula step and are uncertain whether delivery has run, check via `bd show <bead-id>` and `bd mol current <mol-id>` — the molecule's next step drives the action, not your judgment.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -8,4 +8,6 @@ For bead-tracked work, delivery runs inside formula steps, not as a peer workflo
 
 **Do NOT** invoke `finishing-a-development-branch` or `wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
 
+When the formula's current step is `create-pr`, execute it immediately — do not pause for authorization. The core `delivery.md` AUTOMATIC category applies: pause only at merge.
+
 If you arrive at the end of a formula step and are uncertain whether delivery has run, check via `bd show <bead-id>` and `bd mol current <mol-id>` — the molecule's next step drives the action, not your judgment.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -1,0 +1,11 @@
+# Delivery (beads-aware addendum)
+
+For bead-tracked work, delivery runs inside formula steps, not as a peer workflow.
+
+- `implement-feature.formula.toml` — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `await-review` step invokes `superpowers:wait-for-pr-comments`.
+- `fix-bug.formula.toml` — same pattern: `create-pr` → `finishing-a-development-branch`, `await-review` → `wait-for-pr-comments`.
+- `merge-and-cleanup.formula.toml` — runs after explicit user authorization; handles the merge itself.
+
+**Do NOT** invoke `finishing-a-development-branch` or `wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
+
+If you arrive at the end of a formula step and are uncertain whether delivery has run, check via `bd show <bead-id>` and `bd mol current <mol-id>` — the molecule's next step drives the action, not your judgment.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -1,13 +1,15 @@
 # Delivery (beads-aware addendum)
 
-For bead-tracked work, delivery runs inside formula steps, not as a peer workflow.
+Terminology: a **formula** is an authoring-time TOML template under `.beads/formulas/`; a **molecule** is its runtime instantiation (via `bd mol pour` or `bd mol wisp`). At implementation time you drive the molecule — refer to its "current step", not to the formula.
 
-- `implement-feature.formula.toml` — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `await-review` step invokes `superpowers:wait-for-pr-comments`.
-- `fix-bug.formula.toml` — same pattern: `create-pr` → `superpowers:finishing-a-development-branch`, `await-review` → `superpowers:wait-for-pr-comments`.
-- `merge-and-cleanup.formula.toml` — runs after explicit user authorization; handles the merge itself.
+For bead-tracked work, delivery runs inside molecule steps, not as a peer workflow. The formulas below show which step of each molecule owns delivery:
 
-**Do NOT** invoke `superpowers:finishing-a-development-branch` or `superpowers:wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
+- `implement-feature` (defined in `implement-feature.formula.toml`) — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `await-review` step invokes `superpowers:wait-for-pr-comments`.
+- `fix-bug` — same pattern: `create-pr` → `superpowers:finishing-a-development-branch`, `await-review` → `superpowers:wait-for-pr-comments`.
+- `merge-and-cleanup` — runs after explicit user authorization; handles the merge itself.
 
-When the formula's current step is `create-pr`, execute it immediately — the AUTOMATIC category in core `delivery.md` applies.
+**Do NOT** invoke `superpowers:finishing-a-development-branch` or `superpowers:wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the current molecule step.
 
-If you arrive at the end of a formula step and are uncertain whether delivery has run, check via `bd show <bead-id>` and `bd mol current <mol-id>` — the molecule's next step drives the action, not your judgment.
+When the molecule's current step is `create-pr`, execute it immediately — the AUTOMATIC category in core `delivery.md` applies.
+
+If you arrive at the end of a molecule step and are uncertain whether delivery has run, check via `bd show <bead-id>` and `bd mol current <mol-id>` — the molecule's next step drives the action, not your judgment.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -3,10 +3,10 @@
 For bead-tracked work, delivery runs inside formula steps, not as a peer workflow.
 
 - `implement-feature.formula.toml` — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `await-review` step invokes `superpowers:wait-for-pr-comments`.
-- `fix-bug.formula.toml` — same pattern: `create-pr` → `finishing-a-development-branch`, `await-review` → `wait-for-pr-comments`.
+- `fix-bug.formula.toml` — same pattern: `create-pr` → `superpowers:finishing-a-development-branch`, `await-review` → `superpowers:wait-for-pr-comments`.
 - `merge-and-cleanup.formula.toml` — runs after explicit user authorization; handles the merge itself.
 
-**Do NOT** invoke `finishing-a-development-branch` or `wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
+**Do NOT** invoke `superpowers:finishing-a-development-branch` or `superpowers:wait-for-pr-comments` as peers of the bead workflow — they run INSIDE the formula step the molecule is currently on.
 
 When the formula's current step is `create-pr`, execute it immediately — the AUTOMATIC category in core `delivery.md` applies.
 

--- a/src/user/.claude/rules/completion-gate.md
+++ b/src/user/.claude/rules/completion-gate.md
@@ -19,4 +19,4 @@ No exceptions. No partial runs. Each step feeds the next.
 **HARD STOP**: After this gate, AUTOMATICALLY execute delivery steps. Do NOT pause for authorization.
 DO NOT commit to main. DO NOT push directly.
 
-Execute IN ORDER, without asking: (1) worktree if not already in one, (2) `finishing-a-development-branch`, (3) `wait-for-pr-comments`. Only pause at the merge step — see `delivery.md` for the action categorization.
+Execute IN ORDER, without asking: (1) `using-git-worktrees` if not already in one, (2) `finishing-a-development-branch`, (3) `wait-for-pr-comments`. Only pause at the merge step — see `delivery.md` for the action categorization.

--- a/src/user/.claude/rules/completion-gate.md
+++ b/src/user/.claude/rules/completion-gate.md
@@ -16,5 +16,7 @@ No exceptions. No partial runs. Each step feeds the next.
 
 **Optional adversarial pass** (operator-initiated): For high-stakes changes (architecture shifts, security-sensitive code, final pre-merge), add `/codex:adversarial-review --wait --model gpt-5.4` as defense-in-depth after the in-house review steps.
 
-**HARD STOP**: After this gate, you MUST run delivery steps before calling work complete.
-DO NOT commit to main. DO NOT push directly. `finishing-a-development-branch` is NEXT.
+**HARD STOP**: After this gate, AUTOMATICALLY execute delivery steps. Do NOT pause for authorization.
+DO NOT commit to main. DO NOT push directly.
+
+Execute IN ORDER, without asking: (1) worktree if not already in one, (2) `finishing-a-development-branch`, (3) `wait-for-pr-comments`. Only pause at the merge step — see `delivery.md` for the action categorization.

--- a/src/user/.claude/rules/delivery.md
+++ b/src/user/.claude/rules/delivery.md
@@ -10,14 +10,39 @@ After completion gate passes for non-trivial work:
 
 Housekeeping (checklist steps 9–10) applies throughout: record discovered work, update memory.
 
-**Merge prohibition**: Creating a PR is NOT authorization to merge. Do NOT merge without explicit user authorization in this session. Authorized phrases: "go ahead and merge", "merge it", "ship it". When in doubt, the user has not authorized it.
+## Action Categories
 
-**PR comments**: Check for BOTH top-level AND inline review comments (e.g., Copilot inline suggestions) before marking a PR as review-complete. Inline comments are easy to miss—always run both commands:
+**AUTOMATIC — execute without user authorization:**
+
+- Create worktree
+- Commit on feature branch
+- Push feature branch
+- Create PR
+- Invoke `wait-for-pr-comments`
+- Apply unambiguous PR feedback
+
+**REQUIRES EXPLICIT AUTHORIZATION:**
+
+- Merging a PR (authorized phrases: "go ahead and merge", "merge it", "ship it")
+- Force-pushing
+- Destructive git operations (`reset --hard`, `clean -fd`, `branch -D`)
+- Pushing directly to main/master
+
+Creating a PR is NOT authorization to merge. But PR creation itself is AUTOMATIC — **do not pause for it**. Pause only at the merge step.
+
+**Red flag**: "Ready when you are" / "ready for delivery" / "awaiting your go-ahead" BEFORE PR creation → STOP. Delivery is automatic. Execute `finishing-a-development-branch` now. Only pause AT the merge step.
+
+## Merge prohibition
+
+Creating a PR is NOT authorization to merge. Do NOT merge without explicit user authorization in this session. When in doubt, the user has not authorized it.
+
+## PR comments
+
+Check for BOTH top-level AND inline review comments (e.g., Copilot inline suggestions) before marking a PR as review-complete. Inline comments are easy to miss — always run both commands:
+
 ```
 gh pr view <PR> --comments
 gh api repos/{owner}/{repo}/pulls/{pr}/comments
 ```
 
 Do NOT merge or clean up worktrees/branches until Copilot review completes or times out.
-
-**PR comments**: Check for BOTH top-level AND inline review comments (e.g., Copilot inline suggestions) before marking a PR as review-complete. Inline comments are easy to miss—always verify both.

--- a/src/user/.claude/rules/delivery.md
+++ b/src/user/.claude/rules/delivery.md
@@ -37,8 +37,8 @@ Creating a PR is NOT authorization to merge. But PR creation itself is AUTOMATIC
 Check for BOTH top-level AND inline review comments (e.g., Copilot inline suggestions) before marking a PR as review-complete. Inline comments are easy to miss — always run both commands:
 
 ```
-gh pr view {pr} --comments
-gh api repos/{owner}/{repo}/pulls/{pr}/comments
+gh pr view <pr> --comments
+gh api repos/<owner>/<repo>/pulls/<pr>/comments
 ```
 
 Do NOT merge or clean up worktrees/branches until Copilot review completes or times out.

--- a/src/user/.claude/rules/delivery.md
+++ b/src/user/.claude/rules/delivery.md
@@ -37,7 +37,7 @@ Creating a PR is NOT authorization to merge. But PR creation itself is AUTOMATIC
 Check for BOTH top-level AND inline review comments (e.g., Copilot inline suggestions) before marking a PR as review-complete. Inline comments are easy to miss — always run both commands:
 
 ```
-gh pr view <PR> --comments
+gh pr view {pr} --comments
 gh api repos/{owner}/{repo}/pulls/{pr}/comments
 ```
 

--- a/src/user/.claude/rules/delivery.md
+++ b/src/user/.claude/rules/delivery.md
@@ -30,11 +30,7 @@ Housekeeping (checklist steps 9–10) applies throughout: record discovered work
 
 Creating a PR is NOT authorization to merge. But PR creation itself is AUTOMATIC — **do not pause for it**. Pause only at the merge step.
 
-**Red flag**: "Ready when you are" / "ready for delivery" / "awaiting your go-ahead" BEFORE PR creation → STOP. Delivery is automatic. Execute `finishing-a-development-branch` now. Only pause AT the merge step.
-
-## Merge prohibition
-
-Creating a PR is NOT authorization to merge. Do NOT merge without explicit user authorization in this session. When in doubt, the user has not authorized it.
+**Red flag**: "Ready when you are" / "ready for delivery" / "awaiting your go-ahead" BEFORE PR creation → STOP. Delivery is automatic. Execute `finishing-a-development-branch` now. Only pause AT the merge step. When in doubt at the merge step, the user has not authorized it.
 
 ## PR comments
 


### PR DESCRIPTION
## Summary

Epic `agents-config-lu3` — three coordinated fixes for bead/molecule workflow drift, discovered during audit of the discord-agent-scaffold session.

- **lu3.1** — Wisp formulas weren't materializing step beads. Adds `pour = true` to all four formulas (required by `wisp.go:249-251`) and rewrites `start-bead` Route C with an explicit execution loop (`bd update --claim` → `bd show` → execute → `bd close --continue`). Adds failure-mode recovery for the "0/0 steps" case and two Red Flags rows.
- **lu3.2** — Beads ↔ superpowers partnership contract. Adds a **Skill Partnership** section to `beads.md` naming inner (partner) vs. off-limits skills (`writing-plans`, `executing-plans`, `subagent-driven-development`). Adds matching Red Flags to `start-bead` and `implement-bead`, plus missing methodology-skill citations to `fix-bug`, `merge-and-cleanup`, and `implement-feature` formulas.
- **lu3.3** — Delivery authorization boundaries. Adds an **Action Categories** block (AUTOMATIC vs AUTHORIZATION-REQUIRED) and a "Ready when you are" red flag to core `delivery.md`. Sharpens `completion-gate.md` HARD STOP. Adds NEW `src/plugins/beads/.claude/rules/delivery.md` overlay that auto-appends (via `rules/*.md` append-on-collision) with bead-specific guidance.

Commits map 1:1 to subtasks; review fixes are separate commits for traceability.

Closes epic `agents-config-lu3` and subtasks `lu3.1`, `lu3.2`, `lu3.3`.

## Test plan

- [x] All four formula TOMLs parse (`bd formula list` lists all 4)
- [x] `scripts/install.sh --dry-run --tools=claude --plugins=beads` succeeds and shows expected diffs; overlay `delivery.md` correctly appended to core `delivery.md`
- [x] Code review (superpowers:code-reviewer) — findings addressed
- [x] Simplification review (code-simplifier) — findings addressed
- [ ] Manual: wisp `brainstorm-bead` against a test bead, confirm `bd mol current` shows materialized step beads (user to verify after merge)
- [ ] Manual: future session audit — confirm agents on a bead no longer invoke `writing-plans` / `executing-plans` / `subagent-driven-development` as peers