### PR TITLE
feat(instructions): add 'spec, diagram and code agreement' constraint

### DIFF
--- a/src/user/.agents/INSTRUCTIONS.md.template
+++ b/src/user/.agents/INSTRUCTIONS.md.template
@@ -13,6 +13,20 @@ Tool-agnostic principles for all AI coding assistants.
 <constraints>
 - **Minimal edits**: Change only what's necessary—no over-engineering
 - **Informed edits**: Research the codebase before editing - never change code you haven't read
+- **Spec, diagram and code agreement**: Specs and HLD diagrams state the
+  **desired** intent; code states the **current** reality. They needn't match in
+  *detail* (code outpaces the spec — expected), but must agree on any element both
+  describe. When authoring or reviewing a derived artifact (diagram, HLD, data view)
+  for an actively-developed system, read the real code — types, signatures,
+  structures — never invent a detail the code already defines, and mark which parts
+  are built vs still intended. Where the code is a refinement or superset of the
+  spec (extra fields, narrower types, added internal steps), that is asymmetry:
+  adopt the code's detail at the artifact's abstraction level and proceed. Where the
+  spec and code **directly conflict on a shared element** (opposite ownership,
+  reversed data direction, mutually exclusive structure), do not pick a winner or
+  paper over it — halt, surface both sides, and escalate to the caller or human to
+  reconcile which is stale. This halt is a risk-asymmetric default (like merge
+  authorization): when unsure which artifact is authoritative, don't guess.
 - **State the decision, not its history**: The main body of specs, plans, design docs,
   prose, and code carries only the current decision. No "Round-N amendment",
   "Supersedes...", "Previously X, now Y", "Changed in YYYY-MM-DD", or similar


### PR DESCRIPTION
## Summary

Adds one constraint to the shared `INSTRUCTIONS.md.template` `<constraints>` block (flattens into every tool's assembled instructions):

> **Spec, diagram and code agreement** — Specs + HLD diagrams state **desired** intent; code states **current** reality. They needn't match on *detail* (code outpaces the spec — expected), but must agree on any element both describe. When authoring/reviewing a derived artifact (diagram, HLD, data view) for an actively-developed system: read the real code, never invent detail it already defines, adopt the code's detail where it's a refinement/superset, and **halt + escalate** where spec and code *directly conflict* on a shared element — a risk-asymmetric default, not a guess.

## Why

When a derived artifact (diagram/HLD/data-view) is authored from the design spec alone, the field-level gaps the spec leaves open get filled by invention rather than by reading the code — producing artifacts that contradict already-implemented types. An internal-consistency review scoped to the spec can't catch that drift; it just makes two wrong things agree. This constraint makes the three sources a tiered set (spec/diagram = desired authority, code = current state) and defines the one hard rule: on overlapping detail they must agree, and a genuine contradiction is a stop-and-escalate, not a unilateral pick.

## Design notes

- **Contradiction vs. asymmetry** is defined inline (refinement/superset = adopt-and-proceed; opposite ownership / reversed data direction / mutually exclusive structure = halt) so the rule fires only on real conflict, not on the code merely being more detailed.
- Anchored to the matrix's existing **risk-asymmetric default** carve-out ('when in doubt, do the safe thing', like merge authorization) rather than asserting an `escalate-conflicting` quadrant — a spec/code disagreement is two stale-able facts, not a clash of L0–L3 laws, so the quadrant didn't strictly fit.
- No file-path citations (survives DYNAMIC-INCLUDE flattening); no embedded history (per 'State the decision, not its history').

## Test Plan

Docs/instruction change — no code. Verification performed:
- [x] New-constraint self-sweep: the PR's only changed file is the constraint itself (not a code-derived artifact) — compliant.
- [x] No file-path citations in the bullet (greps clean).
- [x] No embedded session/PR/date history (greps clean).
- [x] Adversarial review pass (over-broad-trigger, matrix-classification, duplication, voice/length) → findings addressed.
- [ ] Reviewer (human / Copilot) sanity-check of wording.

## Follow-up surfaced (not in this PR)

The adversarial pass noted the `<decision-matrix>` has no clean quadrant for 'two source-of-truth artifacts disagree and I can't tell which is stale' — handled here via the risk-asymmetric framing, but the matrix itself could grow a quadrant for it. Flagging for a possible future bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)