### PR TITLE
feat(beads): extract bd-migrate-deps.sh — bidirectional dep-edge retargeting for brainstorm-bead STEP 6

### DIFF
--- a/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
+++ b/src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml
@@ -578,8 +578,9 @@ STEP 5 — Create children under Y (migrate first, then fresh-create)
 STEP 6 — Migrate edges from X to Y per §3 mechanical rubric
 ──────────────────────────────────────────────────────────────────────────
 
-For each dep edge on X (excluding the parent-child edge, already preserved
-via Y.parent = X.parent), apply the rubric:
+For each dep edge involving X (in BOTH directions — outbound X→OTHER and
+inbound OTHER→X — excluding the parent-child edge, already preserved via
+Y.parent = X.parent), apply the rubric:
 
   | dep_type                                                                 | linked status         | action          |
   |--------------------------------------------------------------------------|-----------------------|-----------------|
@@ -588,45 +589,23 @@ via Y.parent = X.parent), apply the rubric:
   | discovered-from, related                                                 | linked is closed      | keep on X       |
   | discovered-from, related                                                 | linked is open / wip  | migrate to Y    |
 
+"Linked bead" = the bead at the other end of the edge from X's perspective
+(the target for outbound, the source for inbound).
+
 The `Y discovered-from {{bead-id}}` edge is already in place from step 4
-(`--deps discovered-from:{{bead-id}}`); do NOT add it again here.
+(`--deps discovered-from:{{bead-id}}`); the helper detects and skips it
+on the inbound leg, so it is never re-added.
 
-Cost bound: at most N = len(X.dependencies) - 1 `bd show` calls (excluding
-the parent edge). Typical N < 10. If any `bd show` fails mid-loop, error
-out clearly; replay handles the rest via the step-1 idempotency probe.
+Cost bound: O(N_out + N_in) — exactly two `bd dep list` calls capture all
+edges and their statuses inline via the `.status` field. No per-edge
+`bd show` status calls. Plus O(N_migrated) `bd dep add` / `bd dep remove`
+pairs. Typical total << 40 bd calls. The helper is fully idempotent —
+already-migrated edges no longer appear in X's dep list (in either
+direction), so a replay is a no-op for them.
 
-  # bd's dependency JSON shape (verified against current CLI):
-  #   { "id": "<target>", "dependency_type": "<dep-type>", "title": ..., "status": ..., ... }
-  # The parent edge is encoded as dependency_type="parent-child" (NOT "parent"); skip it.
-  bd show {{bead-id}} --json \\
-    | jq -r '.[0].dependencies // [] | .[] | "\\(.dependency_type)\\t\\(.id)"' \\
-  | while IFS="$(printf '\\t')" read -r dep_type target_id; do
-      [ "$dep_type" = "parent-child" ] && continue
-      [ "$dep_type" = "discovered-from" ] && [ "$target_id" = "{{bead-id}}" ] && continue
-      case "$dep_type" in
-        blocks|blocked-by|tracks|until|caused-by|validates|relates-to|supersedes)
-          MIGRATE=1 ;;
-        discovered-from|related)
-          target_status=$(bd show "$target_id" --json | jq -r '.[0].status // "open"')
-          [ "$target_status" = "closed" ] && MIGRATE=0 || MIGRATE=1 ;;
-        *)
-          # Unknown dep type — be conservative; migrate by default and log.
-          echo "WARN: unknown dep_type '$dep_type' on edge {{bead-id}} -> $target_id; migrating to Y by default."
-          MIGRATE=1 ;;
-      esac
-      if [ "$MIGRATE" = "1" ]; then
-        # Gate the X-side remove on a successful Y-side add: if `bd dep add`
-        # fails for any reason (not just "already exists"), keep the original
-        # edge on X to preserve dep graph integrity. Don't drop edges.
-        if bd dep add "$Y_ID" "$target_id" --type "$dep_type"; then
-          # `bd dep remove` is positional-only (issue-id, depends-on-id); no --type flag.
-          bd dep remove "{{bead-id}}" "$target_id" || \\
-            echo "WARN: bd dep remove {{bead-id}} $target_id failed; X edge to $target_id retained."
-        else
-          echo "WARN: bd dep add $Y_ID $target_id --type $dep_type failed; not removing X edge to preserve dep graph."
-        fi
-      fi
-    done
+  ~/.beads/scripts/bd-migrate-deps.sh \\
+    --source "{{bead-id}}" \\
+    --target "$Y_ID"
 
 ──────────────────────────────────────────────────────────────────────────
 STEP 7 — Stamp produced-bead-<Y-id> on X (replay-safe boundary)

--- a/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
+++ b/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
@@ -7,8 +7,8 @@
 #
 # Symmetric rubric (applies in BOTH directions):
 #   dep_type                                                  | linked status   | action
-#   blocks (or "blocked-by" for legacy edges created with     | any             | migrate
-#     `bd dep add --type blocked-by`; normalized on write)    |                 |
+#   blocks (or "blocked-by" emitted by bd dep list depending   | any             | migrate
+#     on traversal perspective; normalized to blocks on write) |                 |
 #   tracks, until, caused-by, validates, relates-to,          | any             | migrate
 #     supersedes                                              |                 |
 #   discovered-from, related                                  | closed          | keep on X
@@ -98,8 +98,8 @@ done
 #   $4 = direction    ("out" for X -> OTHER, "in" for OTHER -> X)
 #
 # For each migrated edge:
-#   - Normalizes "blocked-by" → "blocks" before calling bd dep add (bd dep add
-#     does not accept "blocked-by"; bd reports it for both ends of a blocks edge).
+#   - Normalizes "blocked-by" → "blocks" before calling bd dep add. bd dep list
+#     emits "blocked-by" for blocks edges depending on traversal perspective.
 #   - Outbound: bd dep add <Y> <OTHER> --type <T>; on success → bd dep remove <X> <OTHER>
 #   - Inbound:  bd dep add <OTHER> <Y> --type <T>; on success → bd dep remove <OTHER> <X>
 #     (positional convention: arg1 is the dependent bead, arg2 is the blocker/target)

--- a/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
+++ b/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# bd-migrate-deps.sh — Migrate dep edges from <source> to <target> (bidirectional).
+#
+# Implements brainstorm-bead.formula.toml STEP 6 §3 mechanical rubric:
+# retarget both OUTBOUND (X -> OTHER) and INBOUND (OTHER -> X) dep edges
+# from a brainstorm seed bead X to its produced implementation bead Y.
+#
+# Symmetric rubric (applies in BOTH directions):
+#   dep_type                                                  | linked status   | action
+#   blocks ("blocked-by" at read level — bd emits this for    | any             | migrate
+#     either end of a blocks edge in both --direction= modes) |                 |
+#   tracks, until, caused-by, validates, relates-to,          | any             | migrate
+#     supersedes                                              |                 |
+#   discovered-from, related                                  | closed          | keep on X
+#   discovered-from, related                                  | open / wip      | migrate
+#   parent-child                                              | any             | SKIP
+#   unknown dep type                                          | any             | WARN + migrate
+#
+# Cost: O(N_out + N_in) — exactly two `bd dep list` calls capture all edges
+# and their statuses inline via the `.status` field. No per-edge `bd show`
+# status calls are issued. Plus O(N_migrated) `bd dep add` / `bd dep remove`
+# pairs. Typical total << 40 bd calls.
+#
+# Idempotent: re-running after a partial failure produces the same end state.
+# Already-migrated edges no longer appear in X's dep list (in either direction),
+# so a replay is a no-op for them.
+#
+# Failure semantics (consistent with sibling helpers):
+#   - bd dep add failure (incl. cycle errors) → WARN, retain X-side, continue.
+#     Does NOT use --no-cycle-check; bd's default cycle detection stays in force.
+#   - bd dep remove failure after a successful add → WARN, retain both edges,
+#     continue. Replay will re-attempt the remove because the X-side edge is
+#     still visible to the iterator.
+#   - All other bd/jq/shell failures → propagate non-zero (set -euo pipefail).
+#
+# Usage:
+#   bd-migrate-deps.sh --source <X> --target <Y>
+#
+# Exit: 0 on success; non-zero on input-arg errors or unguarded bd/jq failures.
+
+set -euo pipefail
+
+SOURCE=""
+TARGET=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: bd-migrate-deps.sh --source <X> --target <Y>
+
+Migrate dep edges from <X> (source) to <Y> (target), in both directions.
+
+Walks both X's outbound edges (X -> OTHER, via `bd dep list <X> --direction=down`)
+and X's inbound edges (OTHER -> X, via `bd dep list <X> --direction=up`), and
+applies the brainstorm-bead §3 mechanical rubric to retarget each edge onto Y.
+
+Skips: parent-child edges (any direction), self-loops (other == X), and the
+freshly-created Y-discovered-from-X seed link (inbound edge where source == Y).
+
+Idempotent. Safe to replay after partial failure.
+
+Options:
+  --source <id>    Bead whose edges are being migrated FROM (required)
+  --target <id>    Bead the edges are being retargeted TO (required)
+  -h, --help       Show this help
+
+Exits non-zero immediately if --source == --target (copy-paste guard) or
+either flag is missing.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            [[ $# -ge 2 ]] || { echo "Error: --source requires a value" >&2; usage; }
+            SOURCE="$2"; shift 2 ;;
+        --target)
+            [[ $# -ge 2 ]] || { echo "Error: --target requires a value" >&2; usage; }
+            TARGET="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$SOURCE" ]] && { echo "Error: --source is required" >&2; usage; }
+[[ -z "$TARGET" ]] && { echo "Error: --target is required" >&2; usage; }
+[[ "$SOURCE" == "$TARGET" ]] && {
+    echo "Error: --source and --target must differ (got '$SOURCE' for both)" >&2
+    exit 1
+}
+
+# Apply the §3 rubric to one edge.
+#
+# Args:
+#   $1 = dep_type     (raw, as emitted by bd dep list — may be "blocked-by")
+#   $2 = other_id     (the bead at the OTHER end of the edge from X's perspective)
+#   $3 = other_status (status of OTHER, read inline from the dep list .status field)
+#   $4 = direction    ("out" for X -> OTHER, "in" for OTHER -> X)
+#
+# For each migrated edge:
+#   - Normalizes "blocked-by" → "blocks" before calling bd dep add (bd dep add
+#     does not accept "blocked-by"; bd reports it for both ends of a blocks edge).
+#   - Outbound: bd dep add <Y> <OTHER> --type <T>; on success → bd dep remove <X> <OTHER>
+#   - Inbound:  bd dep add <OTHER> <Y> --type <T>; on success → bd dep remove <OTHER> <X>
+#     (positional convention: arg1 is the dependent bead, arg2 is the blocker/target)
+migrate_edge() {
+    local dep_type="$1"
+    local other_id="$2"
+    local other_status="$3"
+    local direction="$4"
+
+    # Skip parent-child in both directions; handled by Y.parent = X.parent
+    # and the §4 children-placement step of brainstorm-bead.
+    [[ "$dep_type" == "parent-child" ]] && return 0
+
+    # Defensive guard: skip self-loops (other == X). Should not occur in
+    # a well-formed graph, but bd dep list could surface one if somehow created.
+    [[ "$other_id" == "$SOURCE" ]] && return 0
+
+    # Decide whether to migrate per the §3 rubric.
+    local migrate
+    case "$dep_type" in
+        blocks|blocked-by|tracks|until|caused-by|validates|relates-to|supersedes)
+            migrate=1 ;;
+        discovered-from|related)
+            if [[ "$other_status" == "closed" ]]; then
+                migrate=0
+            else
+                migrate=1
+            fi ;;
+        *)
+            # Unknown dep type — be conservative; migrate by default and log.
+            echo "WARN: unknown dep_type '$dep_type' on edge involving $SOURCE and $other_id; migrating to $TARGET by default."
+            migrate=1 ;;
+    esac
+
+    [[ "$migrate" == "1" ]] || return 0
+
+    # Normalize the wire-format "blocked-by" to the write-format "blocks"
+    # before calling bd dep add (in BOTH legs — bd emits "blocked-by" for
+    # either end of a blocks edge, regardless of traversal direction).
+    local add_type="$dep_type"
+    [[ "$add_type" == "blocked-by" ]] && add_type="blocks"
+
+    # Build the (dependent, blocker) tuple for bd dep add per the positional
+    # convention: arg1 = dependent bead, arg2 = blocker/target bead.
+    local add_dependent add_blocker remove_a remove_b
+    if [[ "$direction" == "out" ]]; then
+        # X -> OTHER becomes Y -> OTHER
+        add_dependent="$TARGET"; add_blocker="$other_id"
+        remove_a="$SOURCE";      remove_b="$other_id"
+    else
+        # OTHER -> X becomes OTHER -> Y
+        add_dependent="$other_id"; add_blocker="$TARGET"
+        remove_a="$other_id";      remove_b="$SOURCE"
+    fi
+
+    # Gate the X-side remove on a successful Y-side add: if `bd dep add`
+    # fails for any reason (incl. cycle detection), keep the original edge
+    # to preserve dep-graph integrity. Never drop edges silently.
+    if bd dep add "$add_dependent" "$add_blocker" --type "$add_type"; then
+        # `bd dep remove` is positional-only (issue-id, depends-on-id); no --type flag.
+        bd dep remove "$remove_a" "$remove_b" \
+            || echo "WARN: bd dep remove $remove_a $remove_b failed; both edges retained (replay will reattempt)."
+    else
+        echo "WARN: bd dep add $add_dependent $add_blocker --type $add_type failed; X edge retained to preserve dep graph."
+    fi
+}
+
+# ── Outbound: X -> OTHER edges ──────────────────────────────────────────────
+# `bd dep list <X> --direction=down --json` returns one entry per outbound
+# edge with .id (other end), .dependency_type, and .status (of the other end).
+OUT_JSON=$(bd dep list "$SOURCE" --direction=down --json)
+while IFS=$'\t' read -r dep_type other_id other_status; do
+    [[ -z "$dep_type" ]] && continue
+    migrate_edge "$dep_type" "$other_id" "$other_status" "out"
+done < <(printf '%s' "$OUT_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')
+
+# ── Inbound: OTHER -> X edges ───────────────────────────────────────────────
+# `bd dep list <X> --direction=up --json` returns one entry per inbound edge
+# with the same shape (.id is the OTHER bead — i.e. the source of the inbound edge).
+# Skip any edge where source == Y: that's the freshly-created
+# Y-discovered-from-X seed link from brainstorm-bead Step 4, which must remain.
+IN_JSON=$(bd dep list "$SOURCE" --direction=up --json)
+while IFS=$'\t' read -r dep_type other_id other_status; do
+    [[ -z "$dep_type" ]] && continue
+    [[ "$other_id" == "$TARGET" ]] && continue
+    migrate_edge "$dep_type" "$other_id" "$other_status" "in"
+done < <(printf '%s' "$IN_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')

--- a/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
+++ b/src/plugins/beads/.beads/scripts/bd-migrate-deps.sh
@@ -7,8 +7,8 @@
 #
 # Symmetric rubric (applies in BOTH directions):
 #   dep_type                                                  | linked status   | action
-#   blocks ("blocked-by" at read level — bd emits this for    | any             | migrate
-#     either end of a blocks edge in both --direction= modes) |                 |
+#   blocks (or "blocked-by" for legacy edges created with     | any             | migrate
+#     `bd dep add --type blocked-by`; normalized on write)    |                 |
 #   tracks, until, caused-by, validates, relates-to,          | any             | migrate
 #     supersedes                                              |                 |
 #   discovered-from, related                                  | closed          | keep on X
@@ -113,6 +113,12 @@ migrate_edge() {
     # and the §4 children-placement step of brainstorm-bead.
     [[ "$dep_type" == "parent-child" ]] && return 0
 
+    # Skip edges to the migration target itself — applies to both the inbound
+    # Y-discovered-from-X seed link and any pre-wired outbound X→Y edges.
+    # bd's add-side would reject the resulting Y→Y self-loop with an error,
+    # but skipping here avoids a noisy WARN for a valid graph state.
+    [[ "$other_id" == "$TARGET" ]] && return 0
+
     # Defensive guard: skip self-loops (other == X). Should not occur in
     # a well-formed graph, but bd dep list could surface one if somehow created.
     [[ "$other_id" == "$SOURCE" ]] && return 0
@@ -136,9 +142,10 @@ migrate_edge() {
 
     [[ "$migrate" == "1" ]] || return 0
 
-    # Normalize the wire-format "blocked-by" to the write-format "blocks"
-    # before calling bd dep add (in BOTH legs — bd emits "blocked-by" for
-    # either end of a blocks edge, regardless of traversal direction).
+    # Normalize "blocked-by" → "blocks" before calling bd dep add.
+    # `bd dep add --type blocked-by` is accepted and stores edges with
+    # dependency_type="blocked-by"; normalizing to the canonical "blocks"
+    # ensures migrated edges have the standard shape.
     local add_type="$dep_type"
     [[ "$add_type" == "blocked-by" ]] && add_type="blocks"
 
@@ -171,19 +178,22 @@ migrate_edge() {
 # `bd dep list <X> --direction=down --json` returns one entry per outbound
 # edge with .id (other end), .dependency_type, and .status (of the other end).
 OUT_JSON=$(bd dep list "$SOURCE" --direction=down --json)
+# Pre-render to variable so jq parse failures propagate via set -e rather than
+# silently producing zero iterations from inside a process-substitution subshell.
+OUT_TSV=$(printf '%s' "$OUT_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')
 while IFS=$'\t' read -r dep_type other_id other_status; do
+    # Guard against empty lines from a zero-item list or malformed records.
     [[ -z "$dep_type" ]] && continue
     migrate_edge "$dep_type" "$other_id" "$other_status" "out"
-done < <(printf '%s' "$OUT_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')
+done <<< "$OUT_TSV"
 
 # ── Inbound: OTHER -> X edges ───────────────────────────────────────────────
 # `bd dep list <X> --direction=up --json` returns one entry per inbound edge
 # with the same shape (.id is the OTHER bead — i.e. the source of the inbound edge).
-# Skip any edge where source == Y: that's the freshly-created
-# Y-discovered-from-X seed link from brainstorm-bead Step 4, which must remain.
+# migrate_edge skips the Y-discovered-from-X seed link (other_id == TARGET).
 IN_JSON=$(bd dep list "$SOURCE" --direction=up --json)
+IN_TSV=$(printf '%s' "$IN_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')
 while IFS=$'\t' read -r dep_type other_id other_status; do
     [[ -z "$dep_type" ]] && continue
-    [[ "$other_id" == "$TARGET" ]] && continue
     migrate_edge "$dep_type" "$other_id" "$other_status" "in"
-done < <(printf '%s' "$IN_JSON" | jq -r '.[] | "\(.dependency_type)\t\(.id)\t\(.status // "open")"')
+done <<< "$IN_TSV"


### PR DESCRIPTION
## Bead

**agents-config-t2u7** — [Impl] brainstorm-bead formula §3 edge migration: also retarget INBOUND deps from other beads to Y

## Summary

- Extracts brainstorm-bead.formula.toml STEP 6 inline dep-migration loop into a new shell helper `bd-migrate-deps.sh` at `src/plugins/beads/.beads/scripts/`
- Extends migration to cover INBOUND dep edges (OTHER→X) in addition to the existing OUTBOUND (X→OTHER) retargeting
- Installs automatically via the existing `*.sh` glob in `install.sh` — no installer edits needed

## Changes

- **NEW**: `src/plugins/beads/.beads/scripts/bd-migrate-deps.sh` (+x, 199 lines)
  - Symmetric §3 rubric applied to both outbound and inbound edges
  - Normalizes `blocked-by → blocks` before `bd dep add` in both legs
  - Correct positional convention for inbound: `bd dep add OTHER Y` (dependent, blocker)
  - Migration gated: add Y-side first, remove X-side only on success; WARN+retain on failure
  - `set -euo pipefail`; only `bd dep add`/`bd dep remove` are guarded for warn-and-continue
  - O(N_out + N_in): exactly 2 `bd dep list` calls; no per-edge `bd show` status queries
  - Fully idempotent; early exit if `--source == --target`
- **MODIFIED**: `src/plugins/beads/.beads/formulas/brainstorm-bead.formula.toml` STEP 6
  - §3 rubric prose retained as documentation (expanded to note bidirectional scope)
  - 53-line inline loop replaced with single helper invocation
  - Cost-bound paragraph updated to reflect O(N_out + N_in)

## Apply-edits summary

`bd-migrate-deps.sh` created (+x, bidirectional §3 rubric), STEP 6 replaced; sha=11b5c6e

## Review summary

- **quality-reviewer**: 7 findings — 1 major (blocked-by comment overclaim, doc-only), 2 minor actionable (jq failure propagation, symmetric TARGET skip), 2 minor deferred (local -r consistency, wording), 2 informational (replay-safety claim, X→Y outbound skip). All blocking/critical/major resolved in commit 11b5c6e.
- **simplify**: 0 findings — already at sibling-helper parity (bd-claim-walk.sh, bd-close-walk.sh)
- **foreign-eyes (Codex)**: degraded to pure Claude fresh-eyes (no new findings)
- **ralf-implement**: 1/3 cycles, PASS

## Verify-AC

15/15 [m] acceptance criteria witnesses PASS (all exit 0):
- File exists + chmod +x ✓
- install.sh --dry-run reports "Would install" (no installer edits) ✓
- STEP 6 calls helper; old inline loop removed ✓
- Outbound/inbound edge iteration ✓
- Status read inline from .status field ✓
- parent-child skip (both directions) ✓
- Inbound seed-link skip (source == Y) ✓
- Symmetric rubric (discovered-from/related + closed → keep) ✓
- blocked-by normalization ✓
- Inbound positional convention ✓
- Migration gating (add-then-remove, WARN guards) ✓
- set -euo pipefail + input validation ✓
- Cost bound documented in header ✓
- No --no-cycle-check ✓
- Early exit on --source == --target ✓
- Syntax check (bash -n) ✓

## Human-required AC follow-ups

| Bead | AC |
|------|-----|
| agents-config-t2u7.2 | Manual smoke test: throwaway X with outbound + inbound (open) + inbound (closed) edges; verify retargeting |
| agents-config-t2u7.3 | Manual end-to-end: full brainstorm-bead finalize with at least one inbound dep edge on the seed bead |

## Acceptance Criteria

**[m] — mechanically verified:**
- [m] bd-migrate-deps.sh exists at src/plugins/beads/.beads/scripts/bd-migrate-deps.sh and is chmod +x
- [m] install.sh requires NO edits; its existing *.sh glob deploys the helper automatically
- [m] brainstorm-bead.formula.toml STEP 6 calls the helper; old inline loop removed
- [m] Helper iterates X outbound edges (bd dep list --direction=down --json)
- [m] Helper iterates X inbound edges via bd dep list --direction=up --json; status from inline .status field
- [m] Both directions skip parent-child edges
- [m] Inbound iteration skips edges where source == Y (seed link)
- [m] Symmetric rubric applied; discovered-from/related + linked-closed → keep on X
- [m] blocked-by normalized → blocks before bd dep add (both legs)
- [m] Inbound migration: bd dep add OTHER Y --type blocks (correct positional convention)
- [m] Migration gated: add Y-side first; remove X-side on success; WARN+retain on failure
- [m] set -euo pipefail; only bd dep add/remove guarded; input-arg errors exit non-zero
- [m] O(N_out + N_in) cost; documented in header; no per-edge bd show calls
- [m] No --no-cycle-check
- [m] Early exit non-zero if --source == --target

**[h] — requires human verification (see follow-up beads above)**
- [h] Manual smoke test (agents-config-t2u7.2)
- [h] Manual end-to-end (agents-config-t2u7.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)