### PR TITLE
feat: universal instruction flattening (jyb.1)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -545,10 +545,11 @@ stage_content_from_dir() {
     done
 }
 
-# ── Utility: flatten AGENTS.md.template for OpenCode ──────────────────────────
+# ── Utility: flatten instruction templates (DYNAMIC-INCLUDE) ──────────────────
 #
-# OpenCode does not support `@` include resolution. This function reads a
-# template containing <!-- DYNAMIC-INCLUDE: path --> and
+# Some tools (like OpenCode) do not support `@` include resolution, or we want
+# a single flat file for distribution. This function reads a template
+# containing <!-- DYNAMIC-INCLUDE: path --> and
 # <!-- DYNAMIC-INCLUDE-RULES: rule1,... --> markers and produces a single
 # flat file with all references inlined.
 #
@@ -684,7 +685,7 @@ stage_and_install_tool() {
     for template in "$staging/AGENTS.md.template" "$staging/GEMINI.md.template"; do
         if [[ -f "$template" ]]; then
             vinfo "Phase 6.5: Flattening $(basename "$template") for $tool"
-            flattened="$(mktemp)"
+            flattened="$(mktemp "$STAGING_DIR/flatten.XXXXXXXX")"
             flatten_agents_md "$template" "$flattened" "$PROJECT_ROOT"
             mv "$flattened" "$template"
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -680,14 +680,16 @@ stage_and_install_tool() {
         fi
     done
 
-    # ── Phase 6.5: Flatten AGENTS.md for OpenCode ─────────────────────────────
-    if [[ "$tool" == "opencode" && -f "$staging/AGENTS.md.template" ]]; then
-        vinfo "Phase 6.5: Flattening AGENTS.md for OpenCode"
-        local flattened
-        flattened="$(mktemp)"
-        flatten_agents_md "$staging/AGENTS.md.template" "$flattened" "$PROJECT_ROOT"
-        mv "$flattened" "$staging/AGENTS.md.template"
-    fi
+    # ── Phase 6.5: Universal instruction flattening ──────────────────────────
+    for template in "$staging/AGENTS.md.template" "$staging/GEMINI.md.template"; do
+        if [[ -f "$template" ]]; then
+            vinfo "Phase 6.5: Flattening $(basename "$template") for $tool"
+            local flattened
+            flattened="$(mktemp)"
+            flatten_agents_md "$template" "$flattened" "$PROJECT_ROOT"
+            mv "$flattened" "$template"
+        fi
+    done
 
     # ── Phase 7: Sync staging → ~/.<tool>/ (reusing existing sync functions) ──
     # Skipped under --prune-only: staging tree (Phases 1-6) is still built so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -609,7 +609,7 @@ stage_and_install_tool() {
     local staging="$STAGING_DIR/$tool"
     # Hoist all loop-internal locals to function scope — see commit 2fe276d:
     # zsh prints the variable's value when `local` is re-invoked in a loop.
-    local file_type plugin_tool_dir plugin_agents_dir
+    local file_type plugin_tool_dir plugin_agents_dir flattened
 
     CURRENT_TOOL="$tool"
     vheader "$tool"
@@ -684,7 +684,6 @@ stage_and_install_tool() {
     for template in "$staging/AGENTS.md.template" "$staging/GEMINI.md.template"; do
         if [[ -f "$template" ]]; then
             vinfo "Phase 6.5: Flattening $(basename "$template") for $tool"
-            local flattened
             flattened="$(mktemp)"
             flatten_agents_md "$template" "$flattened" "$PROJECT_ROOT"
             mv "$flattened" "$template"

--- a/scripts/smoke/test-universal-flattening.sh
+++ b/scripts/smoke/test-universal-flattening.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# scripts/smoke/test-universal-flattening.sh
+#
+# Verifies that AGENTS.md.template (and GEMINI.md.template) are flattened
+# for all tools using the DYNAMIC-INCLUDE markers.
+#
+# This test is expected to FAIL until the universal flattening logic is implemented.
+
+set -euo pipefail
+
+# Worktree Root (absolute path)
+WORKTREE_ROOT="/Users/scott/src/projects/agents-config/.claude/worktrees/feat/agents-config-jyb.1-universal-instruction-flattening"
+
+# Use a temporary directory for the test
+TEST_ROOT=$(mktemp -d /tmp/universal-flattening-test-XXXXXX)
+MOCK_HOME="${TEST_ROOT}/home"
+MOCK_PROJECT="${TEST_ROOT}/project"
+
+echo "==> Setting up mock environment at ${TEST_ROOT}"
+
+mkdir -p "${MOCK_HOME}/.claude"
+mkdir -p "${MOCK_HOME}/.gemini"
+mkdir -p "${MOCK_HOME}/.config/opencode"
+
+mkdir -p "${MOCK_PROJECT}/src/user/.agents"
+mkdir -p "${MOCK_PROJECT}/src/user/.claude"
+mkdir -p "${MOCK_PROJECT}/src/user/.gemini"
+mkdir -p "${MOCK_PROJECT}/src/user/.opencode"
+mkdir -p "${MOCK_PROJECT}/scripts"
+
+# Copy install.sh to mock project
+cp "${WORKTREE_ROOT}/scripts/install.sh" "${MOCK_PROJECT}/scripts/install.sh"
+
+# Create a content file to include
+echo "Shared Agent Content" > "${MOCK_PROJECT}/shared-content.md"
+
+# Create templates with DYNAMIC-INCLUDE
+cat > "${MOCK_PROJECT}/src/user/.opencode/AGENTS.md.template" <<EOF
+# OpenCode Agents
+<!-- DYNAMIC-INCLUDE: shared-content.md -->
+EOF
+
+cat > "${MOCK_PROJECT}/src/user/.claude/AGENTS.md.template" <<EOF
+# Claude Agents
+<!-- DYNAMIC-INCLUDE: shared-content.md -->
+EOF
+
+cat > "${MOCK_PROJECT}/src/user/.gemini/GEMINI.md.template" <<EOF
+# Gemini Instructions
+<!-- DYNAMIC-INCLUDE: shared-content.md -->
+EOF
+
+# Run install.sh
+export PROJECT_ROOT="${MOCK_PROJECT}"
+export HOME="${MOCK_HOME}"
+
+echo "==> Running install.sh"
+# Use --tools to limit scope and avoid auto-detection issues in a minimal mock
+bash "${MOCK_PROJECT}/scripts/install.sh" --yes --verbose --tools=opencode,claude,gemini
+
+echo "==> Verifying results"
+
+FAILED=0
+
+# OpenCode should be flattened (existing behavior)
+if grep -q "Shared Agent Content" "${MOCK_HOME}/.config/opencode/AGENTS.md"; then
+    echo "OK: OpenCode AGENTS.md is flattened"
+else
+    echo "FAIL: OpenCode AGENTS.md is NOT flattened"
+    FAILED=1
+fi
+
+# Claude should BE flattened (expected feature)
+if grep -q "Shared Agent Content" "${MOCK_HOME}/.claude/AGENTS.md"; then
+    echo "OK: Claude AGENTS.md is flattened"
+else
+    echo "FAIL: Claude AGENTS.md is NOT flattened"
+    FAILED=1
+fi
+
+# Gemini should BE flattened (expected feature)
+if grep -q "Shared Agent Content" "${MOCK_HOME}/.gemini/GEMINI.md"; then
+    echo "OK: Gemini GEMINI.md is flattened"
+else
+    echo "FAIL: Gemini GEMINI.md is NOT flattened"
+    FAILED=1
+fi
+
+if [ $FAILED -eq 1 ]; then
+    echo "==> Universal flattening test FAILED (Expected for RED step)"
+    exit 1
+else
+    echo "==> Universal flattening test PASSED"
+    exit 0
+fi

--- a/scripts/smoke/test-universal-flattening.sh
+++ b/scripts/smoke/test-universal-flattening.sh
@@ -4,7 +4,6 @@
 # Verifies that AGENTS.md.template (and GEMINI.md.template) are flattened
 # for all tools using the DYNAMIC-INCLUDE markers.
 #
-# This test is expected to FAIL until the universal flattening logic is implemented.
 
 set -euo pipefail
 
@@ -88,7 +87,7 @@ else
 fi
 
 if [ $FAILED -eq 1 ]; then
-    echo "==> Universal flattening test FAILED (Expected for RED step)"
+    echo "==> Universal flattening test FAILED (Regression)"
     exit 1
 else
     echo "==> Universal flattening test PASSED"

--- a/scripts/smoke/test-universal-flattening.sh
+++ b/scripts/smoke/test-universal-flattening.sh
@@ -13,6 +13,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Use a temporary directory for the test
 TEST_ROOT=$(mktemp -d /tmp/universal-flattening-test-XXXXXX)
+trap 'rm -rf "$TEST_ROOT"' EXIT
 MOCK_HOME="${TEST_ROOT}/home"
 MOCK_PROJECT="${TEST_ROOT}/project"
 

--- a/scripts/smoke/test-universal-flattening.sh
+++ b/scripts/smoke/test-universal-flattening.sh
@@ -8,8 +8,9 @@
 
 set -euo pipefail
 
-# Worktree Root (absolute path)
-WORKTREE_ROOT="/Users/scott/src/projects/agents-config/.claude/worktrees/feat/agents-config-jyb.1-universal-instruction-flattening"
+# Derive repository root from script location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Use a temporary directory for the test
 TEST_ROOT=$(mktemp -d /tmp/universal-flattening-test-XXXXXX)
@@ -29,7 +30,7 @@ mkdir -p "${MOCK_PROJECT}/src/user/.opencode"
 mkdir -p "${MOCK_PROJECT}/scripts"
 
 # Copy install.sh to mock project
-cp "${WORKTREE_ROOT}/scripts/install.sh" "${MOCK_PROJECT}/scripts/install.sh"
+cp "${REPO_ROOT}/scripts/install.sh" "${MOCK_PROJECT}/scripts/install.sh"
 
 # Create a content file to include
 echo "Shared Agent Content" > "${MOCK_PROJECT}/shared-content.md"


### PR DESCRIPTION
- Bead: agents-config-jyb.1 - Universal instruction flattening: modify install.sh to run flatten_agents_md for all tools
- Acceptance Criteria:
  - Modify Phase 6.5 in scripts/install.sh to perform flattening for Claude, Codex, and Gemini, not just OpenCode.
  - This ensures deterministic delivery of instructions across all supported CLIs.
- RALF-IT Summary: 1 iteration. Generalized Phase 6.5 logic to be tool-agnostic.
- Validation Report: PASSED. Smoke test `scripts/smoke/test-universal-flattening.sh` confirmed correct flattening across all tools in a mock environment.