### PR TITLE
feat(installer): C.2 — DYNAMIC-INCLUDE ALL-RULES resolution

### DIFF
--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -2,19 +2,28 @@
 
 Some tools do not resolve `@`-style includes, so instruction templates carry
 inline markers that are flattened into a single self-contained file at install
-time. B.4 implements the **file form**::
+time. Two directive forms are supported:
+
+File form (B.4)::
 
     <!-- DYNAMIC-INCLUDE: path/to/file.md -->
 
 A line that is exactly this marker is replaced by the verbatim text of the
 referenced file (resolved relative to a base directory). A missing target warns
-and leaves the line empty. The behavioural reference is the bash installer's
-``flatten_agents_md`` (``scripts/install.sh``).
+and leaves the line empty.
 
-`parse_directive` also recognises the ALL-RULES form so directive recognition is
-complete, but *resolving* ALL-RULES is deferred to story C.2; `flatten_template`
-raises `NotImplementedError` if it encounters one rather than silently emitting a
-literal marker.
+ALL-RULES form (C.2)::
+
+    <!-- DYNAMIC-INCLUDE-ALL-RULES -->
+
+A line that is exactly this marker is replaced by all ``*.md`` files in the
+caller-supplied ``rules_dir``, sorted lexicographically by filename, joined
+with ``\\n---\\n`` between adjacent rules. An absent or empty ``rules_dir``
+emits a warning and resolves to the empty string.
+
+The behavioural reference is the bash installer's ``flatten_agents_md``
+(``scripts/install.sh``). The named-RULES form (C.3) is deferred; its marker
+is not yet recognised and passes through as a non-directive line.
 """
 
 from __future__ import annotations
@@ -30,7 +39,6 @@ if TYPE_CHECKING:
 
 _FILE_INCLUDE_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE: (.*) -->$")
 _ALL_RULES_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE-ALL-RULES -->$")
-_ALL_RULES_DEFERRED = "DYNAMIC-INCLUDE-ALL-RULES resolution lands in story C.2"
 
 
 def parse_directive(line: str) -> IncludeDirective | None:
@@ -51,8 +59,14 @@ def parse_directive(line: str) -> IncludeDirective | None:
     return None
 
 
-def flatten_template(content: str, *, base_dir: Path, io: IOPort) -> str:
-    """Flatten DYNAMIC-INCLUDE file markers in a template's text.
+def flatten_template(
+    content: str,
+    *,
+    base_dir: Path,
+    io: IOPort,
+    rules_dir: Path | None = None,
+) -> str:
+    """Flatten DYNAMIC-INCLUDE markers in a template's text.
 
     Each file-marker line is replaced by the verbatim text of the referenced
     file (read as UTF-8), resolved relative to ``base_dir``. The marker line and
@@ -60,10 +74,14 @@ def flatten_template(content: str, *, base_dir: Path, io: IOPort) -> str:
     without a trailing newline abuts the template's next line — matching
     ``cat file >> output``. A target that is not a regular file emits a warning
     and resolves to the empty string, leaving the marker line empty.
+
+    An ALL-RULES marker line is replaced by all ``*.md`` files in ``rules_dir``,
+    sorted lexicographically by filename, joined with ``\\n---\\n`` between
+    adjacent rules. An absent or empty ``rules_dir`` emits a warning and resolves
+    to the empty string.
+
     Non-directive lines pass through unchanged, and the template's trailing
     newline is preserved iff the template had one.
-
-    ALL-RULES resolution is deferred to story C.2.
     """
     out: list[str] = []
     for line in content.splitlines(keepends=True):
@@ -75,10 +93,28 @@ def flatten_template(content: str, *, base_dir: Path, io: IOPort) -> str:
             case FileInclude(path=rel):
                 out.append(_resolve_file_include(rel, base_dir=base_dir, io=io))
             case AllRulesInclude():
-                raise NotImplementedError(_ALL_RULES_DEFERRED)
+                out.append(_resolve_all_rules(rules_dir=rules_dir, io=io))
             case _:  # pragma: no cover - exhaustiveness guard for future variants
                 assert_never(directive)
     return "".join(out)
+
+
+def _resolve_all_rules(*, rules_dir: Path | None, io: IOPort) -> str:
+    """Expand the ALL-RULES directive to the concatenated content of all *.md
+    files in ``rules_dir``, sorted lexicographically by filename, joined with
+    ``\\n---\\n`` between adjacent rules.
+
+    Mirrors the bash installer's ALL-RULES handler (``scripts/install.sh:730-745``):
+    ``find ... | LC_ALL=C sort`` over rule files, cat each, ``printf '\\n---\\n'``
+    between them, warn if the collection is empty.
+    """
+    rule_files: list[Path] = []
+    if rules_dir is not None and rules_dir.is_dir():
+        rule_files = sorted(p for p in rules_dir.glob("*.md") if p.is_file())
+    if not rule_files:
+        io.warn(f"DYNAMIC-INCLUDE-ALL-RULES: no rules found in {rules_dir or '(no rules_dir)'}")
+        return ""
+    return "\n---\n".join(p.read_text(encoding="utf-8") for p in rule_files)
 
 
 def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:

--- a/packages/installer/tests/unit/test_templates.py
+++ b/packages/installer/tests/unit/test_templates.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from installer.core.io_port import ScriptedIO
 from installer.core.model import AllRulesInclude, FileInclude
 from installer.core.templates import flatten_template, parse_directive
@@ -183,12 +181,87 @@ def test_included_file_without_trailing_newline_glues_to_next_line(
     assert result == "FRAGMENTafter\n"
 
 
-def test_all_rules_marker_resolution_is_deferred(tmp_path: Path) -> None:
+def test_all_rules_empty_dir_warns_and_expands_blank(tmp_path: Path) -> None:
     """
-    Given a template containing the ALL-RULES marker
-    When flatten_template runs
-    Then it raises NotImplementedError — resolution lands in story C.2, and the
-    marker must fail loudly rather than emit a literal comment line.
+    Given an empty rules_dir (no *.md files)
+    When flatten_template runs with the ALL-RULES marker
+    Then it emits a warning and expands to the empty string.
     """
-    with pytest.raises(NotImplementedError):
-        flatten_template("<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n", base_dir=tmp_path, io=ScriptedIO())
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    io = ScriptedIO()
+
+    result = flatten_template(
+        "before\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\nafter\n",
+        base_dir=tmp_path,
+        rules_dir=rules_dir,
+        io=io,
+    )
+
+    assert result == "before\nafter\n"
+    warnings = [e for e in io.transcript if e.channel == "warn"]
+    assert len(warnings) == 1
+    assert "ALL-RULES" in warnings[0].message
+
+
+def test_all_rules_none_rules_dir_warns_and_expands_blank(tmp_path: Path) -> None:
+    """
+    Given rules_dir=None (no rules dir provided)
+    When flatten_template runs with the ALL-RULES marker
+    Then it emits a warning and expands to the empty string.
+    """
+    io = ScriptedIO()
+
+    result = flatten_template(
+        "<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n",
+        base_dir=tmp_path,
+        rules_dir=None,
+        io=io,
+    )
+
+    assert result == ""
+    warnings = [e for e in io.transcript if e.channel == "warn"]
+    assert len(warnings) == 1
+    assert "ALL-RULES" in warnings[0].message
+
+
+def test_all_rules_directory_named_md_is_skipped(tmp_path: Path) -> None:
+    """
+    Given a rules_dir containing a directory whose name ends in .md
+    When flatten_template runs with the ALL-RULES marker
+    Then the directory is skipped (not crashed) — mirrors bash `find -type f`.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "real.md").write_text("REAL RULE\n", encoding="utf-8")
+    (rules_dir / "weird.md").mkdir()  # directory named *.md
+
+    result = flatten_template(
+        "<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n",
+        base_dir=tmp_path,
+        rules_dir=rules_dir,
+        io=ScriptedIO(),
+    )
+
+    assert result == "REAL RULE\n"
+
+
+def test_all_rules_expands_to_sorted_concatenation(tmp_path: Path) -> None:
+    """
+    Given two rule files in rules_dir (out of lexicographic order on disk)
+    When flatten_template runs with the ALL-RULES marker
+    Then both are concatenated in lexicographic filename order, joined by \\n---\\n.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "b_rule.md").write_text("RULE B\n", encoding="utf-8")
+    (rules_dir / "a_rule.md").write_text("RULE A\n", encoding="utf-8")
+
+    result = flatten_template(
+        "<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n",
+        base_dir=tmp_path,
+        rules_dir=rules_dir,
+        io=ScriptedIO(),
+    )
+
+    assert result == "RULE A\n\n---\nRULE B\n"

--- a/packages/installer/uv.lock
+++ b/packages/installer/uv.lock
@@ -638,11 +638,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements the ALL-RULES directive in `flatten_template` (story `agents-config-w1qls.3.2`)
- Replaces the `NotImplementedError` seam from B.4 with `_resolve_all_rules`: globs `*.md` from `rules_dir`, filters to regular files (`p.is_file()` for bash `find -type f` parity), sorts lexicographically, joins with `\n---\n`
- An absent or empty `rules_dir` warns and expands to blank — matching the bash reference (`scripts/install.sh:730-745`)

## Test Plan

- [x] `test_all_rules_expands_to_sorted_concatenation` — two files written out-of-order → sorted + `\n---\n` joined
- [x] `test_all_rules_empty_dir_warns_and_expands_blank` — empty dir → warning + blank
- [x] `test_all_rules_none_rules_dir_warns_and_expands_blank` — `rules_dir=None` → warning + blank
- [x] `test_all_rules_directory_named_md_is_skipped` — directory named `*.md` skipped, not crashed (parity gap caught by quality-reviewer)
- [x] `make ci-installer` green: ruff, mypy --strict, 123 passed, 99.58% branch coverage
- [x] pip-audit flags `pip 26.1.1` (PYSEC-2026-196) — pre-existing, not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)