### PR TITLE
docs(cx6.7.9): note CONTEXT.md/CONTEXT-MAP.md as soft convention in shared INSTRUCTIONS

### DIFF
--- a/src/user/.agents/INSTRUCTIONS.md.template
+++ b/src/user/.agents/INSTRUCTIONS.md.template
@@ -13,6 +13,7 @@ Tool-agnostic principles for all AI coding assistants.
 <constraints>
 - **Minimal edits**: Change only what's necessary—no over-engineering
 - **Informed edits**: Research the codebase before editing - never change code you haven't read
+- **Domain vocabulary**: If the project has a `CONTEXT.md` at the repo root (or a `CONTEXT-MAP.md` pointing to per-context glossaries in a multi-context repo), read it and use its terminology when discussing domain concepts. Soft convention — absence is not a blocker
 - **Parallel ops**: Independent tool calls in single message
 - **Root causes**: Find root causes, no temporary fixes—principal engineer standards
 - **Dependencies**: If a library version is newer than model training data, look up current docs via available documentation tools (e.g., context7 MCP if available, or web search) before using it


### PR DESCRIPTION
## Summary
- Adds a **Domain vocabulary** constraint to `src/user/.agents/INSTRUCTIONS.md.template` so deployed agents check for a project-root `CONTEXT.md` (or `CONTEXT-MAP.md` for multi-context repos) and use its terminology when discussing domain concepts
- Framed as a soft convention — absence is not a blocker
- Aligns deployed agents with the `grill-with-docs` / `improve-codebase-architecture` convention promoted in cx6.7.5

## Acceptance criteria
- [x] Shared template includes a CONTEXT.md awareness note (`INSTRUCTIONS.md.template` is the appropriate shared template; no `AGENTS.md.template` exists in `src/user/.agents/`)
- [x] Note frames CONTEXT.md as a soft convention (read if present, do not require)
- [x] Multi-context CONTEXT-MAP.md variant is mentioned
- [x] Note references the convention by concept (no file-path citations)

## Test plan
- [ ] Verify diff lands inside `<constraints>` block, between **Informed edits** and **Parallel ops**
- [ ] Confirm phrasing carries forward into all four per-tool AGENTS.md outputs via `DYNAMIC-INCLUDE` at install time

Closes agents-config-cx6.7.9