### PR TITLE
docs(templates): add canonical decision-matrix, reconcile persona vs orchestration escalation

### DIFF
--- a/src/user/.agents/AGENT-PERSONA.md.template
+++ b/src/user/.agents/AGENT-PERSONA.md.template
@@ -15,6 +15,6 @@
 
 - You assume too much
 - Doubt yourself until you've checked facts
-- Ask when unsure
+- Apply the canonical decision matrix to every ask-vs-decide moment
 
 </your-persona>

--- a/src/user/.agents/AGENT-PERSONA.md.template
+++ b/src/user/.agents/AGENT-PERSONA.md.template
@@ -1,4 +1,4 @@
-<your_persona>
+<your-persona>
 
 **YOU**: A snarky, arrogant, boastful principle software architect with 20 years of experience in Systems Design and Clean Code Refactoring. 
 

--- a/src/user/.agents/INSTRUCTIONS.md.template
+++ b/src/user/.agents/INSTRUCTIONS.md.template
@@ -25,6 +25,41 @@ Tool-agnostic principles for all AI coding assistants.
 - **Coordination**: Never `git restore` another agent's files—ask the user or owning agent first
 </constraints>
 
+<decision-matrix>
+<!-- Canonical escalation hierarchy. Reference by concept, not by file path —
+     this content is flattened into all assembled instruction files at install
+     time via DYNAMIC-INCLUDE. Do not add per-tool copies. -->
+
+When facing a question or unknown, classify the situation, then act:
+
+| Situation                                                              | Action   | Quadrant                       |
+|------------------------------------------------------------------------|----------|--------------------------------|
+| Verifiable fact                                                        | Verify   | verify-facts                   |
+| In-scope decision; OR architectural but clear best option exists       | Decide   | decide-in-scope                |
+| Architectural w/ genuinely balanced trade-offs, or option-space needs human context | Escalate | escalate-architectural |
+| Conflicting directions L0–L3 precedence cannot resolve                 | Escalate | escalate-conflicting           |
+
+- **verify-facts** — the answer exists in the codebase, docs, git history, or
+  prior conversation. Read/grep/test. Do NOT ask.
+- **decide-in-scope** — implementation detail, naming, local refactor,
+  reasonable trade-off within stated requirements, OR an architectural question
+  where you can identify a clearly better option by standard engineering
+  judgment. Choose it. Do NOT ask for validation.
+- **escalate-architectural** — architectural or requirements implications where
+  a clearly better option CANNOT be identified: trade-offs are genuinely
+  balanced with no engineering-judgment winner, or the options themselves
+  depend on human context unavailable to the agent. If you can rank options,
+  you are in decide-in-scope — do NOT escalate for approval.
+- **escalate-conflicting** — instructions, constraints, or stakeholders pull
+  in incompatible directions that L0–L3 law precedence cannot resolve. Escalate,
+  surfacing the conflict with your read of each side.
+
+**Risk-asymmetric defaults are NOT escalations.** Specific rules that say
+"when in doubt, do the safe thing" (merge authorization, `git restore`
+coordination, merge-guard's `pass 0`) override the matrix on their narrow
+domain and are not affected by this change.
+</decision-matrix>
+
 <workflow>
 <!-- PRESERVE: development process requirements -->
 1. Features and bug fixes: Design → Tests → Implement → Refactor (TDD: red-green-refactor)
@@ -35,7 +70,8 @@ Tool-agnostic principles for all AI coding assistants.
 <orchestration>
 <!-- PRESERVE: high-level process for non-trivial tasks -->
 - **Plan first**: Plan mode for multi-step tasks or architectural decisions. Re-plan immediately when blocked. Write specs in the plan file for small-context specs.
-- **Decide, don't defer**: Use your best judgment on implementation details and non-architectural questions. Only escalate to the user when: (a) the answer has significant architectural or requirements implications not already specified, or (b) there are conflicting directions that require human resolution. Decide everything else yourself. Do not ask questions you can answer from the codebase, existing instructions, or standard engineering judgment.
+- **Decide, don't defer**: apply the canonical decision matrix.
+  Quadrants `verify-facts` and `decide-in-scope` resolve without the user.
 - **Subagents**: Offload research, exploration, parallel analysis. One task per subagent. Keep main context clean.
 - **Self-improvement**: After ANY user correction → invoke `self-improving-agent` skill. No "I'll do better" without a written rule.
 - **Verify before done**: NEVER mark complete without proof. Audit against `<verification-checklist>`. Use `verify-checklist` skill for structured reporting.

--- a/src/user/.agents/INSTRUCTIONS.md.template
+++ b/src/user/.agents/INSTRUCTIONS.md.template
@@ -70,7 +70,7 @@ domain and are not affected by this change.
 <orchestration>
 <!-- PRESERVE: high-level process for non-trivial tasks -->
 - **Plan first**: Plan mode for multi-step tasks or architectural decisions. Re-plan immediately when blocked. Write specs in the plan file for small-context specs.
-- **Decide, don't defer**: apply the canonical decision matrix.
+- **Decide, don't defer**: Apply the canonical decision matrix.
   Quadrants `verify-facts` and `decide-in-scope` resolve without the user.
 - **Subagents**: Offload research, exploration, parallel analysis. One task per subagent. Keep main context clean.
 - **Self-improvement**: After ANY user correction → invoke `self-improving-agent` skill. No "I'll do better" without a written rule.

--- a/src/user/.agents/agents/tech-lead.md
+++ b/src/user/.agents/agents/tech-lead.md
@@ -77,12 +77,16 @@ You will:
 
 ### Decision Criteria for Human Escalation
 
-- Subagent explicitly requests human input
-- Multiple agents report conflicting recommendations
-- Critical architectural decisions with long-term implications
-- Resource constraints or technical limitations encountered
-- Ambiguous requirements needing clarification
-- Team appears stuck after multiple attempts
+Apply the canonical decision matrix. Role-specific additions for the
+tech-lead orchestrator:
+
+- A dispatched subagent explicitly requests human input
+- Multiple subagents report conflicting recommendations
+- Team appears stuck after multiple attempts (loop detection)
+
+The architectural-decisions, resource-constraints, and
+ambiguous-requirements bullets dropped here are already covered by the
+`escalate-architectural` quadrant of the canonical decision matrix.
 
 ## Communication Protocols
 

--- a/src/user/.agents/agents/tech-lead.md
+++ b/src/user/.agents/agents/tech-lead.md
@@ -84,8 +84,8 @@ tech-lead orchestrator:
 - Multiple subagents report conflicting recommendations
 - Team appears stuck after multiple attempts (loop detection)
 
-The architectural-decisions, resource-constraints, and
-ambiguous-requirements bullets dropped here are already covered by the
+The architectural decisions, resource constraints, and
+ambiguous requirements bullets dropped here are already covered by the
 `escalate-architectural` quadrant of the canonical decision matrix.
 
 ## Communication Protocols

--- a/src/user/.agents/skills/ralf-implement/implementer-prompt.md
+++ b/src/user/.agents/skills/ralf-implement/implementer-prompt.md
@@ -31,7 +31,7 @@ Agent tool (general-purpose, mode: "auto"):
     6. Self-review against the Definition of Done
     7. Report back with a structured implementation summary
 
-    If ANYTHING is unclear, ask before proceeding. Don't guess.
+    If unclear, apply the canonical decision matrix. Don't guess.
 
     ## Report Format
 

--- a/src/user/.agents/skills/ralf-implement/implementer-prompt.md
+++ b/src/user/.agents/skills/ralf-implement/implementer-prompt.md
@@ -31,7 +31,7 @@ Agent tool (general-purpose, mode: "auto"):
     6. Self-review against the Definition of Done
     7. Report back with a structured implementation summary
 
-    If unclear, apply the canonical decision matrix. Don't guess.
+    If anything is unclear, apply the canonical decision matrix. Don't guess.
 
     ## Report Format
 


### PR DESCRIPTION
## Summary

- Introduces `<decision-matrix>` block in `INSTRUCTIONS.md.template` as the canonical escalation hierarchy (four named quadrants: `verify-facts`, `decide-in-scope`, `escalate-architectural`, `escalate-conflicting`)
- Resolves conflict: `AGENT-PERSONA.md.template` said "Ask when unsure" while `<orchestration>` said "Decide, don't defer" — conflicting escalation defaults
- Collapses the verbose "Decide, don't defer" bullet to a two-line matrix pointer
- Aligns `agents/tech-lead.md` (6→3 bullets) and `ralf-implement/implementer-prompt.md` to reference the matrix

## Bead

`agents-config-abn9.5` — [Impl] Reconcile persona 'Doubt yourself, ask when unsure' vs orchestration 'Decide, don't defer'

## Acceptance Criteria

1. `<decision-matrix>` block (exact tag name) inserted between `</constraints>` and `<workflow>` in INSTRUCTIONS.md.template with all four named quadrants and risk-asymmetric-defaults caveat.
2. AGENT-PERSONA.md.template: 'Ask when unsure' removed; matrix reference added; lines 'You assume too much' and 'Doubt yourself until you've checked facts' preserved.
3. INSTRUCTIONS.md.template `<orchestration>` 'Decide, don't defer' bullet collapsed to two-line matrix reference.
4. agents/tech-lead.md Decision Criteria section: three orchestrator-specific bullets retained; three generic bullets dropped with rationale.
5. skills/ralf-implement/implementer-prompt.md line 34 replaced with matrix reference.
6. All new matrix references use conceptual phrasing (quadrant names or 'canonical decision matrix') — no file-path citations.
7. Cross-tool propagation requires no per-tool edits (DYNAMIC-INCLUDE markers verified in all 4 per-tool templates).
8. **[human]** Smoke test: fresh agent cites correct quadrant for Q1 decide-in-scope, Q2 escalate-architectural, Q3 tech-lead role-specific, Q4 escalate-conflicting, Q5 decide-in-scope.

## Changes (4 files, 5 edits, commit 17831d6)

- `src/user/.agents/INSTRUCTIONS.md.template` — inserted 35-line `<decision-matrix>` block; collapsed "Decide, don't defer" bullet
- `src/user/.agents/AGENT-PERSONA.md.template` — "Ask when unsure" → "Apply the canonical decision matrix to every ask-vs-decide moment"
- `src/user/.agents/agents/tech-lead.md` — Decision Criteria: 6 generic bullets → 3 orchestrator-specific + rationale comment
- `src/user/.agents/skills/ralf-implement/implementer-prompt.md` — "If ANYTHING is unclear, ask before proceeding" → "If unclear, apply the canonical decision matrix."

## Review

- **quality-reviewer**: 0 findings (clean)
- **simplify**: 1 minor flag — tech-lead.md rationale wording narrates a prior change rather than stating forward guidance; deferred because AC#4 mandates the exact prose verbatim

## Verification (7/7 mechanical ACs PASS)

| AC | Witness | Result |
|----|---------|--------|
| AC1 | `grep '<decision-matrix>'` at INSTRUCTIONS:28 | ✓ PASS |
| AC2 | `grep 'Ask when unsure'` returns 0; matrix ref at persona:18 | ✓ PASS |
| AC3 | orchestration bullet collapsed at INSTRUCTIONS:73 | ✓ PASS |
| AC4 | 3 orchestrator bullets present; 'Critical architectural' absent | ✓ PASS |
| AC5 | ralf-implement:34 replaced; old text absent | ✓ PASS |
| AC6 | No file-path citations in new references | ✓ PASS |
| AC7 | DYNAMIC-INCLUDE in all 4 per-tool templates | ✓ PASS |
| AC8 | Human smoke test — not machine-verifiable; requires interactive fresh-agent run | ⏳ Human |

🤖 Generated with [Claude Code](https://claude.com/claude-code)