### PR TITLE
docs(installer): package-scoped AGENTS.md + fix stale 'no build system' claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,8 @@ It's simple: this project hosts "agent configuration" (and tools, helpers, etc.)
 
 Other notes:
 
-- No build system, tests, or linting - this is pure documentation
-- Changes should follow existing formatting conventions in each file type
+- Most of the repo (config content under `src/`) is documentation and templates with no build step — changes there just follow existing formatting conventions per file type.
+- **Exception — `packages/installer/` is a real Python package with a mandatory quality gate.** Before pushing any change under `packages/installer/`, run `make ci-installer` from the repo root (or `make ci` for the whole repo). It runs lint, format-check, typecheck, coverage, audit, and entry-verify — the same gate CI enforces. See `packages/installer/AGENTS.md` for the package-scoped workflow.
 
 ## Project Milestones (current, not target)
 

--- a/packages/installer/AGENTS.md
+++ b/packages/installer/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md — `packages/installer/`
+
+Package-scoped guidance for the Python installer. The repo-root `AGENTS.md`
+still applies; this file adds what is specific to this package. Unlike the
+config content under `src/`, **this is real code with a real quality gate.**
+
+## The quality gate is mandatory — run it, do not approximate it
+
+Before pushing **any** change under `packages/installer/`, run the canonical
+gate from the repo root:
+
+```bash
+make ci-installer   # the full gate CI enforces
+```
+
+It runs, in order: `ruff check` (lint), `ruff format --check` (formatting),
+`mypy --strict src` (types), `pytest --cov` (tests + coverage),
+`pip-audit` (deps), `install.py --help` (entry verify). `make ci` adds
+`actionlint`.
+
+Do **not** hand-pick a subset (e.g. `ruff check` alone). `ruff check` (linter)
+and `ruff format` (formatter) are orthogonal — passing one says nothing about
+the other. The `Makefile` is the single source of truth for the gate; mirror it
+exactly. Faster inner loop while iterating: `make test-installer` (pytest only),
+but the full gate must pass before push.
+
+## Toolchain
+
+- `uv`-managed; Python ≥ 3.11 (`uv` auto-installs it first run).
+- Run tools via `uv run …` from inside `packages/installer/`, or the `make`
+  targets from the repo root.
+- Config lives in `pyproject.toml`: ruff (line-length 100, strict rule set),
+  mypy `strict = true`, coverage `branch = true` / `fail_under = 90`.
+
+## Design principles for this package
+
+- **Python over Bash** — logic that needs testing lives in Python; shell stays a
+  thin wrapper. This package is the port of `scripts/install.sh`.
+- **`scripts/install.sh` is the behavioural spec.** Until the golden-master
+  parity suite is green, the bash installer's observable behaviour is the
+  contract a port must match — cite specific line ranges when porting.
+- **Pure core, injected I/O.** Engine modules under `core/` are pure functions;
+  all terminal interaction routes through the `IOPort` protocol (`TerminalIO`
+  real, `ScriptedIO` test fake). No module calls `print`/`input` or imports
+  `rich` directly.
+- Layout: `core/` (engine: model, staging, sync, templates, …), `tools/`
+  (per-tool adapters keyed by the `Tool` enum), `cli.py`, `config.py`.
+
+## Tests
+
+- Behavioural, not tautological — each test pins a coded decision, never the
+  language/stdlib/regex. Screen every test against "what coded decision does
+  this pin?" before writing it.
+- Unit tests drive the engine through `ScriptedIO`; assert against its
+  transcript. Coverage floor is 90% branch (enforced by `pytest --cov`).
+
+## Do not run the installer automatically
+
+Never invoke `scripts/install.sh` or `scripts/install.py` to "try it out" —
+only the user runs the installer, and only when they explicitly ask. The gate's
+`install.py --help` entry-verify is the only sanctioned automatic invocation.
+
+## Reference
+
+Architecture and the Epic A→H story sequence: `docs/architecture/installer/installer-design.md`.

--- a/packages/installer/CLAUDE.md
+++ b/packages/installer/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Refer to the @AGENTS.md file in the same directory.


### PR DESCRIPTION
## Summary

Adds a package-scoped instruction file for `packages/installer/` and fixes an actively-false claim in the root `AGENTS.md`.

**Motivation:** PR #114 failed CI on `ruff format --check` because the completion gate ran a hand-picked subset (`ruff check` + `mypy` + `pytest`) instead of the project's canonical `make ci-installer`. Root cause: the root `AGENTS.md` — auto-loaded every session — asserted *"No build system, tests, or linting - this is pure documentation."* That is false since the installer package landed, and it steered agents away from the gate.

**Changes:**
- **`AGENTS.md` (root):** corrected the stale note. `src/` content is docs/templates (no build); `packages/installer/` is a real Python package with a mandatory `make ci-installer` gate.
- **`packages/installer/AGENTS.md` (new):** package-scoped guidance — the gate (run it, don't approximate it; `ruff check` ≠ `ruff format`), toolchain (uv, Python ≥3.11, config floors), Python-over-bash + `scripts/install.sh` parity contract, pure-core/injected-IOPort design, test conventions (behavioural, 90% branch floor), and the "never auto-run the installer" rule.
- **`packages/installer/CLAUDE.md` (new):** one-line pointer to the sibling `AGENTS.md` (mirrors the repo-root `CLAUDE.md` → `AGENTS.md` convention; guarantees Claude Code auto-loads it when working in the subtree).

This is the structural counterpart to the behavioural memory captured after #114: the nested `AGENTS.md` surfaces the gate proactively when an agent touches installer code, instead of relying on the agent remembering to go look for the `Makefile`.

## Test plan

- `make ci-installer` from the repo root: **all gates green** — lint, `ruff format --check`, `mypy --strict`, pytest (83 passed), coverage 100%, pip-audit clean, entry-verify.
- Markdown-only change; no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
