### PR TITLE
fix(beads): add bd-record-decision.sh; eliminate bd decision record folklore (agents-config-y7nc)

### DIFF
--- a/docs/specs/2026-04-19-ralf-it-form-reevaluation-design.md
+++ b/docs/specs/2026-04-19-ralf-it-form-reevaluation-design.md
@@ -294,7 +294,15 @@ Rewritten delegation rule reflects the two-skill split:
   | `ralf:required` | `brainstorm-bead.finalize` (or manual) | Formula step dispatches `ralf-implement` (implement step) or `ralf-review` (review step) |
   | `ralf:cycles=N` | `brainstorm-bead.finalize` (or manual) | Override `MAX_ITERATIONS` (optional; skill default otherwise). Setters MUST remove any existing `ralf:cycles=*` first. |
 
-### R12. `bd decision` record
+### R12. Decision record (`bd create --type decision`)
+
+`decision` is an issue **type**, not a CLI namespace — there is no
+`bd decision record` subcommand. Create the record with:
+
+```bash
+bd create 'RALF split into ralf-review + ralf-implement; both inner-methodology only' --type decision
+# aliases: --type dec, --type adr
+```
 
 - Title: "RALF split into ralf-review + ralf-implement; both inner-methodology only"
 - Notes: Two-worlds collapsed to one family of two skills. `ralf-review`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,6 +62,7 @@ fi
 #   7. Sync staging → ~/.<tool>/ (hash-compare, diff, confirm)
 #
 # For beads plugin: staging/<beads>/formulas/ → ~/.beads/formulas/
+#                   staging/<beads>/scripts/   → ~/.beads/scripts/  (chmod +x on install)
 #
 # Flags:
 #   --dry-run            Show what would be done without making changes
@@ -881,6 +882,82 @@ stage_and_install_beads() {
             fi
         done
     fi
+
+    # ── Sync beads scripts → ~/.beads/scripts/ ───────────────────────────────
+    # Scripts are installed with chmod +x. Not tracked by --prune (scripts are
+    # rare and hand-managed; add _scan_namespace call here if that changes).
+    local dest_scripts staging_scripts plugin_scripts_dir found_any_script
+    local script_name dest_script script_src_hash script_dst_hash
+    dest_scripts="$HOME/.beads/scripts"
+    staging_scripts="$STAGING_DIR/.beads/scripts"
+
+    for plugin in "${PLUGINS[@]}"; do
+        plugin_scripts_dir="$SRC_PLUGINS/$plugin/.beads/scripts"
+        [[ -d "$plugin_scripts_dir" ]] || continue
+        mkdir -p "$staging_scripts"
+        for script in "$plugin_scripts_dir"/*.sh; do
+            [[ -f "$script" ]] || continue
+            script_name="$(basename "$script")"
+            stage_item "$script" "$staging_scripts/$script_name" "other"
+        done
+    done
+
+    if [[ ! -d "$staging_scripts" ]]; then
+        vinfo "No beads scripts staged"
+        return 0
+    fi
+
+    if [[ "$DRY_RUN" != true && "$PRUNE_ONLY" != true ]] && plugin_enabled "beads"; then
+        mkdir -p "$dest_scripts"
+    fi
+
+    found_any_script=false
+    for script in "$staging_scripts"/*.sh; do
+        [[ -f "$script" ]] || continue
+        found_any_script=true
+        script_name="$(basename "$script")"
+        dest_script="$dest_scripts/$script_name"
+
+        if [[ ! -f "$dest_script" ]]; then
+            if [[ "$DRY_RUN" == true ]]; then
+                vok "Would install scripts/$script_name (new)"
+            else
+                cp "$script" "$dest_script"
+                chmod +x "$dest_script"
+                vok "Installed scripts/$script_name (new)"
+            fi
+            (( tool_installed[beads]++ )) || true
+        else
+            script_src_hash="$(compute_hash "$script")"
+            script_dst_hash="$(compute_hash "$dest_script")"
+
+            if [[ "$script_src_hash" == "$script_dst_hash" ]]; then
+                vok "scripts/$script_name is up to date"
+                (( tool_skipped[beads]++ )) || true
+            else
+                if [[ "$SHOW_DIFFS" == true ]]; then
+                    info "scripts/$script_name differs:"
+                    diff --color=auto -u "$dest_script" "$script" || true
+                    echo
+                fi
+                if [[ "$DRY_RUN" == true ]]; then
+                    vok "Would update scripts/$script_name"
+                    (( tool_updated[beads]++ )) || true
+                elif confirm "Overwrite ~/.beads/scripts/$script_name?"; then
+                    backup "$dest_script"
+                    cp "$script" "$dest_script"
+                    chmod +x "$dest_script"
+                    vok "Updated scripts/$script_name"
+                    (( tool_updated[beads]++ )) || true
+                else
+                    warn "Skipped scripts/$script_name"
+                    (( tool_skipped[beads]++ )) || true
+                fi
+            fi
+        fi
+    done
+
+    [[ "$found_any_script" == false ]] && vinfo "No script files staged"
 }
 
 # ── Sync templates from a source dir into a dest dir ──────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -933,7 +933,7 @@ stage_and_install_beads() {
 
             if [[ "$script_src_hash" == "$script_dst_hash" ]]; then
                 # Content matches but exec bit may have been lost — restore it without a full copy.
-                [[ -x "$dest_script" ]] || { chmod +x "$dest_script"; vinfo "Restored +x on scripts/$script_name"; }
+                [[ "$DRY_RUN" == true ]] || { [[ -x "$dest_script" ]] || { chmod +x "$dest_script"; vinfo "Restored +x on scripts/$script_name"; }; }
                 vok "scripts/$script_name is up to date"
                 (( tool_skipped[beads]++ )) || true
             else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -932,6 +932,8 @@ stage_and_install_beads() {
             script_dst_hash="$(compute_hash "$dest_script")"
 
             if [[ "$script_src_hash" == "$script_dst_hash" ]]; then
+                # Content matches but exec bit may have been lost — restore it without a full copy.
+                [[ -x "$dest_script" ]] || { chmod +x "$dest_script"; vinfo "Restored +x on scripts/$script_name"; }
                 vok "scripts/$script_name is up to date"
                 (( tool_skipped[beads]++ )) || true
             else

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -162,8 +162,13 @@ or earlier brainstorming), you MUST either:
   bd update {{bead-id}} --acceptance="<one line per acceptance criterion>"
   bd update {{bead-id}} --notes="<full spec document>"
 
-If the spec required closing existing technical ambiguity, note it:
-  bd decision record --title="<decision>" --notes="<rationale>"
+If the spec required closing existing technical ambiguity, record it:
+  ~/.beads/scripts/bd-record-decision.sh \
+    --bead-id {{bead-id}} \
+    --title "<brief decision statement>" \
+    --notes "<rationale>" \
+    --implemented      # decision resolved in this spec; closes the decision bead
+  # --needs-approval   # impacts future work; keeps open and flags for human review
 
 Do NOT start implementing. Do NOT create a worktree. This is a spec step.
 """

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -168,7 +168,7 @@ If the spec required closing existing technical ambiguity, record it:
     --title "<brief decision statement>" \
     --notes "<rationale>" \
     --implemented      # decision resolved in this spec; closes the decision bead
-  # --needs-approval   # impacts future work; keeps open and flags for human review
+    --needs-approval   # impacts future work; keeps open and flags for human review
 
 Do NOT start implementing. Do NOT create a worktree. This is a spec step.
 """

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -163,10 +163,10 @@ or earlier brainstorming), you MUST either:
   bd update {{bead-id}} --notes="<full spec document>"
 
 If the spec required closing existing technical ambiguity, record it:
-  ~/.beads/scripts/bd-record-decision.sh \
-    --bead-id {{bead-id}} \
-    --title "<brief decision statement>" \
-    --notes "<rationale>" \
+  ~/.beads/scripts/bd-record-decision.sh \\
+    --bead-id {{bead-id}} \\
+    --title "<brief decision statement>" \\
+    --notes "<rationale>" \\
     --implemented      # decision resolved in this spec; closes the decision bead
     --needs-approval   # impacts future work; keeps open and flags for human review
 

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -167,6 +167,7 @@ If the spec required closing existing technical ambiguity, record it:
     --bead-id {{bead-id}} \\
     --title "<brief decision statement>" \\
     --notes "<rationale>" \\
+    # choose one:
     --implemented      # decision resolved in this spec; closes the decision bead
     --needs-approval   # impacts future work; keeps open and flags for human review
 

--- a/src/plugins/beads/.beads/scripts/bd-record-decision.sh
+++ b/src/plugins/beads/.beads/scripts/bd-record-decision.sh
@@ -19,7 +19,8 @@ set -euo pipefail
 BEAD_ID=""
 TITLE=""
 NOTES=""
-OUTCOME=""
+IMPLEMENTED=false
+NEEDS_APPROVAL=false
 
 usage() {
     echo "Usage: $(basename "$0") --bead-id <id> --title <text> --notes <text> (--implemented | --needs-approval)" >&2
@@ -31,17 +32,27 @@ while [[ $# -gt 0 ]]; do
         --bead-id)        BEAD_ID="$2";       shift 2 ;;
         --title)          TITLE="$2";         shift 2 ;;
         --notes)          NOTES="$2";         shift 2 ;;
-        --implemented)    OUTCOME="implemented";    shift ;;
-        --needs-approval) OUTCOME="needs-approval"; shift ;;
+        --implemented)    IMPLEMENTED=true;   shift ;;
+        --needs-approval) NEEDS_APPROVAL=true; shift ;;
         -h|--help)        usage ;;
         *) echo "Unknown option: $1" >&2; usage ;;
     esac
 done
 
-[[ -z "$BEAD_ID" ]]  && { echo "Error: --bead-id is required" >&2;  usage; }
-[[ -z "$TITLE" ]]    && { echo "Error: --title is required" >&2;    usage; }
-[[ -z "$NOTES" ]]    && { echo "Error: --notes is required" >&2;    usage; }
-[[ -z "$OUTCOME" ]]  && { echo "Error: --implemented or --needs-approval is required" >&2; usage; }
+[[ -z "$BEAD_ID" ]] && { echo "Error: --bead-id is required" >&2; usage; }
+[[ -z "$TITLE" ]]   && { echo "Error: --title is required" >&2;   usage; }
+[[ -z "$NOTES" ]]   && { echo "Error: --notes is required" >&2;   usage; }
+
+if [[ "$IMPLEMENTED" == true && "$NEEDS_APPROVAL" == true ]]; then
+    echo "Error: --implemented and --needs-approval are mutually exclusive" >&2
+    usage
+fi
+if [[ "$IMPLEMENTED" == false && "$NEEDS_APPROVAL" == false ]]; then
+    echo "Error: one of --implemented or --needs-approval is required" >&2
+    usage
+fi
+
+OUTCOME=$([[ "$IMPLEMENTED" == true ]] && echo "implemented" || echo "needs-approval")
 
 # Create the decision bead and capture its ID
 CREATE_OUTPUT=$(bd create "$TITLE" --type decision 2>&1)

--- a/src/plugins/beads/.beads/scripts/bd-record-decision.sh
+++ b/src/plugins/beads/.beads/scripts/bd-record-decision.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# bd-record-decision.sh — Record an architectural decision as a tracked bead.
+#
+# Creates a decision-type bead, links it to the source bead via a
+# discovered-from dependency, then applies the outcome:
+#
+#   --implemented    Decision is resolved in the current spec or work.
+#                    Closes the decision bead immediately.
+#
+#   --needs-approval Decision impacts future work and requires human sign-off.
+#                    Keeps the bead open and adds the 'human' label.
+#
+# Usage:
+#   bd-record-decision.sh --bead-id <id> --title "<text>" --notes "<text>"
+#                         (--implemented | --needs-approval)
+
+set -euo pipefail
+
+BEAD_ID=""
+TITLE=""
+NOTES=""
+OUTCOME=""
+
+usage() {
+    echo "Usage: $(basename "$0") --bead-id <id> --title <text> --notes <text> (--implemented | --needs-approval)" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bead-id)        BEAD_ID="$2";       shift 2 ;;
+        --title)          TITLE="$2";         shift 2 ;;
+        --notes)          NOTES="$2";         shift 2 ;;
+        --implemented)    OUTCOME="implemented";    shift ;;
+        --needs-approval) OUTCOME="needs-approval"; shift ;;
+        -h|--help)        usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$BEAD_ID" ]]  && { echo "Error: --bead-id is required" >&2;  usage; }
+[[ -z "$TITLE" ]]    && { echo "Error: --title is required" >&2;    usage; }
+[[ -z "$NOTES" ]]    && { echo "Error: --notes is required" >&2;    usage; }
+[[ -z "$OUTCOME" ]]  && { echo "Error: --implemented or --needs-approval is required" >&2; usage; }
+
+# Create the decision bead and capture its ID
+CREATE_OUTPUT=$(bd create "$TITLE" --type decision 2>&1)
+echo "$CREATE_OUTPUT"
+
+DEC_ID=$(echo "$CREATE_OUTPUT" | sed -n 's/.*Created issue: \([^ ]*\).*/\1/p')
+if [[ -z "$DEC_ID" ]]; then
+    echo "Error: could not extract decision bead ID from bd create output" >&2
+    exit 1
+fi
+
+# Attach rationale
+bd update "$DEC_ID" --notes="$NOTES"
+
+# Link decision to source bead — this decision was discovered while working on it
+bd dep add "$DEC_ID" "$BEAD_ID" --type discovered-from
+
+# Apply outcome
+if [[ "$OUTCOME" == "implemented" ]]; then
+    bd close "$DEC_ID" --reason "Resolved in spec/work for $BEAD_ID"
+    echo "Decision $DEC_ID created and closed (resolved in current spec)."
+elif [[ "$OUTCOME" == "needs-approval" ]]; then
+    bd label add "$DEC_ID" human
+    bd update "$DEC_ID" --append-notes "Needs human approval before implementation can proceed."
+    echo "Decision $DEC_ID created and flagged for human review."
+fi

--- a/src/plugins/beads/.beads/scripts/bd-record-decision.sh
+++ b/src/plugins/beads/.beads/scripts/bd-record-decision.sh
@@ -29,10 +29,16 @@ usage() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --bead-id)        BEAD_ID="$2";       shift 2 ;;
-        --title)          TITLE="$2";         shift 2 ;;
-        --notes)          NOTES="$2";         shift 2 ;;
-        --implemented)    IMPLEMENTED=true;   shift ;;
+        --bead-id)
+            [[ $# -ge 2 ]] || { echo "Error: --bead-id requires a value" >&2; usage; }
+            BEAD_ID="$2"; shift 2 ;;
+        --title)
+            [[ $# -ge 2 ]] || { echo "Error: --title requires a value" >&2; usage; }
+            TITLE="$2"; shift 2 ;;
+        --notes)
+            [[ $# -ge 2 ]] || { echo "Error: --notes requires a value" >&2; usage; }
+            NOTES="$2"; shift 2 ;;
+        --implemented)    IMPLEMENTED=true;    shift ;;
         --needs-approval) NEEDS_APPROVAL=true; shift ;;
         -h|--help)        usage ;;
         *) echo "Unknown option: $1" >&2; usage ;;
@@ -54,13 +60,10 @@ fi
 
 OUTCOME=$([[ "$IMPLEMENTED" == true ]] && echo "implemented" || echo "needs-approval")
 
-# Create the decision bead and capture its ID
-CREATE_OUTPUT=$(bd create "$TITLE" --type decision 2>&1)
-echo "$CREATE_OUTPUT"
-
-DEC_ID=$(echo "$CREATE_OUTPUT" | sed -n 's/.*Created issue: \([^ ]*\).*/\1/p')
+# Create the decision bead and capture its ID via --json (stable; avoids text-format fragility)
+DEC_ID=$(bd create "$TITLE" --type decision --json | jq -r '(.[0].id // .id) // empty')
 if [[ -z "$DEC_ID" ]]; then
-    echo "Error: could not extract decision bead ID from bd create output" >&2
+    echo "Error: could not extract decision bead ID from bd create --json output" >&2
     exit 1
 fi
 

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -2,7 +2,7 @@
 
 Task tracking workflow (run with `dangerouslyDisableSandbox: true`).
 
-`bd <command> [args]` — Types: bug | feature | task | epic | chore
+`bd <command> [args]` — Types: bug | feature | task | epic | chore | decision
 Priority: 0-4 / P0-P4 (0=critical, 2=medium, 4=backlog). NOT "high"/"medium"/"low".
 
 **Basic workflow**: `bd ready` → pick a bead → `start-bead <id>` → molecule executes → `merge-and-cleanup`


### PR DESCRIPTION
## Summary

- Fixes `bd decision record` folklore in agent instructions — the subcommand does not exist; `decision` is an issue type
- Adds `~/.beads/scripts/bd-record-decision.sh` helper that creates a tracked decision bead, links it to the source bead via `discovered-from` dep, and either closes it (`--implemented`) or flags it for human review (`--needs-approval`)
- Updates `scripts/install.sh` to sync `src/plugins/beads/.beads/scripts/` → `~/.beads/scripts/` with `chmod +x`
- Fixes `brainstorm-bead.formula.toml` to reference the new script instead of the ghost command
- Adds `decision` to the types list in `beads.md`

## Test plan
- [ ] `grep -rn 'bd decision record' src/` returns no hits
- [ ] `bash -n src/plugins/beads/.beads/scripts/bd-record-decision.sh` passes
- [ ] `scripts/install.sh --dry-run --plugins=beads` shows scripts staging
- [ ] Script rejects both `--implemented` and `--needs-approval` simultaneously with a clear error
- [ ] Script rejects missing values for `--bead-id`, `--title`, `--notes` with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)