### PR TITLE
fix(reply-and-resolve): repair post-replies.sh silent failures + add sidecar idempotency

### DIFF
--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -242,13 +242,31 @@ ${CLAUDE_SKILL_DIR}/post-replies.sh \
   [--skip-comment-ids "<csv>"]
 # per item, one of:
 #   POSTED <comment_id>
-#   FAILED <comment_id> <reason>
-#   SKIPPED <comment_id>            # matched --skip-comment-ids
+#   FAILED <comment_id> <reason> [— <gh-stderr-one-line>]
+#   SKIPPED <comment_id>            # matched skip-set (sidecar or --skip-comment-ids)
 #   FILTERED <comment_id> (classification=<class>)  # not replyable
 ```
 
-**NOT idempotent** — on a partial-run retry, the caller MUST pass
-`--skip-comment-ids` with the csv of already-posted comment_ids.
+`<comment_id>` is the canonical id per `kind`:
+
+| `kind` | `<comment_id>` source |
+|---|---|
+| `review_thread` | `.reply_to_comment_id` (numeric REST databaseId) |
+| `issue_comment` | `.issue_comment_id` (numeric REST databaseId) |
+| `review_summary` | `summary-<12-char sha1 of item JSON>` (synthetic; stable across re-runs against the same item content) |
+
+FAILED lines surface the underlying `gh` stderr appended after the bare
+reason label (e.g., `FAILED 12345 gh-rest-reply-failed — HTTP 422:
+Validation Failed`).
+
+**Self-recording idempotency** — each successful POST appends its
+`<comment_id>` to a sidecar `<inventory>.posted`. On startup the
+sidecar is unioned with `--skip-comment-ids` to form the effective
+skip-set, so crash-recovery re-runs against the same inventory SKIP
+previously-posted items automatically. A 100%-success run deletes the
+sidecar; partial-failure runs preserve it for the next retry. Callers
+MAY still pass `--skip-comment-ids` explicitly, but no longer need to
+on a clean retry against the same inventory path.
 
 **Resolve FIX review threads** (Phase 3 — replaces inline GraphQL
 `resolveReviewThread` block):

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -266,7 +266,7 @@ skip-set, so crash-recovery re-runs against the same inventory SKIP
 previously-posted items automatically. A 100%-success run deletes the
 sidecar; partial-failure runs preserve it for the next retry. Callers
 MAY still pass `--skip-comment-ids` explicitly, but no longer need to
-on a clean retry against the same inventory path.
+do so on a clean retry against the same inventory path.
 
 **Resolve FIX review threads** (Phase 3 — replaces inline GraphQL
 `resolveReviewThread` block):

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -263,10 +263,15 @@ Validation Failed`).
 `<comment_id>` to a sidecar `<inventory>.posted`. On startup the
 sidecar is unioned with `--skip-comment-ids` to form the effective
 skip-set, so crash-recovery re-runs against the same inventory SKIP
-previously-posted items automatically. A 100%-success run deletes the
-sidecar; partial-failure runs preserve it for the next retry. Callers
-MAY still pass `--skip-comment-ids` explicitly, but no longer need to
-do so on a clean retry against the same inventory path.
+previously-posted items automatically.
+
+Sidecar cleanup:
+- **100%-success run, no `--skip-comment-ids` supplied** → sidecar is deleted.
+- **100%-success run with `--skip-comment-ids` supplied** → sidecar is preserved. The operator has externally asserted some items are already done, so we can't claim the sidecar is a complete record of what this run handled.
+- **Partial-failure run** → sidecar is preserved for the next retry.
+
+Callers MAY still pass `--skip-comment-ids` explicitly, but no longer
+need to do so on a clean retry against the same inventory path.
 
 **Resolve FIX review threads** (Phase 3 — replaces inline GraphQL
 `resolveReviewThread` block):

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -150,10 +150,14 @@ while IFS= read -r item; do
     review_summary)
       # No per-item id; synthesize one from sha1(item-json) so retries against
       # the same content are idempotent and distinguishable from sibling summaries.
-      # Canonicalize with `jq --sort-keys` so the cid depends only on content,
+      # Canonicalize with `jq -c --sort-keys` so the cid depends only on content,
       # not on jq's emitted key order (otherwise two semantically identical
-      # items could hash differently and break idempotency).
-      cid="summary-$(printf '%s' "$item" | jq --sort-keys . | shasum -a 1 | cut -d' ' -f1 | cut -c1-12)"
+      # items could hash differently and break idempotency). `-c` (compact
+      # output) is REQUIRED for cross-version/platform stability: jq's
+      # pretty-print whitespace and indentation can shift across jq versions,
+      # which would change the hash bytes and break idempotency across
+      # environments. Compact form is deterministic.
+      cid="summary-$(printf '%s' "$item" | jq -c --sort-keys . | shasum -a 1 | cut -d' ' -f1 | cut -c1-12)"
       ;;
     *)              cid="$(echo "$item" | jq -r '.thread_id // .reply_to_comment_id // .issue_comment_id // empty')" ;;
   esac

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -122,7 +122,10 @@ while IFS= read -r item; do
     review_summary)
       # No per-item id; synthesize one from sha1(item-json) so retries against
       # the same content are idempotent and distinguishable from sibling summaries.
-      cid="summary-$(printf '%s' "$item" | shasum -a 1 | cut -d' ' -f1 | cut -c1-12)"
+      # Canonicalize with `jq --sort-keys` so the cid depends only on content,
+      # not on jq's emitted key order (otherwise two semantically identical
+      # items could hash differently and break idempotency).
+      cid="summary-$(printf '%s' "$item" | jq --sort-keys . | shasum -a 1 | cut -d' ' -f1 | cut -c1-12)"
       ;;
     *)              cid="$(echo "$item" | jq -r '.thread_id // .reply_to_comment_id // .issue_comment_id // empty')" ;;
   esac

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -25,7 +25,15 @@
 #   POSTED record and let a subsequent retry (without the flag) re-post
 #   duplicates.
 # - Callers MAY still pass --skip-comment-ids explicitly; both sources
-#   union into the same skip-set.
+#   union into the same skip-set. The CSV input tolerates whitespace
+#   (spaces, tabs, newlines): "11111, 22222" is normalized to "11111,22222"
+#   before being spliced into the skipset so the membership check still
+#   matches.
+# - A sidecar write failure (e.g., unwritable directory, full disk) AFTER
+#   a successful GitHub POST is a run failure: the script emits a WARNING
+#   on stderr naming the cid and the manual recovery action, sets the
+#   failure flag, and exits 1. Without this, the cid would be posted but
+#   not persisted, and the next retry would re-post a duplicate.
 # - The sidecar's lifecycle is bounded by the inventory itself: inventory
 #   filenames are keyed by (owner, repo, pr, head_sha) so each new push
 #   gets a fresh inventory and a fresh sidecar.
@@ -102,13 +110,22 @@ done
 
 POSTED_SIDECAR="${INV}.posted"
 
+# Normalize --skip-comment-ids: strip ALL whitespace so operators or tooling
+# passing "11111, 22222" (with spaces/newlines) still match the *,<cid>,*
+# skipset membership test. Without this, the whitespace would be glued onto
+# the cid in the skipset and silently fail to match, causing duplicate POSTs.
+SKIP_CSV="$(printf '%s' "$SKIP_CSV" | tr -d '[:space:]')"
+
 skipset=","
 if [ -n "$SKIP_CSV" ]; then
   skipset="${skipset}${SKIP_CSV},"
 fi
 # Union any prior <inventory>.posted entries into the skipset.
+# Defensively strip whitespace per line — we control the writer, but the
+# normalization is cheap and symmetric with the CSV handling above.
 if [ -f "$POSTED_SIDECAR" ]; then
   while IFS= read -r prior_cid; do
+    prior_cid="$(printf '%s' "$prior_cid" | tr -d '[:space:]')"
     [ -n "$prior_cid" ] || continue
     skipset="${skipset}${prior_cid},"
   done < "$POSTED_SIDECAR"
@@ -201,7 +218,20 @@ while IFS= read -r item; do
   if printf '%s' "$body" | gh api "$post_url" \
       --method POST --field body=@- >/dev/null 2>"$ERR"; then
     echo "POSTED $cid"
-    [ -n "$cid" ] && printf '%s\n' "$cid" >> "$POSTED_SIDECAR"
+    # Sidecar recording is part of the idempotency contract. The append CANNOT
+    # be expressed as `&& printf ... >> $POSTED_SIDECAR`: under `set -e`, a
+    # failed `>>` inside an `&&`-list is NOT treated as a fatal error, so the
+    # write loss would be silent — the cid would be POSTED to GitHub but never
+    # persisted, and a crash-recovery retry would re-post a duplicate. The
+    # GitHub-side and sidecar-side state are already divergent at this point;
+    # surface it loudly and fail the run so the operator can manually append
+    # the cid before retrying.
+    if [ -n "$cid" ]; then
+      if ! printf '%s\n' "$cid" >> "$POSTED_SIDECAR"; then
+        echo "WARNING $cid sidecar-append-failed: posted to GitHub but $POSTED_SIDECAR write failed; manually append $cid to that file before retrying or the next run will re-post a duplicate" >&2
+        any_failed=1
+      fi
+    fi
   else
     err_msg="$(tr '\n' ' ' <"$ERR" | sed 's/  */ /g; s/^ //; s/ $//')"
     echo "FAILED $cid ${fail_label}${err_msg:+ — $err_msg}"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -2,12 +2,25 @@
 # Purpose: post a reply to every inventory thread/comment.
 #
 # Dispatches by `kind`:
-#   review_thread → REST POST /repos/{o}/{r}/pulls/{n}/comments/{reply_to_comment_id}/replies
-#   issue_comment → REST POST /repos/{o}/{r}/issues/{n}/comments
+#   review_thread  → REST POST /repos/{o}/{r}/pulls/{n}/comments/{reply_to_comment_id}/replies
+#   issue_comment  → REST POST /repos/{o}/{r}/issues/{n}/comments
+#   review_summary → REST POST /repos/{o}/{r}/issues/{n}/comments
+#                    (review_summary has no per-item id; synthetic cid is
+#                     `summary-<12-char sha1 of the item JSON>` so retries
+#                     against the same content are idempotent.)
 #
-# IDEMPOTENCY: this helper is NOT idempotent. If a partial run posted some
-# replies and then crashed, the caller MUST pass --skip-comment-ids with the
-# csv of already-posted comment_ids on the next invocation.
+# IDEMPOTENCY: this helper is self-recording. Each successful POST is
+# appended to a sidecar file <inventory>.posted (one cid per line). On
+# startup the sidecar is read and unioned with --skip-comment-ids to form
+# the effective skip-set, so crash-recovery re-runs against the same
+# inventory will SKIP previously-posted items automatically.
+# - On a 100%-success run (any_failed=0) the sidecar is deleted.
+# - On a partial-failure run the sidecar is preserved for the next retry.
+# - Callers MAY still pass --skip-comment-ids explicitly; both sources
+#   union into the same skip-set.
+# - The sidecar's lifecycle is bounded by the inventory itself: inventory
+#   filenames are keyed by (owner, repo, pr, head_sha) so each new push
+#   gets a fresh inventory and a fresh sidecar.
 #
 # Inputs:
 #   --inventory        <file>  inventory JSON (must contain .items array)
@@ -19,14 +32,22 @@
 # Outputs:
 #   stdout: per item, one of:
 #     POSTED <comment_id>
-#     FAILED <comment_id> <reason>
-#     SKIPPED <comment_id> (matched --skip-comment-ids)
+#     FAILED <comment_id> <reason> [— <gh-stderr-one-line>]
+#     SKIPPED <comment_id> (matched skip-set: sidecar ∪ --skip-comment-ids)
 #     FILTERED <comment_id> (classification=<value>) — item is not replyable
 #       (e.g., ESCALATE without escalation_filed=true); not an error
 #   exit codes:
 #     0 = all items posted (or skipped) successfully
 #     1 = at least one item failed
 #     2 = bad flag usage / missing input
+#
+# <comment_id> is the canonical id per kind:
+#   kind=review_thread  → .reply_to_comment_id  (numeric REST databaseId)
+#   kind=issue_comment  → .issue_comment_id     (numeric REST databaseId)
+#   kind=review_summary → summary-<12-char sha1 of item JSON> (synthetic; stable)
+#   otherwise           → .thread_id // .reply_to_comment_id // .issue_comment_id
+# (Inventory items do NOT carry a top-level .comment_id — see
+#  build-inventory-body.sh and SKILL.md §"Inventory schema".)
 set -euo pipefail
 
 usage() {
@@ -34,8 +55,10 @@ usage() {
 Usage: $(basename "$0") --inventory <file> --owner <o> --repo <r> --pr <n>
                         [--skip-comment-ids <csv>]
 
-Posts replies to each inventory item; not idempotent — caller must pass
---skip-comment-ids on re-invocation.
+Posts replies to each inventory item. Self-recording: each POSTED cid is
+appended to <inventory>.posted; subsequent runs against the same
+inventory automatically SKIP previously-posted items. A 100%-success run
+deletes the sidecar; partial-failure runs preserve it for retry.
 EOF
   exit 2
 }
@@ -66,22 +89,43 @@ done
 [ -n "$PR" ]    || { echo "error: --pr is required" >&2; exit 2; }
 [ -f "$INV" ]   || { echo "error: inventory file not found: $INV" >&2; exit 2; }
 
-skipset=""
+POSTED_SIDECAR="${INV}.posted"
+
+skipset=","
 if [ -n "$SKIP_CSV" ]; then
-  skipset=",$SKIP_CSV,"
+  skipset="${skipset}${SKIP_CSV},"
 fi
+# Union any prior <inventory>.posted entries into the skipset.
+if [ -f "$POSTED_SIDECAR" ]; then
+  while IFS= read -r prior_cid; do
+    [ -n "$prior_cid" ] || continue
+    skipset="${skipset}${prior_cid},"
+  done < "$POSTED_SIDECAR"
+fi
+[ "$skipset" = "," ] && skipset=""
 
 any_failed=0
 
 TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
+ERR="$(mktemp)"
+trap 'rm -f "$TMP" "$ERR"' EXIT
 jq -c '.items[]?' "$INV" > "$TMP"
 
 while IFS= read -r item; do
   [ -n "$item" ] || continue
-  cid="$(echo "$item" | jq -r '.comment_id // empty')"
   kind="$(echo "$item" | jq -r '.kind // empty')"
   classification="$(echo "$item" | jq -r '.classification // ""')"
+  # Canonical id dispatch — see header comment for the per-kind contract.
+  case "$kind" in
+    review_thread)  cid="$(echo "$item" | jq -r '.reply_to_comment_id // empty')" ;;
+    issue_comment)  cid="$(echo "$item" | jq -r '.issue_comment_id // empty')" ;;
+    review_summary)
+      # No per-item id; synthesize one from sha1(item-json) so retries against
+      # the same content are idempotent and distinguishable from sibling summaries.
+      cid="summary-$(printf '%s' "$item" | shasum -a 1 | cut -d' ' -f1 | cut -c1-12)"
+      ;;
+    *)              cid="$(echo "$item" | jq -r '.thread_id // .reply_to_comment_id // .issue_comment_id // empty')" ;;
+  esac
 
   if [ -n "$cid" ] && [ -n "$skipset" ] && [[ "$skipset" == *",$cid,"* ]]; then
     echo "SKIPPED $cid"
@@ -106,39 +150,56 @@ while IFS= read -r item; do
     continue
   fi
 
-  if [ "$kind" = "issue_comment" ]; then
-    if gh api "repos/$OWNER/$REPO/issues/$PR/comments" \
-      -X POST -f body="$body" >/dev/null 2>&1; then
-      echo "POSTED $cid"
-    else
-      echo "FAILED $cid gh-issue-comment-post-failed"
-      any_failed=1
-    fi
+  # Per-kind POST target. issue_comment + review_summary share the REST
+  # issue-comments endpoint (gh pr comment is a wrapper around it). Unknown
+  # kinds fall through to the review_thread path (historical behavior).
+  case "$kind" in
+    issue_comment|review_summary)
+      post_url="repos/$OWNER/$REPO/issues/$PR/comments"
+      fail_label="gh-issue-comment-post-failed"
+      ;;
+    *)
+      reply_to="$(echo "$item" | jq -r '.reply_to_comment_id // empty')"
+      if [ -z "$reply_to" ]; then
+        echo "FAILED $cid reply_to_comment_id_missing"
+        any_failed=1
+        continue
+      fi
+      # REST endpoint /pulls/<n>/comments/<id>/replies requires the integer
+      # databaseId, not the GraphQL node id string.
+      if ! [[ "$reply_to" =~ ^[0-9]+$ ]]; then
+        echo "FAILED $cid reply_to_comment_id_not_numeric"
+        any_failed=1
+        continue
+      fi
+      post_url="repos/$OWNER/$REPO/pulls/$PR/comments/${reply_to}/replies"
+      fail_label="gh-rest-reply-failed"
+      ;;
+  esac
+
+  # The leading printf|gh pipe is load-bearing: it isolates gh's stdin from
+  # the outer loop's `< "$TMP"` redirection AND prevents gh's `@<file>` /
+  # typed-value parsing from misinterpreting body content (apostrophes,
+  # leading @, newlines). $ERR is truncated per attempt and surfaced into
+  # the FAILED line so script-internal vs API-rejection failures are
+  # distinguishable.
+  : > "$ERR"
+  if printf '%s' "$body" | gh api "$post_url" \
+      --method POST --field body=@- >/dev/null 2>"$ERR"; then
+    echo "POSTED $cid"
+    [ -n "$cid" ] && printf '%s\n' "$cid" >> "$POSTED_SIDECAR"
   else
-    # Default: review_thread (or unknown kind treated as such).
-    # Use REST replies endpoint: POST /repos/{o}/{r}/pulls/{n}/comments/{reply_to_comment_id}/replies
-    reply_to="$(echo "$item" | jq -r '.reply_to_comment_id // empty')"
-    if [ -z "$reply_to" ]; then
-      echo "FAILED $cid reply_to_comment_id_missing"
-      any_failed=1
-      continue
-    fi
-    # Validate reply_to_comment_id is numeric — REST endpoint /pulls/<n>/comments/<id>/replies
-    # requires the integer databaseId, not the GraphQL node id string.
-    if ! [[ "$reply_to" =~ ^[0-9]+$ ]]; then
-      echo "FAILED $cid reply_to_comment_id_not_numeric"
-      any_failed=1
-      continue
-    fi
-    if gh api "repos/$OWNER/$REPO/pulls/$PR/comments/${reply_to}/replies" \
-      --method POST -f body="$body" >/dev/null 2>&1; then
-      echo "POSTED $cid"
-    else
-      echo "FAILED $cid gh-rest-reply-failed"
-      any_failed=1
-    fi
+    err_msg="$(tr '\n' ' ' <"$ERR" | sed 's/  */ /g; s/^ //; s/ $//')"
+    echo "FAILED $cid ${fail_label}${err_msg:+ — $err_msg}"
+    any_failed=1
   fi
 done < "$TMP"
+
+# 100% success: drop the sidecar so it can't leak into an unrelated run.
+# Partial failures preserve it so the next retry inherits the skip-set.
+if [ "$any_failed" -eq 0 ] && [ -f "$POSTED_SIDECAR" ]; then
+  rm -f "$POSTED_SIDECAR"
+fi
 
 [ "$any_failed" -eq 0 ] || exit 1
 exit 0

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -14,8 +14,16 @@
 # startup the sidecar is read and unioned with --skip-comment-ids to form
 # the effective skip-set, so crash-recovery re-runs against the same
 # inventory will SKIP previously-posted items automatically.
-# - On a 100%-success run (any_failed=0) the sidecar is deleted.
+# - On a 100%-success run (any_failed=0) AND when --skip-comment-ids was
+#   NOT supplied, the sidecar is deleted: the script can prove the sidecar
+#   is a complete record of what this inventory needed.
 # - On a partial-failure run the sidecar is preserved for the next retry.
+# - When --skip-comment-ids was supplied the sidecar is preserved even on
+#   any_failed=0: the operator has externally asserted some items are
+#   already done, so the script can NOT claim the sidecar is a complete
+#   record of what THIS run posted. Deleting it would lose the prior-run
+#   POSTED record and let a subsequent retry (without the flag) re-post
+#   duplicates.
 # - Callers MAY still pass --skip-comment-ids explicitly; both sources
 #   union into the same skip-set.
 # - The sidecar's lifecycle is bounded by the inventory itself: inventory
@@ -58,7 +66,10 @@ Usage: $(basename "$0") --inventory <file> --owner <o> --repo <r> --pr <n>
 Posts replies to each inventory item. Self-recording: each POSTED cid is
 appended to <inventory>.posted; subsequent runs against the same
 inventory automatically SKIP previously-posted items. A 100%-success run
-deletes the sidecar; partial-failure runs preserve it for retry.
+deletes the sidecar UNLESS --skip-comment-ids was supplied (in which
+case the operator has externally asserted some items are already done
+and the script can't prove the sidecar is complete, so it is preserved);
+partial-failure runs preserve the sidecar for retry.
 EOF
   exit 2
 }
@@ -200,7 +211,12 @@ done < "$TMP"
 
 # 100% success: drop the sidecar so it can't leak into an unrelated run.
 # Partial failures preserve it so the next retry inherits the skip-set.
-if [ "$any_failed" -eq 0 ] && [ -f "$POSTED_SIDECAR" ]; then
+# When --skip-comment-ids was supplied we preserve it too: the operator has
+# externally asserted that some items are already done, so we can't confidently
+# claim the sidecar is a complete record of what THIS run handled. Deleting
+# it would lose the prior-run POSTED record and let a subsequent retry
+# (without the flag) re-post duplicates.
+if [ "$any_failed" -eq 0 ] && [ -z "$SKIP_CSV" ] && [ -f "$POSTED_SIDECAR" ]; then
   rm -f "$POSTED_SIDECAR"
 fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -29,19 +29,6 @@ assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
-# Inventory fixture for behavior tests
-INV="$TMP/inv.json"
-cat >"$INV" <<'JSON'
-{
-  "schema_version": 1,
-  "pr": {"number": 1, "owner": "o", "repo": "r"},
-  "items": [
-    {"comment_id": "c1", "classification": "FIX", "fix_outcome": "committed"},
-    {"comment_id": "c2", "classification": "FIX", "fix_outcome": "committed"}
-  ]
-}
-JSON
-
 # --- Fake-gh shim: pr comment posts succeed ---
 FAKEBIN="$TMP/bin"
 mkdir -p "$FAKEBIN"
@@ -52,27 +39,151 @@ exit 0
 FAKE
 chmod +x "$FAKEBIN/gh"
 
-# Behavior test: --skip-comment-ids flag must be ACCEPTED (not rejected as
-# unknown). Convention: unknown-flag rejections use exit 2 (per the
-# audit-subagent-report contract used elsewhere in this skill). In red
-# phase the script doesn't exist → rc=127. In green phase the flag is
-# accepted and the script proceeds past flag parsing.
-PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV" --owner o --repo r --pr 1 \
-  --skip-comment-ids "c1,c2" > "$TMP/skip-out.txt" 2>&1
+# Inventory fixture matching the real schema produced by build-inventory-body.sh:
+#   review_thread → top-level .reply_to_comment_id (numeric)
+#   issue_comment → top-level .issue_comment_id (numeric)
+# NO top-level .comment_id field exists in real inventories.
+INV_MIXED="$TMP/inv-mixed.json"
+cat >"$INV_MIXED" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "kind": "review_thread",
+      "thread_id": "T_kwDO_thread1",
+      "reply_to_comment_id": 11111,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "Fixed in abc123. (apostrophe's are fine.)"
+    },
+    {
+      "kind": "issue_comment",
+      "thread_id": null,
+      "reply_to_comment_id": null,
+      "issue_comment_id": 22222,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "Acknowledged on issue comment."
+    }
+  ]
+}
+JSON
+
+# Behavior test: --skip-comment-ids must be accepted as a flag.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --skip-comment-ids "11111,22222" > "$TMP/skip-out.txt" 2>&1
 rc_skip=$?
 assert "--skip-comment-ids is not rejected as unknown flag (rc != 2)" \
   "[ \$rc_skip -ne 2 ]"
 
+# Behavior test (POSTED contract): every POSTED line must carry a non-empty
+# comment_id token. Regression guard against a prior bug where the script
+# read a non-existent .comment_id field and emitted 'POSTED ' (empty token
+# after the space) for every successful post.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  > "$TMP/posted-out.txt" 2>&1
+rc_posted=$?
+if [ "$rc_posted" = "0" ]; then
+  echo "  ok: mixed-kind inventory exits 0 with successful fake gh"
+else
+  echo "  FAIL: mixed-kind inventory should exit 0; got $rc_posted; output: $(cat "$TMP/posted-out.txt")"
+  FAIL=1
+fi
+if grep -qE '^POSTED 11111$' "$TMP/posted-out.txt"; then
+  echo "  ok: review_thread POSTED line names .reply_to_comment_id (11111)"
+else
+  echo "  FAIL: expected 'POSTED 11111' for review_thread; got: $(cat "$TMP/posted-out.txt")"
+  FAIL=1
+fi
+if grep -qE '^POSTED 22222$' "$TMP/posted-out.txt"; then
+  echo "  ok: issue_comment POSTED line names .issue_comment_id (22222)"
+else
+  echo "  FAIL: expected 'POSTED 22222' for issue_comment; got: $(cat "$TMP/posted-out.txt")"
+  FAIL=1
+fi
+if grep -qE '^POSTED[[:space:]]*$' "$TMP/posted-out.txt"; then
+  echo "  FAIL: emitted 'POSTED' with empty comment_id (cid-dispatch regression)"
+  FAIL=1
+else
+  echo "  ok: no 'POSTED <empty>' lines"
+fi
+
+# Behavior test (SKIP contract with real id shape): passing the real numeric
+# ids in --skip-comment-ids must SKIP both items.
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --skip-comment-ids "11111,22222" > "$TMP/skipped-out.txt" 2>&1
+if grep -qE '^SKIPPED 11111$' "$TMP/skipped-out.txt" && grep -qE '^SKIPPED 22222$' "$TMP/skipped-out.txt"; then
+  echo "  ok: --skip-comment-ids matches real id fields per kind"
+else
+  echo "  FAIL: --skip-comment-ids did not match; got: $(cat "$TMP/skipped-out.txt")"
+  FAIL=1
+fi
+
+# Behavior test (FAILED contract): when gh fails, the FAILED line must (a)
+# carry a non-empty cid, (b) surface the underlying gh stderr instead of the
+# bare 'gh-rest-reply-failed' label. Regression guard against prior silent
+# failures where the cid was empty and the gh stderr was swallowed.
+FAKEBIN_FAIL="$TMP/bin-fail"
+mkdir -p "$FAKEBIN_FAIL"
+cat > "$FAKEBIN_FAIL/gh" <<'FAKE'
+#!/usr/bin/env bash
+echo "HTTP 422: Validation Failed (fake-gh-stderr-marker)" >&2
+exit 1
+FAKE
+chmod +x "$FAKEBIN_FAIL/gh"
+
+PATH="$FAKEBIN_FAIL:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  > "$TMP/failed-out.txt" 2>&1
+rc_failed=$?
+if [ "$rc_failed" = "1" ]; then
+  echo "  ok: failing gh causes exit 1"
+else
+  echo "  FAIL: failing gh should exit 1; got $rc_failed"
+  FAIL=1
+fi
+if grep -qE '^FAILED 11111 ' "$TMP/failed-out.txt"; then
+  echo "  ok: FAILED line for review_thread names .reply_to_comment_id (11111)"
+else
+  echo "  FAIL: expected 'FAILED 11111 ...'; got: $(cat "$TMP/failed-out.txt")"
+  FAIL=1
+fi
+if grep -qE '^FAILED 22222 ' "$TMP/failed-out.txt"; then
+  echo "  ok: FAILED line for issue_comment names .issue_comment_id (22222)"
+else
+  echo "  FAIL: expected 'FAILED 22222 ...'; got: $(cat "$TMP/failed-out.txt")"
+  FAIL=1
+fi
+if grep -qE '^FAILED[[:space:]]+[^[:space:]]+[[:space:]]+gh-[a-z-]+-failed[[:space:]]*$' "$TMP/failed-out.txt"; then
+  echo "  FAIL: FAILED line ends at bare reason label (gh stderr swallowed)"
+  FAIL=1
+else
+  echo "  ok: FAILED line carries content beyond the bare reason label"
+fi
+if grep -q 'fake-gh-stderr-marker' "$TMP/failed-out.txt"; then
+  echo "  ok: FAILED line surfaces underlying gh stderr"
+else
+  echo "  FAIL: gh stderr ('fake-gh-stderr-marker') not surfaced; got: $(cat "$TMP/failed-out.txt")"
+  FAIL=1
+fi
+
 # Behavior test: items missing reply_body must emit FAILED <cid> reply_body_missing
-# and the process must exit 1 (any_failed). Fixture INV has c1 and c2 with
-# classification=FIX but no reply_body field.
+# with a non-empty cid, and process must exit 1.
 INV_NO_BODY="$TMP/inv-no-body.json"
 cat >"$INV_NO_BODY" <<'JSON'
 {
   "schema_version": 1,
   "pr": {"number": 1, "owner": "o", "repo": "r"},
   "items": [
-    {"comment_id": "c1", "classification": "FIX", "fix_outcome": "committed"}
+    {
+      "kind": "review_thread",
+      "thread_id": "T_x",
+      "reply_to_comment_id": 33333,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed"
+    }
   ]
 }
 JSON
@@ -85,15 +196,14 @@ else
   echo "  FAIL: missing reply_body should exit 1, got $rc_nobody"
   FAIL=1
 fi
-if grep -q 'FAILED c1 reply_body_missing' "$TMP/nobody-out.txt"; then
-  echo "  ok: emits FAILED <cid> reply_body_missing"
+if grep -qE '^FAILED 33333 reply_body_missing$' "$TMP/nobody-out.txt"; then
+  echo "  ok: emits FAILED <cid> reply_body_missing with non-empty cid"
 else
-  echo "  FAIL: missing FAILED c1 reply_body_missing output; got: $(cat "$TMP/nobody-out.txt")"
+  echo "  FAIL: missing 'FAILED 33333 reply_body_missing'; got: $(cat "$TMP/nobody-out.txt")"
   FAIL=1
 fi
 
-# Behavior test: ESCALATE+escalation_filed=true items must be POSTED
-# (not FILTERED). Use a stub gh that always succeeds.
+# Behavior test: ESCALATE+escalation_filed=true items must be POSTED (not FILTERED).
 INV_ESCALATE="$TMP/inv-escalate.json"
 cat >"$INV_ESCALATE" <<'JSON'
 {
@@ -101,11 +211,12 @@ cat >"$INV_ESCALATE" <<'JSON'
   "pr": {"number": 1, "owner": "o", "repo": "r"},
   "items": [
     {
-      "comment_id": "cE",
+      "kind": "review_thread",
+      "thread_id": "T_kwDO_escalate",
+      "reply_to_comment_id": 44444,
+      "issue_comment_id": null,
       "classification": "ESCALATE",
       "escalation_filed": true,
-      "kind": "review_thread",
-      "reply_to_comment_id": "12345",
       "reply_body": "Captured for follow-up; will respond on a later push to this PR or in a related issue.",
       "rationale": "needs human review"
     }
@@ -115,10 +226,178 @@ JSON
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_ESCALATE" --owner o --repo r --pr 1 \
   > "$TMP/escalate-out.txt" 2>&1
 rc_escalate=$?
-if [ "$rc_escalate" = "0" ] && grep -q 'POSTED cE' "$TMP/escalate-out.txt"; then
+if [ "$rc_escalate" = "0" ] && grep -qE '^POSTED 44444$' "$TMP/escalate-out.txt"; then
   echo "  ok: ESCALATE+escalation_filed=true is POSTED (not FILTERED)"
 else
-  echo "  FAIL: ESCALATE+escalation_filed=true should exit 0 with POSTED cE; got rc=$rc_escalate, output: $(cat "$TMP/escalate-out.txt")"
+  echo "  FAIL: ESCALATE+escalation_filed=true should exit 0 with POSTED 44444; got rc=$rc_escalate, output: $(cat "$TMP/escalate-out.txt")"
+  FAIL=1
+fi
+
+# Behavior test (review_summary support): review_summary items have all
+# three id fields null (validation guard 3) — must dispatch to the issue
+# comments endpoint, synthesize a stable non-empty cid, and POST cleanly.
+INV_RSUM="$TMP/inv-rsum.json"
+cat >"$INV_RSUM" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "kind": "review_summary",
+      "thread_id": null,
+      "reply_to_comment_id": null,
+      "issue_comment_id": null,
+      "classification": "SKIP",
+      "reply_body": "Acknowledged review summary; no per-thread action required."
+    }
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  > "$TMP/rsum-out.txt" 2>&1
+rc_rsum=$?
+if [ "$rc_rsum" = "0" ] && grep -qE '^POSTED summary-[0-9a-f]+$' "$TMP/rsum-out.txt"; then
+  echo "  ok: review_summary POSTED with synthetic non-empty cid"
+else
+  echo "  FAIL: review_summary should POST with 'POSTED summary-<hash>'; got rc=$rc_rsum output: $(cat "$TMP/rsum-out.txt")"
+  FAIL=1
+fi
+# Same-content re-run must produce the SAME synthetic cid (idempotency anchor).
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  > "$TMP/rsum-out2.txt" 2>&1
+cid1="$(grep -oE 'summary-[0-9a-f]+' "$TMP/rsum-out.txt"  | head -1)"
+cid2="$(grep -oE 'summary-[0-9a-f]+' "$TMP/rsum-out2.txt" | head -1)"
+if [ -n "$cid1" ] && [ "$cid1" = "$cid2" ]; then
+  echo "  ok: review_summary synthetic cid is stable across runs ($cid1)"
+else
+  echo "  FAIL: review_summary synthetic cid not stable; first=$cid1 second=$cid2"
+  FAIL=1
+fi
+
+# Behavior test (union skip-set): when BOTH the sidecar AND --skip-comment-ids
+# carry different cids, both sources must apply (union, not override).
+INV_UNION="$TMP/inv-union.json"
+cat >"$INV_UNION" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"kind": "review_thread", "thread_id": "T_a", "reply_to_comment_id": 81111, "issue_comment_id": null, "classification": "FIX", "fix_outcome": "committed", "reply_body": "ok"},
+    {"kind": "review_thread", "thread_id": "T_b", "reply_to_comment_id": 82222, "issue_comment_id": null, "classification": "FIX", "fix_outcome": "committed", "reply_body": "ok"}
+  ]
+}
+JSON
+printf '81111\n' > "${INV_UNION}.posted"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_UNION" --owner o --repo r --pr 1 \
+  --skip-comment-ids "82222" > "$TMP/union-out.txt" 2>&1
+if grep -qE '^SKIPPED 81111$' "$TMP/union-out.txt" \
+   && grep -qE '^SKIPPED 82222$' "$TMP/union-out.txt" \
+   && ! grep -qE '^POSTED ' "$TMP/union-out.txt"; then
+  echo "  ok: sidecar ∪ --skip-comment-ids both apply (union, not override)"
+else
+  echo "  FAIL: union skip-set didn't skip both; got: $(cat "$TMP/union-out.txt")"
+  FAIL=1
+fi
+
+# Behavior test (sidecar idempotency): a successful 100% run MUST delete
+# any prior <inventory>.posted sidecar so re-runs don't keep stale state.
+INV_SIDECAR_CLEAN="$TMP/inv-sidecar-clean.json"
+cat >"$INV_SIDECAR_CLEAN" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "kind": "review_thread",
+      "thread_id": "T_x",
+      "reply_to_comment_id": 55555,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "Fixed in def456."
+    }
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_CLEAN" --owner o --repo r --pr 1 \
+  > "$TMP/sidecar-clean-out.txt" 2>&1
+if [ -f "${INV_SIDECAR_CLEAN}.posted" ]; then
+  echo "  FAIL: 100% success should delete <inventory>.posted sidecar; still present"
+  FAIL=1
+else
+  echo "  ok: 100% success deletes <inventory>.posted sidecar"
+fi
+
+# Behavior test (sidecar idempotency): a prior <inventory>.posted sidecar
+# MUST be honored as an implicit skip-set on the next invocation. Simulate
+# a crashed prior run that already POSTED 55555 before dying.
+PRE_POSTED="${INV_SIDECAR_CLEAN}.posted"
+printf '55555\n' > "$PRE_POSTED"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_CLEAN" --owner o --repo r --pr 1 \
+  > "$TMP/sidecar-skip-out.txt" 2>&1
+if grep -qE '^SKIPPED 55555$' "$TMP/sidecar-skip-out.txt" \
+   && ! grep -qE '^POSTED 55555$' "$TMP/sidecar-skip-out.txt"; then
+  echo "  ok: prior <inventory>.posted entries are honored as implicit skip-set"
+else
+  echo "  FAIL: prior sidecar entry 55555 should SKIP (and not POST); got: $(cat "$TMP/sidecar-skip-out.txt")"
+  FAIL=1
+fi
+
+# Behavior test (sidecar idempotency): a partial-failure run MUST preserve
+# the sidecar so the next invocation can pick up where it left off.
+INV_SIDECAR_PARTIAL="$TMP/inv-sidecar-partial.json"
+cat >"$INV_SIDECAR_PARTIAL" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "kind": "review_thread",
+      "thread_id": "T_a",
+      "reply_to_comment_id": 66666,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "ok"
+    },
+    {
+      "kind": "review_thread",
+      "thread_id": "T_b",
+      "reply_to_comment_id": 77777,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "ok"
+    }
+  ]
+}
+JSON
+# Fake gh that succeeds for /66666/replies, fails for /77777/replies.
+FAKEBIN_PART="$TMP/bin-partial"
+mkdir -p "$FAKEBIN_PART"
+cat > "$FAKEBIN_PART/gh" <<'FAKE'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    *"/comments/77777/replies"*) echo "fail-on-77777" >&2; exit 1 ;;
+  esac
+done
+exit 0
+FAKE
+chmod +x "$FAKEBIN_PART/gh"
+PATH="$FAKEBIN_PART:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_PARTIAL" --owner o --repo r --pr 1 \
+  > "$TMP/sidecar-partial-out.txt" 2>&1
+rc_partial=$?
+if [ "$rc_partial" = "1" ]; then
+  echo "  ok: partial-failure run exits 1"
+else
+  echo "  FAIL: partial-failure run should exit 1; got $rc_partial"
+  FAIL=1
+fi
+if [ -f "${INV_SIDECAR_PARTIAL}.posted" ] && grep -qE '^66666$' "${INV_SIDECAR_PARTIAL}.posted"; then
+  echo "  ok: partial-failure run preserves sidecar with the 66666 success"
+else
+  echo "  FAIL: sidecar should exist and contain 66666 after partial run; sidecar=$(cat "${INV_SIDECAR_PARTIAL}.posted" 2>&1 || echo missing)"
   FAIL=1
 fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -322,6 +322,23 @@ else
   FAIL=1
 fi
 
+# Behavior test (cross-version stability anchor): review_summary cid for a
+# pinned fixture item must equal a known hash. Regression guard against
+# removing `-c` from the jq canonicalization in the dispatch — jq's
+# pretty-print whitespace varies across versions/platforms, so without `-c`
+# the hash drifts and idempotency breaks across environments. The expected
+# hash below was computed via:
+#   printf '%s' "$item" | jq -c --sort-keys . | shasum -a 1 \
+#     | cut -d' ' -f1 | cut -c1-12
+# against the INV_RSUM fixture item content above.
+EXPECTED_RSUM_CID="summary-aad5a242e21c"
+if grep -qE "^POSTED ${EXPECTED_RSUM_CID}\$" "$TMP/rsum-out.txt"; then
+  echo "  ok: review_summary cid matches pinned canonical hash ($EXPECTED_RSUM_CID)"
+else
+  echo "  FAIL: review_summary cid does not match pinned hash; expected $EXPECTED_RSUM_CID, got: $(grep '^POSTED summary-' "$TMP/rsum-out.txt")"
+  FAIL=1
+fi
+
 # Behavior tests (endpoint correctness): each kind must dispatch to the
 # correct REST endpoint. These guard against regressions where, e.g.,
 # review_summary accidentally hit /pulls/.../replies — a bug the old

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -561,6 +561,54 @@ else
   FAIL=1
 fi
 
+# Behavior test (whitespace normalization): --skip-comment-ids with spaces in the CSV
+# must still match the skipset cids. Regression guard against operators or tooling
+# that pass "11111, 22222" instead of "11111,22222".
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --skip-comment-ids "11111, 22222" > "$TMP/csv-ws-out.txt" 2>&1
+if grep -qE '^SKIPPED 11111$' "$TMP/csv-ws-out.txt" \
+   && grep -qE '^SKIPPED 22222$' "$TMP/csv-ws-out.txt"; then
+  echo "  ok: --skip-comment-ids tolerates whitespace in the CSV"
+else
+  echo "  FAIL: --skip-comment-ids did not match with whitespace; got: $(cat "$TMP/csv-ws-out.txt")"
+  FAIL=1
+fi
+
+# Behavior test (sidecar append failure is surfaced): if the sidecar path is
+# un-writable (simulated by making it a directory), the script must emit a
+# WARNING on stderr and exit 1 — NOT silently print POSTED while the state
+# write is lost.
+INV_WRITE_FAIL="$TMP/inv-write-fail.json"
+cat >"$INV_WRITE_FAIL" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"kind":"review_thread","thread_id":"T_x","reply_to_comment_id":77777,"issue_comment_id":null,"classification":"FIX","fix_outcome":"committed","reply_body":"ok"}
+  ]
+}
+JSON
+# Make the sidecar path a directory so >> fails.
+mkdir -p "${INV_WRITE_FAIL}.posted"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_WRITE_FAIL" --owner o --repo r --pr 1 \
+  > "$TMP/write-fail-out.txt" 2> "$TMP/write-fail-err.txt"
+rc_wf=$?
+if [ "$rc_wf" = "1" ]; then
+  echo "  ok: sidecar append failure causes exit 1"
+else
+  echo "  FAIL: sidecar append failure should exit 1, got $rc_wf"
+  FAIL=1
+fi
+if grep -q 'sidecar-append-failed' "$TMP/write-fail-err.txt"; then
+  echo "  ok: sidecar append failure surfaces WARNING on stderr"
+else
+  echo "  FAIL: sidecar append failure should emit WARNING with 'sidecar-append-failed'; got stderr: $(cat "$TMP/write-fail-err.txt")"
+  FAIL=1
+fi
+# Cleanup the directory-sidecar so EXIT trap doesn't try to delete a non-empty dir
+rmdir "${INV_WRITE_FAIL}.posted" 2>/dev/null || rm -rf "${INV_WRITE_FAIL}.posted"
+
 # Failure path: invoking without --inventory must fail (flag validation)
 if "$SCRIPT" --owner o --repo r --pr 1 2>/dev/null; then
   echo "  FAIL: accepted invocation without --inventory"

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -29,12 +29,60 @@ assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
 assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
 
-# --- Fake-gh shim: pr comment posts succeed ---
+# --- Fake-gh shim: validates endpoint + required flags; logs every call ---
+# Why validate, not just exit 0: a bare `exit 0` shim cannot catch wrong-
+# endpoint regressions (e.g., review_summary accidentally hitting the
+# /pulls/.../replies path, or a missing --method POST / --field body=@-).
+# Logging to $FAKE_GH_LOG lets behavior tests assert which endpoint was hit
+# per kind.
 FAKEBIN="$TMP/bin"
 mkdir -p "$FAKEBIN"
+export FAKE_GH_LOG="$TMP/fake-gh.log"
 cat > "$FAKEBIN/gh" <<'FAKE'
 #!/usr/bin/env bash
-# Fake gh — any invocation succeeds.
+# Fake gh — validates endpoint + required flags; logs every invocation.
+LOG="${FAKE_GH_LOG:-/tmp/fake-gh.log}"
+echo "$@" >> "$LOG"
+# Locate the endpoint arg (first positional after 'api', skipping flags).
+endpoint=""
+saw_api=0
+skip_next=0
+for a in "$@"; do
+  if [ "$skip_next" = "1" ]; then skip_next=0; continue; fi
+  case "$a" in
+    api) saw_api=1; continue ;;
+    --method|--field|-f|-F|-H|--header|--input|--hostname)
+      skip_next=1; continue ;;
+    --*=*) continue ;;
+    --*) continue ;;
+    *)
+      if [ "$saw_api" = "1" ] && [ -z "$endpoint" ]; then endpoint="$a"; fi
+      ;;
+  esac
+done
+case "$endpoint" in
+  repos/*/*/issues/*/comments) ;;
+  repos/*/*/pulls/*/comments/*/replies)
+    cid_segment="$(echo "$endpoint" | awk -F/ '{print $(NF-1)}')"
+    if ! [[ "$cid_segment" =~ ^[0-9]+$ ]]; then
+      echo "fake-gh: non-numeric comment id in pulls/.../replies endpoint: $cid_segment" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "fake-gh: unexpected endpoint: $endpoint" >&2
+    exit 2 ;;
+esac
+case " $* " in
+  *" --method POST "*) ;;
+  *) echo "fake-gh: missing --method POST" >&2; exit 2 ;;
+esac
+case " $* " in
+  *" --field body=@- "*) ;;
+  *) echo "fake-gh: missing --field body=@- (stdin body contract)" >&2; exit 2 ;;
+esac
+# Drain stdin (body) so the caller's pipe doesn't error.
+cat >/dev/null
 exit 0
 FAKE
 chmod +x "$FAKEBIN/gh"
@@ -271,6 +319,66 @@ if [ -n "$cid1" ] && [ "$cid1" = "$cid2" ]; then
   echo "  ok: review_summary synthetic cid is stable across runs ($cid1)"
 else
   echo "  FAIL: review_summary synthetic cid not stable; first=$cid1 second=$cid2"
+  FAIL=1
+fi
+
+# Behavior tests (endpoint correctness): each kind must dispatch to the
+# correct REST endpoint. These guard against regressions where, e.g.,
+# review_summary accidentally hit /pulls/.../replies — a bug the old
+# always-exit-0 fake gh would not have caught.
+
+# review_summary → /issues/N/comments (NOT /pulls/...).
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  > "$TMP/rsum-endpoint-out.txt" 2>&1
+if grep -qE 'repos/o/r/issues/1/comments' "$FAKE_GH_LOG" \
+   && ! grep -qE 'repos/o/r/pulls/' "$FAKE_GH_LOG"; then
+  echo "  ok: review_summary hits /issues/N/comments (not /pulls/...)"
+else
+  echo "  FAIL: review_summary endpoint wrong; fake-gh log: $(cat "$FAKE_GH_LOG")"
+  FAIL=1
+fi
+
+# review_thread → /pulls/N/comments/<reply_to>/replies.
+: > "$FAKE_GH_LOG"
+INV_RT="$TMP/inv-rt.json"
+cat >"$INV_RT" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"kind":"review_thread","thread_id":"T_x","reply_to_comment_id":99999,"issue_comment_id":null,"classification":"FIX","fix_outcome":"committed","reply_body":"ok"}
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RT" --owner o --repo r --pr 1 \
+  > "$TMP/rt-endpoint-out.txt" 2>&1
+if grep -qE 'repos/o/r/pulls/1/comments/99999/replies' "$FAKE_GH_LOG"; then
+  echo "  ok: review_thread hits /pulls/N/comments/<reply_to>/replies"
+else
+  echo "  FAIL: review_thread endpoint wrong; fake-gh log: $(cat "$FAKE_GH_LOG")"
+  FAIL=1
+fi
+
+# issue_comment → /issues/N/comments (NOT /pulls/...).
+: > "$FAKE_GH_LOG"
+INV_IC="$TMP/inv-ic.json"
+cat >"$INV_IC" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"kind":"issue_comment","thread_id":null,"reply_to_comment_id":null,"issue_comment_id":88888,"classification":"FIX","fix_outcome":"committed","reply_body":"ok"}
+  ]
+}
+JSON
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_IC" --owner o --repo r --pr 1 \
+  > "$TMP/ic-endpoint-out.txt" 2>&1
+if grep -qE 'repos/o/r/issues/1/comments' "$FAKE_GH_LOG" \
+   && ! grep -qE 'repos/o/r/pulls/' "$FAKE_GH_LOG"; then
+  echo "  ok: issue_comment hits /issues/N/comments (not /pulls/...)"
+else
+  echo "  FAIL: issue_comment endpoint wrong; fake-gh log: $(cat "$FAKE_GH_LOG")"
   FAIL=1
 fi
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -23,7 +23,7 @@ echo "[post-replies_test]"
 assert "script file exists" "[ -f '$SCRIPT' ]"
 assert "script is executable" "[ -x '$SCRIPT' ]"
 assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
-assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "documents inputs/outputs in header" "head -50 '$SCRIPT' | grep -qiE 'input|output|exit'"
 assert "accepts --inventory flag" "grep -q -- '--inventory' '$SCRIPT'"
 assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
 assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
@@ -398,6 +398,58 @@ if [ -f "${INV_SIDECAR_PARTIAL}.posted" ] && grep -qE '^66666$' "${INV_SIDECAR_P
   echo "  ok: partial-failure run preserves sidecar with the 66666 success"
 else
   echo "  FAIL: sidecar should exist and contain 66666 after partial run; sidecar=$(cat "${INV_SIDECAR_PARTIAL}.posted" 2>&1 || echo missing)"
+  FAIL=1
+fi
+
+# Behavior test (sidecar idempotency, --skip-comment-ids): when the operator
+# supplies --skip-comment-ids, even a 100%-success run (every item handled
+# via sidecar-skip ∪ CSV-skip) MUST preserve the sidecar. The operator has
+# externally asserted some items are already done, so the script can NOT
+# claim the sidecar is a complete record of what THIS run posted; deleting
+# it would lose prior-run POSTED state and let a subsequent retry (without
+# the flag) re-post duplicates.
+INV_SIDECAR_SKIP_CSV="$TMP/inv-sidecar-skipcsv.json"
+cat >"$INV_SIDECAR_SKIP_CSV" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {
+      "kind": "review_thread",
+      "thread_id": "T_x",
+      "reply_to_comment_id": 91111,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "x"
+    },
+    {
+      "kind": "review_thread",
+      "thread_id": "T_y",
+      "reply_to_comment_id": 92222,
+      "issue_comment_id": null,
+      "classification": "FIX",
+      "fix_outcome": "committed",
+      "reply_body": "y"
+    }
+  ]
+}
+JSON
+# Pre-populate sidecar with X (91111); operator asserts Y (92222) is done.
+printf '91111\n' > "${INV_SIDECAR_SKIP_CSV}.posted"
+PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_SKIP_CSV" --owner o --repo r --pr 1 \
+  --skip-comment-ids "92222" > "$TMP/sidecar-skipcsv-out.txt" 2>&1
+rc_skipcsv=$?
+if [ "$rc_skipcsv" = "0" ]; then
+  echo "  ok: sidecar∪CSV-only run (no POST needed) exits 0"
+else
+  echo "  FAIL: sidecar∪CSV-only run should exit 0; got $rc_skipcsv; out: $(cat "$TMP/sidecar-skipcsv-out.txt")"
+  FAIL=1
+fi
+if [ -f "${INV_SIDECAR_SKIP_CSV}.posted" ] && grep -qE '^91111$' "${INV_SIDECAR_SKIP_CSV}.posted"; then
+  echo "  ok: sidecar preserved when --skip-comment-ids supplied (prior-run POSTED record retained)"
+else
+  echo "  FAIL: sidecar must survive when --skip-comment-ids supplied; sidecar=$(cat "${INV_SIDECAR_SKIP_CSV}.posted" 2>&1 || echo missing)"
   FAIL=1
 fi
 


### PR DESCRIPTION
## Summary

Implements **agents-config-7kgbk** (P1), absorbing the duplicate **agents-config-lutqu** (P1).

Root cause was a single-line bug with wide blast radius: `post-replies.sh` extracted the per-iteration `cid` from a non-existent `.comment_id` field on inventory items (real fields are `.reply_to_comment_id` / `.issue_comment_id` / `.thread_id` per `wait-for-pr-comments/SKILL.md` §"Inventory schema"). That produced `POSTED ` and `FAILED  <reason>` lines with empty tokens, defeated `--skip-comment-ids`, and tempted operators into duplicate-posting on re-runs.

## Changes (`post-replies.sh`)

- **Per-kind cid dispatch** — `review_thread → .reply_to_comment_id`, `issue_comment → .issue_comment_id`, `review_summary → summary-<12-char sha1 of item JSON>` (synthetic but stable across same-content re-runs).
- **`review_summary` support** — previously fell through to the `/pulls/.../replies` endpoint and failed; now shares the REST `/issues/.../comments` endpoint with `issue_comment`.
- **Surface gh stderr on FAILED lines** — was swallowed by `>/dev/null 2>&1`; now appended after the bare reason label so script-internal vs API-rejection failures are distinguishable.
- **Body encoding hardened** — `printf '%s' "$body" | gh api … --field body=@-` via stdin avoids `gh`'s `-f` typed-value / `@<file>` interpretation for bodies containing apostrophes, leading `@`, or newlines.
- **Self-recording idempotency** — `<inventory>.posted` sidecar; cid appended on every successful POST, unioned with `--skip-comment-ids` on startup, deleted on 100%-success run, preserved on partial failure for the next retry.
- **Internal cleanup** — single trap-managed `$ERR` (replaces per-iteration `mktemp`); consolidated two POST branches into one `gh api $post_url` call with a `kind → (url, fail_label)` case lookup.

## Tests

`post-replies_test.sh` rewritten against the real inventory schema. **31 assertions** cover:

- POSTED/FAILED/SKIPPED contracts with non-empty cid per kind
- gh stderr surfaced into FAILED lines
- Sidecar idempotency lifecycle (record-on-success, delete-on-100%, preserve-on-partial)
- Union skip-set (sidecar ∪ `--skip-comment-ids`)
- `review_summary` synthetic cid stability across re-runs

All 7 sibling tests in `reply-and-resolve-pr-threads/` continue to pass.

## Completion gate

- **quality-reviewer**: 1 critical + 2 high + 3 major + 5 minor. C1 (`review_summary` support) + H2 (union test) + M2 (single `$ERR`) + M3 (negative-pattern guard) applied. **H1** (sentinel cid for malformed inventory items) deferred → **agents-config-zru2w** (P2 follow-up).
- **simplify**: 3 parallel reviewers. POST-branch consolidation applied (quality finding). Reuse + efficiency findings judged not-warranted.
- **verify-checklist**: tests green, constraint sweep clean (no tracker IDs in code/docs), worktree isolated.

## Test plan

- [x] `bash src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh` → 31 ok / 0 FAIL
- [x] All 7 `*_test.sh` files in the skill folder pass
- [ ] Run end-to-end on the next PR that lands `wait-for-pr-comments` → `reply-and-resolve-pr-threads` to confirm real-world POSTED lines name the cid and sidecar deletes cleanly on 100%-success

🤖 Generated with [Claude Code](https://claude.com/claude-code)