### PR TITLE
feat(beads): extract bd orchestration sequences into idempotent shell helpers

### DIFF
--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -43,19 +43,11 @@ Brainstorming IS work — the bead's status must reflect that, so that
 `bd ready` and `bd list --status=open` never show a bead that is
 actively being brainstormed as 'available'.
 
-  bd update {{bead-id}} --status in_progress
+  ~/.beads/scripts/bd-claim-walk.sh --bead-id {{bead-id}}
 
-Walk the parent chain and mark each ancestor epic in_progress (stops
-when there is no parent):
-
-  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-  while [ -n "$PARENT" ]; do
-    bd update "$PARENT" --status in_progress
-    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-  done
-
-The claim is cheap even if `assess` later decides the bead needs no
-further brainstorming.
+The claim walk marks this bead and all ancestor epics in_progress.
+Read the `walked=N` output to confirm the chain depth. The claim is
+cheap even if `assess` later decides the bead needs no further brainstorming.
 """
 
 # =============================================================================
@@ -463,51 +455,65 @@ resulting labels are applied to Y via step 4's --labels, not to X.
   [ -n "$COPY_LABELS" ]   && Y_LABELS="$Y_LABELS,$COPY_LABELS"
 
 ──────────────────────────────────────────────────────────────────────────
-STEP 4 — Create Y atomically
+STEP 4 — Create implementation bead via helper script (idempotent)
 ──────────────────────────────────────────────────────────────────────────
 
-Create Y in a SINGLE `bd create` call so identity, labels, and the
-discovered-from edge to X are established together (no orphan-Y window).
+⚠️  CRITICAL — SEQUENTIAL CALL: Issue the script invocation below as a
+SINGLE, ISOLATED tool call. Do NOT batch it with any other tool call in
+the same message. Wait for the `result=...` line before proceeding.
+This is the mutation that creates the implementation bead; parallel
+dispatch can produce duplicate beads even if the rest of finalize is correct.
 
-  # Write spec/AC to per-process temp files via mktemp (avoid content collision
-  # on concurrent runs). The EXIT trap cleans them up regardless of how the step
-  # exits.
+Write spec and AC to temp files, then invoke the script:
+
   Y_SPEC=$(mktemp)
   Y_AC=$(mktemp)
   trap 'rm -f "$Y_SPEC" "$Y_AC"' EXIT
   printf %s "$X_NOTES" > "$Y_SPEC"
   printf %s "$X_AC"    > "$Y_AC"
 
-  # Build PARENT_ARG conditionally — bd rejects empty --parent.
-  PARENT_ARG=""
-  [ -n "$X_PARENT" ] && PARENT_ARG="--parent $X_PARENT"
+  # Use an array for the optional --parent flag to avoid word-splitting on the value.
+  PARENT_FLAG=()
+  [ -n "$X_PARENT" ] && PARENT_FLAG=(--parent "$X_PARENT")
 
-  Y_CREATE_JSON=$(bd create \\
+  # || true: the script exits 1 on result=escalate|result=error; we parse RESULT below.
+  RESULT=$(~/.beads/scripts/bd-finalize-create-impl-bead.sh \\
+    --source-bead-id "{{bead-id}}" \\
     --type "$Y_TYPE" \\
     --priority "$X_PRIORITY" \\
-    $PARENT_ARG \\
     --title "$Y_TITLE" \\
-    --description "$(cat "$Y_SPEC")" \\
-    --acceptance "$(cat "$Y_AC")" \\
     --labels "$Y_LABELS" \\
-    --deps "discovered-from:{{bead-id}}" \\
-    --no-inherit-labels \\
-    --json)
+    --spec-file "$Y_SPEC" \\
+    --ac-file "$Y_AC" \\
+    "${PARENT_FLAG[@]}") || true
+  # OUTPUT CONTRACT: result=<verb> y_id=<id>  (space-separated; verb is first word)
 
-  # bd create --json returns a single object (NOT an array); the id is at .id.
-  Y_ID=$(echo "$Y_CREATE_JSON" | jq -r '.id')
-
-  if [ -z "$Y_ID" ] || [ "$Y_ID" = "null" ]; then
-    echo "ERROR: bd create did not return a Y id; aborting."
-    exit 1
-  fi
+  case "${RESULT%% *}" in
+    result=created|result=exists)
+      Y_ID="${RESULT#* y_id=}"
+      echo "Implementation bead: $Y_ID (${RESULT%% *})"
+      ;;
+    result=escalate|result=error)
+      bd label add {{bead-id}} human
+      bd comments add {{bead-id}} "finalize halted at step 4: $RESULT"
+      echo "ERROR: $RESULT"
+      exit 1
+      ;;
+    *)
+      echo "ERROR: unexpected output from bd-finalize-create-impl-bead.sh: $RESULT"
+      exit 1
+      ;;
+  esac
 
 Notes on this step:
 
-- `--no-inherit-labels` prevents X.parent's labels from leaking onto Y; Y's
-  labels are EXACTLY what `--labels` lists.
-- Field-vs-flag mapping: the `acceptance_criteria` bead field is set via
-  `bd create --acceptance "..."` (NOT `--acceptance-criteria`).
+- The script probes for an existing non-closed bead carrying
+  produced-from-{{bead-id}} before issuing bd create. If one exists,
+  it returns result=exists with that id rather than creating a new bead.
+  This is the second line of defence against duplicate impl beads; Step 1b
+  is the first.
+- `--no-inherit-labels` (inside the script) prevents X.parent's labels
+  from leaking onto Y; Y's labels are EXACTLY what `--labels` lists.
 - I1 claim-walk: Y is created `open` here; it is not yet "starting work,"
   so I1 does NOT require a fresh claim-walk against Y. Y.parent = X.parent,
   which X's Phase 0 claim already marked in_progress and walked. The next
@@ -656,20 +662,13 @@ breadcrumb comment so a comment failure does not block forward progress.
 STEP 8 — Close X with reason; run I2 close-walk
 ──────────────────────────────────────────────────────────────────────────
 
-  bd close {{bead-id}} --reason "brainstormed; produced $Y_ID"
+  ~/.beads/scripts/bd-close-walk.sh \\
+    --bead-id "{{bead-id}}" \\
+    --reason "brainstormed; produced $Y_ID"
 
-  # I2 close-walk (per beads.md): walk the parent chain and close each
-  # ancestor whose remaining children are all closed. Y is now an open
-  # child of X.parent (Y.parent = X.parent), so the walk halts at X.parent
-  # — which is the correct outcome (the epic still has active work via Y).
-  PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-  while [ -n "$PARENT" ]; do
-    NON_CLOSED=$(bd list --parent="$PARENT" --json \\
-      | jq '[.[] | select(.status != "closed")] | length')
-    [ "$NON_CLOSED" = "0" ] || break
-    bd close "$PARENT" --reason "All children closed"
-    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-  done
+  # The I2 ancestor walk halts at X.parent because Y is now an open child
+  # of X.parent (Y.parent = X.parent) — the epic still has active work via Y.
+  # Read the `closed=...` output for the audit trail.
 
 ──────────────────────────────────────────────────────────────────────────
 STEP 9 — Burn the wisp; report hand-off

--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -460,9 +460,8 @@ STEP 4 — Create implementation bead via helper script (idempotent)
 
 ⚠️  CRITICAL — SEQUENTIAL CALL: Issue the script invocation below as a
 SINGLE, ISOLATED tool call. Do NOT batch it with any other tool call in
-the same message. Wait for the `result=...` line before proceeding.
-This is the mutation that creates the implementation bead; parallel
-dispatch can produce duplicate beads even if the rest of finalize is correct.
+the same message. The script creates the implementation bead; parallel
+dispatch can produce duplicates even if everything else is correct.
 
 Write spec and AC to temp files, then invoke the script:
 
@@ -472,12 +471,11 @@ Write spec and AC to temp files, then invoke the script:
   printf %s "$X_NOTES" > "$Y_SPEC"
   printf %s "$X_AC"    > "$Y_AC"
 
-  # Use an array for the optional --parent flag to avoid word-splitting on the value.
+  # Array for the optional --parent flag (avoids word-splitting on the value).
   PARENT_FLAG=()
   [ -n "$X_PARENT" ] && PARENT_FLAG=(--parent "$X_PARENT")
 
-  # || true: the script exits 1 on result=escalate|result=error; we parse RESULT below.
-  RESULT=$(~/.beads/scripts/bd-finalize-create-impl-bead.sh \\
+  Y_ID=$(~/.beads/scripts/bd-finalize-create-impl-bead.sh \\
     --source-bead-id "{{bead-id}}" \\
     --type "$Y_TYPE" \\
     --priority "$X_PRIORITY" \\
@@ -485,33 +483,19 @@ Write spec and AC to temp files, then invoke the script:
     --labels "$Y_LABELS" \\
     --spec-file "$Y_SPEC" \\
     --ac-file "$Y_AC" \\
-    "${PARENT_FLAG[@]}") || true
-  # OUTPUT CONTRACT: result=<verb> y_id=<id>  (space-separated; verb is first word)
-
-  case "${RESULT%% *}" in
-    result=created|result=exists)
-      Y_ID="${RESULT#* y_id=}"
-      echo "Implementation bead: $Y_ID (${RESULT%% *})"
-      ;;
-    result=escalate|result=error)
-      bd label add {{bead-id}} human
-      bd comments add {{bead-id}} "finalize halted at step 4: $RESULT"
-      echo "ERROR: $RESULT"
-      exit 1
-      ;;
-    *)
-      echo "ERROR: unexpected output from bd-finalize-create-impl-bead.sh: $RESULT"
-      exit 1
-      ;;
-  esac
+    "${PARENT_FLAG[@]}") || exit 1
+  echo "Implementation bead: $Y_ID"
 
 Notes on this step:
 
+- The script outputs just the Y bead ID on success (exit 0). On failure
+  (exit 1), it writes diagnostics to stderr. For the escalate case
+  (multiple orphan impl beads), it also adds the 'human' label and an
+  audit comment to {{bead-id}} before exiting — no extra bd calls needed here.
 - The script probes for an existing non-closed bead carrying
-  produced-from-{{bead-id}} before issuing bd create. If one exists,
-  it returns result=exists with that id rather than creating a new bead.
-  This is the second line of defence against duplicate impl beads; Step 1b
-  is the first.
+  produced-from-{{bead-id}} before issuing bd create. If one exists, it
+  returns that bead's ID (idempotent resume). This is the second line of
+  defence against duplicate impl beads; Step 1b is the first.
 - `--no-inherit-labels` (inside the script) prevents X.parent's labels
   from leaking onto Y; Y's labels are EXACTLY what `--labels` lists.
 - I1 claim-walk: Y is created `open` here; it is not yet "starting work,"

--- a/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
+++ b/src/plugins/beads/.beads/formulas/fix-bug.formula.toml
@@ -102,12 +102,7 @@ Read the bead and its labels:
    bd label add <mol-id> worktree-path-<encoded>
 
 7. Claim the bead and walk the parent chain:
-   bd update {{bead-id}} --status in_progress
-   PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-   while [ -n "$PARENT" ]; do
-     bd update "$PARENT" --status in_progress
-     PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-   done
+   ~/.beads/scripts/bd-claim-walk.sh --bead-id {{bead-id}}
 
 ## Definition of Done
 Poured molecule + worktree exists + worktree-path-* label stamped on molecule.

--- a/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
+++ b/src/plugins/beads/.beads/formulas/implement-feature.formula.toml
@@ -104,12 +104,7 @@ Read the bead and its labels:
    Then: bd label add <mol-id> worktree-path-<encoded>
 
 7. Claim the bead and walk the parent chain:
-   bd update {{bead-id}} --status in_progress
-   PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-   while [ -n "$PARENT" ]; do
-     bd update "$PARENT" --status in_progress
-     PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-   done
+   ~/.beads/scripts/bd-claim-walk.sh --bead-id {{bead-id}}
 
 ## Definition of Done
 Poured molecule + worktree exists + worktree-path-* label stamped on molecule.

--- a/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
+++ b/src/plugins/beads/.beads/formulas/merge-and-cleanup.formula.toml
@@ -298,16 +298,15 @@ Clean up all artifacts from the merged work.
      bd close {{bead-id}} --reason "Merged PR #{{pr}} and all child gates closed"
 
 6. Walk the parent chain; close each ancestor epic whose remaining
-   children are all closed (stops at the first ancestor that still
-   has any non-closed children, or when there is no parent):
+   children are all closed:
 
-     PARENT=$(bd show {{bead-id}} --json | jq -r '.[0].parent // empty')
-     while [ -n "$PARENT" ]; do
-       NON_CLOSED=$(bd list --parent="$PARENT" --json | jq '[.[] | select(.status != "closed")] | length')
-       [ "$NON_CLOSED" = "0" ] || break
-       bd close "$PARENT" --reason "All children closed"
-       PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
-     done
+     ~/.beads/scripts/bd-close-walk.sh \\
+       --bead-id "{{bead-id}}" \\
+       --reason "Merged PR #{{pr}} and all child gates closed"
+
+   Note: {{bead-id}} was already closed in step 5; the script detects
+   this and skips the initial close, proceeding directly to the ancestor
+   walk. Read the `closed=...` output for the audit trail.
 
 7. Burn this wisp:
      bd mol burn <this-mol-id>

--- a/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
+++ b/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# bd-claim-walk.sh — Mark a bead and all ancestor epics in_progress (Beads I1 claim walk).
+#
+# Implements the Beads I1 invariant: before any work starts on a bead, the bead
+# AND every ancestor epic must be marked in_progress so they never appear as
+# available in `bd ready`.
+#
+# Usage:
+#   bd-claim-walk.sh --bead-id <id>
+#
+# Output (stdout, one line):
+#   walked=<N>   number of beads marked in_progress (1 = just the target, no parent)
+#
+# Exit: 0 on success; non-zero on error.
+
+set -euo pipefail
+
+BEAD_ID=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: bd-claim-walk.sh --bead-id <id>
+
+Mark a bead and all ancestor epics in_progress (Beads I1 claim walk).
+
+Walks UP the parent chain from <id>, marking each bead in_progress until
+there are no more parents. Idempotent — already-in_progress beads are
+updated without error.
+
+Options:
+  --bead-id <id>   ID of the bead whose work is starting (required)
+  -h, --help       Show this help
+
+Output (one line on stdout):
+  walked=<N>   number of beads marked in_progress (target + ancestors)
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bead-id)
+            [[ $# -ge 2 ]] || { echo "Error: --bead-id requires a value" >&2; usage; }
+            BEAD_ID="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$BEAD_ID" ]] && { echo "Error: --bead-id is required" >&2; usage; }
+
+COUNT=0
+CURRENT="$BEAD_ID"
+
+while [[ -n "$CURRENT" ]]; do
+    COUNT=$((COUNT + 1))
+    SHOW_JSON=$(bd show "$CURRENT" --json)
+    STATUS=$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // "open"')
+    NEXT=$(printf '%s' "$SHOW_JSON" | jq -r '.[0].parent // empty')
+    # Skip beads that are already in_progress or closed — never reopen a closed bead.
+    if [[ "$STATUS" != "in_progress" && "$STATUS" != "closed" ]]; then
+        bd update "$CURRENT" --status in_progress
+    fi
+    CURRENT="$NEXT"
+done
+
+echo "walked=$COUNT"

--- a/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
+++ b/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
@@ -9,7 +9,7 @@
 #   bd-claim-walk.sh --bead-id <id>
 #
 # Output (stdout, one line):
-#   walked=<N>   number of beads marked in_progress (1 = just the target, no parent)
+#   walked=<N>   chain depth traversed (includes beads already in_progress/closed that were skipped)
 #
 # Exit: 0 on success; non-zero on error.
 
@@ -32,7 +32,7 @@ Options:
   -h, --help       Show this help
 
 Output (one line on stdout):
-  walked=<N>   number of beads marked in_progress (target + ancestors)
+  walked=<N>   chain depth traversed (includes already-in_progress/closed beads that were skipped)
 EOF
     exit 1
 }

--- a/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
+++ b/src/plugins/beads/.beads/scripts/bd-claim-walk.sh
@@ -24,8 +24,8 @@ Usage: bd-claim-walk.sh --bead-id <id>
 Mark a bead and all ancestor epics in_progress (Beads I1 claim walk).
 
 Walks UP the parent chain from <id>, marking each bead in_progress until
-there are no more parents. Idempotent — already-in_progress beads are
-updated without error.
+there are no more parents. Idempotent — already-in_progress and closed
+beads are skipped without error.
 
 Options:
   --bead-id <id>   ID of the bead whose work is starting (required)

--- a/src/plugins/beads/.beads/scripts/bd-close-walk.sh
+++ b/src/plugins/beads/.beads/scripts/bd-close-walk.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# bd-close-walk.sh — Close a bead then cascade-close empty ancestor epics (Beads I2 close walk).
+#
+# Implements the Beads I2 invariant: after closing a bead, walk the parent chain
+# and close each ancestor whose remaining children are all closed. Stops at the
+# first ancestor that still has non-closed children.
+#
+# Usage:
+#   bd-close-walk.sh --bead-id <id> --reason <text>
+#
+# Output (stdout, one line):
+#   closed=<csv>   comma-separated IDs of all beads closed (target + any ancestors)
+#                  empty string after '=' means nothing was closed (all already closed)
+#
+# Exit: 0 on success; non-zero on error.
+
+set -euo pipefail
+
+BEAD_ID=""
+REASON=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: bd-close-walk.sh --bead-id <id> --reason <text>
+
+Close a bead then cascade-close empty ancestor epics (Beads I2 close walk).
+
+Closes <id> with the given reason, then walks UP the parent chain. At each
+ancestor, checks if all children are closed; if so, closes the ancestor with
+"All children closed". Stops at the first ancestor with non-closed children.
+
+If <id> is already closed, skips the initial close and proceeds with the
+ancestor walk (idempotent re-entry).
+
+Options:
+  --bead-id <id>    ID of the bead to close (required)
+  --reason <text>   Close reason for the target bead (required)
+  -h, --help        Show this help
+
+Output (one line on stdout):
+  closed=<csv>   comma-separated IDs closed in this run (empty if nothing needed closing)
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bead-id)
+            [[ $# -ge 2 ]] || { echo "Error: --bead-id requires a value" >&2; usage; }
+            BEAD_ID="$2"; shift 2 ;;
+        --reason)
+            [[ $# -ge 2 ]] || { echo "Error: --reason requires a value" >&2; usage; }
+            REASON="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$BEAD_ID" ]] && { echo "Error: --bead-id is required" >&2; usage; }
+[[ -z "$REASON" ]] && { echo "Error: --reason is required" >&2; usage; }
+
+CLOSED=()
+
+# Read status and parent from a single bd show call.
+SHOW_JSON=$(bd show "$BEAD_ID" --json)
+STATUS=$(printf '%s' "$SHOW_JSON" | jq -r '.[0].status // "open"')
+PARENT=$(printf '%s' "$SHOW_JSON" | jq -r '.[0].parent // empty')
+
+# Close target bead — skip if already closed (idempotent re-entry)
+if [[ "$STATUS" != "closed" ]]; then
+    bd close "$BEAD_ID" --reason "$REASON"
+    CLOSED+=("$BEAD_ID")
+fi
+
+# I2 ancestor walk: close each parent whose children are all now closed
+while [[ -n "$PARENT" ]]; do
+    NON_CLOSED=$(bd list --parent="$PARENT" --json \
+        | jq '[.[] | select(.status != "closed")] | length')
+    [[ "$NON_CLOSED" == "0" ]] || break
+    bd close "$PARENT" --reason "All children closed"
+    CLOSED+=("$PARENT")
+    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+done
+
+# Guard against bash 3.x empty-array unbound-variable error under set -u
+if [[ ${#CLOSED[@]} -eq 0 ]]; then
+    echo "closed="
+else
+    CLOSED_CSV=$(IFS=,; echo "${CLOSED[*]}")
+    echo "closed=${CLOSED_CSV}"
+fi

--- a/src/plugins/beads/.beads/scripts/bd-close-walk.sh
+++ b/src/plugins/beads/.beads/scripts/bd-close-walk.sh
@@ -72,14 +72,20 @@ if [[ "$STATUS" != "closed" ]]; then
     CLOSED+=("$BEAD_ID")
 fi
 
-# I2 ancestor walk: close each parent whose children are all now closed
+# I2 ancestor walk: close each parent whose children are all now closed.
+# Read status + next parent in one bd show call so replay-safe skips are free.
 while [[ -n "$PARENT" ]]; do
-    NON_CLOSED=$(bd list --parent="$PARENT" --json \
-        | jq '[.[] | select(.status != "closed")] | length')
-    [[ "$NON_CLOSED" == "0" ]] || break
-    bd close "$PARENT" --reason "All children closed"
-    CLOSED+=("$PARENT")
-    PARENT=$(bd show "$PARENT" --json | jq -r '.[0].parent // empty')
+    PARENT_SHOW=$(bd show "$PARENT" --json)
+    PARENT_STATUS=$(printf '%s' "$PARENT_SHOW" | jq -r '.[0].status // "open"')
+    NEXT_PARENT=$(printf '%s' "$PARENT_SHOW" | jq -r '.[0].parent // empty')
+    if [[ "$PARENT_STATUS" != "closed" ]]; then
+        NON_CLOSED=$(bd list --parent="$PARENT" --json \
+            | jq '[.[] | select(.status != "closed")] | length')
+        [[ "$NON_CLOSED" == "0" ]] || break
+        bd close "$PARENT" --reason "All children closed"
+        CLOSED+=("$PARENT")
+    fi
+    PARENT="$NEXT_PARENT"
 done
 
 # Guard against bash 3.x empty-array unbound-variable error under set -u

--- a/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
+++ b/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# bd-finalize-create-impl-bead.sh — Create the implementation bead during brainstorm finalize.
+#
+# Wraps brainstorm-bead formula Step 4 ("Create Y atomically") in a single
+# idempotent command. The LLM issues one invocation; the script handles the
+# intra-step orphan guard (probe → create-or-short-circuit) so the formula
+# cannot produce duplicate implementation beads via parallel tool-call batching.
+#
+# Before calling bd create, the script probes for an existing non-closed bead
+# carrying the produced-from-<source-bead-id> label. If one exists, it returns
+# that bead's ID instead of creating a new one (result=exists). If two or more
+# exist, it exits non-zero so finalize can escalate to human triage.
+#
+# Usage:
+#   bd-finalize-create-impl-bead.sh \
+#     --source-bead-id <id> \
+#     --type <feature|bug|task> \
+#     --priority <0-4> \
+#     --title <text> \
+#     --labels <csv> \
+#     --spec-file <path> \
+#     --ac-file <path> \
+#     [--parent <id>]
+#
+# Output (stdout, one line):
+#   result=created  y_id=<id>                                    # fresh creation
+#   result=exists   y_id=<id>                                    # pre-existing; skipped create
+#   result=escalate message=<N non-closed impl beads for <id>>   # exit 1; human triage needed
+#   result=error    message=<text>                               # exit 1; fatal
+#
+# Exit: 0 on result=created|exists; 1 on result=escalate|error.
+
+set -euo pipefail
+
+SOURCE_BEAD_ID=""
+TYPE=""
+PRIORITY=""
+TITLE=""
+LABELS=""
+SPEC_FILE=""
+AC_FILE=""
+PARENT=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: bd-finalize-create-impl-bead.sh \
+  --source-bead-id <id> \
+  --type <feature|bug|task> \
+  --priority <0-4> \
+  --title <text> \
+  --labels <csv> \
+  --spec-file <path> \
+  --ac-file <path> \
+  [--parent <id>]
+
+Create the implementation bead during brainstorm-bead finalize (Step 4).
+
+Probes for an existing non-closed bead carrying label produced-from-<source-bead-id>
+before issuing bd create. Returns the existing bead ID if one is found (idempotent
+re-entry), creates a new one if none exists. Escalates if multiple non-closed
+candidates exist (requires human triage).
+
+This script gives the LLM a single named invocation for Step 4 of brainstorm-bead
+finalize, preventing the parallel-tool-call race that produces duplicate
+implementation beads.
+
+Options:
+  --source-bead-id  ID of the brainstorm seed bead — used for the orphan probe
+                    and the produced-from dep edge (required)
+  --type            Bead type: feature, bug, or task (required)
+  --priority        Priority 0-4 (required)
+  --title           Title for the new implementation bead (required)
+  --labels          Comma-separated labels to apply; must include
+                    produced-from-<source-bead-id> and other finalize labels (required)
+  --spec-file       Path to file containing the spec/notes content (required)
+  --ac-file         Path to file containing the acceptance criteria (required)
+  --parent          Parent bead ID; omit if source bead has no parent (optional)
+  -h, --help        Show this help
+
+Output (one line on stdout):
+  result=created  y_id=<id>
+  result=exists   y_id=<id>
+  result=escalate message=<text>
+  result=error    message=<text>
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-bead-id)
+            [[ $# -ge 2 ]] || { echo "Error: --source-bead-id requires a value" >&2; usage; }
+            SOURCE_BEAD_ID="$2"; shift 2 ;;
+        --type)
+            [[ $# -ge 2 ]] || { echo "Error: --type requires a value" >&2; usage; }
+            TYPE="$2"; shift 2 ;;
+        --priority)
+            [[ $# -ge 2 ]] || { echo "Error: --priority requires a value" >&2; usage; }
+            PRIORITY="$2"; shift 2 ;;
+        --title)
+            [[ $# -ge 2 ]] || { echo "Error: --title requires a value" >&2; usage; }
+            TITLE="$2"; shift 2 ;;
+        --labels)
+            [[ $# -ge 2 ]] || { echo "Error: --labels requires a value" >&2; usage; }
+            LABELS="$2"; shift 2 ;;
+        --spec-file)
+            [[ $# -ge 2 ]] || { echo "Error: --spec-file requires a value" >&2; usage; }
+            SPEC_FILE="$2"; shift 2 ;;
+        --ac-file)
+            [[ $# -ge 2 ]] || { echo "Error: --ac-file requires a value" >&2; usage; }
+            AC_FILE="$2"; shift 2 ;;
+        --parent)
+            [[ $# -ge 2 ]] || { echo "Error: --parent requires a value" >&2; usage; }
+            PARENT="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# Validate required args
+for _flag_var in SOURCE_BEAD_ID TYPE PRIORITY TITLE LABELS SPEC_FILE AC_FILE; do
+    if [[ -z "${!_flag_var}" ]]; then
+        _flag_name=$(echo "$_flag_var" | tr '[:upper:]_' '[:lower:]-')
+        echo "Error: --${_flag_name} is required" >&2
+        usage
+    fi
+done
+
+[[ -f "$SPEC_FILE" ]] || { printf 'result=error message=spec-file-not-found:%s\n' "$SPEC_FILE"; exit 1; }
+[[ -f "$AC_FILE"   ]] || { printf 'result=error message=ac-file-not-found:%s\n'   "$AC_FILE";   exit 1; }
+
+# Validate that --labels includes produced-from-<source-bead-id> — required for the
+# intra-step orphan probe to find this bead on any subsequent retry.
+case ",${LABELS}," in
+    *,"produced-from-${SOURCE_BEAD_ID}",*) ;;
+    *)  printf 'result=error message=labels-must-include-produced-from-%s\n' "$SOURCE_BEAD_ID"
+        exit 1 ;;
+esac
+
+# ── Intra-step orphan probe ─────────────────────────────────────────────────
+# Check for non-closed beads already carrying produced-from-<source> label.
+# This guard is a second line of defence against the parallel-tool-call race:
+# even if Step 1b's top-of-finalize probe was bypassed, this probe fires
+# immediately before bd create and catches any bead that exists in the gap.
+ORPHAN_JSON=$(bd list --label "produced-from-${SOURCE_BEAD_ID}" --json 2>/dev/null) || {
+    printf 'result=error message=bd-list-failed-for-orphan-probe\n'
+    exit 1
+}
+ORPHAN_COUNT=$(printf '%s' "$ORPHAN_JSON" | jq '[.[] | select(.status != "closed")] | length' 2>/dev/null) || {
+    printf 'result=error message=jq-parse-failed-on-orphan-probe\n'
+    exit 1
+}
+
+if [[ "$ORPHAN_COUNT" -ge 2 ]]; then
+    printf 'result=escalate message=%d non-closed impl beads found for %s\n' "$ORPHAN_COUNT" "$SOURCE_BEAD_ID"
+    exit 1
+fi
+
+if [[ "$ORPHAN_COUNT" -eq 1 ]]; then
+    EXISTING_ID=$(printf '%s' "$ORPHAN_JSON" | jq -r '[.[] | select(.status != "closed")] | .[0].id')
+    printf 'result=exists y_id=%s\n' "$EXISTING_ID"
+    exit 0
+fi
+
+# ── Create implementation bead ──────────────────────────────────────────────
+PARENT_ARGS=()
+[[ -n "$PARENT" ]] && PARENT_ARGS=("--parent" "$PARENT")
+
+CREATE_JSON=$(bd create \
+    --type "$TYPE" \
+    --priority "$PRIORITY" \
+    "${PARENT_ARGS[@]}" \
+    --title "$TITLE" \
+    --description "$(cat "$SPEC_FILE")" \
+    --acceptance "$(cat "$AC_FILE")" \
+    --labels "$LABELS" \
+    --deps "discovered-from:${SOURCE_BEAD_ID}" \
+    --no-inherit-labels \
+    --json) || {
+    printf 'result=error message=bd-create-failed\n'
+    exit 1
+}
+
+# bd create --json returns either an object {id:...} or array [{id:...}] depending
+# on bd version; handle both forms defensively.
+Y_ID=$(printf '%s' "$CREATE_JSON" | jq -r '(.[0].id // .id) // empty' 2>/dev/null)
+
+if [[ -z "$Y_ID" || "$Y_ID" == "null" ]]; then
+    printf 'result=error message=bd-create-returned-no-id\n'
+    exit 1
+fi
+
+printf 'result=created y_id=%s\n' "$Y_ID"

--- a/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
+++ b/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
@@ -15,7 +15,7 @@
 #   bd-finalize-create-impl-bead.sh \
 #     --source-bead-id <id> \
 #     --type <feature|bug|task> \
-#     --priority <0-4> \
+#     --priority <0-4|P0-P4> \
 #     --title <text> \
 #     --labels <csv> \
 #     --spec-file <path> \
@@ -23,10 +23,10 @@
 #     [--parent <id>]
 #
 # Output (stdout, one line):
-#   result=created  y_id=<id>                                    # fresh creation
-#   result=exists   y_id=<id>                                    # pre-existing; skipped create
-#   result=escalate message=<N non-closed impl beads for <id>>   # exit 1; human triage needed
-#   result=error    message=<text>                               # exit 1; fatal
+#   result=created  y_id=<id>              # fresh creation
+#   result=exists   y_id=<id>              # pre-existing; skipped create
+#   result=escalate count=<N> source=<id>  # exit 1; human triage needed
+#   result=error    message=<token>        # exit 1; fatal (hyphen-separated, no spaces)
 #
 # Exit: 0 on result=created|exists; 1 on result=escalate|error.
 
@@ -46,7 +46,7 @@ usage() {
 Usage: bd-finalize-create-impl-bead.sh \
   --source-bead-id <id> \
   --type <feature|bug|task> \
-  --priority <0-4> \
+  --priority <0-4|P0-P4> \
   --title <text> \
   --labels <csv> \
   --spec-file <path> \
@@ -80,8 +80,8 @@ Options:
 Output (one line on stdout):
   result=created  y_id=<id>
   result=exists   y_id=<id>
-  result=escalate message=<text>
-  result=error    message=<text>
+  result=escalate count=<N> source=<id>
+  result=error    message=<hyphen-separated-token>
 EOF
     exit 1
 }
@@ -152,7 +152,7 @@ ORPHAN_COUNT=$(printf '%s' "$ORPHAN_JSON" | jq '[.[] | select(.status != "closed
 }
 
 if [[ "$ORPHAN_COUNT" -ge 2 ]]; then
-    printf 'result=escalate message=%d non-closed impl beads found for %s\n' "$ORPHAN_COUNT" "$SOURCE_BEAD_ID"
+    printf 'result=escalate count=%d source=%s\n' "$ORPHAN_COUNT" "$SOURCE_BEAD_ID"
     exit 1
 fi
 

--- a/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
+++ b/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
@@ -3,13 +3,12 @@
 #
 # Wraps brainstorm-bead formula Step 4 ("Create Y atomically") in a single
 # idempotent command. The LLM issues one invocation; the script handles the
-# intra-step orphan guard (probe → create-or-short-circuit) so the formula
-# cannot produce duplicate implementation beads via parallel tool-call batching.
+# intra-step orphan guard (probe → create-or-short-circuit), escalation
+# bookkeeping (human label + audit comment on source bead), and all error
+# paths — so the formula needs no case statement or extra bd calls.
 #
-# Before calling bd create, the script probes for an existing non-closed bead
-# carrying the produced-from-<source-bead-id> label. If one exists, it returns
-# that bead's ID instead of creating a new one (result=exists). If two or more
-# exist, it exits non-zero so finalize can escalate to human triage.
+# Callers invoke as:
+#   Y_ID=$(bd-finalize-create-impl-bead.sh --source-bead-id X ...) || exit 1
 #
 # Usage:
 #   bd-finalize-create-impl-bead.sh \
@@ -22,13 +21,12 @@
 #     --ac-file <path> \
 #     [--parent <id>]
 #
-# Output (stdout, one line):
-#   result=created  y_id=<id>              # fresh creation
-#   result=exists   y_id=<id>              # pre-existing; skipped create
-#   result=escalate count=<N> source=<id>  # exit 1; human triage needed
-#   result=error    message=<token>        # exit 1; fatal (hyphen-separated, no spaces)
+# Output:
+#   stdout (exit 0): the new (or pre-existing) implementation bead ID — nothing else
+#   stderr (exit 1): diagnostic message; source bead has been labelled 'human'
+#                    and an audit comment added (escalate case only)
 #
-# Exit: 0 on result=created|exists; 1 on result=escalate|error.
+# Exit: 0 on success; 1 on any failure.
 
 set -euo pipefail
 
@@ -77,11 +75,9 @@ Options:
   --parent          Parent bead ID; omit if source bead has no parent (optional)
   -h, --help        Show this help
 
-Output (one line on stdout):
-  result=created  y_id=<id>
-  result=exists   y_id=<id>
-  result=escalate count=<N> source=<id>
-  result=error    message=<hyphen-separated-token>
+Output:
+  stdout (exit 0): the new or pre-existing implementation bead ID (one line)
+  stderr (exit 1): diagnostic; source bead gets 'human' label + audit comment on escalate
 EOF
     exit 1
 }
@@ -126,14 +122,14 @@ for _flag_var in SOURCE_BEAD_ID TYPE PRIORITY TITLE LABELS SPEC_FILE AC_FILE; do
     fi
 done
 
-[[ -f "$SPEC_FILE" ]] || { printf 'result=error message=spec-file-not-found:%s\n' "$SPEC_FILE"; exit 1; }
-[[ -f "$AC_FILE"   ]] || { printf 'result=error message=ac-file-not-found:%s\n'   "$AC_FILE";   exit 1; }
+[[ -f "$SPEC_FILE" ]] || { echo "Error: spec-file not found: $SPEC_FILE" >&2; exit 1; }
+[[ -f "$AC_FILE"   ]] || { echo "Error: ac-file not found: $AC_FILE" >&2;       exit 1; }
 
 # Validate that --labels includes produced-from-<source-bead-id> — required for the
 # intra-step orphan probe to find this bead on any subsequent retry.
 case ",${LABELS}," in
     *,"produced-from-${SOURCE_BEAD_ID}",*) ;;
-    *)  printf 'result=error message=labels-must-include-produced-from-%s\n' "$SOURCE_BEAD_ID"
+    *)  echo "Error: --labels must include produced-from-${SOURCE_BEAD_ID}" >&2
         exit 1 ;;
 esac
 
@@ -143,22 +139,27 @@ esac
 # even if Step 1b's top-of-finalize probe was bypassed, this probe fires
 # immediately before bd create and catches any bead that exists in the gap.
 ORPHAN_JSON=$(bd list --label "produced-from-${SOURCE_BEAD_ID}" --json 2>/dev/null) || {
-    printf 'result=error message=bd-list-failed-for-orphan-probe\n'
+    echo "Error: bd list failed during orphan probe" >&2
     exit 1
 }
 ORPHAN_COUNT=$(printf '%s' "$ORPHAN_JSON" | jq '[.[] | select(.status != "closed")] | length' 2>/dev/null) || {
-    printf 'result=error message=jq-parse-failed-on-orphan-probe\n'
+    echo "Error: jq parse failed on orphan probe output" >&2
     exit 1
 }
 
 if [[ "$ORPHAN_COUNT" -ge 2 ]]; then
-    printf 'result=escalate count=%d source=%s\n' "$ORPHAN_COUNT" "$SOURCE_BEAD_ID"
+    # Multiple orphan impl beads exist — escalate to human; all bookkeeping done here.
+    bd label add "$SOURCE_BEAD_ID" human || true
+    bd comments add "$SOURCE_BEAD_ID" \
+        "finalize halted: ${ORPHAN_COUNT} non-closed impl beads carry produced-from-${SOURCE_BEAD_ID}; manual triage required." || true
+    echo "Error: ${ORPHAN_COUNT} non-closed impl beads found for ${SOURCE_BEAD_ID}; source bead flagged for human triage" >&2
     exit 1
 fi
 
 if [[ "$ORPHAN_COUNT" -eq 1 ]]; then
+    # Pre-existing impl bead found — idempotent resume; output its ID.
     EXISTING_ID=$(printf '%s' "$ORPHAN_JSON" | jq -r '[.[] | select(.status != "closed")] | .[0].id')
-    printf 'result=exists y_id=%s\n' "$EXISTING_ID"
+    printf '%s\n' "$EXISTING_ID"
     exit 0
 fi
 
@@ -177,7 +178,7 @@ CREATE_JSON=$(bd create \
     --deps "discovered-from:${SOURCE_BEAD_ID}" \
     --no-inherit-labels \
     --json) || {
-    printf 'result=error message=bd-create-failed\n'
+    echo "Error: bd create failed" >&2
     exit 1
 }
 
@@ -186,8 +187,8 @@ CREATE_JSON=$(bd create \
 Y_ID=$(printf '%s' "$CREATE_JSON" | jq -r '(.[0].id // .id) // empty' 2>/dev/null)
 
 if [[ -z "$Y_ID" || "$Y_ID" == "null" ]]; then
-    printf 'result=error message=bd-create-returned-no-id\n'
+    echo "Error: bd create returned no id" >&2
     exit 1
 fi
 
-printf 'result=created y_id=%s\n' "$Y_ID"
+printf '%s\n' "$Y_ID"

--- a/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
+++ b/src/plugins/beads/.beads/scripts/bd-finalize-create-impl-bead.sh
@@ -64,9 +64,9 @@ implementation beads.
 
 Options:
   --source-bead-id  ID of the brainstorm seed bead — used for the orphan probe
-                    and the produced-from dep edge (required)
+                    and to stamp the produced-from label on Y (required)
   --type            Bead type: feature, bug, or task (required)
-  --priority        Priority 0-4 (required)
+  --priority        Priority: integer 0-4 or P0-P4 format (required)
   --title           Title for the new implementation bead (required)
   --labels          Comma-separated labels to apply; must include
                     produced-from-<source-bead-id> and other finalize labels (required)


### PR DESCRIPTION
## Summary

- Adds three shell helpers to `src/plugins/beads/.beads/scripts/`: `bd-claim-walk.sh`, `bd-close-walk.sh`, `bd-finalize-create-impl-bead.sh`
- Updates four formula files (brainstorm-bead, implement-feature, fix-bug, merge-and-cleanup) to replace inline bash with single script invocations
- **Fixes the duplicate implementation-bead bug** (root cause: `bd create` in brainstorm finalize Step 4 could be issued twice by LLM parallel tool-call batching; the new script has an intra-step orphan probe guard)

## What each script does

**`bd-claim-walk.sh`** — Beads I1 claim walk: marks a bead and all ancestor epics `in_progress`. Probes status before each update so it never re-opens a closed ancestor. Replaces a copy-pasted 5-line while loop in three formula files.

**`bd-close-walk.sh`** — Beads I2 close walk: closes a bead then cascade-closes empty ancestor epics. Idempotent re-entry (skips close if already closed, proceeds with ancestor walk). Replaces a copy-pasted 5-line while loop in two formula files.

**`bd-finalize-create-impl-bead.sh`** — Wraps brainstorm-bead finalize Step 4 in one idempotent command. Probes for an existing non-closed bead carrying `produced-from-<source-id>` before issuing `bd create`; returns the pre-existing ID if found (idempotent resume). On failure (escalate: multiple orphans, or error), the script handles all bookkeeping internally (human label + audit comment on source bead) and exits 1 with diagnostics on stderr. stdout on success is just the bare bead ID — formula Step 4 is simply `Y_ID=$(script ...) || exit 1`.

## Why scripts instead of prose

The previous inline bash gave the LLM opportunities to batch side-effectful `bd` calls in the same parallel tool-call turn. A named script invocation collapses "create Y" from a multi-line bash block into a single command — one invocation = one side effect. The orphan probe inside the script is a second line of defence that fires even if the top-of-finalize Step 1b probe was bypassed.

## Installation

All three scripts are in `src/plugins/beads/.beads/scripts/` (flat directory). The existing `install.sh` glob (`plugin_scripts_dir/*.sh`) installs them to `~/.beads/scripts/` with `chmod +x` — no install.sh changes needed.

## Test plan
- [ ] `--help` on each script prints purpose + full contract
- [ ] No-args on each script exits 1 with error + usage
- [ ] `bash -n` syntax check passes on all three
- [ ] TOML validity check with `tomli` passes on all four modified formulas
- [ ] Script references present in formula files; zero inline `PARENT=$(bd show` loops remaining
- [ ] Duplicate-bead scenario: invoke `bd-finalize-create-impl-bead.sh` twice with same args; second call returns the same bead ID as the first (idempotent resume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)