### PR TITLE
feat(skills): optimize PR review comment processing — 11 helpers, model retier, subagent schema (abn9.4)

### DIFF
--- a/project-config.toml
+++ b/project-config.toml
@@ -22,7 +22,7 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
-test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -n1 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\"' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines, POSIX-compatible
+test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -n1 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\"' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines (find -print0 / sort -z / xargs -0 are common GNU/BSD extensions, not POSIX; portable on macOS + Linux)
 
 # ---------------------------------------------------------------------------
 # [coverage] — code coverage settings

--- a/project-config.toml
+++ b/project-config.toml
@@ -22,7 +22,7 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
-test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -n1 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\"' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines (find -print0 / sort -z / xargs -0 are common GNU/BSD extensions, not POSIX; portable on macOS + Linux)
+test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\" || exit 1' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines (find -print0 / sort -z / xargs -0 are common GNU/BSD extensions, not POSIX; portable on macOS + Linux)
 
 # ---------------------------------------------------------------------------
 # [coverage] — code coverage settings

--- a/project-config.toml
+++ b/project-config.toml
@@ -22,7 +22,7 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
-test      = "bash -c 'for f in $(find src/user/.agents/skills -name \"*_test.sh\" | sort); do echo \"[TEST] $f\"; bash \"$f\" || exit 1; done'"   # skill smoke tests (added by abn9.4)
+test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -n1 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\"' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines, POSIX-compatible
 
 # ---------------------------------------------------------------------------
 # [coverage] — code coverage settings

--- a/project-config.toml
+++ b/project-config.toml
@@ -17,8 +17,11 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 # Read by: green-loop (quality gate per iteration), quality-sweep
 # ---------------------------------------------------------------------------
 [gates]
-# This project is pure documentation — no build, typecheck, or lint.
-# Gates are stubs; stages detect empty commands and skip gracefully.
+# This project is primarily documentation — no build, typecheck, or lint —
+# but it now ships an automated bash smoke-test suite for the skill helper
+# scripts under src/user/.agents/skills (added by abn9.4). The build/
+# typecheck/lint gates remain empty stubs and stages detect them as such and
+# skip gracefully; the test gate is wired up to the smoke-test runner.
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
@@ -39,7 +42,7 @@ test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | 
 #   - quality-sweep does not separately enforce a coverage threshold.
 # When true (or absent), the existing semantics apply: empty/missing
 # report-location triggers human-flag, and green-loop's DoD enforces threshold.
-applicable       = false  # this project is pure documentation — no tests, no coverage
+applicable       = false  # smoke tests exist (see [gates].test) but coverage tooling is intentionally not wired up for this docs-leaning repo
 threshold        = 80     # percent; ignored when applicable = false; per-bead override: coverage-threshold-<n> label
 report-location  = ""     # n/a — applicable = false suppresses coverage handling
 format           = ""     # n/a

--- a/project-config.toml
+++ b/project-config.toml
@@ -22,7 +22,7 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
-test      = ""   # no automated test suite
+test      = "bash -c 'for f in $(find src/user/.agents/skills -name \"*_test.sh\" | sort); do echo \"[TEST] $f\"; bash \"$f\" || exit 1; done'"   # skill smoke tests (added by abn9.4)
 
 # ---------------------------------------------------------------------------
 # [coverage] — code coverage settings

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -59,15 +59,15 @@ Standalone mode is deferred to a follow-up bead.
 
 ### Phase 0 — Mode detection + schema validation
 
-Apply the six Phase 0 precedence rules above. After mode is resolved, run schema validation against the supplied path:
+Apply the six Phase 0 precedence rules above. After mode is resolved, run schema validation against the supplied path with the Phase 0 guard set:
 
 ```bash
 ~/.claude/skills/wait-for-pr-comments/validate-inventory.sh \
-  <inventory-path> \
+  --phase 0 <inventory-path> \
   || { echo "schema validation failed"; exit 1; }
 ```
 
-`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The validator enforces ten guards (all documented in §"Schema validation guards" below). Phase 0 checks guards 1–9; guard 10 (replyable items have `reply_body`) is deferred to Phase 2 because `render-reply-bodies.sh` is what populates the field.
+`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The validator enforces ten guards (all documented in §"Schema validation guards" below). `--phase 0` runs guards 1–9; `--phase 2` (the default) runs all ten. Guard 10 (replyable items have `reply_body`) is deferred to Phase 2 because `render-reply-bodies.sh` is what populates the field — Phase 0 invocations would always fail it on a raw inventory.
 
 ### Phase 1 — Read inventory + verify head SHA
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -6,7 +6,7 @@ description: >
   (`--from-inventory`), or `--resume` for crash recovery from a partial run.
   Does not fix code. Keywords: reply, resolve, thread, acknowledge, close
   out, post fix confirmation, bookkeeping, rebut, ack.
-model: opus[1m]
+model: sonnet[1m]
 effort: low
 ---
 
@@ -181,6 +181,63 @@ Emit a structured close-out summary:
 ```
 
 **Skill B does NOT unlink the inventory** — `wait-for-pr-comments` (Skill A) owns the file's lifecycle. Skill A unlinks at its own Phase 9 success after Skill B reports success and the final unresolved-threads check passes. Touching the file here would race Skill A's bookkeeping.
+
+## Helper-script invocation patterns
+
+All inline GraphQL/jq blocks have been factored into helpers. Each phase
+invokes the relevant helper; the SKILL.md prose above narrates *what* the
+phase does, while these reference invocations are the canonical *how*.
+
+**Verify PR head SHA** (Phase 1 — replaces inline `gh api` + retry loop):
+
+```bash
+${CLAUDE_SKILL_DIR}/verify-head-sha.sh \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+  --expected-sha "$EXPECTED_SHA"
+# exit 0 = match; exit 1 = persistent mismatch after retries
+```
+
+**Probe per-item fix SHAs against the PR branch** (Phase 1.5 — replaces
+inline `git merge-base --is-ancestor` loop):
+
+```bash
+${CLAUDE_SKILL_DIR}/probe-fix-shas.sh \
+  --branch "$PR_BRANCH" \
+  --items "$INVENTORY_FILE"
+# stdout: {present: [...], missing: [...]}
+```
+
+**Post replies for every inventory item** (Phase 2 — replaces inline
+per-`kind` `gh api` blocks):
+
+```bash
+${CLAUDE_SKILL_DIR}/post-replies.sh \
+  --inventory "$INVENTORY_FILE" \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+  [--skip-comment-ids "<csv>"]
+# per item: POSTED <id> / FAILED <id> <reason> / SKIPPED <id>
+```
+
+**NOT idempotent** — on a partial-run retry, the caller MUST pass
+`--skip-comment-ids` with the csv of already-posted comment_ids.
+
+**Resolve FIX review threads** (Phase 3 — replaces inline GraphQL
+`resolveReviewThread` block):
+
+```bash
+${CLAUDE_SKILL_DIR}/resolve-threads.sh \
+  --inventory "$INVENTORY_FILE"
+# per thread: RESOLVED <thread_id> / FAILED <thread_id> <reason>
+```
+
+**Build the final operator-facing report** (Phase 4 — replaces inline
+markdown template):
+
+```bash
+${CLAUDE_SKILL_DIR}/build-final-report.sh \
+  --inventory "$INVENTORY_FILE"
+# stdout: markdown summary including every item's comment_id
+```
 
 ## Reply text templates
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -67,7 +67,7 @@ Apply the six Phase 0 precedence rules above. After mode is resolved, run schema
   || { echo "schema validation failed"; exit 1; }
 ```
 
-`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The nine guards the validator enforces are documented in §"Schema validation guards" below — they are the contract this skill assumes is honored before Phase 1 begins.
+`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. Guards 1–9 of the ten guards the validator enforces are documented in §"Schema validation guards" below — they are the contract this skill assumes is honored before Phase 1 begins. Guard 10 (replyable items have `reply_body`) is checked in Phase 2 after `render-reply-bodies.sh` runs.
 
 ### Phase 1 — Read inventory + verify head SHA
 
@@ -204,19 +204,38 @@ ${CLAUDE_SKILL_DIR}/probe-fix-shas.sh \
 # stdout: {present: [...], missing: [...]}
 ```
 
-**Post replies for every inventory item** (Phase 2 — replaces inline
-per-`kind` `gh api` blocks):
+**Render reply bodies** (Phase 2, step 1 — populates `.reply_body` on every
+replyable item using the pinned template matrix below):
+
+```bash
+RENDERED="$(mktemp)"
+${CLAUDE_SKILL_DIR}/render-reply-bodies.sh \
+  --inventory "$INVENTORY_FILE" \
+  --out "$RENDERED"
+# exit 0 = all bodies rendered; exit 1 = render error (missing required field)
+```
+
+**Validate rendered inventory** (Phase 2, step 2 — guard 10 confirms
+`render-reply-bodies.sh` populated every replyable item):
+
+```bash
+~/.claude/skills/wait-for-pr-comments/validate-inventory.sh "$RENDERED" \
+  || { echo "post-render validation failed"; exit 1; }
+```
+
+**Post replies for every inventory item** (Phase 2, step 3 — uses rendered
+inventory so every replyable item already has `.reply_body`):
 
 ```bash
 ${CLAUDE_SKILL_DIR}/post-replies.sh \
-  --inventory "$INVENTORY_FILE" \
+  --inventory "$RENDERED" \
   --owner "$OWNER" --repo "$REPO" --pr "$PR" \
   [--skip-comment-ids "<csv>"]
 # per item, one of:
 #   POSTED <comment_id>
 #   FAILED <comment_id> <reason>
 #   SKIPPED <comment_id>            # matched --skip-comment-ids
-#   FILTERED <comment_id> (classification=<class>)  # classification != FIX|SKIP
+#   FILTERED <comment_id> (classification=<class>)  # not replyable
 ```
 
 **NOT idempotent** — on a partial-run retry, the caller MUST pass
@@ -244,6 +263,8 @@ ${CLAUDE_SKILL_DIR}/build-final-report.sh \
 
 PR-public text. **No internal jargon** (`bd`, bead IDs, `ESCALATE`, `inventory`, `phase`, `crash_recovery`, `fix_outcome`) appears in any reply.
 
+**These are the canonical templates.** `render-reply-bodies.sh` implements this matrix exactly — it is the single owner of reply text. Do not improvise alternate wording in Phase 2; use `render-reply-bodies.sh` output verbatim.
+
 | State | Reply template |
 |---|---|
 | FIX, `fix_outcome=committed` | `Fixed in <fix_commit_sha>. <fix_summary>` |
@@ -257,7 +278,7 @@ PR-public text. **No internal jargon** (`bd`, bead IDs, `ESCALATE`, `inventory`,
 
 ## Schema validation guards
 
-`validate-inventory.sh` (shipped with `wait-for-pr-comments`) enforces these nine guards. Skill B Phase 0 invokes the validator and aborts on any failure. The guards exist so Phase 2/3 can trust the inventory shape:
+`validate-inventory.sh` (shipped with `wait-for-pr-comments`) enforces ten guards. Skill B Phase 0 invokes the validator before Phase 1 (pre-render); Phase 2 invokes it again after `render-reply-bodies.sh` (post-render, to catch guard 10). Skill B aborts on any failure. The guards exist so Phase 2/3 can trust the inventory shape:
 
 1. **Non-empty rationale** — reject if any item has `rationale == "" or null`. Rationale is user-facing for SKIP replies; an empty rationale would post an empty PR comment.
 2. **`escalation_filed` only on ESCALATE** — reject if any item has `classification != "ESCALATE"` and `escalation_filed == true`.
@@ -268,6 +289,7 @@ PR-public text. **No internal jargon** (`bd`, bead IDs, `ESCALATE`, `inventory`,
 7. **`already_addressed` outcome carries SHA** — reject if any item has `fix_outcome == "already_addressed"` and `fix_commit_sha` is null.
 8. **ESCALATE must be filed** — reject if any item has `classification == "ESCALATE"` and `escalation_filed != true`. Skill A's interactive Phase 3.5 reclassifies ESCALATEs to FIX/SKIP/DEFER before write; autonomous Phase 3.5 sets `escalation_filed=true`. An unfiled ESCALATE at write time means a Skill A bug — without this guard, Skill B would silently skip the item without a reply.
 9. **Schema sanity** — reject if JSON parse fails or `schema_version != 1`.
+10. **Replyable items have `reply_body`** — reject if any replyable item (FIX, SKIP, or ESCALATE-with-`escalation_filed=true`) has a null or empty `reply_body`. This guard runs on the rendered inventory (after `render-reply-bodies.sh`) to confirm rendering succeeded. Guard 10 is NOT checked on the raw inventory at Phase 0 — `render-reply-bodies.sh` is what populates the field.
 
 On reject: validator logs the violating item to stderr; Skill B aborts with no replies posted.
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -67,7 +67,7 @@ Apply the six Phase 0 precedence rules above. After mode is resolved, run schema
   || { echo "schema validation failed"; exit 1; }
 ```
 
-`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. Guards 1–9 of the ten guards the validator enforces are documented in §"Schema validation guards" below — they are the contract this skill assumes is honored before Phase 1 begins. Guard 10 (replyable items have `reply_body`) is checked in Phase 2 after `render-reply-bodies.sh` runs.
+`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The validator enforces ten guards (all documented in §"Schema validation guards" below). Phase 0 checks guards 1–9; guard 10 (replyable items have `reply_body`) is deferred to Phase 2 because `render-reply-bodies.sh` is what populates the field.
 
 ### Phase 1 — Read inventory + verify head SHA
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -212,7 +212,11 @@ ${CLAUDE_SKILL_DIR}/post-replies.sh \
   --inventory "$INVENTORY_FILE" \
   --owner "$OWNER" --repo "$REPO" --pr "$PR" \
   [--skip-comment-ids "<csv>"]
-# per item: POSTED <id> / FAILED <id> <reason> / SKIPPED <id>
+# per item, one of:
+#   POSTED <comment_id>
+#   FAILED <comment_id> <reason>
+#   SKIPPED <comment_id>            # matched --skip-comment-ids
+#   FILTERED <comment_id> (classification=<class>)  # classification != FIX|SKIP
 ```
 
 **NOT idempotent** — on a partial-run retry, the caller MUST pass

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -138,15 +138,12 @@ Reply body text is taken **only** from the pinned reply matrix in §"Reply text 
 
 ### Phase 3 — Resolve only FIX `review_thread`s
 
-GraphQL mutation, variable-bound:
+Invoke the resolve helper against the inventory (handles the GraphQL mutation per-thread internally):
 
 ```bash
-gh api graphql -f query='
-  mutation($id:ID!){
-    resolveReviewThread(input:{threadId:$id}){
-      thread{ isResolved }
-    }
-  }' -F id=<thread_id>
+${CLAUDE_SKILL_DIR}/resolve-threads.sh --inventory <inventory-path>
+# per-thread output: RESOLVED <thread_id> or FAILED <thread_id> <reason>
+# exit 0 if all resolved or none to resolve; exit 1 if any failed
 ```
 
 **Resolve target set:** items with `kind == "review_thread"` AND `classification == "FIX"` AND a non-null `fix_outcome` (i.e., `committed` or `already_addressed`). All four conditions must hold.

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Purpose: render the operator-facing markdown summary of a completed
+# reply-and-resolve run.
+#
+# Inputs:
+#   --inventory <file>  inventory JSON (must contain .items array)
+#
+# Outputs:
+#   stdout: markdown report. Includes the comment_id of every inventory item.
+#   exit codes:
+#     0 = success
+#     2 = bad flag usage / missing input file
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --inventory <file>
+
+Renders the final operator-facing markdown report for a reply-and-resolve run.
+EOF
+  exit 2
+}
+
+INV=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --inventory) INV="${2:-}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$INV" ] || { echo "error: --inventory is required" >&2; exit 2; }
+[ -f "$INV" ] || { echo "error: inventory file not found: $INV" >&2; exit 2; }
+
+PR_NUM="$(jq -r '.pr.number // "?"' "$INV")"
+OWNER="$(jq -r '.pr.owner // "?"' "$INV")"
+REPO="$(jq -r '.pr.repo // "?"' "$INV")"
+TOTAL="$(jq -r '(.items // []) | length' "$INV")"
+FIX_COUNT="$(jq -r '[(.items // [])[] | select((.classification // "") == "FIX")] | length' "$INV")"
+
+echo "# PR Review Reply & Resolve Report"
+echo
+echo "**PR:** $OWNER/$REPO#$PR_NUM"
+echo "**Total items:** $TOTAL"
+echo "**FIX items:** $FIX_COUNT"
+echo
+echo "## Items"
+echo
+
+jq -r '
+  (.items // [])[]
+  | "- **\(.comment_id // "?"):** \(.classification // "?") / \(.fix_outcome // "n/a")"
+' "$INV"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Smoke test for build-final-report.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/build-final-report.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[build-final-report_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
+
+# Minimal inventory fixture
+INV="$TMP/inv.json"
+cat >"$INV" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 42, "owner": "o", "repo": "r"},
+  "items": [
+    {"comment_id": "c1", "classification": "FIX", "fix_outcome": "committed"}
+  ]
+}
+JSON
+
+# Happy path: produces non-empty output on stdout
+OUTPUT="$("$SCRIPT" --inventory "$INV" 2>/dev/null || true)"
+if [ -n "$OUTPUT" ]; then
+  echo "  ok: produces non-empty output on happy path"
+else
+  echo "  FAIL: produced empty output on happy path"
+  FAIL=1
+fi
+
+# Failure path: missing flag
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: nonexistent inventory
+if "$SCRIPT" --inventory /nonexistent/path.json 2>/dev/null; then
+  echo "  FAIL: accepted nonexistent inventory file"
+  FAIL=1
+else
+  echo "  ok: rejects nonexistent inventory file"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
@@ -39,12 +39,15 @@ cat >"$INV" <<'JSON'
 }
 JSON
 
-# Happy path: produces non-empty output on stdout
-OUTPUT="$("$SCRIPT" --inventory "$INV" 2>/dev/null || true)"
-if [ -n "$OUTPUT" ]; then
-  echo "  ok: produces non-empty output on happy path"
+# Happy path: output must reference the fixture's comment_id (c1).
+# Capture rc explicitly — no `|| true` masking real exit codes.
+"$SCRIPT" --inventory "$INV" > "$TMP/out.txt" 2>&1
+rc_happy=$?
+assert "exits 0 on valid inventory" "[ \$rc_happy -eq 0 ]"
+if grep -q 'c1' "$TMP/out.txt"; then
+  echo "  ok: report references fixture comment_id"
 else
-  echo "  FAIL: produced empty output on happy path"
+  echo "  FAIL: report missing fixture comment_id; got: $(cat "$TMP/out.txt")"
   FAIL=1
 fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/build-final-report_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for build-final-report.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -21,8 +21,8 @@
 #     POSTED <comment_id>
 #     FAILED <comment_id> <reason>
 #     SKIPPED <comment_id> (matched --skip-comment-ids)
-#     FILTERED <comment_id> (classification=<value>) — item's classification is
-#       neither FIX nor SKIP (e.g., ESCALATE handled elsewhere); not an error
+#     FILTERED <comment_id> (classification=<value>) — item is not replyable
+#       (e.g., ESCALATE without escalation_filed=true); not an error
 #   exit codes:
 #     0 = all items posted (or skipped) successfully
 #     1 = at least one item failed
@@ -88,9 +88,12 @@ while IFS= read -r item; do
     continue
   fi
 
-  # Only FIX and SKIP classifications get replies via this helper.
-  # ESCALATE items are handled separately (escalation notice posted in-model).
-  if [ "$classification" != "FIX" ] && [ "$classification" != "SKIP" ]; then
+  # Only replyable items proceed: FIX, SKIP, and ESCALATE with escalation_filed=true.
+  escalation_filed="$(echo "$item" | jq -r '.escalation_filed // false')"
+  if [ "$classification" = "FIX" ] || [ "$classification" = "SKIP" ] || \
+     { [ "$classification" = "ESCALATE" ] && [ "$escalation_filed" = "true" ]; }; then
+    : # replyable — fall through to reply_body check
+  else
     echo "FILTERED $cid (classification=$classification)"
     continue
   fi

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -89,7 +89,7 @@ while IFS= read -r item; do
   # Only FIX and SKIP classifications get replies via this helper.
   # ESCALATE items are handled separately (escalation notice posted in-model).
   if [ "$classification" != "FIX" ] && [ "$classification" != "SKIP" ]; then
-    echo "POSTED $cid (skipped: classification=$classification)"
+    echo "FILTERED $cid (classification=$classification)"
     continue
   fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -118,6 +118,13 @@ while IFS= read -r item; do
       any_failed=1
       continue
     fi
+    # Validate reply_to_comment_id is numeric — REST endpoint /pulls/<n>/comments/<id>/replies
+    # requires the integer databaseId, not the GraphQL node id string.
+    if ! [[ "$reply_to" =~ ^[0-9]+$ ]]; then
+      echo "FAILED $cid reply_to_comment_id_not_numeric"
+      any_failed=1
+      continue
+    fi
     if gh api "repos/$OWNER/$REPO/pulls/$PR/comments/${reply_to}/replies" \
       --method POST -f body="$body" >/dev/null 2>&1; then
       echo "POSTED $cid"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -79,10 +79,25 @@ while IFS= read -r item; do
   [ -n "$item" ] || continue
   cid="$(echo "$item" | jq -r '.comment_id // empty')"
   kind="$(echo "$item" | jq -r '.kind // empty')"
-  body="$(echo "$item" | jq -r '.reply_body // .fix_summary // "Addressed."')"
+  classification="$(echo "$item" | jq -r '.classification // ""')"
 
   if [ -n "$cid" ] && [ -n "$skipset" ] && [[ "$skipset" == *",$cid,"* ]]; then
     echo "SKIPPED $cid"
+    continue
+  fi
+
+  # Only FIX and SKIP classifications get replies via this helper.
+  # ESCALATE items are handled separately (escalation notice posted in-model).
+  if [ "$classification" != "FIX" ] && [ "$classification" != "SKIP" ]; then
+    echo "POSTED $cid (skipped: classification=$classification)"
+    continue
+  fi
+
+  # reply_body is required — caller (Skill B Phase 2) renders templates.
+  body="$(echo "$item" | jq -r '.reply_body // empty')"
+  if [ -z "$body" ]; then
+    echo "FAILED $cid reply_body_missing"
+    any_failed=1
     continue
   fi
 
@@ -96,12 +111,18 @@ while IFS= read -r item; do
     fi
   else
     # Default: review_thread (or unknown kind treated as such).
-    if gh api graphql -f query='mutation($tid:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$tid,body:$body}){comment{id}}}' \
-      -f tid="$(echo "$item" | jq -r '.thread_id // empty')" \
-      -f body="$body" >/dev/null 2>&1; then
+    # Use REST replies endpoint: POST /repos/{o}/{r}/pulls/{n}/comments/{reply_to_comment_id}/replies
+    reply_to="$(echo "$item" | jq -r '.reply_to_comment_id // empty')"
+    if [ -z "$reply_to" ]; then
+      echo "FAILED $cid reply_to_comment_id_missing"
+      any_failed=1
+      continue
+    fi
+    if gh api "repos/$OWNER/$REPO/pulls/$PR/comments/${reply_to}/replies" \
+      --method POST -f body="$body" >/dev/null 2>&1; then
       echo "POSTED $cid"
     else
-      echo "FAILED $cid gh-graphql-reply-failed"
+      echo "FAILED $cid gh-rest-reply-failed"
       any_failed=1
     fi
   fi

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Purpose: post a reply to every inventory thread/comment.
+#
+# Dispatches by `kind`:
+#   review_thread → GraphQL addPullRequestReviewThreadReply mutation
+#   issue_comment → REST POST /repos/{o}/{r}/issues/{n}/comments
+#
+# IDEMPOTENCY: this helper is NOT idempotent. If a partial run posted some
+# replies and then crashed, the caller MUST pass --skip-comment-ids with the
+# csv of already-posted comment_ids on the next invocation.
+#
+# Inputs:
+#   --inventory        <file>  inventory JSON (must contain .items array)
+#   --owner            <o>     repository owner
+#   --repo             <r>     repository name
+#   --pr               <n>     PR number
+#   --skip-comment-ids <csv>   (optional) csv of comment_ids to skip
+#
+# Outputs:
+#   stdout: per item, one of:
+#     POSTED <comment_id>
+#     FAILED <comment_id> <reason>
+#     SKIPPED <comment_id> (matched --skip-comment-ids)
+#   exit codes:
+#     0 = all items posted (or skipped) successfully
+#     1 = at least one item failed
+#     2 = bad flag usage / missing input
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --inventory <file> --owner <o> --repo <r> --pr <n>
+                        [--skip-comment-ids <csv>]
+
+Posts replies to each inventory item; not idempotent — caller must pass
+--skip-comment-ids on re-invocation.
+EOF
+  exit 2
+}
+
+INV=""
+OWNER=""
+REPO=""
+PR=""
+SKIP_CSV=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --inventory)        INV="${2:-}";      shift 2 ;;
+    --owner)            OWNER="${2:-}";    shift 2 ;;
+    --repo)             REPO="${2:-}";     shift 2 ;;
+    --pr)               PR="${2:-}";       shift 2 ;;
+    --skip-comment-ids) SKIP_CSV="${2:-}"; shift 2 ;;
+    -h|--help)          usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$INV" ]   || { echo "error: --inventory is required" >&2; exit 2; }
+[ -n "$OWNER" ] || { echo "error: --owner is required" >&2; exit 2; }
+[ -n "$REPO" ]  || { echo "error: --repo is required" >&2; exit 2; }
+[ -n "$PR" ]    || { echo "error: --pr is required" >&2; exit 2; }
+[ -f "$INV" ]   || { echo "error: inventory file not found: $INV" >&2; exit 2; }
+
+skipset=""
+if [ -n "$SKIP_CSV" ]; then
+  skipset=",$SKIP_CSV,"
+fi
+
+any_failed=0
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+jq -c '.items[]?' "$INV" > "$TMP"
+
+while IFS= read -r item; do
+  [ -n "$item" ] || continue
+  cid="$(echo "$item" | jq -r '.comment_id // empty')"
+  kind="$(echo "$item" | jq -r '.kind // empty')"
+  body="$(echo "$item" | jq -r '.reply_body // .fix_summary // "Addressed."')"
+
+  if [ -n "$cid" ] && [ -n "$skipset" ] && [[ "$skipset" == *",$cid,"* ]]; then
+    echo "SKIPPED $cid"
+    continue
+  fi
+
+  if [ "$kind" = "issue_comment" ]; then
+    if gh api "repos/$OWNER/$REPO/issues/$PR/comments" \
+      -X POST -f body="$body" >/dev/null 2>&1; then
+      echo "POSTED $cid"
+    else
+      echo "FAILED $cid gh-issue-comment-post-failed"
+      any_failed=1
+    fi
+  else
+    # Default: review_thread (or unknown kind treated as such).
+    if gh api graphql -f query='mutation($tid:ID!,$body:String!){addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$tid,body:$body}){comment{id}}}' \
+      -f tid="$(echo "$item" | jq -r '.thread_id // empty')" \
+      -f body="$body" >/dev/null 2>&1; then
+      echo "POSTED $cid"
+    else
+      echo "FAILED $cid gh-graphql-reply-failed"
+      any_failed=1
+    fi
+  fi
+done < "$TMP"
+
+[ "$any_failed" -eq 0 ] || exit 1
+exit 0

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -2,7 +2,7 @@
 # Purpose: post a reply to every inventory thread/comment.
 #
 # Dispatches by `kind`:
-#   review_thread → GraphQL addPullRequestReviewThreadReply mutation
+#   review_thread → REST POST /repos/{o}/{r}/pulls/{n}/comments/{reply_to_comment_id}/replies
 #   issue_comment → REST POST /repos/{o}/{r}/issues/{n}/comments
 #
 # IDEMPOTENCY: this helper is NOT idempotent. If a partial run posted some
@@ -21,6 +21,8 @@
 #     POSTED <comment_id>
 #     FAILED <comment_id> <reason>
 #     SKIPPED <comment_id> (matched --skip-comment-ids)
+#     FILTERED <comment_id> (classification=<value>) — item's classification is
+#       neither FIX nor SKIP (e.g., ESCALATE handled elsewhere); not an error
 #   exit codes:
 #     0 = all items posted (or skipped) successfully
 #     1 = at least one item failed

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -115,10 +115,10 @@ JSON
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_ESCALATE" --owner o --repo r --pr 1 \
   > "$TMP/escalate-out.txt" 2>&1
 rc_escalate=$?
-if grep -q 'POSTED cE' "$TMP/escalate-out.txt"; then
+if [ "$rc_escalate" = "0" ] && grep -q 'POSTED cE' "$TMP/escalate-out.txt"; then
   echo "  ok: ESCALATE+escalation_filed=true is POSTED (not FILTERED)"
 else
-  echo "  FAIL: ESCALATE+escalation_filed=true should emit POSTED cE; got: $(cat "$TMP/escalate-out.txt")"
+  echo "  FAIL: ESCALATE+escalation_filed=true should exit 0 with POSTED cE; got rc=$rc_escalate, output: $(cat "$TMP/escalate-out.txt")"
   FAIL=1
 fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -29,7 +29,40 @@ assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
 assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
-assert "accepts --skip-comment-ids flag" "grep -q -- '--skip-comment-ids' '$SCRIPT'"
+
+# Inventory fixture for behavior tests
+INV="$TMP/inv.json"
+cat >"$INV" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"comment_id": "c1", "classification": "FIX", "fix_outcome": "committed"},
+    {"comment_id": "c2", "classification": "FIX", "fix_outcome": "committed"}
+  ]
+}
+JSON
+
+# --- Fake-gh shim: pr comment posts succeed ---
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — any invocation succeeds.
+exit 0
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Behavior test: --skip-comment-ids flag must be ACCEPTED (not rejected as
+# unknown). Convention: unknown-flag rejections use exit 2 (per the
+# audit-subagent-report contract used elsewhere in this skill). In red
+# phase the script doesn't exist → rc=127. In green phase the flag is
+# accepted and the script proceeds past flag parsing.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV" --owner o --repo r --pr 1 \
+  --skip-comment-ids "c1,c2" > "$TMP/skip-out.txt" 2>&1
+rc_skip=$?
+assert "--skip-comment-ids is not rejected as unknown flag (rc != 2)" \
+  "[ \$rc_skip -ne 2 ]"
 
 # Failure path: invoking without --inventory must fail (flag validation)
 if "$SCRIPT" --owner o --repo r --pr 1 2>/dev/null; then

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -92,6 +92,36 @@ else
   FAIL=1
 fi
 
+# Behavior test: ESCALATE+escalation_filed=true items must be POSTED
+# (not FILTERED). Use a stub gh that always succeeds.
+INV_ESCALATE="$TMP/inv-escalate.json"
+cat >"$INV_ESCALATE" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "comment_id": "cE",
+      "classification": "ESCALATE",
+      "escalation_filed": true,
+      "kind": "review_thread",
+      "reply_to_comment_id": "12345",
+      "reply_body": "Captured for follow-up; will respond on a later push to this PR or in a related issue.",
+      "rationale": "needs human review"
+    }
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_ESCALATE" --owner o --repo r --pr 1 \
+  > "$TMP/escalate-out.txt" 2>&1
+rc_escalate=$?
+if grep -q 'POSTED cE' "$TMP/escalate-out.txt"; then
+  echo "  ok: ESCALATE+escalation_filed=true is POSTED (not FILTERED)"
+else
+  echo "  FAIL: ESCALATE+escalation_filed=true should emit POSTED cE; got: $(cat "$TMP/escalate-out.txt")"
+  FAIL=1
+fi
+
 # Failure path: invoking without --inventory must fail (flag validation)
 if "$SCRIPT" --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted invocation without --inventory"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Smoke test for post-replies.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/post-replies.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[post-replies_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --skip-comment-ids flag" "grep -q -- '--skip-comment-ids' '$SCRIPT'"
+
+# Failure path: invoking without --inventory must fail (flag validation)
+if "$SCRIPT" --owner o --repo r --pr 1 2>/dev/null; then
+  echo "  FAIL: accepted invocation without --inventory"
+  FAIL=1
+else
+  echo "  ok: rejects missing --inventory"
+fi
+
+# Failure path: bad inventory path must fail
+if "$SCRIPT" --inventory /nonexistent/path.json --owner o --repo r --pr 1 2>/dev/null; then
+  echo "  FAIL: accepted nonexistent inventory file"
+  FAIL=1
+else
+  echo "  ok: rejects nonexistent inventory file"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -64,6 +64,35 @@ rc_skip=$?
 assert "--skip-comment-ids is not rejected as unknown flag (rc != 2)" \
   "[ \$rc_skip -ne 2 ]"
 
+# Behavior test: items missing reply_body must emit FAILED <cid> reply_body_missing
+# and the process must exit 1 (any_failed). Fixture INV has c1 and c2 with
+# classification=FIX but no reply_body field.
+INV_NO_BODY="$TMP/inv-no-body.json"
+cat >"$INV_NO_BODY" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"comment_id": "c1", "classification": "FIX", "fix_outcome": "committed"}
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_NO_BODY" --owner o --repo r --pr 1 \
+  > "$TMP/nobody-out.txt" 2>&1
+rc_nobody=$?
+if [ "$rc_nobody" = "1" ]; then
+  echo "  ok: missing reply_body causes exit 1"
+else
+  echo "  FAIL: missing reply_body should exit 1, got $rc_nobody"
+  FAIL=1
+fi
+if grep -q 'FAILED c1 reply_body_missing' "$TMP/nobody-out.txt"; then
+  echo "  ok: emits FAILED <cid> reply_body_missing"
+else
+  echo "  FAIL: missing FAILED c1 reply_body_missing output; got: $(cat "$TMP/nobody-out.txt")"
+  FAIL=1
+fi
+
 # Failure path: invoking without --inventory must fail (flag validation)
 if "$SCRIPT" --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted invocation without --inventory"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for post-replies.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Purpose: probe each inventory item's fix_sha for ancestry on the given branch.
+# Items whose fix_sha is an ancestor of the branch tip go in `present`;
+# items missing or not ancestors go in `missing`.
+#
+# Inputs:
+#   --branch <ref>   branch (or ref) to probe against (e.g., the PR's head branch)
+#   --items  <file>  JSON file: inventory items array (each may have fix_sha and comment_id)
+#
+# Outputs:
+#   stdout: JSON {present: [{comment_id, fix_sha, ...}], missing: [...]}
+#   exit codes:
+#     0 = probe completed (regardless of present/missing split)
+#     2 = bad flag usage / missing input file
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --branch <ref> --items <file>
+
+Probes each item's fix_sha for ancestry on <ref>; emits {present, missing} JSON.
+EOF
+  exit 2
+}
+
+BRANCH=""
+ITEMS=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --branch) BRANCH="${2:-}"; shift 2 ;;
+    --items)  ITEMS="${2:-}";  shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$BRANCH" ] || { echo "error: --branch is required" >&2; exit 2; }
+[ -n "$ITEMS" ]  || { echo "error: --items is required" >&2; exit 2; }
+[ -f "$ITEMS" ]  || { echo "error: items file not found: $ITEMS" >&2; exit 2; }
+
+# Per item: classify as present/missing.
+PRESENT="[]"
+MISSING="[]"
+
+# Use a temp file to capture iteration output (avoids subshell variable scope).
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+jq -c '.[]?' "$ITEMS" > "$TMP"
+
+while IFS= read -r item; do
+  [ -n "$item" ] || continue
+  fix_sha="$(echo "$item" | jq -r '.fix_sha // empty')"
+  if [ -n "$fix_sha" ] && git merge-base --is-ancestor "$fix_sha" "$BRANCH" 2>/dev/null; then
+    PRESENT="$(jq -nc --argjson a "$PRESENT" --argjson i "$item" '$a + [$i]')"
+  else
+    MISSING="$(jq -nc --argjson a "$MISSING" --argjson i "$item" '$a + [$i]')"
+  fi
+done < "$TMP"
+
+jq -nc --argjson p "$PRESENT" --argjson m "$MISSING" '{present: $p, missing: $m}'

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
@@ -42,24 +42,27 @@ done
 [ -n "$ITEMS" ]  || { echo "error: --items is required" >&2; exit 2; }
 [ -f "$ITEMS" ]  || { echo "error: items file not found: $ITEMS" >&2; exit 2; }
 
-# Per item: classify as present/missing.
-PRESENT="[]"
-MISSING="[]"
+# Per item: classify as present/missing. Bucketed items are appended to two
+# JSONL temp files (one line per item) and slurped into arrays once at the end —
+# this keeps the loop linear in inventory size, instead of re-running
+# `jq '$a + [$i]'` on the growing accumulator for every item (O(n²)).
+TMP_ITEMS="$(mktemp)"
+TMP_PRESENT="$(mktemp)"
+TMP_MISSING="$(mktemp)"
+trap 'rm -f "$TMP_ITEMS" "$TMP_PRESENT" "$TMP_MISSING"' EXIT
 
-# Use a temp file to capture iteration output (avoids subshell variable scope).
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
-
-jq -c '.[]?' "$ITEMS" > "$TMP"
+jq -c '.[]?' "$ITEMS" > "$TMP_ITEMS"
 
 while IFS= read -r item; do
   [ -n "$item" ] || continue
   fix_sha="$(echo "$item" | jq -r '.fix_commit_sha // empty')"
   if [ -n "$fix_sha" ] && git merge-base --is-ancestor "$fix_sha" "$BRANCH" 2>/dev/null; then
-    PRESENT="$(jq -nc --argjson a "$PRESENT" --argjson i "$item" '$a + [$i]')"
+    printf '%s\n' "$item" >> "$TMP_PRESENT"
   else
-    MISSING="$(jq -nc --argjson a "$MISSING" --argjson i "$item" '$a + [$i]')"
+    printf '%s\n' "$item" >> "$TMP_MISSING"
   fi
-done < "$TMP"
+done < "$TMP_ITEMS"
 
+PRESENT="$(jq -cs '.' "$TMP_PRESENT")"
+MISSING="$(jq -cs '.' "$TMP_MISSING")"
 jq -nc --argjson p "$PRESENT" --argjson m "$MISSING" '{present: $p, missing: $m}'

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# Purpose: probe each inventory item's fix_sha for ancestry on the given branch.
-# Items whose fix_sha is an ancestor of the branch tip go in `present`;
-# items missing or not ancestors go in `missing`.
+# Purpose: probe each inventory item's fix_commit_sha for ancestry on the
+# given branch. Items whose fix_commit_sha is an ancestor of the branch tip
+# go in `present`; items missing or not ancestors go in `missing`.
 #
 # Inputs:
 #   --branch <ref>   branch (or ref) to probe against (e.g., the PR's head branch)
-#   --items  <file>  JSON file: inventory items array (each may have fix_sha and comment_id)
+#   --items  <file>  JSON file: inventory items array (each may have
+#                    fix_commit_sha and comment_id)
 #
 # Outputs:
-#   stdout: JSON {present: [{comment_id, fix_sha, ...}], missing: [...]}
+#   stdout: JSON {present: [{comment_id, fix_commit_sha, ...}], missing: [...]}
 #   exit codes:
 #     0 = probe completed (regardless of present/missing split)
 #     2 = bad flag usage / missing input file
@@ -18,7 +19,7 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") --branch <ref> --items <file>
 
-Probes each item's fix_sha for ancestry on <ref>; emits {present, missing} JSON.
+Probes each item's fix_commit_sha for ancestry on <ref>; emits {present, missing} JSON.
 EOF
   exit 2
 }
@@ -53,7 +54,7 @@ jq -c '.[]?' "$ITEMS" > "$TMP"
 
 while IFS= read -r item; do
   [ -n "$item" ] || continue
-  fix_sha="$(echo "$item" | jq -r '.fix_sha // empty')"
+  fix_sha="$(echo "$item" | jq -r '.fix_commit_sha // empty')"
   if [ -n "$fix_sha" ] && git merge-base --is-ancestor "$fix_sha" "$BRANCH" 2>/dev/null; then
     PRESENT="$(jq -nc --argjson a "$PRESENT" --argjson i "$item" '$a + [$i]')"
   else

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Smoke test for probe-fix-shas.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/probe-fix-shas.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[probe-fix-shas_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --branch flag" "grep -q -- '--branch' '$SCRIPT'"
+assert "accepts --items flag" "grep -q -- '--items' '$SCRIPT'"
+
+# Minimal inventory fixture
+ITEMS="$TMP/items.json"
+echo '[{"comment_id":"c1","fix_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}]' >"$ITEMS"
+
+# Failure path: missing flags
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: unknown flag rejected
+if "$SCRIPT" --branch main --items "$ITEMS" --bogus 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for probe-fix-shas.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
@@ -31,7 +31,7 @@ assert "accepts --items flag" "grep -q -- '--items' '$SCRIPT'"
 # Items fixture: one nonexistent SHA so the script's existence-check has
 # something to classify as "missing". Real probe uses git locally; no network.
 ITEMS="$TMP/items.json"
-echo '[{"comment_id":"c1","fix_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}]' >"$ITEMS"
+echo '[{"comment_id":"c1","fix_commit_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}]' >"$ITEMS"
 
 # Happy path: with the fixture, expect JSON output containing
 # present/missing buckets. The SHA is bogus so it should be reported as

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/probe-fix-shas_test.sh
@@ -28,9 +28,19 @@ assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'inp
 assert "accepts --branch flag" "grep -q -- '--branch' '$SCRIPT'"
 assert "accepts --items flag" "grep -q -- '--items' '$SCRIPT'"
 
-# Minimal inventory fixture
+# Items fixture: one nonexistent SHA so the script's existence-check has
+# something to classify as "missing". Real probe uses git locally; no network.
 ITEMS="$TMP/items.json"
 echo '[{"comment_id":"c1","fix_sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}]' >"$ITEMS"
+
+# Happy path: with the fixture, expect JSON output containing
+# present/missing buckets. The SHA is bogus so it should be reported as
+# missing, but the structure must still be well-formed.
+"$SCRIPT" --branch main --items "$ITEMS" > "$TMP/out.json" 2>&1
+rc_happy=$?
+assert "exits 0 on happy path" "[ \$rc_happy -eq 0 ]"
+assert "output has present key" "jq -e 'has(\"present\")' '$TMP/out.json' >/dev/null 2>&1"
+assert "output has missing key" "jq -e 'has(\"missing\")' '$TMP/out.json' >/dev/null 2>&1"
 
 # Failure path: missing flags
 if "$SCRIPT" 2>/dev/null; then
@@ -40,8 +50,8 @@ else
   echo "  ok: rejects missing required flags"
 fi
 
-# Failure path: unknown flag rejected
-if "$SCRIPT" --branch main --items "$ITEMS" --bogus 2>/dev/null; then
+# Failure path: unknown flag (--bogus FIRST so it's seen before any I/O)
+if "$SCRIPT" --bogus --branch main --items "$ITEMS" 2>/dev/null; then
   echo "  FAIL: accepted unknown flag"
   FAIL=1
 else

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies.sh
@@ -53,37 +53,17 @@ done
 [ -n "$OUT" ] || { echo "error: --out is required" >&2; exit 2; }
 [ -f "$INV" ] || { echo "error: inventory file not found: $INV" >&2; exit 2; }
 
-TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
+TMP_OUT="$(mktemp)"
+TMP_ERR="$(mktemp)"
+trap 'rm -f "$TMP_OUT" "$TMP_ERR"' EXIT
 
-# Walk items and validate that FIX-committed items have required fields
-# before we attempt rendering. Defense in depth: validate-inventory.sh
-# catches most of this, but render-reply-bodies is the template owner.
-any_error=0
-
-while IFS= read -r item; do
-  [ -n "$item" ] || continue
-  cid="$(echo "$item" | jq -r '.comment_id // "<?>"')"
-  classification="$(echo "$item" | jq -r '.classification // ""')"
-  fix_outcome="$(echo "$item" | jq -r '.fix_outcome // ""')"
-
-  if [ "$classification" = "FIX" ] && [ "$fix_outcome" = "committed" ]; then
-    sha="$(echo "$item" | jq -r '.fix_commit_sha // ""')"
-    summary="$(echo "$item" | jq -r '.fix_summary // ""')"
-    dup="$(echo "$item" | jq -r '.duplicate_of // ""')"
-    # duplicate_of path doesn't need sha+summary in the rendered output,
-    # but the item still needs duplicate_of to be non-empty.
-    if [ -z "$dup" ]; then
-      [ -n "$sha" ] || { echo "error: FIX-committed item $cid missing fix_commit_sha" >&2; any_error=1; }
-      [ -n "$summary" ] || { echo "error: FIX-committed item $cid missing fix_summary" >&2; any_error=1; }
-    fi
-  fi
-done < <(jq -c '.items[]?' "$INV")
-
-[ "$any_error" -eq 0 ] || exit 1
-
-# Render reply_body for each item via jq.
-# Template matrix (from SKILL.md §Reply text templates):
+# Render reply_body for each item via a single jq invocation. Validation is
+# co-located with rendering via jq's `error()` so a malformed replyable item
+# fails the whole render with a clear diagnostic — no silent pass-through and
+# no second pass that could disagree with the first.
+#
+# Template matrix (from SKILL.md §Reply text templates — this helper is the
+# single owner of the matrix):
 #   FIX + committed + duplicate_of non-null  → "Fixed via the change addressing <duplicate_of>."
 #   FIX + committed                          → "Fixed in <fix_commit_sha>. <fix_summary>"
 #   FIX + already_addressed                  → "Already addressed in <fix_commit_sha>."
@@ -93,24 +73,41 @@ done < <(jq -c '.items[]?' "$INV")
 #   ESCALATE + escalation_filed=true (other) → "Captured for follow-up; will respond on a later push to this PR or in a related issue."
 #   ESCALATE + escalation_filed != true      → (no reply_body set)
 #   anything else                            → (no reply_body set)
+#
+# Recovery DEFER/ABANDON templates from SKILL.md are NOT rendered here:
+# Phase 1.5 recovery triage in `--resume` mode reclassifies ABANDON items to
+# SKIP and stamps DEFER items with a tracking_link; by the time this helper
+# runs, those items look like ordinary SKIPs to the matrix above.
 
-jq '
+if ! jq '
   .items = [
     .items[]? |
     if .classification == "FIX" then
       if .fix_outcome == "committed" then
         if (.duplicate_of // "") != "" then
           . + {reply_body: ("Fixed via the change addressing " + .duplicate_of + ".")}
+        elif (.fix_commit_sha // "") == "" then
+          error("FIX-committed item \(.comment_id // "<?>") missing fix_commit_sha")
+        elif (.fix_summary // "") == "" then
+          error("FIX-committed item \(.comment_id // "<?>") missing fix_summary")
         else
           . + {reply_body: ("Fixed in " + .fix_commit_sha + ". " + .fix_summary)}
         end
       elif .fix_outcome == "already_addressed" then
-        . + {reply_body: ("Already addressed in " + .fix_commit_sha + ".")}
+        if (.fix_commit_sha // "") == "" then
+          error("FIX-already_addressed item \(.comment_id // "<?>") missing fix_commit_sha")
+        else
+          . + {reply_body: ("Already addressed in " + .fix_commit_sha + ".")}
+        end
       else
         .
       end
     elif .classification == "SKIP" then
-      . + {reply_body: .rationale}
+      if (.rationale // "") == "" then
+        error("SKIP item \(.comment_id // "<?>") missing rationale")
+      else
+        . + {reply_body: .rationale}
+      end
     elif .classification == "ESCALATE" and .escalation_filed == true then
       if .rationale == "exceeded re-review round cap" then
         . + {reply_body: "Round limit reached on this PR; deferring further iterations to a human reviewer."}
@@ -121,7 +118,10 @@ jq '
       .
     end
   ]
-' "$INV" > "$TMP"
+' "$INV" > "$TMP_OUT" 2> "$TMP_ERR"; then
+  cat "$TMP_ERR" >&2
+  exit 1
+fi
 
-cp "$TMP" "$OUT"
+mv "$TMP_OUT" "$OUT"
 exit 0

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Purpose: render reply_body for every replyable inventory item using the
+# pinned reply-text template matrix from reply-and-resolve-pr-threads SKILL.md.
+#
+# This is the single owner of the reply template matrix. It reads an inventory
+# JSON file, populates .reply_body on every replyable item, and writes the
+# resulting inventory JSON to the output path. Items that are not replyable
+# (e.g., ESCALATE without escalation_filed=true, unknown classifications) are
+# passed through unchanged with no reply_body set.
+#
+# Inputs:
+#   --inventory <file>  inventory JSON path (must contain .items array)
+#   --out       <file>  output path for inventory-with-reply_body
+#
+# Outputs:
+#   <out-file>: same inventory JSON with .reply_body populated on replyable items
+#   exit codes:
+#     0 = success
+#     1 = render error (e.g., FIX-committed item missing required field)
+#     2 = bad flag usage / missing input
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --inventory <file> --out <file>
+
+Renders reply_body for every replyable inventory item using the pinned
+reply template matrix. Emits inventory JSON with .reply_body populated.
+
+Exit codes:
+  0 = success
+  1 = render error (missing required field on a replyable item)
+  2 = bad flag usage / missing input
+EOF
+  exit 2
+}
+
+INV=""
+OUT=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --inventory) INV="${2:-}"; shift 2 ;;
+    --out)       OUT="${2:-}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$INV" ] || { echo "error: --inventory is required" >&2; exit 2; }
+[ -n "$OUT" ] || { echo "error: --out is required" >&2; exit 2; }
+[ -f "$INV" ] || { echo "error: inventory file not found: $INV" >&2; exit 2; }
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+# Walk items and validate that FIX-committed items have required fields
+# before we attempt rendering. Defense in depth: validate-inventory.sh
+# catches most of this, but render-reply-bodies is the template owner.
+any_error=0
+
+while IFS= read -r item; do
+  [ -n "$item" ] || continue
+  cid="$(echo "$item" | jq -r '.comment_id // "<?>"')"
+  classification="$(echo "$item" | jq -r '.classification // ""')"
+  fix_outcome="$(echo "$item" | jq -r '.fix_outcome // ""')"
+
+  if [ "$classification" = "FIX" ] && [ "$fix_outcome" = "committed" ]; then
+    sha="$(echo "$item" | jq -r '.fix_commit_sha // ""')"
+    summary="$(echo "$item" | jq -r '.fix_summary // ""')"
+    dup="$(echo "$item" | jq -r '.duplicate_of // ""')"
+    # duplicate_of path doesn't need sha+summary in the rendered output,
+    # but the item still needs duplicate_of to be non-empty.
+    if [ -z "$dup" ]; then
+      [ -n "$sha" ] || { echo "error: FIX-committed item $cid missing fix_commit_sha" >&2; any_error=1; }
+      [ -n "$summary" ] || { echo "error: FIX-committed item $cid missing fix_summary" >&2; any_error=1; }
+    fi
+  fi
+done < <(jq -c '.items[]?' "$INV")
+
+[ "$any_error" -eq 0 ] || exit 1
+
+# Render reply_body for each item via jq.
+# Template matrix (from SKILL.md §Reply text templates):
+#   FIX + committed + duplicate_of non-null  → "Fixed via the change addressing <duplicate_of>."
+#   FIX + committed                          → "Fixed in <fix_commit_sha>. <fix_summary>"
+#   FIX + already_addressed                  → "Already addressed in <fix_commit_sha>."
+#   SKIP                                     → "<rationale>"
+#   ESCALATE + escalation_filed=true + rationale=="exceeded re-review round cap"
+#                                            → "Round limit reached on this PR; deferring further iterations to a human reviewer."
+#   ESCALATE + escalation_filed=true (other) → "Captured for follow-up; will respond on a later push to this PR or in a related issue."
+#   ESCALATE + escalation_filed != true      → (no reply_body set)
+#   anything else                            → (no reply_body set)
+
+jq '
+  .items = [
+    .items[]? |
+    if .classification == "FIX" then
+      if .fix_outcome == "committed" then
+        if (.duplicate_of // "") != "" then
+          . + {reply_body: ("Fixed via the change addressing " + .duplicate_of + ".")}
+        else
+          . + {reply_body: ("Fixed in " + .fix_commit_sha + ". " + .fix_summary)}
+        end
+      elif .fix_outcome == "already_addressed" then
+        . + {reply_body: ("Already addressed in " + .fix_commit_sha + ".")}
+      else
+        .
+      end
+    elif .classification == "SKIP" then
+      . + {reply_body: .rationale}
+    elif .classification == "ESCALATE" and .escalation_filed == true then
+      if .rationale == "exceeded re-review round cap" then
+        . + {reply_body: "Round limit reached on this PR; deferring further iterations to a human reviewer."}
+      else
+        . + {reply_body: "Captured for follow-up; will respond on a later push to this PR or in a related issue."}
+      end
+    else
+      .
+    end
+  ]
+' "$INV" > "$TMP"
+
+cp "$TMP" "$OUT"
+exit 0

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/render-reply-bodies_test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Smoke test for render-reply-bodies.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/render-reply-bodies.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[render-reply-bodies_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
+assert "accepts --out flag" "grep -q -- '--out' '$SCRIPT'"
+
+# Helper: build a single-item inventory JSON
+make_inv() {
+  local item="$1"
+  echo "{\"schema_version\":1,\"pr\":{\"number\":1},\"items\":[$item]}"
+}
+
+# --- FIX committed ---
+INV_FIX_COMMITTED="$TMP/inv-fix-committed.json"
+make_inv '{"comment_id":"c1","classification":"FIX","fix_outcome":"committed","fix_commit_sha":"abc123","fix_summary":"fixed the thing"}' > "$INV_FIX_COMMITTED"
+OUT_FIX_COMMITTED="$TMP/out-fix-committed.json"
+"$SCRIPT" --inventory "$INV_FIX_COMMITTED" --out "$OUT_FIX_COMMITTED" > "$TMP/fix-committed.log" 2>&1
+rc_fix_committed=$?
+assert "FIX+committed exits 0" "[ \$rc_fix_committed -eq 0 ]"
+assert "FIX+committed sets reply_body" \
+  "jq -e '.items[0].reply_body == \"Fixed in abc123. fixed the thing\"' '$OUT_FIX_COMMITTED' >/dev/null 2>&1"
+
+# --- FIX already_addressed ---
+INV_FIX_AA="$TMP/inv-fix-aa.json"
+make_inv '{"comment_id":"c2","classification":"FIX","fix_outcome":"already_addressed","fix_commit_sha":"def456"}' > "$INV_FIX_AA"
+OUT_FIX_AA="$TMP/out-fix-aa.json"
+"$SCRIPT" --inventory "$INV_FIX_AA" --out "$OUT_FIX_AA" > "$TMP/fix-aa.log" 2>&1
+rc_fix_aa=$?
+assert "FIX+already_addressed exits 0" "[ \$rc_fix_aa -eq 0 ]"
+assert "FIX+already_addressed sets reply_body" \
+  "jq -e '.items[0].reply_body == \"Already addressed in def456.\"' '$OUT_FIX_AA' >/dev/null 2>&1"
+
+# --- FIX duplicate_of ---
+INV_FIX_DUP="$TMP/inv-fix-dup.json"
+make_inv '{"comment_id":"c3","classification":"FIX","fix_outcome":"committed","fix_commit_sha":"ghi","fix_summary":"s","duplicate_of":"https://github.com/o/r/pull/1#discussion_r999"}' > "$INV_FIX_DUP"
+OUT_FIX_DUP="$TMP/out-fix-dup.json"
+"$SCRIPT" --inventory "$INV_FIX_DUP" --out "$OUT_FIX_DUP" > "$TMP/fix-dup.log" 2>&1
+rc_fix_dup=$?
+assert "FIX+duplicate_of exits 0" "[ \$rc_fix_dup -eq 0 ]"
+assert "FIX+duplicate_of sets reply_body with linked permalink" \
+  "jq -e '.items[0].reply_body == \"Fixed via the change addressing https://github.com/o/r/pull/1#discussion_r999.\"' '$OUT_FIX_DUP' >/dev/null 2>&1"
+
+# --- SKIP ---
+INV_SKIP="$TMP/inv-skip.json"
+make_inv '{"comment_id":"c4","classification":"SKIP","rationale":"out of scope"}' > "$INV_SKIP"
+OUT_SKIP="$TMP/out-skip.json"
+"$SCRIPT" --inventory "$INV_SKIP" --out "$OUT_SKIP" > "$TMP/skip.log" 2>&1
+rc_skip=$?
+assert "SKIP exits 0" "[ \$rc_skip -eq 0 ]"
+assert "SKIP sets reply_body to rationale" \
+  "jq -e '.items[0].reply_body == \"out of scope\"' '$OUT_SKIP' >/dev/null 2>&1"
+
+# --- ESCALATE + filed + cap-exceeded rationale ---
+INV_ESC_CAP="$TMP/inv-esc-cap.json"
+make_inv '{"comment_id":"c5","classification":"ESCALATE","escalation_filed":true,"rationale":"exceeded re-review round cap"}' > "$INV_ESC_CAP"
+OUT_ESC_CAP="$TMP/out-esc-cap.json"
+"$SCRIPT" --inventory "$INV_ESC_CAP" --out "$OUT_ESC_CAP" > "$TMP/esc-cap.log" 2>&1
+rc_esc_cap=$?
+assert "ESCALATE+cap-exceeded exits 0" "[ \$rc_esc_cap -eq 0 ]"
+assert "ESCALATE+cap-exceeded sets cap-exceeded template" \
+  "jq -e '.items[0].reply_body == \"Round limit reached on this PR; deferring further iterations to a human reviewer.\"' '$OUT_ESC_CAP' >/dev/null 2>&1"
+
+# --- ESCALATE + filed + other rationale ---
+INV_ESC_AUTO="$TMP/inv-esc-auto.json"
+make_inv '{"comment_id":"c6","classification":"ESCALATE","escalation_filed":true,"rationale":"some other reason"}' > "$INV_ESC_AUTO"
+OUT_ESC_AUTO="$TMP/out-esc-auto.json"
+"$SCRIPT" --inventory "$INV_ESC_AUTO" --out "$OUT_ESC_AUTO" > "$TMP/esc-auto.log" 2>&1
+rc_esc_auto=$?
+assert "ESCALATE+autonomous exits 0" "[ \$rc_esc_auto -eq 0 ]"
+assert "ESCALATE+autonomous sets autonomous-filed template" \
+  "jq -e '.items[0].reply_body == \"Captured for follow-up; will respond on a later push to this PR or in a related issue.\"' '$OUT_ESC_AUTO' >/dev/null 2>&1"
+
+# --- ESCALATE + NOT filed → no reply_body ---
+INV_ESC_UNFILED="$TMP/inv-esc-unfiled.json"
+make_inv '{"comment_id":"c7","classification":"ESCALATE","escalation_filed":false,"rationale":"some reason"}' > "$INV_ESC_UNFILED"
+OUT_ESC_UNFILED="$TMP/out-esc-unfiled.json"
+"$SCRIPT" --inventory "$INV_ESC_UNFILED" --out "$OUT_ESC_UNFILED" > "$TMP/esc-unfiled.log" 2>&1
+rc_esc_unfiled=$?
+assert "ESCALATE+not-filed exits 0" "[ \$rc_esc_unfiled -eq 0 ]"
+assert "ESCALATE+not-filed has no reply_body" \
+  "jq -e '.items[0] | has(\"reply_body\") | not' '$OUT_ESC_UNFILED' >/dev/null 2>&1"
+
+# --- Unknown classification → no reply_body, no error ---
+INV_UNKNOWN="$TMP/inv-unknown.json"
+make_inv '{"comment_id":"c8","classification":"WEIRD","rationale":"something"}' > "$INV_UNKNOWN"
+OUT_UNKNOWN="$TMP/out-unknown.json"
+"$SCRIPT" --inventory "$INV_UNKNOWN" --out "$OUT_UNKNOWN" > "$TMP/unknown.log" 2>&1
+rc_unknown=$?
+assert "unknown classification exits 0" "[ \$rc_unknown -eq 0 ]"
+assert "unknown classification has no reply_body" \
+  "jq -e '.items[0] | has(\"reply_body\") | not' '$OUT_UNKNOWN' >/dev/null 2>&1"
+
+# --- FIX+committed missing fix_commit_sha → error (exit 1) ---
+INV_BAD="$TMP/inv-bad.json"
+make_inv '{"comment_id":"c9","classification":"FIX","fix_outcome":"committed","fix_summary":"s"}' > "$INV_BAD"
+OUT_BAD="$TMP/out-bad.json"
+"$SCRIPT" --inventory "$INV_BAD" --out "$OUT_BAD" > "$TMP/bad.log" 2>&1
+rc_bad=$?
+assert "FIX+committed missing fix_commit_sha exits 1" "[ \$rc_bad -eq 1 ]"
+
+# --- Bad CLI invocation → exit 2 ---
+"$SCRIPT" --no-such-flag 2>/dev/null
+rc_cli=$?
+assert "bad CLI flag exits 2" "[ \$rc_cli -eq 2 ]"
+
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "no args exits 2" "[ \$rc_no_args -eq 2 ]"
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Purpose: resolve each FIX review-thread in the inventory via GraphQL
+# `resolveReviewThread` mutation.
+#
+# Only acts on items with:
+#   kind == "review_thread" (or absent + thread_id present)
+#   classification == "FIX"
+#   thread_id non-empty
+#
+# Inputs:
+#   --inventory <file>  inventory JSON (must contain .items array)
+#
+# Outputs:
+#   stdout: per thread, one of:
+#     RESOLVED <thread_id>
+#     FAILED <thread_id> <reason>
+#   exit codes:
+#     0 = all targets resolved (or none to resolve)
+#     1 = at least one resolve failed
+#     2 = bad flag usage / missing input
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --inventory <file>
+
+Resolves every FIX review-thread in the inventory via GraphQL.
+EOF
+  exit 2
+}
+
+INV=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --inventory) INV="${2:-}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$INV" ] || { echo "error: --inventory is required" >&2; exit 2; }
+[ -f "$INV" ] || { echo "error: inventory file not found: $INV" >&2; exit 2; }
+
+any_failed=0
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+jq -c '
+  .items[]?
+  | select((.classification // "") == "FIX")
+  | select(((.kind // "review_thread") == "review_thread"))
+  | select((.thread_id // "") != "")
+' "$INV" > "$TMP"
+
+while IFS= read -r item; do
+  [ -n "$item" ] || continue
+  tid="$(echo "$item" | jq -r '.thread_id')"
+
+  if gh api graphql \
+    -f query='mutation($tid:ID!){resolveReviewThread(input:{threadId:$tid}){thread{isResolved}}}' \
+    -f tid="$tid" >/dev/null 2>&1; then
+    echo "RESOLVED $tid"
+  else
+    echo "FAILED $tid gh-graphql-resolve-failed"
+    any_failed=1
+  fi
+done < "$TMP"
+
+[ "$any_failed" -eq 0 ] || exit 1
+exit 0

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
@@ -51,9 +51,13 @@ trap 'rm -f "$TMP"' EXIT
 
 jq -c '
   .items[]?
-  | select((.classification // "") == "FIX")
-  | select(((.kind // "review_thread") == "review_thread"))
-  | select((.thread_id // "") != "")
+  | select(
+      ((.classification // "") == "FIX") and
+      ((.kind // "review_thread") == "review_thread") and
+      ((.thread_id // "") != "") and
+      ((.fix_outcome // null) != null) and
+      ((.fix_outcome // "") != "failed")
+    )
 ' "$INV" > "$TMP"
 
 while IFS= read -r item; do

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads.sh
@@ -55,8 +55,7 @@ jq -c '
       ((.classification // "") == "FIX") and
       ((.kind // "review_thread") == "review_thread") and
       ((.thread_id // "") != "") and
-      ((.fix_outcome // null) != null) and
-      ((.fix_outcome // "") != "failed")
+      ((.fix_outcome // "") == "committed" or (.fix_outcome // "") == "already_addressed")
     )
 ' "$INV" > "$TMP"
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for resolve-threads.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke test for resolve-threads.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/resolve-threads.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[resolve-threads_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
+
+# Failure path: missing required flag
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: nonexistent inventory file
+if "$SCRIPT" --inventory /nonexistent/path.json 2>/dev/null; then
+  echo "  FAIL: accepted nonexistent inventory file"
+  FAIL=1
+else
+  echo "  ok: rejects nonexistent inventory file"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
@@ -6,6 +6,8 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/resolve-threads.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 FAIL=0
 
 assert() {
@@ -25,6 +27,44 @@ assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
 assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
 assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
 
+# Inventory fixture: one FIX item with a thread_id ready to resolve.
+INV="$TMP/inv.json"
+cat >"$INV" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 42, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "comment_id": "c1",
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "thread_id": "THREAD_ABC123"
+    }
+  ]
+}
+JSON
+
+# --- Fake-gh shim: handles resolveReviewThread mutation ---
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — accepts the GraphQL mutation, returns success.
+echo '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Happy path: with fake gh, expect "RESOLVED THREAD_ABC123" in output.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV" > "$TMP/out.txt" 2>&1
+rc_happy=$?
+assert "exits 0 on happy path with fake gh" "[ \$rc_happy -eq 0 ]"
+if grep -q 'RESOLVED THREAD_ABC123' "$TMP/out.txt"; then
+  echo "  ok: emits RESOLVED <thread_id> line"
+else
+  echo "  FAIL: missing RESOLVED <thread_id> output; got: $(cat "$TMP/out.txt")"
+  FAIL=1
+fi
+
 # Failure path: missing required flag
 if "$SCRIPT" 2>/dev/null; then
   echo "  FAIL: accepted invocation with no flags"
@@ -39,6 +79,14 @@ if "$SCRIPT" --inventory /nonexistent/path.json 2>/dev/null; then
   FAIL=1
 else
   echo "  ok: rejects nonexistent inventory file"
+fi
+
+# Failure path: unknown flag (--bogus FIRST so it's seen before any I/O)
+if "$SCRIPT" --bogus --inventory "$INV" 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
 fi
 
 exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/resolve-threads_test.sh
@@ -27,7 +27,8 @@ assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
 assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
 assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
 
-# Inventory fixture: one FIX item with a thread_id ready to resolve.
+# Inventory fixture: one FIX item with fix_outcome=committed (should resolve)
+# plus one FIX item with fix_outcome=failed (should NOT resolve).
 INV="$TMP/inv.json"
 cat >"$INV" <<'JSON'
 {
@@ -39,6 +40,12 @@ cat >"$INV" <<'JSON'
       "classification": "FIX",
       "fix_outcome": "committed",
       "thread_id": "THREAD_ABC123"
+    },
+    {
+      "comment_id": "c2",
+      "classification": "FIX",
+      "fix_outcome": "failed",
+      "thread_id": "THREAD_DEF456"
     }
   ]
 }
@@ -59,10 +66,16 @@ PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV" > "$TMP/out.txt" 2>&1
 rc_happy=$?
 assert "exits 0 on happy path with fake gh" "[ \$rc_happy -eq 0 ]"
 if grep -q 'RESOLVED THREAD_ABC123' "$TMP/out.txt"; then
-  echo "  ok: emits RESOLVED <thread_id> line"
+  echo "  ok: emits RESOLVED <thread_id> line for committed item"
 else
   echo "  FAIL: missing RESOLVED <thread_id> output; got: $(cat "$TMP/out.txt")"
   FAIL=1
+fi
+if grep -q 'THREAD_DEF456' "$TMP/out.txt"; then
+  echo "  FAIL: failed-outcome thread should NOT be resolved; got: $(cat "$TMP/out.txt")"
+  FAIL=1
+else
+  echo "  ok: failed-outcome thread is filtered out (not resolved)"
 fi
 
 # Failure path: missing required flag

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/skill_b_frontmatter_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/skill_b_frontmatter_test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Frontmatter contract test for Skill B (reply-and-resolve-pr-threads).
+# Asserts AC8: model: sonnet[1m], effort: low.
+# Currently fails because model is opus[1m] (effort is already low).
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL_MD="$HERE/SKILL.md"
+FAIL=0
+
+echo "[skill_b_frontmatter_test]"
+
+if [ ! -f "$SKILL_MD" ]; then
+  echo "  FAIL: SKILL.md not found at $SKILL_MD"
+  exit 1
+else
+  echo "  ok: SKILL.md exists"
+fi
+
+# Extract frontmatter block (between first two '---' lines)
+FM="$(awk '/^---$/{n++; next} n==1{print}' "$SKILL_MD")"
+
+# AC8: model must be sonnet[1m]
+if echo "$FM" | grep -qE '^model:[[:space:]]+sonnet\[1m\][[:space:]]*$'; then
+  echo "  ok: model is sonnet[1m]"
+else
+  echo "  FAIL: model is not sonnet[1m] (frontmatter: $(echo "$FM" | grep -E '^model:'))"
+  FAIL=1
+fi
+
+# AC8: effort must be low
+if echo "$FM" | grep -qE '^effort:[[:space:]]+low[[:space:]]*$'; then
+  echo "  ok: effort is low"
+else
+  echo "  FAIL: effort is not low (frontmatter: $(echo "$FM" | grep -E '^effort:'))"
+  FAIL=1
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/skill_b_frontmatter_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/skill_b_frontmatter_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Frontmatter contract test for Skill B (reply-and-resolve-pr-threads).
 # Asserts AC8: model: sonnet[1m], effort: low.
-# Currently fails because model is opus[1m] (effort is already low).
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
@@ -59,7 +59,13 @@ while [ "$attempt" -lt 3 ]; do
   # we should retry for eventual consistency) from a failed gh call (auth /
   # network / 5xx) where we should fail fast instead of looping.
   if RESPONSE="$(gh api "repos/$OWNER/$REPO/pulls/$PR" 2>"$GH_ERR")"; then
-    ACTUAL="$(echo "$RESPONSE" | jq -r '.headRefOid // .head.sha // empty' 2>/dev/null || true)"
+    # Treat JSON parse failures as a hard gh-failure: a non-JSON response means
+    # gh succeeded but returned something we cannot trust, not a real SHA
+    # mismatch worth retrying.
+    if ! ACTUAL="$(printf '%s' "$RESPONSE" | jq -r '.headRefOid // .head.sha // empty' 2>"$GH_ERR")"; then
+      echo "error: jq failed to parse gh response for repos/$OWNER/$REPO/pulls/$PR: $(cat "$GH_ERR")" >&2
+      exit 1
+    fi
     if [ -n "$ACTUAL" ] && [ "$ACTUAL" = "$EXPECTED" ]; then
       exit 0
     fi

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Purpose: verify the PR's current head SHA matches an expected value.
+# Retries up to 2 times with a 5s delay on mismatch (covers GitHub eventual
+# consistency after a push).
+#
+# Inputs:
+#   --owner        <o>    repository owner
+#   --repo         <r>    repository name
+#   --pr           <n>    PR number
+#   --expected-sha <sha>  expected head SHA
+#
+# Outputs:
+#   stdout: (none on success)
+#   exit codes:
+#     0 = head SHA matches
+#     1 = persistent mismatch / gh failure
+#     2 = bad flag usage
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> --expected-sha <sha>
+
+Verifies PR head SHA matches expected. Retries up to 2 times.
+EOF
+  exit 2
+}
+
+OWNER=""
+REPO=""
+PR=""
+EXPECTED=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner)        OWNER="${2:-}";    shift 2 ;;
+    --repo)         REPO="${2:-}";     shift 2 ;;
+    --pr)           PR="${2:-}";       shift 2 ;;
+    --expected-sha) EXPECTED="${2:-}"; shift 2 ;;
+    -h|--help)      usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$OWNER" ] && [ -n "$REPO" ] && [ -n "$PR" ] && [ -n "$EXPECTED" ] || {
+  echo "error: --owner, --repo, --pr, --expected-sha are all required" >&2
+  exit 2
+}
+
+attempt=0
+while [ "$attempt" -lt 3 ]; do
+  RESPONSE="$(gh api "repos/$OWNER/$REPO/pulls/$PR" 2>/dev/null || echo '{}')"
+  ACTUAL="$(echo "$RESPONSE" | jq -r '.headRefOid // .head.sha // empty' 2>/dev/null || true)"
+
+  if [ -n "$ACTUAL" ] && [ "$ACTUAL" = "$EXPECTED" ]; then
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+  if [ "$attempt" -lt 3 ]; then
+    sleep 5
+  fi
+done
+
+echo "error: PR $OWNER/$REPO#$PR head SHA is '$ACTUAL', expected '$EXPECTED'" >&2
+exit 1

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha.sh
@@ -49,13 +49,23 @@ done
   exit 2
 }
 
+GH_ERR="$(mktemp)"
+trap 'rm -f "$GH_ERR"' EXIT
+
+ACTUAL=""
 attempt=0
 while [ "$attempt" -lt 3 ]; do
-  RESPONSE="$(gh api "repos/$OWNER/$REPO/pulls/$PR" 2>/dev/null || echo '{}')"
-  ACTUAL="$(echo "$RESPONSE" | jq -r '.headRefOid // .head.sha // empty' 2>/dev/null || true)"
-
-  if [ -n "$ACTUAL" ] && [ "$ACTUAL" = "$EXPECTED" ]; then
-    exit 0
+  # Distinguish a successful gh call (where SHA might legitimately mismatch and
+  # we should retry for eventual consistency) from a failed gh call (auth /
+  # network / 5xx) where we should fail fast instead of looping.
+  if RESPONSE="$(gh api "repos/$OWNER/$REPO/pulls/$PR" 2>"$GH_ERR")"; then
+    ACTUAL="$(echo "$RESPONSE" | jq -r '.headRefOid // .head.sha // empty' 2>/dev/null || true)"
+    if [ -n "$ACTUAL" ] && [ "$ACTUAL" = "$EXPECTED" ]; then
+      exit 0
+    fi
+  else
+    echo "error: gh api failed for repos/$OWNER/$REPO/pulls/$PR: $(cat "$GH_ERR")" >&2
+    exit 1
   fi
 
   attempt=$((attempt + 1))

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for verify-head-sha.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Smoke test for verify-head-sha.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/verify-head-sha.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[verify-head-sha_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --expected-sha flag" "grep -q -- '--expected-sha' '$SCRIPT'"
+
+# Failure path: missing required flag must fail
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: unknown flag rejected
+if "$SCRIPT" --owner o --repo r --pr 1 --expected-sha abc --bogus 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/verify-head-sha_test.sh
@@ -6,6 +6,8 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/verify-head-sha.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 FAIL=0
 
 assert() {
@@ -28,6 +30,22 @@ assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 assert "accepts --expected-sha flag" "grep -q -- '--expected-sha' '$SCRIPT'"
 
+# --- Fake-gh shim: returns canned headRefOid ---
+EXPECTED="expected-sha-abc123"
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<FAKE
+#!/usr/bin/env bash
+# Fake gh — returns canned PR head ref oid.
+echo '{"headRefOid":"$EXPECTED"}'
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Happy path: matching --expected-sha with fake gh response → exit 0.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --expected-sha "$EXPECTED" > "$TMP/out.txt" 2>&1
+rc_happy=$?
+assert "exits 0 when expected-sha matches fake-gh response" "[ \$rc_happy -eq 0 ]"
+
 # Failure path: missing required flag must fail
 if "$SCRIPT" 2>/dev/null; then
   echo "  FAIL: accepted invocation with no flags"
@@ -36,8 +54,8 @@ else
   echo "  ok: rejects missing required flags"
 fi
 
-# Failure path: unknown flag rejected
-if "$SCRIPT" --owner o --repo r --pr 1 --expected-sha abc --bogus 2>/dev/null; then
+# Failure path: unknown flag (--bogus FIRST so it's seen before any I/O)
+if "$SCRIPT" --bogus --owner o --repo r --pr 1 --expected-sha abc 2>/dev/null; then
   echo "  FAIL: accepted unknown flag"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -225,14 +225,10 @@ After all FIX items processed, the inventory carries each item's
 
 Run `verify-checklist` across all `committed`-outcome subagents' work.
 
-**On failure:** build the inventory body (mirror the Phase 7 builder block —
-the temp file may not exist yet at this point) and write it as `partial`:
+**On failure:** build the inventory body and write it as `partial`:
 ```bash
-jq -n \
-  --argjson items "$ITEMS_JSON" \
-  --argjson pr "$PR_JSON" \
-  --argjson polling "$POLLING_JSON" \
-  '{schema_version: 1, pr: $pr, polling: $polling, items: $items}' \
+${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
+  --items "$ITEMS_FILE" --pr "$PR_FILE" --polling "$POLLING_FILE" \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
@@ -249,7 +245,7 @@ Report to caller; abort (Skill B is NOT invoked).
 Confirm each FIX/`committed` item's `fix_commit_sha` is in
 `git rev-list <phase4_baseline_sha>..HEAD`.
 
-**On mismatch:** build the inventory body (same `jq -n` block as Phase 5a)
+**On mismatch:** build the inventory body (same `build-inventory-body.sh` invocation as Phase 5a)
 and invoke:
 ```bash
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
@@ -265,8 +261,7 @@ Report to caller; abort.
 
 Run `git push`.
 
-**On failure:** keep local commits. Build the inventory body (same `jq -n`
-block as Phase 5a) **with `pr.head_sha_after_push = head_sha_at_inventory`**
+**On failure:** keep local commits. Build the inventory body (same `build-inventory-body.sh` invocation as Phase 5a) **with `pr.head_sha_after_push = head_sha_at_inventory`**
 (no remote update happened), then:
 ```bash
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
@@ -323,15 +318,11 @@ normally and proceed to Phase 7.
 
 ### Phase 7 — Write inventory
 
-Build the JSON body via `jq` pipeline (NO heredoc — sandbox-blocked per
-`git-commits.md`); write atomically via the helper:
+Build the inventory body via helper and write atomically:
 
 ```bash
-jq -n \
-  --argjson items "$ITEMS_JSON" \
-  --argjson pr "$PR_JSON" \
-  --argjson polling "$POLLING_JSON" \
-  '{schema_version: 1, pr: $pr, polling: $polling, items: $items}' \
+${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
+  --items "$ITEMS_FILE" --pr "$PR_FILE" --polling "$POLLING_FILE" \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
@@ -381,36 +372,12 @@ manually (add `--mode autonomous --bead-id <id>` if applicable)."
 After Skill B completes, verify no review threads were missed before
 considering the await-review step done.
 
-1. **Query** GraphQL for all unresolved, non-outdated review threads
-   (paginate if >100):
+1. **Query** for all unresolved, non-outdated review threads (pagination handled internally):
    ```bash
-   gh api graphql \
-     -F owner="<owner>" -F repo="<repo>" -F pr="<pr-number>" \
-     -f query='
-     query($owner: String!, $repo: String!, $pr: Int!) {
-       repository(owner: $owner, name: $repo) {
-         pullRequest(number: $pr) {
-           reviewThreads(first: 100) {
-             pageInfo { hasNextPage endCursor }
-             nodes {
-               id
-               isResolved
-               isOutdated
-               comments(first: 1) {
-                 nodes {
-                   author { login }
-                   body
-                   databaseId
-                 }
-               }
-             }
-           }
-         }
-       }
-     }'
+   ${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
+     --owner "$OWNER" --repo "$REPO" --pr "$PR"
+   # stdout: {count: N, thread_ids: ["<graphql-thread-id>", ...]}
    ```
-   If `hasNextPage == true`, repeat with `-F after="<endCursor>"` and
-   accumulate nodes until exhausted.
 2. **Count** threads where `isResolved == false` and `isOutdated == false`.
 3. **If count > 0**: treat as a new review round. Return to **Phase 3
    (round +1)**. Phase 3 must **re-fetch full thread details** (the Phase 9
@@ -680,11 +647,8 @@ POSIX-atomic) — handled by `write-inventory.sh`.
 Phase 8 success):
 
 ```bash
-jq -n \
-  --argjson items "$ITEMS_JSON" \
-  --argjson pr "$PR_JSON" \
-  --argjson polling "$POLLING_JSON" \
-  '{schema_version: 1, pr: $pr, polling: $polling, items: $items}' \
+${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
+  --items "$ITEMS_FILE" --pr "$PR_FILE" --polling "$POLLING_FILE" \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
@@ -727,8 +691,7 @@ ${CLAUDE_SKILL_DIR}/audit-subagent-report.sh \
 # exit 2 = schema violation {field,message}
 ```
 
-**Build inventory body** (Phases 5a / 5b / 5c / 7 / 8 — replaces the inline
-`jq -n` block):
+**Build inventory body** (Phases 5a / 5b / 5c / 7 / 8):
 
 ```bash
 ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -283,12 +283,14 @@ Abort.
 
 1. **Trigger a fresh review cycle** (idempotency guard):
    ```bash
-   gh pr edit <N> --remove-reviewer @copilot
-   gh pr edit <N> --add-reviewer @copilot
+   ${CLAUDE_SKILL_DIR}/request-rereview.sh \
+     --owner "$OWNER" --repo "$REPO" --pr "$PR"
+   # exit 0 on success; exit 1 on gh failure
    ```
-   The `remove-reviewer` + `add-reviewer` pair reliably triggers a new
-   `review_requested` event even when Copilot is already on the list.
-   (`--add-reviewer` alone is idempotent and silently does nothing.)
+   The helper performs the `remove-reviewer` + `add-reviewer` pair which
+   reliably triggers a new `review_requested` event even when Copilot is
+   already on the list. (`--add-reviewer` alone is idempotent and silently
+   does nothing.)
 
 2. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 
@@ -701,8 +703,8 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 ```
 
-**Request Copilot re-review** (Phase 6 — replaces the remove+add `gh pr edit`
-pair):
+**Request Copilot re-review** (Phase 6 — replaces the legacy remove+add
+reviewer pair):
 
 ```bash
 ${CLAUDE_SKILL_DIR}/request-rereview.sh \

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -10,8 +10,8 @@ description: >
   `reply-and-resolve-pr-threads` to reply to every thread and resolve the
   FIXED ones. Keywords: respond, address, fix, handle, triage, classify, PR,
   review, Copilot, feedback.
-model: opus[1m]
-effort: high
+model: sonnet[1m]
+effort: medium
 ---
 
 # wait-for-pr-comments
@@ -201,6 +201,17 @@ re-merge any user reclassifications into the inventory before Phase 4.
 3. For each FIX item:
    - Capture `<pre_subagent_sha> = git rev-parse HEAD` BEFORE dispatch.
    - Pass `<pre_subagent_sha>` to the subagent as input context.
+   - **Dispatch with an explicit `opus` model** (do NOT inherit orchestrator):
+     ```
+     Agent({
+       subagent_type: "bead-implementor",
+       model: "opus",
+       prompt: <task-spec>
+     })
+     ```
+     The orchestrator runs on `sonnet[1m]`; the FIX subagent MUST run on
+     `opus` so fix correctness is not regressed by the orchestrator's lower
+     tier. See Red Flags.
    - Subagent runs the **Per-comment subagent contract** (below).
    - **Audit the report** using **Orchestrator-side enforcement** (below).
      Any audit violation re-classifies the item to ESCALATE with rationale
@@ -457,7 +468,31 @@ Each FIX item is dispatched to a dedicated subagent. The subagent:
 4. **Reports back** with: `comment_id`, `fix_outcome`, `fix_summary`,
    `fix_commit_sha` (only for `committed` and `already_addressed`),
    `fix_gate_variant` (only for `committed`), and verification evidence
-   (test command + output, only for `committed`).
+   (test command + output, only for `committed`). See **Subagent report
+   schema** below for the authoritative contract; the orchestrator validates
+   every report via `audit-subagent-report.sh`.
+
+### Subagent report schema
+
+The per-comment fix subagent returns a JSON report. The orchestrator validates
+every report via `audit-subagent-report.sh` (exit 2 on schema violation, exit
+1 on audit violation). This is the **authoritative contract**:
+
+```yaml
+fields:
+  comment_id:      string  (required)
+  fix_outcome:     enum    (required) [committed | deferred | already_addressed | escalated | abandoned]
+  fix_summary:     string  (required)
+  fix_commit_sha:  string  (required when fix_outcome in {committed, already_addressed})
+  fix_gate_variant: enum   (required when fix_outcome == committed) [fast | full]
+  verification_evidence:
+    test_command:  string  (required when fix_outcome == committed)
+    output:        string  (required when fix_outcome == committed)
+```
+
+Schema mismatches → `audit-subagent-report.sh` exits 2 with
+`{field, message}` on stdout. Audit mismatches (SHA missing in worktree, SHA
+not an ancestor of the post-fix HEAD) → exit 1 with `{violation, rationale}`.
 
 ### `already_addressed` SHA-discovery procedure
 
@@ -665,6 +700,60 @@ failures). `<last_completed_phase>` is one of `5a-verify-failed`,
 `5b-commit-verify-failed`, `5c-push-failed`, `7-write-inventory`,
 `8-skill-b-done`, `9-final-check-done`.
 
+**Detect PR context** (Phase 1):
+
+```bash
+${CLAUDE_SKILL_DIR}/detect-pr-context.sh [--pr <n-or-url>]
+# stdout: {pr_number, owner, repo, inventory_path, concurrency_state}
+```
+
+**Fetch + normalize comments** (Phase 3 inventory build):
+
+```bash
+${CLAUDE_SKILL_DIR}/fetch-and-normalize-comments.sh \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR"
+# stdout: JSON array of normalized items (kind, thread_id, body_full, ...)
+```
+
+**Audit a per-comment subagent's report** (Phase 4, after each FIX subagent):
+
+```bash
+${CLAUDE_SKILL_DIR}/audit-subagent-report.sh \
+  --pre-sha "$PRE_SHA" \
+  --baseline-sha "$BASELINE_SHA" \
+  --report "$REPORT_JSON" \
+  --worktree-root "$WT_ROOT"
+# exit 0 = pass; exit 1 = audit violation {violation,rationale};
+# exit 2 = schema violation {field,message}
+```
+
+**Build inventory body** (Phases 5a / 5b / 5c / 7 / 8 — replaces the inline
+`jq -n` block):
+
+```bash
+${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
+  --items "$ITEMS_FILE" \
+  --pr "$PR_FILE" \
+  --polling "$POLLING_FILE" \
+  > /tmp/pr-inventory-build-<n>.json
+```
+
+**Request Copilot re-review** (Phase 6 — replaces the remove+add `gh pr edit`
+pair):
+
+```bash
+${CLAUDE_SKILL_DIR}/request-rereview.sh \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR"
+```
+
+**Count unresolved threads** (Phase 9 — replaces the inline GraphQL block):
+
+```bash
+${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR"
+# stdout: {count: <n>, thread_ids: [...]}
+```
+
 **Validate inventory** — Skill B Phase 0 invokes this; pinned here so the
 agent has a copy-pasteable template:
 
@@ -816,6 +905,7 @@ process.
 | "I'll inline `--mode autonomous` from the hook text" | The hook does not pass `--mode`. Autonomous mode is set ONLY by formulas (which also pass `--bead-id`). If you're invoking from chat, leave it interactive. |
 | "Skill B failed but I'll unlink the inventory anyway" | No. On Skill B failure, leave the inventory in place. Skill A only unlinks after Phase 9 final check passes and `write-inventory.sh complete 9-final-check-done` succeeds. |
 | "I'll keep the squashed commits clean — combine all subagent fixes into one" | Each subagent's commit stands alone. **No squashing.** Commit message format pinned: `fix(<scope>): <summary> (PR #<n> comment <comment_id>)`. |
+| "I'll let the per-comment fix subagent inherit the orchestrator's model" | Wrong. The orchestrator runs `sonnet[1m]` (this skill's frontmatter). Inheriting means the fix subagent ALSO runs on `sonnet[1m]`, which regresses fix correctness — `wait-for-pr-comments` is the cheap triage tier; **fix work needs `opus`**. The Phase 4 `Agent({...})` dispatch MUST set `model: "opus"` explicitly. |
 
 ---
 

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -450,10 +450,10 @@ every report via `audit-subagent-report.sh` (exit 2 on schema violation, exit
 ```yaml
 fields:
   comment_id:      string  (required)
-  fix_outcome:     enum    (required) [committed | deferred | already_addressed | escalated | abandoned]
+  fix_outcome:     enum    (required) [committed | already_addressed | failed | deferred | escalated | abandoned]
   fix_summary:     string  (required)
   fix_commit_sha:  string  (required when fix_outcome in {committed, already_addressed})
-  fix_gate_variant: enum   (required when fix_outcome == committed) [fast | full]
+  fix_gate_variant: enum   (required when fix_outcome == committed) [lite | full]
   verification_evidence:
     test_command:  string  (required when fix_outcome == committed)
     output:        string  (required when fix_outcome == committed)
@@ -687,8 +687,10 @@ ${CLAUDE_SKILL_DIR}/fetch-and-normalize-comments.sh \
 ${CLAUDE_SKILL_DIR}/audit-subagent-report.sh \
   --pre-sha "$PRE_SHA" \
   --baseline-sha "$BASELINE_SHA" \
-  --report "$REPORT_JSON" \
+  --report "$REPORT_FILE" \
   --worktree-root "$WT_ROOT"
+# NOTE: --report takes a FILE PATH containing the subagent's JSON report,
+# not inline JSON. ($REPORT_FILE is a path on disk.)
 # exit 0 = pass; exit 1 = audit violation {violation,rationale};
 # exit 2 = schema violation {field,message}
 ```

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Purpose: validate a per-comment fix subagent's report against the fix_outcome
+# schema, then run audit checks (SHA ancestry, commit count, diff hunks).
+#
+# Inputs:
+#   --pre-sha       <sha>   HEAD SHA before fix subagent ran
+#   --baseline-sha  <sha>   merge-base / base branch SHA
+#   --report        <file>  JSON file produced by the fix subagent
+#   --worktree-root <path>  absolute path to the worktree (git -C target)
+#
+# Outputs:
+#   stdout:
+#     exit 0 → (no output)
+#     exit 1 → JSON {violation, rationale}   audit failure
+#     exit 2 → JSON {field,     message}     schema violation
+#   exit codes:
+#     0 = audit pass
+#     1 = audit failure (ancestry / commit-count / hunk-regex)
+#     2 = schema violation (missing/invalid required field)
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --pre-sha <sha> --baseline-sha <sha> --report <file> --worktree-root <path>
+
+Validates fix_outcome schema (exit 2) + audits SHA ancestry (exit 1). Exit 0 = pass.
+EOF
+  exit 2
+}
+
+PRE_SHA=""
+BASELINE_SHA=""
+REPORT=""
+WT_ROOT=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pre-sha)       PRE_SHA="${2:-}";      shift 2 ;;
+    --baseline-sha)  BASELINE_SHA="${2:-}"; shift 2 ;;
+    --report)        REPORT="${2:-}";       shift 2 ;;
+    --worktree-root) WT_ROOT="${2:-}";      shift 2 ;;
+    -h|--help)       usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$PRE_SHA" ] && [ -n "$BASELINE_SHA" ] && [ -n "$REPORT" ] && [ -n "$WT_ROOT" ] || {
+  echo "error: --pre-sha, --baseline-sha, --report, --worktree-root are all required" >&2
+  exit 2
+}
+
+[ -f "$REPORT" ] || { echo "error: report file not found: $REPORT" >&2; exit 2; }
+
+emit_schema_violation() {
+  jq -nc --arg f "$1" --arg m "$2" '{field: $f, message: $m}'
+  exit 2
+}
+
+emit_audit_violation() {
+  jq -nc --arg v "$1" --arg r "$2" '{violation: $v, rationale: $r}'
+  exit 1
+}
+
+# --- Schema validation ---
+# Required: comment_id (string), fix_outcome (enum).
+COMMENT_ID="$(jq -r '.comment_id // empty' "$REPORT" 2>/dev/null || true)"
+[ -n "$COMMENT_ID" ] || emit_schema_violation "comment_id" "missing required field"
+
+FIX_OUTCOME="$(jq -r '.fix_outcome // empty' "$REPORT" 2>/dev/null || true)"
+[ -n "$FIX_OUTCOME" ] || emit_schema_violation "fix_outcome" "missing required field"
+
+case "$FIX_OUTCOME" in
+  committed|deferred|already_addressed|escalated|abandoned) ;;
+  *) emit_schema_violation "fix_outcome" "invalid enum value: $FIX_OUTCOME" ;;
+esac
+
+FIX_SUMMARY="$(jq -r '.fix_summary // empty' "$REPORT" 2>/dev/null || true)"
+[ -n "$FIX_SUMMARY" ] || emit_schema_violation "fix_summary" "missing required field"
+
+# Conditional requirements
+case "$FIX_OUTCOME" in
+  committed|already_addressed)
+    FIX_SHA="$(jq -r '.fix_commit_sha // empty' "$REPORT" 2>/dev/null || true)"
+    [ -n "$FIX_SHA" ] || emit_schema_violation "fix_commit_sha" "required when fix_outcome=$FIX_OUTCOME"
+    ;;
+esac
+
+if [ "$FIX_OUTCOME" = "committed" ]; then
+  FIX_VARIANT="$(jq -r '.fix_gate_variant // empty' "$REPORT" 2>/dev/null || true)"
+  case "$FIX_VARIANT" in
+    fast|full) ;;
+    *) emit_schema_violation "fix_gate_variant" "required when fix_outcome=committed; got: $FIX_VARIANT" ;;
+  esac
+
+  EV_CMD="$(jq -r '.verification_evidence.test_command // empty' "$REPORT" 2>/dev/null || true)"
+  EV_OUT="$(jq -r '.verification_evidence.output // empty' "$REPORT" 2>/dev/null || true)"
+  [ -n "$EV_CMD" ] || emit_schema_violation "verification_evidence.test_command" "required when fix_outcome=committed"
+  [ -n "$EV_OUT" ] || emit_schema_violation "verification_evidence.output" "required when fix_outcome=committed"
+fi
+
+# --- Audit checks (only for outcomes that claim a commit exists) ---
+case "$FIX_OUTCOME" in
+  committed|already_addressed)
+    FIX_SHA="$(jq -r '.fix_commit_sha' "$REPORT")"
+
+    # SHA must exist in the worktree.
+    if ! git -C "$WT_ROOT" cat-file -e "${FIX_SHA}^{commit}" 2>/dev/null; then
+      emit_audit_violation "fix_commit_sha_not_found" \
+        "fix_commit_sha $FIX_SHA does not exist in worktree $WT_ROOT"
+    fi
+
+    # SHA must be an ancestor of (or equal to) pre_sha — that is, the fix
+    # is reachable from the post-fix HEAD claimed by the subagent.
+    if ! git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" "$PRE_SHA" 2>/dev/null; then
+      emit_audit_violation "fix_commit_not_in_history" \
+        "fix_commit_sha $FIX_SHA is not an ancestor of pre-sha $PRE_SHA"
+    fi
+    ;;
+esac
+
+exit 0

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Purpose: validate a per-comment fix subagent's report against the fix_outcome
-# schema, then run audit checks (SHA ancestry, commit count, diff hunks).
+# schema, then run audit checks (SHA ancestry, commit count).
 #
 # Inputs:
 #   --pre-sha       <sha>   HEAD SHA before fix subagent ran
@@ -15,7 +15,7 @@
 #     exit 2 → JSON {field,     message}     schema violation
 #   exit codes:
 #     0 = audit pass
-#     1 = audit failure (ancestry / commit-count / hunk-regex)
+#     1 = audit failure (ancestry / commit-count)
 #     2 = schema violation (missing/invalid required field)
 set -euo pipefail
 

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
@@ -4,7 +4,7 @@
 #
 # Inputs:
 #   --pre-sha       <sha>   HEAD SHA before fix subagent ran
-#   --baseline-sha  <sha>   merge-base / base branch SHA
+#   --baseline-sha  <sha>   phase4_baseline_sha — the HEAD SHA captured at Phase 4 start, before any fix subagents run
 #   --report        <file>  JSON file produced by the fix subagent
 #   --worktree-root <path>  absolute path to the worktree (git -C target)
 #
@@ -72,7 +72,7 @@ FIX_OUTCOME="$(jq -r '.fix_outcome // empty' "$REPORT" 2>/dev/null || true)"
 [ -n "$FIX_OUTCOME" ] || emit_schema_violation "fix_outcome" "missing required field"
 
 case "$FIX_OUTCOME" in
-  committed|deferred|already_addressed|escalated|abandoned) ;;
+  committed|deferred|already_addressed|escalated|abandoned|failed) ;;
   *) emit_schema_violation "fix_outcome" "invalid enum value: $FIX_OUTCOME" ;;
 esac
 
@@ -90,7 +90,7 @@ esac
 if [ "$FIX_OUTCOME" = "committed" ]; then
   FIX_VARIANT="$(jq -r '.fix_gate_variant // empty' "$REPORT" 2>/dev/null || true)"
   case "$FIX_VARIANT" in
-    fast|full) ;;
+    lite|full) ;;
     *) emit_schema_violation "fix_gate_variant" "required when fix_outcome=committed; got: $FIX_VARIANT" ;;
   esac
 
@@ -116,6 +116,23 @@ case "$FIX_OUTCOME" in
     if git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" "$PRE_SHA" 2>/dev/null; then
       emit_audit_violation "fix_commit_predates_subagent" \
         "fix_commit_sha $FIX_SHA predates or equals pre-sha $PRE_SHA (must be a newer commit)"
+    fi
+
+    # Fix commit must be reachable from current HEAD
+    if ! git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" HEAD 2>/dev/null; then
+      emit_audit_violation "fix_commit_not_in_head" \
+        "fix_commit_sha $FIX_SHA is not an ancestor of current HEAD"
+    fi
+
+    # Exactly one new commit since pre_sha, and it must match the reported SHA
+    COMMIT_COUNT=$(git -C "$WT_ROOT" rev-list "${PRE_SHA}..HEAD" --count 2>/dev/null)
+    ACTUAL_FIX_SHA=$(git -C "$WT_ROOT" rev-list "${PRE_SHA}..HEAD" 2>/dev/null | head -1)
+    if [ "$COMMIT_COUNT" != "1" ]; then
+      emit_audit_violation "unexpected_commit_count" \
+        "expected exactly 1 new commit since pre-sha $PRE_SHA; got $COMMIT_COUNT"
+    elif [ "$ACTUAL_FIX_SHA" != "$FIX_SHA" ]; then
+      emit_audit_violation "fix_commit_sha_mismatch" \
+        "reported fix_commit_sha $FIX_SHA differs from actual new commit $ACTUAL_FIX_SHA"
     fi
     ;;
   already_addressed)

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report.sh
@@ -102,7 +102,7 @@ fi
 
 # --- Audit checks (only for outcomes that claim a commit exists) ---
 case "$FIX_OUTCOME" in
-  committed|already_addressed)
+  committed)
     FIX_SHA="$(jq -r '.fix_commit_sha' "$REPORT")"
 
     # SHA must exist in the worktree.
@@ -111,11 +111,27 @@ case "$FIX_OUTCOME" in
         "fix_commit_sha $FIX_SHA does not exist in worktree $WT_ROOT"
     fi
 
-    # SHA must be an ancestor of (or equal to) pre_sha — that is, the fix
-    # is reachable from the post-fix HEAD claimed by the subagent.
-    if ! git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" "$PRE_SHA" 2>/dev/null; then
-      emit_audit_violation "fix_commit_not_in_history" \
-        "fix_commit_sha $FIX_SHA is not an ancestor of pre-sha $PRE_SHA"
+    # For committed: the fix is a NEW commit made AFTER pre_sha. It must NOT
+    # be an ancestor of pre_sha (otherwise it predates the subagent's run).
+    if git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" "$PRE_SHA" 2>/dev/null; then
+      emit_audit_violation "fix_commit_predates_subagent" \
+        "fix_commit_sha $FIX_SHA predates or equals pre-sha $PRE_SHA (must be a newer commit)"
+    fi
+    ;;
+  already_addressed)
+    FIX_SHA="$(jq -r '.fix_commit_sha' "$REPORT")"
+
+    # SHA must exist in the worktree.
+    if ! git -C "$WT_ROOT" cat-file -e "${FIX_SHA}^{commit}" 2>/dev/null; then
+      emit_audit_violation "fix_commit_sha_not_found" \
+        "fix_commit_sha $FIX_SHA does not exist in worktree $WT_ROOT"
+    fi
+
+    # For already_addressed: the fix predates the session start, so it MUST be
+    # an ancestor of baseline_sha (it existed before the session).
+    if ! git -C "$WT_ROOT" merge-base --is-ancestor "$FIX_SHA" "$BASELINE_SHA" 2>/dev/null; then
+      emit_audit_violation "fix_commit_not_in_baseline" \
+        "fix_commit_sha $FIX_SHA is not an ancestor of baseline-sha $BASELINE_SHA"
     fi
     ;;
 esac

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -81,7 +81,7 @@ cat >"$AUDIT_FAIL" <<JSON
   "fix_outcome": "committed",
   "fix_commit_sha": "$NONEXISTENT_SHA",
   "fix_summary": "claimed but unverifiable",
-  "fix_gate_variant": "fast",
+  "fix_gate_variant": "lite",
   "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
 }
 JSON
@@ -119,7 +119,7 @@ cat >"$AUDIT_PASS" <<JSON
   "fix_outcome": "committed",
   "fix_commit_sha": "$HEAD_SHA",
   "fix_summary": "fixed and verified",
-  "fix_gate_variant": "fast",
+  "fix_gate_variant": "lite",
   "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
 }
 JSON
@@ -175,7 +175,7 @@ cat >"$AUDIT_FAIL_DIR" <<JSON
   "fix_outcome": "committed",
   "fix_commit_sha": "$PARENT_SHA",
   "fix_summary": "wrong direction",
-  "fix_gate_variant": "fast",
+  "fix_gate_variant": "lite",
   "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
 }
 JSON

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Smoke test for audit-subagent-report.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+#
+# Contract:
+#   exit 0 = audit pass
+#   exit 1 = audit failure (JSON {violation,rationale} on stdout)
+#   exit 2 = schema violation (JSON {field,message} on stdout)
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/audit-subagent-report.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[audit-subagent-report_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents exit codes (0/1/2) in header" "head -40 '$SCRIPT' | grep -qE 'exit'"
+assert "accepts --pre-sha flag" "grep -q -- '--pre-sha' '$SCRIPT'"
+assert "accepts --baseline-sha flag" "grep -q -- '--baseline-sha' '$SCRIPT'"
+assert "accepts --report flag" "grep -q -- '--report' '$SCRIPT'"
+assert "accepts --worktree-root flag" "grep -q -- '--worktree-root' '$SCRIPT'"
+
+# Build a valid-ish report fixture
+VALID_REPORT="$TMP/valid.json"
+cat >"$VALID_REPORT" <<'JSON'
+{
+  "schema_version": 1,
+  "comment_id": "abc123",
+  "classification": "FIX",
+  "fix_outcome": "committed",
+  "pre_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "post_sha": "cafebabecafebabecafebabecafebabecafebabe",
+  "files_touched": ["src/foo.ts"],
+  "rationale": "Applied the suggested fix."
+}
+JSON
+
+# Schema violation fixture — missing required field "classification"
+SCHEMA_BAD="$TMP/schema-bad.json"
+cat >"$SCHEMA_BAD" <<'JSON'
+{
+  "schema_version": 1,
+  "comment_id": "abc123",
+  "fix_outcome": "committed",
+  "pre_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "post_sha": "cafebabecafebabecafebabecafebabecafebabe",
+  "rationale": "missing classification"
+}
+JSON
+
+# Happy path: any of {exit 0, exit 1} acceptable as a passing structural test —
+# the audit might legitimately conclude "fail" because pre_sha != HEAD in this
+# tmp dir. What MUST hold is that exit is not 2 (schema is well-formed).
+out_valid="$( "$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$VALID_REPORT" --worktree-root "$TMP" 2>/dev/null || true )"
+rc_valid=$?
+# We re-run capturing rc properly
+"$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$VALID_REPORT" --worktree-root "$TMP" >/dev/null 2>&1
+rc_valid=$?
+if [ "$rc_valid" = "2" ]; then
+  echo "  FAIL: well-formed report reported as schema violation (exit 2)"
+  FAIL=1
+else
+  echo "  ok: well-formed report does not exit 2"
+fi
+
+# Schema violation path: missing field must yield exit 2
+"$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$SCHEMA_BAD" --worktree-root "$TMP" >/dev/null 2>&1
+rc_bad=$?
+if [ "$rc_bad" = "2" ]; then
+  echo "  ok: schema-bad report exits 2"
+else
+  echo "  FAIL: schema-bad report should exit 2, got $rc_bad"
+  FAIL=1
+fi
+
+# Failure path: missing --report flag must error
+if "$SCRIPT" --pre-sha x --baseline-sha y --worktree-root "$TMP" 2>/dev/null; then
+  echo "  FAIL: accepted invocation missing --report"
+  FAIL=1
+else
+  echo "  ok: rejects missing --report"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -11,6 +11,7 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/audit-subagent-report.sh"
+WT="/Users/scott/src/projects/agents-config/.claude/worktrees/feat/agents-config-abn9.4-optimize-pr-review-comments"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 FAIL=0
@@ -35,51 +36,23 @@ assert "accepts --baseline-sha flag" "grep -q -- '--baseline-sha' '$SCRIPT'"
 assert "accepts --report flag" "grep -q -- '--report' '$SCRIPT'"
 assert "accepts --worktree-root flag" "grep -q -- '--worktree-root' '$SCRIPT'"
 
-# Build a valid-ish report fixture
-VALID_REPORT="$TMP/valid.json"
-cat >"$VALID_REPORT" <<'JSON'
-{
-  "schema_version": 1,
-  "comment_id": "abc123",
-  "classification": "FIX",
-  "fix_outcome": "committed",
-  "pre_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-  "post_sha": "cafebabecafebabecafebabecafebabecafebabe",
-  "files_touched": ["src/foo.ts"],
-  "rationale": "Applied the suggested fix."
-}
-JSON
-
-# Schema violation fixture — missing required field "classification"
+# --- Exit-2 fixture: schema violation — missing required field ---
+# A valid schema requires at minimum: comment_id, classification, fix_outcome.
+# This fixture omits comment_id, so the script must exit 2 and emit
+# {field, message} JSON on stdout.
 SCHEMA_BAD="$TMP/schema-bad.json"
 cat >"$SCHEMA_BAD" <<'JSON'
 {
   "schema_version": 1,
-  "comment_id": "abc123",
-  "fix_outcome": "committed",
-  "pre_sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-  "post_sha": "cafebabecafebabecafebabecafebabecafebabe",
-  "rationale": "missing classification"
+  "classification": "FIX",
+  "fix_outcome": "committed"
 }
 JSON
 
-# Happy path: any of {exit 0, exit 1} acceptable as a passing structural test —
-# the audit might legitimately conclude "fail" because pre_sha != HEAD in this
-# tmp dir. What MUST hold is that exit is not 2 (schema is well-formed).
-out_valid="$( "$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$VALID_REPORT" --worktree-root "$TMP" 2>/dev/null || true )"
-rc_valid=$?
-# We re-run capturing rc properly
-"$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$VALID_REPORT" --worktree-root "$TMP" >/dev/null 2>&1
-rc_valid=$?
-if [ "$rc_valid" = "2" ]; then
-  echo "  FAIL: well-formed report reported as schema violation (exit 2)"
-  FAIL=1
-else
-  echo "  ok: well-formed report does not exit 2"
-fi
-
-# Schema violation path: missing field must yield exit 2
-"$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef --baseline-sha cafebabecafebabecafebabecafebabecafebabe --report "$SCHEMA_BAD" --worktree-root "$TMP" >/dev/null 2>&1
+"$SCRIPT" --pre-sha deadbeefdeadbeefdeadbeefdeadbeefdeadbeef \
+          --baseline-sha cafebabecafebabecafebabecafebabecafebabe \
+          --report "$SCHEMA_BAD" \
+          --worktree-root "$WT" > "$TMP/out-bad.json" 2>&1
 rc_bad=$?
 if [ "$rc_bad" = "2" ]; then
   echo "  ok: schema-bad report exits 2"
@@ -87,9 +60,83 @@ else
   echo "  FAIL: schema-bad report should exit 2, got $rc_bad"
   FAIL=1
 fi
+if grep -qE '"field"|"message"' "$TMP/out-bad.json"; then
+  echo "  ok: schema violation emits {field,message} on stdout"
+else
+  echo "  FAIL: schema violation output missing field/message keys; got: $(cat "$TMP/out-bad.json")"
+  FAIL=1
+fi
 
-# Failure path: missing --report flag must error
-if "$SCRIPT" --pre-sha x --baseline-sha y --worktree-root "$TMP" 2>/dev/null; then
+# --- Exit-1 fixture: audit failure ---
+# Valid schema, but fix_commit_sha references a SHA that provably does NOT
+# exist in this repo. The ancestry/existence check must fail → exit 1 with
+# {violation, rationale} JSON on stdout.
+NONEXISTENT_SHA="0000000000000000000000000000000000000001"
+AUDIT_FAIL="$TMP/audit-fail.json"
+cat >"$AUDIT_FAIL" <<JSON
+{
+  "schema_version": 1,
+  "comment_id": "c1",
+  "classification": "FIX",
+  "fix_outcome": "committed",
+  "fix_commit_sha": "$NONEXISTENT_SHA",
+  "fix_summary": "claimed but unverifiable",
+  "fix_gate_variant": "fast",
+  "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
+}
+JSON
+
+HEAD_SHA="$(git -C "$WT" rev-parse HEAD 2>/dev/null || echo "0000000000000000000000000000000000000000")"
+"$SCRIPT" --pre-sha "$HEAD_SHA" \
+          --baseline-sha "$HEAD_SHA" \
+          --report "$AUDIT_FAIL" \
+          --worktree-root "$WT" > "$TMP/out-fail.json" 2>&1
+rc_fail=$?
+if [ "$rc_fail" = "1" ]; then
+  echo "  ok: audit-failure report exits 1"
+else
+  echo "  FAIL: audit-failure report should exit 1, got $rc_fail"
+  FAIL=1
+fi
+if grep -qE '"violation"|"rationale"' "$TMP/out-fail.json"; then
+  echo "  ok: audit failure emits {violation,rationale} on stdout"
+else
+  echo "  FAIL: audit-failure output missing violation/rationale keys; got: $(cat "$TMP/out-fail.json")"
+  FAIL=1
+fi
+
+# --- Exit-0 fixture: audit pass ---
+# Valid schema and ancestry check passes (HEAD is trivially an ancestor of
+# itself, and fix_commit_sha exists). Pass HEAD as both fix_commit_sha and
+# pre/baseline sha so all ancestry checks succeed.
+AUDIT_PASS="$TMP/audit-pass.json"
+cat >"$AUDIT_PASS" <<JSON
+{
+  "schema_version": 1,
+  "comment_id": "c1",
+  "classification": "FIX",
+  "fix_outcome": "committed",
+  "fix_commit_sha": "$HEAD_SHA",
+  "fix_summary": "fixed and verified",
+  "fix_gate_variant": "fast",
+  "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
+}
+JSON
+
+"$SCRIPT" --pre-sha "$HEAD_SHA" \
+          --baseline-sha "$HEAD_SHA" \
+          --report "$AUDIT_PASS" \
+          --worktree-root "$WT" > "$TMP/out-pass.json" 2>&1
+rc_pass=$?
+if [ "$rc_pass" = "0" ]; then
+  echo "  ok: valid+ancestry-clean report exits 0"
+else
+  echo "  FAIL: valid+ancestry-clean report should exit 0, got $rc_pass (output: $(cat "$TMP/out-pass.json"))"
+  FAIL=1
+fi
+
+# --- Flag-validation path: missing --report must error ---
+if "$SCRIPT" --pre-sha "$HEAD_SHA" --baseline-sha "$HEAD_SHA" --worktree-root "$WT" 2>/dev/null; then
   echo "  FAIL: accepted invocation missing --report"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for audit-subagent-report.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 #
 # Contract:
 #   exit 0 = audit pass

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -105,10 +105,11 @@ else
   FAIL=1
 fi
 
-# --- Exit-0 fixture: audit pass ---
-# Valid schema and ancestry check passes (HEAD is trivially an ancestor of
-# itself, and fix_commit_sha exists). Pass HEAD as both fix_commit_sha and
-# pre/baseline sha so all ancestry checks succeed.
+# --- Exit-0 fixture: audit pass (committed outcome) ---
+# For `committed`, the fix is a NEW commit AFTER pre_sha — so fix_commit_sha
+# must NOT be an ancestor of pre_sha. Set pre_sha=HEAD~1 and fix_sha=HEAD:
+# is-ancestor(HEAD, HEAD~1) is FALSE → audit passes.
+PARENT_SHA="$(git -C "$WT" rev-parse HEAD~1 2>/dev/null || echo "$HEAD_SHA")"
 AUDIT_PASS="$TMP/audit-pass.json"
 cat >"$AUDIT_PASS" <<JSON
 {
@@ -123,15 +124,71 @@ cat >"$AUDIT_PASS" <<JSON
 }
 JSON
 
-"$SCRIPT" --pre-sha "$HEAD_SHA" \
+"$SCRIPT" --pre-sha "$PARENT_SHA" \
           --baseline-sha "$HEAD_SHA" \
           --report "$AUDIT_PASS" \
           --worktree-root "$WT" > "$TMP/out-pass.json" 2>&1
 rc_pass=$?
 if [ "$rc_pass" = "0" ]; then
-  echo "  ok: valid+ancestry-clean report exits 0"
+  echo "  ok: valid+ancestry-clean report exits 0 (committed)"
 else
   echo "  FAIL: valid+ancestry-clean report should exit 0, got $rc_pass (output: $(cat "$TMP/out-pass.json"))"
+  FAIL=1
+fi
+
+# --- Exit-0 fixture: audit pass (already_addressed outcome) ---
+# For `already_addressed`, the fix predates the session — so fix_commit_sha
+# must be an ancestor of baseline_sha. Set baseline=HEAD and fix=HEAD~1:
+# is-ancestor(HEAD~1, HEAD) is TRUE → audit passes.
+AUDIT_PASS_AA="$TMP/audit-pass-aa.json"
+cat >"$AUDIT_PASS_AA" <<JSON
+{
+  "schema_version": 1,
+  "comment_id": "c2",
+  "classification": "FIX",
+  "fix_outcome": "already_addressed",
+  "fix_commit_sha": "$PARENT_SHA",
+  "fix_summary": "addressed in earlier commit"
+}
+JSON
+
+"$SCRIPT" --pre-sha "$HEAD_SHA" \
+          --baseline-sha "$HEAD_SHA" \
+          --report "$AUDIT_PASS_AA" \
+          --worktree-root "$WT" > "$TMP/out-pass-aa.json" 2>&1
+rc_pass_aa=$?
+if [ "$rc_pass_aa" = "0" ]; then
+  echo "  ok: already_addressed report exits 0 when fix is ancestor of baseline"
+else
+  echo "  FAIL: already_addressed report should exit 0, got $rc_pass_aa (output: $(cat "$TMP/out-pass-aa.json"))"
+  FAIL=1
+fi
+
+# --- Exit-1 fixture: committed but fix_sha predates pre_sha (wrong direction) ---
+# fix=HEAD~1, pre=HEAD → is-ancestor(HEAD~1, HEAD) is TRUE → audit must FAIL.
+AUDIT_FAIL_DIR="$TMP/audit-fail-dir.json"
+cat >"$AUDIT_FAIL_DIR" <<JSON
+{
+  "schema_version": 1,
+  "comment_id": "c3",
+  "classification": "FIX",
+  "fix_outcome": "committed",
+  "fix_commit_sha": "$PARENT_SHA",
+  "fix_summary": "wrong direction",
+  "fix_gate_variant": "fast",
+  "verification_evidence": {"test_command": "bash test.sh", "output": "ok"}
+}
+JSON
+
+"$SCRIPT" --pre-sha "$HEAD_SHA" \
+          --baseline-sha "$HEAD_SHA" \
+          --report "$AUDIT_FAIL_DIR" \
+          --worktree-root "$WT" > "$TMP/out-fail-dir.json" 2>&1
+rc_fail_dir=$?
+if [ "$rc_fail_dir" = "1" ]; then
+  echo "  ok: committed report with fix predating pre_sha exits 1"
+else
+  echo "  FAIL: committed-predates-pre report should exit 1, got $rc_fail_dir"
   FAIL=1
 fi
 

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -50,7 +50,9 @@ assert "accepts --report flag" "grep -q -- '--report' '$SCRIPT'"
 assert "accepts --worktree-root flag" "grep -q -- '--worktree-root' '$SCRIPT'"
 
 # --- Exit-2 fixture: schema violation — missing required field ---
-# A valid schema requires at minimum: comment_id, classification, fix_outcome.
+# The audit script validates these required top-level fields on the report:
+# schema_version, comment_id, fix_outcome, fix_summary (per audit-subagent-
+# report.sh and the documented per-comment subagent contract in SKILL.md).
 # This fixture omits comment_id, so the script must exit 2 and emit
 # {field, message} JSON on stdout.
 SCHEMA_BAD="$TMP/schema-bad.json"

--- a/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/audit-subagent-report_test.sh
@@ -11,10 +11,24 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/audit-subagent-report.sh"
-WT="/Users/scott/src/projects/agents-config/.claude/worktrees/feat/agents-config-abn9.4-optimize-pr-review-comments"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 FAIL=0
+
+# Build a self-contained throwaway git repo to use as --worktree-root.
+# This keeps the test portable (no hardcoded developer paths, runs on CI).
+WT="$TMP/test-repo"
+mkdir -p "$WT"
+git -C "$WT" init --quiet
+git -C "$WT" config user.email "test@test.com"
+git -C "$WT" config user.name  "Test"
+git -C "$WT" config commit.gpgsign false
+echo "initial" > "$WT/file.txt"
+git -C "$WT" add file.txt
+git -C "$WT" commit -m "initial" --quiet
+echo "second" >> "$WT/file.txt"
+git -C "$WT" add file.txt
+git -C "$WT" commit -m "second" --quiet
 
 assert() {
   if eval "$2"; then

--- a/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Purpose: assemble the canonical inventory JSON body from items, pr metadata,
+# and polling metadata. This is the single owner of the inventory schema —
+# all phases of `wait-for-pr-comments` invoke this script instead of inlining
+# the jq pipeline.
+#
+# Inputs:
+#   --items   <file>  JSON file: array of inventory items
+#   --pr      <file>  JSON file: PR metadata object (number, owner, repo, head_sha, ...)
+#   --polling <file>  JSON file: polling metadata object (started_at, duration_s, ...)
+#
+# Outputs:
+#   stdout: JSON {schema_version: 1, pr: <obj>, polling: <obj>, items: <array>}
+#   exit codes:
+#     0 = success
+#     2 = bad flag usage / missing input file
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --items <file> --pr <file> --polling <file>
+
+Assembles inventory JSON body. Emits to stdout.
+EOF
+  exit 2
+}
+
+ITEMS=""
+PR=""
+POLLING=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --items)   ITEMS="${2:-}";   shift 2 ;;
+    --pr)      PR="${2:-}";      shift 2 ;;
+    --polling) POLLING="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$ITEMS" ]   || { echo "error: --items is required" >&2; exit 2; }
+[ -n "$PR" ]      || { echo "error: --pr is required" >&2; exit 2; }
+[ -n "$POLLING" ] || { echo "error: --polling is required" >&2; exit 2; }
+[ -f "$ITEMS" ]   || { echo "error: items file not found: $ITEMS" >&2; exit 2; }
+[ -f "$PR" ]      || { echo "error: pr file not found: $PR" >&2; exit 2; }
+[ -f "$POLLING" ] || { echo "error: polling file not found: $POLLING" >&2; exit 2; }
+
+jq -n \
+  --slurpfile items   "$ITEMS" \
+  --slurpfile pr      "$PR" \
+  --slurpfile polling "$POLLING" \
+  '{schema_version: 1, pr: $pr[0], polling: $polling[0], items: $items[0]}'

--- a/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for build-inventory-body.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
@@ -37,17 +37,15 @@ echo '[{"comment_id":"c1","classification":"FIX"}]' >"$ITEMS"
 echo '{"number":42,"owner":"o","repo":"r","head_sha":"abc"}' >"$PR"
 echo '{"started_at":"2026-05-10T00:00:00Z","duration_s":12}' >"$POLLING"
 
-# Happy path: outputs JSON containing required top-level keys
-OUTPUT="$("$SCRIPT" --items "$ITEMS" --pr "$PR" --polling "$POLLING" 2>/dev/null || true)"
-if [ -n "$OUTPUT" ] && echo "$OUTPUT" | grep -q '"schema_version"' \
-   && echo "$OUTPUT" | grep -q '"pr"' \
-   && echo "$OUTPUT" | grep -q '"polling"' \
-   && echo "$OUTPUT" | grep -q '"items"'; then
-  echo "  ok: output contains schema_version, pr, polling, items keys"
-else
-  echo "  FAIL: output missing required top-level keys (got: $OUTPUT)"
-  FAIL=1
-fi
+# Happy path: outputs JSON with required top-level structure.
+# Capture rc explicitly — no `|| true` masking real exit codes.
+"$SCRIPT" --items "$ITEMS" --pr "$PR" --polling "$POLLING" > "$TMP/out.json" 2>&1
+rc=$?
+assert "exits 0 on valid inputs" "[ \$rc -eq 0 ]"
+assert "output has schema_version=1" "jq -e '.schema_version == 1' '$TMP/out.json' >/dev/null 2>&1"
+assert "output has pr object" "jq -e '(.pr | type) == \"object\"' '$TMP/out.json' >/dev/null 2>&1"
+assert "output has polling object" "jq -e '(.polling | type) == \"object\"' '$TMP/out.json' >/dev/null 2>&1"
+assert "output has items array" "jq -e '(.items | type) == \"array\"' '$TMP/out.json' >/dev/null 2>&1"
 
 # Failure path: missing --items must error
 if "$SCRIPT" --pr "$PR" --polling "$POLLING" 2>/dev/null; then

--- a/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/build-inventory-body_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Smoke test for build-inventory-body.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/build-inventory-body.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[build-inventory-body_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --items flag" "grep -q -- '--items' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --polling flag" "grep -q -- '--polling' '$SCRIPT'"
+
+# Build minimal fixtures
+ITEMS="$TMP/items.json"
+PR="$TMP/pr.json"
+POLLING="$TMP/polling.json"
+echo '[{"comment_id":"c1","classification":"FIX"}]' >"$ITEMS"
+echo '{"number":42,"owner":"o","repo":"r","head_sha":"abc"}' >"$PR"
+echo '{"started_at":"2026-05-10T00:00:00Z","duration_s":12}' >"$POLLING"
+
+# Happy path: outputs JSON containing required top-level keys
+OUTPUT="$("$SCRIPT" --items "$ITEMS" --pr "$PR" --polling "$POLLING" 2>/dev/null || true)"
+if [ -n "$OUTPUT" ] && echo "$OUTPUT" | grep -q '"schema_version"' \
+   && echo "$OUTPUT" | grep -q '"pr"' \
+   && echo "$OUTPUT" | grep -q '"polling"' \
+   && echo "$OUTPUT" | grep -q '"items"'; then
+  echo "  ok: output contains schema_version, pr, polling, items keys"
+else
+  echo "  FAIL: output missing required top-level keys (got: $OUTPUT)"
+  FAIL=1
+fi
+
+# Failure path: missing --items must error
+if "$SCRIPT" --pr "$PR" --polling "$POLLING" 2>/dev/null; then
+  echo "  FAIL: accepted invocation missing --items"
+  FAIL=1
+else
+  echo "  ok: rejects missing --items"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Purpose: count unresolved (and non-outdated) review threads on a PR.
+#
+# Inputs:
+#   --owner <o>  repository owner
+#   --repo  <r>  repository name
+#   --pr    <n>  PR number
+#
+# Outputs:
+#   stdout: JSON {count: <n>, thread_ids: [<id>, ...]}
+#   exit codes:
+#     0 = success
+#     1 = gh / network failure
+#     2 = bad flag usage
+#
+# GraphQL projection:
+#   pullRequest.reviewThreads(first:100, after:$cursor) {
+#     nodes { id, isResolved, isOutdated }
+#     pageInfo { hasNextPage, endCursor }
+#   }
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n>
+
+Counts non-resolved, non-outdated review threads. Emits JSON {count, thread_ids}.
+EOF
+  exit 2
+}
+
+OWNER=""
+REPO=""
+PR=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner) OWNER="${2:-}"; shift 2 ;;
+    --repo)  REPO="${2:-}";  shift 2 ;;
+    --pr)    PR="${2:-}";    shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$OWNER" ] && [ -n "$REPO" ] && [ -n "$PR" ] || {
+  echo "error: --owner, --repo, --pr are all required" >&2
+  exit 2
+}
+
+QUERY='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100,after:$cursor){nodes{id isResolved isOutdated} pageInfo{hasNextPage endCursor}}}}}'
+
+cursor=""
+all_threads="[]"
+
+while :; do
+  if [ -n "$cursor" ]; then
+    PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -F "cursor=$cursor" -f query="$QUERY" 2>/dev/null || echo '')"
+  else
+    PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -f query="$QUERY" 2>/dev/null || echo '')"
+  fi
+
+  if [ -z "$PAGE" ]; then
+    echo "error: gh api graphql failed" >&2
+    exit 1
+  fi
+
+  NODES="$(echo "$PAGE" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []' 2>/dev/null || echo '[]')"
+  all_threads="$(jq -nc --argjson a "$all_threads" --argjson b "$NODES" '$a + $b')"
+
+  HAS_NEXT="$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null || echo false)"
+  if [ "$HAS_NEXT" != "true" ]; then
+    break
+  fi
+  cursor="$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')"
+  [ -n "$cursor" ] || break
+done
+
+echo "$all_threads" | jq -c '
+  map(select(.isResolved == false and .isOutdated == false))
+  | {count: length, thread_ids: map(.id)}
+'

--- a/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads.sh
@@ -55,30 +55,46 @@ QUERY='query($owner:String!,$repo:String!,$pr:Int!,$cursor:String){repository(ow
 cursor=""
 all_threads="[]"
 
+GH_ERR="$(mktemp)"
+trap 'rm -f "$GH_ERR"' EXIT
+
 while :; do
   if [ -n "$cursor" ]; then
-    PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -F "cursor=$cursor" -f query="$QUERY" 2>/dev/null || echo '')"
+    if ! PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -F "cursor=$cursor" -f query="$QUERY" 2>"$GH_ERR")"; then
+      echo "error: gh api graphql failed: $(cat "$GH_ERR")" >&2
+      exit 1
+    fi
   else
-    PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -f query="$QUERY" 2>/dev/null || echo '')"
+    if ! PAGE="$(gh api graphql -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" -f query="$QUERY" 2>"$GH_ERR")"; then
+      echo "error: gh api graphql failed: $(cat "$GH_ERR")" >&2
+      exit 1
+    fi
   fi
 
-  if [ -z "$PAGE" ]; then
-    echo "error: gh api graphql failed" >&2
+  if ! NODES="$(printf '%s' "$PAGE" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []' 2>"$GH_ERR")"; then
+    echo "error: jq failed to parse reviewThreads.nodes: $(cat "$GH_ERR")" >&2
+    exit 1
+  fi
+  if ! all_threads="$(jq -nc --argjson a "$all_threads" --argjson b "$NODES" '$a + $b' 2>"$GH_ERR")"; then
+    echo "error: jq failed to merge thread pages: $(cat "$GH_ERR")" >&2
     exit 1
   fi
 
-  NODES="$(echo "$PAGE" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []' 2>/dev/null || echo '[]')"
-  all_threads="$(jq -nc --argjson a "$all_threads" --argjson b "$NODES" '$a + $b')"
-
-  HAS_NEXT="$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null || echo false)"
+  if ! HAS_NEXT="$(printf '%s' "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>"$GH_ERR")"; then
+    echo "error: jq failed to read pageInfo.hasNextPage: $(cat "$GH_ERR")" >&2
+    exit 1
+  fi
   if [ "$HAS_NEXT" != "true" ]; then
     break
   fi
-  cursor="$(echo "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')"
+  if ! cursor="$(printf '%s' "$PAGE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty' 2>"$GH_ERR")"; then
+    echo "error: jq failed to read pageInfo.endCursor: $(cat "$GH_ERR")" >&2
+    exit 1
+  fi
   [ -n "$cursor" ] || break
 done
 
-echo "$all_threads" | jq -c '
+printf '%s' "$all_threads" | jq -c '
   map(select(.isResolved == false and .isOutdated == false))
   | {count: length, thread_ids: map(.id)}
 '

--- a/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for count-unresolved-threads.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Smoke test for count-unresolved-threads.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/count-unresolved-threads.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[count-unresolved-threads_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "documents GraphQL projection in header" "head -60 '$SCRIPT' | grep -qiE 'graphql|projection|query'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+
+# Failure path: missing required flag
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: unknown flag
+if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/count-unresolved-threads_test.sh
@@ -6,6 +6,8 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/count-unresolved-threads.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 FAIL=0
 
 assert() {
@@ -28,6 +30,23 @@ assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
+# --- Fake-gh shim for happy path (no real network) ---
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — returns a single-page reviewThreads response with no unresolved.
+echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false}}}}}}'
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Happy path: with fake gh in PATH, expect JSON {count, thread_ids} output.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --owner o --repo r --pr 1 > "$TMP/out.json" 2>&1
+rc_happy=$?
+assert "exits 0 on happy path with fake gh" "[ \$rc_happy -eq 0 ]"
+assert "output has numeric count" "jq -e '.count != null and (.count | type) == \"number\"' '$TMP/out.json' >/dev/null 2>&1"
+assert "output has thread_ids array" "jq -e '(.thread_ids | type) == \"array\"' '$TMP/out.json' >/dev/null 2>&1"
+
 # Failure path: missing required flag
 if "$SCRIPT" 2>/dev/null; then
   echo "  FAIL: accepted invocation with no flags"
@@ -36,8 +55,8 @@ else
   echo "  ok: rejects missing required flags"
 fi
 
-# Failure path: unknown flag
-if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+# Failure path: unknown flag (--bogus FIRST so it's rejected before any I/O)
+if "$SCRIPT" --bogus --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted unknown flag"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
@@ -45,25 +45,26 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Resolve PR number/owner/repo using gh
+# Resolve PR number/owner/repo using gh. Use mktemp + trap to avoid the
+# predictable-path symlink / race issues of /tmp/.pr-ctx.$$.
+TMP_CTX="$(mktemp)"
+trap 'rm -f "$TMP_CTX"' EXIT
+
 if [ -n "$PR_INPUT" ]; then
-  if ! gh pr view "$PR_INPUT" --json number,headRepository,headRepositoryOwner > /tmp/.pr-ctx.$$ 2>/dev/null; then
+  if ! gh pr view "$PR_INPUT" --json number,headRepository,headRepositoryOwner > "$TMP_CTX" 2>/dev/null; then
     echo "error: gh pr view failed for '$PR_INPUT'" >&2
-    rm -f /tmp/.pr-ctx.$$
     exit 1
   fi
 else
-  if ! gh pr view --json number,headRepository,headRepositoryOwner > /tmp/.pr-ctx.$$ 2>/dev/null; then
+  if ! gh pr view --json number,headRepository,headRepositoryOwner > "$TMP_CTX" 2>/dev/null; then
     echo "error: gh pr view failed (no PR detected for current branch)" >&2
-    rm -f /tmp/.pr-ctx.$$
     exit 1
   fi
 fi
 
-PR_NUMBER="$(jq -r '.number // empty' /tmp/.pr-ctx.$$)"
-OWNER="$(jq -r '.headRepositoryOwner.login // empty' /tmp/.pr-ctx.$$)"
-REPO="$(jq -r '.headRepository.name // empty' /tmp/.pr-ctx.$$)"
-rm -f /tmp/.pr-ctx.$$
+PR_NUMBER="$(jq -r '.number // empty' "$TMP_CTX")"
+OWNER="$(jq -r '.headRepositoryOwner.login // empty' "$TMP_CTX")"
+REPO="$(jq -r '.headRepository.name // empty' "$TMP_CTX")"
 
 if [ -z "$PR_NUMBER" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "error: could not resolve pr_number/owner/repo" >&2

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
@@ -76,9 +76,13 @@ if ! mkdir -p "$INVENTORY_DIR" 2>/dev/null; then
   echo "error: failed to create state directory: $INVENTORY_DIR" >&2
   exit 1
 fi
-# Get head SHA (short) from PR; falls back to "unknown" if gh fails. The path
-# is a detection hint for concurrency probing, not a write target.
-HEAD_SHA="$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null | head -c 12)"
+# Get head SHA (short) from PR. The path is a detection hint for concurrency
+# probing, not a write target, so we keep gh failures non-fatal: the `|| true`
+# stops `set -e` from aborting on a gh error, and an empty pipeline result
+# falls back to "unknown" on the next line. Without `|| true`, `set -euo
+# pipefail` would make `gh api` failures kill the helper before the fallback
+# can run.
+HEAD_SHA="$( (gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null || true) | head -c 12)"
 [ -n "$HEAD_SHA" ] || HEAD_SHA="unknown"
 INVENTORY_PATH="$INVENTORY_DIR/${OWNER}-${REPO}-${PR_NUMBER}-${HEAD_SHA}.json"
 CONCURRENCY_STATE="$INVENTORY_DIR/${OWNER}-${REPO}-${PR_NUMBER}-${HEAD_SHA}.state.json"

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
@@ -72,7 +72,10 @@ if [ -z "$PR_NUMBER" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
 fi
 
 INVENTORY_DIR="$HOME/.claude/state/pr-inventory"
-mkdir -p "$INVENTORY_DIR" 2>/dev/null || true
+if ! mkdir -p "$INVENTORY_DIR" 2>/dev/null; then
+  echo "error: failed to create state directory: $INVENTORY_DIR" >&2
+  exit 1
+fi
 # Get head SHA (short) from PR; falls back to "unknown" if gh fails. The path
 # is a detection hint for concurrency probing, not a write target.
 HEAD_SHA="$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null | head -c 12)"

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Purpose: detect PR context (number, owner, repo, paths) from CLI flag or current branch.
+#
+# Inputs:
+#   --pr <n-or-url>   optional — PR number or URL; absent = auto-detect from current branch
+#
+# Outputs:
+#   stdout: JSON {pr_number, owner, repo, inventory_path, concurrency_state}
+#   exit codes:
+#     0 = success
+#     1 = could not detect PR / gh failure
+#     2 = bad flag usage
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--pr <n-or-url>]
+
+Detects PR context for the current worktree.
+Emits JSON to stdout: {pr_number, owner, repo, inventory_path, concurrency_state}
+EOF
+  exit 2
+}
+
+PR_INPUT=""
+
+if [ $# -eq 0 ]; then
+  : # auto-detect path; allowed
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)
+      [ $# -ge 2 ] || usage
+      PR_INPUT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "error: unknown flag: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+# Resolve PR number/owner/repo using gh
+if [ -n "$PR_INPUT" ]; then
+  if ! gh pr view "$PR_INPUT" --json number,headRepository,headRepositoryOwner > /tmp/.pr-ctx.$$ 2>/dev/null; then
+    echo "error: gh pr view failed for '$PR_INPUT'" >&2
+    rm -f /tmp/.pr-ctx.$$
+    exit 1
+  fi
+else
+  if ! gh pr view --json number,headRepository,headRepositoryOwner > /tmp/.pr-ctx.$$ 2>/dev/null; then
+    echo "error: gh pr view failed (no PR detected for current branch)" >&2
+    rm -f /tmp/.pr-ctx.$$
+    exit 1
+  fi
+fi
+
+PR_NUMBER="$(jq -r '.number // empty' /tmp/.pr-ctx.$$)"
+OWNER="$(jq -r '.headRepositoryOwner.login // empty' /tmp/.pr-ctx.$$)"
+REPO="$(jq -r '.headRepository.name // empty' /tmp/.pr-ctx.$$)"
+rm -f /tmp/.pr-ctx.$$
+
+if [ -z "$PR_NUMBER" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  echo "error: could not resolve pr_number/owner/repo" >&2
+  exit 1
+fi
+
+INVENTORY_PATH="/tmp/pr-${PR_NUMBER}-inventory.json"
+CONCURRENCY_STATE="/tmp/pr-${PR_NUMBER}-state.json"
+
+jq -nc \
+  --argjson pr "$PR_NUMBER" \
+  --arg owner "$OWNER" \
+  --arg repo "$REPO" \
+  --arg inv "$INVENTORY_PATH" \
+  --arg cc "$CONCURRENCY_STATE" \
+  '{pr_number: $pr, owner: $owner, repo: $repo, inventory_path: $inv, concurrency_state: $cc}'

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context.sh
@@ -70,8 +70,14 @@ if [ -z "$PR_NUMBER" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   exit 1
 fi
 
-INVENTORY_PATH="/tmp/pr-${PR_NUMBER}-inventory.json"
-CONCURRENCY_STATE="/tmp/pr-${PR_NUMBER}-state.json"
+INVENTORY_DIR="$HOME/.claude/state/pr-inventory"
+mkdir -p "$INVENTORY_DIR" 2>/dev/null || true
+# Get head SHA (short) from PR; falls back to "unknown" if gh fails. The path
+# is a detection hint for concurrency probing, not a write target.
+HEAD_SHA="$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.head.sha' 2>/dev/null | head -c 12)"
+[ -n "$HEAD_SHA" ] || HEAD_SHA="unknown"
+INVENTORY_PATH="$INVENTORY_DIR/${OWNER}-${REPO}-${PR_NUMBER}-${HEAD_SHA}.json"
+CONCURRENCY_STATE="$INVENTORY_DIR/${OWNER}-${REPO}-${PR_NUMBER}-${HEAD_SHA}.state.json"
 
 jq -nc \
   --argjson pr "$PR_NUMBER" \

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
@@ -32,13 +32,16 @@ assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'inp
 # Named flags only
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
-# Happy path: invoking without args runs (we don't care about the gh result,
-# only that flag parsing works and the script is callable)
-output=$("$SCRIPT" --pr 1 2>&1) || true
-assert "produces some output when invoked with --pr" "[ -n \"\$output\" ] || [ -f '$SCRIPT' ]"
+# Happy path: invocation with --pr must either produce JSON-shaped output
+# containing the expected context keys, or exit non-zero. A passing
+# invocation that emits no recognizable output is a contract violation.
+output=$("$SCRIPT" --pr 1 2>&1); rc=$?
+assert "exits non-zero or emits pr_number/owner/repo in JSON output" \
+  "echo \"\$output\" | grep -qE '\"pr_number\"|\"owner\"|\"repo\"' || [ \$rc -ne 0 ]"
 
-# Failure path: unknown flag should be rejected
-if "$SCRIPT" --bogus-flag-xyz 2>/dev/null; then
+# Failure path: unknown flag should be rejected (--bogus FIRST so it's seen
+# before any valid flag, preventing I/O before flag validation)
+if "$SCRIPT" --bogus-flag-xyz --pr 1 2>/dev/null; then
   echo "  FAIL: accepted unknown flag --bogus-flag-xyz"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for detect-pr-context.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/detect-pr-context_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Smoke test for detect-pr-context.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/detect-pr-context.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[detect-pr-context_test]"
+
+# Existence + executable
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+
+# Header contract: set -euo pipefail at top of script
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+
+# Header contract: documents inputs/outputs
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+
+# Named flags only
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+
+# Happy path: invoking without args runs (we don't care about the gh result,
+# only that flag parsing works and the script is callable)
+output=$("$SCRIPT" --pr 1 2>&1) || true
+assert "produces some output when invoked with --pr" "[ -n \"\$output\" ] || [ -f '$SCRIPT' ]"
+
+# Failure path: unknown flag should be rejected
+if "$SCRIPT" --bogus-flag-xyz 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag --bogus-flag-xyz"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Purpose: fetch all PR review-thread comments and issue comments, normalize into a single JSON array.
+# Purpose: fetch the first page of PR review-thread comments and issue comments, normalize into a single JSON array.
+#
+# v1 scope: single-page only — reviewThreads(first:100) and comments(first:100)
+# with no pagination. PRs with more than 100 threads (or more than 100 comments
+# in any single thread) will silently produce an incomplete inventory. Pagination
+# is tracked separately and intentionally deferred.
 #
 # Inputs:
 #   --owner <o>    repository owner

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
@@ -103,5 +103,9 @@ echo "$THREADS_JSON" | jq --argjson issues "$ISSUE_COMMENTS_JSON" '
         body_excerpt: ((.body // "") | .[0:200]),
         body_full: (.body // "")
       });
-  if type == "array" then . else (review_items + issue_items) end
+  if type != "object" then
+    error("unexpected GraphQL response shape (expected object, got \(type))")
+  else
+    review_items + issue_items
+  end
 '

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Purpose: fetch all PR review-thread comments and issue comments, normalize into a single JSON array.
+#
+# Inputs:
+#   --owner <o>    repository owner
+#   --repo  <r>    repository name
+#   --pr    <n>    PR number
+#
+# Outputs:
+#   stdout: JSON array of items, each:
+#     { kind, thread_id, reply_to_comment_id, issue_comment_id,
+#       is_outdated, author, body_excerpt, body_full }
+#   exit codes:
+#     0 = success
+#     1 = gh / network failure
+#     2 = bad flag usage
+#
+# GraphQL projection (review threads):
+#   pullRequest.reviewThreads.nodes {
+#     id, isResolved, isOutdated,
+#     comments(first: 100) { nodes { id, databaseId, author{login}, body } }
+#   }
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n>
+
+Fetches PR review-thread comments + issue comments, emits normalized JSON array on stdout.
+EOF
+  exit 2
+}
+
+OWNER=""
+REPO=""
+PR=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner) OWNER="${2:-}"; shift 2 ;;
+    --repo)  REPO="${2:-}";  shift 2 ;;
+    --pr)    PR="${2:-}";    shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$OWNER" ] && [ -n "$REPO" ] && [ -n "$PR" ] || {
+  echo "error: --owner, --repo, --pr are all required" >&2
+  exit 2
+}
+
+# Fetch review-thread comments via GraphQL (single page; production callers can paginate).
+GRAPHQL_QUERY='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{id isResolved isOutdated comments(first:100){nodes{id databaseId author{login} body}}}}}}}'
+
+THREADS_JSON="$(gh api graphql \
+  -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" \
+  -f query="$GRAPHQL_QUERY" 2>/dev/null || echo '{}')"
+
+# Fetch issue-level comments via REST.
+ISSUE_COMMENTS_JSON="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments" 2>/dev/null || echo '[]')"
+
+# Normalize both sources into a single array.
+echo "$THREADS_JSON" | jq --argjson issues "$ISSUE_COMMENTS_JSON" '
+  def review_items:
+    (.data.repository.pullRequest.reviewThreads.nodes // [])
+    | map(
+        . as $t
+        | ($t.comments.nodes // [])
+        | map({
+            kind: "review_thread",
+            thread_id: $t.id,
+            reply_to_comment_id: .id,
+            issue_comment_id: null,
+            is_outdated: ($t.isOutdated // false),
+            author: (.author.login // null),
+            body_excerpt: ((.body // "") | .[0:200]),
+            body_full: (.body // "")
+          })
+      )
+    | flatten;
+  def issue_items:
+    $issues
+    | map({
+        kind: "issue_comment",
+        thread_id: null,
+        reply_to_comment_id: null,
+        issue_comment_id: .id,
+        is_outdated: false,
+        author: (.user.login // null),
+        body_excerpt: ((.body // "") | .[0:200]),
+        body_full: (.body // "")
+      });
+  if type == "array" then . else (review_items + issue_items) end
+'

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments.sh
@@ -55,12 +55,22 @@ done
 # Fetch review-thread comments via GraphQL (single page; production callers can paginate).
 GRAPHQL_QUERY='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{id isResolved isOutdated comments(first:100){nodes{id databaseId author{login} body}}}}}}}'
 
-THREADS_JSON="$(gh api graphql \
+# Capture stderr separately and propagate gh / network failures (do not silently swallow).
+GH_ERR="$(mktemp)"
+trap 'rm -f "$GH_ERR"' EXIT
+
+if ! THREADS_JSON="$(gh api graphql \
   -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR" \
-  -f query="$GRAPHQL_QUERY" 2>/dev/null || echo '{}')"
+  -f query="$GRAPHQL_QUERY" 2>"$GH_ERR")"; then
+  echo "error: gh api graphql failed: $(cat "$GH_ERR")" >&2
+  exit 1
+fi
 
 # Fetch issue-level comments via REST.
-ISSUE_COMMENTS_JSON="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments" 2>/dev/null || echo '[]')"
+if ! ISSUE_COMMENTS_JSON="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments" 2>"$GH_ERR")"; then
+  echo "error: gh api issues comments failed: $(cat "$GH_ERR")" >&2
+  exit 1
+fi
 
 # Normalize both sources into a single array.
 echo "$THREADS_JSON" | jq --argjson issues "$ISSUE_COMMENTS_JSON" '
@@ -72,7 +82,7 @@ echo "$THREADS_JSON" | jq --argjson issues "$ISSUE_COMMENTS_JSON" '
         | map({
             kind: "review_thread",
             thread_id: $t.id,
-            reply_to_comment_id: .id,
+            reply_to_comment_id: .databaseId,
             issue_comment_id: null,
             is_outdated: ($t.isOutdated // false),
             author: (.author.login // null),

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Smoke test for fetch-and-normalize-comments.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/fetch-and-normalize-comments.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[fetch-and-normalize-comments_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+
+# Failure path: missing required flag must fail
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: unknown flag rejected
+if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag --bogus"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for fetch-and-normalize-comments.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 
@@ -34,8 +33,16 @@ FAKEBIN="$TMP/bin"
 mkdir -p "$FAKEBIN"
 cat > "$FAKEBIN/gh" <<'FAKE'
 #!/usr/bin/env bash
-# Fake gh — returns an empty (but well-formed) review-comments page.
-# Real script will paginate and normalize; an empty page is a valid result.
+# Fake gh — returns well-formed empty responses for both the GraphQL
+# review-threads query and the REST issue-comments endpoint.
+# The GraphQL path requires an object shape (data.repository.pullRequest...);
+# the REST issues path returns a JSON array.
+for arg in "$@"; do
+  if [ "$arg" = "graphql" ]; then
+    echo '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
+    exit 0
+  fi
+done
 echo '[]'
 FAKE
 chmod +x "$FAKEBIN/gh"

--- a/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/fetch-and-normalize-comments_test.sh
@@ -6,6 +6,8 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/fetch-and-normalize-comments.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 FAIL=0
 
 assert() {
@@ -27,6 +29,23 @@ assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
+# --- Fake-gh shim for happy path ---
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — returns an empty (but well-formed) review-comments page.
+# Real script will paginate and normalize; an empty page is a valid result.
+echo '[]'
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Happy path: with fake gh, expect a JSON array on stdout.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --owner o --repo r --pr 1 > "$TMP/out.json" 2>&1
+rc_happy=$?
+assert "exits 0 on happy path with fake gh" "[ \$rc_happy -eq 0 ]"
+assert "output is a JSON array" "jq -e 'type == \"array\"' '$TMP/out.json' >/dev/null 2>&1"
+
 # Failure path: missing required flag must fail
 if "$SCRIPT" 2>/dev/null; then
   echo "  FAIL: accepted invocation with no flags"
@@ -35,8 +54,8 @@ else
   echo "  ok: rejects missing required flags"
 fi
 
-# Failure path: unknown flag rejected
-if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+# Failure path: unknown flag (--bogus FIRST so flag-parser sees it before I/O)
+if "$SCRIPT" --bogus --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted unknown flag --bogus"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -51,12 +51,18 @@ done
 
 PR_REF="$OWNER/$REPO#$PR"
 
-# Remove @copilot — tolerate "not currently a reviewer" by capturing stderr.
-gh pr edit "$PR" --repo "$OWNER/$REPO" --remove-reviewer @copilot >/dev/null 2>&1 || true
+GH_ERR="$(mktemp)"
+trap 'rm -f "$GH_ERR"' EXIT
+
+# Remove @copilot — tolerate "not currently a reviewer" (a common no-op error).
+gh pr edit "$PR" --repo "$OWNER/$REPO" --remove-reviewer @copilot >/dev/null 2>"$GH_ERR" || true
 
 sleep 2
 
-if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-reviewer @copilot >/dev/null 2>&1; then
-  echo "error: gh pr edit --add-reviewer failed for $PR_REF" >&2
+# Add @copilot — capture stderr so callers (and operators debugging auth /
+# permission / rate-limit / invalid-PR failures) see the underlying gh message,
+# not just a generic exit code.
+if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-reviewer @copilot >/dev/null 2>"$GH_ERR"; then
+  echo "error: gh pr edit --add-reviewer failed for $PR_REF: $(cat "$GH_ERR")" >&2
   exit 1
 fi

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Purpose: request a Copilot re-review via the remove+re-add reviewer
+# idempotency dance. The `gh pr edit --remove-reviewer @copilot && sleep && gh
+# pr edit --add-reviewer @copilot` pattern reliably triggers a new review
+# event even when @copilot is already listed.
+#
+# Inputs:
+#   --owner <o>  repository owner
+#   --repo  <r>  repository name
+#   --pr    <n>  PR number
+#
+# Outputs:
+#   stdout: (none on success)
+#   exit codes:
+#     0 = re-review requested
+#     1 = gh failure
+#     2 = bad flag usage
+#
+# GraphQL projection: none directly; uses `gh pr edit` REST under the hood.
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n>
+
+Removes and re-adds @copilot as a reviewer to trigger a Copilot re-review.
+EOF
+  exit 2
+}
+
+OWNER=""
+REPO=""
+PR=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --owner) OWNER="${2:-}"; shift 2 ;;
+    --repo)  REPO="${2:-}";  shift 2 ;;
+    --pr)    PR="${2:-}";    shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$OWNER" ] && [ -n "$REPO" ] && [ -n "$PR" ] || {
+  echo "error: --owner, --repo, --pr are all required" >&2
+  exit 2
+}
+
+PR_REF="$OWNER/$REPO#$PR"
+
+# Remove @copilot — tolerate "not currently a reviewer" by capturing stderr.
+gh pr edit "$PR" --repo "$OWNER/$REPO" --remove-reviewer @copilot >/dev/null 2>&1 || true
+
+sleep 2
+
+if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-reviewer @copilot >/dev/null 2>&1; then
+  echo "error: gh pr edit --add-reviewer failed for $PR_REF" >&2
+  exit 1
+fi

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # Smoke test for request-rereview.sh
-# Helper does not exist yet — these tests MUST fail in red phase.
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -6,6 +6,8 @@ set -u
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$HERE/request-rereview.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 FAIL=0
 
 assert() {
@@ -28,6 +30,21 @@ assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
+# --- Fake-gh shim: any gh invocation succeeds with empty stdout ---
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — accepts remove+add reviewer calls, exits 0.
+exit 0
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+# Happy path: with fake gh, request-rereview should exit 0.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --owner o --repo r --pr 1 > "$TMP/out.txt" 2>&1
+rc_happy=$?
+assert "exits 0 on happy path with fake gh" "[ \$rc_happy -eq 0 ]"
+
 # Failure path: missing required flag must error
 if "$SCRIPT" 2>/dev/null; then
   echo "  FAIL: accepted invocation with no flags"
@@ -36,8 +53,8 @@ else
   echo "  ok: rejects missing required flags"
 fi
 
-# Failure path: unknown flag rejected
-if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+# Failure path: unknown flag (--bogus FIRST so it's seen before any I/O)
+if "$SCRIPT" --bogus --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted unknown flag"
   FAIL=1
 else

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Smoke test for request-rereview.sh
+# Helper does not exist yet — these tests MUST fail in red phase.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/request-rereview.sh"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[request-rereview_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "documents GraphQL projection in header" "head -60 '$SCRIPT' | grep -qiE 'graphql|projection|query'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+
+# Failure path: missing required flag must error
+if "$SCRIPT" 2>/dev/null; then
+  echo "  FAIL: accepted invocation with no flags"
+  FAIL=1
+else
+  echo "  ok: rejects missing required flags"
+fi
+
+# Failure path: unknown flag rejected
+if "$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null; then
+  echo "  FAIL: accepted unknown flag"
+  FAIL=1
+else
+  echo "  ok: rejects unknown flag"
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/skill_a_frontmatter_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/skill_a_frontmatter_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Frontmatter contract test for Skill A (wait-for-pr-comments).
+# Asserts AC3: model: sonnet[1m], effort: medium.
+# Currently fails because frontmatter is model: opus[1m], effort: high.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL_MD="$HERE/SKILL.md"
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[skill_a_frontmatter_test]"
+
+assert "SKILL.md exists" "[ -f '$SKILL_MD' ]"
+
+# Extract frontmatter block (between first two '---' lines)
+FM="$(awk '/^---$/{n++; next} n==1{print}' "$SKILL_MD")"
+
+# AC3: model must be sonnet[1m]
+if echo "$FM" | grep -qE '^model:[[:space:]]+sonnet\[1m\][[:space:]]*$'; then
+  echo "  ok: model is sonnet[1m]"
+else
+  echo "  FAIL: model is not sonnet[1m] (frontmatter: $(echo "$FM" | grep -E '^model:'))"
+  FAIL=1
+fi
+
+# AC3: effort must be medium
+if echo "$FM" | grep -qE '^effort:[[:space:]]+medium[[:space:]]*$'; then
+  echo "  ok: effort is medium"
+else
+  echo "  FAIL: effort is not medium (frontmatter: $(echo "$FM" | grep -E '^effort:'))"
+  FAIL=1
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/skill_a_frontmatter_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/skill_a_frontmatter_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Frontmatter contract test for Skill A (wait-for-pr-comments).
 # Asserts AC3: model: sonnet[1m], effort: medium.
-# Currently fails because frontmatter is model: opus[1m], effort: high.
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -97,6 +97,19 @@ run_guard "already_addressed-requires-sha" \
 run_guard "ESCALATE-must-be-filed" \
     '[.items[] | select(.classification == "ESCALATE" and (.escalation_filed != true))]' || FAIL=1
 
+# Guard 9 (renumbered): schema sanity — already handled via Guard 0 above.
+
+# Guard 10: every replyable item must have a non-empty reply_body.
+# "Replyable" means: FIX, SKIP, or ESCALATE-with-escalation_filed=true.
+# This guard runs AFTER render-reply-bodies.sh has populated reply_body;
+# it catches render failures that slipped through.
+run_guard "replyable-has-reply_body" \
+    '[.items[] | select(
+        (.classification == "FIX" or .classification == "SKIP" or
+         (.classification == "ESCALATE" and .escalation_filed == true))
+        and (.reply_body == null or .reply_body == "")
+     )]' || FAIL=1
+
 if [ "$FAIL" -ne 0 ]; then
     echo "error: schema validation failed for $PATH_IN" >&2
     exit 1

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -1,28 +1,66 @@
 #!/usr/bin/env bash
 # validate-inventory.sh — schema validation guard for the PR-review hand-off contract.
 #
-# Reads the inventory JSON file at the given path and runs nine `jq` predicates
-# (one per Schema Validation Guard in docs/specs/2026-04-26-pr-review-skill-redesign.md).
-# Exits 0 if all guards pass; non-zero with a human-readable error to stderr otherwise.
+# Reads the inventory JSON file at the given path and runs the documented
+# `jq` predicates (one per Schema Validation Guard in
+# docs/specs/2026-04-26-pr-review-skill-redesign.md). Exits 0 if all guards
+# pass; non-zero with a human-readable error to stderr otherwise.
 #
 # Usage:
-#   validate-inventory.sh <inventory_json_path>
+#   validate-inventory.sh [--phase 0|2] <inventory_json_path>
+#
+# --phase controls which guards run:
+#   --phase 2 (default) — runs all ten guards (the full post-render contract)
+#   --phase 0           — runs guards 1–9 only, skipping guard 10
+#                         (replyable-has-reply_body). Phase 0 is invoked on
+#                         the RAW inventory before `render-reply-bodies.sh`
+#                         populates `reply_body`, so guard 10 cannot yet
+#                         apply.
 #
 # Exit codes:
-#   0  — all guards pass
+#   0  — all checked guards pass
 #   1  — validation failed (one or more guards rejected the input)
-#   64 — wrong arg count (EX_USAGE)
+#   64 — bad usage (wrong arg count, unknown flag, bad --phase value)
 #   65 — jq write failed (EX_DATAERR)
 #   66 — input file not found (EX_NOINPUT)
 
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-    echo "usage: validate-inventory.sh <inventory_json_path>" >&2
-    exit 64
-fi
+PHASE="2"
+PATH_IN=""
 
-PATH_IN="$1"
+usage() {
+    echo "usage: validate-inventory.sh [--phase 0|2] <inventory_json_path>" >&2
+    exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --phase)
+            [ "$#" -ge 2 ] || usage
+            PHASE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        --*)
+            echo "error: unknown flag: $1" >&2
+            usage
+            ;;
+        *)
+            [ -z "$PATH_IN" ] || usage
+            PATH_IN="$1"
+            shift
+            ;;
+    esac
+done
+
+[ -n "$PATH_IN" ] || usage
+case "$PHASE" in
+    0|2) ;;
+    *) echo "error: --phase must be 0 or 2 (got: $PHASE)" >&2; usage ;;
+esac
 
 if [ ! -f "$PATH_IN" ]; then
     echo "error: file not found: $PATH_IN" >&2
@@ -101,14 +139,18 @@ run_guard "ESCALATE-must-be-filed" \
 
 # Guard 10: every replyable item must have a non-empty reply_body.
 # "Replyable" means: FIX, SKIP, or ESCALATE-with-escalation_filed=true.
-# This guard runs AFTER render-reply-bodies.sh has populated reply_body;
-# it catches render failures that slipped through.
-run_guard "replyable-has-reply_body" \
-    '[.items[] | select(
-        (.classification == "FIX" or .classification == "SKIP" or
-         (.classification == "ESCALATE" and .escalation_filed == true))
-        and (.reply_body == null or .reply_body == "")
-     )]' || FAIL=1
+# This guard runs AFTER render-reply-bodies.sh has populated reply_body
+# (Phase 2 only); it catches render failures that slipped through. Phase 0
+# invocations skip it because the raw inventory does not yet carry the
+# field.
+if [ "$PHASE" = "2" ]; then
+    run_guard "replyable-has-reply_body" \
+        '[.items[] | select(
+            (.classification == "FIX" or .classification == "SKIP" or
+             (.classification == "ESCALATE" and .escalation_filed == true))
+            and (.reply_body == null or .reply_body == "")
+         )]' || FAIL=1
+fi
 
 if [ "$FAIL" -ne 0 ]; then
     echo "error: schema validation failed for $PATH_IN" >&2

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Smoke test for validate-inventory.sh
+#
+# Verifies the --phase flag honors the pipeline contract:
+#   --phase 0 runs guards 1-9 only (raw inventory; reply_body not yet populated)
+#   --phase 2 (default) runs all ten guards
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/validate-inventory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[validate-inventory_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents --phase flag in header" "head -30 '$SCRIPT' | grep -q -- '--phase'"
+
+# Bad flag usage — exit 64
+"$SCRIPT" --phase 3 /tmp/whatever 2>/dev/null
+rc_bad_phase=$?
+assert "rejects --phase 3 with exit 64" "[ \$rc_bad_phase -eq 64 ]"
+
+"$SCRIPT" --no-such-flag /tmp/whatever 2>/dev/null
+rc_unknown=$?
+assert "rejects unknown flag with exit 64" "[ \$rc_unknown -eq 64 ]"
+
+# Missing file — exit 66
+"$SCRIPT" /nonexistent/path.json 2>/dev/null
+rc_missing=$?
+assert "missing file exits 66" "[ \$rc_missing -eq 66 ]"
+
+# --- Raw inventory: a FIX-committed item lacks reply_body (typical Phase 0 input) ---
+# Guard 10 would reject this; guards 1-9 should pass.
+RAW="$TMP/raw.json"
+cat >"$RAW" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "comment_id": "c1",
+      "kind": "review_thread",
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "fix_commit_sha": "abc123",
+      "fix_summary": "fixed",
+      "fix_gate_variant": "lite",
+      "rationale": "needs fixing"
+    }
+  ]
+}
+JSON
+
+"$SCRIPT" --phase 0 "$RAW" 2>/dev/null
+rc_phase0_raw=$?
+assert "--phase 0 accepts raw inventory missing reply_body" "[ \$rc_phase0_raw -eq 0 ]"
+
+"$SCRIPT" --phase 2 "$RAW" 2>/dev/null
+rc_phase2_raw=$?
+assert "--phase 2 rejects raw inventory missing reply_body (exit 1)" "[ \$rc_phase2_raw -eq 1 ]"
+
+# Default (no --phase) must behave as --phase 2 for backwards compat
+"$SCRIPT" "$RAW" 2>/dev/null
+rc_default_raw=$?
+assert "default (no flag) rejects raw inventory missing reply_body" "[ \$rc_default_raw -eq 1 ]"
+
+# --- Rendered inventory: reply_body populated; both phases accept ---
+RENDERED="$TMP/rendered.json"
+cat >"$RENDERED" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "comment_id": "c1",
+      "kind": "review_thread",
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "fix_commit_sha": "abc123",
+      "fix_summary": "fixed",
+      "fix_gate_variant": "lite",
+      "rationale": "needs fixing",
+      "reply_body": "Fixed in abc123. fixed"
+    }
+  ]
+}
+JSON
+
+"$SCRIPT" --phase 0 "$RENDERED" 2>/dev/null
+rc_phase0_rendered=$?
+assert "--phase 0 accepts rendered inventory" "[ \$rc_phase0_rendered -eq 0 ]"
+
+"$SCRIPT" --phase 2 "$RENDERED" 2>/dev/null
+rc_phase2_rendered=$?
+assert "--phase 2 accepts rendered inventory" "[ \$rc_phase2_rendered -eq 0 ]"
+
+# --- Bad schema_version (Guard 0) — both phases reject ---
+BAD_VERSION="$TMP/bad-version.json"
+cat >"$BAD_VERSION" <<'JSON'
+{"schema_version": 2, "items": []}
+JSON
+
+"$SCRIPT" --phase 0 "$BAD_VERSION" 2>/dev/null
+rc_v_p0=$?
+assert "--phase 0 rejects wrong schema_version" "[ \$rc_v_p0 -eq 1 ]"
+
+"$SCRIPT" --phase 2 "$BAD_VERSION" 2>/dev/null
+rc_v_p2=$?
+assert "--phase 2 rejects wrong schema_version" "[ \$rc_v_p2 -eq 1 ]"
+
+exit $FAIL


### PR DESCRIPTION
## Bead

**** — [Impl] Optimize PR review comment processing: extract polling logic to helper scripts

Closes bead  (spec). Absorbs bead  (subagent report contract).

---

## Summary

Refactors `wait-for-pr-comments` (Skill A) and `reply-and-resolve-pr-threads` (Skill B) so mechanical work runs as local-CPU helper scripts and the model is invoked only where judgment is required.

- **11 new bash helper scripts** extracted from inline phase prose (6 for Skill A, 5 for Skill B)
- **Both SKILL.md files refactored**: phase prose replaced with stable command invocations; zero inline jq/GraphQL remaining
- **Model tier split**: Skill A drops to `sonnet[1m]`/`medium`; per-comment fix subagents dispatched explicitly as `bead-implementor` with `model: "opus"`
- **Subagent fix_outcome contract formalized** (R3): documented schema + `audit-subagent-report.sh` validates at runtime (exit 2 on schema violation)
- **Smoke tests**: 13 co-located `*_test.sh` files (one per helper + 2 frontmatter tests); all pass

---

## Acceptance Criteria

- [m] No inline jq pipeline or GraphQL query body in phase-prose sections of either SKILL.md
- [m] The 5 duplicate inventory-builder blocks in Skill A replaced by `build-inventory-body.sh` invocations; jq pipeline appears once, in the helper
- [m] Skill A frontmatter: `model: sonnet[1m]`, `effort: medium`
- [m] Skill A Phase 4 prose documents subagent dispatch with `subagent_type: "bead-implementor"` and `model: "opus"`; includes Red Flag against silent model inheritance
- [m] Skill B has all 5 R2 helpers; SKILL.md prose references each by stable command; no inline implementations remain
- [m] Subagent fix_outcome JSON schema documented in Skill A; `audit-subagent-report.sh` validates (exit 2 on schema violation); `agents-config-3qz` closed
- [m] Every new helper: `set -euo pipefail`, named flags only, header block with inputs/outputs/exit-codes, co-located `*_test.sh`
- [m] Skill B frontmatter: `model: sonnet[1m]`, `effort: low`
- [m] Build passes. Typecheck passes. Tests pass (smoke tests for all new helpers)

---

## Implementation Summary (RALF 2/3 cycles)

**Cycle 1 (Codex `gpt-5.5` foreign-eyes → FAIL):** Initial implementation had 4 Critical + 6 Major production bugs:
1. `audit-subagent-report.sh` ancestry check direction inverted for `committed` vs `already_addressed`
2. `resolve-threads.sh` resolved ALL FIX threads regardless of `fix_outcome` (would resolve unfixed threads)
3. `post-replies.sh` used wrong endpoint for `review_thread` items (GraphQL vs REST), fallback reply body not from pinned templates, no classification filter
4. `detect-pr-context.sh` emitted `/tmp` inventory path instead of persistent `~/.claude/state/pr-inventory/`
5. `probe-fix-shas.sh` read `.fix_sha` instead of `.fix_commit_sha`
6. Skill A Phase 6 retained inline `gh pr edit` commands instead of invoking `request-rereview.sh`

**Cycle 2 (Gemini `gemini-2.5-pro` foreign-eyes → PASS):** All bugs fixed + asymmetric test fixtures added to `audit-subagent-report_test.sh` proving both ancestry semantics.

---

## Foreign-Eyes Status

| Cycle | Model | Verdict | Action |
|-------|-------|---------|--------|
| 1 | Codex gpt-5.5 | NEEDS_REVISION | 6 bugs fixed in cycle 2 |
| 2 | Gemini gemini-2.5-pro | PASS | 2 deferred MINOR items (jq-in-loop performance; 12-char SHA) |

---

## Verify-AC Results

| AC | Status |
|----|--------|
| AC1: zero inline jq/GraphQL in phase prose | PASS — grep returns 0 matches |
| AC2: 5 duplicate blocks → single helper | PASS — 6 invocations of build-inventory-body.sh |
| AC3: Skill A frontmatter sonnet[1m]/medium | PASS — verified by smoke test |
| AC4: Phase 4 bead-implementor + opus + Red Flag | PASS — all 3 present |
| AC5: 5 Skill B helpers + prose by command | PASS — all 5 exist |
| AC6: schema documented + 3qz closed | PASS — section present; 3qz status=closed |
| AC7: every helper conventions | PASS — all 11 helpers verified |
| AC8: Skill B frontmatter sonnet[1m]/low | PASS — verified by smoke test |
| AC9: smoke tests pass | PASS — 13/13 exit 0 |

---

## Commits

```
9e130a6 test(abn9.4): red-phase smoke tests for 11 new helper scripts
87bc465 chore(config): add smoke-test runner for skill helper scripts (abn9.4)
ab5fd41 test(abn9.4): iter2 — tighten smoke test assertions per review
f5be2b0 feat(skills): add 6 helpers to wait-for-pr-comments (abn9.4)
d5f3536 feat(skills): add 5 helpers to reply-and-resolve-pr-threads (abn9.4)
8cb4783 refactor(skills): retier model to sonnet[1m] + document helper invocations (abn9.4)
4461088 refactor(skills): remove remaining inline jq/GraphQL blocks from phase prose (abn9.4)
bfa9b9f fix(skills): cycle2 — audit ancestry, resolve filter, post-replies endpoint+template, detect-pr path, probe field name (abn9.4)
96852e9 fix(skills): POSTED→FILTERED log token for classification-skipped items in post-replies.sh
```

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)