### PR TITLE
feat(install): add --prune and --prune-only flags for orphaned items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ This configuration assumes the following Claude Code plugins are installed:
 ## Repository Structure
 
 - `scripts/` - Installation and maintenance scripts
-  - `install.sh` - Multi-tool installer with auto-detection, `--dry-run`, `--tools=` and `--plugins=` overrides
+  - `install.sh` - Multi-tool installer with auto-detection, `--dry-run`, `--tools=`/`--plugins=` overrides, and `--prune`/`--prune-only` for removing orphaned items not in the source
 - `docs/plans/` - Design documents for features in development
 - `docs/specs/` - Design specifications for implemented features
 - `src/user/.agents/` - **Shared content** (copied into all detected tools)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Slash commands that can be invoked directly:
 
 # Install accepting all changes
 ./scripts/install.sh --yes
+
+# Install AND remove orphaned items not in the source (with backup)
+./scripts/install.sh --prune
+
+# Skip install; only scan + prune orphans
+./scripts/install.sh --prune-only --dry-run    # preview
+./scripts/install.sh --prune-only --yes        # execute
 ```
 
 The install script:
@@ -124,9 +131,37 @@ The install script:
 - Syncs `agents/`, `skills/`, and `commands/` directories using hash comparison per item
 - Union-merges `settings.json.template` into existing `settings.json` (preserves your values, adds new keys/entries)
 - Creates timestamped backups before overwriting anything
-- Warns about items that aren't tracked in the project
+- Warns about items that aren't tracked in the project (or removes them with `--prune`)
 
 Requires bash or zsh, plus `jq` for JSON merging. Use `--dry-run` to preview changes without writing.
+
+#### Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Show what would change without writing |
+| `--yes`, `-y` | Auto-accept all prompts (suppresses diffs in quiet mode) |
+| `--verbose`, `-v` | Per-file progress (phases, up-to-date, installed, diffs) |
+| `--tools=TOOLS` | Comma-separated tool list (`claude`, `codex`, `gemini`); default auto-detect |
+| `--plugins=PLUGINS` | Comma-separated plugin list (`beads`); default auto-detect; pass `--plugins=` to disable all |
+| `--prune` | After install, remove orphans under `~/.<tool>/{commands,skills,agents,rules}/` and `~/.beads/formulas/` not present in current staging (with backup) |
+| `--prune-only` | Skip install (Phase 7); only scan + prune orphans (mutually exclusive with `--prune`) |
+| `--help`, `-h` | Show help |
+
+#### Pruning orphans
+
+`--prune` and `--prune-only` identify and (optionally) remove items that exist
+in your tool config dirs but no longer exist in this repo's source — useful for
+keeping your install in sync after files are renamed or deleted upstream.
+
+- **Scope:** top-level entries directly inside `~/.<tool>/{commands,skills,agents,rules}/` and `~/.beads/formulas/`. Nothing else (top-level `*.md`, `settings.json`, `hooks/`, etc.) is ever pruned.
+- **Backups:** orphans are moved to `~/.<tool>/<namespace>-backup/<basename>.backup-<timestamp>` before deletion. The `*-backup/` siblings are themselves excluded from future scans.
+- **Modes:**
+  - `--dry-run` lists orphans and exits without changes.
+  - `--yes` backs up + deletes all orphans without prompting.
+  - Interactive (default): displays orphans, then prompts `[a]ll / [o]ne-by-one / [c]ancel`. Cancel and EOF leave everything in place.
+  - Non-interactive without `--yes` or `--dry-run`: `--prune` warns and skips the prune phase (install still runs); `--prune-only` hard-fails (exit non-zero).
+- **Beads:** `~/.beads/formulas/` is scanned whenever `--prune`/`--prune-only` is active, regardless of whether the beads plugin is auto-detected. If beads isn't an active plugin, all formulas in your dest are flagged as orphans (strict mode).
 
 ### Manual
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -526,7 +526,10 @@ stage_and_install_tool() {
     CURRENT_TOOL="$tool"
     vheader "$tool"
 
-    [[ "$DRY_RUN" != true ]] && mkdir -p "$dest_dir"
+    # Skip dest_dir creation under --prune-only: Phase 7 is skipped, so creating
+    # ~/.<tool>/ would leave behind an empty directory on systems that didn't
+    # already have one. Staging dir is still required for scan_orphans.
+    [[ "$DRY_RUN" != true && "$PRUNE_ONLY" != true ]] && mkdir -p "$dest_dir"
     mkdir -p "$staging"
 
     # ── Phase 1: Stage shared templates (.agents/*.md.template → staging/) ───

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1090,6 +1090,20 @@ _delete_all_orphans() {
 }
 
 prune_orphans() {
+    # Non-interactive guard runs FIRST — before the empty-orphan fast path —
+    # so --prune-only without -y/--dry-run hard-fails regardless of orphan
+    # count (intent unfulfilled: caller asked for action with no auth).
+    # --dry-run and -y are themselves the auth, so they're exempt.
+    if [[ ! -t 0 && "$DRY_RUN" != true && "$AUTO_YES" != true ]]; then
+        if [[ "$PRUNE_ONLY" == true ]]; then
+            err "prune-only requires --yes or --dry-run in non-interactive mode"
+            exit 1
+        else
+            warn "prune phase requires confirmation, skipping"
+            return 0
+        fi
+    fi
+
     if [[ ${#ORPHANS[@]} -eq 0 ]]; then
         info "No orphans detected."
         return 0
@@ -1107,17 +1121,6 @@ prune_orphans() {
     if [[ "$AUTO_YES" == true ]]; then
         _delete_all_orphans
         return 0
-    fi
-
-    # Non-interactive without -y / --dry-run
-    if [[ ! -t 0 ]]; then
-        if [[ "$PRUNE_ONLY" == true ]]; then
-            err "prune-only requires --yes or --dry-run in non-interactive mode"
-            exit 1
-        else
-            warn "prune phase requires confirmation, skipping"
-            return 0
-        fi
     fi
 
     # Interactive: 3-way prompt

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,11 @@ fi
 #   --verbose, -v        Show per-file progress (phases, up-to-date, installed)
 #   --tools=claude,...   Comma-separated list of tools (default: auto-detect)
 #   --plugins=beads,...  Comma-separated list of plugins (default: auto-detect)
+#   --prune              After install, remove orphans (with backup) under
+#                        ~/.<tool>/{commands,skills,agents,rules}/ and
+#                        ~/.beads/formulas/ that are not in current staging
+#   --prune-only         Skip Phase 7 (install) and only scan + prune orphans
+#                        (mutually exclusive with --prune)
 #   --help, -h           Show this help
 #
 # Output modes:
@@ -84,6 +89,8 @@ VERBOSE=false
 TOOLS_OVERRIDE=""
 PLUGINS_OVERRIDE=""
 PLUGINS_FLAG_SET=false
+PRUNE=false
+PRUNE_ONLY=false
 
 for arg in "$@"; do
     case "$arg" in
@@ -92,8 +99,10 @@ for arg in "$@"; do
         --verbose|-v)  VERBOSE=true ;;
         --tools=*)     TOOLS_OVERRIDE="${arg#--tools=}" ;;
         --plugins=*)   PLUGINS_OVERRIDE="${arg#--plugins=}"; PLUGINS_FLAG_SET=true ;;
+        --prune)       PRUNE=true ;;
+        --prune-only)  PRUNE_ONLY=true ;;
         --help|-h)
-            echo "Usage: install.sh [--dry-run] [--yes|-y] [--verbose|-v] [--tools=TOOLS] [--plugins=PLUGINS] [--help|-h]"
+            echo "Usage: install.sh [--dry-run] [--yes|-y] [--verbose|-v] [--tools=TOOLS] [--plugins=PLUGINS] [--prune] [--prune-only] [--help|-h]"
             echo ""
             echo "Installs shared and tool-specific agent config into ~/.<tool>/ directories"
             echo "for Claude Code, OpenAI Codex CLI, and Google Gemini CLI."
@@ -110,12 +119,20 @@ for arg in "$@"; do
             echo "                     Default: auto-detect (claude always, others if ~/.<tool>/ exists)"
             echo "  --plugins=PLUGINS  Comma-separated plugins: beads"
             echo "                     Default: auto-detect (enabled if bd is on PATH or ~/.beads/ exists)"
+            echo "  --prune            After install, remove orphans under ~/.<tool>/{commands,skills,agents,rules}/"
+            echo "                     and ~/.beads/formulas/ that are not in current staging (with backup)"
+            echo "  --prune-only       Skip install (Phase 7); only scan + prune orphans (mutually exclusive with --prune)"
             echo "  --help, -h         Show this help"
             exit 0
             ;;
         *) echo "Unknown option: $arg" >&2; exit 1 ;;
     esac
 done
+
+if [[ "$PRUNE" == true && "$PRUNE_ONLY" == true ]]; then
+    echo "Error: --prune and --prune-only are mutually exclusive." >&2
+    exit 1
+fi
 
 # Diffs are shown in verbose mode, or when the user is about to be prompted for
 # confirmation (they need to see the change to decide). Quiet + dry-run gives a
@@ -203,6 +220,12 @@ plugin_enabled() {
     in_list "$1" "${PLUGINS[@]}"
 }
 
+# True when --prune or --prune-only was passed (the two flags are mutually
+# exclusive; "active" means the prune phase will run).
+prune_active() {
+    [[ "$PRUNE" == true || "$PRUNE_ONLY" == true ]]
+}
+
 # ── Utility: split a comma-separated string into a named array ────────────────
 #
 # Handles the bash (read -ra) vs zsh (read -rA) split. The target array name
@@ -254,10 +277,16 @@ if [[ "$PLUGINS_FLAG_SET" == true ]]; then
             exit 1
         fi
     done
-    # Warn about explicitly excluded plugins (already-installed files are not removed)
+    # Warn about explicitly excluded plugins. Wording depends on whether prune is
+    # active: under --prune/--prune-only the excluded plugin's previously-installed
+    # files DO become orphans and may be removed (strict mode, AC#16).
     for plugin in "${ALL_PLUGINS[@]}"; do
         if ! in_list "$plugin" "${PLUGINS[@]}"; then
-            warn "Plugin '$plugin' excluded via --plugins= — files already installed are not removed."
+            if prune_active; then
+                warn "Plugin '$plugin' excluded via --plugins= — under --prune, previously-installed files become orphans and may be removed."
+            else
+                warn "Plugin '$plugin' excluded via --plugins= — files already installed are not removed (use --prune or --prune-only to remove orphans under strict mode)."
+            fi
         fi
     done
 else
@@ -280,30 +309,55 @@ vinfo "Plugins: ${PLUGINS[*]:-none}"
 
 # ── Per-tool counters ─────────────────────────────────────────────────────
 
-declare -A tool_installed tool_updated tool_skipped tool_merged tool_backed_up
+declare -A tool_installed tool_updated tool_skipped tool_merged tool_backed_up tool_pruned
 for tool in "${ALL_TOOLS[@]}" "${ALL_PLUGINS[@]}"; do
     tool_installed[$tool]=0
     tool_updated[$tool]=0
     tool_skipped[$tool]=0
     tool_merged[$tool]=0
     tool_backed_up[$tool]=0
+    tool_pruned[$tool]=0
 done
 
 # Current tool being processed (used by utility functions)
 CURRENT_TOOL=""
 
-# ── Utility: back up a file with timestamp ────────────────────────────────
+# ── Utility: back up a file or directory with timestamp ────────────────────
+#
+# Path-aware: if the parent dir is one of the prune-managed namespaces
+# {commands, skills, agents, rules, formulas}, route the backup into a
+# sibling <namespace>-backup/ directory under the grandparent. Otherwise,
+# fall back to in-place "<path>.backup-<timestamp>" alongside the original.
+# Handles both files (cp) and directories (cp -R).
 
 backup() {
-    local file="$1"
-    if [[ -f "$file" ]]; then
-        local timestamp
-        timestamp="$(date +%Y%m%d-%H%M%S)"
-        local backup_file="${file}.backup-${timestamp}"
-        cp "$file" "$backup_file"
-        vinfo "Backed up $(basename "$file") -> $(basename "$backup_file")"
-        (( tool_backed_up[$CURRENT_TOOL]++ )) || true
+    local target="$1"
+    [[ -e "$target" ]] || return 0
+
+    local timestamp parent grandparent base backup_dir backup_path
+    timestamp="$(date +%Y%m%d-%H%M%S)"
+    parent="$(basename "$(dirname "$target")")"
+    base="$(basename "$target")"
+
+    case "$parent" in
+        commands|skills|agents|rules|formulas)
+            grandparent="$(dirname "$(dirname "$target")")"
+            backup_dir="$grandparent/${parent}-backup"
+            backup_path="$backup_dir/${base}.backup-${timestamp}"
+            mkdir -p "$backup_dir"
+            ;;
+        *)
+            backup_path="${target}.backup-${timestamp}"
+            ;;
+    esac
+
+    if [[ -d "$target" ]]; then
+        cp -R "$target" "$backup_path"
+    else
+        cp "$target" "$backup_path"
     fi
+    vinfo "Backed up $base -> $(basename "$(dirname "$backup_path")")/$(basename "$backup_path")"
+    (( tool_backed_up[$CURRENT_TOOL]++ )) || true
 }
 
 # ── Utility: compute a recursive hash for a directory or file ─────────────
@@ -533,6 +587,13 @@ stage_and_install_tool() {
     done
 
     # ── Phase 7: Sync staging → ~/.<tool>/ (reusing existing sync functions) ──
+    # Skipped under --prune-only: staging tree (Phases 1-6) is still built so
+    # scan_orphans has a comparison baseline, but no files are written to ~/.
+    if [[ "$PRUNE_ONLY" == true ]]; then
+        vinfo "Phase 7: skipped (--prune-only)"
+        return 0
+    fi
+
     vinfo "Phase 7: Sync to $dest_dir"
 
     # Sync templates: staging has *.md.template; sync_templates strips the suffix
@@ -575,6 +636,13 @@ stage_and_install_beads() {
             stage_item "$formula" "$staging_formulas/$formula_name" "toml"
         done
     done
+
+    # Skip the actual install when running --prune-only; staging is preserved
+    # for scan_orphans to compare against.
+    if [[ "$PRUNE_ONLY" == true ]]; then
+        vinfo "beads sync: skipped (--prune-only)"
+        return 0
+    fi
 
     # Sync staged formulas → ~/.beads/formulas/
     local found_any=false
@@ -625,14 +693,17 @@ stage_and_install_beads() {
     [[ "$found_any" == false ]] && vinfo "No formula files staged"
 
     # Warn about formulas in dest that aren't in staged source
-    local extra_name
-    for dest_file in "$dest_formulas"/*.toml; do
-        [[ -f "$dest_file" ]] || continue
-        extra_name="$(basename "$dest_file")"
-        if [[ ! -f "$staging_formulas/$extra_name" ]]; then
-            warn "formulas/$extra_name exists in ~/.beads/formulas but not in plugin source (keeping)"
-        fi
-    done
+    # (suppressed when --prune/--prune-only is active — prune phase will report and act on these)
+    if ! prune_active; then
+        local extra_name
+        for dest_file in "$dest_formulas"/*.toml; do
+            [[ -f "$dest_file" ]] || continue
+            extra_name="$(basename "$dest_file")"
+            if [[ ! -f "$staging_formulas/$extra_name" ]]; then
+                warn "formulas/$extra_name exists in ~/.beads/formulas but not in plugin source (keeping)"
+            fi
+        done
+    fi
 }
 
 # ── Sync templates from a source dir into a dest dir ──────────────────────
@@ -768,13 +839,16 @@ sync_directory() {
     done
 
     # Warn about items in dest that aren't in source
-    for dest_item in "$dest_parent"/*; do
-        [[ -e "$dest_item" ]] || continue
-        item_name="$(basename "$dest_item")"
-        if [[ ! -e "$src_parent/$item_name" ]]; then
-            warn "$dir_name/$item_name exists in ~/.$CURRENT_TOOL but not in $label source (keeping)"
-        fi
-    done
+    # (suppressed when --prune/--prune-only is active — prune phase will report and act on these)
+    if ! prune_active; then
+        for dest_item in "$dest_parent"/*; do
+            [[ -e "$dest_item" ]] || continue
+            item_name="$(basename "$dest_item")"
+            if [[ ! -e "$src_parent/$item_name" ]]; then
+                warn "$dir_name/$item_name exists in ~/.$CURRENT_TOOL but not in $label source (keeping)"
+            fi
+        done
+    fi
 }
 
 # ── Merge or copy a settings file ─────────────────────────────────────────
@@ -914,32 +988,227 @@ sync_settings_file() {
     fi
 }
 
+# ── Orphan scanning and pruning ───────────────────────────────────────────────
+#
+# An orphan is a top-level entry directly inside ~/.<tool>/{commands,skills,
+# agents,rules}/ or ~/.beads/formulas/ that does NOT exist in the current run's
+# staging tree. Item granularity is the top-level entry — we don't recurse into
+# nested skill directories. Legacy in-place backup files matching *.backup-*
+# (produced by older versions of backup() before the namespace refactor) are
+# skipped so they aren't treated as orphans. Sibling <namespace>-backup/ dirs
+# (the new layout) live at the GRANDPARENT level alongside the namespace, so
+# they are never visited by this scan in the first place. Anything outside
+# these scoped subdirs (top-level *.md, settings.json, hooks/, etc.) is never
+# pruned.
+
+ORPHANS=()
+
+# Append orphans found in a single dest namespace to ORPHANS, tagged with the
+# given tool/namespace labels. Skips legacy *.backup-* entries (in-place backups
+# from older backup() implementations); classifies as dir/file.
+_scan_namespace() {
+    local tool="$1" ns_label="$2" dest="$3" staging="$4"
+    [[ -d "$dest" ]] || return 0
+    local entry base kind
+    for entry in "$dest"/*; do
+        [[ -e "$entry" ]] || continue
+        base="$(basename "$entry")"
+        [[ "$base" == *.backup-* ]] && continue
+        [[ -e "$staging/$base" ]] && continue
+        if [[ -d "$entry" ]]; then kind="dir"; else kind="file"; fi
+        ORPHANS+=("$tool|$ns_label|$entry|$kind")
+    done
+}
+
+scan_orphans() {
+    ORPHANS=()
+    local tool sub
+    local prune_subdirs=(commands skills agents rules)
+
+    for tool in "${TOOLS[@]}"; do
+        for sub in "${prune_subdirs[@]}"; do
+            _scan_namespace "$tool" "$sub" "$HOME/.$tool/$sub" "$STAGING_DIR/$tool/$sub"
+        done
+    done
+
+    # ~/.beads/formulas/ — scanned whenever --prune/--prune-only runs,
+    # regardless of beads plugin auto-detection. If beads isn't an active plugin
+    # the staging dir is empty (or absent), so all dest formulas register as
+    # orphans — consistent with strict mode (AC#19).
+    _scan_namespace "beads" "formulas" "$HOME/.beads/formulas" "$STAGING_DIR/.beads/formulas"
+}
+
+# Display the orphan list grouped by tool, then namespace, with a summary count.
+_display_orphans() {
+    local last_tool="" last_ns="" tool ns path kind line
+    header "Orphans detected (${#ORPHANS[@]} total)"
+    for line in "${ORPHANS[@]}"; do
+        IFS='|' read -r tool ns path kind <<< "$line"
+        if [[ "$tool" != "$last_tool" ]]; then
+            printf "\n${BOLD}%s${RESET}\n" "$tool"
+            last_tool="$tool"
+            last_ns=""
+        fi
+        if [[ "$ns" != "$last_ns" ]]; then
+            printf "  %s/\n" "$ns"
+            last_ns="$ns"
+        fi
+        printf "    [%s] %s\n" "$kind" "$path"
+    done
+    echo ""
+}
+
+# Backup + delete one orphan, increment counter for its tool bucket.
+_delete_orphan() {
+    local tool="$1" path="$2"
+    local prev="$CURRENT_TOOL"
+    CURRENT_TOOL="$tool"
+    backup "$path"
+    rm -rf "$path"
+    (( tool_pruned[$tool]++ )) || true
+    CURRENT_TOOL="$prev"
+}
+
+# Backup + delete every orphan in ORPHANS, then report the count.
+_delete_all_orphans() {
+    local line tool ns path kind
+    for line in "${ORPHANS[@]}"; do
+        IFS='|' read -r tool ns path kind <<< "$line"
+        _delete_orphan "$tool" "$path"
+    done
+    ok "Pruned ${#ORPHANS[@]} orphan(s)."
+}
+
+prune_orphans() {
+    if [[ ${#ORPHANS[@]} -eq 0 ]]; then
+        info "No orphans detected."
+        return 0
+    fi
+
+    _display_orphans
+
+    # Dry-run: display only, no deletes/backups
+    if [[ "$DRY_RUN" == true ]]; then
+        info "Dry-run: ${#ORPHANS[@]} orphan(s) listed above; no changes made."
+        return 0
+    fi
+
+    # Auto-yes: backup + delete all without prompting
+    if [[ "$AUTO_YES" == true ]]; then
+        _delete_all_orphans
+        return 0
+    fi
+
+    # Non-interactive without -y / --dry-run
+    if [[ ! -t 0 ]]; then
+        if [[ "$PRUNE_ONLY" == true ]]; then
+            err "prune-only requires --yes or --dry-run in non-interactive mode"
+            exit 1
+        else
+            warn "prune phase requires confirmation, skipping"
+            return 0
+        fi
+    fi
+
+    # Interactive: 3-way prompt
+    local action
+    while true; do
+        printf "${YELLOW}?${RESET}  Action? [a]ll, [o]ne-by-one, [c]ancel: "
+        if ! read -r action; then
+            # EOF -> cancel
+            info "Cancelled (EOF). No changes made."
+            return 0
+        fi
+        case "$action" in
+            a|A)
+                _delete_all_orphans
+                return 0
+                ;;
+            o|O)
+                local line tool ns path kind ans quit=false
+                for line in "${ORPHANS[@]}"; do
+                    [[ "$quit" == true ]] && break
+                    IFS='|' read -r tool ns path kind <<< "$line"
+                    while true; do
+                        printf "${YELLOW}?${RESET}  Delete %s? [y/N/q] " "$path"
+                        if ! read -r ans; then
+                            ans=""  # EOF -> default skip
+                        fi
+                        case "$ans" in
+                            y|Y) _delete_orphan "$tool" "$path"; break ;;
+                            q|Q) info "Quit per-item loop; remaining orphans left in place."; quit=true; break ;;
+                            n|N|"") break ;;
+                            *)   warn "Invalid input — please answer y, N, or q." ;;
+                        esac
+                    done
+                done
+                return 0
+                ;;
+            c|C|"")
+                info "Cancelled. No changes made."
+                return 0
+                ;;
+            *)
+                warn "Invalid input — please answer a, o, or c."
+                ;;
+        esac
+    done
+}
+
 # ── Staging directory (cleaned up on exit) ────────────────────────────────────
 
 STAGING_DIR="$(mktemp -d /tmp/agents-config-install-XXXXXX)"
 trap 'rm -rf "$STAGING_DIR"' EXIT
 
 # ── Main loop ─────────────────────────────────────────────────────────────
+#
+# Phases 1-6 (staging) always run; Phase 7 (sync to ~/) is skipped inside
+# stage_and_install_tool / stage_and_install_beads when PRUNE_ONLY=true so
+# scan_orphans still has a populated staging tree to compare against.
 
 for tool in "${TOOLS[@]}"; do
     stage_and_install_tool "$tool"
 done
 
-if plugin_enabled "beads"; then
+# Beads staging must run whenever --prune/--prune-only is active so scan_orphans
+# has a comparison baseline for ~/.beads/formulas/ (AC#19), even if beads is not
+# in the active PLUGINS array. When beads is excluded, the staging build loops
+# over an empty plugin set and produces an empty staging dir — under strict mode,
+# all dest formulas then register as orphans, which is the intended behavior.
+if plugin_enabled "beads" || prune_active; then
     stage_and_install_beads
 fi
 
+# Prune phase (post-install) — only when --prune or --prune-only is active
+if prune_active; then
+    scan_orphans
+    prune_orphans
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────────
+#
+# Build the report set: active TOOLS + active PLUGINS, plus any plugin that
+# isn't in PLUGINS but accumulated activity (e.g., beads pruned when the
+# plugin wasn't auto-detected, per AC#19).
+
+REPORT_TARGETS=("${TOOLS[@]}" "${PLUGINS[@]}")
+for plugin in "${ALL_PLUGINS[@]}"; do
+    in_list "$plugin" "${REPORT_TARGETS[@]}" && continue
+    if (( ${tool_pruned[$plugin]:-0} + ${tool_backed_up[$plugin]:-0} > 0 )); then
+        REPORT_TARGETS+=("$plugin")
+    fi
+done
 
 if [[ "$VERBOSE" == true ]]; then
     header "Summary"
 
-    for tool in "${TOOLS[@]}" "${PLUGINS[@]}"; do
+    for tool in "${REPORT_TARGETS[@]}"; do
         printf "\n${BOLD}-- %s --${RESET}\n" "$tool"
         printf "  Installed:  %s\n" "${tool_installed[$tool]}"
         printf "  Updated:    %s\n" "${tool_updated[$tool]}"
         printf "  Merged:     %s\n" "${tool_merged[$tool]}"
         printf "  Backed up:  %s\n" "${tool_backed_up[$tool]}"
+        printf "  Pruned:     %s\n" "${tool_pruned[$tool]}"
         printf "  Skipped:    %s\n" "${tool_skipped[$tool]}"
     done
 
@@ -959,8 +1228,8 @@ else
     # Quiet summary: one line per target with non-zero changes; "all up to date" otherwise.
     total_changes=0
     summary_lines=()
-    for tool in "${TOOLS[@]}" "${PLUGINS[@]}"; do
-        changed=$(( ${tool_installed[$tool]} + ${tool_updated[$tool]} + ${tool_merged[$tool]} ))
+    for tool in "${REPORT_TARGETS[@]}"; do
+        changed=$(( ${tool_installed[$tool]} + ${tool_updated[$tool]} + ${tool_merged[$tool]} + ${tool_pruned[$tool]} ))
         (( total_changes += changed )) || true
         if (( changed > 0 )); then
             parts=()
@@ -968,6 +1237,7 @@ else
             (( ${tool_updated[$tool]}    > 0 )) && parts+=("${tool_updated[$tool]} updated")
             (( ${tool_merged[$tool]}     > 0 )) && parts+=("${tool_merged[$tool]} merged")
             (( ${tool_backed_up[$tool]}  > 0 )) && parts+=("${tool_backed_up[$tool]} backed up")
+            (( ${tool_pruned[$tool]}     > 0 )) && parts+=("${tool_pruned[$tool]} pruned")
             summary_lines+=("${tool}: $(IFS=', '; printf '%s' "${parts[*]}")")
         fi
     done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -624,7 +624,14 @@ stage_and_install_beads() {
     vheader "beads formulas"
     CURRENT_TOOL="beads"
 
-    [[ "$DRY_RUN" != true ]] && mkdir -p "$dest_formulas"
+    # Only create ~/.beads/formulas/ when beads is an active plugin AND we're
+    # actually going to install (not --prune-only). Without these gates, a
+    # --prune/--prune-only run with beads disabled or absent would silently
+    # create a brand-new ~/.beads/formulas tree on machines that never had
+    # beads installed. Staging dir is still required for scan_orphans.
+    if [[ "$DRY_RUN" != true && "$PRUNE_ONLY" != true ]] && plugin_enabled "beads"; then
+        mkdir -p "$dest_formulas"
+    fi
     mkdir -p "$staging_formulas"
 
     # Stage formulas from all active plugins with a .beads/formulas/ subdir

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,6 +30,15 @@ elif [ -n "${ZSH_VERSION:-}" ]; then
     setopt nullglob
 fi
 
+# Index base for array indexing in C-style for-loops. zsh arrays are 1-indexed
+# by default; bash arrays are 0-indexed. Used by the parallel ORPHAN_* arrays
+# (and any future indexed iteration).
+if [ -n "${ZSH_VERSION:-}" ]; then
+    _ARRAY_BASE=1
+else
+    _ARRAY_BASE=0
+fi
+
 # --------------------------------------------------------------------------
 # install.sh — Sync agent config into tool-specific home directories
 #
@@ -1011,11 +1020,23 @@ sync_settings_file() {
 # these scoped subdirs (top-level *.md, settings.json, hooks/, etc.) is never
 # pruned.
 
-ORPHANS=()
+# Parallel arrays — indexed orphan records. Pipe-delimited single-array storage
+# was unsafe because filenames are user-controlled and may contain `|` or
+# newlines, which would misparse via `IFS='|' read` and could end up
+# backing up / deleting the wrong target. Four arrays, indexed in lockstep:
+#   ORPHAN_TOOLS[i]  — tool bucket (e.g. "claude", "beads")
+#   ORPHAN_NS[i]     — namespace label (e.g. "commands", "formulas")
+#   ORPHAN_PATHS[i]  — absolute path to the orphan
+#   ORPHAN_KINDS[i]  — "dir" or "file"
+ORPHAN_TOOLS=()
+ORPHAN_NS=()
+ORPHAN_PATHS=()
+ORPHAN_KINDS=()
 
-# Append orphans found in a single dest namespace to ORPHANS, tagged with the
-# given tool/namespace labels. Skips legacy *.backup-* entries (in-place backups
-# from older backup() implementations); classifies as dir/file.
+# Append orphans found in a single dest namespace to the parallel ORPHAN_*
+# arrays, tagged with the given tool/namespace labels. Skips legacy *.backup-*
+# entries (in-place backups from older backup() implementations); classifies as
+# dir/file.
 _scan_namespace() {
     local tool="$1" ns_label="$2" dest="$3" staging="$4"
     [[ -d "$dest" ]] || return 0
@@ -1026,12 +1047,18 @@ _scan_namespace() {
         [[ "$base" == *.backup-* ]] && continue
         [[ -e "$staging/$base" ]] && continue
         if [[ -d "$entry" ]]; then kind="dir"; else kind="file"; fi
-        ORPHANS+=("$tool|$ns_label|$entry|$kind")
+        ORPHAN_TOOLS+=("$tool")
+        ORPHAN_NS+=("$ns_label")
+        ORPHAN_PATHS+=("$entry")
+        ORPHAN_KINDS+=("$kind")
     done
 }
 
 scan_orphans() {
-    ORPHANS=()
+    ORPHAN_TOOLS=()
+    ORPHAN_NS=()
+    ORPHAN_PATHS=()
+    ORPHAN_KINDS=()
     local tool sub
     local prune_subdirs=(commands skills agents rules)
 
@@ -1049,11 +1076,20 @@ scan_orphans() {
 }
 
 # Display the orphan list grouped by tool, then namespace, with a summary count.
+# Hoist all loop-internal locals to function scope — see commit 2fe276d:
+# zsh prints the variable's value when `local` is re-invoked in a loop.
+# Array indexing uses _ARRAY_BASE so the same C-style loop works under zsh
+# (1-indexed) and bash (0-indexed).
 _display_orphans() {
-    local last_tool="" last_ns="" tool ns path kind line
-    header "Orphans detected (${#ORPHANS[@]} total)"
-    for line in "${ORPHANS[@]}"; do
-        IFS='|' read -r tool ns path kind <<< "$line"
+    local last_tool="" last_ns="" tool ns path kind i n stop
+    n=${#ORPHAN_PATHS[@]}
+    stop=$(( n + _ARRAY_BASE ))
+    header "Orphans detected (${n} total)"
+    for (( i = _ARRAY_BASE; i < stop; i++ )); do
+        tool="${ORPHAN_TOOLS[i]}"
+        ns="${ORPHAN_NS[i]}"
+        path="${ORPHAN_PATHS[i]}"
+        kind="${ORPHAN_KINDS[i]}"
         if [[ "$tool" != "$last_tool" ]]; then
             printf "\n${BOLD}%s${RESET}\n" "$tool"
             last_tool="$tool"
@@ -1079,14 +1115,16 @@ _delete_orphan() {
     CURRENT_TOOL="$prev"
 }
 
-# Backup + delete every orphan in ORPHANS, then report the count.
+# Backup + delete every orphan, then report the count. Iterate by index across
+# the parallel ORPHAN_* arrays (zsh/bash index-base safe via _ARRAY_BASE).
 _delete_all_orphans() {
-    local line tool ns path kind
-    for line in "${ORPHANS[@]}"; do
-        IFS='|' read -r tool ns path kind <<< "$line"
-        _delete_orphan "$tool" "$path"
+    local i n stop
+    n=${#ORPHAN_PATHS[@]}
+    stop=$(( n + _ARRAY_BASE ))
+    for (( i = _ARRAY_BASE; i < stop; i++ )); do
+        _delete_orphan "${ORPHAN_TOOLS[i]}" "${ORPHAN_PATHS[i]}"
     done
-    ok "Pruned ${#ORPHANS[@]} orphan(s)."
+    ok "Pruned ${n} orphan(s)."
 }
 
 prune_orphans() {
@@ -1104,7 +1142,7 @@ prune_orphans() {
         fi
     fi
 
-    if [[ ${#ORPHANS[@]} -eq 0 ]]; then
+    if [[ ${#ORPHAN_PATHS[@]} -eq 0 ]]; then
         info "No orphans detected."
         return 0
     fi
@@ -1113,7 +1151,7 @@ prune_orphans() {
 
     # Dry-run: display only, no deletes/backups
     if [[ "$DRY_RUN" == true ]]; then
-        info "Dry-run: ${#ORPHANS[@]} orphan(s) listed above; no changes made."
+        info "Dry-run: ${#ORPHAN_PATHS[@]} orphan(s) listed above; no changes made."
         return 0
     fi
 
@@ -1138,10 +1176,17 @@ prune_orphans() {
                 return 0
                 ;;
             o|O)
-                local line tool ns path kind ans quit=false
-                for line in "${ORPHANS[@]}"; do
+                # Hoist all loop-internal locals to function scope — see commit
+                # 2fe276d: zsh prints the variable's value when `local` is
+                # re-invoked in a loop. Array indexing is _ARRAY_BASE-aware so
+                # the loop works in both zsh (1-indexed) and bash (0-indexed).
+                local tool path ans i n stop quit=false
+                n=${#ORPHAN_PATHS[@]}
+                stop=$(( n + _ARRAY_BASE ))
+                for (( i = _ARRAY_BASE; i < stop; i++ )); do
                     [[ "$quit" == true ]] && break
-                    IFS='|' read -r tool ns path kind <<< "$line"
+                    tool="${ORPHAN_TOOLS[i]}"
+                    path="${ORPHAN_PATHS[i]}"
                     while true; do
                         printf "${YELLOW}?${RESET}  Delete %s? [y/N/q] " "$path"
                         if ! read -r ans; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1225,13 +1225,16 @@ if [[ "$VERBOSE" == true ]]; then
         printf "  Skipped:    %s\n" "${tool_skipped[$tool]}"
     done
 
-    # Show tools and plugins that were in ALL_* but not active (auto-detect skipped)
+    # Show tools and plugins that were in ALL_* but not reported above
+    # (key off REPORT_TARGETS, not TOOLS/PLUGINS, so a plugin pruned outside
+    # the active set — e.g. beads under strict mode, AC#19 — isn't double-printed
+    # as both a real block and a "not detected, skipped" footer).
     for tool in "${ALL_TOOLS[@]}"; do
-        in_list "$tool" "${TOOLS[@]}" || \
+        in_list "$tool" "${REPORT_TARGETS[@]}" || \
             printf "\n${DIM}-- %s (not detected, skipped) --${RESET}\n" "$tool"
     done
     for plugin in "${ALL_PLUGINS[@]}"; do
-        in_list "$plugin" "${PLUGINS[@]}" || \
+        in_list "$plugin" "${REPORT_TARGETS[@]}" || \
             printf "\n${DIM}-- %s (not detected, skipped) --${RESET}\n" "$plugin"
     done
 


### PR DESCRIPTION
## Summary

Adds opt-in pruning of items in user-space namespace dirs (`~/.<tool>/{commands,skills,agents,rules}/` and `~/.beads/formulas/`) that are not present in the current run's staging tree.

Closes `agents-config-wyf`.

### CLI surface

| Flag | Behavior |
|------|----------|
| `--prune` | Run normal install, then run orphan-prune pass at the end |
| `--prune-only` | Skip install (Phase 7); only scan + prune orphans |

Mutually exclusive (combining = exit 1).

### Three operating modes

- `--dry-run` + prune flag → report orphans only, no changes
- `-y` + prune flag → backup + delete all orphans without prompting
- Interactive (tty) → show full orphan list, then prompt `[a]ll/[o]ne-by-one/[c]ancel`

Non-tty without `-y`/`--dry-run`: `--prune` warns + skips prune phase (install pass result drives exit); `--prune-only` hard-fails (exit 1).

### Backup destinations

Items in namespace dirs back up to parent-level siblings to avoid contaminating agent runtimes:

| Live | Backup |
|------|--------|
| `~/.claude/commands/foo.md` | `~/.claude/commands-backup/foo.md.backup-<ts>` |
| `~/.claude/skills/old-skill/` | `~/.claude/skills-backup/old-skill.backup-<ts>/` |
| `~/.beads/formulas/x.toml` | `~/.beads/formulas-backup/x.toml.backup-<ts>` |

`backup()` was refactored to be path-aware: namespace items route to `<namespace>-backup/`; top-level files (`AGENTS.md`, `settings.json`, etc.) keep in-place backup behavior.

### Behavior change

This **changes** existing in-place backup behavior for `~/.beads/formulas/` overwrites — backups previously went to `~/.beads/formulas/<name>.toml.backup-<ts>`; they now go to `~/.beads/formulas-backup/<name>.toml.backup-<ts>`. Intentional consolidation per spec scope.

### Plugin semantics (strict)

Excluding plugins via `--plugins=` makes their previously-installed user-space items orphans under `--prune`. Existing `--plugins=` warning text updated to mention this.

## Test plan

- [x] `bash -n scripts/install.sh` clean
- [x] `./scripts/install.sh --help | grep -i prune` shows both flags
- [x] `./scripts/install.sh --prune --prune-only` exits 1 with mutual-exclusion error
- [x] `./scripts/install.sh --prune --dry-run` lists orphans, makes no changes
- [x] `./scripts/install.sh --prune-only --dry-run` lists same orphans, Phase 7 skipped
- [x] `./scripts/install.sh --prune-only --dry-run --plugins=` shows beads formulas as orphans (strict mode)
- [x] `./scripts/install.sh --prune --plugins= </dev/null` warns + skips prune phase
- [x] `./scripts/install.sh --prune-only </dev/null` hard-fails (exit 1)
- [ ] User-driven destructive test (interactive 3-way prompt; `-y` actual delete)

## Notes

No test infra exists in this shell-script project; verification is via manual AC scenarios. 23 AC items in the bead spec, all addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)