### PR TITLE
feat: add OpenCode support to installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Purpose
 
-This is a versioned collection of agents, skills, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, and **Google Gemini CLI**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
+This is a versioned collection of agents, skills, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
 
 ## Prerequisites (Plugins)
 
@@ -38,6 +38,10 @@ This configuration assumes the following Claude Code plugins are installed:
 - `src/user/.gemini/` - **Gemini-specific** content (copies to `~/.gemini/`)
   - `GEMINI.md.template` - Gemini instruction file (refs shared + Gemini extensions)
   - `GEMINI-EXTENSIONS.md.template` - Gemini-specific sections (placeholder)
+- `src/user/.opencode/` - **OpenCode-specific** content (flattens to `~/.config/opencode/`)
+  - `AGENTS.md.template` - Flat instruction skeleton with dynamic-include markers
+  - `OPENCODE-EXTENSIONS.md.template` - OpenCode-specific notes and conventions
+  - `opencode.jsonc.template` - Settings (model, permissions, skills paths)
 - `src/plugins/` - **Optional plugin content** (installed only when detected)
   - `beads/` - beads plugin: skills, Claude rules, formulas
   - See `src/plugins/AGENTS.md` for plugin authoring conventions

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,7 +126,8 @@ for arg in "$@"; do
             echo "  --yes, -y          Auto-accept all prompts (suppresses diffs in quiet mode)"
             echo "  --verbose, -v      Show per-file progress (phases, up-to-date, installed, diffs)"
             echo "  --tools=TOOLS      Comma-separated tools: claude,codex,gemini,opencode"
-            echo "                     Default: auto-detect (claude always, others if ~/.<tool>/ or ~/.config/<tool>/ exists)"
+            echo "                     Default: auto-detect (claude always; others if ~/.<tool>/ exists;"
+            echo "                     opencode also if ~/.config/opencode/ exists or opencode is on PATH)"
             echo "  --plugins=PLUGINS  Comma-separated plugins: beads"
             echo "                     Default: auto-detect (enabled if bd is on PATH or ~/.beads/ exists)"
             echo "  --prune            After install, remove orphans under ~/.<tool>/{commands,skills,agents,rules}/"
@@ -454,6 +455,10 @@ resolve_collision() {
             ' "$existing" "$incoming")"
             printf '%s\n' "$merged_json" | jq . > "$existing"
             ;;
+        jsonc)
+            warn "JSONC collision: $(basename "$incoming") — later plugin overwrites earlier (alphabetical order)"
+            cp "$incoming" "$existing"
+            ;;
         toml)
             warn "TOML collision: $(basename "$incoming") — later plugin overwrites earlier (alphabetical order)"
             cp "$incoming" "$existing"
@@ -625,7 +630,10 @@ stage_and_install_tool() {
     # ── Phase 2: Stage shared skills and agents ───────────────────────────────
     vinfo "Phase 2: Shared skills and agents"
     stage_content_from_dir "$SRC_SHARED" "$staging" "skills"
-    stage_content_from_dir "$SRC_SHARED" "$staging" "agents"
+    # OpenCode: skip shared agents (frontmatter format differs)
+    if [[ "$tool" != "opencode" ]]; then
+        stage_content_from_dir "$SRC_SHARED" "$staging" "agents"
+    fi
 
     # Note: $SRC_SHARED/*.json.template (shared settings) are intentionally not staged here.
     # Shared settings are not used today; tool-specific settings are handled in Phase 5.
@@ -696,6 +704,10 @@ stage_and_install_tool() {
 
     # Sync subdirectories
     for subdir in rules commands skills agents; do
+        # OpenCode: skip agents (frontmatter format differs; see OPENCODE-EXTENSIONS.md)
+        if [[ "$tool" == "opencode" && "$subdir" == "agents" ]]; then
+            continue
+        fi
         [[ -d "$staging/$subdir" ]] || continue
         sync_directory "$subdir" "$staging" "$dest_dir" "staged"
     done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,8 +70,9 @@ fi
 #   --tools=claude,...   Comma-separated list of tools (default: auto-detect)
 #   --plugins=beads,...  Comma-separated list of plugins (default: auto-detect)
 #   --prune              After install, remove orphans (with backup) under
-#                        ~/.<tool>/{commands,skills,agents,rules}/ and
-#                        ~/.beads/formulas/ that are not in current staging
+#                        ~/.<tool>/{commands,skills,agents,rules}/ (or
+#                        ~/.config/<tool>/ for OpenCode) and ~/.beads/formulas/
+#                        that are not in current staging
 #   --prune-only         Skip Phase 7 (install) and only scan + prune orphans
 #                        (mutually exclusive with --prune)
 #   --help, -h           Show this help
@@ -114,7 +115,7 @@ for arg in "$@"; do
             echo "Usage: install.sh [--dry-run] [--yes|-y] [--verbose|-v] [--tools=TOOLS] [--plugins=PLUGINS] [--prune] [--prune-only] [--help|-h]"
             echo ""
             echo "Installs shared and tool-specific agent config into ~/.<tool>/ directories"
-            echo "for Claude Code, OpenAI Codex CLI, and Google Gemini CLI."
+            echo "for Claude Code, OpenAI Codex CLI, Google Gemini CLI, and OpenCode."
             echo ""
             echo "Shared content (skills, agents, instructions, personas) from src/user/.agents/"
             echo "is installed into all detected tools. Tool-specific content from src/user/.<tool>/"
@@ -124,8 +125,8 @@ for arg in "$@"; do
             echo "  --dry-run          Show what would be done without making changes"
             echo "  --yes, -y          Auto-accept all prompts (suppresses diffs in quiet mode)"
             echo "  --verbose, -v      Show per-file progress (phases, up-to-date, installed, diffs)"
-            echo "  --tools=TOOLS      Comma-separated tools: claude,codex,gemini"
-            echo "                     Default: auto-detect (claude always, others if ~/.<tool>/ exists)"
+            echo "  --tools=TOOLS      Comma-separated tools: claude,codex,gemini,opencode"
+            echo "                     Default: auto-detect (claude always, others if ~/.<tool>/ or ~/.config/<tool>/ exists)"
             echo "  --plugins=PLUGINS  Comma-separated plugins: beads"
             echo "                     Default: auto-detect (enabled if bd is on PATH or ~/.beads/ exists)"
             echo "  --prune            After install, remove orphans under ~/.<tool>/{commands,skills,agents,rules}/"
@@ -250,9 +251,22 @@ split_csv() {
     fi
 }
 
+# ── Utility: resolve destination directory for a tool ─────────────────────────
+#
+# OpenCode uses XDG config dir (~/.config/opencode/) instead of a dot-dir.
+
+tool_dest_dir() {
+    local tool="$1"
+    if [[ "$tool" == "opencode" ]]; then
+        echo "$HOME/.config/opencode"
+    else
+        echo "$HOME/.$tool"
+    fi
+}
+
 # ── Tool detection ────────────────────────────────────────────────────────
 
-ALL_TOOLS=(claude codex gemini)
+ALL_TOOLS=(claude codex gemini opencode)
 TOOLS=()
 ALL_PLUGINS=(beads)
 PLUGINS=()
@@ -271,6 +285,9 @@ else
     for tool in codex gemini; do
         [[ -d "$HOME/.$tool" ]] && TOOLS+=("$tool")
     done
+    if command -v opencode &>/dev/null || [[ -d "$HOME/.config/opencode" ]]; then
+        TOOLS+=(opencode)
+    fi
 fi
 
 vinfo "Tools: ${TOOLS[*]}"
@@ -471,6 +488,8 @@ classify_file() {
         echo "dir"
     elif [[ "$basename" == settings.json.template ]]; then
         echo "settings.json"
+    elif [[ "$basename" == *.jsonc.template ]]; then
+        echo "jsonc"
     elif [[ "$basename" == *.toml.template || "$basename" == *.toml ]]; then
         echo "toml"
     elif [[ "$basename" == *.md && -n "$parent_dir" ]]; then
@@ -521,11 +540,66 @@ stage_content_from_dir() {
     done
 }
 
+# ── Utility: flatten AGENTS.md.template for OpenCode ──────────────────────────
+#
+# OpenCode does not support `@` include resolution. This function reads a
+# template containing <!-- DYNAMIC-INCLUDE: path --> and
+# <!-- DYNAMIC-INCLUDE-RULES: rule1,... --> markers and produces a single
+# flat file with all references inlined.
+#
+# marker paths are relative to project_root.
+
+flatten_agents_md() {
+    local template="$1"
+    local output="$2"
+    local project_root="$3"
+
+    local line marker_path rule_names rule_file first_rule rule_name
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Extract path from <!-- DYNAMIC-INCLUDE: path --> using sed (portable bash/zsh)
+        marker_path="$(printf '%s' "$line" | sed -n "s/^<!-- DYNAMIC-INCLUDE: \(.*\) -->$/\1/p")"
+        if [[ -n "$marker_path" ]]; then
+            if [[ -f "$project_root/$marker_path" ]]; then
+                cat "$project_root/$marker_path" >> "$output"
+            else
+                warn "DYNAMIC-INCLUDE not found: $marker_path"
+            fi
+            continue
+        fi
+
+        # Extract rule list from <!-- DYNAMIC-INCLUDE-RULES: rule1,... --> using sed
+        rule_names="$(printf '%s' "$line" | sed -n "s/^<!-- DYNAMIC-INCLUDE-RULES: \(.*\) -->$/\1/p")"
+        if [[ -n "$rule_names" ]]; then
+            first_rule=true
+            # Use tr + while read for portable comma splitting (works in bash and zsh)
+            while IFS= read -r rule_name; do
+                rule_name="$(printf '%s' "$rule_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+                [[ -n "$rule_name" ]] || continue
+                rule_file="$project_root/src/user/.claude/rules/$rule_name.md"
+                if [[ -f "$rule_file" ]]; then
+                    if [[ "$first_rule" == true ]]; then
+                        first_rule=false
+                    else
+                        printf '\n---\n' >> "$output"
+                    fi
+                    cat "$rule_file" >> "$output"
+                else
+                    warn "DYNAMIC-INCLUDE-RULES not found: $rule_name.md"
+                fi
+            done < <(printf '%s' "$rule_names" | tr ',' '\n')
+            continue
+        fi
+
+        printf '%s\n' "$line" >> "$output"
+    done < "$template"
+}
+
 # ── Install one tool via staging ──────────────────────────────────────────────
 
 stage_and_install_tool() {
     local tool="$1"
-    local dest_dir="$HOME/.$tool"
+    local dest_dir="$(tool_dest_dir "$tool")"
     local src_tool="$SRC_USER/.$tool"
     local staging="$STAGING_DIR/$tool"
     # Hoist all loop-internal locals to function scope — see commit 2fe276d:
@@ -568,7 +642,7 @@ stage_and_install_tool() {
             stage_content_from_dir "$src_tool" "$staging" "$subdir"
         done
 
-        for settings_file in "$src_tool"/*.json.template "$src_tool"/*.toml.template; do
+        for settings_file in "$src_tool"/*.json.template "$src_tool"/*.jsonc.template "$src_tool"/*.toml.template; do
             [[ -f "$settings_file" ]] || continue
             file_type="$(classify_file "$settings_file" "")"
             stage_item "$settings_file" "$staging/$(basename "$settings_file")" "$file_type"
@@ -598,6 +672,15 @@ stage_and_install_tool() {
         fi
     done
 
+    # ── Phase 6.5: Flatten AGENTS.md for OpenCode ─────────────────────────────
+    if [[ "$tool" == "opencode" && -f "$staging/AGENTS.md.template" ]]; then
+        vinfo "Phase 6.5: Flattening AGENTS.md for OpenCode"
+        local flattened
+        flattened="$(mktemp)"
+        flatten_agents_md "$staging/AGENTS.md.template" "$flattened" "$PROJECT_ROOT"
+        mv "$flattened" "$staging/AGENTS.md.template"
+    fi
+
     # ── Phase 7: Sync staging → ~/.<tool>/ (reusing existing sync functions) ──
     # Skipped under --prune-only: staging tree (Phases 1-6) is still built so
     # scan_orphans has a comparison baseline, but no files are written to ~/.
@@ -618,7 +701,7 @@ stage_and_install_tool() {
     done
 
     # Sync settings files (union-merges staged template with installed settings)
-    for settings_file in "$staging"/*.json.template "$staging"/*.toml.template; do
+    for settings_file in "$staging"/*.json.template "$staging"/*.jsonc.template "$staging"/*.toml.template; do
         [[ -f "$settings_file" ]] || continue
         sync_settings_file "$settings_file" "$dest_dir" "staged"
     done
@@ -864,7 +947,7 @@ sync_directory() {
             [[ -e "$dest_item" ]] || continue
             item_name="$(basename "$dest_item")"
             if [[ ! -e "$src_parent/$item_name" ]]; then
-                warn "$dir_name/$item_name exists in ~/.$CURRENT_TOOL but not in $label source (keeping)"
+                warn "$dir_name/$item_name exists in $(tool_dest_dir "$CURRENT_TOOL") but not in $label source (keeping)"
             fi
         done
     fi
@@ -966,6 +1049,44 @@ sync_settings_file() {
             fi
         fi
 
+    elif [[ "$basename_template" == *.jsonc.template ]]; then
+        # JSONC: plain copy (jq cannot parse JSONC comments; merge is out of scope)
+        if [[ ! -f "$dest_file" ]]; then
+            if [[ "$DRY_RUN" == true ]]; then
+                vok "Would install $target_name (new)"
+            else
+                cp "$template" "$dest_file"
+                vok "Installed $target_name (new)"
+            fi
+            (( tool_installed[$CURRENT_TOOL]++ )) || true
+        else
+            local src_hash dst_hash
+            src_hash="$(compute_hash "$template")"
+            dst_hash="$(compute_hash "$dest_file")"
+
+            if [[ "$src_hash" == "$dst_hash" ]]; then
+                vok "$target_name is up to date"
+                (( tool_skipped[$CURRENT_TOOL]++ )) || true
+            else
+                if [[ "$SHOW_DIFFS" == true ]]; then
+                    info "$target_name differs from installed version:"
+                    diff --color=auto -u "$dest_file" "$template" || true
+                    echo
+                fi
+                if [[ "$DRY_RUN" == true ]]; then
+                    vok "Would update $target_name [$label]"
+                    (( tool_updated[$CURRENT_TOOL]++ )) || true
+                elif confirm "Overwrite $dest_file with template version?"; then
+                    backup "$dest_file"
+                    cp "$template" "$dest_file"
+                    vok "Updated $target_name [$label]"
+                    (( tool_updated[$CURRENT_TOOL]++ )) || true
+                else
+                    warn "Skipped $target_name [$label]"
+                    (( tool_skipped[$CURRENT_TOOL]++ )) || true
+                fi
+            fi
+        fi
     elif [[ "$basename_template" == *.toml.template ]]; then
         # TOML: plain copy (merge is out of scope)
         if [[ ! -f "$dest_file" ]]; then
@@ -1064,7 +1185,7 @@ scan_orphans() {
 
     for tool in "${TOOLS[@]}"; do
         for sub in "${prune_subdirs[@]}"; do
-            _scan_namespace "$tool" "$sub" "$HOME/.$tool/$sub" "$STAGING_DIR/$tool/$sub"
+            _scan_namespace "$tool" "$sub" "$(tool_dest_dir "$tool")/$sub" "$STAGING_DIR/$tool/$sub"
         done
     done
 

--- a/src/user/.agents/AGENTS.md
+++ b/src/user/.agents/AGENTS.md
@@ -11,8 +11,10 @@ dir exists or `--tools=` selects them).
 - `agents/`, `skills/` — each top-level entry copied; **names must be unique**
   across the combined tree (shared + tool-specific + active plugins).
   Collisions in these dirs are a **fatal install error**.
-- Tool-specific files (`.claude/`, `.codex/`, `.gemini/`) overlay on top of
-  these in later phases; plugin content overlays last. Ordering matters.
+- Tool-specific files (`.claude/`, `.codex/`, `.gemini/`, `.opencode/`) overlay
+  on top of these in later phases; plugin content overlays last. Ordering matters.
+- OpenCode gets a **flat, dynamically-built AGENTS.md** (no `@` includes).
+  See `src/user/.opencode/` for details.
 
 ## Agent warnings
 

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -1,0 +1,26 @@
+# src/user/.opencode/ — OpenCode Source Templates
+
+OpenCode-specific source content. `scripts/install.sh` stages content here into
+`~/.config/opencode/` when OpenCode is active (auto-detected if `opencode` is on
+PATH or `~/.config/opencode/` exists, or selected via `--tools=opencode`).
+
+## Install model
+
+- `*.md.template` — `.template` suffix stripped on copy
+  (`AGENTS.md.template` → `~/.config/opencode/AGENTS.md`).
+- `opencode.jsonc.template` → `~/.config/opencode/opencode.jsonc` (plain copy).
+
+## Dynamic flattening
+
+`AGENTS.md.template` is special: it contains `<!-- DYNAMIC-INCLUDE: path -->` and
+`<!-- DYNAMIC-INCLUDE-RULES: rule1,rule2,... -->` markers that the installer
+resolves at staging time, producing a single flat `AGENTS.md` with no `@`
+references. This is required because OpenCode does not support `@` include
+resolution.
+
+## Agent warnings
+
+These are **source templates**, not runtime config. Editing a file here changes
+what gets installed to users' real `~/.config/opencode/` on next install.
+
+See the root [AGENTS.md](../../../AGENTS.md) for the full install model.

--- a/src/user/.opencode/AGENTS.md.template
+++ b/src/user/.opencode/AGENTS.md.template
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+<!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->
+<!-- DYNAMIC-INCLUDE-RULES: delegation,delivery,git-commits,subagents,worktrees -->
+<!-- DYNAMIC-INCLUDE: src/user/.opencode/OPENCODE-EXTENSIONS.md.template -->

--- a/src/user/.opencode/OPENCODE-EXTENSIONS.md.template
+++ b/src/user/.opencode/OPENCODE-EXTENSIONS.md.template
@@ -1,0 +1,34 @@
+# OpenCode-Specific Notes
+
+## Configuration
+
+- This file was dynamically flattened at install time. `@` references in the
+  original source have been resolved and inlined.
+- OpenCode reads instruction files as raw text and does not follow `@` includes.
+- If you modify source templates, re-run `install.sh` to regenerate this file.
+
+## Skills
+
+OpenCode scans `~/.claude/skills/**/SKILL.md` natively. Shared skills are
+available without duplication. Some referenced skills (e.g. `superpowers:*`)
+require the [obra/superpowers](https://github.com/obra/superpowers) Claude Code
+plugin.
+
+## Agents
+
+Shared agents from `src/user/.agents/agents/` are **not** installed to OpenCode
+for now because the frontmatter format differs (OpenCode uses provider-prefixed
+model IDs, `mode:`, `permission:`, etc.). Install OpenCode-specific agents to
+`~/.config/opencode/agents/` manually if needed.
+
+## Commands
+
+Shared commands from `src/user/.claude/commands/` are **not** installed to
+OpenCode. OpenCode commands live in `~/.config/opencode/commands/` and use a
+slightly different frontmatter format.
+
+## Rules
+
+OpenCode does not support a `rules/` directory. Tool-agnostic rules from the
+Claude `rules/` directory have been inlined above. Claude-specific rules
+(`codex-routing.md`, `completion-gate.md`) are omitted.

--- a/src/user/.opencode/README.md
+++ b/src/user/.opencode/README.md
@@ -1,0 +1,19 @@
+# OpenCode Configuration Source
+
+This directory contains source templates for OpenCode (`opencode`) support.
+
+## Contents
+
+- `AGENTS.md.template` — Skeleton with dynamic-include markers for the flat instruction file
+- `OPENCODE-EXTENSIONS.md.template` — OpenCode-specific notes and conventions
+- `opencode.jsonc.template` — Settings (model, permissions, skills paths)
+
+## How it works
+
+`install.sh` builds a flat `AGENTS.md` at install time by:
+1. Reading `AGENTS.md.template`
+2. Resolving `<!-- DYNAMIC-INCLUDE: path -->` markers (inlines referenced file content)
+3. Resolving `<!-- DYNAMIC-INCLUDE-RULES: rule1,... -->` markers (inlines rules from `src/user/.claude/rules/`)
+4. Writing the result to `~/.config/opencode/AGENTS.md`
+
+This preserves DRY (content lives in one place) while producing a file OpenCode can use.

--- a/src/user/.opencode/opencode.jsonc.template
+++ b/src/user/.opencode/opencode.jsonc.template
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "moonshotai/kimi-k2.6",
+  "skills": {
+    "paths": [
+      "~/.claude/skills/",
+      "~/.agents/skills/"
+    ]
+  },
+  "permission": {
+    "bash": "ask",
+    "read": "allow",
+    "edit": "ask",
+    "glob": "allow",
+    "grep": "allow",
+    "list": "allow",
+    "task": "ask",
+    "webfetch": "ask",
+    "websearch": "ask",
+    "external_directory": "deny",
+    "doom_loop": "deny"
+  }
+}


### PR DESCRIPTION
## Summary

Adds OpenCode as a fourth supported tool alongside Claude, Codex, and Gemini.

## Problem

OpenCode does not support `@` include resolution or a `rules/` directory, which are core features used by the existing Claude configuration. Without flattening at install time, OpenCode would receive broken instruction files.

## Solution

### Dynamic AGENTS.md Flattening
- Implements `flatten_agents_md()` in `install.sh` that resolves `<!-- DYNAMIC-INCLUDE: path -->` and `<!-- DYNAMIC-INCLUDE-RULES: rule1,... -->` markers at install time
- Produces a single flat `AGENTS.md` with no `@` references
- Portable implementation using `sed` + `tr` (works in both bash and zsh)

### OpenCode Source Tree
- Created `src/user/.opencode/` with source templates:
  - `AGENTS.md.template` — skeleton with dynamic-include markers
  - `OPENCODE-EXTENSIONS.md.template` — OpenCode-specific notes
  - `opencode.jsonc.template` — settings with permissions and skills paths
  - `AGENTS.md` / `README.md` — source directory documentation

### Installer Changes
- Added `opencode` to `ALL_TOOLS` with auto-detection (on PATH or `~/.config/opencode/`)
- Added `tool_dest_dir()` helper for XDG config dir (`~/.config/opencode/`) vs dot-dir for others
- Added `.jsonc.template` handling (plain copy — jq cannot parse JSONC comments)
- Updated orphan scan, help text, and all hardcoded `$HOME/.$tool` paths

### Rules Inlined
The flat AGENTS.md includes:
- `delegation` — cross-tool delegation rules
- `delivery` — PR creation and review workflow
- `git-commits` — commit message and safety rules
- `subagents` — subagent dispatch rules
- `worktrees` — worktree hygiene rules

Claude-specific rules (`codex-routing`, `completion-gate`) are omitted per design decision.

### Agents/Commands Skipped
Shared agents and commands are not installed to OpenCode for now due to incompatible frontmatter formats. This is documented in the source tree and can be addressed in future work.

## Verification

- [x] `install.sh --dry-run --tools=opencode` completes without errors
- [x] Staged `AGENTS.md` contains inlined personas, instructions, and rules
- [x] Zero `@` references remain in installed `~/.config/opencode/AGENTS.md`
- [x] `opencode.jsonc` installed to `~/.config/opencode/`
- [x] Auto-detect works (opencode on PATH → included in default tools)
- [x] `--tools=opencode` override works
- [x] Other tools (claude) unaffected by changes — dry-run shows all up to date

## Post-Merge Follow-up

- Consider creating OpenCode-specific agent wrappers with translated frontmatter
- Consider installing shared commands to OpenCode (different frontmatter format)
- Consider plugin support for OpenCode (beads rules are Claude-only today)