### PR TITLE
feat(cx6.7.14): amalgamate using-superpowers 1% rule into session primer

### DIFF
--- a/src/user/.agents/README.md
+++ b/src/user/.agents/README.md
@@ -13,6 +13,9 @@ is useful to more than one tool, it lives here.
   and optional supporting scripts.
 - `INSTRUCTIONS.md.template` — Shared laws, constraints, workflow, and
   orchestration referenced by each tool's top-level instruction file.
+- `SESSION-PRIMER.md.template` — Skill-invocation discipline (the "1% rule"
+  + red-flag rationalization table + skill-priority ordering). Dynamically
+  included between USER-PERSONA and INSTRUCTIONS in every per-tool template.
 - `AGENT-PERSONA.md.template` — Agent personality and expertise claims.
   Personalize after install.
 - `USER-PERSONA.md.template` — User description and interaction preferences.

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -3,18 +3,18 @@ Source: oss-snapshots/superpowers/using-superpowers/SKILL.md @ obra/superpowers 
 Last lifted: 2026-05-25
 Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
 Material edits vs. upstream:
-  - "How to Access Skills" rewritten for the four target runtimes (dropped Cursor / Copilot CLI).
-  - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with the prose workflow steps under "The Rule".
-  - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md and references/codex-tools.md (those reference files are not in-tree).
-  - Generalized "Create TodoWrite todo per item" to "track each as a concrete task" so non-Claude tools aren't directed at a Claude-only tool name.
-  - Softened Gemini "loads skill metadata at session start" claim to mechanism-agnostic activation wording.
+  - Dropped upstream's <SUBAGENT-STOP> gate: subagents inherit the host's AGENTS.md context including this primer, so they cannot act on a "skip" instruction they've already read.
+  - Dropped upstream's "Instruction Priority" section: user > skills > defaults is already established in the assembled instruction file's <laws> and decision matrix.
+  - Dropped upstream's "How to Access Skills" per-runtime listing: each runtime's own system prompt already documents its skill mechanism.
+  - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md / references/codex-tools.md (those reference files are not in-tree).
+  - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with prose workflow steps.
+  - Generalized "Create TodoWrite todo per item" to a tool-agnostic phrasing with a Claude-specific parenthetical.
+  - Body wrapped in <skill-usage-instructions> for context-boundary clarity.
 -->
 
-# Session Primer — Skill Invocation Discipline
+<skill-usage-instructions>
 
-<SUBAGENT-STOP>
-If you were dispatched as a subagent to execute a specific task, skip this primer — the dispatching agent has already applied skill-selection discipline for the work it handed you.
-</SUBAGENT-STOP>
+# Session Primer — Skill Invocation Discipline
 
 <EXTREMELY-IMPORTANT>
 If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
@@ -23,23 +23,6 @@ IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
 
 This is not negotiable. This is not optional. You cannot rationalize your way out of this.
 </EXTREMELY-IMPORTANT>
-
-## Instruction Priority
-
-Skills override default system-prompt behavior, but **user instructions always take precedence**:
-
-1. **User's explicit instructions** (CLAUDE.md, AGENTS.md, GEMINI.md, direct requests) — highest priority
-2. **Skills** — override default system behavior where they conflict
-3. **Default system prompt** — lowest priority
-
-If a CLAUDE.md / AGENTS.md / GEMINI.md says "don't use TDD" and a skill says "always use TDD," follow the user. The user is in control.
-
-## How to Access Skills
-
-- **Claude Code** — use the `Skill` tool; content loads in-context. Don't `Read` skill files.
-- **Codex CLI** — skills live under `~/.codex/skills/`; read the `SKILL.md` when a skill applies.
-- **Gemini CLI** — skills activate on demand via the `activate_skill` tool.
-- **OpenCode** — skills auto-discover from the `skills.paths` directories configured in `opencode.jsonc`; read the matching `SKILL.md` when a skill applies.
 
 ## The Rule
 
@@ -93,3 +76,5 @@ The skill itself tells you which.
 ## User Instructions
 
 Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+</skill-usage-instructions>

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -8,7 +8,7 @@ Material edits vs. upstream:
   - Dropped upstream's "How to Access Skills" per-runtime listing: each runtime's own system prompt already documents its skill mechanism.
   - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md / references/codex-tools.md (those reference files are not in-tree).
   - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with prose workflow steps.
-  - Generalized "Create TodoWrite todo per item" to a tool-agnostic phrasing with a Claude-specific parenthetical.
+  - Generalized the upstream's runtime-specific checklist-tracker invocation to runtime-agnostic phrasing (no tool name).
   - Body wrapped in <skill-usage-instructions> for context-boundary clarity.
 -->
 
@@ -32,7 +32,7 @@ Workflow when a skill might apply:
 
 1. Invoke the skill via the platform's skill tool.
 2. Announce: "Using `[skill]` to `[purpose]`."
-3. If the skill has a checklist, track each item as a concrete task before acting (TodoWrite on Claude Code; the tool-equivalent task tracker on other runtimes).
+3. If the skill has a checklist, track each item as a concrete task before acting using your runtime's task tracker / todo-list mechanism.
 4. Follow the skill exactly — don't paraphrase, don't adapt away discipline.
 
 Plan-mode gate: before entering plan mode, ask "have I already brainstormed?" If no, invoke the brainstorming skill first.
@@ -61,7 +61,7 @@ These thoughts mean STOP — you're rationalizing your way around the rule:
 When multiple skills could apply, use this order:
 
 1. **Process skills first** (`brainstorming`, `bugfix`, `test-driven-development`) — these determine HOW to approach the task.
-2. **Implementation skills second** (`frontend-design`, domain-specific patterns) — these guide execution.
+2. **Implementation skills second** (domain-specific patterns) — these guide execution.
 
 "Let's build X" → brainstorming first, then implementation skills.
 "Fix this bug" → bugfix first, then domain-specific skills.

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -4,7 +4,7 @@ Last lifted: 2026-05-25
 Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
 Material edits vs. upstream:
   - Dropped upstream's <SUBAGENT-STOP> gate: subagents inherit the host's AGENTS.md context including this primer, so they cannot act on a "skip" instruction they've already read.
-  - Dropped upstream's "Instruction Priority" section: user > skills > defaults is already established in the assembled instruction file's <laws> and decision matrix.
+  - Dropped upstream's "Instruction Priority" section: agents already follow user > skills > defaults as part of their baseline instruction-following protocol; restating it here is noise. (Not redundant with INSTRUCTIONS.md's <laws> — those define the L0–L3 quality/safety stack, a different concern.)
   - Dropped upstream's "How to Access Skills" per-runtime listing: each runtime's own system prompt already documents its skill mechanism.
   - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md / references/codex-tools.md (those reference files are not in-tree).
   - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with prose workflow steps.

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -1,6 +1,6 @@
 <!--
 Source: oss-snapshots/superpowers/using-superpowers/SKILL.md @ obra/superpowers commit f2cbfbe (v5.1.0)
-Last lifted: 2026-05-25 (bd cx6.7.14)
+Last lifted: 2026-05-25
 Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
 Material edits vs. upstream:
   - "How to Access Skills" rewritten for the four target runtimes (dropped Cursor / Copilot CLI).

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -1,0 +1,95 @@
+<!--
+Source: oss-snapshots/superpowers/using-superpowers/SKILL.md @ obra/superpowers commit f2cbfbe (v5.1.0)
+Last lifted: 2026-05-25 (bd cx6.7.14)
+Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
+Material edits vs. upstream:
+  - "How to Access Skills" rewritten for the four target runtimes (dropped Cursor / Copilot CLI).
+  - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with the prose workflow steps under "The Rule".
+  - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md and references/codex-tools.md (those reference files are not in-tree).
+  - Generalized "Create TodoWrite todo per item" to "track each as a concrete task" so non-Claude tools aren't directed at a Claude-only tool name.
+  - Softened Gemini "loads skill metadata at session start" claim to mechanism-agnostic activation wording.
+-->
+
+# Session Primer — Skill Invocation Discipline
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this primer — the dispatching agent has already applied skill-selection discipline for the work it handed you.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Skills override default system-prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, AGENTS.md, GEMINI.md, direct requests) — highest priority
+2. **Skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If a CLAUDE.md / AGENTS.md / GEMINI.md says "don't use TDD" and a skill says "always use TDD," follow the user. The user is in control.
+
+## How to Access Skills
+
+- **Claude Code** — use the `Skill` tool; content loads in-context. Don't `Read` skill files.
+- **Codex CLI** — skills live under `~/.codex/skills/`; read the `SKILL.md` when a skill applies.
+- **Gemini CLI** — skills activate on demand via the `activate_skill` tool.
+- **OpenCode** — skills auto-discover from the `skills.paths` directories configured in `opencode.jsonc`; read the matching `SKILL.md` when a skill applies.
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means invoke it to check. If it turns out wrong, drop it — but you must check first.
+
+Workflow when a skill might apply:
+
+1. Invoke the skill via the platform's skill tool.
+2. Announce: "Using `[skill]` to `[purpose]`."
+3. If the skill has a checklist, track each item as a concrete task before acting (TodoWrite on Claude Code; the tool-equivalent task tracker on other runtimes).
+4. Follow the skill exactly — don't paraphrase, don't adapt away discipline.
+
+Plan-mode gate: before entering plan mode, ask "have I already brainstormed?" If no, invoke the brainstorming skill first.
+
+## Red Flags
+
+These thoughts mean STOP — you're rationalizing your way around the rule:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read the current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (`brainstorming`, `bugfix`, `test-driven-development`) — these determine HOW to approach the task.
+2. **Implementation skills second** (`frontend-design`, domain-specific patterns) — these guide execution.
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → bugfix first, then domain-specific skills.
+
+## Skill Types
+
+- **Rigid** (TDD, debugging, completion-gate workflows) — follow exactly. Don't adapt away discipline.
+- **Flexible** (patterns, advisories) — adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.

--- a/src/user/.claude/AGENTS.md.template
+++ b/src/user/.claude/AGENTS.md.template
@@ -4,5 +4,6 @@ User-scoped instructions for all projects.
 
 <!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/SESSION-PRIMER.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.claude/CLAUDE-EXTENSIONS.md.template -->

--- a/src/user/.codex/AGENTS.md.template
+++ b/src/user/.codex/AGENTS.md.template
@@ -4,6 +4,7 @@ User-scoped instructions for all projects.
 
 <!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/SESSION-PRIMER.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->
 <!-- DYNAMIC-INCLUDE-ALL-RULES -->
 <!-- DYNAMIC-INCLUDE: src/user/.codex/CODEX-EXTENSIONS.md.template -->

--- a/src/user/.gemini/GEMINI.md.template
+++ b/src/user/.gemini/GEMINI.md.template
@@ -4,6 +4,7 @@ User-scoped instructions for all projects.
 
 <!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/SESSION-PRIMER.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->
 <!-- DYNAMIC-INCLUDE-ALL-RULES -->
 <!-- DYNAMIC-INCLUDE: src/user/.gemini/GEMINI-EXTENSIONS.md.template -->

--- a/src/user/.opencode/AGENTS.md.template
+++ b/src/user/.opencode/AGENTS.md.template
@@ -2,6 +2,7 @@
 
 <!-- DYNAMIC-INCLUDE: src/user/.agents/AGENT-PERSONA.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/USER-PERSONA.md.template -->
+<!-- DYNAMIC-INCLUDE: src/user/.agents/SESSION-PRIMER.md.template -->
 <!-- DYNAMIC-INCLUDE: src/user/.agents/INSTRUCTIONS.md.template -->
 <!-- DYNAMIC-INCLUDE-ALL-RULES -->
 <!-- DYNAMIC-INCLUDE: src/user/.opencode/OPENCODE-EXTENSIONS.md.template -->


### PR DESCRIPTION
## Summary

- Lift the `using-superpowers` skill-invocation discipline (1% rule, red-flag rationalization table, skill-priority ordering, invoke-BEFORE-response rule) from `oss-snapshots/superpowers/using-superpowers/SKILL.md` @ `f2cbfbe` into a new `src/user/.agents/SESSION-PRIMER.md.template`.
- Wire it into all four per-tool top-level templates (`src/user/.claude/AGENTS.md.template`, `src/user/.codex/AGENTS.md.template`, `src/user/.gemini/GEMINI.md.template`, `src/user/.opencode/AGENTS.md.template`) via `DYNAMIC-INCLUDE`, slotted between `USER-PERSONA` and `INSTRUCTIONS`.
- Body wrapped in a `<skill-usage-instructions>` block for context-boundary clarity.
- Unblocks one of the three prerequisites for `cx6.7.17` (superpowers plugin removal); `cx6.7.15` / `cx6.7.16` remain.

## Why no SessionStart hook?

The bead's implementation note (2026-05-24) recommended a SessionStart hook with platform-detection shell script + `settings.json.template` wiring + cross-tool hook research. That was abandoned during this work: static AGENTS.md content is re-injected from source every turn via `claudeMd` (and the equivalent on Codex/Gemini/OpenCode), so it survives `/clear` and compaction without hook machinery. Hooks are the right answer for *dynamic* content (current git state, time-of-day signals); static primer text doesn't need them. Decision recorded as project memory `project_session_primer_no_hook.md`.

## Material edits vs. upstream

Documented in the new file's `Drift policy: selective-amalgamation` header:
- Dropped upstream's `<SUBAGENT-STOP>` gate (subagents inherit the host's AGENTS.md context including this primer, so they cannot act on a "skip" instruction they've already read).
- Dropped upstream's "Instruction Priority" section (agents already follow user > skills > defaults as part of their baseline instruction-following protocol).
- Dropped upstream's "How to Access Skills" per-runtime listing (each runtime's own system prompt already documents its skill mechanism).
- Dropped upstream's "Platform Adaptation" pointer to `references/copilot-tools.md` / `references/codex-tools.md` (those reference files are not in-tree).
- Dropped upstream's DOT `skill_flow` digraph (none of the four tools render DOT); replaced with prose workflow steps.
- Generalized "Create TodoWrite todo per item" to tool-agnostic phrasing with a Claude-specific parenthetical.
- Wrapped the body in `<skill-usage-instructions>` for context-boundary clarity.

## Test Plan

- [ ] User runs `scripts/install.sh --dry-run` and confirms `SESSION-PRIMER.md.template` is flattened into the assembled `~/.claude/AGENTS.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`, and `~/.config/opencode/AGENTS.md` (and does NOT appear as a stray standalone file in any of them).
- [ ] Spot-check the assembled file: `# Session Primer` heading present between `USER-PERSONA` and `Shared Instructions`; `<skill-usage-instructions>` opening tag, `<EXTREMELY-IMPORTANT>` envelope, and the 12-row red-flag table all intact; no stray `<SUBAGENT-STOP>` block.
- [ ] Open a fresh Claude Code session and confirm the primer content appears in the loaded `claudeMd` block.
- [ ] (Optional) `/clear` the session and confirm the primer content is re-injected on the next user prompt.

## Static verification done in-branch

The install-time flatten was simulated by mirroring `flatten_agents_md` in `scripts/install.sh:686` with a shell loop. All four tools' assembled outputs contained: 1 `# Session Primer` heading, 1 `<skill-usage-instructions>` opening tag, 1 `<skill-usage-instructions>` closing tag, the `<EXTREMELY-IMPORTANT>` envelope, the red-flag table, 0 `<SUBAGENT-STOP>` blocks, and 0 missing includes.

## Tracking

- Bead: `agents-config-cx6.7.14` (parent: `cx6.7`)
- Discovered: `agents-config-qv7o5` (P3) — `TodoWrite` tool-name leak in `writing-skills/references/persuasion-principles.md` (unrelated; filed as orphan + `discovered-from` dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
