### PR TITLE
feat(installer): D.4 — Gemini frontmatter transform + orchestrator transform pass

### DIFF
--- a/packages/installer/docs/plans/2026-06-06-w1qls.4.4-gemini-frontmatter-transform.md
+++ b/packages/installer/docs/plans/2026-06-06-w1qls.4.4-gemini-frontmatter-transform.md
@@ -1,0 +1,550 @@
+# D.4 — Gemini Frontmatter Transform Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Strip Claude-only YAML frontmatter keys (`skills`/`color`/`memory`) and convert the comma-separated `tools:` string to a YAML sequence in Gemini agent files, and introduce the first call site (`core/orchestrator.py`) that runs `post_staging_transforms` across every active adapter.
+
+**Architecture:** A pure module-level helper in `tools/gemini.py` (`transform_agent_frontmatter`) does the YAML round-trip via `pyyaml`. `GeminiAdapter.post_staging_transforms` applies it to `agents/` items in the plan; the three identity adapters keep returning the plan unchanged. A new `core/orchestrator.py::stage_and_transform` builds each tool's plan then runs its transform pass — the first real consumer of the method, enabling pragma removal on all four adapters. The orchestrator is **not** wired into `cli.main()` yet (plan-walking sync lands in Epic E); a tracked bead + prose comments hold the wiring debt.
+
+**Tech Stack:** Python ≥3.11, `pyyaml` (already a dependency), `pytest`/`--cov-branch`, `mypy --strict`, `ruff`.
+
+---
+
+## File Structure
+
+- Create: `src/installer/core/orchestrator.py` — `stage_and_transform(tools, *, repo_root, io)`; first call site for `post_staging_transforms`.
+- Modify: `src/installer/tools/gemini.py` — add `transform_agent_frontmatter`; implement real `post_staging_transforms`; drop its `# pragma: no cover`.
+- Modify: `src/installer/tools/claude.py`, `codex.py`, `opencode.py` — drop `# pragma: no cover` from `post_staging_transforms` (now reached via orchestrator).
+- Modify: `src/installer/cli.py` — prose comment noting deferred orchestrator wiring (no tracker ID).
+- Create: `tests/unit/test_gemini_frontmatter.py` — pure-helper edge cases, real-source agent, adapter-method behaviour.
+- Create: `tests/unit/test_orchestrator.py` — all-four-adapter transform-pass coverage.
+
+### The bash contract being ported (`scripts/install.sh:639-684`, Phase 6.6 at `:892-897`)
+
+- Operates only inside the first `---`…`---` frontmatter block.
+- Strips top-level keys `skills:`/`color:`/`memory:` **and their indented sub-blocks**.
+- Rewrites `tools: Read, Grep` → `tools: [Read, Grep]` only when the value is non-empty and not already a `[`-array.
+- Files without frontmatter pass through unchanged.
+
+Option A (pyyaml round-trip) approved: parse → mutate dict → `safe_dump(sort_keys=False)`. Byte-diff vs the awk output is acceptable because H.2's golden-master AC is "zero **post-normalisation** diff".
+
+---
+
+## Task 1: Pure helper `transform_agent_frontmatter`
+
+**Files:**
+- Modify: `src/installer/tools/gemini.py`
+- Test: `tests/unit/test_gemini_frontmatter.py`
+
+- [ ] **Step 1: Write failing tests for the pure helper**
+
+```python
+"""Behavioural tests for the Gemini frontmatter transform.
+
+Each test pins a coded decision (which keys are stripped, the tools
+string→sequence rule, the no-frontmatter passthrough, body preservation),
+never YAML/stdlib behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from installer.tools.gemini import transform_agent_frontmatter
+
+
+def _frontmatter(content: bytes) -> dict[str, object]:
+    text = content.decode("utf-8")
+    body = text.split("---\n", 2)[2]  # noqa: F841  # parsed for clarity
+    fm_text = text.split("---\n", 2)[1]
+    parsed = yaml.safe_load(fm_text)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_strips_claude_only_keys() -> None:
+    src = b"---\nname: a\nskills: x\ncolor: purple\nmemory: y\ntools: Read\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    fm = _frontmatter(out)
+    assert "skills" not in fm
+    assert "color" not in fm
+    assert "memory" not in fm
+    assert fm["name"] == "a"
+
+
+def test_strips_key_with_indented_block() -> None:
+    src = b"---\nname: a\nskills:\n  - one\n  - two\ntools: Read\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    fm = _frontmatter(out)
+    assert "skills" not in fm
+    assert fm["name"] == "a"
+
+
+def test_converts_csv_tools_to_sequence() -> None:
+    src = b"---\nname: a\ntools: Read, Grep, Glob\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    fm = _frontmatter(out)
+    assert fm["tools"] == ["Read", "Grep", "Glob"]
+
+
+def test_single_tool_becomes_one_element_sequence() -> None:
+    src = b"---\nname: a\ntools: Read\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    assert _frontmatter(out)["tools"] == ["Read"]
+
+
+def test_already_sequence_tools_not_double_wrapped() -> None:
+    src = b"---\nname: a\ntools:\n  - Read\n  - Grep\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    assert _frontmatter(out)["tools"] == ["Read", "Grep"]
+
+
+def test_no_frontmatter_passes_through_byte_identical() -> None:
+    src = b"# Just a markdown agent\nNo frontmatter here.\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_unterminated_frontmatter_passes_through() -> None:
+    src = b"---\nname: a\ntools: Read\n(no closing fence)\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_nothing_to_change_returns_byte_identical() -> None:
+    src = b"---\nname: a\ntools:\n- Read\n---\nbody\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_body_after_frontmatter_is_preserved() -> None:
+    body = "# Title\n\nLine with --- dashes\nclosing\n"
+    src = ("---\nname: a\ncolor: red\ntools: Read\n---\n" + body).encode("utf-8")
+    out = transform_agent_frontmatter(src).decode("utf-8")
+    assert out.endswith(body)
+
+
+def test_real_source_agent_is_gemini_clean() -> None:
+    """Real-source coverage: the actually-shipped quality-reviewer agent loses
+    its Claude-only keys and gains a tools sequence."""
+    repo_root = Path(__file__).resolve().parents[4]
+    agent = repo_root / "src" / "user" / ".agents" / "agents" / "quality-reviewer.md"
+    if not agent.is_file():  # pragma: no cover  # defensive: real tree may move
+        import pytest
+
+        pytest.skip(f"real agent source not found at {agent}")
+    out = transform_agent_frontmatter(agent.read_bytes())
+    fm = _frontmatter(out)
+    assert "color" not in fm
+    assert "skills" not in fm
+    assert "memory" not in fm
+    assert isinstance(fm["tools"], list)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_gemini_frontmatter.py -q`
+Expected: FAIL — `ImportError: cannot import name 'transform_agent_frontmatter'`.
+
+- [ ] **Step 3: Implement the helper in `tools/gemini.py`**
+
+Add the import block and helper (above the class):
+
+```python
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan
+
+_CLAUDE_ONLY_KEYS = ("skills", "color", "memory")
+
+
+def transform_agent_frontmatter(content: bytes) -> bytes:
+    """Translate a shared (Claude-style) agent file's YAML frontmatter into the
+    form Gemini's agent loader accepts: drop Claude-only keys (skills, color,
+    memory) and convert a comma-separated ``tools:`` string into a YAML
+    sequence. Port of bash ``transform_gemini_agent_frontmatter``
+    (scripts/install.sh:639-684), via a pyyaml round-trip.
+
+    Returns ``content`` unchanged when it has no leading ``---``…``---`` block,
+    when that block is unterminated, when it does not parse to a mapping, or
+    when there is nothing to strip/convert. The body after the closing fence is
+    preserved byte-for-byte.
+    """
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content
+
+    lines = text.split("\n")
+    if not lines or lines[0] != "---":
+        return content
+    closing = next((i for i in range(1, len(lines)) if lines[i] == "---"), None)
+    if closing is None:
+        return content
+
+    try:
+        data = yaml.safe_load("\n".join(lines[1:closing]))
+    except yaml.YAMLError:
+        return content
+    if not isinstance(data, dict):
+        return content
+
+    changed = False
+    for key in _CLAUDE_ONLY_KEYS:
+        if key in data:
+            del data[key]
+            changed = True
+
+    tools = data.get("tools")
+    if isinstance(tools, str):
+        items = [t.strip() for t in tools.split(",") if t.strip()]
+        if items:
+            data["tools"] = items
+            changed = True
+
+    if not changed:
+        return content
+
+    dumped = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    body = "\n".join(lines[closing + 1 :])
+    return ("---\n" + dumped + "---\n" + body).encode("utf-8")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_gemini_frontmatter.py -q`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/tools/gemini.py packages/installer/tests/unit/test_gemini_frontmatter.py
+git commit -m "feat(installer): D.4 — pyyaml frontmatter transform helper for Gemini agents"
+```
+
+---
+
+## Task 2: `GeminiAdapter.post_staging_transforms`
+
+**Files:**
+- Modify: `src/installer/tools/gemini.py` (replace no-op method; drop pragma)
+- Test: `tests/unit/test_gemini_frontmatter.py` (append)
+
+- [ ] **Step 1: Write failing adapter-method tests**
+
+Append to `tests/unit/test_gemini_frontmatter.py`:
+
+```python
+from installer.core.io_port import ScriptedIO
+from installer.core.model import (
+    FileKind,
+    Provenance,
+    StagedItem,
+    StagingPlan,
+    Tool,
+)
+from installer.tools.gemini import GeminiAdapter
+
+_PROV = Provenance(kind="tool", name="gemini")
+
+
+def _agent_item(relname: str, content: bytes) -> StagedItem:
+    return StagedItem(
+        source_path=Path("src") / relname,
+        dest_relpath=Path("agents") / relname,
+        kind=FileKind.NAMESPACED_MD,
+        namespace="agents",
+        provenance=_PROV,
+        content=content,
+    )
+
+
+def test_post_staging_transforms_rewrites_agent_items() -> None:
+    item = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read, Grep\n---\nbody\n")
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    out = GeminiAdapter().post_staging_transforms(plan, ScriptedIO())
+    new_content = out.items[item.dest_relpath].content
+    assert new_content is not None
+    assert b"color:" not in new_content
+    assert _frontmatter(new_content)["tools"] == ["Read", "Grep"]
+
+
+def test_post_staging_transforms_logs_phase_when_agents_present() -> None:
+    item = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read\n---\nbody\n")
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    io = ScriptedIO()
+    GeminiAdapter().post_staging_transforms(plan, io)
+    assert any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_post_staging_transforms_leaves_non_agent_items_untouched() -> None:
+    item = StagedItem(
+        source_path=Path("src/GEMINI.md"),
+        dest_relpath=Path("GEMINI.md"),
+        kind=FileKind.OTHER,
+        namespace=None,
+        provenance=_PROV,
+        content=b"---\ncolor: red\ntools: Read\n---\nx\n",
+    )
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    io = ScriptedIO()
+    out = GeminiAdapter().post_staging_transforms(plan, io)
+    assert out.items[item.dest_relpath].content == item.content
+    assert not any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_post_staging_transforms_returns_same_plan_when_no_agents() -> None:
+    plan = StagingPlan(items={}, tool=Tool.GEMINI)
+    assert GeminiAdapter().post_staging_transforms(plan, ScriptedIO()) is plan
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_gemini_frontmatter.py -q`
+Expected: FAIL — the current no-op method neither rewrites content nor logs.
+
+- [ ] **Step 3: Replace the method body and drop the pragma**
+
+```python
+    def post_staging_transforms(self, plan: StagingPlan, io: IOPort) -> StagingPlan:
+        logged = False
+        for relpath, item in list(plan.items.items()):
+            if item.namespace != "agents" or item.content is None:
+                continue
+            if not logged:
+                io.info("Transforming agent frontmatter for Gemini", verbose=True)
+                logged = True
+            new_content = transform_agent_frontmatter(item.content)
+            if new_content != item.content:
+                plan.items[relpath] = replace(item, content=new_content)
+        return plan
+```
+
+Remove the `# noqa: ARG002` on `io` and the `# pragma: no cover` on the return type.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_gemini_frontmatter.py -q`
+Expected: PASS (14 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/tools/gemini.py packages/installer/tests/unit/test_gemini_frontmatter.py
+git commit -m "feat(installer): D.4 — GeminiAdapter.post_staging_transforms applies the transform"
+```
+
+---
+
+## Task 3: `core/orchestrator.py` + pragma removal on identity adapters
+
+**Files:**
+- Create: `src/installer/core/orchestrator.py`
+- Modify: `src/installer/tools/claude.py`, `codex.py`, `opencode.py` (drop pragma)
+- Modify: `src/installer/cli.py` (prose comment)
+- Test: `tests/unit/test_orchestrator.py`
+
+- [ ] **Step 1: Write failing orchestrator tests**
+
+```python
+"""The transform pass over every active adapter — first call site for
+ToolAdapter.post_staging_transforms. Pins: Gemini rewrites agent frontmatter;
+the identity adapters return their plans unchanged through this call site."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from installer.core.io_port import ScriptedIO
+from installer.core.model import Tool
+from installer.core.orchestrator import stage_and_transform
+from installer.core.staging import build_plan
+from installer.tools.registry import get_adapter
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "quality.md").write_bytes(
+        b"---\nname: quality\ncolor: purple\ntools: Read, Grep\n---\nReview body.\n"
+    )
+    # minimal tool roots so source_dir exists (templates optional)
+    for tool in ("claude", "codex", "gemini", "opencode"):
+        (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
+    return repo
+
+
+def test_stage_and_transform_gemini_rewrites_agent_frontmatter(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    plans = stage_and_transform([Tool.GEMINI], repo_root=repo, io=ScriptedIO())
+    content = plans[Tool.GEMINI].items[Path("agents/quality.md")].content
+    assert content is not None
+    fm = yaml.safe_load(content.decode("utf-8").split("---\n", 2)[1])
+    assert "color" not in fm
+    assert fm["tools"] == ["Read", "Grep"]
+
+
+def test_stage_and_transform_claude_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    io = ScriptedIO()
+    plans = stage_and_transform([Tool.CLAUDE], repo_root=repo, io=io)
+    baseline = build_plan(get_adapter(Tool.CLAUDE), repo_root=repo)
+    rp = Path("agents/quality.md")
+    assert plans[Tool.CLAUDE].items[rp].content == baseline.items[rp].content
+    assert not any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_stage_and_transform_codex_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    plans = stage_and_transform([Tool.CODEX], repo_root=repo, io=ScriptedIO())
+    baseline = build_plan(get_adapter(Tool.CODEX), repo_root=repo)
+    rp = Path("agents/quality.md")
+    assert plans[Tool.CODEX].items[rp].content == baseline.items[rp].content
+
+
+def test_stage_and_transform_opencode_skips_shared_agents(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    plans = stage_and_transform([Tool.OPENCODE], repo_root=repo, io=ScriptedIO())
+    assert Path("agents/quality.md") not in plans[Tool.OPENCODE].items
+
+
+def test_stage_and_transform_preserves_tool_order(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    plans = stage_and_transform(
+        [Tool.GEMINI, Tool.CLAUDE], repo_root=repo, io=ScriptedIO()
+    )
+    assert list(plans) == [Tool.GEMINI, Tool.CLAUDE]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_orchestrator.py -q`
+Expected: FAIL — `ModuleNotFoundError: installer.core.orchestrator`.
+
+- [ ] **Step 3: Create `core/orchestrator.py`**
+
+```python
+"""Run-orchestration seam: stage every active tool, then apply its
+post-staging transform pass.
+
+This is the FIRST call site for ``ToolAdapter.post_staging_transforms`` across
+all four adapters. It is deliberately NOT yet invoked from ``cli.main()``: the
+plan-walking sync that would consume these transformed plans does not exist yet
+(``core/sync.py`` is the single-file B.2 slice; plan-walking sync arrives with
+the Epic E merge dispatch). When the full install pipeline is wired into
+``main()``, it MUST route every active tool through this function — not
+``build_plan``→``sync`` directly — or adapter transforms (e.g. the Gemini
+frontmatter transform) will silently never run in real installs. That wiring is
+tracked as its own story.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from installer.core.staging import build_plan
+from installer.tools.registry import get_adapter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan, Tool
+
+
+def stage_and_transform(
+    tools: Iterable[Tool], *, repo_root: Path, io: IOPort
+) -> dict[Tool, StagingPlan]:
+    """Build a StagingPlan for each active tool (staging Phases 1-5) and run
+    that tool's adapter ``post_staging_transforms`` pass over it. Returns the
+    transformed plan per tool, preserving iteration order.
+    """
+    plans: dict[Tool, StagingPlan] = {}
+    for tool in tools:
+        adapter = get_adapter(tool)
+        plan = build_plan(adapter, repo_root=repo_root)
+        plans[tool] = adapter.post_staging_transforms(plan, io)
+    return plans
+```
+
+- [ ] **Step 4: Drop `# pragma: no cover` from the three identity adapters**
+
+In `claude.py`, `codex.py`, `opencode.py`, change the method's closing line from
+`) -> StagingPlan:  # pragma: no cover` to `) -> StagingPlan:` (keep the
+`# noqa: ARG002` on `io` — it stays genuinely unused in the identity no-op).
+
+- [ ] **Step 5: Add the prose deferral comment to `cli.py`**
+
+Replace the existing B.1/B.2 comment block above `Config(...)` with:
+
+```python
+    # B.1: instantiation proves Config construction succeeds end-to-end.
+    # The full install pipeline is not wired here yet. When core/sync.py grows
+    # to walk a StagingPlan (Epic E), main() must drive
+    # core.orchestrator.stage_and_transform(tools, ...) — NOT build_plan→sync
+    # directly — so adapter post-staging transforms (e.g. the Gemini frontmatter
+    # transform) actually run in real installs. Tracked as a dedicated story.
+    Config(home=resolved_home, tools=tools)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_orchestrator.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/installer/src/installer/core/orchestrator.py \
+        packages/installer/src/installer/tools/claude.py \
+        packages/installer/src/installer/tools/codex.py \
+        packages/installer/src/installer/tools/opencode.py \
+        packages/installer/src/installer/cli.py \
+        packages/installer/tests/unit/test_orchestrator.py
+git commit -m "feat(installer): D.4 — orchestrator transform pass; drop post-staging pragmas"
+```
+
+---
+
+## Task 4: Full gate + completion
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the canonical gate from the repo root**
+
+Run: `make ci-installer`
+Expected: ruff check clean, ruff format clean, `mypy --strict src` clean, `pytest --cov` ≥90% branch, `pip-audit` clean, `install.py --help` ok.
+
+- [ ] **Step 2: Fix any gate findings, re-run until green.**
+
+- [ ] **Step 3: Completion gate** — `quality-reviewer` agent → address findings → `simplify` skill → address findings → `verify-checklist`.
+
+- [ ] **Step 4: Delivery** — `finishing-a-development-branch` (PR) → `wait-for-pr-comments`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Strip skills/color/memory" → Task 1 (`_CLAUDE_ONLY_KEYS`, tests `test_strips_claude_only_keys`, `test_strips_key_with_indented_block`).
+- "tools string → YAML sequence" → Task 1 (`test_converts_csv_tools_to_sequence`, single-element, already-sequence).
+- "Files without frontmatter pass through unchanged" → Task 1 (`test_no_frontmatter_passes_through_byte_identical`, unterminated).
+- "Unit + integration tests cover real-source and edge-case agents" → Task 1 (`test_real_source_agent_is_gemini_clean`) + edge cases; Task 3 integration via `stage_and_transform`.
+- "Orchestrator invokes post_staging_transforms on every active adapter after staging" → Task 3 (`stage_and_transform`, tests across all four tools).
+- "Remove pragma from post_staging_transforms on every adapter; identity adapters get behavioural assertions through the orchestrator call site" → Task 2 (gemini) + Task 3 (claude/codex/opencode pragma removal + identity tests).
+- "Build/Typecheck/Tests pass" → Task 4 (`make ci-installer`).
+- Safety net (don't lose main-wiring) → bead created + prose comments in `orchestrator.py` and `cli.py` (Task 3 steps 3 & 5).
+
+**Placeholder scan:** none — every code/test step shows full content.
+
+**Type consistency:** `transform_agent_frontmatter(content: bytes) -> bytes`, `stage_and_transform(tools, *, repo_root, io) -> dict[Tool, StagingPlan]`, `_CLAUDE_ONLY_KEYS` used consistently across tasks.

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -51,7 +51,11 @@ def main(argv: list[str] | None = None, *, home: Path | None = None) -> int:
         )
         return 2
 
-    # B.1: instantiation proves Config construction succeeds end-to-end;
-    # B.2's sync engine will consume the returned value.
+    # B.1: instantiation proves Config construction succeeds end-to-end.
+    # The full install pipeline is not wired here yet. When core/sync.py grows
+    # to walk a StagingPlan (Epic E), main() must drive
+    # core.orchestrator.stage_and_transform(tools, ...) — NOT build_plan->sync
+    # directly — so adapter post-staging transforms (e.g. the Gemini frontmatter
+    # transform) actually run in real installs. Tracked as a dedicated story.
     Config(home=resolved_home, tools=tools)
     return 0

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -1,0 +1,42 @@
+"""Run-orchestration seam: stage every active tool, then apply its
+post-staging transform pass.
+
+This is the FIRST call site for ``ToolAdapter.post_staging_transforms`` across
+all four adapters. It is deliberately NOT yet invoked from ``cli.main()``: the
+plan-walking sync that would consume these transformed plans does not exist yet
+(``core/sync.py`` is the single-file B.2 slice; plan-walking sync arrives with
+the Epic E merge dispatch). When the full install pipeline is wired into
+``main()``, it MUST route every active tool through this function — not
+``build_plan``->``sync`` directly — or adapter transforms (e.g. the Gemini
+frontmatter transform) will silently never run in real installs. That wiring is
+tracked as its own story.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from installer.core.staging import build_plan
+from installer.tools.registry import get_adapter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan, Tool
+
+
+def stage_and_transform(
+    tools: Iterable[Tool], *, repo_root: Path, io: IOPort
+) -> dict[Tool, StagingPlan]:
+    """Build a StagingPlan for each active tool (staging Phases 1-5) and run
+    that tool's adapter ``post_staging_transforms`` pass over it. Returns the
+    transformed plan per tool, preserving iteration order.
+    """
+    plans: dict[Tool, StagingPlan] = {}
+    for tool in tools:
+        adapter = get_adapter(tool)
+        plan = build_plan(adapter, repo_root=repo_root)
+        plans[tool] = adapter.post_staging_transforms(plan, io)
+    return plans

--- a/packages/installer/src/installer/tools/claude.py
+++ b/packages/installer/src/installer/tools/claude.py
@@ -39,5 +39,5 @@ class ClaudeAdapter:
         self,
         plan: StagingPlan,
         io: IOPort,  # noqa: ARG002  # protocol parameter; ClaudeAdapter accepts uniformly
-    ) -> StagingPlan:  # pragma: no cover
+    ) -> StagingPlan:
         return plan

--- a/packages/installer/src/installer/tools/codex.py
+++ b/packages/installer/src/installer/tools/codex.py
@@ -38,5 +38,5 @@ class CodexAdapter:
         self,
         plan: StagingPlan,
         io: IOPort,  # noqa: ARG002  # protocol parameter; CodexAdapter accepts uniformly
-    ) -> StagingPlan:  # pragma: no cover
+    ) -> StagingPlan:
         return plan

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -89,9 +90,20 @@ class GeminiAdapter:
     ) -> bool:
         return True
 
-    def post_staging_transforms(
-        self,
-        plan: StagingPlan,
-        io: IOPort,  # noqa: ARG002  # protocol parameter; GeminiAdapter accepts uniformly
-    ) -> StagingPlan:  # pragma: no cover
+    def post_staging_transforms(self, plan: StagingPlan, io: IOPort) -> StagingPlan:
+        """Apply the Claude→Gemini agent frontmatter transform to every staged
+        ``agents/`` file. Mirrors bash Phase 6.6 (scripts/install.sh:892-897):
+        emits one verbose phase line when agent files are present, then rewrites
+        each in place. Non-agent items and directory entries are left untouched.
+        """
+        logged = False
+        for relpath, item in list(plan.items.items()):
+            if item.namespace != "agents" or item.content is None:
+                continue
+            if not logged:
+                io.info("Transforming agent frontmatter for Gemini", verbose=True)
+                logged = True
+            new_content = transform_agent_frontmatter(item.content)
+            if new_content != item.content:
+                plan.items[relpath] = replace(item, content=new_content)
         return plan

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -32,7 +32,7 @@ def transform_agent_frontmatter(content: bytes) -> bytes:
         return content
 
     lines = text.split("\n")
-    if not lines or lines[0] != "---":
+    if lines[0] != "---":
         return content
     closing = next((i for i in range(1, len(lines)) if lines[i] == "---"), None)
     if closing is None:

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -3,9 +3,64 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
+
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan
+
+_CLAUDE_ONLY_KEYS = ("skills", "color", "memory")
+
+
+def transform_agent_frontmatter(content: bytes) -> bytes:
+    """Translate a shared (Claude-style) agent file's YAML frontmatter into the
+    form Gemini's agent loader accepts: drop Claude-only keys (skills, color,
+    memory) and convert a comma-separated ``tools:`` string into a YAML
+    sequence. Port of bash ``transform_gemini_agent_frontmatter``
+    (scripts/install.sh:639-684), via a pyyaml round-trip.
+
+    Returns ``content`` unchanged when it has no leading ``---``…``---`` block,
+    when that block is unterminated, when it does not parse to a mapping, or
+    when there is nothing to strip or convert (so an already-clean file is
+    never gratuitously reformatted). The body after the closing fence is
+    preserved byte-for-byte.
+    """
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content
+
+    lines = text.split("\n")
+    if not lines or lines[0] != "---":
+        return content
+    closing = next((i for i in range(1, len(lines)) if lines[i] == "---"), None)
+    if closing is None:
+        return content
+
+    try:
+        data = yaml.safe_load("\n".join(lines[1:closing]))
+    except yaml.YAMLError:
+        return content
+    if not isinstance(data, dict):
+        return content
+
+    changed = False
+    for key in _CLAUDE_ONLY_KEYS:
+        if key in data:
+            del data[key]
+            changed = True
+    tools = data.get("tools")
+    if isinstance(tools, str):
+        items = [t.strip() for t in tools.split(",") if t.strip()]
+        if items:
+            data["tools"] = items
+            changed = True
+    if not changed:
+        return content
+
+    dumped = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    body = "\n".join(lines[closing + 1 :])
+    return ("---\n" + dumped + "---\n" + body).encode("utf-8")
 
 
 class GeminiAdapter:

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -48,5 +48,5 @@ class OpenCodeAdapter:
         self,
         plan: StagingPlan,
         io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCodeAdapter accepts uniformly
-    ) -> StagingPlan:  # pragma: no cover
+    ) -> StagingPlan:
         return plan

--- a/packages/installer/tests/unit/test_gemini_frontmatter.py
+++ b/packages/installer/tests/unit/test_gemini_frontmatter.py
@@ -12,7 +12,22 @@ from pathlib import Path
 import pytest
 import yaml
 
-from installer.tools.gemini import transform_agent_frontmatter
+from installer.core.io_port import ScriptedIO
+from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
+from installer.tools.gemini import GeminiAdapter, transform_agent_frontmatter
+
+_PROV = Provenance(kind="tool", name="gemini")
+
+
+def _agent_item(relname: str, content: bytes) -> StagedItem:
+    return StagedItem(
+        source_path=Path("src") / relname,
+        dest_relpath=Path("agents") / relname,
+        kind=FileKind.NAMESPACED_MD,
+        namespace="agents",
+        provenance=_PROV,
+        content=content,
+    )
 
 
 def _frontmatter(content: bytes) -> dict[str, object]:
@@ -90,3 +105,42 @@ def test_real_source_agent_is_gemini_clean() -> None:
     assert "skills" not in fm
     assert "memory" not in fm
     assert isinstance(fm["tools"], list)
+
+
+def test_post_staging_transforms_rewrites_agent_items() -> None:
+    item = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read, Grep\n---\nbody\n")
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    out = GeminiAdapter().post_staging_transforms(plan, ScriptedIO())
+    new_content = out.items[item.dest_relpath].content
+    assert new_content is not None
+    assert b"color:" not in new_content
+    assert _frontmatter(new_content)["tools"] == ["Read", "Grep"]
+
+
+def test_post_staging_transforms_logs_phase_when_agents_present() -> None:
+    item = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read\n---\nbody\n")
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    io = ScriptedIO()
+    GeminiAdapter().post_staging_transforms(plan, io)
+    assert any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_post_staging_transforms_leaves_non_agent_items_untouched() -> None:
+    item = StagedItem(
+        source_path=Path("src/GEMINI.md"),
+        dest_relpath=Path("GEMINI.md"),
+        kind=FileKind.OTHER,
+        namespace=None,
+        provenance=_PROV,
+        content=b"---\ncolor: red\ntools: Read\n---\nx\n",
+    )
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    io = ScriptedIO()
+    out = GeminiAdapter().post_staging_transforms(plan, io)
+    assert out.items[item.dest_relpath].content == item.content
+    assert not any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_post_staging_transforms_returns_same_plan_when_no_agents() -> None:
+    plan = StagingPlan(items={}, tool=Tool.GEMINI)
+    assert GeminiAdapter().post_staging_transforms(plan, ScriptedIO()) is plan

--- a/packages/installer/tests/unit/test_gemini_frontmatter.py
+++ b/packages/installer/tests/unit/test_gemini_frontmatter.py
@@ -1,0 +1,92 @@
+"""Behavioural tests for the Gemini frontmatter transform.
+
+Each test pins a coded decision (which keys are stripped, the tools
+string->sequence rule, the no-frontmatter passthrough, byte-identity when
+there is nothing to change, body preservation), never YAML/stdlib behaviour.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from installer.tools.gemini import transform_agent_frontmatter
+
+
+def _frontmatter(content: bytes) -> dict[str, object]:
+    """Parse the YAML frontmatter out of a transformed agent file, for
+    asserting on the resulting mapping."""
+    parsed = yaml.safe_load(content.decode("utf-8").split("---\n", 2)[1])
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_strips_claude_only_keys() -> None:
+    src = b"---\nname: a\nskills: x\ncolor: purple\nmemory: y\ntools: Read\n---\nbody\n"
+    fm = _frontmatter(transform_agent_frontmatter(src))
+    assert "skills" not in fm
+    assert "color" not in fm
+    assert "memory" not in fm
+    assert fm["name"] == "a"
+
+
+def test_converts_csv_tools_to_sequence() -> None:
+    src = b"---\nname: a\ntools: Read, Grep, Glob\n---\nbody\n"
+    assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read", "Grep", "Glob"]
+
+
+def test_single_tool_becomes_one_element_sequence() -> None:
+    src = b"---\nname: a\ntools: Read\n---\nbody\n"
+    assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read"]
+
+
+def test_already_sequence_tools_not_double_wrapped() -> None:
+    src = b"---\nname: a\ntools:\n  - Read\n  - Grep\n---\nbody\n"
+    assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read", "Grep"]
+
+
+def test_strips_key_with_indented_block() -> None:
+    src = b"---\nname: a\nskills:\n  - one\n  - two\ntools: Read\n---\nbody\n"
+    fm = _frontmatter(transform_agent_frontmatter(src))
+    assert "skills" not in fm
+    assert fm["name"] == "a"
+
+
+def test_no_frontmatter_passes_through_byte_identical() -> None:
+    src = b"# Just a markdown agent\nNo frontmatter here.\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_unterminated_frontmatter_passes_through() -> None:
+    src = b"---\nname: a\ntools: Read\n(no closing fence)\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_unchanged_frontmatter_returns_byte_identical() -> None:
+    # Quoted scalar + already-list tools: nothing to strip or convert, so the
+    # original bytes must survive verbatim (no gratuitous pyyaml reformatting
+    # such as dropping the quotes).
+    src = b'---\nname: a\ndescription: "keep quotes"\ntools:\n- Read\n---\nbody\n'
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_body_after_frontmatter_is_preserved() -> None:
+    body = "# Title\n\nLine with --- dashes\nclosing\n"
+    src = ("---\nname: a\ncolor: red\ntools: Read\n---\n" + body).encode("utf-8")
+    assert transform_agent_frontmatter(src).decode("utf-8").endswith(body)
+
+
+def test_real_source_agent_is_gemini_clean() -> None:
+    """Real-source coverage: the actually-shipped quality-reviewer agent loses
+    its Claude-only keys and gains a tools sequence."""
+    repo_root = Path(__file__).resolve().parents[4]
+    agent = repo_root / "src" / "user" / ".agents" / "agents" / "quality-reviewer.md"
+    if not agent.is_file():  # pragma: no cover  # defensive: real tree may move
+        pytest.skip(f"real agent source not found at {agent}")
+    fm = _frontmatter(transform_agent_frontmatter(agent.read_bytes()))
+    assert "color" not in fm
+    assert "skills" not in fm
+    assert "memory" not in fm
+    assert isinstance(fm["tools"], list)

--- a/packages/installer/tests/unit/test_gemini_frontmatter.py
+++ b/packages/installer/tests/unit/test_gemini_frontmatter.py
@@ -107,6 +107,34 @@ def test_real_source_agent_is_gemini_clean() -> None:
     assert isinstance(fm["tools"], list)
 
 
+def test_invalid_utf8_passes_through_unchanged() -> None:
+    # A non-UTF-8 (e.g. binary) staged file must not crash the install.
+    src = b"\xff\xfe\x00not utf-8"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_malformed_yaml_frontmatter_passes_through_unchanged() -> None:
+    # A YAML typo in one agent file must not abort the whole install — it is
+    # left verbatim rather than raised.
+    src = b'---\nkey: "unterminated\n---\nbody\n'
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_non_mapping_frontmatter_passes_through_unchanged() -> None:
+    # Frontmatter that parses to a sequence/scalar (not a mapping) is left as-is.
+    src = b"---\n- a\n- b\n---\nbody\n"
+    assert transform_agent_frontmatter(src) == src
+
+
+def test_empty_tools_string_is_not_converted() -> None:
+    # An empty tools value yields no sequence items, so it is left untouched
+    # (mirrors the bash length>0 guard); other keys still transform.
+    src = b'---\nname: a\ncolor: red\ntools: ""\n---\nbody\n'
+    fm = _frontmatter(transform_agent_frontmatter(src))
+    assert "color" not in fm
+    assert fm["tools"] == ""
+
+
 def test_post_staging_transforms_rewrites_agent_items() -> None:
     item = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read, Grep\n---\nbody\n")
     plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
@@ -144,3 +172,20 @@ def test_post_staging_transforms_leaves_non_agent_items_untouched() -> None:
 def test_post_staging_transforms_returns_same_plan_when_no_agents() -> None:
     plan = StagingPlan(items={}, tool=Tool.GEMINI)
     assert GeminiAdapter().post_staging_transforms(plan, ScriptedIO()) is plan
+
+
+def test_post_staging_transforms_logs_phase_once_for_multiple_agents() -> None:
+    a = _agent_item("a.md", b"---\nname: a\ncolor: red\ntools: Read\n---\nx\n")
+    b = _agent_item("b.md", b"---\nname: b\ncolor: blue\ntools: Grep\n---\ny\n")
+    plan = StagingPlan(items={a.dest_relpath: a, b.dest_relpath: b}, tool=Tool.GEMINI)
+    io = ScriptedIO()
+    GeminiAdapter().post_staging_transforms(plan, io)
+    assert sum("frontmatter" in e.message.lower() for e in io.transcript) == 1
+
+
+def test_post_staging_transforms_keeps_already_clean_agent_item() -> None:
+    # An agent already in Gemini form is not re-wrapped in a new StagedItem.
+    item = _agent_item("a.md", b"---\nname: a\ntools:\n- Read\n---\nbody\n")
+    plan = StagingPlan(items={item.dest_relpath: item}, tool=Tool.GEMINI)
+    out = GeminiAdapter().post_staging_transforms(plan, ScriptedIO())
+    assert out.items[item.dest_relpath] is item

--- a/packages/installer/tests/unit/test_orchestrator.py
+++ b/packages/installer/tests/unit/test_orchestrator.py
@@ -1,0 +1,73 @@
+"""The transform pass over every active adapter — first call site for
+ToolAdapter.post_staging_transforms.
+
+Pins: Gemini rewrites agent frontmatter; the identity adapters (Claude, Codex)
+return their agent items unchanged through this call site; OpenCode contributes
+no shared agents at all; and each tool is routed through its own adapter in a
+single call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from installer.core.io_port import ScriptedIO
+from installer.core.model import Tool
+from installer.core.orchestrator import stage_and_transform
+
+_AGENT = Path("agents/quality.md")
+_CLAUDE_AGENT = b"---\nname: quality\ncolor: purple\ntools: Read, Grep\n---\nReview body.\n"
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "quality.md").write_bytes(_CLAUDE_AGENT)
+    for tool in ("claude", "codex", "gemini", "opencode"):
+        (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
+    return repo
+
+
+def _frontmatter(content: bytes) -> dict[str, object]:
+    parsed = yaml.safe_load(content.decode("utf-8").split("---\n", 2)[1])
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_stage_and_transform_gemini_rewrites_agent_frontmatter(tmp_path: Path) -> None:
+    plans = stage_and_transform([Tool.GEMINI], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+    content = plans[Tool.GEMINI].items[_AGENT].content
+    assert content is not None
+    fm = _frontmatter(content)
+    assert "color" not in fm
+    assert fm["tools"] == ["Read", "Grep"]
+
+
+def test_stage_and_transform_claude_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
+    io = ScriptedIO()
+    plans = stage_and_transform([Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=io)
+    assert plans[Tool.CLAUDE].items[_AGENT].content == _CLAUDE_AGENT
+    assert not any("frontmatter" in e.message.lower() for e in io.transcript)
+
+
+def test_stage_and_transform_codex_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
+    plans = stage_and_transform([Tool.CODEX], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+    assert plans[Tool.CODEX].items[_AGENT].content == _CLAUDE_AGENT
+
+
+def test_stage_and_transform_opencode_skips_shared_agents(tmp_path: Path) -> None:
+    plans = stage_and_transform([Tool.OPENCODE], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+    assert _AGENT not in plans[Tool.OPENCODE].items
+
+
+def test_stage_and_transform_dispatches_correct_adapter_per_tool(tmp_path: Path) -> None:
+    plans = stage_and_transform(
+        [Tool.GEMINI, Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=ScriptedIO()
+    )
+    gemini_content = plans[Tool.GEMINI].items[_AGENT].content
+    assert gemini_content is not None
+    assert "color" not in _frontmatter(gemini_content)
+    assert plans[Tool.CLAUDE].items[_AGENT].content == _CLAUDE_AGENT


### PR DESCRIPTION
## Summary

Implements **D.4 — Gemini frontmatter transform** (bead `agents-config-w1qls.4.4`), the port of the bash installer's `transform_gemini_agent_frontmatter` (`scripts/install.sh:639-684`, Phase 6.6 call site `:892-897`).

- **`tools/gemini.py` — `transform_agent_frontmatter(content: bytes) -> bytes`**: pyyaml round-trip that strips Claude-only frontmatter keys (`skills`/`color`/`memory`, including nested blocks) and converts a comma-separated `tools:` string into a YAML sequence. Returns bytes **unchanged** when there is no leading `---`…`---` block, the block is unterminated, it doesn't parse to a mapping, the content isn't UTF-8, or there is nothing to strip/convert (no gratuitous reformatting). Body after the closing fence is byte-preserved.
- **`tools/gemini.py` — `GeminiAdapter.post_staging_transforms`**: applies the transform to every staged `agents/` item in place; emits one verbose phase line when agent files are present (mirrors bash Phase 6.6 `vinfo`).
- **`core/orchestrator.py` — `stage_and_transform(tools, *, repo_root, io)`** (new): builds each active tool's plan then runs its `post_staging_transforms`. This is the **first call site** for the method across all four adapters.
- **Pragma removal**: `# pragma: no cover` dropped from `post_staging_transforms` on all four adapters (Claude/Codex/Gemini/OpenCode). The three identity adapters earn behavioural coverage through the orchestrator call site (per the w1qls.2.1 forward pragma-removal tracking).

## Design decision (approved)

**pyyaml round-trip (Option A)**, not a line-oriented awk port. This reflows YAML *representation* (e.g. `description: |-` block scalars), so output is **not byte-identical** to the bash awk — this is intentional and acceptable because the golden-master story (H.2) compares **post-normalisation**. Semantic content is identical.

## Scope — deliberately deferred (not a gap)

The orchestrator is **not** wired into `cli.main()` in this PR. Plan-walking sync doesn't exist until Epic E, so wiring it now would build-and-discard plans (dead code). The deferral is documented in prose in `core/orchestrator.py` and `cli.py` (no tracker IDs in code, per repo rule) and tracked as a dedicated bead (`agents-config-hmxpp`, discovered-from D.4, **blocks** H.1 golden-master).

## Test plan

- [x] `make ci-installer` green: **175 tests, 99.84% coverage** (floor 90%), `gemini.py` 100%
- [x] `mypy --strict src` clean, `ruff check` + `ruff format --check` clean
- [x] `pip-audit` clean, `install.py --help` entry-verify ok
- [x] Real-source coverage: shipped `quality-reviewer.md` loses Claude keys, gains a `tools` sequence
- [x] Edge cases: nested-block strip, CSV/single/already-sequence/empty `tools`, no-frontmatter / unterminated / malformed-YAML / non-mapping / non-UTF-8 passthrough, body preservation
- [x] Integration: `stage_and_transform` across all four tools — Gemini transforms, Claude/Codex identity, OpenCode skips shared agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)
