### PR TITLE
fix(beads): make discovered-work snippets valid bash (2ir, follow-up to #13)

### DIFF
--- a/src/plugins/beads/.agents/skills/create-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/create-bead/SKILL.md
@@ -71,10 +71,13 @@ orphan-with-`discovered-from`:
 ```bash
 PARENT=$(bd show <current-bead-id> --json | jq -r '.[0].parent // empty')
 
-# If the discovered work is a logical SIBLING SUBTASK of the current
-# bead's parent epic, create it INSIDE the epic so it lands with the
-# siblings (not as an orphan connected only by a dep link):
-if [ -n "$PARENT" ] && <new-work-is-sibling-subtask-of-$PARENT>; then
+# Decide placement via the sibling test (see rules/beads.md I3):
+# would this work have been on the parent epic's original plan, if
+# we'd thought of it then? Yes → sibling. No → orphan + discovered-from.
+IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
+
+if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
+  # Create INSIDE the parent epic as a sibling:
   bd create "<title>" -t <type> -p <priority> --parent "$PARENT"
 else
   # Otherwise create as an orphan and link with discovered-from:

--- a/src/plugins/beads/.agents/skills/create-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/create-bead/SKILL.md
@@ -69,7 +69,7 @@ tracked home — prefer **epic-sibling placement** over the default
 orphan-with-`discovered-from`:
 
 ```bash
-PARENT=$(bd show <current-bead-id> --json | jq -r '.[0].parent // empty')
+PARENT=$(bd show "<current-bead-id>" --json | jq -r '.[0].parent // empty')
 
 # Decide placement via the sibling test (see rules/beads.md I3):
 # would this work have been on the parent epic's original plan, if
@@ -78,11 +78,11 @@ IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
 
 if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
   # Create INSIDE the parent epic as a sibling:
-  bd create "<title>" -t <type> -p <priority> --parent "$PARENT"
+  bd create "<title>" -t "<type>" -p "<priority>" --parent "$PARENT"
 else
   # Otherwise create as an orphan and link with discovered-from:
-  NEW=$(bd create "<title>" -t <type> -p <priority> --json | jq -r '.id')
-  bd dep add "$NEW" <current-bead-id> --type discovered-from
+  NEW=$(bd create "<title>" -t "<type>" -p "<priority>" --json | jq -r '.id')
+  bd dep add "$NEW" "<current-bead-id>" --type discovered-from
 fi
 ```
 

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -302,9 +302,13 @@ Complete the lifecycle and preserve context for future sessions.
 
      PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
 
-     # If the discovered work is a logical sibling subtask of the same
-     # parent epic, create it INSIDE the epic:
-     if [ -n "$PARENT" ] && <work-is-sibling-subtask-of-$PARENT>; then
+     # Decide placement via the sibling test (see rules/beads.md I3):
+     # would this work have been on the parent epic's original plan, if
+     # we'd thought of it? Yes → sibling. No → orphan + discovered-from.
+     IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
+
+     if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
+       # Create INSIDE the parent epic as a sibling:
        bd create "Tech debt: ..." -t chore -p 3 --parent "$PARENT"
      else
        # Otherwise create as an orphan and link with discovered-from:

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -316,10 +316,10 @@ Complete the lifecycle and preserve context for future sessions.
 
      if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
        # Create INSIDE the parent epic as a sibling:
-       bd create "Found: ..." -t <type> -p <prio> --parent "$PARENT"
+       bd create "Found: ..." -t "<type>" -p "<prio>" --parent "$PARENT"
      else
        # Otherwise create as an orphan and link with discovered-from:
-       NEW=$(bd create "Found: ..." -t <type> -p <prio> --json | jq -r '.id')
+       NEW=$(bd create "Found: ..." -t "<type>" -p "<prio>" --json | jq -r '.id')
        bd dep add "$NEW" {{bead-id}} --type discovered-from
      fi
 

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -309,10 +309,13 @@ Complete the lifecycle and preserve context for future sessions.
 
      PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
 
-     # If the discovered work is a logical sibling subtask of the same
-     # parent epic, create it INSIDE the epic so it lands with the
-     # siblings (not as an orphan with only a dep link):
-     if [ -n "$PARENT" ] && <work-is-sibling-subtask-of-$PARENT>; then
+     # Decide placement via the sibling test (see rules/beads.md I3):
+     # would this work have been on the parent epic's original plan, if
+     # we'd thought of it? Yes → sibling. No → orphan + discovered-from.
+     IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
+
+     if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
+       # Create INSIDE the parent epic as a sibling:
        bd create "Found: ..." -t <type> -p <prio> --parent "$PARENT"
      else
        # Otherwise create as an orphan and link with discovered-from:


### PR DESCRIPTION
## Summary

Follow-up to [#13](https://github.com/scotthamilton77/agents-config/pull/13). Copilot's round-2 review on that PR flagged a shell-syntax issue in 3 of the discovered-work snippets — but the issue was discovered after the PR had already been merged, so the fix goes here in `agents-config-2ir`.

### The issue

All three discovered-work snippets contained:
```bash
if [ -n "$PARENT" ] && <work-is-sibling-subtask-of-$PARENT>; then
```

The `<...>` token was a placeholder, like the `<type>` and `<priority>` placeholders used elsewhere in the same files — but inside an `if`-condition, bash parses `<` as input-redirect, so copy/pasting literally would try to open a file. Unlike string-arg placeholders (safe), boolean-context placeholders are syntactically dangerous.

### The fix

Introduce an explicit `IS_SIBLING_SUBTASK` boolean with a comment block explaining how to set it, then use a valid bash test:

```bash
# Decide placement via the sibling test (see rules/beads.md I3):
# would this work have been on the parent epic's original plan, if
# we'd thought of it? Yes → sibling. No → orphan + discovered-from.
IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes

if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
  ...
```

Snippet now parses cleanly with `bash -n`.

### Files changed

- `src/plugins/beads/.agents/skills/create-bead/SKILL.md`
- `src/plugins/beads/.beads/formulas/implement-feature.formula.toml`
- `src/plugins/beads/.beads/formulas/fix-bug.formula.toml`

### Tracking

- Bead: `agents-config-2ir` (discovered-from `agents-config-9cz`)
- Copilot round-2 comments on PR #13: `3107495666`, `3107495677`, `3107495680` — this PR is the fix.

## Test plan

- [x] No remaining `<...>` in bash boolean contexts across `src/plugins/beads/`
- [x] `create-bead/SKILL.md` bash block parses with `bash -n`
- [x] Both formula TOMLs parse with `tomli`
- [x] TOML step counts unchanged (`implement-feature: 11`, `fix-bug: 11`)