### PR TITLE
feat(installer): replace orphan scan with explicit prune-list inclusion filter

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1327,10 +1327,11 @@ _load_prune_list() {
 _load_prune_list
 
 _in_prune_list() {
-    local tool="$1" ns="$2" base="$3" entry
+    local tool="$1" ns="$2" base="$3" key entry
+    key="$tool/$ns/$base"
     for entry in "${PRUNE_LIST[@]}"; do
-        [[ "$entry" == "$tool/$ns/$base" ]] && return 0
-        [[ "$entry" == "*/$ns/$base"     ]] && return 0
+        # shellcheck disable=SC2254
+        case "$key" in ($entry) return 0;; esac
     done
     return 1
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1310,6 +1310,31 @@ ORPHAN_NS=()
 ORPHAN_PATHS=()
 ORPHAN_KINDS=()
 
+PRUNE_LIST=()
+
+_load_prune_list() {
+    local list_file
+    list_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/prune-list"
+    [[ -f "$list_file" ]] || return 0
+    local line
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line#"${line%%[! ]*}"}"
+        line="${line%"${line##*[! ]}"}"
+        [[ -n "$line" ]] && PRUNE_LIST+=("$line")
+    done < "$list_file"
+}
+_load_prune_list
+
+_in_prune_list() {
+    local tool="$1" ns="$2" base="$3" entry
+    for entry in "${PRUNE_LIST[@]}"; do
+        [[ "$entry" == "$tool/$ns/$base" ]] && return 0
+        [[ "$entry" == "*/$ns/$base"     ]] && return 0
+    done
+    return 1
+}
+
 # Append orphans found in a single dest namespace to the parallel ORPHAN_*
 # arrays, tagged with the given tool/namespace labels. Skips legacy *.backup-*
 # entries (in-place backups from older backup() implementations); classifies as
@@ -1323,6 +1348,7 @@ _scan_namespace() {
         base="$(basename "$entry")"
         [[ "$base" == *.backup-* ]] && continue
         [[ -e "$staging/$base" ]] && continue
+        _in_prune_list "$tool" "$ns_label" "$base" || continue
         if [[ -d "$entry" ]]; then kind="dir"; else kind="file"; fi
         ORPHAN_TOOLS+=("$tool")
         ORPHAN_NS+=("$ns_label")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -70,11 +70,11 @@ fi
 #   --verbose, -v        Show per-file progress (phases, up-to-date, installed)
 #   --tools=claude,...   Comma-separated list of tools (default: auto-detect)
 #   --plugins=beads,...  Comma-separated list of plugins (default: auto-detect)
-#   --prune              After install, remove orphans (with backup) under
+#   --prune              After install, remove retired paths listed in scripts/prune-list (with backup) under
 #                        ~/.<tool>/{commands,skills,agents,rules}/ (or
 #                        ~/.config/<tool>/ for OpenCode) and ~/.beads/formulas/
 #                        that are not in current staging
-#   --prune-only         Skip Phase 7 (install) and only scan + prune orphans
+#   --prune-only         Skip Phase 7 (install) and only scan + remove retired paths listed in scripts/prune-list
 #                        (mutually exclusive with --prune)
 #   --help, -h           Show this help
 #
@@ -131,9 +131,8 @@ for arg in "$@"; do
             echo "                     opencode also if ~/.config/opencode/ exists or opencode is on PATH)"
             echo "  --plugins=PLUGINS  Comma-separated plugins: beads"
             echo "                     Default: auto-detect (enabled if bd is on PATH or ~/.beads/ exists)"
-            echo "  --prune            After install, remove orphans under ~/.<tool>/{commands,skills,agents,rules}/"
-            echo "                     and ~/.beads/formulas/ that are not in current staging (with backup)"
-            echo "  --prune-only       Skip install (Phase 7); only scan + prune orphans (mutually exclusive with --prune)"
+            echo "  --prune            After install, remove retired paths listed in scripts/prune-list (with backup)"
+            echo "  --prune-only       Skip install (Phase 7); scan + remove retired paths from scripts/prune-list (mutually exclusive with --prune)"
             echo "  --help, -h         Show this help"
             exit 0
             ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1314,7 +1314,7 @@ PRUNE_LIST=()
 
 _load_prune_list() {
     local list_file
-    list_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/prune-list"
+    list_file="$SCRIPT_DIR/prune-list"
     [[ -f "$list_file" ]] || return 0
     local line
     while IFS= read -r line; do

--- a/scripts/prune-list
+++ b/scripts/prune-list
@@ -1,0 +1,9 @@
+# prune-list — paths this repo previously installed and has since removed.
+# Format: tool/namespace/basename  OR  */namespace/basename  (all tools)
+# Add an entry here when removing a skill/agent/command/rule from src/user/.
+
+# Retired in d0a98bd: superpowers audit — condition-based-waiting removed
+*/skills/condition-based-waiting
+
+# Retired in d0a98bd: superpowers audit — testing-anti-patterns removed
+*/skills/testing-anti-patterns


### PR DESCRIPTION
## Summary

- Replaces the aggressive \"flag everything not in staging\" orphan detection with a conservative explicit inclusion filter
- Adds `scripts/prune-list` — a graveyard manifest of paths this repo previously installed and has since removed; only listed entries are eligible for pruning
- Supports `tool/namespace/basename` (exact) and `*/namespace/basename` (all tools) pattern forms
- Seeds the list with two skills retired in d0a98bd: `condition-based-waiting` and `testing-anti-patterns`

**Before:** `--prune-only --dry-run` falsely flagged `~/.claude/skills/graphify` (graphify plugin) and `~/.codex/rules/default.rules` (Codex CLI) as orphans
**After:** 0 orphans detected; only explicitly retired paths are ever pruned

## Workflow going forward

When removing a skill/agent/command/rule from `src/user/`, add its destination key to `scripts/prune-list` in the same commit.

## Test plan

- [ ] `./scripts/install.sh --prune-only --dry-run` shows 0 orphans
- [ ] `mkdir -p ~/.claude/skills/condition-based-waiting && ./scripts/install.sh --prune-only --dry-run` shows 1 orphan, then `rm -rf` it
- [ ] `~/.claude/skills/graphify` and `~/.codex/rules/default.rules` are untouched after a real `--prune-only` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)