### PR TITLE
docs(beads): canonical bd notes/comments reference + dedup formula prose

### DIFF
--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -326,9 +326,7 @@ Record the dispatch decision for audit:
 
   bd comments add {{bead-id}} "implement-fix: dispatched <skill-name>"
 
-`bd comments add` is non-destructive: it creates a separate comment and does
-not replace issue notes. For cumulative step output, use `bd update
---append-notes`; do not use `--notes`, which replaces existing notes.
+`bd comments add` is non-destructive; do NOT use `--notes` (replaces notes) — use `--append-notes` for step output. See beads rules §Notes vs Comments.
 
 Persist step output before closing green-loop. Here `<step-bead-id>` is the current green-loop molecule step bead:
 

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -276,9 +276,7 @@ Record the dispatch decision for audit:
 
   bd comments add {{bead-id}} "implement: dispatched <skill-name>"
 
-`bd comments add` is non-destructive: it creates a separate comment and does
-not replace issue notes. For cumulative step output, use `bd update
---append-notes`; do not use `--notes`, which replaces existing notes.
+`bd comments add` is non-destructive; do NOT use `--notes` (replaces notes) — use `--append-notes` for step output. See beads rules §Notes vs Comments.
 
 Persist step output before closing green-loop. Here `<step-bead-id>` is the current green-loop molecule step bead:
 

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -255,3 +255,17 @@ Beads and superpowers are partners with distinct roles. Do not confuse them.
 **Rule:** off-limits skills compete with the bead lifecycle. On a bead, use
 `start-bead` → `brainstorm-bead` → `implement-bead` instead. Off-limits skills
 remain available for non-bead work.
+
+---
+
+## Notes vs Comments: bd update semantics
+
+Three commands serve distinct roles — mixing them up causes lost context.
+
+| Command | Semantics | When to use |
+|---|---|---|
+| `bd update <id> --append-notes "..."` | Appends to existing notes | Step output, escalation context, cumulative status, run breadcrumbs |
+| `bd update <id> --notes "..."` | **Replaces** existing notes entirely | Initial bead creation, or `brainstorm-bead` spec writes — intentional overwrites only |
+| `bd comments add <id> "..."` | Creates a separate, non-destructive comment | Lifecycle audit breadcrumbs, molecule→bead tracing, events that should not pollute notes |
+
+**Footgun alert**: `--notes` is a destructive overwrite. If you mean "add to this", use `--append-notes`.

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -545,7 +545,7 @@ authoritative.** Do not infer mode from invocation context.
 | `--mode` value | Trigger source | Behavior on ESCALATE |
 |---|---|---|
 | `interactive` (default) | Operator in chat | Pause Phase 3.5; emit ONE batched prompt listing every ESCALATE item with rationale + a summary of FIX items as a sanity check. The user resolves each ESCALATE → `FIX-with-direction` / `SKIP-with-rationale` / `DEFER`, AND may re-classify any FIX → SKIP/ESCALATE. Reclassifications flow into the inventory before Phase 4. |
-| `autonomous` | `run-queue`, formula step, scheduled trigger | Apply `bd label add <bead-id> human` (NOT `bd human <id>` — see Red Flags), then `bd update <bead-id> --append-notes "<batched-escalate-list>"` (`--append-notes` appends; `--notes` would REPLACE existing notes). Each item formatted as: `ESCALATE: <comment_id> (@<author>): <body_excerpt> — rationale: <rationale>`. Mark each ESCALATE item `escalation_filed=true` in the inventory. Continue to Phase 4 with FIX items only. |
+| `autonomous` | `run-queue`, formula step, scheduled trigger | Apply `bd label add <bead-id> human` (NOT `bd human <id>` — see Red Flags), then `bd update <bead-id> --append-notes "<batched-escalate-list>"` (see beads rules §Notes vs Comments). Each item formatted as: `ESCALATE: <comment_id> (@<author>): <body_excerpt> — rationale: <rationale>`. Mark each ESCALATE item `escalation_filed=true` in the inventory. Continue to Phase 4 with FIX items only. |
 
 **Hard guard at Phase 1**: `--mode autonomous` requires `--bead-id <id>`
 (non-empty). Absence → fatal startup error


### PR DESCRIPTION
## Summary
- Adds `## Notes vs Comments: bd update semantics` section to `src/plugins/beads/.claude/rules/beads.md` with a 3-command reference table and footgun callout
- Trims the duplicated 3-line teaching from `implement-feature.formula.toml` and `fix-bug.formula.toml` to one-liner + canonical citation (A3 treatment)
- Trims `--append-notes appends; --notes would REPLACE` parenthetical in `wait-for-pr-comments/SKILL.md` to `(see beads rules §Notes vs Comments)`

Closes agents-config-avq.

## Test plan
- [ ] `beads.md` ends with new `## Notes vs Comments` section containing 3-command table and footgun callout
- [ ] `implement-feature.formula.toml`: old 3-line prose block gone, one-liner present
- [ ] `fix-bug.formula.toml`: same
- [ ] `wait-for-pr-comments/SKILL.md`: parenthetical replaced with canonical reference
- [ ] `brainstorm-bead.formula.toml`, `create-bead/SKILL.md`, `docs/specs/` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)