### PR TITLE
feat: per-stage claude -p orchestration for implement-bead

### DIFF
--- a/docs/specs/bead-pipeline-architecture.md
+++ b/docs/specs/bead-pipeline-architecture.md
@@ -494,7 +494,7 @@ The stage-role-name component is one of: `preflight`, `diagnose`, `red-tests`, `
 
 Default invocation: `claude -p --session-id <uuidv5> "/implement-bead <bead-id>"`.
 
-`/implement-bead` is a project-scoped slash command at `src/plugins/beads/.claude/commands/implement-bead.md`. Claude Code resolves project-scoped commands by walking up from cwd to find a `.claude/` directory. Because worktrees are full git checkouts at `.claude/worktrees/<name>/`, each worktree has its own copy of the slash command file and resolution succeeds from any subdirectory of the worktree.
+The `/implement-bead` command is installed globally to `~/.claude/commands/` by `install.sh` (via the beads plugin overlay phase); it is discoverable from any cwd via Claude Code's global command lookup, not via project-local walk-up.
 
 Slash-command invocation requires slash-commands enabled (the default; broken only by `--disable-slash-commands`).
 

--- a/project-config.toml
+++ b/project-config.toml
@@ -30,12 +30,11 @@ test      = ""   # no automated test suite
 # ---------------------------------------------------------------------------
 [coverage]
 threshold        = 80     # percent; per-bead override: coverage-threshold-<n> label
-# report-location is intentionally empty: this is a pure-documentation project
-# with no test suite and therefore no coverage tooling. Preflight treats an
-# empty string as "no coverage configured" and applies the human-flag protocol
-# unless overridden. Projects with real coverage should set a path here, e.g.:
-#   report-location = "coverage/lcov.info"
-report-location  = ""     # explicit opt-out: no coverage report for a documentation project
+# report-location: empty string is treated as absent — preflight will apply the
+# human-flag protocol. Set a real path (e.g. coverage/lcov.info) or remove this
+# key to trigger the protocol. This project has no test suite or coverage tooling,
+# so the human-flag protocol is the expected outcome for any bead that reaches preflight.
+report-location  = ""     # empty string treated as absent — preflight applies human-flag protocol
 format           = ""     # n/a
 
 # ---------------------------------------------------------------------------

--- a/project-config.toml
+++ b/project-config.toml
@@ -1,0 +1,80 @@
+# project-config.toml
+# Per-project configuration for the bead pipeline architecture.
+# Lives at the repository root. Read by per-stage orchestrators to configure
+# quality gates, coverage thresholds, foreign-CLI model selection, and more.
+#
+# Schema defined in: docs/specs/bead-pipeline-architecture.md §5.1
+#
+# All sections are optional. Absent sections use per-stage defaults.
+# Stage role names (not numbers) are the authority in all section names.
+
+[project]
+name            = "agents-config"
+default-formula = "implement-feature"  # fallback when no formula-* label on bead
+
+# ---------------------------------------------------------------------------
+# [gates] — default quality-gate commands
+# Read by: green-loop (quality gate per iteration), quality-sweep
+# ---------------------------------------------------------------------------
+[gates]
+# This project is pure documentation — no build, typecheck, or lint.
+# Gates are stubs; stages detect empty commands and skip gracefully.
+build     = ""   # no build step
+typecheck = ""   # no type checker
+lint      = ""   # no linter
+test      = ""   # no automated test suite
+
+# ---------------------------------------------------------------------------
+# [coverage] — code coverage settings
+# Read by: green-loop, quality-sweep
+# ---------------------------------------------------------------------------
+[coverage]
+threshold        = 80     # percent; per-bead override: coverage-threshold-<n> label
+report-location  = ""     # no coverage report for a documentation project
+format           = ""     # n/a
+
+# ---------------------------------------------------------------------------
+# [lint-autofix] — lint auto-fix command
+# Read by: quality-sweep (runs BEFORE build/typecheck/lint/test)
+# ---------------------------------------------------------------------------
+[lint-autofix]
+command = ""   # no lint auto-fix for this project
+
+# ---------------------------------------------------------------------------
+# [static-analysis] — extra checks (semgrep, depcheck, etc.)
+# Read by: quality-sweep
+# Absent or all-empty → quality-sweep is skippable (preflight marks it so)
+# ---------------------------------------------------------------------------
+[static-analysis]
+# commands = ["semgrep --config auto ."]   # example; uncomment when needed
+
+# ---------------------------------------------------------------------------
+# [functional-tests] — UI/e2e commands
+# Read by: verify-ac
+# ---------------------------------------------------------------------------
+[functional-tests]
+# commands = ["playwright test"]   # example; uncomment when needed
+
+# ---------------------------------------------------------------------------
+# [review-requirements] — PR review defaults
+# Read by: review-cycle
+# ---------------------------------------------------------------------------
+[review-requirements]
+copilot-required         = true
+human-approvers-required = 0     # copilot-only by default; override per bead
+
+# ---------------------------------------------------------------------------
+# [foreign-cli] — foreign-CLI binary paths and model selections
+# Read by: red-tests (Codex adversarial test review),
+#          green-loop (RALF-IT foreign-eyes iterations),
+#          any stage invoking adversarial-codex
+# ---------------------------------------------------------------------------
+[foreign-cli]
+# codex_binary_path              = ""     # default: ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs
+# gemini_binary_path             = "gemini"
+codex_red_tests_model            = "gpt-5.5"    # adversarial test review
+codex_green_loop_iter1_model     = "gpt-5.5"    # RALF-IT iter 1 implementation review
+codex_adversarial_review_model   = "gpt-5.4"    # review-level:deep only
+gemini_green_loop_iter2_model    = "gemini-2.5-pro"
+codex_max_concurrent             = 1
+gemini_max_concurrent            = 1

--- a/project-config.toml
+++ b/project-config.toml
@@ -30,7 +30,12 @@ test      = ""   # no automated test suite
 # ---------------------------------------------------------------------------
 [coverage]
 threshold        = 80     # percent; per-bead override: coverage-threshold-<n> label
-report-location  = ""     # no coverage report for a documentation project
+# report-location is intentionally empty: this is a pure-documentation project
+# with no test suite and therefore no coverage tooling. Preflight treats an
+# empty string as "no coverage configured" and applies the human-flag protocol
+# unless overridden. Projects with real coverage should set a path here, e.g.:
+#   report-location = "coverage/lcov.info"
+report-location  = ""     # explicit opt-out: no coverage report for a documentation project
 format           = ""     # n/a
 
 # ---------------------------------------------------------------------------

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# scripts/bead-driver-test.sh
+# Minimal test harness for the per-stage claude -p bead pipeline (bead 7bk.9).
+#
+# IMPORTANT: This is a TEST HARNESS only. It is interactive, single-instance,
+# and MUST NOT run unattended in production. Continuous-loop autonomy requires
+# the production driver from agents-config-7bk.11. Until then, the architecture
+# runs in operator-supervised single-shot mode.
+#
+# Behavior:
+#   1. Polls bd for implementation-ready beads via:
+#        bd ready --label implementation-ready --json
+#   2. For each ready bead, spawns:
+#        claude -p --session-id <uuidv5> "/implement-bead <bead-id>"
+#      from the correct cwd per the architecture's cwd contract.
+#   3. Waits for the claude process to exit, then loops.
+#
+# Usage:
+#   bash scripts/bead-driver-test.sh [--once] [--dry-run]
+#
+# Options:
+#   --once      Process one bead then exit (useful for testing)
+#   --dry-run   Print what would be run without spawning claude processes
+#
+# Environment variables:
+#   REPO_ROOT   Override the repository root (default: git toplevel)
+#   POLL_INTERVAL_SECS  Seconds between bd ready polls (default: 5)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || echo "${SCRIPT_DIR}/..")}"
+POLL_INTERVAL_SECS="${POLL_INTERVAL_SECS:-5}"
+
+OPT_ONCE=false
+OPT_DRY_RUN=false
+
+for arg in "$@"; do
+  case "${arg}" in
+    --once)     OPT_ONCE=true ;;
+    --dry-run)  OPT_DRY_RUN=true ;;
+    *)
+      echo "Unknown option: ${arg}" >&2
+      echo "Usage: $0 [--once] [--dry-run]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# UUIDv5 derivation
+# Namespace pinned per architecture spec section 5.3.
+# ---------------------------------------------------------------------------
+NAMESPACE_UUID="27ece4fd-4a06-49bf-a921-bf07ecb0dc10"
+
+uuidv5() {
+  local name="$1"
+  # Use Python if available (most reliable cross-platform approach).
+  if command -v python3 &>/dev/null; then
+    python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('${NAMESPACE_UUID}'), '${name}'))"
+    return
+  fi
+  # Fallback: derive via openssl + manual v5 encoding.
+  # RFC 4122 §4.3: SHA-1 hash of namespace bytes + name, then format.
+  local ns_hex
+  ns_hex=$(echo -n "${NAMESPACE_UUID}" | tr -d '-')
+  local hash
+  hash=$(printf '%s%s' "${ns_hex}" "${name}" | xxd -r -p | openssl sha1 -binary | xxd -p | tr -d '\n')
+  # Insert version (5) and variant bits.
+  local b0="${hash:0:8}"
+  local b1="${hash:8:4}"
+  local b2="5${hash:13:3}"  # version = 5
+  local b3
+  b3=$(printf '%02x' $(( (16#${hash:16:2} & 0x3f) | 0x80 )))
+  local b4="${hash:18:2}${hash:20:8}"
+  echo "${b0}-${b1}-${b2}-${b3}${hash:18:2}-${hash:20:12}"
+}
+
+# ---------------------------------------------------------------------------
+# cwd resolution per architecture spec section 5.4
+# ---------------------------------------------------------------------------
+resolve_cwd() {
+  local bead_id="$1"
+  local stage_role="$2"
+
+  case "${stage_role}" in
+    preflight|merge-or-handoff)
+      echo "${REPO_ROOT}"
+      ;;
+    *)
+      # Decode worktree-path-* label from the bead's active molecule.
+      local mol_id encoded_path decoded_path
+      mol_id=$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
+        | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)
+
+      if [ -z "${mol_id}" ]; then
+        # No active molecule yet — fall back to repo root (preflight will pour one).
+        echo "${REPO_ROOT}"
+        return
+      fi
+
+      # Decode worktree-path label: first __ -> /, then _u -> _
+      encoded_path=$(bd label list "${mol_id}" 2>/dev/null \
+        | grep '^worktree-path-' | head -1 | sed 's/^worktree-path-//' || true)
+
+      if [ -z "${encoded_path}" ]; then
+        echo "${REPO_ROOT}"
+        return
+      fi
+
+      decoded_path=$(echo "${encoded_path}" | sed 's/__/\x00/g' | sed 's/_u/_/g' | sed 's/\x00/\//g')
+      echo "${decoded_path}"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Main poll loop
+# ---------------------------------------------------------------------------
+echo "==> bead-driver-test.sh starting"
+echo "    REPO_ROOT: ${REPO_ROOT}"
+echo "    POLL_INTERVAL_SECS: ${POLL_INTERVAL_SECS}"
+"${OPT_ONCE}" && echo "    Mode: --once (exit after first bead)"
+"${OPT_DRY_RUN}" && echo "    Mode: --dry-run (no claude processes spawned)"
+echo ""
+
+if ! command -v bd &>/dev/null; then
+  echo "ERROR: 'bd' not found on PATH — install beads before running this driver" >&2
+  exit 1
+fi
+
+if ! command -v claude &>/dev/null && ! "${OPT_DRY_RUN}"; then
+  echo "ERROR: 'claude' not found on PATH — install Claude Code CLI before running this driver" >&2
+  exit 1
+fi
+
+processed=0
+
+while true; do
+  # Query for implementation-ready beads (excludes human-labeled beads per bd semantics).
+  ready_beads=$(bd ready --label implementation-ready --json 2>/dev/null || echo '[]')
+  count=$(echo "${ready_beads}" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+
+  if [ "${count}" -eq 0 ]; then
+    if "${OPT_ONCE}" && [ "${processed}" -gt 0 ]; then
+      echo "==> No more ready beads. Exiting (--once)."
+      exit 0
+    fi
+    echo "    No implementation-ready beads. Polling again in ${POLL_INTERVAL_SECS}s..."
+    sleep "${POLL_INTERVAL_SECS}"
+    continue
+  fi
+
+  echo "==> Found ${count} implementation-ready bead(s)"
+
+  # Process the highest-priority ready bead.
+  bead_id=$(echo "${ready_beads}" | python3 -c "import sys,json; beads=json.load(sys.stdin); print(beads[0]['id'] if beads else '')" 2>/dev/null || true)
+
+  if [ -z "${bead_id}" ]; then
+    echo "    Could not parse bead ID from ready list. Sleeping..." >&2
+    sleep "${POLL_INTERVAL_SECS}"
+    continue
+  fi
+
+  # Determine current stage from the molecule's current step.
+  stage_role=$(bd mol current "$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
+    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)" \
+    2>/dev/null | grep '^id:' | awk '{print $2}' || echo "preflight")
+
+  # Derive session ID (UUIDv5) for resumable sessions.
+  session_id=$(uuidv5 "${bead_id}:${stage_role}")
+
+  # Resolve cwd for this stage.
+  stage_cwd=$(resolve_cwd "${bead_id}" "${stage_role}")
+
+  echo "    Bead:     ${bead_id}"
+  echo "    Stage:    ${stage_role}"
+  echo "    cwd:      ${stage_cwd}"
+  echo "    Session:  ${session_id}"
+
+  if "${OPT_DRY_RUN}"; then
+    echo "    [dry-run] would spawn: claude -p --session-id ${session_id} \"/implement-bead ${bead_id}\""
+  else
+    echo "    Spawning claude -p ..."
+    (cd "${stage_cwd}" && claude -p --session-id "${session_id}" "/implement-bead ${bead_id}")
+    echo "    claude -p exited."
+  fi
+
+  processed=$((processed + 1))
+
+  if "${OPT_ONCE}"; then
+    echo "==> Exiting after one bead (--once)."
+    exit 0
+  fi
+
+  # Brief pause before next poll to avoid hammering bd.
+  sleep "${POLL_INTERVAL_SECS}"
+done

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -58,25 +58,12 @@ NAMESPACE_UUID="27ece4fd-4a06-49bf-a921-bf07ecb0dc10"
 
 uuidv5() {
   local name="$1"
-  # Use Python if available (most reliable cross-platform approach).
-  if command -v python3 &>/dev/null; then
-    python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('${NAMESPACE_UUID}'), '${name}'))"
-    return
+  if ! command -v python3 &>/dev/null; then
+    echo "ERROR: python3 not found — required for UUIDv5 derivation" >&2
+    exit 1
   fi
-  # Fallback: derive via openssl + manual v5 encoding.
-  # RFC 4122 §4.3: SHA-1 hash of namespace bytes + name, then format.
-  local ns_hex
-  ns_hex=$(echo -n "${NAMESPACE_UUID}" | tr -d '-')
-  local hash
-  hash=$(printf '%s%s' "${ns_hex}" "${name}" | xxd -r -p | openssl sha1 -binary | xxd -p | tr -d '\n')
-  # Insert version (5) and variant bits.
-  local b0="${hash:0:8}"
-  local b1="${hash:8:4}"
-  local b2="5${hash:13:3}"  # version = 5
-  local b3
-  b3=$(printf '%02x' $(( (16#${hash:16:2} & 0x3f) | 0x80 )))
-  local b4="${hash:18:2}${hash:20:8}"
-  echo "${b0}-${b1}-${b2}-${b3}${hash:18:2}-${hash:20:12}"
+  python3 -c "import sys, uuid; print(uuid.uuid5(uuid.UUID(sys.argv[1]), sys.argv[2]))" \
+    "${NAMESPACE_UUID}" "${name}"
 }
 
 # ---------------------------------------------------------------------------
@@ -111,7 +98,12 @@ resolve_cwd() {
         return
       fi
 
-      decoded_path=$(echo "${encoded_path}" | sed 's/__/\x00/g' | sed 's/_u/_/g' | sed 's/\x00/\//g')
+      decoded_path=$(python3 -c "
+import sys
+s = sys.argv[1]
+out = s.replace('__', '\x00').replace('_u', '_').replace('\x00', '/')
+print(out)
+" "${encoded_path}")
       echo "${decoded_path}"
       ;;
   esac
@@ -156,8 +148,13 @@ while true; do
 
   echo "==> Found ${count} implementation-ready bead(s)"
 
-  # Process the highest-priority ready bead.
-  bead_id=$(echo "${ready_beads}" | python3 -c "import sys,json; beads=json.load(sys.stdin); print(beads[0]['id'] if beads else '')" 2>/dev/null || true)
+  # Process the highest-priority ready bead (lowest numeric priority value = highest urgency).
+  bead_id=$(echo "${ready_beads}" | python3 -c "
+import sys, json
+beads = json.load(sys.stdin)
+beads.sort(key=lambda b: b.get('priority', 99))
+print(beads[0]['id'] if beads else '')
+" 2>/dev/null || true)
 
   if [ -z "${bead_id}" ]; then
     echo "    Could not parse bead ID from ready list. Sleeping..." >&2
@@ -166,9 +163,27 @@ while true; do
   fi
 
   # Determine current stage from the molecule's current step.
-  stage_role=$(bd mol current "$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
-    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)" \
-    2>/dev/null | grep '^id:' | awk '{print $2}' || echo "preflight")
+  mol_id_for_stage=$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
+    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)
+  if [ -z "${mol_id_for_stage}" ]; then
+    stage_role="preflight"
+  else
+    stage_role=$(bd mol current "${mol_id_for_stage}" --json 2>/dev/null \
+      | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+steps = data if isinstance(data, list) else [data]
+ready = [s for s in steps if s.get('status') not in ('closed',) and s.get('id')]
+if not ready:
+    sys.exit('ERROR: no current step found in molecule')
+print(ready[0].get('role') or ready[0].get('id'))
+" 2>/dev/null)
+    if [ -z "${stage_role}" ]; then
+      echo "ERROR: could not determine current stage for mol ${mol_id_for_stage} — molecule may be complete or malformed" >&2
+      sleep "${POLL_INTERVAL_SECS}"
+      continue
+    fi
+  fi
 
   # Derive session ID (UUIDv5) for resumable sessions.
   session_id=$(uuidv5 "${bead_id}:${stage_role}")

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -69,11 +69,28 @@ uuidv5() {
 # ---------------------------------------------------------------------------
 # Find the active (non-closed) molecule for a bead, via the
 # for-bead-<bead-id> label convention. Echoes the molecule ID, or empty.
+# If >1 active molecules exist, emits a warning and returns the most-recently
+# updated one so the caller can surface the ambiguity.
 # ---------------------------------------------------------------------------
 active_mol_id() {
   local bead_id="$1"
   bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
-    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null \
+    | python3 -c "
+import sys, json
+mols = [m for m in json.load(sys.stdin) if m.get('status') != 'closed']
+if not mols:
+    print('')
+    sys.exit(0)
+if len(mols) > 1:
+    mols.sort(key=lambda m: m.get('updated_at', ''), reverse=True)
+    print(
+        f'WARNING: {len(mols)} active molecules for bead — ambiguity detected; '
+        f'resuming most-recently-updated ({mols[0][\"id\"]}). '
+        f'Investigate: {[m[\"id\"] for m in mols]}',
+        file=sys.stderr
+    )
+print(mols[0]['id'])
+" 2>/dev/null \
     || true
 }
 
@@ -104,6 +121,7 @@ resolve_cwd() {
         | grep '^worktree-path-' | head -1 | sed 's/^worktree-path-//' || true)
 
       if [ -z "${encoded_path}" ]; then
+        # No worktree-path label — fall back to repo root (pre-worktree stages).
         echo "${REPO_ROOT}"
         return
       fi
@@ -114,6 +132,19 @@ s = sys.argv[1]
 out = s.replace('__', '\x00').replace('_u', '_').replace('\x00', '/')
 print(out)
 " "${encoded_path}")
+
+      # Validate: directory must exist.
+      if [ ! -d "${decoded_path}" ]; then
+        echo "ERROR: worktree-path label decoded to '${decoded_path}' but that directory does not exist" >&2
+        exit 1
+      fi
+
+      # Validate: path must be inside a git work tree.
+      if ! git -C "${decoded_path}" rev-parse --is-inside-work-tree &>/dev/null; then
+        echo "ERROR: decoded worktree path '${decoded_path}' is not inside a git work tree" >&2
+        exit 1
+      fi
+
       echo "${decoded_path}"
       ;;
   esac
@@ -177,6 +208,9 @@ print(beads[0]['id'] if beads else '')
   if [ -z "${mol_id_for_stage}" ]; then
     stage_role="preflight"
   else
+    # Known stage roles per architecture spec section 5.4.
+    KNOWN_STAGE_ROLES="preflight red-tests green-loop quality-sweep verify-ac create-pr review-cycle merge-or-handoff diagnose"
+
     stage_role=$(bd mol current "${mol_id_for_stage}" --json 2>/dev/null \
       | python3 -c "
 import sys, json
@@ -186,7 +220,8 @@ ready = [s for s in steps if s.get('status') not in ('closed',) and s.get('id')]
 if not ready:
     print('__complete__')
     sys.exit(0)
-print(ready[0].get('role') or ready[0].get('id'))
+role = ready[0].get('role') or ''
+print(role)
 " 2>/dev/null || true)
     if [ "${stage_role}" = "__complete__" ]; then
       echo "    Molecule ${mol_id_for_stage} is complete for bead ${bead_id} — skipping." >&2
@@ -195,6 +230,20 @@ print(ready[0].get('role') or ready[0].get('id'))
     fi
     if [ -z "${stage_role}" ]; then
       echo "ERROR: could not determine current stage for mol ${mol_id_for_stage} — molecule may be malformed" >&2
+      sleep "${POLL_INTERVAL_SECS}"
+      continue
+    fi
+
+    # Validate stage_role against the known set.
+    role_valid=false
+    for known in ${KNOWN_STAGE_ROLES}; do
+      if [ "${stage_role}" = "${known}" ]; then
+        role_valid=true
+        break
+      fi
+    done
+    if ! "${role_valid}"; then
+      echo "ERROR: derived stage role '${stage_role}' is not in the known set (${KNOWN_STAGE_ROLES}) — molecule step may be missing a role field or using a step ID instead; mol=${mol_id_for_stage}" >&2
       sleep "${POLL_INTERVAL_SECS}"
       continue
     fi

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -67,6 +67,17 @@ uuidv5() {
 }
 
 # ---------------------------------------------------------------------------
+# Find the active (non-closed) molecule for a bead, via the
+# for-bead-<bead-id> label convention. Echoes the molecule ID, or empty.
+# ---------------------------------------------------------------------------
+active_mol_id() {
+  local bead_id="$1"
+  bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
+    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null \
+    || true
+}
+
+# ---------------------------------------------------------------------------
 # cwd resolution per architecture spec section 5.4
 # ---------------------------------------------------------------------------
 resolve_cwd() {
@@ -80,8 +91,7 @@ resolve_cwd() {
     *)
       # Decode worktree-path-* label from the bead's active molecule.
       local mol_id encoded_path decoded_path
-      mol_id=$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
-        | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)
+      mol_id=$(active_mol_id "${bead_id}")
 
       if [ -z "${mol_id}" ]; then
         # No active molecule yet — fall back to repo root (preflight will pour one).
@@ -163,8 +173,7 @@ print(beads[0]['id'] if beads else '')
   fi
 
   # Determine current stage from the molecule's current step.
-  mol_id_for_stage=$(bd list --label "for-bead-${bead_id}" --type molecule --json 2>/dev/null \
-    | python3 -c "import sys,json; mols=[m for m in json.load(sys.stdin) if m.get('status')!='closed']; print(mols[0]['id'] if mols else '')" 2>/dev/null || true)
+  mol_id_for_stage=$(active_mol_id "${bead_id}")
   if [ -z "${mol_id_for_stage}" ]; then
     stage_role="preflight"
   else

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -184,11 +184,17 @@ data = json.load(sys.stdin)
 steps = data if isinstance(data, list) else [data]
 ready = [s for s in steps if s.get('status') not in ('closed',) and s.get('id')]
 if not ready:
-    sys.exit('ERROR: no current step found in molecule')
+    print('__complete__')
+    sys.exit(0)
 print(ready[0].get('role') or ready[0].get('id'))
-" 2>/dev/null)
+" 2>/dev/null || true)
+    if [ "${stage_role}" = "__complete__" ]; then
+      echo "    Molecule ${mol_id_for_stage} is complete for bead ${bead_id} — skipping." >&2
+      sleep "${POLL_INTERVAL_SECS}"
+      continue
+    fi
     if [ -z "${stage_role}" ]; then
-      echo "ERROR: could not determine current stage for mol ${mol_id_for_stage} — molecule may be complete or malformed" >&2
+      echo "ERROR: could not determine current stage for mol ${mol_id_for_stage} — molecule may be malformed" >&2
       sleep "${POLL_INTERVAL_SECS}"
       continue
     fi

--- a/scripts/bead-driver-test.sh
+++ b/scripts/bead-driver-test.sh
@@ -90,7 +90,7 @@ if len(mols) > 1:
         file=sys.stderr
     )
 print(mols[0]['id'])
-" 2>/dev/null \
+" \
     || true
 }
 
@@ -111,9 +111,11 @@ resolve_cwd() {
       mol_id=$(active_mol_id "${bead_id}")
 
       if [ -z "${mol_id}" ]; then
-        # No active molecule yet — fall back to repo root (preflight will pour one).
-        echo "${REPO_ROOT}"
-        return
+        # No active molecule yet — this is only valid for preflight/merge-or-handoff,
+        # but those stages are handled above by the case statement. Reaching here
+        # means an unknown stage has no molecule, which is an error.
+        echo "ERROR: no active molecule for bead ${bead_id} at stage '${stage_role}' — preflight may not have run yet" >&2
+        exit 1
       fi
 
       # Decode worktree-path label: first __ -> /, then _u -> _
@@ -121,9 +123,9 @@ resolve_cwd() {
         | grep '^worktree-path-' | head -1 | sed 's/^worktree-path-//' || true)
 
       if [ -z "${encoded_path}" ]; then
-        # No worktree-path label — fall back to repo root (pre-worktree stages).
-        echo "${REPO_ROOT}"
-        return
+        # Molecule exists but has no worktree-path label — always an error.
+        echo "ERROR: molecule ${mol_id} has no worktree-path label" >&2
+        exit 1
       fi
 
       decoded_path=$(python3 -c "

--- a/scripts/smoke/setup.sh
+++ b/scripts/smoke/setup.sh
@@ -2,9 +2,10 @@
 # scripts/smoke/setup.sh
 # Smoke test harness for the bead pipeline architecture (bead 7bk.9).
 #
-# Red-phase: sets up the scratch environment and seed bead, but does NOT
-# yet invoke bead-driver-test.sh (which doesn't exist yet).  Exits with a
-# clear TODO message so CI sees a controlled failure.
+# Sets up a scratch project directory with a minimal source/test layout,
+# a project-config.toml, an initialized beads tracker, and a seed bead.
+# Exits non-zero with a TODO marker because end-to-end driver invocation
+# is not yet wired into this harness — wire it in before flipping the exit.
 #
 # Usage: bash scripts/smoke/setup.sh
 # Environment variables:
@@ -33,7 +34,7 @@ chmod +x "${SMOKE_DIR}/src/hello.sh"
 mkdir -p "${SMOKE_DIR}/tests"
 cat > "${SMOKE_DIR}/tests/test_hello.sh" <<'TESTEOF'
 #!/usr/bin/env bash
-# Intentionally failing placeholder test (red phase)
+# Intentionally failing placeholder test — red-tests stage will replace it.
 echo "FAIL: test_hello not yet implemented"
 exit 1
 TESTEOF
@@ -81,12 +82,14 @@ fi
 echo "    Seed bead id: ${SEED_ID:-<unknown>}"
 
 # ---------------------------------------------------------------------------
-# TODO: invoke bead-driver-test.sh once scope item 4 is implemented
+# TODO: invoke scripts/bead-driver-test.sh against ${SMOKE_DIR} to exercise
+# the full pipeline end-to-end. Until that wiring lands, exit non-zero so
+# CI flags this harness as incomplete.
 # ---------------------------------------------------------------------------
 echo ""
-echo "TODO: scripts/bead-driver-test.sh does not exist yet."
-echo "      This is expected during the red phase (bead 7bk.9 scope item 4)."
-echo "      Re-run this script after the green phase to exercise the full pipeline."
+echo "TODO: end-to-end driver invocation not yet wired into this harness."
+echo "      Seed bead and scratch project are ready at: ${SMOKE_DIR}"
+echo "      Wire in: bash scripts/bead-driver-test.sh --once (with REPO_ROOT=${SMOKE_DIR})"
 echo ""
 echo "Smoke setup complete. Scratch dir: ${SMOKE_DIR}"
-exit 1  # Controlled red-phase failure — driver not yet available
+exit 1  # Controlled failure until end-to-end driver invocation is wired in.

--- a/scripts/smoke/setup.sh
+++ b/scripts/smoke/setup.sh
@@ -40,16 +40,18 @@ TESTEOF
 chmod +x "${SMOKE_DIR}/tests/test_hello.sh"
 
 # ---------------------------------------------------------------------------
-# project-config.toml (minimal schema — will be validated once scope item 9 lands)
+# project-config.toml (minimal subset matching actual schema per section 5.1)
 # ---------------------------------------------------------------------------
 cat > "${SMOKE_DIR}/project-config.toml" <<'CFGEOF'
 [project]
 name = "smoke-test-project"
-language = "bash"
+default-formula = "implement-feature"
 
-[bead-pipeline]
-# Smoke-only: driver path will be validated by bead-driver-test.sh
-driver = "scripts/bead-driver-test.sh"
+[gates]
+build = ""
+typecheck = ""
+lint = ""
+test = "echo 'no tests'"
 CFGEOF
 
 # ---------------------------------------------------------------------------

--- a/scripts/smoke/setup.sh
+++ b/scripts/smoke/setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/smoke/setup.sh
+# Smoke test harness for the bead pipeline architecture (bead 7bk.9).
+#
+# Red-phase: sets up the scratch environment and seed bead, but does NOT
+# yet invoke bead-driver-test.sh (which doesn't exist yet).  Exits with a
+# clear TODO message so CI sees a controlled failure.
+#
+# Usage: bash scripts/smoke/setup.sh
+# Environment variables:
+#   SMOKE_DIR  - override the scratch directory (default: /tmp/bead-pipeline-smoke-<ts>)
+
+set -euo pipefail
+
+TIMESTAMP=$(date +%s)
+SMOKE_DIR="${SMOKE_DIR:-/tmp/bead-pipeline-smoke-${TIMESTAMP}}"
+
+echo "==> Creating smoke scratch directory: ${SMOKE_DIR}"
+mkdir -p "${SMOKE_DIR}"
+
+# ---------------------------------------------------------------------------
+# Minimal project structure
+# ---------------------------------------------------------------------------
+echo "==> Writing project files"
+
+mkdir -p "${SMOKE_DIR}/src"
+cat > "${SMOKE_DIR}/src/hello.sh" <<'SRCEOF'
+#!/usr/bin/env bash
+echo "hello from smoke project"
+SRCEOF
+chmod +x "${SMOKE_DIR}/src/hello.sh"
+
+mkdir -p "${SMOKE_DIR}/tests"
+cat > "${SMOKE_DIR}/tests/test_hello.sh" <<'TESTEOF'
+#!/usr/bin/env bash
+# Intentionally failing placeholder test (red phase)
+echo "FAIL: test_hello not yet implemented"
+exit 1
+TESTEOF
+chmod +x "${SMOKE_DIR}/tests/test_hello.sh"
+
+# ---------------------------------------------------------------------------
+# project-config.toml (minimal schema — will be validated once scope item 9 lands)
+# ---------------------------------------------------------------------------
+cat > "${SMOKE_DIR}/project-config.toml" <<'CFGEOF'
+[project]
+name = "smoke-test-project"
+language = "bash"
+
+[bead-pipeline]
+# Smoke-only: driver path will be validated by bead-driver-test.sh
+driver = "scripts/bead-driver-test.sh"
+CFGEOF
+
+# ---------------------------------------------------------------------------
+# Initialize beads tracker
+# ---------------------------------------------------------------------------
+echo "==> Initialising beads in ${SMOKE_DIR}"
+cd "${SMOKE_DIR}"
+if ! command -v bd &>/dev/null; then
+  echo "ERROR: 'bd' not found on PATH — install beads before running smoke tests"
+  exit 1
+fi
+bd init --prefix smoke 2>&1 | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+# Seed bead
+# ---------------------------------------------------------------------------
+echo "==> Creating seed bead"
+SEED_ID=$(bd create --type feature --priority 2 \
+  --title "Smoke: hello-world feature" \
+  --description "Trivial feature to exercise the full bead pipeline end-to-end." \
+  --json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+
+if [ -z "${SEED_ID}" ]; then
+  # bd create may print id differently; fall back to listing
+  SEED_ID=$(bd list --json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+fi
+echo "    Seed bead id: ${SEED_ID:-<unknown>}"
+
+# ---------------------------------------------------------------------------
+# TODO: invoke bead-driver-test.sh once scope item 4 is implemented
+# ---------------------------------------------------------------------------
+echo ""
+echo "TODO: scripts/bead-driver-test.sh does not exist yet."
+echo "      This is expected during the red phase (bead 7bk.9 scope item 4)."
+echo "      Re-run this script after the green phase to exercise the full pipeline."
+echo ""
+echo "Smoke setup complete. Scratch dir: ${SMOKE_DIR}"
+exit 1  # Controlled red-phase failure — driver not yet available

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/smoke/verify-artifacts.sh
+# Artifact existence check for bead 7bk.9 (Per-step claude -p orchestration).
+#
+# Checks that every artifact the bead is required to produce actually exists.
+# Intended to be run at the END of the green phase; MUST fail during the red
+# phase because the artifacts do not yet exist.
+#
+# Exit codes:
+#   0  — all checks pass
+#   1  — one or more checks failed
+#
+# Usage: bash scripts/smoke/verify-artifacts.sh [REPO_ROOT]
+#   REPO_ROOT defaults to the directory two levels above this script.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${1:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+PASS=0
+FAIL=0
+
+check_file() {
+  local label="$1"
+  local path="$2"
+  if [ -f "${path}" ]; then
+    echo "  PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  ${label}"
+    echo "        expected: ${path}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_executable() {
+  local label="$1"
+  local path="$2"
+  if [ -x "${path}" ]; then
+    echo "  PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  ${label}"
+    echo "        expected executable: ${path}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_file_contains() {
+  local label="$1"
+  local path="$2"
+  local pattern="$3"
+  if [ -f "${path}" ] && grep -q "${pattern}" "${path}"; then
+    echo "  PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  ${label}"
+    echo "        expected '${pattern}' in: ${path}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "==> Artifact verification for bead 7bk.9"
+echo "    Repo root: ${REPO_ROOT}"
+echo ""
+
+# Scope item 2: slash command
+check_file \
+  "implement-bead slash command exists" \
+  "${REPO_ROOT}/src/plugins/beads/.claude/commands/implement-bead.md"
+
+# Scope item 7: bead-implementor agent
+check_file \
+  "bead-implementor agent exists" \
+  "${REPO_ROOT}/src/plugins/beads/.agents/agents/bead-implementor.md"
+
+# Scope item 4: shell driver script
+check_file \
+  "bead-driver-test.sh exists" \
+  "${REPO_ROOT}/scripts/bead-driver-test.sh"
+
+# Scope item 4 / setup.sh: setup script must itself be executable
+check_executable \
+  "scripts/smoke/setup.sh is executable" \
+  "${REPO_ROOT}/scripts/smoke/setup.sh"
+
+# Scope item 9: project-config.toml at repo root
+check_file \
+  "project-config.toml exists at repo root" \
+  "${REPO_ROOT}/project-config.toml"
+
+# Scope item 5: implement-feature formula has 8 role-named stages (check "preflight")
+check_file_contains \
+  "implement-feature.formula.toml contains 'preflight' stage" \
+  "${REPO_ROOT}/src/plugins/beads/.beads/formulas/implement-feature.formula.toml" \
+  "preflight"
+
+# Scope item 6: fix-bug formula has diagnose stage
+check_file_contains \
+  "fix-bug.formula.toml contains 'diagnose' stage name" \
+  "${REPO_ROOT}/src/plugins/beads/.beads/formulas/fix-bug.formula.toml" \
+  'name = "diagnose"'
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [ "${FAIL}" -gt 0 ]; then
+  echo "FAIL — ${FAIL} artifact(s) missing or incorrect"
+  exit 1
+fi
+
+echo "PASS — all artifacts verified"
+exit 0

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -13,6 +13,9 @@
 # Usage: bash scripts/smoke/verify-artifacts.sh [REPO_ROOT]
 #   REPO_ROOT defaults to the directory two levels above this script.
 
+# -e is intentionally absent: we want ALL checks to run and accumulate into
+# PASS/FAIL counts before deciding the exit code at the end, not bail on the
+# first failed check_file / check_executable / check_file_contains call.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,7 +54,7 @@ check_file_contains() {
   local label="$1"
   local path="$2"
   local pattern="$3"
-  if [ -f "${path}" ] && grep -q "${pattern}" "${path}"; then
+  if [ -f "${path}" ] && grep -qF "${pattern}" "${path}"; then
     echo "  PASS  ${label}"
     PASS=$((PASS + 1))
   else

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -100,7 +100,7 @@ check_file_contains \
 check_file_contains \
   "fix-bug.formula.toml contains 'diagnose' stage name" \
   "${REPO_ROOT}/src/plugins/beads/.beads/formulas/fix-bug.formula.toml" \
-  'name = "diagnose"'
+  '"diagnose"'
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/src/plugins/beads/.agents/agents/bead-implementor.md
+++ b/src/plugins/beads/.agents/agents/bead-implementor.md
@@ -1,0 +1,149 @@
+---
+name: bead-implementor
+description: |-
+  TDD test-writing in red-tests, iterative implementation in green-loop, and
+  debugging in diagnose. Dispatched by the per-stage orchestrator (via the
+  shell driver's claude -p invocation) to do all hands-on coding work inside
+  a bead's worktree.
+
+  Examples:
+  <example>
+  Context: red-tests stage orchestrator needs failing tests written against the bead's AC.
+  user: "Write failing tests for the AC bullets in bead proj-42. Worktree: /path/to/worktree."
+  assistant: "Dispatching bead-implementor to write the TDD red-phase tests — it'll cd into the worktree, write tests against the AC, run them to confirm they fail, and report back."
+  <commentary>
+  This is the canonical red-tests invocation: the orchestrator hands the agent an AC list and a worktree path; the agent writes tests, confirms failure, and returns evidence.
+  </commentary>
+  </example>
+  <example>
+  Context: green-loop iteration 1 — need minimum implementation to make failing tests pass.
+  user: "Make the failing tests in the worktree pass. Root cause note: <diagnose output>. RALF-IT iter 1."
+  assistant: "Dispatching bead-implementor at effort:high for iteration 1 — it'll implement the minimum code to make tests green, run the full suite, and return a RALF-IT iteration report."
+  <commentary>
+  Green-loop iter 1 runs at effort:high; subsequent iterations at effort:medium. The agent does not decide iteration count — the orchestrator does.
+  </commentary>
+  </example>
+tools: Read, Edit, Write, Grep, Glob, Bash
+skills:
+  - superpowers:test-driven-development
+  - superpowers:writing-unit-tests
+  - superpowers:testing-anti-patterns
+  - superpowers:using-git-worktrees
+  - superpowers:verification-before-completion
+  - superpowers:systematic-debugging
+  - superpowers:root-cause-tracing
+model: sonnet
+effort: medium
+color: blue
+---
+
+You are the bead-implementor: the hands-on coding agent dispatched by the
+per-stage orchestrator inside the bead pipeline. You write tests, implement
+code, debug, and verify — always inside the worktree path given to you.
+
+## Operating Contract
+
+The orchestrator dispatches you with:
+
+1. A **worktree path** — cd into it before any work. Never operate from a
+   different directory. Validate it is a real git worktree:
+   ```bash
+   git -C <path> rev-parse --is-inside-work-tree
+   ```
+2. A **stage name** — one of: `diagnose`, `red-tests`, `green-loop`.
+3. **Stage-specific inputs** — AC bullets, root-cause note, iteration number,
+   previous iteration state. Read whatever the orchestrator supplies.
+4. A **step-bead ID** — close it when you are done:
+   ```bash
+   bd close <step-bead-id> --reason "<brief summary of what you did>"
+   ```
+
+## Stage Behaviors
+
+### diagnose (bug-class beads only)
+
+Apply `superpowers:systematic-debugging` and `superpowers:root-cause-tracing`.
+
+1. Reproduce the bug reliably from the bead description.
+2. Trace the failure to the root cause — not the symptom.
+3. Append a structured root-cause note to the step-bead:
+   ```bash
+   bd update <step-bead-id> --append-notes "Root cause: <explanation>"
+   ```
+4. If the root cause exceeds the bead's stated scope, do NOT fix it inline.
+   Instead, apply the human-flag protocol and exit:
+   ```bash
+   bd label add <step-bead-id> human
+   bd label add <source-bead-id> human
+   bd update <step-bead-id> --append-notes "Root cause exceeds scope: <reason>"
+   ```
+
+### red-tests
+
+Apply `superpowers:test-driven-development`, `superpowers:writing-unit-tests`,
+`superpowers:testing-anti-patterns`.
+
+1. Read every `[m]`-tagged AC bullet from the bead description.
+2. Write failing tests covering: happy path, edge cases, error paths.
+3. Run the tests and confirm they FAIL. Failure is correct.
+4. Commit the failing tests to the feature branch.
+5. Do NOT write any implementation code in this stage.
+
+Rules:
+- Do NOT mock what you have not verified you understand.
+- Do NOT write test-only methods in production code.
+- If a test passes before any implementation, either the test is wrong or the
+  feature already exists. Investigate; do not proceed blindly.
+
+### green-loop
+
+Apply `superpowers:test-driven-development`.
+
+1. Write the minimum code to make all failing tests pass.
+2. Run the full test suite after each meaningful change.
+3. At the end of the iteration, run the quality gate (build/typecheck/lint/test).
+4. Commit implementation to the feature branch.
+5. Report: number of tests passing, build/lint/typecheck status, any remaining
+   failing tests.
+
+Iteration effort: the orchestrator sets effort via frontmatter override at
+dispatch time (effort:high for iter 1, effort:medium for iters 2+). Do not
+change this.
+
+Rules:
+- Minimum viable implementation — write only what tests require.
+- No speculative features, no over-engineering.
+- Fix the root cause (for bug-class beads), not the symptom.
+
+## What You Do NOT Do
+
+- **No orchestration.** You do not read the molecule DAG, claim source beads,
+  or drive the pipeline. The orchestrator does that.
+- **No merge actions.** No `gh pr merge`, no squash.
+- **No scope expansion.** If you discover work outside the bead's stated scope,
+  file a new bead and link it; do not fix it inline.
+- **No unauthorized git operations.** No force-push, no branch deletion, no
+  `git reset --hard` unless the orchestrator explicitly instructs.
+
+## Verification Before Completion
+
+Apply `superpowers:verification-before-completion`. Never declare a stage done
+without running the relevant commands and confirming output:
+
+- Tests: run and paste exit code + first-failure excerpt if non-zero.
+- Build: run and paste exit code.
+- Lint/typecheck: run and paste exit code.
+
+"I believe it passes" is not evidence. Run the commands.
+
+## Discovered Work
+
+If you find bugs, TODOs, or related work during implementation, capture them
+immediately via the orchestrator (or directly if you have bd access):
+
+```bash
+NEW=$(bd create "Found: <description>" -t bug -p 2 --json | jq -r '.id')
+bd dep add "$NEW" <source-bead-id> --type discovered-from
+```
+
+Do NOT fix discovered issues inline. File and move on.

--- a/src/plugins/beads/.agents/agents/bead-implementor.md
+++ b/src/plugins/beads/.agents/agents/bead-implementor.md
@@ -1,10 +1,9 @@
 ---
 name: bead-implementor
 description: |-
-  TDD test-writing in red-tests, iterative implementation in green-loop, and
-  debugging in diagnose. Dispatched by the per-stage orchestrator (via the
-  shell driver's claude -p invocation) to do all hands-on coding work inside
-  a bead's worktree.
+  Hands-on coding subagent for the bead pipeline. Owns all implementation work
+  within a single pipeline stage: writing failing tests (red-tests), iterating
+  code to make them pass (green-loop), or diagnosing root causes (diagnose).
 
   Examples:
   <example>

--- a/src/plugins/beads/.agents/agents/bead-implementor.md
+++ b/src/plugins/beads/.agents/agents/bead-implementor.md
@@ -53,10 +53,11 @@ The orchestrator dispatches you with:
 2. A **stage name** — one of: `diagnose`, `red-tests`, `green-loop`.
 3. **Stage-specific inputs** — AC bullets, root-cause note, iteration number,
    previous iteration state. Read whatever the orchestrator supplies.
-4. A **step-bead ID** — close it when you are done:
-   ```bash
-   bd close <step-bead-id> --reason "<brief summary of what you did>"
-   ```
+4. A **step-bead ID** — reference it for notes and updates, but do NOT
+   close it. Step-bead lifecycle (open → close) is owned exclusively by
+   the `implement-bead` orchestrator. The orchestrator closes the step-bead
+   after you return. If you close it, `bd close` will fail (already closed)
+   or advance the molecule outside the orchestrator's control.
 
 ## Stage Behaviors
 

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -2,38 +2,29 @@
 name: implement-bead
 description: >
   Use when a bead has the implementation-ready label and is ready for
-  autonomous execution. Pours the appropriate formula, then orchestrates
-  subagents through the molecule DAG step by step. The invoking agent is
-  the ORCHESTRATOR only — all implementation work is done by subagents.
-  Do NOT invoke this skill for beads that have not been through brainstorming
-  (use start-bead to route correctly).
+  autonomous execution. Drives ONE stage of the bead's molecule and exits.
+  Invoked by the shell driver via `claude -p /implement-bead <bead-id>`.
+  The invoking agent is the ORCHESTRATOR only — all implementation work
+  is done by subagents. Do NOT invoke this skill for beads that have not
+  been through brainstorming (use start-bead to route correctly).
 model: sonnet[1m]
 effort: high
 ---
 
 # implement-bead
 
-Pour a formula and orchestrate subagents through the resulting molecule DAG.
-The main agent manages; subagents build.
+Drive ONE stage of the bead's molecule DAG and exit. The shell driver
+(`scripts/bead-driver-test.sh`) calls this skill once per ready stage via
+`claude -p --session-id <uuidv5> "/implement-bead <bead-id>"`. This skill
+reads the current step, executes it, closes the step, and exits. The shell
+driver handles looping — this skill MUST NOT loop to the next step.
 
 ## When to Use
 
-The bead MUST have label `implementation-ready`. One of the following
-invocation contexts must apply:
-
-- **`run-queue` in a dedicated session** — autonomous; no per-bead user
-  authorization needed (the operator authorized the queue when they
-  started it).
-- **`start-bead` Route A** for a bead where no
-  `implementation-readied-session-<sid-prefix-8>` label matching the
-  current session's SID prefix is present (the marker for the current
-  session is absent, regardless of whether other session markers exist).
-- **In-session override** — user explicitly and affirmatively authorizes
-  implementation in the current session (e.g. "implement it now",
-  "yes, go"). Completing brainstorming in the same session is NOT
-  implicit authorization.
-
-**Do NOT use when:** bead lacks `implementation-ready` label — use `start-bead`.
+- Invoked by the shell driver via `claude -p /implement-bead <bead-id>`
+- The bead MUST have label `implementation-ready`
+- Do NOT invoke directly for beads that lack `implementation-ready` — use `start-bead`
+- Do NOT invoke in the same session where brainstorming is happening (session separation rule)
 
 ## The Process
 
@@ -67,15 +58,14 @@ Decide from the result array:
   unlabeled in-progress work. Escalate:
   ```bash
   bd comments add <bead-id> "Probe returned no labeled molecules, but I suspect an unlabeled molecule exists because: <reason>."
-  bd human <bead-id>
+  bd label add <bead-id> human
   ```
-  Otherwise proceed to Step 3.
+  Otherwise proceed to Step 3 to pour a new molecule.
 
-- **length 1** → extract and resume (go to Step 4):
+- **length 1** → extract and go directly to Step 4 (find the current step):
   ```bash
   MOL_ID=$(bd list --label for-bead-<bead-id> --type molecule --json \
     | jq -r '[.[] | select(.status != "closed")] | .[0].id')
-  bd mol current "$MOL_ID"
   ```
   Do NOT pour a new formula over existing in-progress work.
 
@@ -89,37 +79,27 @@ Decide from the result array:
     | jq '[.[] | select(.status != "closed")
                | {id, title, status, updated_at, created_at}]'
   ```
-  Resolve if one clearly supersedes the others — an open
-  implement-feature/fix-bug pour supersedes a stale brainstorm-bead
-  wisp; a more recent pour supersedes an abandoned earlier one. Resume
-  the winner (go to Step 4) and tell the user your reasoning; the user
-  can burn the loser later.
+  Resolve if one clearly supersedes the others. Resume the winner (go to
+  Step 4) and record your reasoning. The user can burn the loser later.
 
-  If the molecules cannot be cleanly disambiguated, escalate WITH your
-  analysis — the human should see your read-out, not a blank flag:
+  If molecules cannot be cleanly disambiguated, escalate WITH your analysis:
   ```bash
-  bd comments add <bead-id> "N active molecules for this bead:
-    - <mol-id-1> (<formula>, status=<s>, updated <ts>): <analysis>
-    - <mol-id-2> (<formula>, status=<s>, updated <ts>): <analysis>
-    Assessment: <duplicative | legacy | needs manual merge>
-    Recommended action: <resume X / burn Y / user decides>"
-  bd human <bead-id>
+  bd comments add <bead-id> "N active molecules for this bead: ..."
+  bd label add <bead-id> human
   ```
   Do NOT silently pick one.
 
 See `rules/beads.md` ("Molecule → bead linkage convention") for the
 stamp procedure applied in Step 3.
 
-### Step 3: Pour the Formula
+### Step 3: Pour the Formula (only if no active molecule from Step 2)
 
 Select formula based on bead type:
 - `bug` → `fix-bug`
 - `feature`, `task`, `chore` → `implement-feature`
 
-Select pour vs. wisp:
-- **Pour** (default): work may span multiple sessions or is non-trivial
-- **Wisp**: only if the work is clearly completable in this single session
-  AND the user explicitly indicated so
+**Pour vs. wisp:** Default to pour (persistent across sessions). Wisp only
+if the bead is trivially small AND single-session completion is certain.
 
 ```bash
 # Default (pour — persistent across sessions)
@@ -134,8 +114,7 @@ bd mol pour fix-bug \
 ```
 
 Note the molecule ID from the output. Immediately stamp the bead→molecule
-lookup label so Step 2's existence probe can find this molecule on any
-future entry (see `rules/beads.md` "Molecule → bead linkage convention"):
+lookup label (see `rules/beads.md` "Molecule → bead linkage convention"):
 
 ```bash
 bd label add <mol-id> for-bead-<bead-id>
@@ -153,68 +132,55 @@ while [ -n "$PARENT" ]; do
 done
 ```
 
-If the bead arrived here via `start-bead` Route A after brainstorming
-in a prior session, the brainstorm-bead formula's `claim` step already
-set the bead (and ancestors) `in_progress` — re-running `bd update --status in_progress` is a safe no-op. Keep the walk here so the
-claim invariant holds no matter which path got us to implementation.
+### Step 4: Find the ONE Current Ready Step
 
-### Step 4: Orchestration Loop
+Query the molecule for its current step using `--json` (text-mode is
+unreliable — see beads bug `2dx`):
 
-Execute each molecule step by dispatching subagents. The main agent
-ONLY orchestrates — it does not write code, run tests, or create PRs.
-
+```bash
+bd mol current <mol-id> --json
 ```
-LOOP:
-  1. next_step = bd mol current <mol-id> --json
-  2. if no next step (molecule complete): exit loop
-  3. step_desc = bd show <step-bead-id>
-  4. dispatch subagent with step instructions (see below)
-  5. wait for subagent to complete and close step bead
-  6. report: "✓ <step title>" to user
-  7. check for bd human escalations: bd human list --json
-     if any new: surface to user and pause loop
-  8. go to 1
+
+If no current step is returned (molecule is complete or all steps closed),
+EXIT immediately. The shell driver will handle close-walk and cleanup.
+Do NOT squash or burn the molecule here — that is the driver's job.
+
+Extract the step bead ID from the result.
+
+### Step 5: Execute the Step
+
+Read the step bead's full description:
+
+```bash
+bd show <step-bead-id>
 ```
+
+Execute the instructions in that step bead. Dispatch subagents as needed
+per the step description. The step description is self-contained — the
+molecule's DAG enforces sequencing; you do not need to explain prior steps
+to each new subagent.
 
 **Subagent dispatch instructions** — for each step, pass:
 1. The full text of the step bead description (from `bd show <step-bead-id>`)
 2. The original bead context: title, AC, and bead ID
-3. The instruction: "Execute this step completely. When done, close the step
-   bead with `bd close <step-bead-id> --reason '<brief summary>'`.
-   Report back what you did."
+3. The cwd contract for this stage (decoded from the molecule's `worktree-path-*`
+   label for most stages; repo root for `preflight` and `merge-or-handoff`)
+4. The instruction: "Execute this step completely. Report back what you did."
 
 **Subagent isolation**: each subagent is independent and has no context
 from previous subagents. The step bead description must be self-contained.
-The molecule's DAG enforces sequencing — you do not need to re-explain
-previous steps to each new subagent.
 
-### Step 5: Molecule Complete
+### Step 6: Close the Step and EXIT
 
-When `bd mol current` returns no more steps:
+When the step is complete, close the step bead:
 
 ```bash
-bd mol squash <mol-id>   # compress to digest (pour)
-# or:
-bd mol burn <mol-id>     # discard (wisp)
+bd close <step-bead-id> --reason "<brief summary of what was done>"
 ```
 
-Report to the user:
-> "Molecule complete for <bead-id>. PR created and awaiting review.
->  Authorize merge when ready with: 'go ahead and merge PR #N'"
-
-## Pour vs. Wisp Decision Guide
-
-| Signal | Pour | Wisp |
-|--------|------|------|
-| Work may span sessions | ✓ | |
-| Complex feature, many steps | ✓ | |
-| User didn't specify | ✓ | |
-| "Quick", "small", "one-shot" in bead title | | ✓ |
-| User says "do it in this session" | | ✓ |
-| Trivial bug with obvious fix | | ✓ |
-
-**Default: Pour.** When in doubt, pour. A poured molecule that finishes in
-one session is fine. A wisped molecule that needs a second session is lost.
+Then EXIT. Do NOT loop to the next step. Do NOT call `bd mol current` again.
+The shell driver polls for the next ready step and spawns a new `claude -p`
+invocation for each subsequent stage.
 
 ## Important Constraints
 
@@ -226,12 +192,16 @@ The main agent MUST NOT:
 - Push branches
 - Make git commits
 
-All of these happen inside subagents executing molecule step beads (the runtime instances of the formula's step definitions).
+All of these happen inside subagents executing the molecule step bead's instructions.
+
+**One step per invocation.** This skill is called once per stage by the
+shell driver. Driving multiple steps in a single invocation defeats the
+per-stage context-bounding and session-id resumption model.
 
 **No unauthorized merges.**
 The implement-feature and fix-bug formulas end at `review-cycle`.
-They do NOT merge. Merging requires explicit user authorization
-and is handled separately via the `merge-and-cleanup` formula.
+They do NOT merge. Merging requires explicit user authorization and is
+handled separately via the `merge-and-cleanup` formula.
 
 **Discovered work:**
 If a subagent reports discovered work, create new beads immediately.
@@ -241,7 +211,8 @@ Do NOT add them to the current molecule or fix them inline.
 
 | Thought | Reality |
 |---------|---------|
-| "I'll just invoke `ralf-it` / `superpowers:subagent-driven-development` / `superpowers:executing-plans` directly" | No. `implement-bead` pours a formula; those methodology skills run INSIDE molecule steps, not as peers. |
+| "I'll loop to the next step before exiting" | No. One step per invocation. Exit after closing the step. The shell driver loops. |
+| "I'll invoke `ralf-it` / `superpowers:subagent-driven-development` directly" | No. Those methodology skills run INSIDE molecule steps, not as peers. |
 | "The step is small — I'll skip the subagent and do it in the main agent" | No. Main agent orchestrates, subagents implement. Dispatch even for small steps. |
 | "I'll skip the formula and just run the work directly" | The formula IS the workflow. Skipping it skips the gate. |
-| "Brainstorming finished cleanly, so the user must want implementation" | No. Hand off to run-queue by default. Ask or wait for explicit authorization. |
+| "Brainstorming finished cleanly, so the user must want implementation" | No. Hand off to run-queue / shell driver by default. |

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -199,9 +199,12 @@ shell driver. Driving multiple steps in a single invocation defeats the
 per-stage context-bounding and session-id resumption model.
 
 **No unauthorized merges.**
-The implement-feature and fix-bug formulas end at `review-cycle`.
-They do NOT merge. Merging requires explicit user authorization and is
-handled separately via the `merge-and-cleanup` formula.
+The implement-feature and fix-bug formulas end at `merge-or-handoff` (not
+`review-cycle`). The `merge-or-handoff` step may pour the `merge-and-cleanup`
+formula, but ONLY when the user has given explicit authorization ("go ahead and
+merge", "ship it", etc.). Completing a PR or finishing the review cycle is NOT
+authorization to merge. The `merge-and-cleanup` formula is the only authorized
+merge path — it requires explicit human sign-off before proceeding.
 
 **Discovered work:**
 If a subagent reports discovered work, create new beads immediately.

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -229,7 +229,7 @@ The main agent MUST NOT:
 All of these happen inside subagents executing molecule step beads (the runtime instances of the formula's step definitions).
 
 **No unauthorized merges.**
-The implement-feature and fix-bug formulas end at `await-review`.
+The implement-feature and fix-bug formulas end at `review-cycle`.
 They do NOT merge. Merging requires explicit user authorization
 and is handled separately via the `merge-and-cleanup` formula.
 

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -41,8 +41,7 @@ required    = true
 
 [[steps]]
 id    = "preflight"
-name = "preflight"
-# stage-role name for shell driver dispatch
+name  = "preflight"
 title = "Preflight: spec validation, formula selection, worktree creation"
 description = """
 Validate the bug bead spec and create the worktree before any investigation.
@@ -109,7 +108,7 @@ git worktree? If so, skip work already done.
 
 [[steps]]
 id    = "diagnose"
-name = "diagnose"
+name  = "diagnose"
 title = "Diagnose: root-cause investigation before any code changes"
 needs = ["preflight"]
 description = """
@@ -176,7 +175,7 @@ where the prior pass left off.
 
 [[steps]]
 id    = "red-tests"
-name = "red-tests"
+name  = "red-tests"
 title = "Red-tests: write failing regression test proving the bug"
 needs = ["diagnose"]
 description = """
@@ -232,7 +231,7 @@ Check filesystem (committed test) and step-bead notes.
 
 [[steps]]
 id    = "green-loop"
-name = "green-loop"
+name  = "green-loop"
 title = "Green-loop: fix the root cause via RALF-IT"
 needs = ["red-tests"]
 description = """
@@ -292,7 +291,7 @@ Read RALF-IT-ITER: marker. Resume at n+1. Crash mid-iter: retry failed iteration
 
 [[steps]]
 id    = "quality-sweep"
-name = "quality-sweep"
+name  = "quality-sweep"
 title = "Quality-sweep: global quality gate across entire project"
 needs = ["green-loop"]
 description = """
@@ -324,7 +323,7 @@ Re-evaluates state; runs only what is not already green.
 
 [[steps]]
 id    = "verify-ac"
-name = "verify-ac"
+name  = "verify-ac"
 title = "Verify-AC: mechanical acceptance criteria validation"
 needs = ["quality-sweep"]
 description = """
@@ -361,7 +360,7 @@ Re-evaluates; continues from prior pass.
 
 [[steps]]
 id    = "create-pr"
-name = "create-pr"
+name  = "create-pr"
 title = "Create-PR: push branch and open pull request"
 needs = ["verify-ac"]
 description = """
@@ -398,7 +397,7 @@ If PR exists and CLOSED: flag-human. Do NOT reopen.
 
 [[steps]]
 id    = "review-cycle"
-name = "review-cycle"
+name  = "review-cycle"
 title = "Review-cycle: address PR review feedback"
 needs = ["create-pr"]
 description = """
@@ -431,7 +430,7 @@ Every review thread has a reply. FIXED items resolved on GitHub.
 
 [[steps]]
 id    = "merge-or-handoff"
-name = "merge-or-handoff"
+name  = "merge-or-handoff"
 title = "Merge-or-handoff: auto-merge or hand off to human"
 needs = ["review-cycle"]
 description = """

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -41,6 +41,9 @@ required    = true
 
 [[steps]]
 id    = "preflight"
+# name is accepted by bd (verified: bd formula show succeeds) and serves as the
+# stage-role identifier used by the shell driver (bead-driver-test.sh). It mirrors
+# id intentionally — id is the structural key; name is the human-readable label.
 name  = "preflight"
 title = "Preflight: spec validation, formula selection, worktree creation"
 description = """

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -72,16 +72,15 @@ Read the bead and its labels:
      bd update {{bead-id}} --append-notes "preflight: no coverage report location configured in project-config.toml"
    Do NOT continue to worktree creation. Exit cleanly.
 
-4. Pour the formula (already poured — this step was created by the pour):
-   Stamp the molecule→bead lookup label if not already stamped:
-     bd label add <mol-id> for-bead-{{bead-id}}
+4. Stamp the molecule→bead lookup label if not already stamped:
+   bd label add <mol-id> for-bead-{{bead-id}}
 
 5. Create the worktree:
    Branch name: fix/{{bead-id}}-<slug-from-title>
    Location: <repo-root>/.claude/worktrees/<branch-name>
    Command:
      git worktree add .claude/worktrees/<branch> -b <branch>
-   CRITICAL: pour first (already done), then create worktree.
+   CRITICAL: the formula is already poured (this step was created by the pour).
    If worktree creation fails: squash the molecule and flag-human.
 
 6. Stamp the worktree-path label on the molecule:

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -66,7 +66,11 @@ Read the bead and its labels:
 
 3. Read project-config.toml and verify quality-gate config.
    If [static-analysis] absent or empty: mark quality-sweep skippable.
-   If no coverage report location: note it; quality-sweep may be skippable.
+   If no coverage report location ([coverage].report-location absent): apply the
+   human-flag protocol and stop this stage:
+     bd label add {{bead-id}} human
+     bd update {{bead-id}} --append-notes "preflight: no coverage report location configured in project-config.toml"
+   Do NOT continue to worktree creation. Exit cleanly.
 
 4. Pour the formula (already poured — this step was created by the pour):
    Stamp the molecule→bead lookup label if not already stamped:

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -1,16 +1,17 @@
 # fix-bug.formula.toml
 #
-# Bug-fix workflow that enforces systematic diagnosis before any code changes.
-# The cardinal sin of bug fixing is patching the symptom. This formula
-# enforces root-cause identification as a hard gate before touching code.
+# Per-stage bug-fix pipeline for the bead architecture.
+# Extends implement-feature with a `diagnose` stage between `preflight`
+# and `red-tests` to enforce root-cause investigation before any code changes.
 #
-# Phases:
-#   1. Diagnose  — reproduce, locate root cause (NOT symptom)
-#   2. Isolation — worktree setup, claim bead
-#   3. Fix       — regression test (red) → fix (green)
-#   4. Gate      — code-review → simplify → verify with evidence
-#   5. Delivery  — PR → await review
-#   6. Housekeep — close bead, record memory, file discovered work
+# Stage sequence:
+#   preflight → diagnose → red-tests → green-loop → quality-sweep → verify-ac
+#   → create-pr → review-cycle → merge-or-handoff
+#
+# The cardinal sin of bug fixing is patching the symptom. The `diagnose`
+# stage is a hard gate: no tests are written until the root cause is identified.
+#
+# See: docs/specs/bead-pipeline-architecture.md §3 (diagnose stage)
 #
 # Usage:
 #   bd mol pour fix-bug \
@@ -18,11 +19,11 @@
 #     --var bead-id=proj-17
 
 formula     = "fix-bug"
-description = "Bug fix: diagnose root cause → regression test → fix → completion gate → PR → close"
+description = "Per-stage bug pipeline: preflight → diagnose → red-tests → green-loop → quality-sweep → verify-ac → create-pr → review-cycle → merge-or-handoff"
 type        = "workflow"
-phase       = "liquid"  # persistent across sessions — steps tracked as beads, synced to git
+phase       = "liquid"  # persistent across sessions
 pour        = true
-version     = 1
+version     = 2
 
 [vars.bug]
 description = "Short description of the bug (e.g. 'Login fails when username contains apostrophe')"
@@ -33,311 +34,426 @@ description = "Bead ID tracking this bug (e.g. proj-17). Must already exist."
 required    = true
 
 # =============================================================================
-# Phase 1: Diagnose
+# Stage: preflight
+# Model: claude-sonnet-4-6  Effort: high
+# cwd: repo root (worktree does not yet exist; preflight creates it)
 # =============================================================================
 
 [[steps]]
-id    = "reproduce"
-title = "Reproduce: confirm the bug exists and is consistent"
+id    = "preflight"
+name = "preflight"
+# stage-role name for shell driver dispatch
+title = "Preflight: spec validation, formula selection, worktree creation"
 description = """
-Before touching any code, reproduce the bug reliably.
+Validate the bug bead spec and create the worktree before any investigation.
+Model: claude-sonnet-4-6  Effort: high
 
-Skill: superpowers:systematic-debugging
+## Inputs
+Read the bead and its labels:
+  bd show {{bead-id}}
+  bd label list {{bead-id}}
 
-Steps:
-1. Find or write a minimal reproduction case
-2. Confirm it fails consistently (not flaky)
-3. Note the exact failure: error message, stack trace, wrong output
-4. Note the expected correct behavior
+## Actions
 
-Write reproduction steps back to the bead:
-  bd update {{bead-id}} --notes "Repro: <steps>\nActual: <what happens>\nExpected: <what should happen>"
+1. Verify `brainstormed` and `implementation-ready` labels are present.
+   If either is absent: apply human-flag protocol and exit.
 
-If you cannot reproduce the bug, stop and ask the user for more
-information. Do not proceed on assumption.
-"""
+2. Confirm bead type is `bug` (or formula-fix-bug label is present).
+   This formula is selected for bug-class beads; a feature bead routed here
+   is an error — flag-human with a clear note.
 
-[[steps]]
-id    = "root-cause"
-title = "Root cause: find the source, not the symptom"
-needs = ["reproduce"]
-description = """
-Trace the failure backward to the original invalid state or wrong assumption.
+3. Read project-config.toml and verify quality-gate config.
+   If [static-analysis] absent or empty: mark quality-sweep skippable.
+   If no coverage report location: note it; quality-sweep may be skippable.
 
-Skill: superpowers:root-cause-tracing
+4. Pour the formula (already poured — this step was created by the pour):
+   Stamp the molecule→bead lookup label if not already stamped:
+     bd label add <mol-id> for-bead-{{bead-id}}
 
-Rules:
-- A symptom is WHERE it breaks. A root cause is WHY it breaks.
-- Do not patch the first place you see the problem — trace further back.
-- Read the code path. Do not assume.
-- If the root cause is in a dependency you do not own, note that explicitly.
+5. Create the worktree:
+   Branch name: fix/{{bead-id}}-<slug-from-title>
+   Location: <repo-root>/.claude/worktrees/<branch-name>
+   Command:
+     git worktree add .claude/worktrees/<branch> -b <branch>
+   CRITICAL: pour first (already done), then create worktree.
+   If worktree creation fails: squash the molecule and flag-human.
 
-Ask: "What invariant was violated? Where was it first violated?"
+6. Stamp the worktree-path label on the molecule:
+   Encoding (apply IN ORDER):  _ → _u  then  / → __
+   bd label add <mol-id> worktree-path-<encoded>
 
-Write the root cause back to the bead before continuing:
-  bd update {{bead-id}} --notes "Root cause: <explanation>"
+7. Claim the bead and walk the parent chain:
+   bd update {{bead-id}} --status in_progress
+   PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+   while [ -n "$PARENT" ]; do
+     bd update "$PARENT" --status in_progress
+     PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+   done
 
-If the root cause is significantly different from the bead description,
-flag the bead for human attention before proceeding:
-  bd label add {{bead-id}} human
-  bd update {{bead-id}} --append-notes "Root cause significantly differs from bead description: <reason>"
-(NOT `bd human <id>` — that's the help command, not a label applier.)
-"""
+## Definition of Done
+Poured molecule + worktree exists + worktree-path-* label stamped on molecule.
+OR: human label + structured gap-note + (if pour completed) molecule squashed.
 
-# =============================================================================
-# Phase 2: Isolation
-# =============================================================================
-
-[[steps]]
-id    = "worktree"
-title = "Set up isolated git worktree"
-needs = ["root-cause"]
-description = """
-Invoke the using-git-worktrees skill to create an isolated branch.
-
-Skill: superpowers:using-git-worktrees
-
-- Branch from main (never from another feature branch)
-- Verify you are IN the worktree directory before writing any code
-- Confirm no leftover state from other work
-
-Then claim the bead and walk the parent chain:
-
-  bd update {{bead-id}} --status in_progress
-
-  # Walk parent chain; mark each ancestor epic in_progress
-  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-  while [ -n "$PARENT" ]; do
-    bd update "$PARENT" --status in_progress
-    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-  done
-
-If `implement-bead` already claimed the bead before pouring this
-formula, the first `bd update` is a no-op — re-running it is safe.
+## Idempotent re-entry
+Check: does an active molecule exist? Does the worktree path decode to a real
+git worktree? If so, skip work already done.
 """
 
 # =============================================================================
-# Phase 3: Fix — Regression Test First, Then Fix
+# Stage: diagnose
+# Model: claude-sonnet-4-6  Effort: high
+# cwd: worktree (decoded from worktree-path-* label)
+#
+# This stage is SPECIFIC to fix-bug. It does NOT appear in implement-feature.
 # =============================================================================
 
 [[steps]]
-id    = "write-regression-test"
-title = "Write a failing regression test that proves the bug"
-needs = ["worktree"]
+id    = "diagnose"
+name = "diagnose"
+title = "Diagnose: root-cause investigation before any code changes"
+needs = ["preflight"]
 description = """
-Write a test that FAILS in the current codebase because of the bug.
+Identify the root cause of the bug before writing any tests or code.
+Model: claude-sonnet-4-6  Effort: high
 
-Skills: superpowers:writing-unit-tests, superpowers:testing-anti-patterns
+## Preloaded skills
+superpowers:systematic-debugging, superpowers:root-cause-tracing
 
-This test is your proof that:
-  (a) the bug exists and is reproducible in the test suite
-  (b) your fix actually addresses it (when it turns green)
-  (c) the bug will never silently return (regression protection)
+## Inputs
+- Bug description from: bd show {{bead-id}}
+- Worktree path: decode worktree-path-* label from molecule
 
-The test should target the ROOT CAUSE location, not just the surface
-symptom. Testing at the wrong layer creates false confidence.
+## Decode worktree-path label before any work
+  1. Decode: __ → /  then  _u → _
+  2. Verify decoded path exists and is a git worktree:
+       git -C <path> rev-parse --is-inside-work-tree
+  3. Operate from that cwd.
 
-Run the test and confirm it FAILS:
-  go test ./...           (or equivalent)
+## Actions
 
-If the test passes before any fix, either the bug is already fixed
-(investigate) or the test is wrong (fix the test).
-"""
+1. Reproduce the bug reliably.
+   - Find or write a minimal reproduction case.
+   - Confirm it fails consistently (not flaky).
+   - Note: exact failure (error message, stack trace, wrong output).
+   - Note: expected correct behavior.
+   If cannot reproduce: flag-human with a note asking for more information.
 
-[[steps]]
-id    = "implement-fix"
-title = "Implement the fix (green phase)"
-needs = ["write-regression-test"]
-description = """
-Fix the root cause identified in the diagnose phase.
+2. Trace the failure backward to the root cause.
+   Apply superpowers:systematic-debugging and superpowers:root-cause-tracing.
+   - A symptom is WHERE it breaks. A root cause is WHY it breaks.
+   - Do not patch the first place you see the problem — trace further back.
+   - Read the code path. Do not assume.
+   - Ask: "What invariant was violated? Where was it first violated?"
 
-Skill: superpowers:test-driven-development
+3. Append root-cause note to step-bead:
+   bd update <step-bead-id> --append-notes "Root cause: <explanation>"
 
-Rules:
-- Fix the ROOT CAUSE, not the symptom
-- Minimum change that makes the regression test pass
-- Do not refactor unrelated code while fixing the bug
-- Do not add features while fixing the bug
-- If the fix requires a larger change than expected, stop and consult
-  the user before proceeding (scope creep hides in bug fixes)
+4. If root cause significantly differs from the bead description:
+   bd label add <step-bead-id> human
+   bd label add {{bead-id}} human
+   bd update <step-bead-id> --append-notes "Root cause significantly differs: <reason>"
+   Exit cleanly. Do NOT proceed.
 
-Run the full test suite — not just the new test:
-  go test ./...   (or equivalent)
+5. If root cause exceeds the bead's stated scope:
+   Apply human-flag protocol. Do NOT fix out-of-scope issues inline.
+   File a new bead for the out-of-scope root cause before flagging.
 
-A bug fix that breaks other tests is not a fix. It is a new bug.
+## Definition of Done
+Root-cause note appended to step-bead notes. Identified cause is consistent
+with the bead's reported symptoms. If root cause exceeds scope: flag-human.
 
-This step is complete only when:
-  [ ] The regression test passes (the bug is fixed)
-  [ ] All existing tests still pass (nothing regressed)
-"""
-
-# =============================================================================
-# Phase 4: Completion Gate
-# =============================================================================
-
-[[steps]]
-id    = "code-review"
-title = "Completion gate: code review"
-needs = ["implement-fix"]
-description = """
-Dispatch quality-reviewer subagent against ALL changed files.
-
-Agent: quality-reviewer
-Scope: every file changed since branch creation, reviewed against:
-  - The root cause identified in the diagnose phase
-  - Whether the fix addresses the cause or just the symptom
-  - SOLID and DRY principles
-  - Security implications (bug fixes can introduce new vulnerabilities)
-  - Whether the regression test is meaningful and at the right layer
-
-Address ALL findings. Pay particular attention to any finding that
-suggests the fix is treating a symptom rather than a root cause.
-"""
-
-[[steps]]
-id    = "simplify"
-title = "Completion gate: simplify"
-needs = ["code-review"]
-description = """
-Invoke the `simplify` skill against changed code.
-
-Skill: simplify
-
-Bug fixes are often hasty. The `simplify` skill catches the
-"it works, ship it" carelessness that bug pressure creates.
-
-Address findings. Re-run tests after any changes.
-"""
-
-[[steps]]
-id    = "verify"
-title = "Completion gate: verify with evidence"
-needs = ["simplify"]
-description = """
-Run the full verification suite. Evidence required — no claims without output.
-
-Skill: superpowers:verification-before-completion
-
-Required gates — show actual command output for each:
-  [ ] Regression test passes  → show output
-  [ ] Full test suite passes  → show output
-  [ ] Build succeeds          → show output
-  [ ] Lint clean              → show output
-  [ ] Type check clean        → show output
-
-HARD STOP: After this gate, do NOT commit to main and do NOT push
-directly. The next step is create-pr. Go there next.
+## Idempotent re-entry
+Check step-bead notes for existing root-cause note. If present, proceed.
+The filesystem state and step-bead notes reflect prior progress; continue from
+where the prior pass left off.
 """
 
 # =============================================================================
-# Phase 5: Delivery
+# Stage: red-tests
+# Model: claude-sonnet-4-6  Effort: medium
+# cwd: worktree
+# =============================================================================
+
+[[steps]]
+id    = "red-tests"
+name = "red-tests"
+title = "Red-tests: write failing regression test proving the bug"
+needs = ["diagnose"]
+description = """
+Write a failing regression test targeting the root cause (not the symptom).
+Model: claude-sonnet-4-6  Effort: medium
+
+## Preloaded skills
+superpowers:test-driven-development, superpowers:writing-unit-tests,
+superpowers:testing-anti-patterns
+
+## Inputs
+- Root-cause note from diagnose step-bead notes
+- Bead AC from: bd show {{bead-id}} ([m]-tagged lines)
+- Worktree path from: worktree-path-* label on molecule
+
+## Actions
+
+1. Dispatch bead-implementor (sonnet, medium effort) to write the regression test:
+   - Test MUST target the root cause location, not the symptom surface.
+   - Testing at the wrong layer creates false confidence.
+   - Confirm test FAILS in current codebase (bug exists).
+   - Commit failing test to feature branch.
+
+2. Run Claude reviewer (test-review skill) on the written test.
+   When review-level:none: skip reviewers (test still written).
+
+3. Run Codex adversarial review (gpt-5.5).
+   Model from: project-config.toml [foreign-cli].codex_red_tests_model
+   When review-level:none: skip.
+
+4. Iteration cap: 2 (override: iteration-cap-red-tests-<n> label).
+   At cap with disagreement: record disagreement note.
+   Escalate human ONLY if BOTH reviewers agree on critical/major design flaw.
+
+5. The regression test is proof that:
+   (a) the bug exists and is reproducible in the test suite
+   (b) the fix actually addresses it (when it turns green)
+   (c) the bug cannot silently return (regression protection)
+
+## Definition of Done
+Failing regression test committed to feature branch. Reviewers approve or
+iteration cap reached with disagreement recorded.
+
+## Idempotent re-entry
+Check filesystem (committed test) and step-bead notes.
+"""
+
+# =============================================================================
+# Stage: green-loop
+# Model: claude-opus-4-7  Effort: medium
+# cwd: worktree
+# =============================================================================
+
+[[steps]]
+id    = "green-loop"
+name = "green-loop"
+title = "Green-loop: fix the root cause via RALF-IT"
+needs = ["red-tests"]
+description = """
+Implement the bug fix (green phase) via RALF-IT iterative refinement.
+Model: claude-opus-4-7  Effort: medium
+
+## Inputs
+- Root-cause note from diagnose step-bead notes (CRITICAL: fix the cause, not symptom)
+- Committed failing regression test from red-tests
+- Worktree path from: worktree-path-* label on molecule
+- Prior RALF-IT state: RALF-IT-ITER:<n>/<MAX> in step-bead notes (default 0)
+
+## RALF-IT loop
+
+MAX_ITERATIONS = 5 (override: iteration-cap-green-loop-<n> label — SOLE override path)
+
+For each iteration:
+
+1. Dispatch bead-implementor to implement the fix:
+   - Effort: high on iter 1, medium on iters 2+
+   - MUST fix the ROOT CAUSE from the diagnose note. Do not patch symptoms.
+   - Minimum change to make the regression test pass.
+   - Do not refactor unrelated code or add features.
+   - Run full test suite — not just the regression test.
+     A fix that breaks other tests is a new bug, not a fix.
+
+2. Run quality gate (build/typecheck/lint/test).
+
+3. Run foreign-eyes review:
+   - Iter 1: Codex (gpt-5.5)
+   - Iter 2: Gemini (gemini-2.5-pro)
+   - Iter 3+: pure-Claude fresh-eyes
+   Record degradation: FOREIGN-EYES-ITER-<n>: codex=<status>, gemini=<status>
+
+4. When review-level:deep: run adversarial-codex after gate.
+
+5. Persist: bd update <step-bead-id> --append-notes "RALF-IT-ITER:<n>/{{MAX}}"
+
+After loop:
+- Run simplify once on the full diff.
+- Run quality-reviewer (claude-opus-4-7[1m]) on the full bead diff.
+- If foreign-eyes degraded in 2+ of N iterations: flag-human.
+
+## Definition of Done
+Regression test passes. Full test suite passes. Build/typecheck/lint pass.
+RALF-IT reports complete. Coverage meets threshold.
+
+## Idempotent re-entry
+Read RALF-IT-ITER: marker. Resume at n+1. Crash mid-iter: retry failed iteration.
+"""
+
+# =============================================================================
+# Stage: quality-sweep
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
+# =============================================================================
+
+[[steps]]
+id    = "quality-sweep"
+name = "quality-sweep"
+title = "Quality-sweep: global quality gate across entire project"
+needs = ["green-loop"]
+description = """
+Run the full project quality suite (not just changed files).
+Model: claude-haiku-4-5  Effort: medium
+
+Skippable when preflight marked it so. Also skips when review-level:none.
+
+## Order (fixed)
+1. Lint auto-fix: [lint-autofix].command (run FIRST)
+2. Build + typecheck + lint (from [gates])
+3. Static analysis ([static-analysis])
+4. Tests ([gates].test)
+
+ALWAYS end with build + tests after any code changes.
+
+## Definition of Done
+All gate commands exit zero (or stage skipped).
+
+## Idempotent re-entry
+Re-evaluates state; runs only what is not already green.
+"""
+
+# =============================================================================
+# Stage: verify-ac
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
+# =============================================================================
+
+[[steps]]
+id    = "verify-ac"
+name = "verify-ac"
+title = "Verify-AC: mechanical acceptance criteria validation"
+needs = ["quality-sweep"]
+description = """
+Validate every [m]-tagged AC bullet against worktree state.
+Model: claude-haiku-4-5  Effort: medium
+
+Skips when review-level:none.
+
+## Actions
+
+For each [m]-tagged AC line:
+1. Dispatch bead-verifier (haiku, low effort) for shell-runnable witnesses.
+2. Assemble validation report.
+
+[h]-tagged lines: confirm human follow-up child beads exist.
+
+Run functional/e2e tests from [functional-tests] in project-config.toml.
+Failures: create bug bead per failure (label human); continue to create-pr.
+
+Persist validation report to step-bead notes AND source bead notes.
+
+## Definition of Done
+Every [m] AC bullet has explicit witness evidence.
+
+## Idempotent re-entry
+Re-evaluates; continues from prior pass.
+"""
+
+# =============================================================================
+# Stage: create-pr
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
 # =============================================================================
 
 [[steps]]
 id    = "create-pr"
-title = "Create pull request"
-needs = ["verify"]
+name = "create-pr"
+title = "Create-PR: push branch and open pull request"
+needs = ["verify-ac"]
 description = """
-Invoke the finishing-a-development-branch skill.
+Create the pull request for the bug fix.
+Model: claude-haiku-4-5  Effort: medium
 
-Skill: superpowers:finishing-a-development-branch
+## Preloaded skills
+superpowers:finishing-a-development-branch
 
-PR body must include:
-- What the bug was (symptom)
-- Root cause (the actual problem)
+## PR body MUST include
+- Bead reference: {{bead-id}} and bead title
+- What the bug was (symptom from bead description)
+- Root cause (the actual problem, from diagnose step-bead notes)
 - How the fix addresses the root cause
 - How to verify: reference the regression test by name
-- Linked to {{bead-id}}
+- verify-ac validation report
+- Bug beads filed during verify-ac (if any)
+- Foreign-eyes status section
 
-Do NOT merge. Await review in the next step.
+## Actions
+1. Invoke superpowers:finishing-a-development-branch.
+2. Stamp pr-url-* label: bd label add <mol-id> pr-url-<encoded-url>
+
+## Idempotent re-entry
+If PR exists and OPEN: skip creation, persist URL.
+If PR exists and CLOSED: flag-human. Do NOT reopen.
 """
 
+# =============================================================================
+# Stage: review-cycle
+# Model: claude-sonnet-4-6  Effort: medium
+# cwd: worktree
+# =============================================================================
+
 [[steps]]
-id    = "await-review"
-title = "Await PR review, address feedback, and acknowledge every thread"
+id    = "review-cycle"
+name = "review-cycle"
+title = "Review-cycle: address PR review feedback"
 needs = ["create-pr"]
 description = """
-Invoke the wait-for-pr-comments skill.
+Drive the PR review loop until all review threads are resolved.
+Model: claude-sonnet-4-6  Effort: medium
 
-Skill: superpowers:wait-for-pr-comments
+Skips entirely when review-level:none.
 
-Pass autonomous-mode args so the skill knows it can escalate via bd:
+## Preloaded skills
+superpowers:wait-for-pr-comments (chains to superpowers:reply-and-resolve-pr-threads)
+
+## Actions
+Invoke superpowers:wait-for-pr-comments with:
   --mode autonomous --bead-id {{bead-id}}
 
-- Wait for Copilot review to complete (or time out)
-- Check BOTH top-level PR comments AND inline review comments
-  (inline comments are easy to miss — always verify both)
-- Classify each comment as FIX/SKIP/ESCALATE
-- Address every FIX item via per-comment subagents (or recognize as
-  already-addressed by an earlier commit)
-- Push combined commits
-- The skill internally chains to superpowers:reply-and-resolve-pr-threads
-  on completion, which replies to every thread (FIX + SKIP + ESCALATE)
-  and resolves only FIXED review_thread items via GraphQL
+Iteration cap: 5 (override: iteration-cap-review-cycle-<n> label).
+Persist: bd update <step-bead-id> --append-notes "REVIEW-BATCH:<n>/<MAX>"
 
-On completion verify before considering the step done:
-  - Every thread has a reply on GitHub
-  - FIXED review_thread items are resolved
-  - Zero internal-jargon strings (no `bd`, no bead IDs, no `ESCALATE`)
-    appear in PR-public replies
+If PR is CLOSED on re-entry: flag-human.
 
-Do NOT merge or clean up the worktree until review is complete.
-
-Specification: docs/specs/2026-04-26-pr-review-skill-redesign.md
+## Definition of Done
+Every review thread has a reply. FIXED items resolved on GitHub.
 """
 
 # =============================================================================
-# Phase 6: Housekeeping
+# Stage: merge-or-handoff
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: repo root
 # =============================================================================
 
 [[steps]]
-id    = "housekeeping"
-title = "Housekeeping: close, remember, file discovered work"
-needs = ["await-review"]
+id    = "merge-or-handoff"
+name = "merge-or-handoff"
+title = "Merge-or-handoff: auto-merge or hand off to human"
+needs = ["review-cycle"]
 description = """
-Complete the lifecycle and preserve context for future sessions.
+Either auto-merge the PR or hand off to the human.
+Model: claude-haiku-4-5  Effort: medium
 
-1. Close the bead:
-     bd close {{bead-id}} --reason "Fixed: <one sentence root cause summary>"
+## Gate 1 — PR-state clean-check
+All of: zero open Copilot threads, zero open human-author threads, all CI green,
+5-minute quiet window. On timeout: NOT clean.
 
-2. Walk the parent chain; close each ancestor epic whose remaining
-   children are all closed (stops at the first ancestor that still
-   has any non-closed children, or when there is no parent):
+## Auto-merge path (auto-mergeable label present AND clean-check clean)
+1. Re-run clean-check immediately before merge.
+2. Pour merge-and-cleanup (phase: liquid — NOT vapor).
+3. Drive merge-and-cleanup: merge PR, delete branch, remove worktree, I2 close-walk.
+   Gate 2 inside merge-and-cleanup blocks until all [h] children closed with
+   verified-by-human label AND merge-{source-id} child closed.
 
-     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-     while [ -n "$PARENT" ]; do
-       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
-       [ "$NON_CLOSED" = "0" ] || break
-       bd close "$PARENT" --reason "All children closed"
-       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-     done
+## Hand-off path (default)
+1. bd update {{bead-id}} --status open
+2. bd label add {{bead-id}} merge-ready
+   bd label add {{bead-id}} human
 
-3. Record any non-obvious insights (root cause patterns are worth preserving):
-     bd remember "Bugs in <subsystem> are often caused by <pattern>"
-
-4. File any new bugs or tech debt discovered during the fix. Prefer
-   epic-sibling placement over orphan-with-dep:
-
-     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-
-     # Decide placement via the sibling test (see rules/beads.md I3):
-     # would this work have been on the parent epic's original plan, if
-     # we'd thought of it? Yes → sibling. No → orphan + discovered-from.
-     IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
-
-     if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
-       # Create INSIDE the parent epic as a sibling:
-       bd create "Tech debt: ..." -t chore -p 3 --parent "$PARENT"
-     else
-       # Otherwise create as an orphan and link with discovered-from:
-       NEW=$(bd create "Tech debt: ..." -t chore -p 3 --json | jq -r '.id')
-       bd dep add "$NEW" {{bead-id}} --type discovered-from
-     fi
-
-   Sibling test (see rules/beads.md I3): would this discovered work
-   have been on the parent epic's original plan, if we'd thought of
-   it? Yes → sibling (--parent). No → orphan + discovered-from.
-
-5. Burn this wisp (if running as vapor):
-     bd mol burn <this-mol-id>
+## Idempotent re-entry
+Check gh pr view --json mergedAt. If non-null: skip merge, proceed to cleanup.
 """

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -66,10 +66,16 @@ Read the bead and its labels:
 
 3. Read project-config.toml and verify quality-gate config.
    If [static-analysis] absent or empty: mark quality-sweep skippable.
-   If no coverage report location ([coverage].report-location absent): apply the
-   human-flag protocol and stop this stage:
+   If no coverage report location ([coverage].report-location absent OR empty
+   string, i.e. `report-location = ""`): apply the human-flag protocol and
+   stop this stage:
      bd label add {{bead-id}} human
+     bd label add <step-bead-id> human
      bd update {{bead-id}} --append-notes "preflight: no coverage report location configured in project-config.toml"
+     bd update <step-bead-id> --append-notes "preflight: no coverage report location configured — molecule parked"
+   An empty string is treated the same as absent: explicit opt-out requires a
+   comment in project-config.toml — a bare empty string is ambiguous and must
+   be resolved by the human.
    Do NOT continue to worktree creation. Exit cleanly.
 
 4. Stamp the molecule→bead lookup label if not already stamped:

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -61,13 +61,9 @@ Read the bead and its labels:
 1. Verify `brainstormed` and `implementation-ready` labels are present.
    If either is absent: apply human-flag protocol and exit.
 
-2. Select formula by reading `formula-<name>` label. Fall back to:
-   - feature → implement-feature  (this formula)
-   - task    → implement-feature
-   - chore   → implement-feature
-   - bug     → fix-bug
-   - epic    → flag-human (epics decompose into children)
-   Multiple formula labels → flag-human.
+2. Note: formula selection and pour have already happened — this step was
+   created by implement-bead pouring implement-feature. There is nothing
+   to select or pour here. Proceed directly to project-config.toml validation.
 
 3. Read project-config.toml and verify:
    - `[gates]` section present (or stubs acceptable).
@@ -78,16 +74,15 @@ Read the bead and its labels:
      Do NOT continue to worktree creation. Exit cleanly.
    - [static-analysis] section: if absent or empty, mark quality-sweep skippable.
 
-4. Pour the formula (already poured — this step was created by the pour):
-   Stamp the molecule→bead lookup label if not already stamped:
-     bd label add <mol-id> for-bead-{{bead-id}}
+4. Stamp the molecule→bead lookup label if not already stamped:
+   bd label add <mol-id> for-bead-{{bead-id}}
 
 5. Create the worktree:
    Branch name: feat/{{bead-id}}-<slug-from-title>
    Location: <repo-root>/.claude/worktrees/<branch-name>
    Command:
      git worktree add .claude/worktrees/<branch> -b <branch>
-   CRITICAL: pour the formula FIRST (already done), then create the worktree.
+   CRITICAL: the formula is already poured (this step was created by the pour).
    If worktree creation fails: squash the molecule and flag-human.
 
 6. Stamp the worktree-path label on the molecule:

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -8,9 +8,9 @@
 #   preflight → red-tests → green-loop → quality-sweep → verify-ac
 #   → create-pr → review-cycle → merge-or-handoff
 #
-# Per-step Model/Effort directives are consumed by the shell driver at
-# dispatch time. The driver reads the step-bead's Model/Effort fields and
-# spawns `claude -p` with the appropriate flags.
+# Note: per-step model/effort flag passthrough from the shell driver is
+# planned for bead 7bk.14. The driver does not currently read per-step
+# Model/Effort fields or pass flags to `claude -p`.
 #
 # See: docs/specs/bead-pipeline-architecture.md §3, §9.1
 #

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -67,10 +67,16 @@ Read the bead and its labels:
 
 3. Read project-config.toml and verify:
    - `[gates]` section present (or stubs acceptable).
-   - Coverage report location ([coverage].report-location): if absent, apply the
-     human-flag protocol and stop this stage:
+   - Coverage report location ([coverage].report-location): if absent OR empty
+     string (i.e. `report-location = ""`), apply the human-flag protocol and
+     stop this stage:
        bd label add {{bead-id}} human
+       bd label add <step-bead-id> human
        bd update {{bead-id}} --append-notes "preflight: no coverage report location configured in project-config.toml"
+       bd update <step-bead-id> --append-notes "preflight: no coverage report location configured — molecule parked"
+     An empty string is treated the same as absent: explicit opt-out requires a
+     comment in project-config.toml — a bare empty string is ambiguous and must
+     be resolved by the human.
      Do NOT continue to worktree creation. Exit cleanly.
    - [static-analysis] section: if absent or empty, mark quality-sweep skippable.
 

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -1,20 +1,18 @@
 # implement-feature.formula.toml
 #
-# Encodes the full TDD feature workflow from INSTRUCTIONS.md,
-# completion-gate.md, delivery.md, and delegation.md into a
-# single reusable molecule.
+# Per-stage feature implementation pipeline for the bead architecture.
+# Each step corresponds to one stage that is driven by a separate
+# `claude -p /implement-bead <bead-id>` invocation from the shell driver.
 #
-# Provides persistent state tracking across sessions and hard gate
-# enforcement — steps cannot be skipped or reordered. Instantiated by
-# the `implement-bead` skill (or directly via `bd mol pour`).
+# Stage sequence:
+#   preflight → red-tests → green-loop → quality-sweep → verify-ac
+#   → create-pr → review-cycle → merge-or-handoff
 #
-# Phases:
-#   1. Intent     — confirm bead is brainstormed, restate plan
-#   2. Isolation  — worktree setup, claim bead
-#   3. TDD        — red (failing tests) → green (implement) → refactor
-#   4. Gate       — code-review → simplify → verify with evidence
-#   5. Delivery   — PR → await review
-#   6. Housekeep  — close bead, record memory, file discovered work
+# Per-step Model/Effort directives are consumed by the shell driver at
+# dispatch time. The driver reads the step-bead's Model/Effort fields and
+# spawns `claude -p` with the appropriate flags.
+#
+# See: docs/specs/bead-pipeline-architecture.md §3, §9.1
 #
 # Usage:
 #   bd mol pour implement-feature \
@@ -22,11 +20,11 @@
 #     --var bead-id=proj-42
 
 formula      = "implement-feature"
-description  = "TDD feature implementation: confirm → worktree → red/green/refactor → completion gate → PR → close"
+description  = "Per-stage feature pipeline: preflight → red-tests → green-loop → quality-sweep → verify-ac → create-pr → review-cycle → merge-or-handoff"
 type         = "workflow"
-phase        = "liquid"  # persistent across sessions — steps tracked as beads, synced to git
+phase        = "liquid"  # persistent across sessions
 pour         = true
-version      = 1
+version      = 2
 
 [vars.feature]
 description = "Short description of the feature being implemented (e.g. 'Add dark mode toggle')"
@@ -37,341 +35,432 @@ description = "Bead ID tracking this work (e.g. proj-42). Must already exist."
 required    = true
 
 # =============================================================================
-# Phase 1: Intent — confirm bead is brainstormed and restate plan
+# Stage: preflight
+# Model: claude-sonnet-4-6  Effort: high
+# cwd: repo root (worktree does not yet exist; preflight creates it)
 # =============================================================================
 
 [[steps]]
-id    = "confirm"
-title = "Confirm bead is brainstormed and restate the implementation plan"
+id    = "preflight"
+name  = "preflight"
+title = "Preflight: spec validation, formula selection, worktree creation"
 description = """
-Verify that bead {{bead-id}} has been through brainstorm-bead and that
-the spec exists in the bead. NEVER invoke superpowers:brainstorming —
-the bead description IS the plan.
+Validate the bead spec and create the worktree before any implementation work.
+Model: claude-sonnet-4-6  Effort: high
 
-Read bead and labels:
-
+## Inputs
+Read the bead and its labels:
   bd show {{bead-id}}
   bd label list {{bead-id}}
 
-== HAPPY PATH (both `brainstormed` AND `implementation-ready` labels present) ==
+## Actions
 
-1. Read the bead description and acceptance criteria.
-2. Restate the implementation plan in 1-3 sentences to prove understanding
-   (e.g. "I will modify <files> to <do X> so that <AC pass>").
-3. Mark this step done. The next step (worktree) runs.
+1. Verify `brainstormed` and `implementation-ready` labels are present.
+   If either is absent: apply human-flag protocol and exit.
 
-DO NOT call `bd update {{bead-id}} --acceptance` or `--notes` —
-brainstorm-bead already wrote the spec; rewriting it would destroy it.
+2. Select formula by reading `formula-<name>` label. Fall back to:
+   - feature → implement-feature  (this formula)
+   - task    → implement-feature
+   - chore   → implement-feature
+   - bug     → fix-bug
+   - epic    → flag-human (epics decompose into children)
+   Multiple formula labels → flag-human.
 
-== MISSING-LABEL PATH (either label absent) ==
+3. Read project-config.toml and verify:
+   - `[gates]` section present (or stubs acceptable).
+   - Coverage report location (if absent, quality-sweep is skippable — note it).
+   - [static-analysis] section: if absent or empty, mark quality-sweep skippable.
 
-Aborting from either branch below means: leave this `confirm` step
-OPEN (do not close it), do NOT call `bd mol burn` from within this
-step, and print this one-line follow-up:
+4. Pour the formula (already poured — this step was created by the pour):
+   Stamp the molecule→bead lookup label if not already stamped:
+     bd label add <mol-id> for-bead-{{bead-id}}
 
-  Molecule paused at confirm. Run brainstorm-bead on this bead and re-attempt, or `bd mol burn <mol-id>` to discard.
+5. Create the worktree:
+   Branch name: feat/{{bead-id}}-<slug-from-title>
+   Location: <repo-root>/.claude/worktrees/<branch-name>
+   Command:
+     git worktree add .claude/worktrees/<branch> -b <branch>
+   CRITICAL: pour the formula FIRST (already done), then create the worktree.
+   If worktree creation fails: squash the molecule and flag-human.
 
-Leave the disposition (re-attempt or burn) to the operator (or to
-run-queue policy).
+6. Stamp the worktree-path label on the molecule:
+   Encoding (apply IN ORDER):
+     _ → _u
+     / → __
+   Then: bd label add <mol-id> worktree-path-<encoded>
 
-Detect execution mode from your own dispatch context:
+7. Claim the bead and walk the parent chain:
+   bd update {{bead-id}} --status in_progress
+   PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
+   while [ -n "$PARENT" ]; do
+     bd update "$PARENT" --status in_progress
+     PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+   done
 
-- AUTONOMOUS mode (you were dispatched by run-queue, or any
-  context where no human is at the keyboard):
-  - Escalate the bead so a human can address it:
-      bd label add {{bead-id}} human
-      bd update {{bead-id}} --append-notes "missing brainstormed/implementation-ready labels; recommend running brainstorm-bead before implementation."
-    (NOT `bd human <id>` — that's the help command, not a label applier.)
-  - Do NOT prompt — there is no operator to answer.
-  - Then abort (per the shared abort mechanism above).
+## Definition of Done
+Poured molecule + worktree exists + worktree-path-* label stamped on molecule.
+OR: human label + structured gap-note + (if pour completed) molecule squashed.
 
-- INTERACTIVE mode (start-bead routed you here, or a human ran
-  `bd mol pour` directly and is in conversation with you):
-  - Print a clear warning: "Bead {{bead-id}} is missing brainstormed/implementation-ready labels — it has not been through brainstorm-bead. Implementation may run on an incomplete spec."
-  - Ask the user:
-    (a) Abort and route the bead through start-bead/brainstorm-bead first.
-    (b) Proceed with implementation using whatever is in the bead now.
-  - On (a): abort (per the shared abort mechanism above).
-  - On (b): proceed to worktree.
+## Idempotent re-entry
+Check: does an active molecule exist? Does the worktree path decode to a real
+git worktree? If so, skip work already done.
 """
 
 # =============================================================================
-# Phase 2: Isolation
+# Stage: red-tests
+# Model: claude-sonnet-4-6  Effort: medium
+# cwd: worktree (decoded from worktree-path-* label)
 # =============================================================================
 
 [[steps]]
-id    = "worktree"
-title = "Set up isolated git worktree"
-needs = ["confirm"]
+id    = "red-tests"
+name  = "red-tests"
+title = "Red-tests: write failing tests covering all [m] AC bullets"
+needs = ["preflight"]
 description = """
-Invoke the using-git-worktrees skill to create an isolated branch.
+Write failing tests (TDD red phase) before any implementation code.
+Model: claude-sonnet-4-6  Effort: medium
 
-Skill: superpowers:using-git-worktrees
+## Preloaded skills
+superpowers:test-driven-development, superpowers:writing-unit-tests,
+superpowers:testing-anti-patterns
 
-- Branch from main (never from another feature branch)
-- Verify you are IN the worktree directory before writing any code
-- Confirm no leftover state from other work
+## Inputs
+- Bead AC from: bd show {{bead-id}} (read [m]-tagged lines)
+- Worktree path: decode worktree-path-* label from molecule
 
-Then claim the bead and walk the parent chain:
+## Decode worktree-path label before any work
+  1. Decode: __ → /  then  _u → _
+  2. Verify decoded path exists and is a git worktree:
+       git -C <path> rev-parse --is-inside-work-tree
+  3. Operate from that cwd.
 
-  bd update {{bead-id}} --status in_progress
+## Actions
 
-  # Walk parent chain; mark each ancestor epic in_progress
-  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-  while [ -n "$PARENT" ]; do
-    bd update "$PARENT" --status in_progress
-    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-  done
+1. Dispatch bead-implementor (sonnet, medium effort) to write tests:
+   - Dispatch with: worktree path, AC bullets (all [m]-tagged lines),
+     step-bead ID, instruction to write failing tests and confirm they fail.
+   - Tests must cover: happy path, edge cases, error paths.
+   - Do NOT mock what has not been verified.
+   - Do NOT write test-only methods in production code.
 
-If `implement-bead` already claimed the bead before pouring this
-formula, the first `bd update` is a no-op — re-running it is safe.
+2. Run the Claude reviewer (test-review skill) on the written tests.
+   When review-level:none is set: skip test reviewers (tests still written).
+
+3. Run Codex adversarial review of the tests (gpt-5.5 default).
+   Model from: project-config.toml [foreign-cli].codex_red_tests_model
+   When review-level:none: skip.
+   Subject to foreign-eyes degradation tracking (FOREIGN-EYES-ITER-<n>).
+
+4. Iteration cap: 2 (override: iteration-cap-red-tests-<n> label).
+   At cap with reviewer disagreement: write disagreement note to step-bead notes.
+   Escalate human ONLY if BOTH reviewers agree on a critical/major design flaw.
+
+5. Commit failing tests to the feature branch.
+
+## Definition of Done
+Tests committed to feature branch; both reviewers approve "shippable" state
+(or iteration cap reached with disagreement note recorded).
+
+## Idempotent re-entry
+Check filesystem (committed tests) and step-bead notes. Continue from prior state.
 """
 
 # =============================================================================
-# Phase 3: TDD — Red / Green / Refactor
+# Stage: green-loop
+# Model: claude-opus-4-7  Effort: medium
+# cwd: worktree
 # =============================================================================
 
 [[steps]]
-id    = "write-tests"
-title = "Write failing tests (red phase)"
-needs = ["worktree"]
+id    = "green-loop"
+name  = "green-loop"
+title = "Green-loop: RALF-IT implementation until tests pass"
+needs = ["red-tests"]
 description = """
-Write tests FIRST. No implementation code at this step.
+Implement the feature (TDD green phase) via RALF-IT iterative refinement.
+Model: claude-opus-4-7  Effort: medium
 
-Skills: superpowers:test-driven-development, superpowers:writing-unit-tests, superpowers:testing-anti-patterns
+## Preloaded skills
+RALF-IT methodology (embedded in controller)
 
-Rules:
-- Tests must be written against the acceptance criteria on the bead (set by brainstorm-bead, restated in the confirm step)
-- Cover: happy path, edge cases, error paths
-- Do NOT mock what you have not verified you understand
-- Do NOT write test-only methods in production code
+## Inputs
+- Committed failing tests from red-tests stage
+- Bead spec from: bd show {{bead-id}}
+- Worktree path from: worktree-path-* label on molecule
+- Prior RALF-IT state: RALF-IT-ITER:<n>/<MAX> in step-bead notes (default 0)
 
-Run the tests and confirm they FAIL. Failure is correct here.
+## RALF-IT loop
 
-  go test ./...           # Go projects
-  pnpm test               # Node/TypeScript projects
-  pytest                  # Python projects
+MAX_ITERATIONS = 5 (override: iteration-cap-green-loop-<n> label — SOLE override path)
 
-If a test passes before any implementation, either the test is wrong
-or the feature already exists. Investigate before continuing.
-"""
+For each iteration:
 
-[[steps]]
-id    = "implement"
-title = "Implement {{feature}} (green phase)"
-needs = ["write-tests"]
-description = """
-Write the minimum code to make all failing tests pass.
+1. Dispatch bead-implementor to write minimum code to make tests pass:
+   - Effort: high on iter 1, medium on iters 2+
+   - Pass: worktree path, bead spec, iteration number, prior state
 
-Skills: superpowers:test-driven-development, then any applicable domain skill
+2. Run quality gate (build/typecheck/lint/test) — from project-config.toml [gates].
+   Gate must pass before review.
 
-Rules:
-- Minimum viable implementation — write only what tests require
-- No speculative features, no over-engineering
-- No abstractions for hypothetical future requirements
+3. Run foreign-eyes review:
+   - Iter 1: Codex (gpt-5.5, or codex_green_loop_iter1_model from project-config.toml)
+   - Iter 2: Gemini (gemini-2.5-pro, or gemini_green_loop_iter2_model)
+   - Iter 3+: pure-Claude fresh-eyes subagent
+   Record degradation: FOREIGN-EYES-ITER-<n>: codex=<status>, gemini=<status>
 
-Run tests after each meaningful change:
-  go test ./...   (or equivalent)
+4. When review-level:deep: run /codex:adversarial-review --model gpt-5.4 after gate.
+   When review-level:none: skip per-iteration code-review and simplify.
 
-This step is complete only when all tests are GREEN.
-"""
+5. Persist iteration marker AFTER iteration completes:
+   bd update <step-bead-id> --append-notes "RALF-IT-ITER:<n>/{{MAX}}"
 
-[[steps]]
-id    = "refactor"
-title = "Refactor for clarity (refactor phase)"
-needs = ["implement"]
-description = """
-Clean up the implementation without changing observable behavior.
-Tests must remain green throughout.
+6. Converge or loop: if reviewers approve and tests green, exit loop.
+   Otherwise continue to next iteration.
 
-Skill: simplify
+After loop:
+- Run simplify skill once on the full diff (not per-iteration).
+- Run quality-reviewer (claude-opus-4-7[1m]) on the full bead diff.
+- If foreign-eyes degraded in 2+ of N iterations: flag-human.
+  Stamp: foreign-eyes-degraded:<n>/<N> on source bead.
 
-Look for:
-- Duplication (three similar lines is a smell; two is acceptable)
-- Names that require a comment to understand
-- Logic that could be expressed more simply
-- Dead code
+Coverage threshold: from project-config.toml [coverage].threshold (default 80%)
+or coverage-threshold-<n> label on bead.
 
-Re-run tests after every change. If tests break, you changed behavior.
-Undo the change and try again.
+## Definition of Done
+RALF-IT reports complete; tests green; coverage meets target; build/typecheck/lint pass.
 
-This step is NOT about adding features or improving performance.
-It is about making the code readable by the next person (who is you,
-in six months, having forgotten everything).
+## Idempotent re-entry
+Read RALF-IT-ITER: marker from step-bead notes. Resume at n+1.
+Crash mid-iteration: marker at prior value, retry failed iteration.
 """
 
 # =============================================================================
-# Phase 4: Completion Gate
+# Stage: quality-sweep
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
 # =============================================================================
 
 [[steps]]
-id    = "code-review"
-title = "Completion gate: code review"
-needs = ["refactor"]
+id    = "quality-sweep"
+name  = "quality-sweep"
+title = "Quality-sweep: global quality gate across entire project"
+needs = ["green-loop"]
 description = """
-Dispatch quality-reviewer subagent against ALL changed files.
+Run the full project quality suite (not just changed files).
+Model: claude-haiku-4-5  Effort: medium
 
-Agent: quality-reviewer
-Scope: every file changed since branch creation, reviewed against:
-  - The implementation plan restated in the confirm step (per the bead spec)
-  - SOLID and DRY principles
-  - Security by design (OWASP top 10, input validation, no injection paths)
-  - Architectural consistency with the rest of the codebase
-  - The standards in INSTRUCTIONS.md
+Skippable when preflight marked it so (no [static-analysis] in project-config.toml,
+or empty gates). Also skips when review-level:none is set.
 
-Address ALL findings before proceeding. If a finding is deferred,
-document the rationale explicitly.
+## Order (fixed)
+1. Lint auto-fix: [lint-autofix].command from project-config.toml (run FIRST)
+2. Build + typecheck + lint (from [gates])
+3. Static analysis (from [static-analysis] — semgrep, depcheck, etc.)
+4. Tests (from [gates].test)
 
-For high-stakes changes (security-sensitive, architecture shifts):
-  /codex:adversarial-review --wait --model gpt-5.4
-"""
+ALWAYS end with build + tests after any code changes (guarantees verify-ac starts green).
 
-[[steps]]
-id    = "simplify"
-title = "Completion gate: simplify"
-needs = ["code-review"]
-description = """
-Invoke the `simplify` skill against changed code.
+## Auto-fix vs flag-human
+Auto-fix unless issues betray a design flaw requiring fundamental changes.
+Use judgment based on the size of the fix.
 
-Skill: simplify
+## Definition of Done
+All gate commands exit zero (or stage skipped per preflight / review-level:none).
 
-This step exists because the implementing agent always misses
-at least one DRY violation or clarity issue. It is not optional.
-
-Address ALL findings. Re-run tests after any changes made here.
-"""
-
-[[steps]]
-id    = "verify"
-title = "Completion gate: verify with evidence"
-needs = ["simplify"]
-description = """
-Run the full verification suite. Evidence is required — no claims without output.
-
-Skill: superpowers:verification-before-completion
-
-Required gates — show the actual command output for each:
-  [ ] Tests pass        → run test suite, paste output
-  [ ] Build succeeds    → run build, paste output
-  [ ] Lint clean        → run linter, paste output
-  [ ] Type check clean  → run type checker, paste output
-
-Do NOT mark this step complete unless all four gates show clean output.
-"I believe it passes" is not evidence. Run the commands.
-
-HARD STOP: After this gate, do NOT commit to main and do NOT push
-directly. The next step is create-pr. Go there next.
+## Idempotent re-entry
+Re-run re-evaluates state and runs only what is not already green.
 """
 
 # =============================================================================
-# Phase 5: Delivery
+# Stage: verify-ac
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
+# =============================================================================
+
+[[steps]]
+id    = "verify-ac"
+name  = "verify-ac"
+title = "Verify-AC: mechanical acceptance criteria validation"
+needs = ["quality-sweep"]
+description = """
+Validate every [m]-tagged AC bullet against worktree state.
+Model: claude-haiku-4-5  Effort: medium
+
+Skips when review-level:none.
+
+## Inputs
+- Bead AC from: bd show {{bead-id}} (parse [m] and [h] tags)
+- Worktree path from: worktree-path-* label on molecule
+- Functional tests from: project-config.toml [functional-tests]
+
+## Actions
+
+For each [m]-tagged AC line:
+1. Dispatch bead-verifier (haiku, low effort) to run shell-runnable witnesses.
+   Collect: exit code + error excerpt.
+2. Assemble validation report.
+
+[h]-tagged AC lines: do NOT validate here. Confirm that human follow-up
+child beads were filed at brainstorm-time finalize (bd list --parent {{bead-id}}
+filtered by label human). If any [h] bullet has no matching follow-up, flag-human.
+
+Run functional/e2e tests from [functional-tests] in project-config.toml.
+If functional tests fail:
+  - Create one bug bead per failure, label human.
+  - Note in step-bead. Continue to create-pr (do NOT loop back).
+
+Persist validation report to BOTH:
+  - Step-bead notes: bd update <step-bead-id> --append-notes "<report>"
+  - Source bead notes: bd update {{bead-id}} --append-notes "<report>"
+  (Report also included in PR description at create-pr.)
+
+## Definition of Done
+Every [m] AC bullet has explicit witness evidence.
+Human-review bullets have follow-up beads filed (confirm presence).
+
+## Idempotent re-entry
+Re-run re-evaluates and continues from prior pass.
+"""
+
+# =============================================================================
+# Stage: create-pr
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: worktree
 # =============================================================================
 
 [[steps]]
 id    = "create-pr"
-title = "Create pull request"
-needs = ["verify"]
+name  = "create-pr"
+title = "Create-PR: push branch and open pull request"
+needs = ["verify-ac"]
 description = """
-Invoke the finishing-a-development-branch skill.
+Create the pull request and persist its URL to the molecule.
+Model: claude-haiku-4-5  Effort: medium
 
-Skill: superpowers:finishing-a-development-branch
+## Preloaded skills
+superpowers:finishing-a-development-branch
 
-- Push the branch to origin
-- Create a PR with a clear summary linked to {{bead-id}}
-- PR title should be ≤70 characters
-- PR body should include: what changed, why, and how to test it
+## Actions
 
-Do NOT merge. Do NOT squash. Await review in the next step.
+1. Invoke superpowers:finishing-a-development-branch.
+
+2. PR body MUST include:
+   - Bead reference: {{bead-id}} and bead title
+   - AC (full list with [m]/[h] tags)
+   - RALF-IT iteration summary (from green-loop step-bead notes)
+   - verify-ac validation report
+   - Bug beads filed during verify-ac (if any)
+   - Human-required AC follow-up bead references (if any [h] lines)
+   - Foreign-eyes status section (list which iterations had degraded foreign-eyes)
+
+3. Stamp pr-url-* label on molecule:
+   Encoding: same bijection as worktree-path (though URLs rarely need it).
+   bd label add <mol-id> pr-url-<encoded-url>
+
+## PR creation failure
+Flag-human with worktree intact. Do NOT tear down the worktree.
+
+## Idempotent re-entry
+Query gh pr view first. If a PR exists for the branch and is OPEN: skip creation,
+persist URL idempotently.
+If PR exists and is CLOSED: flag-human. Do NOT auto-reopen or create a new PR.
 """
 
+# =============================================================================
+# Stage: review-cycle
+# Model: claude-sonnet-4-6  Effort: medium
+# cwd: worktree
+# =============================================================================
+
 [[steps]]
-id    = "await-review"
-title = "Await PR review, address feedback, and acknowledge every thread"
+id    = "review-cycle"
+name  = "review-cycle"
+title = "Review-cycle: address PR review feedback"
 needs = ["create-pr"]
 description = """
-Invoke the wait-for-pr-comments skill.
+Drive the PR review loop until all review threads are resolved.
+Model: claude-sonnet-4-6  Effort: medium
 
-Skill: superpowers:wait-for-pr-comments
+Skips entirely when review-level:none.
 
-Pass autonomous-mode args so the skill knows it can escalate via bd:
+## Preloaded skills
+superpowers:wait-for-pr-comments (chains internally to superpowers:reply-and-resolve-pr-threads)
+
+## Actions
+
+Invoke superpowers:wait-for-pr-comments with:
   --mode autonomous --bead-id {{bead-id}}
 
-- Wait for Copilot review to complete (or time out)
-- Check BOTH top-level PR comments AND inline review comments
-  (inline comments are easy to miss — always verify both)
-- Classify each comment as FIX/SKIP/ESCALATE
-- Address every FIX item via per-comment subagents (or recognize as
-  already-addressed by an earlier commit)
-- Push combined commits
-- The skill internally chains to superpowers:reply-and-resolve-pr-threads
-  on completion, which replies to every thread (FIX + SKIP + ESCALATE)
-  and resolves only FIXED review_thread items via GraphQL
+The skill:
+1. Polls Copilot via background script (zero Anthropic tokens during wait).
+2. Classifies each comment: FIX / SKIP / ESCALATE.
+3. Dispatches per-comment fix subagents (sonnet) for FIX-class items.
+4. Pushes combined commits.
+5. Internally chains to superpowers:reply-and-resolve-pr-threads:
+   replies to every thread + resolves FIXED review_thread items via GraphQL.
 
-On completion verify before considering the step done:
-  - Every thread has a reply on GitHub
-  - FIXED review_thread items are resolved
-  - Zero internal-jargon strings (no `bd`, no bead IDs, no `ESCALATE`)
-    appear in PR-public replies
+One iteration = one outbound reply-batch.
+Iteration cap: 5 (override: iteration-cap-review-cycle-<n> label).
+Early exit when no remaining FIX-class items.
 
-Do NOT merge or clean up the worktree until review is complete
-or has explicitly timed out.
+Exit conditions (mutually exclusive):
+- review-exit-copilot-only (default when review-exit-human-approvers-<n> absent)
+- review-exit-human-approvers-<n>: require N human approvers
 
-Specification: docs/specs/2026-04-26-pr-review-skill-redesign.md
+Persist after each batch:
+  bd update <step-bead-id> --append-notes "REVIEW-BATCH:<n>/<MAX>"
+
+If PR is CLOSED on re-entry: flag-human. Do NOT poll a closed PR.
+
+## Definition of Done
+Every review thread has a reply. FIXED items resolved on GitHub.
+No in-flight FIX work.
 """
 
 # =============================================================================
-# Phase 6: Housekeeping
+# Stage: merge-or-handoff
+# Model: claude-haiku-4-5  Effort: medium
+# cwd: repo root (worktree may be torn down)
 # =============================================================================
 
 [[steps]]
-id    = "housekeeping"
-title = "Housekeeping: close, remember, file discovered work"
-needs = ["await-review"]
+id    = "merge-or-handoff"
+name  = "merge-or-handoff"
+title = "Merge-or-handoff: auto-merge or hand off to human"
+needs = ["review-cycle"]
 description = """
-Complete the lifecycle and preserve context for future sessions.
+Either auto-merge the PR or hand off to the human.
+Model: claude-haiku-4-5  Effort: medium
 
-1. Close the bead:
-     bd close {{bead-id}} --reason "Implemented and PR merged"
+## Gate 1 — PR-state clean-check
+Conditions (ALL must be true for auto-merge path):
+  - Zero open Copilot review threads
+  - Zero open human-author review threads
+  - All CI checks green
+  - 5-minute quiet window with no new comments or review activity
+On wait-for-pr-comments timeout: treat clean-check as NOT clean.
 
-2. Walk the parent chain; close each ancestor epic whose remaining
-   children are all closed (stops at the first ancestor that still
-   has any non-closed children, or when there is no parent):
+## Auto-merge path (auto-mergeable label present AND clean-check clean)
+1. Re-run clean-check immediately before merge call.
+2. Pour merge-and-cleanup formula (phase: liquid — NOT vapor).
+3. Drive merge-and-cleanup:
+   - Merge the PR
+   - Delete branch (local + remote)
+   - Remove worktree (decode from worktree-path-* label)
+   - Run parent-chain I2 close-walk
+   Note: merge-and-cleanup gate-step (Gate 2) blocks until ALL [h] follow-up
+   children are closed with verified-by-human label AND the merge-{source-id}
+   child is closed.
 
-     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-     while [ -n "$PARENT" ]; do
-       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
-       [ "$NON_CLOSED" = "0" ] || break
-       bd close "$PARENT" --reason "All children closed"
-       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-     done
+## Hand-off path (default — auto-mergeable absent OR clean-check dirty)
+1. Transition bead to open: bd update {{bead-id}} --status open
+2. Stamp labels: bd label add {{bead-id}} merge-ready
+                 bd label add {{bead-id}} human
+   (merge-ready = why it's on human list; human = surfaces via bd human list)
+3. Note: bead is now excluded from bd ready (human label gates it).
+   Human runs /merge-and-cleanup when ready.
 
-3. Record any non-obvious decisions or hard-won insights:
-     bd remember "insight about this system or pattern"
-     bd decision record --title="Why we chose X over Y"
-
-4. File any work discovered during implementation. Prefer epic-sibling
-   placement over orphan-with-dep:
-
-     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-
-     # Decide placement via the sibling test (see rules/beads.md I3):
-     # would this work have been on the parent epic's original plan, if
-     # we'd thought of it? Yes → sibling. No → orphan + discovered-from.
-     IS_SIBLING_SUBTASK=false  # set to true only when the answer is yes
-
-     if [ -n "$PARENT" ] && [ "$IS_SIBLING_SUBTASK" = true ]; then
-       # Create INSIDE the parent epic as a sibling:
-       bd create "Found: ..." -t "<type>" -p "<prio>" --parent "$PARENT"
-     else
-       # Otherwise create as an orphan and link with discovered-from:
-       NEW=$(bd create "Found: ..." -t "<type>" -p "<prio>" --json | jq -r '.id')
-       bd dep add "$NEW" {{bead-id}} --type discovered-from
-     fi
-
-   Sibling test (see rules/beads.md I3): would this discovered work
-   have been on the parent epic's original plan, if we'd thought of
-   it? Yes → sibling (--parent). No → orphan + discovered-from.
-
-5. Burn this wisp (if running as vapor):
-     bd mol burn <this-mol-id>
+## Idempotent re-entry
+Query gh pr view --json mergedAt first. If non-null: skip merge, proceed to cleanup.
 """

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -71,7 +71,11 @@ Read the bead and its labels:
 
 3. Read project-config.toml and verify:
    - `[gates]` section present (or stubs acceptable).
-   - Coverage report location (if absent, quality-sweep is skippable — note it).
+   - Coverage report location ([coverage].report-location): if absent, apply the
+     human-flag protocol and stop this stage:
+       bd label add {{bead-id}} human
+       bd update {{bead-id}} --append-notes "preflight: no coverage report location configured in project-config.toml"
+     Do NOT continue to worktree creation. Exit cleanly.
    - [static-analysis] section: if absent or empty, mark quality-sweep skippable.
 
 4. Pour the formula (already poured — this step was created by the pour):

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -42,6 +42,9 @@ required    = true
 
 [[steps]]
 id    = "preflight"
+# name is accepted by bd (verified: bd formula show succeeds) and serves as the
+# stage-role identifier used by the shell driver (bead-driver-test.sh). It mirrors
+# id intentionally — id is the structural key; name is the human-readable label.
 name  = "preflight"
 title = "Preflight: spec validation, formula selection, worktree creation"
 description = """

--- a/src/plugins/beads/.claude/commands/implement-bead.md
+++ b/src/plugins/beads/.claude/commands/implement-bead.md
@@ -28,15 +28,15 @@ Arguments: `$ARGUMENTS` receives the bead ID (e.g. `proj-42`).
   skill-lookup path; the session is interactive.
 - **Shell driver `claude -p`** — the driver spawns `claude -p --session-id
   <uuidv5> "/implement-bead <bead-id>"` from the stage's cwd. Claude Code
-  resolves this project-scoped slash command by walking up from cwd to find
-  the `.claude/` directory containing this file.
+  resolves this as a globally-installed slash command (see below).
 
-## Slash-command resolution from worktrees
+## Slash-command resolution
 
-Claude Code resolves project-scoped commands by walking up from cwd to the
-nearest `.claude/` directory. Because worktrees are full git checkouts, each
-worktree contains a copy of this file and resolution succeeds from any
-subdirectory of the worktree without additional configuration.
+This command is installed globally to `~/.claude/commands/` by the project's
+`install.sh` installer (via the beads plugin overlay phase). It is therefore
+available from any cwd — including worktree subdirectories — via Claude Code's
+global command discovery, without any project-local `.claude/` directory or
+walk-up resolution required.
 
 ## Notes
 

--- a/src/plugins/beads/.claude/commands/implement-bead.md
+++ b/src/plugins/beads/.claude/commands/implement-bead.md
@@ -1,0 +1,48 @@
+# implement-bead
+
+Invoke the implement-bead skill for the given bead ID.
+
+This slash command is the entry point for the shell driver's per-stage
+`claude -p` invocation. It takes a single argument — the bead ID — and
+hands off to the implement-bead skill, which reads the appropriate stage
+step-bead, dispatches subagents/skills per the stage spec, persists
+state-out to bd/filesystem, and exits.
+
+## Invocation
+
+```
+/implement-bead <bead-id>
+```
+
+Arguments: `$ARGUMENTS` receives the bead ID (e.g. `proj-42`).
+
+## Behavior
+
+1. Parse `$ARGUMENTS` as the bead ID.
+2. Invoke the `implement-bead` skill with that bead ID.
+3. The skill drives ONE stage of the bead's active molecule and exits.
+
+## Supported invocation contexts
+
+- **Interactive Claude session** — skill is discovered via the normal
+  skill-lookup path; the session is interactive.
+- **Shell driver `claude -p`** — the driver spawns `claude -p --session-id
+  <uuidv5> "/implement-bead <bead-id>"` from the stage's cwd. Claude Code
+  resolves this project-scoped slash command by walking up from cwd to find
+  the `.claude/` directory containing this file.
+
+## Slash-command resolution from worktrees
+
+Claude Code resolves project-scoped commands by walking up from cwd to the
+nearest `.claude/` directory. Because worktrees are full git checkouts, each
+worktree contains a copy of this file and resolution succeeds from any
+subdirectory of the worktree without additional configuration.
+
+## Notes
+
+- The driver sets cwd before spawning each `claude -p` invocation per the
+  cwd contract in the architecture spec (section 5.4).
+- The `--session-id` (UUIDv5 from namespace + `<bead-id>:<stage-role>`) enables
+  transparent resumption if the process is killed and restarted.
+- This command is a thin wrapper. All orchestration logic lives in the
+  implement-bead skill.

--- a/src/plugins/beads/.claude/rules/delivery.md
+++ b/src/plugins/beads/.claude/rules/delivery.md
@@ -4,8 +4,8 @@ Terminology: a **formula** is an authoring-time TOML template under `.beads/form
 
 For bead-tracked work, delivery runs inside molecule steps, not as a peer workflow. The formulas below show which step of each molecule owns delivery:
 
-- `implement-feature` (defined in `implement-feature.formula.toml`) — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `await-review` step invokes `superpowers:wait-for-pr-comments`, which internally chains to `superpowers:reply-and-resolve-pr-threads` for thread reply + resolve (no separate molecule step needed).
-- `fix-bug` — same pattern: `create-pr` → `superpowers:finishing-a-development-branch`, `await-review` → `superpowers:wait-for-pr-comments` (internally chains to `superpowers:reply-and-resolve-pr-threads`).
+- `implement-feature` (defined in `implement-feature.formula.toml`) — the `create-pr` step invokes `superpowers:finishing-a-development-branch`; the `review-cycle` step invokes `superpowers:wait-for-pr-comments`, which internally chains to `superpowers:reply-and-resolve-pr-threads` for thread reply + resolve (no separate molecule step needed).
+- `fix-bug` — same pattern: `create-pr` → `superpowers:finishing-a-development-branch`, `review-cycle` → `superpowers:wait-for-pr-comments` (internally chains to `superpowers:reply-and-resolve-pr-threads`).
 - `merge-and-cleanup` — runs after explicit user authorization; handles the merge itself.
 
 **Do NOT** invoke `superpowers:finishing-a-development-branch`, `superpowers:wait-for-pr-comments`, or `superpowers:reply-and-resolve-pr-threads` as peers of the bead workflow — they run INSIDE the current molecule step (or via Skill A's internal chain to Skill B).


### PR DESCRIPTION
## Summary
- Rewrites `implement-bead` skill to drive ONE stage per invocation and exit (not a full-molecule loop)
- Adds `/implement-bead` slash command for `claude -p` invocation
- Restructures `implement-feature.formula.toml` into 8 role-named stages: preflight, red-tests, green-loop, quality-sweep, verify-ac, create-pr, review-cycle, merge-or-handoff
- Restructures `fix-bug.formula.toml` with same 8 stages plus `diagnose` at position 2
- Adds `bead-implementor.md` agent for per-stage hands-on work
- Adds `scripts/bead-driver-test.sh` test shell driver replacing run-queue skill
- Adds `project-config.toml` schema example at repo root
- Adds smoke test harness at `scripts/smoke/`

## Why
Replaces the single-session run-queue polling model with per-stage `claude -p` execution. Each molecule stage now gets its own claude invocation with bounded context, enabling reliable session resumption and cost-controlled per-stage model selection.

Canonical spec: `docs/specs/bead-pipeline-architecture.md`
Bead: agents-config-7bk.9

## How to Test
- Run `bash scripts/smoke/verify-artifacts.sh` — all 7 checks should pass
- Run `bash -n scripts/bead-driver-test.sh scripts/smoke/setup.sh scripts/smoke/verify-artifacts.sh` — syntax clean
- Review `implement-bead/SKILL.md` — should describe single-stage execution, not a loop

Generated with Claude Code