### PR TITLE
feat(w1qls.2.4): DYNAMIC-INCLUDE file form

### DIFF
--- a/docs/plans/2026-05-31-w1qls.2.4-dynamic-include-file-form.md
+++ b/docs/plans/2026-05-31-w1qls.2.4-dynamic-include-file-form.md
@@ -1,0 +1,59 @@
+# B.4 — DYNAMIC-INCLUDE file form Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `core/templates.py` with `parse_directive()` and `flatten_template()` so a `<!-- DYNAMIC-INCLUDE: path -->` marker line resolves to the referenced file's verbatim content, matching the bash `flatten_agents_md` reference.
+
+**Architecture:** A new `core/templates.py` module. `parse_directive` recognises both the file and ALL-RULES marker forms (the data model defines both); `flatten_template` resolves the file form and raises `NotImplementedError` on ALL-RULES (the C.2 seam). Pure text transform (`str -> str`) with `IOPort` injected for the missing-file warning. `model.py`, `staging.py`, `sync.py` untouched.
+
+**Tech Stack:** Python 3.11+, `pathlib.Path`, `re`, pytest, ScriptedIO fake.
+
+---
+
+### Task 1: Write failing tests for `core/templates.py`
+
+**Files:**
+- Create: `packages/installer/tests/unit/test_templates.py`
+
+- [ ] **Step 1: Write the failing tests** covering the table in the spec — `parse_directive` recognition (file form, ALL-RULES, prose→None, leading-whitespace→None, deferred named-RULES→None, empty-path→None) and `flatten_template` behaviour (single inline, multi-marker ordering, missing-file warn+empty, pass-through, trailing-newline-iff, verbatim-`cat` glue, ALL-RULES→NotImplementedError).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd packages/installer && uv run pytest tests/unit/test_templates.py -v
+```
+
+Expected: failures — `ModuleNotFoundError: No module named 'installer.core.templates'`.
+
+---
+
+### Task 2: Implement `core/templates.py`
+
+**Files:**
+- Create: `packages/installer/src/installer/core/templates.py`
+
+- [ ] **Step 1: Implement `parse_directive` + `flatten_template`** matching the bash-parity semantics in the spec (exact-anchor regexes, `-n` empty-path guard, `is_file()` missing-file warn, verbatim substitution, `splitlines(keepends=True)` reassembly, `match`/`assert_never` exhaustiveness).
+
+- [ ] **Step 2: Run targeted tests to green**
+
+```bash
+cd packages/installer && uv run pytest tests/unit/test_templates.py -v
+```
+
+- [ ] **Step 3: Full suite + static gates (no regressions)**
+
+```bash
+cd packages/installer && uv run pytest -q && uv run mypy src && uv run ruff check .
+```
+
+Expected: all tests pass; mypy clean; ruff clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/installer/src/installer/core/templates.py \
+        packages/installer/tests/unit/test_templates.py \
+        docs/specs/2026-05-31-w1qls.2.4-dynamic-include-file-form.md \
+        docs/plans/2026-05-31-w1qls.2.4-dynamic-include-file-form.md
+git commit -m "feat(w1qls.2.4): DYNAMIC-INCLUDE file form in core/templates.py"
+```

--- a/docs/specs/2026-05-31-w1qls.2.4-dynamic-include-file-form.md
+++ b/docs/specs/2026-05-31-w1qls.2.4-dynamic-include-file-form.md
@@ -1,0 +1,97 @@
+# B.4 — DYNAMIC-INCLUDE file form
+
+**Story:** agents-config-w1qls.2.4
+**Parent epic:** w1qls.2 — First end-to-end claude install (minimal)
+**Status:** design approved
+
+## Problem
+
+Instruction templates carry inline include markers so a single flat file can be
+distributed to tools that do not resolve `@`-style includes. The file form is:
+
+```
+<!-- DYNAMIC-INCLUDE: path/to/file.md -->
+```
+
+A line that is exactly this marker must be replaced by the verbatim content of
+the referenced file (resolved relative to the project root). The bash installer's
+`flatten_agents_md` (`scripts/install.sh`) is the behavioural spec. This story
+ports the **file form only**; the ALL-RULES form is story C.2 and the named-RULES
+form is deferred (C.3, intentionally absent from the data model).
+
+## Decision
+
+Introduce `packages/installer/src/installer/core/templates.py` with two functions:
+
+```python
+def parse_directive(line: str) -> IncludeDirective | None:
+    """Recognise a DYNAMIC-INCLUDE directive on a single line, exactly
+    (no leading/trailing whitespace). Returns FileInclude / AllRulesInclude,
+    or None for any non-directive line."""
+
+def flatten_template(content: str, *, base_dir: Path, io: IOPort) -> str:
+    """Replace each file-form marker line with the referenced file's verbatim
+    text (resolved under base_dir). Missing file -> warn + empty line."""
+```
+
+Recognition covers **both** the file and ALL-RULES marker forms because the data
+model (`FileInclude`, `AllRulesInclude`) defines both; this keeps C.2 a pure
+*resolution* change. `flatten_template` resolves the file form and `raise`s
+`NotImplementedError` on the ALL-RULES form — a loud, single-line seam for C.2
+rather than silently emitting a literal marker.
+
+### Bash-parity semantics (the reference is the spec)
+
+- **Verbatim substitution.** The marker line (and its own newline) is consumed;
+  the referenced file's bytes are appended exactly as `cat` would. No separator
+  newline is injected — if the included file lacks a trailing newline, its last
+  line glues directly to the template's next line. This mirrors
+  `cat "$file" >> "$output"`.
+- **Exact anchoring.** The marker must occupy the whole line. A line with leading
+  whitespace, surrounding prose, or an empty path is **not** a directive and
+  passes through unchanged (mirrors the bash `^...$` anchors and `-n` guard).
+- **Missing file is non-fatal.** A marker whose target is not a regular file
+  (missing or a directory — mirrors bash `[[ -f ]]`) emits `io.warn(...)` and
+  resolves to the empty string, leaving the marker line empty.
+- **Trailing newline preserved iff present.** Reassembly via
+  `splitlines(keepends=True)` + `"".join(...)` preserves the template's final
+  newline exactly.
+
+## Module boundary rationale
+
+The flattening logic belongs in `core/templates.py` (per the installer design's
+module map), not in `core/staging.py`. `staging.py` owns path-level transforms
+(`strip_template_suffix`); `templates.py` owns content-level transforms. The two
+compose at the staging layer in a later story (C.1) when sync graduates to
+walking a `StagingPlan`. B.4 keeps `flatten_template` a pure text transform
+(`str -> str`) with `IOPort` injected for the one warning channel; the bytes↔str
+boundary is the staging layer's concern, not this function's.
+
+`model.py`, `staging.py`, and `sync.py` are untouched.
+
+## Test cases
+
+File: `tests/unit/test_templates.py`
+
+| Scenario | What it pins |
+|---|---|
+| `parse_directive` on a file marker → `FileInclude(Path(...))` | file-form recognition |
+| `parse_directive` on `DYNAMIC-INCLUDE-ALL-RULES` → `AllRulesInclude()` | ALL-RULES recognition (C.2 seam) |
+| `parse_directive` on prose → `None` | non-directive pass-through |
+| `parse_directive` on a leading-whitespace marker → `None` | exact-anchor decision |
+| `parse_directive` on the deferred `DYNAMIC-INCLUDE-RULES:` form → `None` | named-RULES deferral (C.3) |
+| `parse_directive` on an empty-path marker → `None` | bash `-n` parity |
+| `flatten_template` with one file marker → inlined content (AC1) | substitution |
+| `flatten_template` with two markers + interleaved prose → ordered output | assembly order |
+| `flatten_template` missing file → `io.warn` + empty line, no raise (AC2) | non-fatal missing |
+| `flatten_template` non-directive lines unchanged (AC3) | pass-through |
+| `flatten_template` trailing newline preserved iff present (AC4) | newline fidelity |
+| `flatten_template` included file w/o trailing newline glues to next line | verbatim-`cat` parity |
+| `flatten_template` on ALL-RULES marker → `NotImplementedError` | C.2 boundary contract |
+
+## Acceptance criteria
+
+- A template with one DYNAMIC-INCLUDE file marker resolves to the inlined content.
+- Missing-file directive produces a warning, not a hard fail.
+- Non-directive lines pass through unchanged.
+- Trailing newlines preserved iff the template had one.

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -1,0 +1,94 @@
+"""DYNAMIC-INCLUDE flattening for instruction templates.
+
+Some tools do not resolve `@`-style includes, so instruction templates carry
+inline markers that are flattened into a single self-contained file at install
+time. B.4 implements the **file form**::
+
+    <!-- DYNAMIC-INCLUDE: path/to/file.md -->
+
+A line that is exactly this marker is replaced by the verbatim text of the
+referenced file (resolved relative to a base directory). A missing target warns
+and leaves the line empty. The behavioural reference is the bash installer's
+``flatten_agents_md`` (``scripts/install.sh``).
+
+`parse_directive` also recognises the ALL-RULES form so directive recognition is
+complete, but *resolving* ALL-RULES is deferred to story C.2; `flatten_template`
+raises `NotImplementedError` if it encounters one rather than silently emitting a
+literal marker.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, assert_never
+
+from installer.core.model import AllRulesInclude, FileInclude, IncludeDirective
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+
+_FILE_INCLUDE_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE: (.*) -->$")
+_ALL_RULES_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE-ALL-RULES -->$")
+_ALL_RULES_DEFERRED = "DYNAMIC-INCLUDE-ALL-RULES resolution lands in story C.2"
+
+
+def parse_directive(line: str) -> IncludeDirective | None:
+    """Recognise a DYNAMIC-INCLUDE directive on a single line.
+
+    The line must match a marker form exactly — no leading or trailing
+    whitespace — mirroring the anchored ``^...$`` patterns in the bash
+    installer. A file marker with an empty path is rejected, matching the bash
+    ``-n`` guard. Returns the matching directive dataclass, or None for any
+    line that is not a directive (including the deferred named-RULES form).
+    """
+    stripped = line.rstrip("\n")
+    file_match = _FILE_INCLUDE_RE.match(stripped)
+    if file_match is not None and file_match.group(1):
+        return FileInclude(path=Path(file_match.group(1)))
+    if _ALL_RULES_RE.match(stripped) is not None:
+        return AllRulesInclude()
+    return None
+
+
+def flatten_template(content: str, *, base_dir: Path, io: IOPort) -> str:
+    """Flatten DYNAMIC-INCLUDE file markers in a template's text.
+
+    Each file-marker line is replaced by the verbatim text of the referenced
+    file (read as UTF-8), resolved relative to ``base_dir``. The marker line and
+    its own newline are consumed; no separator is injected, so an included file
+    without a trailing newline abuts the template's next line — matching
+    ``cat file >> output``. A target that is not a regular file emits a warning
+    and resolves to the empty string, leaving the marker line empty.
+    Non-directive lines pass through unchanged, and the template's trailing
+    newline is preserved iff the template had one.
+
+    ALL-RULES resolution is deferred to story C.2.
+    """
+    out: list[str] = []
+    for line in content.splitlines(keepends=True):
+        directive = parse_directive(line)
+        if directive is None:
+            out.append(line)
+            continue
+        match directive:
+            case FileInclude(path=rel):
+                out.append(_resolve_file_include(rel, base_dir=base_dir, io=io))
+            case AllRulesInclude():
+                raise NotImplementedError(_ALL_RULES_DEFERRED)
+            case _:  # pragma: no cover - exhaustiveness guard for future variants
+                assert_never(directive)
+    return "".join(out)
+
+
+def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
+    """Read the verbatim text of an included file, or warn and return ''.
+
+    Mirrors the bash ``[[ -f ... ]]`` guard: a missing target *or* a directory
+    is non-fatal — it warns and resolves to the empty string.
+    """
+    target = base_dir / rel
+    if not target.is_file():
+        io.warn(f"DYNAMIC-INCLUDE not found: {rel}")
+        return ""
+    return target.read_text(encoding="utf-8")

--- a/packages/installer/tests/unit/test_templates.py
+++ b/packages/installer/tests/unit/test_templates.py
@@ -1,0 +1,202 @@
+"""Unit tests for installer.core.templates — B.4 (DYNAMIC-INCLUDE file form).
+
+Each test pins a behaviour the B.4 story contract requires
+(docs/specs/2026-05-31-w1qls.2.4-dynamic-include-file-form.md). The behavioural
+reference is the bash installer's flatten_agents_md (scripts/install.sh).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.io_port import ScriptedIO
+from installer.core.model import AllRulesInclude, FileInclude
+from installer.core.templates import flatten_template, parse_directive
+
+# ───────────────────────── parse_directive ─────────────────────────
+
+
+def test_file_marker_is_recognised() -> None:
+    """
+    Given a line that is exactly a file-form DYNAMIC-INCLUDE marker
+    When parse_directive is called
+    Then it returns a FileInclude carrying the marker's path.
+    """
+    assert parse_directive("<!-- DYNAMIC-INCLUDE: rules/foo.md -->") == FileInclude(
+        path=Path("rules/foo.md")
+    )
+
+
+def test_all_rules_marker_is_recognised() -> None:
+    """
+    Given the ALL-RULES marker line
+    When parse_directive is called
+    Then it returns AllRulesInclude (recognition seam for story C.2).
+    """
+    assert parse_directive("<!-- DYNAMIC-INCLUDE-ALL-RULES -->") == AllRulesInclude()
+
+
+def test_prose_line_is_not_a_directive() -> None:
+    """
+    Given an ordinary prose line
+    When parse_directive is called
+    Then it returns None.
+    """
+    assert parse_directive("This is just a normal sentence.") is None
+
+
+def test_marker_with_leading_whitespace_is_not_a_directive() -> None:
+    """
+    Given a marker preceded by whitespace (not anchored to column 0)
+    When parse_directive is called
+    Then it returns None — the bash patterns anchor on ^...$.
+    """
+    assert parse_directive("    <!-- DYNAMIC-INCLUDE: rules/foo.md -->") is None
+
+
+def test_named_rules_form_is_not_recognised() -> None:
+    """
+    Given the deferred named-RULES form (story C.3, absent from the model)
+    When parse_directive is called
+    Then it returns None rather than being mistaken for the file form.
+    """
+    assert parse_directive("<!-- DYNAMIC-INCLUDE-RULES: a, b -->") is None
+
+
+def test_empty_path_marker_is_not_a_directive() -> None:
+    """
+    Given a file marker with an empty path
+    When parse_directive is called
+    Then it returns None — mirrors the bash `-n` non-empty guard.
+    """
+    assert parse_directive("<!-- DYNAMIC-INCLUDE:  -->") is None
+
+
+# ───────────────────────── flatten_template ─────────────────────────
+
+
+def test_single_marker_resolves_to_inlined_content(tmp_path: Path) -> None:
+    """
+    Given a template whose only line is a file marker
+    When flatten_template runs against a base dir containing that file
+    Then the output is the referenced file's verbatim content (AC1).
+    """
+    (tmp_path / "inc.md").write_text("INCLUDED BODY\n", encoding="utf-8")
+    io = ScriptedIO()
+
+    result = flatten_template(
+        "<!-- DYNAMIC-INCLUDE: inc.md -->\n", base_dir=tmp_path, io=io
+    )
+
+    assert result == "INCLUDED BODY\n"
+
+
+def test_markers_and_prose_assemble_in_order(tmp_path: Path) -> None:
+    """
+    Given a template interleaving prose and two file markers
+    When flatten_template runs
+    Then each marker is replaced in place and prose is preserved in order.
+    """
+    (tmp_path / "a.md").write_text("AAA\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("BBB\n", encoding="utf-8")
+    template = (
+        "header\n"
+        "<!-- DYNAMIC-INCLUDE: a.md -->\n"
+        "middle\n"
+        "<!-- DYNAMIC-INCLUDE: b.md -->\n"
+        "footer\n"
+    )
+
+    result = flatten_template(template, base_dir=tmp_path, io=ScriptedIO())
+
+    assert result == "header\nAAA\nmiddle\nBBB\nfooter\n"
+
+
+def test_missing_file_warns_and_leaves_line_empty(tmp_path: Path) -> None:
+    """
+    Given a marker whose target file does not exist
+    When flatten_template runs
+    Then it does not raise, emits a warning, and drops the marker line (AC2).
+    """
+    io = ScriptedIO()
+
+    result = flatten_template(
+        "before\n<!-- DYNAMIC-INCLUDE: missing.md -->\nafter\n",
+        base_dir=tmp_path,
+        io=io,
+    )
+
+    assert result == "before\nafter\n"
+    warnings = [e for e in io.transcript if e.channel == "warn"]
+    assert len(warnings) == 1
+    assert "missing.md" in warnings[0].message
+
+
+def test_non_directive_lines_pass_through_unchanged(tmp_path: Path) -> None:
+    """
+    Given a template with no markers
+    When flatten_template runs
+    Then the content is returned byte-for-byte (AC3).
+    """
+    template = "line one\nline two\n\nline four\n"
+
+    result = flatten_template(template, base_dir=tmp_path, io=ScriptedIO())
+
+    assert result == template
+
+
+def test_trailing_newline_is_preserved_when_present(tmp_path: Path) -> None:
+    """
+    Given a template ending in a newline
+    When flatten_template runs
+    Then the trailing newline is preserved (AC4).
+    """
+    result = flatten_template("alpha\nbeta\n", base_dir=tmp_path, io=ScriptedIO())
+
+    assert result == "alpha\nbeta\n"
+
+
+def test_absent_trailing_newline_is_not_invented(tmp_path: Path) -> None:
+    """
+    Given a template that does not end in a newline
+    When flatten_template runs
+    Then no trailing newline is added (AC4, negative case).
+    """
+    result = flatten_template("alpha\nbeta", base_dir=tmp_path, io=ScriptedIO())
+
+    assert result == "alpha\nbeta"
+
+
+def test_included_file_without_trailing_newline_glues_to_next_line(
+    tmp_path: Path,
+) -> None:
+    """
+    Given an included file with no trailing newline, followed by a prose line
+    When flatten_template runs
+    Then the included content abuts the next line with no injected separator —
+    matching `cat file >> output` (the marker line's own newline is consumed).
+    """
+    (tmp_path / "frag.md").write_text("FRAGMENT", encoding="utf-8")  # no newline
+
+    result = flatten_template(
+        "<!-- DYNAMIC-INCLUDE: frag.md -->\nafter\n",
+        base_dir=tmp_path,
+        io=ScriptedIO(),
+    )
+
+    assert result == "FRAGMENTafter\n"
+
+
+def test_all_rules_marker_resolution_is_deferred(tmp_path: Path) -> None:
+    """
+    Given a template containing the ALL-RULES marker
+    When flatten_template runs
+    Then it raises NotImplementedError — resolution lands in story C.2, and the
+    marker must fail loudly rather than emit a literal comment line.
+    """
+    with pytest.raises(NotImplementedError):
+        flatten_template(
+            "<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n", base_dir=tmp_path, io=ScriptedIO()
+        )

--- a/packages/installer/tests/unit/test_templates.py
+++ b/packages/installer/tests/unit/test_templates.py
@@ -86,9 +86,7 @@ def test_single_marker_resolves_to_inlined_content(tmp_path: Path) -> None:
     (tmp_path / "inc.md").write_text("INCLUDED BODY\n", encoding="utf-8")
     io = ScriptedIO()
 
-    result = flatten_template(
-        "<!-- DYNAMIC-INCLUDE: inc.md -->\n", base_dir=tmp_path, io=io
-    )
+    result = flatten_template("<!-- DYNAMIC-INCLUDE: inc.md -->\n", base_dir=tmp_path, io=io)
 
     assert result == "INCLUDED BODY\n"
 
@@ -102,11 +100,7 @@ def test_markers_and_prose_assemble_in_order(tmp_path: Path) -> None:
     (tmp_path / "a.md").write_text("AAA\n", encoding="utf-8")
     (tmp_path / "b.md").write_text("BBB\n", encoding="utf-8")
     template = (
-        "header\n"
-        "<!-- DYNAMIC-INCLUDE: a.md -->\n"
-        "middle\n"
-        "<!-- DYNAMIC-INCLUDE: b.md -->\n"
-        "footer\n"
+        "header\n<!-- DYNAMIC-INCLUDE: a.md -->\nmiddle\n<!-- DYNAMIC-INCLUDE: b.md -->\nfooter\n"
     )
 
     result = flatten_template(template, base_dir=tmp_path, io=ScriptedIO())
@@ -197,6 +191,4 @@ def test_all_rules_marker_resolution_is_deferred(tmp_path: Path) -> None:
     marker must fail loudly rather than emit a literal comment line.
     """
     with pytest.raises(NotImplementedError):
-        flatten_template(
-            "<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n", base_dir=tmp_path, io=ScriptedIO()
-        )
+        flatten_template("<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n", base_dir=tmp_path, io=ScriptedIO())


### PR DESCRIPTION
## Summary

- Adds `packages/installer/src/installer/core/templates.py` implementing the **file form** of DYNAMIC-INCLUDE: a `<!-- DYNAMIC-INCLUDE: path -->` marker line resolves to the referenced file's verbatim content (resolved under a base dir), faithfully porting the bash `flatten_agents_md`.
- `parse_directive` recognises **both** the file and ALL-RULES marker forms (the data model defines both); `flatten_template` resolves the file form and raises `NotImplementedError` on ALL-RULES — a loud, single-line seam for story C.2 rather than silently emitting a literal marker.
- Bash-parity semantics: marker line consumed and replaced by verbatim `cat`; missing target warns (non-fatal) and leaves the line empty; exact `^...$` anchoring; empty-path `-n` guard; trailing newline preserved iff the template had one.
- `model.py`, `staging.py`, `sync.py` are untouched; the bytes↔str boundary and staging-walk wiring are a later story (C.1).

## Implements

Bead `agents-config-w1qls.2.4` (B.4 — DYNAMIC-INCLUDE file form), Epic B of the Python installer rewrite.

## Test plan

- 14 new unit tests in `tests/unit/test_templates.py`, all behavioural — recognition (file form, ALL-RULES, prose, leading-whitespace, deferred named-RULES, empty-path), assembly order, missing-file non-fatality + warning, pass-through, trailing-newline fidelity (both directions), verbatim-`cat` glue, and the C.2 `NotImplementedError` seam.
- Full suite: **97 passed**. `mypy --strict`: **clean**. `ruff`: **clean**. Coverage on the changed module: **100% line + branch**.

## Follow-up (tracked)

- `agents-config-w1qls.3.1.1` (discovered-from this story): add a path-traversal guard when C.1 wires `flatten_template` into the staging walk. Deliberately out of scope here — the transform is currently fed only by the project's own trusted template tree, and the bash reference has no such guard. It is an improvement-over-parity to land at the integration seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
