### PR TITLE
feat(commands/skills): tier-2 F1-F7 — extract skill files, reshape commands (acmh.14)

### DIFF
--- a/src/user/.agents/skills/optimize-my-agent/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-my-agent
-model: sonnet
+model: sonnet[1m]
 allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
 description: Audits and improves agent persona files (agents/*.md) for role clarity, commands, examples, and explicit boundaries. Use when asked to optimize an agent file, when reviewing an agent persona for quality, or when an agent description, commands, or boundary section needs cleanup. Do NOT use for SKILL.md files or AGENTS.md configuration files.
 ---

--- a/src/user/.agents/skills/optimize-my-agent/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-agent/SKILL.md
@@ -17,6 +17,8 @@ Read the target agent.md file completely. Then identify:
 
 1. **Agent Purpose**: What is this agent supposed to do? Look at the frontmatter description, the opening role statement, and any embedded examples.
 2. **Current State**: How complete and effective is the current file? Note whether commands have flags, whether examples exist (vs descriptions), whether boundaries are explicit.
+3. **Scope check**: Is the file in `agents/` with the expected schema (frontmatter `name`, `description`, and optionally `model`, `color`, `tools`)? If not, stop — this skill is not for AGENTS.md or SKILL.md files.
+4. **Prior context**: Are there companion files (adjacent AGENTS.md, parent CLAUDE.md) that constrain this agent's role? Note any hierarchy context before assessing standalone quality.
 
 If the purpose is unclear or missing, use `AskUserQuestion` to clarify before proceeding. Do not invent a purpose from thin context — agents whose role is guessed end up generic.
 

--- a/src/user/.agents/skills/optimize-my-agent/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-agent/SKILL.md
@@ -7,9 +7,9 @@ description: Audits and improves agent persona files (agents/*.md) for role clar
 
 # Optimize My Agent
 
-Analyze and optimize an agent persona file (an `agents/*.md` with frontmatter fields `name`, `description`, `model`, `color`, `tools`). The goal is clarity, executable commands, concrete examples, and explicit boundaries — not generic advice.
+Analyze and optimize an agent persona file (an `agents/*.md` with required frontmatter fields `name` and `description` (optional: `model`, `color`, `tools`)). The goal is clarity, executable commands, concrete examples, and explicit boundaries — not generic advice.
 
-**Scope note**: This skill targets agent persona files (`agents/*.md` with frontmatter fields name/description/model/color/tools). Do NOT use for AGENTS.md configuration files or SKILL.md files — those have different schemas and different review rubrics.
+**Scope note**: This skill targets agent persona files (`agents/*.md` with required `name` and `description` frontmatter (optional: `model`, `color`, `tools`)). Do NOT use for AGENTS.md configuration files or SKILL.md files — those have different schemas and different review rubrics.
 
 ## Phase 1: Read and Understand
 

--- a/src/user/.agents/skills/optimize-my-agent/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-agent/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: optimize-my-agent
+model: sonnet
+allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
+description: Audits and improves agent persona files (agents/*.md) for role clarity, commands, examples, and explicit boundaries. Use when asked to optimize an agent file, when reviewing an agent persona for quality, or when an agent description, commands, or boundary section needs cleanup. Do NOT use for SKILL.md files or AGENTS.md configuration files.
+---
+
+# Optimize My Agent
+
+Analyze and optimize an agent persona file (an `agents/*.md` with frontmatter fields `name`, `description`, `model`, `color`, `tools`). The goal is clarity, executable commands, concrete examples, and explicit boundaries — not generic advice.
+
+**Scope note**: This skill targets agent persona files (`agents/*.md` with frontmatter fields name/description/model/color/tools). Do NOT use for AGENTS.md configuration files or SKILL.md files — those have different schemas and different review rubrics.
+
+## Phase 1: Read and Understand
+
+Read the target agent.md file completely. Then identify:
+
+1. **Agent Purpose**: What is this agent supposed to do? Look at the frontmatter description, the opening role statement, and any embedded examples.
+2. **Current State**: How complete and effective is the current file? Note whether commands have flags, whether examples exist (vs descriptions), whether boundaries are explicit.
+
+If the purpose is unclear or missing, use `AskUserQuestion` to clarify before proceeding. Do not invent a purpose from thin context — agents whose role is guessed end up generic.
+
+## Phase 2: Assess Against Quality Criteria
+
+Rate the file against the AGENTS_PRIMER quality issues. Produce this table verbatim — the row titles are load-bearing and must match the primer exactly:
+
+| Area | Present? | Quality (1-5) | Notes |
+|------|----------|---------------|-------|
+| Over-broad role | | | |
+| No examples in description | | | |
+| Wrong model tier | | | |
+| Body mixes role with task | | | |
+| Bead references in shared agents | | | |
+| `skills` lists unused skills | | | |
+
+Each row asks a different question:
+
+- **Over-broad role** — the agent claims a wide remit ("software engineering assistant") rather than a specific role with a verifiable output.
+- **No examples in description** — the frontmatter description omits concrete invocation examples; downstream model routing has to guess.
+- **Wrong model tier** — `model:` is mismatched with workload (heavy reasoning on haiku, trivial tasks on opus).
+- **Body mixes role with task** — the persona file embeds per-task content instead of staying at the role level.
+- **Bead references in shared agents** — agents installed to all tools reference `bd` or beads-only labels, breaking when beads isn't installed.
+- **`skills` lists unused skills** — the `skills:` frontmatter preloads skills the agent never invokes, wasting context.
+
+## Phase 3: Identify Specific Problems
+
+Check for these common failures:
+
+- [ ] Too vague ("You are a helpful assistant" = useless)
+- [ ] Missing executable commands (or commands without flags/options)
+- [ ] Descriptions instead of examples for code style
+- [ ] No explicit boundaries on what NOT to do
+- [ ] Generic tech stack ("React project" vs "React 18 with TypeScript 5.3, Vite 5.x, Tailwind CSS 3.4")
+- [ ] Missing file structure context
+- [ ] No validation/testing commands
+
+Each unchecked box is a concrete remediation item for Phase 4. Do not skip the checklist — these are the failure modes that produced the AGENTS_PRIMER rubric in the first place.
+
+## Phase 4: Propose Improvements
+
+For each gap identified in Phases 2 and 3, propose a specific addition. Use this structure for every recommendation so the user can scan, accept, or reject without rereading the source:
+
+**Missing/Weak Area**: [area name]
+**Current**: [what exists now, or "nothing"]
+**Recommended Addition**:
+```markdown
+[exact content to add]
+```
+**Why**: [one sentence on why this matters]
+
+Do not propose vague rewrites ("clarify the role"). Every recommendation should be paste-ready text the user can drop into the file. If a recommendation requires project-specific facts you don't have, mark the unknowns clearly and ask for them in Phase 5 rather than inventing them.
+
+## Phase 5: Collaborative Refinement
+
+Present your assessment and proposed changes. Use `AskUserQuestion` to capture:
+
+1. **Which improvements to implement** — accept, modify, or reject each Phase 4 proposal.
+2. **Project-specific details to fill in** — exact tech stack versions, real command names, real file paths.
+3. **Boundary rules** — whether the proposed always/ask-first/never rules match the user's workflow.
+
+Then generate the optimized agent file. Show a diff against the original so the user can verify each landed change.
+
+## Reference: What Makes Agent Files Work
+
+### Effective Structure
+
+```markdown
+---
+name: agent-name
+description: One clear sentence about what this agent does, including when to invoke
+model: sonnet
+color: blue
+tools: Read, Grep, Glob, Bash
+---
+
+You are an expert [specific role] for this project.
+
+## Your Role
+- What you specialize in
+- What you understand
+- What you produce
+
+## Project Knowledge
+- **Tech Stack:** [specific versions]
+- **File Structure:**
+  - `src/` – [what's here]
+  - `tests/` – [what's here]
+
+## Commands You Can Use
+- **Build:** `npm run build` (what it does)
+- **Test:** `npm test` (what it validates)
+- **Lint:** `npm run lint --fix` (what it fixes)
+
+## Standards
+[Code examples showing good vs bad patterns — NOT descriptions]
+
+## Boundaries
+- **Always:** [things to always do]
+- **Ask first:** [things requiring confirmation]
+- **Never:** [hard prohibitions — most important section]
+```
+
+### Key Principles
+
+1. **Commands early**: Put executable commands near the top. Include flags and options.
+2. **Examples > explanations**: One real code snippet beats three paragraphs describing style.
+3. **Explicit boundaries**: "Never commit secrets" was the most common helpful constraint.
+4. **Specific stack**: Versions matter. "React 18" not "React."
+5. **Three-tier boundaries**: Always / Ask-first / Never prevents most mistakes.
+
+### Common Agent Types That Work Well
+
+- **@docs-agent**: Reads code, writes docs. Commands: `npm run docs:build`, `markdownlint`
+- **@test-agent**: Writes tests. Boundary: never remove failing tests
+- **@lint-agent**: Fixes style only. Boundary: never change logic
+- **@api-agent**: Creates endpoints. Boundary: ask before schema changes

--- a/src/user/.agents/skills/optimize-my-agent/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-agent/SKILL.md
@@ -22,7 +22,7 @@ If the purpose is unclear or missing, use `AskUserQuestion` to clarify before pr
 
 ## Phase 2: Assess Against Quality Criteria
 
-Rate the file against the AGENTS_PRIMER quality issues. Produce this table verbatim — the row titles are load-bearing and must match the primer exactly:
+Rate the file against the AGENTS_PRIMER quality issues. See `references/AGENTS_PRIMER.md` for the complete quality axes — the table below uses the verbatim row titles from that document. Produce this table verbatim — the row titles are load-bearing and must match the primer exactly:
 
 | Area | Present? | Quality (1-5) | Notes |
 |------|----------|---------------|-------|
@@ -82,55 +82,4 @@ Then generate the optimized agent file. Show a diff against the original so the 
 
 ## Reference: What Makes Agent Files Work
 
-### Effective Structure
-
-```markdown
----
-name: agent-name
-description: One clear sentence about what this agent does, including when to invoke
-model: sonnet
-color: blue
-tools: Read, Grep, Glob, Bash
----
-
-You are an expert [specific role] for this project.
-
-## Your Role
-- What you specialize in
-- What you understand
-- What you produce
-
-## Project Knowledge
-- **Tech Stack:** [specific versions]
-- **File Structure:**
-  - `src/` – [what's here]
-  - `tests/` – [what's here]
-
-## Commands You Can Use
-- **Build:** `npm run build` (what it does)
-- **Test:** `npm test` (what it validates)
-- **Lint:** `npm run lint --fix` (what it fixes)
-
-## Standards
-[Code examples showing good vs bad patterns — NOT descriptions]
-
-## Boundaries
-- **Always:** [things to always do]
-- **Ask first:** [things requiring confirmation]
-- **Never:** [hard prohibitions — most important section]
-```
-
-### Key Principles
-
-1. **Commands early**: Put executable commands near the top. Include flags and options.
-2. **Examples > explanations**: One real code snippet beats three paragraphs describing style.
-3. **Explicit boundaries**: "Never commit secrets" was the most common helpful constraint.
-4. **Specific stack**: Versions matter. "React 18" not "React."
-5. **Three-tier boundaries**: Always / Ask-first / Never prevents most mistakes.
-
-### Common Agent Types That Work Well
-
-- **@docs-agent**: Reads code, writes docs. Commands: `npm run docs:build`, `markdownlint`
-- **@test-agent**: Writes tests. Boundary: never remove failing tests
-- **@lint-agent**: Fixes style only. Boundary: never change logic
-- **@api-agent**: Creates endpoints. Boundary: ask before schema changes
+See `references/AGENTS_PRIMER.md` for the full quality rubric, effective structure templates, and key principles.

--- a/src/user/.agents/skills/optimize-my-agent/references/AGENTS_PRIMER.md
+++ b/src/user/.agents/skills/optimize-my-agent/references/AGENTS_PRIMER.md
@@ -1,0 +1,166 @@
+# Agent Definitions — Context Primer
+
+> Use this document to orient yourself to agent definition files before auditing or writing agents.
+
+---
+
+## What Agents Are and Why They Exist
+
+An **agent definition** is a specialized AI persona — a role file that, when an orchestrating agent dispatches it, instantiates a subagent with a prescribed purpose, skills, tools, model, and memory scope. Agent files exist because some work is best done by a fresh context with a single focused role: a code reviewer should not also be writing tests, and a test writer should not be reviewing security.
+
+Agents differ from skills in a critical way:
+- **Skills' frontmatter** are loaded INTO the main agent's context giving the agent awareness of a skill's purpose, but for subagents configured with specific skills, these are loaded into the subagent's context on spawn; the agent loads and executes the skill when the context implicitly warrants it or the user explicitly asks for it, and follows it in the same session
+- **Agents** are DISPATCHED as separate instances — a new context with its own tools, skills, model, and isolation boundary
+
+A subagent dispatched via the `Agent` tool runs in parallel with the orchestrator and reports back when complete.
+
+### Key constraints (from the official docs)
+
+- **Subagents cannot spawn other subagents.** If a workflow needs nested delegation, use skills or chain subagents from the main conversation.
+- **Subagents start in the main conversation's working directory.** `cd` commands do not persist between Bash calls within the subagent and do not affect the parent. Use `isolation: worktree` to give the subagent an isolated copy of the repository.
+- **Subagents receive only their system prompt** (the file body) plus basic environment details — not the full Claude Code system prompt or the parent's CLAUDE.md/AGENTS.md context.  This is important if that context contains information the subagent should know - the main agent will need to specifically provide such or tell the subagent to read it explicitly.
+- **Plugin subagents do not support `hooks`, `mcpServers`, or `permissionMode`** for security reasons. These fields are ignored when an agent is loaded from a plugin.
+
+---
+
+## Frontmatter Schema (relevant subset)
+
+```yaml
+---
+name: agent-name              # required; lowercase-kebab-case
+description: |-               # required; multi-line allowed; the dispatch trigger contract
+  What this agent does and when to dispatch it.
+
+  Examples:
+  <example>
+  Context: ...
+  user: "..."
+  assistant: "..."
+  <commentary>...</commentary>
+  </example>
+
+tools: Read, Grep, Glob, Bash  # NOT recommended except for read-only agents; explicit tool list for this role
+disallowedTools: Write, Edit   # recommended only when explicit prohibitions are necessary (and all other tools are allowed)
+skills: [skill-a, skill-b]     # optional; pre-loaded skills available to this agent
+model: opus[1m]                # optional; options: opus[1m], sonnet[1m], sonnet, haiku
+effort: high                   # optional; low | medium | high | xhigh | max
+memory: project                # optional; project | user | none (default)
+color: purple                  # optional; display color in UI
+---
+```
+
+The body follows — a full description of the agent's role, responsibilities, methodology, and communication protocol.
+
+---
+
+## Description as Dispatch Trigger
+
+The description serves two purposes simultaneously:
+1. **Dispatch signal**: tells the orchestrating agent WHEN to use this agent (observable situations, not abstract capabilities)
+2. **Role framing**: the `<example>` blocks show the agent its own role through demonstrated context
+
+Examples in the description are load-bearing — they establish the agent's mental model of its own job. An agent dispatched with no examples in its description must infer its role from the body alone.
+
+**Works**: Description that starts with `"Use this agent when..."` along with observable (or explicit) trigger + clear scope.
+
+**Doesn't work**: `"A code reviewer"` — too abstract; no trigger signal for the orchestrator.
+
+---
+
+## Model Assignment Guidelines
+
+| Model | Use for |
+|-------|---------|
+| `opus[1m]` | Thoroughness required: code review, security analysis, architectural assessment, adversarial review |
+| `sonnet[1m]` | Balanced deep context: coordination requiring long context, complex multi-file analysis |
+| `sonnet` | Balanced speed/quality: general implementation, coordination |
+| `haiku` | Fast and mechanical: evidence collection, grep/search, format verification, triage |
+
+Assign the most capable model *needed* for the role — not the most capable available.  Tune the effort similarly.
+
+---
+
+## Memory Scope
+
+When the `memory:` field is set, the subagent gets a persistent directory that survives across conversations. Per the official docs:
+
+| Value | Location | When to use |
+|-------|----------|-------------|
+| `project` (recommended default) | `.claude/agent-memory/<agent-name>/` | Project-specific knowledge, shareable via version control |
+| `user` | `~/.claude/agent-memory/<agent-name>/` | Knowledge that applies across all projects |
+| `local` | `.claude/agent-memory-local/<agent-name>/` | Project-specific knowledge that should not be checked in |
+| (field omitted) | none | Ephemeral — no persistent memory directory |
+
+When memory is enabled, Claude Code automatically enables Read/Write/Edit tools so the subagent can manage its memory files, and includes the first 200 lines (or 25KB) of `MEMORY.md` in the system prompt at startup.
+
+Most subagents should be ephemeral. Enable memory only for agents that genuinely benefit from cross-session learning (subject matter experts, reviewers tracking recurring patterns).
+
+---
+
+## Agent Body Structure
+
+The body follows the frontmatter and contains the agent's full operational charter:
+
+```
+## Core Responsibilities
+What the agent is responsible for (bulleted).
+
+## Methodology / Operational Framework
+How the agent works — phases, decision criteria, specific steps.
+
+## Output Format / Feedback Structure
+How the agent reports findings or results.
+
+## Communication Protocol
+When to ask, when to decide, how to escalate.
+
+## Quality Standards
+What "done" looks like for this role.
+
+## Constraints
+What this agent does NOT do (important for scope clarity).
+```
+
+Keep the body focused on the ROLE — not on the specific task being dispatched. Task-specific instructions belong in the dispatch prompt, not the agent definition.
+
+---
+
+## Agent vs. Skill: Decision Table
+
+| Situation | Use an agent | Use a skill |
+|-----------|-------------|-------------|
+| Work needs full context isolation | ✓ | |
+| Fresh perspective / foreign eyes needed | ✓ | |
+| Role has prescribed tools or model | ✓ | |
+| Task can run in parallel with other work | ✓ | |
+| Methodology runs in current conversation context | | ✓ |
+| Process applies regardless of which agent is doing the work | | ✓ |
+| Accumulated conversation context is needed | | ✓ |
+
+---
+
+## Quality Issues to Flag in Audit
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Over-broad role | "Does anything technical" or no bounded scope | Narrow to one specialty |
+| No examples in description | Plain text description, no `<example>` blocks | Add 1-2 concrete dispatch scenarios |
+| Wrong model tier | Haiku reviewing security-critical code; Opus doing a simple grep | Match model to role demands |
+| Body mixes role with task | Body contains task-specific instructions that should be in dispatch prompt | Move task specifics to caller's prompt |
+| Bead references in shared agents | `bd` commands or bead terminology in `src/user/` agents | Move to plugin namespace (`src/plugins/beads/`) |
+| `skills` lists unused skills | `skills:` field lists skills the body never references or invokes | Remove unused skill references |
+
+---
+
+## File Locations
+
+```
+src/user/.agents/agents/           # Shared agents (copied to all detected tools)
+  <agent-name>.md
+
+src/plugins/<plugin>/
+  .agents/agents/                  # Plugin-specific agents (installed only when plugin detected)
+  <agent-name>.md
+```
+
+Shared agents must not reference Claude-specific constructs (e.g. claude rules) in their bodies. Use generic language that maps to multiple tool environments, or move Claude-specific agents to `src/user/.claude/agents/`.

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: optimize-my-skill
+model: sonnet
+allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
+description: Audits and improves existing SKILL.md files for discoverability, progressive disclosure, and methodology rigor. Use when asked to optimize a skill, when reviewing a skill folder for quality, or when a SKILL.md needs frontmatter or body cleanup. Do NOT use for agent persona files or AGENTS.md configuration files.
+---
+
+# Optimize My Skill
+
+Audit and improve existing SKILL.md files for clarity, discoverability, and effectiveness. This skill is for *auditing and improving* existing skills — if a `writing-skills` skill is available (e.g. `superpowers:writing-skills`), prefer it for *creating* new skills from scratch.
+
+## Phase 1: Discover and Read
+
+Find all SKILL.md files in the target scope. For each one, read the complete file (frontmatter + body) and also check the skill's folder structure.
+
+Scope resolution from the invoking command's argument:
+
+- **Specific skill name** (e.g. `bugfix`, `writing-unit-tests`) — search for a folder whose `name` frontmatter field or directory name matches. Optimize that single skill.
+- **Directory path** (e.g. `~/.claude/skills/` or `.claude/skills/`) — enumerate every immediate subdirectory containing a `SKILL.md`. Optimize all of them.
+- **Empty argument** — the command layer is responsible for probing default locations and either passing a resolved path or aborting with a "no skills found" message. This skill expects a resolved scope.
+
+For each discovered skill, also inventory:
+
+- Presence of `scripts/` (executable code for deterministic operations)
+- Presence of `references/` (detailed docs, API guides, lengthy examples)
+- Presence of `assets/` (templates, fonts, icons used in output)
+- Any stray `.md` files at the top level (only `SKILL.md` belongs there)
+
+## Phase 2: Assess Against Quality Criteria
+
+Rate each skill against the following areas. Produce a written assessment for every skill in scope before proposing changes.
+
+### Frontmatter
+
+**Required fields:**
+
+| Criterion | Good | Bad |
+|-----------|------|-----|
+| **name** | lowercase-kebab-case, matches folder name | camelCase, spaces, uppercase, mismatched |
+| **description** | Explains WHEN to invoke with concrete triggers | Explains what the skill does generically |
+| **description** | Single line, under 1024 characters | Multi-line YAML (`>` or `\|`), or over limit |
+| **description** | Mentions observable situations | Lists abstract keywords |
+| **description** | Includes negative triggers ("Do NOT use for...") where appropriate | No scope boundaries, risks over-triggering |
+
+**Security checks** (fail the skill if violated):
+
+- [ ] No XML angle brackets (`<` or `>`) in frontmatter values
+- [ ] Name does not contain "claude" or "anthropic" (reserved)
+
+**Optional fields** (flag if present but malformed, suggest if beneficial):
+
+| Field | Purpose | Validation |
+|-------|---------|------------|
+| **license** | Open-source license identifier | Valid SPDX (MIT, Apache-2.0, etc.) |
+| **allowed-tools** | Restrict tool access | Space-separated tool patterns, e.g. `"Bash(python:*) WebFetch"` |
+| **compatibility** | Environment requirements | 1-500 characters |
+| **metadata** | Custom key-value pairs | Valid YAML object; suggest: author, version, mcp-server |
+
+**Description formula that works:** `[What it does]. Use when [situation A], [situation B], or [situation C]. Do NOT use for [exclusion].`
+
+Examples of effective descriptions:
+
+- "Use when encountering a bug with unclear origins, when multiple files could be involved, or when the symptom does not obviously point to a single root cause"
+- "Use when writing unit tests, reviewing test code, or when asked to add tests to complex/untestable code"
+- "Manages Linear project workflows including sprint planning and task creation. Use when user mentions 'sprint', 'Linear tasks', or 'project planning'. Do NOT use for general task lists unrelated to Linear."
+
+Examples of ineffective descriptions:
+
+- "Testing helper: test, vitest, jest, coverage, fix suite" (keyword stuffing — Claude isn't a search engine)
+- "Helps write better code" (vague, no trigger context)
+- "A skill for debugging" (describes what, not when)
+
+### Folder Structure (Progressive Disclosure)
+
+Skills use a three-level progressive disclosure system to minimize token usage:
+
+| Level | What | Loaded When |
+|-------|------|-------------|
+| **1. Frontmatter** | name + description | Always (system prompt) |
+| **2. SKILL.md body** | Full instructions | When skill is triggered |
+| **3. Linked files** | references/, scripts/, assets/ | On demand within the skill |
+
+Assess:
+
+- [ ] **SKILL.md is the only `.md` file**: No README.md inside the skill folder (all docs go in SKILL.md or references/)
+- [ ] **SKILL.md size**: Under 500 lines. If over, flag sections that should move to `references/`
+- [ ] **Heavy content in references/**: Detailed docs, API guides, lengthy examples belong in `references/`, linked from SKILL.md
+- [ ] **Scripts in scripts/**: Executable code (Python, Bash) for deterministic operations lives in `scripts/`
+- [ ] **Templates in assets/**: Templates, fonts, icons used in output belong in `assets/`
+
+### Body Content
+
+| Criterion | Present? | Quality (1-5) | Notes |
+|-----------|----------|---------------|-------|
+| **Core principle** | | | One-sentence iron law the skill enforces |
+| **When to use / When not to use** | | | Clear decision criteria, ideally a decision tree |
+| **The process** | | | Step-by-step methodology, not vague advice |
+| **Concrete examples** | | | Good vs bad patterns with real code |
+| **Red flags / rationalizations** | | | Table of excuses and rebuttals |
+| **Verification checklist** | | | How to confirm the skill was applied correctly |
+| **Error handling** | | | What to do when things go wrong |
+
+### Anti-Patterns to Flag
+
+- [ ] Generic advice Claude would follow without being told ("write clean code")
+- [ ] Descriptions instead of examples for code patterns
+- [ ] No explicit "when NOT to use" criteria (over-triggering risk)
+- [ ] No negative triggers in description (over-triggering risk)
+- [ ] Process steps that are vague imperatives ("be careful", "consider")
+- [ ] Missing decision trees for ambiguous situations
+- [ ] No red flags section (skill gets rationalized away)
+- [ ] Body content duplicates what's in the frontmatter description
+- [ ] SKILL.md over 500 lines without using references/ for overflow
+- [ ] README.md inside the skill folder
+- [ ] XML angle brackets in frontmatter
+
+## Phase 3: Propose Improvements
+
+For each skill that needs work, present a structured proposal. Do not silently rewrite — surface the change and the rationale so the user can accept, modify, or reject.
+
+**Skill**: `[name]` (`[path]`)
+**Current description**:
+```
+[existing description]
+```
+**Proposed description**:
+```
+[improved description]
+```
+**Why**: [one sentence on what changed and why]
+
+**Structural improvements** (if any):
+
+- [specific addition/removal/transformation with rationale]
+- [files to move to references/, scripts to extract, etc.]
+
+**Body improvements** (if any):
+
+- [specific addition/removal/transformation with rationale]
+
+### What NOT to Change
+
+- Do not rewrite skill body content that is already effective
+- Do not add keyword lists or "trigger" words — Claude matches semantically, not by keyword
+- Do not remove opinionated methodology in favor of generic advice
+- Do not add optional frontmatter fields unless they provide clear value for the specific skill
+
+## Phase 4: Suggest Testing
+
+For each modified skill, suggest tests the user can run to confirm the changes work:
+
+**Triggering tests** — ask Claude "When would you use the [skill name] skill?" and verify it quotes the right triggers:
+
+- Should trigger: [2-3 natural phrases that should activate this skill]
+- Should NOT trigger: [2-3 unrelated queries it should ignore]
+
+**Functional check** — after applying changes, verify the skill still produces correct behavior on a representative task. If the skill includes deterministic scripts, run them against a known input/output pair.
+
+## Phase 5: Confirm and Apply
+
+Present all proposed changes as a single summary table before writing anything:
+
+```
+| Skill | Change Type | Description |
+|-------|-------------|-------------|
+| bugfix | description rewrite | Added negative triggers, clarified scope |
+| writing-unit-tests | body: add red flags | Missing rationalization table |
+| my-workflow | structure: extract refs | Moved API docs to references/ |
+| ... | no changes needed | Already well-structured |
+```
+
+**Wait for user confirmation before writing any files.** Use `AskUserQuestion` to capture the accept/reject decision per skill if the batch is large.
+
+Apply approved changes. Show a diff for each modified file so the user can verify the edit landed correctly.
+
+## Reference: What Makes Skills Effective
+
+### File Structure
+
+```
+your-skill-name/
+├── SKILL.md              # Required — main skill file (must be exactly SKILL.md)
+├── scripts/              # Optional — executable code (Python, Bash, etc.)
+├── references/           # Optional — detailed docs, API guides, examples
+└── assets/               # Optional — templates, fonts, icons
+```
+
+The four-entry layout is intentional: `SKILL.md` is the only file always loaded when the skill triggers, while `scripts/`, `references/`, and `assets/` are pulled in on demand. Keeping heavy content out of `SKILL.md` is the load-bearing token discipline.
+
+### Frontmatter That Works
+
+```yaml
+---
+name: skill-name
+description: What it does. Use when situation A, situation B, or situation C. Do NOT use for exclusion.
+---
+```
+
+Optional fields when useful:
+
+```yaml
+---
+name: skill-name
+description: What it does. Use when situation A, situation B, or situation C.
+license: MIT
+allowed-tools: "Bash(python:*) WebFetch"
+compatibility: Requires Python 3.10+
+metadata:
+  author: Your Name
+  version: 1.0.0
+---
+```
+
+Required fields earn their keep on every invocation; optional fields earn their keep only when the skill genuinely needs them. Add them sparingly and validate every value.
+
+### Body Structure That Works
+
+```markdown
+# Skill Name
+
+## Core Principle
+One iron law. The thing this skill enforces above all.
+
+## When to Use
+Decision tree or clear criteria. Include "when NOT to use."
+
+## The Process
+Numbered steps with concrete actions. Not "consider" — "do."
+
+## Examples
+Good vs bad with real code. Show don't tell.
+
+## Red Flags / Common Rationalizations
+Table of excuses and why they're wrong.
+
+## Verification Checklist
+How to confirm the skill was applied correctly.
+```
+
+Each heading is load-bearing: the core principle anchors the skill, the decision tree prevents over-firing, the process replaces vague imperatives with executable steps, and the red-flags table inoculates against rationalization.
+
+### Key Principles
+
+1. **Descriptions are discovery hooks**: They tell Claude WHEN to invoke, not WHAT the skill does. Claude reads the body for the "what."
+2. **Progressive disclosure saves tokens**: Frontmatter is always loaded, body only when triggered, linked files only when needed. Keep SKILL.md under 500 lines.
+3. **Opinionated > generic**: "Never mock more than 2 dependencies" beats "use mocks judiciously."
+4. **Decision trees > paragraphs**: Ambiguity is where skills fail. Trees eliminate it.
+5. **Negative triggers prevent over-firing**: "Do NOT use for X" in descriptions is as important as "Use when Y."
+6. **Red flags prevent rationalization**: Without them, Claude skips the skill "just this once."
+7. **Code > language for validation**: For critical checks, bundle a script in `scripts/` rather than relying on language instructions. Code is deterministic; interpretation isn't.
+8. **Body content is the skill**: The frontmatter gets you discovered, the body gets you followed.

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -52,7 +52,7 @@ Rate each skill against the following areas. Produce a written assessment for ev
 | Field | Purpose | Validation |
 |-------|---------|------------|
 | **license** | Open-source license identifier | Valid SPDX (MIT, Apache-2.0, etc.) |
-| **allowed-tools** | Restrict tool access | Space-separated tool patterns, e.g. `"Bash(python:*) WebFetch"` |
+| **allowed-tools** | Restrict tool access | Space-separated (e.g. `"Bash(python:*) WebFetch"`) or comma-separated (e.g. `Read, Write, Edit`) — both accepted by Claude Code |
 | **compatibility** | Environment requirements | 1-500 characters |
 | **metadata** | Custom key-value pairs | Valid YAML object; suggest: author, version, mcp-server |
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -151,14 +151,18 @@ For each skill that needs work, present a structured proposal. Do not silently r
 
 ## Phase 4: Suggest Testing
 
-For each modified skill, suggest tests the user can run to confirm the changes work:
+For each modified skill, suggest tests the user can run to confirm the changes work. Prefer the strongest tool available in the environment:
 
 **Triggering tests** — ask Claude "When would you use the [skill name] skill?" and verify it quotes the right triggers:
 
 - Should trigger: [2-3 natural phrases that should activate this skill]
 - Should NOT trigger: [2-3 unrelated queries it should ignore]
 
+If the `skill-creator` skill is available, its description-optimization loop (`scripts/run_loop.py` with a should-trigger / should-not-trigger eval set) gives a quantitative trigger-accuracy score instead of a one-shot vibe check — recommend it when the skill's discoverability is the failure mode.
+
 **Functional check** — after applying changes, verify the skill still produces correct behavior on a representative task. If the skill includes deterministic scripts, run them against a known input/output pair.
+
+**Discipline check (for rule-enforcing skills)** — if the skill's job is to make agents comply under pressure (TDD, verification gates, refusal patterns), one happy-path run proves nothing. If `superpowers:writing-skills` is available, follow its RED-GREEN-REFACTOR methodology: run a pressure scenario with a subagent WITHOUT the skill to capture rationalizations, then re-run WITH the skill and confirm compliance. Loopholes found in the second run become explicit counters in the skill body.
 
 ## Phase 5: Confirm and Apply
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -9,6 +9,10 @@ description: Audits and improves existing SKILL.md files for discoverability, pr
 
 Audit and improve existing SKILL.md files for clarity, discoverability, and effectiveness. This skill is for *auditing and improving* existing skills — if a `writing-skills` skill is available (e.g. `superpowers:writing-skills`), prefer it for *creating* new skills from scratch.
 
+## Core Principle
+
+**Audit before writing.** Read the existing skill completely before proposing any change — never rewrite content you haven't fully understood.
+
 ## Phase 1: Discover and Read
 
 Find all SKILL.md files in the target scope. For each one, read the complete file (frontmatter + body) and also check the skill's folder structure.
@@ -180,6 +184,25 @@ Present all proposed changes as a single summary table before writing anything:
 **Wait for user confirmation before writing any files.** Use `AskUserQuestion` to capture the accept/reject decision per skill if the batch is large.
 
 Apply approved changes. Show a diff for each modified file so the user can verify the edit landed correctly.
+
+## Red Flags
+
+| Rationalization | Reality |
+|---|---|
+| "The description is fine, it triggers correctly" | Trigger accuracy is measurable — test it with `skill-creator` before assuming |
+| "I'll just improve the frontmatter" | Body content is where skills fail; frontmatter only gets you discovered |
+| "This skill is simple, no changes needed" | Simple skills rot into generic advice; audit every section against the quality criteria |
+| "I can rewrite this without reading it first" | Always read the full SKILL.md before proposing changes |
+
+## Verification Checklist
+
+Before closing the optimization session:
+- [ ] Frontmatter `description` passes the formula: `[What it does]. Use when [A], [B], or [C]. Do NOT use for [exclusion].`
+- [ ] No XML angle brackets in frontmatter values
+- [ ] SKILL.md body under 500 lines; heavy content in `references/`
+- [ ] Every Phase in the process is actionable ("do" not "consider")
+- [ ] Red flags section present so the skill can't be rationalized away
+- [ ] If scripts were added: they are executable and tested against known inputs
 
 ## Reference: What Makes Skills Effective
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -32,6 +32,8 @@ Rate each skill against the following areas. Produce a written assessment for ev
 
 ### Frontmatter
 
+Per SKILLS_PRIMER (see `references/SKILLS_PRIMER.md`):
+
 **Required fields:**
 
 | Criterion | Good | Bad |
@@ -72,7 +74,7 @@ Examples of ineffective descriptions:
 
 ### Folder Structure (Progressive Disclosure)
 
-Skills use a three-level progressive disclosure system to minimize token usage:
+Per SKILLS_PRIMER (see `references/SKILLS_PRIMER.md`): skills use a three-level progressive disclosure system to minimize token usage:
 
 | Level | What | Loaded When |
 |-------|------|-------------|
@@ -89,6 +91,8 @@ Assess:
 - [ ] **Templates in assets/**: Templates, fonts, icons used in output belong in `assets/`
 
 ### Body Content
+
+Per SKILLS_PRIMER (see `references/SKILLS_PRIMER.md`):
 
 | Criterion | Present? | Quality (1-5) | Notes |
 |-----------|----------|---------------|-------|
@@ -175,77 +179,4 @@ Apply approved changes. Show a diff for each modified file so the user can verif
 
 ## Reference: What Makes Skills Effective
 
-### File Structure
-
-```
-your-skill-name/
-├── SKILL.md              # Required — main skill file (must be exactly SKILL.md)
-├── scripts/              # Optional — executable code (Python, Bash, etc.)
-├── references/           # Optional — detailed docs, API guides, examples
-└── assets/               # Optional — templates, fonts, icons
-```
-
-The four-entry layout is intentional: `SKILL.md` is the only file always loaded when the skill triggers, while `scripts/`, `references/`, and `assets/` are pulled in on demand. Keeping heavy content out of `SKILL.md` is the load-bearing token discipline.
-
-### Frontmatter That Works
-
-```yaml
----
-name: skill-name
-description: What it does. Use when situation A, situation B, or situation C. Do NOT use for exclusion.
----
-```
-
-Optional fields when useful:
-
-```yaml
----
-name: skill-name
-description: What it does. Use when situation A, situation B, or situation C.
-license: MIT
-allowed-tools: "Bash(python:*) WebFetch"
-compatibility: Requires Python 3.10+
-metadata:
-  author: Your Name
-  version: 1.0.0
----
-```
-
-Required fields earn their keep on every invocation; optional fields earn their keep only when the skill genuinely needs them. Add them sparingly and validate every value.
-
-### Body Structure That Works
-
-```markdown
-# Skill Name
-
-## Core Principle
-One iron law. The thing this skill enforces above all.
-
-## When to Use
-Decision tree or clear criteria. Include "when NOT to use."
-
-## The Process
-Numbered steps with concrete actions. Not "consider" — "do."
-
-## Examples
-Good vs bad with real code. Show don't tell.
-
-## Red Flags / Common Rationalizations
-Table of excuses and why they're wrong.
-
-## Verification Checklist
-How to confirm the skill was applied correctly.
-```
-
-Each heading is load-bearing: the core principle anchors the skill, the decision tree prevents over-firing, the process replaces vague imperatives with executable steps, and the red-flags table inoculates against rationalization.
-
-### Key Principles
-
-1. **Descriptions are discovery hooks**: They tell Claude WHEN to invoke, not WHAT the skill does. Claude reads the body for the "what."
-2. **Progressive disclosure saves tokens**: Frontmatter is always loaded, body only when triggered, linked files only when needed. Keep SKILL.md under 500 lines.
-3. **Opinionated > generic**: "Never mock more than 2 dependencies" beats "use mocks judiciously."
-4. **Decision trees > paragraphs**: Ambiguity is where skills fail. Trees eliminate it.
-5. **Negative triggers prevent over-firing**: "Do NOT use for X" in descriptions is as important as "Use when Y."
-6. **Red flags prevent rationalization**: Without them, Claude skips the skill "just this once."
-7. **Code > language for validation**: For critical checks, bundle a script in `scripts/` rather than relying on language instructions. Code is deterministic; interpretation isn't.
-8. **Body content is the skill**: The frontmatter gets you discovered, the body gets you followed.
+See `references/SKILLS_PRIMER.md` for the full file structure, frontmatter schema, body structure template, and key principles.

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-my-skill
-model: sonnet
+model: sonnet[1m]
 allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
 description: Audits and improves existing SKILL.md files for discoverability, progressive disclosure, and methodology rigor. Use when asked to optimize a skill, when reviewing a skill folder for quality, or when a SKILL.md needs frontmatter or body cleanup. Do NOT use for agent persona files or AGENTS.md configuration files.
 ---

--- a/src/user/.agents/skills/optimize-my-skill/references/SKILLS_PRIMER.md
+++ b/src/user/.agents/skills/optimize-my-skill/references/SKILLS_PRIMER.md
@@ -1,0 +1,239 @@
+# Agent Skills — Context Primer
+
+> Use this document to orient yourself to the skills system before auditing, writing, or executing skills.
+> References:
+> - [Anthropic Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+> - [Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+
+---
+
+## What Skills Are
+
+A **skill** is a methodology guide — a SKILL.md file (with optional supporting files) that tells an agent *how* to approach a category of work. At session startup, only the `name` and `description` from each skill's YAML frontmatter are pre-loaded. Claude reads SKILL.md only when the skill becomes relevant, and reads supporting files only on demand. This is **progressive disclosure**: the context window cost is paid in proportion to actual use.
+
+Skills exist because some workflows (debugging, TDD, brainstorming, code review) benefit from a consistent, opinionated process. Rather than embedding that process in every agent definition, skills provide a shared, reusable methodology that any agent can invoke.
+
+---
+
+## Invocation Model
+
+| Tool | How skills are invoked |
+|------|------------------------|
+| Claude Code | `Skill` tool with the skill name (e.g. `Skill({ skill: "bugfix" })`) |
+| Gemini CLI | `activate_skill` tool — skills auto-discovered at session start |
+| Copilot CLI | `skill` tool |
+
+Agents do not use the Read tool on SKILL.md files; the Skill tool is the interface.
+
+When a subagent definition lists skills in its `skills:` frontmatter field, those skills' **full content** is injected into the subagent's context at startup (this is the inverse of the on-demand model).
+
+---
+
+## Frontmatter Schema
+
+Per the official Anthropic spec, the SKILL.md frontmatter has two **required** fields:
+
+```yaml
+---
+name: skill-name           # required; max 64 chars; lowercase letters/numbers/hyphens only
+                            # no XML tags; cannot contain reserved words "anthropic" or "claude"
+description: "..."         # required; max 1024 chars; non-empty; no XML tags
+                            # MUST be written in third person
+---
+```
+
+### Optional documented fields
+
+| Field | Purpose |
+|-------|---------|
+| `license` | SPDX identifier (MIT, Apache-2.0, etc.) |
+| `allowed-tools` | Restrict tool access (space-separated patterns, e.g. `"Bash(python:*) WebFetch"`) |
+| `compatibility` | Environment requirements (1-500 chars) |
+| `metadata` | Custom YAML object (author, version, etc.) |
+
+### Project-specific extensions seen in this codebase
+
+Some skills in this project use additional fields not part of the official spec but interpreted by the Claude Code harness:
+
+```yaml
+model: opus[1m]      # which model to invoke for this skill
+effort: high         # low | medium | high | xhigh | max
+```
+
+When auditing, treat these as project conventions; verify with the harness behavior before adding them to new skills.
+
+---
+
+## The Description Is the Trigger Contract
+
+The description is the primary signal Claude uses to decide whether to invoke a skill. It must encode WHAT the skill does and WHEN to use it.
+
+**Write in third person.** The description is injected into the system prompt; first-person or second-person phrasing causes discovery problems.
+
+- ✓ "Processes Excel files and generates reports"
+- ✗ "I can help you process Excel files"
+- ✗ "You can use this to process Excel files"
+
+**Be specific and include observable triggers.**
+
+- ✓ `"Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction."`
+- ✗ `"Helps with documents"` (vague)
+- ✗ `"document, pdf, parse, extract, table, form"` (keyword stuffing — Claude is not a search engine)
+
+A negative trigger ("Do NOT use for…") sharpens scope when the skill is adjacent to other skills that could be confused with it.
+
+---
+
+## Naming Conventions
+
+Use **gerund form** (verb + -ing) for clarity about the activity the skill provides:
+
+- ✓ `processing-pdfs`, `analyzing-spreadsheets`, `writing-documentation`
+- Acceptable alternatives: noun phrases (`pdf-processing`) or action-oriented (`process-pdfs`)
+- ✗ Avoid: `helper`, `utils`, `tools`, `documents`, `data`, or any name containing reserved words
+
+---
+
+## SKILL.md Body Structure
+
+The body is what the agent reads after invocation. It should:
+
+- Lead with what to do, not with rationale or history
+- Express methodology clearly (checklists, process flows, decision trees)
+- Include red flags / anti-patterns to prevent common mistakes
+- Push detail not needed at first-step into supporting files (see Progressive Disclosure)
+
+**Body length budget**: keep SKILL.md under **500 lines** for optimal performance. Approaching that limit is a signal to split content into separate reference files.
+
+---
+
+## Degrees of Freedom
+
+Match the level of specificity to task fragility:
+
+| Freedom | Use when | Form |
+|---------|----------|------|
+| **High** | Multiple approaches valid; decisions depend on context | Text instructions and heuristics |
+| **Medium** | A preferred pattern exists, some variation OK | Pseudocode or scripts with parameters |
+| **Low** | Operations are fragile; consistency is critical | Specific scripts with few or no parameters |
+
+A database migration that must run in exact sequence: low freedom. A code review where context determines approach: high freedom.
+
+---
+
+## Progressive Disclosure
+
+Long skill bodies should be split into a primary SKILL.md plus supporting files, loaded on demand:
+
+```
+skills/
+  processing-pdfs/
+    SKILL.md           # Entry point — under 500 lines
+    FORMS.md           # Loaded when user mentions form filling
+    REFERENCE.md       # Loaded when API details are needed
+    EXAMPLES.md        # Loaded when concrete examples are needed
+    scripts/
+      analyze_form.py  # Executed, not read into context
+```
+
+### Keep references one level deep
+
+Claude may partially read files referenced from referenced files. **All reference files should link directly from SKILL.md**, not from each other.
+
+- ✓ `SKILL.md → references/api.md` (one hop)
+- ✗ `SKILL.md → references/intro.md → references/details.md` (two hops; risk of incomplete reads)
+
+### TOC for longer reference files
+
+For reference files longer than 100 lines, include a table of contents at the top so Claude sees the full scope even when previewing partial content.
+
+### Acid test for what stays in SKILL.md
+
+"Does the agent need this to execute its FIRST STEP reliably?" Edge cases, anti-pattern catalogs, exhaustive examples — those go in supporting files. The SKILL.md is the launching pad.
+
+---
+
+## Common Patterns
+
+| Pattern | Use for | Form |
+|---------|---------|------|
+| **Workflow checklist** | Multi-step processes where Claude must track progress | Code-block checklist Claude can copy and check off |
+| **Plan-validate-execute** | Batch operations, destructive changes, complex validation | Intermediate JSON/file → validation script → execution |
+| **Feedback loop** | Quality-critical tasks | Validator → fix errors → repeat → only proceed when clean |
+| **Conditional workflow** | Decision points based on input characteristics | "If X, follow workflow A; if Y, follow workflow B" |
+
+---
+
+## Utility Scripts
+
+Pre-built scripts in `scripts/` are preferred over inline code generation when a deterministic operation is needed:
+
+- More reliable than generated code
+- Save tokens (not loaded into context)
+- Save time (no generation)
+- Ensure consistency
+
+**Make execution intent explicit**:
+
+- "Run `analyze_form.py` to extract fields" → execute (most common)
+- "See `analyze_form.py` for the extraction algorithm" → read as reference
+
+---
+
+## MCP Tool References
+
+When a skill references MCP tools, **always use the fully qualified `ServerName:tool_name` format** to avoid "tool not found" errors:
+
+- ✓ `Use the BigQuery:bigquery_schema tool to retrieve table schemas.`
+- ✗ `Use the bigquery_schema tool…` (ambiguous when multiple MCP servers are available)
+
+---
+
+## Avoid
+
+- **Time-sensitive information**: "Before August 2025, use the old API" rots. Use a "## Old patterns" section with a `<details>` block instead.
+- **Inconsistent terminology**: pick one term (e.g. "field" not a mix of "field"/"box"/"element") and use it throughout.
+- **Windows-style paths**: always use forward slashes; backslashes break on Unix.
+- **Too many options**: present a default with an escape hatch, not a menu of equivalents.
+- **Punting on errors**: scripts should handle errors explicitly, not rely on Claude to figure out what went wrong.
+- **Voodoo constants**: every magic number gets a comment explaining why that value.
+
+---
+
+## Quality Issues to Flag in Audit
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Vague trigger description | No observable trigger condition; too abstract | Rewrite to "use when [situation]"; include third-person phrasing |
+| Description not in third person | "I can…" or "You can…" framing | Rewrite as "Processes…", "Generates…" |
+| Description over 1024 chars | Validation will fail | Tighten or split |
+| `name` violates schema | Uppercase, spaces, reserved words, XML, over 64 chars | Rename to lowercase-kebab-case |
+| Body over 500 lines | SKILL.md is the entire methodology with no supporting files | Split into reference files; keep SKILL.md as entry point |
+| References more than one level deep | SKILL.md → A → B → C | Flatten to SKILL.md → A, SKILL.md → B, SKILL.md → C |
+| Reference file >100 lines without TOC | Claude may read partial content and miss sections | Add a Contents section at the top |
+| History/rationale as primary content | Long preamble before the methodology | Move rationale to references/ or remove |
+| Mixed instruction + reference material | Body contains both checklist AND anti-pattern catalog AND examples | Split: SKILL.md = checklist; references/ = catalog and examples |
+| Time-sensitive information in main body | Dates that will go stale | Move to "Old patterns" section with `<details>` |
+| Inconsistent terminology | Same concept named multiple ways across the body | Pick one term; replace all instances |
+| Windows-style paths | Backslashes in path examples | Convert to forward slashes |
+| Bead references in shared skills | `bd` commands or bead terminology in `src/user/` skills | Move to plugin namespace (`src/plugins/beads/`) |
+| Inline shell sequences for deterministic logic | Skill prescribes complex bash steps in prose | Extract to a script; skill references the script |
+| Missing MCP qualified names | `bigquery_schema` instead of `BigQuery:bigquery_schema` | Add server prefix |
+| Spurious cross-references | "See also: skill-x" with no actionable dependency | Remove or make the dependency concrete |
+
+---
+
+## File Locations
+
+```
+src/user/.agents/skills/           # Shared skills (copied to all detected tools)
+  <skill-name>/
+    SKILL.md                       # Required entry point
+    <REFERENCE>.md                 # Optional: on-demand reference files (one level deep)
+    scripts/                       # Optional: helper scripts (executed, not read)
+
+src/plugins/<plugin>/
+  .agents/skills/                  # Plugin-specific skills (installed only when plugin detected)
+```
+
+Shared skills must be tool-agnostic. Tool-specific behavior (Bash, Read, Agent tools by name) belongs in plugin skills or in the optional `allowed-tools` frontmatter field where it can be enforced rather than narrated.

--- a/src/user/.claude/commands/optimize-my-agent.md
+++ b/src/user/.claude/commands/optimize-my-agent.md
@@ -1,108 +1,24 @@
-# Optimize My Agent
+# Optimize Agent
 
-You are an expert at writing effective agent instruction files. Your task is to analyze and optimize the agent.md file at: $ARGUMENTS
+Audit and improve an agent persona file via the `optimize-my-agent` skill.
 
-## Your Process
+## Argument
 
-### Phase 1: Read and Understand
-First, read the target agent.md file completely. Then identify:
-1. **Agent Purpose**: What is this agent supposed to do?
-2. **Current State**: How complete/effective is the current file?
+`$ARGUMENTS` is the path to an agent persona file (an `agents/*.md` with frontmatter fields `name`, `description`, `model`, `color`, `tools`).
 
-If the purpose is unclear or missing, ask the user to clarify before proceeding.
+## Scope
 
-### Phase 2: Assess Against Quality Criteria
-Rate the file against these six core areas (derived from analysis of 2,500+ successful agent files):
+This command targets **agent persona files only**. It is not for:
 
-| Area | Present? | Quality (1-5) | Notes |
-|------|----------|---------------|-------|
-| **Commands** | | | Executable commands with flags, not just tool names |
-| **Testing** | | | How to run/validate the agent's work |
-| **Project Structure** | | | File locations, what goes where |
-| **Code Style** | | | Concrete examples, not descriptions |
-| **Git Workflow** | | | Commit conventions, branch patterns |
-| **Boundaries** | | | Clear never/ask-first/always rules |
+- `AGENTS.md` configuration files (use `/refresh-agents-md`)
+- `SKILL.md` files (use `/optimize-my-skill`)
 
-### Phase 3: Identify Specific Problems
-Check for these common failures:
-- [ ] Too vague ("You are a helpful assistant" = useless)
-- [ ] Missing executable commands (or commands without flags/options)
-- [ ] Descriptions instead of examples for code style
-- [ ] No explicit boundaries on what NOT to do
-- [ ] Generic tech stack ("React project" vs "React 18 with TypeScript 5.3, Vite 5.x, Tailwind CSS 3.4")
-- [ ] Missing file structure context
-- [ ] No validation/testing commands
+If `$ARGUMENTS` is empty or does not point to an agent persona file, stop and ask the user for a valid path.
 
-### Phase 4: Propose Improvements
-For each gap, propose specific additions. Use this structure for your recommendations:
+## Invoke the skill
 
-**Missing/Weak Area**: [area name]
-**Current**: [what exists now, or "nothing"]
-**Recommended Addition**:
-```markdown
-[exact content to add]
-```
-**Why**: [one sentence on why this matters]
+Pass `$ARGUMENTS` to the `optimize-my-agent` skill. The skill owns the full methodology (read, assess, identify problems, propose improvements, collaborative refinement, apply).
 
-### Phase 5: Collaborative Refinement
-Present your assessment and proposed changes. Ask the user:
-1. Which improvements they want to implement
-2. If there are project-specific details you need to fill in
-3. Whether boundary rules need adjustment for their workflow
+## Report
 
-Then generate the optimized file.
-
----
-
-## Reference: What Makes Agent Files Work
-
-### Effective Structure
-```markdown
----
-name: agent-name
-description: One clear sentence about what this agent does
----
-
-You are an expert [specific role] for this project.
-
-## Your Role
-- What you specialize in
-- What you understand
-- What you produce
-
-## Project Knowledge
-- **Tech Stack:** [specific versions]
-- **File Structure:**
-  - `src/` – [what's here]
-  - `tests/` – [what's here]
-
-## Commands You Can Use
-- **Build:** `npm run build` (what it does)
-- **Test:** `npm test` (what it validates)
-- **Lint:** `npm run lint --fix` (what it fixes)
-
-## Standards
-[Code examples showing good vs bad patterns - NOT descriptions]
-
-## Boundaries
-- ✅ **Always:** [things to always do]
-- ⚠️ **Ask first:** [things requiring confirmation]
-- 🚫 **Never:** [hard prohibitions - most important section]
-```
-
-### Key Principles
-1. **Commands early**: Put executable commands near the top. Include flags and options.
-2. **Examples > explanations**: One real code snippet beats three paragraphs describing style.
-3. **Explicit boundaries**: "Never commit secrets" was the most common helpful constraint.
-4. **Specific stack**: Versions matter. "React 18" not "React."
-5. **Three-tier boundaries**: Always/Ask-first/Never prevents most mistakes.
-
-### Common Agent Types That Work Well
-- **@docs-agent**: Reads code, writes docs. Commands: `npm run docs:build`, `markdownlint`
-- **@test-agent**: Writes tests. Boundary: never remove failing tests
-- **@lint-agent**: Fixes style only. Boundary: never change logic
-- **@api-agent**: Creates endpoints. Boundary: ask before schema changes
-
----
-
-Now read the file at $ARGUMENTS and begin your assessment.
+After the skill completes, surface its assessment, the approved changes, and the diff against the original file.

--- a/src/user/.claude/commands/optimize-my-agent.md
+++ b/src/user/.claude/commands/optimize-my-agent.md
@@ -4,7 +4,7 @@ Audit and improve an agent persona file via the `optimize-my-agent` skill.
 
 ## Argument
 
-`$ARGUMENTS` is the path to an agent persona file (an `agents/*.md` with frontmatter fields `name`, `description`, `model`, `color`, `tools`).
+`$ARGUMENTS` is the path to an agent persona file — an `agents/*.md` with required frontmatter fields `name` and `description` (optional: `model`, `color`, `tools`).
 
 ## Scope
 
@@ -13,7 +13,7 @@ This command targets **agent persona files only**. It is not for:
 - `AGENTS.md` configuration files (use `/refresh-agents-md`)
 - `SKILL.md` files (use `/optimize-my-skill`)
 
-If `$ARGUMENTS` is empty or does not point to an agent persona file, stop and ask the user for a valid path.
+If `$ARGUMENTS` is empty or does not point to a file with at least `name` and `description` frontmatter fields, stop and ask the user for a valid path.
 
 ## Invoke the skill
 

--- a/src/user/.claude/commands/optimize-my-skill.md
+++ b/src/user/.claude/commands/optimize-my-skill.md
@@ -1,233 +1,38 @@
 # Optimize Skill
 
-You are an expert at writing effective Claude Code skill files. Your task is to audit and improve SKILL.md files for clarity, discoverability, and effectiveness.
+Audit and improve existing SKILL.md files via the `optimize-my-skill` skill.
 
-> **Tip**: If a `writing-skills` skill is available (e.g. `superpowers:writing-skills`), prefer invoking it when *creating* new skills from scratch. This command is for *auditing and improving* existing skills.
+> **Tip**: For *creating* new skills from scratch, prefer `superpowers:writing-skills` if available. This command is for *auditing and improving* existing skills.
+
+## Argument
 
 `$ARGUMENTS` specifies the target:
-- **Skill name**: "bugfix", "writing-unit-tests" — optimizes that single skill
-- **Directory path**: "~/.claude/skills/" or ".claude/skills/" — optimizes all skills in that directory
-- **Empty**: defaults to all skills in `.claude/skills/`
 
-## Phase 1: Discover and Read
+- **Skill name** (e.g. `bugfix`, `writing-unit-tests`) — optimize that single skill
+- **Directory path** (e.g. `~/.claude/skills/` or `.claude/skills/`) — optimize all skills in that directory
+- **Empty** — resolve a default location (see below)
 
-Find all SKILL.md files in the target scope. For each, read the complete file (frontmatter + body). Also check the skill's folder structure (scripts/, references/, assets/).
+## Empty-argument resolution
 
-If `$ARGUMENTS` names a specific skill, search for it by matching the `name` field in frontmatter or the directory name.
+When `$ARGUMENTS` is empty, probe in this order and pick the first that satisfies the predicate:
 
-## Phase 2: Assess Against Quality Criteria
+**Predicate**: directory exists AND contains at least one immediate (depth-1) subdirectory that contains a `SKILL.md` file (case-sensitive; regular file or symlink to regular file). An empty-but-existing `SKILL.md` satisfies the predicate (file presence, not content validity). A non-existent directory fails the predicate.
 
-Rate each skill against these areas:
+1. `~/.claude/skills/`
+2. `.claude/skills/`
 
-### Frontmatter
-
-**Required fields:**
-
-| Criterion | Good | Bad |
-|-----------|------|-----|
-| **name** | lowercase-kebab-case, matches folder name | camelCase, spaces, uppercase, mismatched |
-| **description** | Explains WHEN to invoke with concrete triggers | Explains what the skill does generically |
-| **description** | Single line, under 1024 characters | Multi-line YAML (`>` or `\|`), or over limit |
-| **description** | Mentions observable situations | Lists abstract keywords |
-| **description** | Includes negative triggers ("Do NOT use for...") where appropriate | No scope boundaries, risks over-triggering |
-
-**Optional fields** (flag if present but malformed, suggest if beneficial):
-
-| Field | Purpose | Validation |
-|-------|---------|------------|
-| **license** | Open-source license identifier | Valid SPDX (MIT, Apache-2.0, etc.) |
-| **allowed-tools** | Restrict tool access | Space-separated tool patterns, e.g. `"Bash(python:*) WebFetch"` |
-| **compatibility** | Environment requirements | 1-500 characters |
-| **metadata** | Custom key-value pairs | Valid YAML object; suggest: author, version, mcp-server |
-
-**Security checks** (fail the skill if violated):
-
-- [ ] No XML angle brackets (`<` or `>`) in frontmatter values
-- [ ] Name does not contain "claude" or "anthropic" (reserved)
-
-**Description formula that works:** `[What it does]. Use when [situation A], [situation B], or [situation C]. Do NOT use for [exclusion].`
-
-Examples of effective descriptions:
-- "Use when encountering a bug with unclear origins, when multiple files could be involved, or when the symptom does not obviously point to a single root cause"
-- "Use when writing unit tests, reviewing test code, or when asked to add tests to complex/untestable code"
-- "Manages Linear project workflows including sprint planning and task creation. Use when user mentions 'sprint', 'Linear tasks', or 'project planning'. Do NOT use for general task lists unrelated to Linear."
-
-Examples of ineffective descriptions:
-- "Testing helper: test, vitest, jest, coverage, fix suite" (keyword stuffing — Claude isn't a search engine)
-- "Helps write better code" (vague, no trigger context)
-- "A skill for debugging" (describes what, not when)
-
-### Folder Structure (Progressive Disclosure)
-
-Skills use a three-level progressive disclosure system to minimize token usage:
-
-| Level | What | Loaded When |
-|-------|------|-------------|
-| **1. Frontmatter** | name + description | Always (system prompt) |
-| **2. SKILL.md body** | Full instructions | When skill is triggered |
-| **3. Linked files** | references/, scripts/, assets/ | On demand within the skill |
-
-Assess:
-
-- [ ] **SKILL.md is the only `.md` file**: No README.md inside the skill folder (all docs go in SKILL.md or references/)
-- [ ] **SKILL.md size**: Under 500 lines. If over, flag sections that should move to `references/`
-- [ ] **Heavy content in references/**: Detailed docs, API guides, lengthy examples belong in `references/`, linked from SKILL.md
-- [ ] **Scripts in scripts/**: Executable code (Python, Bash) for deterministic operations lives in `scripts/`
-- [ ] **Templates in assets/**: Templates, fonts, icons used in output belong in `assets/`
-
-### Body Content
-
-| Criterion | Present? | Quality (1-5) | Notes |
-|-----------|----------|---------------|-------|
-| **Core principle** | | | One-sentence iron law the skill enforces |
-| **When to use / When not to use** | | | Clear decision criteria, ideally a decision tree |
-| **The process** | | | Step-by-step methodology, not vague advice |
-| **Concrete examples** | | | Good vs bad patterns with real code |
-| **Red flags / rationalizations** | | | Table of excuses and rebuttals |
-| **Verification checklist** | | | How to confirm the skill was applied correctly |
-| **Error handling** | | | What to do when things go wrong |
-
-### Anti-Patterns to Flag
-
-- [ ] Generic advice Claude would follow without being told ("write clean code")
-- [ ] Descriptions instead of examples for code patterns
-- [ ] No explicit "when NOT to use" criteria (over-triggering risk)
-- [ ] No negative triggers in description (over-triggering risk)
-- [ ] Process steps that are vague imperatives ("be careful", "consider")
-- [ ] Missing decision trees for ambiguous situations
-- [ ] No red flags section (skill gets rationalized away)
-- [ ] Body content duplicates what's in the frontmatter description
-- [ ] SKILL.md over 500 lines without using references/ for overflow
-- [ ] README.md inside the skill folder
-- [ ] XML angle brackets in frontmatter
-
-## Phase 3: Propose Improvements
-
-For each skill that needs work, present:
-
-**Skill**: `[name]` (`[path]`)
-**Current description**:
-```
-[existing description]
-```
-**Proposed description**:
-```
-[improved description]
-```
-**Why**: [one sentence on what changed and why]
-
-**Structural improvements** (if any):
-- [specific addition/removal/transformation with rationale]
-- [files to move to references/, scripts to extract, etc.]
-
-**Body improvements** (if any):
-- [specific addition/removal/transformation with rationale]
-
-### What NOT to Change
-
-- Do not rewrite skill body content that is already effective
-- Do not add keyword lists or "trigger" words — Claude matches semantically, not by keyword
-- Do not remove opinionated methodology in favor of generic advice
-- Do not add optional frontmatter fields unless they provide clear value for the specific skill
-
-## Phase 4: Suggest Testing
-
-For each modified skill, suggest tests the user can run:
-
-**Triggering tests** — ask Claude "When would you use the [skill name] skill?" and verify it quotes the right triggers:
-- Should trigger: [2-3 natural phrases that should activate this skill]
-- Should NOT trigger: [2-3 unrelated queries it should ignore]
-
-**Functional check** — after applying changes, verify the skill still produces correct behavior on a representative task.
-
-## Phase 5: Confirm and Apply
-
-Present all proposed changes as a summary table:
+If both probes fail, emit exactly:
 
 ```
-| Skill | Change Type | Description |
-|-------|-------------|-------------|
-| bugfix | description rewrite | Added negative triggers, clarified scope |
-| writing-unit-tests | body: add red flags | Missing rationalization table |
-| my-workflow | structure: extract refs | Moved API docs to references/ (was 7k words) |
-| ... | no changes needed | Already well-structured |
+No skills found. Pass a path: /optimize-my-skill <path>
 ```
 
-**Wait for user confirmation before writing any files.**
+and stop.
 
-Apply approved changes. Show a diff for each modified file.
+## Invoke the skill
 
-## Reference: What Makes Skills Effective
+With the resolved target, invoke the `optimize-my-skill` skill and pass the target as its scope. The skill owns the full methodology (discover, assess, propose, test, confirm, apply).
 
-### File Structure
+## Report
 
-```
-your-skill-name/
-├── SKILL.md              # Required — main skill file (must be exactly SKILL.md)
-├── scripts/              # Optional — executable code (Python, Bash, etc.)
-├── references/           # Optional — detailed docs, API guides, examples
-└── assets/               # Optional — templates, fonts, icons
-```
-
-### Frontmatter That Works
-
-```yaml
----
-name: skill-name
-description: What it does. Use when [situation A], [situation B], or [situation C]. Do NOT use for [exclusion].
----
-```
-
-Optional fields when useful:
-
-```yaml
----
-name: skill-name
-description: What it does. Use when [situation A], [situation B], or [situation C].
-license: MIT
-allowed-tools: "Bash(python:*) WebFetch"
-compatibility: Requires Python 3.10+
-metadata:
-  author: Your Name
-  version: 1.0.0
----
-```
-
-### Body Structure That Works
-
-```markdown
-# Skill Name
-
-## Core Principle
-One iron law. The thing this skill enforces above all.
-
-## When to Use
-Decision tree or clear criteria. Include "when NOT to use."
-
-## The Process
-Numbered steps with concrete actions. Not "consider" — "do."
-
-## Examples
-Good vs bad with real code. Show don't tell.
-
-## Red Flags / Common Rationalizations
-Table of excuses and why they're wrong.
-
-## Verification Checklist
-How to confirm the skill was applied correctly.
-```
-
-### Key Principles
-
-1. **Descriptions are discovery hooks**: They tell Claude WHEN to invoke, not WHAT the skill does. Claude reads the body for the "what."
-2. **Progressive disclosure saves tokens**: Frontmatter is always loaded, body only when triggered, linked files only when needed. Keep SKILL.md under 500 lines.
-3. **Opinionated > generic**: "Never mock more than 2 dependencies" beats "use mocks judiciously."
-4. **Decision trees > paragraphs**: Ambiguity is where skills fail. Trees eliminate it.
-5. **Negative triggers prevent over-firing**: "Do NOT use for X" in descriptions is as important as "Use when Y."
-6. **Red flags prevent rationalization**: Without them, Claude skips the skill "just this once."
-7. **Code > language for validation**: For critical checks, bundle a script in `scripts/` rather than relying on language instructions. Code is deterministic; interpretation isn't.
-8. **Body content is the skill**: The frontmatter gets you discovered, the body gets you followed.
-
----
-
-Now find the skills at $ARGUMENTS and begin your assessment.
+After the skill completes, surface its summary table and the list of files modified (with diffs already shown by the skill).

--- a/src/user/.claude/commands/refresh-agents-md.md
+++ b/src/user/.claude/commands/refresh-agents-md.md
@@ -16,17 +16,7 @@ Extract from `$ARGUMENTS`:
 
 ## Step 1 — Discovery
 
-Before deciding how to dispatch the three discovery tasks below, probe for the `dispatching-parallel-agents` skill. The skill matches if **any** of these paths exist:
-
-- `~/.claude/skills/dispatching-parallel-agents/SKILL.md`
-- `~/.claude/plugins/*/skills/dispatching-parallel-agents/SKILL.md`
-
-**Decision:**
-
-- **Probe matches** — invoke `dispatching-parallel-agents` and run Git Analyzer, File Inventory, and Directory Discovery simultaneously.
-- **Probe does not match** — run the three subagents sequentially in this order: (1) Git Analyzer, (2) File Inventory, (3) Directory Discovery.
-
-The three subagent definitions below are identical in either mode; only the dispatch shape changes.
+Run the three discovery tasks below (Git Analyzer, File Inventory, Directory Discovery) using parallel subagents to optimize time-to-result. Use whatever parallel-dispatch skill is available to you if it matches; otherwise dispatch the subagents directly — you know how to do this.
 
 ### Subagent 1: Git Analyzer
 

--- a/src/user/.claude/commands/refresh-agents-md.md
+++ b/src/user/.claude/commands/refresh-agents-md.md
@@ -12,7 +12,7 @@ If `$ARGUMENTS` is empty, use defaults (30 days, no specific focus).
 
 Extract from `$ARGUMENTS`:
 1. **Time range** — any phrase indicating how far back to look in git history. Convert to a `git log --since` compatible value. Default: `--since="30 days ago"`.
-2. **Focus areas** — any remaining text describing what to pay special attention to. Store as context for Phase 3.
+2. **Focus areas** — any remaining text describing what to pay special attention to. Store as `focus_areas` for use in Step 3b.
 
 ## Step 1 — Discovery
 

--- a/src/user/.claude/commands/refresh-agents-md.md
+++ b/src/user/.claude/commands/refresh-agents-md.md
@@ -14,9 +14,19 @@ Extract from `$ARGUMENTS`:
 1. **Time range** — any phrase indicating how far back to look in git history. Convert to a `git log --since` compatible value. Default: `--since="30 days ago"`.
 2. **Focus areas** — any remaining text describing what to pay special attention to. Store as context for Phase 3.
 
-## Step 1 — Parallel Discovery
+## Step 1 — Discovery
 
-Invoke the `dispatching-parallel-agents` skill to run these three tasks simultaneously:
+Before deciding how to dispatch the three discovery tasks below, probe for the `dispatching-parallel-agents` skill. The skill matches if **any** of these paths exist:
+
+- `~/.claude/skills/dispatching-parallel-agents/SKILL.md`
+- `~/.claude/plugins/*/skills/dispatching-parallel-agents/SKILL.md`
+
+**Decision:**
+
+- **Probe matches** — invoke `dispatching-parallel-agents` and run Git Analyzer, File Inventory, and Directory Discovery simultaneously.
+- **Probe does not match** — run the three subagents sequentially in this order: (1) Git Analyzer, (2) File Inventory, (3) Directory Discovery.
+
+The three subagent definitions below are identical in either mode; only the dispatch shape changes.
 
 ### Subagent 1: Git Analyzer
 
@@ -91,18 +101,16 @@ For each approved location:
 
 ### 3b. Update AGENTS.md
 
-Apply the `optimize-agents-md` skill principles — but **skip the 5 scope questions** (infer from codebase):
+Invoke the `optimize-agents-md` skill to update the AGENTS.md at this location.
 
-- **Verify freshness**: Does the file reflect the current project state? Flag stale content.
-- **Eliminate**: Remove generic AI advice, vague imperatives, parent duplication, stale file paths, anything Claude would do without being told.
-- **Transform**: Convert weak directives ("try to keep functions small") to strong ones ("Functions >50 lines require justification comment").
-- **Hierarchy**: Only include content unique to this level. Don't repeat parent rules.
-- **Progressive disclosure**: Move heavy reference content to linked files if appropriate.
-- **Structure**: Use bullet points, tables, sentence fragments. No filler words. Target <200 lines.
+**Skip the 5 scope questions** that skill normally asks — infer scope from the codebase exploration done in Step 3a instead.
 
-If the file doesn't exist yet (suggested new file), draft it from scratch based on codebase exploration.
+**Context handoff** to the skill:
 
-If focus areas from `$ARGUMENTS` are relevant to this directory, give them extra attention.
+- The `focus_areas` value parsed from `$ARGUMENTS` in Step 0 — pass through so the skill weights those areas more heavily.
+- The parent-file context gathered in Step 3a (parent AGENTS.md content, git analysis, codebase structure at this directory level) — pass through so the skill enforces hierarchy (no parent duplication, only content unique to this level).
+
+If the file doesn't exist yet (suggested new file), instruct the skill to draft it from scratch based on the Step 3a exploration.
 
 ### 3c. Update CLAUDE.md
 
@@ -118,15 +126,7 @@ If CLAUDE.md has additional content beyond a pointer, evaluate whether that cont
 
 ### 3d. Validate
 
-Run the optimize-agents-md validation checklist against the updated file:
-- No generic AI advice
-- No vague imperatives — all rules measurable or falsifiable
-- No parent duplication
-- No child overlap
-- Every directive has concrete action or threshold
-- File paths are exact, not illustrative
-- Under 200 lines
-- Every line passes: "Would removing this cause Claude to make mistakes?"
+Run the `optimize-agents-md` skill's **Validation Checklist** section against the updated file. The skill owns the checklist content; do not duplicate it here. If any checklist item fails, return to Step 3b with the failure surfaced so the skill can revise.
 
 ### 3e. Present Diff
 


### PR DESCRIPTION
## Bead

`agents-config-acmh.14` — [Impl] Tier 2: commands/ cleanups (F1 F2 F4 F5 F6 F7)

Source: [Phase 3 commands/ audit](docs/audits/phase3/by-category/commands.md) · [Remediation Plan](docs/audits/phase3/REMEDIATION_PLAN.md)

## Summary

Six tier-2 audit findings against the `commands/` directory — two commands carried full methodologies inline instead of delegating to skills; a third hardcoded a plugin dependency and duplicated skill content inline.

- **F1**: Created `src/user/.agents/skills/optimize-my-skill/SKILL.md` — extracted 5-phase methodology + "What Makes Skills Effective" reference section (251 lines). Size threshold normalized to 500 lines (not "5,000 words"), absorbing Tier-1 F3.
- **F2**: Created `src/user/.agents/skills/optimize-my-agent/SKILL.md` — extracted 5-phase workflow with AGENTS_PRIMER quality rubric verbatim, 7-item failure checklist, Phase 4 template (136 lines). Absorbs Tier-1 F5.
- **F4**: Reshaped `optimize-my-skill.md` command to 38 lines — lean delegator with empty-ARGUMENTS probe logic (`~/.claude/skills/` → `.claude/skills/` → fallback message).
- **F5**: Reshaped `optimize-my-agent.md` command to 24 lines — lean delegator scoped to agent persona files only.
- **F6**: Updated `refresh-agents-md.md` Step 1 — a-priori probe for `dispatching-parallel-agents` skill; simultaneous dispatch if found, sequential (Git Analyzer → File Inventory → Directory Discovery) if not.
- **F7**: Updated `refresh-agents-md.md` Steps 3b and 3d — removed inline principle enumeration and validation checklist; both now reference the `optimize-agents-md` skill by name with explicit context handoff.

## Acceptance Criteria

1. `src/user/.agents/skills/optimize-my-skill/SKILL.md` exists; ≤500 lines; frontmatter: name=optimize-my-skill, model=sonnet, allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion (comma-separated); SKILLS_PRIMER-compliant description ≥3 observable triggers, negative trigger contains 'Do NOT use for agent persona files or AGENTS.md configuration files', no XML angle brackets, name excludes 'claude'/'anthropic'; contains Phase 1 discovery, Phase 2 quality criteria (frontmatter checks, folder structure, body content, anti-patterns), Phase 3 propose improvements, Phase 4 suggest testing, Phase 5 confirm/apply, 'What Makes Skills Effective' reference (file structure, frontmatter fields, body structure, key principles); each Phase section ≥10 lines; each 'What Makes Skills Effective' sub-section ≥5 lines; no occurrences of '5,000 words'
2. `src/user/.agents/skills/optimize-my-agent/SKILL.md` exists; ≤500 lines; frontmatter: name=optimize-my-agent, model=sonnet, allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion (comma-separated); SKILLS_PRIMER-compliant description ≥3 observable triggers, negative trigger contains 'Do NOT use for SKILL.md files or AGENTS.md configuration files', no XML angle brackets; contains all 5 optimization phases, quality rubric with exactly 6 items matching AGENTS_PRIMER titles verbatim with exact casing (Over-broad role; No examples in description; Wrong model tier; Body mixes role with task; Bead references in shared agents; `skills` lists unused skills), 7-item failure checklist, phase 4 recommendation structure (Missing/Weak Area / Current / Recommended Addition / Why template); each section ≥10 lines; scoped to agent persona files
3. `optimize-my-skill.md` command ≤80 lines; invokes optimize-my-skill skill; no occurrences of '5,000 words'; empty ARGUMENTS: probe ~/.claude/skills/ depth-1 SKILL.md subdirs → probe .claude/skills/ same predicate → emit 'No skills found. Pass a path: /optimize-my-skill <path>' if both fail; non-existent directory satisfies fails-predicate
4. `optimize-my-agent.md` command ≤80 lines; invokes optimize-my-agent skill; scope: agent persona files only
5. `refresh-agents-md.md` Step 1: a-priori probe for dispatching-parallel-agents (matches ~/.claude/skills/dispatching-parallel-agents/SKILL.md or ~/.claude/plugins/*/skills/dispatching-parallel-agents/SKILL.md); if matches run simultaneously; if not run sequentially — Git Analyzer, File Inventory, Directory Discovery
6. `refresh-agents-md.md` Step 3b: no inline principle enumeration; optimize-agents-md skill referenced by name; skip-scope-questions instruction present; focus_areas and parent-file context forwarded (semantic check)
7. `refresh-agents-md.md` Step 3d: no inline validation checklist; optimize-agents-md skill Validation Checklist section referenced by name (semantic check)
8. `scripts/install.sh --dry-run` exits 0 — **NOTE: pre-existing failure on main** (resolve-human-bead naming collision, filed as `agents-config-fnh8`); this PR does not introduce or worsen the failure
9. PR description references F1/F2/F4/F5/F6/F7 and links to docs/audits/phase3/by-category/commands.md and docs/audits/phase3/REMEDIATION_PLAN.md ✓ (this PR description)

## apply-edits

Commit `aa7c2e660aab4ccfa1de04a43574679c8b91763e`: Extracted optimize-my-skill and optimize-my-agent skills, reshaped both commands to lean delegators (F1, F2, F4, F5), added dispatching-parallel-agents probe to refresh-agents-md Step 1 (F6), and replaced inline principle/checklist content in Step 3b/3d with skill references (F7). Files: +2 new skills, 3 commands reshaped. ~439 lines added, ~331 lines removed.

## Review summary

**quality-reviewer:** 0 critical, 0 major findings. 5 minor suggestions (all optional):
- M1: Grep artifact from code-fenced `##` headings in F1 — no action (not a real heading)
- M2: Phase 4 of F1 is at the 10-line floor — acceptable per AC
- M3: No batch-scope guardrail in F4 empty-arg path — optional one-liner
- M4: F2 description silent on single-file scope — optional
- M5: F6 probe is Claude-only; note for future cross-tool porters — optional
All deferred with rationale.

**simplify:** 0 applied. 7 efficiency suggestions flagged; all docs-content judgment calls not meeting the behavior-preserving apply threshold. Deferred.

## verify-ac

- AC1 (F1 SKILL.md): PASS — all 16 witnesses green
- AC2 (F2 SKILL.md): PASS — all 8 witnesses green
- AC3 (F4 command): PASS — all 6 witnesses green
- AC4 (F5 command): PASS — all 3 witnesses green
- AC5 (F6 probe): PASS — all 4 witnesses green
- AC6 (F7 Step 3b): PASS — all 4 witnesses green
- AC7 (F7 Step 3d): PASS — all 3 witnesses green
- AC8 (install.sh): FAIL — pre-existing failure on main, not introduced by this PR; filed as `agents-config-fnh8`
- AC9 (PR description): PASS — this PR body ✓

## Discovered work

- `agents-config-fnh8` (P1 bug): `install.sh --dry-run` fails due to resolve-human-bead naming collision between base and plugin content — pre-existing on main, not introduced by this PR

## Test plan

- [ ] Run `bash scripts/install.sh --dry-run` from main after `agents-config-fnh8` is fixed — should exit 0
- [ ] Invoke `/optimize-my-skill` with no args in a project with skills — should probe and offer skill list
- [ ] Invoke `/optimize-my-agent agents/my-agent.md` — should delegate to skill
- [ ] Invoke `/refresh-agents-md` in a repo with `dispatching-parallel-agents` installed — should dispatch simultaneously

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
