### PR TITLE
refactor(7bk.19.3): make implement-bead §8 outcomes stage-blind

### DIFF
--- a/docs/specs/tdd-green-report-v1.md
+++ b/docs/specs/tdd-green-report-v1.md
@@ -20,8 +20,19 @@ no removed fields, no structural deviations.
   tests (left by `tdd-red-team`, or — in `fix-bug` — the failing test
   written by `tdd-red-team` to capture the bug) pass without breaking
   existing tests.
-- **Expected derived gate roll-up: `pass`** — specifically, every
-  present `evidence` block has `exit_code == 0` and `skipped == false`.
+- **`status: complete` is per-iteration.** It signals only that the
+  agent finished its iteration's attempt at making the failing tests
+  pass — NOT loop convergence. Convergence
+  (`evidence.tests.failing == 0` from the most recent iteration) is
+  determined by `ralf-implement` across iterations, not by this agent.
+  The agent emits `status: complete` for any iteration that ran to
+  completion and recorded its evidence; it does NOT self-bound based
+  on whether its own iteration converged.
+- **Expected derived gate roll-up on convergence: `pass`** —
+  specifically, every present `evidence` block has `exit_code == 0`
+  and `skipped == false`. This is the convergence signal that
+  `ralf-implement` reads to decide whether to dispatch another
+  iteration or advance the pipeline.
 - A persistent `fail` derivation across iterations indicates the agent
   has not converged. The formula step owns iteration policy:
   - The formula step's `MAX_ITERATIONS` cap controls when the orchestrator

--- a/docs/specs/tdd-red-report-v1.md
+++ b/docs/specs/tdd-red-report-v1.md
@@ -19,13 +19,18 @@ no removed fields, no structural deviations.
 - The agent's task: add tests that capture an intended behavior NOT YET
   implemented in the codebase. The tests must FAIL when run against the
   current production code.
-- **Expected derived gate roll-up: `fail`** — specifically,
-  `evidence.tests.failing > 0`. The orchestrator does not advance the
-  pipeline on a `pass` derivation from a red-team dispatch; that
-  outcome means the new tests didn't actually test anything new.
-- The agent SHOULD flag an unexpected `pass` derivation in
-  `escalations` with `reason: "red-tests-passed-unexpectedly"`. The
-  orchestrator escalates such reports to a human.
+- **Stage-specific success criterion for `status: complete`:** the
+  derived gate roll-up is `fail` — specifically,
+  `evidence.tests.failing > 0`. The agent emits `status: complete` ONLY
+  when this criterion is satisfied. The orchestrator's outcome rule is
+  stage-blind and advances the pipeline on `complete`; the
+  stage-specific knowledge that "fail-is-success" for red-tests lives
+  here, in this agent's contract, not in the orchestrator.
+- If the test command's derived gate would be `pass` (tests passed
+  unexpectedly — meaning the new tests didn't actually test anything
+  new), the agent MUST emit `status: needs_human` with `escalations[]`
+  containing `reason: "red-tests-passed-unexpectedly"`. The agent MUST
+  NOT emit `status: complete` in this case.
 - The agent's commits MUST contain only test-file additions or
   modifications. No production-code changes are permitted in the red
   phase; production-code changes belong to `tdd-green-team`.

--- a/docs/specs/worker-report-v1.md
+++ b/docs/specs/worker-report-v1.md
@@ -106,7 +106,7 @@ NOT remove or restructure the core fields above.
 
 | Value | Meaning |
 |-------|---------|
-| `complete` | Worker finished its task. The orchestrator inspects `evidence` (and the derived gate roll-up — see below) to decide whether to advance, loop again, or stop. |
+| `complete` | Worker considers its stage-specific success criterion (per its per-agent spec) satisfied. The orchestrator advances the pipeline on `complete` regardless of the derived gate. Per-agent specs define what "success" means (e.g., red-team: tests fail as intended; green-team: iteration ran to completion and recorded its evidence — loop convergence is `ralf-implement`'s call, not the worker's; diagnoser: non-empty `root_cause_note`); the worker emits `needs_human` when its stage-specific criterion is not met. |
 | `needs_human` | Worker hit a condition only a human can resolve. Orchestrator stamps the `human` label on the step-bead and stops. |
 | `failed` | Worker could not complete (e.g., tools unavailable, target missing). Distinct from `complete` with a failing derived gate. |
 

--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -131,18 +131,13 @@ For `(red-tests, fix-bug)` and `(green-loop, fix-bug)`, retrieve the prior diagn
 
 ## 8. Apply status outcomes to the step-bead
 
-All `human` stamps in this section apply to BOTH the step-bead AND the source bead (human-flag protocol).
+Outcomes are stage-blind: `status` is the only outcome input. Stage-specific success criteria — including red-tests' "fail-is-success" — live in each worker's per-agent spec, which is also where the worker decides between `complete` and `needs_human` based on the derived gate. The orchestrator's derived gate roll-up is forensic context (recorded via the audit label, the report file on disk, and the `--append-notes` evidence appended on escalation paths), not an outcome branch. All `human` stamps cover BOTH the step-bead AND the source bead (human-flag protocol).
 
 1. Direct-dispatch path (no `ralf:required`) — exactly one report processed:
-   - `complete` + gate `pass` → close step-bead with summary; exit.
-   - `complete` + gate `fail` or `partial` → stamp `human` on step-bead AND source bead, append gate-fail evidence to step-bead notes, close step-bead with summary; exit.
+   - `complete` → close step-bead with summary; exit.
    - `needs_human` → stamp `human` on step-bead AND source bead, append escalations, close step-bead with summary; exit.
    - `failed` (real or synthesized) → stamp `human` on step-bead AND source bead, append failure detail, close step-bead with summary; exit.
-2. Orchestration path (RALF) — `ralf-implement` or `ralf-review` returns an aggregate verdict (final report, final derived gate, foreign-eyes status) on convergence or max-cycles exhaustion. Apply the same outcome rules above using the aggregate verdict (every `human` stamp covers BOTH step-bead AND source bead), then close the step-bead and exit. The orchestration skill stamps per-iteration audit labels during the loop; this skill closes the step-bead at the end.
-
-## 9. Outcome-rule override metadata
-
-Before applying §8, read the step-bead labels (per §1) for `outcome-on-fail:advance` (step-bead-scoped, NOT source-bead-scoped). When present, invert §8's `complete + gate: fail` rule from "stamp `human`, close, escalate" to "close step-bead with summary, advance" — `gate: fail` is treated as the success signal for this step. Applies on BOTH the direct dispatch path AND the orchestration (RALF-aggregate) path; the override is a single metadata-driven label read, not a formula-identity branch. The `failed` status (synthetic-on-crash and per-agent runtime-field failures) is NOT subject to the override — those still escalate per §8. Default (label absent): §8 unchanged.
+2. Orchestration path (RALF) — `ralf-implement` or `ralf-review` returns an aggregate verdict (final report, foreign-eyes status) on convergence or max-cycles exhaustion. Apply the same status-only rules above using the aggregate verdict (every `human` stamp covers BOTH step-bead AND source bead), then close the step-bead and exit. The orchestration skill owns per-iteration gate inspection during the loop and stamps per-iteration audit labels; this skill closes the step-bead at the end.
 
 ## Audit-label scope
 

--- a/tests/verify-implement-bead.sh
+++ b/tests/verify-implement-bead.sh
@@ -164,28 +164,20 @@ assert_line_count_le "$SLASH" 40 "AC16d: slash command ≤ 40 lines"
 assert_no_grep "bead-implementor" "$SKILL" "AC17a: SKILL.md has NO bead-implementor references"
 assert_no_grep "bead-implementor" "$SLASH" "AC17b: slash command has NO bead-implementor references"
 
-# AC 18 — Outcome-rule override metadata (PR #36 comment 3193307037)
-# 18a: SKILL.md mentions the literal label name `outcome-on-fail:advance`
-assert_grep "outcome-on-fail:advance" "$SKILL" "AC18a: SKILL.md documents outcome-on-fail:advance step-bead override"
+# AC 18 — Stage-blind outcome rules (option (c) per bead 7bk.19.3)
+# Workers self-police via stage-aware `status` emission; the orchestrator
+# acts on `status` alone. The previous override mechanism
+# (`outcome-on-fail:advance` label) is removed in favor of worker-side
+# success criteria documented in per-agent specs.
 
-# 18b: override applies to BOTH dispatch paths — file mentions "direct" AND ("RALF" or "orchestration" or "aggregate") near the override.
-# Approximate via per-file co-occurrence: the override section must reference both the direct-dispatch and the RALF/orchestration/aggregate path.
-if grep -F -q "outcome-on-fail:advance" "$SKILL" 2>/dev/null \
-   && grep -E -i -q "direct( dispatch)?" "$SKILL" 2>/dev/null \
-   && grep -E -i -q "(RALF|ralf-aggregate|aggregate|orchestration)" "$SKILL" 2>/dev/null; then
-  ok "AC18b: SKILL.md states override applies to BOTH direct dispatch AND RALF/orchestration paths"
-else
-  bad "AC18b: SKILL.md states override applies to BOTH direct dispatch AND RALF/orchestration paths"
-fi
+# 18a: SKILL.md does NOT contain the removed override label
+assert_no_grep "outcome-on-fail:advance" "$SKILL" "AC18a: SKILL.md does NOT contain removed outcome-on-fail:advance override label"
 
-# 18c: `failed` status is NOT subject to the override — proves correctness around synthetic-on-crash.
-# Approximate: `failed` AND "NOT" (case-insensitive) co-occur in the override context.
-if grep -F -q "failed" "$SKILL" 2>/dev/null \
-   && grep -E -i -q "(NOT subject|not subject|still escalate)" "$SKILL" 2>/dev/null; then
-  ok "AC18c: SKILL.md states failed status is NOT subject to the outcome-on-fail:advance override"
-else
-  bad "AC18c: SKILL.md states failed status is NOT subject to the outcome-on-fail:advance override"
-fi
+# 18b: SKILL.md §8 does NOT contain a gate-conditional outcome branch
+assert_no_grep 'complete` + gate' "$SKILL" 'AC18b: SKILL.md §8 has no `complete` + gate outcome branch'
+
+# 18c: SKILL.md states outcome rules are stage-blind
+assert_grep "stage-blind" "$SKILL" "AC18c: SKILL.md §8 states outcome rules are stage-blind"
 
 TOTAL=$((PASS + FAIL))
 printf "\nTotal: %d  Pass: %d  Fail: %d\n" "$TOTAL" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Implements **option (c)** for the §8 outcome-rule defect that surfaced in the post-merge review of PR #36 (worker-report-v1 rewrite, bead `agents-config-7bk.19.3`).

Under (c), the orchestrator's outcome rule becomes **stage-blind** — `status` is the only outcome input. Workers self-police via stage-aware `status` emission per their per-agent specs:

- `tdd-red-team`: emits `complete` only when `evidence.tests.failing > 0` (fail-is-success); MUST emit `needs_human` on unexpected pass.
- `tdd-green-team`: per-iteration `complete` (iteration ran, evidence recorded); convergence is `ralf-implement`'s call, not the worker's.
- `bug-diagnoser`: emits `complete` only with non-empty `root_cause_note`; otherwise `needs_human` (already aligned).

The §9 `outcome-on-fail:advance` override mechanism — added in PR #36 to patch the defect — is deleted as architectural drift under (c). It required the orchestrator to know per-stage semantics (which the `[h]` anti-drift principle forbids), and once `status: complete` carries stage-success-met semantics, the override has nothing to override.

## Files changed

- `src/plugins/beads/.agents/skills/implement-bead/SKILL.md` — §8 rewritten stage-blind (3 outcomes: `complete` → advance; `needs_human` → escalate; `failed` → escalate). §9 deleted. 144/150 lines.
- `docs/specs/worker-report-v1.md` §1.1 — `complete` row reframed (worker considers stage-specific success criterion satisfied; orchestrator advances regardless of derived gate).
- `docs/specs/tdd-red-report-v1.md` — SHOULD→MUST emit `needs_human` on unexpected pass; explicit MUST NOT emit `complete` in that case.
- `docs/specs/tdd-green-report-v1.md` — explicit per-iteration semantic clause for `status: complete`.
- `tests/verify-implement-bead.sh` — AC18 rewritten to assert the new architecture (no override label, no gate-conditional branch, outcomes are stage-blind).

## Architectural rationale (option (c))

| Concern | Pre-(c) | Post-(c) |
|---|---|---|
| Where stage knowledge lives | Orchestrator (§9 override) + worker | Worker only (per-agent specs) |
| Orchestrator outcome inputs | `status` + derived gate | `status` |
| Red-tests "fail-is-success" | §9 override label flips outcome | Worker emits `complete` only when `failing > 0` |
| `[h]` anti-drift discipline | Violated (orchestrator stage-aware via override) | Honored (orchestrator stage-blind) |

Quality-reviewer dispatched in-house: **APPROVE** with 3 findings (1 MEDIUM + 2 LOW). MEDIUM (`worker-report-v1.md:109` green-team gloss) and LOW#2 (`SKILL.md:134` parenthetical) addressed in-place. LOW#3 (AC18c assertion hardening) accepted as optional, left as-is per reviewer's "your call."

## Test plan

- [x] `bash tests/verify-implement-bead.sh` → **40 PASS / 0 FAIL** (SKILL.md = 144/150 lines)
- [x] `grep -rn "outcome-on-fail" --include="*.md" --include="*.toml" --include="*.sh"` returns only `tests/verify-implement-bead.sh:170` (the `assert_no_grep` line that asserts its absence)
- [x] Quality-reviewer agent run; findings addressed
- [x] `simplify` skill three-axis review; none warranted (the AC18 nested-if collapse to flat helpers was already realized in the original edit)
- [ ] Copilot inline + top-level review (this PR)

## Bead trail

- Bead `agents-config-7bk.19.3` (the spec; option (c) decision recorded as forensic note dated 2026-05-06).
- Parent epic `7bk.19` (worker-agent-layer redesign).
- Builds on PR #36 (`dd1153de`, the originating rewrite).
- Out-of-scope items remain on `7bk.19.4` (formula TOML wiring) and `7bk.19.5` (architecture spec catalog + smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)