### PR TITLE
fix(installer): suppress install-phase orphan warnings for non-prune-list items

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -768,7 +768,7 @@ stage_and_install_tool() {
                 if [[ "$DRY_RUN" == true && -f "$inc_counterpart" ]]; then
                     vok "Would remove $(basename "$inc_counterpart") (spurious standalone from prior install)"
                     (( tool_updated[$CURRENT_TOOL]++ )) || true
-                elif [[ "$DRY_RUN" != true && "$PRUNE_ONLY" != true && -f "$inc_counterpart" ]]; then
+                elif [[ "$DRY_RUN" != true && -f "$inc_counterpart" ]]; then
                     backup "$inc_counterpart"
                     rm "$inc_counterpart"
                     vok "Removed $(basename "$inc_counterpart") (spurious standalone from prior install)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -904,15 +904,15 @@ stage_and_install_beads() {
 
     [[ "$found_any" == false ]] && vinfo "No formula files staged"
 
-    # Warn about formulas in dest that aren't in staged source
+    # Warn about formulas in dest that are retired (on prune-list) but not yet pruned
     # (suppressed when --prune/--prune-only is active — prune phase will report and act on these)
     if ! prune_active; then
         local extra_name
         for dest_file in "$dest_formulas"/*.toml; do
             [[ -f "$dest_file" ]] || continue
             extra_name="$(basename "$dest_file")"
-            if [[ ! -f "$staging_formulas/$extra_name" ]]; then
-                warn "formulas/$extra_name exists in ~/.beads/formulas but not in plugin source (keeping)"
+            if [[ ! -f "$staging_formulas/$extra_name" ]] && _in_prune_list "beads" "formulas" "$extra_name"; then
+                warn "formulas/$extra_name exists in ~/.beads/formulas but not in plugin source — retired, run --prune to remove"
             fi
         done
     fi
@@ -1130,14 +1130,14 @@ sync_directory() {
         fi
     done
 
-    # Warn about items in dest that aren't in source
+    # Warn about items in dest that are retired (on prune-list) but not yet pruned
     # (suppressed when --prune/--prune-only is active — prune phase will report and act on these)
     if ! prune_active; then
         for dest_item in "$dest_parent"/*; do
             [[ -e "$dest_item" ]] || continue
             item_name="$(basename "$dest_item")"
-            if [[ ! -e "$src_parent/$item_name" ]]; then
-                warn "$dir_name/$item_name exists in $(tool_dest_dir "$CURRENT_TOOL") but not in $label source (keeping)"
+            if [[ ! -e "$src_parent/$item_name" ]] && _in_prune_list "$CURRENT_TOOL" "$dir_name" "$item_name"; then
+                warn "$dir_name/$item_name exists in $(tool_dest_dir "$CURRENT_TOOL") but not in source — retired, run --prune to remove"
             fi
         done
     fi


### PR DESCRIPTION
## Summary

- The install phase had two warning sites flagging *every* file in a dest namespace missing from source — including externally-managed files like \`~/.claude/skills/graphify\` (graphify plugin). Both now gate on \`_in_prune_list\` so only explicitly-retired paths produce a warning.
- Phase 6.75 include-only counterpart cleanup was gated with \`PRUNE_ONLY != true\`, meaning it ran during normal install but was silently skipped during \`--prune-only\`. Removed the guard — cleanup now runs consistently regardless of prune flag.

**Before:** \`./scripts/install.sh -y\` printed \`! skills/graphify exists in ~/.claude but not in staged source (keeping)\`; \`--prune-only\` silently skipped include-only counterpart removal
**After:** no false-positive warnings; \`--prune-only\` runs the Phase 6.75 cleanup too

Addresses two Copilot comments posted after PR #58 merged (r3214671107, r3214671114).

## Test plan

- [ ] \`./scripts/install.sh -y\` (or \`--dry-run\`) produces no mention of \`graphify\`
- [ ] \`./scripts/install.sh --prune-only --dry-run\` still shows 0 orphans
- [ ] \`./scripts/install.sh --prune-only --dry-run\` reports "Would remove" for any installed include-only counterparts

🤖 Generated with [Claude Code](https://claude.com/claude-code)