### PR TITLE
fix(skills): post-merge Copilot follow-ups on bl3 PR #20

### DIFF
--- a/docs/specs/2026-04-26-pr-review-skill-redesign.md
+++ b/docs/specs/2026-04-26-pr-review-skill-redesign.md
@@ -245,7 +245,7 @@ Schema (`schema_version: 1`):
     }
   ],
   "crash_recovery": {
-    "skill_a_completed": true,                // false until Phase 8 succeeds
+    "skill_a_completed": true,                // true once Phase 7 writes "complete" (and remains true through Phase 8); false only on Phase 5x partial-write
     "last_completed_phase": "8-skill-b-done"
   }
 }

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -541,7 +541,7 @@ POSIX-atomic) — handled by `write-inventory.sh`.
     }
   ],
   "crash_recovery": {
-    "skill_a_completed": true,                // false until Phase 8 succeeds
+    "skill_a_completed": true,                // true once Phase 7 writes "complete" (and remains true through Phase 8); false only on Phase 5x partial-write
     "last_completed_phase": "8-skill-b-done"
   }
 }

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -67,8 +67,11 @@ run_guard "non-FIX-null-fix_outcome" \
     '[.items[] | select(.classification != "FIX" and .fix_outcome != null)]' || FAIL=1
 
 # Guard 5: FIX items must have valid fix_outcome (committed | already_addressed | failed)
+# Explicit equality checks rather than IN(...), which is jq 1.6+. macOS and some
+# Linux distros still ship jq 1.5; using IN() would make the validator abort on
+# a jq compile error before any guard ran.
 run_guard "FIX-valid-fix_outcome" \
-    '[.items[] | select(.classification == "FIX" and (.fix_outcome | IN("committed", "already_addressed", "failed") | not))]' || FAIL=1
+    '[.items[] | select(.classification == "FIX" and (.fix_outcome != "committed" and .fix_outcome != "already_addressed" and .fix_outcome != "failed"))]' || FAIL=1
 
 # Guard 6: committed FIX requires fix_commit_sha + fix_summary + fix_gate_variant
 run_guard "committed-requires-all-fields" \

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -68,8 +68,9 @@ run_guard "non-FIX-null-fix_outcome" \
 
 # Guard 5: FIX items must have valid fix_outcome (committed | already_addressed | failed)
 # Explicit equality checks rather than IN(...), which is jq 1.6+. macOS and some
-# Linux distros still ship jq 1.5; using IN() would make the validator abort on
-# a jq compile error before any guard ran.
+# Linux distros still ship jq 1.5; using IN() there would make Guard 5 fail to
+# compile, surfacing as a guard error from run_guard (other guards still run via
+# `|| FAIL=1`), and the validator would exit non-zero overall.
 run_guard "FIX-valid-fix_outcome" \
     '[.items[] | select(.classification == "FIX" and (.fix_outcome != "committed" and .fix_outcome != "already_addressed" and .fix_outcome != "failed"))]' || FAIL=1
 


### PR DESCRIPTION
Three Copilot inline comments arrived ~5 minutes after PR #20 merged. All three are legitimate. This is the fast follow-up.

## Findings + fixes

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `validate-inventory.sh` Guard 5 | `IN("committed", "already_addressed", "failed")` is a jq 1.6+ builtin; jq 1.5 (still on macOS / some distros) compile-errors on it, aborting the validator before any guard runs | Rewrite as explicit equality checks (`!=` chain) — same semantics, jq 1.5 compatible |
| 2 | `wait-for-pr-comments/SKILL.md` schema example (line ~544) | Comment says `skill_a_completed: false until Phase 8 succeeds`, but Phase 7's helper invocation is `write-inventory.sh complete 7-write-inventory ...` which sets it to `true` — internal contradiction that misleads concurrency-recovery logic | Replace comment with the actual semantics: `true once Phase 7 writes 'complete' (and remains true through Phase 8); false only on Phase 5x partial-write` |
| 3 | `docs/specs/2026-04-26-pr-review-skill-redesign.md` schema example | Same root cause as #2 (the spec was the source of the SKILL.md comment) | Same fix |

## Why this is a follow-up PR and not part of #20

Merge fired before this Copilot round arrived. (Lesson: 2-minute wait was too short.)

## Verification

- Rewritten Guard 5 still rejects bogus `fix_outcome` values (smoke test passed locally)
- jq 1.6 `IN()` removed entirely — validator is now jq-1.5+ compatible
- Schema-comment edits don't change any executable behavior; pure doc accuracy fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)