### PR TITLE
feat(w1qls.2.2): minimal core/sync.py — single-file copy, hash-skip, dry-run

### DIFF
--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -32,12 +32,18 @@ def sync(
     """Install one file from the adapter's source tree to its dest tree.
 
     Resolves ``adapter.source_dir(repo_root) / relpath`` and
-    ``adapter.dest_dir(home) / relpath``. Skips when the destination
+    ``adapter.dest_dir(home) / relpath``. Rejects a ``relpath`` that is
+    absolute or contains a ``..`` component with `ValueError`, since either
+    would let ``Path / relpath`` write outside the adapter tree. Skips when
+    the destination
     already holds matching bytes (sha-256); otherwise writes the source
     bytes — unless ``dry_run`` is set, in which case it previews the
     would-be write through ``io`` and touches nothing. Returns a
     `Counters` with exactly one of created / updated / skipped incremented.
     """
+    if relpath.is_absolute() or ".." in relpath.parts:
+        raise ValueError(f"relpath escapes the adapter tree: {relpath}")  # noqa: TRY003  # single call-site; subclass not justified
+
     counters = Counters()
     source = adapter.source_dir(repo_root) / relpath
     dest = adapter.dest_dir(home) / relpath

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -1,0 +1,67 @@
+"""Minimal single-file sync engine (B.2).
+
+Copies one source file to one destination, resolving both ends through a
+`ToolAdapter`. The smallest slice of the eventual Phase-7 sync described in
+`docs/specs/2026-05-17-python-installer-rewrite.md`: later stories grow it
+to walk a `StagingPlan`, route conflicts through the merge registry, and
+place path-aware backups.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from installer.core.model import Counters
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.tools.base import ToolAdapter
+
+
+def sync(
+    adapter: ToolAdapter,
+    relpath: Path,
+    *,
+    repo_root: Path,
+    home: Path,
+    io: IOPort,
+    dry_run: bool = False,
+) -> Counters:
+    """Install one file from the adapter's source tree to its dest tree.
+
+    Resolves ``adapter.source_dir(repo_root) / relpath`` and
+    ``adapter.dest_dir(home) / relpath``. Skips when the destination
+    already holds matching bytes (sha-256); otherwise writes the source
+    bytes — unless ``dry_run`` is set, in which case it previews the
+    would-be write through ``io`` and touches nothing. Returns a
+    `Counters` with exactly one of created / updated / skipped incremented.
+    """
+    counters = Counters()
+    source = adapter.source_dir(repo_root) / relpath
+    dest = adapter.dest_dir(home) / relpath
+
+    content = source.read_bytes()
+    dest_exists = dest.is_file()
+
+    if dest_exists and _sha256(dest.read_bytes()) == _sha256(content):
+        counters.skipped += 1
+        return counters
+
+    if dry_run:
+        verb = "update" if dest_exists else "create"
+        io.info(f"would {verb} {dest}")
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+
+    if dest_exists:
+        counters.updated += 1
+    else:
+        counters.created += 1
+    return counters
+
+
+def _sha256(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()

--- a/packages/installer/src/installer/tools/claude.py
+++ b/packages/installer/src/installer/tools/claude.py
@@ -16,12 +16,10 @@ class ClaudeAdapter:
     name: str = "claude"
     detection_signal: str = ".claude/settings.json"
 
-    # exercised by w1qls.2.2 (B.2)
-    def source_dir(self, repo_root: Path) -> Path:  # pragma: no cover
+    def source_dir(self, repo_root: Path) -> Path:
         return repo_root / "src" / "user" / ".claude"
 
-    # exercised by w1qls.2.2 (B.2)
-    def dest_dir(self, home: Path) -> Path:  # pragma: no cover
+    def dest_dir(self, home: Path) -> Path:
         return home / ".claude"
 
     def is_detected(self, home: Path) -> bool:

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -14,6 +14,7 @@ absent. See the writing-unit-tests skill's Tautology Filter.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -334,6 +335,10 @@ def test_parent_traversal_relpath_is_rejected(tmp_path: Path) -> None:
     assert not (tmp_path / "escape.md").exists()
 
 
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="root bypasses the 0o444 mode bit, so the write would succeed",
+)
 def test_write_to_read_only_destination_surfaces_permission_error(tmp_path: Path) -> None:
     """
     Given a destination that differs from the source and is read-only

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -282,6 +282,58 @@ def test_missing_source_file_raises(tmp_path: Path) -> None:
         )
 
 
+def test_absolute_relpath_is_rejected(tmp_path: Path) -> None:
+    """
+    Given an absolute relpath (which ``Path / relpath`` would resolve to,
+    discarding the adapter source/dest roots entirely)
+    When sync runs
+    Then a ValueError surfaces before any write, and nothing lands outside
+    the dest root.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    outside = tmp_path / "etc" / "passwd"
+    outside.parent.mkdir()
+
+    with pytest.raises(ValueError):
+        sync(
+            _IdentityAdapter(),
+            outside,  # absolute path — would escape the dest root entirely
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+        )
+
+    assert not outside.exists()
+
+
+def test_parent_traversal_relpath_is_rejected(tmp_path: Path) -> None:
+    """
+    Given a relpath containing a ``..`` component (which would climb out of
+    the adapter dest tree)
+    When sync runs
+    Then a ValueError surfaces before any write, and no file is created
+    above the dest root.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+
+    with pytest.raises(ValueError):
+        sync(
+            _IdentityAdapter(),
+            Path("../escape.md"),  # climbs out of the dest tree
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+        )
+
+    assert not (tmp_path / "escape.md").exists()
+
+
 def test_write_to_read_only_destination_surfaces_permission_error(tmp_path: Path) -> None:
     """
     Given a destination that differs from the source and is read-only

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -1,0 +1,309 @@
+"""Unit tests for installer.core.sync (B.2 — minimal single-file sync).
+
+Each test pins a behaviour the B.2 story contract requires
+(docs/specs/2026-05-17-python-installer-rewrite.md, Epic B.2). The sync
+engine is exercised through a minimal identity-pass-through ToolAdapter so
+the tests are independent of any real tool's path layout; the real
+ClaudeAdapter is driven once, end-to-end, in test_sync_claude.py to cover
+its source_dir/dest_dir behaviourally.
+
+Tautology tests — isinstance(_, ToolAdapter), path-literal assertions like
+adapter.source_dir(r) == r / "src" / "user" / ".claude" — are deliberately
+absent. See the writing-unit-tests skill's Tautology Filter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.io_port import IOPort, ScriptedIO
+from installer.core.model import StagingPlan
+from installer.core.sync import sync
+
+
+class _IdentityAdapter:
+    """Minimal ToolAdapter double. source_dir/dest_dir are identity
+    pass-throughs, so a test controls the real source/dest roots directly
+    via sync's repo_root / home arguments. The remaining protocol members
+    are inert — the sync engine never consults them."""
+
+    name: str = "fake"
+    detection_signal: str = ".fake"
+
+    def source_dir(self, repo_root: Path) -> Path:
+        return repo_root
+
+    def dest_dir(self, home: Path) -> Path:
+        return home
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002  # inert stub
+        return True
+
+    def scoped_namespaces(self) -> tuple[str, ...]:
+        return ()
+
+    def should_install_namespace(
+        self,
+        namespace: str,  # noqa: ARG002  # inert stub
+        source: str,  # noqa: ARG002  # inert stub
+    ) -> bool:
+        return True
+
+    def post_staging_transforms(
+        self,
+        plan: StagingPlan,
+        io: IOPort,  # noqa: ARG002  # inert stub
+    ) -> StagingPlan:
+        return plan
+
+
+def test_absent_destination_is_created_from_source(tmp_path: Path) -> None:
+    """
+    Given a source file and a destination that does not yet exist
+    When sync installs the file
+    Then the destination holds the source bytes and exactly one create is
+    counted.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"  # deliberately absent — first install
+    (src_root).mkdir()
+    (src_root / "f.md").write_bytes(b"hello\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+    )
+
+    assert (dest_root / "f.md").read_bytes() == b"hello\n"
+    assert (counters.created, counters.updated, counters.skipped) == (1, 0, 0)
+
+
+def test_missing_parent_directories_are_created(tmp_path: Path) -> None:
+    """
+    Given a destination whose intermediate namespace directories do not
+    exist (first-ever install into ~/.claude/rules/)
+    When sync installs a nested file
+    Then the intermediate directories and the file are created.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "rules").mkdir(parents=True)
+    (src_root / "rules" / "deep.md").write_bytes(b"rule\n")
+
+    sync(
+        _IdentityAdapter(),
+        Path("rules/deep.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+    )
+
+    assert (dest_root / "rules" / "deep.md").read_bytes() == b"rule\n"
+
+
+def test_identical_destination_is_skipped_without_rewrite(tmp_path: Path) -> None:
+    """
+    Given a destination whose bytes already match the source (sha-256)
+    When sync runs
+    Then no write occurs and exactly one skip is counted.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "f.md").write_bytes(b"same\n")
+    (dest_root / "f.md").write_bytes(b"same\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+    )
+
+    assert (dest_root / "f.md").read_bytes() == b"same\n"
+    assert (counters.created, counters.updated, counters.skipped) == (0, 0, 1)
+
+
+def test_skip_does_not_write_to_read_only_destination(tmp_path: Path) -> None:
+    """
+    Given an up-to-date destination that is read-only (0o444)
+    When sync runs
+    Then it skips cleanly without raising — proving the skip path never
+    opens the destination for writing.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "f.md").write_bytes(b"same\n")
+    dest = dest_root / "f.md"
+    dest.write_bytes(b"same\n")
+    dest.chmod(0o444)
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+    )
+
+    assert counters.skipped == 1
+
+
+def test_changed_source_overwrites_destination(tmp_path: Path) -> None:
+    """
+    Given a destination whose bytes differ from the source
+    When sync runs
+    Then the destination is rewritten with the source bytes and exactly
+    one update is counted.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "f.md").write_bytes(b"new content\n")
+    (dest_root / "f.md").write_bytes(b"old content\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+    )
+
+    assert (dest_root / "f.md").read_bytes() == b"new content\n"
+    assert (counters.created, counters.updated, counters.skipped) == (0, 1, 0)
+
+
+def test_dry_run_creates_no_file_on_disk(tmp_path: Path) -> None:
+    """
+    Given --dry-run and an absent destination
+    When sync runs
+    Then nothing is written to disk, yet the would-be create is reported
+    in the returned summary.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    (src_root / "f.md").write_bytes(b"hello\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        dry_run=True,
+    )
+
+    assert not (dest_root / "f.md").exists()
+    assert counters.created == 1
+
+
+def test_dry_run_preview_names_the_would_be_write(tmp_path: Path) -> None:
+    """
+    Given --dry-run
+    When sync would write a file
+    Then a preview line naming the destination is emitted through IOPort.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    (src_root / "f.md").write_bytes(b"hello\n")
+    io = ScriptedIO()
+
+    sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=io,
+        dry_run=True,
+    )
+
+    dest = dest_root / "f.md"
+    assert any(str(dest) in entry.message for entry in io.transcript)
+
+
+def test_dry_run_leaves_existing_file_unmodified(tmp_path: Path) -> None:
+    """
+    Given --dry-run and a destination whose bytes differ from the source
+    When sync runs
+    Then the destination keeps its original bytes and the would-be update
+    is reported.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "f.md").write_bytes(b"new content\n")
+    (dest_root / "f.md").write_bytes(b"old content\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("f.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        dry_run=True,
+    )
+
+    assert (dest_root / "f.md").read_bytes() == b"old content\n"
+    assert counters.updated == 1
+
+
+def test_missing_source_file_raises(tmp_path: Path) -> None:
+    """
+    Given a relpath with no corresponding source file
+    When sync runs
+    Then a FileNotFoundError surfaces rather than a silent no-op — the
+    caller must learn the source is missing.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        sync(
+            _IdentityAdapter(),
+            Path("absent.md"),
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+        )
+
+
+def test_write_to_read_only_destination_surfaces_permission_error(tmp_path: Path) -> None:
+    """
+    Given a destination that differs from the source and is read-only
+    When sync attempts the write
+    Then a PermissionError surfaces rather than being swallowed.
+
+    Assumes a non-root test runner (root bypasses the 0o444 mode bit).
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "f.md").write_bytes(b"new content\n")
+    dest = dest_root / "f.md"
+    dest.write_bytes(b"old content\n")
+    dest.chmod(0o444)
+
+    with pytest.raises(PermissionError):
+        sync(
+            _IdentityAdapter(),
+            Path("f.md"),
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+        )

--- a/packages/installer/tests/unit/test_sync_claude.py
+++ b/packages/installer/tests/unit/test_sync_claude.py
@@ -1,0 +1,43 @@
+"""Behavioural coverage for ClaudeAdapter via the B.2 sync engine.
+
+Drives the *real* ClaudeAdapter end-to-end through sync so that its
+source_dir / dest_dir earn behavioural coverage — the ``# pragma: no
+cover`` markers those two methods carried (forward-tracked from
+w1qls.2.1) come off in this story. The engine's own branch behaviour
+(skip / update / dry-run / failure modes) is unit-tested against a fake
+adapter in test_sync.py; this file asserts only that sync wires the real
+adapter's source and destination roots correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.io_port import ScriptedIO
+from installer.core.sync import sync
+from installer.tools.claude import ClaudeAdapter
+
+
+def test_claude_adapter_installs_file_under_dot_claude(tmp_path: Path) -> None:
+    """
+    Given a file in the repo's src/user/.claude/ tree
+    When sync installs it for the real ClaudeAdapter
+    Then it lands under <home>/.claude/ with the source bytes — exercising
+    ClaudeAdapter.source_dir and dest_dir behaviourally.
+    """
+    repo_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    source = repo_root / "src" / "user" / ".claude" / "settings.json"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b'{"k": 1}\n')
+
+    counters = sync(
+        ClaudeAdapter(),
+        Path("settings.json"),
+        repo_root=repo_root,
+        home=home,
+        io=ScriptedIO(),
+    )
+
+    assert (home / ".claude" / "settings.json").read_bytes() == b'{"k": 1}\n'
+    assert counters.created == 1


### PR DESCRIPTION
## Summary

Implements **Epic B.2** of the Python installer rewrite (`docs/specs/2026-05-17-python-installer-rewrite.md`): the smallest possible sync engine — copy one source file to one dest file, sha-256 hash-compare to skip no-op writes, honour `--dry-run`.

- New `core/sync.py`: `sync(adapter, relpath, *, repo_root, home, io, dry_run=False) -> Counters`. Resolves source/dest through the injected `ToolAdapter`, skips on a sha-256 byte match, previews the would-be write through `IOPort` under `--dry-run`, and returns a `Counters` with exactly one of created/updated/skipped incremented.
- Retires the two `# pragma: no cover` markers on `ClaudeAdapter.source_dir`/`dest_dir` — now earned behaviourally via the real-adapter end-to-end test (forward-tracked from B.1 / w1qls.2.1).
- Deliberately the **minimal** slice: later stories grow sync to walk a `StagingPlan`, route conflicts through the merge registry, and place path-aware backups.

## Acceptance criteria

- [x] One-file install produces the expected dest file
- [x] Re-run with no source change is a no-op (sha-256 hash-skip, no writes)
- [x] `--dry-run` produces no writes; preview output names the would-be write
- [x] `# pragma: no cover` removed from `ClaudeAdapter.source_dir`/`dest_dir`; covered behaviourally
- [x] Build / typecheck / tests pass

## Test plan

11 new tests (10 engine via an identity-pass-through fake adapter + 1 real-`ClaudeAdapter` end-to-end), incl. permission failure-mode guards (read-only skip proves the skip path never opens for write; read-only differing dest surfaces `PermissionError`; missing source raises `FileNotFoundError`).

```
uv run pytest --cov   → 77 passed, 100% coverage (gate 90%)
uv run ruff check     → All checks passed!
uv run ruff format --check → 20 files already formatted
uv run mypy --strict src   → Success: no issues found in 11 source files
```

In-house quality-reviewer: "the slice is sound, ship it" (0 Critical/High/Medium). `simplify`: none warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
