### PR TITLE
chore(config): lean bd-prime override, memory-routing rule, retire bd-remember store

### DIFF
--- a/.beads/AGENTS.md
+++ b/.beads/AGENTS.md
@@ -1,0 +1,20 @@
+# `.beads/` — maintenance notes
+
+## `PRIME.md` is the project's `bd prime` output
+
+`bd prime` emits `PRIME.md` **verbatim** for this repo (verified 1:1) — it fully
+replaces bd's built-in prime text *and* suppresses the auto-injected bd-memory
+dump. It loads at **every session start and before each compaction**, so every
+line is a recurring token cost across all future conversations. Keep it ruthlessly
+minimal.
+
+When editing `PRIME.md`:
+
+- Add only beads knowledge that is **high-frequency or error/data-loss-preventing**.
+  Deep machinery (molecules, formulas, HEP, claim/close-walk, labels) belongs in
+  skills or `archive/`, not here.
+- Don't reproduce the command catalog — point to `bd --help` / `bd <cmd> --help`.
+- Never tell readers to "run `bd prime` for more" — it's circular; `bd prime` emits
+  this file.
+- Say nothing about which memory system to use. Memory routing lives in the
+  `memory-routing` rule; bd's own memory injection is already suppressed by this override.

--- a/.beads/PRIME.md
+++ b/.beads/PRIME.md
@@ -1,0 +1,66 @@
+# Beads — Project Issue Tracker
+
+This project tracks durable work with **bd (beads)**.
+
+## Task tracking
+
+- **bd is for durable work** — issues, discovered follow-ups, anything that must
+  outlive the session. File the bead *before* writing code for it; mark it
+  in-progress when you start.
+- **In-session planning is yours** — use your native Task / ToDo tools freely to
+  plan and track the steps of the work you're doing right now. bd tracks *what*
+  needs doing across sessions; your task list tracks *how* you execute it this one.
+- Don't run `bd edit` — it opens `$EDITOR` and hangs a non-interactive agent.
+  Edit fields inline: `bd update <id> --title/--description/--notes/--design`.
+
+## Essential commands
+
+```bash
+bd --help  /  bd <command> --help   # authoritative flag reference — read before guessing
+bd ready                            # claimable work (no open blockers) — default 100 rows
+bd list                             # open issues — default 50 rows; --all includes closed
+bd show <id>                        # full detail + dependencies
+bd update <id> --claim              # claim work
+bd create --title="…" --description="…" --type=task|bug|feature|epic --priority=P2
+bd dep add <id> <depends-on>        # <id> depends on <depends-on>
+bd close <id> [<id> …]              # complete (space-separate to batch)
+bd search <query>                   # find by keyword
+```
+
+- Add **`--json`** to read commands for machine-readable output.
+- `bd ready` / `bd list` truncate (100 / 50 rows) — pass **`--limit 0`** for an unbounded list.
+- Priority is `0`–`4` / `P0`–`P4` (0 = critical, 2 = medium, 4 = backlog) — never "high/medium/low".
+
+## Gotchas worth knowing
+
+- **`--notes` / `--description` / `--acceptance` overwrite the entire field.** To add
+  without clobbering, use **`--append-notes`**. Replace-variants are for initial write
+  or deliberate overwrite only.
+- **`bd … --json` shapes that trip `jq`:**
+    - `bd show <id> --json` is a single-element **array** — index `.[0]`.
+    - Multi-line fields (`notes` / `description` / `acceptance`) carry literal newlines
+      `jq` rejects — read them with Python, not `jq`.
+    - `.dependencies[]` (in `bd show --json`) is the **full target bead** plus a
+      `.dependency_type` field, not a lean edge:
+      `.[0].dependencies | map({id, type: .dependency_type})`.
+    - `bd label list <id> --json` is a **flat array of strings** — `jq 'index("foo")'`,
+      not `.labels | index(...)`.
+    - `bd dep list <id> --direction up|down --json` → `{id, dependency_type, status}`
+      where `.id` is the bead at the *other* end of the edge.
+- **`blocks` has a type wall:** epics block only epics, non-epics block only non-epics —
+  cross-type is a hard error. For a soft task→epic link use `--type related-to`.
+- **`bd create --parent <id>` auto-creates the dependency edge** — don't also
+  `bd dep add <child> <parent>`; bd rejects it as a deadlock.
+- **`bd create` is pure capture** — filing a bead is not starting it. Reserve
+  "Starting work on <id>…" for when the user explicitly directs work on a specific bead.
+
+## Session close — work isn't done until it's pushed
+
+```bash
+git pull --rebase
+bd dolt push          # sync beads to the Dolt remote
+git push
+git status            # must read "up to date with origin"
+```
+
+If a push fails, resolve and retry — never leave work stranded locally.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,27 +1,5 @@
 {
   "hooks": {
-    "PreCompact": [
-      {
-        "hooks": [
-          {
-            "command": "bd prime",
-            "type": "command"
-          }
-        ],
-        "matcher": ""
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "command": "bd prime",
-            "type": "command"
-          }
-        ],
-        "matcher": ""
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,54 +20,6 @@ This is a versioned collection of agents, skills, commands, and templates for AI
 4. **Guardrail every completion claim with mechanical evidence** (completion gate, verify-checklist)
 5. **Persist context** (work tickets, memories, formulas) so work survives compaction, agent handoff, and overnight runs
 
-### New State - Ideas to keep us on track
-
-Your job, agent, is to also keep these in mind as we continue to brainstorm and develop the details of the target architecture.  Eventually we can purge these from the project context once we fully capture this scope in the backlog.
-
-#### Core Orchestration & Architecture
-* **The Deterministic Code-First Orchestrator:**
-    * Move orchestration logic out of Markdown (`SKILL.md`) and Bash scripts into a compiled/scripted language (Python/Go).
-    * The orchestrator manages state transitions; agents are treated as isolated functions that read specs and write code.
-* **WMS (Work Management System) Decoupling:**
-    * Abstract the underlying tracker (Beads, GitHub, Jira) behind a CLI wrapper.
-    * Execution agents must have ZERO awareness of the WMS. The Orchestrator handles all state updates and graph traversal.
-
-#### The Mechanical Pipeline Gates
-* **The "Agent-Ready" Thin Slice:**
-    * A Unit of Work (UoW) is only ready when it is atomic and backed by machine-verifiable Acceptance Tests (ATs).
-    * No judgmental/subjective criteria allowed in the execution phase.
-* **The Red/Green Mechanical Gate:**
-    * The transition from Test Writing to Implementation is gated by a deterministic runner (`npm test`, `pytest`).
-    * Tests must compile against stubs and actively *fail* before implementation begins. No LLM "vibe checks" allowed for this gate.
-
-#### Feedback Loops & Error Handling
-* **The 3-Strike Circuit Breaker:**
-    * Hardcode a limit on adversarial AI-to-AI review cycles. If an agent fails to pass the mechanical tests/reviews 3 times, the pipeline halts. Throw away the dirty git branch.
-* **Dual Autopsy Agents (RCA):**
-    * Triggered on a 3-Strike failure. Generates machine-readable facts, not excuses.
-    * *Specification RCA Agent:* Looks for logical contradictions, missing context, and untestable criteria.
-    * *Architecture Health RCA Agent:* Looks for tight coupling, legacy tech debt, and state contamination.
-* **The Historical Linter (Pre-Mortem Agent):**
-    * Reviews specs *before* execution, but only allowed to flag weaknesses if it can cite a specific, documented historical failure or ADR. Eliminates strawman hallucinations.
-
-#### UX & Human-in-the-Loop
-* **The "Cool Idea" Quarantine:**
-    * A behavioral protocol for the interactive brainstorming agent. Actively isolates out-of-scope, complex ideas into an Icebox so the human can focus on the immediate thin slice without fear of losing the idea.
-* **Visual AT Analysis Engine (Concept):**
-    * Escape "bullet-point review hell" using spatial/visual node graphs (e.g., D3.js).
-    * Map ATs against stable `CONTEXT.md` domains. Size by complexity, color by risk.
-    * Use multimodal AI to analyze the topological graph and highlight architectural violations instantly.
-* **Dreaming / Subconscious Backlog Process (Concept):**
-    * Verbatim (Scott, 2026-05-17, while designing the PDLC state machine in `agents-config-wgclw.1`): a background process that periodically scans the backlog looking for new connections, broken connections, stale connections, between work items. Consider this a "dreaming" process or subconscious process of strengthening edges between memory nodes.
-    * Purpose: supports topic-correlated Idea resurfacing (option C from the holding-place exit-condition tradeoff) AND sequencing recommendations during "what's next to work on" pulls — e.g. "you want to work on X, but Y might be a blocking dependency for X."
-    * Provenance backreference: captured live during the brainstorm of `agents-config-wgclw.1` (PDLC State Machine Design); parked here pending an official Capture surface.
-
-#### Architecture and Objectives
-* **Architecture Context:**
-  * A project needs a high-level architecture (CONTEXT.md, HLD artifacts (TBD)) and every objective must be linkable to a specific part of the architecture.
-* **Architecture Heatmap:**
-  * Given an HLD, we should be able to show the work associated with the HLD components (at whatever state they are in) to show which parts are theoretical, which are planned, which are done, and to whatever degree.  This can help in prioritization/bucketing, but also allows us to maintain focus on specific components without losing track of the rest of the architecture, and perform audits to see where we're veering off MVP or tracer bullet goals.
-
 ### Current state — FAILED work in progress
 
 The architecture has run into a problematic ocean of complexity and inverted engineering where agents are doing the wrong things (things algorithms should be doing).  We're presently in a REDESIGN phase where much of the old and suspect architecture has been pushed under the `archive/` folder to serve as references until we don't need them anymore.  You should NOT peek in there unless/until you need to.  (Don't let its contents poison your understanding of current and future state).
@@ -152,52 +104,6 @@ Milestones form a sequential `blocks` chain: M0 → M1 → M2 → M3 → M4. Eac
 | `agents-config-t142` | open | **M4** — Overnight autonomy |
 
 All milestones are P1. Work that maps to a milestone is a child of that milestone bead.
-
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
-## Beads Issue Tracker
-
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
-
-### Quick Reference
-
-```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work
-bd close <id>         # Complete work
-```
-
-### Rules
-
-- Use `bd` for ALL discovered work tracking — *except for in-session planning*, do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-- Run `bd prime` for detailed command reference and session close protocol
-
-## Session Completion
-
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
-
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd dolt push
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-<!-- END BEADS INTEGRATION -->
 
 ## graphify
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,48 @@
+### New State - Ideas to keep us on track
+
+Your job, agent, is to also keep these in mind as we continue to brainstorm and develop the details of the target architecture.  Eventually we can purge these from the project context once we fully capture this scope in the backlog.
+
+#### Core Orchestration & Architecture
+* **The Deterministic Code-First Orchestrator:**
+    * Move orchestration logic out of Markdown (`SKILL.md`) and Bash scripts into a compiled/scripted language (Python/Go).
+    * The orchestrator manages state transitions; agents are treated as isolated functions that read specs and write code.
+* **WMS (Work Management System) Decoupling:**
+    * Abstract the underlying tracker (Beads, GitHub, Jira) behind a CLI wrapper.
+    * Execution agents must have ZERO awareness of the WMS. The Orchestrator handles all state updates and graph traversal.
+
+#### The Mechanical Pipeline Gates
+* **The "Agent-Ready" Thin Slice:**
+    * A Unit of Work (UoW) is only ready when it is atomic and backed by machine-verifiable Acceptance Tests (ATs).
+    * No judgmental/subjective criteria allowed in the execution phase.
+* **The Red/Green Mechanical Gate:**
+    * The transition from Test Writing to Implementation is gated by a deterministic runner (`npm test`, `pytest`).
+    * Tests must compile against stubs and actively *fail* before implementation begins. No LLM "vibe checks" allowed for this gate.
+
+#### Feedback Loops & Error Handling
+* **The 3-Strike Circuit Breaker:**
+    * Hardcode a limit on adversarial AI-to-AI review cycles. If an agent fails to pass the mechanical tests/reviews 3 times, the pipeline halts. Throw away the dirty git branch.
+* **Dual Autopsy Agents (RCA):**
+    * Triggered on a 3-Strike failure. Generates machine-readable facts, not excuses.
+    * *Specification RCA Agent:* Looks for logical contradictions, missing context, and untestable criteria.
+    * *Architecture Health RCA Agent:* Looks for tight coupling, legacy tech debt, and state contamination.
+* **The Historical Linter (Pre-Mortem Agent):**
+    * Reviews specs *before* execution, but only allowed to flag weaknesses if it can cite a specific, documented historical failure or ADR. Eliminates strawman hallucinations.
+
+#### UX & Human-in-the-Loop
+* **The "Cool Idea" Quarantine:**
+    * A behavioral protocol for the interactive brainstorming agent. Actively isolates out-of-scope, complex ideas into an Icebox so the human can focus on the immediate thin slice without fear of losing the idea.
+* **Visual AT Analysis Engine (Concept):**
+    * Escape "bullet-point review hell" using spatial/visual node graphs (e.g., D3.js).
+    * Map ATs against stable `CONTEXT.md` domains. Size by complexity, color by risk.
+    * Use multimodal AI to analyze the topological graph and highlight architectural violations instantly.
+* **Dreaming / Subconscious Backlog Process (Concept):**
+    * Verbatim (Scott, 2026-05-17, while designing the PDLC state machine in `agents-config-wgclw.1`): a background process that periodically scans the backlog looking for new connections, broken connections, stale connections, between work items. Consider this a "dreaming" process or subconscious process of strengthening edges between memory nodes.
+    * Purpose: supports topic-correlated Idea resurfacing (option C from the holding-place exit-condition tradeoff) AND sequencing recommendations during "what's next to work on" pulls — e.g. "you want to work on X, but Y might be a blocking dependency for X."
+    * Provenance backreference: captured live during the brainstorm of `agents-config-wgclw.1` (PDLC State Machine Design); parked here pending an official Capture surface.
+
+#### Architecture and Objectives
+* **Architecture Context:**
+  * A project needs a high-level architecture (CONTEXT.md, HLD artifacts (TBD)) and every objective must be linkable to a specific part of the architecture.
+* **Architecture Heatmap:**
+  * Given an HLD, we should be able to show the work associated with the HLD components (at whatever state they are in) to show which parts are theoretical, which are planned, which are done, and to whatever degree.  This can help in prioritization/bucketing, but also allows us to maintain focus on specific components without losing track of the rest of the architecture, and perform audits to see where we're veering off MVP or tracer bullet goals.
+

--- a/packages/installer/AGENTS.md
+++ b/packages/installer/AGENTS.md
@@ -53,6 +53,11 @@ but the full gate must pass before push.
   this pin?" before writing it.
 - Unit tests drive the engine through `ScriptedIO`; assert against its
   transcript. Coverage floor is 90% branch (enforced by `pytest --cov`).
+- **`# pragma: no cover` on `Protocol` method declarations is load-bearing.**
+  With `--cov-branch`, coverage.py counts the inter-declaration branches on
+  `...`-bodied `typing.Protocol` methods; removing the pragma drops branch
+  coverage measurably (e.g. `core/io_port.py` 100% → 87%) even though the
+  methods have no executable body. Keep them.
 
 ## Do not run the installer automatically
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,18 @@
+# `scripts/` — installer maintenance notes
+
+`install.sh` (74 KB) is the **live behavioural spec** for the Python port under
+`packages/installer/` — not dead code. When editing it:
+
+- **Adding a managed namespace dir** (`commands` / `skills` / `agents` / `rules`
+  / `formulas`): update **both** `backup()`'s namespace list **and**
+  `scan_orphans`' `prune_subdirs` list. Miss the first and backups leak into
+  runtime-discoverable locations; miss the second and prune skips orphans.
+- **Never name a shell variable `path` under zsh.** zsh ties lowercase `path` to
+  `PATH`, so assigning it breaks every external command in scope (`date`, `rm`,
+  …). Same for `cdpath` / `fpath` / `manpath` / etc. — use `file_path`,
+  `target_path`, etc. `install.sh` is a bash-4/zsh polyglot; use the `_ARRAY_BASE`
+  shim (1 for zsh, 0 for bash) for any index-based array loop.
+- **Auto-detect is config-dir-based, not CLI-presence.** It always includes
+  `claude`; it adds `codex` / `gemini` only when `~/.codex/` / `~/.gemini/`
+  exists, or when `--tools=` forces them. Don't describe it as "detecting
+  installed CLIs".

--- a/src/user/.agents/SESSION-PRIMER-README.md
+++ b/src/user/.agents/SESSION-PRIMER-README.md
@@ -1,0 +1,13 @@
+<!--
+Source: oss-snapshots/superpowers/using-superpowers/SKILL.md @ obra/superpowers commit f2cbfbe (v5.1.0)
+Last lifted: 2026-05-25
+Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
+Material edits vs. upstream:
+  - Dropped upstream's <SUBAGENT-STOP> gate: subagents inherit the host's AGENTS.md context including this primer, so they cannot act on a "skip" instruction they've already read.
+  - Dropped upstream's "Instruction Priority" section: agents already follow user > skills > defaults as part of their baseline instruction-following protocol; restating it here is noise. (Not redundant with INSTRUCTIONS.md's <laws> — those define the L0–L3 quality/safety stack, a different concern.)
+  - Dropped upstream's "How to Access Skills" per-runtime listing: each runtime's own system prompt already documents its skill mechanism.
+  - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md / references/codex-tools.md (those reference files are not in-tree).
+  - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with prose workflow steps.
+  - Generalized the upstream's runtime-specific checklist-tracker invocation to runtime-agnostic phrasing (no tool name).
+  - Body wrapped in <skill-usage-instructions> for context-boundary clarity.
+-->

--- a/src/user/.agents/SESSION-PRIMER.md.template
+++ b/src/user/.agents/SESSION-PRIMER.md.template
@@ -1,17 +1,3 @@
-<!--
-Source: oss-snapshots/superpowers/using-superpowers/SKILL.md @ obra/superpowers commit f2cbfbe (v5.1.0)
-Last lifted: 2026-05-25
-Drift policy: selective-amalgamation — content was rewritten for project-owned voice and the four-tool surface (Claude Code, Codex CLI, Gemini CLI, OpenCode). Do not auto-resync from upstream.
-Material edits vs. upstream:
-  - Dropped upstream's <SUBAGENT-STOP> gate: subagents inherit the host's AGENTS.md context including this primer, so they cannot act on a "skip" instruction they've already read.
-  - Dropped upstream's "Instruction Priority" section: agents already follow user > skills > defaults as part of their baseline instruction-following protocol; restating it here is noise. (Not redundant with INSTRUCTIONS.md's <laws> — those define the L0–L3 quality/safety stack, a different concern.)
-  - Dropped upstream's "How to Access Skills" per-runtime listing: each runtime's own system prompt already documents its skill mechanism.
-  - Dropped upstream's "Platform Adaptation" pointer to references/copilot-tools.md / references/codex-tools.md (those reference files are not in-tree).
-  - Dropped upstream's DOT skill_flow digraph (none of the four tools render DOT); replaced with prose workflow steps.
-  - Generalized the upstream's runtime-specific checklist-tracker invocation to runtime-agnostic phrasing (no tool name).
-  - Body wrapped in <skill-usage-instructions> for context-boundary clarity.
--->
-
 <skill-usage-instructions>
 
 # Session Primer — Skill Invocation Discipline

--- a/src/user/.agents/rules/memory-routing.md
+++ b/src/user/.agents/rules/memory-routing.md
@@ -1,0 +1,13 @@
+# Memory Routing
+
+A durable fact has exactly one correct home, decided by its **scope**. Route before you write.
+
+| Fact's scope | Home | Why |
+|---|---|---|
+| **Repo-specific** — a convention, gotcha, decision, or workflow that only means something inside one project | That repo's `AGENTS.md` — or a **folder-scoped** `AGENTS.md` when it only applies to a subtree (e.g. one package) | Versioned with the code, travels with the repo, visible to every tool and teammate that opens it |
+| **General** — your working style, a user preference, or a correction that holds across every project | Your runtime's native/personal memory system | Follows you between projects; not bound to any one codebase |
+
+- **Scope is the test, not topic.** "*This* installer needs `make ci` before push" → repo `AGENTS.md`. "User prefers vodka over rum" → native memory.
+- **Go folder-scoped when the fact is narrower than the repo** — a fact that only applies under `packages/foo/` belongs in `packages/foo/AGENTS.md`, not the root.
+- **One home, never two.** Don't mirror a fact into both native memory and an `AGENTS.md`; duplicated facts drift and then contradict each other.
+- **No native memory on your runtime?** General facts have no durable store — surface them to the user instead of inventing one.

--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -78,6 +78,16 @@ Skills whose Claude-specific features (`!`-command syntax, `disable-model-invoca
 | `handoff` | `src/user/.claude/skills/handoff/` | `oss-snapshots/pocock/handoff/` (pristine upstream; local extensions in deployed copy) | `mattpocock/skills @ e74f0061` | 2026-05-23 | rewrite-and-divorce (project-extended, Claude-specific) |
 | `zoom-out` | `src/user/.claude/skills/zoom-out/` | `oss-snapshots/pocock/zoom-out/` | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
 
+## Common pitfall — extracted helpers must be wired in
+
+When you extract a helper script out of in-model skill code, the live path keeps
+using the in-model code until `SKILL.md` is rewired to invoke the helper. So
+smoke tests, Copilot, and first-pass review can all pass while the helper chain
+carries a latent, unexercised contract bug. Treat "helper added but not yet
+invoked by `SKILL.md`" as a review smell, and drive the documented helper chain
+end-to-end on a fixture before merging — an architecture-challenge review pass
+catches these cross-file contract gaps that per-line review misses.
+
 ## Companion folders
 
 - `<repo-root>/oss-snapshots/` — unmodified reference clones of upstream skill catalogs, pinned to specific commits. Each snapshot folder carries its own `AGENTS.md` documenting source repo, commit, and per-skill inventory.


### PR DESCRIPTION
Context-hygiene pass to stop session-start noise and resolve a memory-system contradiction (native file-based memory vs the bd-prime 'do not use MEMORY.md' directive).

Highlights:
- `.beads/PRIME.md` overrides `bd prime` with a lean emission (verified 1:1, 66 lines); suppresses the 31-entry bd-memory dump.
- New `memory-routing` rule: repo-specific facts to AGENTS.md, general/behavioral to native memory.
- Beads gotchas consolidated into PRIME.md; folder-scoped notes added (scripts/, installer, skills).
- Duplicate bd-prime hooks dropped from project settings; 'New State' ideas moved to IDEAS.md.
- All 31 bd-remember memories retired (content preserved in the homes above).

Config/docs only — no installer code paths changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)