### PR TITLE
feat(w1qls.2.3): .template suffix strip in staging

### DIFF
--- a/docs/specs/2026-05-31-w1qls.2.3-template-suffix-strip.md
+++ b/docs/specs/2026-05-31-w1qls.2.3-template-suffix-strip.md
@@ -1,0 +1,50 @@
+# B.3 — .template suffix strip in staging
+
+**Story:** agents-config-w1qls.2.3
+**Parent epic:** w1qls.2 — First end-to-end claude install (minimal)
+**Status:** design approved
+
+## Problem
+
+Source files named `*.template` (e.g. `AGENTS.md.template`, `settings.json.template`) must arrive at the install destination without the `.template` suffix. The suffix is a source-layer annotation that signals "this file requires template processing"; consumers should never see it.
+
+## Decision
+
+Introduce `packages/installer/src/installer/core/staging.py` with a single pure function:
+
+```python
+def strip_template_suffix(path: Path) -> Path:
+    """Strip .template if it is the final suffix; return path unchanged otherwise."""
+    if path.suffix == ".template":
+        return path.with_suffix("")
+    return path
+```
+
+`Path.with_suffix("")` removes only the final component, so double-suffixed names (`AGENTS.md.template`) correctly collapse to `AGENTS.md`. The function is pure — no I/O, no adapter dependency — making it trivially testable and safe to call in any context.
+
+## Module boundary rationale
+
+The strip belongs in `core/staging.py`, not in `core/sync.py`, because:
+
+- The spec says the transform happens "on the way into the StagingPlan" — i.e. at staging time, before writes.
+- B.4 (DYNAMIC-INCLUDE file form) adds detection logic to the same staging phase. `stage_file()` in B.4 will call `strip_template_suffix()` internally.
+- Landing the module now means B.4 extends an existing file rather than creating one mid-story.
+
+No changes to `core/sync.py` or `core/model.py`. The wiring of the staging layer into the sync walk comes later, when sync graduates to walking a `StagingPlan`.
+
+## Test cases
+
+File: `tests/unit/test_staging.py`
+
+| Input | Expected output | What it pins |
+|---|---|---|
+| `Path("AGENTS.md.template")` | `Path("AGENTS.md")` | double-suffix strip (primary AC) |
+| `Path("AGENTS.md")` | `Path("AGENTS.md")` | non-template pass-through |
+| `Path("rules/AGENTS.md.template")` | `Path("rules/AGENTS.md")` | directory components untouched |
+| `Path("some.template")` | `Path("some")` | bare `.template` name — edge case |
+
+## Acceptance criteria
+
+- `AGENTS.md.template` produces `dest_relpath == Path("AGENTS.md")` via `strip_template_suffix`.
+- Files without `.template` suffix produce an identical `dest_relpath`.
+- Tests cover both cases (and the two edge cases above).

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -1,0 +1,24 @@
+"""Staging-phase transforms applied to source files on their way into a StagingPlan.
+
+B.3: strip_template_suffix — removes the .template suffix from a path's final
+component so that AGENTS.md.template arrives at the destination as AGENTS.md.
+
+B.4 will extend this module with stage_file(), which calls strip_template_suffix
+internally alongside DYNAMIC-INCLUDE detection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def strip_template_suffix(path: Path) -> Path:
+    """Strip .template if it is the final suffix; return path unchanged otherwise.
+
+    Uses Path.with_suffix("") so that double-suffixed names such as
+    AGENTS.md.template correctly collapse to AGENTS.md without touching
+    any earlier suffix component.
+    """
+    if path.suffix == ".template":
+        return path.with_suffix("")
+    return path

--- a/packages/installer/tests/unit/test_staging.py
+++ b/packages/installer/tests/unit/test_staging.py
@@ -1,0 +1,47 @@
+"""Unit tests for installer.core.staging — B.3 (.template suffix strip).
+
+Each test pins a behaviour the B.3 story contract requires
+(docs/specs/2026-05-31-w1qls.2.3-template-suffix-strip.md).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.staging import strip_template_suffix
+
+
+def test_template_suffix_is_stripped() -> None:
+    """
+    Given a path whose final suffix is .template
+    When strip_template_suffix is called
+    Then the .template suffix is removed and the remaining name is unchanged.
+    """
+    assert strip_template_suffix(Path("AGENTS.md.template")) == Path("AGENTS.md")
+
+
+def test_non_template_path_is_unchanged() -> None:
+    """
+    Given a path with no .template suffix
+    When strip_template_suffix is called
+    Then the path is returned unchanged.
+    """
+    assert strip_template_suffix(Path("AGENTS.md")) == Path("AGENTS.md")
+
+
+def test_directory_components_are_preserved() -> None:
+    """
+    Given a nested path whose filename ends in .template
+    When strip_template_suffix is called
+    Then directory components are untouched and only the filename suffix changes.
+    """
+    assert strip_template_suffix(Path("rules/AGENTS.md.template")) == Path("rules/AGENTS.md")
+
+
+def test_bare_template_name_strips_to_stem() -> None:
+    """
+    Given a path whose entire name is <stem>.template (no prior extension)
+    When strip_template_suffix is called
+    Then the .template suffix is removed, leaving just the stem.
+    """
+    assert strip_template_suffix(Path("some.template")) == Path("some")


### PR DESCRIPTION
## Summary
- Add `core/staging.py` with `strip_template_suffix(path)` — a pure function that strips a final `.template` suffix via `Path.with_suffix(\"\")`, so `AGENTS.md.template` installs as `AGENTS.md`.
- Files without the suffix pass through unchanged.
- B.3 building block for the Python installer rewrite; B.4 will extend this module with `stage_file()` (DYNAMIC-INCLUDE detection). No changes to `sync.py` or `model.py`.

Closes bead agents-config-w1qls.2.3 (Epic B, story B.3).

## Test Plan
- [x] 4 unit tests in `tests/unit/test_staging.py` cover double-suffix strip, pass-through, nested-path preservation, and bare-`.template` edge case
- [x] Full suite green: 83 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy` clean

## Verification
- quality-reviewer: APPROVE, no blocking findings
- simplify: none warranted (10-line pure function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)