### PR TITLE
feat(cx6.7.8): empirical dogfood pass on optimize-my-skill

### DIFF
--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -38,9 +38,12 @@ Audit and improve existing SKILL.md files for clarity, discoverability, and effe
 
 ## Boundaries (default: audit-only)
 
-Phases 1–5 are **read-only against tracked skill content** — `SKILL.md`, frontmatter, and body. The skill discovers, assesses, proposes, and (under `--deep`) measures, but it does not modify that content until **Phase 6** has user confirmation. Permitted writes before Phase 6 are limited to gitignored side-files: workspace artifacts under `<skill-dir>/.eval-runs/`, and an auto-drafted `<skill-dir>/evals.json` written only when absent (Phase 4a step 1 fallback, user-reviewed before the loop runs). An existing `evals.json` is reused as-is and never overwritten.
+Phases 1–5 are **read-only against the target skill's tracked files** — `SKILL.md`, frontmatter, body, plus `references/`, `scripts/`, `agents/`, `assets/`, and any existing `evals.json`. The skill discovers, assesses, proposes, and (under `--deep`) measures, but does not modify those tracked files until **Phase 6** has user confirmation. Permitted writes before Phase 6 are limited to:
 
-A run that silently mutates a target SKILL.md during audit is a defect, not a feature, regardless of how well-intentioned the change.
+1. Workspace artifacts under `<skill-dir>/.eval-runs/` (gitignored).
+2. Auto-drafting `<skill-dir>/evals.json` only when absent (Phase 4a step 1 fallback, user-reviewed before the loop runs). An existing `evals.json` — git-versioned alongside the skill — is reused as-is and never overwritten.
+
+A run that silently mutates any tracked skill-folder content during audit is a defect, not a feature, regardless of how well-intentioned the change.
 
 ## Phase 1: Discover and Read
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -36,6 +36,12 @@ Audit and improve existing SKILL.md files for clarity, discoverability, and effe
 
 **Audit before writing.** Read the existing skill completely before proposing any change — never rewrite content you haven't fully understood.
 
+## Boundaries (default: audit-only)
+
+Phases 1–5 are **read-only against the target skill folder**. The skill discovers, assesses, proposes, and (under `--deep`) measures — but it does not modify any target `SKILL.md`, frontmatter, or body content until **Phase 6** has user confirmation. The only writes permitted before Phase 6 are workspace artifacts under `<skill-dir>/.eval-runs/` (gitignored) and the eval set draft at `<skill-dir>/evals.json` (Phase 4a, user-reviewed before the loop runs).
+
+A run that silently mutates a target SKILL.md during audit is a defect, not a feature, regardless of how well-intentioned the change.
+
 ## Phase 1: Discover and Read
 
 Find all SKILL.md files in the target scope. For each one, read the complete file (frontmatter + body) and also check the skill's folder structure.
@@ -148,6 +154,34 @@ Per SKILLS_PRIMER (see `references/SKILLS_PRIMER.md`):
 ## Phase 3: Propose Improvements
 
 For each skill that needs work, present a structured proposal. Do not silently rewrite — surface the change and the rationale so the user can accept, modify, or reject.
+
+### Multi-skill scope: lead with priority summary
+
+When the resolved scope contains more than one skill (directory-path argument enumerating multiple `SKILL.md` files), **present a priority-grouped summary table FIRST**, then offer per-skill detail on request rather than dumping every proposal inline.
+
+```
+| Skill | Priority | Headline finding |
+|-------|----------|------------------|
+| <name> | Critical | <one-line> |
+| <name> | High     | <one-line> |
+| <name> | Medium   | <one-line> |
+| <name> | Low      | <one-line> |
+| <name> | OK       | No changes needed |
+```
+
+Priority rubric:
+
+- **Critical** — description fails the formula entirely OR XML/reserved-name security check fails
+- **High** — description present but missing negative triggers / scope boundaries (over-trigger risk)
+- **Medium** — body content gaps (missing red flags, verification checklist, decision trees)
+- **Low** — cosmetic frontmatter polish, line-count discipline, structural cleanup
+- **OK** — passes all criteria; no changes needed
+
+After the summary, surface detailed per-skill proposals only for Medium-and-higher entries by default; Low and OK can be collapsed into a one-line note unless the user asks for everything. This keeps multi-skill audits scannable without losing depth.
+
+For single-skill scope, skip the summary table and go straight to the per-skill proposal below.
+
+### Per-skill proposal template
 
 **Skill**: `[name]` (`[path]`)
 **Current description**:

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -38,7 +38,7 @@ Audit and improve existing SKILL.md files for clarity, discoverability, and effe
 
 ## Boundaries (default: audit-only)
 
-Phases 1–5 are **read-only against the target skill folder**. The skill discovers, assesses, proposes, and (under `--deep`) measures — but it does not modify any target `SKILL.md`, frontmatter, or body content until **Phase 6** has user confirmation. The only writes permitted before Phase 6 are workspace artifacts under `<skill-dir>/.eval-runs/` (gitignored) and the eval set draft at `<skill-dir>/evals.json` (Phase 4a, user-reviewed before the loop runs).
+Phases 1–5 are **read-only against tracked skill content** — `SKILL.md`, frontmatter, and body. The skill discovers, assesses, proposes, and (under `--deep`) measures, but it does not modify that content until **Phase 6** has user confirmation. Permitted writes before Phase 6 are limited to gitignored side-files: workspace artifacts under `<skill-dir>/.eval-runs/`, and an auto-drafted `<skill-dir>/evals.json` written only when absent (Phase 4a step 1 fallback, user-reviewed before the loop runs). An existing `evals.json` is reused as-is and never overwritten.
 
 A run that silently mutates a target SKILL.md during audit is a defect, not a feature, regardless of how well-intentioned the change.
 

--- a/src/user/.agents/skills/optimize-my-skill/evals.json
+++ b/src/user/.agents/skills/optimize-my-skill/evals.json
@@ -1,0 +1,109 @@
+[
+  {
+    "query": "Can you optimize the bugfix skill? Its description seems too vague.",
+    "should_trigger": true,
+    "expectations": [
+      "Reads bugfix/SKILL.md before proposing any change",
+      "Reports concrete findings against the description formula (what / when / not-for)",
+      "Surfaces a structured proposal with current vs proposed description and a one-sentence rationale"
+    ]
+  },
+  {
+    "query": "Audit the optimize-my-agent skill folder for frontmatter compliance and progressive-disclosure issues.",
+    "should_trigger": true,
+    "expectations": [
+      "Reads the target SKILL.md's frontmatter and folder structure",
+      "Reports specific frontmatter issues (name kebab-case, description schema, allowed-tools shape) — not generic advice",
+      "Checks SKILL.md line count vs the 500-line guideline and flags candidates for references/"
+    ]
+  },
+  {
+    "query": "Review every skill under src/user/.agents/skills/ and tell me which ones need their descriptions improved.",
+    "should_trigger": true,
+    "expectations": [
+      "Enumerates skills in the directory (does not silently pick one)",
+      "Produces a per-skill assessment, not a single global summary",
+      "Surfaces per-skill structured proposals with current vs proposed descriptions"
+    ]
+  },
+  {
+    "query": "The merge-guard SKILL.md is over 500 lines — should I split parts of it into references/?",
+    "should_trigger": true,
+    "expectations": [
+      "Reads merge-guard/SKILL.md to assess actual content distribution, not just line count",
+      "Identifies specific sections that are good extraction candidates (lengthy examples, detailed API docs)",
+      "Recommends action grounded in the progressive-disclosure rubric, not a yes/no without rationale"
+    ]
+  },
+  {
+    "query": "Improve the description on writing-unit-tests — it keeps over-triggering on general code review requests.",
+    "should_trigger": true,
+    "expectations": [
+      "Reads writing-unit-tests/SKILL.md before proposing changes",
+      "Diagnoses concrete over-triggering causes in the current description (missing negative triggers, vague triggers)",
+      "Proposes a revised description with explicit 'Do NOT use for' scope boundaries"
+    ]
+  },
+  {
+    "query": "Optimize my AGENTS.md file — it's getting too long and unwieldy.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Audit the simplify agent persona file under src/user/.agents/agents/.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Refactor scripts/run_loop.py for clarity — too much duplication in the result-printing branches.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Update the project README so the install instructions match the new --plugins= flag.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Help me write a new pytest fixture for parsing ISO 8601 dates with timezones.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Make this skill's description more reliable at triggering — it keeps getting passed over for adjacent skills.",
+    "should_trigger": true,
+    "expectations": [
+      "Asks for skill identification when no skill is named, OR reads the in-scope SKILL.md if context implies one",
+      "Diagnoses concrete under-triggering causes (missing trigger phrases, overly narrow scope, sibling-skill cannibalization)",
+      "Surfaces a description proposal grounded in the audited skill's current text"
+    ]
+  },
+  {
+    "query": "Can you fix the frontmatter on writing-skills? I think the description is non-compliant.",
+    "should_trigger": true,
+    "expectations": [
+      "Reads writing-skills/SKILL.md frontmatter before commenting",
+      "Reports specific compliance findings (XML-bracket check, name format, description schema)",
+      "Proposes targeted corrections rather than a wholesale rewrite"
+    ]
+  },
+  {
+    "query": "I want to write a brand new skill for parsing PDFs from scratch — no existing skill to start from.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Help me edit the whats-next skill — I want to add a new section.",
+    "should_trigger": false,
+    "expectations": []
+  },
+  {
+    "query": "Make the bugfix skill's description better at triggering — it keeps over-firing on tasks that are clearly not bugs.",
+    "should_trigger": true,
+    "expectations": [
+      "Reads bugfix/SKILL.md to ground the analysis",
+      "Diagnoses concrete over-triggering causes in the current description",
+      "Proposes explicit negative triggers or scope-narrowing language with rationale"
+    ]
+  }
+]

--- a/src/user/.agents/skills/optimize-my-skill/evals.json
+++ b/src/user/.agents/skills/optimize-my-skill/evals.json
@@ -21,9 +21,9 @@
     "query": "Review every skill under src/user/.agents/skills/ and tell me which ones need their descriptions improved.",
     "should_trigger": true,
     "expectations": [
-      "Enumerates skills in the directory (does not silently pick one)",
-      "Produces a per-skill assessment, not a single global summary",
-      "Surfaces per-skill structured proposals with current vs proposed descriptions"
+      "Leads with a priority-grouped summary table covering every skill in scope (columns: Skill / Priority / Headline finding)",
+      "Uses the Critical / High / Medium / Low / OK priority rubric",
+      "Surfaces detailed current-vs-proposed proposals only for Medium-and-higher entries; Low/OK collapsed into a one-line note unless the user asks for everything"
     ]
   },
   {


### PR DESCRIPTION
## Summary

First real-customer use of the `--deep` flow shipped in cx6.7.3. Closes `agents-config-cx6.7.8` (Empirical dogfood pass on optimize-my-skill).

- **evals.json** — 15 hand-curated entries (8 should-trigger / 7 should-not-trigger). Mix: 5 clear-trigger + 5 clear-no-trigger + 5 adversarial near-miss queries probing real overlap with `writing-skills` and `skill-creator`.
- **SKILL.md — two new body sections, both grounded in Phase 4b feedback:**
  - `Boundaries (default: audit-only)` — codifies the no-writes-to-target contract for Phases 1-5. Cited grader-0001 + grader-0002 both flagging this as implicit-but-unenforced.
  - `Multi-skill scope: lead with priority summary` (inside Phase 3) — directory-scope audits lead with a Critical/High/Medium/Low/OK summary table; Low/OK collapsed by default. Cited user feedback verbatim from run-0003: "Output is too verbose - I need a concise summary of recommendations."

## Phase 4a finding (NOT actioned in this PR; logged for follow-up)

All 5 description variants scored 0/3 trigger rate on every `should_trigger:true` query across 225 haiku eval calls. Since this skill demonstrably triggers in real Claude Code sessions, this is most likely a systematic blind spot in the `claude -p` haiku eval mechanism, not a description defect. **Follow-up spike filed as `agents-config-6wun7`** (`discovered-from` cx6.7.8) to investigate the eval mechanism vs real Claude Code skill selection.

## Phase 4b results

| Run | Task | Grade | Notes |
|---|---|---|---|
| 0001 | Audit bugfix description | 3/3 PASS | Found 2 high-sev description issues |
| 0002 | Audit optimize-my-agent | 3/3 PASS | Found 2 body gaps (no Red Flags, no Verification Checklist) |
| 0003 | Review all 17 skills | 3/3 PASS | 4 critical + 3 medium + 7 low priority findings |

User feedback: 0001 and 0002 "good"; 0003 "too verbose — I need a concise summary" (→ drove the multi-skill summary body edit).

## Model spend

~$1.85–$2.35 (rough estimate; Phase 4a haiku evals + Phase 4b sonnet subagents). Full per-stage breakdown in cx6.7.8 bead notes.

## Test plan

- [x] `evals.json` parses cleanly: 15 entries, all required fields, 8 trigger / 7 no-trigger
- [x] `SKILL.md` is 468 lines (under 500-line guideline)
- [x] Only `SKILL.md` at skill top level
- [x] `.eval-runs/` workspace artifacts confirmed gitignored, zero tracked files
- [x] Quality reviewer: clean (no Critical/High; 2 Medium addressed)
- [x] Simplify pass: no findings warranted on prose changes
- [ ] Copilot review (post-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)