### PR TITLE
test(smoke): verify DYNAMIC-INCLUDE flattening across all installed tools (jyb.5)

### DIFF
--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -79,8 +79,9 @@ check_file_contains() {
 #   INSTRUCTIONS.md.template — and that none of the raw DYNAMIC-INCLUDE
 #   markers leaked through unprocessed.
 #
-#   This is a positive flattening assertion: existence of the file is
-#   already covered by check_file; this function answers the harder
+#   This is a positive flattening assertion: the sandbox-installed files are
+#   not checked for bare existence elsewhere; check_file_contains handles
+#   missing files implicitly ([ -f ] guard). This function answers the harder
 #   question "did the install actually inline the shared content?"
 verify_flattening() {
   local label_prefix="$1"

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -182,7 +182,8 @@ echo ""
 echo "==> Universal-flattening checks (bead jyb.5)"
 
 if ! command -v jq &>/dev/null; then
-  echo "  SKIP  install.sh requires jq; flattening checks not run"
+  echo "  FAIL  install.sh requires jq; flattening checks not run (install jq to enable this section)"
+  FAIL=$((FAIL + 1))
 else
   SANDBOX_HOME="$(mktemp -d "${TMPDIR:-/tmp}/verify-artifacts-flatten.XXXXXXXX")"
   trap 'rm -rf "${SANDBOX_HOME}"' EXIT

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -109,15 +109,34 @@ verify_flattening() {
   # Match the marker syntax (`<!-- DYNAMIC-INCLUDE`) rather than the bare
   # word — the inlined INSTRUCTIONS template legitimately mentions
   # "DYNAMIC-INCLUDE" in a prose comment about the mechanism itself.
+  #
+  # Split into explicit cases so a missing file or a grep I/O error does
+  # NOT silently PASS via `! grep …` (any non-zero exit, including grep's
+  # error exit 2, would otherwise be treated as "no match found").
   local label="${label_prefix}: no unprocessed DYNAMIC-INCLUDE markers"
-  if [ -f "${instructions_path}" ] \
-       && ! grep -qE '<!-- DYNAMIC-INCLUDE(-RULES)?:' "${instructions_path}"; then
-    echo "  PASS  ${label}"
-    PASS=$((PASS + 1))
-  else
+  if [ ! -f "${instructions_path}" ]; then
     echo "  FAIL  ${label}"
-    echo "        unexpected DYNAMIC-INCLUDE marker in: ${instructions_path}"
+    echo "        file not found: ${instructions_path}"
     FAIL=$((FAIL + 1))
+  else
+    grep -qE '<!-- DYNAMIC-INCLUDE(-RULES)?:' "${instructions_path}"
+    local rc=$?
+    case "${rc}" in
+      0)
+        echo "  FAIL  ${label}"
+        echo "        unexpected DYNAMIC-INCLUDE marker in: ${instructions_path}"
+        FAIL=$((FAIL + 1))
+        ;;
+      1)
+        echo "  PASS  ${label}"
+        PASS=$((PASS + 1))
+        ;;
+      *)
+        echo "  FAIL  ${label}"
+        echo "        grep error (exit ${rc}) reading: ${instructions_path}"
+        FAIL=$((FAIL + 1))
+        ;;
+    esac
   fi
 }
 

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -64,6 +64,59 @@ check_file_contains() {
   fi
 }
 
+# verify_flattening (bead jyb.5):
+#   Run install.sh into a sandbox HOME and verify that DYNAMIC-INCLUDE
+#   markers in each tool's instruction template were actually replaced
+#   with the contents of the referenced shared templates.
+#
+#   For each of Claude, Codex, Gemini, and OpenCode we check that the
+#   assembled top-level instruction file contains representative strings
+#   from AGENT-PERSONA.md.template, USER-PERSONA.md.template, and
+#   INSTRUCTIONS.md.template — and that none of the raw DYNAMIC-INCLUDE
+#   markers leaked through unprocessed.
+#
+#   This is a positive flattening assertion: existence of the file is
+#   already covered by check_file; this function answers the harder
+#   question "did the install actually inline the shared content?"
+verify_flattening() {
+  local label_prefix="$1"
+  local instructions_path="$2"
+
+  # Representative substrings from each shared template that gets
+  # DYNAMIC-INCLUDE'd into every tool's AGENTS.md / GEMINI.md.
+  check_file_contains \
+    "${label_prefix}: AGENT-PERSONA content inlined" \
+    "${instructions_path}" \
+    "snarky, arrogant, boastful"
+  check_file_contains \
+    "${label_prefix}: USER-PERSONA content inlined" \
+    "${instructions_path}" \
+    "54yo architect, Sci-Fi nerd"
+  check_file_contains \
+    "${label_prefix}: INSTRUCTIONS laws block inlined" \
+    "${instructions_path}" \
+    "L0 Codebase"
+  check_file_contains \
+    "${label_prefix}: INSTRUCTIONS decision-matrix inlined" \
+    "${instructions_path}" \
+    "verify-facts"
+
+  # Negative check: an unprocessed marker means flattening was skipped.
+  # Match the marker syntax (`<!-- DYNAMIC-INCLUDE`) rather than the bare
+  # word — the inlined INSTRUCTIONS template legitimately mentions
+  # "DYNAMIC-INCLUDE" in a prose comment about the mechanism itself.
+  local label="${label_prefix}: no unprocessed DYNAMIC-INCLUDE markers"
+  if [ -f "${instructions_path}" ] \
+       && ! grep -qE '<!-- DYNAMIC-INCLUDE(-RULES)?:' "${instructions_path}"; then
+    echo "  PASS  ${label}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  ${label}"
+    echo "        unexpected DYNAMIC-INCLUDE marker in: ${instructions_path}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 echo "==> Artifact verification for bead 7bk.9"
 echo "    Repo root: ${REPO_ROOT}"
 echo ""
@@ -116,6 +169,41 @@ check_file_contains \
   "fix-bug.formula.toml contains 'diagnose' stage name" \
   "${REPO_ROOT}/src/plugins/beads/.beads/formulas/fix-bug.formula.toml" \
   '"diagnose"'
+
+# ── DYNAMIC-INCLUDE flattening (bead jyb.5) ────────────────────────────────
+# Drive a sandboxed install and verify shared template content was actually
+# inlined into each tool's assembled instruction file. install.sh writes to
+# ~/.<tool>/ and ~/.config/opencode/, so we point HOME at a scratch dir.
+echo ""
+echo "==> Universal-flattening checks (bead jyb.5)"
+
+if ! command -v jq &>/dev/null; then
+  echo "  SKIP  install.sh requires jq; flattening checks not run"
+else
+  SANDBOX_HOME="$(mktemp -d "${TMPDIR:-/tmp}/verify-artifacts-flatten.XXXXXXXX")"
+  echo "    Sandbox HOME: ${SANDBOX_HOME}"
+
+  # Force the install to target every tool that supports DYNAMIC-INCLUDE
+  # (claude, codex, gemini, opencode). --plugins= disables plugin
+  # auto-detection so the test does not depend on the host bd/beads state.
+  install_log="${SANDBOX_HOME}/install.log"
+  if HOME="${SANDBOX_HOME}" \
+       bash "${REPO_ROOT}/scripts/install.sh" \
+            --yes \
+            --tools=claude,codex,gemini,opencode \
+            --plugins= \
+            >"${install_log}" 2>&1; then
+    echo "    install.sh: OK"
+  else
+    echo "    install.sh: FAILED (see ${install_log})"
+    FAIL=$((FAIL + 1))
+  fi
+
+  verify_flattening "claude/AGENTS.md"   "${SANDBOX_HOME}/.claude/AGENTS.md"
+  verify_flattening "codex/AGENTS.md"    "${SANDBOX_HOME}/.codex/AGENTS.md"
+  verify_flattening "gemini/GEMINI.md"   "${SANDBOX_HOME}/.gemini/GEMINI.md"
+  verify_flattening "opencode/AGENTS.md" "${SANDBOX_HOME}/.config/opencode/AGENTS.md"
+fi
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -185,31 +185,36 @@ if ! command -v jq &>/dev/null; then
   echo "  FAIL  install.sh requires jq; flattening checks not run (install jq to enable this section)"
   FAIL=$((FAIL + 1))
 else
-  SANDBOX_HOME="$(mktemp -d "${TMPDIR:-/tmp}/verify-artifacts-flatten.XXXXXXXX")"
-  trap 'rm -rf "${SANDBOX_HOME}"' EXIT
-  echo "    Sandbox HOME: ${SANDBOX_HOME}"
-
-  # --tools= explicitly lists every tool that supports DYNAMIC-INCLUDE.
-  # This intentionally bypasses install.sh's auto-detection logic; the test
-  # is scoped to "did flattening happen?", not "did detection work?".
-  # --plugins= disables plugin auto-detection so the test does not depend
-  # on the host bd/beads state.
-  install_log="${SANDBOX_HOME}/install.log"
-  if HOME="${SANDBOX_HOME}" \
-       bash "${REPO_ROOT}/scripts/install.sh" \
-            --yes \
-            --tools=claude,codex,gemini,opencode \
-            --plugins= \
-            >"${install_log}" 2>&1; then
-    echo "    install.sh: OK"
-    verify_flattening "claude/AGENTS.md"   "${SANDBOX_HOME}/.claude/AGENTS.md"
-    verify_flattening "codex/AGENTS.md"    "${SANDBOX_HOME}/.codex/AGENTS.md"
-    verify_flattening "gemini/GEMINI.md"   "${SANDBOX_HOME}/.gemini/GEMINI.md"
-    verify_flattening "opencode/AGENTS.md" "${SANDBOX_HOME}/.config/opencode/AGENTS.md"
-  else
-    echo "    install.sh: FAILED (see ${install_log})"
-    cat "${install_log}" >&2
+  SANDBOX_HOME="$(mktemp -d "${TMPDIR:-/tmp}/verify-artifacts-flatten.XXXXXXXX")" || SANDBOX_HOME=""
+  if [ -z "${SANDBOX_HOME}" ] || [ ! -d "${SANDBOX_HOME}" ]; then
+    echo "  FAIL  mktemp: could not create sandbox directory; skipping flattening checks"
     FAIL=$((FAIL + 1))
+  else
+    trap 'rm -rf "${SANDBOX_HOME}"' EXIT
+    echo "    Sandbox HOME: ${SANDBOX_HOME}"
+
+    # --tools= explicitly lists every tool that supports DYNAMIC-INCLUDE.
+    # This intentionally bypasses install.sh's auto-detection logic; the test
+    # is scoped to "did flattening happen?", not "did detection work?".
+    # --plugins= disables plugin auto-detection so the test does not depend
+    # on the host bd/beads state.
+    install_log="${SANDBOX_HOME}/install.log"
+    if HOME="${SANDBOX_HOME}" \
+         bash "${REPO_ROOT}/scripts/install.sh" \
+              --yes \
+              --tools=claude,codex,gemini,opencode \
+              --plugins= \
+              >"${install_log}" 2>&1; then
+      echo "    install.sh: OK"
+      verify_flattening "claude/AGENTS.md"   "${SANDBOX_HOME}/.claude/AGENTS.md"
+      verify_flattening "codex/AGENTS.md"    "${SANDBOX_HOME}/.codex/AGENTS.md"
+      verify_flattening "gemini/GEMINI.md"   "${SANDBOX_HOME}/.gemini/GEMINI.md"
+      verify_flattening "opencode/AGENTS.md" "${SANDBOX_HOME}/.config/opencode/AGENTS.md"
+    else
+      echo "    install.sh: FAILED (see ${install_log})"
+      cat "${install_log}" >&2
+      FAIL=$((FAIL + 1))
+    fi
   fi
 fi
 

--- a/scripts/smoke/verify-artifacts.sh
+++ b/scripts/smoke/verify-artifacts.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # scripts/smoke/verify-artifacts.sh
-# Artifact existence check for bead 7bk.9 (Per-step claude -p orchestration).
+# Artifact existence and flattening verification for the bead pipeline.
+# Initially created for bead 7bk.9 (Per-step claude -p orchestration);
+# extended by bead jyb.5 to verify DYNAMIC-INCLUDE flattening.
 #
-# Checks that every artifact the bead is required to produce actually exists.
+# Checks that every artifact the bead is required to produce actually exists,
+# and that DYNAMIC-INCLUDE markers in instruction templates were inlined
+# into the assembled output files at install time.
 # Intended to be run at the END of the green phase; MUST fail during the red
 # phase because the artifacts do not yet exist.
 #
@@ -181,11 +185,14 @@ if ! command -v jq &>/dev/null; then
   echo "  SKIP  install.sh requires jq; flattening checks not run"
 else
   SANDBOX_HOME="$(mktemp -d "${TMPDIR:-/tmp}/verify-artifacts-flatten.XXXXXXXX")"
+  trap 'rm -rf "${SANDBOX_HOME}"' EXIT
   echo "    Sandbox HOME: ${SANDBOX_HOME}"
 
-  # Force the install to target every tool that supports DYNAMIC-INCLUDE
-  # (claude, codex, gemini, opencode). --plugins= disables plugin
-  # auto-detection so the test does not depend on the host bd/beads state.
+  # --tools= explicitly lists every tool that supports DYNAMIC-INCLUDE.
+  # This intentionally bypasses install.sh's auto-detection logic; the test
+  # is scoped to "did flattening happen?", not "did detection work?".
+  # --plugins= disables plugin auto-detection so the test does not depend
+  # on the host bd/beads state.
   install_log="${SANDBOX_HOME}/install.log"
   if HOME="${SANDBOX_HOME}" \
        bash "${REPO_ROOT}/scripts/install.sh" \
@@ -194,15 +201,15 @@ else
             --plugins= \
             >"${install_log}" 2>&1; then
     echo "    install.sh: OK"
+    verify_flattening "claude/AGENTS.md"   "${SANDBOX_HOME}/.claude/AGENTS.md"
+    verify_flattening "codex/AGENTS.md"    "${SANDBOX_HOME}/.codex/AGENTS.md"
+    verify_flattening "gemini/GEMINI.md"   "${SANDBOX_HOME}/.gemini/GEMINI.md"
+    verify_flattening "opencode/AGENTS.md" "${SANDBOX_HOME}/.config/opencode/AGENTS.md"
   else
     echo "    install.sh: FAILED (see ${install_log})"
+    cat "${install_log}" >&2
     FAIL=$((FAIL + 1))
   fi
-
-  verify_flattening "claude/AGENTS.md"   "${SANDBOX_HOME}/.claude/AGENTS.md"
-  verify_flattening "codex/AGENTS.md"    "${SANDBOX_HOME}/.codex/AGENTS.md"
-  verify_flattening "gemini/GEMINI.md"   "${SANDBOX_HOME}/.gemini/GEMINI.md"
-  verify_flattening "opencode/AGENTS.md" "${SANDBOX_HOME}/.config/opencode/AGENTS.md"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Closes `agents-config-jyb.5` — Universal instruction flattening: update smoke tests to verify inlined content.

Enhances `scripts/smoke/verify-artifacts.sh` to drive a sandboxed install and verify that DYNAMIC-INCLUDE markers in instruction templates are actually inlined into the assembled output files for each tool (Claude, Codex, Gemini, OpenCode).

## Bead context

- **Bead:** `agents-config-jyb.5` (rerouted from `agents-config-jyb.4` — original had empty `acceptance_criteria`, triggering Trigger B → docs-only formula reroute)
- **Parent epic:** `agents-config-jyb` (Examine @file inclusion markers for consistency)

## Acceptance criteria

Original bead had no `[m]` / `[h]` AC bullets — covered by description and validated mechanically via the smoke test passing.

## apply-edits summary

Added `verify_flattening` checks for AGENT-PERSONA, USER-PERSONA, and INSTRUCTIONS content across claude / codex / gemini / opencode assembled instruction files. 31 passed, 0 failed (11 pre-existing + 20 new flattening checks).

## review summary

- **quality-reviewer:** 2 major findings, 5 minor.
  - **M1** (fixed in ad9ac10) — install-failure cascade: the four `verify_flattening` calls now only run when install.sh succeeds.
  - **M2** (fixed in ad9ac10) — sandbox cleanup: added `trap 'rm -rf "${SANDBOX_HOME}"' EXIT`.
  - **m1** (fixed in ad9ac10) — banner now reflects multi-bead scope.
  - **m3** (fixed in ad9ac10) — added inline comment explaining `--tools=` bypasses auto-detection by design.
  - **m2, m4, m5** — info / moot; no action.
- **simplify:** 0 findings.

## verify-ac

No `[m]` AC lines on the bead — warn-and-pass per docs-only formula. No `[h]` bullets, so no follow-up beads required.

## Test plan

- [x] `bash scripts/smoke/verify-artifacts.sh` reports 31/31 passing
- [x] Install failure now surfaces `install.log` to stderr instead of cascading 17 misleading FAILs
- [x] Sandbox HOME cleaned up on script exit

## Discovered work

- `agents-config-fn0y` (P4 chore) — broaden `verify-artifacts.sh` header banner attribution

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>