### PR TITLE
chore: replace all superpowers: references with bare skill names

### DIFF
--- a/src/user/.agents/agents/quality-reviewer.md
+++ b/src/user/.agents/agents/quality-reviewer.md
@@ -29,7 +29,7 @@ description: |-
   </commentary>
   </example>
 tools: Read, Grep, Glob, Bash
-skills: [superpowers:requesting-code-review, superpowers:receiving-code-review]
+skills: []
 model: opus[1m]
 color: purple
 ---

--- a/src/user/.agents/agents/quality-reviewer.md
+++ b/src/user/.agents/agents/quality-reviewer.md
@@ -29,7 +29,6 @@ description: |-
   </commentary>
   </example>
 tools: Read, Grep, Glob, Bash
-skills: []
 model: opus[1m]
 color: purple
 ---

--- a/src/user/.agents/rules/completion-gate.md
+++ b/src/user/.agents/rules/completion-gate.md
@@ -19,4 +19,4 @@ No exceptions. No partial runs. Each step feeds the next.
 **HARD STOP**: After this gate, AUTOMATICALLY execute delivery steps. Do NOT pause for authorization.
 DO NOT commit to main. DO NOT push directly.
 
-Execute IN ORDER, without asking: (1) `superpowers:using-git-worktrees` if not already in one, (2) `superpowers:finishing-a-development-branch`, (3) `wait-for-pr-comments` (which internally chains to `reply-and-resolve-pr-threads` for thread reply + resolve). Only pause at the merge step — see `delivery.md` for the action categorization.
+Execute IN ORDER, without asking: (1) `using-git-worktrees` if not already in one, (2) `finishing-a-development-branch`, (3) `wait-for-pr-comments` (which internally chains to `reply-and-resolve-pr-threads` for thread reply + resolve). Only pause at the merge step — see `delivery.md` for the action categorization.

--- a/src/user/.agents/rules/delegation.md
+++ b/src/user/.agents/rules/delegation.md
@@ -2,10 +2,10 @@
 
 MANDATORY delegation for non-trivial work (skip for obvious one-liners, config changes, typos):
 
-- Planning → `superpowers:brainstorming` skill
-- Implementation (default) → `superpowers:test-driven-development` first, then any applicable domain skills
+- Planning → `brainstorming` skill
+- Implementation (default) → `test-driven-development` first, then any applicable domain skills
 - NEVER invoke `ralf-implement` unless defined as part of the scope of work to be done, or the user explicitly requests it with a target, Definition of Done, context, and optional max cycle count
 - NEVER invoke `ralf-review` unless defined as part of the scope of work to be done, or the user explicitly requests it with a target artifact, review criteria, context, and optional max cycle count
-- Tests (writing OR designing/spec'ing — including a test plan in a brainstorm or design doc) → `writing-unit-tests` skill BEFORE drafting test names or assertions; + `superpowers:test-driven-development` skill for the red-green-refactor cycle
+- Tests (writing OR designing/spec'ing — including a test plan in a brainstorm or design doc) → `writing-unit-tests` skill BEFORE drafting test names or assertions; + `test-driven-development` skill for the red-green-refactor cycle
 
 **Cross-tool delegation:** see `claude-to-codex-routing.md` for picking a Codex model when delegating review or coding work to the Codex plugin.

--- a/src/user/.agents/rules/delivery.md
+++ b/src/user/.agents/rules/delivery.md
@@ -4,8 +4,8 @@ Implements shared `<verification-checklist>` steps 6–8 with Claude-specific to
 
 After completion gate passes for non-trivial work:
 
-1. `superpowers:using-git-worktrees` skill — isolate work if not already in a worktree (checklist step 6)
-2. `superpowers:finishing-a-development-branch` skill — create PR, push branch (checklist step 7)
+1. `using-git-worktrees` skill — isolate work if not already in a worktree (checklist step 6)
+2. `finishing-a-development-branch` skill — create PR, push branch (checklist step 7)
 3. `wait-for-pr-comments` skill — **mandatory, not optional**; monitor for Copilot review, classify each comment as FIX/SKIP/ESCALATE, fix all FIX items via per-comment subagents (or recognize as already-addressed), push combined commits, then by default invoke `reply-and-resolve-pr-threads` for thread reply + resolve (checklist step 8)
 
 Housekeeping (checklist steps 9–10) applies throughout: record discovered work, update memory.
@@ -41,7 +41,7 @@ When mid-implementation work surfaces a new issue, **classify before filing** to
 
 Creating a PR is NOT authorization to merge. But PR creation itself is AUTOMATIC — **do not pause for it**. Pause only at the merge step.
 
-**Red flag**: "Ready when you are" / "ready for delivery" / "awaiting your go-ahead" BEFORE PR creation → STOP. Delivery is automatic. Execute `superpowers:finishing-a-development-branch` now. Only pause AT the merge step. When in doubt at the merge step, the user has not authorized it.
+**Red flag**: "Ready when you are" / "ready for delivery" / "awaiting your go-ahead" BEFORE PR creation → STOP. Delivery is automatic. Execute `finishing-a-development-branch` now. Only pause AT the merge step. When in doubt at the merge step, the user has not authorized it.
 
 ## PR comments
 

--- a/src/user/.agents/rules/worktrees.md
+++ b/src/user/.agents/rules/worktrees.md
@@ -5,7 +5,7 @@ All git worktrees **must** be created inside `<project-root>/.claude/worktrees/`
 - **Preferred:** Use the active assistant's native worktree tool when available (e.g., Claude Code's `EnterWorktree`) — it places worktrees here automatically
 - **Manual:** `git worktree add .claude/worktrees/<name> -b <branch>` (run from the project root)
 
-**Override:** The `superpowers:using-git-worktrees` skill defaults to `.worktrees/` at the project root. Disregard that default — `<project-root>/.claude/worktrees/` is the required location regardless of what any skill specifies.
+**Override:** The `using-git-worktrees` skill defaults to `.worktrees/` at the project root. Disregard that default — `<project-root>/.claude/worktrees/` is the required location regardless of what any skill specifies.
 
 ## Worktree cleanup after merge
 

--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -114,8 +114,7 @@ digraph synthesis {
 
 **Honesty clause:** If a thread's findings are inconclusive, say so. "Git history shows no relevant changes in the last 20 commits" is a valid finding. "I couldn't reproduce the failure" is a valid finding. Do NOT speculate to fill gaps.
 
-**Fallback:** If root cause remains unclear after synthesis, escalate to complementary skill:
-- `superpowers:systematic-debugging` — full sequential 4-phase approach (includes root-cause tracing and condition-based waiting)
+**Fallback:** If root cause remains unclear after synthesis, document findings (what each thread ruled out, what remains unexplained) and escalate to the user with a targeted investigation proposal.
 
 ## Implementation Phase
 

--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -22,15 +22,13 @@ digraph when_to_use {
     "Multiple files involved?" [shape=diamond];
     "Symptom unclear?" [shape=diamond];
     "Use this skill" [shape=doublecircle];
-    "Use systematic-debugging" [shape=box];
-
     "Bug reported" -> "Root cause obvious?";
     "Root cause obvious?" -> "Fix directly" [label="yes, single line"];
     "Root cause obvious?" -> "Multiple files involved?" [label="no"];
     "Multiple files involved?" -> "Use this skill" [label="yes"];
     "Multiple files involved?" -> "Symptom unclear?" [label="no, single file"];
     "Symptom unclear?" -> "Use this skill" [label="yes"];
-    "Symptom unclear?" -> "Use systematic-debugging" [label="no"];
+    "Symptom unclear?" -> "Fix directly" [label="no, clear single-file symptom"];
 }
 ```
 

--- a/src/user/.agents/skills/optimize-my-skill/SKILL.md
+++ b/src/user/.agents/skills/optimize-my-skill/SKILL.md
@@ -30,7 +30,7 @@ Known divergences from upstream `anthropics/skill-creator @ f458cee`:
 
 # Optimize My Skill
 
-Audit and improve existing SKILL.md files for clarity, discoverability, and effectiveness. This skill is for *auditing and improving* existing skills — if a `writing-skills` skill is available (e.g. `superpowers:writing-skills`), prefer it for *creating* new skills from scratch.
+Audit and improve existing SKILL.md files for clarity, discoverability, and effectiveness. This skill is for *auditing and improving* existing skills — if a `writing-skills` skill is available, prefer it for *creating* new skills from scratch.
 
 ## Core Principle
 

--- a/src/user/.agents/skills/ralf-implement/SKILL.md
+++ b/src/user/.agents/skills/ralf-implement/SKILL.md
@@ -230,7 +230,7 @@ This bead (`agents-config-abn9.10`) covers R3.1 (the ralf-implement rename and S
 
 This SKILL.md is the **canonical home** for `ralf:required` label semantics. The two formula files (`implement-feature.formula.toml`, `fix-bug.formula.toml`) carry a header pointer comment back here rather than re-stating the semantics inline:
 
-- `ralf:required` on a source bead is the dispatch signal that tells the `green-loop` formula step to invoke this skill (`ralf-implement`) instead of running a single-shot `superpowers:test-driven-development` dispatch.
+- `ralf:required` on a source bead is the dispatch signal that tells the `green-loop` formula step to invoke this skill (`ralf-implement`) instead of running a single-shot `test-driven-development` dispatch.
 - `ralf:cycles=N` on the source bead overrides the default cycle cap (`RALF_IMPLEMENT_DEFAULT_CYCLES=3`). The label form is `ralf:cycles=N` where `N` is a decimal integer in `1..20`. Multiple `ralf:cycles=` labels on the same bead are a configuration error — remove existing `ralf:cycles=` labels before adding a replacement.
 - `ralf:required` is honored only by `green-loop` (implementation) and (for ralf-review, post-abn9.13) `review-cycle` stages. It does NOT cause this skill to be invoked from `preflight`, `red-tests`, `quality-sweep`, `verify-ac`, `create-pr`, or `merge-or-handoff` — those stages have their own dispatch contracts.
 

--- a/src/user/.agents/skills/test-review/SKILL.md
+++ b/src/user/.agents/skills/test-review/SKILL.md
@@ -22,7 +22,7 @@ description: Use when doing code review of unit or integration tests, reviewing 
 ## When NOT to Use
 
 - Writing tests from scratch (use `writing-unit-tests` skill instead)
-- Debugging a test failure caused by production code (use `bugfix` or `superpowers:systematic-debugging`)
+- Debugging a test failure caused by production code (use `bugfix` skill)
 - Throwaway spike/prototype tests
 
 ## Scope Determination
@@ -49,11 +49,11 @@ Before manual review, invoke these companion skills and agents for their special
 
 | Skill/Agent | What It Catches | How to Use |
 |---|---|---|
-| `superpowers:test-driven-development` skill | Mock behavior testing, test-only production methods, mocking without understanding, incomplete mocks | Apply its gate functions to every mock and assertion |
+| `test-driven-development` skill | Mock behavior testing, test-only production methods, mocking without understanding, incomplete mocks | Apply its gate functions to every mock and assertion |
 | `writing-unit-tests` skill | Implementation-testing, untestable code, mock overuse, poor isolation, skip hygiene | Apply its behavior-vs-implementation lens and test doubles hierarchy |
 | `quality-reviewer` agent | Security issues in test fixtures, code quality, missing edge cases | Dispatch as subagent on the test files |
 
-**Workflow:** Apply `superpowers:test-driven-development` + `writing-unit-tests` criteria first (test-specific), then dispatch `quality-reviewer` agent (general quality).
+**Workflow:** Apply `test-driven-development` + `writing-unit-tests` criteria first (test-specific), then dispatch `quality-reviewer` agent (general quality).
 
 ### Step 3: Manual Review Against Checklist
 

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -20,9 +20,9 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
-**Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time.
+**Context:** If working in an isolated worktree, it should have been created via the `using-git-worktrees` skill at execution time.
 
-**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+**Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
 - (User preferences for plan location override this default)
 
 ## Scope Check
@@ -56,7 +56,7 @@ This structure informs the task decomposition. Each task should produce self-con
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -142,18 +142,19 @@ If you find issues, fix them inline. No need to re-review — just fix and move 
 
 After saving the plan, offer execution choice:
 
-**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
 
 **1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
 
-**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+**2. Inline Execution** - Execute tasks in this session following the `test-driven-development` red-green-refactor cycle, with checkpoints for review
 
 **Which approach?"**
 
 **If Subagent-Driven chosen:**
-- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
-- Fresh subagent per task + two-stage review
+- Dispatch one fresh subagent per task
+- Each subagent receives: task spec, required context, and instructions to use `test-driven-development` skill
+- Review subagent output before dispatching the next task
 
 **If Inline Execution chosen:**
-- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
-- Batch execution with checkpoints for review
+- Execute tasks sequentially using `test-driven-development` (red → green → refactor → commit per task)
+- Checkpoint after each task: verify tests pass, commit, update plan checkboxes

--- a/src/user/.agents/skills/writing-skills/SKILL.md
+++ b/src/user/.agents/skills/writing-skills/SKILL.md
@@ -27,11 +27,8 @@ Documented divergences since:
   - references/testing-skills-with-subagents.md — line "Add symptoms of ABOUT
     to violate." repaired to "Add symptoms of when you're ABOUT to violate
     the rule." (upstream truncation typo).
-Internal cross-references in bundled refs may use upstream conventions (e.g.,
-plugin-namespaced skill names like "superpowers:test-driven-development")
-that do not match this skill's own bare-name convention. If a
-cross-reference dangles in a deployment, consult the upstream source
-for resolution.
+Internal cross-references use bare-name skill conventions (e.g., `test-driven-development`).
+If a cross-reference dangles in a deployment, verify the skill exists in your installation.
 -->
 
 # Writing Skills
@@ -50,7 +47,7 @@ don't know if the skill teaches the right thing. If you didn't watch the
 description compete with realistic near-miss queries, you don't know if it
 will trigger when it should.
 
-**REQUIRED BACKGROUND:** You MUST understand `superpowers:test-driven-development` before
+**REQUIRED BACKGROUND:** You MUST understand `test-driven-development` before
 using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle.
 This skill adapts TDD to documentation.
 
@@ -71,7 +68,7 @@ the **test approach** (how you verify it works).
 
 | Type | Examples | Register | Test approach |
 |------|----------|----------|---------------|
-| **Discipline** | `superpowers:test-driven-development`, `verification-before-completion` — rules you must obey under pressure | Hard MUSTs, Iron Law, "no exceptions," explicit rationalization tables, red flags lists | Pressure scenarios with combined time + sunk-cost + authority pressure; agent must comply under stress |
+| **Discipline** | `test-driven-development`, `verification-before-completion` — rules you must obey under pressure | Hard MUSTs, Iron Law, "no exceptions," explicit rationalization tables, red flags lists | Pressure scenarios with combined time + sunk-cost + authority pressure; agent must comply under stress |
 | **Technique** | `condition-based-waiting`, `root-cause-tracing` — how-to guides for a method | Soft, explain-the-why, theory-of-mind framing, examples beat MUSTs | Application scenarios: can the agent use the technique correctly on a new problem? |
 | **Reference** | API docs, schemas, library guides | Neutral documentation voice, scan-optimized tables, no admonitions | Retrieval scenarios: can the agent find the right info and apply it? |
 
@@ -519,7 +516,7 @@ A worked example of skill testing lives in `examples/CLAUDE_MD_TESTING.md`.
 When referencing other skills, use the skill name with explicit requirement
 markers:
 
-- ✅ `REQUIRED SUB-SKILL: Use superpowers:test-driven-development`
+- ✅ `REQUIRED SUB-SKILL: Use test-driven-development`
 - ✅ `REQUIRED BACKGROUND: You MUST understand systematic-debugging`
 - ❌ `See skills/testing/test-driven-development` — unclear if required
 - ❌ `@skills/testing/test-driven-development/SKILL.md` — force-loads, burns context

--- a/src/user/.agents/skills/writing-skills/SKILL.md
+++ b/src/user/.agents/skills/writing-skills/SKILL.md
@@ -68,8 +68,8 @@ the **test approach** (how you verify it works).
 
 | Type | Examples | Register | Test approach |
 |------|----------|----------|---------------|
-| **Discipline** | `test-driven-development`, `verification-before-completion` — rules you must obey under pressure | Hard MUSTs, Iron Law, "no exceptions," explicit rationalization tables, red flags lists | Pressure scenarios with combined time + sunk-cost + authority pressure; agent must comply under stress |
-| **Technique** | `condition-based-waiting`, `root-cause-tracing` — how-to guides for a method | Soft, explain-the-why, theory-of-mind framing, examples beat MUSTs | Application scenarios: can the agent use the technique correctly on a new problem? |
+| **Discipline** | `test-driven-development`, `verify-checklist` — rules you must obey under pressure | Hard MUSTs, Iron Law, "no exceptions," explicit rationalization tables, red flags lists | Pressure scenarios with combined time + sunk-cost + authority pressure; agent must comply under stress |
+| **Technique** | `grill-with-docs`, `prototype` — how-to guides for a method | Soft, explain-the-why, theory-of-mind framing, examples beat MUSTs | Application scenarios: can the agent use the technique correctly on a new problem? |
 | **Reference** | API docs, schemas, library guides | Neutral documentation voice, scan-optimized tables, no admonitions | Retrieval scenarios: can the agent find the right info and apply it? |
 
 **Why the register split matters.** The two upstream sources of this skill
@@ -517,7 +517,7 @@ When referencing other skills, use the skill name with explicit requirement
 markers:
 
 - ✅ `REQUIRED SUB-SKILL: Use test-driven-development`
-- ✅ `REQUIRED BACKGROUND: You MUST understand systematic-debugging`
+- ✅ `REQUIRED BACKGROUND: You MUST understand bugfix`
 - ❌ `See skills/testing/test-driven-development` — unclear if required
 - ❌ `@skills/testing/test-driven-development/SKILL.md` — force-loads, burns context
 

--- a/src/user/.agents/skills/writing-skills/references/testing-skills-with-subagents.md
+++ b/src/user/.agents/skills/writing-skills/references/testing-skills-with-subagents.md
@@ -28,7 +28,7 @@ You run scenarios without the skill (RED - watch agent fail), write skill addres
 
 **Core principle:** If you didn't watch an agent fail without the skill, you don't know if the skill prevents the right failures.
 
-**REQUIRED BACKGROUND:** You MUST understand superpowers:test-driven-development before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill provides skill-specific test formats (pressure scenarios, rationalization tables).
+**REQUIRED BACKGROUND:** You MUST understand `test-driven-development` before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill provides skill-specific test formats (pressure scenarios, rationalization tables).
 
 **Complete worked example:** See ../examples/CLAUDE_MD_TESTING.md for a full test campaign testing CLAUDE.md documentation variants.
 

--- a/src/user/.agents/skills/writing-unit-tests/SKILL.md
+++ b/src/user/.agents/skills/writing-unit-tests/SKILL.md
@@ -160,7 +160,7 @@ If nothing in the current story invokes `source_dir(repo_root)`, a test for it i
 | **Spy** | Records calls to real object | Verifying side effects (analytics, logging) |
 | **Mock** | Verifies specific calls | Almost never — last resort |
 
-If you need 5+ mocks, the code is too coupled. Refactor it. (This matches the Refusal Criteria threshold above — same "too coupled" line, different framing.) See `superpowers:test-driven-development` for the dedicated mock/fake/spy/stub anti-pattern catalog.
+If you need 5+ mocks, the code is too coupled. Refactor it. (This matches the Refusal Criteria threshold above — same "too coupled" line, different framing.) See `test-driven-development` for the dedicated mock/fake/spy/stub anti-pattern catalog.
 
 ## Test Isolation
 

--- a/src/user/.claude/commands/optimize-my-skill.md
+++ b/src/user/.claude/commands/optimize-my-skill.md
@@ -2,7 +2,7 @@
 
 Audit and improve existing SKILL.md files via the `optimize-my-skill` skill.
 
-> **Tip**: For *creating* new skills from scratch, prefer `superpowers:writing-skills` if available. This command is for *auditing and improving* existing skills.
+> **Tip**: For *creating* new skills from scratch, prefer the `writing-skills` skill. This command is for *auditing and improving* existing skills.
 
 ## Arguments
 

--- a/src/user/.claude/skills/handoff/SKILL.md
+++ b/src/user/.claude/skills/handoff/SKILL.md
@@ -48,7 +48,7 @@ After writing, print the absolute file path on its own line so the user can pass
 5. **Open questions and blockers** — anything the next agent needs to resolve before progress
 6. **Next concrete steps** — ordered, actionable
 7. **References** — paths and URLs only; do NOT duplicate content from PRDs, plans, ADRs, issues/beads, commits, or diffs
-8. **Suggested skills** — skills the next agent should invoke (e.g. `superpowers:brainstorming`, `implement-bead`, `bugfix`)
+8. **Suggested skills** — skills the next agent should invoke (e.g. `brainstorming`, `implement-bead`, `bugfix`)
 
 ## Constraints
 

--- a/src/user/.claude/skills/handoff/SKILL.md
+++ b/src/user/.claude/skills/handoff/SKILL.md
@@ -48,7 +48,7 @@ After writing, print the absolute file path on its own line so the user can pass
 5. **Open questions and blockers** — anything the next agent needs to resolve before progress
 6. **Next concrete steps** — ordered, actionable
 7. **References** — paths and URLs only; do NOT duplicate content from PRDs, plans, ADRs, issues/beads, commits, or diffs
-8. **Suggested skills** — skills the next agent should invoke (e.g. `brainstorming`, `implement-bead`, `bugfix`)
+8. **Suggested skills** — skills the next agent should invoke (e.g. `brainstorming`, `prototype`, `bugfix`)
 
 ## Constraints
 

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -21,9 +21,8 @@ resolution.
 ## Skills
 
 OpenCode scans `~/.claude/skills/**/SKILL.md` natively. Shared skills are
-available without duplication. Some referenced skills (e.g. `superpowers:*`)
-require the [obra/superpowers](https://github.com/obra/superpowers) Claude Code
-plugin.
+available without duplication. Skills use bare names (e.g. `test-driven-development`)
+and are installed from this repo's `src/` directory.
 
 ## Agents
 


### PR DESCRIPTION
## Summary

- Audited all `superpowers:*` references across `src/` — 16 files, 5 distinct skill names
- **Adopted skills (simple rename):** `using-git-worktrees`, `brainstorming`, `test-driven-development`, `finishing-a-development-branch`, `writing-skills` — all now referenced by bare name
- **Unadopted skills (removed or replaced):** `requesting-code-review` / `receiving-code-review` dropped from `quality-reviewer` frontmatter; `systematic-debugging` fallback replaced with user-escalation prose; `subagent-driven-development` / `executing-plans` replaced with our actual TDD + subagent dispatch model in `writing-plans`
- **Bonus:** `writing-plans` save path corrected from `docs/superpowers/plans/` → `docs/plans/` (project convention); opencode AGENTS.md superpowers plugin note removed

## Test plan

- [ ] `grep -r "superpowers:" src/` returns zero results
- [ ] Verify `writing-plans/SKILL.md` execution handoff reads sensibly with no dangling references
- [ ] Verify `bugfix/SKILL.md` fallback prose is actionable without named skill dependency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)