### PR TITLE
docs(cx6.7.7): close-out provenance registry sweep

### DIFF
--- a/oss-snapshots/anthropics/AGENTS.md
+++ b/oss-snapshots/anthropics/AGENTS.md
@@ -25,5 +25,5 @@ The following skills exist in the source repo but were not adopted — all are U
 
 ## Notes
 
-- Namespace folder is `anthropics/` (not `claude-plugins-official/` as the original cx6.6 bead title suggested — naming updated to match the actual GitHub org).
-- Analysis of overlap with the native `skill-creator:skill-creator` skill and decisions on amalgamation are deferred to cx6.7.
+- Namespace folder is `anthropics/` (renamed mid-cycle to match the actual GitHub org, replacing an earlier `claude-plugins-official/` label).
+- `skill-creator` was amalgamated into two in-tree skills: `src/user/.agents/skills/writing-skills/` (creation/editing methodology) and `src/user/.agents/skills/optimize-my-skill/` (audit methodology). Provenance is recorded in each host SKILL.md's HTML-comment header and in the project-wide registry at `src/user/.agents/skills/AGENTS.md`.

--- a/oss-snapshots/pocock/AGENTS.md
+++ b/oss-snapshots/pocock/AGENTS.md
@@ -20,7 +20,7 @@ Per-skill notes record the upstream source path, the 4vn5.2 audit verdict, the c
 | Skill | Upstream path | Audit | cx6.7.5 verdict | Landing target / notes |
 |-------|---------------|-------|-----------------|------------------------|
 | `caveman/` | `productivity/caveman` | Gap-fill | **promoted (project-extended fork)** | `src/user/.agents/skills/caveman/` — local fork from `.claude/skills/caveman/` (intensity levels + boundaries). Drift policy: rewrite-and-divorce. |
-| `diagnose/` | `engineering/diagnose` | Compare-and-improve | **amalgamate → `bugfix`** (pending) | Pull into native `bugfix`: loop-construction toolkit for Thread 2, "iterate on the loop itself" rules, ranked-hypothesis cadence in Synthesis Gate, copy `scripts/hitl-loop.template.sh` as `bugfix/scripts/`. |
+| `diagnose/` | `engineering/diagnose` | Compare-and-improve | **deferred — verdict open** | `bugfix` received a sibling lift from `oss-snapshots/superpowers/systematic-debugging/`; diagnose-specific patterns (loop-construction toolkit for Thread 2, "iterate on the loop itself" rules, ranked-hypothesis cadence in Synthesis Gate, and `scripts/hitl-loop.template.sh`) remain upstream-only. A follow-up tracks whether to lift, drop, or close with rationale. |
 | `git-guardrails-claude-code/` | `misc/git-guardrails-claude-code` | Compare-and-improve | **deferred** | Existing `claude-sandbox.md` policy covers the same surface via documentation; hook-based mechanical enforcement is a separate decision. Revisit if/when policy-only enforcement proves insufficient. |
 | `grill-me/` | `productivity/grill-me` | Compare-and-improve | **deferred** | Stripped-down variant of `grill-with-docs`, which is being promoted. Re-evaluate only if a lighter grilling cadence is wanted separately. |
 | `grill-with-docs/` | `engineering/grill-with-docs` | Compare-and-improve | **promoted (pristine)** | `src/user/.agents/skills/grill-with-docs/` — byte-identical to upstream (verified `diff -rq` clean). Drift policy: accept-periodic-resync. |
@@ -34,7 +34,7 @@ Per-skill notes record the upstream source path, the 4vn5.2 audit verdict, the c
 | `to-issues/` | `engineering/to-issues` | Compare-and-improve | **out of scope** | Deferred to `agents-config-wgclw.7`. |
 | `to-prd/` | `engineering/to-prd` | Compare-and-improve | **out of scope** | Deferred to `agents-config-wgclw.7`. |
 | `triage/` | `engineering/triage` | Gap-fill | **out of scope** | Deferred to `agents-config-wgclw.7`. |
-| `write-a-skill/` | `productivity/write-a-skill` | Compare-and-improve | **deferred** | Compare against existing `writing-skills` amalgam (cx6.7.2); if a delta is worth pulling in, file a follow-up. |
+| `write-a-skill/` | `productivity/write-a-skill` | Compare-and-improve | **deferred — verdict open** | Compare against the in-tree `writing-skills` amalgam (superpowers + anthropics). A follow-up tracks the comparison and verdict (lift deltas, close with rationale). |
 | `zoom-out/` | `engineering/zoom-out` | Gap-fill | **promoted (pristine)** | `src/user/.agents/skills/zoom-out/`. Drift policy: accept-periodic-resync. Kept separate from `where-does-this-fit` (renamed from `big-picture`) — different triggers, complementary skills. |
 
 ## Out of scope — `deprecated/` subtree

--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -65,6 +65,8 @@ Skills built from scratch in-repo do not appear here. This table tracks only OSS
 | `writing-unit-tests` | `oss-snapshots/pocock/tdd/` (amalgamated deltas only) | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
 | `verify-checklist` | `oss-snapshots/superpowers/verification-before-completion/` (amalgamated lift only — Iron Law framing, gate function) | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-24 | accept-periodic-resync |
 | `bugfix` | `oss-snapshots/superpowers/systematic-debugging/` (selective amalgamation — 3-strike escalation, multi-component boundary instrumentation lifted only) | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-24 | selective-amalgamation |
+| `wait-for-pr-comments` | `oss-snapshots/superpowers/receiving-code-review/` (selective amalgamation — pushback discipline lifted into `references/handling-feedback.md`) | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-24 | selective-amalgamation |
+| `reply-and-resolve-pr-threads` | `oss-snapshots/superpowers/receiving-code-review/` (selective amalgamation — host SKILL.md cites sibling `wait-for-pr-comments/references/handling-feedback.md` as the canonical pushback-discipline reference; no independent reference file) | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-24 | selective-amalgamation |
 
 Update this table whenever a skill is added, replaced, or amalgamated from an OSS source.
 

--- a/src/user/.agents/skills/optimize-agents-md/SKILL.md
+++ b/src/user/.agents/skills/optimize-agents-md/SKILL.md
@@ -3,7 +3,7 @@ name: optimize-agents-md
 model: sonnet
 allowed-tools: Read, Write, Edit, Glob, Grep
 argument-hint: "[file-path]"
-description: Use when CLAUDE.md or AGENTS.md files need optimization, when agent behavior degrades, when AGENT.md or CLAUDE.md files exceed 200 lines, or when merging redundant instructions across hierarchy.  Use when the user asks to update or optimize AGENTS.md or CLAUDE.md files.
+description: Use when CLAUDE.md or AGENTS.md files need optimization, when agent behavior degrades, when AGENTS.md or CLAUDE.md files exceed 200 lines, or when merging redundant instructions across hierarchy. Use when the user asks to update or optimize AGENTS.md or CLAUDE.md files.
 ---
 
 # Optimize AGENTS.md / CLAUDE.md


### PR DESCRIPTION
## Summary

Close-out audit for the final cross-namespace `optimize-my-skill` pass + provenance registry reconciliation.

### Registry corrections
- Two new rows in `src/user/.agents/skills/AGENTS.md` for amalgam-host skills that were carrying OSS provenance HTML headers but were missing from the project-wide registry:
  - `wait-for-pr-comments` — receiving-code-review lift in `references/handling-feedback.md`.
  - `reply-and-resolve-pr-threads` — same source; references the sibling reference file.

### Staleness in namespace docs
- `oss-snapshots/anthropics/AGENTS.md`: the "amalgamation deferred" sentence was a year stale — skill-creator landed in `writing-skills` and `optimize-my-skill` long ago. Replaced with current state.
- `oss-snapshots/pocock/AGENTS.md`: `diagnose/` row was carrying a "(pending)" amalgamation verdict with no tracking; replaced with "deferred — verdict open" and a filed follow-up. `write-a-skill/` row had a similarly open-ended deferral; same treatment.

### Frontmatter audit pass
- Fixed `AGENT.md → AGENTS.md` typo (plus a doubled space) in `optimize-agents-md` frontmatter description.
- Audited 27 src-tree skills + handoff; one structural issue surfaced (zoom-out has a Claude-only frontmatter key but lives in the shared tree) — filed as a follow-up.

### Discovered work filed (linked discovered-from to cx6.7.7)
- `agents-config-5s7ab` (P2) — pocock/diagnose verdict (lift / drop / close).
- `agents-config-psyw2` (P3) — pocock/write-a-skill comparison verdict.
- `agents-config-0ysqf` (P3) — zoom-out shared-vs-Claude-only frontmatter contradiction.

### Out of scope, not done
- Per-skill `--deep` optimize-my-skill runs across all 27 deployable skills (would cost ~$50+ and was already done for the one skill where it added meaningful signal under `cx6.7.8`). Did a manual frontmatter-and-description audit instead and surfaced only material findings.
- Tracker-ID cleanup in namespace AGENTS.md `Related beads` sections and similar — covered by the standing sweep bead.

### Close-walk note
This closes `cx6.7.7`. The parent epic `cx6.7` still has three open children (`.15`, `.16`, `.17`); cx6.7 does not transitively close.

## Test plan
- [ ] `git diff origin/main` shows only the 4 expected documentation files
- [ ] No new tracker IDs introduced in any edited file
- [ ] Registry rows match the existing row formatting
- [ ] `install.sh --dry-run` from main reports no skill-list changes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)