### PR TITLE
fix(hft): guard brainstorm-bead overwrite + switch create-bead capture to --append-notes

### DIFF
--- a/src/plugins/beads/.agents/skills/create-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/create-bead/SKILL.md
@@ -97,8 +97,9 @@ tangential) → orphan + `discovered-from`.
 
 If the user gave requirements, constraints, or acceptance criteria, add them:
 ```bash
+# Note: bd has no --append-acceptance; a repeat create will replace AC intentionally.
 bd update <id> --acceptance="<preliminary criteria>"
-bd update <id> --notes="<any additional context>"
+bd update <id> --append-notes="<any additional context>"
 ```
 
 If the bead is a dependency of other work:

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -149,6 +149,16 @@ Write the spec as a structured document covering:
 - Open questions: anything still unresolved (if any)
 
 Write back to the bead:
+
+⚠️ Before writing: `--notes=` REPLACES the entire notes field, and
+`--acceptance=` REPLACES the entire acceptance-criteria field. Inspect
+the current state with `bd show {{bead-id}}` first. If the bead has
+prior investigation context (notes from `create-bead`, user discussion,
+or earlier brainstorming), you MUST either:
+  (a) merge the prior content into your spec document before writing, or
+  (b) preserve it via `bd comments add {{bead-id}} "..."` BEFORE running
+      the update commands below.
+
   bd update {{bead-id}} --acceptance="<one line per acceptance criterion>"
   bd update {{bead-id}} --notes="<full spec document>"
 


### PR DESCRIPTION
## Summary

Closes the remaining `--notes=` overwrite traps surfaced by `agents-config-hft` after R1 (the dangerous mechanical fix-bug formula bug) already shipped on main.

- **`brainstorm-bead.formula.toml` write-spec step**: adds a 9-line guard preamble inside the `description = """..."""` block, above the `bd update --acceptance=` line. Carries the greppable sentinel `REPLACES the entire notes field`, reminds the agent that `--notes=` and `--acceptance=` overwrite, and funnels any pre-existing context through either (a) merge-into-spec or (b) non-destructive `bd comments add`. Revise step intentionally untouched (it legitimately overwrites by design).
- **`create-bead/SKILL.md` Step 3**: switches the additional-context capture from `--notes=` to `--append-notes=`, adds an inline comment explaining why no `--append-acceptance` flag exists today.

## Why

`bd update --notes=` and `--acceptance=` are destructive overwrites. When two formula steps run sequentially against the same bead, the second silently destroys the first's content. The fix-bug formula bug (sequential `--notes` overwrites) shipped via main earlier in the `hft` work (R1). This PR finishes the audit by:

1. Adding an advisory guard to `brainstorm-bead`'s write-spec, where prior context (from `create-bead`, user discussion, or earlier brainstorming) could be silently clobbered.
2. Switching `create-bead`'s additional-context capture to the safe append flavor.

## Verification

Per the bead's AC (no project test/build harness — verification is grep-based + manual):

| Check | Expected | Actual |
|---|---|---|
| `grep -cE 'bd update .* --notes "' fix-bug.formula.toml` | 0 | 0 |
| `grep -c "REPLACES the entire notes field" brainstorm-bead.formula.toml` | >=1 | 1 |
| `grep -cE 'bd update <id> --notes=' create-bead/SKILL.md` | 0 | 0 |
| `grep -c "append-acceptance" create-bead/SKILL.md` | >=1 | 1 |
| Live overwrite audit | only intentional sites | write-spec 162-163, revise 213-214, create-bead `--acceptance=` 101 |
| Revise step untouched | yes | confirmed (no diff hunk in revise region) |
| Manual repro on throwaway bead | PASS | PASS — both `SENTINEL-REPRO` and `SENTINEL-ROOT-CAUSE` survive sequential `--append-notes` |

## Quality gate

- `quality-reviewer` agent: SHIP recommendation; two minor wording findings (acceptance-criteria terminology, ordering of "Inspect first") applied this PR.
- `simplify` skill: none warranted.
- `verify-checklist`: report below.

## Discovered work filed

- `agents-config-f298` — upstream bd CLI: add `--append-acceptance` / `--append-design` / `--append-description` for full append-parity. (`discovered-from agents-config-hft`)
- `agents-config-2yyb` — brainstorm-bead writes spec to notes field but rules/beads.md says specs go in description; resolve inconsistency. (`discovered-from agents-config-hft`)

## Test plan

- [x] AC grep checks all pass (5 of 5)
- [x] Manual throwaway-bead repro: PASS
- [x] TOML still parses cleanly (verified by quality-reviewer)
- [x] Revise step untouched

Closes `agents-config-hft`.