### PR TITLE
fix(beads): work around 2dx + lp3 via for-bead-<id> molecule label

### DIFF
--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -57,8 +57,54 @@ bd list --label for-bead-<bead-id> --type molecule --json \
   | jq '[.[] | select(.status != "closed")]'
 ```
 
-If the result array is non-empty: resume the molecule (go to Step 4).
-Do NOT pour a new formula over existing in-progress work.
+Decide from the result array:
+
+- **length 0** → no active molecule. BUT if you suspect a pre-convention
+  or otherwise unlabeled molecule exists (prior activity visible in the
+  bead's history, user references one), STOP — do NOT pour over
+  unlabeled in-progress work. Escalate:
+  ```bash
+  bd comments add <bead-id> "Probe returned no labeled molecules, but I
+    suspect an unlabeled molecule exists because: <reason>."
+  bd human <bead-id>
+  ```
+  Otherwise proceed to Step 3.
+
+- **length 1** → extract and resume (go to Step 4):
+  ```bash
+  MOL_ID=$(bd list --label for-bead-<bead-id> --type molecule --json \
+    | jq -r '[.[] | select(.status != "closed")] | .[0].id')
+  bd mol current "$MOL_ID"
+  ```
+  Do NOT pour a new formula over existing in-progress work.
+
+- **length 2+** → analyze first; don't escalate blindly. Multiple
+  non-closed molecules for one bead is legitimate when distinct formulas
+  coexist (a lingering brainstorm-bead wisp alongside an
+  implement-feature pour) or when parallel agents share the same Dolt
+  server. Inspect each:
+  ```bash
+  bd list --label for-bead-<bead-id> --type molecule --json \
+    | jq '[.[] | select(.status != "closed")
+               | {id, title, status, updated_at, created_at}]'
+  ```
+  Resolve if one clearly supersedes the others — an open
+  implement-feature/fix-bug pour supersedes a stale brainstorm-bead
+  wisp; a more recent pour supersedes an abandoned earlier one. Resume
+  the winner (go to Step 4) and tell the user your reasoning; the user
+  can burn the loser later.
+
+  If the molecules cannot be cleanly disambiguated, escalate WITH your
+  analysis — the human should see your read-out, not a blank flag:
+  ```bash
+  bd comments add <bead-id> "N active molecules for this bead:
+    - <mol-id-1> (<formula>, status=<s>, updated <ts>): <analysis>
+    - <mol-id-2> (<formula>, status=<s>, updated <ts>): <analysis>
+    Assessment: <duplicative | legacy | needs manual merge>
+    Recommended action: <resume X / burn Y / user decides>"
+  bd human <bead-id>
+  ```
+  Do NOT silently pick one.
 
 See `rules/beads.md` ("Molecule → bead linkage convention") for the
 stamp procedure applied in Step 3.

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -47,12 +47,21 @@ Confirm `implementation-ready` label is present. If absent, stop and invoke
 
 ### Step 2: Check for Existing Molecule
 
+Molecules have no structural parent-edge back to the bead (beads `lp3`)
+and the tree-mode text path silently drops `--type` / `--parent` filters
+(beads `2dx`). Query via the `for-bead-<bead-id>` label convention with
+`--json`:
+
 ```bash
-bd list --parent <bead-id> --type mol 2>/dev/null
+bd list --label for-bead-<bead-id> --type molecule --json \
+  | jq '[.[] | select(.status != "closed")]'
 ```
 
-If an active molecule exists for this bead: resume it (go to Step 4).
+If the result array is non-empty: resume the molecule (go to Step 4).
 Do NOT pour a new formula over existing in-progress work.
+
+See `rules/beads.md` ("Molecule → bead linkage convention") for the
+stamp procedure applied in Step 3.
 
 ### Step 3: Pour the Formula
 
@@ -77,8 +86,15 @@ bd mol pour fix-bug \
   --var bead-id=<bead-id>
 ```
 
-Note the molecule ID from the output. Claim the bead and walk the
-parent chain (see `rules/beads.md` I1):
+Note the molecule ID from the output. Immediately stamp the bead→molecule
+lookup label so Step 2's existence probe can find this molecule on any
+future entry (see `rules/beads.md` "Molecule → bead linkage convention"):
+
+```bash
+bd label add <mol-id> for-bead-<bead-id>
+```
+
+Then claim the bead and walk the parent chain (see `rules/beads.md` I1):
 
 ```bash
 bd update <bead-id> --status in_progress

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -64,8 +64,7 @@ Decide from the result array:
   bead's history, user references one), STOP — do NOT pour over
   unlabeled in-progress work. Escalate:
   ```bash
-  bd comments add <bead-id> "Probe returned no labeled molecules, but I
-    suspect an unlabeled molecule exists because: <reason>."
+  bd comments add <bead-id> "Probe returned no labeled molecules, but I suspect an unlabeled molecule exists because: <reason>."
   bd human <bead-id>
   ```
   Otherwise proceed to Step 3.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -46,11 +46,54 @@ Why this shape — two beads motivate every character:
   not set `parent = <bead-id>`, so `bd list --parent <bead-id>` returns
   `[]` even when a molecule exists (beads `lp3`).
 
-If the result array is non-empty → resume:
-```bash
-bd mol current <mol-id>
-```
-Then execute the current step. Do NOT create a new molecule.
+Decide from the result array:
+
+- **length 0** → no active molecule. BUT if you suspect a pre-convention
+  or otherwise unlabeled molecule exists (prior activity visible in the
+  bead's history, user references one), STOP — do NOT pour/wisp over
+  unlabeled in-progress work. Escalate:
+  ```bash
+  bd comments add <bead-id> "Probe returned no labeled molecules, but I
+    suspect an unlabeled molecule exists because: <reason>."
+  bd human <bead-id>
+  ```
+  Otherwise proceed to Step 3.
+
+- **length 1** → extract and resume:
+  ```bash
+  MOL_ID=$(bd list --label for-bead-<bead-id> --type molecule --json \
+    | jq -r '[.[] | select(.status != "closed")] | .[0].id')
+  bd mol current "$MOL_ID"
+  ```
+  Then execute the current step. Do NOT create a new molecule.
+
+- **length 2+** → analyze first; don't escalate blindly. Multiple
+  non-closed molecules for one bead is legitimate when distinct formulas
+  coexist (a lingering brainstorm-bead wisp alongside an
+  implement-feature pour) or when parallel agents share the same Dolt
+  server. Inspect each:
+  ```bash
+  bd list --label for-bead-<bead-id> --type molecule --json \
+    | jq '[.[] | select(.status != "closed")
+               | {id, title, status, updated_at, created_at}]'
+  ```
+  Resolve if one clearly supersedes the others — an open
+  implement-feature/fix-bug pour supersedes a stale brainstorm-bead
+  wisp; a more recent pour supersedes an abandoned earlier one. Resume
+  the winner and tell the user your reasoning in the routing message;
+  the user can burn the loser later.
+
+  If the molecules cannot be cleanly disambiguated, escalate WITH your
+  analysis — the human should see your read-out, not a blank flag:
+  ```bash
+  bd comments add <bead-id> "N active molecules for this bead:
+    - <mol-id-1> (<formula>, status=<s>, updated <ts>): <analysis>
+    - <mol-id-2> (<formula>, status=<s>, updated <ts>): <analysis>
+    Assessment: <duplicative | legacy | needs manual merge>
+    Recommended action: <resume X / burn Y / user decides>"
+  bd human <bead-id>
+  ```
+  Do NOT silently pick one.
 
 See `rules/beads.md` ("Molecule → bead linkage convention") for the full
 rationale and the stamp procedure.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -30,17 +30,30 @@ Note: type, status, labels, AC, description, dependencies.
 
 ### Step 2: Check for Existing Molecule
 
-Before doing anything else, check if a molecule already exists for this bead:
+Before doing anything else, check if an active molecule already exists for
+this bead. Use the `for-bead-<bead-id>` label (stamped by Route C on wisp
+and by `implement-bead` on pour) and query with `--json`:
+
 ```bash
-bd list --parent <bead-id> --type mol 2>/dev/null
-bd mol list 2>/dev/null | grep <bead-id>
+bd list --label for-bead-<bead-id> --type molecule --json \
+  | jq '[.[] | select(.status != "closed")]'
 ```
 
-If an active molecule exists → resume it:
+Why this shape — two beads motivate every character:
+- `--json` bypasses the tree-text path, which silently drops `--type` and
+  seeds the queried id into results (beads `2dx`).
+- The label is the only reliable bead→molecule edge; `bd mol pour` does
+  not set `parent = <bead-id>`, so `bd list --parent <bead-id>` returns
+  `[]` even when a molecule exists (beads `lp3`).
+
+If the result array is non-empty → resume:
 ```bash
 bd mol current <mol-id>
 ```
 Then execute the current step. Do NOT create a new molecule.
+
+See `rules/beads.md` ("Molecule → bead linkage convention") for the full
+rationale and the stamp procedure.
 
 ### Step 3: Route the Bead
 
@@ -124,9 +137,12 @@ brainstorm-bead formula's first step (`claim`) — you do not need to
 claim the bead manually here; driving the molecule will run the claim
 step and mark the bead (and parent chain) `in_progress` before `assess`.
 
-Action: wisp the brainstorm-bead formula:
+Action: wisp the brainstorm-bead formula, then stamp the bead→molecule
+lookup label (see `rules/beads.md` "Molecule → bead linkage convention"):
 ```bash
 bd mol wisp create brainstorm-bead --var bead-id=<id>
+# Capture the wisp-id from the command output, then:
+bd label add <wisp-id> for-bead-<id>
 ```
 
 Then drive the molecule as the MAIN AGENT (brainstorming requires

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -39,7 +39,7 @@ bd list --label for-bead-<bead-id> --type molecule --json \
   | jq '[.[] | select(.status != "closed")]'
 ```
 
-Why this shape — two beads motivate every character:
+Why this shape — two bugs motivate every character:
 - `--json` bypasses the tree-text path, which silently drops `--type` and
   seeds the queried id into results (beads `2dx`).
 - The label is the only reliable bead→molecule edge; `bd mol pour` does
@@ -53,8 +53,7 @@ Decide from the result array:
   bead's history, user references one), STOP — do NOT pour/wisp over
   unlabeled in-progress work. Escalate:
   ```bash
-  bd comments add <bead-id> "Probe returned no labeled molecules, but I
-    suspect an unlabeled molecule exists because: <reason>."
+  bd comments add <bead-id> "Probe returned no labeled molecules, but I suspect an unlabeled molecule exists because: <reason>."
   bd human <bead-id>
   ```
   Otherwise proceed to Step 3.

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -140,9 +140,9 @@ step and mark the bead (and parent chain) `in_progress` before `assess`.
 Action: wisp the brainstorm-bead formula, then stamp the bead→molecule
 lookup label (see `rules/beads.md` "Molecule → bead linkage convention"):
 ```bash
-bd mol wisp create brainstorm-bead --var bead-id=<id>
+bd mol wisp create brainstorm-bead --var bead-id=<bead-id>
 # Capture the wisp-id from the command output, then:
-bd label add <wisp-id> for-bead-<id>
+bd label add <wisp-id> for-bead-<bead-id>
 ```
 
 Then drive the molecule as the MAIN AGENT (brainstorming requires

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -111,7 +111,8 @@ is looking for work), use `bd ready --label implementation-ready` instead.
 
 ## Bead Lifecycle and Labels
 
-Labels track a bead's state through the pipeline:
+Labels track state through the pipeline. Most apply to beads; a few
+apply to molecules (the `Set by` and `Meaning` columns note the subject):
 
 | Label | Set by | Meaning |
 |-------|--------|---------|
@@ -136,7 +137,7 @@ bd ready --label <label>
 Molecules created for a bead via `bd mol pour` or `bd mol wisp` have NO
 structural link back to the bead they were poured/wisped for: `parent`
 is `null` and neither title nor description encodes the bead id (beads
-`lp3`, upstream bug). Until `bd` fixes this, SKILLs stamp an explicit
+`lp3`, upstream bug). Until `bd` fixes this, skills stamp an explicit
 lookup label on the molecule immediately after pour/wisp:
 
 ```bash

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -118,6 +118,7 @@ Labels track a bead's state through the pipeline:
 | `brainstormed` | brainstorm-bead formula (finalize step) | Spec written and reviewed |
 | `implementation-ready` | brainstorm-bead formula (finalize step) | Ready for implement-bead / run-queue |
 | `implementation-readied-session-<sid>` | brainstorm-bead formula (finalize step) | Marks a session that applied `implementation-ready`; used by `start-bead` Route A for same-session gating. `<sid>` is the first 8 hex chars of the applying session's ID. |
+| `for-bead-<bead-id>` | `start-bead` (Route C wisp) and `implement-bead` (pour) | Applied to the molecule (not the bead). Gives `start-bead` / `implement-bead` a reliable lookup edge from bead to molecule — see "Molecule → bead linkage convention" below. |
 | `human` | Any agent via `bd human <id>` | Needs human attention |
 
 Label commands:
@@ -127,6 +128,49 @@ bd label remove <id> <label>
 bd label list <id>
 bd ready --label <label>
 ```
+
+---
+
+## Molecule → bead linkage convention
+
+Molecules created for a bead via `bd mol pour` or `bd mol wisp` have NO
+structural link back to the bead they were poured/wisped for: `parent`
+is `null` and neither title nor description encodes the bead id (beads
+`lp3`, upstream bug). Until `bd` fixes this, SKILLs stamp an explicit
+lookup label on the molecule immediately after pour/wisp:
+
+```bash
+bd label add <mol-id> for-bead-<bead-id>
+```
+
+The `for-bead-<bead-id>` label applies to the **molecule root**, not the
+bead itself. It is the convention behind the existence probes in
+`start-bead` Step 2 and `implement-bead` Step 2.
+
+**Existence probe** — canonical form for "does an active molecule exist
+for this bead?":
+
+```bash
+bd list --label for-bead-<bead-id> --type molecule --json \
+  | jq '[.[] | select(.status != "closed")]'
+```
+
+Two bugs make the `--json` part non-negotiable: the tree-mode text path
+silently drops `--type` / `--parent` filters and seeds the queried id
+into its output (beads `2dx`). `--json` flips `prettyFormat` off in `bd`
+and routes through the direct filtered query, so both `--label` and
+`--type` are honored.
+
+**Why label, not reparenting**: setting `parent = <bead-id>` on the
+molecule would entangle lifecycles — the I2 close-walk would cascade-close
+the bead when the molecule squashes, which is wrong (molecule steps done
+≠ bead delivered/merged). Labels are lifecycle-neutral and already the
+idiom for cross-cutting tags.
+
+**When the upstream bugs land**: once `bd` fixes `2dx` (tree path honors
+filters) and `lp3` (`bd mol pour` sets `parent = <bead-id>` or adds a
+structural edge), this convention becomes redundant. Drop the stamp and
+switch the probe to `bd list --parent <bead-id> --type molecule --json`.
 
 ---
 


### PR DESCRIPTION
## Summary

Two upstream `beads` bugs break the "does an active molecule exist for this bead?" probe used by `start-bead` Step 2 and `implement-bead` Step 2:

- **agents-config-2dx** — `bd list --parent X` defaults to `--tree`, and the tree path silently drops `--type` (and other filters) while seeding the queried id into results (`getHierarchicalChildren` in `cmd/bd/list.go`). Text output and JSON output diverge.
- **agents-config-lp3** — `bd mol pour` leaves the molecule's `parent = null`. Even on the reliable `--json` path, `bd list --parent <bead-id> --json` returns `[]` for a bead that has an active molecule.

Combined, the "check for existing molecule" step in both skills was structurally broken: text mode lies, JSON mode is empty.

## Workaround (consumer-side — no `beads` patch)

Stamp every molecule created for a bead with a `for-bead-<bead-id>` label at pour/wisp time, then probe:

```bash
bd list --label for-bead-<bead-id> --type molecule --json \
  | jq '[.[] | select(.status != "closed")]'
```

- `--json` sidesteps **2dx** (bypasses tree path → `--type` honored).
- The label sidesteps **lp3** (gives a real bead→molecule edge without reparenting).

**Why label, not `bd update <mol-id> --parent <bead-id>`:** reparenting would entangle lifecycles — the I2 close-walk would cascade-close the bead when the molecule squashes (molecule steps done ≠ bead delivered/merged). Labels are lifecycle-neutral and already the idiom for cross-cutting tags (cf. `implementation-readied-session-<sid>`).

## Changes

- `src/plugins/beads/.agents/skills/start-bead/SKILL.md` — Step 2 probe rewritten; Route C (wisp) stamps the label after `bd mol wisp create`.
- `src/plugins/beads/.agents/skills/implement-bead/SKILL.md` — Step 2 probe rewritten; Step 3 (pour) stamps the label after `bd mol pour`.
- `src/plugins/beads/.claude/rules/beads.md` — new *Molecule → bead linkage convention* section documenting the workaround, the probe, the rationale against reparenting, and the rollback path once upstream bugs are fixed. New `for-bead-<bead-id>` row added to the lifecycle-label table.

## Verification

Empirically verified on this repo:
- Negative case: `bd list --label for-bead-fake --type molecule --json` → `[]` (length 0).
- Positive case: stamped `for-bead-lu3.4` on live molecule `mol-gs8`, probe returned the molecule; rollback by removing label.

## Test plan

- [ ] New `start-bead` session on a bead with no molecule → probe returns empty, routes to brainstorm/implement.
- [ ] After pouring via `implement-bead`, re-entering `start-bead` on the same bead → probe finds the molecule, routes to resume.
- [ ] `bd label list <mol-id>` shows `for-bead-<bead-id>` after both pour and wisp.

Closes agents-config-2dx, agents-config-lp3.