### PR TITLE
feat(beads): enforce parent-chain claim/close + epic-sibling placement (9cz)

### DIFF
--- a/src/plugins/beads/.agents/skills/create-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/create-bead/SKILL.md
@@ -61,6 +61,33 @@ For child tasks under an epic:
 bd create "<title>" -t task -p <priority> --parent <epic-id>
 ```
 
+#### Placement of discovered work
+
+When a bead is captured mid-implementation — i.e. you're inside
+another in-progress bead and you hit something that needs its own
+tracked home — prefer **epic-sibling placement** over the default
+orphan-with-`discovered-from`:
+
+```bash
+PARENT=$(bd show <current-bead-id> --json | jq -r '.[0].parent // empty')
+
+# If the discovered work is a logical SIBLING SUBTASK of the current
+# bead's parent epic, create it INSIDE the epic so it lands with the
+# siblings (not as an orphan connected only by a dep link):
+if [ -n "$PARENT" ] && <new-work-is-sibling-subtask-of-$PARENT>; then
+  bd create "<title>" -t <type> -p <priority> --parent "$PARENT"
+else
+  # Otherwise create as an orphan and link with discovered-from:
+  NEW=$(bd create "<title>" -t <type> -p <priority> --json | jq -r '.id')
+  bd dep add "$NEW" <current-bead-id> --type discovered-from
+fi
+```
+
+**Sibling test** (from `rules/beads.md` I3): would this discovered
+work have been on the epic's original plan, if we'd thought of it?
+Yes → `--parent <epic-id>`. No (sub-step of the current bead, or only
+tangential) → orphan + `discovered-from`.
+
 ### Step 3: Add Preliminary Context (if provided)
 
 If the user gave requirements, constraints, or acceptance criteria, add them:

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -92,8 +92,7 @@ done
 
 If the bead arrived here via `start-bead` Route A after brainstorming
 in a prior session, the brainstorm-bead formula's `claim` step already
-set the bead (and ancestors) `in_progress` — re-running `bd update
---status in_progress` is a safe no-op. Keep the walk here so the
+set the bead (and ancestors) `in_progress` — re-running `bd update --status in_progress` is a safe no-op. Keep the walk here so the
 claim invariant holds no matter which path got us to implementation.
 
 ### Step 4: Orchestration Loop

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -77,11 +77,24 @@ bd mol pour fix-bug \
   --var bead-id=<bead-id>
 ```
 
-Note the molecule ID from the output. Mark the bead in_progress:
+Note the molecule ID from the output. Claim the bead and walk the
+parent chain (see `rules/beads.md` I1):
+
 ```bash
 bd update <bead-id> --status in_progress
+
+PARENT=$(bd show <bead-id> --json | jq -r '.[0].parent // empty')
+while [ -n "$PARENT" ]; do
+  bd update "$PARENT" --status in_progress
+  PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
 ```
-If the bead has a parent, mark that in_progress too.
+
+If the bead arrived here via `start-bead` Route A after brainstorming
+in a prior session, the brainstorm-bead formula's `claim` step already
+set the bead (and ancestors) `in_progress` — re-running `bd update
+--status in_progress` is a safe no-op. Keep the walk here so the
+claim invariant holds no matter which path got us to implementation.
 
 ### Step 4: Orchestration Loop
 

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -103,8 +103,8 @@ bd close <id> --reason "<one-line summary>"
 # Walk parent chain; close each ancestor whose remaining children are all closed
 PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
 while [ -n "$PARENT" ]; do
-  OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
-  [ "$OPEN" = "0" ] || break
+  NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
+  [ "$NON_CLOSED" = "0" ] || break
   bd close "$PARENT" --reason "All children closed"
   PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
 done

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -78,7 +78,38 @@ Condition: ALL of the following are true:
 - No architectural implications
 - Completable in a single focused turn
 
-Action: do it inline. No formula, no molecule. Close the bead when done.
+Action: do it inline. No formula, no molecule. The inline route still
+owes the bead's lifecycle the same claim/close invariants the formulas
+enforce — do NOT skip them just because the work is small.
+
+Before starting:
+
+```bash
+bd update <id> --status in_progress
+
+# Walk parent chain; mark each ancestor epic in_progress
+PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
+while [ -n "$PARENT" ]; do
+  bd update "$PARENT" --status in_progress
+  PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
+```
+
+After finishing:
+
+```bash
+bd close <id> --reason "<one-line summary>"
+
+# Walk parent chain; close each ancestor whose remaining children are all closed
+PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
+while [ -n "$PARENT" ]; do
+  OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
+  [ "$OPEN" = "0" ] || break
+  bd close "$PARENT" --reason "All children closed"
+  PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
+```
+
 If in doubt, it is NOT trivial. Use Route C.
 
 ---
@@ -87,6 +118,11 @@ If in doubt, it is NOT trivial. Use Route C.
 
 Condition: anything that does not meet Route A or B criteria.
 This is the default route for feature, task, and chore beads without full specs.
+
+The bead's claim walk (I1 in `rules/beads.md`) is handled by the
+brainstorm-bead formula's first step (`claim`) — you do not need to
+claim the bead manually here; driving the molecule will run the claim
+step and mark the bead (and parent chain) `in_progress` before `assess`.
 
 Action: wisp the brainstorm-bead formula:
 ```bash

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -8,6 +8,7 @@
 # is the ralf-spec-review step, which dispatches a fresh-eyes subagent.
 #
 # Phases:
+#   0. Claim     — mark bead (and parent-chain epics) in_progress before any work
 #   1. Assess    — read bead, identify gaps and questions
 #   2. Discuss   — interactive session with user (brainstorming skill)
 #   3. Write     — produce spec and acceptance criteria
@@ -30,12 +31,41 @@ description = "Bead ID to brainstorm (e.g. proj-42). Must already exist."
 required    = true
 
 # =============================================================================
+# Phase 0: Claim
+# =============================================================================
+
+[[steps]]
+id    = "claim"
+title = "Claim bead and parent-chain epics"
+description = """
+Mark this bead (and any parent-chain epics) in_progress before any work.
+Brainstorming IS work — the bead's status must reflect that, so that
+`bd ready` and `bd list --status=open` never show a bead that is
+actively being brainstormed as 'available'.
+
+  bd update {{bead-id}} --status in_progress
+
+Walk the parent chain and mark each ancestor epic in_progress (stops
+when there is no parent):
+
+  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+  while [ -n "$PARENT" ]; do
+    bd update "$PARENT" --status in_progress
+    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+  done
+
+The claim is cheap even if `assess` later decides the bead needs no
+further brainstorming.
+"""
+
+# =============================================================================
 # Phase 1: Assess
 # =============================================================================
 
 [[steps]]
 id    = "assess"
 title = "Assess: read bead, identify what's missing"
+needs = ["claim"]
 description = """
 Read the bead fully. Understand what it is and what's unclear.
 

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -284,12 +284,12 @@ Complete the lifecycle and preserve context for future sessions.
 
 2. Walk the parent chain; close each ancestor epic whose remaining
    children are all closed (stops at the first ancestor that still
-   has open children, or when there is no parent):
+   has any non-closed children, or when there is no parent):
 
      PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
      while [ -n "$PARENT" ]; do
-       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
-       [ "$OPEN" = "0" ] || break
+       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
+       [ "$NON_CLOSED" = "0" ] || break
        bd close "$PARENT" --reason "All children closed"
        PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
      done

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -99,10 +99,19 @@ Skill: superpowers:using-git-worktrees
 - Verify you are IN the worktree directory before writing any code
 - Confirm no leftover state from other work
 
-Then claim the bead:
+Then claim the bead and walk the parent chain:
+
   bd update {{bead-id}} --status in_progress
 
-If the bead has a parent, mark that in_progress too.
+  # Walk parent chain; mark each ancestor epic in_progress
+  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+  while [ -n "$PARENT" ]; do
+    bd update "$PARENT" --status in_progress
+    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+  done
+
+If `implement-bead` already claimed the bead before pouring this
+formula, the first `bd update` is a no-op — re-running it is safe.
 """
 
 # =============================================================================
@@ -273,14 +282,39 @@ Complete the lifecycle and preserve context for future sessions.
 1. Close the bead:
      bd close {{bead-id}} --reason "Fixed: <one sentence root cause summary>"
 
-2. If all siblings in a parent epic are now closed, close the parent.
+2. Walk the parent chain; close each ancestor epic whose remaining
+   children are all closed (stops at the first ancestor that still
+   has open children, or when there is no parent):
+
+     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+     while [ -n "$PARENT" ]; do
+       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
+       [ "$OPEN" = "0" ] || break
+       bd close "$PARENT" --reason "All children closed"
+       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+     done
 
 3. Record any non-obvious insights (root cause patterns are worth preserving):
      bd remember "Bugs in <subsystem> are often caused by <pattern>"
 
-4. File any new bugs or tech debt discovered during the fix:
-     bd create "Tech debt: ..." -t chore -p 3
-     bd dep add <new-id> {{bead-id}} --type discovered-from
+4. File any new bugs or tech debt discovered during the fix. Prefer
+   epic-sibling placement over orphan-with-dep:
+
+     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+
+     # If the discovered work is a logical sibling subtask of the same
+     # parent epic, create it INSIDE the epic:
+     if [ -n "$PARENT" ] && <work-is-sibling-subtask-of-$PARENT>; then
+       bd create "Tech debt: ..." -t chore -p 3 --parent "$PARENT"
+     else
+       # Otherwise create as an orphan and link with discovered-from:
+       NEW=$(bd create "Tech debt: ..." -t chore -p 3 --json | jq -r '.id')
+       bd dep add "$NEW" {{bead-id}} --type discovered-from
+     fi
+
+   Sibling test (see rules/beads.md I3): would this discovered work
+   have been on the parent epic's original plan, if we'd thought of
+   it? Yes → sibling (--parent). No → orphan + discovered-from.
 
 5. Burn this wisp (if running as vapor):
      bd mol burn <this-mol-id>

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -82,12 +82,19 @@ Skill: superpowers:using-git-worktrees
 - Verify you are IN the worktree directory before writing any code
 - Confirm no leftover state from other work
 
-Then claim the bead:
+Then claim the bead and walk the parent chain:
+
   bd update {{bead-id}} --status in_progress
 
-If the bead has a parent epic, mark that in_progress too:
-  bd show {{bead-id}}   # check for parent
-  bd update <parent-id> --status in_progress
+  # Walk parent chain; mark each ancestor epic in_progress
+  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+  while [ -n "$PARENT" ]; do
+    bd update "$PARENT" --status in_progress
+    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+  done
+
+If `implement-bead` already claimed the bead before pouring this
+formula, the first `bd update` is a no-op — re-running it is safe.
 """
 
 # =============================================================================
@@ -281,17 +288,41 @@ Complete the lifecycle and preserve context for future sessions.
 1. Close the bead:
      bd close {{bead-id}} --reason "Implemented and PR merged"
 
-2. If all siblings in a parent epic are now closed, close the parent:
-     bd show {{bead-id}}    # check for parent
-     bd list --parent=<parent-id>  # check siblings
+2. Walk the parent chain; close each ancestor epic whose remaining
+   children are all closed (stops at the first ancestor that still
+   has open children, or when there is no parent):
+
+     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+     while [ -n "$PARENT" ]; do
+       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
+       [ "$OPEN" = "0" ] || break
+       bd close "$PARENT" --reason "All children closed"
+       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+     done
 
 3. Record any non-obvious decisions or hard-won insights:
      bd remember "insight about this system or pattern"
      bd decision record --title="Why we chose X over Y"
 
-4. File any work discovered during implementation:
-     bd create "Found: ..." -t bug -p 1
-     bd dep add <new-id> {{bead-id}} --type discovered-from
+4. File any work discovered during implementation. Prefer epic-sibling
+   placement over orphan-with-dep:
+
+     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+
+     # If the discovered work is a logical sibling subtask of the same
+     # parent epic, create it INSIDE the epic so it lands with the
+     # siblings (not as an orphan with only a dep link):
+     if [ -n "$PARENT" ] && <work-is-sibling-subtask-of-$PARENT>; then
+       bd create "Found: ..." -t <type> -p <prio> --parent "$PARENT"
+     else
+       # Otherwise create as an orphan and link with discovered-from:
+       NEW=$(bd create "Found: ..." -t <type> -p <prio> --json | jq -r '.id')
+       bd dep add "$NEW" {{bead-id}} --type discovered-from
+     fi
+
+   Sibling test (see rules/beads.md I3): would this discovered work
+   have been on the parent epic's original plan, if we'd thought of
+   it? Yes → sibling (--parent). No → orphan + discovered-from.
 
 5. Burn this wisp (if running as vapor):
      bd mol burn <this-mol-id>

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -290,12 +290,12 @@ Complete the lifecycle and preserve context for future sessions.
 
 2. Walk the parent chain; close each ancestor epic whose remaining
    children are all closed (stops at the first ancestor that still
-   has open children, or when there is no parent):
+   has any non-closed children, or when there is no parent):
 
      PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
      while [ -n "$PARENT" ]; do
-       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
-       [ "$OPEN" = "0" ] || break
+       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
+       [ "$NON_CLOSED" = "0" ] || break
        bd close "$PARENT" --reason "All children closed"
        PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
      done

--- a/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
+++ b/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
@@ -227,12 +227,12 @@ Clean up all artifacts from the merged work.
 
 5. Walk the parent chain; close each ancestor epic whose remaining
    children are all closed (stops at the first ancestor that still
-   has open children, or when there is no parent):
+   has any non-closed children, or when there is no parent):
 
      PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
      while [ -n "$PARENT" ]; do
-       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
-       [ "$OPEN" = "0" ] || break
+       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
+       [ "$NON_CLOSED" = "0" ] || break
        bd close "$PARENT" --reason "All children closed"
        PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
      done

--- a/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
+++ b/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
@@ -225,9 +225,17 @@ Clean up all artifacts from the merged work.
 4. Close the bead:
      bd close {{bead-id}} --reason "Merged PR #{{pr}}"
 
-5. If all siblings in a parent epic are now closed, close the parent:
-     bd show {{bead-id}}
-     bd list --parent=<parent-id>
+5. Walk the parent chain; close each ancestor epic whose remaining
+   children are all closed (stops at the first ancestor that still
+   has open children, or when there is no parent):
+
+     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+     while [ -n "$PARENT" ]; do
+       OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
+       [ "$OPEN" = "0" ] || break
+       bd close "$PARENT" --reason "All children closed"
+       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+     done
 
 6. Burn this wisp:
      bd mol burn <this-mol-id>

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -10,17 +10,74 @@ Priority: 0-4 / P0-P4 (0=critical, 2=medium, 4=backlog). NOT "high"/"medium"/"lo
 **Rules**:
 - Use bd for ALL tracking, `--json` for programmatic use
 - No markdown TODO lists unless user explicitly requests
-- Discovered work → create bead NOW with `discovered-from:<parent-id>` dep before continuing; don't defer and don't fix inline
 - Acceptance criteria: "Build passes. Typecheck passes. Tests pass."
 - Epic children parallel by default — only explicit deps create sequence
 - For bead-tracked work, specs may be written directly into the bead description (`bd update <id> --description "..."`) — the bead is the plan file
 - **`bd create` is pure capture — no claim, no implementation.** Never say "starting work" / "beginning" when the user asks to create/file/capture/track a bead. Reserve "Starting work on task [id]..." strictly for when the user explicitly directs you to START WORK on a specific bead identifier.
 
-**Parent/child workflow** (you forget this):
-- Claiming child → mark parent `in_progress` too
-- Before work → `bd show <parent-id>` for acceptance criteria and siblings
+## Parent-chain invariants
+
+These are mechanical invariants that every entry point into work on a
+bead must uphold — whether you're running a formula step, taking the
+trivial inline route in `start-bead`, or filing discovered work
+mid-implementation. "I'll just do a quick thing" is not an exemption.
+
+**I1. Claim walk — when work starts on a child, walk UP.**
+
+Before any work (including brainstorming), mark the bead AND every
+ancestor epic `in_progress`. Brainstorming is work — a bead that is
+actively being brainstormed must never appear as `open` in `bd ready`.
+
+```bash
+bd update <id> --status in_progress
+PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
+while [ -n "$PARENT" ]; do
+  bd update "$PARENT" --status in_progress
+  PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
+```
+
+**I2. Close walk — when work completes, walk UP and close what's empty.**
+
+After closing a child, walk the parent chain and close each ancestor
+epic whose remaining children are all closed. Stop at the first
+ancestor that still has open children, or when there is no parent.
+
+```bash
+bd close <id> --reason "<summary>"
+PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
+while [ -n "$PARENT" ]; do
+  OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
+  [ "$OPEN" = "0" ] || break
+  bd close "$PARENT" --reason "All children closed"
+  PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
+```
+
+**I3. Discovered-work placement — siblings go IN the epic, not beside it.**
+
+When work is discovered mid-implementation, capture it immediately
+(don't defer, don't fix inline). Decide placement with the **sibling
+test**:
+
+> **Sibling subtask**: work the parent epic's original decomposition
+> should have included as a peer bullet — something that exists on its
+> own merits, not only because of how the current bead is being
+> implemented.
+
+- **Passes the sibling test** → create with `--parent <epic-id>` so it
+  lands in the epic alongside its siblings.
+- **Fails the sibling test** (sub-step of the current bead, or only
+  tangentially related) → create as an orphan and link with:
+  `bd dep add <new-id> <current-id> --type discovered-from`
+
+The test: "would this have been on the epic's original plan, if we'd
+thought of it?" Yes → sibling. No → orphan + dep.
+
+**Other parent/child expectations:**
 - Before user review → run completion gate pipeline
-- After close → if all siblings closed, close parent recursively
+  (I1's claim walk already surfaces the parent chain for AC / sibling
+  context — no separate `bd show <parent-id>` lookup needed)
 
 ---
 

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -41,14 +41,15 @@ done
 
 After closing a child, walk the parent chain and close each ancestor
 epic whose remaining children are all closed. Stop at the first
-ancestor that still has open children, or when there is no parent.
+ancestor that still has any non-closed children (`open` or
+`in_progress`), or when there is no parent.
 
 ```bash
 bd close <id> --reason "<summary>"
 PARENT=$(bd show <id> --json | jq -r '.[0].parent // empty')
 while [ -n "$PARENT" ]; do
-  OPEN=$(bd list --parent="$PARENT" --status=open --json | jq 'length')
-  [ "$OPEN" = "0" ] || break
+  NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
+  [ "$NON_CLOSED" = "0" ] || break
   bd close "$PARENT" --reason "All children closed"
   PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
 done


### PR DESCRIPTION
## Summary

Closes the three workflow gaps captured in `agents-config-9cz`:

1. **Claim walk missing at start-of-work** — brainstorm-bead formula had no claim step; Route B/C in `start-bead` didn't claim either. Observed in the wild on `agents-config-lu3.4` (active brainstorming with `status=open`).
2. **Parent-epic closure phrased as observation, not command** — housekeeping steps said "if all siblings closed, close the parent" without a concrete command or chain walk.
3. **Discovered-work defaulted to orphan** — guidance taught `bd dep add ... --type discovered-from` only; siblings of the current bead that belonged inside the parent epic landed outside it.

## Enhancements (all 5)

- **E1** `brainstorm-bead.formula.toml` — new `claim` step (walks parent chain); `assess` now `needs = ["claim"]`.
- **E2** `start-bead/SKILL.md` — Route B gets explicit claim-then-close with parent walk; Route C notes claim is handled by the formula.
- **E3** `implement-feature.formula.toml`, `fix-bug.formula.toml`, `merge-and-cleanup.formula.toml` — housekeeping/cleanup now uses a concrete recursive `while` loop to close each ancestor epic whose remaining children are all closed.
- **E4** `create-bead/SKILL.md` + both implementation formulas — discovered-work guidance teaches the **sibling test**: "would this have been on the parent epic's original plan?" Yes → `--parent <epic-id>`. No → orphan + `discovered-from`.
- **E5** `.claude/rules/beads.md` — 4-line "Parent/child workflow" blurb promoted to named **"Parent-chain invariants"** section (I1 claim walk, I2 close walk, I3 discovered-work placement). Canonical home for the sibling-test definition.

Also updated `implement-bead/SKILL.md` Step 3 to show the full I1 claim walk with a no-op note for the brainstorm → implement hand-off path.

## Review cycle (completion gate)

- **Code review** (superpowers:code-reviewer): caught a 🔴 blocking bug — `bd show --json` returns an array, not an object. Fixed all 23 occurrences of `jq -r '.parent // empty'` → `jq -r '.[0].parent // empty'`. Verified empirically: walk from `lu3.4` resolves to parent `lu3` and terminates at depth 1. Also addressed S2 (Route C note), S3 (tighter sibling-subtask definition), S4 (no-op note in implement-bead), S5 (drop redundant "before work" bullet).
- **Code simplifier** (code-simplifier): concurred on embedding snippets inline (don't extract to helper); canonical sibling-subtask definition now lives in `beads.md` I3 with short references elsewhere; dropped `brainstorm-bead` filler prose and `create-bead` redundant "Rule of thumb" bullets.
- **TOML validation** (tomli + `bd formula list`): all four formulas parse; step counts `brainstorm-bead: 6`, `implement-feature: 11`, `fix-bug: 11`, `merge-and-cleanup: 6`.

## Files changed

- `src/plugins/beads/.agents/skills/create-bead/SKILL.md`
- `src/plugins/beads/.agents/skills/implement-bead/SKILL.md`
- `src/plugins/beads/.agents/skills/start-bead/SKILL.md`
- `src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml`
- `src/plugins/beads/.beads/formulas/fix-bug.formula.toml`
- `src/plugins/beads/.beads/formulas/implement-feature.formula.toml`
- `src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml`
- `src/plugins/beads/.claude/rules/beads.md`

## Test plan

This repo has no test/build/lint system (documentation only), so verification is:

- [x] All 4 TOML files parse with `tomli` (Python) and `bd formula list` (Go)
- [x] Step sequences match expectations (brainstorm-bead gained `claim`; other formulas unchanged in structure)
- [x] Empirical jq walk verified against real beads (`lu3.4` → `lu3` → terminates; `9cz` → terminates immediately)
- [x] No stale `.parent // empty` expressions remain (0 grep hits)

## Notes

- No upstream `bd` CLI changes required; fix is entirely in plugin content.
- Bead `agents-config-9cz` will be closed via `merge-and-cleanup` after authorization.