### PR TITLE
feat(whats-next): scope display_ids to active --mode's sections (i07e)

### DIFF
--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -287,8 +287,8 @@ def extract_typed_ancestors(bead_id, ancestry_map, known, shorten):
 def select_section_beads(mode, human_beads, planning_beads, brainstorm_beads, impl_beads):
     """Canonical mode->sections mapping.
 
-    Parallel implementation: the output-emission if/elif at
-    collect.py:476-488 encodes the same mapping. Keep them in sync.
+    Parallel implementation: the output-emission if/elif in main()
+    encodes the same mapping. Keep them in sync.
     """
     if mode == 'all':
         return human_beads + planning_beads + brainstorm_beads + impl_beads

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -290,15 +290,15 @@ def select_section_beads(mode, human_beads, planning_beads, brainstorm_beads, im
     Parallel implementation: the output-emission if/elif in main()
     encodes the same mapping. Keep them in sync.
     """
-    if mode == 'all':
+    if mode == "all":
         return human_beads + planning_beads + brainstorm_beads + impl_beads
-    if mode == 'human':
+    if mode == "human":
         return human_beads
-    if mode == 'brainstorm':
+    if mode == "brainstorm":
         return brainstorm_beads
-    if mode == 'implementation':
+    if mode == "implementation":
         return impl_beads
-    if mode == 'planning':
+    if mode == "planning":
         return planning_beads
     return []  # unreachable under argparse choices=
 

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -284,6 +284,25 @@ def extract_typed_ancestors(bead_id, ancestry_map, known, shorten):
 # Main
 # ---------------------------------------------------------------------------
 
+def select_section_beads(mode, human_beads, planning_beads, brainstorm_beads, impl_beads):
+    """Canonical mode->sections mapping.
+
+    Parallel implementation: the output-emission if/elif at
+    collect.py:476-488 encodes the same mapping. Keep them in sync.
+    """
+    if mode == 'all':
+        return human_beads + planning_beads + brainstorm_beads + impl_beads
+    if mode == 'human':
+        return human_beads
+    if mode == 'brainstorm':
+        return brainstorm_beads
+    if mode == 'implementation':
+        return impl_beads
+    if mode == 'planning':
+        return planning_beads
+    return []  # unreachable under argparse choices=
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Fetch and filter beads for the whats-next skill."
@@ -431,12 +450,7 @@ def main():
             return bid[len(prefix) + 1:]
         return bid
 
-    display_ids = (
-        [b["id"] for b in human_beads]
-        + [b["id"] for b in brainstorm_beads]
-        + [b["id"] for b in impl_beads]
-        + [b["id"] for b in planning_beads]
-    )
+    display_ids = [b["id"] for b in select_section_beads(mode, human_beads, planning_beads, brainstorm_beads, impl_beads)]
     ancestry_map = resolve_all_ancestry(display_ids, known)
 
     def enrich(beads):

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -424,7 +424,7 @@ pass "T8b: childless feature with implementation-ready is excluded from --mode p
 # excludes children with merge-gate / human labels) keeps Y visible.
 # -----------------------------------------------------------------------------
 TMP_T9=$(mktemp -d)
-trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9"' EXIT
+trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9" "${TMP_T10:-}"' EXIT
 
 cat > "$TMP_T9/bd" <<'SHIM'
 #!/usr/bin/env bash
@@ -483,5 +483,109 @@ assert "proj-yfeat" in ids, \
     f"feature-Y with merge-gate/human children MUST appear under implementation (formula-gate children are excluded from active_child_count); got: {ids}"
 PY
 pass "T9: feature-Y impl bead with merge-gate / [Human verify] children surfaces under --mode implementation (narrowed Rule B)"
+
+# -----------------------------------------------------------------------------
+# T10. Mode-isolation regression: --mode <m> must only call bd show for the
+# ancestors of beads in the section(s) that mode emits.
+#
+# Defect under test (collect.py:434-440): display_ids is the union of ALL
+# four sections regardless of mode, which causes resolve_all_ancestry to
+# fire `bd show <parent>` for every section's parents even when only one
+# section will be emitted. Under `--mode human`, only the human section's
+# parent (h1-parent) should be fetched; the brainstorm/impl/planning
+# parents (b1-parent, i1-parent, p1-parent) MUST NOT be fetched.
+#
+# The shim here is the only T-shim that LOGS its `show` invocations
+# (T9's shim does not). Each `bd show <id> ...` invocation appends a
+# single line `show <id>` to $TMP_T10/show.log.
+# -----------------------------------------------------------------------------
+TMP_T10=$(mktemp -d)
+# trap already includes ${TMP_T10:-} (set above on the T9 trap line).
+SHOW_LOG="$TMP_T10/show.log"
+: > "$SHOW_LOG"
+export SHOW_LOG
+
+cat > "$TMP_T10/bd" <<SHIM
+#!/usr/bin/env bash
+# Log only \`bd show <id> ...\` invocations, one event per line.
+if [ "\$1" = "show" ]; then
+  echo "show \$2" >> "$SHOW_LOG"
+fi
+case "\$*" in
+  "list --label human --limit 0 --json")
+    echo '[{"id":"proj-h1","issue_type":"task","status":"open","priority":1,"title":"H","labels":["human"],"parent":"h1-parent"}]' ;;
+  "list --status open,in_progress --limit 0 --json")
+    # Active inventory contains ONLY the four leaf beads — none of their
+    # parents. This forces resolve_all_ancestry to issue \`bd show <parent>\`
+    # for every parent it encounters in display_ids.
+    cat <<'JSON'
+[
+  {"id":"proj-h1","issue_type":"task","status":"open","priority":1,"title":"H","labels":["human"],"parent":"h1-parent"},
+  {"id":"proj-b1","issue_type":"task","status":"open","priority":1,"title":"B","labels":[],"parent":"b1-parent"},
+  {"id":"proj-i1","issue_type":"task","status":"open","priority":1,"title":"I","labels":["implementation-ready"],"parent":"i1-parent"},
+  {"id":"proj-p1","issue_type":"feature","status":"open","priority":1,"title":"P","labels":[],"parent":"p1-parent"}
+]
+JSON
+    ;;
+  "ready --json")
+    cat <<'JSON'
+[
+  {"id":"proj-b1","issue_type":"task","status":"open","priority":1,"title":"B","labels":[],"parent":"b1-parent","created_at":"2026-05-01"},
+  {"id":"proj-i1","issue_type":"task","status":"open","priority":1,"title":"I","labels":["implementation-ready"],"parent":"i1-parent","created_at":"2026-05-01"}
+]
+JSON
+    ;;
+  "list --type milestone --ready --limit 0 --json") echo '[]' ;;
+  "list --type epic --ready --limit 0 --json") echo '[]' ;;
+  "list --type feature --ready --limit 0 --json")
+    echo '[{"id":"proj-p1","issue_type":"feature","status":"open","priority":1,"title":"P","labels":[],"parent":"p1-parent"}]' ;;
+  "show h1-parent --json")
+    echo '[{"id":"h1-parent","issue_type":"task","parent":"","title":"parent bead","status":"open","priority":2,"labels":[]}]' ;;
+  "show b1-parent --json")
+    echo '[{"id":"b1-parent","issue_type":"task","parent":"","title":"parent bead","status":"open","priority":2,"labels":[]}]' ;;
+  "show i1-parent --json")
+    echo '[{"id":"i1-parent","issue_type":"task","parent":"","title":"parent bead","status":"open","priority":2,"labels":[]}]' ;;
+  "show p1-parent --json")
+    echo '[{"id":"p1-parent","issue_type":"task","parent":"","title":"parent bead","status":"open","priority":2,"labels":[]}]' ;;
+  *) echo '[]' ;;
+esac
+SHIM
+chmod +x "$TMP_T10/bd"
+
+OUT_T10="$TMP_T10/human.json"
+PATH="$TMP_T10:$PATH" python3 "$COLLECT_PY" --mode human \
+    >"$OUT_T10" 2>"$TMP_T10/err.human"
+ec=$?
+[ "$ec" -eq 0 ] \
+    || fail "T10: collect.py --mode human exited $ec (stderr: $(cat "$TMP_T10/err.human"))"
+
+# Group (a) — sanity assertions (do NOT discriminate fixed vs unfixed).
+OUT_T10="$OUT_T10" python3 - <<'PY' \
+    || fail "T10a: --mode human output shape wrong (top-level section keys)"
+import json, os
+out = json.load(open(os.environ["OUT_T10"]))
+assert "human" in out, f"--mode human must emit 'human' key; got: {sorted(out.keys())}"
+human_ids = [b.get("id") for b in out.get("human", [])]
+assert "proj-h1" in human_ids, f"human section must include proj-h1; got: {human_ids}"
+for k in ("brainstorm", "implementation", "planning_ready"):
+    assert k not in out, f"--mode human MUST NOT emit '{k}' (got keys: {sorted(out.keys())})"
+PY
+pass "T10a: --mode human emits only the 'human' section key and includes proj-h1"
+
+# Group (b) — isolation assertions. THESE FAIL on the unfixed defect.
+# (b1) h1-parent MUST be in the log (the human section's parent is always
+#      legitimately fetched, fixed or unfixed).
+grep -qE '^show h1-parent$' "$SHOW_LOG" \
+    || fail "T10b1: expected 'show h1-parent' in $SHOW_LOG (log: $(cat "$SHOW_LOG"))"
+
+# (b2) None of {b1-parent, i1-parent, p1-parent} may be fetched — under
+#      --mode human, the brainstorm/impl/planning sections are not emitted,
+#      so their parents must not be resolved.
+for forbidden in b1-parent i1-parent p1-parent; do
+    if grep -qE "^show ${forbidden}\$" "$SHOW_LOG"; then
+        fail "T10b2: --mode human leaked 'show $forbidden' — display_ids must be scoped to the active mode's sections (log: $(cat "$SHOW_LOG"))"
+    fi
+done
+pass "T10b: --mode human fetches only h1-parent; brainstorm/impl/planning parents are not fetched (display_ids scoped to emitted sections)"
 
 echo "All collect.py red-phase tests reached — script exits 0 only when every assertion above passes."

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -488,9 +488,9 @@ pass "T9: feature-Y impl bead with merge-gate / [Human verify] children surfaces
 # T10. Mode-isolation regression: --mode <m> must only call bd show for the
 # ancestors of beads in the section(s) that mode emits.
 #
-# Defect under test (collect.py:434-440): display_ids is the union of ALL
-# four sections regardless of mode, which causes resolve_all_ancestry to
-# fire `bd show <parent>` for every section's parents even when only one
+# Defect under test: the prior unconditional 4-section union construction
+# of display_ids in collect.py caused resolve_all_ancestry to fire
+# `bd show <parent>` for every section's parents even when only one
 # section will be emitted. Under `--mode human`, only the human section's
 # parent (h1-parent) should be fetched; the brainstorm/impl/planning
 # parents (b1-parent, i1-parent, p1-parent) MUST NOT be fetched.

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -424,7 +424,7 @@ pass "T8b: childless feature with implementation-ready is excluded from --mode p
 # excludes children with merge-gate / human labels) keeps Y visible.
 # -----------------------------------------------------------------------------
 TMP_T9=$(mktemp -d)
-trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9" "${TMP_T10:-}"' EXIT
+trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9" ${TMP_T10:+"$TMP_T10"}' EXIT
 
 cat > "$TMP_T9/bd" <<'SHIM'
 #!/usr/bin/env bash
@@ -500,7 +500,7 @@ pass "T9: feature-Y impl bead with merge-gate / [Human verify] children surfaces
 # single line `show <id>` to $TMP_T10/show.log.
 # -----------------------------------------------------------------------------
 TMP_T10=$(mktemp -d)
-# trap already includes ${TMP_T10:-} (set above on the T9 trap line).
+# trap already includes ${TMP_T10:+"$TMP_T10"} (set above on the T9 trap line).
 SHOW_LOG="$TMP_T10/show.log"
 : > "$SHOW_LOG"
 export SHOW_LOG


### PR DESCRIPTION
## Summary

Scopes `display_ids` in `whats-next/collect.py` to only the sections the active `--mode` will emit, eliminating wasted `bd show` CLI fan-out on parent chains for sections that the output dispatch drops.

**Bead:** `agents-config-i07e` — [Impl] whats-next collect.py: build display_ids from mode-selected sections only
**Source:** PR #72 Copilot R11 (perf nitpick on `whats-next/collect.py`).

## Change

- New module-level helper `select_section_beads(mode, ...)` at `collect.py:287-303` — single canonical home of the mode→sections mapping.
- Call-site at `collect.py:453` now scopes `display_ids` to the mode's emitted sections.
- Output-emission `if/elif` at `collect.py:476-488` unchanged (the helper's docstring names it as the parallel implementation).
- `--mode all` preserves the 4-section union (perf unchanged by design).

## Acceptance Criteria

All `[m]`-tagged (no `[h]` bullets in this bead):

- [m] `resolve_all_ancestry` is invoked only with the IDs in the section that `--mode <m>` emits. For `--mode all`, that is the union of all four sections; for any single-section `--mode`, that is only the beads in that section.
- [m] `--mode all` behavior is unchanged: `display_ids` is the union of all four sections (human + planning + brainstorm + impl).
- [m] Existing `collect_test.sh` assertions T1–T9 remain green.
- [m] New assertion T10 in `collect_test.sh`: bd-shim-based mode-isolation regression.

## Implementation iteration summary (green-loop)

- Score: PASS · Cycles: 1/1 (direct dispatch, non-RALF) · Severity: blocking:0, critical:0, major:0, minor:0
- Helper added at `collect.py:287-303` per spec D1; call-site swapped at line 453.
- All 11 `collect_test.sh` assertions green via direct `bash` invocation (T1, T2, T3a, T3b, T5, T6, T8a, T8b, T9, T10a, T10b).

## Verify-AC report (4/4 [m] bullets witnessed)

- **AC1** → T10b PASS in `collect_test.sh` — under `--mode human`, `show.log` records only `show h1-parent`; b1/i1/p1 parents NOT fetched.
- **AC2** → `select_section_beads` returns `human_beads + planning_beads + brainstorm_beads + impl_beads` for `mode=='all'`.
- **AC3** → Direct `bash` invocation: PASS T1, T2, T3a, T3b, T5, T6, T8a, T8b, T9.
- **AC4** → T10a + T10b PASS lines emitted by `collect_test.sh`.

[h] bullets: 0 (none in AC). No human-required follow-up beads needed.
Functional tests (`[functional-tests].commands`): empty, none to run.

## Discovered work (filed during this bead)

- `agents-config-9a38` — [bug] `dep-health-check/_test.sh` AC4/AC5 failing (missing `beads`/`findings` keys, `bead_count` type mismatch). Pre-existing failures in unrelated skill; surfaced because they make the wrapped project test runner exit non-zero. Being fixed in a parallel session — NOT part of this PR's scope.

## Foreign-eyes status

N/A — direct dispatch (no `ralf:required` on source bead, so no foreign-eyes iterations were run).

## Test plan

- [x] `bash src/user/.agents/skills/whats-next/collect_test.sh` exit 0 — all 11 assertions green (T1–T9 + T10a + T10b).
- [x] T10b discriminator: `show.log` under `--mode human` contains `show h1-parent` and NONE of `show b1-parent`, `show i1-parent`, `show p1-parent`.
- [x] `--mode all` perf unchanged (helper returns 4-section union for `mode='all'`).
