### PR TITLE
fix(beads): confirm step replaces brainstorm in implement-feature (smg)

### DIFF
--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -69,8 +69,7 @@ Aborting from either branch below means: leave this `confirm` step
 OPEN (do not close it), do NOT call `bd mol burn` from within this
 step, and print this one-line follow-up:
 
-  Molecule paused at confirm. Run brainstorm-bead on this bead and
-  re-attempt, or `bd mol burn <mol-id>` to discard.
+  Molecule paused at confirm. Run brainstorm-bead on this bead and re-attempt, or `bd mol burn <mol-id>` to discard.
 
 Leave the disposition (re-attempt or burn) to the operator (or to
 run-queue policy).
@@ -81,16 +80,13 @@ Detect execution mode from your own dispatch context:
   context where no human is at the keyboard):
   - Escalate the bead so a human can address it:
       bd human {{bead-id}}
-  - Note in escalation: "missing brainstormed/implementation-ready
-    labels; recommend running brainstorm-bead before implementation."
+  - Note in escalation: "missing brainstormed/implementation-ready labels; recommend running brainstorm-bead before implementation."
   - Do NOT prompt — there is no operator to answer.
   - Then abort (per the shared abort mechanism above).
 
 - INTERACTIVE mode (start-bead routed you here, or a human ran
   `bd mol pour` directly and is in conversation with you):
-  - Print a clear warning: "Bead {{bead-id}} is missing
-    brainstormed/implementation-ready labels — it has not been through
-    brainstorm-bead. Implementation may run on an incomplete spec."
+  - Print a clear warning: "Bead {{bead-id}} is missing brainstormed/implementation-ready labels — it has not been through brainstorm-bead. Implementation may run on an incomplete spec."
   - Ask the user:
     (a) Abort and route the bead through start-bead/brainstorm-bead first.
     (b) Proceed with implementation using whatever is in the bead now.

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -9,7 +9,7 @@
 # the `implement-bead` skill (or directly via `bd mol pour`).
 #
 # Phases:
-#   1. Intent     — brainstorm requirements, write acceptance criteria
+#   1. Intent     — confirm bead is brainstormed, restate plan
 #   2. Isolation  — worktree setup, claim bead
 #   3. TDD        — red (failing tests) → green (implement) → refactor
 #   4. Gate       — code-review → simplify → verify with evidence
@@ -22,7 +22,7 @@
 #     --var bead-id=proj-42
 
 formula      = "implement-feature"
-description  = "TDD feature implementation: brainstorm → worktree → red/green/refactor → completion gate → PR → close"
+description  = "TDD feature implementation: confirm → worktree → red/green/refactor → completion gate → PR → close"
 type         = "workflow"
 phase        = "liquid"  # persistent across sessions — steps tracked as beads, synced to git
 pour         = true
@@ -37,32 +37,65 @@ description = "Bead ID tracking this work (e.g. proj-42). Must already exist."
 required    = true
 
 # =============================================================================
-# Phase 1: Intent
+# Phase 1: Intent — confirm bead is brainstormed and restate plan
 # =============================================================================
 
 [[steps]]
-id    = "brainstorm"
-title = "Brainstorm: requirements for {{feature}}"
+id    = "confirm"
+title = "Confirm bead is brainstormed and restate the implementation plan"
 description = """
-Invoke the brainstorming skill BEFORE any design, tests, or code.
+Verify that bead {{bead-id}} has been through brainstorm-bead and that
+the spec exists in the bead. NEVER invoke superpowers:brainstorming —
+the bead description IS the plan.
 
-Skill: superpowers:brainstorming
+Read bead and labels:
 
-Questions to resolve:
-- What problem does this actually solve?
-- Who uses it and how?
-- What does "done" look like? (acceptance criteria)
-- What are the edge cases and error paths?
-- Any architectural implications or constraints?
-- Is there a simpler approach that solves the same problem?
+  bd show {{bead-id}}
+  bd label list {{bead-id}}
 
-Output: written acceptance criteria and a clear implementation plan.
+== HAPPY PATH (both `brainstormed` AND `implementation-ready` labels present) ==
 
-Write criteria back to the bead so it persists across sessions:
-  bd update {{bead-id}} --acceptance="<one line per criterion>"
+1. Read the bead description and acceptance criteria.
+2. Restate the implementation plan in 1-3 sentences to prove understanding
+   (e.g. "I will modify <files> to <do X> so that <AC pass>").
+3. Mark this step done. The next step (worktree) runs.
 
-If anything is ambiguous or contradictory, stop and ask the user
-before proceeding to the next step.
+DO NOT call `bd update {{bead-id}} --acceptance` or `--notes` —
+brainstorm-bead already wrote the spec; rewriting it would destroy it.
+
+== MISSING-LABEL PATH (either label absent) ==
+
+Aborting from either branch below means: leave this `confirm` step
+OPEN (do not close it), do NOT call `bd mol burn` from within this
+step, and print this one-line follow-up:
+
+  Molecule paused at confirm. Run brainstorm-bead on this bead and
+  re-attempt, or `bd mol burn <mol-id>` to discard.
+
+Leave the disposition (re-attempt or burn) to the operator (or to
+run-queue policy).
+
+Detect execution mode from your own dispatch context:
+
+- AUTONOMOUS mode (you were dispatched by run-queue, or any
+  context where no human is at the keyboard):
+  - Escalate the bead so a human can address it:
+      bd human {{bead-id}}
+  - Note in escalation: "missing brainstormed/implementation-ready
+    labels; recommend running brainstorm-bead before implementation."
+  - Do NOT prompt — there is no operator to answer.
+  - Then abort (per the shared abort mechanism above).
+
+- INTERACTIVE mode (start-bead routed you here, or a human ran
+  `bd mol pour` directly and is in conversation with you):
+  - Print a clear warning: "Bead {{bead-id}} is missing
+    brainstormed/implementation-ready labels — it has not been through
+    brainstorm-bead. Implementation may run on an incomplete spec."
+  - Ask the user:
+    (a) Abort and route the bead through start-bead/brainstorm-bead first.
+    (b) Proceed with implementation using whatever is in the bead now.
+  - On (a): abort (per the shared abort mechanism above).
+  - On (b): proceed to worktree.
 """
 
 # =============================================================================
@@ -72,7 +105,7 @@ before proceeding to the next step.
 [[steps]]
 id    = "worktree"
 title = "Set up isolated git worktree"
-needs = ["brainstorm"]
+needs = ["confirm"]
 description = """
 Invoke the using-git-worktrees skill to create an isolated branch.
 
@@ -111,7 +144,7 @@ Write tests FIRST. No implementation code at this step.
 Skills: superpowers:test-driven-development, superpowers:writing-unit-tests, superpowers:testing-anti-patterns
 
 Rules:
-- Tests must be written against the acceptance criteria from the brainstorm step
+- Tests must be written against the acceptance criteria on the bead (set by brainstorm-bead, restated in the confirm step)
 - Cover: happy path, edge cases, error paths
 - Do NOT mock what you have not verified you understand
 - Do NOT write test-only methods in production code
@@ -184,7 +217,7 @@ Dispatch code-reviewer subagent against ALL changed files.
 
 Agent: superpowers:code-reviewer
 Scope: every file changed since branch creation, reviewed against:
-  - The implementation plan from the brainstorm step
+  - The implementation plan restated in the confirm step (per the bead spec)
   - SOLID and DRY principles
   - Security by design (OWASP top 10, input validation, no injection paths)
   - Architectural consistency with the rest of the codebase


### PR DESCRIPTION
## Summary

- Replace the unconditional `brainstorm` step at the head of `implement-feature.formula.toml` with a new `confirm` step.
- The `confirm` step verifies the bead carries the `brainstormed` and `implementation-ready` labels, restates the plan, and never invokes `superpowers:brainstorming`.
- Mode-aware fallback when labels are missing: autonomous (`bd human` + abort) vs. interactive (warn + ask user).

## Why

`implement-feature` had a chicken-and-egg problem: its first step poured `superpowers:brainstorming` on every run, even when `brainstorm-bead` had already produced a fully-brainstormed, implementation-ready spec. That re-brainstormed work that was already done — wasting cycles and risking spec drift on beads the lifecycle already considered ready.

## What changed

- Replaced the `brainstorm` step with a `confirm` step that:
  - Validates `brainstormed` + `implementation-ready` labels are present.
  - Restates the plan from the bead description rather than re-eliciting it.
  - Branches behavior by orchestrator mode (autonomous vs. interactive) when labels are absent.
- Updated the worktree step's `needs` to point at `confirm` instead of `brainstorm`.
- Updated the formula header / banner / description text to reflect the new first step.
- Two cross-reference fixes within the formula at lines 149 and 222.

## Test plan

- TOML parses cleanly.
- All 12 acceptance criteria on bead `agents-config-smg` are satisfied.
- `fix-bug.formula.toml` and `implement-bead/SKILL.md` are byte-identical to `main` (no unintended bleed).

## Out of scope

- The analogous chicken-and-egg in `fix-bug.formula.toml` — tracked separately as `agents-config-hft`.

## Linked beads

- `agents-config-smg`
