### PR TITLE
feat(7bk.19.1): add worker-report-v1 schema and audit-label spec

### DIFF
--- a/docs/specs/bug-diagnoser-report-v1.md
+++ b/docs/specs/bug-diagnoser-report-v1.md
@@ -16,7 +16,6 @@ The `bug-diagnoser-report-v1` schema is the shared core extended with
 
 ```text
 status: complete | needs_human | failed
-iteration: 1                       # optional; typically omitted (single-shot)
 evidence:                          # typically empty {} for diagnose-only
   tests:                           # OPTIONAL; present if the diagnoser
     command: "..."                 # ran tests to confirm the bug

--- a/docs/specs/bug-diagnoser-report-v1.md
+++ b/docs/specs/bug-diagnoser-report-v1.md
@@ -1,0 +1,128 @@
+# Spec: `bug-diagnoser-report-v1` — report schema for the `bug-diagnoser` agent
+
+## Summary
+
+`bug-diagnoser` performs root-cause analysis for bug-class beads. It is
+dispatched in `fix-bug`'s `diagnose` stage, between `preflight` and
+`red-tests`. Its worker-report uses the shared
+[`worker-report-v1`](./worker-report-v1.md) core PLUS one required
+field — `root_cause_note` — that captures the agent's primary
+deliverable.
+
+## Schema
+
+The `bug-diagnoser-report-v1` schema is the shared core extended with
+`root_cause_note`. Schema-template notation; not copy-paste YAML.
+
+```text
+status: complete | needs_human | failed
+iteration: 1                       # optional; typically omitted (single-shot)
+evidence:                          # typically empty {} for diagnose-only
+  tests:                           # OPTIONAL; present if the diagnoser
+    command: "..."                 # ran tests to confirm the bug
+    exit_code: 1
+    skipped: false
+    passing: 7
+    failing: 1
+escalations:
+  - reason: "..."
+    detail: "..."
+discovered_work:
+  - title: "..."
+    type: bug | task | chore
+    priority: 0..4
+    detail: "..."
+commits: []                        # always empty — diagnoser does not commit
+root_cause_note: |                 # REQUIRED — non-empty free text
+  Free-text root-cause analysis. Identifies the underlying defect,
+  the path from defect to symptom, and the proposed fix direction
+  (which may include suggested test cases for tdd-red-team to author).
+```
+
+### Field reference (extension)
+
+**`root_cause_note`** — REQUIRED, non-empty free text. The diagnoser's
+primary deliverable. The downstream `tdd-red-team` and `tdd-green-team`
+dispatches in `fix-bug` read this from the diagnoser's worker-report
+file (path is deterministic via the audit-convention) and use it as
+input context. An empty or absent `root_cause_note` is malformed; the
+orchestrator MUST treat such a report as `status: failed` (synthesizing
+if necessary) and escalate.
+
+The note is not structured; the agent decides headings, length, and
+phrasing. The minimum content the downstream stages need:
+
+- What the underlying defect is.
+- Why the surface symptom (the failing test, the user-reported bug)
+  manifests from that defect.
+- A proposed fix direction (what production code is likely to change).
+
+A diagnose that cannot identify a root cause MUST set
+`status: needs_human` with an escalation describing what is unclear,
+rather than emitting a vague `root_cause_note`. The downstream stages
+are not equipped to make architectural decisions on the diagnoser's
+behalf.
+
+### Required vs optional summary (additive over core)
+
+| Field | Required? | Notes |
+|-------|-----------|-------|
+| `root_cause_note` | required | non-empty free text |
+
+All shared-core required-vs-optional rules from
+[`worker-report-v1`](./worker-report-v1.md) §1.2 apply unchanged.
+
+## Stage-specific expectations
+
+- The agent's task: investigate the failing test or bug-symptom evidence
+  attached to the bead and emit a written root-cause analysis. NO
+  production-code changes.
+- **Expected `commits`: empty list `[]`.** The diagnoser does not commit.
+  A non-empty `commits` array from a `bug-diagnoser` dispatch is a
+  contract violation; the orchestrator's audit may surface this.
+- **Expected `evidence`: typically empty `{}`.** The diagnoser does not
+  run build / lint / typecheck gates. If the diagnoser ran tests to
+  confirm the bug or narrow the cause, the `tests` block reports the
+  FAILING state (`failing > 0`) — that is informational, not a gate.
+- **Derived gate roll-up is not meaningful for diagnose.** The
+  orchestrator does not gate on the diagnose-stage evidence derivation;
+  the relevant signal is `status` plus the presence of a non-empty
+  `root_cause_note`.
+
+## Worker-side notes
+
+- The agent receives the bug bead's description, attached failure
+  evidence (logs, repro steps, failing-test names), and any prior
+  context from the orchestrator's task spec.
+- The agent emits the `root_cause_note` via the `Write` tool to the
+  orchestrator-supplied report path (per shared core §5).
+
+## Orchestrator handling
+
+- Audit label stamped: `worker-audit-bug-diagnoser`. Single-shot
+  dispatch; no iteration counter.
+- The orchestrator extracts `root_cause_note` from the report file and
+  passes it to subsequent stages' task specs:
+  - `red-tests` (tdd-red-team) — to author a test that captures the
+    bug.
+  - `green-loop` (tdd-green-team) — to inform the production-code fix.
+- Path for downstream consumption:
+  `<repo-root>/.beads/worker-reports/<step-bead-id>/bug-diagnoser.yaml`.
+
+## Cross-stage handoff
+
+Because the orchestrator passes `root_cause_note` to downstream agents
+through the task spec, the downstream agents never need to read the
+diagnoser's report file directly. The `bug-diagnoser-report-v1` shape
+is the single source of truth for diagnose-stage output; the
+orchestrator is the courier.
+
+## Related
+
+- [`worker-report-v1.md`](./worker-report-v1.md) — the shared core
+  schema and conventions.
+- [`tdd-green-report-v1.md`](./tdd-green-report-v1.md) — the
+  downstream agent in `fix-bug` that consumes this report's
+  `root_cause_note`.
+- `docs/specs/bead-pipeline-architecture.md` — the `diagnose` stage
+  description.

--- a/docs/specs/bug-diagnoser-report-v1.md
+++ b/docs/specs/bug-diagnoser-report-v1.md
@@ -106,7 +106,7 @@ All shared-core required-vs-optional rules from
     bug.
   - `green-loop` (tdd-green-team) — to inform the production-code fix.
 - Path for downstream consumption:
-  `<repo-root>/.beads/worker-reports/<step-bead-id>/bug-diagnoser.yaml`.
+  `<repo-root>/.beads/worker-audit/<step-bead-id>/bug-diagnoser.yaml`.
 
 ## Cross-stage handoff
 

--- a/docs/specs/tdd-green-report-v1.md
+++ b/docs/specs/tdd-green-report-v1.md
@@ -36,9 +36,9 @@ no removed fields, no structural deviations.
 ## Worker-side notes
 
 - Each iteration is a separate dispatch with its own report file:
-  `<step-bead-id>/tdd-green-team-iter<N>.yaml`.
-- The agent receives the iteration counter from the orchestrator and
-  records it in the report's `iteration` field.
+  `<step-bead-id>/tdd-green-team-iter<N>.yaml`. The iteration counter
+  is encoded in the file path and audit label by the orchestrator; the
+  worker does not record it inside the YAML body.
 - The worker MUST run the full test command as part of its verification
   before commit; the orchestrator does not re-run tests post-dispatch.
 - When the test runner exits non-zero before emitting parseable counts

--- a/docs/specs/tdd-green-report-v1.md
+++ b/docs/specs/tdd-green-report-v1.md
@@ -1,0 +1,81 @@
+# Spec: `tdd-green-report-v1` — report schema for the `tdd-green-team` agent
+
+## Summary
+
+`tdd-green-team` makes failing tests pass (the green phase of TDD),
+iteratively under RALF-IT control. Its worker-report uses the shared
+[`worker-report-v1`](./worker-report-v1.md) core with **no additional
+fields**. This document defines the agent's stage-specific expectations
+and orchestrator interpretation.
+
+## Schema
+
+Identical to `worker-report-v1` core (see
+[`worker-report-v1.md`](./worker-report-v1.md) §1). No additional fields,
+no removed fields, no structural deviations.
+
+## Stage-specific expectations
+
+- The agent's task: implement production code that makes the failing
+  tests (left by `tdd-red-team`, or — in `fix-bug` — the failing test
+  written by `tdd-red-team` to capture the bug) pass without breaking
+  existing tests.
+- **Expected derived gate roll-up: `pass`** — specifically, every
+  present `evidence` block has `exit_code == 0` and `skipped == false`.
+- A persistent `fail` derivation across iterations indicates the agent
+  has not converged. The formula step owns iteration policy:
+  - The formula step's `MAX_ITERATIONS` cap controls when the orchestrator
+    stops dispatching.
+  - On cap exhaustion, the orchestrator stamps the `human` label and
+    files an escalation note.
+- `evidence.tests.passing` and `evidence.tests.failing` are required
+  and MUST be present whenever a test command runs. The orchestrator's
+  green-loop convergence test reads `failing == 0` from the most
+  recent iteration.
+
+## Worker-side notes
+
+- Each iteration is a separate dispatch with its own report file:
+  `<step-bead-id>/tdd-green-team-iter<N>.yaml`.
+- The agent receives the iteration counter from the orchestrator and
+  records it in the report's `iteration` field.
+- The worker MUST run the full test command as part of its verification
+  before commit; the orchestrator does not re-run tests post-dispatch.
+- When the test runner exits non-zero before emitting parseable counts
+  (e.g., a compile error introduced by the iteration's changes), the
+  worker sets `passing: null, failing: null` and captures the runner's
+  stderr in `escalations` with `reason: "tests-runner-unparseable"`.
+  The orchestrator treats unparseable counts as a `fail` derivation
+  for convergence-tracking purposes and continues the loop (or escalates
+  on cap).
+- In `fix-bug`, the agent's task spec includes the diagnose stage's
+  `root_cause_note` (the orchestrator extracts it from the
+  `bug-diagnoser` worker-report file before dispatching). The
+  `tdd-green-team` worker-report itself does NOT include
+  `root_cause_note`.
+
+## Orchestrator handling
+
+- Audit label stamped per iteration:
+  `worker-audit-tdd-green-team-iter<N>`. Iteration suffixes
+  intentionally grow the label set (forensic trail).
+- The orchestrator reads each iteration's report, derives the gate
+  roll-up from `evidence`, and decides:
+  - `pass` → green-loop converged; advance to the next stage.
+  - `fail` → green-loop continues; dispatch iteration N+1 (subject to
+    `MAX_ITERATIONS`).
+  - `partial` → unusual for green-loop; escalate.
+  - `n/a` (empty `evidence`) → indicates a worker that produced no test
+    evidence; treated as `fail` for convergence and surfaced via audit.
+
+## Related
+
+- [`worker-report-v1.md`](./worker-report-v1.md) — the shared core
+  schema and conventions.
+- [`tdd-red-report-v1.md`](./tdd-red-report-v1.md) — the paired
+  red-phase agent's spec.
+- [`bug-diagnoser-report-v1.md`](./bug-diagnoser-report-v1.md) — the
+  upstream stage in `fix-bug` whose `root_cause_note` feeds this
+  agent's task spec.
+- `docs/specs/bead-pipeline-architecture.md` — the `green-loop` stage
+  description.

--- a/docs/specs/tdd-red-report-v1.md
+++ b/docs/specs/tdd-red-report-v1.md
@@ -1,0 +1,64 @@
+# Spec: `tdd-red-report-v1` — report schema for the `tdd-red-team` agent
+
+## Summary
+
+`tdd-red-team` writes failing tests (the red phase of TDD) for a
+feature-class bead's acceptance criteria. Its worker-report uses the
+shared [`worker-report-v1`](./worker-report-v1.md) core with **no
+additional fields**. This document defines the agent's stage-specific
+expectations and orchestrator interpretation.
+
+## Schema
+
+Identical to `worker-report-v1` core (see
+[`worker-report-v1.md`](./worker-report-v1.md) §1). No additional fields,
+no removed fields, no structural deviations.
+
+## Stage-specific expectations
+
+- The agent's task: add tests that capture an intended behavior NOT YET
+  implemented in the codebase. The tests must FAIL when run against the
+  current production code.
+- **Expected derived gate roll-up: `fail`** — specifically,
+  `evidence.tests.failing > 0`. The orchestrator does not advance the
+  pipeline on a `pass` derivation from a red-team dispatch; that
+  outcome means the new tests didn't actually test anything new.
+- The agent SHOULD flag an unexpected `pass` derivation in
+  `escalations` with `reason: "red-tests-passed-unexpectedly"`. The
+  orchestrator escalates such reports to a human.
+- The agent's commits MUST contain only test-file additions or
+  modifications. No production-code changes are permitted in the red
+  phase; production-code changes belong to `tdd-green-team`.
+- `evidence.tests.passing` and `evidence.tests.failing` are required
+  and MUST be present whenever a test command runs (per the shared
+  core's null-permitted carve-out for unparseable runner output).
+
+## Worker-side notes
+
+- Run the test command as part of the worker's verification before
+  commit. The act of writing failing tests is incomplete without
+  proving they fail.
+- The full test runner output should be visible in the commit (e.g.,
+  in the commit message body or a referenced log). Do not duplicate
+  output into the report.
+- Non-test file changes in the same dispatch are a contract violation;
+  the orchestrator's audit may surface this to a human.
+
+## Orchestrator handling
+
+- Audit label stamped: `worker-audit-tdd-red-team[-iter<N>]`.
+- Single-shot dispatch in `implement-feature`'s `red-tests` stage. No
+  iteration counter unless a future formula introduces RALF-IT for the
+  red phase.
+- On `status: needs_human` or escalation, orchestrator stamps the
+  `human` label on the step-bead and stops; the next stage
+  (`green-loop`) does not run.
+
+## Related
+
+- [`worker-report-v1.md`](./worker-report-v1.md) — the shared core
+  schema and conventions.
+- [`tdd-green-report-v1.md`](./tdd-green-report-v1.md) — the
+  paired green-phase agent's spec.
+- `docs/specs/bead-pipeline-architecture.md` — the `red-tests` stage
+  description.

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -24,6 +24,15 @@ This document defines:
 It is documentation only — no JSON-schema enforcement, matching the
 existing spec style under `docs/specs/`.
 
+## Quick reference
+
+| | |
+|---|---|
+| **Report path** | `<repo-root>/.beads/worker-reports/<step-bead-id>/<agent-name>[-iter<N>].yaml` |
+| **Audit label** | `worker-report-<agent-name>[-iter<N>]` — stamped on the step-bead |
+| **Required fields** | `status`, `evidence`, `gate_status`, `escalations`, `discovered_work`, `commits` |
+| **Orchestrator minimum** | `status` + `gate_status` — missing either → synthesize a `status: failed` report |
+
 ## Background
 
 PR #28 introduced the per-stage `claude -p` pipeline (bead `7bk.9`).
@@ -78,9 +87,7 @@ discovered_work:
     type: bug | task | chore
     priority: 0..4
     detail: "optional context"
-    # NOTE: no parent_hint or relation field. The orchestrator owns
-    # placement per beads.md I3 (sibling test). Default is a
-    # discovered-from edge to the source bead.
+    # NOTE: no parent_hint or relation field — orchestrator decides placement
 commits:
   - sha: "full 40-char sha"
     message: "one-line commit message"
@@ -157,19 +164,19 @@ list when the worker made no commits (e.g., a diagnose-only dispatch).
 
 ### 1.2 Required vs optional summary
 
-Top-level **required** fields: `status`, `evidence`, `gate_status`,
-`escalations`, `discovered_work`, `commits`.
+| Field | Required? | Notes |
+|-------|-----------|-------|
+| `status` | required | |
+| `evidence` | required | inner blocks optional — present only when command ran |
+| `gate_status` | required | |
+| `escalations` | required | `[]` when empty |
+| `discovered_work` | required | `[]` when empty |
+| `commits` | required | `[]` when empty |
+| `iteration` | optional | omit on single-shot dispatches |
+| `root_cause_note` | optional | required for `bug-diagnoser`, optional for TDD agents |
 
-Top-level **optional** fields: `iteration`, `root_cause_note`.
-
-Within `evidence`, the `tests` / `build` / `lint` / `typecheck` blocks
-are individually optional, present only when the worker ran the
-corresponding command. Within a block, all listed sub-fields are
-required when the block is present.
-
-Empty-list-valued required fields (`escalations`, `discovered_work`,
-`commits`) are written as `[]`. An omitted required field is malformed
-(see §4).
+Within an `evidence` block, all listed sub-fields are required when the
+block is present. An omitted top-level required field is malformed.
 
 ## 2. File-based audit convention
 
@@ -204,7 +211,7 @@ control over the path scheme.
 
 After the worker exits — whether it completed normally, crashed, or
 emitted a malformed file — the orchestrator stamps a label on the
-**step-bead** (not the source bead, not the molecule):
+**step-bead** (not the source-bead, not the molecule):
 
 ```
 worker-report-<agent-name>[-iter<N>]
@@ -234,19 +241,11 @@ These labels are **forensic-only**:
   loop that runs three iterations leaves three iteration-suffixed
   labels on the step-bead. This is the desired forensic trail, not a
   bug.
-
-If filterability becomes useful later, a separate stable label (e.g.
-`worker-reported`) can be added as a sibling without disturbing the
-iteration-stamped audit labels.
-
-Note: agent names contain hyphens (`tdd-red-team`, `bug-diagnoser`), and
-the label format is also dash-separated, so the boundary between the
-agent-name segment and the `-iter<N>` suffix is not unambiguous to a
-regex parser. Audit labels are not designed to be parsed
-programmatically — the forensic-only, no-routing-filter policy means
-the boundary is never a runtime concern. If structured retrieval becomes
-necessary, use the stable companion label approach above rather than
-parsing audit labels.
+- **Not designed for programmatic parsing.** Agent names and the label
+  format both use hyphens; the boundary between agent-name and
+  `-iter<N>` is ambiguous to a regex. If structured retrieval is needed,
+  add a stable companion label (e.g. `worker-reported`) rather than
+  parsing audit labels.
 
 ## 4. Malformed and crashed-worker handling
 
@@ -258,10 +257,9 @@ Two failure modes are routine and must not derail the pipeline:
    or it parses but is missing a required field the orchestrator must
    read.
 
-In both cases the orchestrator **synthesizes** a worker-report on the
-worker's behalf, writes that synthetic report to the same path the
-worker was supposed to write, and stamps the audit label as if the
-worker had succeeded. The synthetic report has:
+In both cases the orchestrator **synthesizes** a `status: failed`
+worker-report, writes it to the orchestrator-supplied path, and stamps
+the audit label. The synthetic report has:
 
 ```yaml
 status: failed
@@ -296,12 +294,9 @@ able to read at minimum:
 - `gate_status`
 
 Either field missing — or unparseable as YAML — triggers the synthesis
-path. Other required fields (§1.2) are also part of the contract; their
-absence is a workmanship issue surfaced through code review rather than
-a runtime malformation. This is intentional two-tier validity: the
-orchestrator must survive a report that is technically incomplete, log
-the gap in the synthetic report's `escalations`, and continue. Full
-schema compliance is enforced by review, not by the runtime path.
+path. Other required fields (§1.2) are contract obligations enforced by
+review, not by the runtime: the orchestrator survives an incomplete
+report; full compliance is a review concern.
 
 ### 4.2 Out of scope: orchestrator self-crash
 

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -36,7 +36,7 @@ existing spec style under `docs/specs/`.
 
 | | |
 |---|---|
-| **Report path** | `<repo-root>/.beads/worker-reports/<step-bead-id>/<agent-name>[-iter<N>].yaml` |
+| **Report path** | `<repo-root>/.beads/worker-audit/<step-bead-id>/<agent-name>[-iter<N>].yaml` |
 | **Audit label** | `worker-audit-<agent-name>[-iter<N>]` — stamped on the step-bead |
 | **Required core fields** | `status`, `evidence`, `escalations`, `discovered_work`, `commits` |
 | **Orchestrator minimum** | `status` — missing → synthesize a `status: failed` report |
@@ -212,7 +212,7 @@ follows a single deterministic convention so that anyone with a
 step-bead id can locate the report from the filesystem alone:
 
 ```
-<repo-root>/.beads/worker-reports/<step-bead-id>/<agent-name>[-iter<N>].yaml
+<repo-root>/.beads/worker-audit/<step-bead-id>/<agent-name>[-iter<N>].yaml
 ```
 
 | Component | Source | Notes |

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -145,10 +145,14 @@ self-reported `gate_status` could disagree with the underlying counts:
 
 | Derived | When |
 |---------|------|
-| `pass` | Every present block has `exit_code == 0` AND `skipped == false` |
-| `fail` | At least one present block has `exit_code != 0` |
-| `partial` | All non-zero exits absent AND at least one block has `skipped == true` |
+| `pass` | Every present block has `skipped == false` AND `exit_code == 0` |
+| `fail` | At least one present block has `skipped == false` AND `exit_code != 0` |
+| `partial` | At least one present block has `skipped == true`, AND no present block satisfies the `fail` rule |
 | `n/a` | `evidence` is `{}` (e.g., synthetic crash report, diagnose-only dispatch) |
+
+The `skipped == false` clause in the `fail` and `pass` rules ensures
+that skipped blocks (which carry `exit_code: null`) are not interpreted
+as either pass or fail — they participate only in the `partial` rule.
 
 **`escalations`** — list of issues the worker is asking the orchestrator
 to surface. Empty list when there are none. Each item is a one-line

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -343,16 +343,31 @@ step-bead together guarantee the failure is visible to anyone running
 
 ### 4.1 Required-field minimum for the orchestrator
 
-For a report to be considered well-formed, the orchestrator MUST be
-able to read at minimum:
+For a report to be considered well-formed against the shared core, the
+orchestrator MUST be able to read at minimum:
 
 - `status`
 
 `status` missing — or unparseable as YAML — triggers the synthesis
-path. Other required fields (§1.2 and per-agent extensions) are
-contract obligations enforced by review, not by the runtime: the
-orchestrator survives an incomplete report; full compliance is a review
-concern.
+path.
+
+**Per-agent specs may add their own runtime-required fields.** A
+per-agent spec that names additional fields the orchestrator MUST
+runtime-check (and, on miss, treat the report as `status: failed` and
+synthesize) overrides the shared-core minimum for reports of that
+agent. The current set:
+
+| Spec | Runtime-required (orchestrator) | On miss |
+|------|---------------------------------|---------|
+| `worker-report-v1` (shared core) | `status` | synthesize |
+| `tdd-red-report-v1` | `status` | synthesize |
+| `tdd-green-report-v1` | `status` | synthesize |
+| `bug-diagnoser-report-v1` | `status`, `root_cause_note` (non-empty) | synthesize + escalate |
+
+All other contract fields (the rest of §1.2, plus any per-agent
+non-runtime-required fields) are contract obligations enforced by
+review, not by the runtime: the orchestrator survives an incomplete
+report; full compliance is a review concern.
 
 ### 4.2 Out of scope: orchestrator self-crash
 

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -269,7 +269,7 @@ status: failed
 gate_status: fail
 evidence: {}
 escalations:
-  - reason: "Worker crashed" | "Worker emitted malformed report"
+  - reason: "Worker crashed"   # or "Worker emitted malformed report" for parse failures
     detail: |
       <full diagnostic context: worker process exit code, stderr tail,
        parse error, and — for malformed — the raw bytes of the file

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -1,0 +1,352 @@
+# Spec: `worker-report-v1` — pinned schema and audit-label convention (agents-config-7bk.19.1)
+
+## Summary
+
+`worker-report-v1` is the pinned YAML contract that every worker agent
+(`tdd-red-team`, `tdd-green-team`, `bug-diagnoser`) returns to the
+`implement-bead` orchestrator after a single dispatch. The contract
+travels via the filesystem, not via the worker's stdout: the orchestrator
+allocates a target path under the repository root, passes that path to
+the worker as part of the task spec, and the worker writes the YAML
+report to the path before exiting. The orchestrator reads the file once
+the worker exits and stamps a forensic audit label on the step-bead so
+the report is discoverable from `bd` alone.
+
+This document defines:
+
+1. The YAML schema, field-by-field.
+2. The deterministic file-path convention.
+3. The audit-label format and policy.
+4. Orchestrator behavior on crashed or malformed workers.
+5. The worker's write-tool contract (absolute-path `Write`, not Bash
+   redirection).
+
+It is documentation only — no JSON-schema enforcement, matching the
+existing spec style under `docs/specs/`.
+
+## Background
+
+PR #28 introduced the per-stage `claude -p` pipeline (bead `7bk.9`).
+Post-review, the `bead-implementor` worker agent was found to have four
+structural defects (see epic `7bk.19`); two of them — Defect A (leaky
+abstraction) and Defect C (no structured report contract) — motivate
+this spec directly:
+
+- **Defect A.** The worker called `bd label add`, `bd update --append-notes`,
+  and read bead state. Workers should be pure task functions with no
+  bead knowledge. The orchestrator owns all bead state transitions.
+- **Defect C.** Workers were instructed to "report back what you did"
+  with no pinned schema. The orchestrator could not reliably parse
+  completion status, evidence, escalations, discovered work, or commits.
+
+`worker-report-v1` is the contract that closes both defects: workers
+emit a structured file at a path the orchestrator chose, and the
+orchestrator — not the worker — translates that file into bead state.
+
+## 1. Schema
+
+A worker-report is a YAML document with the following shape. The example
+below is canonical: every field shown is part of the contract, optional
+fields are annotated, and nothing else is permitted at the top level.
+
+```yaml
+status: complete | needs_human | failed
+iteration: 1                       # optional; orchestrator-supplied for RALF-IT
+                                   # loops, omitted for single-shot dispatches
+evidence:
+  tests:
+    command: "..."
+    exit_code: 0
+    passing: 42                    # required for green-loop convergence tracking
+    failing: 0                     # required for green-loop convergence tracking
+    output_excerpt: "..."
+  build:     { command: "...", exit_code: 0 }
+  lint:      { command: "...", exit_code: 0 }
+  typecheck: { command: "...", exit_code: 0 }
+gate_status: pass | fail | partial  # rolled-up gate verdict for orchestrator
+                                    # decision-making
+root_cause_note: |                  # optional; required for bug-diagnoser,
+                                    # optional for others. tdd-green-team in
+                                    # fix-bug receives this from the prior
+                                    # diagnose dispatch.
+  Free-text root-cause analysis.
+escalations:
+  - reason: "one-line reason human needed"
+    detail: "why this can't be resolved by the worker"
+discovered_work:
+  - title: "summary of found issue"
+    type: bug | task | chore
+    priority: 0..4
+    detail: "optional context"
+    # NOTE: no parent_hint or relation field. The orchestrator owns
+    # placement per beads.md I3 (sibling test). Default is a
+    # discovered-from edge to the source bead.
+commits:
+  - sha: "full 40-char sha"
+    message: "one-line commit message"
+```
+
+### 1.1 Field reference
+
+**`status`** — terminal verdict for the dispatch.
+
+| Value | Meaning |
+|-------|---------|
+| `complete` | Worker finished its task. The orchestrator inspects `evidence` / `gate_status` to decide whether to advance, loop again, or stop. |
+| `needs_human` | Worker hit a condition only a human can resolve. Orchestrator stamps the `human` label on the step-bead and stops. |
+| `failed` | Worker could not complete (e.g., tools unavailable, target missing). Distinct from `complete + gate_status: fail`. |
+
+**`iteration`** — orchestrator-supplied iteration number for RALF-IT
+loops. Omitted on single-shot dispatches. The formula step owns the
+loop; the orchestrator merely passes the current count through to the
+worker so it lands in the report and the audit label.
+
+**`evidence`** — machine-verifiable artifacts the worker produced.
+
+- `evidence.tests.passing` and `evidence.tests.failing` are **required**
+  whenever a test command runs, because `green-loop` convergence is
+  measured by them. A worker that ran no tests omits the `tests` block
+  entirely. When the test runner exits non-zero before emitting parseable
+  counts (e.g., compile error, missing fixtures), set `passing: null,
+  failing: null` and capture the runner's stderr in `output_excerpt`.
+- `evidence.tests.output_excerpt` is a tail of test runner output,
+  capped to roughly 4KB. The full output should be visible in the
+  worker's commit, not duplicated into the report.
+- `build`, `lint`, `typecheck` blocks are each present only when the
+  worker ran the corresponding command. Missing blocks mean "did not
+  run", not "ran and passed".
+
+**`gate_status`** — rolled-up verdict across all evidence blocks,
+computed by the worker. Decoupled from `status` because a worker can
+finish (`status: complete`) with a failing gate (`gate_status: fail`) —
+that is the normal state during a `red-tests` dispatch.
+
+| Value | Meaning |
+|-------|---------|
+| `pass` | All evidence blocks present in the report exited 0. |
+| `fail` | At least one evidence block exited non-zero. |
+| `partial` | Some required gates were intentionally skipped (e.g., no project lint configured). |
+
+**`root_cause_note`** — free-text root-cause analysis. **Required for
+`bug-diagnoser`**, optional for the TDD agents. In `fix-bug`, the
+`tdd-green-team` dispatch reads the diagnose stage's note from its
+prior worker-report and may carry it forward in its own report; this
+preserves the audit trail across stages.
+
+**`escalations`** — list of issues the worker is asking the orchestrator
+to surface. Empty list when there are none. Each item is a one-line
+`reason` plus a longer `detail`. Setting `status: needs_human` without
+populating `escalations` is malformed.
+
+**`discovered_work`** — work the worker noticed during its dispatch but
+did NOT do. This is the worker's contribution to the orchestrator's
+discovered-work bookkeeping.
+
+Whether a `discovered_work` item is filed as a sibling of the source
+bead or as an orphan with a `discovered-from` edge is decided by the
+orchestrator, not the worker. The worker MUST NOT emit a `parent_hint`,
+`relation`, or any other placement directive. The orchestrator applies
+the sibling test (see `src/plugins/beads/.claude/rules/beads.md` I3) to
+decide placement. The default — when no sibling fit is obvious — is the
+orphan + `discovered-from` form.
+
+**`commits`** — SHAs of commits the worker produced during the dispatch.
+Full 40-char SHAs only; abbreviated SHAs are malformed. The
+`message` field is the commit's first line, for human scanning. Empty
+list when the worker made no commits (e.g., a diagnose-only dispatch).
+
+### 1.2 Required vs optional summary
+
+Top-level **required** fields: `status`, `evidence`, `gate_status`,
+`escalations`, `discovered_work`, `commits`.
+
+Top-level **optional** fields: `iteration`, `root_cause_note`.
+
+Within `evidence`, the `tests` / `build` / `lint` / `typecheck` blocks
+are individually optional, present only when the worker ran the
+corresponding command. Within a block, all listed sub-fields are
+required when the block is present.
+
+Empty-list-valued required fields (`escalations`, `discovered_work`,
+`commits`) are written as `[]`. An omitted required field is malformed
+(see §4).
+
+## 2. File-based audit convention
+
+The orchestrator chooses where the worker writes its report. The path
+follows a single deterministic convention so that anyone with a
+step-bead id can locate the report from the filesystem alone:
+
+```
+<repo-root>/.beads/worker-reports/<step-bead-id>/<agent-name>[-iter<N>].yaml
+```
+
+| Component | Source | Notes |
+|-----------|--------|-------|
+| `<repo-root>` | `dirname $(git rev-parse --path-format=absolute --git-common-dir)` | `--show-toplevel` returns the *worktree* root inside a feature worktree; `--git-common-dir` resolves the shared `.git` dir, and `dirname` gives the main repo root. |
+| `<step-bead-id>` | The step-bead the orchestrator was dispatched for | E.g. `agents-config-7bk.19.1.r3`. |
+| `<agent-name>` | The dispatched worker's role name | E.g. `tdd-red-team`, `tdd-green-team`, `bug-diagnoser`. |
+| `[-iter<N>]` | RALF-IT iteration counter, supplied by the formula step | Appended only when an iteration counter applies. Single-shot dispatches omit the suffix entirely. |
+
+**Outside any worktree.** The path lives under the main repository root,
+not under a feature worktree. Reports must survive worktree cleanup so
+the audit trail is intact even after the worktree that produced them is
+removed.
+
+**Orchestrator-supplied, not worker-derived.** The worker does not
+compute its own report path. The orchestrator passes the absolute path
+to the worker as part of the task spec, the worker writes the file, and
+the orchestrator reads it after the worker exits. This keeps the worker
+bead-agnostic (Defect A) and gives the orchestrator a single point of
+control over the path scheme.
+
+## 3. Audit label
+
+After the worker exits — whether it completed normally, crashed, or
+emitted a malformed file — the orchestrator stamps a label on the
+**step-bead** (not the source bead, not the molecule):
+
+```
+worker-report-<agent-name>[-iter<N>]
+```
+
+Examples: `worker-report-tdd-red-team`,
+`worker-report-tdd-green-team-iter2`,
+`worker-report-bug-diagnoser`.
+
+The label is a boolean-style marker, dash-separated. The full report
+path is fully recoverable from the label and the step-bead id via the
+§2 convention; embedding the path in the label was considered and
+rejected to avoid shell-quoting and character-set friction.
+
+### 3.1 Audit-label policy
+
+These labels are **forensic-only**:
+
+- **Append-only.** Labels are added, never removed.
+- **Not garbage-collected.** Labels persist for the lifetime of the
+  step-bead in the bd database.
+- **Not used for `bd ready --label` filtering.** The pipeline's routing
+  decisions key off other labels (`implementation-ready`, `human`,
+  formula-name labels, etc.); audit labels exist purely to make worker
+  reports retrievable after the fact.
+- **Iteration suffixes intentionally grow the label set.** A RALF-IT
+  loop that runs three iterations leaves three iteration-suffixed
+  labels on the step-bead. This is the desired forensic trail, not a
+  bug.
+
+If filterability becomes useful later, a separate stable label (e.g.
+`worker-reported`) can be added as a sibling without disturbing the
+iteration-stamped audit labels.
+
+Note: agent names contain hyphens (`tdd-red-team`, `bug-diagnoser`), and
+the label format is also dash-separated, so the boundary between the
+agent-name segment and the `-iter<N>` suffix is not unambiguous to a
+regex parser. Audit labels are not designed to be parsed
+programmatically — the forensic-only, no-routing-filter policy means
+the boundary is never a runtime concern. If structured retrieval becomes
+necessary, use the stable companion label approach above rather than
+parsing audit labels.
+
+## 4. Malformed and crashed-worker handling
+
+Two failure modes are routine and must not derail the pipeline:
+
+1. **Crashed worker.** The worker exits non-zero, OR exits zero but
+   never writes the report file at the orchestrator-supplied path.
+2. **Malformed report.** The file exists but cannot be parsed as YAML,
+   or it parses but is missing a required field the orchestrator must
+   read.
+
+In both cases the orchestrator **synthesizes** a worker-report on the
+worker's behalf, writes that synthetic report to the same path the
+worker was supposed to write, and stamps the audit label as if the
+worker had succeeded. The synthetic report has:
+
+```yaml
+status: failed
+gate_status: fail
+evidence: {}
+escalations:
+  - reason: "Worker crashed" | "Worker emitted malformed report"
+    detail: |
+      <full diagnostic context: worker process exit code, stderr tail,
+       parse error, and — for malformed — the raw bytes of the file
+       the worker wrote>
+discovered_work: []
+commits: []
+```
+
+The `evidence` block is empty (`{}`) in the synthetic report because the
+orchestrator does not know which commands the worker attempted before
+crashing. The worker's process exit code belongs in `escalations.detail`,
+not in an `evidence.tests.exit_code` field — conflating the two would
+misrepresent what the test runner (if any) returned.
+
+The synthetic report's existence on disk plus the audit label on the
+step-bead together guarantee the failure is visible to anyone running
+`bd show <step-bead-id>` followed by a glance at the report directory.
+
+### 4.1 Required-field minimum for the orchestrator
+
+For a report to be considered well-formed, the orchestrator MUST be
+able to read at minimum:
+
+- `status`
+- `gate_status`
+
+Either field missing — or unparseable as YAML — triggers the synthesis
+path. Other required fields (§1.2) are also part of the contract; their
+absence is a workmanship issue surfaced through code review rather than
+a runtime malformation. This is intentional two-tier validity: the
+orchestrator must survive a report that is technically incomplete, log
+the gap in the synthetic report's `escalations`, and continue. Full
+schema compliance is enforced by review, not by the runtime path.
+
+### 4.2 Out of scope: orchestrator self-crash
+
+If the orchestrator itself crashes after the worker has exited but
+before the report is read or the audit label stamped, the step-bead is
+left in a "worker ran but no audit label" limbo. Detecting and
+recovering from this case is **out of scope for `worker-report-v1`**
+and for epic `7bk.19`; it should be filed as a follow-up bead if it
+becomes a real-world problem.
+
+## 5. Worker write-tool contract
+
+Workers MUST emit their report using the `Write` tool with an absolute
+path — NOT Bash redirection (`echo ... > path` or here-docs).
+
+The reason is sandbox-mechanical: `claude -p` subagents launched inside
+a feature worktree may run with CWD or sandbox constraints that block
+Bash redirection to paths outside the worktree. The report path lives
+under the main repository root (§2), which is outside the worktree, so
+Bash-redirection writes can fail silently or be denied. The `Write`
+tool resolves the absolute path through Claude Code's filesystem layer,
+which honors the sandbox's allow-list rather than the shell's CWD.
+
+A tracer-bullet test under `scripts/smoke/` will be added by bead
+`7bk.19.5` to exercise this contract end-to-end: a synthetic worker
+dispatched inside a worktree writes a report to the main-tree path and
+the test asserts the file appears.
+
+## 6. Related work
+
+- **Epic `7bk.19`** — the parent redesign of the worker agent layer.
+- **`7bk.19.2`** — creates the three worker agents that emit
+  `worker-report-v1`.
+- **`7bk.19.3`** — rewrites the `implement-bead` orchestrator to
+  allocate the report path, parse the report, stamp the audit label,
+  and synthesize on crash/malformation.
+- **`7bk.19.4`** — wires `implement-feature.formula.toml` and
+  `fix-bug.formula.toml` to dispatch the new worker agents with
+  explicit stage and iteration arguments.
+- **`7bk.19.5`** — updates `docs/specs/bead-pipeline-architecture.md` to
+  reference this contract from the relevant stage descriptions, and
+  adds the smoke / tracer-bullet that proves the §5 write-tool
+  contract holds in practice.
+- **`docs/specs/bead-pipeline-architecture.md`** — the canonical
+  pipeline architecture; this contract is one of the per-stage
+  state-out artifacts referenced there.
+- **`src/plugins/beads/.claude/rules/beads.md`** — the I3 sibling-test
+  rule that governs how the orchestrator places `discovered_work` items.

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -262,10 +262,15 @@ match returns every audit label without enumerating agent names. The
 content after the prefix may evolve over future spec versions; the
 prefix is the durable retrieval handle.
 
-The label is a boolean-style marker, dash-separated. The full report
-path is fully recoverable from the label and the step-bead id via the
-§2 convention; embedding the path in the label was considered and
-rejected to avoid shell-quoting and character-set friction.
+The label is a boolean-style marker, dash-separated. The label exists
+as a presence indicator (this report has been written) — not as the
+encoding of the path. Path reconstruction is the §2 convention applied
+to known inputs (`<step-bead-id>`, `<agent-name>`, optional iteration
+counter); the orchestrator already holds those inputs at dispatch time
+and does not need to parse them out of a label. Embedding the path
+itself in the label was considered and rejected to avoid shell-quoting
+and character-set friction. See §3.1 on why parsing the suffix back
+into structured pieces is not a supported retrieval pattern.
 
 ### 3.1 Audit-label policy
 

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -73,8 +73,6 @@ including allowed enum values.
 
 ```text
 status: complete | needs_human | failed
-iteration: 1                       # optional; orchestrator-supplied for RALF-IT
-                                   # loops, omitted for single-shot dispatches
 evidence:
   tests:
     command: "..."
@@ -111,11 +109,6 @@ NOT remove or restructure the core fields above.
 | `complete` | Worker finished its task. The orchestrator inspects `evidence` (and the derived gate roll-up — see below) to decide whether to advance, loop again, or stop. |
 | `needs_human` | Worker hit a condition only a human can resolve. Orchestrator stamps the `human` label on the step-bead and stops. |
 | `failed` | Worker could not complete (e.g., tools unavailable, target missing). Distinct from `complete` with a failing derived gate. |
-
-**`iteration`** — orchestrator-supplied iteration number for RALF-IT
-loops. Omitted on single-shot dispatches. The formula step owns the
-loop; the orchestrator merely passes the current count through to the
-worker so it lands in the report and the audit label.
 
 **`evidence`** — machine-verifiable artifacts the worker produced. Each
 block (`tests`, `build`, `lint`, `typecheck`) is optional at the block
@@ -186,7 +179,6 @@ duplicated into the report.
 | `escalations` | required | `[]` when empty |
 | `discovered_work` | required | `[]` when empty |
 | `commits` | required | `[]` when empty |
-| `iteration` | optional | omit on single-shot dispatches |
 
 Per-agent specs may add further required or optional fields above the
 core. Within a present `evidence` block, all listed sub-fields are

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -56,9 +56,12 @@ orchestrator — not the worker — translates that file into bead state.
 
 A worker-report is a YAML document with the following shape. The example
 below is canonical: every field shown is part of the contract, optional
-fields are annotated, and nothing else is permitted at the top level.
+fields are annotated, and nothing else is permitted at the top level. It
+uses schema-template notation (pipe-separated alternatives, range syntax
+for `priority`) — it is **not** copy-paste YAML. See §1.1 for the full
+field reference, including allowed enum values.
 
-```yaml
+```text
 status: complete | needs_human | failed
 iteration: 1                       # optional; orchestrator-supplied for RALF-IT
                                    # loops, omitted for single-shot dispatches

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -1,25 +1,33 @@
-# Spec: `worker-report-v1` — pinned schema and audit-label convention (agents-config-7bk.19.1)
+# Spec: `worker-report-v1` — shared core for worker agent reports (agents-config-7bk.19.1)
 
 ## Summary
 
-`worker-report-v1` is the pinned YAML contract that every worker agent
-(`tdd-red-team`, `tdd-green-team`, `bug-diagnoser`) returns to the
-`implement-bead` orchestrator after a single dispatch. The contract
-travels via the filesystem, not via the worker's stdout: the orchestrator
-allocates a target path under the repository root, passes that path to
-the worker as part of the task spec, and the worker writes the YAML
-report to the path before exiting. The orchestrator reads the file once
-the worker exits and stamps a forensic audit label on the step-bead so
-the report is discoverable from `bd` alone.
+`worker-report-v1` is the shared core that every worker agent's YAML
+report inherits: completion status, evidence blocks, escalations,
+discovered work, commits, and the file/label conventions that make
+reports discoverable from `bd` alone. The contract travels via the
+filesystem, not via the worker's stdout — the orchestrator allocates a
+target path under the repository root, passes it to the worker as part
+of the task spec, and the worker writes the YAML report to that path
+before exiting. The orchestrator reads the file once the worker exits
+and stamps a forensic audit label on the step-bead.
+
+Three per-agent specs extend this core with agent-specific fields and
+expectations:
+
+- [`tdd-red-report-v1.md`](./tdd-red-report-v1.md) — `tdd-red-team`
+- [`tdd-green-report-v1.md`](./tdd-green-report-v1.md) — `tdd-green-team`
+- [`bug-diagnoser-report-v1.md`](./bug-diagnoser-report-v1.md) — `bug-diagnoser`
 
 This document defines:
 
-1. The YAML schema, field-by-field.
+1. The shared core schema, field-by-field.
 2. The deterministic file-path convention.
 3. The audit-label format and policy.
 4. Orchestrator behavior on crashed or malformed workers.
 5. The worker's write-tool contract (absolute-path `Write`, not Bash
    redirection).
+6. The per-agent extension model.
 
 It is documentation only — no JSON-schema enforcement, matching the
 existing spec style under `docs/specs/`.
@@ -29,9 +37,10 @@ existing spec style under `docs/specs/`.
 | | |
 |---|---|
 | **Report path** | `<repo-root>/.beads/worker-reports/<step-bead-id>/<agent-name>[-iter<N>].yaml` |
-| **Audit label** | `worker-report-<agent-name>[-iter<N>]` — stamped on the step-bead |
-| **Required fields** | `status`, `evidence`, `gate_status`, `escalations`, `discovered_work`, `commits` |
-| **Orchestrator minimum** | `status` + `gate_status` — missing either → synthesize a `status: failed` report |
+| **Audit label** | `worker-audit-<agent-name>[-iter<N>]` — stamped on the step-bead |
+| **Required core fields** | `status`, `evidence`, `escalations`, `discovered_work`, `commits` |
+| **Orchestrator minimum** | `status` — missing → synthesize a `status: failed` report |
+| **Per-agent extensions** | `tdd-red-report-v1`, `tdd-green-report-v1`, `bug-diagnoser-report-v1` |
 
 ## Background
 
@@ -48,18 +57,19 @@ this spec directly:
   with no pinned schema. The orchestrator could not reliably parse
   completion status, evidence, escalations, discovered work, or commits.
 
-`worker-report-v1` is the contract that closes both defects: workers
-emit a structured file at a path the orchestrator chose, and the
-orchestrator — not the worker — translates that file into bead state.
+`worker-report-v1` is the contract that closes both defects. The shared
+core defines what every agent must emit; per-agent specs add the
+agent-specific output shape (e.g. `bug-diagnoser`'s `root_cause_note`).
+This split removes conditional fields from any single agent's prompt —
+each agent has exactly one concrete schema to follow, reducing
+hallucination surface.
 
-## 1. Schema
+## 1. Shared core schema
 
-A worker-report is a YAML document with the following shape. The example
-below is canonical: every field shown is part of the contract, optional
-fields are annotated, and nothing else is permitted at the top level. It
-uses schema-template notation (pipe-separated alternatives, range syntax
-for `priority`) — it is **not** copy-paste YAML. See §1.1 for the full
-field reference, including allowed enum values.
+The example below shows the shared core. It uses schema-template
+notation (pipe-separated alternatives, range syntax for `priority`) —
+it is **not** copy-paste YAML. See §1.1 for the full field reference,
+including allowed enum values.
 
 ```text
 status: complete | needs_human | failed
@@ -68,20 +78,13 @@ iteration: 1                       # optional; orchestrator-supplied for RALF-IT
 evidence:
   tests:
     command: "..."
-    exit_code: 0
-    passing: 42                    # required for green-loop convergence tracking
-    failing: 0                     # required for green-loop convergence tracking
-    output_excerpt: "..."
-  build:     { command: "...", exit_code: 0 }
-  lint:      { command: "...", exit_code: 0 }
-  typecheck: { command: "...", exit_code: 0 }
-gate_status: pass | fail | partial  # rolled-up gate verdict for orchestrator
-                                    # decision-making
-root_cause_note: |                  # optional; required for bug-diagnoser,
-                                    # optional for others. tdd-green-team in
-                                    # fix-bug receives this from the prior
-                                    # diagnose dispatch.
-  Free-text root-cause analysis.
+    exit_code: 0                   # null when skipped: true
+    skipped: false
+    passing: 42                    # null permitted only when runner exited
+    failing: 0                     # non-zero before emitting parseable counts
+  build:     { command: "...", exit_code: 0, skipped: false }
+  lint:      { command: "...", exit_code: 0, skipped: false }
+  typecheck: { command: "...", exit_code: 0, skipped: false }
 escalations:
   - reason: "one-line reason human needed"
     detail: "why this can't be resolved by the worker"
@@ -92,9 +95,12 @@ discovered_work:
     detail: "optional context"
     # NOTE: no parent_hint or relation field — orchestrator decides placement
 commits:
-  - sha: "full 40-char sha"
-    message: "one-line commit message"
+  - "0123456789abcdef0123456789abcdef01234567"  # full 40-char SHA
 ```
+
+Per-agent specs MAY add further required fields (e.g.,
+`bug-diagnoser-report-v1` adds `root_cause_note`). Per-agent specs MUST
+NOT remove or restructure the core fields above.
 
 ### 1.1 Field reference
 
@@ -102,46 +108,47 @@ commits:
 
 | Value | Meaning |
 |-------|---------|
-| `complete` | Worker finished its task. The orchestrator inspects `evidence` / `gate_status` to decide whether to advance, loop again, or stop. |
+| `complete` | Worker finished its task. The orchestrator inspects `evidence` (and the derived gate roll-up — see below) to decide whether to advance, loop again, or stop. |
 | `needs_human` | Worker hit a condition only a human can resolve. Orchestrator stamps the `human` label on the step-bead and stops. |
-| `failed` | Worker could not complete (e.g., tools unavailable, target missing). Distinct from `complete + gate_status: fail`. |
+| `failed` | Worker could not complete (e.g., tools unavailable, target missing). Distinct from `complete` with a failing derived gate. |
 
 **`iteration`** — orchestrator-supplied iteration number for RALF-IT
 loops. Omitted on single-shot dispatches. The formula step owns the
 loop; the orchestrator merely passes the current count through to the
 worker so it lands in the report and the audit label.
 
-**`evidence`** — machine-verifiable artifacts the worker produced.
+**`evidence`** — machine-verifiable artifacts the worker produced. Each
+block (`tests`, `build`, `lint`, `typecheck`) is optional at the block
+level; absence means the agent did not run that kind of check. When a
+block IS present, all listed sub-fields are required.
 
-- `evidence.tests.passing` and `evidence.tests.failing` are **required**
-  whenever a test command runs, because `green-loop` convergence is
-  measured by them. A worker that ran no tests omits the `tests` block
-  entirely. When the test runner exits non-zero before emitting parseable
-  counts (e.g., compile error, missing fixtures), set `passing: null,
-  failing: null` and capture the runner's stderr in `output_excerpt`.
-- `evidence.tests.output_excerpt` is a tail of test runner output,
-  capped to roughly 4KB. The full output should be visible in the
-  worker's commit, not duplicated into the report.
-- `build`, `lint`, `typecheck` blocks are each present only when the
-  worker ran the corresponding command. Missing blocks mean "did not
-  run", not "ran and passed".
+Within a present block:
 
-**`gate_status`** — rolled-up verdict across all evidence blocks,
-computed by the worker. Decoupled from `status` because a worker can
-finish (`status: complete`) with a failing gate (`gate_status: fail`) —
-that is the normal state during a `red-tests` dispatch.
+- `command` (string), `exit_code` (int or null), `skipped` (bool) —
+  required.
+- `skipped: true` means the gate was intentionally skipped (e.g., no
+  project lint configured); `exit_code` is `null` when skipped.
+- For the `tests` block only: `passing` (int or null), `failing` (int
+  or null) are required. `null` is permitted only when the runner exited
+  non-zero before emitting parseable counts (e.g., compile error,
+  missing fixtures). The runner's stderr in that case goes into
+  `escalations` with `reason: "tests-runner-unparseable"`.
 
-| Value | Meaning |
-|-------|---------|
-| `pass` | All evidence blocks present in the report exited 0. |
-| `fail` | At least one evidence block exited non-zero. |
-| `partial` | Some required gates were intentionally skipped (e.g., no project lint configured). |
+The full test runner / build / lint / typecheck output should be
+visible in the worker's commit. The report carries only structured
+counts and outcomes — not duplicated raw output.
 
-**`root_cause_note`** — free-text root-cause analysis. **Required for
-`bug-diagnoser`**, optional for the TDD agents. In `fix-bug`, the
-`tdd-green-team` dispatch reads the diagnose stage's note from its
-prior worker-report and may carry it forward in its own report; this
-preserves the audit trail across stages.
+**Gate-status derivation.** `worker-report-v1` does NOT include a
+`gate_status` field. The orchestrator derives the rolled-up verdict
+from the evidence blocks, which removes the conflict surface where a
+self-reported `gate_status` could disagree with the underlying counts:
+
+| Derived | When |
+|---------|------|
+| `pass` | Every present block has `exit_code == 0` AND `skipped == false` |
+| `fail` | At least one present block has `exit_code != 0` |
+| `partial` | All non-zero exits absent AND at least one block has `skipped == true` |
+| `n/a` | `evidence` is `{}` (e.g., synthetic crash report, diagnose-only dispatch) |
 
 **`escalations`** — list of issues the worker is asking the orchestrator
 to surface. Empty list when there are none. Each item is a one-line
@@ -160,26 +167,47 @@ the sibling test (see `src/plugins/beads/.claude/rules/beads.md` I3) to
 decide placement. The default — when no sibling fit is obvious — is the
 orphan + `discovered-from` form.
 
-**`commits`** — SHAs of commits the worker produced during the dispatch.
-Full 40-char SHAs only; abbreviated SHAs are malformed. The
-`message` field is the commit's first line, for human scanning. Empty
-list when the worker made no commits (e.g., a diagnose-only dispatch).
+**`commits`** — list of full 40-char SHAs the worker produced during
+the dispatch. Abbreviated SHAs are malformed. Empty list when the
+worker made no commits (e.g., a diagnose-only dispatch). Commit
+messages are queryable via `git log <sha>` and are intentionally NOT
+duplicated into the report.
 
 ### 1.2 Required vs optional summary
 
 | Field | Required? | Notes |
 |-------|-----------|-------|
 | `status` | required | |
-| `evidence` | required | inner blocks optional — present only when command ran |
-| `gate_status` | required | |
+| `evidence` | required | inner blocks optional — present only when command ran or was skipped |
 | `escalations` | required | `[]` when empty |
 | `discovered_work` | required | `[]` when empty |
 | `commits` | required | `[]` when empty |
 | `iteration` | optional | omit on single-shot dispatches |
-| `root_cause_note` | optional | required for `bug-diagnoser`, optional for TDD agents |
 
-Within an `evidence` block, all listed sub-fields are required when the
-block is present. An omitted top-level required field is malformed.
+Per-agent specs may add further required or optional fields above the
+core. Within a present `evidence` block, all listed sub-fields are
+required. An omitted top-level required field is malformed.
+
+### 1.3 Per-agent extensions
+
+| Agent | Schema | Adds |
+|-------|--------|------|
+| `tdd-red-team` | [`tdd-red-report-v1`](./tdd-red-report-v1.md) | (no additional fields; agent-specific expectations only) |
+| `tdd-green-team` | [`tdd-green-report-v1`](./tdd-green-report-v1.md) | (no additional fields; agent-specific expectations only) |
+| `bug-diagnoser` | [`bug-diagnoser-report-v1`](./bug-diagnoser-report-v1.md) | `root_cause_note` (required) |
+
+Per-agent specs describe:
+
+- Any additional required fields beyond the core.
+- Any structural deviations from the core (none currently).
+- Stage-specific orchestrator expectations (e.g., red-team expects the
+  derived gate roll-up to be `fail`, green-team expects `pass`).
+
+The core defines the structure that lets the orchestrator parse and
+audit any worker's report uniformly. Per-agent specs prevent each
+worker agent from carrying conditional logic ("am I a diagnoser? then
+also emit X") in its prompt — every agent has exactly one concrete
+schema.
 
 ## 2. File-based audit convention
 
@@ -217,12 +245,18 @@ emitted a malformed file — the orchestrator stamps a label on the
 **step-bead** (not the source-bead, not the molecule):
 
 ```
-worker-report-<agent-name>[-iter<N>]
+worker-audit-<agent-name>[-iter<N>]
 ```
 
-Examples: `worker-report-tdd-red-team`,
-`worker-report-tdd-green-team-iter2`,
-`worker-report-bug-diagnoser`.
+Examples: `worker-audit-tdd-red-team`,
+`worker-audit-tdd-green-team-iter2`,
+`worker-audit-bug-diagnoser`.
+
+The `worker-audit-` prefix is a stable namespace: filtering with
+`bd label list <step-bead-id>` and a "starts-with `worker-audit-`"
+match returns every audit label without enumerating agent names. The
+content after the prefix may evolve over future spec versions; the
+prefix is the durable retrieval handle.
 
 The label is a boolean-style marker, dash-separated. The full report
 path is fully recoverable from the label and the step-bead id via the
@@ -244,10 +278,13 @@ These labels are **forensic-only**:
   loop that runs three iterations leaves three iteration-suffixed
   labels on the step-bead. This is the desired forensic trail, not a
   bug.
-- **Not designed for programmatic parsing.** Agent names and the label
-  format both use hyphens; the boundary between agent-name and
-  `-iter<N>` is ambiguous to a regex. If structured retrieval is needed,
-  add a stable companion label (e.g. `worker-reported`) rather than
+- **Not designed for full programmatic parsing.** Agent names and the
+  label format both use hyphens; the boundary between agent-name and
+  `-iter<N>` is ambiguous to a regex. The stable `worker-audit-`
+  prefix supports namespace filtering ("starts with"), but parsing the
+  agent name + iteration out of the suffix is not a supported use case.
+  If structured retrieval beyond namespace filtering is needed, add a
+  separate stable companion label (e.g. `worker-reported`) rather than
   parsing audit labels.
 
 ## 4. Malformed and crashed-worker handling
@@ -266,7 +303,6 @@ the audit label. The synthetic report has:
 
 ```yaml
 status: failed
-gate_status: fail
 evidence: {}
 escalations:
   - reason: "Worker crashed"   # or "Worker emitted malformed report" for parse failures
@@ -278,11 +314,19 @@ discovered_work: []
 commits: []
 ```
 
-The `evidence` block is empty (`{}`) in the synthetic report because the
-orchestrator does not know which commands the worker attempted before
-crashing. The worker's process exit code belongs in `escalations.detail`,
-not in an `evidence.tests.exit_code` field — conflating the two would
-misrepresent what the test runner (if any) returned.
+The `evidence` block is empty (`{}`) because the orchestrator does not
+know which commands the worker attempted before crashing; the derived
+gate roll-up is `n/a` (see §1.1). The worker's process exit code
+belongs in `escalations.detail`, not in an `evidence.tests.exit_code`
+field — conflating the two would misrepresent what the test runner
+(if any) returned.
+
+The synthetic report contains only shared-core fields. Per-agent
+extensions (e.g. `bug-diagnoser`'s `root_cause_note`) are NOT included
+in the synthetic shape — agent-specific output is impossible to
+fabricate post-crash, and downstream consumers must treat
+`status: failed` as a signal that the agent's specific deliverables are
+unavailable.
 
 The synthetic report's existence on disk plus the audit label on the
 step-bead together guarantee the failure is visible to anyone running
@@ -294,12 +338,12 @@ For a report to be considered well-formed, the orchestrator MUST be
 able to read at minimum:
 
 - `status`
-- `gate_status`
 
-Either field missing — or unparseable as YAML — triggers the synthesis
-path. Other required fields (§1.2) are contract obligations enforced by
-review, not by the runtime: the orchestrator survives an incomplete
-report; full compliance is a review concern.
+`status` missing — or unparseable as YAML — triggers the synthesis
+path. Other required fields (§1.2 and per-agent extensions) are
+contract obligations enforced by review, not by the runtime: the
+orchestrator survives an incomplete report; full compliance is a review
+concern.
 
 ### 4.2 Out of scope: orchestrator self-crash
 
@@ -331,20 +375,22 @@ the test asserts the file appears.
 ## 6. Related work
 
 - **Epic `7bk.19`** — the parent redesign of the worker agent layer.
-- **`7bk.19.2`** — creates the three worker agents that emit
-  `worker-report-v1`.
+- **`tdd-red-report-v1`**, **`tdd-green-report-v1`**,
+  **`bug-diagnoser-report-v1`** — per-agent extensions of this core.
+- **`7bk.19.2`** — creates the three worker agents that emit the
+  per-agent reports.
 - **`7bk.19.3`** — rewrites the `implement-bead` orchestrator to
-  allocate the report path, parse the report, stamp the audit label,
-  and synthesize on crash/malformation.
+  allocate the report path, parse the report, derive the gate roll-up,
+  stamp the audit label, and synthesize on crash/malformation.
 - **`7bk.19.4`** — wires `implement-feature.formula.toml` and
   `fix-bug.formula.toml` to dispatch the new worker agents with
   explicit stage and iteration arguments.
 - **`7bk.19.5`** — updates `docs/specs/bead-pipeline-architecture.md` to
-  reference this contract from the relevant stage descriptions, and
+  reference these contracts from the relevant stage descriptions, and
   adds the smoke / tracer-bullet that proves the §5 write-tool
   contract holds in practice.
 - **`docs/specs/bead-pipeline-architecture.md`** — the canonical
-  pipeline architecture; this contract is one of the per-stage
-  state-out artifacts referenced there.
+  pipeline architecture; these contracts are the per-stage state-out
+  artifacts referenced there.
 - **`src/plugins/beads/.claude/rules/beads.md`** — the I3 sibling-test
   rule that governs how the orchestrator places `discovered_work` items.


### PR DESCRIPTION
## Summary

- Adds **`docs/specs/worker-report-v1.md`** as the shared core schema for worker agent reports (status, evidence, escalations, discovered_work, commits, optional iteration). Gate verdict is derived from `evidence` blocks (no separate `gate_status` field) using an explicit `skipped: bool` flag per block.
- Adds three **per-agent specs** that extend the core: `tdd-red-report-v1.md`, `tdd-green-report-v1.md`, `bug-diagnoser-report-v1.md`. Per-agent split removes conditional fields from any single agent prompt — each agent has one concrete schema.
- Defines deterministic file-path convention, `worker-audit-<agent-name>[-iter<N>]` audit-label format and forensic-only policy, crashed/malformed-worker synthesis behavior, and the absolute-path `Write` worker contract.
- Closes bead `agents-config-7bk.19.1`; unblocks `7bk.19.2`, `7bk.19.3`, `7bk.19.4`, `7bk.19.5`.

## Test Plan

- [x] Doc set exists at `docs/specs/{worker-report-v1,tdd-red-report-v1,tdd-green-report-v1,bug-diagnoser-report-v1}.md`
- [x] Shared core schema covers status, evidence, escalations, discovered_work, commits, iteration
- [x] Gate roll-up derivation rules cover pass/fail/partial/n/a; skipped blocks excluded from fail/pass
- [x] Audit convention covers: path format, RALF-IT iteration handling, label format with stable `worker-audit-` prefix, forensic-only policy, malformed/crashed handling
- [x] `bug-diagnoser-report-v1` runtime-requires non-empty `root_cause_note`; §4.1 documents per-agent runtime-required overrides
- [x] Orchestrator owns `discovered_work` placement (sibling-test); worker MUST NOT emit placement directives
- [x] All review feedback addressed; threads replied + resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)