### PR TITLE
chore(codex): remove redundant honor-system startup contract

### DIFF
--- a/src/user/.codex/AGENTS.md.template
+++ b/src/user/.codex/AGENTS.md.template
@@ -2,21 +2,6 @@
 
 User-scoped instructions for all projects.
 
-## Required Startup Actions
-
-Before responding to any user message or taking any action, read these files from `~/.codex/` immediately and in full:
-
-1. `~/.codex/AGENT-PERSONA.md`
-2. `~/.codex/USER-PERSONA.md`
-3. `~/.codex/INSTRUCTIONS.md`
-4. `~/.codex/CODEX-EXTENSIONS.md`
-
-These are mandatory startup reads, not optional references.
-Do not wait for the files to become relevant.
-Do not announce or narrate that you are reading these files — just read them silently.
-Do not answer questions, summarize the repo, or perform any work until all four files have been read.
-If any file is missing or unreadable, stop and report that as the blocker.
-
 <!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->


### PR DESCRIPTION
## Summary

- Removes the `## Required Startup Actions` section from `src/user/.codex/AGENTS.md.template`
- This manual-read "honor system" contract (telling Codex to explicitly read four files before acting) is now redundant: the `DYNAMIC-INCLUDE` markers inline the content directly at install time
- Keeps the file clean and consistent with how Claude's template works — the included content speaks for itself

Closes jyb.3

## Test plan

- [ ] Verify `AGENTS.md.template` no longer contains the `## Required Startup Actions` section
- [ ] Verify the four `DYNAMIC-INCLUDE` markers are still present and intact
- [ ] Run `scripts/install.sh --dry-run` to confirm no install-time regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)