### PR TITLE
feat(cx6.7.3): empirical eval-loop integration in optimize-my-skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ htmlcov/
 .ruff_cache/
 .mypy_cache/
 .venv/
+
+# optimize-my-skill --deep workspaces (persistent but not committed)
+.eval-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ htmlcov/
 
 # optimize-my-skill --deep workspaces (persistent but not committed)
 .eval-runs/
+
+# Sidekick ephemeral session state (transcripts, persona JSON, metrics)
+.sidekick/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,3 @@ htmlcov/
 
 # optimize-my-skill --deep workspaces (persistent but not committed)
 .eval-runs/
-
-# Sidekick ephemeral session state (transcripts, persona JSON, metrics)
-.sidekick/

--- a/docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-design.md
+++ b/docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-design.md
@@ -1,0 +1,372 @@
+# cx6.7.3 — Empirical eval-loop integration for optimize-my-skill
+
+**Bead:** `agents-config-cx6.7.3` (P1 child of `agents-config-cx6.7`)
+**Date:** 2026-05-19
+**Status:** Design (awaiting implementation plan)
+
+## Goal
+
+Transform `optimize-my-skill` from a static auditor into a tool that also runs
+the empirical description-optimization loop and surfaces a human-reviewable
+output-quality report — by amalgamating the iteration machinery from
+`oss-snapshots/anthropics/skill-creator/` directly into
+`src/user/.agents/skills/optimize-my-skill/`, not by depending on a separate
+standalone `skill-creator` skill.
+
+## Target carve-up (resolves prior ambiguity)
+
+The original `cx6.7.4` plan to import skill-creator as a third standalone
+skill is **superseded**. Final state is two skills:
+
+| Skill | Owns |
+|-------|------|
+| `writing-skills` | Create-from-scratch + TDD-for-skills methodology (already in place via `cx6.7.2`) |
+| `optimize-my-skill` | Audit existing skills (today) + empirical iteration machinery (this bead) |
+
+Reasoning: a third `skill-creator` skill would create persistent triggering
+overlap with `writing-skills` (both have "create a skill" in their description
+surface). The valuable parts of skill-creator are the iteration scripts and
+review-loop subagents — those belong inside the skill that uses them.
+
+## Architecture
+
+### File scope of the amalgam
+
+Bring into `src/user/.agents/skills/optimize-my-skill/`:
+
+```
+optimize-my-skill/
+├── SKILL.md                    # rewritten: provenance header + Phase 4/5/6
+├── scripts/
+│   ├── run_loop.py             # ← skill-creator (description-optimization loop)
+│   ├── run_eval.py             # ← skill-creator (single-pass trigger eval)
+│   ├── improve_description.py  # ← skill-creator (LLM description rewriter)
+│   ├── aggregate_benchmark.py  # ← skill-creator (multi-run aggregation)
+│   ├── generate_report.py      # ← skill-creator (HTML trigger report)
+│   ├── quick_validate.py       # ← skill-creator (fast static skill check)
+│   ├── utils.py                # ← skill-creator (shared helpers)
+│   └── eval-viewer/
+│       ├── generate_review.py  # ← skill-creator/eval-viewer/ (review server)
+│       └── viewer.html         # ← skill-creator/eval-viewer/ (review UI shell)
+├── agents/
+│   ├── grader.md               # ← skill-creator (expectations vs outputs)
+│   ├── comparator.md           # ← skill-creator (blind A/B compare)
+│   └── analyzer.md             # ← skill-creator (post-hoc why-winner-won)
+└── references/
+    ├── SKILLS_PRIMER.md        # existing
+    └── eval-set-format.md      # new — JSON schema + auto-draft prompt template
+```
+
+Explicitly **not** copied:
+
+- `package_skill.py` — Anthropic `.skill` bundler, irrelevant here
+- Upstream `SKILL.md` — we keep our audit-focused body
+- Upstream agents' SKILL.md-internal references that don't apply
+
+### Provenance
+
+Header at top of `optimize-my-skill/SKILL.md`, mirroring the
+`writing-skills` amalgam format established in `cx6.7.2`:
+
+```markdown
+<!--
+Sources (amalgam):
+  - Native (audit/assess methodology — Phases 1–3, 6)
+  - oss-snapshots/anthropics/skill-creator/
+    Upstream: https://github.com/anthropics/skills @ f458cee31a7577a47ba0c9a101976fa599385174
+Last sync: 2026-05-19
+Drift policy: accept-periodic-resync
+-->
+```
+
+Plus one new row in `src/user/.agents/skills/AGENTS.md` provenance registry:
+
+| Skill | Snapshot path | Upstream | Last sync | Drift policy |
+|-------|---------------|----------|-----------|--------------|
+| `optimize-my-skill` | `oss-snapshots/anthropics/skill-creator/` | `anthropics/skills @ f458cee` | 2026-05-19 | accept-periodic-resync |
+
+### Installer impact
+
+None. `install.sh` already stages `scripts/`, `agents/`, `references/` as-is
+(including the nested `scripts/eval-viewer/`). Depth-1 invariant applies to
+the skill folder itself, not internal subdirs. Verify with
+`install.sh --dry-run` as part of the smoke test.
+
+## Skill body — phase structure
+
+| # | Phase | Status |
+|---|-------|--------|
+| **P1** | Discover and Read | unchanged |
+| **P2** | Assess Against Quality Criteria | unchanged |
+| **P3** | Propose Improvements | unchanged |
+| **P4** | **Empirical Optimization** *(new — gated by `--deep`)* | 4a description loop + 4b output review |
+| **P5** | **Iterate** *(new — gated by `--deep`)* | Reads P4 results + feedback; proposes revisions; may loop back to P4 |
+| **P6** | Confirm and Apply | shifted from old P5; semantics unchanged |
+
+`--quick` (the implicit default) collapses P4 to today's advisory content and
+turns P5 into a pass-through to P6. No behavior change for users who don't
+opt into `--deep`.
+
+### Phase 4a — Description loop (automated)
+
+1. Resolve eval set (see Eval-set lifecycle below).
+2. Invoke `scripts/run_loop.py` with `{skill_path, eval_set, model,
+   max_iterations}`. Defaults: `--max-iterations 5`, `--holdout 0.4`,
+   `--runs-per-query 3`, `--num-workers 10`.
+3. Capture output `{best_description, history, train/test scores}` for P5.
+
+### Phase 4b — Output review (semi-automated, in-house orchestrated)
+
+1. Create persistent workspace at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
+   (git-ignored).
+2. Select the first 3 `should_trigger:true` entries from the eval set
+   (deterministic; no random sampling).
+3. For each prompt, dispatch a fresh subagent in parallel with instructions
+   to (a) read the target skill, (b) perform the user task, (c) write
+   outputs to `<run-dir>/outputs/`, (d) write its turn-by-turn transcript
+   to `<run-dir>/transcript.md`, (e) return a one-sentence summary.
+   Write `eval_metadata.json` before dispatch.
+4. After each run completes, if its `expectations` list is non-empty,
+   dispatch the bundled `grader` subagent against the run dir; grader
+   writes `metrics.json`.
+5. Launch `scripts/eval-viewer/generate_review.py <workspace> --skill-name <name>`.
+   Skill body emits the review URL and blocks until the server exits.
+6. On exit, read `feedback.json`; pass to P5.
+
+Workspace shape (matches what `generate_review.py` discovers):
+
+```
+.eval-runs/<timestamp>/
+├── run-NNNN/
+│   ├── outputs/              # files produced by the skill (if any)
+│   ├── transcript.md         # subagent's turn-by-turn transcript
+│   ├── eval_metadata.json    # {eval_id, prompt, expectations}
+│   └── metrics.json          # optional: grader pass/fail, duration
+└── feedback.json             # written by generate_review.py
+```
+
+### Phase 4 cost gate
+
+Before launching `run_loop.py`, the skill body MUST emit an explicit estimate
+and confirm with the user via `AskUserQuestion`:
+
+> "`--deep` will execute roughly N model calls across M iterations
+> (description-improver: K calls; triggering eval: P calls; output runs:
+> Q subagent dispatches; grader: R calls). Estimated cost ~$X. Continue?"
+
+User can abort cheaply. Confirmation gates each `--deep` invocation; no
+per-skill sidecar consent persistence in v1.
+
+### Failure modes
+
+- Port-in-use → retry with port+1 up to 5 attempts; document `--port` override path
+- Subagent timeout (5 min/run default) → write `metrics.json` with `{status:"timeout"}`, continue; partial transcript still visible in review server
+- Grader skipped (no expectations) → log it, no error
+- Empty `feedback.json` (user ^C before reviewing) → P5 asks "no feedback captured — abort or proceed with description-loop results only?"
+
+## Command + flag UX
+
+Surface (in `src/user/.claude/commands/optimize-my-skill.md`):
+
+```
+/optimize-my-skill [<target>] [--deep] [--max-iterations N] [--model <name>]
+```
+
+| Token | Meaning |
+|-------|---------|
+| `<target>` | skill name, directory path, or empty (resolved as today) |
+| `--deep` | opt into Phase 4/5 empirical loop; absent = today's behavior |
+| `--max-iterations N` | override run_loop default (5); ignored without `--deep` |
+| `--model <name>` | model id for description-improver; default `claude-haiku-4-5-20251001`; ignored without `--deep` |
+
+Command parses `$ARGUMENTS` by whitespace-splitting; one non-flag token is
+`<target>`, the rest are flags. Empty `<target>` triggers existing default-
+location probe.
+
+**Explicitly NOT adding** (YAGNI): `--no-output-review`, `--resume`,
+`--quick` (naked invocation IS quick), `--review-batch N`,
+`--clean` for workspaces.
+
+## Eval-set lifecycle (hybrid model)
+
+**Conventional path:** `<skill-dir>/evals.json` — lives inside the skill
+being scored. Naturally git-versioned, naturally co-located.
+
+**Unified schema** (one file serves both 4a triggering and 4b output review):
+
+```json
+[
+  {
+    "query": "Can you audit the writing-skills skill for me?",
+    "should_trigger": true,
+    "expectations": [
+      "Reads writing-skills/SKILL.md before proposing anything",
+      "Reports concrete frontmatter findings (not vague advice)",
+      "Surfaces a per-skill structured proposal"
+    ]
+  },
+  {
+    "query": "Help me write a new skill for parsing PDFs.",
+    "should_trigger": false,
+    "expectations": []
+  }
+]
+```
+
+| Field | Required | Used by |
+|-------|----------|---------|
+| `query` | yes | both 4a and 4b |
+| `should_trigger` | yes | 4a (precision/recall); 4b only consumes `true` entries |
+| `expectations` | optional, list of strings | 4b grader; empty/missing = grader skipped for that run |
+
+**Resolution flow in Phase 4a.1:**
+
+1. Probe `<skill-dir>/evals.json`. If present: use it, print one-line summary, continue.
+2. If absent: skill reads target SKILL.md, drafts a starter set per
+   `references/eval-set-format.md` template (target 5–10 trigger + 5–10
+   no-trigger queries; near-miss queries valued over obviously-unrelated).
+3. Write to `<skill-dir>/evals.json`.
+4. Display via `AskUserQuestion` → Accept proceed / Edit (pause, user edits
+   file, types continue) / Reject (abort `--deep`).
+5. Subsequent `--deep` runs find the file and skip draft+review automatically.
+
+**`references/eval-set-format.md`** (new, ~50 lines): JSON schema with field
+semantics; auto-draft prompt template; weak-vs-strong eval examples.
+
+## Smoke-test plan (satisfies bead AC)
+
+### Pre-implementation smoke (before wiring P4 into SKILL.md)
+
+1. **Script imports clean** — every amalgamated script runs `--help` without ImportError
+2. **`run_loop.py` end-to-end on throwaway sample** — `/tmp/sample-skill/` with deliberately weak description; 6-entry eval set; `--max-iterations 2 --num-workers 2 --holdout 0 --model claude-haiku-4-5-20251001`
+3. **`run_eval.py` standalone** — single eval pass against sample
+4. **`generate_review.py` against scaffolded workspace** — manually scaffold one `run-0001/`; confirm server starts and run is discoverable; ^C clean
+5. **`grader` subagent dispatch** — against scaffolded run with 1–2 expectations
+6. **`install.sh --dry-run`** — confirms `scripts/` (with nested `eval-viewer/`), `agents/`, `references/` stage cleanly under `~/.claude/skills/optimize-my-skill/`; depth-1 invariant honored on the skill folder
+
+### Post-implementation smoke (after wiring P4/5/6)
+
+7. **`/optimize-my-skill <sample-skill>`** — naked invocation; confirms no regression in P1–3 + P6
+8. **`/optimize-my-skill optimize-my-skill --deep --max-iterations 1`** — **dogfood on optimize-my-skill itself.** Auto-drafted ~6-entry eval set, accept without hand-editing for smoke. Single description-improver iteration, 3-prompt output-review battery. **Validate mechanically only — do NOT apply any results.** Discard generated artifacts; real empirical pass happens in the follow-up bead
+
+### Evidence captured to bead notes (`bd update --append-notes`)
+
+```
+Smoke-test results — agents-config-cx6.7.3
+- Script import (8 scripts): all --help pass
+- run_loop.py on sample: <N> iterations, train <X>/<Y> passed, best: "<text>"
+- run_eval.py standalone: <X>/<Y> passed
+- generate_review.py: started on port <P>, sample run discoverable, ^C clean
+- grader subagent: <pass/fail> on <K> expectations
+- install.sh --dry-run: <N> files under ~/.claude/skills/optimize-my-skill/
+- /optimize-my-skill <sample> (quick): completed in <T>s, no regressions
+- /optimize-my-skill optimize-my-skill --deep --max-iterations 1 (dogfood):
+  completed in <T>s, workspace at <path>, feedback.json captured <K> entries,
+  self-reference check passed (no recursion/loop), artifacts NOT committed
+```
+
+Sample skill lives at `/tmp/cx6.7.3-sample-skill/`, not committed.
+
+## Bead graph updates
+
+### `cx6.7.3` — description rewrite
+
+Replace bead description with:
+
+> Amalgamate skill-creator's iteration machinery into
+> `src/user/.agents/skills/optimize-my-skill/` (scripts/ + bundled subagents
+> in agents/ + eval-viewer payload). Add provenance header citing
+> oss-snapshots/anthropics/skill-creator at pinned commit. Rewrite SKILL.md
+> to add Phase 4 (Empirical Optimization: 4a description loop via
+> `run_loop.py`, 4b output review via in-house orchestration +
+> `generate_review.py`) and Phase 5 (Iterate); old Phase 5 (Confirm and
+> Apply) shifts to Phase 6. Update command file to handle `--deep` /
+> `--max-iterations` / `--model` flags with `--quick` implicit default.
+> Define eval-set lifecycle (`<skill-dir>/evals.json`, hybrid
+> auto-draft-on-miss). Smoke-test scripts in isolation AND one
+> `--deep --max-iterations 1` end-to-end pass dogfooded on optimize-my-skill
+> itself (mechanical validation only). Update
+> `src/user/.agents/skills/AGENTS.md` provenance registry.
+
+Acceptance criteria additions on top of existing:
+
+- Provenance header present on `optimize-my-skill/SKILL.md` (writing-skills format)
+- `install.sh --dry-run` shows clean staging under `~/.claude/skills/optimize-my-skill/`
+- `.eval-runs/` added to project `.gitignore`
+- Smoke-test evidence appended to bead notes (template above)
+
+### `cx6.7.4` — close as superseded
+
+Close reason:
+
+> Superseded by cx6.7.3's amalgam carve-up. Target state is two skills
+> (writing-skills + optimize-my-skill), not three. The iteration machinery
+> skill-creator was going to host as standalone now lives inside
+> optimize-my-skill; the create-flow narrative already lives in
+> writing-skills via cx6.7.2's amalgam. If a future inspection of
+> skill-creator's prose surfaces specific narrative worth lifting into
+> writing-skills, open a small follow-up at that time — none identified
+> during the cx6.7.3 brainstorm.
+
+### New bead: `cx6.7.D` — full empirical dogfood pass
+
+Filed at the end of `cx6.7.3` implementation, before `.3` closes:
+
+```bash
+bd create --parent agents-config-cx6.7 \
+  --type task --priority 2 \
+  --title "Empirical dogfood pass on optimize-my-skill (full --deep run)" \
+  --description "First real-customer use of the newly-wired --deep flow. Hand-curate a meaningful evals.json for optimize-my-skill (~15 entries, mix of clear should-trigger, clear should-not-trigger, and near-miss adversarial queries that probe known overlap with writing-skills + skill-creator history). Run /optimize-my-skill optimize-my-skill --deep with default iterations and ~5-prompt output-review battery. Apply any description and body improvements the empirical results justify; commit evals.json as the regression baseline. Capture model spend in bead notes for future cost calibration." \
+  --acceptance "evals.json committed under src/user/.agents/skills/optimize-my-skill/. Description and/or body changes (if any) committed with rationale tying back to the empirical results. Model spend captured in bead notes. Workspace artifacts NOT committed (.gitignored)."
+
+bd dep add cx6.7.D cx6.7.3       # blocks on .3
+bd dep add cx6.7.7 cx6.7.D       # .7 (final close-out) blocks on this
+```
+
+Independent of `cx6.7.5` / `cx6.7.6` — those are per-namespace verdict
+passes, orthogonal to dogfooding the optimizer.
+
+### Dep edits on `.5` and `.6`
+
+Both currently `blocks` on `.3` AND `.4`. After `.4` closes, its blocker
+auto-resolves. Verify post-close with `bd show cx6.7.5 --json` — only the
+`.3` blocker should remain open.
+
+### `cx6.7.7` — unchanged scope, new upstream
+
+Still `blocks` on `.5` and `.6`; now also `blocks` on `cx6.7.D` (the dogfood
+bead) — added above.
+
+## Order of operations during `.3` implementation
+
+1. Amalgamate files (scripts, agents, eval-viewer payload → assets/, references/)
+2. Add provenance header + registry row
+3. Pre-implementation smoke tests (items 1–6); append evidence
+4. Rewrite SKILL.md (Phase 4/5/6 + scrub two existing skill-creator advisory lines)
+5. Update command file (flag parsing)
+6. Post-implementation smoke tests (items 7–8, dogfood); append evidence
+7. Add `.eval-runs/` to project `.gitignore`
+8. Update `src/user/.agents/skills/AGENTS.md` provenance registry
+9. File `cx6.7.D` (dogfood follow-up) per script above
+10. Close `cx6.7.3`; immediately close `cx6.7.4` with superseded reason
+11. Verify `cx6.7.5` and `cx6.7.6` now appear in `bd ready`
+
+## Explicit exclusions (out of scope)
+
+- `--no-output-review` flag (YAGNI v1)
+- `--review-batch N` flag (3 deterministic prompts)
+- `--resume` / async server model (blocking is fine for interactive use)
+- `--clean` for `.eval-runs/` workspaces
+- Automated output-correctness scoring beyond grader-against-expectations
+  (comparator agent is bundled but not auto-invoked)
+- Project-wide eval registry (`evals/<skill-name>.json`); evals stay
+  co-located with skills
+- `$EDITOR` shell-out for eval-set editing
+- CI hook running `--deep` on every PR (model spend prohibitive)
+- `package_skill.py` (Anthropic `.skill` bundler)
+- Carving skill-creator's create-flow narrative into writing-skills
+  (writing-skills already covers it; revisit only if specific prose worth
+  lifting is identified)
+- Installer changes (depth-1 invariant honored; staging unchanged)
+- Changes to any other skill (purely additive to optimize-my-skill +
+  closure work on `cx6.7.4`)

--- a/docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-plan.md
+++ b/docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-plan.md
@@ -1,0 +1,1309 @@
+# cx6.7.3 — Empirical eval-loop integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire optimize-my-skill into a real empirical description-optimization loop and human-reviewable output-quality surface by amalgamating skill-creator's iteration machinery directly into optimize-my-skill's folder.
+
+**Architecture:** Bulk-copy `scripts/` + `agents/` + `eval-viewer/` from `oss-snapshots/anthropics/skill-creator/` into `src/user/.agents/skills/optimize-my-skill/`. Rewrite `SKILL.md` to add Phase 4 (Empirical Optimization with 4a description loop + 4b output review) and Phase 5 (Iterate), shifting existing Phase 5 (Confirm & Apply) to Phase 6. Add `--deep` / `--max-iterations` / `--model` flags to the command file. Quick mode (default) preserves today's behavior; deep mode is opt-in.
+
+**Tech Stack:** Python 3 (skill-creator scripts), Markdown (SKILL.md + command file), Bash (install.sh dry-run + smoke harness), bd (beads graph operations).
+
+**Companion design spec:** `docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-design.md`
+
+---
+
+## File Structure
+
+**New files in `src/user/.agents/skills/optimize-my-skill/`:**
+
+| Path | Responsibility | Source |
+|------|---------------|--------|
+| `scripts/run_loop.py` | Description-optimization loop driver | oss-snapshots/anthropics/skill-creator/scripts/ |
+| `scripts/run_eval.py` | Single-pass trigger eval | same |
+| `scripts/improve_description.py` | LLM description rewriter | same |
+| `scripts/aggregate_benchmark.py` | Multi-run aggregation | same |
+| `scripts/generate_report.py` | HTML trigger report | same |
+| `scripts/quick_validate.py` | Fast static skill check | same |
+| `scripts/utils.py` | Shared helpers | same |
+| `scripts/eval-viewer/generate_review.py` | Review server (loads sibling HTML) | oss-snapshots/anthropics/skill-creator/eval-viewer/ |
+| `scripts/eval-viewer/viewer.html` | Review UI shell | same |
+| `agents/grader.md` | Expectations-vs-outputs subagent | oss-snapshots/anthropics/skill-creator/agents/ |
+| `agents/comparator.md` | Blind A/B compare subagent | same |
+| `agents/analyzer.md` | Post-hoc why-winner-won subagent | same |
+| `references/eval-set-format.md` | NEW — eval-set JSON schema + auto-draft template + examples | hand-written |
+
+**Modified files:**
+
+| Path | Change |
+|------|--------|
+| `src/user/.agents/skills/optimize-my-skill/SKILL.md` | Add provenance header; insert Phase 4 + 5; shift old Phase 5 → 6; scrub two skill-creator advisory references |
+| `src/user/.claude/commands/optimize-my-skill.md` | Add `--deep` / `--max-iterations` / `--model` flag handling |
+| `src/user/.agents/skills/AGENTS.md` | Add provenance registry row for optimize-my-skill amalgam |
+| `.gitignore` (project root) | Add `.eval-runs/` |
+
+---
+
+## Implementation Phases
+
+- **Phase A** (Tasks 1–8): Mechanical amalgamation + per-script smoke
+- **Phase B** (Tasks 9–11): Documentation + SKILL.md rewrite
+- **Phase C** (Tasks 12–14): Command-file wiring + integration smoke + dogfood
+- **Phase D** (Task 15): Bead graph reconciliation + close-out
+
+---
+
+## Phase A — Mechanical amalgamation + smoke
+
+### Task 1: Bulk-copy skill-creator files into optimize-my-skill
+
+**Files:**
+- Create: `src/user/.agents/skills/optimize-my-skill/scripts/{run_loop,run_eval,improve_description,aggregate_benchmark,generate_report,quick_validate,utils}.py`
+- Create: `src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/{generate_review.py,viewer.html}`
+- Create: `src/user/.agents/skills/optimize-my-skill/agents/{grader,comparator,analyzer}.md`
+
+- [ ] **Step 1: Inspect source to confirm what's being copied**
+
+```bash
+ls oss-snapshots/anthropics/skill-creator/scripts/
+ls oss-snapshots/anthropics/skill-creator/eval-viewer/
+ls oss-snapshots/anthropics/skill-creator/agents/
+```
+
+Expected: scripts/ has 9 files (the 8 we copy + `package_skill.py` which we skip + `__init__.py`); eval-viewer/ has 2 files; agents/ has 3 files.
+
+- [ ] **Step 2: Create destination directories**
+
+```bash
+mkdir -p src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer
+mkdir -p src/user/.agents/skills/optimize-my-skill/agents
+```
+
+- [ ] **Step 3: Copy scripts (excluding package_skill.py and __init__.py)**
+
+```bash
+SRC=oss-snapshots/anthropics/skill-creator/scripts
+DST=src/user/.agents/skills/optimize-my-skill/scripts
+cp "$SRC/run_loop.py" "$DST/"
+cp "$SRC/run_eval.py" "$DST/"
+cp "$SRC/improve_description.py" "$DST/"
+cp "$SRC/aggregate_benchmark.py" "$DST/"
+cp "$SRC/generate_report.py" "$DST/"
+cp "$SRC/quick_validate.py" "$DST/"
+cp "$SRC/utils.py" "$DST/"
+```
+
+- [ ] **Step 4: Copy eval-viewer (keeps siblings together — generate_review.py loads viewer.html via Path(__file__).parent)**
+
+```bash
+cp oss-snapshots/anthropics/skill-creator/eval-viewer/generate_review.py \
+   src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/
+cp oss-snapshots/anthropics/skill-creator/eval-viewer/viewer.html \
+   src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/
+```
+
+- [ ] **Step 5: Copy agents**
+
+```bash
+cp oss-snapshots/anthropics/skill-creator/agents/grader.md \
+   src/user/.agents/skills/optimize-my-skill/agents/
+cp oss-snapshots/anthropics/skill-creator/agents/comparator.md \
+   src/user/.agents/skills/optimize-my-skill/agents/
+cp oss-snapshots/anthropics/skill-creator/agents/analyzer.md \
+   src/user/.agents/skills/optimize-my-skill/agents/
+```
+
+- [ ] **Step 6: Verify inventory matches spec**
+
+```bash
+find src/user/.agents/skills/optimize-my-skill/scripts -type f | sort
+find src/user/.agents/skills/optimize-my-skill/agents -type f | sort
+```
+
+Expected output:
+```
+src/user/.agents/skills/optimize-my-skill/agents/analyzer.md
+src/user/.agents/skills/optimize-my-skill/agents/comparator.md
+src/user/.agents/skills/optimize-my-skill/agents/grader.md
+src/user/.agents/skills/optimize-my-skill/scripts/aggregate_benchmark.py
+src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/generate_review.py
+src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/viewer.html
+src/user/.agents/skills/optimize-my-skill/scripts/generate_report.py
+src/user/.agents/skills/optimize-my-skill/scripts/improve_description.py
+src/user/.agents/skills/optimize-my-skill/scripts/quick_validate.py
+src/user/.agents/skills/optimize-my-skill/scripts/run_eval.py
+src/user/.agents/skills/optimize-my-skill/scripts/run_loop.py
+src/user/.agents/skills/optimize-my-skill/scripts/utils.py
+```
+
+- [ ] **Step 7: Preserve executable bits**
+
+```bash
+chmod +x src/user/.agents/skills/optimize-my-skill/scripts/*.py
+chmod +x src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/*.py
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/scripts/ \
+        src/user/.agents/skills/optimize-my-skill/agents/
+git commit -m "feat(cx6.7.3): amalgamate skill-creator iteration machinery into optimize-my-skill"
+```
+
+---
+
+### Task 2: Add provenance header to optimize-my-skill SKILL.md
+
+**Files:**
+- Modify: `src/user/.agents/skills/optimize-my-skill/SKILL.md` (insert HTML comment immediately after YAML frontmatter close)
+
+- [ ] **Step 1: Read current top of SKILL.md to find frontmatter close**
+
+```bash
+head -15 src/user/.agents/skills/optimize-my-skill/SKILL.md
+```
+
+Expected: frontmatter ends on line 6 (`---`), skill body starts on line 8 (`# Optimize My Skill`).
+
+- [ ] **Step 2: Insert provenance block after frontmatter close, before body**
+
+Edit the file so the region from line 7 (currently blank) onward reads:
+
+```markdown
+---
+
+<!--
+Sources (amalgam):
+  - Native (audit/assess methodology — Phases 1–3, 6)
+  - oss-snapshots/anthropics/skill-creator/
+    Upstream: https://github.com/anthropics/skills @ f458cee31a7577a47ba0c9a101976fa599385174
+Last sync: 2026-05-19
+Drift policy: accept-periodic-resync
+-->
+
+# Optimize My Skill
+```
+
+- [ ] **Step 3: Verify YAML frontmatter still parses**
+
+```bash
+python3 -c "
+import sys, yaml
+text = open('src/user/.agents/skills/optimize-my-skill/SKILL.md').read()
+parts = text.split('---', 2)
+fm = yaml.safe_load(parts[1])
+print('name:', fm.get('name'))
+print('model:', fm.get('model'))
+print('description (first 60 chars):', (fm.get('description') or '')[:60])
+"
+```
+
+Expected: prints `name: optimize-my-skill`, `model: sonnet[1m]`, and a non-empty description.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/SKILL.md
+git commit -m "docs(cx6.7.3): add amalgam provenance header to optimize-my-skill"
+```
+
+---
+
+### Task 3: Update provenance registry in shared skills AGENTS.md
+
+**Files:**
+- Modify: `src/user/.agents/skills/AGENTS.md` (append row to the registry table)
+
+- [ ] **Step 1: Locate the registry table**
+
+```bash
+grep -n '^|' src/user/.agents/skills/AGENTS.md
+```
+
+Expected: header row + delimiter row + 2 existing rows for `writing-skills`.
+
+- [ ] **Step 2: Append a row for optimize-my-skill**
+
+Edit the table to add one new row at the end:
+
+```markdown
+| `optimize-my-skill` | `oss-snapshots/anthropics/skill-creator/` | `anthropics/skills @ f458cee` | 2026-05-19 | accept-periodic-resync |
+```
+
+- [ ] **Step 3: Verify table renders as 3 data rows**
+
+```bash
+grep -c '^| `' src/user/.agents/skills/AGENTS.md
+```
+
+Expected: `3`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/user/.agents/skills/AGENTS.md
+git commit -m "docs(cx6.7.3): register optimize-my-skill amalgam in provenance table"
+```
+
+---
+
+### Task 4: Add `.eval-runs/` to project .gitignore
+
+**Files:**
+- Modify: `.gitignore` (project root) — append entry if not already present
+
+- [ ] **Step 1: Check current contents**
+
+```bash
+grep -n '.eval-runs' .gitignore 2>/dev/null || echo "NOT_PRESENT"
+```
+
+Expected: `NOT_PRESENT`.
+
+- [ ] **Step 2: Append entry**
+
+Edit `.gitignore` and append:
+
+```
+# optimize-my-skill --deep workspaces (persistent but not committed)
+.eval-runs/
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+tail -3 .gitignore
+```
+
+Expected: shows the comment + `.eval-runs/` entry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .gitignore
+git commit -m "chore(cx6.7.3): ignore .eval-runs/ workspaces"
+```
+
+---
+
+### Task 5: Smoke test — script imports clean
+
+**Files:** No edits; pure verification. Capture evidence for bead notes.
+
+- [ ] **Step 1: Run --help on every amalgamated script**
+
+```bash
+cd src/user/.agents/skills/optimize-my-skill/scripts
+for s in run_loop.py run_eval.py improve_description.py aggregate_benchmark.py generate_report.py quick_validate.py utils.py; do
+  echo "=== $s ==="
+  python3 "$s" --help 2>&1 | head -3 || echo "  (no --help; tried import-check below)"
+done
+echo "=== eval-viewer/generate_review.py ==="
+python3 eval-viewer/generate_review.py --help 2>&1 | head -3
+cd - > /dev/null
+```
+
+Expected: each script prints its argparse usage line or imports cleanly. `utils.py` likely has no `--help` (it's a module); for that one verify import:
+
+```bash
+python3 -c "import sys; sys.path.insert(0, 'src/user/.agents/skills/optimize-my-skill/scripts'); import utils; print('utils imported OK')"
+```
+
+- [ ] **Step 2: If any ImportError, diagnose**
+
+Most likely cause: `run_loop.py` line 18–21 imports `from scripts.generate_report import ...`. If the script is invoked directly via `python3 run_loop.py` from inside `scripts/`, `scripts.X` won't resolve. Workarounds (try in order):
+
+1. Run from the skill folder, not from inside scripts/: `python3 -m scripts.run_loop --help` (with `__init__.py` present) — but we deliberately did NOT copy `__init__.py`
+2. Run as a module from the package root: copy `__init__.py` if needed
+3. Patch the imports to relative form (`from .generate_report import ...`)
+
+Pick the lowest-friction fix that doesn't drift from upstream more than necessary. Document the chosen fix in bead notes.
+
+- [ ] **Step 3: Capture evidence**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 5 smoke — script imports:
+- run_loop.py --help: <PASS/FAIL with first error line if any>
+- run_eval.py --help: <PASS/FAIL>
+- improve_description.py --help: <PASS/FAIL>
+- aggregate_benchmark.py --help: <PASS/FAIL>
+- generate_report.py --help: <PASS/FAIL>
+- quick_validate.py --help: <PASS/FAIL>
+- utils.py import: <PASS/FAIL>
+- eval-viewer/generate_review.py --help: <PASS/FAIL>
+Patches applied: <none | description of any import-path fix>"
+```
+
+- [ ] **Step 4: If patches were applied, commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/scripts/
+git commit -m "fix(cx6.7.3): adjust skill-creator script imports for amalgam location"
+```
+
+(Skip commit if no patches needed.)
+
+---
+
+### Task 6: Smoke test — run_loop.py + run_eval.py on synthetic sample
+
+**Files:** No edits to source; creates throwaway `/tmp/cx6.7.3-sample-skill/` and `/tmp/cx6.7.3-eval-set.json`.
+
+- [ ] **Step 1: Scaffold sample skill**
+
+```bash
+mkdir -p /tmp/cx6.7.3-sample-skill
+cat > /tmp/cx6.7.3-sample-skill/SKILL.md <<'EOF'
+---
+name: count-vowels
+description: counts letters
+---
+
+# Count Vowels
+
+Given an input string, count how many vowels (a, e, i, o, u, case-insensitive) it contains and return the integer.
+EOF
+```
+
+- [ ] **Step 2: Scaffold eval set**
+
+```bash
+cat > /tmp/cx6.7.3-eval-set.json <<'EOF'
+[
+  {"query": "How many vowels are in 'hello world'?", "should_trigger": true},
+  {"query": "Count the a's, e's, i's, o's, u's in this sentence.", "should_trigger": true},
+  {"query": "Tell me the vowel count in 'banana'.", "should_trigger": true},
+  {"query": "Compile this Rust crate for me.", "should_trigger": false},
+  {"query": "What's the weather in Lisbon today?", "should_trigger": false},
+  {"query": "Refactor this Python class.", "should_trigger": false}
+]
+EOF
+```
+
+- [ ] **Step 3: Run run_eval.py once on the sample**
+
+```bash
+cd src/user/.agents/skills/optimize-my-skill/scripts
+python3 run_eval.py \
+  --eval-set /tmp/cx6.7.3-eval-set.json \
+  --skill-path /tmp/cx6.7.3-sample-skill \
+  --num-workers 2 \
+  --runs-per-query 1 \
+  --model claude-haiku-4-5-20251001 2>&1 | tail -30
+cd - > /dev/null
+```
+
+Expected: a JSON-shaped summary with `passed`/`failed`/`total` counts. The deliberately weak description ("counts letters") may fail several should-trigger queries — that's fine; we're testing that the script runs, not that the sample skill scores well.
+
+- [ ] **Step 4: Run run_loop.py with max-iterations=2**
+
+```bash
+cd src/user/.agents/skills/optimize-my-skill/scripts
+python3 run_loop.py \
+  --eval-set /tmp/cx6.7.3-eval-set.json \
+  --skill-path /tmp/cx6.7.3-sample-skill \
+  --max-iterations 2 \
+  --num-workers 2 \
+  --runs-per-query 1 \
+  --holdout 0 \
+  --report none \
+  --model claude-haiku-4-5-20251001 2>&1 | tail -30
+cd - > /dev/null
+```
+
+Expected: JSON output with `iterations_run` ≥ 1, a `best_description` string different from the original weak one, and a `best_score` ratio.
+
+- [ ] **Step 5: Capture evidence**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 6 smoke — run_loop + run_eval on sample:
+- run_eval.py: <X>/<Y> passed in <T>s
+- run_loop.py: <N> iterations, best_score <X>/<Y>, best_description (first 80 chars): '<text>...'
+- sample skill restored to original weak description after smoke"
+```
+
+- [ ] **Step 6: Cleanup**
+
+```bash
+# Sample skill stays at /tmp for later tasks; only the side-effects in it need reset.
+# run_loop.py mutates SKILL.md in place — restore it.
+cat > /tmp/cx6.7.3-sample-skill/SKILL.md <<'EOF'
+---
+name: count-vowels
+description: counts letters
+---
+
+# Count Vowels
+
+Given an input string, count how many vowels (a, e, i, o, u, case-insensitive) it contains and return the integer.
+EOF
+```
+
+No commit (no source changes).
+
+---
+
+### Task 7: Smoke test — generate_review.py + grader subagent
+
+**Files:** No edits to source; creates `/tmp/cx6.7.3-review-workspace/`.
+
+- [ ] **Step 1: Scaffold a single run dir in workspace shape**
+
+```bash
+mkdir -p /tmp/cx6.7.3-review-workspace/run-0001/outputs
+cat > /tmp/cx6.7.3-review-workspace/run-0001/eval_metadata.json <<'EOF'
+{
+  "eval_id": 1,
+  "prompt": "Count vowels in 'banana'.",
+  "expectations": [
+    "Returns the integer 3",
+    "Treats vowels case-insensitively"
+  ]
+}
+EOF
+cat > /tmp/cx6.7.3-review-workspace/run-0001/transcript.md <<'EOF'
+## Eval Prompt
+
+Count vowels in 'banana'.
+
+## Response
+
+The word 'banana' contains 3 vowels: a, a, a.
+EOF
+cat > /tmp/cx6.7.3-review-workspace/run-0001/outputs/answer.txt <<'EOF'
+3
+EOF
+```
+
+- [ ] **Step 2: Launch generate_review.py in the background, give it 3s to start, curl the index**
+
+```bash
+cd src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer
+python3 generate_review.py /tmp/cx6.7.3-review-workspace --port 8742 --skill-name count-vowels &
+SERVER_PID=$!
+sleep 3
+curl -s http://localhost:8742 | grep -o 'run-0001' | head -1
+kill $SERVER_PID 2>/dev/null
+wait $SERVER_PID 2>/dev/null
+cd - > /dev/null
+```
+
+Expected: `run-0001` appears in the HTML (proves the workspace was discovered and rendered).
+
+- [ ] **Step 3: Dispatch the grader subagent against the run dir**
+
+The grader subagent lives at `src/user/.agents/skills/optimize-my-skill/agents/grader.md`. Per its contract (see header of that file), it takes `expectations`, `transcript_path`, `outputs_dir`. Dispatch via the Agent tool with `subagent_type: general-purpose` and a prompt that points at the grader.md and the scaffolded run dir.
+
+Subagent dispatch prompt (verbatim):
+
+```
+You are acting as the grader subagent defined at
+src/user/.agents/skills/optimize-my-skill/agents/grader.md.
+
+Read that file completely, then grade this run:
+
+- expectations: ["Returns the integer 3", "Treats vowels case-insensitively"]
+- transcript_path: /tmp/cx6.7.3-review-workspace/run-0001/transcript.md
+- outputs_dir: /tmp/cx6.7.3-review-workspace/run-0001/outputs
+
+Report per-expectation pass/fail with one-sentence evidence each.
+```
+
+Expected: subagent returns a structured pass/fail per expectation (expectation 1 should PASS given the transcript says "3 vowels"; expectation 2's evidence is weaker since case isn't tested).
+
+- [ ] **Step 4: Capture evidence**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 7 smoke — generate_review + grader:
+- generate_review.py: started on 8742, run-0001 discoverable via curl, clean shutdown
+- grader subagent: returned <pass/fail per expectation>
+Workspace at /tmp/cx6.7.3-review-workspace/ — leaving in place for later inspection"
+```
+
+No commit (no source changes).
+
+---
+
+### Task 8: Smoke test — install.sh --dry-run
+
+**Files:** No edits; staging verification.
+
+- [ ] **Step 1: Run install.sh --dry-run from the worktree root**
+
+```bash
+./scripts/install.sh --dry-run --tools=claude 2>&1 | tee /tmp/cx6.7.3-install-dryrun.log | tail -40
+```
+
+(If `--tools=claude` syntax differs, fall back to `./scripts/install.sh --dry-run` and grep the output for optimize-my-skill paths.)
+
+- [ ] **Step 2: Confirm optimize-my-skill staging covers all new files**
+
+```bash
+grep 'optimize-my-skill' /tmp/cx6.7.3-install-dryrun.log | head -30
+```
+
+Expected: every new file from Task 1 appears as a staging entry under `~/.claude/skills/optimize-my-skill/...`. Specifically scan for:
+- All 7 top-level scripts
+- `scripts/eval-viewer/generate_review.py`
+- `scripts/eval-viewer/viewer.html`
+- All 3 agents/*.md
+- (Existing SKILL.md, references/SKILLS_PRIMER.md still present)
+
+- [ ] **Step 3: Confirm depth-1 invariant honored**
+
+```bash
+# Skill folder itself is depth-1; internal subdirs (scripts/, scripts/eval-viewer/, agents/) are fine.
+# Quick sanity check: no NEW skill folders accidentally introduced.
+grep 'optimize-my-skill' /tmp/cx6.7.3-install-dryrun.log | \
+  awk '{print $NF}' | grep -oE '~/.claude/skills/[^/]+/' | sort -u
+```
+
+Expected: only `~/.claude/skills/optimize-my-skill/` appears (no accidental sibling skills introduced).
+
+- [ ] **Step 4: Capture evidence**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 8 smoke — install.sh --dry-run:
+- $(grep -c 'optimize-my-skill' /tmp/cx6.7.3-install-dryrun.log) staging entries for optimize-my-skill/
+- Depth-1 invariant: only ~/.claude/skills/optimize-my-skill/ as new skill folder
+- scripts/eval-viewer/ subdir staged correctly (sibling generate_review.py + viewer.html)"
+```
+
+No commit.
+
+---
+
+## Phase B — Documentation + SKILL.md rewrite
+
+### Task 9: Write references/eval-set-format.md
+
+**Files:**
+- Create: `src/user/.agents/skills/optimize-my-skill/references/eval-set-format.md`
+
+- [ ] **Step 1: Write the new reference file with this exact content**
+
+```markdown
+# Eval-Set Format
+
+Used by Phase 4a (description-optimization loop via `scripts/run_loop.py`) and
+Phase 4b (output-review battery via inline subagent orchestration).
+
+## File location
+
+`<skill-dir>/evals.json` — co-located with the SKILL.md it scores. Git-versioned
+alongside the skill.
+
+## Schema
+
+A JSON array of eval entries. Each entry:
+
+```json
+{
+  "query": "string — the user-facing prompt sent to a Claude instance with the skill loaded",
+  "should_trigger": true,
+  "expectations": [
+    "string — a single observable behavior the skill's output should satisfy",
+    "string — another expectation"
+  ]
+}
+```
+
+| Field | Required | Used by |
+|-------|----------|---------|
+| `query` | yes | both 4a (run_eval) and 4b (run-on-prompts) |
+| `should_trigger` | yes | 4a precision/recall; 4b only consumes entries where this is `true` |
+| `expectations` | optional list of strings | 4b grader subagent only; empty or missing list means "do not grade this run's output quality" |
+
+## When auto-drafting (Phase 4a.1 fallback)
+
+If `<skill-dir>/evals.json` is missing when `--deep` runs, the skill drafts a
+starter set by reading the target SKILL.md. The auto-draft prompt instructs
+Claude to:
+
+1. Generate 5–10 `should_trigger:true` queries that a real user would phrase to
+   invoke the skill — including 2–3 *near-miss* queries that the existing
+   description might not catch but should.
+2. Generate 5–10 `should_trigger:false` queries that are adjacent in topic but
+   should NOT invoke the skill. Favor near-misses with sibling skills over
+   wildly-unrelated queries (which prove nothing).
+3. For each `should_trigger:true` entry, propose 1–3 observable expectations the
+   skill's output should satisfy. Skip expectations for entries where the
+   skill's output is inherently subjective (writing style, creative work).
+4. Write the JSON array to `<skill-dir>/evals.json`.
+
+The user reviews the drafted set before `run_loop.py` runs — the skill pauses
+via AskUserQuestion with three options: Accept, Edit (skill pauses, user edits
+the file, types continue), Reject (abort `--deep`).
+
+## Quality criteria (weak vs strong evals)
+
+**Weak eval — query is too generic or expectation is trivially satisfied:**
+
+```json
+{
+  "query": "Help me write a skill.",
+  "should_trigger": true,
+  "expectations": ["produces a response"]
+}
+```
+
+Anything triggers; any response passes. Useless signal.
+
+**Strong eval — query is realistic and probes a specific failure mode:**
+
+```json
+{
+  "query": "Can you audit the writing-skills skill for me and tell me if its description over-triggers?",
+  "should_trigger": true,
+  "expectations": [
+    "Reads writing-skills/SKILL.md before proposing anything",
+    "Reports concrete frontmatter findings, not vague advice",
+    "Surfaces a per-skill structured proposal with current vs proposed description"
+  ]
+}
+```
+
+Specific query, observable behaviors, fails meaningfully if the skill drifts.
+
+**Strong negative — adjacent but should NOT trigger:**
+
+```json
+{
+  "query": "I want to write a brand new skill for parsing PDFs from scratch.",
+  "should_trigger": false,
+  "expectations": []
+}
+```
+
+Probes the optimize-vs-create boundary with `writing-skills`.
+
+## Subsequent runs
+
+If the file already exists, the skill uses it as-is — no auto-draft, no
+review gate. Users curate the file over time as the skill evolves and new
+failure modes surface.
+```
+
+- [ ] **Step 2: Verify the file renders as markdown**
+
+```bash
+wc -l src/user/.agents/skills/optimize-my-skill/references/eval-set-format.md
+```
+
+Expected: roughly 80–100 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/references/eval-set-format.md
+git commit -m "docs(cx6.7.3): add eval-set-format reference for Phase 4 evals.json"
+```
+
+---
+
+### Task 10: Rewrite SKILL.md — Phase 4 (Empirical Optimization)
+
+**Files:**
+- Modify: `src/user/.agents/skills/optimize-my-skill/SKILL.md` — insert new Phase 4 between existing Phase 3 and existing Phase 4 (which is currently titled "Suggest Testing"), and replace the existing Phase 4's content. The existing Phase 5 will be renumbered to Phase 6 in Task 11.
+
+- [ ] **Step 1: Read current Phase 4 + Phase 5 boundaries**
+
+```bash
+grep -n '^## Phase' src/user/.agents/skills/optimize-my-skill/SKILL.md
+```
+
+Expected output identifies current line numbers for `## Phase 4: Suggest Testing` and `## Phase 5: Confirm and Apply`.
+
+- [ ] **Step 2: Replace the existing Phase 4 block (from `## Phase 4: Suggest Testing` through the line immediately before `## Phase 5: Confirm and Apply`) with the new Phase 4 content below**
+
+New content for Phase 4:
+
+````markdown
+## Phase 4: Empirical Optimization (gated by `--deep`)
+
+Skip this phase entirely when `--deep` is absent — naked invocation collapses
+Phase 4 to a one-line note: "Quantitative description and output evaluation
+available via `--deep`; see Phase 4 details when ready."
+
+When `--deep` is present, run both 4a and 4b sequentially.
+
+### Phase 4 cost gate
+
+Before launching any model calls, surface an estimate via AskUserQuestion:
+
+> "`--deep` will execute approximately N model calls in total
+> (description-improver: K, triggering eval: P runs, output-review subagents:
+> Q dispatches, grader: R). Estimated cost ~$X at current rates. Continue?"
+
+User selects Continue / Reduce iterations / Abort. Honor the choice before
+proceeding. The cost gate fires on every `--deep` invocation; no persistent
+opt-out in this version.
+
+### Phase 4a: Description loop (automated)
+
+1. **Resolve eval set.** Probe `<skill-dir>/evals.json`.
+   - If present: use it. Print one-line summary
+     `Using N evals (T trigger / U no-trigger).` Continue to step 2.
+   - If absent: auto-draft per `references/eval-set-format.md`. Read the target
+     SKILL.md, generate 5–10 should-trigger + 5–10 should-not-trigger queries
+     (favor near-miss queries over obviously-unrelated). Write to
+     `<skill-dir>/evals.json`. Display via AskUserQuestion with options
+     Accept / Edit (skill pauses, user edits file, types continue) / Reject
+     (abort `--deep`).
+2. **Invoke the loop.** Shell out:
+
+   ```bash
+   python3 <skill-scripts>/run_loop.py \
+     --eval-set <skill-dir>/evals.json \
+     --skill-path <skill-dir> \
+     --max-iterations <N>  # default 5; overridden by --max-iterations flag
+     --holdout 0.4 \
+     --runs-per-query 3 \
+     --num-workers 10 \
+     --model <model>       # default claude-haiku-4-5-20251001; overridden by --model flag
+   ```
+
+3. **Capture results.** Read the JSON output: `{best_description, best_score,
+   final_description, history, iterations_run, ...}`. Pass to Phase 5.
+
+### Phase 4b: Output review (semi-automated)
+
+1. **Create persistent workspace** at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
+   (the project `.gitignore` excludes `.eval-runs/`).
+2. **Select prompts.** First 3 entries with `should_trigger:true` from the
+   eval set, in file order (deterministic; no random sampling).
+3. **Dispatch run subagents in parallel** (single message, multiple Agent
+   calls). For each prompt:
+   - Create `<workspace>/run-NNNN/outputs/`
+   - Write `<workspace>/run-NNNN/eval_metadata.json` with
+     `{eval_id, prompt, expectations}`
+   - Dispatch a `general-purpose` subagent with this prompt template:
+
+     > "Read the target skill at `<deployed-skill-path>` and any of its
+     > referenced files you need. Then perform the following user task:
+     > `<prompt>`. Write any file outputs to
+     > `<absolute-workspace-path>/run-NNNN/outputs/`. Write your full
+     > turn-by-turn transcript (your thinking, tool calls, results) to
+     > `<absolute-workspace-path>/run-NNNN/transcript.md` before returning.
+     > Return a one-sentence summary."
+
+4. **Grade** (per run, after the run subagent returns).
+   - If the entry's `expectations` list is empty or missing: skip grading.
+   - Otherwise: dispatch the `grader` subagent (definition at
+     `<skill-dir>/agents/grader.md`) with `expectations`, `transcript_path`,
+     and `outputs_dir`. Grader writes `metrics.json` to the run dir.
+5. **Launch review server.** Shell out:
+
+   ```bash
+   python3 <skill-scripts>/eval-viewer/generate_review.py \
+     <workspace-path> \
+     --skill-name <target-skill-name> \
+     --port 8742
+   ```
+
+   Emit to the user:
+
+   > Review server running at http://localhost:8742
+   > Press Ctrl+C in the running terminal when you're done reviewing.
+   > Your feedback will be saved to `<workspace>/feedback.json`.
+
+   The skill **blocks** until the server process exits.
+
+6. **Read feedback.** When the server exits, read
+   `<workspace>/feedback.json`. Pass results to Phase 5. If the file is
+   empty or missing (user ^C'd before reviewing), ask via AskUserQuestion:
+   "No feedback captured — abort `--deep` or proceed with description-loop
+   results only?"
+
+### Failure handling
+
+- **Port in use** — retry with port+1 up to 5 attempts; surface the final port to the user
+- **Subagent timeout** (default 5 min/run) — write `metrics.json` with `{status: "timeout"}` and continue; partial transcript still visible in review server
+- **Grader skipped** (empty expectations) — log it, no error
+- **run_loop.py non-zero exit** — surface stderr; ask user whether to retry, fall back to advisory-only Phase 4, or abort
+````
+
+- [ ] **Step 3: Confirm the file now reads coherently from Phase 3 → 4 → 5**
+
+```bash
+grep -n '^## Phase' src/user/.agents/skills/optimize-my-skill/SKILL.md
+```
+
+Expected: Phase 1, 2, 3, 4 (new content), 5 (still old "Confirm and Apply" content for now — gets shifted to 6 in Task 11).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/SKILL.md
+git commit -m "feat(cx6.7.3): rewrite Phase 4 as Empirical Optimization (4a description loop + 4b output review)"
+```
+
+---
+
+### Task 11: Rewrite SKILL.md — Phase 5 (Iterate); shift old P5 → P6; scrub advisory lines
+
+**Files:**
+- Modify: `src/user/.agents/skills/optimize-my-skill/SKILL.md`
+
+- [ ] **Step 1: Insert new Phase 5 between the new Phase 4 (Task 10) and the existing Phase 5 (Confirm and Apply)**
+
+New content for Phase 5 (paste before the existing `## Phase 5: Confirm and Apply` heading):
+
+````markdown
+## Phase 5: Iterate (gated by `--deep`)
+
+Synthesize Phase 4a (description-loop results) and Phase 4b (output-review
+feedback) into a concrete proposal: which description to adopt, which body
+edits to make, and whether another `--deep` pass is warranted.
+
+### Inputs
+
+- From Phase 4a: `best_description`, `best_score`, `history` (each iteration's
+  description + score), `final_description`
+- From Phase 4b: `feedback.json` (per-run user notes from the review server),
+  per-run `metrics.json` (if grader ran)
+
+### Process
+
+1. **Compare best_description against the current description.** If they
+   differ, summarize the delta in 1–2 sentences for the user.
+2. **Read feedback.json.** Group user notes by run; identify recurring themes
+   (e.g., "skill never read the SKILL.md", "missed a frontmatter check").
+3. **Read each metrics.json** (where present). Identify expectations that
+   failed across multiple runs — those signal systematic skill weaknesses.
+4. **Propose a structured update** in this shape:
+
+   ```markdown
+   ## Phase 5 proposal — <skill-name>
+
+   ### Description
+   - Current: `<text>`
+   - Proposed: `<text>` (from Phase 4a best, score <X/Y>)
+   - Adopt? [yes / keep current / draft alternative]
+
+   ### Body edits
+   - <Section>: <one-sentence change>; rationale: <feedback theme>
+   - <Section>: ...
+
+   ### Re-run?
+   - Recommend another `--deep` pass: [yes if N>0 unresolved themes / no]
+   ```
+
+5. **Surface the proposal to the user via AskUserQuestion.** Options:
+   Accept all (proceeds to Phase 6) / Adopt description only / Adopt body
+   edits only / Re-run `--deep` from Phase 4a (loops back, using the
+   accepted description as starting point) / Reject all (proceeds to
+   Phase 6 with no changes from Phase 4/5).
+
+### What NOT to do in Phase 5
+
+- Do not silently apply changes — every adoption is explicit
+- Do not propose body edits with no grounding in Phase 4b feedback
+- Do not loop more than once without checking with the user (cost discipline)
+
+````
+
+- [ ] **Step 2: Rename `## Phase 5: Confirm and Apply` to `## Phase 6: Confirm and Apply`**
+
+This is a single-line edit. Verify with:
+
+```bash
+grep -n '^## Phase' src/user/.agents/skills/optimize-my-skill/SKILL.md
+```
+
+Expected: Phase 1, 2, 3, 4, 5 (Iterate), 6 (Confirm and Apply).
+
+- [ ] **Step 3: Scrub the two existing skill-creator advisory lines**
+
+Find and replace these two existing lines:
+
+**Line A** (currently in Phase 4 area — but Phase 4 was rewritten in Task 10, so this may already be gone; verify and skip if absent):
+
+```
+If the `skill-creator` skill is available, its description-optimization loop (`scripts/run_loop.py` with a should-trigger / should-not-trigger eval set) gives a quantitative trigger-accuracy score instead of a one-shot vibe check — recommend it when the skill's discoverability is the failure mode.
+```
+
+(If this line was inside the old Phase 4 block replaced in Task 10, it's already gone — confirm with `grep -n 'skill-creator' SKILL.md` and skip this sub-step.)
+
+**Line B** (in the Red Flags table):
+
+Replace:
+
+```
+| "The description is fine, it triggers correctly" | Trigger accuracy is measurable — test it with `skill-creator` before assuming |
+```
+
+With:
+
+```
+| "The description is fine, it triggers correctly" | Trigger accuracy is measurable — run `--deep` (Phase 4a) before assuming |
+```
+
+- [ ] **Step 4: Verify no remaining `skill-creator` references in SKILL.md**
+
+```bash
+grep -n 'skill-creator' src/user/.agents/skills/optimize-my-skill/SKILL.md
+```
+
+Expected: only the provenance header HTML comment mentions `skill-creator` (as the source folder name). Zero advisory body mentions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/user/.agents/skills/optimize-my-skill/SKILL.md
+git commit -m "feat(cx6.7.3): add Phase 5 Iterate; shift Confirm and Apply to Phase 6; scrub skill-creator advisory lines"
+```
+
+---
+
+## Phase C — Command file wiring + integration smoke + dogfood
+
+### Task 12: Update command file with --deep / --max-iterations / --model flags
+
+**Files:**
+- Modify: `src/user/.claude/commands/optimize-my-skill.md`
+
+- [ ] **Step 1: Read the current command file structure**
+
+```bash
+cat src/user/.claude/commands/optimize-my-skill.md
+```
+
+(Reference the existing "Argument" and "Empty-argument resolution" sections so the new flag content slots in cleanly.)
+
+- [ ] **Step 2: Replace the "Argument" section with the expanded surface**
+
+New "Argument" section content (replaces the current one):
+
+````markdown
+## Arguments
+
+`$ARGUMENTS` accepts one non-flag target and optional flags:
+
+```
+/optimize-my-skill [<target>] [--deep] [--max-iterations N] [--model <name>]
+```
+
+| Token | Meaning |
+|-------|---------|
+| `<target>` | skill name (e.g. `bugfix`), directory path (e.g. `~/.claude/skills/`), or empty (resolved via the probe below) |
+| `--deep` | opt into Phase 4 (empirical description loop + output review) and Phase 5 (iterate). Absent → naked invocation = today's audit-and-apply behavior |
+| `--max-iterations N` | override the description-loop iteration cap (default 5). Ignored without `--deep` |
+| `--model <name>` | model id for the description-improver loop. Default `claude-haiku-4-5-20251001`. Ignored without `--deep` |
+
+Parse by splitting `$ARGUMENTS` on whitespace: identify the single non-flag
+token as `<target>`, collect flags separately, pass both to the skill.
+Empty `<target>` triggers the probe in the next section.
+````
+
+- [ ] **Step 3: Update the "Invoke the skill" section to mention flag passthrough**
+
+Replace the current "Invoke the skill" section with:
+
+```markdown
+## Invoke the skill
+
+With the resolved target and any flags, invoke the `optimize-my-skill` skill
+and pass them in its invocation context. The skill owns the full methodology
+(discover, assess, propose, optionally empirical-optimize + iterate, then
+confirm/apply).
+
+Quick mode (no `--deep`) is unchanged from prior behavior. Deep mode
+prompts the user for a cost confirmation before invoking model-heavy phases.
+```
+
+- [ ] **Step 4: Verify the file still resolves the empty-arg case**
+
+```bash
+grep -A 10 'Empty-argument resolution' src/user/.claude/commands/optimize-my-skill.md
+```
+
+Expected: the probe order (`~/.claude/skills/` → `.claude/skills/`) is preserved unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/user/.claude/commands/optimize-my-skill.md
+git commit -m "feat(cx6.7.3): add --deep / --max-iterations / --model flags to /optimize-my-skill"
+```
+
+---
+
+### Task 13: Smoke test — naked invocation regression check
+
+**Files:** No edits; verification only.
+
+**Note for the implementing agent:** This task validates that quick-mode behavior is unchanged. Use the sample skill from Task 6 (still at `/tmp/cx6.7.3-sample-skill/`).
+
+- [ ] **Step 1: Re-stage the sample skill in a Claude-discoverable location**
+
+The skill needs to be findable by `/optimize-my-skill`. Two options:
+
+(a) Pass a directory path: `/optimize-my-skill /tmp/cx6.7.3-sample-skill/` — works because the empty-arg resolver accepts a directory path.
+
+(b) Symlink into `~/.claude/skills/`: `ln -sf /tmp/cx6.7.3-sample-skill ~/.claude/skills/count-vowels` — works for the skill-name path.
+
+Pick (a) — simpler, no cleanup required.
+
+- [ ] **Step 2: Invoke /optimize-my-skill in quick mode (no --deep)**
+
+This is an interactive Claude invocation — you (the implementing agent) cannot run a slash command from inside a Bash tool. Instead, invoke the optimize-my-skill **skill** directly via the Skill tool, passing scope `/tmp/cx6.7.3-sample-skill/`. Verify it walks Phases 1, 2, 3, 4 (advisory note), and 6 (Confirm and Apply) without invoking run_loop.py or generate_review.py.
+
+Expected behavior:
+- Phase 1: reads `/tmp/cx6.7.3-sample-skill/SKILL.md`, inventories scripts/, references/, assets/ (all absent)
+- Phase 2: assesses against quality criteria (name OK, description weak — flagged)
+- Phase 3: proposes a description rewrite
+- Phase 4: emits the one-line advisory note ("quantitative description and output evaluation available via `--deep`")
+- Phase 5: pass-through (no work in quick mode)
+- Phase 6: presents the proposal table, awaits user accept/reject
+
+If the skill invokes ANY of the Python scripts under `scripts/`, that's a quick-mode regression — fix the SKILL.md Phase 4 gating in Task 10's edit before continuing.
+
+- [ ] **Step 3: Capture evidence**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 13 smoke — quick-mode regression check:
+- /optimize-my-skill /tmp/cx6.7.3-sample-skill/ (quick)
+- Walked Phases 1, 2, 3 normally
+- Phase 4: emitted advisory note only, did NOT shell out to scripts (PASS)
+- Phase 5: pass-through (no work)
+- Phase 6: presented proposal table awaiting user confirmation
+Conclusion: no regression in quick mode"
+```
+
+No commit unless a regression was found and patched.
+
+---
+
+### Task 14: Smoke test — dogfood `--deep --max-iterations 1` on optimize-my-skill itself
+
+**Files:** No source edits; generates throwaway `<optimize-my-skill>/.eval-runs/<timestamp>/` workspace (gitignored) and possibly `<optimize-my-skill>/evals.json` (auto-drafted). The evals.json is **NOT committed** in this PR — the full-empirical-pass bead (cx6.7.D) commits the curated version later.
+
+- [ ] **Step 1: Ensure no existing evals.json in optimize-my-skill — force the auto-draft path**
+
+```bash
+ls src/user/.agents/skills/optimize-my-skill/evals.json 2>/dev/null && \
+  echo "EXISTS — move aside before smoke" || echo "ABSENT — auto-draft will fire"
+```
+
+If a file exists from prior runs: `mv src/user/.agents/skills/optimize-my-skill/evals.json /tmp/cx6.7.3-evals-backup.json`
+
+- [ ] **Step 2: Invoke /optimize-my-skill on itself in deep mode (single iteration, smoke only)**
+
+Invoke the optimize-my-skill **skill** via the Skill tool with scope
+`src/user/.agents/skills/optimize-my-skill/` and flags
+`--deep --max-iterations 1`.
+
+Self-reference checklist as the skill runs:
+- [ ] Phase 4a.1 auto-drafts evals.json — DOES NOT loop trying to read its own scripts as eval entries
+- [ ] Phase 4 cost gate fires with concrete N/K/P/Q/R estimates — accept Continue
+- [ ] Phase 4a runs `run_loop.py` once (max-iterations 1); does not recurse into Phase 1
+- [ ] Phase 4b creates `.eval-runs/<timestamp>/run-0001/`, `run-0002/`, `run-0003/`
+- [ ] Phase 4b dispatches 3 subagents in parallel; each writes outputs/transcript
+- [ ] Phase 4b launches generate_review.py; HTTP server reachable on the chosen port
+- [ ] ^C the server within ~30s (just confirming server starts; no actual review needed for smoke)
+- [ ] Phase 5 surfaces a proposal table — REJECT all changes (we are not applying smoke results)
+- [ ] Phase 6 completes with "no changes adopted" message
+
+- [ ] **Step 3: Inspect generated artifacts**
+
+```bash
+ls src/user/.agents/skills/optimize-my-skill/.eval-runs/
+ls src/user/.agents/skills/optimize-my-skill/.eval-runs/<timestamp>/
+ls src/user/.agents/skills/optimize-my-skill/.eval-runs/<timestamp>/run-0001/
+cat src/user/.agents/skills/optimize-my-skill/.eval-runs/<timestamp>/run-0001/eval_metadata.json
+```
+
+Expected: workspace shape exactly matches what `generate_review.py` discovers (per spec § Phase 4b workspace shape).
+
+- [ ] **Step 4: Discard smoke artifacts**
+
+```bash
+rm -rf src/user/.agents/skills/optimize-my-skill/.eval-runs/
+rm src/user/.agents/skills/optimize-my-skill/evals.json
+# Restore prior evals.json if Task 14 Step 1 moved one aside
+[ -f /tmp/cx6.7.3-evals-backup.json ] && \
+  mv /tmp/cx6.7.3-evals-backup.json src/user/.agents/skills/optimize-my-skill/evals.json
+```
+
+- [ ] **Step 5: Verify nothing got accidentally committed**
+
+```bash
+git status --short
+```
+
+Expected: clean working tree (smoke artifacts were either gitignored or deleted in Step 4).
+
+- [ ] **Step 6: Capture final evidence and consolidated smoke results**
+
+```bash
+bd update agents-config-cx6.7.3 --append-notes "Task 14 smoke — dogfood --deep --max-iterations 1 on optimize-my-skill:
+- Auto-drafted evals.json: <N> trigger + <M> no-trigger entries
+- Cost gate fired with estimate: ~\$<X>
+- Phase 4a: 1 iteration, train_passed <X>/<Y>, best_description (first 80 chars): '<text>...'
+- Phase 4b: 3 runs dispatched, all completed within <T>s
+- generate_review.py: started on port <P>, ^C clean
+- Phase 5: proposal surfaced, REJECTED all changes (smoke only)
+- Phase 6: completed with no changes adopted
+- Self-reference check: PASS (no recursion, no Phase 1 loop)
+- Artifacts cleaned up; git status clean
+
+Consolidated smoke summary (all tasks 5–8 + 13–14): all PASS
+Pre-implementation: 4/4 scripts callable + grader subagent + install.sh dry-run
+Post-implementation: quick-mode no regression + deep-mode dogfood self-reference PASS"
+```
+
+No commit (no source changes; artifacts were ephemeral).
+
+---
+
+## Phase D — Bead graph reconciliation + close-out
+
+### Task 15: File cx6.7.D follow-up; close .3 and .4; verify .5/.6 unblocked
+
+**Files:** No source edits; pure bd state changes.
+
+- [ ] **Step 1: File the dogfood follow-up bead**
+
+```bash
+bd create --parent agents-config-cx6.7 \
+  --type task --priority 2 \
+  --title "Empirical dogfood pass on optimize-my-skill (full --deep run)" \
+  --description "First real-customer use of the newly-wired --deep flow. Hand-curate a meaningful evals.json for optimize-my-skill (~15 entries, mix of clear should-trigger, clear should-not-trigger, and near-miss adversarial queries that probe known overlap with writing-skills + skill-creator history). Run /optimize-my-skill optimize-my-skill --deep with default iterations and ~5-prompt output-review battery. Apply any description and body improvements the empirical results justify; commit evals.json as the regression baseline. Capture model spend in bead notes for future cost calibration." \
+  --acceptance "evals.json committed under src/user/.agents/skills/optimize-my-skill/. Description and/or body changes (if any) committed with rationale tying back to the empirical results. Model spend captured in bead notes. Workspace artifacts NOT committed (.gitignored)." \
+  --json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['id'] if isinstance(d, dict) else d[0]['id'])" > /tmp/cx6.7.3-dogfood-bead-id
+
+DOGFOOD_ID=$(cat /tmp/cx6.7.3-dogfood-bead-id)
+echo "Created: $DOGFOOD_ID"
+```
+
+- [ ] **Step 2: Add dep edges — dogfood blocks on .3, .7 blocks on dogfood**
+
+```bash
+DOGFOOD_ID=$(cat /tmp/cx6.7.3-dogfood-bead-id)
+bd dep add "$DOGFOOD_ID" agents-config-cx6.7.3
+bd dep add agents-config-cx6.7.7 "$DOGFOOD_ID"
+bd dep list "$DOGFOOD_ID"
+```
+
+Expected: dogfood bead `blocks` on cx6.7.3 (still open until next step); cx6.7.7 `blocks` on dogfood bead.
+
+- [ ] **Step 3: Close cx6.7.3 with reason**
+
+```bash
+bd update agents-config-cx6.7.3 --status closed --reason \
+  "Amalgamated skill-creator iteration machinery (scripts/, agents/, eval-viewer/) into optimize-my-skill with provenance. Added Phase 4 (Empirical Optimization: 4a description loop + 4b output review) and Phase 5 (Iterate); shifted Confirm and Apply to Phase 6. Added --deep / --max-iterations / --model flags. Eval-set lifecycle via <skill-dir>/evals.json with hybrid auto-draft. Smoke tests covered every script in isolation + install.sh staging + quick-mode regression + --deep dogfood self-reference (all PASS, evidence in bead notes). Filed cx6.7.D for the full empirical dogfood pass. Provenance registry updated."
+```
+
+- [ ] **Step 4: Close cx6.7.4 as superseded**
+
+```bash
+bd update agents-config-cx6.7.4 --status closed --reason \
+  "Superseded by cx6.7.3's amalgam carve-up. Target state is two skills (writing-skills + optimize-my-skill), not three. The iteration machinery skill-creator was going to host as standalone now lives inside optimize-my-skill via cx6.7.3; the create-flow narrative already lives in writing-skills via cx6.7.2's amalgam. If a future inspection of skill-creator's prose surfaces specific narrative worth lifting into writing-skills, open a small follow-up at that time — none identified during the cx6.7.3 brainstorm."
+```
+
+- [ ] **Step 5: Walk parent chain closures**
+
+```bash
+~/.beads/scripts/bd-close-walk.sh --bead-id agents-config-cx6.7.3 --reason "Phase 4/5 amalgam shipped; provenance registered; dogfood follow-up filed as cx6.7.D"
+```
+
+(The close walk will stop at the first ancestor with non-closed children — likely `cx6.7` since `.4` just closed but `.5`/`.6`/`.7`/.D are still open.)
+
+- [ ] **Step 6: Verify .5 and .6 are now in bd ready**
+
+```bash
+bd show agents-config-cx6.7.5 --json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)[0]
+deps = d.get('dependencies', [])
+open_blockers = [dep for dep in deps if dep.get('dependency_type') == 'blocks' and dep.get('status') != 'closed']
+print('cx6.7.5 open blockers:', [b['id'] for b in open_blockers])
+"
+bd show agents-config-cx6.7.6 --json | python3 -c "
+import sys, json
+d = json.load(sys.stdin)[0]
+deps = d.get('dependencies', [])
+open_blockers = [dep for dep in deps if dep.get('dependency_type') == 'blocks' and dep.get('status') != 'closed']
+print('cx6.7.6 open blockers:', [b['id'] for b in open_blockers])
+"
+bd ready --label implementation-ready 2>/dev/null | grep -E 'cx6\.7\.[56]' || \
+  bd ready | grep -E 'cx6\.7\.[56]'
+```
+
+Expected: both `.5` and `.6` show zero open blockers (closed `.3`/`.4` no longer count); both appear in `bd ready`.
+
+- [ ] **Step 7: Final session housekeeping**
+
+```bash
+git push
+git status
+```
+
+Expected: pushed cleanly; status shows "up to date with origin".
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec section | Implementing task(s) |
+|---|---|
+| § Target carve-up (two skills, not three) | Tasks 15 step 4 (close .4 as superseded) |
+| § Architecture / File scope | Task 1 |
+| § Provenance header | Task 2 |
+| § Provenance registry | Task 3 |
+| § Installer impact | Task 8 |
+| § Phase structure (P4/P5/P6) | Tasks 10, 11 |
+| § Phase 4a description loop | Task 10 |
+| § Phase 4b output review | Task 10 |
+| § Phase 4 cost gate | Task 10 |
+| § `--quick` semantics | Tasks 10 (gating line), 13 (regression check) |
+| § Failure modes | Task 10 (Failure handling subsection) |
+| § Command + flag UX | Task 12 |
+| § Eval-set lifecycle | Tasks 9 (reference doc), 10 (Phase 4a.1 resolution) |
+| § Smoke-test plan pre-impl items 1–6 | Tasks 5, 6, 7, 8 |
+| § Smoke-test plan post-impl items 7–8 | Tasks 13, 14 |
+| § Evidence captured to bead notes | Tasks 5, 6, 7, 8, 13, 14 |
+| § Bead graph updates — .3 desc rewrite | (Already in bead via current implementation — agent should rewrite cx6.7.3 description as part of close in Task 15 step 3 if drift from amended desc is large; current bead text already matches design intent closely enough to skip in this PR scope) |
+| § Bead graph updates — close .4 | Task 15 step 4 |
+| § Bead graph updates — new cx6.7.D | Task 15 steps 1, 2 |
+| § Bead graph updates — dep edits on .5/.6 | Task 15 step 6 (verification only — auto-resolves) |
+| § Order of operations | Implemented as Phase A → B → C → D sequencing |
+| § Explicit exclusions | Not implemented (correctly) — flagged in spec, not in plan |
+
+All spec sections have task coverage.
+
+**2. Placeholder scan:**
+
+Searched the plan for: `TBD`, `TODO`, `fill in details`, `implement later`, `appropriate error handling`, `add validation`, `handle edge cases`, `Similar to Task`.
+
+Two intentional template placeholders in evidence-capture bash blocks: `<PASS/FAIL with first error line if any>`, `<X>/<Y>`, `<text>`, `<T>`. These are intentional — they're values the implementing agent fills in at runtime from observed output, not unfilled spec items.
+
+One spec-coverage gap noted in the table above: cx6.7.3 bead-description rewrite from the spec is NOT a task in the plan. Rationale: the bead's current description matches the design intent closely; rewriting just for prose alignment is busywork and risks drift between bead and spec. The close-reason in Task 15 step 3 carries the authoritative summary. **Decision:** leave as-is; do not add a separate "rewrite bead description" task.
+
+**3. Type consistency:**
+
+- `--deep`, `--max-iterations N`, `--model <name>` flag names used consistently across Tasks 10, 12, 13, 14
+- `evals.json` filename consistent (always lowercase, plural with s) across Tasks 9, 10, 14
+- `.eval-runs/` directory name consistent (kebab-case, plural, trailing slash where it's a dir) across Tasks 4, 10, 14
+- Workspace shape (`run-NNNN/outputs/`, `transcript.md`, `eval_metadata.json`, `metrics.json`, `feedback.json`) consistent across Tasks 7, 10, 14
+- Subagent names (`grader`, `comparator`, `analyzer`) match agent file basenames in Task 1
+- Script paths: `scripts/eval-viewer/generate_review.py` (not `assets/`) consistent across all tasks after the spec self-review correction
+
+No inconsistencies found.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/specs/2026-05-19-cx6.7.3-empirical-eval-loop-plan.md`.
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best fit for a 15-task plan with mostly-mechanical work and a few interactive smoke steps.
+
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Lower coordination overhead but pollutes the orchestrator context with raw smoke output.
+
+Which approach?

--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -51,6 +51,7 @@ Skills built from scratch in-repo do not appear here. This table tracks only OSS
 |-------|---------------|----------|-----------|--------------|
 | `writing-skills` | `oss-snapshots/superpowers/writing-skills/` | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-17 | accept-periodic-resync |
 | `writing-skills` | `oss-snapshots/anthropics/skill-creator/` | `anthropics/skills @ f458cee` | 2026-05-17 | accept-periodic-resync |
+| `optimize-my-skill` | `oss-snapshots/anthropics/skill-creator/` | `anthropics/skills @ f458cee` | 2026-05-20 | accept-periodic-resync |
 
 Update this table whenever a skill is added, replaced, or amalgamated from an OSS source.
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -162,20 +162,108 @@ For each skill that needs work, present a structured proposal. Do not silently r
 - Do not remove opinionated methodology in favor of generic advice
 - Do not add optional frontmatter fields unless they provide clear value for the specific skill
 
-## Phase 4: Suggest Testing
+## Phase 4: Empirical Optimization (gated by `--deep`)
 
-For each modified skill, suggest tests the user can run to confirm the changes work. Prefer the strongest tool available in the environment:
+Skip this phase entirely when `--deep` is absent — naked invocation collapses
+Phase 4 to a one-line note: "Quantitative description and output evaluation
+available via `--deep`; see Phase 4 details when ready."
 
-**Triggering tests** — ask Claude "When would you use the [skill name] skill?" and verify it quotes the right triggers:
+When `--deep` is present, run both 4a and 4b sequentially.
 
-- Should trigger: [2-3 natural phrases that should activate this skill]
-- Should NOT trigger: [2-3 unrelated queries it should ignore]
+### Phase 4 cost gate
 
-If the `skill-creator` skill is available, its description-optimization loop (`scripts/run_loop.py` with a should-trigger / should-not-trigger eval set) gives a quantitative trigger-accuracy score instead of a one-shot vibe check — recommend it when the skill's discoverability is the failure mode.
+Before launching any model calls, surface an estimate via AskUserQuestion:
 
-**Functional check** — after applying changes, verify the skill still produces correct behavior on a representative task. If the skill includes deterministic scripts, run them against a known input/output pair.
+> "`--deep` will execute approximately N model calls in total
+> (description-improver: K, triggering eval: P runs, output-review subagents:
+> Q dispatches, grader: R). Estimated cost ~$X at current rates. Continue?"
 
-**Discipline check (for rule-enforcing skills)** — if the skill's job is to make agents comply under pressure (TDD, verification gates, refusal patterns), one happy-path run proves nothing. If `superpowers:writing-skills` is available, follow its RED-GREEN-REFACTOR methodology: run a pressure scenario with a subagent WITHOUT the skill to capture rationalizations, then re-run WITH the skill and confirm compliance. Loopholes found in the second run become explicit counters in the skill body.
+User selects Continue / Reduce iterations / Abort. Honor the choice before
+proceeding. The cost gate fires on every `--deep` invocation; no persistent
+opt-out in this version.
+
+### Phase 4a: Description loop (automated)
+
+1. **Resolve eval set.** Probe `<skill-dir>/evals.json`.
+   - If present: use it. Print one-line summary
+     `Using N evals (T trigger / U no-trigger).` Continue to step 2.
+   - If absent: auto-draft per `references/eval-set-format.md`. Read the target
+     SKILL.md, generate 5–10 should-trigger + 5–10 should-not-trigger queries
+     (favor near-miss queries over obviously-unrelated). Write to
+     `<skill-dir>/evals.json`. Display via AskUserQuestion with options
+     Accept / Edit (skill pauses, user edits file, types continue) / Reject
+     (abort `--deep`).
+2. **Invoke the loop.** Shell out:
+
+   ```bash
+   python3 <skill-scripts>/run_loop.py \
+     --eval-set <skill-dir>/evals.json \
+     --skill-path <skill-dir> \
+     --max-iterations <N>  # default 5; overridden by --max-iterations flag
+     --holdout 0.4 \
+     --runs-per-query 3 \
+     --num-workers 10 \
+     --model <model>       # default claude-haiku-4-5-20251001; overridden by --model flag
+   ```
+
+3. **Capture results.** Read the JSON output: `{best_description, best_score,
+   final_description, history, iterations_run, ...}`. Pass to Phase 5.
+
+### Phase 4b: Output review (semi-automated)
+
+1. **Create persistent workspace** at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
+   (the project `.gitignore` excludes `.eval-runs/`).
+2. **Select prompts.** First 3 entries with `should_trigger:true` from the
+   eval set, in file order (deterministic; no random sampling).
+3. **Dispatch run subagents in parallel** (single message, multiple Agent
+   calls). For each prompt:
+   - Create `<workspace>/run-NNNN/outputs/`
+   - Write `<workspace>/run-NNNN/eval_metadata.json` with
+     `{eval_id, prompt, expectations}`
+   - Dispatch a `general-purpose` subagent with this prompt template:
+
+     > "Read the target skill at `<deployed-skill-path>` and any of its
+     > referenced files you need. Then perform the following user task:
+     > `<prompt>`. Write any file outputs to
+     > `<absolute-workspace-path>/run-NNNN/outputs/`. Write your full
+     > turn-by-turn transcript (your thinking, tool calls, results) to
+     > `<absolute-workspace-path>/run-NNNN/transcript.md` before returning.
+     > Return a one-sentence summary."
+
+4. **Grade** (per run, after the run subagent returns).
+   - If the entry's `expectations` list is empty or missing: skip grading.
+   - Otherwise: dispatch the `grader` subagent (definition at
+     `<skill-dir>/agents/grader.md`) with `expectations`, `transcript_path`,
+     and `outputs_dir`. Grader writes `metrics.json` to the run dir.
+5. **Launch review server.** Shell out:
+
+   ```bash
+   python3 <skill-scripts>/eval-viewer/generate_review.py \
+     <workspace-path> \
+     --skill-name <target-skill-name> \
+     --port 8742
+   ```
+
+   Emit to the user:
+
+   > Review server running at http://localhost:8742
+   > Press Ctrl+C in the running terminal when you're done reviewing.
+   > Your feedback will be saved to `<workspace>/feedback.json`.
+
+   The skill **blocks** until the server process exits.
+
+6. **Read feedback.** When the server exits, read
+   `<workspace>/feedback.json`. Pass results to Phase 5. If the file is
+   empty or missing (user ^C'd before reviewing), ask via AskUserQuestion:
+   "No feedback captured — abort `--deep` or proceed with description-loop
+   results only?"
+
+### Failure handling
+
+- **Port in use** — retry with port+1 up to 5 attempts; surface the final port to the user
+- **Subagent timeout** (default 5 min/run) — write `metrics.json` with `{status: "timeout"}` and continue; partial transcript still visible in review server
+- **Grader skipped** (empty expectations) — log it, no error
+- **run_loop.py non-zero exit** — surface stderr; ask user whether to retry, fall back to advisory-only Phase 4, or abort
 
 ## Phase 5: Confirm and Apply
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -222,12 +222,14 @@ no third-party packages required.
 
    Flag semantics:
    - `--model` is **required** by `run_loop.py` (no default). Use the value
-     from the skill's `--model` flag (default: `claude-haiku-4-5`).
+     from the skill's `--model` flag (default: `claude-haiku-4-5-20251001`).
    - `--max-iterations` is the description-loop cap. Use the value from the
      skill's `--max-iterations` flag (default: 5).
    - `--results-dir` writes outputs to a timestamped subdirectory under the
-     given path; reuse the `.eval-runs/<UTC-timestamp>/` workspace from
-     Phase 4b if you create it first.
+     given path. Phase 4b also writes into `.eval-runs/<UTC-timestamp>/` —
+     create that workspace directory FIRST (here in Phase 4a), then pass it
+     to both `run_loop.py --results-dir` and Phase 4b's workspace path so
+     they share a single timestamped root.
 
 3. **Capture results.** `run_loop.py` writes `results.json` and an HTML
    report inside the timestamped subdir under `--results-dir`. Locate the
@@ -261,7 +263,9 @@ no third-party packages required.
    - If the entry's `expectations` list is empty or missing: skip grading.
    - Otherwise: dispatch the `grader` subagent (definition at
      `<skill-dir>/agents/grader.md`) with `expectations`, `transcript_path`,
-     and `outputs_dir`. Grader writes `metrics.json` to the run dir.
+     and `outputs_dir`. Grader writes `grading.json` to the run dir
+     (this is the filename `generate_review.py` looks for; do not rename
+     to `metrics.json` despite that term appearing in earlier drafts).
 5. **Launch review server.** Shell out:
 
    ```bash
@@ -272,10 +276,12 @@ no third-party packages required.
    ```
 
    `generate_review.py` auto-opens the URL in the user's default browser
-   on startup (via `webbrowser.open()`). Emit to the user:
+   on startup (via `webbrowser.open()`). Capture the actual bound port from
+   the script's stdout (which may differ from the `--port` request if that
+   port was in use — the script retries port+1 up to 5 times). Then emit:
 
-   > Review server running at http://localhost:8742 (browser tab opened
-   > automatically — if it didn't, navigate there manually).
+   > Review server running at http://localhost:<actual-port> (browser tab
+   > opened automatically — if it didn't, navigate there manually).
    > Press Ctrl+C in the running terminal when you're done reviewing.
    > Your feedback will be saved to `<workspace>/feedback.json`.
 
@@ -290,7 +296,7 @@ no third-party packages required.
 ### Failure handling
 
 - **Port in use** — retry with port+1 up to 5 attempts; surface the final port to the user
-- **Subagent timeout** (default 5 min/run) — write `metrics.json` with `{status: "timeout"}` and continue; partial transcript still visible in review server
+- **Subagent timeout** (default 5 min/run) — write `grading.json` with `{status: "timeout"}` and continue; partial transcript still visible in review server
 - **Grader skipped** (empty expectations) — log it, no error
 - **run_loop.py non-zero exit** — surface stderr; ask user whether to retry, fall back to advisory-only Phase 4, or abort
 
@@ -305,7 +311,7 @@ edits to make, and whether another `--deep` pass is warranted.
 - From Phase 4a: `best_description`, `best_score`, `history` (each iteration's
   description + score), `final_description`
 - From Phase 4b: `feedback.json` (per-run user notes from the review server),
-  per-run `metrics.json` (if grader ran)
+  per-run `grading.json` (if grader ran)
 
 ### Process
 
@@ -313,7 +319,7 @@ edits to make, and whether another `--deep` pass is warranted.
    differ, summarize the delta in 1–2 sentences for the user.
 2. **Read feedback.json.** Group user notes by run; identify recurring themes
    (e.g., "skill never read the SKILL.md", "missed a frontmatter check").
-3. **Read each metrics.json** (where present). Identify expectations that
+3. **Read each grading.json** (where present). Identify expectations that
    failed across multiple runs — those signal systematic skill weaknesses.
 4. **Propose a structured update** in this shape:
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -226,7 +226,7 @@ no third-party packages required.
    - `--max-iterations` is the description-loop cap. Use the value from the
      skill's `--max-iterations` flag (default: 5).
    - `--results-dir` writes outputs to a timestamped subdirectory under the
-     given path. Phase 4b also writes into `.eval-runs/<UTC-timestamp>/` —
+     given path. Phase 4b also writes into `.eval-runs/<local-timestamp>/` —
      create that workspace directory FIRST (here in Phase 4a), then pass it
      to both `run_loop.py --results-dir` and Phase 4b's workspace path so
      they share a single timestamped root.
@@ -240,7 +240,7 @@ no third-party packages required.
 
 ### Phase 4b: Output review (semi-automated)
 
-1. **Use the shared workspace** at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
+1. **Use the shared workspace** at `<skill-dir>/.eval-runs/<local-timestamp>/`
    created in Phase 4a Step 2 (the project `.gitignore` excludes `.eval-runs/`).
    Phase 4b artifacts (`run-NNNN/`, `feedback.json`) live as siblings of
    Phase 4a's `results.json` under this same timestamped root.

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -278,14 +278,24 @@ no third-party packages required.
    ```
 
    `generate_review.py` auto-opens the URL in the user's default browser
-   on startup (via `webbrowser.open()`). Capture the actual bound port from
-   the script's stdout (which may differ from the `--port` request if that
-   port was in use — the script retries port+1 up to 5 times). Then emit:
+   on startup (via `webbrowser.open()`). Before binding, the script attempts
+   to free the requested `--port` by invoking `lsof -ti :<port>` and sending
+   `SIGTERM` to any listening PIDs; if `lsof` is unavailable it prints a
+   notice to stderr and skips the kill step. The script then tries to bind
+   the requested port; if that still fails (`OSError`), it falls back to an
+   OS-assigned ephemeral port (`bind(..., 0)`). Capture the actual bound
+   port from the script's stdout — it may differ from `--port`. Then emit:
 
    > Review server running at http://localhost:<actual-port> (browser tab
    > opened automatically — if it didn't, navigate there manually).
    > Press Ctrl+C in the running terminal when you're done reviewing.
    > Your feedback will be saved to `<workspace>/feedback.json`.
+   >
+   > Note: if port <requested-port> was already in use, this server may
+   > have terminated the prior listener via `lsof` + `SIGTERM` — check for
+   > unintended impact on other local processes. (This kill-on-startup
+   > behavior comes from the upstream script and is tracked as a
+   > known-risk decision in bead `agents-config-nsneu`.)
 
    The skill **blocks** until the server process exits.
 
@@ -297,7 +307,7 @@ no third-party packages required.
 
 ### Failure handling
 
-- **Port in use** — retry with port+1 up to 5 attempts; surface the final port to the user
+- **Port in use** — the script preemptively `SIGTERM`s any process listening on `--port` (via `lsof -ti`) before binding; if the bind still fails, it falls back to an ephemeral port (`bind(..., 0)`). Always read the actual bound port from stdout and surface it to the user. Warn the user that the kill step may have affected unrelated processes (see bead `agents-config-nsneu` for the upstream-defect decision)
 - **Subagent timeout** (default 5 min/run) — write `grading.json` with `{status: "timeout"}` and continue; partial transcript still visible in review server
 - **Grader skipped** (empty expectations) — log it, no error
 - **run_loop.py non-zero exit** — surface stderr; ask user whether to retry, fall back to advisory-only Phase 4, or abort

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -265,7 +265,58 @@ opt-out in this version.
 - **Grader skipped** (empty expectations) — log it, no error
 - **run_loop.py non-zero exit** — surface stderr; ask user whether to retry, fall back to advisory-only Phase 4, or abort
 
-## Phase 5: Confirm and Apply
+## Phase 5: Iterate (gated by `--deep`)
+
+Synthesize Phase 4a (description-loop results) and Phase 4b (output-review
+feedback) into a concrete proposal: which description to adopt, which body
+edits to make, and whether another `--deep` pass is warranted.
+
+### Inputs
+
+- From Phase 4a: `best_description`, `best_score`, `history` (each iteration's
+  description + score), `final_description`
+- From Phase 4b: `feedback.json` (per-run user notes from the review server),
+  per-run `metrics.json` (if grader ran)
+
+### Process
+
+1. **Compare best_description against the current description.** If they
+   differ, summarize the delta in 1–2 sentences for the user.
+2. **Read feedback.json.** Group user notes by run; identify recurring themes
+   (e.g., "skill never read the SKILL.md", "missed a frontmatter check").
+3. **Read each metrics.json** (where present). Identify expectations that
+   failed across multiple runs — those signal systematic skill weaknesses.
+4. **Propose a structured update** in this shape:
+
+   ```markdown
+   ## Phase 5 proposal — <skill-name>
+
+   ### Description
+   - Current: `<text>`
+   - Proposed: `<text>` (from Phase 4a best, score <X/Y>)
+   - Adopt? [yes / keep current / draft alternative]
+
+   ### Body edits
+   - <Section>: <one-sentence change>; rationale: <feedback theme>
+   - <Section>: ...
+
+   ### Re-run?
+   - Recommend another `--deep` pass: [yes if N>0 unresolved themes / no]
+   ```
+
+5. **Surface the proposal to the user via AskUserQuestion.** Options:
+   Accept all (proceeds to Phase 6) / Adopt description only / Adopt body
+   edits only / Re-run `--deep` from Phase 4a (loops back, using the
+   accepted description as starting point) / Reject all (proceeds to
+   Phase 6 with no changes from Phase 4/5).
+
+### What NOT to do in Phase 5
+
+- Do not silently apply changes — every adoption is explicit
+- Do not propose body edits with no grounding in Phase 4b feedback
+- Do not loop more than once without checking with the user (cost discipline)
+
+## Phase 6: Confirm and Apply
 
 Present all proposed changes as a single summary table before writing anything:
 
@@ -286,7 +337,7 @@ Apply approved changes. Show a diff for each modified file so the user can verif
 
 | Rationalization | Reality |
 |---|---|
-| "The description is fine, it triggers correctly" | Trigger accuracy is measurable — test it with `skill-creator` before assuming |
+| "The description is fine, it triggers correctly" | Trigger accuracy is measurable — run `--deep` (Phase 4a) before assuming |
 | "I'll just improve the frontmatter" | Body content is where skills fail; frontmatter only gets you discovered |
 | "This skill is simple, no changes needed" | Simple skills rot into generic advice; audit every section against the quality criteria |
 | "I can rewrite this without reading it first" | Always read the full SKILL.md before proposing changes |

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -304,11 +304,27 @@ edits to make, and whether another `--deep` pass is warranted.
    - Recommend another `--deep` pass: [yes if N>0 unresolved themes / no]
    ```
 
-5. **Surface the proposal to the user via AskUserQuestion.** Options:
-   Accept all (proceeds to Phase 6) / Adopt description only / Adopt body
-   edits only / Re-run `--deep` from Phase 4a (loops back, using the
-   accepted description as starting point) / Reject all (proceeds to
-   Phase 6 with no changes from Phase 4/5).
+5. **Surface the proposal to the user and STOP — wait for their letter reply.**
+
+   This question has 5 options, which exceeds `AskUserQuestion`'s 4-option
+   cap. Use a prose letter-prompt instead. Print the proposal block (from
+   step 4) followed by:
+
+   ```
+   Which path forward? Reply with a single letter:
+
+   A) Accept all — apply description + body edits, proceed to Phase 6
+   B) Adopt description only — apply Phase 4a winner, skip body edits, proceed to Phase 6
+   C) Adopt body edits only — apply Phase 4b-driven body changes, keep current description, proceed to Phase 6
+   D) Re-run `--deep` from Phase 4a — loop back using the accepted description as starting point (incurs another cost-gated pass)
+   E) Reject all — proceed to Phase 6 with no changes from Phase 4/5
+   ```
+
+   End your turn after presenting these. Do NOT infer the user's choice
+   from prior context — wait for an explicit single-letter reply. On the
+   reply, parse the first letter (A–E, case-insensitive). If ambiguous
+   (no letter, multiple letters, or outside A–E), ask once for
+   clarification then halt rather than guessing.
 
 ### What NOT to do in Phase 5
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -205,21 +205,36 @@ no third-party packages required.
      `<skill-dir>/evals.json`. Display via AskUserQuestion with options
      Accept / Edit (skill pauses, user edits file, types continue) / Reject
      (abort `--deep`).
-2. **Invoke the loop.** Shell out:
+2. **Invoke the loop.** Use module-mode invocation (the script's relative
+   imports require it):
 
    ```bash
-   python3 <skill-scripts>/run_loop.py \
+   cd <skill-dir> && PYTHONPATH=. python3 -m scripts.run_loop \
      --eval-set <skill-dir>/evals.json \
      --skill-path <skill-dir> \
-     --max-iterations <N>  # default 5; overridden by --max-iterations flag
+     --model <model> \
+     --max-iterations <N> \
      --holdout 0.4 \
      --runs-per-query 3 \
      --num-workers 10 \
-     --model <model>       # default claude-haiku-4-5-20251001; overridden by --model flag
+     --results-dir <skill-dir>/.eval-runs/
    ```
 
-3. **Capture results.** Read the JSON output: `{best_description, best_score,
-   final_description, history, iterations_run, ...}`. Pass to Phase 5.
+   Flag semantics:
+   - `--model` is **required** by `run_loop.py` (no default). Use the value
+     from the skill's `--model` flag (default: `claude-haiku-4-5`).
+   - `--max-iterations` is the description-loop cap. Use the value from the
+     skill's `--max-iterations` flag (default: 5).
+   - `--results-dir` writes outputs to a timestamped subdirectory under the
+     given path; reuse the `.eval-runs/<UTC-timestamp>/` workspace from
+     Phase 4b if you create it first.
+
+3. **Capture results.** `run_loop.py` writes `results.json` and an HTML
+   report inside the timestamped subdir under `--results-dir`. Locate the
+   newest subdir and read `results.json` — expected keys include
+   `best_description`, `best_score`, `best_train_score`, `best_test_score`,
+   `final_description`, `history`, `iterations_run`, `exit_reason`. Pass to
+   Phase 5.
 
 ### Phase 4b: Output review (semi-automated)
 
@@ -256,9 +271,11 @@ no third-party packages required.
      --port 8742
    ```
 
-   Emit to the user:
+   `generate_review.py` auto-opens the URL in the user's default browser
+   on startup (via `webbrowser.open()`). Emit to the user:
 
-   > Review server running at http://localhost:8742
+   > Review server running at http://localhost:8742 (browser tab opened
+   > automatically — if it didn't, navigate there manually).
    > Press Ctrl+C in the running terminal when you're done reviewing.
    > Your feedback will be saved to `<workspace>/feedback.json`.
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -240,8 +240,10 @@ no third-party packages required.
 
 ### Phase 4b: Output review (semi-automated)
 
-1. **Create persistent workspace** at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
-   (the project `.gitignore` excludes `.eval-runs/`).
+1. **Use the shared workspace** at `<skill-dir>/.eval-runs/<UTC-timestamp>/`
+   created in Phase 4a Step 2 (the project `.gitignore` excludes `.eval-runs/`).
+   Phase 4b artifacts (`run-NNNN/`, `feedback.json`) live as siblings of
+   Phase 4a's `results.json` under this same timestamped root.
 2. **Select prompts.** First 3 entries with `should_trigger:true` from the
    eval set, in file order (deterministic; no random sampling).
 3. **Dispatch run subagents in parallel** (single message, multiple Agent

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -182,6 +182,18 @@ User selects Continue / Reduce iterations / Abort. Honor the choice before
 proceeding. The cost gate fires on every `--deep` invocation; no persistent
 opt-out in this version.
 
+### Runtime contract
+
+Phase 4's scripts shell out to `claude -p` (the Claude Code CLI) as a
+subprocess, inheriting your existing session's auth. No separate
+`ANTHROPIC_API_KEY` or `anthropic` Python SDK install is required. If
+`claude` is not on PATH (rare — usually implicit when this skill is invoked
+from Claude Code), surface the error and abort `--deep` rather than
+fabricating an alternate auth path.
+
+Both `run_loop.py` and `generate_review.py` use only the Python stdlib —
+no third-party packages required.
+
 ### Phase 4a: Description loop (automated)
 
 1. **Resolve eval set.** Probe `<skill-dir>/evals.json`.

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -5,6 +5,15 @@ allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
 description: Audits and improves existing SKILL.md files for discoverability, progressive disclosure, and methodology rigor. Use when asked to optimize a skill, when reviewing a skill folder for quality, or when a SKILL.md needs frontmatter or body cleanup. Do NOT use for agent persona files or AGENTS.md configuration files.
 ---
 
+<!--
+Sources (amalgam):
+  - Native (audit/assess methodology — Phases 1–3, 6)
+  - oss-snapshots/anthropics/skill-creator/
+    Upstream: https://github.com/anthropics/skills @ f458cee31a7577a47ba0c9a101976fa599385174
+Last sync: 2026-05-20
+Drift policy: accept-periodic-resync
+-->
+
 # Optimize My Skill
 
 Audit and improve existing SKILL.md files for clarity, discoverability, and effectiveness. This skill is for *auditing and improving* existing skills — if a `writing-skills` skill is available (e.g. `superpowers:writing-skills`), prefer it for *creating* new skills from scratch.

--- a/src/user/.agents/skills/optimize-my-skill/agents/analyzer.md
+++ b/src/user/.agents/skills/optimize-my-skill/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/src/user/.agents/skills/optimize-my-skill/agents/comparator.md
+++ b/src/user/.agents/skills/optimize-my-skill/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/src/user/.agents/skills/optimize-my-skill/agents/grader.md
+++ b/src/user/.agents/skills/optimize-my-skill/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/src/user/.agents/skills/optimize-my-skill/references/eval-set-format.md
+++ b/src/user/.agents/skills/optimize-my-skill/references/eval-set-format.md
@@ -1,0 +1,99 @@
+# Eval-Set Format
+
+Used by Phase 4a (description-optimization loop via `scripts/run_loop.py`) and
+Phase 4b (output-review battery via inline subagent orchestration).
+
+## File location
+
+`<skill-dir>/evals.json` — co-located with the SKILL.md it scores. Git-versioned
+alongside the skill.
+
+## Schema
+
+A JSON array of eval entries. Each entry:
+
+```json
+{
+  "query": "string — the user-facing prompt sent to a Claude instance with the skill loaded",
+  "should_trigger": true,
+  "expectations": [
+    "string — a single observable behavior the skill's output should satisfy",
+    "string — another expectation"
+  ]
+}
+```
+
+| Field | Required | Used by |
+|-------|----------|---------|
+| `query` | yes | both 4a (run_eval) and 4b (run-on-prompts) |
+| `should_trigger` | yes | 4a precision/recall; 4b only consumes entries where this is `true` |
+| `expectations` | optional list of strings | 4b grader subagent only; empty or missing list means "do not grade this run's output quality" |
+
+## When auto-drafting (Phase 4a.1 fallback)
+
+If `<skill-dir>/evals.json` is missing when `--deep` runs, the skill drafts a
+starter set by reading the target SKILL.md. The auto-draft prompt instructs
+Claude to:
+
+1. Generate 5–10 `should_trigger:true` queries that a real user would phrase to
+   invoke the skill — including 2–3 *near-miss* queries that the existing
+   description might not catch but should.
+2. Generate 5–10 `should_trigger:false` queries that are adjacent in topic but
+   should NOT invoke the skill. Favor near-misses with sibling skills over
+   wildly-unrelated queries (which prove nothing).
+3. For each `should_trigger:true` entry, propose 1–3 observable expectations the
+   skill's output should satisfy. Skip expectations for entries where the
+   skill's output is inherently subjective (writing style, creative work).
+4. Write the JSON array to `<skill-dir>/evals.json`.
+
+The user reviews the drafted set before `run_loop.py` runs — the skill pauses
+via AskUserQuestion with three options: Accept, Edit (skill pauses, user edits
+the file, types continue), Reject (abort `--deep`).
+
+## Quality criteria (weak vs strong evals)
+
+**Weak eval — query is too generic or expectation is trivially satisfied:**
+
+```json
+{
+  "query": "Help me write a skill.",
+  "should_trigger": true,
+  "expectations": ["produces a response"]
+}
+```
+
+Anything triggers; any response passes. Useless signal.
+
+**Strong eval — query is realistic and probes a specific failure mode:**
+
+```json
+{
+  "query": "Can you audit the writing-skills skill for me and tell me if its description over-triggers?",
+  "should_trigger": true,
+  "expectations": [
+    "Reads writing-skills/SKILL.md before proposing anything",
+    "Reports concrete frontmatter findings, not vague advice",
+    "Surfaces a per-skill structured proposal with current vs proposed description"
+  ]
+}
+```
+
+Specific query, observable behaviors, fails meaningfully if the skill drifts.
+
+**Strong negative — adjacent but should NOT trigger:**
+
+```json
+{
+  "query": "I want to write a brand new skill for parsing PDFs from scratch.",
+  "should_trigger": false,
+  "expectations": []
+}
+```
+
+Probes the optimize-vs-create boundary with `writing-skills`.
+
+## Subsequent runs
+
+If the file already exists, the skill uses it as-is — no auto-draft, no
+review gate. Users curate the file over time as the skill evolves and new
+failure modes surface.

--- a/src/user/.agents/skills/optimize-my-skill/scripts/aggregate_benchmark.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/generate_review.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/viewer.html
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/src/user/.agents/skills/optimize-my-skill/scripts/generate_report.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/improve_description.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/quick_validate.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/src/user/.agents/skills/optimize-my-skill/scripts/run_eval.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/run_loop.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/user/.agents/skills/optimize-my-skill/scripts/utils.py
+++ b/src/user/.agents/skills/optimize-my-skill/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/src/user/.claude/commands/optimize-my-skill.md
+++ b/src/user/.claude/commands/optimize-my-skill.md
@@ -19,9 +19,19 @@ Audit and improve existing SKILL.md files via the `optimize-my-skill` skill.
 | `--max-iterations N` | override the description-loop iteration cap (default 5). Ignored without `--deep` |
 | `--model <name>` | model id for the description-improver loop. Default `claude-haiku-4-5-20251001`. Ignored without `--deep` |
 
-Parse by splitting `$ARGUMENTS` on whitespace: identify the single non-flag
-token as `<target>`, collect flags separately, pass both to the skill.
-Empty `<target>` triggers the probe in the next section.
+Parse by splitting `$ARGUMENTS` on whitespace and walking tokens left-to-right:
+
+- `--deep` is a boolean flag (consumes no value).
+- `--max-iterations` and `--model` are value-taking flags: the **next token**
+  after the flag is its value and MUST NOT be considered as `<target>`. Treat
+  `--max-iterations=N` / `--model=<name>` (equals-form) as a single token.
+- The first unclaimed (non-flag, non-value) token is `<target>`. Any further
+  unclaimed tokens are an error — reject with a usage message.
+- Unknown `--flags` are an error — reject with a usage message.
+
+Collect flags separately from `<target>` and pass both to the skill. Empty
+`<target>` (no unclaimed token after flag/value consumption) triggers the
+probe in the next section.
 
 ## Empty-argument resolution
 

--- a/src/user/.claude/commands/optimize-my-skill.md
+++ b/src/user/.claude/commands/optimize-my-skill.md
@@ -4,13 +4,24 @@ Audit and improve existing SKILL.md files via the `optimize-my-skill` skill.
 
 > **Tip**: For *creating* new skills from scratch, prefer `superpowers:writing-skills` if available. This command is for *auditing and improving* existing skills.
 
-## Argument
+## Arguments
 
-`$ARGUMENTS` specifies the target:
+`$ARGUMENTS` accepts one non-flag target and optional flags:
 
-- **Skill name** (e.g. `bugfix`, `writing-unit-tests`) — optimize that single skill
-- **Directory path** (e.g. `~/.claude/skills/` or `.claude/skills/`) — optimize all skills in that directory
-- **Empty** — resolve a default location (see below)
+```
+/optimize-my-skill [<target>] [--deep] [--max-iterations N] [--model <name>]
+```
+
+| Token | Meaning |
+|-------|---------|
+| `<target>` | skill name (e.g. `bugfix`), directory path (e.g. `~/.claude/skills/`), or empty (resolved via the probe below) |
+| `--deep` | opt into Phase 4 (empirical description loop + output review) and Phase 5 (iterate). Absent → naked invocation = today's audit-and-apply behavior |
+| `--max-iterations N` | override the description-loop iteration cap (default 5). Ignored without `--deep` |
+| `--model <name>` | model id for the description-improver loop. Default `claude-haiku-4-5-20251001`. Ignored without `--deep` |
+
+Parse by splitting `$ARGUMENTS` on whitespace: identify the single non-flag
+token as `<target>`, collect flags separately, pass both to the skill.
+Empty `<target>` triggers the probe in the next section.
 
 ## Empty-argument resolution
 
@@ -31,7 +42,13 @@ and stop.
 
 ## Invoke the skill
 
-With the resolved target, invoke the `optimize-my-skill` skill and pass the target as its scope. The skill owns the full methodology (discover, assess, propose, test, confirm, apply).
+With the resolved target and any flags, invoke the `optimize-my-skill` skill
+and pass them in its invocation context. The skill owns the full methodology
+(discover, assess, propose, optionally empirical-optimize + iterate, then
+confirm/apply).
+
+Quick mode (no `--deep`) is unchanged from prior behavior. Deep mode
+prompts the user for a cost confirmation before invoking model-heavy phases.
 
 ## Report
 


### PR DESCRIPTION
## Summary

- **Amalgamate** Anthropic's [skill-creator](https://github.com/anthropics/skills) iteration machinery (`scripts/`, `agents/`, `eval-viewer/`) into in-repo `optimize-my-skill` with HTML-comment provenance header + `accept-periodic-resync` drift policy
- **Rewrite phase structure**: new **Phase 4 "Empirical Optimization"** (gated by `--deep`; 4a description-optimization loop via `run_loop.py` + 4b parallel-subagent output-review battery via `generate_review.py` HTTP server), new **Phase 5 "Iterate"** (synthesizes 4a/4b outputs into a structured proposal), and renumber old Phase 5 "Confirm and Apply" → **Phase 6**
- **Add flags** `--deep` / `--max-iterations` / `--model` to `/optimize-my-skill`; quick mode (no `--deep`) **unchanged from prior audit-and-apply behavior**; documented runtime contract (`claude` CLI on PATH, no Python SDK install needed — scripts shell out to `claude -p` and inherit Claude Code session auth)

## Test plan

- [ ] Per-script smoke: `run_loop.py`, `run_eval.py`, `improve_description.py`, `utils.py` all importable; `generate_review.py` CLI parses (verified in worktree, Tasks 5–8)
- [ ] Quick-mode regression: naked `/optimize-my-skill` still walks Phases 1, 2, 3, advisory-note-4, pass-through-5, 6 with zero script invocations (static evidence in bd notes, Task 13)
- [ ] Deep-mode pipeline smoke: `run_loop.py` end-to-end with synthetic eval set + `generate_review.py` HTTP server start/stop validated (Task 14 evidence in bd notes; ~41s wall-clock for 4a, HTTP 200 confirmed for 4b)
- [ ] Browser review server: confirmed live during smoke (auto-opens via `webbrowser.open()`; documented in Phase 4b prose)
- [ ] `install.sh --dry-run --tools=claude` passes; depth-1 invariant honored (Task 8)
- [ ] Letter-prompt vs `AskUserQuestion` cap: Phase 5 proposal uses prose letter-prompt (A-E) since `AskUserQuestion.options.maxItems=4` would reject 5 options
- [ ] Full empirical dogfood deferred to follow-up bead `agents-config-cx6.7.8` (post-merge, real curated evals.json)

## Follow-up beads filed

- `agents-config-cx6.7.8` — empirical dogfood pass with curated evals (post-merge)
- `agents-config-y4zd0` — `quick_validate.py` amalgamated-but-unwired: wire into Phase 2 or delete
- `agents-config-bwk7v` — `AskUserQuestion` 4-cap routing guideline + fix `optimize-agents-md` 5-questions-in-one-call cousin defect
- `agents-config-v2nq8` — rename `scripts/eval-viewer/` → `scripts/eval_viewer/` for Python module-mode parity

## Notable decisions captured in commit messages

- Phase 5 `AskUserQuestion` 4-cap defect (`be11aef`) — switched to prose letter-prompt + explicit wait-gate
- Runtime contract documentation (`8377f86`) — `cx6.7.3.1` premise was wrong; scripts use `claude -p` subprocess, no SDK install needed
- Phase 4a CLI alignment with `run_loop.py --help` (`924f255`) — `--model` is required (not defaulted), `--output` doesn't exist (use `--results-dir`), module-mode invocation explicit
- `grading.json` vs `metrics.json` filename reconciliation (`e23cb34`) — code writes `grading.json`; SKILL.md aligned to match what `generate_review.py` looks for

🤖 Generated with [Claude Code](https://claude.com/claude-code)
