### PR TITLE
feat(bn9um): lift compare-against-working-examples pattern into bugfix Thread 3

### DIFF
--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -84,7 +84,7 @@ Return: The test code AND the failure output.
 Read all relevant source files from entry point to failure point.
 Trace the data flow: what values enter, how they transform, where they exit.
 Identify where the data could become invalid.
-If similar working code exists in the codebase, read it and list every difference, however small — do not assume that cannot matter.
+If similar working code exists in the codebase, read it and list every difference, however small — do not assume any of them cannot matter.
 Return: Annotated data flow showing the path and suspect points.
 ```
 

--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -12,7 +12,7 @@ Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e9498
 Last sync: 2026-05-24
 Note: cx6.7.12 amalgamation lift (selective patterns lifted; see `Patterns lifted:` below)
 Drift policy: selective-amalgamation. `bugfix` is the canonical in-tree path with its own parallel-evidence design; upstream is consulted for pattern lifts only, never wholesale resync. Iron Law framing and 4-phase structure intentionally diverge.
-Patterns lifted: 3-strike fix-failure escalation; multi-component boundary instrumentation.
+Patterns lifted: 3-strike fix-failure escalation; multi-component boundary instrumentation; compare-against-working-examples (Thread 3 extension, bn9um lift).
 -->
 
 # Bugfix
@@ -84,6 +84,7 @@ Return: The test code AND the failure output.
 Read all relevant source files from entry point to failure point.
 Trace the data flow: what values enter, how they transform, where they exit.
 Identify where the data could become invalid.
+If similar working code exists in the codebase, read it and list every difference, however small — do not assume that cannot matter.
 Return: Annotated data flow showing the path and suspect points.
 ```
 

--- a/src/user/.agents/skills/bugfix/SKILL.md
+++ b/src/user/.agents/skills/bugfix/SKILL.md
@@ -12,7 +12,7 @@ Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e9498
 Last sync: 2026-05-24
 Note: cx6.7.12 amalgamation lift (selective patterns lifted; see `Patterns lifted:` below)
 Drift policy: selective-amalgamation. `bugfix` is the canonical in-tree path with its own parallel-evidence design; upstream is consulted for pattern lifts only, never wholesale resync. Iron Law framing and 4-phase structure intentionally diverge.
-Patterns lifted: 3-strike fix-failure escalation; multi-component boundary instrumentation; compare-against-working-examples (Thread 3 extension, bn9um lift).
+Patterns lifted: 3-strike fix-failure escalation; multi-component boundary instrumentation; compare-against-working-examples (Thread 3 extension).
 -->
 
 # Bugfix


### PR DESCRIPTION
## Summary
- Adds one sentence to Thread 3 (Data Flow Trace) in `src/user/.agents/skills/bugfix/SKILL.md` directing the agent to read similar working code in the codebase and enumerate every difference, however small, before forming a hypothesis.
- Updates the provenance HTML-comment `Patterns lifted:` line to record this lift alongside the two patterns lifted by cx6.7.12.

## Why
Pattern-deviation bugs ("this call site does X but seven peer call sites do Y") are not surfaced by reading the failing path in isolation. Comparing against a known-working analog and enumerating differences is the diff-signal move that catches them. The current Thread 3 prose covers reading the failing path top-down but not the comparison move.

## Provenance
Lifted from `oss-snapshots/superpowers/systematic-debugging/SKILL.md` Phase 2 (upstream commit `f2cbfbe`, v5.1.0). Must land before `cx6.7.17` removes the source.

## Bead
- Closes `agents-config-bn9um` (orphan + `discovered-from` edge to `cx6.7.12`)
- Unblocks one of four open prerequisites on `agents-config-cx6.7.17`

## Test plan
- [ ] CI lint / parity checks pass
- [ ] Copilot review surfaces no issues with the inline placement or provenance update