### PR TITLE
fix(installer): path-traversal guard in flatten_template

### DIFF
--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -128,7 +128,7 @@ def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
     the traversal guard in ``sync.py``.
     """
     if rel.is_absolute() or ".." in rel.parts:
-        raise ValueError(f"DYNAMIC-INCLUDE path escapes base_dir: {rel}")  # noqa: TRY003
+        raise ValueError(f"DYNAMIC-INCLUDE path escapes base_dir: {rel}")  # noqa: TRY003  # single call-site; subclass not justified
     target = base_dir / rel
     if not target.is_file():
         io.warn(f"DYNAMIC-INCLUDE not found: {rel}")

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -122,7 +122,13 @@ def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
 
     Mirrors the bash ``[[ -f ... ]]`` guard: a missing target *or* a directory
     is non-fatal — it warns and resolves to the empty string.
+
+    Raises ``ValueError`` for absolute paths or paths containing ``..`` —
+    either would let ``base_dir / rel`` resolve outside ``base_dir``. Mirrors
+    the traversal guard in ``sync.py``.
     """
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ValueError(f"DYNAMIC-INCLUDE path escapes base_dir: {rel}")  # noqa: TRY003
     target = base_dir / rel
     if not target.is_file():
         io.warn(f"DYNAMIC-INCLUDE not found: {rel}")

--- a/packages/installer/tests/unit/test_templates.py
+++ b/packages/installer/tests/unit/test_templates.py
@@ -265,3 +265,38 @@ def test_all_rules_expands_to_sorted_concatenation(tmp_path: Path) -> None:
     )
 
     assert result == "RULE A\n\n---\nRULE B\n"
+
+
+# ───────────────────────── traversal guard ─────────────────────────
+
+
+def test_absolute_include_path_raises(tmp_path: Path) -> None:
+    """
+    Given a DYNAMIC-INCLUDE marker whose path is absolute
+    When flatten_template runs
+    Then it raises ValueError — absolute paths escape base_dir unconditionally.
+    """
+    import pytest
+
+    with pytest.raises(ValueError, match="escapes"):
+        flatten_template(
+            "<!-- DYNAMIC-INCLUDE: /etc/passwd -->\n",
+            base_dir=tmp_path,
+            io=ScriptedIO(),
+        )
+
+
+def test_dotdot_include_path_raises(tmp_path: Path) -> None:
+    """
+    Given a DYNAMIC-INCLUDE marker whose path contains a '..' component
+    When flatten_template runs
+    Then it raises ValueError — '..' traversal escapes base_dir.
+    """
+    import pytest
+
+    with pytest.raises(ValueError, match="escapes"):
+        flatten_template(
+            "<!-- DYNAMIC-INCLUDE: ../secret.md -->\n",
+            base_dir=tmp_path,
+            io=ScriptedIO(),
+        )


### PR DESCRIPTION
## Summary

- Adds a path-traversal guard to `_resolve_file_include` in `core/templates.py`
- Raises `ValueError` for include paths that are absolute or contain `..` — either would allow `base_dir / rel` to escape the template tree
- Mirrors the existing guard in `sync.py` exactly, closing the parity gap flagged by quality-reviewer during B.4

## Scope

This is a security improvement-over-parity item surfaced during story w1qls.2.4 (B.4 DYNAMIC-INCLUDE file form) and tracked as w1qls.3.1.1. The guard belongs at the C.1 integration seam where the trust model for marker-supplied paths is decided.

The bash reference (`scripts/install.sh`) has no equivalent guard — this is intentional improvement, not parity drift.

## Test Plan

- [x] `test_absolute_include_path_raises` — absolute path raises `ValueError` with "escapes" in message
- [x] `test_dotdot_include_path_raises` — `..`-containing path raises `ValueError`
- [x] All 128 existing tests pass
- [x] Full CI gate: `make ci-installer` clean (ruff, mypy strict, pytest --cov 99.58%, pip-audit, entry-verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)