### PR TITLE
feat(installer): D.2 — GeminiAdapter with dir-probe detection and shared-ns staging

### DIFF
--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan
+
+
+class GeminiAdapter:
+    """Adapter for Google's Gemini CLI. Probes ~/.gemini/ as a directory —
+    mirrors the bash installer's [[ -d "$HOME/.gemini" ]] detection."""
+
+    name: str = "gemini"
+    detection_signal: str = ".gemini"
+
+    def source_dir(self, repo_root: Path) -> Path:
+        return repo_root / "src" / "user" / ".gemini"
+
+    def dest_dir(self, home: Path) -> Path:
+        return home / ".gemini"
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / ".gemini").is_dir()
+
+    def scoped_namespaces(self) -> tuple[str, ...]:
+        return ()
+
+    def should_install_namespace(
+        self,
+        namespace: str,  # noqa: ARG002  # protocol parameter; GeminiAdapter accepts uniformly
+        source: str,  # noqa: ARG002  # protocol parameter; GeminiAdapter accepts uniformly
+    ) -> bool:
+        return True
+
+    def post_staging_transforms(
+        self,
+        plan: StagingPlan,
+        io: IOPort,  # noqa: ARG002  # protocol parameter; GeminiAdapter accepts uniformly
+    ) -> StagingPlan:  # pragma: no cover
+        return plan

--- a/packages/installer/src/installer/tools/registry.py
+++ b/packages/installer/src/installer/tools/registry.py
@@ -4,10 +4,12 @@ from installer.core.model import Tool
 from installer.tools.base import ToolAdapter
 from installer.tools.claude import ClaudeAdapter
 from installer.tools.codex import CodexAdapter
+from installer.tools.gemini import GeminiAdapter
 
 _REGISTRY: dict[Tool, ToolAdapter] = {
     Tool.CLAUDE: ClaudeAdapter(),
     Tool.CODEX: CodexAdapter(),
+    Tool.GEMINI: GeminiAdapter(),
 }
 
 

--- a/packages/installer/tests/unit/test_staging_gemini.py
+++ b/packages/installer/tests/unit/test_staging_gemini.py
@@ -1,0 +1,72 @@
+"""End-to-end staging plan build over a fixture repo, driving the real
+GeminiAdapter — this is where GeminiAdapter.scoped_namespaces and
+should_install_namespace earn behavioural coverage.
+
+Pins the key Gemini divergence from ClaudeAdapter: Gemini contributes zero
+tool-scoped namespace items (scoped_namespaces() == ()) while still accepting
+all shared namespaces (should_install_namespace → True for "shared").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.model import StagingPlan, Tool
+from installer.core.staging import build_plan
+from installer.tools.gemini import GeminiAdapter
+
+
+def _make_gemini_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    gemini = repo / "src" / "user" / ".gemini"
+    # shared namespaces
+    (shared / "rules").mkdir(parents=True)
+    (shared / "rules" / "delegation.md").write_bytes(b"shared rule")
+    (shared / "skills").mkdir(parents=True)
+    (shared / "skills" / "shared-skill").mkdir()
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "shared-agent.md").write_bytes(b"agent")
+    (shared / "INSTRUCTIONS.md.template").write_bytes(b"# shared root tmpl")
+    # gemini tool root — templates only, no namespace subdirs
+    gemini.mkdir(parents=True)
+    (gemini / "GEMINI.md.template").write_bytes(b"# Gemini instructions\n")
+    return repo
+
+
+def test_gemini_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
+    """
+    Given a repo with shared rules/skills/agents content
+    When build_plan runs with GeminiAdapter
+    Then shared namespace items appear in the plan.
+
+    Pins: should_install_namespace returns True for shared source, so
+    Phase 2 includes rules, skills, and agents.
+    """
+    repo = _make_gemini_repo(tmp_path)
+
+    plan = build_plan(GeminiAdapter(), repo_root=repo)
+
+    assert isinstance(plan, StagingPlan)
+    assert plan.tool == Tool.GEMINI
+    dests = set(plan.items)
+    assert Path("rules/delegation.md") in dests
+    assert Path("skills/shared-skill") in dests
+    assert Path("agents/shared-agent.md") in dests
+    assert Path("GEMINI.md") in dests  # tool template (Phase 3), suffix stripped
+
+
+def test_gemini_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
+    """
+    Given GeminiAdapter.scoped_namespaces() returns ()
+    When build_plan runs
+    Then no Phase-4 tool-namespace items appear in the plan.
+
+    Pins: empty scoped_namespaces means Gemini adds no tool-scoped namespace
+    directories — the correct divergence from ClaudeAdapter (which adds commands/).
+    """
+    repo = _make_gemini_repo(tmp_path)
+
+    plan = build_plan(GeminiAdapter(), repo_root=repo)
+
+    assert not any(i.namespace == "commands" for i in plan.items.values())

--- a/packages/installer/tests/unit/test_sync_gemini.py
+++ b/packages/installer/tests/unit/test_sync_gemini.py
@@ -1,0 +1,40 @@
+"""Behavioural coverage for GeminiAdapter via the sync engine.
+
+Drives the real GeminiAdapter end-to-end through sync so that its
+source_dir / dest_dir earn behavioural coverage. The engine's own branch
+behaviour is unit-tested in test_sync.py; this file asserts only that sync
+wires the real adapter's source and destination roots correctly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.io_port import ScriptedIO
+from installer.core.sync import sync
+from installer.tools.gemini import GeminiAdapter
+
+
+def test_gemini_adapter_installs_file_under_dot_gemini(tmp_path: Path) -> None:
+    """
+    Given a file in the repo's src/user/.gemini/ tree
+    When sync installs it for the real GeminiAdapter
+    Then it lands under <home>/.gemini/ with the source bytes — exercising
+    GeminiAdapter.source_dir and dest_dir behaviourally.
+    """
+    repo_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    source = repo_root / "src" / "user" / ".gemini" / "AGENTS.md"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"# Gemini AGENTS\n")
+
+    counters = sync(
+        GeminiAdapter(),
+        Path("AGENTS.md"),
+        repo_root=repo_root,
+        home=home,
+        io=ScriptedIO(),
+    )
+
+    assert (home / ".gemini" / "AGENTS.md").read_bytes() == b"# Gemini AGENTS\n"
+    assert counters.created == 1

--- a/packages/installer/tests/unit/test_tools_gemini.py
+++ b/packages/installer/tests/unit/test_tools_gemini.py
@@ -1,0 +1,46 @@
+"""Behavioral tests for GeminiAdapter.
+
+Each test pins a coded decision. Tautology tests (attribute literals,
+isinstance checks, @runtime_checkable machinery) are absent per the
+writing-unit-tests tautology filter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.tools.gemini import GeminiAdapter
+
+
+def test_gemini_adapter_detected_when_dot_gemini_dir_exists(tmp_path: Path) -> None:
+    """
+    Given ~/.gemini/ exists as a directory
+    When is_detected is called with that home
+    Then it returns True.
+
+    Pins: directory-presence detection (mirrors bash [[ -d "$HOME/.gemini" ]]).
+    """
+    (tmp_path / ".gemini").mkdir()
+    assert GeminiAdapter().is_detected(tmp_path) is True
+
+
+def test_gemini_adapter_not_detected_when_dot_gemini_absent(tmp_path: Path) -> None:
+    """
+    Given ~/.gemini/ does not exist
+    When is_detected is called
+    Then it returns False.
+
+    Pins: fresh-home guard — installer skips Gemini when not installed.
+    """
+    assert GeminiAdapter().is_detected(tmp_path) is False
+
+
+def test_gemini_adapter_not_detected_when_dot_gemini_is_a_file(tmp_path: Path) -> None:
+    """
+    Given ~/.gemini exists but is a file (not a directory)
+    When is_detected is called
+    Then it returns False.
+
+    Pins: probe is a directory check, not a mere existence check.
+    """
+    (tmp_path / ".gemini").write_text("oops")
+    assert GeminiAdapter().is_detected(tmp_path) is False

--- a/packages/installer/tests/unit/test_tools_registry.py
+++ b/packages/installer/tests/unit/test_tools_registry.py
@@ -52,20 +52,31 @@ def test_parse_tool_name_accepts_codex() -> None:
     assert parse_tool_name("codex") is Tool.CODEX
 
 
+def test_parse_tool_name_accepts_gemini() -> None:
+    """
+    Given Tool.GEMINI is registered
+    When parse_tool_name("gemini") is called
+    Then it returns Tool.GEMINI.
+
+    Pins: registry-is-truth for gemini — GeminiAdapter wired in the registry.
+    """
+    assert parse_tool_name("gemini") is Tool.GEMINI
+
+
 def test_parse_tool_name_rejects_enum_value_not_in_registry() -> None:
     """
-    Given the registry contains Tool.CLAUDE and Tool.CODEX
+    Given the registry does not contain Tool.OPENCODE
     When parse_tool_name("opencode") is called
     Then UnknownToolError is raised
     And the error.name is "opencode"
-    And the error.valid is ("claude", "codex").
+    And the error.valid is ("claude", "codex", "gemini").
 
     Pins: registry-is-truth — Tool enum existence alone is insufficient.
     """
     with pytest.raises(UnknownToolError) as exc_info:
         parse_tool_name("opencode")
     assert exc_info.value.name == "opencode"
-    assert exc_info.value.valid == ("claude", "codex")
+    assert exc_info.value.valid == ("claude", "codex", "gemini")
 
 
 def test_parse_tool_name_rejects_non_enum_string() -> None:


### PR DESCRIPTION
## Summary

- Adds `GeminiAdapter` in `packages/installer/src/installer/tools/gemini.py` implementing the `ToolAdapter` protocol — `source_dir` = `src/user/.gemini/`, `dest_dir` = `~/.gemini/`, `is_detected` probes `~/.gemini/` as a directory (mirrors `[[ -d "$HOME/.gemini" ]]` from `scripts/install.sh:286`), `scoped_namespaces()` returns `()` (no tool-scoped namespace subdirs in `.gemini/`), `post_staging_transforms` is a no-op (frontmatter transform deferred to D.4)
- Registers `Tool.GEMINI → GeminiAdapter()` in `tools/registry.py`; updates registry tests to expect `("claude", "codex", "gemini")` as the valid tool set

## Test Plan

- [x] 3 unit tests: `is_detected` returns True on dir, False on absent, False on file-not-dir
- [x] 1 sync integration test: file from `src/user/.gemini/` lands in `~/.gemini/` with correct bytes
- [x] 2 staging tests: shared namespaces (rules/skills/agents) staged; no tool-scoped namespace items (`scoped_namespaces() == ()`)
- [x] Registry test: `parse_tool_name("gemini")` resolves; `valid` tuple updated
- [x] 142 tests, 99.61% branch coverage, ruff + mypy `--strict` + pip-audit all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)