### PR TITLE
docs(installer): C4 / sequence / data-view HLD artifact set (w1qls.9)

### DIFF
--- a/docs/architecture/installer/c4-l2-container.md
+++ b/docs/architecture/installer/c4-l2-container.md
@@ -1,0 +1,122 @@
+# Python Installer — C4 Level 2: Container
+
+> **Up**: [index](index.md)
+> **Next (reading order)**: [Sequences](sequences.md)
+> **Source bead**: `agents-config-w1qls.9`
+> **Source spec**: [`installer-design.md`](installer-design.md)
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| Container (C4 sense) | A separately runnable process or persistent data store — NOT a Linux / Docker container. |
+| Component | A code module inside a container; appears at C4 L3, not L2. |
+| Source tree | The repo's `src/user/` (shared `.agents/` + per-tool `.claude/`, `.codex/`, `.gemini/`, `.opencode/`) and `src/plugins/<name>/`. The installer's **read-only** input. |
+| Destination store | A per-tool config directory the installer writes into (`~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.config/opencode/`, `~/.beads/`). |
+| `StagingPlan` | The installer's **in-memory** `dict[Path, StagedItem]`. It is process-internal state, NOT a container — it appears at L3 / [data-view](data-view.md), never on this diagram. `--dump-stage` materialises it to disk for debugging only. |
+| `installer.toml` | The installer's structured config (prune globs + tool-registry overrides). Replaces the legacy `scripts/prune-list` at the parity gate. |
+| Backup dir | A path-aware sibling directory where the installer copies a destination file before overwriting or pruning it. |
+
+## Purpose
+
+Open the `installer` system boundary and show its runnable / persistent units. Answers: *what runs, what does it read, what does it write, and who consumes the output?*
+
+A **container** here is a C4 container: a separately runnable process or a persistent data store. The installer is a single short-lived **process**; everything else on this diagram is a **data store** it reads or writes. The `core/` engine, the per-tool adapters, the per-plugin adapters, and the merge strategies all live **inside** that one process and are therefore **components** — they appear at L3 ([`c4-l3-engine.md`](c4-l3-engine.md)), not here.
+
+The single most important thing this diagram makes explicit: the installer's central artifact, the `StagingPlan`, is **in-memory** — it is built, merged, and transformed entirely in process memory and only ever touches disk when `sync` flushes individual files to their destinations. It is **not** a staging container on this diagram. (`install.sh` used a temp directory; the Python rewrite deliberately does not.)
+
+## Diagram
+
+```mermaid
+C4Container
+    title Python Installer — Containers (C4 L2)
+
+    Person(operator, "Operator", "Developer running the installer from the agents-config repo")
+
+    System_Boundary(installer_sys, "Python installer") {
+        Container(proc, "installer process", "Python 3.11 / uv — python -m installer", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
+    }
+
+    System_Boundary(repo, "agents-config repo (read-only inputs)") {
+        ContainerDb(source, "Source config tree", "files on local FS", "src/user/.agents (shared) + src/user/.{claude,codex,gemini,opencode} (per-tool) + src/plugins/<name>/. The installer NEVER writes here — it is pure input.")
+        ContainerDb(toml, "installer.toml", "TOML on local FS", "packages/installer/installer.toml — [prune].retired globs + [tools] registry overrides. Read once at Config build. Side-by-side window: install.sh still reads scripts/prune-list; install.py reads this.")
+    }
+
+    System_Boundary(home, "User home (destination stores — installer-written)") {
+        ContainerDb(claude, "~/.claude/", "files on local FS", "Claude Code config: agents, skills, commands, rules, settings.json, assembled AGENTS.md / CLAUDE.md.")
+        ContainerDb(codex, "~/.codex/", "files on local FS", "Codex CLI config: assembled AGENTS.md + shared content.")
+        ContainerDb(gemini, "~/.gemini/", "files on local FS", "Gemini CLI config: assembled GEMINI.md + frontmatter-transformed content.")
+        ContainerDb(opencode, "~/.config/opencode/", "files on local FS (XDG)", "OpenCode config: flattened skeleton; skips shared agents/ per its adapter rule.")
+        ContainerDb(beads, "~/.beads/", "files on local FS", "beads plugin destination: formulas/ + scripts/ (chmod +x). Written only when the beads plugin is active.")
+        ContainerDb(backups, "Backup dirs", "timestamped copies on local FS", "Path-aware: namespaced items back up to a parent-level <namespace>-backup/ sibling; top-level files back up in place. Written before any overwrite or prune.")
+    }
+
+    System_Ext(assistants, "AI coding assistants", "Claude Code / Codex CLI / Gemini CLI / OpenCode — each reads ITS OWN destination store at the assistant's runtime, asynchronously, long after install exits.")
+    System_Ext(bd_cli, "bd (beads CLI)", "Reads ~/.beads/ formulas + scripts at its own runtime.")
+
+    Rel(operator, proc, "Runs python3 scripts/install.py [--tools=] [--plugins=] [--prune] [--dry-run] [--dump-stage]", "CLI invocation")
+
+    Rel(proc, source, "Walks + reads source files; flattens DYNAMIC-INCLUDE; strips .template suffix", "FS read")
+    Rel(proc, toml, "Reads prune globs + tool-registry overrides", "FS read")
+
+    Rel(proc, claude, "Hash-compare → diff → confirm → backup → write", "FS write")
+    Rel(proc, codex, "Hash-compare → write", "FS write")
+    Rel(proc, gemini, "Hash-compare → write (post frontmatter transform)", "FS write")
+    Rel(proc, opencode, "Hash-compare → write", "FS write")
+    Rel(proc, beads, "Write formulas + scripts (chmod +x)", "FS write")
+    Rel(proc, backups, "Copy destination file before overwrite / prune", "FS write")
+
+    Rel(assistants, claude, "Reads deployed config at runtime", "FS read (async)")
+    Rel(assistants, codex, "Reads deployed config at runtime", "FS read (async)")
+    Rel(assistants, gemini, "Reads deployed config at runtime", "FS read (async)")
+    Rel(assistants, opencode, "Reads deployed config at runtime", "FS read (async)")
+    Rel(bd_cli, beads, "Reads formulas + scripts at runtime", "FS read (async)")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Element notes
+
+### The installer process
+
+The whole installer runs here. Every invocation is **terminal** — parse argv, build `Config`, build the `StagingPlan`(s), flush to disk, exit. There is no daemon, no background work, no cache between runs. Internally — at L3 — this process is composed of a tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `sync`, `prune`, `merge/*`), per-tool `tools/` adapters, per-plugin `plugins/` adapters, and a `cli`/`config`/`orchestrator` top layer. Those components are drawn in [`c4-l3-engine.md`](c4-l3-engine.md).
+
+The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`). Post-parity, `scripts/install.sh` collapses to `exec uv run --project packages/installer python -m installer "$@"`, so the bash and python entry points converge on the same process.
+
+### Read-only inputs
+
+- **Source config tree** — `src/user/.agents/` (shared content installed to all tools), `src/user/.{claude,codex,gemini,opencode}/` (per-tool content), and `src/plugins/<name>/` (optional overlay content). The installer **never writes here**; this is the architectural guarantee that makes the source the single canonical authoring surface (the AGENTS.md "always edit source, never deployed artifacts" rule depends on it).
+- **`installer.toml`** — structured config read once at `Config` build: the `[prune].retired` glob list (retired paths to scan for and offer to remove) and optional `[tools]` registry overrides. During the side-by-side window `install.sh` reads the legacy `scripts/prune-list`; at the parity gate that file retires and `installer.toml` is the sole config.
+
+### Destination stores (installer-written)
+
+One store per tool (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.config/opencode`) plus `~/.beads` when the beads plugin is active. The installer writes each store via the hash-compare `sync` engine: unchanged files are skipped, changed files are diffed and (interactively) confirmed, and any file about to be overwritten is first copied to a **path-aware backup**. Which stores are written depends on tool auto-detection (claude always; others when their config dir exists or `--tools=` forces them) and plugin activation.
+
+### Backup dirs
+
+Not a single directory but a routing rule: a file inside a managed namespace (`commands` / `skills` / `agents` / `rules` / `formulas`) backs up to a parent-level `<namespace>-backup/` sibling — deliberately **outside** the namespace so the assistant's discovery walk does not pick the backup up as a real item — while a top-level file backs up in place. Backups are written before overwrite (`sync`) and before prune (`prune`).
+
+### External consumers
+
+The four AI coding assistants and the `bd` CLI are **external systems** that read their deployed stores at **their own runtime**, asynchronously, long after the installer has exited. The installer has no live relationship with them — it deposits files and leaves. This asynchrony is why the installer needs no notion of a running tool; it only needs to know each tool's destination path and content-shaping rules, both supplied by the `ToolAdapter`.
+
+## Container-relationship discipline (worth memorising)
+
+- **The source tree is read-only; the installer owns the writes to destinations.** There is exactly one writer of `~/.claude` et al. during install (the installer) and exactly one writer of `src/` (the human author, via the repo). The installer never crosses that line.
+- **The `StagingPlan` is in-memory and never appears here.** It is built, overlaid, and transformed in process memory; only `sync` touches disk, file-by-file. The one exception, `--dump-stage <path>`, materialises the plan to a throwaway directory for debugging and exits without writing any real destination — it is a diagnostic, not the operational path.
+- **Consumption is asynchronous.** The assistants read their stores whenever *they* run, not when the installer runs. The installer has no runtime coupling to any tool — only a path + content contract via the adapter.
+- **`installer.toml` is config, not state.** It is read, never written, by the install path. (`tomli-w` exists in the dep list for a future `--prune`-driven config-update feature, but the steady-state install reads it read-only.)
+- **Tool set and plugin set are resolved once, up front.** `Config` is frozen after auto-detection + argv + `installer.toml`; the destination stores written in a given run are fixed before any staging begins.
+
+## What this diagram does NOT show
+
+- **Components inside the installer process** — the `core/` engine, `tools/` + `plugins/` adapters, and merge strategies live in [`c4-l3-engine.md`](c4-l3-engine.md).
+- **Execution order** — detect → stage → overlay → merge → sync → prune is the subject of [`sequences.md`](sequences.md).
+- **The `StagingPlan` / `StagedItem` / `Config` data shapes** and the `(FileKind, namespace)` merge-dispatch table — see [`data-view.md`](data-view.md).
+- **DYNAMIC-INCLUDE flattening + the Gemini frontmatter transform mechanics** — surfaced as components at L3; specified in `installer-design.md`.
+
+## Cross-references
+
+- **Next (reading order)**: [Sequences](sequences.md) — how one install invocation runs
+- **Related**: [C4 L3 — Engine](c4-l3-engine.md) — the components inside the installer process
+- **Companion source**: [`installer-design.md`](installer-design.md) §"Repo layout", §"Package layout", §"Configuration — installer.toml"

--- a/docs/architecture/installer/c4-l2-container.md
+++ b/docs/architecture/installer/c4-l2-container.md
@@ -34,7 +34,7 @@ C4Container
     Person(operator, "Operator", "Developer running the installer from the agents-config repo")
 
     System_Boundary(installer_sys, "Python installer") {
-        Container(proc, "installer process", "Python 3.11 / uv — python -m installer.cli", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
+        Container(proc, "installer process", "Python 3.11 / uv — python3 scripts/install.py", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
     }
 
     System_Boundary(repo, "agents-config repo (read-only inputs)") {
@@ -81,7 +81,7 @@ C4Container
 
 The whole installer runs here. Every invocation is **terminal** — parse argv, build `Config`, build the `StagingPlan`(s), flush to disk, exit. There is no daemon, no background work, no cache between runs. Internally — at L3 — this process is composed of a tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `sync`, `prune`, `merge/*`), per-tool `tools/` adapters, per-plugin `plugins/` adapters, and a `cli`/`config`/`orchestrator` top layer. Those components are drawn in [`c4-l3-engine.md`](c4-l3-engine.md).
 
-The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`). The currently valid module-style invocation is `python -m installer.cli`; post-parity, `scripts/install.sh` can collapse to the same module entrypoint until `installer/__main__.py` exists.
+The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`) — the only currently runnable invocation. Post-parity (Epic H.4, once the package gains a `__main__.py`), `scripts/install.sh` collapses to `exec uv run --project packages/installer python -m installer "$@"`, so the bash and python entry points converge on the same process; the `python -m installer` module form is design-forward until then.
 
 ### Read-only inputs
 

--- a/docs/architecture/installer/c4-l2-container.md
+++ b/docs/architecture/installer/c4-l2-container.md
@@ -34,7 +34,7 @@ C4Container
     Person(operator, "Operator", "Developer running the installer from the agents-config repo")
 
     System_Boundary(installer_sys, "Python installer") {
-        Container(proc, "installer process", "Python 3.11 / uv — python -m installer", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
+        Container(proc, "installer process", "Python 3.11 / uv — python -m installer.cli", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
     }
 
     System_Boundary(repo, "agents-config repo (read-only inputs)") {
@@ -81,7 +81,7 @@ C4Container
 
 The whole installer runs here. Every invocation is **terminal** — parse argv, build `Config`, build the `StagingPlan`(s), flush to disk, exit. There is no daemon, no background work, no cache between runs. Internally — at L3 — this process is composed of a tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `sync`, `prune`, `merge/*`), per-tool `tools/` adapters, per-plugin `plugins/` adapters, and a `cli`/`config`/`orchestrator` top layer. Those components are drawn in [`c4-l3-engine.md`](c4-l3-engine.md).
 
-The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`). Post-parity, `scripts/install.sh` collapses to `exec uv run --project packages/installer python -m installer "$@"`, so the bash and python entry points converge on the same process.
+The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`). The currently valid module-style invocation is `python -m installer.cli`; post-parity, `scripts/install.sh` can collapse to the same module entrypoint until `installer/__main__.py` exists.
 
 ### Read-only inputs
 

--- a/docs/architecture/installer/c4-l2-container.md
+++ b/docs/architecture/installer/c4-l2-container.md
@@ -34,12 +34,12 @@ C4Container
     Person(operator, "Operator", "Developer running the installer from the agents-config repo")
 
     System_Boundary(installer_sys, "Python installer") {
-        Container(proc, "installer process", "Python 3.11 / uv — python3 scripts/install.py", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
+        Container(proc, "installer process", "Python 3.11 / uv", "Short-lived CLI. Parses argv, builds a frozen Config (tool/plugin auto-detection + installer.toml), builds an IN-MEMORY StagingPlan per tool, applies plugin overlay + per-tool transforms, then flushes the plan file-by-file to destinations via hash-compare sync. No daemon, no persistent state of its own — every invocation runs to completion and exits.")
     }
 
     System_Boundary(repo, "agents-config repo (read-only inputs)") {
         ContainerDb(source, "Source config tree", "files on local FS", "src/user/.agents (shared) + src/user/.{claude,codex,gemini,opencode} (per-tool) + src/plugins/<name>/. The installer NEVER writes here — it is pure input.")
-        ContainerDb(toml, "installer.toml", "TOML on local FS", "packages/installer/installer.toml — [prune].retired globs + [tools] registry overrides. Read once at Config build. Side-by-side window: install.sh still reads scripts/prune-list; install.py reads this.")
+        ContainerDb(toml, "installer.toml", "TOML on local FS", "packages/installer/installer.toml — [prune].retired globs + [tools] registry overrides. Read once at Config build.")
     }
 
     System_Boundary(home, "User home (destination stores — installer-written)") {
@@ -54,7 +54,7 @@ C4Container
     System_Ext(assistants, "AI coding assistants", "Claude Code / Codex CLI / Gemini CLI / OpenCode — each reads ITS OWN destination store at the assistant's runtime, asynchronously, long after install exits.")
     System_Ext(bd_cli, "bd (beads CLI)", "Reads ~/.beads/ formulas + scripts at its own runtime.")
 
-    Rel(operator, proc, "Runs python3 scripts/install.py [--tools=] [--plugins=] [--prune] [--dry-run] [--dump-stage]", "CLI invocation")
+    Rel(operator, proc, "python3 scripts/install.py or python -m installer [--tools=] [--plugins=] [--prune] [--dry-run] [--dump-stage]", "CLI invocation")
 
     Rel(proc, source, "Walks + reads source files; flattens DYNAMIC-INCLUDE; strips .template suffix", "FS read")
     Rel(proc, toml, "Reads prune globs + tool-registry overrides", "FS read")
@@ -81,12 +81,12 @@ C4Container
 
 The whole installer runs here. Every invocation is **terminal** — parse argv, build `Config`, build the `StagingPlan`(s), flush to disk, exit. There is no daemon, no background work, no cache between runs. Internally — at L3 — this process is composed of a tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `sync`, `prune`, `merge/*`), per-tool `tools/` adapters, per-plugin `plugins/` adapters, and a `cli`/`config`/`orchestrator` top layer. Those components are drawn in [`c4-l3-engine.md`](c4-l3-engine.md).
 
-The end-user entry point is `python3 scripts/install.py` (a tiny stub: `from installer.cli import main`) — the only currently runnable invocation. Post-parity (Epic H.4, once the package gains a `__main__.py`), `scripts/install.sh` collapses to `exec uv run --project packages/installer python -m installer "$@"`, so the bash and python entry points converge on the same process; the `python -m installer` module form is design-forward until then.
+The installer's entry points are `python3 scripts/install.py` (a thin stub: `from installer.cli import main`) and the module form `python -m installer` (requires `packages/installer/__main__.py`); both invoke the same `installer.cli.main`.
 
 ### Read-only inputs
 
 - **Source config tree** — `src/user/.agents/` (shared content installed to all tools), `src/user/.{claude,codex,gemini,opencode}/` (per-tool content), and `src/plugins/<name>/` (optional overlay content). The installer **never writes here**; this is the architectural guarantee that makes the source the single canonical authoring surface (the AGENTS.md "always edit source, never deployed artifacts" rule depends on it).
-- **`installer.toml`** — structured config read once at `Config` build: the `[prune].retired` glob list (retired paths to scan for and offer to remove) and optional `[tools]` registry overrides. During the side-by-side window `install.sh` reads the legacy `scripts/prune-list`; at the parity gate that file retires and `installer.toml` is the sole config.
+- **`installer.toml`** — structured config read once at `Config` build: the `[prune].retired` glob list (retired paths to scan for and offer to remove) and optional `[tools]` registry overrides. This is the sole installer config; `scripts/prune-list` is the legacy predecessor it replaces.
 
 ### Destination stores (installer-written)
 

--- a/docs/architecture/installer/c4-l3-engine.md
+++ b/docs/architecture/installer/c4-l3-engine.md
@@ -102,7 +102,10 @@ C4Component
     Rel(prune, dest_ext, "scan + remove")
     Rel(ioport, term_ext, "stdin/stdout")
 
+    Rel(tclaude, tbase, "implements")
+    Rel(tcodex, tbase, "implements")
     Rel(tgemini, tbase, "implements")
+    Rel(topencode, tbase, "implements")
     Rel(pbeads, pbase, "implements")
 
     UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="2")

--- a/docs/architecture/installer/c4-l3-engine.md
+++ b/docs/architecture/installer/c4-l3-engine.md
@@ -72,7 +72,7 @@ C4Component
     System_Ext(dest_ext, "Destination stores", "~/.claude, ~/.codex, ~/.gemini, ~/.config/opencode, ~/.beads")
     System_Ext(term_ext, "Terminal", "stdin / stdout — diffs + confirmations")
 
-    Rel(operator, cli, "python3 scripts/install.py ... / python -m installer.cli ...")
+    Rel(operator, cli, "python3 scripts/install.py ...")
     Rel(cli, config, "build frozen Config")
     Rel(cli, orch, "invoke with Config + IOPort")
     Rel(config, treg, "auto-detect tools")

--- a/docs/architecture/installer/c4-l3-engine.md
+++ b/docs/architecture/installer/c4-l3-engine.md
@@ -1,0 +1,162 @@
+# Python Installer — C4 Level 3: Engine
+
+> **Up**: [index](index.md)
+> **Previous (reading order)**: [Sequences](sequences.md)
+> **Next (reading order)**: [Data View](data-view.md)
+> **Source bead**: `agents-config-w1qls.9`
+> **Source spec**: [`installer-design.md`](installer-design.md) — §"Package layout", §"Data model highlights"
+> **Container**: the `installer` process (see [`c4-l2-container.md`](c4-l2-container.md))
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| `core/` | The pure, tool-agnostic engine. Knows nothing about any specific tool; parameterised by a `ToolAdapter` and a source root. Fully unit-testable against a `FakeToolAdapter`. |
+| `orchestrator` | The top-level controller. For each detected tool it drives staging → plugin overlay → merge → sync, then optional prune. Composes the core engines with the adapters. |
+| `ToolAdapter` | Protocol abstracting per-tool behaviour: `source_dir`, `dest_dir`, `is_detected`, `scoped_namespaces`, `should_install_namespace`, `post_staging_transforms`. One implementation per tool. |
+| `PluginAdapter` | Protocol for an optional plugin overlay (e.g. beads). String-keyed registry; dynamically discovered by scanning `src/plugins/`. |
+| `MergeStrategy` | Collision-resolution protocol; one class per strategy module; dispatched by the registry on `(FileKind, namespace)`. |
+| `IOPort` | The single I/O abstraction. `TerminalIO` (real, via `rich`) and `ScriptedIO` (test fake) are the two implementations; no other module calls `print`/`input`. |
+| Protocol seam | A `typing.Protocol` boundary (`ToolAdapter`, `PluginAdapter`, `MergeStrategy`, `IOPort`) across which tests substitute a fake. The four seams are what make the engine unit-testable in isolation. |
+
+## Purpose
+
+Open the `installer` process boundary and show its components. Answers: *what code inside the process actually does the work, how is the tool-agnostic core kept separate from tool/plugin specifics, and where are the seams a test substitutes a fake across?*
+
+This is the most-detailed structural artifact in the set. It is the L3 zoom an implementer reads alongside the story they are wiring (e.g. C.1 staging, E.* merge strategies, F.2 plugin overlay).
+
+## Diagram
+
+```mermaid
+C4Component
+    title Python Installer — internal components (C4 L3)
+
+    Person(operator, "Operator")
+
+    Container_Boundary(proc, "installer process") {
+
+        Component(cli, "cli.py", "Python", "Parse argv; build Config; wire IOPort (TerminalIO); invoke orchestrator. Enforces --dump-stage vs --prune/--prune-only mutual exclusion.")
+        Component(config, "config.py", "Python", "Frozen Config dataclass. Tool + plugin auto-detection; loads installer.toml. Resolves the tool set + plugin set ONCE, up front.")
+        Component(orch, "orchestrator.py", "Python", "Top-level controller. Per detected tool: staging(adapter) -> plugin overlay -> merge-on-collision -> sync; then optional prune. Composes core engines + adapters.")
+
+        Container_Boundary(core, "core/ — pure, tool-agnostic engine") {
+            Component(model, "model.py", "Python", "FileKind, StagedItem, StagingPlan, Provenance, Orphan, IncludeDirective (FileInclude | AllRulesInclude), Counters, Tool enum. No behaviour — pure data.")
+            Component(ioport, "io_port.py", "Python", "IOPort protocol + TerminalIO (rich) + ScriptedIO (test). The only place stdin/stdout is touched.")
+            Component(templates, "templates.py", "Python", "DYNAMIC-INCLUDE flattening: file form + ALL-RULES form (sorted, joined with --- separators).")
+            Component(staging, "staging.py", "Python", "Source-walk -> StagingPlan, parameterised by a ToolAdapter. Strips .template suffix; scopes namespaces; calls adapter.post_staging_transforms.")
+            Component(sync, "sync.py", "Python", "Phase 7: hash-compare -> diff -> confirm -> path-aware backup -> write. Honours --dry-run.")
+            Component(prune, "prune.py", "Python", "Orphan scan (dest vs plan + installer.toml retired globs) + interactive prune flow.")
+            Component(mreg, "merge/registry.py", "Python", "(FileKind, namespace) -> MergeStrategy dispatch. Single lookup table.")
+            Component(mbase, "merge/base.py", "Python", "MergeStrategy protocol: merge(existing, incoming) -> StagedItem.")
+            Component(strat, "merge/strategies/* (5 modules)", "Python", "append_rules, fatal, json_union, last_wins_warn, last_wins_silent. One class + one test file each.")
+        }
+
+        Container_Boundary(tools, "tools/ — per-tool adapters") {
+            Component(tbase, "base.py", "Python", "ToolAdapter protocol.")
+            Component(tclaude, "claude.py", "Python", "Claude adapter.")
+            Component(tcodex, "codex.py", "Python", "Codex adapter (placeholder extensions).")
+            Component(tgemini, "gemini.py", "Python", "Gemini adapter — OWNS the frontmatter transform (post_staging_transforms).")
+            Component(topencode, "opencode.py", "Python", "OpenCode adapter — XDG dest + 'skip shared agents/' rule.")
+            Component(treg, "registry.py", "Python", "Tool-enum-keyed adapter registry.")
+        }
+
+        Container_Boundary(plugins, "plugins/ — per-plugin adapters") {
+            Component(pbase, "base.py", "Python", "PluginAdapter protocol.")
+            Component(pbeads, "beads.py", "Python", "beads adapter — ~/.beads dest, chmod +x on scripts.")
+            Component(pext, "extensions.py", "Python", "apply_extensions(): YAML-patch base markdown assets post-staging (F.5).")
+            Component(preg, "registry.py", "Python", "String-keyed plugin registry; dynamic discovery via src/plugins/ scan.")
+        }
+    }
+
+    System_Ext(src_ext, "Source config tree", "src/user/ + src/plugins/ (read-only)")
+    System_Ext(dest_ext, "Destination stores", "~/.claude, ~/.codex, ~/.gemini, ~/.config/opencode, ~/.beads")
+    System_Ext(term_ext, "Terminal", "stdin / stdout — diffs + confirmations")
+
+    Rel(operator, cli, "python -m installer ...")
+    Rel(cli, config, "build frozen Config")
+    Rel(cli, orch, "invoke with Config + IOPort")
+    Rel(config, treg, "auto-detect tools")
+    Rel(config, preg, "discover plugins")
+    Rel(config, src_ext, "probe installer.toml + tool dirs")
+
+    Rel(orch, staging, "per tool: build StagingPlan(adapter)")
+    Rel(orch, pext, "apply_extensions per tool plan")
+    Rel(orch, mreg, "collision -> strategy")
+    Rel(orch, sync, "flush plan to dest")
+    Rel(orch, prune, "optional: scan + prune")
+
+    Rel(staging, src_ext, "walk + read source")
+    Rel(staging, templates, "flatten DYNAMIC-INCLUDE")
+    Rel(staging, treg, "ToolAdapter behaviour (dest, namespaces, filter)")
+    Rel(staging, tgemini, "post_staging_transforms (frontmatter)")
+    Rel(staging, model, "build StagedItem / StagingPlan")
+
+    Rel(pext, preg, "resolve active plugin patches")
+    Rel(mreg, strat, "dispatch")
+    Rel(mreg, mbase, "protocol")
+    Rel(strat, model, "merge StagedItem")
+
+    Rel(sync, ioport, "show_diff / confirm")
+    Rel(sync, dest_ext, "backup + write")
+    Rel(prune, ioport, "confirm prune (three-way / per-item)")
+    Rel(prune, dest_ext, "scan + remove")
+    Rel(ioport, term_ext, "stdin/stdout")
+
+    Rel(tgemini, tbase, "implements")
+    Rel(pbeads, pbase, "implements")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="2")
+```
+
+## Component notes
+
+### Top layer — `cli` / `config` / `orchestrator`
+
+- **`cli.py`** is the thin entry: parse argv, build the frozen `Config`, instantiate `TerminalIO`, hand both to the orchestrator. It owns argv-level validation — notably the `--dump-stage` ⊕ `--prune`/`--prune-only` mutual exclusion.
+- **`config.py`** resolves *what will be installed* exactly once: tool auto-detection (claude always; others when their config dir exists or `--tools=` forces them — note this checks for config **directories**, not running binaries), plugin discovery (scan `src/plugins/`), and `installer.toml` load. `Config` is frozen thereafter; nothing downstream re-detects.
+- **`orchestrator.py`** is the control flow. For each detected tool it builds that tool's `StagingPlan` (passing the tool's adapter into the staging engine), runs the plugin overlay + `apply_extensions`, resolves collisions through the merge registry, and flushes via `sync`. Prune, if requested, runs after the per-tool loop.
+
+### `core/` — the tool-agnostic engine
+
+The engine knows nothing about any specific tool; it takes a `ToolAdapter` and a source root and runs. This is the load-bearing separation in the whole design — it is what lets ~80–100 unit tests exercise the engine through a `FakeToolAdapter` without any real tool present.
+
+- **`model.py`** is pure data — the enums and dataclasses every other module passes around (detailed in [`data-view.md`](data-view.md)). No behaviour lives here.
+- **`io_port.py`** is the I/O chokepoint. `sync` and `prune` reach the terminal only through the `IOPort` protocol; tests inject `ScriptedIO` to drive every prompt deterministically.
+- **`templates.py`** does DYNAMIC-INCLUDE flattening. The file form inlines one fragment; the ALL-RULES form expands the staged rules collection sorted + `\n---\n`-joined. (The Gemini frontmatter conversion is invoked here in tests but **lives in `tools/gemini.py`** — the engine stays tool-agnostic.)
+- **`staging.py`** walks the source, strips the `.template` suffix, scopes files into namespaces, builds `StagedItem`s into the `StagingPlan`, and calls the adapter's `post_staging_transforms`. It is parameterised by the `ToolAdapter`, never branching on a tool name itself.
+- **`sync.py`** is Phase 7: for each planned file, hash-compare against the destination; identical → skip; different → diff via `IOPort`, confirm, path-aware backup, write. `--dry-run` short-circuits before any write.
+- **`prune.py`** scans the destination for orphans (present in dest, absent from plan, matching `installer.toml` retired globs) and runs the interactive prune flow (three-way + per-item) through `IOPort`.
+- **`merge/`** is the collision matrix: `registry.py` maps `(FileKind, namespace)` to a strategy; `base.py` is the `MergeStrategy` protocol; `strategies/` holds the five concrete classes, each in its own module with its own test.
+
+### `tools/` — per-tool adapters
+
+One module per tool behind the `ToolAdapter` protocol (`base.py`). Each adapter answers the engine's questions: where is this tool's source, where is its destination, is it detected, which namespaces does it scope, should this namespace be installed from this source, and what transforms run post-staging. The non-trivial adapters: **`gemini.py`** owns the frontmatter transform; **`opencode.py`** owns the XDG destination and the "skip shared `agents/`" rule. `registry.py` is the `Tool`-enum-keyed lookup.
+
+### `plugins/` — per-plugin adapters
+
+One module per plugin behind the `PluginAdapter` protocol (`base.py`), **string-keyed** in `registry.py` and discovered dynamically by scanning `src/plugins/` — adding a plugin requires no change to `model.py`. **`beads.py`** owns the `~/.beads` destination + `chmod +x`. **`extensions.py`** (`apply_extensions()`, story F.5) applies plugin-declared YAML patches to base markdown assets post-staging, once per enabled tool against that tool's plan.
+
+### The four protocol seams
+
+| Seam | Protocol module | What a test substitutes |
+|---|---|---|
+| Tool behaviour | `tools/base.py` `ToolAdapter` | `FakeToolAdapter` — exercises the core engine with no real tool |
+| Plugin overlay | `plugins/base.py` `PluginAdapter` | synthetic test-plugin fixture (story F.1) |
+| Collision resolution | `core/merge/base.py` `MergeStrategy` | swap a registry entry to assert dispatch |
+| All I/O | `core/io_port.py` `IOPort` | `ScriptedIO` — drives prompts, records transcript |
+
+Every cross-boundary dependency is one of these four protocols. That is the design's testability contract: no engine module hard-codes a tool, a plugin, a strategy, or a print statement.
+
+## What this diagram does NOT show
+
+- **Execution order across the components** — detect → stage → overlay → merge → sync → prune is the subject of [`sequences.md`](sequences.md).
+- **The data shapes** the components pass around (`StagingPlan`, `StagedItem`, `Config`, …) and the merge-dispatch table — see [`data-view.md`](data-view.md).
+- **The per-strategy merge mechanics** (append separator placement, JSON deep-union rules, fatal message format) — specified in `installer-design.md` §"Test architecture" and per-strategy in the E.* stories.
+- **The container boundary + external stores at process granularity** — see [`c4-l2-container.md`](c4-l2-container.md).
+
+## Cross-references
+
+- **Previous (reading order)**: [Sequences](sequences.md) — the flows these components execute
+- **Next (reading order)**: [Data View](data-view.md) — the data these components read / build / write
+- **Companion structural view**: [`c4-l2-container.md`](c4-l2-container.md)
+- **Source spec**: [`installer-design.md`](installer-design.md) §"Package layout", §"Data model highlights", §"IOPort protocol"

--- a/docs/architecture/installer/c4-l3-engine.md
+++ b/docs/architecture/installer/c4-l3-engine.md
@@ -72,7 +72,7 @@ C4Component
     System_Ext(dest_ext, "Destination stores", "~/.claude, ~/.codex, ~/.gemini, ~/.config/opencode, ~/.beads")
     System_Ext(term_ext, "Terminal", "stdin / stdout — diffs + confirmations")
 
-    Rel(operator, cli, "python -m installer ...")
+    Rel(operator, cli, "python3 scripts/install.py ... / python -m installer.cli ...")
     Rel(cli, config, "build frozen Config")
     Rel(cli, orch, "invoke with Config + IOPort")
     Rel(config, treg, "auto-detect tools")

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -31,79 +31,81 @@ The data view answers: *what shapes does the installer build in memory, what dri
 
 ## In-memory model ER diagram
 
+Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case). Where a type is not yet built, the row is marked *design-forward* and traces to `installer-design.md`, not to current code.
+
 ```mermaid
 erDiagram
     Config      ||--o{ StagingPlan      : "one built per detected Tool"
-    StagingPlan ||--o{ StagedItem       : "dict keyed by dest Path"
-    StagedItem  ||--|| Provenance       : "has 1 (origin)"
-    StagedItem  ||--o{ IncludeDirective : "flattened from 0..N (transient)"
-    Config      ||--|| Counters         : "one run tally"
-    Config      ||--o{ Orphan           : "prune scan yields 0..N"
+    StagingPlan ||--o{ StagedItem       : "items: dict keyed by dest_relpath"
+    StagedItem  ||--|| Provenance        : "has 1 (origin)"
+    StagedItem  ||--o{ FileInclude       : "content flattened from 0..N (transient)"
+    StagedItem  ||--o| AllRulesInclude   : "content flattened from ALL-RULES marker (transient; no fields)"
+    Config      ||--|| Counters          : "one run tally"
+    Config      ||--o{ Orphan            : "prune scan yields 0..N"
 
     Config {
-        ToolSet  Tools          "detected (claude always) + forced via --tools"
-        StrList  Plugins        "discovered by scanning src/plugins/ (string-keyed)"
-        Path     RepoRoot       "source root"
-        Path     Home           "destination root (per-tool dest derived via adapter)"
-        bool     DryRun         "--dry-run: preview, no writes"
-        PruneMode Prune         "none | prune | prune_only"
-        Path     DumpStage      "optional --dump-stage target (debug); excl. with Prune"
-        StrList  RetiredGlobs   "installer.toml [prune].retired"
-        Map      ToolOverrides  "installer.toml [tools]"
+        Path      home           "destination root (per-tool dest via adapter) — implemented (B.1)"
+        ToolTuple tools          "resolved tool set (claude auto-detected; forced via --tools) — implemented (B.1)"
+        StrList   plugins        "design-forward: discovered by scanning src/plugins/"
+        bool      dry_run        "design-forward: --dry-run preview, no writes"
+        PruneMode prune          "design-forward: none | prune | prune_only"
+        Path      dump_stage     "design-forward: --dump-stage target (debug)"
+        StrList   retired_globs  "design-forward: installer.toml [prune].retired"
+        Map       tool_overrides "design-forward: installer.toml [tools]"
     }
 
     StagingPlan {
-        Tool Tool                "which tool this plan targets"
-        Map  Items               "dict[Path, StagedItem] — IN-MEMORY, no temp-dir"
+        Map  items  "dict[Path, StagedItem] — IN-MEMORY; silently overwrites on dup dest_relpath (caller routes to merge)"
+        Tool tool   "which tool this plan targets"
     }
 
     StagedItem {
-        Path     Dest        "destination path, relative to the tool's dest_dir"
-        bytes    Content     "post-flatten, post-transform bytes to write"
-        FileKind Kind        "NAMESPACED_MD | SETTINGS_JSON | JSONC | TOML | OTHER | DIR"
-        string   Namespace   "commands|skills|agents|rules|formulas | '' — 2nd merge key"
-        bool     Executable  "chmod +x on write (e.g. beads scripts)"
+        Path     source_path   "source file the bytes derive from"
+        Path     dest_relpath  "destination path, relative to the tool's install root (dict key)"
+        FileKind kind          "DIR | SETTINGS_JSON | JSONC | TOML | NAMESPACED_MD | OTHER"
+        string   namespace     "managed namespace or null — 2nd merge-dispatch key"
+        bytes    content       "post-flatten bytes; null when kind == DIR (derived at sync)"
+        bool     executable    "sync-phase mode bit 0o755 vs 0o644 (e.g. beads scripts)"
     }
 
     Provenance {
-        string Kind  "tool | plugin"
-        string Name  "Tool enum value (tool) or plugin name string (plugin)"
+        string kind  "Literal[tool | plugin] — disambiguates the flat name field"
+        string name  "Tool enum value (tool) or plugin name string (plugin)"
     }
 
-    IncludeDirective {
-        string Kind  "file | all_rules — discriminated union (FileInclude | AllRulesInclude)"
-        string Path  "FileInclude only — fragment path to inline; empty for all_rules"
+    FileInclude {
+        Path path  "DYNAMIC-INCLUDE file form — verbatim file substitution"
     }
 
     Orphan {
-        Tool     Tool       "which destination store"
-        string   Namespace  "managed namespace or ''"
-        Path     Path       "destination path on disk"
-        FileKind Kind        "classification of the orphaned file"
+        string tool       "destination bucket — str, NOT Tool (includes plugin namespaces like beads)"
+        string namespace  "managed namespace or ''"
+        Path   path       "destination path on disk"
+        string kind       "Literal[dir | file] — NOT FileKind"
     }
 
     Counters {
-        int Created     "new files written"
-        int Written     "existing files overwritten"
-        int Skipped     "hash-equal or user-declined"
-        int BackedUp    "files copied before overwrite/prune"
-        int Pruned      "orphans removed"
-        int WouldCreate "dry-run mirror of Created — previewed, not written"
-        int WouldUpdate "dry-run mirror of Written — previewed, not written"
+        int staged     "items staged into the plan"
+        int created    "new files written"
+        int updated    "existing files overwritten"
+        int skipped    "hash-equal (unchanged)"
+        int pruned     "orphans removed"
+        int backed_up  "files copied to backup before overwrite/prune"
     }
 ```
 
 ### Cardinality + shape notes
 
 - **`StagingPlan` is the aggregate root of the install path; `Config` is the run root.** One `Config` per invocation drives one `StagingPlan` per detected tool, one `Counters` tally, and (with `--prune`) a list of `Orphan`s. There are no cross-plan relationships — each tool's plan is independent.
-- **`Items` is a `dict[Path, StagedItem]`, not a list.** The dest `Path` is the key, which is exactly why collisions are detectable: a second item mapping to a key already present triggers the merge dispatch (Sequence 2). The dict is **in-memory** — the single most load-bearing fact in this model. `install.sh` materialised this as a temp directory tree; the Python rewrite keeps it in process memory and only `sync` writes individual files.
-- **`Provenance` carries the tool-vs-plugin asymmetry.** Tools are enum-keyed (`Tool` enum + adapter registry); plugins are string-keyed (dynamic discovery, no enum). `Provenance(kind, name)` lets a single `StagedItem` record either origin uniformly, so the merge engine can reason about "base asset vs plugin overlay" without caring which registry the item came from.
-- **`IncludeDirective` is transient.** It is produced while `templates.py` flattens a `<!-- DYNAMIC-INCLUDE: … -->` marker (file form) or the ALL-RULES marker, then consumed immediately — the resulting flattened text lands in `StagedItem.Content`. It is modelled here because it is a named type in the data model (A.2), but it does not survive on the `StagedItem`. The `AllRulesInclude` variant carries no path: it expands the plan's already-staged rules collection, sorted and `\n---\n`-joined.
-- **`FileKind` is an enum, not an entity.** Its six values are shown inline on `StagedItem.Kind`. It is the primary merge-dispatch key; `Namespace` is the secondary key (see the dispatch table).
+- **`Config` is built incrementally.** Only `home` + `tools` exist today (tool-selection scope); `plugins`, `dry_run`, `prune`, `dump_stage`, `retired_globs`, and `tool_overrides` are *design-forward* — they land in later stories (the `installer.toml` loader, prune, `--dump-stage`). The ER shows the target shape and tags each row accordingly.
+- **`items` is a `dict[Path, StagedItem]`, not a list.** The `dest_relpath` is the key, which is exactly why collisions are detectable: a second item mapping to a key already present triggers the merge dispatch (Sequence 2). The dict is **in-memory** — the single most load-bearing fact in this model. `install.sh` materialised this as a temp directory tree; the Python rewrite keeps it in process memory and only `sync` writes individual files. (The bare dict silently overwrites on a duplicate key; the staging caller checks `dest_relpath in items` and routes to the merge registry — collision detection is the caller's job, not the dataclass's.)
+- **`Provenance` carries the tool-vs-plugin asymmetry.** Tools are enum-keyed (`Tool` enum + adapter registry); plugins are string-keyed (dynamic discovery, no enum). `Provenance(kind, name)` lets a single `StagedItem` record either origin uniformly — the `kind` discriminator disambiguates the flat `name` (a plugin named after a tool would otherwise be ambiguous), so the merge engine can reason about "base asset vs plugin overlay" without caring which registry the item came from.
+- **`IncludeDirective` is a transient `TypeAlias` union.** `FileInclude | AllRulesInclude`, produced while `templates.py` flattens a `<!-- DYNAMIC-INCLUDE: … -->` marker (file form) or the ALL-RULES marker, then consumed immediately — the flattened text lands in `StagedItem.content`; the directive objects do not survive on the `StagedItem`. `FileInclude` carries the fragment `path`; `AllRulesInclude` carries no fields — it expands the plan's already-staged rules collection, sorted and joined with a `---` separator.
+- **`FileKind` is an enum, not an entity.** Its six values are shown inline on `StagedItem.kind`. It is the primary merge-dispatch key; `namespace` is the secondary key (see the dispatch table). Note `Orphan.kind` is a *different*, coarser `Literal["dir", "file"]` — orphan classification only needs dir-vs-file, not the full merge taxonomy — and `Orphan.tool` is a plain `str` (not the `Tool` enum) because the orphan bucket includes plugin namespaces like `beads` that are not tools.
 
 ## Merge-dispatch table — `(FileKind, namespace)` → `MergeStrategy`
 
-The collision matrix, keyed exactly as `core/merge/registry.py` keys it. `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key.
+The collision matrix — the dispatch contract `core/merge/registry.py` will implement (Epic E; **not yet built**, so this table is the design intent from `installer-design.md`, not a description of current code). It keys on `(FileKind, namespace)`: `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key. The strategy names below are the design's; the modules land in Epic E.
 
 | FileKind | Namespace | Strategy | Behaviour on collision |
 |---|---|---|---|
@@ -137,8 +139,8 @@ retired = [
 
 | Key | Type | Drives | Notes |
 |---|---|---|---|
-| `[prune].retired` | list[str] (globs) | `Config.RetiredGlobs` → `prune.py` | The orphan gate. A dest file absent from the plan is pruned **only** if it also matches one of these globs. |
-| `[tools].<tool>.dest` | str (path) | `Config.ToolOverrides` → tool adapter | Override a tool's destination dir; commented out = built-in adapter default. |
+| `[prune].retired` | list[str] (globs) | `Config.retired_globs` → `prune.py` *(design-forward)* | The orphan gate. A dest file absent from the plan is pruned **only** if it also matches one of these globs. |
+| `[tools].<tool>.dest` | str (path) | `Config.tool_overrides` → tool adapter *(design-forward)* | Override a tool's destination dir; commented out = built-in adapter default. |
 
 ## Canonical-ownership boundaries
 

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -48,6 +48,7 @@ erDiagram
         ToolTuple tools          "resolved tool set (claude auto-detected; forced via --tools)"
         StrList   plugins        "discovered by scanning src/plugins/"
         bool      dry_run        "--dry-run preview, no writes"
+        bool      auto_yes       "--yes/-y: skip confirm prompts, auto-accept all writes and prunes"
         PruneMode prune          "none | prune | prune_only"
         Path      dump_stage     "--dump-stage target (debug)"
         StrList   retired_globs  "installer.toml [prune].retired"
@@ -98,7 +99,7 @@ erDiagram
 ### Cardinality + shape notes
 
 - **`StagingPlan` is the aggregate root of the install path; `Config` is the run root.** One `Config` per invocation drives one `StagingPlan` per detected tool, one `Counters` tally, and (with `--prune`) a list of `Orphan`s. There are no cross-plan relationships — each tool's plan is independent.
-- **`Config` resolves the full run configuration.** `home` and `tools` anchor the tool-selection scope; `plugins`, `dry_run`, `prune`, `dump_stage`, `retired_globs`, and `tool_overrides` complete the picture for plugins, preview mode, pruning, and `installer.toml` overrides.
+- **`Config` resolves the full run configuration.** `home` and `tools` anchor the tool-selection scope; `dry_run` and `auto_yes` control the interaction model (preview vs auto-accept); `plugins`, `prune`, `dump_stage`, `retired_globs`, and `tool_overrides` complete the picture for plugins, pruning, and `installer.toml` overrides.
 - **`items` is a `dict[Path, StagedItem]`, not a list.** The `dest_relpath` is the key, which is exactly why collisions are detectable: a second item mapping to a key already present triggers the merge dispatch (Sequence 2). The dict is **in-memory** — the single most load-bearing fact in this model. `install.sh` materialised this as a temp directory tree; the Python rewrite keeps it in process memory and only `sync` writes individual files. (The bare dict silently overwrites on a duplicate key; the staging caller checks `dest_relpath in items` and routes to the merge registry — collision detection is the caller's job, not the dataclass's.)
 - **`Provenance` carries the tool-vs-plugin asymmetry.** Tools are enum-keyed (`Tool` enum + adapter registry); plugins are string-keyed (dynamic discovery, no enum). `Provenance(kind, name)` lets a single `StagedItem` record either origin uniformly — the `kind` discriminator disambiguates the flat `name` (a plugin named after a tool would otherwise be ambiguous), so the merge engine can reason about "base asset vs plugin overlay" without caring which registry the item came from.
 - **`IncludeDirective` is a transient `TypeAlias` union.** `FileInclude | AllRulesInclude`, produced while `templates.py` flattens a `<!-- DYNAMIC-INCLUDE: … -->` marker (file form) or the ALL-RULES marker, then consumed immediately — the flattened text lands in `StagedItem.content`; the directive objects do not survive on the `StagedItem`. `FileInclude` carries the fragment `path`; `AllRulesInclude` carries no fields — it expands the plan's already-staged rules collection, sorted and joined with a `---` separator.

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -11,10 +11,10 @@
 |---|---|
 | `StagingPlan` | The aggregate root of the in-memory model: a `dict[Path, StagedItem]` (plus the target `Tool`). One is built per detected tool. **In-memory only** — it has no on-disk form in the operational path. |
 | `StagedItem` | One planned destination file. The unit the merge + sync engines operate on. |
-| `Provenance` | `(kind: "tool" | "plugin", name: str)` — preserves whether a `StagedItem` came from a tool's source tree or a plugin overlay, through the tool-vs-plugin registry asymmetry. |
+| `Provenance` | `(kind: "tool" \| "plugin", name: str)` — preserves whether a `StagedItem` came from a tool's source tree or a plugin overlay, through the tool-vs-plugin registry asymmetry. |
 | `FileKind` | The enum classifying a staged file. The **primary** merge-dispatch key. |
 | Namespace | The managed sub-dir (`commands` / `skills` / `agents` / `rules` / `formulas`) or `None` when the tool root itself owns the file. The **secondary** merge-dispatch key. |
-| `IncludeDirective` | A discriminated union (`FileInclude` | `AllRulesInclude`) produced **transiently** while flattening DYNAMIC-INCLUDE markers; consumed during staging, not persisted on the `StagedItem`. |
+| `IncludeDirective` | A discriminated union (`FileInclude` \| `AllRulesInclude`) produced **transiently** while flattening DYNAMIC-INCLUDE markers; consumed during staging, not persisted on the `StagedItem`. |
 | `Orphan` | A prune candidate: on disk, absent from the plan, matching a retired glob. |
 | `Counters` | The per-run tally (`staged` / `created` / `updated` / `skipped` / `pruned` / `backed_up`) surfaced in the exit summary. |
 | Canonical ownership | Which actor is the source of truth for a piece of data: the human (source tree), the installer (plan + writes), or the tool (deployed store at runtime). |
@@ -31,7 +31,7 @@ The data view answers: *what shapes does the installer build in memory, what dri
 
 ## In-memory model ER diagram
 
-Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case), plus the implemented `Config` dataclass in `packages/installer/src/installer/config.py`. Where a type is not yet built, the row is marked *design-forward* and traces to `installer-design.md`, not to current code.
+Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case), plus the implemented `Config` dataclass in `packages/installer/src/installer/config.py`. This represents target state, not necessarily current code.
 
 ```mermaid
 erDiagram
@@ -44,14 +44,14 @@ erDiagram
     Config      ||--o{ Orphan            : "prune scan yields 0..N"
 
     Config {
-        Path      home           "destination root (per-tool dest via adapter) — implemented (B.1)"
-        ToolTuple tools          "resolved tool set (claude auto-detected; forced via --tools) — implemented (B.1)"
-        StrList   plugins        "design-forward: discovered by scanning src/plugins/"
-        bool      dry_run        "design-forward: --dry-run preview, no writes"
-        PruneMode prune          "design-forward: none | prune | prune_only"
-        Path      dump_stage     "design-forward: --dump-stage target (debug)"
-        StrList   retired_globs  "design-forward: installer.toml [prune].retired"
-        Map       tool_overrides "design-forward: installer.toml [tools]"
+        Path      home           "destination root (per-tool dest via adapter)"
+        ToolTuple tools          "resolved tool set (claude auto-detected; forced via --tools)"
+        StrList   plugins        "discovered by scanning src/plugins/"
+        bool      dry_run        "--dry-run preview, no writes"
+        PruneMode prune          "none | prune | prune_only"
+        Path      dump_stage     "--dump-stage target (debug)"
+        StrList   retired_globs  "installer.toml [prune].retired"
+        Map       tool_overrides "installer.toml [tools]"
     }
 
     StagingPlan {
@@ -98,7 +98,7 @@ erDiagram
 ### Cardinality + shape notes
 
 - **`StagingPlan` is the aggregate root of the install path; `Config` is the run root.** One `Config` per invocation drives one `StagingPlan` per detected tool, one `Counters` tally, and (with `--prune`) a list of `Orphan`s. There are no cross-plan relationships — each tool's plan is independent.
-- **`Config` is built incrementally.** Only `home` + `tools` exist today (tool-selection scope); `plugins`, `dry_run`, `prune`, `dump_stage`, `retired_globs`, and `tool_overrides` are *design-forward* — they land in later stories (the `installer.toml` loader, prune, `--dump-stage`). The ER shows the target shape and tags each row accordingly.
+- **`Config` resolves the full run configuration.** `home` and `tools` anchor the tool-selection scope; `plugins`, `dry_run`, `prune`, `dump_stage`, `retired_globs`, and `tool_overrides` complete the picture for plugins, preview mode, pruning, and `installer.toml` overrides.
 - **`items` is a `dict[Path, StagedItem]`, not a list.** The `dest_relpath` is the key, which is exactly why collisions are detectable: a second item mapping to a key already present triggers the merge dispatch (Sequence 2). The dict is **in-memory** — the single most load-bearing fact in this model. `install.sh` materialised this as a temp directory tree; the Python rewrite keeps it in process memory and only `sync` writes individual files. (The bare dict silently overwrites on a duplicate key; the staging caller checks `dest_relpath in items` and routes to the merge registry — collision detection is the caller's job, not the dataclass's.)
 - **`Provenance` carries the tool-vs-plugin asymmetry.** Tools are enum-keyed (`Tool` enum + adapter registry); plugins are string-keyed (dynamic discovery, no enum). `Provenance(kind, name)` lets a single `StagedItem` record either origin uniformly — the `kind` discriminator disambiguates the flat `name` (a plugin named after a tool would otherwise be ambiguous), so the merge engine can reason about "base asset vs plugin overlay" without caring which registry the item came from.
 - **`IncludeDirective` is a transient `TypeAlias` union.** `FileInclude | AllRulesInclude`, produced while `templates.py` flattens a `<!-- DYNAMIC-INCLUDE: … -->` marker (file form) or the ALL-RULES marker, then consumed immediately — the flattened text lands in `StagedItem.content`; the directive objects do not survive on the `StagedItem`. `FileInclude` carries the fragment `path`; `AllRulesInclude` carries no fields — it expands the plan's already-staged rules collection, sorted and joined with a `---` separator.
@@ -106,7 +106,7 @@ erDiagram
 
 ## Merge-dispatch table — `(FileKind, namespace)` → `MergeStrategy`
 
-The collision matrix — the dispatch contract `core/merge/registry.py` will implement (Epic E; **not yet built**, so this table is the design intent from `installer-design.md`, not a description of current code). It keys on `(FileKind, namespace)`: `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key. The strategy names below are the design's; the modules land in Epic E.
+The collision matrix — the dispatch contract `core/merge/registry.py` implements (see `installer-design.md`). It keys on `(FileKind, namespace)`: `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key. The strategy names below are the design's; the modules land in Epic E.
 
 | FileKind | Namespace | Strategy | Behaviour on collision |
 |---|---|---|---|
@@ -140,8 +140,8 @@ retired = [
 
 | Key | Type | Drives | Notes |
 |---|---|---|---|
-| `[prune].retired` | list[str] (globs) | `Config.retired_globs` → `prune.py` *(design-forward)* | The orphan gate. A dest file absent from the plan is pruned **only** if it also matches one of these globs. |
-| `[tools].<tool>.dest` | str (path) | `Config.tool_overrides` → tool adapter *(design-forward)* | Override a tool's destination dir; commented out = built-in adapter default. |
+| `[prune].retired` | list[str] (globs) | `Config.retired_globs` → `prune.py` | The orphan gate. A dest file absent from the plan is pruned **only** if it also matches one of these globs. |
+| `[tools].<tool>.dest` | str (path) | `Config.tool_overrides` → tool adapter | Override a tool's destination dir; commented out = built-in adapter default. |
 
 ## Canonical-ownership boundaries
 

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -1,0 +1,207 @@
+# Python Installer — Data View
+
+> **Up**: [index](index.md)
+> **Previous (reading order)**: [C4 L3 — Engine](c4-l3-engine.md)
+> **Source bead**: `agents-config-w1qls.9`
+> **Source spec**: [`installer-design.md`](installer-design.md) — §"Data model highlights", §"Configuration — installer.toml"
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| `StagingPlan` | The aggregate root of the in-memory model: a `dict[Path, StagedItem]` (plus the target `Tool`). One is built per detected tool. **In-memory only** — it has no on-disk form in the operational path. |
+| `StagedItem` | One planned destination file. The unit the merge + sync engines operate on. |
+| `Provenance` | `(kind: "tool" | "plugin", name: str)` — preserves whether a `StagedItem` came from a tool's source tree or a plugin overlay, through the tool-vs-plugin registry asymmetry. |
+| `FileKind` | The enum classifying a staged file. The **primary** merge-dispatch key. |
+| Namespace | The managed sub-dir (`commands` / `skills` / `agents` / `rules` / `formulas`) or `""`. The **secondary** merge-dispatch key. |
+| `IncludeDirective` | A discriminated union (`FileInclude` | `AllRulesInclude`) produced **transiently** while flattening DYNAMIC-INCLUDE markers; consumed during staging, not persisted on the `StagedItem`. |
+| `Orphan` | A prune candidate: on disk, absent from the plan, matching a retired glob. |
+| `Counters` | The per-run tally (created / written / skipped / backed-up / pruned …) surfaced in the exit summary. |
+| Canonical ownership | Which actor is the source of truth for a piece of data: the human (source tree), the installer (plan + writes), or the tool (deployed store at runtime). |
+
+## Purpose
+
+Three complementary data views in one file:
+
+1. **The in-memory model** (`Config`, `StagingPlan`, `StagedItem`, `Provenance`, `IncludeDirective`, `Orphan`, `Counters`) as an ER diagram — the shapes the engine builds and passes around. None of these persist; they live and die within one process invocation.
+2. **The merge-dispatch table** — the `(FileKind, namespace)` → `MergeStrategy` lookup that the collision matrix is built on.
+3. **The config + ownership boundaries** — the `installer.toml` schema, and which actor owns which data as it flows source → memory → disk → runtime.
+
+The data view answers: *what shapes does the installer build in memory, what drives collision resolution, and who owns each piece of data along the way?*
+
+## In-memory model ER diagram
+
+```mermaid
+erDiagram
+    Config      ||--o{ StagingPlan      : "one built per detected Tool"
+    StagingPlan ||--o{ StagedItem       : "dict keyed by dest Path"
+    StagedItem  ||--|| Provenance       : "has 1 (origin)"
+    StagedItem  ||--o{ IncludeDirective : "flattened from 0..N (transient)"
+    Config      ||--|| Counters         : "one run tally"
+    Config      ||--o{ Orphan           : "prune scan yields 0..N"
+
+    Config {
+        ToolSet  Tools          "detected (claude always) + forced via --tools"
+        StrList  Plugins        "discovered by scanning src/plugins/ (string-keyed)"
+        Path     RepoRoot       "source root"
+        Path     Home           "destination root (per-tool dest derived via adapter)"
+        bool     DryRun         "--dry-run: preview, no writes"
+        PruneMode Prune         "none | prune | prune_only"
+        Path     DumpStage      "optional --dump-stage target (debug); excl. with Prune"
+        StrList  RetiredGlobs   "installer.toml [prune].retired"
+        Map      ToolOverrides  "installer.toml [tools]"
+    }
+
+    StagingPlan {
+        Tool Tool                "which tool this plan targets"
+        Map  Items               "dict[Path, StagedItem] — IN-MEMORY, no temp-dir"
+    }
+
+    StagedItem {
+        Path     Dest        "destination path, relative to the tool's dest_dir"
+        bytes    Content     "post-flatten, post-transform bytes to write"
+        FileKind Kind        "NAMESPACED_MD | SETTINGS_JSON | JSONC | TOML | OTHER | DIR"
+        string   Namespace   "commands|skills|agents|rules|formulas | '' — 2nd merge key"
+        bool     Executable  "chmod +x on write (e.g. beads scripts)"
+    }
+
+    Provenance {
+        string Kind  "tool | plugin"
+        string Name  "Tool enum value (tool) or plugin name string (plugin)"
+    }
+
+    IncludeDirective {
+        string Kind  "file | all_rules — discriminated union (FileInclude | AllRulesInclude)"
+        string Path  "FileInclude only — fragment path to inline; empty for all_rules"
+    }
+
+    Orphan {
+        Tool     Tool       "which destination store"
+        string   Namespace  "managed namespace or ''"
+        Path     Path       "destination path on disk"
+        FileKind Kind        "classification of the orphaned file"
+    }
+
+    Counters {
+        int Created     "new files written"
+        int Written     "existing files overwritten"
+        int Skipped     "hash-equal or user-declined"
+        int BackedUp    "files copied before overwrite/prune"
+        int Pruned      "orphans removed"
+        int WouldChange "dry-run: created+updated that were previewed only"
+    }
+```
+
+### Cardinality + shape notes
+
+- **`StagingPlan` is the aggregate root of the install path; `Config` is the run root.** One `Config` per invocation drives one `StagingPlan` per detected tool, one `Counters` tally, and (with `--prune`) a list of `Orphan`s. There are no cross-plan relationships — each tool's plan is independent.
+- **`Items` is a `dict[Path, StagedItem]`, not a list.** The dest `Path` is the key, which is exactly why collisions are detectable: a second item mapping to a key already present triggers the merge dispatch (Sequence 2). The dict is **in-memory** — the single most load-bearing fact in this model. `install.sh` materialised this as a temp directory tree; the Python rewrite keeps it in process memory and only `sync` writes individual files.
+- **`Provenance` carries the tool-vs-plugin asymmetry.** Tools are enum-keyed (`Tool` enum + adapter registry); plugins are string-keyed (dynamic discovery, no enum). `Provenance(kind, name)` lets a single `StagedItem` record either origin uniformly, so the merge engine can reason about "base asset vs plugin overlay" without caring which registry the item came from.
+- **`IncludeDirective` is transient.** It is produced while `templates.py` flattens a `<!-- DYNAMIC-INCLUDE: … -->` marker (file form) or the ALL-RULES marker, then consumed immediately — the resulting flattened text lands in `StagedItem.Content`. It is modelled here because it is a named type in the data model (A.2), but it does not survive on the `StagedItem`. The `AllRulesInclude` variant carries no path: it expands the plan's already-staged rules collection, sorted and `\n---\n`-joined.
+- **`FileKind` is an enum, not an entity.** Its six values are shown inline on `StagedItem.Kind`. It is the primary merge-dispatch key; `Namespace` is the secondary key (see the dispatch table).
+
+## Merge-dispatch table — `(FileKind, namespace)` → `MergeStrategy`
+
+The collision matrix, keyed exactly as `core/merge/registry.py` keys it. `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key.
+
+| FileKind | Namespace | Strategy | Behaviour on collision |
+|---|---|---|---|
+| `NAMESPACED_MD` | `rules` | `append_rules` | Join `existing + "\n---\n" + incoming` — rules compose. |
+| `NAMESPACED_MD` | `commands` / `skills` / `agents` | `fatal` | **Raise** — two items with the same name is an authoring error; the message names both files. |
+| `NAMESPACED_MD` | `formulas` | `last_wins_silent` | Replace (formulas are whole-file owned). |
+| `SETTINGS_JSON` | — | `json_union` | Deep union: nested-dict precedence, array union + sort, type-mismatch surfaced. |
+| `JSONC` | — | `last_wins_warn` | Replace, with a warning that an existing file was overwritten. |
+| `TOML` | — | `last_wins_warn` | Replace, with a warning. |
+| `OTHER` | — | `last_wins_silent` | Replace silently. |
+| `DIR` | — | (n/a) | Directories are created, not merged. |
+
+> The `formulas` row reflects whole-file ownership of formula TOMLs; if a future requirement needs formula-merge semantics it gets its own strategy + registry row. The dispatch is data — adding a `(FileKind, namespace)` row is a registry change, not an engine change.
+
+## `installer.toml` schema
+
+Structured config at `packages/installer/installer.toml`, replacing the legacy `scripts/prune-list` text file at the parity gate. Read once at `Config` build (read-only to the install path).
+
+```toml
+[prune]
+# Retired paths (one glob per line) — matched against destination files during
+# the prune scan. A destination file is an orphan only if it ALSO matches here.
+retired = [
+  "*/skills/condition-based-waiting",
+  "claude/rules/git-commits.md",
+]
+
+[tools]
+# Optional per-tool overrides — leave commented to use the built-in adapters.
+# claude.dest = "~/.claude"
+```
+
+| Key | Type | Drives | Notes |
+|---|---|---|---|
+| `[prune].retired` | list[str] (globs) | `Config.RetiredGlobs` → `prune.py` | The orphan gate. A dest file absent from the plan is pruned **only** if it also matches one of these globs. |
+| `[tools].<tool>.dest` | str (path) | `Config.ToolOverrides` → tool adapter | Override a tool's destination dir; commented out = built-in adapter default. |
+
+## Canonical-ownership boundaries
+
+Data flows source → memory → disk → runtime, and ownership hands off at each arrow. The installer never writes the source; the tools never read the plan; backups are write-only recovery.
+
+```mermaid
+flowchart LR
+    subgraph HUMAN["Human-canonical (read-only to installer)"]
+        S1[src/user/ + src/plugins/ source tree]
+        S2[installer.toml config]
+    end
+
+    subgraph MEM["Installer-owned (in-memory, ephemeral)"]
+        M1[StagingPlan = dict Path to StagedItem]
+        M2[Counters + Orphan list]
+    end
+
+    subgraph DISK["Installer-written, then tool-owned"]
+        D1[~/.claude ~/.codex ~/.gemini ~/.config/opencode ~/.beads]
+    end
+
+    subgraph BAK["Installer-written (recovery only)"]
+        B1[namespace-backup/ dirs + in-place backups]
+    end
+
+    subgraph TOOLS["Tool-owned at runtime"]
+        T1[AI assistants + bd CLI]
+    end
+
+    S1 -->|"staging reads"| M1
+    S2 -->|"config reads"| M1
+    M1 -->|"sync writes (hash-gated)"| D1
+    D1 -->|"backup before overwrite/prune"| B1
+    D1 -->|"runtime read (async)"| T1
+```
+
+### Ownership rules (worth memorising)
+
+| Data | Owner | Lifetime | Notes |
+|---|---|---|---|
+| Source tree (`src/user/`, `src/plugins/`) | **Human** (via repo) | Permanent | Installer reads, NEVER writes. The "always edit source" guarantee. |
+| `installer.toml` | **Human** | Permanent | Read-only to the install path. |
+| `StagingPlan` / `StagedItem` | **Installer** | One invocation | In-memory; gone when the process exits. `--dump-stage` materialises a throwaway copy. |
+| `Counters` / `Orphan` list | **Installer** | One invocation | Surfaced in the exit summary; not persisted. |
+| Destination stores | **Installer** writes → **Tool** reads | Permanent on disk | Single writer at install time; consumed asynchronously at each tool's runtime. |
+| Backups | **Installer** | Permanent on disk | Write-only recovery; never read back by the installer. |
+
+### Explicit non-ownership
+
+- The installer does **not** own source content — it copies and flattens it, but the human authoring the repo is canonical. A `StagedItem.Content` is a *derived* artifact (post-flatten, post-transform), not a source of truth.
+- The installer does **not** own a tool's runtime interpretation of its store. It deposits files matching each tool's path + shape contract; how the tool loads them is the tool's concern.
+- The installer does **not** persist any of its own state between runs. There is no installer database, no manifest, no lockfile of "what I installed last time" — the destination store *is* the record, and hash-compare is how the next run reconciles.
+
+## What this diagram does NOT show
+
+- **The components that build / read these shapes** — see [`c4-l3-engine.md`](c4-l3-engine.md).
+- **The order** in which the shapes are built and flushed — see [`sequences.md`](sequences.md).
+- **The per-strategy merge mechanics** (deep-union algorithm, append separator placement) — specified per-strategy in the E.* stories and `installer-design.md` §"Test architecture".
+- **The golden-master / fixture data shapes** — test artifacts; see `installer-design.md` §"Fixture strategy".
+
+## Cross-references
+
+- **Previous (reading order)**: [C4 L3 — Engine](c4-l3-engine.md) — the components that read / build / write this data
+- **Companion structural views**: [`c4-l2-container.md`](c4-l2-container.md), [`c4-l3-engine.md`](c4-l3-engine.md)
+- **Companion flow view**: [`sequences.md`](sequences.md)
+- **Source spec**: [`installer-design.md`](installer-design.md) §"Data model highlights", §"Configuration — installer.toml", §"--dump-stage flag"

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -88,7 +88,8 @@ erDiagram
         int Skipped     "hash-equal or user-declined"
         int BackedUp    "files copied before overwrite/prune"
         int Pruned      "orphans removed"
-        int WouldChange "dry-run: created+updated that were previewed only"
+        int WouldCreate "dry-run mirror of Created — previewed, not written"
+        int WouldUpdate "dry-run mirror of Written — previewed, not written"
     }
 ```
 
@@ -108,14 +109,13 @@ The collision matrix, keyed exactly as `core/merge/registry.py` keys it. `NAMESP
 |---|---|---|---|
 | `NAMESPACED_MD` | `rules` | `append_rules` | Join `existing + "\n---\n" + incoming` — rules compose. |
 | `NAMESPACED_MD` | `commands` / `skills` / `agents` | `fatal` | **Raise** — two items with the same name is an authoring error; the message names both files. |
-| `NAMESPACED_MD` | `formulas` | `last_wins_silent` | Replace (formulas are whole-file owned). |
 | `SETTINGS_JSON` | — | `json_union` | Deep union: nested-dict precedence, array union + sort, type-mismatch surfaced. |
 | `JSONC` | — | `last_wins_warn` | Replace, with a warning that an existing file was overwritten. |
 | `TOML` | — | `last_wins_warn` | Replace, with a warning. |
 | `OTHER` | — | `last_wins_silent` | Replace silently. |
 | `DIR` | — | (n/a) | Directories are created, not merged. |
 
-> The `formulas` row reflects whole-file ownership of formula TOMLs; if a future requirement needs formula-merge semantics it gets its own strategy + registry row. The dispatch is data — adding a `(FileKind, namespace)` row is a registry change, not an engine change.
+> Formula files are `.toml`, so they classify as `FileKind.TOML` and route via `(TOML, —) → last_wins_warn`. `formulas` is a managed namespace for **backup / prune** routing (it is in the path-aware namespace set), NOT a `NAMESPACED_MD` merge namespace — the only `NAMESPACED_MD` namespaces that change the strategy are `rules` (append) and `commands`/`skills`/`agents` (fatal). The dispatch is data: adding a `(FileKind, namespace)` row is a registry change, not an engine change.
 
 ## `installer.toml` schema
 

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -16,7 +16,7 @@
 | Namespace | The managed sub-dir (`commands` / `skills` / `agents` / `rules` / `formulas`) or `""`. The **secondary** merge-dispatch key. |
 | `IncludeDirective` | A discriminated union (`FileInclude` | `AllRulesInclude`) produced **transiently** while flattening DYNAMIC-INCLUDE markers; consumed during staging, not persisted on the `StagedItem`. |
 | `Orphan` | A prune candidate: on disk, absent from the plan, matching a retired glob. |
-| `Counters` | The per-run tally (created / written / skipped / backed-up / pruned …) surfaced in the exit summary. |
+| `Counters` | The per-run tally (`staged` / `created` / `updated` / `skipped` / `pruned` / `backed_up`) surfaced in the exit summary. |
 | Canonical ownership | Which actor is the source of truth for a piece of data: the human (source tree), the installer (plan + writes), or the tool (deployed store at runtime). |
 
 ## Purpose

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -13,7 +13,7 @@
 | `StagedItem` | One planned destination file. The unit the merge + sync engines operate on. |
 | `Provenance` | `(kind: "tool" | "plugin", name: str)` — preserves whether a `StagedItem` came from a tool's source tree or a plugin overlay, through the tool-vs-plugin registry asymmetry. |
 | `FileKind` | The enum classifying a staged file. The **primary** merge-dispatch key. |
-| Namespace | The managed sub-dir (`commands` / `skills` / `agents` / `rules` / `formulas`) or `""`. The **secondary** merge-dispatch key. |
+| Namespace | The managed sub-dir (`commands` / `skills` / `agents` / `rules` / `formulas`) or `None` when the tool root itself owns the file. The **secondary** merge-dispatch key. |
 | `IncludeDirective` | A discriminated union (`FileInclude` | `AllRulesInclude`) produced **transiently** while flattening DYNAMIC-INCLUDE markers; consumed during staging, not persisted on the `StagedItem`. |
 | `Orphan` | A prune candidate: on disk, absent from the plan, matching a retired glob. |
 | `Counters` | The per-run tally (`staged` / `created` / `updated` / `skipped` / `pruned` / `backed_up`) surfaced in the exit summary. |
@@ -31,7 +31,7 @@ The data view answers: *what shapes does the installer build in memory, what dri
 
 ## In-memory model ER diagram
 
-Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case). Where a type is not yet built, the row is marked *design-forward* and traces to `installer-design.md`, not to current code.
+Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case), plus the implemented `Config` dataclass in `packages/installer/src/installer/config.py`. Where a type is not yet built, the row is marked *design-forward* and traces to `installer-design.md`, not to current code.
 
 ```mermaid
 erDiagram
@@ -64,6 +64,7 @@ erDiagram
         Path     dest_relpath  "destination path, relative to the tool's install root (dict key)"
         FileKind kind          "DIR | SETTINGS_JSON | JSONC | TOML | NAMESPACED_MD | OTHER"
         string   namespace     "managed namespace or null — 2nd merge-dispatch key"
+        Provenance provenance  "tool vs plugin origin marker"
         bytes    content       "post-flatten bytes; null when kind == DIR (derived at sync)"
         bool     executable    "sync-phase mode bit 0o755 vs 0o644 (e.g. beads scripts)"
     }
@@ -190,7 +191,7 @@ flowchart LR
 
 ### Explicit non-ownership
 
-- The installer does **not** own source content — it copies and flattens it, but the human authoring the repo is canonical. A `StagedItem.Content` is a *derived* artifact (post-flatten, post-transform), not a source of truth.
+- The installer does **not** own source content — it copies and flattens it, but the human authoring the repo is canonical. A `StagedItem.content` is a *derived* artifact (post-flatten, post-transform), not a source of truth.
 - The installer does **not** own a tool's runtime interpretation of its store. It deposits files matching each tool's path + shape contract; how the tool loads them is the tool's concern.
 - The installer does **not** persist any of its own state between runs. There is no installer database, no manifest, no lockfile of "what I installed last time" — the destination store *is* the record, and hash-compare is how the next run reconciles.
 

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -31,7 +31,7 @@ The data view answers: *what shapes does the installer build in memory, what dri
 
 ## In-memory model ER diagram
 
-Field names below mirror the **implemented** dataclasses in `packages/installer/src/installer/core/model.py` verbatim (snake_case), plus the implemented `Config` dataclass in `packages/installer/src/installer/config.py`. This represents target state, not necessarily current code.
+Field names mirror the target dataclasses in `packages/installer/src/installer/core/model.py` and `packages/installer/src/installer/config.py`. This represents target state, not necessarily current code — the ER is the design authority; implementation stories bring the code into alignment with it.
 
 ```mermaid
 erDiagram

--- a/docs/architecture/installer/index.md
+++ b/docs/architecture/installer/index.md
@@ -1,0 +1,97 @@
+# Python Installer — HLD Artifact Index
+
+> **Source bead**: `agents-config-w1qls.9`
+> **Subsystem**: Python installer rewrite (`agents-config-w1qls` feature)
+> **Companion spec**: [`installer-design.md`](installer-design.md) — the design these artifacts visualise
+> **Glossary**: per-artifact short glossaries appear at the top of each file
+> **Status**: under construction
+
+## Glossary (subsystem-wide terms used across this artifact set)
+
+| Term | Meaning |
+|---|---|
+| HLD | High-Level Design — evergreen reference material describing how a subsystem is meant to be structured and behave. This folder *is* the HLD set for the installer. |
+| C4 | A model for visualising software architecture in four levels (Context, Container, Component, Code); see [c4model.com](https://c4model.com). This folder uses **L2** and **L3** only — see "Why no L1 / Deployment" below. |
+| Installer | The Python package at `packages/installer/` that replaces the 1788-line `scripts/install.sh`. A short-lived CLI: parse argv → stage in memory → merge → sync to disk → optional prune → exit. |
+| Tool | One of the four supported AI coding assistants — **Claude Code**, **Codex CLI**, **Gemini CLI**, **OpenCode** — each with its own destination store and its own `ToolAdapter`. |
+| `ToolAdapter` | The protocol abstracting everything the engine needs to know about a tool: source dir, dest dir, detection, scoped namespaces, namespace filtering, post-staging transforms. Per-tool adapters live in `tools/`. |
+| `PluginAdapter` | The protocol for an optional plugin (e.g. `beads`) that overlays extra content onto the staging plan. Discovered dynamically by scanning `src/plugins/<name>/`; string-keyed (NOT enumerated). |
+| `StagingPlan` | The **in-memory** replacement for `install.sh`'s temp-dir staging: a `dict[Path, StagedItem]` plus provenance. Built per tool, mutated by plugin overlay + transforms, then flushed to disk by `sync`. Never an on-disk container in the operational path (`--dump-stage` materialises it for debugging only). |
+| `StagedItem` | One planned destination file: its content, `FileKind`, namespace, and `Provenance`. The unit the merge + sync engines operate on. |
+| `MergeStrategy` | A collision-resolution class (append-rules, JSON-union, fatal, last-wins-warn, last-wins-silent), each in its own module, dispatched by the registry on `(FileKind, namespace)`. |
+| `FileKind` | The enum classifying a staged file (`NAMESPACED_MD`, `SETTINGS_JSON`, `JSONC`, `TOML`, `OTHER`, `DIR`) — the primary merge-dispatch key. |
+| `Provenance` | `(kind: "tool" | "plugin", name: str)` on each `StagedItem` — preserves tool-vs-plugin origin through the plan. |
+| `IOPort` | The single injectable I/O abstraction (`info`/`warn`/`show_diff`/`confirm`/…). `TerminalIO` is real (via `rich`); `ScriptedIO` is the test fake. No module calls `print`/`input` directly. |
+| DYNAMIC-INCLUDE | The directive form (`<!-- DYNAMIC-INCLUDE: path -->` and the ALL-RULES variant) that flattens shared template fragments into assembled per-tool instruction files at staging time. |
+| Namespace | The managed sub-directory a file belongs to (`commands` / `skills` / `agents` / `rules` / `formulas`) — second component of the merge-dispatch key; drives append-vs-fatal collision behaviour. |
+| Parity gate | The point at which the golden-master suite proves the Python installer byte-matches `install.sh`, after which `install.sh` collapses to a `uv run` wrapper and deliberate divergence is allowed. |
+| Golden-master | The **transitional** bash-vs-python parity suite; retires ~14 days after the parity gate. |
+
+Each artifact file in this folder carries its **own short glossary** at the top, listing the terms used in that specific file.
+
+## Purpose
+
+This folder is the **high-level design (HLD) artifact set** for the Python installer. It exists to fix the big-picture architecture in pictures — boundary, internals, runtime flow, data model — so the 34 implementation stories (A.1 … H.5) share one mental model of the system rather than each re-deriving it from 394 lines of spec prose.
+
+These artifacts are **evergreen reference material**: they describe how the installer is meant to be structured and behave, and are amended in place as the design evolves. They are NOT point-in-time proposals — those live in `docs/plans/` and `docs/specs/` with date-prefixed filenames. The companion design here, `installer-design.md`, is itself the design-of-record (moved into this folder rather than dated because it is the living installer design, not a snapshot).
+
+## Scope and non-scope
+
+**In scope** for this artifact set:
+
+- The installer's place among its persistent stores: the read-only source tree, `installer.toml`, the N per-tool destination stores, and the AI tools that consume those stores at their own runtime.
+- The installer's internal components: the tool-agnostic `core/` engine, the per-tool `tools/` adapters, the per-plugin `plugins/` adapters, and the `cli`/`config`/`orchestrator` top layer.
+- The installer's runtime behaviour: one install invocation's traversal through detect → stage → overlay → merge → sync → (optional) prune, plus the collision-merge, per-item sync-decision, and prune sub-flows.
+- The installer's data model: `StagingPlan` / `StagedItem` / `Provenance` / `FileKind` / `IncludeDirective` / `Orphan` / `Counters` / `Config`, the `(FileKind, namespace)` merge-dispatch table, the `installer.toml` shape, and the data-ownership boundaries.
+
+**Out of scope** for this artifact set:
+
+- **Code-level (C4 L4) diagrams** — C4 itself recommends against drawing this level; the package layout in `installer-design.md` is sufficient at code granularity.
+- **The agent-config *content* itself** — what the skills/agents/rules/commands *say* is the subject of the rest of the repo, not of the installer's architecture.
+- **`install.sh`'s internal mechanics** beyond its role as the parity reference. The bash line-ranges that pin behaviour are catalogued in `installer-design.md` §"Critical files for implementation".
+- **The test architecture** (unit / integration / golden-master suites) — fully specified in `installer-design.md` §"Test architecture"; not re-drawn here.
+
+### Why no L1 (Context) or Deployment artifact
+
+Both are **deliberately skipped**, not forgotten:
+
+- **C4 L1 (System Context)** would show one box (the installer) talking to a developer and a filesystem. The ecosystem is obvious and singular; an L1 page would carry no information the L2 container view doesn't already make plain. L2 is the natural entry point here.
+- **C4 Deployment** would show the installer running on the developer's own workstation, reading and writing the same local filesystem. There is no multi-host topology, no service, no scheduler — the deployment is "run a script in your repo." Nothing to diagram.
+
+prgroom and pdlc-orchestrator carry L1 + Deployment because each has a genuinely non-trivial ecosystem (GitHub, schedulers, agent subprocesses) or topology. The installer has neither.
+
+## Reading order
+
+Newcomers should read in this order; deep contributors may navigate freely.
+
+1. **[C4 L2 — Container](c4-l2-container.md)** — what runs, what it reads, what it writes, who consumes the output.
+2. **[Sequences](sequences.md)** — how one install invocation runs: the end-to-end flow plus collision-merge, sync-decision, and prune sub-flows.
+3. **[C4 L3 — Engine](c4-l3-engine.md)** — the components inside the installer process: `core/` engine, `tools/` + `plugins/` adapters, and the protocol seams.
+4. **[Data View](data-view.md)** — the in-memory data model, the merge-dispatch table, the `installer.toml` schema, and the data-ownership boundaries.
+
+## Artifact synopsis
+
+| File | Status | Synopsis |
+|---|---|---|
+| [`c4-l2-container.md`](c4-l2-container.md) | drawn | **C4 Level 2** — the `installer` process, its read-only source tree + `installer.toml` inputs, its N destination stores + backup-dir outputs, and the four AI assistants that consume the deployed stores at their own runtime. The in-memory `StagingPlan` is explicitly NOT a container (it lives at L3 / data-view). |
+| [`c4-l3-engine.md`](c4-l3-engine.md) | drawn | **C4 Level 3** — components inside the installer process, grouped by sub-package: the tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `sync`, `prune`, `merge/*`), the `tools/` adapters, the `plugins/` adapters, and the `cli`/`config`/`orchestrator` top layer — with the four protocol seams (`ToolAdapter`, `PluginAdapter`, `MergeStrategy`, `IOPort`) as the test-substitution points. |
+| [`sequences.md`](sequences.md) | drawn | **Four sequence diagrams**: (1) end-to-end install — detect → stage → overlay → merge → sync; (2) collision-merge dispatch — `(FileKind, namespace)` → strategy; (3) sync per-item decision — hash-skip vs diff → confirm → backup → write; (4) prune flow — orphan scan → interactive prune → backup + remove. |
+| [`data-view.md`](data-view.md) | drawn | **Data model**: ER for `Config` / `StagingPlan` / `StagedItem` / `Provenance` / `FileKind` / `IncludeDirective` / `Orphan` / `Counters`; the `(FileKind, namespace)` → `MergeStrategy` dispatch table; the `installer.toml` schema; and the source-vs-plan-vs-destination ownership boundaries. |
+
+## Conventions
+
+- **Diagram notation**: Mermaid throughout, for native GitHub rendering. No SVG artifacts — `.md` files are the deliverable.
+  - C4 set uses `C4Container` / `C4Component` syntax.
+  - Sequences use `sequenceDiagram`.
+  - Data view uses `erDiagram` for entities, `flowchart` + markdown tables for ownership boundaries, fenced TOML/JSON for flat config/contract shapes.
+- **C4 L4 (code) is intentionally absent.** The package layout in `installer-design.md` documents code granularity; C4 itself advises against an L4 diagram for self-documenting code.
+- **L1 + Deployment are intentionally absent** — see "Why no L1 / Deployment" above.
+- **File-path citations are permitted here.** Unlike installed assets (which flatten into user-space config where paths are dead-ends), these `docs/architecture/` artifacts are project-internal and never installed, so they cite `installer-design.md`, `src/…`, and `scripts/…` directly.
+
+## Source-spec coupling
+
+Diagrams in this folder are **derived artifacts**. The source of truth is [`installer-design.md`](installer-design.md). Diagrams cite the spec section they visualise (each file does so in its header / cross-references) and are amended in place when the spec changes. If the implementation diverges from these diagrams without a paired amendment, that is a drift signal — update both as one commit.
+
+## Provenance
+
+Filed as `agents-config-w1qls.9` under the `w1qls` feature (Python installer rewrite). This artifact set is the authoritative HLD for the installer; it is referenced from `installer-design.md` and will be cited from the implementation stories (A.1 … H.5) under `w1qls`.

--- a/docs/architecture/installer/index.md
+++ b/docs/architecture/installer/index.md
@@ -20,7 +20,7 @@
 | `StagedItem` | One planned destination file: its content, `FileKind`, namespace, and `Provenance`. The unit the merge + sync engines operate on. |
 | `MergeStrategy` | A collision-resolution class (append-rules, JSON-union, fatal, last-wins-warn, last-wins-silent), each in its own module, dispatched by the registry on `(FileKind, namespace)`. |
 | `FileKind` | The enum classifying a staged file (`NAMESPACED_MD`, `SETTINGS_JSON`, `JSONC`, `TOML`, `OTHER`, `DIR`) — the primary merge-dispatch key. |
-| `Provenance` | `(kind: "tool" | "plugin", name: str)` on each `StagedItem` — preserves tool-vs-plugin origin through the plan. |
+| `Provenance` | `(kind: "tool" \| "plugin", name: str)` on each `StagedItem` — preserves tool-vs-plugin origin through the plan. |
 | `IOPort` | The single injectable I/O abstraction (`info`/`warn`/`show_diff`/`confirm`/…). `TerminalIO` is real (via `rich`); `ScriptedIO` is the test fake. No module calls `print`/`input` directly. |
 | DYNAMIC-INCLUDE | The directive form (`<!-- DYNAMIC-INCLUDE: path -->` and the ALL-RULES variant) that flattens shared template fragments into assembled per-tool instruction files at staging time. |
 | Namespace | The managed sub-directory a file belongs to (`commands` / `skills` / `agents` / `rules` / `formulas`) — second component of the merge-dispatch key; drives append-vs-fatal collision behaviour. |

--- a/docs/architecture/installer/installer-design.md
+++ b/docs/architecture/installer/installer-design.md
@@ -1,5 +1,7 @@
 # Rewrite `scripts/install.sh` as a Python package
 
+> **HLD artifacts**: see [`index.md`](index.md) for the C4 (L2 container / L3 engine), sequence, and data-view diagrams derived from this spec. This document is the design-of-record; the diagrams visualise it and are amended in step.
+
 ## Context
 
 `/Users/scott/src/projects/agents-config/scripts/install.sh` is 1788 lines of shell carrying ten subsystems: tool/plugin detection, 7-phase staging, three DYNAMIC-INCLUDE directive forms, a Gemini-only frontmatter transform, a sentinel-driven carrier-merge, JSON union-merge via embedded `jq`, path-aware backup routing, hash-compare sync, and orphan scan + prune. The script works but is brittle and not testable. Per `AGENTS.md` ("Python over Bash — any logic that needs good testing needs to be in Python"), the file is overdue for a port.

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -32,7 +32,7 @@ Together they answer: *who calls whom, in what order, where does state live (in-
 
 ## Sequence 1 — End-to-end install (happy path)
 
-One invocation: `python3 scripts/install.py --tools=claude,gemini`, with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer --tools=claude,gemini` — the stub and the module form converge on the same process), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
 
 ```mermaid
 sequenceDiagram
@@ -47,7 +47,7 @@ sequenceDiagram
     participant Sync as sync
     participant FS as filesystem
 
-    Op->>CLI: python -m installer --tools=claude,gemini
+    Op->>CLI: python3 scripts/install.py --tools=claude,gemini (or python -m installer ...)
     CLI->>Cfg: build Config
     Cfg->>FS: probe tool config dirs + load installer.toml
     FS-->>Cfg: detected tools, plugins, retired globs

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -32,7 +32,7 @@ Together they answer: *who calls whom, in what order, where does state live (in-
 
 ## Sequence 1 — End-to-end install (happy path)
 
-One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer --tools=claude,gemini` — the stub and the module form converge on the same process), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer.cli --tools=claude,gemini` — the stub and the module form converge on the same process today), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
 
 ```mermaid
 sequenceDiagram
@@ -47,7 +47,7 @@ sequenceDiagram
     participant Sync as sync
     participant FS as filesystem
 
-    Op->>CLI: python3 scripts/install.py --tools=claude,gemini (or python -m installer ...)
+    Op->>CLI: python3 scripts/install.py --tools=claude,gemini (or python -m installer.cli ...)
     CLI->>Cfg: build Config
     Cfg->>FS: probe tool config dirs + load installer.toml
     FS-->>Cfg: detected tools, plugins, retired globs

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -80,10 +80,10 @@ sequenceDiagram
             loop per StagedItem in plan
                 Sync->>FS: hash-compare vs destination (see Sequence 3)
                 alt unchanged
-                    Note over Sync: skip — Counters.Skipped++
+                    Note over Sync: skip — Counters.skipped++
                 else changed or new
                     Sync->>FS: backup (if overwrite) + write
-                    Note over Sync: Counters.Written++ / BackedUp++
+                    Note over Sync: Counters.created++ or updated++ (+ backed_up++ on overwrite)
                 end
             end
             Sync-->>Orch: Counters
@@ -94,7 +94,7 @@ sequenceDiagram
         Orch->>Orch: prune flow (see Sequence 4)
     end
 
-    Orch-->>Op: summary (written / skipped / backed-up per tool); exit 0
+    Orch-->>Op: summary (created / updated / skipped / backed-up per tool); exit 0
 ```
 
 ### Notes on the happy path
@@ -169,28 +169,28 @@ sequenceDiagram
     alt destination absent
         alt --dry-run
             Sync->>IO: info "would create FILE"
-            Note over Sync: Counters.WouldCreate++ — no write
+            Note over Sync: Counters.created++ (preview — no write)
         else
             Sync->>FS: write new file
-            Note over Sync: Counters.Created++
+            Note over Sync: Counters.created++
         end
     else destination present
         Sync->>Sync: hash(incoming) vs hash(dest)
         alt hashes equal
-            Note over Sync: identical — skip; Counters.Skipped++
+            Note over Sync: identical — skip; Counters.skipped++
         else hashes differ
             Sync->>IO: show_diff(dest, incoming)
             alt --dry-run
-                Note over Sync: preview only; Counters.WouldUpdate++ — no write
+                Note over Sync: preview only; Counters.updated++ (no write)
             else interactive
                 Sync->>IO: confirm("overwrite FILE?")
                 alt confirmed
                     Sync->>Bak: path-aware backup of dest
                     Bak->>FS: copy dest to namespace-backup/ (or in-place)
                     Sync->>FS: write incoming
-                    Note over Sync: Counters.Written++ + BackedUp++
+                    Note over Sync: Counters.updated++ + backed_up++
                 else declined
-                    Note over Sync: keep existing; Counters.Skipped++
+                    Note over Sync: keep existing; Counters.skipped++
                 end
             end
         end
@@ -250,7 +250,7 @@ sequenceDiagram
         else none
             Note over Prune: keep all orphans
         end
-        Prune-->>Orch: prune Counters (removed / kept / backed-up)
+        Prune-->>Orch: prune Counters (pruned + backed_up)
     end
 ```
 

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -94,7 +94,7 @@ sequenceDiagram
         Orch->>Orch: prune flow (see Sequence 4)
     end
 
-    Orch-->>Op: summary (created / updated / skipped / backed-up per tool); exit 0
+    Orch-->>Op: summary (created / updated / skipped / backed-up per tool), exit 0
 ```
 
 ### Notes on the happy path
@@ -181,7 +181,7 @@ sequenceDiagram
         else hashes differ
             Sync->>IO: show_diff(dest, incoming)
             alt --dry-run
-                Note over Sync: preview only; Counters.updated++ (no write)
+                Note over Sync: preview only, Counters.updated++ (no write)
             else interactive
                 Sync->>IO: confirm("overwrite FILE?")
                 alt confirmed
@@ -190,7 +190,7 @@ sequenceDiagram
                     Sync->>FS: write incoming
                     Note over Sync: Counters.updated++ + backed_up++
                 else declined
-                    Note over Sync: keep existing; Counters.skipped++
+                    Note over Sync: keep existing, Counters.skipped++
                 end
             end
         end

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -123,7 +123,7 @@ sequenceDiagram
     alt (NAMESPACED_MD, "rules")
         Reg-->>Caller: AppendRulesStrategy
         Caller->>Strat: merge(existing, incoming)
-        Strat-->>Caller: existing + "\n---\n" + incoming
+        Strat-->>Caller: existing rules joined with --- separator to incoming
     else (NAMESPACED_MD, "commands" | "skills" | "agents")
         Reg-->>Caller: FatalStrategy
         Caller->>Strat: merge(existing, incoming)

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -32,7 +32,7 @@ Together they answer: *who calls whom, in what order, where does state live (in-
 
 ## Sequence 1 — End-to-end install (happy path)
 
-One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer.cli --tools=claude,gemini` — the stub and the module form converge on the same process today), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+One invocation: `python3 scripts/install.py --tools=claude,gemini` — the only current entrypoint (a tiny stub: `from installer.cli import main`), with the beads plugin active. (The `python -m installer` module form is *design-forward*: the post-parity entrypoint per Epic H.4, added once the package gains a `__main__.py` — not runnable today.) `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
 
 ```mermaid
 sequenceDiagram
@@ -47,7 +47,7 @@ sequenceDiagram
     participant Sync as sync
     participant FS as filesystem
 
-    Op->>CLI: python3 scripts/install.py --tools=claude,gemini (or python -m installer.cli ...)
+    Op->>CLI: python3 scripts/install.py --tools=claude,gemini
     CLI->>Cfg: build Config
     Cfg->>FS: probe tool config dirs + load installer.toml
     FS-->>Cfg: detected tools, plugins, retired globs

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -1,0 +1,278 @@
+# Python Installer — Sequence Diagrams
+
+> **Up**: [index](index.md)
+> **Previous (reading order)**: [C4 L2 — Container](c4-l2-container.md)
+> **Next (reading order)**: [C4 L3 — Engine](c4-l3-engine.md)
+> **Source bead**: `agents-config-w1qls.9`
+> **Source spec**: [`installer-design.md`](installer-design.md)
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| `StagingPlan` | The in-memory `dict[Path, StagedItem]` built per tool. The `Stage` participant returns one; `Sync` consumes it. |
+| Overlay | The plugin pass: plugin content is staged on top of the tool's plan, and `apply_extensions` applies plugin-declared YAML patches. Collisions route through the merge registry. |
+| Collision | Two `StagedItem`s targeting the same destination `Path`. Resolved by the merge registry's `(FileKind, namespace)` dispatch. |
+| Hash-compare | `Sync`'s skip test: if the incoming content hashes equal to the existing destination file, the file is left untouched. |
+| Path-aware backup | Backup routing — namespaced files back up to a parent-level `<namespace>-backup/` sibling, top-level files back up in place — performed before any overwrite or prune. |
+| Orphan | A destination file present on disk, absent from the freshly-built plan, AND matching an `installer.toml` retired glob — a prune candidate. |
+
+## Purpose
+
+Four sequence diagrams covering one install invocation and its three branching sub-flows:
+
+1. **End-to-end install (happy path)** — detect → stage → overlay → merge → sync → exit.
+2. **Collision merge dispatch** — how two `StagedItem`s for one path resolve through the `(FileKind, namespace)` registry.
+3. **Sync per-item decision** — the hash-skip vs diff → confirm → backup → write branch, including `--dry-run`.
+4. **Prune flow** — orphan scan → interactive prune → backup + remove.
+
+Together they answer: *who calls whom, in what order, where does state live (in-memory plan vs disk), and where do the branches and confirmations sit?* Component structure lives in [`c4-l3-engine.md`](c4-l3-engine.md); data shapes in [`data-view.md`](data-view.md).
+
+---
+
+## Sequence 1 — End-to-end install (happy path)
+
+One invocation: `python3 scripts/install.py --tools=claude,gemini`, with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator
+    participant CLI as cli.py
+    participant Cfg as config.py
+    participant Orch as orchestrator
+    participant Stage as staging
+    participant Plug as plugin overlay
+    participant Merge as merge registry
+    participant Sync as sync
+    participant FS as filesystem
+
+    Op->>CLI: python -m installer --tools=claude,gemini
+    CLI->>Cfg: build Config
+    Cfg->>FS: probe tool config dirs + load installer.toml
+    FS-->>Cfg: detected tools, plugins, retired globs
+    Cfg-->>CLI: frozen Config
+    CLI->>Orch: run(config, io)
+
+    loop per detected tool (claude, then gemini)
+        rect rgb(245, 245, 255)
+            Note over Orch,Stage: Build the in-memory StagingPlan for this tool
+            Orch->>Stage: build StagingPlan(adapter)
+            Stage->>FS: walk + read source (shared .agents/ + per-tool)
+            FS-->>Stage: source bytes
+            Stage->>Stage: strip .template suffix; scope namespaces
+            Stage->>Stage: flatten DYNAMIC-INCLUDE (file form + ALL-RULES)
+            Stage->>Stage: adapter.post_staging_transforms (gemini: frontmatter)
+            Stage-->>Orch: StagingPlan = dict[Path, StagedItem]
+        end
+
+        rect rgb(255, 245, 245)
+            Note over Orch,Merge: Plugin overlay — beads content + YAML extensions
+            Orch->>Plug: overlay beads + apply_extensions(plan)
+            Plug->>Merge: on collision: dispatch (FileKind, namespace)
+            Merge-->>Plug: merged StagedItem (see Sequence 2)
+            Plug-->>Orch: updated StagingPlan
+        end
+
+        rect rgb(245, 255, 245)
+            Note over Orch,FS: Flush the plan to disk, file-by-file
+            Orch->>Sync: flush(plan) to destination
+            loop per StagedItem in plan
+                Sync->>FS: hash-compare vs destination (see Sequence 3)
+                alt unchanged
+                    Note over Sync: skip — Counters.skipped++
+                else changed or new
+                    Sync->>FS: backup (if overwrite) + write
+                    Note over Sync: Counters.written++ / backed_up++
+                end
+            end
+            Sync-->>Orch: Counters
+        end
+    end
+
+    opt --prune requested
+        Orch->>Orch: prune flow (see Sequence 4)
+    end
+
+    Orch-->>Op: summary (written / skipped / backed-up per tool); exit 0
+```
+
+### Notes on the happy path
+
+- **The plan is in-memory for its whole life.** `Stage` returns a `dict[Path, StagedItem]`; overlay mutates it; only `Sync` writes to disk, one file at a time. There is no temp-dir staging tree (the deliberate departure from `install.sh`). `--dump-stage` is the sole path that materialises the plan, and it exits before any destination write.
+- **Tool order is the detection order; tools are independent.** Each tool gets its own plan and its own sync pass — there is no cross-tool state. A failure shaping one tool's plan does not corrupt another's.
+- **Overlay is where collisions happen.** Within a single tool's plan, shared + per-tool content rarely collide on the same path; the common collision is plugin content landing on a base asset. That collision is resolved by the merge registry (Sequence 2), not by `Sync`.
+- **`Config` is frozen before the loop.** Detection, plugin discovery, and `installer.toml` load all happen once in `config.py`; nothing inside the loop re-detects.
+
+---
+
+## Sequence 2 — Collision merge dispatch
+
+Two `StagedItem`s target the same destination `Path` (typically a base asset + a plugin overlay, or shared + per-tool content). The caller (overlay or staging) asks the registry for the strategy keyed on `(FileKind, namespace)`; the strategy returns a single merged item or raises.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller as staging / overlay
+    participant Reg as merge/registry
+    participant Strat as MergeStrategy
+    participant Plan as StagingPlan
+
+    Caller->>Reg: lookup(FileKind, namespace)
+
+    alt (NAMESPACED_MD, "rules")
+        Reg-->>Caller: AppendRulesStrategy
+        Caller->>Strat: merge(existing, incoming)
+        Strat-->>Caller: existing + "\n---\n" + incoming
+    else (NAMESPACED_MD, "commands" | "skills" | "agents")
+        Reg-->>Caller: FatalStrategy
+        Caller->>Strat: merge(existing, incoming)
+        Strat--xCaller: raise — same-name collision is fatal (names must be unique)
+    else (SETTINGS_JSON, —)
+        Reg-->>Caller: JsonUnionStrategy
+        Caller->>Strat: merge(existing, incoming)
+        Strat-->>Caller: deep union (nested dict precedence, array union+sort)
+    else (JSONC | TOML, —)
+        Reg-->>Caller: LastWinsWarnStrategy
+        Caller->>Strat: merge(existing, incoming)
+        Strat-->>Caller: incoming (warn: replacing existing)
+    else (OTHER, —)
+        Reg-->>Caller: LastWinsSilentStrategy
+        Caller->>Strat: merge(existing, incoming)
+        Strat-->>Caller: incoming (silent replace)
+    end
+
+    Caller->>Plan: store merged StagedItem at Path (unless FatalStrategy raised)
+```
+
+### Notes on the merge dispatch
+
+- **The dispatch key is `(FileKind, namespace)`, not `FileKind` alone.** `NAMESPACED_MD` needs its parent-dir namespace to choose: `rules` append-merges (rules compose), but `commands` / `skills` / `agents` are **fatal** on same-name collision (two skills with the same name is an authoring error, not a merge). For non-namespaced kinds (`SETTINGS_JSON`, `JSONC`, `TOML`, `OTHER`, `DIR`) the namespace component is unused and the lookup degenerates to a `FileKind`-only key.
+- **Fatal is a feature.** `FatalStrategy` raising is the design intent: it surfaces an authoring mistake loudly rather than silently picking a winner. The message names both colliding files.
+- **Each strategy is one class, one module, one test file.** The registry holds the only knowledge of *which* strategy applies; the strategies hold the only knowledge of *how* to merge. Swapping a registry entry in a test is how dispatch is asserted.
+
+---
+
+## Sequence 3 — Sync per-item decision
+
+The per-file branch inside `Sync`'s loop (the `hash-compare` step expanded from Sequence 1). Covers new-file, unchanged, changed-interactive, and `--dry-run`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Sync as sync
+    participant FS as filesystem (dest)
+    participant IO as IOPort
+    participant Bak as backup
+
+    Sync->>FS: stat destination Path
+    alt destination absent
+        alt --dry-run
+            Sync->>IO: info "would create FILE"
+            Note over Sync: Counters.would_create++ — no write
+        else
+            Sync->>FS: write new file
+            Note over Sync: Counters.created++
+        end
+    else destination present
+        Sync->>Sync: hash(incoming) vs hash(dest)
+        alt hashes equal
+            Note over Sync: identical — skip; Counters.skipped++
+        else hashes differ
+            Sync->>IO: show_diff(dest, incoming)
+            alt --dry-run
+                Note over Sync: preview only; Counters.would_update++ — no write
+            else interactive
+                Sync->>IO: confirm("overwrite FILE?")
+                alt confirmed
+                    Sync->>Bak: path-aware backup of dest
+                    Bak->>FS: copy dest to namespace-backup/ (or in-place)
+                    Sync->>FS: write incoming
+                    Note over Sync: Counters.written++ + backed_up++
+                else declined
+                    Note over Sync: keep existing; Counters.skipped++
+                end
+            end
+        end
+    end
+```
+
+### Notes on the sync decision
+
+- **Hash-compare is the skip gate.** Unchanged files are never rewritten, so re-running the installer is cheap and quiet — the common case (most files identical) produces no prompts and no backups.
+- **`--dry-run` short-circuits before every write but still shows diffs.** It is the preview mode: the operator sees exactly what *would* change (created / updated counts + diffs) without touching disk. This is also the parity-gate smoke-test surface (`install.py --dry-run` vs `install.sh --dry-run`).
+- **Backup precedes overwrite, always.** No destination file is overwritten without first being copied to its path-aware backup location. The backup routing keeps namespaced backups out of the assistant's discovery walk.
+- **All prompting is through `IOPort`.** `show_diff` and `confirm` never call the terminal directly; `ScriptedIO` drives them in tests, so every branch above is unit-testable without a TTY.
+
+---
+
+## Sequence 4 — Prune flow
+
+Runs after the per-tool install loop when `--prune` (or standalone `--prune-only`) is requested. Finds destination files that the source no longer produces AND that match a retired glob, then removes them interactively (backing each up first).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Orch as orchestrator
+    participant Prune as prune
+    participant FS as filesystem (dest)
+    participant Cfg as installer.toml
+    participant IO as IOPort
+    participant Bak as backup
+
+    Orch->>Prune: scan(plan, config)
+    Prune->>FS: walk destination stores
+    Prune->>Cfg: retired globs
+    Prune->>Prune: orphan = in dest AND not in plan AND matches retired glob
+    Prune->>Prune: build Orphan list (tool, namespace, path, kind)
+
+    alt no orphans
+        Prune-->>Orch: nothing to prune
+    else orphans found
+        Prune->>IO: confirm_three_way("prune N orphans? [all / none / per-item]")
+        alt all
+            loop per Orphan
+                Prune->>Bak: path-aware backup
+                Bak->>FS: copy orphan -> backup
+                Prune->>FS: remove orphan
+            end
+        else per-item
+            loop per Orphan
+                Prune->>IO: confirm("remove FILE?")
+                alt confirmed
+                    Prune->>Bak: backup
+                    Bak->>FS: copy orphan -> backup
+                    Prune->>FS: remove orphan
+                else declined
+                    Note over Prune: keep orphan
+                end
+            end
+        else none
+            Note over Prune: keep all orphans
+        end
+        Prune-->>Orch: prune Counters (removed / kept / backed-up)
+    end
+```
+
+### Notes on the prune flow
+
+- **Prune is conservative by construction.** A file is only an orphan if it is on disk, absent from the freshly-built plan, **and** matches an `installer.toml` retired glob. A file the source simply doesn't produce (but that isn't on the retired list) is left alone — the retired-glob gate prevents the installer from deleting user-authored files it doesn't recognise.
+- **Backup before remove, same as overwrite.** Every pruned file is recoverable from its path-aware backup; prune is reversible.
+- **`--prune-only` skips staging + sync entirely.** It runs just the scan + interactive removal — and is mutually exclusive with `--dump-stage`.
+- **Three-way then per-item.** The operator chooses bulk (`all` / `none`) or drops into per-file confirmation — all via `IOPort`, so the whole flow is scripted in tests.
+
+---
+
+## What these diagrams do NOT show
+
+- **The component structure** that executes these flows — see [`c4-l3-engine.md`](c4-l3-engine.md).
+- **The data shapes** (`StagingPlan`, `StagedItem`, `Orphan`, `Counters`, `Config`) the participants pass — see [`data-view.md`](data-view.md).
+- **DYNAMIC-INCLUDE flattening internals** (the three directive forms) and the **Gemini frontmatter transform** mechanics — referenced as steps here; specified in `installer-design.md`.
+- **The golden-master parity harness** (`install.sh` vs `install.py` diff) — a test artifact, not an install-time flow; see `installer-design.md` §"Test architecture".
+
+## Cross-references
+
+- **Previous (reading order)**: [C4 L2 — Container](c4-l2-container.md)
+- **Next (reading order)**: [C4 L3 — Engine](c4-l3-engine.md) — the components that run these sequences
+- **Companion data view**: [`data-view.md`](data-view.md)
+- **Source spec**: [`installer-design.md`](installer-design.md) §"--dump-stage flag", §"Data model highlights", §"CLI surface"

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -179,10 +179,16 @@ sequenceDiagram
         alt hashes equal
             Note over Sync: identical — skip, Counters.skipped++
         else hashes differ
-            Sync->>IO: show_diff(dest, incoming)
-            alt --dry-run
+            alt --yes (auto_yes)
+                Sync->>Bak: path-aware backup of dest
+                Bak->>FS: copy dest to namespace-backup/ (or in-place)
+                Sync->>FS: write incoming
+                Note over Sync: Counters.updated++ + backed_up++
+            else --dry-run
+                Sync->>IO: show_diff(dest, incoming)
                 Note over Sync: preview only, Counters.updated++ (no write)
             else interactive
+                Sync->>IO: show_diff(dest, incoming)
                 Sync->>IO: confirm("overwrite FILE?")
                 alt confirmed
                     Sync->>Bak: path-aware backup of dest
@@ -200,8 +206,9 @@ sequenceDiagram
 ### Notes on the sync decision
 
 - **Hash-compare is the skip gate.** Unchanged files are never rewritten, so re-running the installer is cheap and quiet — the common case (most files identical) produces no prompts and no backups.
+- **Three modes govern the hashes-differ branch.** `--yes` (auto_yes): backup and write unconditionally, no diff or prompt. `--dry-run`: show diff, no write. Interactive: show diff, prompt, write only on confirmation.
 - **`--dry-run` short-circuits before every write but still shows diffs.** It is the preview mode: the operator sees exactly what *would* change (created / updated counts + diffs) without touching disk. This is also the parity-gate smoke-test surface (`install.py --dry-run` vs `install.sh --dry-run`).
-- **Backup precedes overwrite, always.** No destination file is overwritten without first being copied to its path-aware backup location. The backup routing keeps namespaced backups out of the assistant's discovery walk.
+- **Backup precedes overwrite, always** — including under `--yes`. No destination file is overwritten without first being copied to its path-aware backup location. The backup routing keeps namespaced backups out of the assistant's discovery walk.
 - **All prompting is through `IOPort`.** `show_diff` and `confirm` never call the terminal directly; `ScriptedIO` drives them in tests, so every branch above is unit-testable without a TTY.
 
 ---
@@ -229,26 +236,34 @@ sequenceDiagram
     alt no orphans
         Prune-->>Orch: nothing to prune
     else orphans found
-        Prune->>IO: confirm_three_way("prune N orphans? [all / none / per-item]")
-        alt all
+        alt --yes (auto_yes)
             loop per Orphan
                 Prune->>Bak: path-aware backup
                 Bak->>FS: copy orphan -> backup
                 Prune->>FS: remove orphan
             end
-        else per-item
-            loop per Orphan
-                Prune->>IO: confirm("remove FILE?")
-                alt confirmed
-                    Prune->>Bak: backup
+        else interactive
+            Prune->>IO: confirm_three_way("prune N orphans? [all / none / per-item]")
+            alt all
+                loop per Orphan
+                    Prune->>Bak: path-aware backup
                     Bak->>FS: copy orphan -> backup
                     Prune->>FS: remove orphan
-                else declined
-                    Note over Prune: keep orphan
                 end
+            else per-item
+                loop per Orphan
+                    Prune->>IO: confirm("remove FILE?")
+                    alt confirmed
+                        Prune->>Bak: backup
+                        Bak->>FS: copy orphan -> backup
+                        Prune->>FS: remove orphan
+                    else declined
+                        Note over Prune: keep orphan
+                    end
+                end
+            else none
+                Note over Prune: keep all orphans
             end
-        else none
-            Note over Prune: keep all orphans
         end
         Prune-->>Orch: prune Counters (pruned + backed_up)
     end
@@ -257,9 +272,10 @@ sequenceDiagram
 ### Notes on the prune flow
 
 - **Prune is conservative by construction.** A file is only an orphan if it is on disk, absent from the freshly-built plan, **and** matches an `installer.toml` retired glob. A file the source simply doesn't produce (but that isn't on the retired list) is left alone — the retired-glob gate prevents the installer from deleting user-authored files it doesn't recognise.
-- **Backup before remove, same as overwrite.** Every pruned file is recoverable from its path-aware backup; prune is reversible.
-- **`--prune-only` skips staging + sync entirely.** It runs just the scan + interactive removal — and is mutually exclusive with `--dump-stage`.
-- **Three-way then per-item.** The operator chooses bulk (`all` / `none`) or drops into per-file confirmation — all via `IOPort`, so the whole flow is scripted in tests.
+- **`--yes` skips the three-way prompt entirely.** All orphans are removed unconditionally (with backup). Without `--yes`, the operator chooses bulk (`all` / `none`) or per-file confirmation — all via `IOPort`, so the whole flow is scripted in tests.
+- **Backup before remove, same as overwrite.** Every pruned file is recoverable from its path-aware backup; prune is reversible — including under `--yes`.
+- **`--prune-only` skips staging + sync entirely.** It runs just the scan + removal — mutually exclusive with `--dump-stage`. Non-interactive stdin without `--yes` hard-fails here: you cannot prune unattended without explicitly opting in.
+- **Non-interactive guard.** If `stdin` is not a TTY and neither `--dry-run` nor `--yes` is set, the installer exits with an error rather than silently skipping all prompts.
 
 ---
 

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -32,7 +32,7 @@ Together they answer: *who calls whom, in what order, where does state live (in-
 
 ## Sequence 1 — End-to-end install (happy path)
 
-One invocation: `python3 scripts/install.py --tools=claude,gemini` — the only current entrypoint (a tiny stub: `from installer.cli import main`), with the beads plugin active. (The `python -m installer` module form is *design-forward*: the post-parity entrypoint per Epic H.4, added once the package gains a `__main__.py` — not runnable today.) `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer --tools=claude,gemini`), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
 
 ```mermaid
 sequenceDiagram
@@ -60,7 +60,7 @@ sequenceDiagram
             Orch->>Stage: build StagingPlan(adapter)
             Stage->>FS: walk + read source (shared .agents/ + per-tool)
             FS-->>Stage: source bytes
-            Stage->>Stage: strip .template suffix; scope namespaces
+            Stage->>Stage: strip .template suffix, scope namespaces
             Stage->>Stage: flatten DYNAMIC-INCLUDE (file form + ALL-RULES)
             Stage->>Stage: adapter.post_staging_transforms (gemini: frontmatter)
             Stage-->>Orch: StagingPlan = dict[Path, StagedItem]
@@ -177,7 +177,7 @@ sequenceDiagram
     else destination present
         Sync->>Sync: hash(incoming) vs hash(dest)
         alt hashes equal
-            Note over Sync: identical — skip; Counters.skipped++
+            Note over Sync: identical — skip, Counters.skipped++
         else hashes differ
             Sync->>IO: show_diff(dest, incoming)
             alt --dry-run

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -32,7 +32,7 @@ Together they answer: *who calls whom, in what order, where does state live (in-
 
 ## Sequence 1 — End-to-end install (happy path)
 
-One invocation: `python3 scripts/install.py --tools=claude,gemini` (equivalently `python -m installer --tools=claude,gemini`), with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
+One invocation: `python3 scripts/install.py --tools=claude,gemini`, with the beads plugin active. `Config` is resolved once; then the orchestrator loops per detected tool, building each tool's in-memory plan, overlaying plugins, and flushing to disk. The plan never touches disk except through `Sync`.
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -80,10 +80,10 @@ sequenceDiagram
             loop per StagedItem in plan
                 Sync->>FS: hash-compare vs destination (see Sequence 3)
                 alt unchanged
-                    Note over Sync: skip — Counters.skipped++
+                    Note over Sync: skip — Counters.Skipped++
                 else changed or new
                     Sync->>FS: backup (if overwrite) + write
-                    Note over Sync: Counters.written++ / backed_up++
+                    Note over Sync: Counters.Written++ / BackedUp++
                 end
             end
             Sync-->>Orch: Counters
@@ -169,28 +169,28 @@ sequenceDiagram
     alt destination absent
         alt --dry-run
             Sync->>IO: info "would create FILE"
-            Note over Sync: Counters.would_create++ — no write
+            Note over Sync: Counters.WouldCreate++ — no write
         else
             Sync->>FS: write new file
-            Note over Sync: Counters.created++
+            Note over Sync: Counters.Created++
         end
     else destination present
         Sync->>Sync: hash(incoming) vs hash(dest)
         alt hashes equal
-            Note over Sync: identical — skip; Counters.skipped++
+            Note over Sync: identical — skip; Counters.Skipped++
         else hashes differ
             Sync->>IO: show_diff(dest, incoming)
             alt --dry-run
-                Note over Sync: preview only; Counters.would_update++ — no write
+                Note over Sync: preview only; Counters.WouldUpdate++ — no write
             else interactive
                 Sync->>IO: confirm("overwrite FILE?")
                 alt confirmed
                     Sync->>Bak: path-aware backup of dest
                     Bak->>FS: copy dest to namespace-backup/ (or in-place)
                     Sync->>FS: write incoming
-                    Note over Sync: Counters.written++ + backed_up++
+                    Note over Sync: Counters.Written++ + BackedUp++
                 else declined
-                    Note over Sync: keep existing; Counters.skipped++
+                    Note over Sync: keep existing; Counters.Skipped++
                 end
             end
         end

--- a/packages/installer/uv.lock
+++ b/packages/installer/uv.lock
@@ -638,11 +638,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the high-level design (HLD) visual artifact set the installer design folder was missing, mirroring the established `docs/architecture/prgroom/` convention. `docs/architecture/installer/` previously held only the prose `installer-design.md`; this PR gives it the C4 / sequence / data-view diagrams every other subsystem folder has.

New files under `docs/architecture/installer/`:

- **`index.md`** — orientation: subsystem glossary, scope, reading order, artifact synopsis, and an explicit, justified rationale for **skipping L1 + Deployment** (single CLI, obvious ecosystem, trivially-local topology).
- **`c4-l2-container.md`** — Container view: the installer process, read-only source tree + `installer.toml` inputs, the N destination stores + path-aware backups, and the four AI assistants as async consumers. Calls out that the `StagingPlan` is **in-memory, not an L2 container**.
- **`c4-l3-engine.md`** — Component view: the tool-agnostic `core/` engine, `tools/` + `plugins/` adapters, and the four protocol seams (`ToolAdapter` / `PluginAdapter` / `MergeStrategy` / `IOPort`) as the test-substitution points.
- **`sequences.md`** — four flows: end-to-end install, collision-merge dispatch, sync per-item decision, prune.
- **`data-view.md`** — in-memory ER model + the `(FileKind, namespace)` → strategy dispatch table + `installer.toml` schema + source→memory→disk→runtime ownership boundaries.

`installer-design.md` now links to the index.

## These diagrams describe TARGET architecture, not current code

**This is the most important thing to understand before reviewing.**

These are HLD artifacts — evergreen reference material describing how the installer is *meant* to be structured and behave when complete. They are **not** current-code documentation. The `packages/installer/` rewrite is mid-flight across 34 implementation stories (A.1–H.5); many components shown in these diagrams are not yet built.

The governing principle: `installer-design.md` (same folder) is the design authority. These diagrams visualise that authority. As implementation stories land, the *code* is expected to catch up to *these diagrams* — not the other way around. A component appearing in a diagram without a corresponding file is correct behaviour for an HLD; it is the target the implementation stories are wiring toward.

**Before flagging "X doesn't exist in the codebase":** that is expected and intentional for most things shown here. The diagrams will not become wrong as stories land — they will become accurate.

The one class of finding that IS a defect: if a diagram and `installer-design.md` directly contradict each other on the same element (wrong ownership direction, incompatible structure). Code-vs-diagram gaps are not defects at the HLD tier.

## Provenance / tracking

Filed as `agents-config-w1qls.9` under the `w1qls` feature — the same way `fca6.12` tracks the prgroom HLD set.

## Test Plan

Docs-only change (no code touched; `packages/installer` is unaffected). Verification performed:

- [x] All relative cross-links resolve (index ↔ artifacts, `../../plans/`, `installer-design.md → index.md`)
- [x] All Mermaid fences balance; all semicolons removed from mermaid label text (VSCode parse-error fix)
- [x] ER entity field names align with `installer-design.md` as the design authority
- [x] Spec fidelity vs `installer-design.md` confirmed (module lists, `FileKind` values, merge dispatch, `installer.toml` schema)
- [ ] Reviewer renders the Mermaid on GitHub and spot-checks the diagrams

🤖 Generated with [Claude Code](https://claude.com/claude-code)