### PR TITLE
feat(skills): plug rationalization loopholes in writing-unit-tests + testing-anti-patterns

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+scheduled_tasks.lock

--- a/src/user/.agents/skills/testing-anti-patterns/SKILL.md
+++ b/src/user/.agents/skills/testing-anti-patterns/SKILL.md
@@ -17,7 +17,7 @@ description: Use when writing or changing tests, adding mocks, asserting on mock
 3. NEVER mock without understanding dependencies
 ```
 
-**Violating the letter of these laws is violating the spirit.** Naming a method `*ForTesting`, marking it `@internal`, or hiding it behind a "social contract" comment is still adding a test-only method. Asserting on `getByTestId('*-mock')` to "confirm setup worked" is still testing mock behavior. The discipline applies to intent, not syntax.
+**Violating the letter of these laws is violating the spirit.** Naming a method `*ForTesting`, marking it `@internal`, or hiding it behind a "social contract" comment is still adding a test-only method. Asserting on any `*-mock` test id (e.g. `getByTestId('sidebar-mock')`) to "confirm setup worked" is still testing mock behavior. The discipline applies to intent, not syntax.
 
 ## When to Use
 

--- a/src/user/.agents/skills/testing-anti-patterns/SKILL.md
+++ b/src/user/.agents/skills/testing-anti-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: testing-anti-patterns
 model: sonnet
 user-invocable: false
-description: Use when writing or changing tests, adding mocks, or tempted to add test-only methods to production code - prevents testing mock behavior, production pollution with test-only methods, and mocking without understanding dependencies
+description: Use when writing or changing tests, adding mocks, asserting on mock-rendered elements, considering a test-only method on a production class, or tempted to mock "to be safe" without understanding the dependency
 ---
 
 # Testing Anti-Patterns
@@ -16,6 +16,16 @@ description: Use when writing or changing tests, adding mocks, or tempted to add
 2. NEVER add test-only methods to production classes
 3. NEVER mock without understanding dependencies
 ```
+
+**Violating the letter of these laws is violating the spirit.** Naming a method `*ForTesting`, marking it `@internal`, or hiding it behind a "social contract" comment is still adding a test-only method. Asserting on `getByTestId('*-mock')` to "confirm setup worked" is still testing mock behavior. The discipline applies to intent, not syntax.
+
+## When to Use
+
+- Writing or modifying tests that require any test double (fake, stub, spy, mock)
+- Adding test cleanup that needs to reach into a production object
+- About to assert on a child component, mock element, or test-id
+- Tempted to add a method to a production class that only tests will call
+- Reviewing test code where mocks dominate the file
 
 ## When NOT to Use
 
@@ -56,6 +66,12 @@ test('renders sidebar', () => {
 // Don't assert on the mock - test Page's behavior with sidebar present
 ```
 
+**Stubbing vs. asserting on stubs (critical distinction):**
+
+It is fine to mock `<Sidebar>` so the test runs fast and deterministically. It is NOT fine to then assert `expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument()`. The mock exists to silence the dependency, not to be the subject of an assertion. If `<Sidebar>` rendering matters to the test, do not mock it. If it doesn't matter, mock it silently and assert on `<Page>`'s own contract.
+
+A test name like *"mounts Sidebar without hitting the network"* is a smell — it's verifying the mock worked, not the page worked.
+
 ### Gate Function
 
 ```
@@ -93,23 +109,24 @@ afterEach(() => session.destroy());
 - Violates YAGNI and separation of concerns
 - Confuses object lifecycle with entity lifecycle
 
-**The fix:**
+**Common dressed-up violations (all still anti-patterns):**
+
+- `destroyForTesting()` — the suffix is a wish, not a guard. Public methods are callable from anywhere.
+- `@internal` JSDoc — comments are not enforcement. A determined or distracted caller will still invoke it.
+- "Social contract" naming — there is no contract. There is only what types and module boundaries enforce.
+
+If your test needs to clean up a workspace, **call the underlying manager from the test directly**:
 
 ```typescript
-// GOOD: Test utilities handle test cleanup
-// Session has no destroy() - it's stateless in production
-
-// In test-utils/
-export async function cleanupSession(session: Session) {
-  const workspace = session.getWorkspaceInfo();
-  if (workspace) {
-    await workspaceManager.destroyWorkspace(workspace.id);
-  }
-}
-
-// In tests
-afterEach(() => cleanupSession(session));
+// GOOD: Test reaches the manager directly — no production API change needed
+afterEach(async () => {
+  await workspaceManager.destroyWorkspace(session.id);
+});
 ```
+
+"Reaching past the abstraction" is the *correct* move for test cleanup. The abstraction protects production callers from accidentally tearing down state — your `afterEach` is supposed to tear down state.
+
+If the cleanup logic is reused across many test files, hoist it into a shared `test-utils/cleanupSession.ts` helper — but the helper still calls `workspaceManager.destroyWorkspace`, never anything on `Session` itself.
 
 ### Gate Function
 
@@ -119,9 +136,10 @@ BEFORE adding any method to production class:
 
   IF yes:
     STOP - Don't add it
-    Put it in test utilities instead
+    Renaming it (*ForTesting, _internal, @internal) does NOT exempt it
+    Put it in test utilities instead, or call the underlying API from the test
 
-  Ask: "Does this class own this resource's lifecycle?"
+  Ask: "Does this class own this resource's lifecycle in production?"
 
   IF no:
     STOP - Wrong class for this method
@@ -243,32 +261,6 @@ BEFORE creating mock responses:
   If uncertain: Include all documented fields
 ```
 
-## Anti-Pattern 5: Integration Tests as Afterthought
-
-**The violation:**
-
-```
-Implementation complete
-No tests written
-"Ready for testing"
-```
-
-**Why this is wrong:**
-
-- Testing is part of implementation, not optional follow-up
-- TDD would have caught this
-- Can't claim complete without tests
-
-**The fix:**
-
-```
-TDD cycle:
-1. Write failing test
-2. Implement to pass
-3. Refactor
-4. THEN claim complete
-```
-
 ## When Mocks Become Too Complex
 
 **Warning signs:**
@@ -282,38 +274,56 @@ TDD cycle:
 
 **Consider:** Integration tests with real components often simpler than complex mocks
 
-## TDD Prevents These Anti-Patterns
+## TDD as Prevention
 
-Strict TDD (write test, watch it fail, implement, refactor) naturally prevents most of the above because you see real behavior before introducing mocks. See the `test-driven-development` skill for the full process.
+Most of these anti-patterns evaporate under strict test-first discipline (write the test, watch it fail, write the minimum to pass, refactor). When you write the test before the implementation, you cannot "mock to be safe" — you do not yet know what the dependencies should look like, so you discover them by writing real ones first. Mocks introduced retroactively to make existing code testable are the breeding ground for these anti-patterns.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "I'll mock the children to be safe / for isolation" | Stubbing for isolation is fine. *Asserting* on the stub is the anti-pattern. Stub silently, assert on real behavior. |
+| "Asserting `getByTestId('sidebar-mock')` confirms my mock setup worked" | Setup is verified by the test running. An assertion on the mock is testing mock behavior — Anti-Pattern 1. |
+| "The clean option requires reaching past the abstraction — that's bad design" | For test cleanup, reaching past the abstraction is the *right* move. Production-grade encapsulation is for production callers, not your `afterEach`. |
+| "`*ForTesting` suffix means production won't call it" | The suffix is a wish, not a guard. Public methods are callable from anywhere. |
+| "`@internal` JSDoc / social contract is enough" | Comments do not enforce anything. Only types and module boundaries do. |
+| "Mocking the slow stuff just to be safe" | "To be safe" without understanding what the real method does is Anti-Pattern 3. Run the real implementation first to learn what the test depends on. |
+| "Partial mock — I only included the fields I use" | Anti-Pattern 4. Downstream code may consume fields you didn't mock. Mirror the full schema. |
+| "The test is brittle but coverage is the priority" | Brittle tests are negative leverage — they break on legitimate refactors and erode trust. Refuse, don't ship. |
 
 ## Quick Reference
 
 | Anti-Pattern                    | Fix                                           |
 | ------------------------------- | --------------------------------------------- |
 | Assert on mock elements         | Test real component or unmock it              |
-| Test-only methods in production | Move to test utilities                        |
+| Test-only methods in production | Move to test utilities, or call the underlying API from the test directly |
+| `*ForTesting` / `@internal` exemption | Doesn't exempt anything — same anti-pattern |
 | Mock without understanding      | Understand dependencies first, mock minimally |
 | Incomplete mocks                | Mirror real API completely                    |
-| Tests as afterthought           | TDD - tests first                             |
 | Over-complex mocks              | Consider integration tests                    |
 
 ## Red Flags
 
 - Assertion checks for `*-mock` test IDs
-- Methods only called in test files
+- Methods only called in test files (regardless of name suffix or JSDoc)
 - Mock setup is >50% of test
 - Test fails when you remove mock
-- Can't explain why mock is needed
+- Can't explain in one sentence why each mock exists
 - Mocking "just to be safe"
+- Test name describes the mock, not the behavior (e.g. "renders sidebar mock")
 
 ## Verification Checklist
 
 Before considering test code complete, confirm:
 
 - [ ] Every assertion targets real behavior, not mock presence
-- [ ] No production method exists solely for test use
+- [ ] No production method exists solely for test use (suffix/JSDoc do not exempt)
 - [ ] Each mock's side effects are understood and accounted for
 - [ ] Mock data structures mirror complete real-world schemas
 - [ ] Mock setup is shorter than (or proportional to) test logic
 - [ ] You can explain in one sentence why each mock exists
 - [ ] Tests fail when the feature under test is broken (not just when mocks change)
+
+## Companion Skill
+
+For the constructive side — what *good* unit tests look like, refusal criteria, the test-doubles hierarchy — see the `writing-unit-tests` skill.

--- a/src/user/.agents/skills/writing-unit-tests/SKILL.md
+++ b/src/user/.agents/skills/writing-unit-tests/SKILL.md
@@ -100,7 +100,7 @@ Tests that code calls a method. Breaks on any internal change. Proves nothing ab
 | **Spy** | Records calls to real object | Verifying side effects (analytics, logging) |
 | **Mock** | Verifies specific calls | Almost never — last resort |
 
-If you need 4+ mocks, the code is too coupled. Refactor it. See `testing-anti-patterns` for the dedicated mock/fake/spy/stub anti-pattern catalog.
+If you need 5+ mocks, the code is too coupled. Refactor it. (This matches the Refusal Criteria threshold above — same "too coupled" line, different framing.) See `testing-anti-patterns` for the dedicated mock/fake/spy/stub anti-pattern catalog.
 
 ## Test Isolation
 
@@ -185,8 +185,8 @@ Each pure function is trivial to test. Integration test verifies wiring.
 If you're about to:
 
 - Write `expect(mock.method).toHaveBeenCalledWith(...)` as your main assertion
-- Assert on call counts (`toHaveBeenCalledOnce`, `toHaveBeenCalledTimes(N)`) as primary verification
-- Create 4+ mocks in `beforeEach`
+- Assert on call counts (`toHaveBeenCalledTimes(N)`) as primary verification
+- Create 5+ mocks in `beforeEach`
 - Cast mocks to `any` to make them typecheck
 - Use loose regex matchers (`/completed|success|ok/i`) on outputs because you haven't read the function
 - Write 20+ lines of test setup

--- a/src/user/.agents/skills/writing-unit-tests/SKILL.md
+++ b/src/user/.agents/skills/writing-unit-tests/SKILL.md
@@ -2,7 +2,7 @@
 name: writing-unit-tests
 model: sonnet
 argument-hint: "[file or function to test]"
-description: Use when writing unit tests, reviewing test code, or when asked to add tests to complex/untestable code
+description: Use when writing or reviewing unit tests, when test setup balloons with mocks, when CI coverage gates are pressuring anti-pattern tests, or when code resists testing — covers behavior-vs-implementation, fakes/stubs/spies/mocks hierarchy, refusal criteria, and rationalizations to reject
 ---
 
 # Writing Unit Tests
@@ -10,6 +10,21 @@ description: Use when writing unit tests, reviewing test code, or when asked to 
 ## Core Principle
 
 If you can't test it simply, the code needs refactoring — not more mocks. Test behavior, not implementation.
+
+## When to Use
+
+- About to write or modify a unit test file
+- Reviewing test code in a PR or commit
+- Asked to add tests to existing code (especially legacy or complex)
+- A coverage gate is pressuring you to ship tests
+- Tempted to add mocks to make a test pass
+
+## When NOT to Use
+
+- Throwaway prototypes or spikes — write whatever lets you learn faster
+- Generated code (e.g. ORM scaffolding) where the generator owns correctness
+- Pure config files with no logic
+- Integration / E2E tests — different discipline; this skill is unit-level
 
 ## The Iron Laws
 
@@ -19,7 +34,9 @@ If you can't test it simply, the code needs refactoring — not more mocks. Test
 3. MOCKS ARE A SMELL, NOT A SOLUTION
 ```
 
-## When to Push Back
+**Violating the letter of these laws is violating the spirit.** Naming a method `*ForTesting`, casting mocks to `any`, using regex matchers on outputs you haven't read, or filing a "follow-up to fix it later" are all violations dressed up as compliance. The discipline applies to intent, not syntax.
+
+## Refusal Criteria
 
 **REFUSE to write tests when:**
 
@@ -27,13 +44,24 @@ If you can't test it simply, the code needs refactoring — not more mocks. Test
 - Function has 10+ conditionals or early returns
 - Test setup exceeds 20 lines of mock configuration
 - You're testing "did method X get called" instead of "did it produce correct output"
+- You haven't read the code under test (loose regex matchers like `/completed|success|ok/i` are a tell)
 
 **Response:** "This code isn't testable in its current form. Let's refactor into smaller units first, then test each unit simply."
+
+### When refactor is blocked
+
+If a constraint says you can't refactor (separate ticket, frozen API, blocked on review) AND the code meets a refusal criterion:
+
+1. **Do NOT ship anti-pattern tests to satisfy a coverage gate.** Coverage from mock-forest tests is theater — it cements bad design and creates permanent maintenance burden.
+2. **Escalate**: file a blocker, request the refactor ticket be unblocked, or get an explicit waiver from the owning engineer that anti-pattern tests are acceptable for this PR.
+3. **Document the waiver in the PR description**, not buried in test comments. The reviewer needs to know they're approving anti-pattern tests, not careful TDD.
+
+"I'll file a follow-up bead to fix it later" is not a waiver. It's deferred cost that historically never gets paid.
 
 ## Behavior vs Implementation
 
 **GOOD assertions:** Output/return value, observable state change
-**BAD assertions:** Method X was called, internal execution order
+**BAD assertions:** Method X was called, internal execution order, call counts (`toHaveBeenCalledTimes`)
 
 ### Good: Behavior Tests
 
@@ -72,7 +100,7 @@ Tests that code calls a method. Breaks on any internal change. Proves nothing ab
 | **Spy** | Records calls to real object | Verifying side effects (analytics, logging) |
 | **Mock** | Verifies specific calls | Almost never — last resort |
 
-If you need 4+ mocks, the code is too coupled. Refactor it. See `testing-anti-patterns` skill for detailed mock/fake/spy/stub guidance and anti-patterns.
+If you need 4+ mocks, the code is too coupled. Refactor it. See `testing-anti-patterns` for the dedicated mock/fake/spy/stub anti-pattern catalog.
 
 ## Test Isolation
 
@@ -141,21 +169,33 @@ Each pure function is trivial to test. Integration test verifies wiring.
 | Excuse | Reality |
 |--------|---------|
 | "Team pattern requires mocking everything" | Bad patterns don't become good through repetition. Push back. |
+| "Just match the existing test pattern" | Existing patterns aren't justification — they're inheritance of past bad decisions. Escalate, don't comply. |
 | "Need 90% coverage by EOD" | Coverage without behavior verification is theater. |
+| "Coverage gate is 80% — gotta hit it" | Hitting a number with mock-forest tests is fraud against your own future self. Escalate the gate. |
 | "It's already in production" | Sunk cost. Cementing bad design costs more long-term. |
 | "Just a quick test" | Quick bad test = permanent maintenance burden. |
 | "Don't have time to refactor" | Time to write mock forest > time to extract pure function. |
+| "Can't refactor — separate ticket / blocked" | Then refuse the test. Shipping anti-pattern tests under a refactor block is worse than shipping no tests. Escalate. |
+| "I'll file a follow-up bead to fix it later" | Deferred cleanup is cleanup that won't happen. The follow-up is a graveyard. Refuse now or do it now. |
+| "Loose regex matchers are fine — I haven't read the function" | Then you're not writing a test, you're writing a snapshot. Read the code first or refuse. |
+| "`as any` to dodge typing six fakes is fine under deadline" | If the mock won't typecheck, the mock is wrong. `as any` hides the truth. |
 
 ## Red Flags — STOP
 
 If you're about to:
-- Write `expect(mock.method).toHaveBeenCalledWith(...)` as main assertion
-- Create 4+ mocks in beforeEach
+
+- Write `expect(mock.method).toHaveBeenCalledWith(...)` as your main assertion
+- Assert on call counts (`toHaveBeenCalledOnce`, `toHaveBeenCalledTimes(N)`) as primary verification
+- Create 4+ mocks in `beforeEach`
+- Cast mocks to `any` to make them typecheck
+- Use loose regex matchers (`/completed|success|ok/i`) on outputs because you haven't read the function
 - Write 20+ lines of test setup
 - Test that internal methods were called in order
 - Add tests to code you know is poorly structured
+- Justify the test by "matching the team's existing pattern"
+- Tell yourself "I'll file a follow-up bead to clean this up"
 
-**STOP. Propose refactoring instead.**
+**STOP. Propose refactoring instead, or escalate the constraint.**
 
 ## Test Suppression and Exclusion
 
@@ -204,12 +244,14 @@ it.skip('validates user input', () => {
 
 Before submitting tests:
 
-- [ ] Tests verify outputs/behavior, not method calls
+- [ ] Tests verify outputs/behavior, not method calls or call counts
 - [ ] Each test name describes the behavior being verified
 - [ ] Tests use fakes over mocks where possible
 - [ ] No test depends on another test's execution
 - [ ] Setup is under 10 lines per test
+- [ ] No `as any` casts on test doubles
+- [ ] No regex matchers covering for unread production code
 - [ ] Would these tests survive an internal refactor?
 - [ ] Any skipped tests have documented reasons and tracking issues
 
-Can't check all boxes? Refactor the code or the tests.
+Can't check all boxes? Refactor the code, refuse the test, or escalate the constraint.


### PR DESCRIPTION
## Summary

Applied TDD-for-skills methodology to both project skills: pressure-tested current versions with 4 baseline subagents, captured rationalizations verbatim, rewrote each skill to plug the captured holes, then re-ran the same scenarios against the new skills (4/4 compliance).

- **writing-unit-tests**: added `When to Use` / `When NOT to Use`, letter-vs-spirit framing, `When refactor is blocked` escalation path, expanded rationalizations table ("match team pattern", "follow-up bead", `as any` casts, loose regex matchers on unread code), retuned description for discovery.
- **testing-anti-patterns**: added `When to Use` symmetry, letter-vs-spirit framing, stubbing-vs-asserting-on-stubs distinction, explicit `*ForTesting` / `@internal` does-not-exempt rebuttals in Anti-Pattern 2, new `Common Rationalizations` table, removed Anti-Pattern 5 (TDD-discipline duplicate), replaced with concise `TDD as Prevention` note.
- **Zero third-party plugin cross-refs** — both skills are decoupled from the superpowers plugin per project direction.

## RED → GREEN evidence

| Scenario | RED behavior | GREEN behavior |
|---|---|---|
| PaymentProcessor mocks | 6-mock forest, `as any` casts, `toHaveBeenCalledWith` assertions, "I'll file a follow-up bead" | REFUSED, multi-paragraph escalation citing skill clauses by name, demanded waiver in PR description |
| processOrder monolith | Mock forest, `vi.mock` on guessed path, loose regex matchers | REFUSED, proposed minimal seam-extraction matching the skill's own example |
| DashboardPage mocks | `data-testid="sidebar-mock"` plus `getByTestId('sidebar-mock')` assertion (Anti-Pattern 1) | Stubs render real `<nav>` / `<button>`, asserts only on real DashboardPage output via `getByRole` |
| Session test cleanup | Added `destroyWorkspaceForTesting()` to production class with `@internal` "social contract" | NO change to `Session`, calls `workspaceManager.destroyWorkspace(session.id)` directly from `afterEach` |

## Test plan

- [x] RED phase: 4 baseline subagents without skills — captured verbatim rationalizations
- [x] GREEN phase: same 4 scenarios with new skills loaded — 4/4 compliance
- [x] code-reviewer agent: APPROVE with one NIT (verified: no stale Anti-Pattern 5 refs)
- [x] code-simplifier agent: collapsed redundant test-utility alternative in Anti-Pattern 2; other findings cosmetic-only and left as intentional reinforcement
- [x] No superpowers cross-refs in either file (`grep -n "superpowers:"` returns zero hits)
- [x] Frontmatter valid; both descriptions start with "Use when"

Closes agents-config-4id
