### PR TITLE
chore(refs): clean up stale references to deleted agents and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Deep methodology guides for specific tasks. Unlike agents (which define *who*), 
 | `merge-guard` | Pre-merge gate that blocks merging while automated reviews are pending or comments are unseen |
 | `optimize-agents-md` | Meta-skill for improving agent definitions |
 | `ralf-it` | Iterative refinement with fresh-eyes subagents that catch what the first pass missed |
-| `root-cause-tracing` | Systematic debugging methodology |
 | `self-improving-agent` | Persist lessons from user corrections as actionable rules |
 | `test-review` | Code review of unit/integration tests for quality and design issues |
 | `testing-anti-patterns` | Common testing mistakes and how to avoid them |

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -163,8 +163,7 @@ needs = ["write-tests"]
 description = """
 Write the minimum code to make all failing tests pass.
 
-Skills: superpowers:test-driven-development, then domain skill
-  (e.g. typescript-developer, backend-developer, etc.)
+Skills: superpowers:test-driven-development, then any applicable domain skill
 
 Rules:
 - Minimum viable implementation — write only what tests require

--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -114,8 +114,8 @@ digraph synthesis {
 **Honesty clause:** If a thread's findings are inconclusive, say so. "Git history shows no relevant changes in the last 20 commits" is a valid finding. "I couldn't reproduce the failure" is a valid finding. Do NOT speculate to fill gaps.
 
 **Fallback:** If root cause remains unclear after synthesis, escalate to complementary skills:
-- `root-cause-tracing` — deep call-stack investigation
-- `systematic-debugging` — full sequential 4-phase approach
+- `superpowers:root-cause-tracing` — deep call-stack investigation
+- `superpowers:systematic-debugging` — full sequential 4-phase approach
 - `condition-based-waiting` — timing/race condition analysis
 
 ## Implementation Phase

--- a/src/user/.agents/skills/test-review/SKILL.md
+++ b/src/user/.agents/skills/test-review/SKILL.md
@@ -23,7 +23,7 @@ description: Use when doing code review of unit or integration tests, reviewing 
 ## When NOT to Use
 
 - Writing tests from scratch (use `writing-unit-tests` skill instead)
-- Debugging a test failure caused by production code (use `bugfix` or `root-cause-tracing`)
+- Debugging a test failure caused by production code (use `bugfix` or `superpowers:root-cause-tracing`)
 - Throwaway spike/prototype tests
 
 ## Scope Determination

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -2,8 +2,8 @@
 
 MANDATORY delegation for non-trivial work (skip for obvious one-liners, config changes, typos):
 
-- Planning → `brainstorming` skill
-- Implementation → `ralf-it` skill (preferred for non-trivial work; handles worktree, TDD, quality gate, and fresh-eyes refinement cycles). For simpler tasks: `test-driven-development` skill first, then any applicable domain skills
+- Planning → `superpowers:brainstorming` skill
+- Implementation → `ralf-it` skill (preferred for non-trivial work; handles worktree, TDD, quality gate, and fresh-eyes refinement cycles). For simpler tasks: `superpowers:test-driven-development` skill first, then any applicable domain skills
 - Tests → `writing-unit-tests` + `testing-anti-patterns` skills
 
 **Cross-tool delegation:** see `codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -3,7 +3,7 @@
 MANDATORY delegation for non-trivial work (skip for obvious one-liners, config changes, typos):
 
 - Planning → `brainstorming` skill
-- Implementation → `ralf-it` skill (preferred for non-trivial work; handles worktree, TDD, quality gate, and fresh-eyes refinement cycles). For simpler tasks: `test-driven-development` skill first, then domain skills (e.g. `typescript-developer`)
+- Implementation → `ralf-it` skill (preferred for non-trivial work; handles worktree, TDD, quality gate, and fresh-eyes refinement cycles). For simpler tasks: `test-driven-development` skill first, then any applicable domain skills
 - Tests → `writing-unit-tests` + `testing-anti-patterns` skills
 
 **Cross-tool delegation:** see `codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.


### PR DESCRIPTION
## Summary

Cleans up live-config references to agents and skills deleted in the recent cleansing sweeps (commits 92fdfda, 827ef3e, 2bab19a, 4dfc98c, 0381c5a).

## Changes

- **`src/user/.claude/rules/delegation.md`** — drop `typescript-developer` example
- **`src/user/.agents/skills/bugfix/SKILL.md`** — qualify `root-cause-tracing` and `systematic-debugging` as `superpowers:`-prefixed (the local skill is gone; superpowers plugin still provides them)
- **`src/user/.agents/skills/test-review/SKILL.md`** — qualify `root-cause-tracing` as `superpowers:root-cause-tracing`
- **`src/plugins/beads/.beads/formulas/implement-feature.formula.toml`** — drop `typescript-developer, backend-developer` examples
- **`README.md`** — remove stale `root-cause-tracing` row from skills table

## Out of scope

Historical references in `docs/plans/` and `docs/specs/` are intentionally left as-is — they are design-doc artifacts that document the rename/deletion history.

## Test plan

- [x] `grep -rn` confirms no remaining stale references to deleted items in `src/` or `README.md`
- [x] `superpowers:` qualified references continue to point at extant plugin skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)