### PR TITLE
feat(y9mm-A): narrow active-child filter to count hep-pause HEP children

### DIFF
--- a/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/implement-bead/SKILL.md
@@ -70,6 +70,12 @@ else
 fi
 [ -z "$HUMAN_ID" ] && { echo "HEP: failed to extract escalation bead id" >&2; exit 1; }
 bd label add "$HUMAN_ID" human
+# Container branch only: `hep-pause` discriminates live HEP escalations
+# from bare `human`-labeled formula-gate children in the active-child
+# filter (see whats-next/collect.py and bd-finalize-container-gate.sh).
+if [ "$IS_CONTAINER" = "1" ]; then
+    bd label add "$HUMAN_ID" hep-pause
+fi
 bd update "$HUMAN_ID" --append-notes \
     "Source: <source-bead-id>
 Step-bead: <step-bead-id>

--- a/src/plugins/beads/.agents/skills/start-bead/SKILL.md
+++ b/src/plugins/beads/.agents/skills/start-bead/SKILL.md
@@ -168,6 +168,12 @@ Decide from the result array:
   fi
   [ -z "$HUMAN_ID" ] && { echo "HEP: failed to extract escalation bead id" >&2; exit 1; }
   bd label add "$HUMAN_ID" human
+  # Container branch only: `hep-pause` discriminates live HEP escalations
+  # from bare `human`-labeled formula-gate children in the active-child
+  # filter (see whats-next/collect.py and bd-finalize-container-gate.sh).
+  if [ "$IS_CONTAINER" = "1" ]; then
+      bd label add "$HUMAN_ID" hep-pause
+  fi
   bd update "$HUMAN_ID" --append-notes \
       "Source: <bead-id>
   Step-bead: N/A (pre-pour)
@@ -253,6 +259,12 @@ Decide from the result array:
   fi
   [ -z "$HUMAN_ID" ] && { echo "HEP: failed to extract escalation bead id" >&2; exit 1; }
   bd label add "$HUMAN_ID" human
+  # Container branch only: `hep-pause` discriminates live HEP escalations
+  # from bare `human`-labeled formula-gate children in the active-child
+  # filter (see whats-next/collect.py and bd-finalize-container-gate.sh).
+  if [ "$IS_CONTAINER" = "1" ]; then
+      bd label add "$HUMAN_ID" hep-pause
+  fi
   bd update "$HUMAN_ID" --append-notes \
       "Source: <bead-id>
   Step-bead: N/A (pre-pour)

--- a/src/plugins/beads/.beads/scripts/bd-finalize-container-gate.sh
+++ b/src/plugins/beads/.beads/scripts/bd-finalize-container-gate.sh
@@ -83,13 +83,16 @@ case "$X_TYPE" in
         # status open or in_progress. open,in_progress covers all non-closed
         # children. `--limit 0` keeps the inventory unbounded so a child past
         # row 50 cannot slip past the container check. We FILTER OUT
-        # formula-gate children (carrying `merge-gate` or `human` label)
-        # before counting: brainstorm finalize attaches merge-gate /
-        # [Human verify] children under feature-Y impl beads, and counting
-        # those toward "feature has active children" wrongly reclassifies
-        # legitimate Y impls as containers.
+        # formula-gate children (carrying `merge-gate`, or `human` WITHOUT
+        # `hep-pause`) before counting: brainstorm finalize attaches
+        # merge-gate / [Human verify] children under feature-Y impl beads,
+        # and counting those toward "feature has active children" wrongly
+        # reclassifies legitimate Y impls as containers. HEP escalation
+        # children carry BOTH `human` AND `hep-pause` — those ARE live
+        # human-pause artifacts under container sources and MUST count so
+        # the container stays classified while human input is pending.
         CHILD_COUNT=$(bd list --parent "$BEAD_ID" --status open,in_progress --limit 0 --json \
-            | jq '[.[] | select(((.labels // []) | (index("merge-gate") or index("human"))) | not)] | length')
+            | jq '[.[] | select((.labels // []) as $l | (($l | index("merge-gate")) or (($l | index("human")) and (($l | index("hep-pause")) | not))) | not)] | length')
         [ "$CHILD_COUNT" -gt 0 ] && CONTAINER=1 || CONTAINER=0 ;;
 esac
 
@@ -139,6 +142,7 @@ if [ "$PRODUCED_COUNT" -gt 1 ]; then
         exit 1
     fi
     bd label add "$ESC_ID" human
+    bd label add "$ESC_ID" hep-pause
     bd update "$ESC_ID" --append-notes \
 "Source: $BEAD_ID
 Step-bead: N/A (pre-pour container gate)
@@ -165,6 +169,7 @@ if [ "$PRODUCED_COUNT" -gt 0 ] || [ "$ORPHAN_REVERSE_COUNT" -gt 0 ]; then
         exit 1
     fi
     bd label add "$ESC_ID" human
+    bd label add "$ESC_ID" hep-pause
     # Tolerant lookup: bd mol current may fail or emit no usable JSON; the
     # `unknown` fallback is informational only. Under set -euo pipefail
     # the failure must be swallowed locally so the HEP path completes

--- a/src/plugins/beads/.claude/rules/beads-labels.md
+++ b/src/plugins/beads/.claude/rules/beads-labels.md
@@ -9,6 +9,7 @@
 | `implementation-readied-session-<sid>` | brainstorm-bead finalize | Session marker for Route A gating (`<sid>` = first 8 hex chars of session ID) |
 | `for-bead-<bead-id>` | start-bead / implement-bead | On molecule (not bead). Lookup edge from bead→molecule |
 | `human` | `bd label add <id> human` | Visibility tag for `bd human list`. NOT a gate on `bd ready` — only blocking deps gate readiness |
+| `hep-pause` | HEP procedure (container branch only) | Identifies a human-escalation bead (HEB) created as a CHILD of a container source. Unlike bare human-labeled children (formula-gate artifacts), hep-pause children ARE counted in active_child_count so the container stays classified while awaiting human resolution. |
 | `ralf:required` | brainstorm-bead finalize or manual | Formula dispatch signal for ralf-implement / ralf-review |
 | `ralf:cycles=N` | brainstorm-bead finalize or manual | Max-cycle override; remove existing `ralf:cycles=` label before adding replacement |
 | `epic-decomposed` | brainstorm-bead finalize (container path) | Audit-trail only; not a filter input. Container bead brainstormed for decomposition; no impl bead produced. Query historical decompositions: `bd list --label epic-decomposed --status closed --limit 0` (the `--limit 0` is required — `bd list` defaults to 50 rows and historical decomposition inventories may exceed that). |

--- a/src/plugins/beads/.claude/rules/beads.md
+++ b/src/plugins/beads/.claude/rules/beads.md
@@ -141,6 +141,14 @@ else
 fi
 [ -z "$HUMAN_ID" ] && { echo "HEP: failed to extract escalation bead id" >&2; exit 1; }
 bd label add "$HUMAN_ID" human
+# Container branch only: the `hep-pause` label discriminates live HEP
+# escalations (which MUST keep the container classified) from bare
+# `human`-labeled formula-gate children (which MUST NOT count toward
+# container status). See the active-child filter in
+# `bd-finalize-container-gate.sh` and `whats-next/collect.py`.
+if [ "$IS_CONTAINER" = "1" ]; then
+    bd label add "$HUMAN_ID" hep-pause
+fi
 bd update "$HUMAN_ID" --append-notes \
     "Source: <source-bead-id>
 Step-bead: <step-bead-id>

--- a/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_a_test.sh
+++ b/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_a_test.sh
@@ -136,11 +136,19 @@ for row in impl:
             )
     else:
         children = []
-    # Filter out formula-gate children (merge-gate / human labeled).
-    active = [
-        c for c in children
-        if not (set(c.get("labels", []) or []) & {"merge-gate", "human"})
-    ]
+    # Mirror the narrowed active-child filter in production
+    # (whats-next/collect.py and bd-finalize-container-gate.sh):
+    # exclude `merge-gate` OR (`human` AND NOT `hep-pause`). HEP escalation
+    # children carrying `human + hep-pause` ARE live container artifacts;
+    # they count toward active_child_count.
+    def _is_formula_gate(c):
+        labels = set(c.get("labels", []) or [])
+        if "merge-gate" in labels:
+            return True
+        if "human" in labels and "hep-pause" not in labels:
+            return True
+        return False
+    active = [c for c in children if not _is_formula_gate(c)]
     if active:
         raise SystemExit(
             f"A2: feature row {bid} has {len(active)} active non-formula-gate "
@@ -222,10 +230,19 @@ for row in pl:
             )
     else:
         children = []
-    active = [
-        c for c in children
-        if not (set(c.get("labels", []) or []) & {"merge-gate", "human"})
-    ]
+    # Mirror the narrowed active-child filter in production
+    # (whats-next/collect.py and bd-finalize-container-gate.sh):
+    # exclude `merge-gate` OR (`human` AND NOT `hep-pause`). HEP escalation
+    # children carrying `human + hep-pause` ARE live container artifacts;
+    # they count toward active_child_count.
+    def _is_formula_gate(c):
+        labels = set(c.get("labels", []) or [])
+        if "merge-gate" in labels:
+            return True
+        if "human" in labels and "hep-pause" not in labels:
+            return True
+        return False
+    active = [c for c in children if not _is_formula_gate(c)]
     if active:
         raise SystemExit(
             f"A4: planning row {bid} has {len(active)} active non-formula-gate "

--- a/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_c_test.sh
+++ b/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_c_test.sh
@@ -197,4 +197,47 @@ CHILDREN=$(bd list --parent "$T1" --limit 0 --json 2>/dev/null \
 bd mol burn "$MOL_T1" --force >/dev/null 2>&1 || true
 pass "C6: plain task → not-container; no human child created"
 
+# =============================================================================
+# C7: feature with a pre-existing HEP escalation child (human+hep-pause) must
+# be recognized by the container gate as a CONTAINER (decision='handled' via
+# clean-decomposition path), not a leaf bead.
+#
+# Scenario: feature F has exactly one open child carrying both `human` and
+# `hep-pause` labels — the post-fix HEP shape sitting under a container
+# source. F has no `produced-bead-*` label (no prior Y produced). The gate
+# is invoked on F.
+#
+# Expected behavior (after fix): the feature CHILD_COUNT probe narrows from
+# "any human-labeled child" to "human-labeled AND NOT hep-pause"; the
+# hep-pause child IS counted → CHILD_COUNT=1 → CONTAINER=1 → with no
+# produced-bead-* label and no orphan reverse edge, the gate falls through
+# to the clean-decomposition outcome → emits `handled`.
+#
+# Current (buggy) behavior: the wider filter excludes the human-labeled
+# child (whether or not it carries hep-pause) → CHILD_COUNT=0 → CONTAINER=0
+# → gate emits `not-container` → ASSERTION FAILS.
+#
+# Second assertion: the pre-existing HEP child must still carry `hep-pause`
+# (we stamped it ourselves; this guards the label-stamping contract).
+# =============================================================================
+F=$(make_bead feature "stress-test C7 feature with HEP child")
+HEP_PRE=$(bd create --parent "$F" --type task --priority 4 \
+    --title "[Human] pre-existing HEP child" --json \
+    | jq -r 'if type=="array" then .[0].id else .id end // empty')
+[ -z "$HEP_PRE" ] && fail "C7: failed to create HEP child under F"
+bd label add "$HEP_PRE" stress-test-fixture >/dev/null 2>&1
+bd label add "$HEP_PRE" human               >/dev/null 2>&1
+bd label add "$HEP_PRE" hep-pause           >/dev/null 2>&1
+CREATED_BEADS+=("$HEP_PRE")
+
+MOL_F=$(make_wisp "$F" "stress-c7")
+DECISION=$(run_gate "$F" "$MOL_F")
+[ "$DECISION" = "handled" ] \
+    || fail "C7: feature with human+hep-pause child decision expected 'handled' (active container → clean-decomposition path), got '$DECISION' — gate's feature CHILD_COUNT probe wrongly excludes hep-pause children from the active-child count"
+
+# Assertion 2: pre-existing HEP child still carries hep-pause.
+has_label "$HEP_PRE" hep-pause \
+    || fail "C7: pre-existing HEP child $HEP_PRE missing 'hep-pause' label — label stamping must be preserved across the gate path"
+pass "C7: feature with one open human+hep-pause child is recognized as container (decision=handled); HEP child retains hep-pause label"
+
 echo "GROUP C: implement-bead routing via container gate helper passed."

--- a/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_d_test.sh
+++ b/src/user/.agents/skills/epic-hygiene-tests/pr72_validate_d_test.sh
@@ -140,7 +140,7 @@ else:
 count = 0
 for c in children:
     labels = c.get("labels", []) or []
-    if "merge-gate" in labels or "human" in labels:
+    if "merge-gate" in labels or ("human" in labels and "hep-pause" not in labels):
         continue
     count += 1
 mod.active_child_count = {fid: count}

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -206,10 +206,14 @@ def is_container(bead_id, bead_type):
     feature         — container only when it has ≥1 non-closed children
                       that are NOT formula-gate children. The
                       active_child_count index below excludes children
-                      labeled `merge-gate` or `human` so feature-Y impl
-                      beads (which always carry a merge-gate child via
-                      brainstorm finalize step 5b) don't get misclassified
-                      as containers.
+                      labeled `merge-gate` or `human` (without
+                      `hep-pause`) so feature-Y impl beads (which always
+                      carry a merge-gate child via brainstorm finalize
+                      step 5b) don't get misclassified as containers.
+                      `human + hep-pause` children ARE counted — those
+                      are live HEP escalations under container sources
+                      and keep the parent classified as a container
+                      while human input is pending.
     """
     if bead_type in CONTAINER_ALWAYS:
         return True
@@ -358,7 +362,12 @@ def main():
         # brainstorm-bead finalize step 5b creates `merge-gate` and (when
         # AC has [h] lines) `human`-labeled `[Human verify]` children
         # under feature-Y impl beads. These don't make Y a container.
-        if "merge-gate" in labels or "human" in labels:
+        # IMPORTANT: bare `human` children are formula-gate artifacts and
+        # are excluded, BUT `human` children that also carry `hep-pause`
+        # are live HEP escalations (created by the HEP procedure under
+        # container sources) — those MUST count so the container stays
+        # classified while human input is pending.
+        if "merge-gate" in labels or ("human" in labels and "hep-pause" not in labels):
             continue
         active_child_count[parent] = active_child_count.get(parent, 0) + 1
 

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -588,4 +588,175 @@ for forbidden in b1-parent i1-parent p1-parent; do
 done
 pass "T10b: --mode human fetches only h1-parent; brainstorm/impl/planning parents are not fetched (display_ids scoped to emitted sections)"
 
+# -----------------------------------------------------------------------------
+# T11. HEP escalation child discrimination via `hep-pause` label.
+#
+# Scenario: A feature bead (no readiness labels) has exactly one open child
+# carrying BOTH `human` AND `hep-pause` labels — the post-fix shape of a HEP
+# escalation bead (HEB) sitting under a container source.
+#
+# Expected behavior (after fix): the production active_child_count loop
+# COUNTS the hep-pause child → is_container() returns True for the feature
+# → the feature is hidden from planning_ready (active container).
+#
+# Current (buggy) behavior: the count-construction loop excludes any
+# `human`-labeled child unconditionally → active_child_count == 0 →
+# is_container() returns False → feature treated as childless → SURFACES
+# in planning_ready → TEST FAILS.
+#
+# Test method: end-to-end via collect.py --mode planning so the production
+# filter is exercised. Assertion: the feature is NOT in planning_ready
+# (it has an active hep-pause child, so it is a container).
+# -----------------------------------------------------------------------------
+TMP_T11=$(mktemp -d)
+trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9" ${TMP_T10:+"$TMP_T10"} "$TMP_T11"' EXIT
+
+cat > "$TMP_T11/bd" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  "list --label human --limit 0 --json")
+    # The hep-pause child also carries `human` so it surfaces here.
+    echo '[{"id":"proj-hebchild","issue_type":"task","status":"open","priority":1,"title":"Human input needed","labels":["human","hep-pause"],"parent":"proj-hepfeat"}]' ;;
+  "list --status open,in_progress --limit 0 --json")
+    # Feature (no readiness labels) + ONE child carrying human+hep-pause.
+    # Under the FIX, the child IS counted → feature is a container.
+    # Under current code, the child is excluded → count=0 → feature is
+    # treated as childless and leaks into planning_ready.
+    cat <<'JSON'
+[
+  {"id":"proj-hepfeat","issue_type":"feature","status":"open","priority":1,"title":"feature paused via HEP","labels":[]},
+  {"id":"proj-hebchild","issue_type":"task","status":"open","priority":1,"title":"Human input needed","labels":["human","hep-pause"],"parent":"proj-hepfeat"}
+]
+JSON
+    ;;
+  "ready --json")
+    # Feature is dep-unblocked (container HEP gates via parent-child shape,
+    # not a blocks edge).
+    cat <<'JSON'
+[
+  {"id":"proj-hepfeat","issue_type":"feature","status":"open","priority":1,"title":"feature paused via HEP","labels":[],"created_at":"2026-05-01"}
+]
+JSON
+    ;;
+  "list --type milestone --ready --limit 0 --json") echo '[]' ;;
+  "list --type epic --ready --limit 0 --json") echo '[]' ;;
+  "list --type feature --ready --limit 0 --json")
+    # Childless-looking feature is returned by the --ready query; planning
+    # filter must drop it because active_child_count > 0 (after fix).
+    cat <<'JSON'
+[
+  {"id":"proj-hepfeat","issue_type":"feature","status":"open","priority":1,"title":"feature paused via HEP","labels":[]}
+]
+JSON
+    ;;
+  *) echo '[]' ;;
+esac
+SHIM
+chmod +x "$TMP_T11/bd"
+
+OUT_T11="$TMP_T11/planning.json"
+PATH="$TMP_T11:$PATH" python3 "$COLLECT_PY" --mode planning \
+    >"$OUT_T11" 2>"$TMP_T11/err.plan"
+ec=$?
+[ "$ec" -eq 0 ] \
+    || fail "T11: collect.py --mode planning exited $ec (stderr: $(cat "$TMP_T11/err.plan"))"
+
+OUT_T11="$OUT_T11" python3 - <<'PY' \
+    || fail "T11: HEP-paused feature (one human+hep-pause child) leaked into planning_ready (active-child filter must count hep-pause children)"
+import json, os
+out = json.load(open(os.environ["OUT_T11"]))
+pr = out.get("planning_ready", [])
+ids = [b.get("id") for b in pr]
+assert "proj-hepfeat" not in ids, (
+    f"feature with one open human+hep-pause child MUST NOT appear in "
+    f"planning_ready (it is an active container; the hep-pause child must "
+    f"be counted toward active_child_count); got planning_ready ids: {ids}"
+)
+PY
+pass "T11: HEP-paused feature with one human+hep-pause child is recognized as a container (excluded from planning_ready)"
+
+# -----------------------------------------------------------------------------
+# T12. Feature with `implementation-ready` whose ONLY active child carries
+# `human+hep-pause` must NOT surface in --mode implementation.
+#
+# Scenario: A feature carrying `implementation-ready` has exactly one open
+# child carrying ['human','hep-pause'] — the post-fix HEP shape. The
+# feature is a paused container, not a leaf impl bead.
+#
+# Expected behavior (after fix): active_child_count == 1 → is_container()
+# True → is_impl_candidate() False → feature NOT in implementation section.
+#
+# Current (buggy) behavior: hep-pause child wrongly excluded → count == 0 →
+# is_container() False → feature TREATED AS LEAF IMPL → appears in
+# implementation section → TEST FAILS.
+# -----------------------------------------------------------------------------
+TMP_T12=$(mktemp -d)
+trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6" "$TMP_T8" "$TMP_T9" ${TMP_T10:+"$TMP_T10"} "$TMP_T11" "$TMP_T12"' EXIT
+
+cat > "$TMP_T12/bd" <<'SHIM'
+#!/usr/bin/env bash
+case "$*" in
+  "list --label human --limit 0 --json")
+    # The hep-pause child carries `human` so it surfaces here too — but the
+    # human SECTION just shows it (irrelevant to the implementation
+    # assertion below).
+    echo '[{"id":"proj-hebchild","issue_type":"task","status":"open","priority":1,"title":"Human input needed","labels":["human","hep-pause"],"parent":"proj-pausedfeat"}]' ;;
+  "list --status open,in_progress --limit 0 --json")
+    # Feature with implementation-ready + ONLY a human+hep-pause child.
+    # Under the FIX, the child is counted → feature is a container →
+    # excluded from implementation. Under current code, the child is
+    # excluded → count=0 → feature treated as a leaf impl bead → leaks
+    # into implementation queue.
+    cat <<'JSON'
+[
+  {"id":"proj-pausedfeat","issue_type":"feature","status":"open","priority":1,"title":"[Impl] feature paused via HEP","labels":["implementation-ready"]},
+  {"id":"proj-hebchild","issue_type":"task","status":"open","priority":1,"title":"Human input needed","labels":["human","hep-pause"],"parent":"proj-pausedfeat"}
+]
+JSON
+    ;;
+  "ready --json")
+    # bd ready returns the paused feature (it has impl-ready label and no
+    # blocking dep, since HEP for containers uses parent-child gating, not
+    # a blocks edge).
+    cat <<'JSON'
+[
+  {"id":"proj-pausedfeat","issue_type":"feature","status":"open","priority":1,"title":"[Impl] feature paused via HEP","labels":["implementation-ready"],"created_at":"2026-05-01"}
+]
+JSON
+    ;;
+  "list --type milestone --ready --limit 0 --json") echo '[]' ;;
+  "list --type epic --ready --limit 0 --json") echo '[]' ;;
+  "list --type feature --ready --limit 0 --json")
+    cat <<'JSON'
+[
+  {"id":"proj-pausedfeat","issue_type":"feature","status":"open","priority":1,"title":"[Impl] feature paused via HEP","labels":["implementation-ready"]}
+]
+JSON
+    ;;
+  *) echo '[]' ;;
+esac
+SHIM
+chmod +x "$TMP_T12/bd"
+
+OUT_T12="$TMP_T12/impl.json"
+PATH="$TMP_T12:$PATH" python3 "$COLLECT_PY" --mode implementation \
+    >"$OUT_T12" 2>"$TMP_T12/err.impl"
+ec=$?
+[ "$ec" -eq 0 ] \
+    || fail "T12: collect.py --mode implementation exited $ec (stderr: $(cat "$TMP_T12/err.impl"))"
+
+OUT_T12="$OUT_T12" python3 - <<'PY' \
+    || fail "T12: paused feature with only human+hep-pause child leaked into implementation queue (active-child filter must count hep-pause children)"
+import json, os
+out = json.load(open(os.environ["OUT_T12"]))
+impl = out.get("implementation", [])
+ids = [b.get("id") for b in impl]
+assert "proj-pausedfeat" not in ids, (
+    f"feature with implementation-ready and ONLY a human+hep-pause child "
+    f"MUST NOT appear in implementation (it is a HEP-paused container, not "
+    f"a leaf impl bead); got implementation ids: {ids}"
+)
+PY
+pass "T12: HEP-paused feature (impl-ready + only human+hep-pause child) is excluded from --mode implementation"
+
 echo "All collect.py red-phase tests reached — script exits 0 only when every assertion above passes."


### PR DESCRIPTION
## Summary

- Narrow `active_child_count` filter in `collect.py` and `bd-finalize-container-gate.sh` from `(merge-gate OR human)` to `(merge-gate OR (human AND NOT hep-pause))` — HEP escalation children under container sources must count so the container stays classified while awaiting human input
- Stamp `hep-pause` on HEP escalation beads created as children of containers at all 6 call sites: `bd-finalize-container-gate.sh`×2, `beads.md`, `start-bead/SKILL.md` Route C×2, `implement-bead/SKILL.md` §0
- Add `hep-pause` row to `beads-labels.md` Label Reference table

**Note:** `SRC_ACTIVE_CHILDREN` IS_CONTAINER detection probes in `beads.md`, `start-bead/SKILL.md`, `implement-bead/SKILL.md` intentionally left with the wide filter — safe at first-escalation time (no HEB child exists yet). Second-escalation safety tracked in y9mm-B.

## Test Plan

- [x] T11: HEP-paused feature with one `human+hep-pause` child → `is_container()=True` (excluded from `planning_ready`)
- [x] T12: `implementation-ready` feature with only `human+hep-pause` child → NOT in `--mode implementation` output
- [x] C7: feature source with only `human+hep-pause` child + no `produced-bead-*` labels → gate returns `handled`; child retains `hep-pause` label
- [x] All PR #72 epic-hygiene tests remain green
- [x] 29/29 test files PASS
- [x] Codex gpt-5.5 foreign-eyes adversarial review: PASS, 0 findings

Closes agents-config-y9mm.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)