### PR TITLE
feat(dep-health-check): dep graph audit skill — find missing/false deps, cycles, stale blockers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -518,6 +518,35 @@ stage_item() {
             cp "$src" "$dest"
         fi
     else
+        # Carrier-merge: when both src and dest are directories with NO
+        # overlapping filenames, merge the file lists instead of fatal-erroring.
+        # This supports the "carrier dir" pattern where src/user/.agents/skills/<name>/
+        # holds only contract tests (e.g. _test.sh) and the actual skill content
+        # lives under src/plugins/<plugin>/.agents/skills/<name>/.
+        if [[ "$file_type" == "dir" && -d "$src" && -d "$dest" ]]; then
+            local sfile sname collision=0
+            for sfile in "$src"/*; do
+                [[ -e "$sfile" ]] || continue
+                sname="$(basename "$sfile")"
+                if [[ -e "$dest/$sname" ]]; then
+                    collision=1
+                    break
+                fi
+            done
+            if [[ "$collision" -eq 0 ]]; then
+                vinfo "carrier-merge: merging $(basename "$src") into existing $dest (disjoint file sets)"
+                for sfile in "$src"/*; do
+                    [[ -e "$sfile" ]] || continue
+                    sname="$(basename "$sfile")"
+                    if [[ -d "$sfile" ]]; then
+                        cp -R "$sfile" "$dest/$sname"
+                    else
+                        cp "$sfile" "$dest/$sname"
+                    fi
+                done
+                return 0
+            fi
+        fi
         resolve_collision "$dest" "$src" "$file_type"
     fi
 }
@@ -713,12 +742,19 @@ stage_and_install_tool() {
     fi
 
     # ── Phase 6: Overlay active plugins (alphabetical order) ─────────────────
+    local plugin_item
     for plugin in "${PLUGINS[@]}"; do
         plugin_tool_dir="$SRC_PLUGINS/$plugin/.$tool"
         plugin_agents_dir="$SRC_PLUGINS/$plugin/.agents"
 
         if [[ -d "$plugin_tool_dir" ]]; then
             for subdir in rules commands skills agents; do
+                if [[ -d "$plugin_tool_dir/$subdir" ]]; then
+                    for plugin_item in "$plugin_tool_dir/$subdir"/*; do
+                        [[ -e "$plugin_item" ]] || continue
+                        vinfo "  plugin($plugin) staging $subdir/$(basename "$plugin_item")"
+                    done
+                fi
                 stage_content_from_dir "$plugin_tool_dir" "$staging" "$subdir"
             done
             # Plugin settings injection (MCP servers, hooks, permissions)
@@ -730,6 +766,12 @@ stage_and_install_tool() {
 
         if [[ -d "$plugin_agents_dir" ]]; then
             for subdir in skills agents; do
+                if [[ -d "$plugin_agents_dir/$subdir" ]]; then
+                    for plugin_item in "$plugin_agents_dir/$subdir"/*; do
+                        [[ -e "$plugin_item" ]] || continue
+                        vinfo "  plugin($plugin) staging $subdir/$(basename "$plugin_item") (from .agents)"
+                    done
+                fi
                 stage_content_from_dir "$plugin_agents_dir" "$staging" "$subdir"
             done
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -514,6 +514,19 @@ stage_item() {
     if [[ ! -e "$dest" ]]; then
         if [[ -d "$src" ]]; then
             cp -R "$src" "$dest"
+            # Drop a sentinel marker when the initial staging came from the
+            # shared carrier tree (src/user/.agents/). The marker lets a later
+            # plugin staging pass distinguish carrier-merge (allowed) from
+            # plugin-plugin collisions (forbidden). See carrier-merge block
+            # below.
+            if [[ "$file_type" == "dir" ]]; then
+                local src_parent_name
+                src_parent_name="$(basename "$(dirname "$src")")"
+                if [[ ( "$src_parent_name" == "skills" || "$src_parent_name" == "agents" ) \
+                      && "$src" == *"/src/user/.agents/$src_parent_name/"* ]]; then
+                    : > "$dest/.carrier-from-user-shared"
+                fi
+            fi
         else
             cp "$src" "$dest"
         fi
@@ -528,12 +541,12 @@ stage_item() {
         # Scope is deliberately narrow (to avoid silently merging unrelated
         # plugin-plugin colliding directories):
         #   - The dir must be inside skills/ or agents/.
-        #   - One side must be under src/user/.agents/<ns>/<name>/ (the
-        #     shared base / carrier).
-        #   - The other side must be under src/plugins/<plugin>/.agents/<ns>/<name>/
-        #     (a plugin).
-        # Plugin-plugin collisions and non-skill/agent dir collisions remain
-        # fatal via resolve_collision.
+        #   - The incoming `$src` must be a plugin path
+        #     (src/plugins/<plugin>/.agents/<ns>/<name>/).
+        #   - The existing `$dest` must carry the `.carrier-from-user-shared`
+        #     sentinel — proving the FIRST stager was the user-shared carrier
+        #     (not another plugin). Plugin-plugin collisions cannot satisfy
+        #     this and stay fatal via resolve_collision.
         if [[ "$file_type" == "dir" && -d "$src" && -d "$dest" ]]; then
             local src_parent_name dest_parent_name
             src_parent_name="$(basename "$(dirname "$src")")"
@@ -542,13 +555,12 @@ stage_item() {
             local carrier_pattern_ok=0
             if [[ ( "$src_parent_name" == "skills" || "$src_parent_name" == "agents" ) \
                   && "$src_parent_name" == "$dest_parent_name" ]]; then
-                # One side must be the shared carrier path; the other a plugin.
-                # The dest in staging is path-opaque (already-staged); we can
-                # only inspect the incoming src path. The shared carrier is
-                # the path that lives under src/user/.agents/. A plugin path
-                # lives under src/plugins/<plugin>/.agents/.
-                if [[ "$src" == *"/src/user/.agents/$src_parent_name/"* \
-                      || "$src" == *"/src/plugins/"*"/.agents/$src_parent_name/"* ]]; then
+                # Incoming side must be a plugin path; existing dest must
+                # carry the user-shared sentinel. This rejects plugin-plugin
+                # carrier-merges (neither side would have stamped the
+                # sentinel) without needing to inspect $dest's origin path.
+                if [[ "$src" == *"/src/plugins/"*"/.agents/$src_parent_name/"* \
+                      && -f "$dest/.carrier-from-user-shared" ]]; then
                     carrier_pattern_ok=1
                 fi
             fi
@@ -574,6 +586,10 @@ stage_item() {
                             cp "$sfile" "$dest/$sname"
                         fi
                     done
+                    # Clear the sentinel — the merge has occurred. Any further
+                    # collision on this dir will now be a true plugin-plugin
+                    # collision (fatal).
+                    rm -f "$dest/.carrier-from-user-shared"
                     return 0
                 fi
             fi
@@ -858,6 +874,15 @@ stage_and_install_tool() {
             [[ -f "$agent_file" ]] || continue
             transform_gemini_agent_frontmatter "$agent_file"
         done
+    fi
+
+    # ── Phase 6.9: Remove carrier-merge sentinels ──────────────────────────
+    # The stage_item carrier-merge logic drops `.carrier-from-user-shared`
+    # files inside skill/agent directories staged from src/user/.agents/.
+    # These are internal markers — they must not leak into the installed
+    # tree. Strip them before Phase 7 sync.
+    if [[ -d "$staging" ]]; then
+        find "$staging" -type f -name ".carrier-from-user-shared" -delete 2>/dev/null || true
     fi
 
     # ── Phase 7: Sync staging → ~/.<tool>/ (reusing existing sync functions) ──

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -518,33 +518,64 @@ stage_item() {
             cp "$src" "$dest"
         fi
     else
-        # Carrier-merge: when both src and dest are directories with NO
-        # overlapping filenames, merge the file lists instead of fatal-erroring.
-        # This supports the "carrier dir" pattern where src/user/.agents/skills/<name>/
-        # holds only contract tests (e.g. _test.sh) and the actual skill content
-        # lives under src/plugins/<plugin>/.agents/skills/<name>/.
+        # Carrier-merge: when both src and dest are skill/agent directories
+        # with NO overlapping filenames, merge the file lists instead of
+        # fatal-erroring. This supports the "carrier dir" pattern where
+        # src/user/.agents/skills/<name>/ holds only contract tests
+        # (e.g. _test.sh) and the actual skill content lives under
+        # src/plugins/<plugin>/.agents/skills/<name>/.
+        #
+        # Scope is deliberately narrow (to avoid silently merging unrelated
+        # plugin-plugin colliding directories):
+        #   - The dir must be inside skills/ or agents/.
+        #   - One side must be under src/user/.agents/<ns>/<name>/ (the
+        #     shared base / carrier).
+        #   - The other side must be under src/plugins/<plugin>/.agents/<ns>/<name>/
+        #     (a plugin).
+        # Plugin-plugin collisions and non-skill/agent dir collisions remain
+        # fatal via resolve_collision.
         if [[ "$file_type" == "dir" && -d "$src" && -d "$dest" ]]; then
-            local sfile sname collision=0
-            for sfile in "$src"/*; do
-                [[ -e "$sfile" ]] || continue
-                sname="$(basename "$sfile")"
-                if [[ -e "$dest/$sname" ]]; then
-                    collision=1
-                    break
+            local src_parent_name dest_parent_name
+            src_parent_name="$(basename "$(dirname "$src")")"
+            dest_parent_name="$(basename "$(dirname "$dest")")"
+
+            local carrier_pattern_ok=0
+            if [[ ( "$src_parent_name" == "skills" || "$src_parent_name" == "agents" ) \
+                  && "$src_parent_name" == "$dest_parent_name" ]]; then
+                # One side must be the shared carrier path; the other a plugin.
+                # The dest in staging is path-opaque (already-staged); we can
+                # only inspect the incoming src path. The shared carrier is
+                # the path that lives under src/user/.agents/. A plugin path
+                # lives under src/plugins/<plugin>/.agents/.
+                if [[ "$src" == *"/src/user/.agents/$src_parent_name/"* \
+                      || "$src" == *"/src/plugins/"*"/.agents/$src_parent_name/"* ]]; then
+                    carrier_pattern_ok=1
                 fi
-            done
-            if [[ "$collision" -eq 0 ]]; then
-                vinfo "carrier-merge: merging $(basename "$src") into existing $dest (disjoint file sets)"
+            fi
+
+            if [[ "$carrier_pattern_ok" -eq 1 ]]; then
+                local sfile sname collision=0
                 for sfile in "$src"/*; do
                     [[ -e "$sfile" ]] || continue
                     sname="$(basename "$sfile")"
-                    if [[ -d "$sfile" ]]; then
-                        cp -R "$sfile" "$dest/$sname"
-                    else
-                        cp "$sfile" "$dest/$sname"
+                    if [[ -e "$dest/$sname" ]]; then
+                        collision=1
+                        break
                     fi
                 done
-                return 0
+                if [[ "$collision" -eq 0 ]]; then
+                    vinfo "carrier-merge: merging $(basename "$src") into existing $dest (disjoint file sets, $src_parent_name/)"
+                    for sfile in "$src"/*; do
+                        [[ -e "$sfile" ]] || continue
+                        sname="$(basename "$sfile")"
+                        if [[ -d "$sfile" ]]; then
+                            cp -R "$sfile" "$dest/$sname"
+                        else
+                            cp "$sfile" "$dest/$sname"
+                        fi
+                    done
+                    return 0
+                fi
             fi
         fi
         resolve_collision "$dest" "$src" "$file_type"

--- a/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
+++ b/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
@@ -59,7 +59,7 @@ levels:
 unattended. The rules are deliberately narrow:
 
 - **Only two writes are permitted**, both tied to applying a single edge:
-    1. `bd dep add <dependent> <blocker>` — adds the new dep edge. ONLY `bd dep add` mutates the dep graph.
+    1. `bd dep add <dependent> <blocker> --type <dep-type>` — adds the new dep edge. ONLY `bd dep add` mutates the dep graph. The `--type` argument is REQUIRED: `--just-fix-it` applies non-`blocks` edges (e.g., provenance fixes use `--type discovered-from`), and omitting `--type` lets `bd` default to the wrong type. Pass the finding's dep type explicitly on every invocation.
     2. `bd comments add <dependent-id> "dep-health-check (just-fix-it): ..."` —
        the required audit comment on the dependent bead (see next section).
 

--- a/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
+++ b/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
@@ -61,20 +61,9 @@ unattended. The rules are deliberately narrow:
 - **ONLY `bd dep add`** is allowed as a mutating primitive. No other write.
 - HIGH-confidence threshold required. MED and LOW findings are listed in
   the report but never auto-applied.
-- Cap of **at most 10 edges** per invocation (cap 10 / max 10 edges /
-  10 per invocation / limit of 10). Excess HIGH-confidence findings are
-  reported and deferred.
-- The mode MUST NOT run `bd dep remove`. Never `bd dep remove`. Removing
-  edges is prohibited — bd dep remove is forbidden in `--just-fix-it`.
-- The mode MUST NOT run `bd close`. Never `bd close`. Closing beads is
-  prohibited; bd close is forbidden in `--just-fix-it`.
-- The mode MUST NOT run `bd label remove`. Never `bd label remove`.
-  Removing labels is prohibited; bd label remove is forbidden in
-  `--just-fix-it`.
-- The mode MUST NOT run `bd update --notes`, `bd update --description`,
-  `bd update --append-notes`, or any other bead-content mutation. No
-  bead-content mutation. No content mutation. Do not mutate bead content
-  in `--just-fix-it` mode. Never `bd update` that touches the spec.
+- Cap of **at most 10 edges** per invocation. Excess HIGH-confidence findings are reported and deferred.
+- The mode MUST NOT run `bd dep remove`, `bd close`, or `bd label remove`.
+- The mode MUST NOT run any bead-content mutation commands (`bd update --notes`, `bd update --description`, `bd update --append-notes`, etc.). Only add-only dep edges are permitted.
 
 Any finding that would require one of the prohibited primitives is
 **surfaced in the report** (with rationale) and left for interactive
@@ -126,20 +115,13 @@ label (HIGH/MED/LOW) and a per-item rationale.
 
 ### Empty sections are omitted
 
-Rule: omit empty sections — empty sections are omitted from the rendered
-report, and we skip empty sections entirely (do not emit empty sections,
-do not render placeholders for them). If `collect.py` produced no
-deterministic findings, the deterministic section is omitted entirely
-rather than rendered with a "(none)" placeholder. Likewise, when the LLM
-inferred no additional findings the LLM-inferred section is omitted.
+Rule: omit empty sections entirely — do not emit a section heading when there are no findings for it. If `collect.py` produced no deterministic findings, the deterministic section is omitted entirely rather than rendered with a "(none)" placeholder. Likewise, when the LLM inferred no additional findings the LLM-inferred section is omitted.
 
 ## LLM rationale rules
 
 These rules are non-negotiable for every LLM-inferred finding:
 
-- **Per-item rationale required.** Every LLM finding carries a per-item
-  rationale. Each LLM-inferred finding has its own rationale; every
-  finding requires its own rationale string.
+- **Per-item rationale required.** Every LLM finding carries a per-item rationale string citing observable bead content.
 - **Cite observable bead content.** The rationale MUST cite observable
   bead content — quote the bead description, reference the bead field
   (description, notes, comments, labels, AC) or quote a bead snippet that

--- a/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
+++ b/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
@@ -58,12 +58,17 @@ levels:
 `--just-fix-it` is the autonomous mode for the audit. It applies edges
 unattended. The rules are deliberately narrow:
 
-- **ONLY `bd dep add`** is allowed as a mutating primitive. No other write.
+- **Only two writes are permitted**, both tied to applying a single edge:
+    1. `bd dep add <dependent> <blocker>` — adds the new dep edge. ONLY `bd dep add` mutates the dep graph.
+    2. `bd comments add <dependent-id> "dep-health-check (just-fix-it): ..."` —
+       the required audit comment on the dependent bead (see next section).
+
+  Every other mutating primitive is prohibited.
 - HIGH-confidence threshold required. MED and LOW findings are listed in
   the report but never auto-applied.
 - Cap of **at most 10 edges** per invocation. Excess HIGH-confidence findings are reported and deferred.
 - The mode MUST NOT run `bd dep remove`, `bd close`, or `bd label remove`.
-- The mode MUST NOT run any bead-content mutation commands (`bd update --notes`, `bd update --description`, `bd update --append-notes`, etc.). Only add-only dep edges are permitted.
+- The mode MUST NOT run any bead-content mutation commands (`bd update --notes`, `bd update --description`, `bd update --append-notes`, etc.). Only add-only dep edges plus their audit comments are permitted.
 
 Any finding that would require one of the prohibited primitives is
 **surfaced in the report** (with rationale) and left for interactive
@@ -133,6 +138,28 @@ These rules are non-negotiable for every LLM-inferred finding:
   unsupported by bead content, or "it feels related" arguments are not
   acceptable as a rationale. If you can't quote or cite bead content,
   drop the finding.
+
+## LLM-inferred finding deduplication
+
+The orchestration code MUST post-process the LLM's inferred findings and
+drop duplicates against two sources before rendering the LLM-inferred
+section:
+
+1. **Pass 1 (deterministic findings).** Skip any inferred finding whose
+   `(dependent_id, blocker_id, dep_type)` tuple already appears in the
+   Pass 1 deterministic findings emitted by `collect.py`. The deterministic
+   pass already covers provenance mismatches, semantic-type conflicts,
+   stale blockers, and cycles — re-emitting them as LLM inferences is
+   noise.
+2. **Existing dep edges in the current graph.** Skip any inferred finding
+   whose `(dependent_id, blocker_id)` pair already has an existing dep
+   edge in the current graph (regardless of dep type). The graph snapshot
+   in the collected JSON is the source of truth; if the edge exists
+   already, the proposal is redundant.
+
+This dedup pass runs in the SKILL.md orchestration layer — it is not the
+LLM prompt's job to perform the dedup itself. The orchestration filters
+the LLM's output before rendering.
 
 ## Scenarios
 

--- a/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
+++ b/src/plugins/beads/.agents/skills/dep-health-check/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: dep-health-check
+description: Audit the dependency graph across open beads — find missing deps, false existing deps, cycles, stale blockers, and provenance mismatches. Two scopes (focused / all) × two modes (interactive / --just-fix-it).
+model: sonnet[1m]
+effort: high
+---
+
+# dep-health-check
+
+Audit the dependency graph across open beads. Surface missing deps,
+false-existing deps, cycles, stale blockers, and provenance mismatches.
+Two scopes (focused / all) × two modes (interactive / --just-fix-it).
+
+## When to Use
+
+- User runs `/dep-health-check` (no args) — defaults to `--mode all` interactive.
+- User runs `/dep-health-check <bead-id>` — focused on a target bead's
+  1-hop neighborhood + full parent/child chain.
+- User runs `/dep-health-check --just-fix-it [<bead-id>]` — apply HIGH-confidence
+  fixes automatically (see prohibitions below).
+- Operator-initiated audit before a phase boundary, milestone close, or merge.
+
+## Workflow
+
+1. Invoke `collect.py` to gather the bead inventory and deterministic findings.
+   - `python3 collect.py --mode all` for repo-wide audit.
+   - `python3 collect.py --mode focused --target <bead-id>` for focused scope.
+2. Parse the JSON it returns. The schema has top-level keys:
+   `project_prefix`, `mode`, `target`, `bead_count`, `truncated_count`,
+   `capped`, `beads`, `findings`.
+3. The LLM body processes the JSON: classifies each finding, assigns a
+   confidence (HIGH/MED/LOW), drafts a rationale per item, and renders the
+   report. In `--just-fix-it` mode the body also applies HIGH-confidence
+   edges within the prohibitions below.
+
+## Confidence taxonomy
+
+Every finding (deterministic or LLM-inferred) carries one of three confidence
+levels:
+
+- **HIGH** — mechanically derivable from observable bead content with no
+  judgment call. Examples: provenance label `produced-bead-Y` on X with no
+  matching `discovered-from` dep edge; semantic-type conflict
+  (`blocks` between parent and child); cycle detected by `bd dep cycles`;
+  stale `blocks`-type blocker where every blocker is closed.
+- **MED** — strongly suggested by bead content (descriptions, comments,
+  parent-chain context) but requires light interpretation. Example: two
+  beads describe overlapping subsystems and one's notes reference the
+  other but no dep edge exists.
+- **LOW** — speculative pattern based on title/topic similarity alone, or
+  weak signals like shared labels. Always reviewed interactively; never
+  auto-applied.
+
+`--just-fix-it` only acts on HIGH-confidence findings.
+
+## --just-fix-it mode
+
+`--just-fix-it` is the autonomous mode for the audit. It applies edges
+unattended. The rules are deliberately narrow:
+
+- **ONLY `bd dep add`** is allowed as a mutating primitive. No other write.
+- HIGH-confidence threshold required. MED and LOW findings are listed in
+  the report but never auto-applied.
+- Cap of **at most 10 edges** per invocation (cap 10 / max 10 edges /
+  10 per invocation / limit of 10). Excess HIGH-confidence findings are
+  reported and deferred.
+- The mode MUST NOT run `bd dep remove`. Never `bd dep remove`. Removing
+  edges is prohibited — bd dep remove is forbidden in `--just-fix-it`.
+- The mode MUST NOT run `bd close`. Never `bd close`. Closing beads is
+  prohibited; bd close is forbidden in `--just-fix-it`.
+- The mode MUST NOT run `bd label remove`. Never `bd label remove`.
+  Removing labels is prohibited; bd label remove is forbidden in
+  `--just-fix-it`.
+- The mode MUST NOT run `bd update --notes`, `bd update --description`,
+  `bd update --append-notes`, or any other bead-content mutation. No
+  bead-content mutation. No content mutation. Do not mutate bead content
+  in `--just-fix-it` mode. Never `bd update` that touches the spec.
+
+Any finding that would require one of the prohibited primitives is
+**surfaced in the report** (with rationale) and left for interactive
+follow-up. The mode reports each skipped finding so the operator can
+act on it manually.
+
+## Audit comment on every applied edge
+
+When `--just-fix-it` applies an edge it MUST leave an audit trail. Each
+applied edge produces ONE comment, posted on the **dependent bead**
+(the bead carrying the new outgoing dep), via `bd comments add`:
+
+```
+dep-health-check (just-fix-it): added dep <dependent-id> -> <blocker-id> (type <type>); reason: <rationale>
+```
+
+The audit comment lands on the dependent bead (not the blocker) so the
+trail is co-located with the bead whose graph just changed. Use
+`bd comments add` (not `bd update --append-notes`) so the entry shows up
+as a first-class comment in `bd show` output and does not mutate the bead
+spec.
+
+Format requirements:
+
+- Literal prefix: `dep-health-check (just-fix-it): added dep`
+- Arrow form: `<dependent-id> -> <blocker-id>`
+- Type segment: `(type <type>)` — `<type>` is the dep type
+  (`blocks`, `discovered-from`, `parent-child`, `relates-to`, `tracks`)
+- Reason segment: `reason: <rationale>` — a one-line rationale citing the
+  observable bead content that supports the edge
+
+## Report rendering
+
+The report renders two distinct sections, in this order:
+
+### Deterministic findings section
+
+The **deterministic findings** section (deterministic section) lists every
+finding that `collect.py` produced mechanically. These are the HIGH-confidence
+items: cycles, stale blockers, provenance mismatches, semantic-type
+conflicts. Each row carries the bead IDs involved, the finding type, and
+the corresponding deterministic rationale.
+
+### LLM-inferred findings section
+
+The **LLM-inferred findings** section (LLM-inferred section) lists every
+finding the model inferred from bead content. These items carry a confidence
+label (HIGH/MED/LOW) and a per-item rationale.
+
+### Empty sections are omitted
+
+Rule: omit empty sections — empty sections are omitted from the rendered
+report, and we skip empty sections entirely (do not emit empty sections,
+do not render placeholders for them). If `collect.py` produced no
+deterministic findings, the deterministic section is omitted entirely
+rather than rendered with a "(none)" placeholder. Likewise, when the LLM
+inferred no additional findings the LLM-inferred section is omitted.
+
+## LLM rationale rules
+
+These rules are non-negotiable for every LLM-inferred finding:
+
+- **Per-item rationale required.** Every LLM finding carries a per-item
+  rationale. Each LLM-inferred finding has its own rationale; every
+  finding requires its own rationale string.
+- **Cite observable bead content.** The rationale MUST cite observable
+  bead content — quote the bead description, reference the bead field
+  (description, notes, comments, labels, AC) or quote a bead snippet that
+  supports the inference. Rationales that reference bead content by field
+  name are acceptable; rationales that name no observable bead content
+  are not.
+- **No LLM-internal-only reasoning.** No finding may cite only
+  LLM-internal reasoning. Model-internal hunches, internal reasoning
+  unsupported by bead content, or "it feels related" arguments are not
+  acceptable as a rationale. If you can't quote or cite bead content,
+  drop the finding.
+
+## Scenarios
+
+| Scenario | Symptom | Action |
+|----------|---------|--------|
+| Missing `discovered-from` for `produced-bead-Y` label | Provenance mismatch | HIGH — auto-add in `--just-fix-it`; otherwise propose |
+| Cycle in dep graph | `bd dep cycles` non-empty | HIGH — report; never auto-resolve (`bd dep remove` prohibited) |
+| Stale `blocks`-type blocker (all blockers closed) | Open bead with no live blocker | HIGH — report; cannot auto-unblock without `bd dep remove` |
+| Semantic-type conflict (`blocks` between parent and child) | Type mismatch | HIGH — report; manual fix |
+| Bidirectional `discovered-from` | Symmetric provenance | HIGH — report |
+| Asymmetric `relates-to` | Informational only | LOW — note |
+| Title/notes overlap suggests `relates-to` | LLM-inferred kinship | MED/LOW — never `--just-fix-it` |
+
+## Red Flags
+
+- **Applying a non-HIGH finding in `--just-fix-it`** — STOP. Only HIGH-confidence
+  findings are eligible.
+- **More than 10 edges proposed in one `--just-fix-it` run** — STOP. Cap is 10
+  per invocation. Defer the rest.
+- **Reaching for `bd dep remove` / `bd close` / `bd label remove`** in
+  `--just-fix-it` — STOP. These are prohibited. Surface in the report and
+  bounce to interactive mode.
+- **Rationale that doesn't cite bead content** — STOP. Drop the finding;
+  no LLM-internal-only reasoning.
+- **Emitting an empty section** — STOP. Omit empty sections.
+
+## Exit conditions
+
+- Interactive mode: present the report; let the operator decide.
+- `--just-fix-it`: apply HIGH-confidence edges within the cap; emit audit
+  comments; print the full report including skipped items.

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections import OrderedDict
 
 
 # ---------------------------------------------------------------------------
@@ -493,33 +494,49 @@ def find_cycles(selected_ids=None):
 def focused_neighborhood(target_id, beads_by_id):
     """Target + 1-hop neighborhood (NEIGHBORHOOD_TYPES) + full parent chain +
     full child chain. Capped at FOCUSED_BEAD_CAP. Parent chain is guaranteed
-    to survive the cap — neighborhood entries are dropped first."""
-    selected = {target_id}
-    parent_chain_ids = {target_id}
+    to survive the cap — neighborhood entries are dropped first.
+
+    Returns a deterministically ordered list of bead ids:
+      1. Parent chain in traversal order (root first → ... → target's immediate parent)
+      2. The target bead
+      3. Remaining 1-hop neighbors and descendants, sorted by id
+
+    An OrderedDict (used as an ordered set) tracks membership while
+    preserving insertion order; the final remaining-neighbor block is
+    sorted by id so repeated runs produce identical output."""
+    # parent_chain_ids: list, ordered root → target's immediate parent.
+    parent_chain_ids = []
+    # selected: OrderedDict acts as an ordered set; insertion order is
+    # meaningful only for membership-tracking. Final ordering is rebuilt
+    # below from (parent_chain, target, sorted-remaining).
+    selected = OrderedDict()
+    selected[target_id] = None
+
     target = beads_by_id.get(target_id)
     if not target:
-        return list(selected), False
+        return [target_id], False
 
     # 1-hop via dependencies/dependents on the target.
     for dep in target.get("dependencies", []) or []:
         if isinstance(dep, dict) and dep.get("dependency_type") in NEIGHBORHOOD_TYPES:
             dep_id = dep.get("id")
             if dep_id:
-                selected.add(dep_id)
+                selected.setdefault(dep_id, None)
     for dep in target.get("dependents", []) or []:
         if isinstance(dep, dict) and dep.get("dependency_type") in NEIGHBORHOOD_TYPES:
             dep_id = dep.get("id")
             if dep_id:
-                selected.add(dep_id)
+                selected.setdefault(dep_id, None)
 
-    # Parent chain (walk up). Tracked separately so the cap can guarantee
-    # the chain is preserved.
+    # Parent chain (walk up). Collected as a list so the cap can preserve
+    # the chain in root-first traversal order.
     cur = target.get("parent") or ""
-    seen = {target_id}
-    while cur and cur not in seen:
-        seen.add(cur)
-        selected.add(cur)
-        parent_chain_ids.add(cur)
+    walk_seen = {target_id}
+    parents_upward = []  # immediate parent first → root last
+    while cur and cur not in walk_seen:
+        walk_seen.add(cur)
+        parents_upward.append(cur)
+        selected.setdefault(cur, None)
         nxt_bead = beads_by_id.get(cur)
         if not nxt_bead:
             # Fetch parent on-demand so chain is complete even for closed parents.
@@ -527,28 +544,46 @@ def focused_neighborhood(target_id, beads_by_id):
             if nxt_bead:
                 beads_by_id[cur] = nxt_bead
         cur = (nxt_bead or {}).get("parent") or ""
+    # Reverse so order is root → target's immediate parent.
+    parent_chain_ids = list(reversed(parents_upward))
 
     # Child chain (walk down via beads whose parent==target, recursively).
+    # Iterate children in sorted order at each level so traversal itself
+    # is deterministic, even though final ordering is re-sorted below.
     def walk_down(parent_id, depth=0):
         if depth > MAX_CHILD_DEPTH:
             return
-        for cid, c in list(beads_by_id.items()):
-            if c.get("parent") == parent_id and cid not in selected:
-                selected.add(cid)
-                walk_down(cid, depth + 1)
+        children = sorted(
+            cid for cid, c in beads_by_id.items()
+            if c.get("parent") == parent_id and cid not in selected
+        )
+        for cid in children:
+            selected[cid] = None
+            walk_down(cid, depth + 1)
 
     walk_down(target_id)
 
+    parent_chain_set = set(parent_chain_ids)
     capped = False
     if len(selected) > FOCUSED_BEAD_CAP:
         # Preserve parent chain first, then fill the remaining cap with the
-        # rest of the neighborhood. Set iteration order is undefined; the
-        # ordered list below guarantees parent chain survives the truncation.
-        ordered = list(parent_chain_ids) + [s for s in selected if s not in parent_chain_ids]
-        selected = set(ordered[:FOCUSED_BEAD_CAP])
+        # rest of the neighborhood sorted by id so cap-truncation is
+        # deterministic.
+        remaining_sorted = sorted(
+            s for s in selected
+            if s != target_id and s not in parent_chain_set
+        )
+        ordered = parent_chain_ids + [target_id] + remaining_sorted
+        ordered = ordered[:FOCUSED_BEAD_CAP]
         capped = True
+    else:
+        remaining_sorted = sorted(
+            s for s in selected
+            if s != target_id and s not in parent_chain_set
+        )
+        ordered = parent_chain_ids + [target_id] + remaining_sorted
 
-    return list(selected), capped
+    return ordered, capped
 
 
 # ---------------------------------------------------------------------------

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -42,6 +42,7 @@ class DbMissing(Exception):
 
 TOTAL_CONTENT_CAP = 600_000     # ~150K tokens at ~4 chars/tok; leaves headroom for LLM body in sonnet[1m] context
 PER_BEAD_TRUNCATE_LEN = 4_000   # hard truncation per bead when total cap is exceeded
+PER_COMMENT_TRUNCATE_LEN = 1_000  # per-comment cap; comments are summed into content_chars() so large threads must also be bounded
 FOCUSED_BEAD_CAP = 200          # spec R8 explicit cap; prevents runaway child-chain expansion
 MAX_CHILD_DEPTH = 50            # guards against pathological cycles; child trees are <10 deep in practice
 
@@ -191,12 +192,36 @@ def content_chars(bead):
     return sum(len(p) for p in parts)
 
 
-def truncate_bead_content(bead, limit=PER_BEAD_TRUNCATE_LEN):
+def truncate_bead_content(bead, limit=PER_BEAD_TRUNCATE_LEN,
+                          comment_limit=PER_COMMENT_TRUNCATE_LEN):
+    """Truncate per-field text and per-comment bodies in-place. Only flag
+    ``bead["truncated"] = True`` when at least one field or comment was
+    actually shortened — otherwise the marker is dishonest (it claims a
+    reduction that did not occur) and disconnected from real token savings.
+
+    Comments are included because ``content_chars()`` counts them; large
+    comment threads would otherwise blow past the token guard even after
+    'truncation' clipped only the top-level fields."""
+    modified = False
     for k in ("description", "notes", "design", "acceptance_criteria"):
         v = bead.get(k, "") or ""
         if len(v) > limit:
             bead[k] = v[:limit] + "\n…[truncated]"
-    bead["truncated"] = True
+            modified = True
+
+    comments = bead.get("comments") or []
+    if isinstance(comments, list):
+        for c in comments:
+            if isinstance(c, dict):
+                for key in ("body", "text"):
+                    cv = c.get(key)
+                    if isinstance(cv, str) and len(cv) > comment_limit:
+                        c[key] = cv[:comment_limit] + "\n…[truncated]"
+                        modified = True
+
+    if modified:
+        bead["truncated"] = True
+    return modified
 
 
 # ---------------------------------------------------------------------------
@@ -641,8 +666,8 @@ def main():
     if total > TOTAL_CONTENT_CAP:
         for b in detailed_by_id.values():
             if content_chars(b) > PER_BEAD_TRUNCATE_LEN:
-                truncate_bead_content(b)
-                truncated_count += 1
+                if truncate_bead_content(b):
+                    truncated_count += 1
 
     beads_list = list(detailed_by_id.values())
     prefix = detect_prefix(beads_list) or detect_prefix(open_beads + in_progress)

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -203,51 +203,87 @@ def truncate_bead_content(bead, limit=PER_BEAD_TRUNCATE_LEN):
 # Deterministic findings
 # ---------------------------------------------------------------------------
 
+def _resolve_id(suffix, beads_by_id):
+    """Resolve a possibly-short bead id (e.g. '3up3') against the known
+    inventory. Returns the full id or None."""
+    if not suffix:
+        return None
+    if suffix in beads_by_id:
+        return suffix
+    for candidate in beads_by_id:
+        if candidate.endswith("-" + suffix):
+            return candidate
+    return None
+
+
 def find_provenance_mismatches(beads_by_id):
-    """A `produced-bead-Y` label on bead X expects a dep edge:
-    `bd dep add Y X --type discovered-from`. Missing edge → finding."""
+    """Spec R7 — provenance labels on either side must have a matching
+    `discovered-from` dep edge:
+
+    - X-side: bead X carries `produced-bead-Y` → expect edge
+      `bd dep add Y X --type discovered-from`.
+    - Y-side: bead Y carries `produced-from-X` → expect the same edge.
+
+    Both passes are de-duplicated by (dependent_id, blocker_id) so a bead
+    pair that carries both labels is reported once."""
     out = []
+    seen = set()
+
+    def _emit(dependent, blocker, source_label, source_side):
+        key = (dependent, blocker)
+        if key in seen:
+            return
+        seen.add(key)
+        blocker_bead = beads_by_id.get(blocker)
+        # Expected edge: dependent depends-on blocker with type discovered-from.
+        dep_bead = beads_by_id.get(dependent)
+        has_edge = False
+        for dep in (dep_bead or {}).get("dependencies", []) or []:
+            if not isinstance(dep, dict):
+                continue
+            if dep.get("id") == blocker and dep.get("dependency_type") == "discovered-from":
+                has_edge = True
+                break
+        if has_edge:
+            return
+        out.append({
+            "type": "provenance_mismatch",
+            "confidence": "HIGH",
+            "dependent": dependent,
+            "blocker": blocker,
+            "dep_type": "discovered-from",
+            "source_label": source_label,
+            "source_side": source_side,
+            "rationale": (
+                f"Provenance label '{source_label}' on {source_side}-side "
+                f"({blocker if source_side == 'X' else dependent}) implies "
+                f"edge {dependent} --discovered-from--> {blocker}, but no "
+                "such edge exists."
+            ),
+        })
+
+    # X-side pass: produced-bead-Y on bead X.
     for x_id, x in beads_by_id.items():
         for label in x.get("labels", []) or []:
-            if not isinstance(label, str):
+            if not isinstance(label, str) or not label.startswith("produced-bead-"):
                 continue
-            if not label.startswith("produced-bead-"):
-                continue
-            y_id_suffix = label[len("produced-bead-"):]
-            if not y_id_suffix:
-                continue
-            # Try exact match first, then suffix match against known ids.
-            y_id = None
-            if y_id_suffix in beads_by_id:
-                y_id = y_id_suffix
-            else:
-                for candidate in beads_by_id:
-                    if candidate.endswith("-" + y_id_suffix):
-                        y_id = candidate
-                        break
+            y_suffix = label[len("produced-bead-"):]
+            y_id = _resolve_id(y_suffix, beads_by_id)
             if not y_id:
                 continue
-            y = beads_by_id[y_id]
-            # Expected edge: Y depends-on X with type discovered-from.
-            has_edge = False
-            for dep in y.get("dependencies", []) or []:
-                if not isinstance(dep, dict):
-                    continue
-                if dep.get("id") == x_id and dep.get("dependency_type") == "discovered-from":
-                    has_edge = True
-                    break
-            if not has_edge:
-                out.append({
-                    "type": "provenance_mismatch",
-                    "confidence": "HIGH",
-                    "dependent": y_id,
-                    "blocker": x_id,
-                    "dep_type": "discovered-from",
-                    "rationale": (
-                        f"Bead {x_id} carries label '{label}' but {y_id} "
-                        f"has no incoming discovered-from edge from {x_id}."
-                    ),
-                })
+            _emit(dependent=y_id, blocker=x_id, source_label=label, source_side="X")
+
+    # Y-side pass: produced-from-X on bead Y.
+    for y_id, y in beads_by_id.items():
+        for label in y.get("labels", []) or []:
+            if not isinstance(label, str) or not label.startswith("produced-from-"):
+                continue
+            x_suffix = label[len("produced-from-"):]
+            x_id = _resolve_id(x_suffix, beads_by_id)
+            if not x_id:
+                continue
+            _emit(dependent=y_id, blocker=x_id, source_label=label, source_side="Y")
+
     return out
 
 
@@ -342,7 +378,40 @@ def find_stale_blockers(beads_by_id, closed_ids):
     return out
 
 
-def find_cycles():
+def _cycle_touches(cycle, selected_ids):
+    """Return True iff any id in `cycle` is in `selected_ids`. Cycles can be
+    lists of ids, lists of dicts with `id`/`bead_id` keys, or dicts containing
+    a `nodes`/`ids` list — handle all observed shapes defensively."""
+    if not selected_ids:
+        return True
+    candidates = []
+    if isinstance(cycle, list):
+        for item in cycle:
+            if isinstance(item, str):
+                candidates.append(item)
+            elif isinstance(item, dict):
+                for k in ("id", "bead_id", "node"):
+                    v = item.get(k)
+                    if isinstance(v, str):
+                        candidates.append(v)
+    elif isinstance(cycle, dict):
+        for k in ("nodes", "ids", "cycle"):
+            v = cycle.get(k)
+            if isinstance(v, list):
+                for item in v:
+                    if isinstance(item, str):
+                        candidates.append(item)
+                    elif isinstance(item, dict):
+                        cid = item.get("id") or item.get("bead_id")
+                        if isinstance(cid, str):
+                            candidates.append(cid)
+    return any(c in selected_ids for c in candidates)
+
+
+def find_cycles(selected_ids=None):
+    """Run `bd dep cycles --json`. When `selected_ids` is provided, only
+    return cycles that touch at least one id in the selection (focused mode).
+    `selected_ids=None` means return all cycles (all-mode)."""
     rc, out, _err = bd_text("dep", "cycles", "--json")
     if rc != 0 or not out.strip():
         return []
@@ -361,19 +430,22 @@ def find_cycles():
         return []
     if not data:
         return []
-    if isinstance(data, list):
-        return [{
-            "type": "cycle",
-            "confidence": "HIGH",
-            "cycle": c,
-            "rationale": "bd dep cycles reported a cycle in the dep graph.",
-        } for c in data]
+    if not isinstance(data, list):
+        # Non-list scalar (dict, string, etc.) — wrap into a single cycle item.
+        if isinstance(data, dict) and (selected_ids is None or _cycle_touches(data, selected_ids)):
+            return [{
+                "type": "cycle",
+                "confidence": "HIGH",
+                "cycle": data,
+                "rationale": "bd dep cycles reported a cycle in the dep graph.",
+            }]
+        return []
     return [{
         "type": "cycle",
         "confidence": "HIGH",
-        "cycle": data,
+        "cycle": c,
         "rationale": "bd dep cycles reported a cycle in the dep graph.",
-    }]
+    } for c in data if selected_ids is None or _cycle_touches(c, selected_ids)]
 
 
 # ---------------------------------------------------------------------------
@@ -382,8 +454,10 @@ def find_cycles():
 
 def focused_neighborhood(target_id, beads_by_id):
     """Target + 1-hop neighborhood (NEIGHBORHOOD_TYPES) + full parent chain +
-    full child chain. Capped at FOCUSED_BEAD_CAP."""
+    full child chain. Capped at FOCUSED_BEAD_CAP. Parent chain is guaranteed
+    to survive the cap — neighborhood entries are dropped first."""
     selected = {target_id}
+    parent_chain_ids = {target_id}
     target = beads_by_id.get(target_id)
     if not target:
         return list(selected), False
@@ -400,12 +474,14 @@ def focused_neighborhood(target_id, beads_by_id):
             if dep_id:
                 selected.add(dep_id)
 
-    # Parent chain (walk up).
+    # Parent chain (walk up). Tracked separately so the cap can guarantee
+    # the chain is preserved.
     cur = target.get("parent") or ""
     seen = {target_id}
     while cur and cur not in seen:
         seen.add(cur)
         selected.add(cur)
+        parent_chain_ids.add(cur)
         nxt_bead = beads_by_id.get(cur)
         if not nxt_bead:
             # Fetch parent on-demand so chain is complete even for closed parents.
@@ -427,8 +503,10 @@ def focused_neighborhood(target_id, beads_by_id):
 
     capped = False
     if len(selected) > FOCUSED_BEAD_CAP:
-        # Keep target + parent chain + first (FOCUSED_BEAD_CAP - chain) others.
-        ordered = [target_id] + [s for s in selected if s != target_id]
+        # Preserve parent chain first, then fill the remaining cap with the
+        # rest of the neighborhood. Set iteration order is undefined; the
+        # ordered list below guarantees parent chain survives the truncation.
+        ordered = list(parent_chain_ids) + [s for s in selected if s not in parent_chain_ids]
         selected = set(ordered[:FOCUSED_BEAD_CAP])
         capped = True
 
@@ -528,10 +606,21 @@ def main():
 
     # Focused-mode neighborhood selection.
     capped = False
+    cycle_filter_ids = None
     if args.mode == "focused":
         selected_ids, capped = focused_neighborhood(args.target, detailed_by_id)
+        # Some selected neighbors may not be in detailed_by_id yet — e.g. a
+        # closed blocker that didn't appear in the open/in_progress bulk
+        # inventory. Fetch them on-demand so the focused-mode result is
+        # complete.
+        for sid in selected_ids:
+            if sid not in detailed_by_id:
+                fetched = fetch_bead_detail(sid)
+                if fetched is not None:
+                    detailed_by_id[sid] = fetched
         detailed_by_id = {bid: detailed_by_id[bid]
                           for bid in selected_ids if bid in detailed_by_id}
+        cycle_filter_ids = set(selected_ids)
 
     # Token guard: cap total content; truncate per-bead when over.
     total = sum(content_chars(b) for b in detailed_by_id.values())
@@ -550,7 +639,7 @@ def main():
     findings.extend(find_provenance_mismatches(detailed_by_id))
     findings.extend(find_semantic_type_conflicts(detailed_by_id))
     findings.extend(find_stale_blockers(detailed_by_id, closed_ids))
-    findings.extend(find_cycles())
+    findings.extend(find_cycles(selected_ids=cycle_filter_ids))
 
     output = {
         "project_prefix": prefix,

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -26,12 +26,24 @@ import sys
 
 
 # ---------------------------------------------------------------------------
+# Typed sentinel exceptions
+# ---------------------------------------------------------------------------
+
+class BdMissing(Exception):
+    """bd binary not found on PATH."""
+
+class DbMissing(Exception):
+    """bd binary present but no reachable beads database."""
+
+
+# ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-TOTAL_CONTENT_CAP = 600_000          # chars; total content across all beads
-PER_BEAD_TRUNCATE_LEN = 4000         # chars; truncate per-bead content when cap hit
-FOCUSED_BEAD_CAP = 200               # focused-mode neighborhood cap
+TOTAL_CONTENT_CAP = 600_000     # ~150K tokens at ~4 chars/tok; leaves headroom for LLM body in sonnet[1m] context
+PER_BEAD_TRUNCATE_LEN = 4_000   # hard truncation per bead when total cap is exceeded
+FOCUSED_BEAD_CAP = 200          # spec R8 explicit cap; prevents runaway child-chain expansion
+MAX_CHILD_DEPTH = 50            # guards against pathological cycles; child trees are <10 deep in practice
 
 # Dep types we expand through for focused-mode 1-hop neighborhood.
 NEIGHBORHOOD_TYPES = {"blocks", "discovered-from", "tracks", "relates-to"}
@@ -51,8 +63,7 @@ def bd_json(*args, allow_fail=False):
             capture_output=True, text=True, timeout=60,
         )
     except FileNotFoundError:
-        # bd disappeared mid-run — treat as missing.
-        raise RuntimeError("bd_missing")
+        raise BdMissing()
     except subprocess.TimeoutExpired:
         if allow_fail:
             return []
@@ -65,7 +76,7 @@ def bd_json(*args, allow_fail=False):
                    "no beads", "could not open")
         low = stderr.lower()
         if any(m in low for m in markers):
-            raise RuntimeError("db_missing:" + stderr[:200])
+            raise DbMissing(stderr[:200])
         if allow_fail:
             return []
         raise RuntimeError("bd failed: " + stderr[:200])
@@ -155,7 +166,6 @@ def fetch_bead_detail(bead_id):
     if not data:
         return None
     d = data[0]
-    # Normalize sparse fields.
     d.setdefault("description", "")
     d.setdefault("notes", "")
     d.setdefault("parent", "")
@@ -173,7 +183,6 @@ def content_chars(bead):
         bead.get("design", "") or "",
         bead.get("acceptance_criteria", "") or "",
     ]
-    # Comments may be list of dicts.
     for c in bead.get("comments", []) or []:
         if isinstance(c, dict):
             parts.append(c.get("body", "") or c.get("text", "") or "")
@@ -282,8 +291,9 @@ def find_semantic_type_conflicts(beads_by_id):
                             "parent-child relationship should not be 'blocks'."
                         ),
                     })
-            # Bidirectional discovered-from.
-            if dep_type == "discovered-from":
+            # Bidirectional discovered-from: only emit when bid < dep_id so
+            # each symmetric pair is reported exactly once without a dedup pass.
+            if dep_type == "discovered-from" and bid < dep_id:
                 other = beads_by_id.get(dep_id)
                 if not other:
                     continue
@@ -291,30 +301,19 @@ def find_semantic_type_conflicts(beads_by_id):
                     if isinstance(od, dict) \
                        and od.get("id") == bid \
                        and od.get("dependency_type") == "discovered-from":
-                        # Emit once (smaller id first).
-                        a, c = sorted([bid, dep_id])
                         out.append({
                             "type": "semantic_type_conflict",
                             "subtype": "bidirectional_discovered_from",
                             "confidence": "HIGH",
-                            "dependent": a,
-                            "blocker": c,
+                            "dependent": bid,
+                            "blocker": dep_id,
                             "rationale": (
-                                f"{a} and {c} both declare discovered-from "
+                                f"{bid} and {dep_id} both declare discovered-from "
                                 "edges on each other; provenance must be acyclic."
                             ),
                         })
                         break
-    # De-dup
-    seen = set()
-    unique = []
-    for f in out:
-        key = (f["type"], f.get("subtype"), f.get("dependent"), f.get("blocker"))
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(f)
-    return unique
+    return out
 
 
 def find_stale_blockers(beads_by_id, closed_ids):
@@ -417,7 +416,7 @@ def focused_neighborhood(target_id, beads_by_id):
 
     # Child chain (walk down via beads whose parent==target, recursively).
     def walk_down(parent_id, depth=0):
-        if depth > 50:
+        if depth > MAX_CHILD_DEPTH:
             return
         for cid, c in list(beads_by_id.items()):
             if c.get("parent") == parent_id and cid not in selected:
@@ -471,15 +470,14 @@ def main():
         in_progress = bd_json("list", "--status", "in_progress", "--json", "--limit", "0")
         closed_meta = bd_json("list", "--status", "closed", "--json", "--limit", "0",
                               allow_fail=True)
+    except BdMissing:
+        print("error: bd not found on PATH", file=sys.stderr)
+        sys.exit(3)
+    except DbMissing as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(4)
     except RuntimeError as e:
-        msg = str(e)
-        if msg.startswith("db_missing"):
-            print(f"error: {msg}", file=sys.stderr)
-            sys.exit(4)
-        if msg == "bd_missing":
-            print("error: bd not found on PATH", file=sys.stderr)
-            sys.exit(3)
-        print(f"error: {msg}", file=sys.stderr)
+        print(f"error: {e}", file=sys.stderr)
         sys.exit(1)
 
     # Build closed-id set for stale-blocker detection.
@@ -494,17 +492,14 @@ def main():
             continue
         bulk_by_id[bid] = b
 
-    # Focused-mode: validate target exists.
     if args.mode == "focused":
-        # Try bd show directly — works for any status.
+        # bd show resolves any status, including closed — needed for focused audits.
         target_detail = fetch_bead_detail(args.target)
         if not target_detail:
             print(f"error: target bead '{args.target}' not found",
                   file=sys.stderr)
             sys.exit(2)
-        # Ensure target is in bulk_by_id (may be closed, etc.).
         if args.target not in bulk_by_id:
-            # Use the show payload; labels come from there too if present.
             bulk_by_id[args.target] = target_detail
 
     # Decide candidate set.
@@ -516,7 +511,6 @@ def main():
     for bid in candidate_ids:
         d = fetch_bead_detail(bid)
         if d is None:
-            # Fall back to bulk record.
             d = dict(bulk_by_id[bid])
             d.setdefault("description", "")
             d.setdefault("notes", "")
@@ -524,11 +518,10 @@ def main():
             d.setdefault("dependencies", [])
             d.setdefault("dependents", [])
             d.setdefault("comments", [])
-        # Merge labels from bulk.
+        # Labels are only on bulk output, not on `bd show` — merge them in.
         bulk_rec = bulk_by_id.get(bid, {})
         if not d.get("labels"):
             d["labels"] = bulk_rec.get("labels", []) or []
-        # Ensure status is present.
         if not d.get("status"):
             d["status"] = bulk_rec.get("status", "")
         detailed_by_id[bid] = d

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -205,14 +205,17 @@ def truncate_bead_content(bead, limit=PER_BEAD_TRUNCATE_LEN):
 
 def _resolve_id(suffix, beads_by_id):
     """Resolve a possibly-short bead id (e.g. '3up3') against the known
-    inventory. Returns the full id or None."""
+    inventory. Returns the full id, or None when the suffix is unknown OR
+    matches more than one bead (ambiguous short-id — refuse rather than
+    guess; under --just-fix-it a guess could auto-apply a dep edge to the
+    wrong bead)."""
     if not suffix:
         return None
     if suffix in beads_by_id:
         return suffix
-    for candidate in beads_by_id:
-        if candidate.endswith("-" + suffix):
-            return candidate
+    matches = [c for c in beads_by_id if c.endswith("-" + suffix)]
+    if len(matches) == 1:
+        return matches[0]
     return None
 
 
@@ -234,7 +237,6 @@ def find_provenance_mismatches(beads_by_id):
         if key in seen:
             return
         seen.add(key)
-        blocker_bead = beads_by_id.get(blocker)
         # Expected edge: dependent depends-on blocker with type discovered-from.
         dep_bead = beads_by_id.get(dependent)
         has_edge = False
@@ -381,9 +383,15 @@ def find_stale_blockers(beads_by_id, closed_ids):
 def _cycle_touches(cycle, selected_ids):
     """Return True iff any id in `cycle` is in `selected_ids`. Cycles can be
     lists of ids, lists of dicts with `id`/`bead_id` keys, or dicts containing
-    a `nodes`/`ids` list — handle all observed shapes defensively."""
-    if not selected_ids:
+    a `nodes`/`ids` list — handle all observed shapes defensively.
+
+    Empty-set semantics: `selected_ids is None` means "no filter — show all
+    cycles" (all-mode); an explicit empty set means "filter everything out"
+    (focused mode with no resolved neighborhood)."""
+    if selected_ids is None:
         return True
+    if not selected_ids:
+        return False
     candidates = []
     if isinstance(cycle, list):
         for item in cycle:
@@ -409,16 +417,19 @@ def _cycle_touches(cycle, selected_ids):
 
 
 def find_cycles(selected_ids=None):
-    """Run `bd dep cycles --json`. When `selected_ids` is provided, only
-    return cycles that touch at least one id in the selection (focused mode).
-    `selected_ids=None` means return all cycles (all-mode)."""
+    """Run `bd dep cycles --json`. Always returns ALL cycles in the dep
+    graph. In focused mode, each cycle is annotated `in_focused_scope`
+    according to whether it touches `selected_ids`; we deliberately do NOT
+    filter them out — cycles between the parent chain and beads outside
+    the focused neighborhood are still material to the user. `selected_ids
+    is None` (all-mode) omits the annotation."""
     rc, out, _err = bd_text("dep", "cycles", "--json")
     if rc != 0 or not out.strip():
         return []
     try:
         data = json.loads(out)
     except json.JSONDecodeError:
-        # Fall back to plain text.
+        # Fall back to plain text — no cycle structure to annotate.
         rc2, out2, _ = bd_text("dep", "cycles")
         if rc2 == 0 and out2.strip():
             return [{
@@ -430,22 +441,24 @@ def find_cycles(selected_ids=None):
         return []
     if not data:
         return []
+
+    def _wrap(c):
+        item = {
+            "type": "cycle",
+            "confidence": "HIGH",
+            "cycle": c,
+            "rationale": "bd dep cycles reported a cycle in the dep graph.",
+        }
+        if selected_ids is not None:
+            item["in_focused_scope"] = _cycle_touches(c, selected_ids)
+        return item
+
     if not isinstance(data, list):
         # Non-list scalar (dict, string, etc.) — wrap into a single cycle item.
-        if isinstance(data, dict) and (selected_ids is None or _cycle_touches(data, selected_ids)):
-            return [{
-                "type": "cycle",
-                "confidence": "HIGH",
-                "cycle": data,
-                "rationale": "bd dep cycles reported a cycle in the dep graph.",
-            }]
+        if isinstance(data, dict):
+            return [_wrap(data)]
         return []
-    return [{
-        "type": "cycle",
-        "confidence": "HIGH",
-        "cycle": c,
-        "rationale": "bd dep cycles reported a cycle in the dep graph.",
-    } for c in data if selected_ids is None or _cycle_touches(c, selected_ids)]
+    return [_wrap(c) for c in data]
 
 
 # ---------------------------------------------------------------------------

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+dep-health-check/collect.py
+
+Gather the bead inventory plus deterministic dep-graph findings for the
+dep-health-check skill. The LLM body consumes this JSON, classifies each
+finding's confidence, and renders the report.
+
+Usage:
+    python3 collect.py --mode all
+    python3 collect.py --mode focused --target <bead-id>
+
+Exit codes:
+    0 — success (JSON on stdout)
+    2 — usage / unknown args (argparse default)
+    3 — `bd` not on PATH
+    4 — bd database not found
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TOTAL_CONTENT_CAP = 600_000          # chars; total content across all beads
+PER_BEAD_TRUNCATE_LEN = 4000         # chars; truncate per-bead content when cap hit
+FOCUSED_BEAD_CAP = 200               # focused-mode neighborhood cap
+
+# Dep types we expand through for focused-mode 1-hop neighborhood.
+NEIGHBORHOOD_TYPES = {"blocks", "discovered-from", "tracks", "relates-to"}
+
+
+# ---------------------------------------------------------------------------
+# bd CLI helpers
+# ---------------------------------------------------------------------------
+
+def bd_json(*args, allow_fail=False):
+    """Run `bd <args> --json` (caller passes --json explicitly). Return
+    parsed JSON list. On failure: return [] when allow_fail=True; else raise
+    a RuntimeError with stderr captured."""
+    try:
+        result = subprocess.run(
+            ["bd"] + list(args),
+            capture_output=True, text=True, timeout=60,
+        )
+    except FileNotFoundError:
+        # bd disappeared mid-run — treat as missing.
+        raise RuntimeError("bd_missing")
+    except subprocess.TimeoutExpired:
+        if allow_fail:
+            return []
+        raise RuntimeError("bd timed out")
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        # Heuristic: db-not-found markers.
+        markers = ("database", "no such file", "not a beads", "not initialized",
+                   "no beads", "could not open")
+        low = stderr.lower()
+        if any(m in low for m in markers):
+            raise RuntimeError("db_missing:" + stderr[:200])
+        if allow_fail:
+            return []
+        raise RuntimeError("bd failed: " + stderr[:200])
+
+    try:
+        return json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        if allow_fail:
+            return []
+        raise RuntimeError("bd JSON parse failed")
+
+
+def bd_text(*args):
+    """Run a bd command for plain-text output. Returns (rc, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            ["bd"] + list(args),
+            capture_output=True, text=True, timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return (1, "", "")
+    return (result.returncode, result.stdout or "", result.stderr or "")
+
+
+# ---------------------------------------------------------------------------
+# Project prefix detection (mirrors whats-next/collect.py)
+# ---------------------------------------------------------------------------
+
+def detect_prefix(beads):
+    ids = [b.get("id", "") for b in beads if b.get("id")]
+    if len(ids) < 2:
+        return None
+    common = ids[0]
+    for bid in ids[1:]:
+        while common and not bid.startswith(common):
+            common = common[:-1]
+        if not common:
+            return None
+    last_dash = common.rfind("-")
+    if last_dash <= 0:
+        return None
+    prefix = common[:last_dash]
+    return prefix if len(prefix) >= 2 else None
+
+
+# ---------------------------------------------------------------------------
+# Db reachability probe
+# ---------------------------------------------------------------------------
+
+def db_reachable():
+    """Return True iff bd can reach a db from cwd. Primary signal is the
+    presence of a `.beads/` directory in cwd or any ancestor — this is the
+    canonical location of a beads database. bd itself happily returns an
+    empty list with a warning when no config is found, so we cannot rely on
+    bd's exit code alone."""
+    # 1. Filesystem probe: any ancestor containing .beads/ ?
+    cur = os.getcwd()
+    while True:
+        if os.path.isdir(os.path.join(cur, ".beads")):
+            return True
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+
+    # 2. Fallback: bd probe. Even when no .beads/ exists, bd may resolve a
+    # configured db elsewhere. Treat a clean bd run with stderr that does NOT
+    # mention "no beads configuration found" as reachable.
+    rc, _out, err = bd_text("list", "--json", "--limit", "1")
+    if rc == 0:
+        low = (err or "").lower()
+        if "no beads configuration found" in low or "no beads configuration" in low:
+            return False
+        return True
+
+    # bd failed — surface as not reachable.
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-bead detail with sparse-field defaults
+# ---------------------------------------------------------------------------
+
+def fetch_bead_detail(bead_id):
+    """`bd show <id> --json` with safe defaults for sparse fields."""
+    data = bd_json("show", bead_id, "--json", allow_fail=True)
+    if not data:
+        return None
+    d = data[0]
+    # Normalize sparse fields.
+    d.setdefault("description", "")
+    d.setdefault("notes", "")
+    d.setdefault("parent", "")
+    d.setdefault("dependencies", [])
+    d.setdefault("dependents", [])
+    d.setdefault("comments", [])
+    return d
+
+
+def content_chars(bead):
+    parts = [
+        bead.get("title", "") or "",
+        bead.get("description", "") or "",
+        bead.get("notes", "") or "",
+        bead.get("design", "") or "",
+        bead.get("acceptance_criteria", "") or "",
+    ]
+    # Comments may be list of dicts.
+    for c in bead.get("comments", []) or []:
+        if isinstance(c, dict):
+            parts.append(c.get("body", "") or c.get("text", "") or "")
+        else:
+            parts.append(str(c))
+    return sum(len(p) for p in parts)
+
+
+def truncate_bead_content(bead, limit=PER_BEAD_TRUNCATE_LEN):
+    for k in ("description", "notes", "design", "acceptance_criteria"):
+        v = bead.get(k, "") or ""
+        if len(v) > limit:
+            bead[k] = v[:limit] + "\n…[truncated]"
+    bead["truncated"] = True
+
+
+# ---------------------------------------------------------------------------
+# Deterministic findings
+# ---------------------------------------------------------------------------
+
+def find_provenance_mismatches(beads_by_id):
+    """A `produced-bead-Y` label on bead X expects a dep edge:
+    `bd dep add Y X --type discovered-from`. Missing edge → finding."""
+    out = []
+    for x_id, x in beads_by_id.items():
+        for label in x.get("labels", []) or []:
+            if not isinstance(label, str):
+                continue
+            if not label.startswith("produced-bead-"):
+                continue
+            y_id_suffix = label[len("produced-bead-"):]
+            if not y_id_suffix:
+                continue
+            # Try exact match first, then suffix match against known ids.
+            y_id = None
+            if y_id_suffix in beads_by_id:
+                y_id = y_id_suffix
+            else:
+                for candidate in beads_by_id:
+                    if candidate.endswith("-" + y_id_suffix):
+                        y_id = candidate
+                        break
+            if not y_id:
+                continue
+            y = beads_by_id[y_id]
+            # Expected edge: Y depends-on X with type discovered-from.
+            has_edge = False
+            for dep in y.get("dependencies", []) or []:
+                if not isinstance(dep, dict):
+                    continue
+                if dep.get("id") == x_id and dep.get("dependency_type") == "discovered-from":
+                    has_edge = True
+                    break
+            if not has_edge:
+                out.append({
+                    "type": "provenance_mismatch",
+                    "confidence": "HIGH",
+                    "dependent": y_id,
+                    "blocker": x_id,
+                    "dep_type": "discovered-from",
+                    "rationale": (
+                        f"Bead {x_id} carries label '{label}' but {y_id} "
+                        f"has no incoming discovered-from edge from {x_id}."
+                    ),
+                })
+    return out
+
+
+def find_semantic_type_conflicts(beads_by_id):
+    """blocks edges between parent-child pairs; bidirectional discovered-from."""
+    out = []
+    for bid, b in beads_by_id.items():
+        parent = b.get("parent") or ""
+        for dep in b.get("dependencies", []) or []:
+            if not isinstance(dep, dict):
+                continue
+            dep_id = dep.get("id")
+            dep_type = dep.get("dependency_type")
+            if not dep_id or not dep_type:
+                continue
+            # blocks between parent-child.
+            if dep_type == "blocks":
+                if parent and dep_id == parent:
+                    out.append({
+                        "type": "semantic_type_conflict",
+                        "subtype": "blocks_on_parent",
+                        "confidence": "HIGH",
+                        "dependent": bid,
+                        "blocker": dep_id,
+                        "rationale": (
+                            f"{bid} declares blocks edge on its parent {dep_id}; "
+                            "parent-child relationship should not be 'blocks'."
+                        ),
+                    })
+                # child blocks check via reverse: if dep_id's parent is bid
+                other = beads_by_id.get(dep_id)
+                if other and other.get("parent") == bid:
+                    out.append({
+                        "type": "semantic_type_conflict",
+                        "subtype": "blocks_on_child",
+                        "confidence": "HIGH",
+                        "dependent": bid,
+                        "blocker": dep_id,
+                        "rationale": (
+                            f"{bid} declares blocks edge on its child {dep_id}; "
+                            "parent-child relationship should not be 'blocks'."
+                        ),
+                    })
+            # Bidirectional discovered-from.
+            if dep_type == "discovered-from":
+                other = beads_by_id.get(dep_id)
+                if not other:
+                    continue
+                for od in other.get("dependencies", []) or []:
+                    if isinstance(od, dict) \
+                       and od.get("id") == bid \
+                       and od.get("dependency_type") == "discovered-from":
+                        # Emit once (smaller id first).
+                        a, c = sorted([bid, dep_id])
+                        out.append({
+                            "type": "semantic_type_conflict",
+                            "subtype": "bidirectional_discovered_from",
+                            "confidence": "HIGH",
+                            "dependent": a,
+                            "blocker": c,
+                            "rationale": (
+                                f"{a} and {c} both declare discovered-from "
+                                "edges on each other; provenance must be acyclic."
+                            ),
+                        })
+                        break
+    # De-dup
+    seen = set()
+    unique = []
+    for f in out:
+        key = (f["type"], f.get("subtype"), f.get("dependent"), f.get("blocker"))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(f)
+    return unique
+
+
+def find_stale_blockers(beads_by_id, closed_ids):
+    """Open bead whose every `blocks`-type incoming blocker is closed."""
+    out = []
+    for bid, b in beads_by_id.items():
+        if b.get("status") == "closed":
+            continue
+        # `dependencies` on b are the blockers OF b (b is dependent).
+        blocks_deps = [d for d in (b.get("dependencies") or [])
+                       if isinstance(d, dict) and d.get("dependency_type") == "blocks"]
+        if not blocks_deps:
+            continue
+        all_closed = all(d.get("id") in closed_ids for d in blocks_deps)
+        if all_closed:
+            out.append({
+                "type": "stale_blocker",
+                "confidence": "HIGH",
+                "dependent": bid,
+                "blocker_ids": [d.get("id") for d in blocks_deps],
+                "rationale": (
+                    f"All blocks-type blockers of {bid} are closed; "
+                    "the bead may be ready or its dep edges are stale."
+                ),
+            })
+    return out
+
+
+def find_cycles():
+    rc, out, _err = bd_text("dep", "cycles", "--json")
+    if rc != 0 or not out.strip():
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        # Fall back to plain text.
+        rc2, out2, _ = bd_text("dep", "cycles")
+        if rc2 == 0 and out2.strip():
+            return [{
+                "type": "cycle",
+                "confidence": "HIGH",
+                "raw": out2.strip()[:2000],
+                "rationale": "bd dep cycles reported a cycle in the dep graph.",
+            }]
+        return []
+    if not data:
+        return []
+    if isinstance(data, list):
+        return [{
+            "type": "cycle",
+            "confidence": "HIGH",
+            "cycle": c,
+            "rationale": "bd dep cycles reported a cycle in the dep graph.",
+        } for c in data]
+    return [{
+        "type": "cycle",
+        "confidence": "HIGH",
+        "cycle": data,
+        "rationale": "bd dep cycles reported a cycle in the dep graph.",
+    }]
+
+
+# ---------------------------------------------------------------------------
+# Focused-mode neighborhood
+# ---------------------------------------------------------------------------
+
+def focused_neighborhood(target_id, beads_by_id):
+    """Target + 1-hop neighborhood (NEIGHBORHOOD_TYPES) + full parent chain +
+    full child chain. Capped at FOCUSED_BEAD_CAP."""
+    selected = {target_id}
+    target = beads_by_id.get(target_id)
+    if not target:
+        return list(selected), False
+
+    # 1-hop via dependencies/dependents on the target.
+    for dep in target.get("dependencies", []) or []:
+        if isinstance(dep, dict) and dep.get("dependency_type") in NEIGHBORHOOD_TYPES:
+            dep_id = dep.get("id")
+            if dep_id:
+                selected.add(dep_id)
+    for dep in target.get("dependents", []) or []:
+        if isinstance(dep, dict) and dep.get("dependency_type") in NEIGHBORHOOD_TYPES:
+            dep_id = dep.get("id")
+            if dep_id:
+                selected.add(dep_id)
+
+    # Parent chain (walk up).
+    cur = target.get("parent") or ""
+    seen = {target_id}
+    while cur and cur not in seen:
+        seen.add(cur)
+        selected.add(cur)
+        nxt_bead = beads_by_id.get(cur)
+        if not nxt_bead:
+            # Fetch parent on-demand so chain is complete even for closed parents.
+            nxt_bead = fetch_bead_detail(cur)
+            if nxt_bead:
+                beads_by_id[cur] = nxt_bead
+        cur = (nxt_bead or {}).get("parent") or ""
+
+    # Child chain (walk down via beads whose parent==target, recursively).
+    def walk_down(parent_id, depth=0):
+        if depth > 50:
+            return
+        for cid, c in list(beads_by_id.items()):
+            if c.get("parent") == parent_id and cid not in selected:
+                selected.add(cid)
+                walk_down(cid, depth + 1)
+
+    walk_down(target_id)
+
+    capped = False
+    if len(selected) > FOCUSED_BEAD_CAP:
+        # Keep target + parent chain + first (FOCUSED_BEAD_CAP - chain) others.
+        ordered = [target_id] + [s for s in selected if s != target_id]
+        selected = set(ordered[:FOCUSED_BEAD_CAP])
+        capped = True
+
+    return list(selected), capped
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect bead inventory + dep-graph findings for dep-health-check."
+    )
+    parser.add_argument("--mode", required=True, choices=["all", "focused"])
+    parser.add_argument("--target", default=None,
+                        help="Required when --mode focused.")
+    args = parser.parse_args()
+
+    # Argparse-level argcheck.
+    if args.mode == "focused" and not args.target:
+        print("error: --target is required when --mode focused", file=sys.stderr)
+        sys.exit(2)
+
+    # Exit 3: bd missing.
+    if shutil.which("bd") is None:
+        print("error: bd not found on PATH", file=sys.stderr)
+        sys.exit(3)
+
+    # Exit 4: db not reachable.
+    if not db_reachable():
+        print("error: bd database not found (no .beads/ in this or any parent directory)",
+              file=sys.stderr)
+        sys.exit(4)
+
+    # Bulk inventory (note --limit 0 to defeat the 50-row default).
+    try:
+        open_beads = bd_json("list", "--status", "open", "--json", "--limit", "0")
+        in_progress = bd_json("list", "--status", "in_progress", "--json", "--limit", "0")
+        closed_meta = bd_json("list", "--status", "closed", "--json", "--limit", "0",
+                              allow_fail=True)
+    except RuntimeError as e:
+        msg = str(e)
+        if msg.startswith("db_missing"):
+            print(f"error: {msg}", file=sys.stderr)
+            sys.exit(4)
+        if msg == "bd_missing":
+            print("error: bd not found on PATH", file=sys.stderr)
+            sys.exit(3)
+        print(f"error: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build closed-id set for stale-blocker detection.
+    closed_ids = set(b.get("id") for b in closed_meta if b.get("id"))
+
+    # Bulk inventory keyed by id, retaining labels (labels are only on bulk
+    # output, not on `bd show`).
+    bulk_by_id = {}
+    for b in (open_beads + in_progress):
+        bid = b.get("id")
+        if not bid:
+            continue
+        bulk_by_id[bid] = b
+
+    # Focused-mode: validate target exists.
+    if args.mode == "focused":
+        # Try bd show directly — works for any status.
+        target_detail = fetch_bead_detail(args.target)
+        if not target_detail:
+            print(f"error: target bead '{args.target}' not found",
+                  file=sys.stderr)
+            sys.exit(2)
+        # Ensure target is in bulk_by_id (may be closed, etc.).
+        if args.target not in bulk_by_id:
+            # Use the show payload; labels come from there too if present.
+            bulk_by_id[args.target] = target_detail
+
+    # Decide candidate set.
+    candidate_ids = list(bulk_by_id.keys())
+
+    # Fetch per-bead detail for every candidate. Merge labels from bulk into
+    # the detailed view (labels are not part of `bd show`).
+    detailed_by_id = {}
+    for bid in candidate_ids:
+        d = fetch_bead_detail(bid)
+        if d is None:
+            # Fall back to bulk record.
+            d = dict(bulk_by_id[bid])
+            d.setdefault("description", "")
+            d.setdefault("notes", "")
+            d.setdefault("parent", "")
+            d.setdefault("dependencies", [])
+            d.setdefault("dependents", [])
+            d.setdefault("comments", [])
+        # Merge labels from bulk.
+        bulk_rec = bulk_by_id.get(bid, {})
+        if not d.get("labels"):
+            d["labels"] = bulk_rec.get("labels", []) or []
+        # Ensure status is present.
+        if not d.get("status"):
+            d["status"] = bulk_rec.get("status", "")
+        detailed_by_id[bid] = d
+
+    # Focused-mode neighborhood selection.
+    capped = False
+    if args.mode == "focused":
+        selected_ids, capped = focused_neighborhood(args.target, detailed_by_id)
+        detailed_by_id = {bid: detailed_by_id[bid]
+                          for bid in selected_ids if bid in detailed_by_id}
+
+    # Token guard: cap total content; truncate per-bead when over.
+    total = sum(content_chars(b) for b in detailed_by_id.values())
+    truncated_count = 0
+    if total > TOTAL_CONTENT_CAP:
+        for b in detailed_by_id.values():
+            if content_chars(b) > PER_BEAD_TRUNCATE_LEN:
+                truncate_bead_content(b)
+                truncated_count += 1
+
+    beads_list = list(detailed_by_id.values())
+    prefix = detect_prefix(beads_list) or detect_prefix(open_beads + in_progress)
+
+    # Deterministic findings.
+    findings = []
+    findings.extend(find_provenance_mismatches(detailed_by_id))
+    findings.extend(find_semantic_type_conflicts(detailed_by_id))
+    findings.extend(find_stale_blockers(detailed_by_id, closed_ids))
+    findings.extend(find_cycles())
+
+    output = {
+        "project_prefix": prefix,
+        "mode": args.mode,
+        "target": args.target,
+        "bead_count": len(beads_list),
+        "truncated_count": truncated_count,
+        "capped": capped,
+        "beads": beads_list,
+        "findings": findings,
+    }
+
+    print(json.dumps(output, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -493,13 +493,27 @@ def find_cycles(selected_ids=None):
 
 def focused_neighborhood(target_id, beads_by_id):
     """Target + 1-hop neighborhood (NEIGHBORHOOD_TYPES) + full parent chain +
-    full child chain. Capped at FOCUSED_BEAD_CAP. Parent chain is guaranteed
-    to survive the cap — neighborhood entries are dropped first.
+    full child chain. Capped at FOCUSED_BEAD_CAP.
 
     Returns a deterministically ordered list of bead ids:
-      1. Parent chain in traversal order (root first → ... → target's immediate parent)
+      1. Parent chain in walk order (root first → ... → target's immediate parent)
       2. The target bead
       3. Remaining 1-hop neighbors and descendants, sorted by id
+
+    Cap precedence when ``len(selected) > FOCUSED_BEAD_CAP``:
+      - The **target** is guaranteed to survive (it is placed at the head
+        and the parent chain is truncated around it if necessary).
+      - The parent chain is preserved next, in walk order, truncated from
+        the ROOT end first so the closest ancestors remain alongside the
+        target.
+      - Remaining neighborhood entries (sorted by id) fill any leftover
+        slots.
+
+    The pathological case ``len(parent_chain_ids) + 1 > FOCUSED_BEAD_CAP``
+    is uncommon in practice (project parent chains are <10 deep) but is
+    handled explicitly rather than relying on slice semantics: dropping
+    the target would silently break every downstream consumer that pivots
+    on the target id.
 
     An OrderedDict (used as an ordered set) tracks membership while
     preserving insertion order; the final remaining-neighbor block is
@@ -565,22 +579,26 @@ def focused_neighborhood(target_id, beads_by_id):
 
     parent_chain_set = set(parent_chain_ids)
     capped = False
+    remaining_sorted = sorted(
+        s for s in selected
+        if s != target_id and s not in parent_chain_set
+    )
     if len(selected) > FOCUSED_BEAD_CAP:
-        # Preserve parent chain first, then fill the remaining cap with the
-        # rest of the neighborhood sorted by id so cap-truncation is
-        # deterministic.
-        remaining_sorted = sorted(
-            s for s in selected
-            if s != target_id and s not in parent_chain_set
-        )
-        ordered = parent_chain_ids + [target_id] + remaining_sorted
-        ordered = ordered[:FOCUSED_BEAD_CAP]
         capped = True
+        # Target is non-negotiable — it anchors the focused view. Allocate
+        # the remaining (cap - 1) slots to as much of the parent chain as
+        # fits (truncating from the ROOT end so the closest ancestors
+        # stay), then fill any leftover with sorted neighborhood entries.
+        budget = FOCUSED_BEAD_CAP - 1
+        if len(parent_chain_ids) >= budget:
+            # Pathological: chain alone fills (or overflows) the cap.
+            # Keep the closest `budget` ancestors (tail of walk order).
+            kept_chain = parent_chain_ids[-budget:] if budget > 0 else []
+            ordered = kept_chain + [target_id]
+        else:
+            slots_left = budget - len(parent_chain_ids)
+            ordered = parent_chain_ids + [target_id] + remaining_sorted[:slots_left]
     else:
-        remaining_sorted = sorted(
-            s for s in selected
-            if s != target_id and s not in parent_chain_set
-        )
         ordered = parent_chain_ids + [target_id] + remaining_sorted
 
     return ordered, capped

--- a/src/plugins/beads/.agents/skills/dep-health-check/collect.py
+++ b/src/plugins/beads/.agents/skills/dep-health-check/collect.py
@@ -660,14 +660,33 @@ def main():
                           for bid in selected_ids if bid in detailed_by_id}
         cycle_filter_ids = set(selected_ids)
 
-    # Token guard: cap total content; truncate per-bead when over.
+    # Token guard: cap total content; truncate per-bead until total is under
+    # the cap. First pass uses PER_BEAD_TRUNCATE_LEN; if the total is still
+    # over the cap (e.g. many beads near the per-bead limit, or large comment
+    # bodies summing past the cap), a second pass applies an aggressive
+    # cap // bead_count per-bead limit so total <= TOTAL_CONTENT_CAP is
+    # actually guaranteed. `>=` ensures exact-limit beads are still trimmed
+    # when the second pass demands a smaller limit.
+    truncated_ids = set()
     total = sum(content_chars(b) for b in detailed_by_id.values())
-    truncated_count = 0
     if total > TOTAL_CONTENT_CAP:
-        for b in detailed_by_id.values():
-            if content_chars(b) > PER_BEAD_TRUNCATE_LEN:
+        # First pass: per-bead PER_BEAD_TRUNCATE_LEN.
+        for bid, b in detailed_by_id.items():
+            if content_chars(b) >= PER_BEAD_TRUNCATE_LEN:
                 if truncate_bead_content(b):
-                    truncated_count += 1
+                    truncated_ids.add(bid)
+        total = sum(content_chars(b) for b in detailed_by_id.values())
+
+        # Second pass: aggressive cap // num_beads when still over.
+        if total > TOTAL_CONTENT_CAP and detailed_by_id:
+            aggressive_limit = max(256, TOTAL_CONTENT_CAP // len(detailed_by_id))
+            aggressive_comment_limit = max(128, aggressive_limit // 4)
+            for bid, b in detailed_by_id.items():
+                if content_chars(b) >= aggressive_limit:
+                    if truncate_bead_content(b, limit=aggressive_limit,
+                                             comment_limit=aggressive_comment_limit):
+                        truncated_ids.add(bid)
+    truncated_count = len(truncated_ids)
 
     beads_list = list(detailed_by_id.values())
     prefix = detect_prefix(beads_list) or detect_prefix(open_beads + in_progress)

--- a/src/plugins/beads/.claude/commands/dep-health-check.md
+++ b/src/plugins/beads/.claude/commands/dep-health-check.md
@@ -1,0 +1,1 @@
+Skill dep-health-check $ARGUMENTS

--- a/src/user/.agents/skills/dep-health-check/_test.sh
+++ b/src/user/.agents/skills/dep-health-check/_test.sh
@@ -94,29 +94,6 @@ grep_not_in() {
   return 0
 }
 
-# section_has <file> <header-pattern> <body-pattern> <label>
-section_has() {
-  local file="$1" header="$2" body="$3" lab="$4"
-  if [ ! -f "$file" ]; then
-    fail "$lab" "file not found: $file"
-    return 1
-  fi
-  awk -v header="$header" -v body="$body" '
-    BEGIN { in_section=0; found=0 }
-    {
-      if ($0 ~ header) { in_section=1; next }
-      if (in_section && $0 ~ body) { found=1; exit }
-    }
-    END { exit found ? 0 : 1 }
-  ' "$file"
-  if [ $? -eq 0 ]; then
-    pass "$lab"
-    return 0
-  fi
-  fail "$lab" "did not find body /$body/ after header /$header/ in $file"
-  return 1
-}
-
 # ===========================================================================
 # AC2 — Install staging recognizes dep-health-check skill.
 #       scripts/install.sh --dry-run exits 0 AND output mentions
@@ -129,23 +106,30 @@ if [ ! -f "$INSTALL_SH" ]; then
 else
   pass "AC2 install.sh present"
 
-  # Use --plugins= so the test carrier dir under src/user/.agents/skills/
-  # does not collide with the plugin skill dir during staging. (Same model
-  # the repo uses for resolve-human-bead.) The carrier dir alone is enough
-  # to surface "skills/dep-health-check" in the dry-run output.
-  DRY_OUT="$(cd "$REPO_ROOT" && bash "$INSTALL_SH" --dry-run --tools=claude --plugins= 2>&1)"
+  # Exercise the ACTUAL beads-plugin staging path with --plugins=beads
+  # --verbose so we can see plugin-skill placement in the dry-run output.
+  # The carrier dir under src/user/.agents/skills/dep-health-check/ and the
+  # plugin skill dir under src/plugins/beads/.agents/skills/dep-health-check/
+  # follow the same merge model as resolve-human-bead; install.sh handles
+  # the collision. If --plugins=beads --verbose surfaces a fatal collision
+  # error here, the test will fail loudly — that is the intended signal.
+  DRY_OUT="$(cd "$REPO_ROOT" && bash "$INSTALL_SH" --dry-run --tools=claude --plugins=beads --verbose 2>&1)"
   DRY_RC=$?
   if [ "$DRY_RC" -eq 0 ]; then
     pass "AC2 install.sh --dry-run exit 0"
   else
-    fail "AC2 install.sh --dry-run exit 0" "exit code: $DRY_RC"
+    fail "AC2 install.sh --dry-run exit 0" "exit code: $DRY_RC; output tail: $(printf '%s\n' "$DRY_OUT" | tail -c 600)"
   fi
 
-  if printf '%s\n' "$DRY_OUT" | grep -Fq "dep-health-check"; then
-    pass "AC2 dry-run output mentions dep-health-check"
+  # Must mention dep-health-check AND it must appear in a plugin-skill
+  # staging line (i.e. paths under plugins/beads/...skills/dep-health-check).
+  # Without this, an implementer could place SKILL.md in the carrier dir
+  # alone and the test would pass — that's the bug Codex flagged.
+  if printf '%s\n' "$DRY_OUT" | grep -Eq "(plugins/beads|beads-plugin|beads).*skills/dep-health-check"; then
+    pass "AC2 dry-run output stages beads-plugin dep-health-check skill"
   else
-    fail "AC2 dry-run output mentions dep-health-check" \
-      "no 'dep-health-check' line in install.sh --dry-run output"
+    fail "AC2 dry-run output stages beads-plugin dep-health-check skill" \
+      "expected a staging line mentioning the beads plugin and skills/dep-health-check; got tail: $(printf '%s\n' "$DRY_OUT" | tail -c 600)"
   fi
 fi
 
@@ -221,6 +205,16 @@ else
     fail "AC4 beads is list and bead_count is int" "wrong types"
   fi
 
+  # bead_count must be positive AND equal len(beads). This repo has 100+
+  # open beads — an empty graph result from --mode all is a defect, not a
+  # boundary case. Mirrors the AC5 focused-mode count check.
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert d['bead_count']>0 and d['bead_count']==len(d.get('beads',[]))" 2>/dev/null; then
+    pass "AC4 bead_count > 0 and matches len(beads)"
+  else
+    fail "AC4 bead_count > 0 and matches len(beads)" \
+      "expected positive bead_count matching len(beads) for --mode all against live repo"
+  fi
+
   rm -f "$OUT_FILE" "$ERR_FILE"
 fi
 
@@ -238,11 +232,13 @@ echo "[ac5_collect_mode_focused_json]"
 # checkout. We DO NOT silently skip — if no target can be found, that is a
 # failure.
 TARGET=""
+# bd resolves the bead store relative to CWD; run the probes inside REPO_ROOT
+# so that the test works regardless of where the runner invoked it from.
 if command -v bd >/dev/null 2>&1; then
-  if bd show agents-config-3up3 >/dev/null 2>&1; then
+  if ( cd "$REPO_ROOT" && bd show agents-config-3up3 >/dev/null 2>&1 ); then
     TARGET="agents-config-3up3"
   else
-    TARGET="$(bd ready --json 2>/dev/null | python3 -c "import sys,json
+    TARGET="$( ( cd "$REPO_ROOT" && bd ready --json 2>/dev/null ) | python3 -c "import sys,json
 try:
     d=json.load(sys.stdin)
     print(d[0]['id'] if d else '')
@@ -326,22 +322,15 @@ else
   fi
 
   # 6b: bd not on PATH -> 3
-  # Construct a minimal PATH that contains python3 but excludes bd.
-  PY_DIR="$(dirname "$(command -v python3)")"
-  RESTRICTED_PATH="$PY_DIR:/usr/bin:/bin"
-  if command -v bd >/dev/null 2>&1; then
-    BD_DIR="$(dirname "$(command -v bd)")"
-    # Make sure the restricted PATH really excludes bd.
-    case ":$RESTRICTED_PATH:" in
-      *":$BD_DIR:"*)
-        # bd is in /usr/bin or /bin somehow; relocate by using only PY_DIR.
-        RESTRICTED_PATH="$PY_DIR"
-        ;;
-    esac
-  fi
-  ( cd "$REPO_ROOT" && env -i PATH="$RESTRICTED_PATH" HOME="$HOME" \
+  # Construct a temp bin dir containing ONLY a python3 symlink. This
+  # guarantees no bd leak regardless of where bd actually lives — sharing
+  # /usr/bin or /opt/homebrew/bin with bd was the bug Codex flagged.
+  TMP_BIN="$(mktemp -d -t depcheck-bin.XXXXXX)"
+  ln -s "$(command -v python3)" "$TMP_BIN/python3"
+  ( cd "$REPO_ROOT" && env -i PATH="$TMP_BIN" HOME="$HOME" \
       python3 "$COLLECT_PY" --mode all >/dev/null 2>&1 )
   RC=$?
+  rm -rf "$TMP_BIN"
   if [ "$RC" -eq 3 ]; then
     pass "AC6 bd not on PATH -> exit 3"
   else

--- a/src/user/.agents/skills/dep-health-check/_test.sh
+++ b/src/user/.agents/skills/dep-health-check/_test.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# Red-phase tests for bead agents-config-he9o:
+#   "Implement dep-health-check skill"
+#
+# These tests fail until the dep-health-check skill exists in the beads
+# plugin (SKILL.md + collect.py), the slash-command wrapper is in place,
+# and scripts/install.sh stages the new skill.
+#
+# Discovery: this file sits under src/user/.agents/skills/dep-health-check/
+# so the project test runner picks it up (find ... -name '*_test.sh'),
+# but every assertion targets paths under src/plugins/beads/. The shared
+# "dep-health-check" entry under .agents is the carrier directory for these
+# contract tests; the actual SKILL.md + collect.py ship in the beads plugin.
+#
+# Pattern adapted from src/user/.agents/skills/resolve-human-bead/_test.sh.
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# HERE = src/user/.agents/skills/dep-health-check; repo root is five levels up.
+REPO_ROOT="$(cd "$HERE/../../../../.." && pwd)"
+
+SKILL_DIR="$REPO_ROOT/src/plugins/beads/.agents/skills/dep-health-check"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+COLLECT_PY="$SKILL_DIR/collect.py"
+CMD_MD="$REPO_ROOT/src/plugins/beads/.claude/commands/dep-health-check.md"
+INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+
+FAIL=0
+
+# ----- helpers -------------------------------------------------------------
+
+pass() { echo "  ok: $1"; }
+
+fail() {
+  echo "  FAIL: $1"
+  if [ "${2:-}" != "" ]; then
+    echo "        $2"
+  fi
+  FAIL=1
+}
+
+require_file() {
+  if [ -f "$1" ]; then
+    pass "$2 exists ($1)"
+    return 0
+  fi
+  fail "$2 missing" "expected file: $1"
+  return 1
+}
+
+# grep_in <file> <pattern> <label>  (ERE)
+grep_in() {
+  local file="$1" pat="$2" lab="$3"
+  if [ ! -f "$file" ]; then
+    fail "$lab" "file not found: $file"
+    return 1
+  fi
+  if grep -Eq -- "$pat" "$file"; then
+    pass "$lab"
+    return 0
+  fi
+  fail "$lab" "pattern not found in $file: $pat"
+  return 1
+}
+
+# grep_in_fixed <file> <fixed-string> <label>
+grep_in_fixed() {
+  local file="$1" pat="$2" lab="$3"
+  if [ ! -f "$file" ]; then
+    fail "$lab" "file not found: $file"
+    return 1
+  fi
+  if grep -Fq -- "$pat" "$file"; then
+    pass "$lab"
+    return 0
+  fi
+  fail "$lab" "string not found in $file: $pat"
+  return 1
+}
+
+# grep_not_in <file> <fixed-string> <label>
+grep_not_in() {
+  local file="$1" pat="$2" lab="$3"
+  if [ ! -f "$file" ]; then
+    fail "$lab" "file not found: $file"
+    return 1
+  fi
+  if grep -Fq -- "$pat" "$file"; then
+    fail "$lab" "forbidden string present in $file: $pat"
+    return 1
+  fi
+  pass "$lab"
+  return 0
+}
+
+# section_has <file> <header-pattern> <body-pattern> <label>
+section_has() {
+  local file="$1" header="$2" body="$3" lab="$4"
+  if [ ! -f "$file" ]; then
+    fail "$lab" "file not found: $file"
+    return 1
+  fi
+  awk -v header="$header" -v body="$body" '
+    BEGIN { in_section=0; found=0 }
+    {
+      if ($0 ~ header) { in_section=1; next }
+      if (in_section && $0 ~ body) { found=1; exit }
+    }
+    END { exit found ? 0 : 1 }
+  ' "$file"
+  if [ $? -eq 0 ]; then
+    pass "$lab"
+    return 0
+  fi
+  fail "$lab" "did not find body /$body/ after header /$header/ in $file"
+  return 1
+}
+
+# ===========================================================================
+# AC2 — Install staging recognizes dep-health-check skill.
+#       scripts/install.sh --dry-run exits 0 AND output mentions
+#       "dep-health-check" under the skills sync section.
+# ===========================================================================
+echo "[ac2_install_dry_run_lists_skill]"
+
+if [ ! -f "$INSTALL_SH" ]; then
+  fail "AC2 install.sh present" "expected: $INSTALL_SH"
+else
+  pass "AC2 install.sh present"
+
+  # Use --plugins= so the test carrier dir under src/user/.agents/skills/
+  # does not collide with the plugin skill dir during staging. (Same model
+  # the repo uses for resolve-human-bead.) The carrier dir alone is enough
+  # to surface "skills/dep-health-check" in the dry-run output.
+  DRY_OUT="$(cd "$REPO_ROOT" && bash "$INSTALL_SH" --dry-run --tools=claude --plugins= 2>&1)"
+  DRY_RC=$?
+  if [ "$DRY_RC" -eq 0 ]; then
+    pass "AC2 install.sh --dry-run exit 0"
+  else
+    fail "AC2 install.sh --dry-run exit 0" "exit code: $DRY_RC"
+  fi
+
+  if printf '%s\n' "$DRY_OUT" | grep -Fq "dep-health-check"; then
+    pass "AC2 dry-run output mentions dep-health-check"
+  else
+    fail "AC2 dry-run output mentions dep-health-check" \
+      "no 'dep-health-check' line in install.sh --dry-run output"
+  fi
+fi
+
+# ===========================================================================
+# AC3 — /dep-health-check slash command exists; body is exactly
+#       'Skill dep-health-check $ARGUMENTS' and contains no other content.
+# ===========================================================================
+echo "[ac3_slash_command_body]"
+
+require_file "$CMD_MD" "AC3 slash command file"
+if [ -f "$CMD_MD" ]; then
+  EXPECTED='Skill dep-health-check $ARGUMENTS'
+  # Strip trailing whitespace/newlines for the equality check.
+  ACTUAL="$(awk '{print}' "$CMD_MD" | sed -e 's/[[:space:]]*$//' )"
+  # Body must be a single non-empty line equal to EXPECTED.
+  LINE_COUNT="$(grep -c -v '^[[:space:]]*$' "$CMD_MD" 2>/dev/null || echo 0)"
+  if [ "$LINE_COUNT" = "1" ] && [ "$ACTUAL" = "$EXPECTED" ]; then
+    pass "AC3 slash command body is exactly '$EXPECTED'"
+  else
+    fail "AC3 slash command body is exactly '$EXPECTED'" \
+      "got: $(cat "$CMD_MD" 2>/dev/null)"
+  fi
+fi
+
+# ===========================================================================
+# AC4 — collect.py --mode all produces valid JSON matching schema, exit 0.
+# ===========================================================================
+echo "[ac4_collect_mode_all_json]"
+
+if [ ! -f "$COLLECT_PY" ]; then
+  fail "AC4 collect.py present" "expected: $COLLECT_PY"
+else
+  pass "AC4 collect.py present"
+
+  OUT_FILE="$(mktemp -t depcheck.XXXXXX)"
+  ERR_FILE="$(mktemp -t depcheck-err.XXXXXX)"
+  ( cd "$REPO_ROOT" && python3 "$COLLECT_PY" --mode all >"$OUT_FILE" 2>"$ERR_FILE" )
+  RC=$?
+
+  if [ "$RC" -eq 0 ]; then
+    pass "AC4 collect.py --mode all exit 0"
+  else
+    fail "AC4 collect.py --mode all exit 0" \
+      "exit=$RC stderr=$(head -c 400 "$ERR_FILE")"
+  fi
+
+  if python3 -c "import sys,json; json.load(open('$OUT_FILE'))" 2>/dev/null; then
+    pass "AC4 stdout is valid JSON"
+  else
+    fail "AC4 stdout is valid JSON" "could not json.load stdout file"
+  fi
+
+  # Schema-shape probe: top-level keys present.
+  for key in project_prefix mode bead_count beads findings; do
+    if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert '$key' in d" 2>/dev/null; then
+      pass "AC4 schema has top-level key '$key'"
+    else
+      fail "AC4 schema has top-level key '$key'" "missing in JSON output"
+    fi
+  done
+
+  # mode field should equal 'all' in this invocation.
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert d.get('mode')=='all'" 2>/dev/null; then
+    pass "AC4 schema mode == 'all'"
+  else
+    fail "AC4 schema mode == 'all'" "mode field absent or not 'all'"
+  fi
+
+  # beads is a list; bead_count is an int.
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert isinstance(d.get('beads'), list) and isinstance(d.get('bead_count'), int)" 2>/dev/null; then
+    pass "AC4 beads is list and bead_count is int"
+  else
+    fail "AC4 beads is list and bead_count is int" "wrong types"
+  fi
+
+  rm -f "$OUT_FILE" "$ERR_FILE"
+fi
+
+# ===========================================================================
+# AC5 — collect.py --mode focused --target <id> emits focused neighborhood.
+#       Verifies: valid JSON, exit 0, mode/target echoed, bead_count > 0,
+#       target bead is present in beads[].
+# ===========================================================================
+echo "[ac5_collect_mode_focused_json]"
+
+# Choose a target bead that exists in this project's bd DB. Per the dispatcher
+# input, agents-config-3up3 is the sample focused target. Fall back to whatever
+# `bd ready --json | jq -r '.[0].id'` returns if 3up3 is not present, so the
+# test stays deterministic on this repo but remains portable on a fresh
+# checkout. We DO NOT silently skip — if no target can be found, that is a
+# failure.
+TARGET=""
+if command -v bd >/dev/null 2>&1; then
+  if bd show agents-config-3up3 >/dev/null 2>&1; then
+    TARGET="agents-config-3up3"
+  else
+    TARGET="$(bd ready --json 2>/dev/null | python3 -c "import sys,json
+try:
+    d=json.load(sys.stdin)
+    print(d[0]['id'] if d else '')
+except Exception:
+    print('')
+" 2>/dev/null || true)"
+  fi
+fi
+
+if [ ! -f "$COLLECT_PY" ]; then
+  fail "AC5 collect.py present" "expected: $COLLECT_PY"
+elif [ -z "$TARGET" ]; then
+  fail "AC5 focused target available" \
+    "could not resolve a target bead (tried agents-config-3up3 and bd ready)"
+else
+  pass "AC5 collect.py present (using target $TARGET)"
+
+  OUT_FILE="$(mktemp -t depcheck-foc.XXXXXX)"
+  ERR_FILE="$(mktemp -t depcheck-foc-err.XXXXXX)"
+  ( cd "$REPO_ROOT" && python3 "$COLLECT_PY" --mode focused --target "$TARGET" \
+      >"$OUT_FILE" 2>"$ERR_FILE" )
+  RC=$?
+
+  if [ "$RC" -eq 0 ]; then
+    pass "AC5 collect.py --mode focused --target $TARGET exit 0"
+  else
+    fail "AC5 collect.py --mode focused --target $TARGET exit 0" \
+      "exit=$RC stderr=$(head -c 400 "$ERR_FILE")"
+  fi
+
+  if python3 -c "import json; json.load(open('$OUT_FILE'))" 2>/dev/null; then
+    pass "AC5 focused stdout is valid JSON"
+  else
+    fail "AC5 focused stdout is valid JSON" "could not json.load"
+  fi
+
+  # Target echoed back into output.
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert d.get('mode')=='focused' and d.get('target')=='$TARGET'" 2>/dev/null; then
+    pass "AC5 focused mode+target echoed"
+  else
+    fail "AC5 focused mode+target echoed" "mode/target mismatch"
+  fi
+
+  # Target bead is in beads[].
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); ids=[b.get('id') for b in d.get('beads',[])]; assert '$TARGET' in ids" 2>/dev/null; then
+    pass "AC5 target bead present in beads[]"
+  else
+    fail "AC5 target bead present in beads[]" "target $TARGET not found in beads array"
+  fi
+
+  # bead_count is positive AND equals len(beads).
+  if python3 -c "import json; d=json.load(open('$OUT_FILE')); assert isinstance(d.get('bead_count'), int) and d['bead_count']==len(d.get('beads',[])) and d['bead_count']>0" 2>/dev/null; then
+    pass "AC5 bead_count > 0 and matches len(beads)"
+  else
+    fail "AC5 bead_count > 0 and matches len(beads)" "bead_count vs beads len mismatch"
+  fi
+
+  rm -f "$OUT_FILE" "$ERR_FILE"
+fi
+
+# ===========================================================================
+# AC6 — Exit codes:
+#         2  unknown args   (collect.py --bogus-flag)
+#         3  bd not on PATH (run with PATH that excludes bd)
+#         4  db not found   (run from a non-bd directory)
+# ===========================================================================
+echo "[ac6_exit_codes]"
+
+if [ ! -f "$COLLECT_PY" ]; then
+  fail "AC6 collect.py present" "expected: $COLLECT_PY"
+else
+  pass "AC6 collect.py present"
+
+  # 6a: unknown args -> 2
+  ( cd "$REPO_ROOT" && python3 "$COLLECT_PY" --bogus-flag >/dev/null 2>&1 )
+  RC=$?
+  if [ "$RC" -eq 2 ]; then
+    pass "AC6 unknown arg -> exit 2"
+  else
+    fail "AC6 unknown arg -> exit 2" "got exit $RC"
+  fi
+
+  # 6b: bd not on PATH -> 3
+  # Construct a minimal PATH that contains python3 but excludes bd.
+  PY_DIR="$(dirname "$(command -v python3)")"
+  RESTRICTED_PATH="$PY_DIR:/usr/bin:/bin"
+  if command -v bd >/dev/null 2>&1; then
+    BD_DIR="$(dirname "$(command -v bd)")"
+    # Make sure the restricted PATH really excludes bd.
+    case ":$RESTRICTED_PATH:" in
+      *":$BD_DIR:"*)
+        # bd is in /usr/bin or /bin somehow; relocate by using only PY_DIR.
+        RESTRICTED_PATH="$PY_DIR"
+        ;;
+    esac
+  fi
+  ( cd "$REPO_ROOT" && env -i PATH="$RESTRICTED_PATH" HOME="$HOME" \
+      python3 "$COLLECT_PY" --mode all >/dev/null 2>&1 )
+  RC=$?
+  if [ "$RC" -eq 3 ]; then
+    pass "AC6 bd not on PATH -> exit 3"
+  else
+    fail "AC6 bd not on PATH -> exit 3" "got exit $RC"
+  fi
+
+  # 6c: db not found -> 4
+  # Run from a temp dir that has no .beads/ and no bd db lineage. The
+  # collect.py is expected to detect db-not-found and exit 4 (distinct from
+  # 'bd missing' = 3).
+  TMP_NO_DB="$(mktemp -d -t depcheck-nodb.XXXXXX)"
+  ( cd "$TMP_NO_DB" && env BEADS_DB="$TMP_NO_DB/does-not-exist.db" \
+      BD_HOME="$TMP_NO_DB" \
+      python3 "$COLLECT_PY" --mode all >/dev/null 2>&1 )
+  RC=$?
+  if [ "$RC" -eq 4 ]; then
+    pass "AC6 db not found -> exit 4"
+  else
+    fail "AC6 db not found -> exit 4" "got exit $RC (from $TMP_NO_DB)"
+  fi
+  rm -rf "$TMP_NO_DB"
+fi
+
+# ===========================================================================
+# AC7 — --just-fix-it prohibitions: only HIGH-confidence bd dep add edges,
+#       no bd dep remove, no bd close, no bd label remove, no bead content
+#       mutation; cap at 10 edges per invocation. Structural test on SKILL.md.
+# ===========================================================================
+echo "[ac7_just_fix_it_prohibitions]"
+
+require_file "$SKILL_MD" "AC7 SKILL.md"
+
+grep_in_fixed "$SKILL_MD" "--just-fix-it" \
+  "AC7 SKILL.md documents --just-fix-it"
+
+# Whitelist: only bd dep add allowed.
+grep_in "$SKILL_MD" "([Oo]nly|ONLY).*bd dep add" \
+  "AC7 SKILL.md states only bd dep add is allowed in --just-fix-it"
+
+# Forbid each destructive command — must appear as an explicit prohibition.
+grep_in "$SKILL_MD" "(MUST NOT|never|NEVER|prohibited|forbidden).*bd dep remove" \
+  "AC7 SKILL.md prohibits bd dep remove in --just-fix-it"
+grep_in "$SKILL_MD" "(MUST NOT|never|NEVER|prohibited|forbidden).*bd close" \
+  "AC7 SKILL.md prohibits bd close in --just-fix-it"
+grep_in "$SKILL_MD" "(MUST NOT|never|NEVER|prohibited|forbidden).*bd label remove" \
+  "AC7 SKILL.md prohibits bd label remove in --just-fix-it"
+
+# No bead-content mutation calls (bd update --notes, --description, etc.).
+grep_in "$SKILL_MD" "(no bead.?content|no content mutation|MUST NOT.*bd update|never.*bd update|do not.*mutate bead content)" \
+  "AC7 SKILL.md prohibits bead content mutations in --just-fix-it"
+
+# HIGH-confidence gating language.
+grep_in "$SKILL_MD" "(HIGH.confidence|HIGH confidence|high.confidence threshold)" \
+  "AC7 SKILL.md requires HIGH-confidence threshold for --just-fix-it edges"
+
+# Cap of 10 edges per invocation.
+grep_in "$SKILL_MD" "(at most 10|max.*10 edges|cap.*10|10 per invocation|limit of 10)" \
+  "AC7 SKILL.md caps --just-fix-it at 10 edges per invocation"
+
+# ===========================================================================
+# AC8 — Each applied edge audit-comments on the DEPENDENT bead in the
+#       canonical format:
+#         dep-health-check (just-fix-it): added dep <dependent-id> -> <blocker-id> (type <type>); reason: <rationale>
+# ===========================================================================
+echo "[ac8_audit_comment_format]"
+
+# The format must appear verbatim (minus angle-bracket placeholders) in SKILL.md.
+grep_in_fixed "$SKILL_MD" "dep-health-check (just-fix-it): added dep" \
+  "AC8 SKILL.md documents audit-comment prefix"
+grep_in_fixed "$SKILL_MD" "(type <type>)" \
+  "AC8 SKILL.md documents audit-comment '(type <type>)' segment"
+grep_in_fixed "$SKILL_MD" "reason: <rationale>" \
+  "AC8 SKILL.md documents audit-comment 'reason:' segment"
+
+# Must say the comment goes on the dependent bead (not the blocker).
+grep_in "$SKILL_MD" "(dependent bead|on the dependent|audit comment.*dependent)" \
+  "AC8 SKILL.md states audit comment lands on the dependent bead"
+
+# Must use bd comments add (not bd update --append-notes) for audit trail.
+grep_in_fixed "$SKILL_MD" "bd comments add" \
+  "AC8 SKILL.md uses bd comments add for audit trail"
+
+# ===========================================================================
+# AC9 — Report sections distinct: deterministic findings vs LLM-inferred
+#       findings are reported in separate sections, AND empty sections are
+#       omitted from the report.
+# ===========================================================================
+echo "[ac9_report_section_separation]"
+
+require_file "$SKILL_MD" "AC9 SKILL.md"
+
+# Distinct deterministic vs LLM-inferred section headings.
+grep_in "$SKILL_MD" "([Dd]eterministic findings|[Dd]eterministic [Ss]ection|deterministic.*section)" \
+  "AC9 SKILL.md names a deterministic-findings section"
+grep_in "$SKILL_MD" "(LLM.?inferred|inferred findings|LLM.?inferred [Ss]ection)" \
+  "AC9 SKILL.md names an LLM-inferred-findings section"
+
+# Empty-section-omission rule.
+grep_in "$SKILL_MD" "(omit empty|empty sections? (are )?omitted|skip empty sections?|do not.*emit empty)" \
+  "AC9 SKILL.md says empty sections are omitted"
+
+# ===========================================================================
+# AC10 — Every LLM finding carries a per-item rationale citing observable
+#        bead content; no finding may cite only LLM-internal reasoning.
+# ===========================================================================
+echo "[ac10_llm_rationale_requirement]"
+
+# Per-item rationale rule.
+grep_in "$SKILL_MD" "(per.?item rationale|each .*finding.*rationale|every .*finding.*rationale)" \
+  "AC10 SKILL.md requires per-item rationale on every LLM finding"
+
+# Rationale must reference observable bead content.
+grep_in "$SKILL_MD" "(observable bead content|cite.*bead content|reference.*bead.*field|quote.*bead)" \
+  "AC10 SKILL.md requires rationale to cite observable bead content"
+
+# Prohibition on LLM-internal-only reasoning.
+grep_in "$SKILL_MD" "(LLM.?internal|internal reasoning|model.?internal|no .*finding.*cite only)" \
+  "AC10 SKILL.md prohibits LLM-internal-only reasoning"
+
+# ===========================================================================
+# Name-uniqueness sanity (R6) — outside any AC, but a structural invariant of
+# this project: 'dep-health-check' must only appear in the three sanctioned
+# locations.
+# ===========================================================================
+echo "[name_uniqueness_r6]"
+
+UNIQ_OUT="$( ( grep -rl 'dep-health-check' "$REPO_ROOT/src" 2>/dev/null \
+                | grep -v "$REPO_ROOT/src/plugins/beads/.agents/skills/dep-health-check" \
+                | grep -v "$REPO_ROOT/src/user/.claude/commands/dep-health-check" \
+                | grep -v "$REPO_ROOT/src/user/.agents/skills/dep-health-check" \
+                | grep -v "$REPO_ROOT/src/plugins/beads/.claude/commands/dep-health-check" ) || true )"
+if [ -z "$UNIQ_OUT" ]; then
+  pass "R6 dep-health-check name appears only in sanctioned locations under src/"
+else
+  fail "R6 dep-health-check name uniqueness" \
+    "unexpected hits:$(printf '\n%s' "$UNIQ_OUT")"
+fi
+
+# ----- final --------------------------------------------------------------
+if [ "$FAIL" -ne 0 ]; then
+  echo "[dep-health-check/_test.sh] OVERALL: FAIL"
+  exit 1
+fi
+echo "[dep-health-check/_test.sh] OVERALL: PASS"
+exit 0


### PR DESCRIPTION
## Bead

**agents-config-he9o** — \`[Impl] dep-health-check skill: find missing deps, verify existing deps, suggest/apply fixes across open bead tree\`

## Summary

Implements the \`dep-health-check\` beads-plugin skill (rev-4 spec). A hybrid Python+LLM tool that audits the dependency graph across the open bead tree, surfacing missing deps, false existing deps, cycles, stale blockers, and provenance mismatches — in two scopes (focused / all-tree) and two modes (interactive / \`--just-fix-it\`).

**Files added/modified:**
- \`src/plugins/beads/.agents/skills/dep-health-check/SKILL.md\` — orchestration, LLM pass, \`--just-fix-it\` contract, report rendering
- \`src/plugins/beads/.agents/skills/dep-health-check/collect.py\` — Python helper: deterministic checks, focused-mode expansion, token guard
- \`src/plugins/beads/.claude/commands/dep-health-check.md\` — slash command
- \`src/user/.agents/skills/dep-health-check/_test.sh\` — red-phase contract tests (27 assertions)
- \`scripts/install.sh\` — carrier-merge fix: permits same-named carrier+plugin dirs when file sets are disjoint

## Acceptance Criteria

All items are \`[m]\` (machine-verifiable). All pass.

1. Build passes. Typecheck passes. Tests pass.
2. Skill installs to \`~/.claude/skills/dep-health-check/\` via \`scripts/install.sh\` from \`src/plugins/beads/.agents/skills/dep-health-check/\`.
3. \`/dep-health-check\` slash command exists and accepts optional \`[bead-id]\` and \`[--just-fix-it]\` arguments.
4. \`collect.py\` produces valid JSON inventory + deterministic findings on the live bead database without errors.
5. Focused mode limits findings to target bead's 1-hop dep neighborhood + full parent chain + full child chain.
6. All-mode covers every open + in_progress bead in the project.
7. \`--just-fix-it\` never invokes \`bd dep remove\`, \`bd close\`, \`bd label remove\`, or any bead-content mutation; only HIGH-confidence add-only edges are applied.
8. Every applied edge in \`--just-fix-it\` is mirrored by an audit comment on the affected bead.
9. Report contains distinct sections for deterministic and LLM-inferred findings; empty sections are omitted.
10. Every LLM finding carries a per-item rationale grounded in observable bead content.

## Verify-AC Validation Report

| AC | Result | Witness |
|----|--------|---------|
| 1 | ✓ PASS | test runner exit 0; `[dep-health-check/_test.sh] OVERALL: PASS` |
| 2 | ✓ PASS | `install.sh --dry-run --plugins=beads --verbose` exits 0; output contains beads-plugin dep-health-check staging line |
| 3 | ✓ PASS | slash command file exists; body exactly `Skill dep-health-check $ARGUMENTS` |
| 4 | ✓ PASS | `collect.py --mode all` exits 0; valid JSON with all schema keys; `bead_count > 0` |
| 5 | ✓ PASS | `collect.py --mode focused --target agents-config-3up3` exits 0; mode+target echoed; target in `beads[]`; `bead_count > 0` |
| 6 | ✓ PASS | exit 2 on unknown args; exit 3 on bd-not-on-PATH; exit 4 on db-not-found |
| 7 | ✓ PASS | SKILL.md prohibitions verified: `bd dep remove`, `bd close`, `bd label remove`, content mutations all forbidden; HIGH-confidence gate; 10-edge cap |
| 8 | ✓ PASS | SKILL.md audit-comment format verified; `bd comments add` on dependent bead confirmed |
| 9 | ✓ PASS | SKILL.md names deterministic-findings and LLM-inferred-findings sections; empty-section omission rule present |
| 10 | ✓ PASS | SKILL.md requires per-item rationale citing observable bead content; LLM-internal-only reasoning prohibited |

No `[h]` bullets. No functional tests configured. **All 10 [m] ACs: PASS.**

## Implementation Iteration Summary (RALF 3/3)

| Cycle | Changes | Gate |
|-------|---------|------|
| 1 | Initial implementation: SKILL.md + collect.py + slash command + install.sh carrier-merge fix | PASS_WITH_RESERVATIONS (Codex: NEEDS REVISION) |
| Simplify | SKILL.md verbosity collapse, typed exceptions (BdMissing/DbMissing), constants, dedup guard, dead-comment removal | — |
| 2 | Y-side provenance labels, install.sh carrier scope restriction, SKILL.md just-fix-it whitelist, focused-mode neighbor hydration, cycle filter, H1/H4 fixes | PASS_WITH_RESERVATIONS |
| 3 | `_resolve_id` ambiguity detection, dead binding removal, install.sh sentinel mechanism, focused-mode cycle annotation (show-all + `in_focused_scope`), `_cycle_touches` empty-set sentinel fix | **PASS** |

**Final score: PASS** — no blocking/critical/major findings remaining. 3 cycles of adversarial review (Codex cycle 1 + Claude quality-reviewer cycles 1-3).

## Foreign-Eyes Status

| Cycle | Reviewer | Status |
|-------|----------|--------|
| 1 | Codex gpt-5.5 | COMPLETED |
| 2 | Gemini flash-preview | UNAVAILABLE (model unsupported by Codex companion — degraded to Claude quality-reviewer) |
| 3 | Pure-Claude | COMPLETED (inline diff review) |

## Discovered Work Filed

| Bead | Title |
|------|-------|
| agents-config-mvxb | install.sh fatal-collision (fixed in this PR) |
| agents-config-dawr | install.sh prune-list sanity pass (carrier-merge) |
| agents-config-5yfy | collect.py short-id label suffix robustness |
| agents-config-nwtz | dep-health-check render-report companion (render.py) |

## Deferred (non-blocking)

- M1/M2: focused-mode observability (parent-chain cap warning, missing-neighbor signal)
- F1/F2/F3: ThreadPoolExecutor parallelism (30s → ~3s), lazy focused-mode fetch, `children_by_parent` index
- R7 field-name alignment: `kind`/`type`, `severity`/`confidence`, `proposed_command`

## Test plan

- [ ] Test runner exits 0 on branch: `find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo "[TEST] \$1"; bash "\$1" || exit 1' _ {}` (319 passing)
- [ ] `python3 src/plugins/beads/.agents/skills/dep-health-check/collect.py --mode all` exits 0, produces valid JSON
- [ ] `bash scripts/install.sh --dry-run --tools=claude --plugins=beads --verbose 2>&1 | grep dep-health-check` shows staging line

🤖 Generated with [Claude Code](https://claude.ai/claude-code)