### PR TITLE
test(staging): add strip_template_suffix edge cases and fix misleading test name

### DIFF
--- a/docs/plans/2026-06-02-w1qls.3.1-shared-toolspecific-staging.md
+++ b/docs/plans/2026-06-02-w1qls.3.1-shared-toolspecific-staging.md
@@ -567,7 +567,7 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_build_plan_collects_all_phases(tmp_path: Path) -> None:
+def test_build_plan_includes_shared_and_tool_phases(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
 
     plan = build_plan(ClaudeAdapter(), repo_root=repo)

--- a/packages/installer/tests/unit/test_staging.py
+++ b/packages/installer/tests/unit/test_staging.py
@@ -53,6 +53,33 @@ def test_bare_template_name_strips_to_stem() -> None:
     assert strip_template_suffix(Path("some.template")) == Path("some")
 
 
+def test_strip_template_suffix_against_embedded_match_is_unchanged() -> None:
+    """
+    Given a path where .template appears as a non-final suffix (e.g. .template.bak)
+    When strip_template_suffix is called
+    Then the path is returned unchanged — only the final suffix is tested.
+    """
+    assert strip_template_suffix(Path("AGENTS.md.template.bak")) == Path("AGENTS.md.template.bak")
+
+
+def test_strip_template_suffix_double_suffix_strips_outermost_only() -> None:
+    """
+    Given a path with two consecutive .template suffixes
+    When strip_template_suffix is called
+    Then only the outermost (final) suffix is stripped, leaving one .template.
+    """
+    assert strip_template_suffix(Path("file.template.template")) == Path("file.template")
+
+
+def test_strip_template_suffix_no_suffix_path_is_unchanged() -> None:
+    """
+    Given a path with no suffix at all (e.g. Makefile)
+    When strip_template_suffix is called
+    Then the path is returned unchanged.
+    """
+    assert strip_template_suffix(Path("Makefile")) == Path("Makefile")
+
+
 def _prov() -> Provenance:
     return Provenance(kind="tool", name="claude")
 

--- a/packages/installer/tests/unit/test_staging_build_plan.py
+++ b/packages/installer/tests/unit/test_staging_build_plan.py
@@ -41,7 +41,7 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_build_plan_collects_all_phases(tmp_path: Path) -> None:
+def test_build_plan_includes_shared_and_tool_phases(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
 
     plan = build_plan(ClaudeAdapter(), repo_root=repo)


### PR DESCRIPTION
## Summary
- Adds three edge-case tests for `strip_template_suffix` (closes w1qls.3.4):
  - Embedded `.template` as a non-final suffix (e.g. `AGENTS.md.template.bak`) — path unchanged, only the final suffix is tested
  - Double `.template` suffix (e.g. `file.template.template`) — outermost only stripped, yielding `file.template`
  - No suffix at all (e.g. `Makefile`) — path unchanged
- Renames `test_build_plan_collects_all_phases` → `test_build_plan_includes_shared_and_tool_phases` (closes w1qls.3.5): the old name implied exhaustive phase enumeration; the test deliberately avoids a `len()` assertion to stay non-brittle as phases are added

## Test Plan
- [x] `make ci-installer` — 123 tests passing, 99.58% branch coverage, ruff ✅, mypy strict ✅, pip-audit clean ✅
- [x] New tests verified to exercise distinct coded decisions (not stdlib tautologies): embedded suffix and double-suffix tests guard against plausible wrong implementations; no-suffix test is borderline but documents intent for a real filename the installer encounters

## Scope
Test-only changes — no production code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)