### PR TITLE
Standardize PR-review helper script parameterization to --flag convention

### DIFF
--- a/src/user/.agents/skills/merge-guard/SKILL.md
+++ b/src/user/.agents/skills/merge-guard/SKILL.md
@@ -42,7 +42,7 @@ digraph merge_guard {
 
 ### Step 1: Determine PR Context
 
-Identify the `owner/repo` and PR number from:
+Identify `owner`, `repo`, and PR number from:
 1. Explicit argument or conversation context
 2. Current branch: `gh pr view --json number,url`
 
@@ -51,7 +51,7 @@ Track how many review comments you have already seen and triaged in this convers
 ### Step 2: Run Eligibility Check
 
 ```bash
-${CLAUDE_SKILL_DIR}/check-merge-eligibility.sh <owner/repo> <pr-number> <comments-seen>
+${CLAUDE_SKILL_DIR}/check-merge-eligibility.sh --owner <owner> --repo <repo> --pr <pr-number> --comments-seen <n>
 ```
 
 The script checks three things:

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -2,11 +2,13 @@
 # check-merge-eligibility.sh — Check whether a PR is safe to merge.
 # Verifies no pending automated reviews and no unseen review comments.
 #
-# Usage: check-merge-eligibility.sh <owner/repo> <pr-number> <comments-seen>
+# Usage: check-merge-eligibility.sh --owner <owner> --repo <repo> --pr <pr-number> --comments-seen <n>
 #
-#   owner/repo     — GitHub repository (e.g. "octocat/hello-world")
-#   pr-number      — Pull request number
-#   comments-seen  — Number of review comments the agent has already triaged.
+# Inputs:
+#   --owner          GitHub owner (e.g. "octocat")
+#   --repo           GitHub repository name (e.g. "hello-world")
+#   --pr             Pull request number
+#   --comments-seen  Number of review comments the agent has already triaged.
 #                    Pass 0 if the agent has not seen any comments.
 #
 # Exit codes:
@@ -27,24 +29,28 @@ set -euo pipefail
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 usage() {
-    echo "Usage: $0 <owner/repo> <pr-number> <comments-seen>" >&2
+    echo "Usage: $0 --owner <owner> --repo <repo> --pr <pr-number> --comments-seen <n>" >&2
     exit 3
 }
 
-[[ $# -ge 3 ]] || usage
+OWNER=""; REPO=""; PR=""; COMMENTS_SEEN=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --owner)         [[ $# -ge 2 ]] || usage; OWNER="${2:-}";         shift 2 ;;
+        --repo)          [[ $# -ge 2 ]] || usage; REPO="${2:-}";          shift 2 ;;
+        --pr)            [[ $# -ge 2 ]] || usage; PR="${2:-}";            shift 2 ;;
+        --comments-seen) [[ $# -ge 2 ]] || usage; COMMENTS_SEEN="${2:-}"; shift 2 ;;
+        *) usage ;;
+    esac
+done
 
-REPO="$1"
-PR="$2"
-COMMENTS_SEEN="$3"
+[[ -n "$OWNER"         ]] || usage
+[[ -n "$REPO"          ]] || usage
+[[ -n "$PR"            ]] || usage
+[[ -n "$COMMENTS_SEEN" ]] || usage
 
-# Validate owner/repo format
-[[ "$REPO" == */* ]] || { echo "Error: first argument must be owner/repo" >&2; exit 3; }
-
-# Validate PR number is a positive integer
-[[ "$PR" =~ ^[0-9]+$ ]] || { echo "Error: PR number must be a positive integer" >&2; exit 3; }
-
-# Validate comments-seen is a non-negative integer
-[[ "$COMMENTS_SEEN" =~ ^[0-9]+$ ]] || { echo "Error: comments-seen must be a non-negative integer" >&2; exit 3; }
+[[ "$PR"            =~ ^[0-9]+$ ]] || { echo "Error: --pr must be a positive integer" >&2; exit 3; }
+[[ "$COMMENTS_SEEN" =~ ^[0-9]+$ ]] || { echo "Error: --comments-seen must be a non-negative integer" >&2; exit 3; }
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -78,7 +84,7 @@ if ! command -v jq &>/dev/null; then
 fi
 
 # Verify PR exists and is open
-pr_state=$(gh_api "repos/${REPO}/pulls/${PR}" --jq '.state') || {
+pr_state=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.state') || {
     echo "Error: failed to fetch PR #${PR}" >&2; exit 3;
 }
 if [[ "$pr_state" != "open" ]]; then
@@ -90,7 +96,7 @@ fi
 
 echo "Checking pending reviewers..." >&2
 
-pending_json=$(gh_api "repos/${REPO}/pulls/${PR}/requested_reviewers") || {
+pending_json=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/requested_reviewers") || {
     echo "Error: failed to fetch requested reviewers" >&2; exit 3;
 }
 
@@ -107,7 +113,7 @@ echo "Checking Copilot review status..." >&2
 
 # Was Copilot requested?
 copilot_requested=false
-request_count=$(gh_api "repos/${REPO}/issues/${PR}/events" \
+request_count=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events" \
     --jq "[.[] | select(
         .event == \"review_requested\" and
         .requested_reviewer.login and
@@ -125,7 +131,7 @@ fi
 # Did Copilot start working?
 copilot_work_started=false
 if [[ "$copilot_requested" == true ]]; then
-    work_count=$(gh_api "repos/${REPO}/issues/${PR}/events" \
+    work_count=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events" \
         --jq '[.[] | select(.event == "copilot_work_started")] | length') || work_count=0
 
     if [[ "$work_count" -gt 0 ]]; then
@@ -137,7 +143,7 @@ fi
 # Did Copilot complete a review?
 copilot_review_complete=false
 if [[ "$copilot_requested" == true ]]; then
-    review_count=$(gh_api "repos/${REPO}/pulls/${PR}/reviews" \
+    review_count=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" \
         --jq "[.[] | select(
             (.user.type == \"Bot\") and
             (.user.login | ${COPILOT_LOGIN_FILTER}) and
@@ -154,7 +160,7 @@ fi
 
 echo "Checking comment counts..." >&2
 
-total_comments=$(gh_api "repos/${REPO}/pulls/${PR}/comments" --jq 'length') || {
+total_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" --jq 'length') || {
     echo "Error: failed to fetch comments" >&2; exit 3;
 }
 

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Smoke test for check-merge-eligibility.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/check-merge-eligibility.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[check-merge-eligibility_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --comments-seen flag" "grep -q -- '--comments-seen' '$SCRIPT'"
+assert "no positional owner/repo parsing" "! grep -qE '^\s*REPO=\"\\\$1\"' '$SCRIPT'"
+
+# Missing required flags — exit 3
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "exits 3 with no flags" "[ \$rc_no_args -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 2>/dev/null
+rc_no_cs=$?
+assert "exits 3 when --comments-seen missing" "[ \$rc_no_cs -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --comments-seen 0 2>/dev/null
+rc_no_pr=$?
+assert "exits 3 when --pr missing" "[ \$rc_no_pr -eq 3 ]"
+
+"$SCRIPT" --owner o --pr 1 --comments-seen 0 2>/dev/null
+rc_no_repo=$?
+assert "exits 3 when --repo missing" "[ \$rc_no_repo -eq 3 ]"
+
+"$SCRIPT" --repo r --pr 1 --comments-seen 0 2>/dev/null
+rc_no_owner=$?
+assert "exits 3 when --owner missing" "[ \$rc_no_owner -eq 3 ]"
+
+# Bad numeric values
+"$SCRIPT" --owner o --repo r --pr notanumber --comments-seen 0 2>/dev/null
+rc_bad_pr=$?
+assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --comments-seen notanumber 2>/dev/null
+rc_bad_cs=$?
+assert "exits 3 for non-integer --comments-seen" "[ \$rc_bad_cs -eq 3 ]"
+
+# Unknown flag
+"$SCRIPT" --owner o --repo r --pr 1 --comments-seen 0 --bogus 2>/dev/null
+rc_bogus=$?
+assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
+
+# Trailing flag with no value — must exit 3 (not silent exit 1)
+"$SCRIPT" --owner 2>/dev/null
+rc_dangling=$?
+assert "exits 3 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 3 ]"
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -53,7 +53,7 @@ Plus tail tokens (operator narration) that are warned-and-ignored.
 3. Bad JSON or missing file at the supplied path = fatal error (do NOT silently fall through).
 4. `--mode autonomous` without `--bead-id` = fatal error.
 5. Standalone invocation (no `--from-inventory` and no `--resume`) = fatal error in v1 (standalone mode is deferred to a follow-up bead).
-6. Schema validation (`validate-inventory.sh <path>`) failure = fatal error.
+6. Schema validation (`validate-inventory.sh --inventory <path>`) failure = fatal error.
 
 On any fatal error: emit a one-line diagnostic naming the rule violated, abort. No replies posted. No inventory writes.
 
@@ -72,7 +72,7 @@ Apply the six Phase 0 precedence rules above. After mode is resolved, run schema
 
 ```bash
 ~/.claude/skills/wait-for-pr-comments/validate-inventory.sh \
-  --phase 0 <inventory-path> \
+  --phase 0 --inventory <inventory-path> \
   || { echo "schema validation failed"; exit 1; }
 ```
 
@@ -228,7 +228,7 @@ ${CLAUDE_SKILL_DIR}/render-reply-bodies.sh \
 `render-reply-bodies.sh` populated every replyable item):
 
 ```bash
-~/.claude/skills/wait-for-pr-comments/validate-inventory.sh "$RENDERED" \
+~/.claude/skills/wait-for-pr-comments/validate-inventory.sh --inventory "$RENDERED" \
   || { echo "post-render validation failed"; exit 1; }
 ```
 

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -81,7 +81,7 @@ default). Formulas pass `--mode autonomous --bead-id {{bead-id}}` explicitly.
 
 **9 phases total** (Phase 5 has three sub-phases). Each named phase is one
 named action with one defined failure mode. Unless otherwise noted, any
-unrecoverable failure invokes `write-inventory.sh partial <phase-id> <path>`,
+unrecoverable failure invokes `write-inventory.sh --state partial --phase <phase-id> --output <path>`,
 reports to the caller, and aborts (Skill B is NOT invoked on Phase 5x
 failure).
 
@@ -121,8 +121,8 @@ Background bash — zero Anthropic tokens during the wait.
     ```
 2. **Capture** `<polling_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
     This timestamp anchors the stale-cache guard for re-review rounds.
-3. **Launch** `poll-copilot-review.sh` in the background. Pass
-    `--skip-request-check` if step 1 returned > 0.
+3. **Launch** `poll-copilot-review.sh --owner "$OWNER" --repo "$REPO" --pr "$PR"` in the background.
+    Pass `--skip-request-check` if step 1 returned > 0.
     In re-review context (round ≥ 2), also pass
     `--since-timestamp <polling_since_timestamp>` so the script rejects
     reviews that predate this run.
@@ -268,8 +268,9 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  partial 5a-verify-failed \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state partial \
+  --phase 5a-verify-failed \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < /tmp/pr-inventory-build-<n>.json
 
 rm -f /tmp/pr-inventory-build-<n>.json
@@ -285,8 +286,9 @@ Confirm each FIX/`committed` item's `fix_commit_sha` is in
 and invoke:
 ```bash
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  partial 5b-commit-verify-failed \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state partial \
+  --phase 5b-commit-verify-failed \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < /tmp/pr-inventory-build-<n>.json
 
 rm -f /tmp/pr-inventory-build-<n>.json
@@ -301,8 +303,9 @@ Run `git push`.
 (no remote update happened), then:
 ```bash
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  partial 5c-push-failed \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state partial \
+  --phase 5c-push-failed \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < /tmp/pr-inventory-build-<n>.json
 
 rm -f /tmp/pr-inventory-build-<n>.json
@@ -330,11 +333,12 @@ Abort.
 
 2. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 
-3. **Launch** `poll-copilot-rereview-start.sh` (80s max window:
+3. **Launch** `poll-copilot-rereview-start.sh --owner "$OWNER" --repo "$REPO" --pr "$PR" --after <rereview_since_timestamp>` (80s max window:
    20s pre-sleep + 6 × 10s polls). This detects the `copilot_work_started`
    event that follows the fresh `review_requested`.
 
 4. **If** `copilot_work_started` detected, launch `poll-copilot-review.sh
+   --owner "$OWNER" --repo "$REPO" --pr "$PR"
    --skip-request-check --since-timestamp <rereview_since_timestamp>`
    to await the actual review. The `--since-timestamp` guard prevents the
    stale-cache bug where the script returns the prior round's review instead
@@ -364,8 +368,9 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  complete 7-write-inventory \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state complete \
+  --phase 7-write-inventory \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < /tmp/pr-inventory-build-<n>.json
 
 rm -f /tmp/pr-inventory-build-<n>.json
@@ -392,8 +397,9 @@ Skill(skill: "reply-and-resolve-pr-threads", args: "--from-inventory <path> [--m
 Write the intermediate completion marker so recovery knows Skill B ran:
 ```bash
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  complete 8-skill-b-done \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state complete \
+  --phase 8-skill-b-done \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json
 ```
 Then proceed to Phase 9.
@@ -424,8 +430,9 @@ considering the await-review step done.
 4. **If count == 0**: write final completion state and clean up:
    ```bash
    ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-     complete 9-final-check-done \
-     ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+     --state complete \
+     --phase 9-final-check-done \
+     --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
      < ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json
 
    rm -f ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json
@@ -690,8 +697,9 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 
 ${CLAUDE_SKILL_DIR}/write-inventory.sh \
-  <state> <last_completed_phase> \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --state <state> \
+  --phase <last_completed_phase> \
+  --output ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   < /tmp/pr-inventory-build-<n>.json
 
 rm -f /tmp/pr-inventory-build-<n>.json
@@ -762,7 +770,7 @@ agent has a copy-pasteable template:
 
 ```bash
 ${CLAUDE_SKILL_DIR}/validate-inventory.sh \
-  ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
+  --inventory ~/.claude/state/pr-inventory/<owner>-<repo>-<n>-<sha>.json \
   || { echo "schema validation failed"; exit 1; }
 ```
 
@@ -900,13 +908,13 @@ process.
 | "The subagent's `already_addressed` report just says 'fixed earlier' — close enough" | Reject. The subagent MUST quote a diff hunk in `fix_summary` (audit guard). Re-classify to ESCALATE with `"subagent contract violated: already_addressed missing diff evidence"`. |
 | "A subagent committed twice — I'll just keep both commits" | Audit guard violated (`expected exactly one commit`). Re-classify to ESCALATE; if commits are stale/broken, `git reset --soft <pre_subagent_sha>` + `git stash push --include-untracked` to isolate. **Never `git reset --hard`.** |
 | "I'll let the agent write its own classification rationale, blank if needed" | Empty rationale is rejected by validation guard 1 (SKIP rationale becomes the public reply). Retry per-item classification with an explicit prompt until rationale is non-empty. |
-| "Phase 5a verify failed but the fixes look fine — push anyway" | No. 5x failures abort the chain. Invoke `write-inventory.sh partial 5a-verify-failed <path>` and report. Skill B is NOT invoked on Phase 5x failure. |
+| "Phase 5a verify failed but the fixes look fine — push anyway" | No. 5x failures abort the chain. Invoke `write-inventory.sh --state partial --phase 5a-verify-failed --output <path>` and report. Skill B is NOT invoked on Phase 5x failure. |
 | "I'll keep polling past the re-review window" | Phase 6 uses a fixed 80s max window (20s pre-sleep + 6 × 10s polls). Do not extend ad-hoc. If Copilot has not started by then, exit Phase 6 normally and proceed to Phase 7. |
 | "I'll merge while the polling script is still running" | Don't. Issue the guard warning; the review could arrive any moment. |
 | "I'll classify already-addressed items as their own bucket" | Already-addressed is NOT a classification. Classify FIX; the per-comment subagent returns `fix_outcome="already_addressed"` with the existing commit SHA. |
 | "Round 4 of re-review is fine, Copilot's just being thorough" | Hard cap fires when round >= 3 AND a new review arrives. Mark FIX-classified round-N+1 items as `ESCALATE` with rationale `"exceeded re-review round cap"`. |
 | "I'll inline `--mode autonomous` from the hook text" | The hook does not pass `--mode`. Autonomous mode is set ONLY by formulas (which also pass `--bead-id`). If you're invoking from chat, leave it interactive. |
-| "Skill B failed but I'll unlink the inventory anyway" | No. On Skill B failure, leave the inventory in place. Skill A only unlinks after Phase 9 final check passes and `write-inventory.sh complete 9-final-check-done` succeeds. |
+| "Skill B failed but I'll unlink the inventory anyway" | No. On Skill B failure, leave the inventory in place. Skill A only unlinks after Phase 9 final check passes and `write-inventory.sh --state complete --phase 9-final-check-done --output <path>` succeeds. |
 | "I'll keep the squashed commits clean — combine all subagent fixes into one" | Each subagent's commit stands alone. **No squashing.** Commit message format pinned: `fix(<scope>): <summary> (PR #<n> comment <comment_id>)`. |
 | "I'll let the per-comment fix subagent inherit the orchestrator's model" | Wrong. The orchestrator runs `sonnet[1m]` (this skill's frontmatter). Inheriting means the fix subagent ALSO runs on `sonnet[1m]`, which regresses fix correctness — `wait-for-pr-comments` is the cheap triage tier; **fix work needs `opus`**. The Phase 4 `Agent({...})` dispatch MUST set `model: "opus"` explicitly. |
 

--- a/src/user/.agents/skills/wait-for-pr-comments/lib.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/lib.sh
@@ -13,11 +13,6 @@ gh_api() {
     printf '%s' "$result"
 }
 
-# Validate owner/repo format — exits 3 on failure
-validate_repo() {
-    [[ "$1" == */* ]] || { echo "Error: first argument must be owner/repo" >&2; exit 3; }
-}
-
 # Pre-flight: verify gh auth and jq availability — exits 3 on failure
 preflight_checks() {
     if ! gh auth status &>/dev/null; then

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -3,9 +3,9 @@
 # Looks for a copilot_work_started event that postdates the given timestamp.
 # Used after fixes are pushed to check if Copilot will perform a second pass.
 #
-# Usage: poll-copilot-rereview-start.sh <owner/repo> <pr-number> <after-timestamp>
+# Usage: poll-copilot-rereview-start.sh --owner <o> --repo <r> --pr <n> --after <ISO-8601-timestamp>
 #
-# after-timestamp: ISO 8601 timestamp — only events after this time are considered
+# --after: ISO 8601 timestamp — only events after this time are considered
 #
 # Configurable polling (set as env vars; defaults give the historical 80s window):
 #   INITIAL_SLEEP   pre-poll delay in seconds (default: 20)
@@ -31,23 +31,34 @@ source "$(dirname "$0")/lib.sh"
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 usage() {
-    echo "Usage: $0 <owner/repo> <pr-number> <after-timestamp>" >&2
+    echo "Usage: $0 --owner <o> --repo <r> --pr <n> --after <ISO-8601-timestamp>" >&2
     exit 3
 }
 
-[[ $# -eq 3 ]] || usage
-
-REPO="$1"
-PR="$2"
-AFTER="$3"
+OWNER=""
+REPO=""
+PR=""
+AFTER=""
 
 INITIAL_SLEEP="${INITIAL_SLEEP:-20}"
 POLL_INTERVAL="${POLL_INTERVAL:-10}"
 POLL_COUNT="${POLL_COUNT:-6}"
 
-validate_repo "$REPO"
-[[ "$PR" =~ ^[0-9]+$ ]] || { echo "Error: PR number must be a positive integer" >&2; exit 3; }
-[[ -n "$AFTER" ]] || { echo "Error: after-timestamp must not be empty" >&2; exit 3; }
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --owner) OWNER="${2:-}"; shift 2 ;;
+        --repo)  REPO="${2:-}";  shift 2 ;;
+        --pr)    PR="${2:-}";    shift 2 ;;
+        --after) AFTER="${2:-}"; shift 2 ;;
+        *) echo "Error: unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+[[ -n "$OWNER" ]] || { echo "Error: --owner is required" >&2; usage; }
+[[ -n "$REPO"  ]] || { echo "Error: --repo is required" >&2; usage; }
+[[ -n "$PR"    ]] || { echo "Error: --pr is required" >&2; usage; }
+[[ -n "$AFTER" ]] || { echo "Error: --after is required" >&2; usage; }
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "Error: --pr must be a positive integer" >&2; exit 3; }
 [[ "$INITIAL_SLEEP" =~ ^[0-9]+$ ]] || { echo "Error: INITIAL_SLEEP must be a non-negative integer" >&2; exit 3; }
 [[ "$POLL_INTERVAL" =~ ^[0-9]+$ ]] || { echo "Error: POLL_INTERVAL must be a non-negative integer" >&2; exit 3; }
 [[ "$POLL_COUNT" =~ ^[0-9]+$ ]] || { echo "Error: POLL_COUNT must be a non-negative integer" >&2; exit 3; }
@@ -65,7 +76,7 @@ sleep "$INITIAL_SLEEP"
 for ((i = 1; i <= POLL_COUNT; i++)); do
     sleep "$POLL_INTERVAL"
 
-    events=$(gh_api "repos/${REPO}/issues/${PR}/events" \
+    events=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events" \
         --jq "[.[] | select(.event == \"copilot_work_started\" and .created_at > \"${AFTER}\")]") || {
         echo "Warning: events API failed (attempt ${i}), continuing" >&2
         continue

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -46,10 +46,10 @@ POLL_COUNT="${POLL_COUNT:-6}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --owner) OWNER="${2:-}"; shift 2 ;;
-        --repo)  REPO="${2:-}";  shift 2 ;;
-        --pr)    PR="${2:-}";    shift 2 ;;
-        --after) AFTER="${2:-}"; shift 2 ;;
+        --owner) [[ $# -ge 2 ]] || usage; OWNER="${2:-}"; shift 2 ;;
+        --repo)  [[ $# -ge 2 ]] || usage; REPO="${2:-}";  shift 2 ;;
+        --pr)    [[ $# -ge 2 ]] || usage; PR="${2:-}";    shift 2 ;;
+        --after) [[ $# -ge 2 ]] || usage; AFTER="${2:-}"; shift 2 ;;
         *) echo "Error: unknown argument: $1" >&2; usage ;;
     esac
 done

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
@@ -53,4 +53,9 @@ assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
 rc_bogus=$?
 assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
 
+# Trailing flag with no value — must exit 3 (not silent exit 1)
+"$SCRIPT" --owner 2>/dev/null
+rc_dangling=$?
+assert "exits 3 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 3 ]"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Smoke test for poll-copilot-rereview-start.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/poll-copilot-rereview-start.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[poll-copilot-rereview-start_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -25 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --after flag" "grep -q -- '--after' '$SCRIPT'"
+assert "no positional owner/repo parsing" "! grep -qE '^\s*REPO=\"\\\$1\"' '$SCRIPT'"
+
+# Missing required flags — exit 3
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "exits 3 with no flags" "[ \$rc_no_args -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 2>/dev/null
+rc_no_after=$?
+assert "exits 3 when --after missing" "[ \$rc_no_after -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --after 2026-01-01T00:00:00Z 2>/dev/null
+rc_no_pr=$?
+assert "exits 3 when --pr missing" "[ \$rc_no_pr -eq 3 ]"
+
+# Bad --pr value
+"$SCRIPT" --owner o --repo r --pr notanumber --after 2026-01-01T00:00:00Z 2>/dev/null
+rc_bad_pr=$?
+assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
+
+# Unknown flag
+"$SCRIPT" --owner o --repo r --pr 1 --after 2026-01-01T00:00:00Z --bogus 2>/dev/null
+rc_bogus=$?
+assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -39,9 +39,9 @@ SINCE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --owner) OWNER="${2:-}"; shift 2 ;;
-        --repo)  REPO="${2:-}";  shift 2 ;;
-        --pr)    PR="${2:-}";    shift 2 ;;
+        --owner) [[ $# -ge 2 ]] || usage; OWNER="${2:-}"; shift 2 ;;
+        --repo)  [[ $# -ge 2 ]] || usage; REPO="${2:-}";  shift 2 ;;
+        --pr)    [[ $# -ge 2 ]] || usage; PR="${2:-}";    shift 2 ;;
         --skip-request-check)
             SKIP_REQUEST=true
             shift

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -3,7 +3,7 @@
 # Replaces the background agent polling in wait-for-pr-comments skill.
 # Zero Anthropic API tokens consumed — pure bash + gh CLI.
 #
-# Usage: poll-copilot-review.sh <owner/repo> <pr-number> [--skip-request-check] [--since-timestamp <ISO-8601>]
+# Usage: poll-copilot-review.sh --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>]
 #
 # Exit codes:
 #   0 — Review found (JSON on stdout)
@@ -27,20 +27,21 @@ source "$(dirname "$0")/lib.sh"
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 usage() {
-    echo "Usage: $0 <owner/repo> <pr-number> [--skip-request-check] [--since-timestamp <ISO-8601>]" >&2
+    echo "Usage: $0 --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>]" >&2
     exit 3
 }
 
-[[ $# -ge 2 ]] || usage
-
-REPO="$1"
-PR="$2"
+OWNER=""
+REPO=""
+PR=""
 SKIP_REQUEST=false
 SINCE=""
 
-shift 2
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --owner) OWNER="${2:-}"; shift 2 ;;
+        --repo)  REPO="${2:-}";  shift 2 ;;
+        --pr)    PR="${2:-}";    shift 2 ;;
         --skip-request-check)
             SKIP_REQUEST=true
             shift
@@ -52,15 +53,17 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Error: unknown argument: $1" >&2
-            exit 3
+            usage
             ;;
     esac
 done
 
-validate_repo "$REPO"
+[[ -n "$OWNER" ]] || { echo "Error: --owner is required" >&2; usage; }
+[[ -n "$REPO"  ]] || { echo "Error: --repo is required" >&2; usage; }
+[[ -n "$PR"    ]] || { echo "Error: --pr is required" >&2; usage; }
 
 # Validate PR number is a positive integer
-[[ "$PR" =~ ^[0-9]+$ ]] || { echo "Error: PR number must be a positive integer" >&2; exit 3; }
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "Error: --pr must be a positive integer" >&2; exit 3; }
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -74,7 +77,7 @@ COPILOT_REVIEW_FILTER="(.user.type == \"Bot\") and (.user.login | ${COPILOT_LOGI
 
 pr_is_open() {
     local state
-    state=$(gh_api "repos/${REPO}/pulls/${PR}" --jq '.state') || return 1
+    state=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.state') || return 1
     [[ "$state" == "open" ]]
 }
 
@@ -89,7 +92,7 @@ if [[ "$SKIP_REQUEST" == false ]]; then
     copilot_requested=false
 
     for i in 1 2 3; do
-        count=$(gh_api "repos/${REPO}/issues/${PR}/events" \
+        count=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events" \
             --jq "[.[] | select(
                 .event == \"review_requested\" and
                 .requested_reviewer.login and
@@ -120,7 +123,7 @@ fi
 echo "Sub-phase B: Checking for copilot_work_started event..." >&2
 
 for i in 1 2 3; do
-    count=$(gh_api "repos/${REPO}/issues/${PR}/events" \
+    count=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events" \
         --jq '[.[] | select(.event == "copilot_work_started")] | length') || {
         echo "Warning: events API failed during start detection, proceeding anyway" >&2
         break
@@ -155,7 +158,7 @@ for i in $(seq 1 20); do
     fi
 
     # Single fetch — derive count from the same response (avoids double API call)
-    reviews=$(gh_api "repos/${REPO}/pulls/${PR}/reviews" \
+    reviews=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/reviews" \
         --jq "[.[] | select(${COPILOT_REVIEW_FILTER})]") || {
         echo "Warning: reviews API failed (attempt ${i})" >&2; sleep 30; continue;
     }
@@ -176,7 +179,7 @@ for i in $(seq 1 20); do
         echo "  Copilot review found (attempt ${i})" >&2
 
         # Single fetch for all comments — split into copilot/human client-side
-        all_comments=$(gh_api "repos/${REPO}/pulls/${PR}/comments") || {
+        all_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments") || {
             echo "Error: failed to fetch comments" >&2; exit 3;
         }
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -56,4 +56,9 @@ assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
 rc_bogus=$?
 assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
 
+# Trailing flag with no value — must exit 3 (not silent exit 1)
+"$SCRIPT" --owner 2>/dev/null
+rc_dangling=$?
+assert "exits 3 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 3 ]"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Smoke test for poll-copilot-review.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/poll-copilot-review.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[poll-copilot-review_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -25 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "no positional owner/repo parsing" "! grep -qE '^\s*REPO=\"\\\$1\"' '$SCRIPT'"
+
+# Missing required flags — exit 3
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "exits 3 with no flags" "[ \$rc_no_args -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r 2>/dev/null
+rc_no_pr=$?
+assert "exits 3 when --pr missing" "[ \$rc_no_pr -eq 3 ]"
+
+"$SCRIPT" --owner o --pr 1 2>/dev/null
+rc_no_repo=$?
+assert "exits 3 when --repo missing" "[ \$rc_no_repo -eq 3 ]"
+
+"$SCRIPT" --repo r --pr 1 2>/dev/null
+rc_no_owner=$?
+assert "exits 3 when --owner missing" "[ \$rc_no_owner -eq 3 ]"
+
+# Bad --pr value
+"$SCRIPT" --owner o --repo r --pr notanumber 2>/dev/null
+rc_bad_pr=$?
+assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
+
+# Unknown flag
+"$SCRIPT" --owner o --repo r --pr 1 --bogus 2>/dev/null
+rc_bogus=$?
+assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments.sh
@@ -37,12 +37,12 @@ MAX_DURATION=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --owner)        OWNER="${2:-}";        shift 2 ;;
-        --repo)         REPO="${2:-}";         shift 2 ;;
-        --pr)           PR="${2:-}";           shift 2 ;;
-        --baseline)     BASELINE="${2:-}";     shift 2 ;;
-        --interval)     INTERVAL="${2:-}";     shift 2 ;;
-        --max-duration) MAX_DURATION="${2:-}"; shift 2 ;;
+        --owner)        [[ $# -ge 2 ]] || usage; OWNER="${2:-}";        shift 2 ;;
+        --repo)         [[ $# -ge 2 ]] || usage; REPO="${2:-}";         shift 2 ;;
+        --pr)           [[ $# -ge 2 ]] || usage; PR="${2:-}";           shift 2 ;;
+        --baseline)     [[ $# -ge 2 ]] || usage; BASELINE="${2:-}";     shift 2 ;;
+        --interval)     [[ $# -ge 2 ]] || usage; INTERVAL="${2:-}";     shift 2 ;;
+        --max-duration) [[ $# -ge 2 ]] || usage; MAX_DURATION="${2:-}"; shift 2 ;;
         *) echo "Error: unknown argument: $1" >&2; usage ;;
     esac
 done

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments.sh
@@ -3,7 +3,7 @@
 # Replaces CronCreate-based re-poll in wait-for-pr-comments skill.
 # Zero Anthropic API tokens consumed — pure bash + gh CLI.
 #
-# Usage: poll-new-comments.sh <owner/repo> <pr-number> <baseline-count> <interval-secs> <max-duration-secs>
+# Usage: poll-new-comments.sh --owner <o> --repo <r> --pr <n> --baseline <count> --interval <secs> --max-duration <secs>
 #
 # Exit codes:
 #   0 — New comments found (JSON on stdout)
@@ -24,27 +24,43 @@ source "$(dirname "$0")/lib.sh"
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 usage() {
-    echo "Usage: $0 <owner/repo> <pr-number> <baseline-count> <interval-secs> <max-duration-secs>" >&2
+    echo "Usage: $0 --owner <o> --repo <r> --pr <n> --baseline <count> --interval <secs> --max-duration <secs>" >&2
     exit 3
 }
 
-[[ $# -eq 5 ]] || usage
+OWNER=""
+REPO=""
+PR=""
+BASELINE=""
+INTERVAL=""
+MAX_DURATION=""
 
-REPO="$1"
-PR="$2"
-BASELINE="$3"
-INTERVAL="$4"
-MAX_DURATION="$5"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --owner)        OWNER="${2:-}";        shift 2 ;;
+        --repo)         REPO="${2:-}";         shift 2 ;;
+        --pr)           PR="${2:-}";           shift 2 ;;
+        --baseline)     BASELINE="${2:-}";     shift 2 ;;
+        --interval)     INTERVAL="${2:-}";     shift 2 ;;
+        --max-duration) MAX_DURATION="${2:-}"; shift 2 ;;
+        *) echo "Error: unknown argument: $1" >&2; usage ;;
+    esac
+done
 
-validate_repo "$REPO"
+[[ -n "$OWNER" ]]        || { echo "Error: --owner is required" >&2; usage; }
+[[ -n "$REPO"  ]]        || { echo "Error: --repo is required" >&2; usage; }
+[[ -n "$PR"    ]]        || { echo "Error: --pr is required" >&2; usage; }
+[[ -n "$BASELINE" ]]     || { echo "Error: --baseline is required" >&2; usage; }
+[[ -n "$INTERVAL" ]]     || { echo "Error: --interval is required" >&2; usage; }
+[[ -n "$MAX_DURATION" ]] || { echo "Error: --max-duration is required" >&2; usage; }
 
 # Validate numeric arguments
 for arg in "$PR" "$BASELINE" "$INTERVAL" "$MAX_DURATION"; do
     [[ "$arg" =~ ^[0-9]+$ ]] || { echo "Error: numeric arguments must be non-negative integers" >&2; exit 3; }
 done
 
-[[ "$INTERVAL" -gt 0 ]] || { echo "Error: interval must be > 0" >&2; exit 3; }
-[[ "$MAX_DURATION" -gt 0 ]] || { echo "Error: max-duration must be > 0" >&2; exit 3; }
+[[ "$INTERVAL" -gt 0 ]]    || { echo "Error: --interval must be > 0" >&2; exit 3; }
+[[ "$MAX_DURATION" -gt 0 ]] || { echo "Error: --max-duration must be > 0" >&2; exit 3; }
 
 # ── Pre-flight checks ────────────────────────────────────────────────────────
 
@@ -62,7 +78,7 @@ for i in $(seq 1 "$max_iterations"); do
     sleep "$INTERVAL"
 
     # Single fetch — derive count client-side (avoids double API call on detection)
-    comments=$(gh_api "repos/${REPO}/pulls/${PR}/comments") || {
+    comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments") || {
         echo "Warning: comments API failed (attempt ${i}), continuing" >&2
         continue
     }

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Smoke test for poll-new-comments.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/poll-new-comments.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[poll-new-comments_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -25 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --owner flag" "grep -q -- '--owner' '$SCRIPT'"
+assert "accepts --repo flag" "grep -q -- '--repo' '$SCRIPT'"
+assert "accepts --pr flag" "grep -q -- '--pr' '$SCRIPT'"
+assert "accepts --baseline flag" "grep -q -- '--baseline' '$SCRIPT'"
+assert "accepts --interval flag" "grep -q -- '--interval' '$SCRIPT'"
+assert "accepts --max-duration flag" "grep -q -- '--max-duration' '$SCRIPT'"
+assert "no positional owner/repo parsing" "! grep -qE '^\s*REPO=\"\\\$1\"' '$SCRIPT'"
+
+# Missing required flags — exit 3
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "exits 3 with no flags" "[ \$rc_no_args -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --baseline 0 --interval 5 2>/dev/null
+rc_no_max=$?
+assert "exits 3 when --max-duration missing" "[ \$rc_no_max -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --baseline 0 --max-duration 60 2>/dev/null
+rc_no_interval=$?
+assert "exits 3 when --interval missing" "[ \$rc_no_interval -eq 3 ]"
+
+# Bad numeric values
+"$SCRIPT" --owner o --repo r --pr notanumber --baseline 0 --interval 5 --max-duration 60 2>/dev/null
+rc_bad_pr=$?
+assert "exits 3 for non-integer --pr" "[ \$rc_bad_pr -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --baseline 0 --interval 0 --max-duration 60 2>/dev/null
+rc_zero_interval=$?
+assert "exits 3 for --interval 0" "[ \$rc_zero_interval -eq 3 ]"
+
+# Unknown flag
+"$SCRIPT" --owner o --repo r --pr 1 --baseline 0 --interval 5 --max-duration 60 --bogus 2>/dev/null
+rc_bogus=$?
+assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
+
+exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-new-comments_test.sh
@@ -59,4 +59,9 @@ assert "exits 3 for --interval 0" "[ \$rc_zero_interval -eq 3 ]"
 rc_bogus=$?
 assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
 
+# Trailing flag with no value — must exit 3 (not silent exit 1)
+"$SCRIPT" --owner 2>/dev/null
+rc_dangling=$?
+assert "exits 3 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 3 ]"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -7,7 +7,7 @@
 # pass; non-zero with a human-readable error to stderr otherwise.
 #
 # Usage:
-#   validate-inventory.sh [--phase 0|2] <inventory_json_path>
+#   validate-inventory.sh --inventory <inventory_json_path> [--phase 0|2]
 #
 # --phase controls which guards run:
 #   --phase 2 (default) — runs all ten guards (the full post-render contract)
@@ -30,12 +30,17 @@ PHASE="2"
 PATH_IN=""
 
 usage() {
-    echo "usage: validate-inventory.sh [--phase 0|2] <inventory_json_path>" >&2
+    echo "usage: validate-inventory.sh --inventory <inventory_json_path> [--phase 0|2]" >&2
     exit 64
 }
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --inventory)
+            [ "$#" -ge 2 ] || usage
+            PATH_IN="$2"
+            shift 2
+            ;;
         --phase)
             [ "$#" -ge 2 ] || usage
             PHASE="$2"
@@ -44,14 +49,9 @@ while [ "$#" -gt 0 ]; do
         -h|--help)
             usage
             ;;
-        --*)
+        *)
             echo "error: unknown flag: $1" >&2
             usage
-            ;;
-        *)
-            [ -z "$PATH_IN" ] || usage
-            PATH_IN="$1"
-            shift
             ;;
     esac
 done

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
@@ -28,18 +28,24 @@ assert "script file exists" "[ -f '$SCRIPT' ]"
 assert "script is executable" "[ -x '$SCRIPT' ]"
 assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
 assert "documents --phase flag in header" "head -30 '$SCRIPT' | grep -q -- '--phase'"
+assert "documents --inventory flag in header" "head -30 '$SCRIPT' | grep -q -- '--inventory'"
 
 # Bad flag usage — exit 64
-"$SCRIPT" --phase 3 /tmp/whatever 2>/dev/null
+"$SCRIPT" --phase 3 --inventory /tmp/whatever 2>/dev/null
 rc_bad_phase=$?
 assert "rejects --phase 3 with exit 64" "[ \$rc_bad_phase -eq 64 ]"
 
-"$SCRIPT" --no-such-flag /tmp/whatever 2>/dev/null
+"$SCRIPT" --no-such-flag 2>/dev/null
 rc_unknown=$?
 assert "rejects unknown flag with exit 64" "[ \$rc_unknown -eq 64 ]"
 
+# Missing --inventory — exit 64
+"$SCRIPT" 2>/dev/null
+rc_no_inv=$?
+assert "missing --inventory exits 64" "[ \$rc_no_inv -eq 64 ]"
+
 # Missing file — exit 66
-"$SCRIPT" /nonexistent/path.json 2>/dev/null
+"$SCRIPT" --inventory /nonexistent/path.json 2>/dev/null
 rc_missing=$?
 assert "missing file exits 66" "[ \$rc_missing -eq 66 ]"
 
@@ -65,18 +71,18 @@ cat >"$RAW" <<'JSON'
 }
 JSON
 
-"$SCRIPT" --phase 0 "$RAW" 2>/dev/null
+"$SCRIPT" --phase 0 --inventory "$RAW" 2>/dev/null
 rc_phase0_raw=$?
 assert "--phase 0 accepts raw inventory missing reply_body" "[ \$rc_phase0_raw -eq 0 ]"
 
-"$SCRIPT" --phase 2 "$RAW" 2>/dev/null
+"$SCRIPT" --phase 2 --inventory "$RAW" 2>/dev/null
 rc_phase2_raw=$?
 assert "--phase 2 rejects raw inventory missing reply_body (exit 1)" "[ \$rc_phase2_raw -eq 1 ]"
 
-# Default (no --phase) must behave as --phase 2 for backwards compat
-"$SCRIPT" "$RAW" 2>/dev/null
+# Default --phase (no --phase flag) must behave as --phase 2
+"$SCRIPT" --inventory "$RAW" 2>/dev/null
 rc_default_raw=$?
-assert "default (no flag) rejects raw inventory missing reply_body" "[ \$rc_default_raw -eq 1 ]"
+assert "default --phase rejects raw inventory missing reply_body" "[ \$rc_default_raw -eq 1 ]"
 
 # --- Rendered inventory: reply_body populated; both phases accept ---
 RENDERED="$TMP/rendered.json"
@@ -100,11 +106,11 @@ cat >"$RENDERED" <<'JSON'
 }
 JSON
 
-"$SCRIPT" --phase 0 "$RENDERED" 2>/dev/null
+"$SCRIPT" --phase 0 --inventory "$RENDERED" 2>/dev/null
 rc_phase0_rendered=$?
 assert "--phase 0 accepts rendered inventory" "[ \$rc_phase0_rendered -eq 0 ]"
 
-"$SCRIPT" --phase 2 "$RENDERED" 2>/dev/null
+"$SCRIPT" --phase 2 --inventory "$RENDERED" 2>/dev/null
 rc_phase2_rendered=$?
 assert "--phase 2 accepts rendered inventory" "[ \$rc_phase2_rendered -eq 0 ]"
 
@@ -114,11 +120,11 @@ cat >"$BAD_VERSION" <<'JSON'
 {"schema_version": 2, "items": []}
 JSON
 
-"$SCRIPT" --phase 0 "$BAD_VERSION" 2>/dev/null
+"$SCRIPT" --phase 0 --inventory "$BAD_VERSION" 2>/dev/null
 rc_v_p0=$?
 assert "--phase 0 rejects wrong schema_version" "[ \$rc_v_p0 -eq 1 ]"
 
-"$SCRIPT" --phase 2 "$BAD_VERSION" 2>/dev/null
+"$SCRIPT" --phase 2 --inventory "$BAD_VERSION" 2>/dev/null
 rc_v_p2=$?
 assert "--phase 2 rejects wrong schema_version" "[ \$rc_v_p2 -eq 1 ]"
 

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
@@ -38,9 +38,9 @@ usage() {
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --state)  STATE="${2:-}";    shift 2 ;;
-        --phase)  PHASE="${2:-}";    shift 2 ;;
-        --output) PATH_OUT="${2:-}"; shift 2 ;;
+        --state)  [ "$#" -ge 2 ] || usage; STATE="${2:-}";    shift 2 ;;
+        --phase)  [ "$#" -ge 2 ] || usage; PHASE="${2:-}";    shift 2 ;;
+        --output) [ "$#" -ge 2 ] || usage; PATH_OUT="${2:-}"; shift 2 ;;
         -h|--help) usage ;;
         *) echo "error: unknown flag: $1" >&2; usage ;;
     esac

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
@@ -5,11 +5,10 @@
 # (mktemp + mv on the same filesystem), and runs retention housekeeping.
 #
 # Usage:
-#   write-inventory.sh <state> <last_completed_phase> <inventory_json_path>
-#     state:                 complete | partial
-#     last_completed_phase:  phase identifier (e.g. "5a-verify-failed",
-#                            "7-write-inventory", "8-skill-b-done")
-#     inventory_json_path:   target path under ~/.claude/state/pr-inventory/
+#   write-inventory.sh --state <state> --phase <last_completed_phase> --output <inventory_json_path>
+#     --state:   complete | partial
+#     --phase:   phase identifier (e.g. "5a-verify-failed", "7-write-inventory", "8-skill-b-done")
+#     --output:  target path under ~/.claude/state/pr-inventory/
 #
 # The script:
 #   1. Reads inventory body from stdin.
@@ -23,35 +22,39 @@
 #
 # Exit codes:
 #   0  — write succeeded
-#   64 — invalid args: wrong count, unknown state, or empty phase/path (EX_USAGE)
+#   64 — invalid args: unknown flag, invalid state, or empty phase/path (EX_USAGE)
 #   65 — jq parse/write failed (EX_DATAERR)
 
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "usage: write-inventory.sh <state> <last_completed_phase> <inventory_json_path>" >&2
-    exit 64
-fi
+STATE=""
+PHASE=""
+PATH_OUT=""
 
-STATE="$1"
-PHASE="$2"
-PATH_OUT="$3"
+usage() {
+    echo "usage: write-inventory.sh --state <state> --phase <phase-id> --output <path>" >&2
+    exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --state)  STATE="${2:-}";    shift 2 ;;
+        --phase)  PHASE="${2:-}";    shift 2 ;;
+        --output) PATH_OUT="${2:-}"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "error: unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+[ -n "$STATE"    ] || { echo "error: --state is required" >&2; exit 64; }
+[ -n "$PHASE"    ] || { echo "error: --phase is required" >&2; exit 64; }
+[ -n "$PATH_OUT" ] || { echo "error: --output is required" >&2; exit 64; }
 
 case "$STATE" in
     complete) COMPLETED=true ;;
     partial)  COMPLETED=false ;;
-    *) echo "error: state must be 'complete' or 'partial', got '$STATE'" >&2; exit 64 ;;
+    *) echo "error: --state must be 'complete' or 'partial', got '$STATE'" >&2; exit 64 ;;
 esac
-
-if [ -z "$PHASE" ]; then
-    echo "error: last_completed_phase must be non-empty" >&2
-    exit 64
-fi
-
-if [ -z "$PATH_OUT" ]; then
-    echo "error: inventory_json_path must be non-empty" >&2
-    exit 64
-fi
 
 DIR_OUT="$(dirname "$PATH_OUT")"
 mkdir -p "$DIR_OUT"

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
@@ -56,6 +56,11 @@ assert "exits 64 for invalid --state" "[ \$rc_bad_state -eq 64 ]"
 rc_bogus=$?
 assert "exits 64 for unknown flag" "[ \$rc_bogus -eq 64 ]"
 
+# Trailing flag with no value — must exit 64 (not silent exit 1)
+"$SCRIPT" --state 2>/dev/null
+rc_dangling=$?
+assert "exits 64 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 64 ]"
+
 # --- Happy path: complete state ---
 OUT_COMPLETE="$TMP/inv-complete.json"
 printf '{"schema_version":1,"pr":{"number":1},"items":[]}' | \

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Smoke test for write-inventory.sh
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/write-inventory.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[write-inventory_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+assert "documents inputs/outputs in header" "head -30 '$SCRIPT' | grep -qiE 'input|output|exit'"
+assert "accepts --state flag" "grep -q -- '--state' '$SCRIPT'"
+assert "accepts --phase flag" "grep -q -- '--phase' '$SCRIPT'"
+assert "accepts --output flag" "grep -q -- '--output' '$SCRIPT'"
+assert "no positional arg parsing (no \$1/\$2/\$3)" "! grep -qE '^\s*STATE=\"\\\$1\"' '$SCRIPT'"
+
+# Missing required flags — exit 64
+"$SCRIPT" 2>/dev/null
+rc_no_args=$?
+assert "exits 64 with no flags" "[ \$rc_no_args -eq 64 ]"
+
+"$SCRIPT" --state complete --phase p1 2>/dev/null
+rc_no_output=$?
+assert "exits 64 when --output missing" "[ \$rc_no_output -eq 64 ]"
+
+"$SCRIPT" --state complete --output /tmp/x.json 2>/dev/null
+rc_no_phase=$?
+assert "exits 64 when --phase missing" "[ \$rc_no_phase -eq 64 ]"
+
+"$SCRIPT" --phase p1 --output /tmp/x.json 2>/dev/null
+rc_no_state=$?
+assert "exits 64 when --state missing" "[ \$rc_no_state -eq 64 ]"
+
+# Bad --state value — exit 64
+"$SCRIPT" --state bogus --phase p1 --output /tmp/x.json 2>/dev/null
+rc_bad_state=$?
+assert "exits 64 for invalid --state" "[ \$rc_bad_state -eq 64 ]"
+
+# Unknown flag — exit 64
+"$SCRIPT" --state complete --phase p1 --output /tmp/x.json --bogus 2>/dev/null
+rc_bogus=$?
+assert "exits 64 for unknown flag" "[ \$rc_bogus -eq 64 ]"
+
+# --- Happy path: complete state ---
+OUT_COMPLETE="$TMP/inv-complete.json"
+printf '{"schema_version":1,"pr":{"number":1},"items":[]}' | \
+  "$SCRIPT" --state complete --phase 7-write-inventory --output "$OUT_COMPLETE" 2>/dev/null
+rc_complete=$?
+assert "exits 0 on complete write" "[ \$rc_complete -eq 0 ]"
+assert "output file exists" "[ -f '$OUT_COMPLETE' ]"
+assert "crash_recovery.skill_a_completed is true" \
+  "jq -e '.crash_recovery.skill_a_completed == true' '$OUT_COMPLETE' >/dev/null 2>&1"
+assert "crash_recovery.last_completed_phase is 7-write-inventory" \
+  "jq -e '.crash_recovery.last_completed_phase == \"7-write-inventory\"' '$OUT_COMPLETE' >/dev/null 2>&1"
+
+# --- Happy path: partial state ---
+OUT_PARTIAL="$TMP/inv-partial.json"
+printf '{"schema_version":1,"pr":{"number":1},"items":[]}' | \
+  "$SCRIPT" --state partial --phase 5a-verify-failed --output "$OUT_PARTIAL" 2>/dev/null
+rc_partial=$?
+assert "exits 0 on partial write" "[ \$rc_partial -eq 0 ]"
+assert "crash_recovery.skill_a_completed is false" \
+  "jq -e '.crash_recovery.skill_a_completed == false' '$OUT_PARTIAL' >/dev/null 2>&1"
+assert "crash_recovery.last_completed_phase is 5a-verify-failed" \
+  "jq -e '.crash_recovery.last_completed_phase == \"5a-verify-failed\"' '$OUT_PARTIAL' >/dev/null 2>&1"
+
+# --- Invalid JSON input — exit 65 ---
+OUT_BAD="$TMP/inv-bad.json"
+printf 'not-json' | "$SCRIPT" --state complete --phase p1 --output "$OUT_BAD" 2>/dev/null
+rc_bad_json=$?
+assert "exits 65 on invalid JSON input" "[ \$rc_bad_json -eq 65 ]"
+
+exit $FAIL


### PR DESCRIPTION
## Summary

Standardizes all helper scripts in the PR-review helper ecosystem to the `--flag` calling convention, eliminating the positional-vs-flag inconsistency that caused repeated `exit 3` failures.

Covers the `wait-for-pr-comments` and `reply-and-resolve-pr-threads` skills (bead `hwjei`) plus the `merge-guard` skill (bead `ujrmm`, folded in for ecosystem-wide uniformity).

## Helpers converted

| Script | Old convention | New convention |
|--------|---------------|----------------|
| `poll-copilot-review.sh` | `<owner/repo> <pr>` | `--owner --repo --pr` |
| `poll-copilot-rereview-start.sh` | `<owner/repo> <pr> <after>` | `--owner --repo --pr --after` |
| `poll-new-comments.sh` | 5 positionals | `--owner --repo --pr --baseline --interval --max-duration` |
| `write-inventory.sh` | `<state> <phase> <path>` | `--state --phase --output` |
| `validate-inventory.sh` | mixed | `--inventory --phase` |
| `check-merge-eligibility.sh` | `<owner/repo> <pr> <comments-seen>` | `--owner --repo --pr --comments-seen` |

## Testing

- All helper smoke tests pass (20 `*_test.sh` suites, 0 failures)
- End-to-end dry-run of skills against new conventions: clean
- Positional-residue grep across source: clean
- `merge-guard` conversion: new 18-assertion smoke test added (script previously had none)

## Notes

The pre-shift dangling-flag guard (`[[ $# -ge 2 ]] || usage` before each `shift 2`) is load-bearing: under `set -euo pipefail`, a trailing valueless flag would otherwise exit silently with code 1 instead of the documented exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>