### PR TITLE
fix(agents): repair broken YAML frontmatter in 12 agent files

### DIFF
--- a/src/user/.agents/agents/api-developer.md
+++ b/src/user/.agents/agents/api-developer.md
@@ -1,32 +1,33 @@
 ---
 name: api-developer
-description: PROACTIVELY design and build developer-friendly APIs with proper documentation, versioning, and security. Specializes in REST, GraphQL, API gateway patterns, and developer experience optimization. Use for API-first development, integration projects, and developer portal creation.
+description: |-
+  PROACTIVELY design and build developer-friendly APIs with proper documentation, versioning, and security. Specializes in REST, GraphQL, API gateway patterns, and developer experience optimization. Use for API-first development, integration projects, and developer portal creation.
 
-Examples:
-<example>
-Context: User needs to expose email classification functionality via API.
-user: "I need to create an API for our email classification service that external developers can use"
-assistant: "I'll use the api-developer agent to design a comprehensive REST API with OpenAPI documentation, authentication, and rate limiting."
-<commentary>
-This requires API design expertise including resource modeling, documentation, security, and developer experience considerations.
-</commentary>
-</example>
-<example>
-Context: User wants to improve existing API performance and developer experience.
-user: "Our current API is slow and developers are complaining about poor documentation"
-assistant: "Let me use the api-developer agent to optimize API performance and create comprehensive developer documentation."
-<commentary>
-API optimization requires expertise in caching, response optimization, documentation generation, and developer experience design.
-</commentary>
-</example>
-<example>
-Context: User needs to integrate with external APIs securely.
-user: "We need to integrate with Gmail API and expose a simplified interface for our users"
-assistant: "I'll use the api-developer agent to create a secure API gateway that abstracts Gmail API complexity."
-<commentary>
-API gateway design requires knowledge of authentication, rate limiting, request transformation, and service composition patterns.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to expose email classification functionality via API.
+  user: "I need to create an API for our email classification service that external developers can use"
+  assistant: "I'll use the api-developer agent to design a comprehensive REST API with OpenAPI documentation, authentication, and rate limiting."
+  <commentary>
+  This requires API design expertise including resource modeling, documentation, security, and developer experience considerations.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to improve existing API performance and developer experience.
+  user: "Our current API is slow and developers are complaining about poor documentation"
+  assistant: "Let me use the api-developer agent to optimize API performance and create comprehensive developer documentation."
+  <commentary>
+  API optimization requires expertise in caching, response optimization, documentation generation, and developer experience design.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs to integrate with external APIs securely.
+  user: "We need to integrate with Gmail API and expose a simplified interface for our users"
+  assistant: "I'll use the api-developer agent to create a secure API gateway that abstracts Gmail API complexity."
+  <commentary>
+  API gateway design requires knowledge of authentication, rate limiting, request transformation, and service composition patterns.
+  </commentary>
+  </example>
 model: sonnet
 color: blue
 ---

--- a/src/user/.agents/agents/backend-developer.md
+++ b/src/user/.agents/agents/backend-developer.md
@@ -1,32 +1,33 @@
 ---
 name: backend-developer
-description: PROACTIVELY develop robust backend systems with focus on scalability, security, and maintainability. Specializes in API design, database optimization, server architecture, and microservices. Use for server-side development, system design, and infrastructure challenges.
+description: |-
+  PROACTIVELY develop robust backend systems with focus on scalability, security, and maintainability. Specializes in API design, database optimization, server architecture, and microservices. Use for server-side development, system design, and infrastructure challenges.
 
-Examples:
-<example>
-Context: User needs to build an email processing service.
-user: "I need to create a backend service that processes Gmail emails and stores classification results"
-assistant: "I'll use the backend-developer agent to design a scalable email processing service with proper database design and queue management."
-<commentary>
-This requires backend expertise for service architecture, database design, async processing, and API development.
-</commentary>
-</example>
-<example>
-Context: User wants to optimize system performance.
-user: "Our email classification API is too slow and can't handle the current load"
-assistant: "Let me use the backend-developer agent to analyze performance bottlenecks and implement scaling strategies."
-<commentary>
-Backend optimization requires knowledge of caching, database optimization, load balancing, and system architecture.
-</commentary>
-</example>
-<example>
-Context: User needs security improvements.
-user: "We need to secure our API endpoints and implement proper authentication"
-assistant: "I'll use the backend-developer agent to implement JWT authentication, API rate limiting, and security best practices."
-<commentary>
-Security implementation requires backend expertise in authentication, authorization, and API protection strategies.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to build an email processing service.
+  user: "I need to create a backend service that processes Gmail emails and stores classification results"
+  assistant: "I'll use the backend-developer agent to design a scalable email processing service with proper database design and queue management."
+  <commentary>
+  This requires backend expertise for service architecture, database design, async processing, and API development.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to optimize system performance.
+  user: "Our email classification API is too slow and can't handle the current load"
+  assistant: "Let me use the backend-developer agent to analyze performance bottlenecks and implement scaling strategies."
+  <commentary>
+  Backend optimization requires knowledge of caching, database optimization, load balancing, and system architecture.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs security improvements.
+  user: "We need to secure our API endpoints and implement proper authentication"
+  assistant: "I'll use the backend-developer agent to implement JWT authentication, API rate limiting, and security best practices."
+  <commentary>
+  Security implementation requires backend expertise in authentication, authorization, and API protection strategies.
+  </commentary>
+  </example>
 model: sonnet
 color: orange
 ---

--- a/src/user/.agents/agents/code-debugger.md
+++ b/src/user/.agents/agents/code-debugger.md
@@ -1,32 +1,33 @@
 ---
 name: code-debugger
-description: PROACTIVELY use this agent when encountering bugs, performance issues, or unexpected behavior that requires systematic investigation and root cause analysis. This agent excels at methodical problem isolation, comprehensive debugging workflows, and implementing sustainable fixes that prevent recurrence. Ideal for mysterious crashes, intermittent failures, performance degradations, integration issues, or any complex technical problem that needs forensic analysis and surgical resolution.
+description: |-
+  PROACTIVELY use this agent when encountering bugs, performance issues, or unexpected behavior that requires systematic investigation and root cause analysis. This agent excels at methodical problem isolation, comprehensive debugging workflows, and implementing sustainable fixes that prevent recurrence. Ideal for mysterious crashes, intermittent failures, performance degradations, integration issues, or any complex technical problem that needs forensic analysis and surgical resolution.
 
-Examples:
-<example>
-Context: User encounters a crash that only happens in production with no clear stack trace.
-user: "Our application crashes randomly in production but works fine locally, and the logs don't show much"
-assistant: "I'll use the code-debugger agent to systematically investigate this production-only crash with comprehensive diagnostic techniques."
-<commentary>
-The debugger will establish monitoring, create reproduction strategies, and analyze production artifacts to isolate the root cause of environment-specific issues.
-</commentary>
-</example>
-<example>
-Context: User experiences performance degradation that started recently.
-user: "The app has gotten really slow over the past week, but we haven't deployed any major changes"
-assistant: "Let me engage the code-debugger to perform performance regression analysis and identify the degradation source."
-<commentary>
-The debugger will use profiling tools, analyze historical performance data, and trace resource utilization to pinpoint what changed to cause the slowdown.
-</commentary>
-</example>
-<example>
-Context: User has an intermittent bug that's hard to reproduce.
-user: "Sometimes our API returns the wrong data, but it only happens maybe 1 in 100 requests"
-assistant: "I'll bring in the code-debugger to tackle this intermittent issue with statistical analysis and comprehensive monitoring."
-<commentary>
-The debugger will set up detailed logging, implement race condition detection, and use systematic reproduction techniques to capture the elusive bug.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User encounters a crash that only happens in production with no clear stack trace.
+  user: "Our application crashes randomly in production but works fine locally, and the logs don't show much"
+  assistant: "I'll use the code-debugger agent to systematically investigate this production-only crash with comprehensive diagnostic techniques."
+  <commentary>
+  The debugger will establish monitoring, create reproduction strategies, and analyze production artifacts to isolate the root cause of environment-specific issues.
+  </commentary>
+  </example>
+  <example>
+  Context: User experiences performance degradation that started recently.
+  user: "The app has gotten really slow over the past week, but we haven't deployed any major changes"
+  assistant: "Let me engage the code-debugger to perform performance regression analysis and identify the degradation source."
+  <commentary>
+  The debugger will use profiling tools, analyze historical performance data, and trace resource utilization to pinpoint what changed to cause the slowdown.
+  </commentary>
+  </example>
+  <example>
+  Context: User has an intermittent bug that's hard to reproduce.
+  user: "Sometimes our API returns the wrong data, but it only happens maybe 1 in 100 requests"
+  assistant: "I'll bring in the code-debugger to tackle this intermittent issue with statistical analysis and comprehensive monitoring."
+  <commentary>
+  The debugger will set up detailed logging, implement race condition detection, and use systematic reproduction techniques to capture the elusive bug.
+  </commentary>
+  </example>
 model: sonnet
 color: red
 ---

--- a/src/user/.agents/agents/code-documenter.md
+++ b/src/user/.agents/agents/code-documenter.md
@@ -1,32 +1,33 @@
 ---
 name: code-documenter
-description: PROACTIVELY use this agent for comprehensive technical documentation creation, maintenance, and knowledge management. Excels at generating API documentation, inline code comments, architectural diagrams, user guides, and maintaining documentation consistency across codebases. Essential for new feature documentation, legacy code explanation, onboarding materials, and ensuring documentation stays synchronized with code evolution. Specializes in making complex technical concepts accessible to diverse audiences through clear, structured, and maintainable documentation.
+description: |-
+  PROACTIVELY use this agent for comprehensive technical documentation creation, maintenance, and knowledge management. Excels at generating API documentation, inline code comments, architectural diagrams, user guides, and maintaining documentation consistency across codebases. Essential for new feature documentation, legacy code explanation, onboarding materials, and ensuring documentation stays synchronized with code evolution. Specializes in making complex technical concepts accessible to diverse audiences through clear, structured, and maintainable documentation.
 
-Examples:
-<example>
-Context: New API endpoints have been implemented but lack documentation.
-user: "We just added several new endpoints to our REST API but they're not documented anywhere"
-assistant: "I'll use the code-documenter agent to create comprehensive API documentation with examples and schemas."
-<commentary>
-The code-documenter will analyze the endpoints, generate OpenAPI/Swagger specs, create usage examples, and ensure documentation follows established patterns.
-</commentary>
-</example>
-<example>
-Context: Complex business logic needs better code comments for maintainability.
-user: "This classification engine code is really hard to understand - we need better documentation"
-assistant: "Let me bring in the code-documenter to add comprehensive inline documentation and architectural explanations."
-<commentary>
-The code-documenter will analyze the code structure, add meaningful comments, create flow diagrams, and document decision rationale for future developers.
-</commentary>
-</example>
-<example>
-Context: New team members need onboarding documentation for the project.
-user: "We're onboarding new developers and need setup guides and architecture documentation"
-assistant: "I'll engage the code-documenter to create comprehensive onboarding materials and architectural documentation."
-<commentary>
-The code-documenter will create step-by-step setup guides, architecture overviews, code organization explanations, and development workflow documentation.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: New API endpoints have been implemented but lack documentation.
+  user: "We just added several new endpoints to our REST API but they're not documented anywhere"
+  assistant: "I'll use the code-documenter agent to create comprehensive API documentation with examples and schemas."
+  <commentary>
+  The code-documenter will analyze the endpoints, generate OpenAPI/Swagger specs, create usage examples, and ensure documentation follows established patterns.
+  </commentary>
+  </example>
+  <example>
+  Context: Complex business logic needs better code comments for maintainability.
+  user: "This classification engine code is really hard to understand - we need better documentation"
+  assistant: "Let me bring in the code-documenter to add comprehensive inline documentation and architectural explanations."
+  <commentary>
+  The code-documenter will analyze the code structure, add meaningful comments, create flow diagrams, and document decision rationale for future developers.
+  </commentary>
+  </example>
+  <example>
+  Context: New team members need onboarding documentation for the project.
+  user: "We're onboarding new developers and need setup guides and architecture documentation"
+  assistant: "I'll engage the code-documenter to create comprehensive onboarding materials and architectural documentation."
+  <commentary>
+  The code-documenter will create step-by-step setup guides, architecture overviews, code organization explanations, and development workflow documentation.
+  </commentary>
+  </example>
 model: sonnet
 color: yellow
 ---

--- a/src/user/.agents/agents/code-refactor.md
+++ b/src/user/.agents/agents/code-refactor.md
@@ -1,32 +1,33 @@
 ---
 name: code-refactor
-description: PROACTIVELY use this agent when you identify code smells, technical debt, performance bottlenecks, or need to modernize legacy systems. This agent excels at systematic code improvement while preserving functionality and minimizing risk. Ideal for large-scale refactoring projects, legacy code modernization, architectural improvements, or when code metrics indicate quality degradation. Use for both preventive maintenance and corrective refactoring initiatives.
+description: |-
+  PROACTIVELY use this agent when you identify code smells, technical debt, performance bottlenecks, or need to modernize legacy systems. This agent excels at systematic code improvement while preserving functionality and minimizing risk. Ideal for large-scale refactoring projects, legacy code modernization, architectural improvements, or when code metrics indicate quality degradation. Use for both preventive maintenance and corrective refactoring initiatives.
 
-Examples:
-<example>
-Context: Code review reveals significant technical debt and code smells in a critical service.
-user: "This payment service has grown unwieldy with 500-line methods and duplicated logic everywhere"
-assistant: "I'll use the code-refactor agent to systematically break down this service and eliminate the technical debt."
-<commentary>
-The code-refactor agent will assess the codebase, identify refactoring priorities, and create a safe incremental improvement plan with comprehensive testing.
-</commentary>
-</example>
-<example>
-Context: Performance issues require structural changes to the codebase.
-user: "Our API response times are degrading as the codebase grows - we need architectural improvements"
-assistant: "Let me engage the code-refactor agent to analyze performance bottlenecks and implement structural optimizations."
-<commentary>
-The agent will profile the code, identify performance anti-patterns, and refactor the architecture while maintaining all existing functionality.
-</commentary>
-</example>
-<example>
-Context: Legacy codebase needs modernization to adopt new language features and patterns.
-user: "We're still using callback-heavy code from 2018 and need to modernize to async/await patterns"
-assistant: "I'll use the code-refactor agent to systematically modernize the codebase to current standards."
-<commentary>
-The agent will create a migration plan, prioritize high-impact areas, and gradually modernize the code while ensuring comprehensive test coverage.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: Code review reveals significant technical debt and code smells in a critical service.
+  user: "This payment service has grown unwieldy with 500-line methods and duplicated logic everywhere"
+  assistant: "I'll use the code-refactor agent to systematically break down this service and eliminate the technical debt."
+  <commentary>
+  The code-refactor agent will assess the codebase, identify refactoring priorities, and create a safe incremental improvement plan with comprehensive testing.
+  </commentary>
+  </example>
+  <example>
+  Context: Performance issues require structural changes to the codebase.
+  user: "Our API response times are degrading as the codebase grows - we need architectural improvements"
+  assistant: "Let me engage the code-refactor agent to analyze performance bottlenecks and implement structural optimizations."
+  <commentary>
+  The agent will profile the code, identify performance anti-patterns, and refactor the architecture while maintaining all existing functionality.
+  </commentary>
+  </example>
+  <example>
+  Context: Legacy codebase needs modernization to adopt new language features and patterns.
+  user: "We're still using callback-heavy code from 2018 and need to modernize to async/await patterns"
+  assistant: "I'll use the code-refactor agent to systematically modernize the codebase to current standards."
+  <commentary>
+  The agent will create a migration plan, prioritize high-impact areas, and gradually modernize the code while ensuring comprehensive test coverage.
+  </commentary>
+  </example>
 model: sonnet
 color: yellow
 ---

--- a/src/user/.agents/agents/code-reviewer.md
+++ b/src/user/.agents/agents/code-reviewer.md
@@ -1,32 +1,33 @@
 ---
 name: code-reviewer
-description: PROACTIVELY review code for quality, security, and maintainability after any code is written or modified. This agent specializes in comprehensive code analysis, identifying critical issues, security vulnerabilities, and improvement opportunities across all programming languages and frameworks.
+description: |-
+  PROACTIVELY review code for quality, security, and maintainability after any code is written or modified. This agent specializes in comprehensive code analysis, identifying critical issues, security vulnerabilities, and improvement opportunities across all programming languages and frameworks.
 
-Examples:
-<example>
-Context: Code has just been written or modified in a commit.
-user: "I just implemented the authentication system"
-assistant: "I'll use the code-reviewer agent to analyze the authentication implementation for security best practices and code quality."
-<commentary>
-Any new code should be reviewed immediately, especially security-critical features like authentication.
-</commentary>
-</example>
-<example>
-Context: User asks for a code review of specific files.
-user: "Can you review the database connection logic in src/db/connection.ts?"
-assistant: "I'll use the code-reviewer agent to thoroughly analyze the database connection implementation."
-<commentary>
-Specific review requests should be handled by the code-reviewer to ensure comprehensive analysis.
-</commentary>
-</example>
-<example>
-Context: Before a pull request or deployment.
-user: "I'm ready to create a PR for the email processing feature"
-assistant: "Let me use the code-reviewer agent first to ensure the code meets all quality standards."
-<commentary>
-Proactive review before PR creation prevents issues from reaching the main branch.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: Code has just been written or modified in a commit.
+  user: "I just implemented the authentication system"
+  assistant: "I'll use the code-reviewer agent to analyze the authentication implementation for security best practices and code quality."
+  <commentary>
+  Any new code should be reviewed immediately, especially security-critical features like authentication.
+  </commentary>
+  </example>
+  <example>
+  Context: User asks for a code review of specific files.
+  user: "Can you review the database connection logic in src/db/connection.ts?"
+  assistant: "I'll use the code-reviewer agent to thoroughly analyze the database connection implementation."
+  <commentary>
+  Specific review requests should be handled by the code-reviewer to ensure comprehensive analysis.
+  </commentary>
+  </example>
+  <example>
+  Context: Before a pull request or deployment.
+  user: "I'm ready to create a PR for the email processing feature"
+  assistant: "Let me use the code-reviewer agent first to ensure the code meets all quality standards."
+  <commentary>
+  Proactive review before PR creation prevents issues from reaching the main branch.
+  </commentary>
+  </example>
 tools: Read, Grep, Glob, Bash
 model: inherit
 color: purple

--- a/src/user/.agents/agents/data-scientist.md
+++ b/src/user/.agents/agents/data-scientist.md
@@ -1,32 +1,33 @@
 ---
 name: data-scientist
-description: PROACTIVELY analyze data using SQL, BigQuery, and statistical methods to extract insights and drive data-driven decision making. Specializes in database analysis, data visualization, performance optimization, and predictive modeling for business intelligence.
+description: |-
+  PROACTIVELY analyze data using SQL, BigQuery, and statistical methods to extract insights and drive data-driven decision making. Specializes in database analysis, data visualization, performance optimization, and predictive modeling for business intelligence.
 
-Examples:
-<example>
-Context: User needs to analyze email processing performance metrics.
-user: "I want to understand which email categories take the longest to process"
-assistant: "I'll use the data-scientist agent to analyze email processing times by category and identify performance bottlenecks."
-<commentary>
-This requires SQL analysis of email processing data to identify patterns and optimization opportunities.
-</commentary>
-</example>
-<example>
-Context: User wants to validate system performance after changes.
-user: "Can you analyze our email classification accuracy over the past month?"
-assistant: "Let me use the data-scientist agent to examine classification accuracy metrics and trends."
-<commentary>
-Requires statistical analysis of classification results to measure system performance and identify improvement areas.
-</commentary>
-</example>
-<example>
-Context: User needs insights for system optimization.
-user: "What patterns can you find in our Gmail processing errors?"
-assistant: "I'll use the data-scientist agent to analyze error patterns and identify root causes."
-<commentary>
-Data analysis is needed to understand error frequency, types, and correlations to improve system reliability.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to analyze email processing performance metrics.
+  user: "I want to understand which email categories take the longest to process"
+  assistant: "I'll use the data-scientist agent to analyze email processing times by category and identify performance bottlenecks."
+  <commentary>
+  This requires SQL analysis of email processing data to identify patterns and optimization opportunities.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to validate system performance after changes.
+  user: "Can you analyze our email classification accuracy over the past month?"
+  assistant: "Let me use the data-scientist agent to examine classification accuracy metrics and trends."
+  <commentary>
+  Requires statistical analysis of classification results to measure system performance and identify improvement areas.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs insights for system optimization.
+  user: "What patterns can you find in our Gmail processing errors?"
+  assistant: "I'll use the data-scientist agent to analyze error patterns and identify root causes."
+  <commentary>
+  Data analysis is needed to understand error frequency, types, and correlations to improve system reliability.
+  </commentary>
+  </example>
 model: sonnet
 color: green
 ---

--- a/src/user/.agents/agents/database-designer.md
+++ b/src/user/.agents/agents/database-designer.md
@@ -1,32 +1,33 @@
 ---
 name: database-designer
-description: PROACTIVELY use this agent when you need comprehensive database architecture design, schema optimization, or data modeling expertise. This agent excels at designing high-performance database systems, optimizing complex queries, planning scalable data architectures, and solving data persistence challenges. Ideal for new database design, schema migrations, performance troubleshooting, data modeling for complex business domains, or any scenario requiring deep database engineering expertise across SQL and NoSQL platforms.
+description: |-
+  PROACTIVELY use this agent when you need comprehensive database architecture design, schema optimization, or data modeling expertise. This agent excels at designing high-performance database systems, optimizing complex queries, planning scalable data architectures, and solving data persistence challenges. Ideal for new database design, schema migrations, performance troubleshooting, data modeling for complex business domains, or any scenario requiring deep database engineering expertise across SQL and NoSQL platforms.
 
-Examples:
-<example>
-Context: User needs to design a database schema for a new application feature.
-user: "I need to design tables for a multi-tenant email processing system with categories and audit trails"
-assistant: "I'll use the database-designer agent to create an optimal schema design with proper normalization and performance considerations."
-<commentary>
-The database-designer will analyze the domain requirements, design normalized tables with appropriate relationships, consider multi-tenancy patterns, and plan for audit trail storage with optimal indexing strategies.
-</commentary>
-</example>
-<example>
-Context: User is experiencing database performance issues.
-user: "Our queries are getting slower as data grows, and some reports are timing out"
-assistant: "Let me engage the database-designer to analyze performance bottlenecks and optimize the database architecture."
-<commentary>
-The database-designer will examine query execution plans, analyze indexing strategies, recommend partitioning schemes, and suggest architectural improvements for better scalability.
-</commentary>
-</example>
-<example>
-Context: User needs to migrate or evolve an existing database schema.
-user: "We need to add new columns and tables while keeping the system running without downtime"
-assistant: "I'll bring in the database-designer to plan a zero-downtime migration strategy."
-<commentary>
-The database-designer will design a migration plan with proper versioning, backward compatibility, rollback strategies, and minimal service disruption.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to design a database schema for a new application feature.
+  user: "I need to design tables for a multi-tenant email processing system with categories and audit trails"
+  assistant: "I'll use the database-designer agent to create an optimal schema design with proper normalization and performance considerations."
+  <commentary>
+  The database-designer will analyze the domain requirements, design normalized tables with appropriate relationships, consider multi-tenancy patterns, and plan for audit trail storage with optimal indexing strategies.
+  </commentary>
+  </example>
+  <example>
+  Context: User is experiencing database performance issues.
+  user: "Our queries are getting slower as data grows, and some reports are timing out"
+  assistant: "Let me engage the database-designer to analyze performance bottlenecks and optimize the database architecture."
+  <commentary>
+  The database-designer will examine query execution plans, analyze indexing strategies, recommend partitioning schemes, and suggest architectural improvements for better scalability.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs to migrate or evolve an existing database schema.
+  user: "We need to add new columns and tables while keeping the system running without downtime"
+  assistant: "I'll bring in the database-designer to plan a zero-downtime migration strategy."
+  <commentary>
+  The database-designer will design a migration plan with proper versioning, backward compatibility, rollback strategies, and minimal service disruption.
+  </commentary>
+  </example>
 model: sonnet
 color: teal
 ---

--- a/src/user/.agents/agents/frontend-developer.md
+++ b/src/user/.agents/agents/frontend-developer.md
@@ -1,32 +1,33 @@
 ---
 name: frontend-developer
-description: PROACTIVELY build modern, responsive frontends with React, Vue, or vanilla JS. Specializes in component architecture, state management, performance optimization, and accessibility. Use for UI development, user experience improvements, and interactive web applications.
+description: |-
+  PROACTIVELY build modern, responsive frontends with React, Vue, or vanilla JS. Specializes in component architecture, state management, performance optimization, and accessibility. Use for UI development, user experience improvements, and interactive web applications.
 
-Examples:
-<example>
-Context: User needs a web interface for email management.
-user: "I need to create a dashboard for viewing and managing email categories"
-assistant: "I'll use the frontend-developer agent to build a responsive email management dashboard with proper state management and accessibility."
-<commentary>
-This requires frontend expertise for creating interactive UI components, managing complex state, and ensuring responsive design.
-</commentary>
-</example>
-<example>
-Context: User wants to improve existing UI performance.
-user: "The email list is loading slowly and the UI feels sluggish"
-assistant: "Let me use the frontend-developer agent to optimize the email list performance with virtualization and lazy loading."
-<commentary>
-Frontend performance optimization requires specialized knowledge of web vitals, rendering optimization, and efficient data loading patterns.
-</commentary>
-</example>
-<example>
-Context: User needs accessibility improvements.
-user: "We need to make our email interface accessible for screen readers"
-assistant: "I'll use the frontend-developer agent to implement WCAG compliance and ARIA labels throughout the email interface."
-<commentary>
-Accessibility requires frontend expertise in semantic HTML, ARIA patterns, and testing with assistive technologies.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs a web interface for email management.
+  user: "I need to create a dashboard for viewing and managing email categories"
+  assistant: "I'll use the frontend-developer agent to build a responsive email management dashboard with proper state management and accessibility."
+  <commentary>
+  This requires frontend expertise for creating interactive UI components, managing complex state, and ensuring responsive design.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to improve existing UI performance.
+  user: "The email list is loading slowly and the UI feels sluggish"
+  assistant: "Let me use the frontend-developer agent to optimize the email list performance with virtualization and lazy loading."
+  <commentary>
+  Frontend performance optimization requires specialized knowledge of web vitals, rendering optimization, and efficient data loading patterns.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs accessibility improvements.
+  user: "We need to make our email interface accessible for screen readers"
+  assistant: "I'll use the frontend-developer agent to implement WCAG compliance and ARIA labels throughout the email interface."
+  <commentary>
+  Accessibility requires frontend expertise in semantic HTML, ARIA patterns, and testing with assistive technologies.
+  </commentary>
+  </example>
 model: sonnet
 color: cyan
 ---

--- a/src/user/.agents/agents/javascript-developer.md
+++ b/src/user/.agents/agents/javascript-developer.md
@@ -1,32 +1,33 @@
 ---
 name: javascript-developer
-description: PROACTIVELY use this agent when you need expert JavaScript development focusing on modern ECMAScript features, performance optimization, and advanced async patterns. This agent excels at solving complex JavaScript challenges, optimizing performance bottlenecks, implementing cutting-edge ES2024+ features, and creating robust client-side and server-side JavaScript solutions. Ideal for async/await optimizations, memory management issues, advanced data processing with iterators/generators, Web API integrations, Node.js performance tuning, or any scenario requiring deep JavaScript language expertise and modern best practices.
+description: |-
+  PROACTIVELY use this agent when you need expert JavaScript development focusing on modern ECMAScript features, performance optimization, and advanced async patterns. This agent excels at solving complex JavaScript challenges, optimizing performance bottlenecks, implementing cutting-edge ES2024+ features, and creating robust client-side and server-side JavaScript solutions. Ideal for async/await optimizations, memory management issues, advanced data processing with iterators/generators, Web API integrations, Node.js performance tuning, or any scenario requiring deep JavaScript language expertise and modern best practices.
 
-Examples:
-<example>
-Context: User needs to optimize a slow data processing function.
-user: "My JavaScript function is processing 10,000 records and it's taking too long"
-assistant: "I'll use the javascript-developer agent to analyze and optimize this performance bottleneck."
-<commentary>
-The JavaScript developer will identify performance issues and implement optimizations using modern techniques like generators, Web Workers, or async batching.
-</commentary>
-</example>
-<example>
-Context: User wants to implement advanced async patterns.
-user: "I need to handle multiple API calls with proper error handling and cancellation"
-assistant: "Let me bring in the javascript-developer to implement robust async patterns with AbortController and Promise management."
-<commentary>
-The JavaScript developer will design elegant async solutions using Promise.allSettled, AbortController, and proper error boundaries.
-</commentary>
-</example>
-<example>
-Context: User encounters memory leaks in a complex application.
-user: "Our web app is consuming too much memory and getting slower over time"
-assistant: "I'll engage the javascript-developer to diagnose and fix memory management issues."
-<commentary>
-The JavaScript developer will analyze memory usage patterns, identify leaks, and implement WeakMap/WeakSet solutions with proper cleanup.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to optimize a slow data processing function.
+  user: "My JavaScript function is processing 10,000 records and it's taking too long"
+  assistant: "I'll use the javascript-developer agent to analyze and optimize this performance bottleneck."
+  <commentary>
+  The JavaScript developer will identify performance issues and implement optimizations using modern techniques like generators, Web Workers, or async batching.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to implement advanced async patterns.
+  user: "I need to handle multiple API calls with proper error handling and cancellation"
+  assistant: "Let me bring in the javascript-developer to implement robust async patterns with AbortController and Promise management."
+  <commentary>
+  The JavaScript developer will design elegant async solutions using Promise.allSettled, AbortController, and proper error boundaries.
+  </commentary>
+  </example>
+  <example>
+  Context: User encounters memory leaks in a complex application.
+  user: "Our web app is consuming too much memory and getting slower over time"
+  assistant: "I'll engage the javascript-developer to diagnose and fix memory management issues."
+  <commentary>
+  The JavaScript developer will analyze memory usage patterns, identify leaks, and implement WeakMap/WeakSet solutions with proper cleanup.
+  </commentary>
+  </example>
 model: sonnet
 color: yellow
 ---

--- a/src/user/.agents/agents/tech-lead.md
+++ b/src/user/.agents/agents/tech-lead.md
@@ -1,32 +1,33 @@
 ---
 name: tech-lead
-description: PROACTIVELY use this agent when you need to orchestrate complex development tasks that require multiple specialized agents working in coordination. This agent excels at breaking down high-level goals into actionable subtasks, managing parallel workflows, and ensuring proper sequencing of development activities. Ideal for multi-faceted projects, feature implementations, debugging sessions requiring multiple perspectives, or any scenario where coordinated expertise from different domains is needed.
+description: |-
+  PROACTIVELY use this agent when you need to orchestrate complex development tasks that require multiple specialized agents working in coordination. This agent excels at breaking down high-level goals into actionable subtasks, managing parallel workflows, and ensuring proper sequencing of development activities. Ideal for multi-faceted projects, feature implementations, debugging sessions requiring multiple perspectives, or any scenario where coordinated expertise from different domains is needed.
 
-Examples:
-<example>
-Context: User wants to implement a new feature that requires both frontend and backend work.
-user: "I need to add a user authentication system to our application"
-assistant: "I'll use the tech-lead agent to break this down and coordinate the implementation."
-<commentary>
-Since this is a complex feature requiring multiple components, the tech-lead will analyze requirements and delegate to appropriate specialized agents.
-</commentary>
-</example>
-<example>
-Context: User encounters a complex bug that might involve multiple layers of the application.
-user: "The payment processing is failing intermittently and I can't figure out why"
-assistant: "Let me bring in the tech-lead to orchestrate a systematic investigation across all relevant components."
-<commentary>
-The tech-lead will coordinate debugging efforts across database, backend, and potentially frontend agents to identify the root cause.
-</commentary>
-</example>
-<example>
-Context: User wants to refactor a large codebase section.
-user: "We need to modernize our API layer to use the latest patterns"
-assistant: "I'll engage the tech-lead to plan and execute this refactoring systematically."
-<commentary>
-The tech-lead will assess the scope, create a refactoring plan, and coordinate code-refactor, code-reviewer, and api-developer agents.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User wants to implement a new feature that requires both frontend and backend work.
+  user: "I need to add a user authentication system to our application"
+  assistant: "I'll use the tech-lead agent to break this down and coordinate the implementation."
+  <commentary>
+  Since this is a complex feature requiring multiple components, the tech-lead will analyze requirements and delegate to appropriate specialized agents.
+  </commentary>
+  </example>
+  <example>
+  Context: User encounters a complex bug that might involve multiple layers of the application.
+  user: "The payment processing is failing intermittently and I can't figure out why"
+  assistant: "Let me bring in the tech-lead to orchestrate a systematic investigation across all relevant components."
+  <commentary>
+  The tech-lead will coordinate debugging efforts across database, backend, and potentially frontend agents to identify the root cause.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to refactor a large codebase section.
+  user: "We need to modernize our API layer to use the latest patterns"
+  assistant: "I'll engage the tech-lead to plan and execute this refactoring systematically."
+  <commentary>
+  The tech-lead will assess the scope, create a refactoring plan, and coordinate code-refactor, code-reviewer, and api-developer agents.
+  </commentary>
+  </example>
 model: sonnet
 color: pink
 ---

--- a/src/user/.agents/agents/typescript-developer.md
+++ b/src/user/.agents/agents/typescript-developer.md
@@ -1,32 +1,33 @@
 ---
 name: typescript-developer
-description: PROACTIVELY build type-safe applications with advanced TypeScript features, generics, and strict type checking. Specializes in enterprise TypeScript architecture, type system design, and compile-time safety. Use for complex type safety requirements, advanced patterns, and type-driven development.
+description: |-
+  PROACTIVELY build type-safe applications with advanced TypeScript features, generics, and strict type checking. Specializes in enterprise TypeScript architecture, type system design, and compile-time safety. Use for complex type safety requirements, advanced patterns, and type-driven development.
 
-Examples:
-<example>
-Context: User needs to implement type-safe email classification system.
-user: "I need to create type-safe interfaces for our email classification pipeline with strict validation"
-assistant: "I'll use the typescript-developer agent to design comprehensive type definitions with branded types and compile-time validation."
-<commentary>
-This requires advanced TypeScript features like branded types, discriminated unions, and type-level validation to ensure type safety.
-</commentary>
-</example>
-<example>
-Context: User wants to refactor JavaScript to TypeScript with strict safety.
-user: "We need to migrate our email processing service to TypeScript with maximum type safety"
-assistant: "Let me use the typescript-developer agent to implement strict TypeScript with zero any types and comprehensive type coverage."
-<commentary>
-Migration to TypeScript requires expertise in advanced type patterns, strict configuration, and enterprise-grade type safety practices.
-</commentary>
-</example>
-<example>
-Context: User needs advanced generic programming for reusable components.
-user: "I want to create reusable, type-safe utility functions for email data transformation"
-assistant: "I'll use the typescript-developer agent to implement advanced generics with constraints and type inference."
-<commentary>
-Advanced generics require deep TypeScript knowledge of constraints, inference, conditional types, and type-level programming.
-</commentary>
-</example>
+  Examples:
+  <example>
+  Context: User needs to implement type-safe email classification system.
+  user: "I need to create type-safe interfaces for our email classification pipeline with strict validation"
+  assistant: "I'll use the typescript-developer agent to design comprehensive type definitions with branded types and compile-time validation."
+  <commentary>
+  This requires advanced TypeScript features like branded types, discriminated unions, and type-level validation to ensure type safety.
+  </commentary>
+  </example>
+  <example>
+  Context: User wants to refactor JavaScript to TypeScript with strict safety.
+  user: "We need to migrate our email processing service to TypeScript with maximum type safety"
+  assistant: "Let me use the typescript-developer agent to implement strict TypeScript with zero any types and comprehensive type coverage."
+  <commentary>
+  Migration to TypeScript requires expertise in advanced type patterns, strict configuration, and enterprise-grade type safety practices.
+  </commentary>
+  </example>
+  <example>
+  Context: User needs advanced generic programming for reusable components.
+  user: "I want to create reusable, type-safe utility functions for email data transformation"
+  assistant: "I'll use the typescript-developer agent to implement advanced generics with constraints and type inference."
+  <commentary>
+  Advanced generics require deep TypeScript knowledge of constraints, inference, conditional types, and type-level programming.
+  </commentary>
+  </example>
 model: sonnet
 color: indigo
 ---


### PR DESCRIPTION
## Summary
- Convert `description:` in all 12 `src/user/.agents/agents/*.md` files from plain scalar to literal block scalar (`|-`) so the multi-line content (Examples + `<example>` XML) parses as a single string
- Indent the description body 2 spaces; all other frontmatter keys (`name`, `model`, `color`, `tools`) and the file bodies below `---` are untouched
- Unblocks Claude Code from loading these agents — previously every one failed with `[WARN] Failed to parse YAML frontmatter ... YAML Parse error: Unexpected token`

## Why
All 12 agent files had `description:` written as a plain scalar, but the field held multi-line content. YAML ended the scalar at the first newline and then tried to interpret `<example>` as a key — `while scanning a simple key ... could not find expected ':'`. Result: none of the custom agents loaded.

## Files
api-developer, backend-developer, code-debugger, code-documenter, code-refactor, code-reviewer, data-scientist, database-designer, frontend-developer, javascript-developer, tech-lead, typescript-developer.

## Test plan
- [x] All 12 files parse as valid YAML frontmatter via `yaml.safe_load`
- [x] Each `description` still contains its `<example>` blocks (semantics preserved — auto-invocation descriptions unchanged)
- [x] Body content below closing `---` is byte-identical (verified by fresh-eyes reviewer via SHA-256 compare)
- [x] `code-reviewer.md` retains its `tools: Read, Grep, Glob, Bash` key
- [x] Installer (`scripts/install.sh`) uses a content-agnostic copy — no code changes needed there
- [ ] After merge: run installer and confirm `~/.claude/agents/*.md` no longer emit parse warnings on session start

Closes agents-config-2cz