### PR TITLE
feat(installer): D.3 — OpenCode adapter (XDG dest + skip shared agents/)

### DIFF
--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan
+
+
+class OpenCodeAdapter:
+    """Adapter for OpenCode. Two divergences from the dot-dir tools:
+    it installs under the XDG config dir (~/.config/opencode/, not ~/.opencode/),
+    and it skips the shared agents/ namespace (frontmatter format differs;
+    see OPENCODE-EXTENSIONS.md). Detected when opencode is on PATH OR the XDG
+    config dir exists — mirrors the bash
+    `command -v opencode || [[ -d ~/.config/opencode ]]`."""
+
+    name: str = "opencode"
+    detection_signal: str = ".config/opencode"
+
+    def source_dir(self, repo_root: Path) -> Path:
+        return repo_root / "src" / "user" / ".opencode"
+
+    def dest_dir(self, home: Path) -> Path:
+        # XDG config dir, not a dot-dir — mirrors the bash tool_dest_dir()
+        # special-case for opencode. NOT $XDG_CONFIG_HOME-aware by design
+        # (the bash installer hardcodes ~/.config/opencode); keep parity.
+        return home / ".config" / "opencode"
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / ".config" / "opencode").is_dir() or shutil.which("opencode") is not None
+
+    def scoped_namespaces(self) -> tuple[str, ...]:
+        return ()
+
+    def should_install_namespace(self, namespace: str, source: str) -> bool:
+        # Skip the shared agents/ namespace: OpenCode's agent frontmatter format
+        # differs from the shared format (see OPENCODE-EXTENSIONS.md). Mirrors the
+        # bash installer's Phase 2 `[[ "$tool" != "opencode" ]]` agents guard.
+        return not (namespace == "agents" and source == "shared")
+
+    def post_staging_transforms(
+        self,
+        plan: StagingPlan,
+        io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCodeAdapter accepts uniformly
+    ) -> StagingPlan:  # pragma: no cover
+        return plan

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
+from shutil import which
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ class OpenCodeAdapter:
         # The dir branch is "the install destination already exists" — derive it
         # from dest_dir() so the XDG path has a single source of truth and
         # detection can't drift from the destination.
-        return self.dest_dir(home).is_dir() or shutil.which("opencode") is not None
+        return self.dest_dir(home).is_dir() or which("opencode") is not None
 
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ()

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -30,7 +30,10 @@ class OpenCodeAdapter:
         return home / ".config" / "opencode"
 
     def is_detected(self, home: Path) -> bool:
-        return (home / ".config" / "opencode").is_dir() or shutil.which("opencode") is not None
+        # The dir branch is "the install destination already exists" — derive it
+        # from dest_dir() so the XDG path has a single source of truth and
+        # detection can't drift from the destination.
+        return self.dest_dir(home).is_dir() or shutil.which("opencode") is not None
 
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ()

--- a/packages/installer/src/installer/tools/registry.py
+++ b/packages/installer/src/installer/tools/registry.py
@@ -4,10 +4,12 @@ from installer.core.model import Tool
 from installer.tools.base import ToolAdapter
 from installer.tools.claude import ClaudeAdapter
 from installer.tools.codex import CodexAdapter
+from installer.tools.opencode import OpenCodeAdapter
 
 _REGISTRY: dict[Tool, ToolAdapter] = {
     Tool.CLAUDE: ClaudeAdapter(),
     Tool.CODEX: CodexAdapter(),
+    Tool.OPENCODE: OpenCodeAdapter(),
 }
 
 

--- a/packages/installer/tests/unit/conftest.py
+++ b/packages/installer/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for the installer unit suite.
+
+OpenCode auto-detection probes the live PATH via ``shutil.which`` (mirrors the
+bash ``command -v opencode``). PATH is global process state — on a developer
+machine with ``opencode`` installed it would silently flip every auto-detect
+result, making tests pass or fail based on who runs them. The autouse fixture
+below pins the PATH probe to "not present" for the whole unit suite so that
+auto-detect tests stay hermetic. Tests that specifically exercise the PATH
+branch (see ``test_tools_opencode.py``) re-stub ``shutil.which`` in their own
+body, which runs after this fixture and therefore wins.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_opencode_path_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("installer.tools.opencode.shutil.which", lambda _cmd: None)

--- a/packages/installer/tests/unit/conftest.py
+++ b/packages/installer/tests/unit/conftest.py
@@ -6,8 +6,13 @@ machine with ``opencode`` installed it would silently flip every auto-detect
 result, making tests pass or fail based on who runs them. The autouse fixture
 below pins the PATH probe to "not present" for the whole unit suite so that
 auto-detect tests stay hermetic. Tests that specifically exercise the PATH
-branch (see ``test_tools_opencode.py``) re-stub ``shutil.which`` in their own
-body, which runs after this fixture and therefore wins.
+branch (see ``test_tools_opencode.py``) re-stub the probe in their own body,
+which runs after this fixture and therefore wins.
+
+The patch targets ``installer.tools.opencode.which`` — the module-local name
+bound by ``from shutil import which`` — NOT ``shutil.which`` on the shared
+stdlib module, so only OpenCode detection is affected and no unrelated
+``shutil.which`` caller is perturbed.
 """
 
 from __future__ import annotations
@@ -17,4 +22,4 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _neutralize_opencode_path_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("installer.tools.opencode.shutil.which", lambda _cmd: None)
+    monkeypatch.setattr("installer.tools.opencode.which", lambda _cmd: None)

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -62,18 +62,22 @@ def test_main_tools_claude_returns_zero(tmp_path: Path) -> None:
     assert main(["--tools=claude"], home=tmp_path) == 0
 
 
-def test_main_tools_opencode_returns_2_and_writes_unknown_tool_to_stderr(
+def test_main_tools_gemini_returns_2_and_writes_unknown_tool_to_stderr(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """
-    When main(["--tools=opencode"], home=any) is invoked
+    When main(["--tools=gemini"], home=any) is invoked
     Then it returns 2
-    And stderr contains "Unknown tool: 'opencode'".
+    And stderr contains "Unknown tool: 'gemini'".
+
+    Pins: gemini is in the Tool enum but unregistered, so the CLI rejects it
+    (registry-is-truth). Uses the only remaining unregistered tool now that
+    opencode has a registered adapter.
     """
-    rc = main(["--tools=opencode"], home=tmp_path)
+    rc = main(["--tools=gemini"], home=tmp_path)
     assert rc == 2
     captured = capsys.readouterr()
-    assert "Unknown tool: 'opencode'" in captured.err
+    assert "Unknown tool: 'gemini'" in captured.err
 
 
 def test_main_tools_empty_returns_2_and_writes_usage_error_to_stderr(

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -126,11 +126,14 @@ def test_duplicate_csv_tokens_are_deduped_first_occurrence_wins(
 
 def test_unregistered_enum_value_in_csv_is_rejected(tmp_path: Path) -> None:
     """
-    When resolve_tools(home=any, override_csv="opencode") is called
+    When resolve_tools(home=any, override_csv="gemini") is called
     Then UnknownToolError is raised.
+
+    Pins: Tool.GEMINI exists in the enum but has no registered adapter, so
+    the registry — not the enum — gates CSV validation.
     """
     with pytest.raises(UnknownToolError):
-        resolve_tools(home=tmp_path, override_csv="opencode")
+        resolve_tools(home=tmp_path, override_csv="gemini")
 
 
 def test_garbage_csv_token_is_rejected(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -1,0 +1,90 @@
+"""End-to-end staging plan build over a fixture repo, driving the real
+OpenCodeAdapter — this is where OpenCodeAdapter.should_install_namespace
+earns behavioural coverage.
+
+Pins the key OpenCode divergence from Claude/Codex: the shared agents/
+namespace is NOT staged (frontmatter format differs; see
+OPENCODE-EXTENSIONS.md), while shared skills/ and rules/ ARE staged
+(rules remain available for DYNAMIC-INCLUDE-ALL-RULES inlining).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.model import StagingPlan, Tool
+from installer.core.staging import build_plan
+from installer.tools.opencode import OpenCodeAdapter
+
+
+def _make_opencode_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    opencode = repo / "src" / "user" / ".opencode"
+    # shared namespaces
+    (shared / "rules").mkdir(parents=True)
+    (shared / "rules" / "delegation.md").write_bytes(b"shared rule")
+    (shared / "skills").mkdir(parents=True)
+    (shared / "skills" / "shared-skill").mkdir()
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "shared-agent.md").write_bytes(b"agent")
+    (shared / "INSTRUCTIONS.md.template").write_bytes(b"# shared root tmpl")
+    # opencode tool root — templates + settings, no namespace subdirs
+    opencode.mkdir(parents=True)
+    (opencode / "AGENTS.md.template").write_bytes(b"# opencode root tmpl")
+    (opencode / "opencode.jsonc.template").write_bytes(b"{}")
+    return repo
+
+
+def test_opencode_build_plan_skips_shared_agents(tmp_path: Path) -> None:
+    """
+    Given a repo with shared agents/ content
+    When build_plan runs with OpenCodeAdapter
+    Then no agents/ items appear in the plan.
+
+    Pins: should_install_namespace returns False for ("agents", "shared"),
+    so Phase 2 omits the shared agents namespace for OpenCode.
+    """
+    repo = _make_opencode_repo(tmp_path)
+
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+
+    assert not any(item.namespace == "agents" for item in plan.items.values())
+    assert Path("agents/shared-agent.md") not in plan.items
+
+
+def test_opencode_build_plan_keeps_shared_skills_and_rules(tmp_path: Path) -> None:
+    """
+    Given a repo with shared skills/ and rules/ content
+    When build_plan runs with OpenCodeAdapter
+    Then skills/ and rules/ items appear in the plan.
+
+    Pins: the agents skip is surgical — skills and rules are still staged
+    (rules feed DYNAMIC-INCLUDE-ALL-RULES; only agents are dropped).
+    """
+    repo = _make_opencode_repo(tmp_path)
+
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+
+    assert isinstance(plan, StagingPlan)
+    assert plan.tool == Tool.OPENCODE
+    assert Path("skills/shared-skill") in plan.items
+    assert Path("rules/delegation.md") in plan.items
+    assert Path("AGENTS.md") in plan.items  # tool template (Phase 3), suffix stripped
+
+
+def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path) -> None:
+    """
+    Given src/user/.opencode/opencode.jsonc.template
+    When build_plan runs with OpenCodeAdapter
+    Then opencode.jsonc appears in the plan (suffix stripped).
+
+    Pins bead AC #3 end-to-end through the adapter: OpenCodeAdapter.source_dir
+    points Phase 5 settings staging at .opencode, so the tool-specific jsonc
+    lands at the OpenCode root rather than being dropped.
+    """
+    repo = _make_opencode_repo(tmp_path)
+
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+
+    assert Path("opencode.jsonc") in plan.items

--- a/packages/installer/tests/unit/test_sync_opencode.py
+++ b/packages/installer/tests/unit/test_sync_opencode.py
@@ -1,0 +1,45 @@
+"""Behavioural coverage for OpenCodeAdapter via the sync engine.
+
+Drives the real OpenCodeAdapter end-to-end through sync so that its
+source_dir / dest_dir earn behavioural coverage. The engine's own branch
+behaviour is unit-tested in test_sync.py; this file asserts only that sync
+wires the real adapter's source and destination roots correctly — in
+particular the XDG destination (~/.config/opencode/, NOT ~/.opencode/).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.io_port import ScriptedIO
+from installer.core.sync import sync
+from installer.tools.opencode import OpenCodeAdapter
+
+
+def test_opencode_adapter_installs_file_under_xdg_config_opencode(tmp_path: Path) -> None:
+    """
+    Given a file in the repo's src/user/.opencode/ tree
+    When sync installs it for the real OpenCodeAdapter
+    Then it lands under <home>/.config/opencode/ with the source bytes —
+    exercising OpenCodeAdapter.source_dir and the XDG dest_dir.
+
+    Pins: the XDG destination divergence — a non-XDG dest (~/.opencode/)
+    would fail this test.
+    """
+    repo_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    source = repo_root / "src" / "user" / ".opencode" / "AGENTS.md"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"# OpenCode AGENTS\n")
+
+    counters = sync(
+        OpenCodeAdapter(),
+        Path("AGENTS.md"),
+        repo_root=repo_root,
+        home=home,
+        io=ScriptedIO(),
+    )
+
+    assert (home / ".config" / "opencode" / "AGENTS.md").read_bytes() == b"# OpenCode AGENTS\n"
+    assert not (home / ".opencode").exists()
+    assert counters.created == 1

--- a/packages/installer/tests/unit/test_tools_opencode.py
+++ b/packages/installer/tests/unit/test_tools_opencode.py
@@ -1,0 +1,73 @@
+"""Behavioural tests for OpenCodeAdapter detection.
+
+OpenCode auto-detection differs from Claude/Codex: it is True when either
+the XDG config dir exists OR `opencode` is on PATH (mirrors the bash
+`command -v opencode || [[ -d ~/.config/opencode ]]`). Each test below pins
+one branch of that OR. The live PATH probe is global state, so every test
+stubs `shutil.which` explicitly to stay hermetic.
+
+Tautology tests (attribute literals like adapter.name, detection_signal
+string, @runtime_checkable machinery) are absent per the writing-unit-tests
+tautology filter."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from installer.tools.opencode import OpenCodeAdapter
+
+_WHICH = "installer.tools.opencode.shutil.which"
+
+
+def _stub_which(monkeypatch: pytest.MonkeyPatch, result: str | None) -> None:
+    """Force shutil.which('opencode') to a fixed result so the PATH branch
+    of is_detected is controlled rather than read from the real environment."""
+    fake: Callable[[str], str | None] = lambda _cmd: result  # noqa: E731
+    monkeypatch.setattr(_WHICH, fake)
+
+
+def test_opencode_detected_when_xdg_config_dir_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given ~/.config/opencode/ exists as a directory and opencode is NOT on PATH
+    When is_detected is called with that home
+    Then it returns True.
+
+    Pins: the XDG-dir branch alone is sufficient (not relying on PATH).
+    """
+    _stub_which(monkeypatch, None)
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+    assert OpenCodeAdapter().is_detected(tmp_path) is True
+
+
+def test_opencode_detected_when_on_path_even_without_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given opencode is on PATH and ~/.config/opencode/ does NOT exist
+    When is_detected is called
+    Then it returns True.
+
+    Pins: the PATH branch alone is sufficient — divergence from Claude/Codex,
+    which probe only a filesystem path.
+    """
+    _stub_which(monkeypatch, "/usr/local/bin/opencode")
+    assert OpenCodeAdapter().is_detected(tmp_path) is True
+
+
+def test_opencode_not_detected_when_neither_path_nor_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given opencode is NOT on PATH and ~/.config/opencode/ does NOT exist
+    When is_detected is called
+    Then it returns False.
+
+    Pins: fresh-home guard — installer skips OpenCode when no signal at all.
+    """
+    _stub_which(monkeypatch, None)
+    assert OpenCodeAdapter().is_detected(tmp_path) is False

--- a/packages/installer/tests/unit/test_tools_opencode.py
+++ b/packages/installer/tests/unit/test_tools_opencode.py
@@ -19,12 +19,13 @@ import pytest
 
 from installer.tools.opencode import OpenCodeAdapter
 
-_WHICH = "installer.tools.opencode.shutil.which"
+_WHICH = "installer.tools.opencode.which"
 
 
 def _stub_which(monkeypatch: pytest.MonkeyPatch, result: str | None) -> None:
-    """Force shutil.which('opencode') to a fixed result so the PATH branch
-    of is_detected is controlled rather than read from the real environment."""
+    """Force the module-local which('opencode') to a fixed result so the PATH
+    branch of is_detected is controlled rather than read from the real
+    environment (patches opencode's own binding, not the shared stdlib seam)."""
     fake: Callable[[str], str | None] = lambda _cmd: result  # noqa: E731
     monkeypatch.setattr(_WHICH, fake)
 

--- a/packages/installer/tests/unit/test_tools_registry.py
+++ b/packages/installer/tests/unit/test_tools_registry.py
@@ -22,14 +22,14 @@ from installer.tools.registry import (
 
 def test_get_adapter_on_unregistered_tool_raises_key_error() -> None:
     """
-    Given the registry does not contain Tool.OPENCODE
-    When the caller invokes get_adapter(Tool.OPENCODE)
+    Given the registry does not contain Tool.GEMINI
+    When the caller invokes get_adapter(Tool.GEMINI)
     Then a KeyError is raised.
 
     Pins: callers must validate via parse_tool_name first.
     """
     with pytest.raises(KeyError):
-        get_adapter(Tool.OPENCODE)
+        get_adapter(Tool.GEMINI)
 
 
 def test_parse_tool_name_accepts_registered_name() -> None:
@@ -52,20 +52,32 @@ def test_parse_tool_name_accepts_codex() -> None:
     assert parse_tool_name("codex") is Tool.CODEX
 
 
+def test_parse_tool_name_accepts_opencode() -> None:
+    """
+    Given Tool.OPENCODE is registered
+    When parse_tool_name("opencode") is called
+    Then it returns Tool.OPENCODE.
+
+    Pins: registry-is-truth for opencode — OpenCodeAdapter wired in the registry.
+    """
+    assert parse_tool_name("opencode") is Tool.OPENCODE
+
+
 def test_parse_tool_name_rejects_enum_value_not_in_registry() -> None:
     """
-    Given the registry contains Tool.CLAUDE and Tool.CODEX
-    When parse_tool_name("opencode") is called
+    Given the registry contains Tool.CLAUDE, Tool.CODEX, and Tool.OPENCODE
+    When parse_tool_name("gemini") is called
     Then UnknownToolError is raised
-    And the error.name is "opencode"
-    And the error.valid is ("claude", "codex").
+    And the error.name is "gemini"
+    And the error.valid is ("claude", "codex", "opencode").
 
-    Pins: registry-is-truth — Tool enum existence alone is insufficient.
+    Pins: registry-is-truth — Tool enum existence alone is insufficient
+    (Tool.GEMINI exists in the enum but has no registered adapter yet).
     """
     with pytest.raises(UnknownToolError) as exc_info:
-        parse_tool_name("opencode")
-    assert exc_info.value.name == "opencode"
-    assert exc_info.value.valid == ("claude", "codex")
+        parse_tool_name("gemini")
+    assert exc_info.value.name == "gemini"
+    assert exc_info.value.valid == ("claude", "codex", "opencode")
 
 
 def test_parse_tool_name_rejects_non_enum_string() -> None:


### PR DESCRIPTION
## Summary

Implements story **D.3 — OpenCode adapter** of the Python installer rewrite
(bead `w1qls.4.3`). Adds `OpenCodeAdapter` and registers it in the tool registry.

Two deliberate divergences from the dot-dir adapters (Claude/Codex), both ported
from the bash installer (`scripts/install.sh`, the behavioural spec):

- **XDG destination** — installs under `~/.config/opencode/`, not `~/.opencode/`
  (mirrors `tool_dest_dir()`, install.sh:259-266). Hardcoded `~/.config`, **not**
  `$XDG_CONFIG_HOME`-aware, to keep bash parity.
- **Skip shared `agents/`** — `should_install_namespace` returns `False` for
  `("agents", "shared")` (OpenCode's agent frontmatter format differs; mirrors the
  Phase 2 `[[ "$tool" != "opencode" ]]` guard, install.sh:786).
- **Detection** — `opencode` on PATH **OR** `~/.config/opencode/` exists
  (mirrors `command -v opencode || [[ -d ~/.config/opencode ]]`, install.sh:289).

## Scope (and what's intentionally out)

- **In scope (per design doc line 278 = "D.3: XDG dest, skip shared agents/"):**
  the adapter, its registration, and the bead's three AC items.
- **Out of scope:** the bash sync-time skip of OpenCode `rules/` (install.sh:928).
  Rules are deliberately left *staged* so DYNAMIC-INCLUDE-ALL-RULES can inline them;
  the rules dest-dir skip belongs to a later sync/flatten story, not the adapter.
- **Out of scope:** `post_staging_transforms` (identity pass-through here; real
  transforms are a Gemini-style story, hence `# pragma: no cover`).

## Notable test-infra change

`is_detected` reads global process state (`shutil.which`). Because a dev/CI box may
have `opencode` on PATH, a new `tests/unit/conftest.py` autouse fixture neutralizes
the probe suite-wide so auto-detect tests stay hermetic; the PATH-detection test
re-stubs `shutil.which` in its own body. Three pre-existing tests that used
`opencode` as the canonical *unregistered* tool example flip to `gemini` (the only
remaining enum value without a registered adapter).

## Test Plan

- [x] `make ci-installer` green: ruff lint+format, `mypy --strict`, 143 tests,
      coverage 99.81% (opencode module 100%), pip-audit, entry-verify.
- [x] Detection pinned through both OR-branches (`test_tools_opencode.py`).
- [x] Agents-skip pinned through real `build_plan`; skills/rules still staged
      (`test_staging_opencode.py`).
- [x] XDG dest pinned end-to-end through `sync` — asserts bytes land under
      `.config/opencode/` and `.opencode/` is NOT created (`test_sync_opencode.py`).
- [x] Bead AC #3 (`opencode.jsonc` lands at dest) pinned via staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
