### PR TITLE
feat(installer): D.1 — CodexAdapter for ~/.codex/ install target

### DIFF
--- a/packages/installer/src/installer/tools/codex.py
+++ b/packages/installer/src/installer/tools/codex.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan
+
+
+class CodexAdapter:
+    """Adapter for OpenAI's Codex CLI. Probes ~/.codex/ as a directory —
+    mirrors the bash installer's [[ -d "$HOME/.codex" ]] detection."""
+
+    name: str = "codex"
+    detection_signal: str = ".codex"
+
+    def source_dir(self, repo_root: Path) -> Path:
+        return repo_root / "src" / "user" / ".codex"
+
+    def dest_dir(self, home: Path) -> Path:
+        return home / ".codex"
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / ".codex").is_dir()
+
+    def scoped_namespaces(self) -> tuple[str, ...]:
+        return ()
+
+    def should_install_namespace(
+        self,
+        namespace: str,  # noqa: ARG002  # protocol parameter; CodexAdapter accepts uniformly
+        source: str,  # noqa: ARG002  # protocol parameter; CodexAdapter accepts uniformly
+    ) -> bool:
+        return True
+
+    def post_staging_transforms(
+        self,
+        plan: StagingPlan,
+        io: IOPort,  # noqa: ARG002  # protocol parameter; CodexAdapter accepts uniformly
+    ) -> StagingPlan:  # pragma: no cover
+        return plan

--- a/packages/installer/src/installer/tools/registry.py
+++ b/packages/installer/src/installer/tools/registry.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from installer.core.model import Tool
 from installer.tools.base import ToolAdapter
 from installer.tools.claude import ClaudeAdapter
+from installer.tools.codex import CodexAdapter
 
 _REGISTRY: dict[Tool, ToolAdapter] = {
     Tool.CLAUDE: ClaudeAdapter(),
+    Tool.CODEX: CodexAdapter(),
 }
 
 

--- a/packages/installer/tests/unit/test_staging_codex.py
+++ b/packages/installer/tests/unit/test_staging_codex.py
@@ -1,0 +1,72 @@
+"""End-to-end staging plan build over a fixture repo, driving the real
+CodexAdapter — this is where CodexAdapter.scoped_namespaces and
+should_install_namespace earn behavioural coverage.
+
+Pins the key Codex divergence from ClaudeAdapter: Codex contributes zero
+tool-scoped namespace items (scoped_namespaces() == ()) while still accepting
+all shared namespaces (should_install_namespace → True for "shared").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.model import StagingPlan, Tool
+from installer.core.staging import build_plan
+from installer.tools.codex import CodexAdapter
+
+
+def _make_codex_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    codex = repo / "src" / "user" / ".codex"
+    # shared namespaces
+    (shared / "rules").mkdir(parents=True)
+    (shared / "rules" / "delegation.md").write_bytes(b"shared rule")
+    (shared / "skills").mkdir(parents=True)
+    (shared / "skills" / "shared-skill").mkdir()
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "shared-agent.md").write_bytes(b"agent")
+    (shared / "INSTRUCTIONS.md.template").write_bytes(b"# shared root tmpl")
+    # codex tool root — templates only, no namespace subdirs
+    codex.mkdir(parents=True)
+    (codex / "AGENTS.md.template").write_bytes(b"# codex root tmpl")
+    return repo
+
+
+def test_codex_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
+    """
+    Given a repo with shared rules/skills/agents content
+    When build_plan runs with CodexAdapter
+    Then shared namespace items appear in the plan.
+
+    Pins: should_install_namespace returns True for shared source, so
+    Phase 2 includes rules, skills, and agents.
+    """
+    repo = _make_codex_repo(tmp_path)
+
+    plan = build_plan(CodexAdapter(), repo_root=repo)
+
+    assert isinstance(plan, StagingPlan)
+    assert plan.tool == Tool.CODEX
+    dests = set(plan.items)
+    assert Path("rules/delegation.md") in dests
+    assert Path("skills/shared-skill") in dests
+    assert Path("agents/shared-agent.md") in dests
+    assert Path("AGENTS.md") in dests  # tool template (Phase 3), suffix stripped
+
+
+def test_codex_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
+    """
+    Given CodexAdapter.scoped_namespaces() returns ()
+    When build_plan runs
+    Then no Phase-4 tool-namespace items appear in the plan.
+
+    Pins: empty scoped_namespaces means Codex adds no tool-scoped namespace
+    directories — the correct divergence from ClaudeAdapter (which adds commands/).
+    """
+    repo = _make_codex_repo(tmp_path)
+
+    plan = build_plan(CodexAdapter(), repo_root=repo)
+
+    assert not any(i.namespace == "commands" for i in plan.items.values())

--- a/packages/installer/tests/unit/test_sync_codex.py
+++ b/packages/installer/tests/unit/test_sync_codex.py
@@ -1,0 +1,40 @@
+"""Behavioural coverage for CodexAdapter via the sync engine.
+
+Drives the real CodexAdapter end-to-end through sync so that its
+source_dir / dest_dir earn behavioural coverage. The engine's own branch
+behaviour is unit-tested in test_sync.py; this file asserts only that sync
+wires the real adapter's source and destination roots correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.io_port import ScriptedIO
+from installer.core.sync import sync
+from installer.tools.codex import CodexAdapter
+
+
+def test_codex_adapter_installs_file_under_dot_codex(tmp_path: Path) -> None:
+    """
+    Given a file in the repo's src/user/.codex/ tree
+    When sync installs it for the real CodexAdapter
+    Then it lands under <home>/.codex/ with the source bytes — exercising
+    CodexAdapter.source_dir and dest_dir behaviourally.
+    """
+    repo_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    source = repo_root / "src" / "user" / ".codex" / "AGENTS.md"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"# Codex AGENTS\n")
+
+    counters = sync(
+        CodexAdapter(),
+        Path("AGENTS.md"),
+        repo_root=repo_root,
+        home=home,
+        io=ScriptedIO(),
+    )
+
+    assert (home / ".codex" / "AGENTS.md").read_bytes() == b"# Codex AGENTS\n"
+    assert counters.created == 1

--- a/packages/installer/tests/unit/test_tools_codex.py
+++ b/packages/installer/tests/unit/test_tools_codex.py
@@ -1,0 +1,46 @@
+"""Behavioral tests for CodexAdapter.
+
+Each test pins a coded decision. Tautology tests (attribute literals,
+isinstance checks, @runtime_checkable machinery) are absent per the
+writing-unit-tests tautology filter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.tools.codex import CodexAdapter
+
+
+def test_codex_adapter_detected_when_dot_codex_dir_exists(tmp_path: Path) -> None:
+    """
+    Given ~/.codex/ exists as a directory
+    When is_detected is called with that home
+    Then it returns True.
+
+    Pins: directory-presence detection (mirrors bash [[ -d "$HOME/.codex" ]]).
+    """
+    (tmp_path / ".codex").mkdir()
+    assert CodexAdapter().is_detected(tmp_path) is True
+
+
+def test_codex_adapter_not_detected_when_dot_codex_absent(tmp_path: Path) -> None:
+    """
+    Given ~/.codex/ does not exist
+    When is_detected is called
+    Then it returns False.
+
+    Pins: fresh-home guard — installer skips Codex when not installed.
+    """
+    assert CodexAdapter().is_detected(tmp_path) is False
+
+
+def test_codex_adapter_not_detected_when_dot_codex_is_a_file(tmp_path: Path) -> None:
+    """
+    Given ~/.codex exists but is a file (not a directory)
+    When is_detected is called
+    Then it returns False.
+
+    Pins: probe is a directory check, not a mere existence check.
+    """
+    (tmp_path / ".codex").write_text("oops")
+    assert CodexAdapter().is_detected(tmp_path) is False

--- a/packages/installer/tests/unit/test_tools_registry.py
+++ b/packages/installer/tests/unit/test_tools_registry.py
@@ -1,7 +1,8 @@
 """Unit tests for installer.tools.registry.
 
 Each test pins a design decision from the B.1 spec
-(docs/specs/2026-05-23-w1qls.2.1-config-claude-adapter-design.md).
+(docs/specs/2026-05-23-w1qls.2.1-config-claude-adapter-design.md) and the
+D.1 CodexAdapter registration story.
 Tautology tests — isinstance(adapter, ToolAdapter), attribute-literal
 assertions like adapter.name == "claude", `@runtime_checkable` machinery
 — are deliberately absent. See the writing-unit-tests skill's Tautology
@@ -21,7 +22,7 @@ from installer.tools.registry import (
 
 def test_get_adapter_on_unregistered_tool_raises_key_error() -> None:
     """
-    Given the registry contains only Tool.CLAUDE
+    Given the registry does not contain Tool.OPENCODE
     When the caller invokes get_adapter(Tool.OPENCODE)
     Then a KeyError is raised.
 
@@ -40,20 +41,31 @@ def test_parse_tool_name_accepts_registered_name() -> None:
     assert parse_tool_name("claude") is Tool.CLAUDE
 
 
+def test_parse_tool_name_accepts_codex() -> None:
+    """
+    Given Tool.CODEX is registered
+    When parse_tool_name("codex") is called
+    Then it returns Tool.CODEX.
+
+    Pins: registry-is-truth for codex — CodexAdapter wired in the registry.
+    """
+    assert parse_tool_name("codex") is Tool.CODEX
+
+
 def test_parse_tool_name_rejects_enum_value_not_in_registry() -> None:
     """
-    Given the registry contains only Tool.CLAUDE
+    Given the registry contains Tool.CLAUDE and Tool.CODEX
     When parse_tool_name("opencode") is called
     Then UnknownToolError is raised
     And the error.name is "opencode"
-    And the error.valid is ("claude",).
+    And the error.valid is ("claude", "codex").
 
     Pins: registry-is-truth — Tool enum existence alone is insufficient.
     """
     with pytest.raises(UnknownToolError) as exc_info:
         parse_tool_name("opencode")
     assert exc_info.value.name == "opencode"
-    assert exc_info.value.valid == ("claude",)
+    assert exc_info.value.valid == ("claude", "codex")
 
 
 def test_parse_tool_name_rejects_non_enum_string() -> None:


### PR DESCRIPTION
## Summary

- Implements `CodexAdapter` in `tools/codex.py`, mirroring `ClaudeAdapter`: source=`src/user/.codex/`, dest=`~/.codex/`, detected when `~/.codex/` exists as a directory (matches bash installer's `[[ -d "$HOME/.codex" ]]` probe, per `scripts/install.sh:287`)
- Registers `Tool.CODEX` in `tools/registry.py` so `parse_tool_name("codex")` resolves and `--tools=codex` works end-to-end
- `scoped_namespaces()` returns `()` (Codex has no tool-root namespace subdirs); `should_install_namespace()` returns `True` (shared skills/agents/rules are included)

## Test Plan

- [x] `test_tools_codex.py` — 3 behavioral tests for `is_detected`: dir exists → True, absent → False, is-a-file → False
- [x] `test_sync_codex.py` — integration test: file in `src/user/.codex/` lands in `home/.codex/` via `sync`
- [x] `test_staging_codex.py` — `build_plan`-driven tests covering `scoped_namespaces` and `should_install_namespace` through the real engine
- [x] `test_tools_registry.py` — added `parse_tool_name("codex")` acceptance test; updated opencode-rejection test to reflect expanded `.valid`
- [x] 135 tests, 99.60% coverage, ruff lint/format clean, mypy --strict clean, pip-audit clean

Closes bead `agents-config-w1qls.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)