### PR TITLE
feat(cx6.7.13): lift Iron Law framing into verify-checklist

### DIFF
--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -63,6 +63,7 @@ Skills built from scratch in-repo do not appear here. This table tracks only OSS
 | `caveman` | `oss-snapshots/pocock/caveman/` (pristine upstream; local extensions in deployed copy) | `mattpocock/skills @ e74f0061` | 2026-05-23 | rewrite-and-divorce (project-extended fork) |
 | `prototype` | `oss-snapshots/pocock/prototype/` | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
 | `writing-unit-tests` | `oss-snapshots/pocock/tdd/` (amalgamated deltas only) | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
+| `verify-checklist` | `oss-snapshots/superpowers/verification-before-completion/` (amalgamated lift only — Iron Law framing, gate function) | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-24 | accept-periodic-resync |
 
 Update this table whenever a skill is added, replaced, or amalgamated from an OSS source.
 

--- a/src/user/.agents/skills/verify-checklist/SKILL.md
+++ b/src/user/.agents/skills/verify-checklist/SKILL.md
@@ -3,11 +3,20 @@ name: verify-checklist
 description: Use when about to declare work complete or report final status to the user, or when user invokes directly — audits all completed work against verification workflows stored in memory and produces a structured completion report
 ---
 
+<!--
+Source: oss-snapshots/superpowers/verification-before-completion/
+Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e949826bea9d7 (v5.1.0)
+Last sync: 2026-05-24
+Drift policy: accept-periodic-resync (amalgamated lift — Iron Law framing + "evidence before claims, always" tagline + identify-run-read-verify-claim gate function only; tracked in agents-config-cx6.7.13)
+-->
+
 # Verify Checklist
 
 ## Core Principle
 
-**Completion without audit is assumption.** Cross-reference every piece of work against the verification workflows in your memory before declaring done. If steps were skipped, do them now. Then produce a structured report with evidence.
+**The Iron Law: no completion claims without fresh verification evidence in this message.**
+
+Claiming work is complete without verification is dishonesty, not efficiency. **Evidence before claims, always.** Completion without audit is assumption — cross-reference every piece of work against the verification workflows in your memory before declaring done. If steps were skipped, do them now. Then produce a structured report with evidence.
 
 ## When to Use
 
@@ -46,11 +55,21 @@ Then proceed with best-effort verification using whatever project conventions yo
 For **each** verification workflow step:
 
 1. **Check**: Did you complete this step during this session? What evidence exists?
-2. **If completed**: Record the result (test output, review findings, commit SHAs)
-3. **If NOT completed**: **Execute it now.** Do not merely report it missing — do the work, then record the result.
-4. **If blocked**: Record why and flag for the user
+2. **If completed**: Record the result (test output, review findings, commit SHAs).
+3. **If NOT completed**: **Execute it now using the gate function below** — do the work, then record the result.
+4. **If blocked**: Record why and flag for the user.
 
 Do not skip steps. Do not reorder steps. Do not decide steps "don't apply."
+
+**The gate function** — apply per step, fresh, in this message:
+
+1. **IDENTIFY** — What command or check proves this step?
+2. **RUN** — Execute the full command (fresh, complete).
+3. **READ** — Full output; check exit code; count failures.
+4. **VERIFY** — Does the output confirm the claim?
+5. **CLAIM** — Only now, with evidence.
+
+Skipping any step is lying, not verifying. Stale evidence ("I ran tests earlier") is not fresh evidence — re-run.
 
 ### 3. Gather Context
 


### PR DESCRIPTION
## Summary

- Amalgamates from `oss-snapshots/superpowers/verification-before-completion/SKILL.md` (v5.1.0, `f2cbfbe`) into `src/user/.agents/skills/verify-checklist/SKILL.md`, before the superpowers plugin is removed (unblocks `agents-config-cx6.7.17`).
- Strengthens the per-step verification discipline; the audit-orchestration structure (Load → Audit → Gather → Report) is preserved unchanged.

## Lifted

- **Iron Law opener** in Core Principle — "no completion claims without fresh verification evidence in this message"; framed as the leading rule, with the prior "completion without audit is assumption" line preserved as the corollary.
- **"Evidence before claims, always"** tagline — surfaced as the discipline statement.
- **5-step gate function** in Step 2 Audit — `IDENTIFY → RUN → READ → VERIFY → CLAIM` — defines what "execute it now" actually means per step, and explicitly rejects stale evidence.
- **Provenance HTML comment** at the top of the file citing source path + commit `f2cbfbe` + v5.1.0 + drift policy (amalgamated lift, not full copy).

## Deliberately NOT lifted (out of scope per bead acceptance criteria)

- Common Failures matrix, Key Patterns, Rationalization Prevention table, Why This Matters, When To Apply, Bottom Line — `verify-checklist` is an *audit orchestrator*, not a general verification rule-book; these belong upstream and are reachable via the provenance pointer.
- The existing `Red Flags — STOP` table in `verify-checklist` covers *reporting* rationalizations (e.g. "I'll skip the discovered work section"), which is a different axis from the upstream's *claim* rationalizations and was kept intact.

## Process note

- Completion gate (quality-reviewer / simplify / verify) skipped on user direction. The change is a 23-line documentation lift to a single SKILL.md with no code or test impact.

## Test plan

- No build / tests / lint configured for documentation (per repo AGENTS.md)
- [ ] Manual review: provenance header cites source path + `f2cbfbe` + v5.1.0
- [ ] Manual review: Core Principle opener leads with the Iron Law line
- [ ] Manual review: Step 2 Audit contains the 5-step `IDENTIFY → RUN → READ → VERIFY → CLAIM` gate
- [ ] Manual review: existing audit-orchestration content (When to Use, The Process, Source Dependency, Red Flags, Quick Reference) is unchanged
- [ ] Copilot review (handled by `wait-for-pr-comments` next)

Bead: `agents-config-cx6.7.13` (blocks: `agents-config-cx6.7.17`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)