### PR TITLE
feat(installer): Epic E — merge collision matrix (protocol + registry + strategies)

### DIFF
--- a/packages/installer/src/installer/core/merge/__init__.py
+++ b/packages/installer/src/installer/core/merge/__init__.py
@@ -1,0 +1,11 @@
+"""Collision-resolution subsystem for the staging phase.
+
+When two staged items target the same ``dest_relpath`` (a collision), the
+staging engine resolves them through a :class:`MergeStrategy` selected by
+the :class:`MergeRegistry` on the item's ``(FileKind, namespace)`` key.
+
+This package ships only the *mechanism* (E.1): the merge contract
+(``base``) and the dispatch registry (``registry``). Concrete strategies
+live under ``strategies/`` (E.2-E.5); the ``default_registry()`` factory
+that wires them is added at the Integrate stage.
+"""

--- a/packages/installer/src/installer/core/merge/__init__.py
+++ b/packages/installer/src/installer/core/merge/__init__.py
@@ -4,8 +4,8 @@ When two staged items target the same ``dest_relpath`` (a collision), the
 staging engine resolves them through a :class:`MergeStrategy` selected by
 the :class:`MergeRegistry` on the item's ``(FileKind, namespace)`` key.
 
-This package ships only the *mechanism* (E.1): the merge contract
-(``base``) and the dispatch registry (``registry``). Concrete strategies
-live under ``strategies/`` (E.2-E.5); the ``default_registry()`` factory
-that wires them is added at the Integrate stage.
+The merge contract lives in ``base`` and the dispatch mechanism in
+``registry``; the concrete strategies live under ``strategies/``. The
+``default_registry()`` factory in ``registry`` is the single place that
+binds each strategy to its ``(FileKind, namespace)`` key.
 """

--- a/packages/installer/src/installer/core/merge/base.py
+++ b/packages/installer/src/installer/core/merge/base.py
@@ -8,7 +8,7 @@ Two symbols form the contract:
   ``dest_relpath`` (so ``dest_relpath``, ``kind``, and ``namespace`` are
   identical on both by definition of the collision).
 - :class:`CollisionError` — the shared *fatal-collision* signal, raised by
-  the fatal strategy (E.5) when two sources may not be merged. It is a
+  the fatal strategy when two sources may not be merged. It is a
   ``RuntimeError`` so it is distinct from the registry's lookup-miss error,
   which is a programmer/wiring error rather than a real file collision.
 """

--- a/packages/installer/src/installer/core/merge/base.py
+++ b/packages/installer/src/installer/core/merge/base.py
@@ -1,0 +1,52 @@
+"""Merge contract shared by every collision strategy.
+
+Two symbols form the contract:
+
+- :class:`MergeStrategy` — the structural protocol every strategy honours:
+  ``merge(existing, incoming) -> StagedItem``. A strategy is invoked when an
+  ``incoming`` item collides with an already-staged ``existing`` at the same
+  ``dest_relpath`` (so ``dest_relpath``, ``kind``, and ``namespace`` are
+  identical on both by definition of the collision).
+- :class:`CollisionError` — the shared *fatal-collision* signal, raised by
+  the fatal strategy (E.5) when two sources may not be merged. It is a
+  ``RuntimeError`` so it is distinct from the registry's lookup-miss error,
+  which is a programmer/wiring error rather than a real file collision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from installer.core.model import StagedItem
+
+
+@runtime_checkable
+class MergeStrategy(Protocol):
+    """Resolve a collision between two items at the same ``dest_relpath``.
+
+    Returns the item to stage. A strategy that synthesises a merged item
+    preserves the shared key fields (``dest_relpath``, ``kind``,
+    ``namespace`` — identical on both by definition of the collision),
+    sets ``content`` to the merged bytes, and takes ``provenance`` and
+    ``source_path`` from ``incoming``.
+    """
+
+    def merge(
+        self, existing: StagedItem, incoming: StagedItem
+    ) -> StagedItem: ...  # pragma: no cover
+
+
+class CollisionError(RuntimeError):
+    """Raised when two sources collide at one destination and may not be
+    merged. The message names BOTH colliding source paths; structured
+    attributes (``existing`` / ``incoming``) let callers and tests assert
+    on data rather than parsing the prose."""
+
+    def __init__(self, existing: Path, incoming: Path) -> None:
+        super().__init__(
+            f"Irreconcilable collision: {existing} and {incoming} "
+            f"both target the same destination and cannot be merged."
+        )
+        self.existing = existing
+        self.incoming = incoming

--- a/packages/installer/src/installer/core/merge/registry.py
+++ b/packages/installer/src/installer/core/merge/registry.py
@@ -1,0 +1,111 @@
+"""Dispatch registry mapping ``(FileKind, namespace)`` to a strategy.
+
+The registry decides *which* :class:`MergeStrategy` resolves a collision.
+For ``NAMESPACED_MD`` the namespace (the item's parent-dir name) selects
+the strategy — e.g. ``(NAMESPACED_MD, "rules")`` append-merges while
+``(NAMESPACED_MD, "commands")`` is fatal. For every other kind
+(``SETTINGS_JSON`` / ``JSONC`` / ``TOML`` / ``OTHER`` / ``DIR``) the
+namespace component is irrelevant and is normalized to ``None`` on both
+``register`` and ``resolve`` so the key degenerates to a ``FileKind``.
+
+The :class:`MergeRegistry` mechanism imports no concrete strategy; the
+:func:`default_registry` factory at the foot of this module is the one place
+that wires the concrete strategies onto their ``(FileKind, namespace)`` keys.
+"""
+
+from __future__ import annotations
+
+from installer.core.merge.base import MergeStrategy
+from installer.core.merge.strategies.append_rules import AppendRulesStrategy
+from installer.core.merge.strategies.fatal import FatalStrategy
+from installer.core.merge.strategies.json_union import JsonUnionStrategy
+from installer.core.merge.strategies.last_wins_silent import LastWinsSilentStrategy
+from installer.core.merge.strategies.last_wins_warn import LastWinsWarnStrategy
+from installer.core.model import FileKind
+
+# Kinds whose collision resolution does not depend on a namespace. Their
+# namespace component is normalized to None so a single registration serves
+# every namespace value seen at lookup time.
+_NON_NAMESPACED_KINDS: frozenset[FileKind] = frozenset(
+    {
+        FileKind.DIR,
+        FileKind.SETTINGS_JSON,
+        FileKind.JSONC,
+        FileKind.TOML,
+        FileKind.OTHER,
+    }
+)
+
+
+def _normalize(kind: FileKind, namespace: str | None) -> tuple[FileKind, str | None]:
+    """Collapse the namespace to None for non-namespaced kinds so register
+    and resolve agree on the key regardless of the caller's namespace."""
+    if kind in _NON_NAMESPACED_KINDS:
+        return (kind, None)
+    return (kind, namespace)
+
+
+class UnknownMergeKeyError(ValueError):
+    """Raised when ``resolve`` is asked for a ``(kind, namespace)`` with no
+    registered strategy — a wiring/programmer error, deliberately NOT a
+    ``CollisionError`` (which is reserved for real file collisions).
+    Structured attrs (``.kind`` / ``.namespace``) let callers and tests
+    assert on data, not on the message string."""
+
+    def __init__(self, kind: FileKind, namespace: str | None) -> None:
+        super().__init__(
+            f"No merge strategy registered for kind {kind.value!r} with namespace {namespace!r}."
+        )
+        self.kind = kind
+        self.namespace = namespace
+
+
+class MergeRegistry:
+    """Mutable ``(FileKind, namespace) -> MergeStrategy`` lookup, easily
+    populated in tests with dummy strategies and at runtime by
+    ``default_registry()``."""
+
+    def __init__(self) -> None:
+        self._strategies: dict[tuple[FileKind, str | None], MergeStrategy] = {}
+
+    def register(self, kind: FileKind, namespace: str | None, strategy: MergeStrategy) -> None:
+        """Bind ``strategy`` to ``(kind, namespace)``. For non-namespaced
+        kinds the namespace is normalized to None before storing."""
+        self._strategies[_normalize(kind, namespace)] = strategy
+
+    def resolve(self, kind: FileKind, namespace: str | None) -> MergeStrategy:
+        """Return the strategy for ``(kind, namespace)``. For non-namespaced
+        kinds the namespace is ignored. Raises :class:`UnknownMergeKeyError`
+        if nothing is registered."""
+        key = _normalize(kind, namespace)
+        try:
+            return self._strategies[key]
+        except KeyError:
+            raise UnknownMergeKeyError(key[0], key[1]) from None
+
+
+def default_registry() -> MergeRegistry:
+    """Build the production registry: every concrete strategy bound to the
+    ``(FileKind, namespace)`` key it resolves.
+
+    ``NAMESPACED_MD`` dispatches by namespace — ``"rules"`` collisions are
+    additive (append) while ``"commands"`` / ``"skills"`` / ``"agents"`` are
+    irreconcilable (fatal). Every non-namespaced kind is registered under the
+    ``None`` namespace; the registry normalizes the namespace away on lookup,
+    so any namespace value passed at resolve time still hits these bindings.
+
+    Kinds NOT wired here (and un-wired ``NAMESPACED_MD`` namespaces) remain a
+    lookup miss: ``resolve`` raises :class:`UnknownMergeKeyError`. The factory
+    adds bindings; it does not make the registry permissive.
+    """
+    registry = MergeRegistry()
+    registry.register(FileKind.NAMESPACED_MD, "rules", AppendRulesStrategy())
+    registry.register(FileKind.NAMESPACED_MD, "commands", FatalStrategy())
+    registry.register(FileKind.NAMESPACED_MD, "skills", FatalStrategy())
+    registry.register(FileKind.NAMESPACED_MD, "agents", FatalStrategy())
+    registry.register(FileKind.SETTINGS_JSON, None, JsonUnionStrategy())
+    registry.register(FileKind.JSONC, None, LastWinsWarnStrategy())
+    registry.register(FileKind.TOML, None, LastWinsWarnStrategy())
+    registry.register(FileKind.OTHER, None, LastWinsSilentStrategy())
+    registry.register(FileKind.DIR, None, FatalStrategy())
+    return registry

--- a/packages/installer/src/installer/core/merge/registry.py
+++ b/packages/installer/src/installer/core/merge/registry.py
@@ -8,9 +8,10 @@ the strategy — e.g. ``(NAMESPACED_MD, "rules")`` append-merges while
 namespace component is irrelevant and is normalized to ``None`` on both
 ``register`` and ``resolve`` so the key degenerates to a ``FileKind``.
 
-The :class:`MergeRegistry` mechanism imports no concrete strategy; the
-:func:`default_registry` factory at the foot of this module is the one place
-that wires the concrete strategies onto their ``(FileKind, namespace)`` keys.
+The :class:`MergeRegistry` class depends only on the :class:`MergeStrategy`
+protocol — never on a concrete strategy. The :func:`default_registry` factory
+at the foot of this module is the one place that binds the concrete strategies
+onto their ``(FileKind, namespace)`` keys.
 """
 
 from __future__ import annotations

--- a/packages/installer/src/installer/core/merge/strategies/__init__.py
+++ b/packages/installer/src/installer/core/merge/strategies/__init__.py
@@ -1,0 +1,6 @@
+"""Concrete merge strategies, one module + test file per strategy.
+
+Empty package marker for E.1: parallel strategy agents (E.2-E.5) each add
+their own module here (``append_rules``, ``json_union``, ``fatal``, …)
+without touching this file.
+"""

--- a/packages/installer/src/installer/core/merge/strategies/__init__.py
+++ b/packages/installer/src/installer/core/merge/strategies/__init__.py
@@ -1,6 +1,6 @@
-"""Concrete merge strategies, one module + test file per strategy.
+"""Concrete merge strategies — one module + test file per strategy.
 
-Empty package marker for E.1: parallel strategy agents (E.2-E.5) each add
-their own module here (``append_rules``, ``json_union``, ``fatal``, …)
-without touching this file.
+Each strategy (``append_rules``, ``fatal``, ``json_union``, ``last_wins_warn``,
+``last_wins_silent``) is an independent module; the ``registry`` module's
+``default_registry()`` binds them to their ``(FileKind, namespace)`` keys.
 """

--- a/packages/installer/src/installer/core/merge/strategies/append_rules.py
+++ b/packages/installer/src/installer/core/merge/strategies/append_rules.py
@@ -1,0 +1,39 @@
+"""Append-merge strategy for ``(NAMESPACED_MD, namespace="rules")`` collisions.
+
+Two same-name rule files from different sources (e.g. a tool's ``rules/foo.md``
+and a plugin's ``rules/foo.md``) are not a conflict — they are additive. This
+strategy concatenates both bodies into one, ``existing`` THEN ``incoming``,
+joined by the canonical rules separator ``b"\\n---\\n"`` (mirroring the
+ALL-RULES join in ``core/templates.py``).
+
+Empty-body edges are handled so the result never carries a stray leading or
+trailing separator: a missing side is simply dropped from the join rather than
+emitting ``b"\\n---\\n"`` against empty bytes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from installer.core.model import StagedItem
+
+_SEPARATOR = b"\n---\n"
+
+
+class AppendRulesStrategy:
+    """Concatenate two colliding rule bodies, ``existing`` then ``incoming``.
+
+    Honours the ``MergeStrategy`` protocol structurally. The synthesised item
+    preserves the shared key fields (``dest_relpath``, ``kind``, ``namespace``
+    — identical on both by definition of the collision), sets ``content`` to
+    the joined bytes, and takes ``provenance`` and ``source_path`` from
+    ``incoming``.
+    """
+
+    def merge(self, existing: StagedItem, incoming: StagedItem) -> StagedItem:
+        sides = [side for side in (existing.content, incoming.content) if side]
+        merged = _SEPARATOR.join(sides)
+        return replace(
+            incoming,
+            content=merged,
+        )

--- a/packages/installer/src/installer/core/merge/strategies/fatal.py
+++ b/packages/installer/src/installer/core/merge/strategies/fatal.py
@@ -1,0 +1,38 @@
+"""Fatal-collision strategy: refuse to merge irreconcilable kinds.
+
+Some collisions cannot be resolved by synthesising a merged item — two
+distinct ``commands`` / ``skills`` / ``agents`` markdown files, or two
+directory units, at the same destination represent a genuine conflict the
+installer must surface rather than silently pick a winner.
+
+:class:`FatalStrategy` is the registry's answer for those keys
+(``(NAMESPACED_MD, {"commands", "skills", "agents"})`` and
+``FileKind.DIR``). Its :meth:`~FatalStrategy.merge` ALWAYS raises
+:class:`CollisionError` naming both colliding source paths — it never
+returns a :class:`StagedItem`.
+"""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+from installer.core.merge.base import CollisionError
+from installer.core.model import StagedItem
+
+
+class FatalStrategy:
+    """Resolve an irreconcilable collision by raising.
+
+    Structurally a :class:`~installer.core.merge.base.MergeStrategy`, but it
+    never produces a merged item: every call raises
+    :class:`CollisionError` carrying both colliding source paths.
+    """
+
+    def merge(self, existing: StagedItem, incoming: StagedItem) -> NoReturn:
+        """Raise :class:`CollisionError` naming both source paths.
+
+        The ``-> NoReturn`` return annotation documents that this method
+        never yields a value; it widens to the ``MergeStrategy`` protocol's
+        ``-> StagedItem`` because ``NoReturn`` is a subtype of every type.
+        """
+        raise CollisionError(existing.source_path, incoming.source_path)

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -1,0 +1,206 @@
+"""Deep union-merge strategy for ``(SETTINGS_JSON, *)`` collisions (E.4).
+
+When two ``settings.json`` payloads (e.g. a tool's and a plugin's) collide at
+the same destination they are not a conflict — they are combined. This is the
+Python port of the jq program at ``scripts/install.sh:431-456``; the bash
+installer's observable behaviour is the contract this module matches. The merge
+rules and the *structural* output formatting (2-space indent, object key order,
+trailing newline) mirror ``jq .``; lexical number normalisation is the one
+deliberate exception (quirk 3 below):
+
+- dict + dict at a shared key -> recurse (deep merge);
+- array + array at a shared key -> concatenate then jq-``unique`` (sort by
+  jq's total order, then dedupe by value);
+- scalar conflict at a shared key -> KEEP EXISTING;
+- type mismatch at a shared key (dict-vs-scalar, array-vs-scalar, …)
+  -> KEEP EXISTING;
+- key only in incoming -> ADD it; key only in existing -> keep it;
+- a top-level operand that is not an object -> the result is ``existing`` whole.
+
+Two jq quirks are reproduced deliberately rather than "fixed":
+
+1. **Empty-object quirk.** jq builds the merged object with ``… | add``; over
+   an empty key-list ``[] | add`` evaluates to ``null``. So deep-merging two
+   objects whose key-merge yields no keys produces JSON ``null`` — including
+   nested ``{}`` + ``{}`` keys, which become ``null`` at that key.
+2. **jq total order.** jq sorts and dedupes arrays by its own total order:
+   ``null < false < true < number < string < array < object``, with arrays
+   compared element-wise (length tiebreak) and objects compared by their
+   sorted key-array first then their values in key order. ``_jq_sort_key``
+   reproduces that ordering.
+
+One jq behaviour is deliberately NOT reproduced:
+
+3. **Number lexemes are not byte-preserved.** jq echoes a number's source form
+   (``1e3`` stays ``1E+3``, ``1.50`` stays ``1.50``); this port round-trips
+   through ``json.loads``/``json.dumps`` and canonicalises them (``1e3`` ->
+   ``1000.0``, ``1.50`` -> ``1.5``). Common-case numbers round-trip faithfully
+   (``1`` vs ``1.0`` stay distinct; integral floats and big ints keep their
+   form). Accepted, not fixed: every ``settings.json`` source is canonical-
+   number JSON — no template carries scientific-notation or trailing-zero
+   literals — and the golden-master parity suite is the backstop should one
+   ever appear.
+
+Output bytes are canonical ``jq .`` formatting: 2-space indent and a single
+trailing newline. ``jq .`` does NOT sort object keys — it preserves each
+object's insertion order. The bash installer emits the merge with ``jq .``
+(``install.sh:456``), not ``jq -S``, so this port matches that: the deep-merge
+skeleton is constructed in sorted-key order by :func:`_deep_merge` (mirroring
+jq's ``($a|keys)+($b|keys)|unique``, which sorts by Unicode codepoint), while
+any object jq passes through verbatim — a key present on only one side whose
+value is an object, or an object nested inside an array — keeps its original
+insertion order.
+
+Irreconcilable input (a ``None`` side, or bytes that are not valid JSON) raises
+:class:`CollisionError` naming both source paths, mirroring jq aborting on bad
+input rather than silently fabricating an empty object.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from typing import Any
+
+from installer.core.merge.base import CollisionError
+from installer.core.model import StagedItem
+
+# jq total-order type ranks. Lower sorts first. ``bool`` is checked before
+# ``int`` because ``bool`` is a subclass of ``int`` in Python.
+_RANK_NULL = 0
+_RANK_BOOL = 1
+_RANK_NUMBER = 2
+_RANK_STRING = 3
+_RANK_ARRAY = 4
+_RANK_OBJECT = 5
+
+
+def _jq_sort_key(value: Any) -> tuple[Any, ...]:
+    """Map a JSON value to a sortable key reproducing jq's total order.
+
+    Type rank dominates (``null < bool < number < string < array < object``);
+    within a rank values compare naturally. Containers recurse so arrays
+    compare element-wise and objects compare by their sorted key-array first,
+    then by their values in key order — matching jq's ``sort``/``unique``.
+    """
+    if value is None:
+        return (_RANK_NULL,)
+    if isinstance(value, bool):
+        # false < true; rely on int(False)=0 < int(True)=1.
+        return (_RANK_BOOL, int(value))
+    if isinstance(value, (int, float)):
+        return (_RANK_NUMBER, float(value))
+    if isinstance(value, str):
+        return (_RANK_STRING, value)
+    if isinstance(value, list):
+        return (_RANK_ARRAY, [_jq_sort_key(elem) for elem in value])
+    # dict: keys sorted first, then the values in that key order.
+    keys = sorted(value.keys())
+    return (
+        _RANK_OBJECT,
+        [_jq_sort_key(k) for k in keys],
+        [_jq_sort_key(value[k]) for k in keys],
+    )
+
+
+def _union_arrays(existing: list[Any], incoming: list[Any]) -> list[Any]:
+    """jq ``[a, b] | add | unique``: concatenate, sort by jq's total order,
+    then drop adjacent duplicates (values with an equal sort key are jq-equal,
+    which correctly treats ``1`` and ``1.0`` as one while keeping ``true`` and
+    ``1`` distinct)."""
+    ordered = sorted(existing + incoming, key=_jq_sort_key)
+    deduped: list[Any] = []
+    last_key: tuple[Any, ...] | None = None
+    for elem in ordered:
+        key = _jq_sort_key(elem)
+        if key != last_key:
+            deduped.append(elem)
+            last_key = key
+    return deduped
+
+
+def _deep_merge(existing: Any, incoming: Any) -> Any:
+    """Port of the jq ``deep_merge`` def. Only object+object recurses; every
+    other top-level shape returns ``existing`` whole. The merged object is
+    built via ``add`` over per-key fragments, so a key-merge yielding no keys
+    collapses to ``None`` (the jq ``[] | add`` quirk)."""
+    if not (isinstance(existing, dict) and isinstance(incoming, dict)):
+        return existing
+
+    # jq builds the merged object via ``($a|keys)+($b|keys)|unique|map(…)``,
+    # and ``keys|unique`` sorts the key-set by Unicode codepoint. Building the
+    # dict in sorted-key order here reproduces that: the CONSTRUCTED skeleton
+    # is sorted at every recursion level, while objects passed through verbatim
+    # (one-side-only object values, objects nested inside arrays) are never
+    # rebuilt and so keep their original insertion order — matching ``jq .``,
+    # which sorts only what the program constructs. ``_to_jq_bytes`` therefore
+    # serialises with ``sort_keys=False``.
+    merged: dict[str, Any] = {}
+    for key in sorted(set(existing) | set(incoming)):
+        in_existing = key in existing
+        in_incoming = key in incoming
+        if in_existing and in_incoming:
+            ev, iv = existing[key], incoming[key]
+            if isinstance(ev, list) and isinstance(iv, list):
+                merged[key] = _union_arrays(ev, iv)
+            elif isinstance(ev, dict) and isinstance(iv, dict):
+                merged[key] = _deep_merge(ev, iv)
+            else:
+                # scalar conflict OR type mismatch -> keep existing.
+                merged[key] = ev
+        elif in_existing:
+            merged[key] = existing[key]
+        else:
+            merged[key] = incoming[key]
+
+    # jq ``[] | add`` is null: an object that merged to no keys becomes null.
+    if not merged:
+        return None
+    return merged
+
+
+def _parse(content: bytes | None) -> Any:
+    """Parse ``content`` as JSON, or raise ``ValueError`` for irreconcilable
+    input. ``None`` content raises directly; malformed JSON and non-UTF-8 bytes
+    raise ``JSONDecodeError`` / ``UnicodeDecodeError`` (both ``ValueError``
+    subclasses). :meth:`JsonUnionStrategy.merge` maps any of these to one
+    ``CollisionError`` naming both source paths in canonical order, so the
+    failure is reported the same way regardless of which side is unparseable."""
+    if content is None:
+        raise ValueError
+    return json.loads(content)
+
+
+def _to_jq_bytes(value: Any) -> bytes:
+    """Serialise to canonical ``jq .`` formatting: 2-space indent, single
+    trailing newline, and — crucially — each object's keys in the order it
+    already holds them (``sort_keys=False``). ``jq .`` does NOT sort keys; it
+    preserves every object's insertion order. The deep-merge skeleton is built
+    in sorted order by :func:`_deep_merge` (mirroring jq's ``keys|unique``), so
+    objects jq constructs come out sorted while objects jq passes through
+    verbatim keep their original order. Sorting here would wrongly re-order the
+    latter (e.g. a one-side-only ``env`` block, or an object inside an array)."""
+    text = json.dumps(value, indent=2, sort_keys=False, ensure_ascii=False)
+    return (text + "\n").encode("utf-8")
+
+
+class JsonUnionStrategy:
+    """Deep union-merge two colliding JSON payloads, jq-parity.
+
+    Honours the ``MergeStrategy`` protocol structurally. The synthesised item
+    preserves the shared key fields (``dest_relpath``, ``kind``, ``namespace``
+    — identical on both by definition of the collision), sets ``content`` to
+    the canonical merged bytes, and takes ``provenance`` and ``source_path``
+    from ``incoming``.
+    """
+
+    def merge(self, existing: StagedItem, incoming: StagedItem) -> StagedItem:
+        # None content or unparseable bytes on either side are irreconcilable;
+        # surface as one CollisionError naming both paths in canonical order.
+        try:
+            existing_json = _parse(existing.content)
+            incoming_json = _parse(incoming.content)
+        except ValueError as exc:
+            raise CollisionError(existing.source_path, incoming.source_path) from exc
+        merged = _deep_merge(existing_json, incoming_json)
+        return replace(incoming, content=_to_jq_bytes(merged))

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -126,10 +126,20 @@ def _union_arrays(existing: list[Any], incoming: list[Any]) -> list[Any]:
     )
     deduped: list[Any] = []
     last_key: tuple[Any, ...] | None = None
+    last_elem: Any = None
     for key, elem in keyed:
-        if key != last_key:
+        # Dedupe on the sort key, but break ties by Python value equality so a
+        # lossy sort key cannot collapse two distinct values. The overflow
+        # guard in ``_jq_sort_key`` maps every huge positive int to the same
+        # +inf key (and every huge negative int to -inf), so ``10**400`` and
+        # ``10**401`` share a key while being distinct, full-precision integers
+        # that ``json.dumps`` preserves verbatim. Without the value check the
+        # second would be silently dropped, losing data. ``1`` vs ``1.0`` still
+        # dedupe because ``1 == 1.0`` in Python, matching jq.
+        if key != last_key or elem != last_elem:
             deduped.append(elem)
             last_key = key
+            last_elem = elem
     return deduped
 
 

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -1,4 +1,4 @@
-"""Deep union-merge strategy for ``(SETTINGS_JSON, *)`` collisions (E.4).
+"""Deep union-merge strategy for ``(SETTINGS_JSON, *)`` collisions.
 
 When two ``settings.json`` payloads (e.g. a tool's and a plugin's) collide at
 the same destination they are not a conflict — they are combined. This is the

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -89,7 +89,16 @@ def _jq_sort_key(value: Any) -> tuple[Any, ...]:
         # false < true; rely on int(False)=0 < int(True)=1.
         return (_RANK_BOOL, int(value))
     if isinstance(value, (int, float)):
-        return (_RANK_NUMBER, float(value))
+        try:
+            return (_RANK_NUMBER, float(value))
+        except OverflowError:
+            # A Python int too large for a float (valid JSON, e.g. a 400-digit
+            # integer literal): jq stores numbers as IEEE doubles, so an
+            # out-of-range int collapses to +/-inf. Mirror that here for
+            # ordering only — the element's exact value is preserved in the
+            # output bytes (json.dumps keeps int precision); just this sort key
+            # approximates, which would otherwise crash with OverflowError.
+            return (_RANK_NUMBER, float("inf") if value > 0 else float("-inf"))
     if isinstance(value, str):
         return (_RANK_STRING, value)
     if isinstance(value, list):

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -108,11 +108,16 @@ def _union_arrays(existing: list[Any], incoming: list[Any]) -> list[Any]:
     then drop adjacent duplicates (values with an equal sort key are jq-equal,
     which correctly treats ``1`` and ``1.0`` as one while keeping ``true`` and
     ``1`` distinct)."""
-    ordered = sorted(existing + incoming, key=_jq_sort_key)
+    # Compute each element's sort key once, then sort + dedupe by it. Sort on
+    # the key alone (``key=`` on the pair's first item): when two keys tie the
+    # raw values must not be compared, since dicts/lists are not orderable.
+    keyed = sorted(
+        ((_jq_sort_key(elem), elem) for elem in (*existing, *incoming)),
+        key=lambda pair: pair[0],
+    )
     deduped: list[Any] = []
     last_key: tuple[Any, ...] | None = None
-    for elem in ordered:
-        key = _jq_sort_key(elem)
+    for key, elem in keyed:
         if key != last_key:
             deduped.append(elem)
             last_key = key

--- a/packages/installer/src/installer/core/merge/strategies/last_wins_silent.py
+++ b/packages/installer/src/installer/core/merge/strategies/last_wins_silent.py
@@ -1,0 +1,28 @@
+"""Last-wins-silent strategy for ``(OTHER, *)``.
+
+``OTHER`` is the catch-all kind for opaque files the installer neither
+parses nor structurally merges. A collision resolves to *last wins*: the
+``incoming`` item replaces the ``existing`` one, and — unlike the JSONC/TOML
+variant — the overwrite is **not** announced. ``OTHER`` collisions are
+expected and benign in normal operation (e.g. re-staging the same asset
+from two sources), so a warning would be noise; the warn variant is reserved
+for the structured-config kinds where a lost merge is worth surfacing.
+"""
+
+from __future__ import annotations
+
+from installer.core.model import StagedItem
+
+
+class LastWinsSilentStrategy:
+    """Resolve an ``OTHER`` collision by replacing ``existing`` with
+    ``incoming`` silently (no warning)."""
+
+    def merge(
+        self,
+        existing: StagedItem,  # noqa: ARG002  # last-wins discards existing
+        incoming: StagedItem,
+    ) -> StagedItem:
+        """Return ``incoming`` unchanged — it already carries its own
+        ``provenance`` and ``source_path``; last-wins stages it verbatim."""
+        return incoming

--- a/packages/installer/src/installer/core/merge/strategies/last_wins_warn.py
+++ b/packages/installer/src/installer/core/merge/strategies/last_wins_warn.py
@@ -1,0 +1,44 @@
+"""Last-wins-with-warning strategy for ``(JSONC, *)`` and ``(TOML, *)``.
+
+JSONC and TOML have no safe structural union the installer can perform
+blindly (comment placement, table ordering, and key-merge semantics are all
+format- and intent-specific), so a collision resolves to *last wins*: the
+``incoming`` item replaces the ``existing`` one. Because that silently
+discards the existing file's content, the overwrite is announced via a
+stdlib :func:`warnings.warn` whose message names BOTH colliding source paths.
+
+This module establishes the package's collision-warning convention: route
+through stdlib ``warnings`` (category :class:`UserWarning`), not ``print`` /
+``logging`` / ``rich``. ``warnings`` is the right channel for a
+"this-degraded-gracefully, here is what happened" signal — it is capturable
+in tests via ``pytest.warns`` and suppressible by callers via the warnings
+filter, neither of which a bare ``print`` affords. The ``merge`` signature
+carries no ``IOPort``, so terminal injection is not an option here.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from installer.core.model import StagedItem
+
+
+class LastWinsWarnStrategy:
+    """Resolve a JSONC/TOML collision by replacing ``existing`` with
+    ``incoming`` and warning that the overwrite happened."""
+
+    def merge(self, existing: StagedItem, incoming: StagedItem) -> StagedItem:
+        """Warn (naming both source paths), then return ``incoming``.
+
+        ``incoming`` already carries its own ``provenance`` and
+        ``source_path``; last-wins stages it verbatim rather than
+        synthesising a new item, so it is returned as-is.
+        """
+        warnings.warn(
+            f"Last-wins overwrite: {incoming.source_path} replaces "
+            f"{existing.source_path} at destination {incoming.dest_relpath} "
+            f"(no structural merge for this file kind).",
+            UserWarning,
+            stacklevel=2,
+        )
+        return incoming

--- a/packages/installer/tests/unit/test_append_rules.py
+++ b/packages/installer/tests/unit/test_append_rules.py
@@ -1,0 +1,139 @@
+"""Unit tests for installer.core.merge.strategies.append_rules (E.2).
+
+Each test pins a coded decision in the append-merge contract for
+``(NAMESPACED_MD, namespace="rules")`` collisions:
+
+- The two rule bodies join with the EXACT separator ``b"\\n---\\n"``.
+- Order is ``existing`` THEN ``incoming`` (deterministic, append-only).
+- The synthesised item carries merged bytes but takes ``provenance`` and
+  ``source_path`` from ``incoming`` while preserving the shared key fields.
+- Empty-content edges never emit a doubled/stray separator or a trailing
+  blank-line artefact.
+
+Tests that would only verify Python/stdlib semantics (bytes concatenation,
+frozen-dataclass immutability) are deliberately absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.merge.base import MergeStrategy
+from installer.core.merge.strategies.append_rules import AppendRulesStrategy
+from installer.core.model import FileKind, Provenance, StagedItem
+
+_SEP = b"\n---\n"
+
+
+def _item(
+    source: str,
+    content: bytes | None,
+    *,
+    dest: str = "rules/foo.md",
+    provenance: Provenance | None = None,
+) -> StagedItem:
+    return StagedItem(
+        source_path=Path(source),
+        dest_relpath=Path(dest),
+        kind=FileKind.NAMESPACED_MD,
+        namespace="rules",
+        provenance=provenance or Provenance(kind="tool", name="claude"),
+        content=content,
+    )
+
+
+def test_strategy_satisfies_merge_strategy_protocol() -> None:
+    """AppendRulesStrategy structurally honours the MergeStrategy contract."""
+    strategy: MergeStrategy = AppendRulesStrategy()
+    assert isinstance(strategy, MergeStrategy)
+
+
+def test_non_empty_bodies_join_existing_then_incoming_with_separator() -> None:
+    """Both bodies present: result is existing + separator + incoming, in that
+    order, with the separator EXACTLY b"\\n---\\n"."""
+    existing = _item("/src/a/foo.md", b"alpha")
+    incoming = _item("/src/b/foo.md", b"beta")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content == b"alpha" + _SEP + b"beta"
+
+
+def test_separator_is_emitted_exactly_once_between_two_bodies() -> None:
+    """A single separator joins two non-empty bodies — no doubling."""
+    existing = _item("/src/a/foo.md", b"one")
+    incoming = _item("/src/b/foo.md", b"two")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content is not None
+    assert merged.content.count(_SEP) == 1
+
+
+def test_empty_existing_yields_incoming_without_leading_separator() -> None:
+    """When existing has no body, the result is just incoming — no stray
+    leading separator or blank-line artefact."""
+    existing = _item("/src/a/foo.md", b"")
+    incoming = _item("/src/b/foo.md", b"beta")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content == b"beta"
+
+
+def test_empty_incoming_yields_existing_without_trailing_separator() -> None:
+    """When incoming has no body, the result is just existing — no stray
+    trailing separator."""
+    existing = _item("/src/a/foo.md", b"alpha")
+    incoming = _item("/src/b/foo.md", b"")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content == b"alpha"
+
+
+def test_both_empty_yields_empty_content() -> None:
+    """Two empty bodies collapse to empty content — no separator at all."""
+    existing = _item("/src/a/foo.md", b"")
+    incoming = _item("/src/b/foo.md", b"")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content == b""
+
+
+def test_none_content_is_treated_as_empty_edge() -> None:
+    """A None body (defensive: NAMESPACED_MD is normally bytes) is handled as
+    the empty-content edge, not concatenated as a literal — existing=None
+    collapses to incoming alone."""
+    existing = _item("/src/a/foo.md", None)
+    incoming = _item("/src/b/foo.md", b"beta")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.content == b"beta"
+
+
+def test_merged_item_takes_provenance_and_source_from_incoming() -> None:
+    """The synthesised item attributes the merge to the incoming source:
+    provenance and source_path come from incoming."""
+    existing = _item("/src/a/foo.md", b"alpha", provenance=Provenance(kind="tool", name="claude"))
+    incoming = _item("/src/b/foo.md", b"beta", provenance=Provenance(kind="plugin", name="beads"))
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.provenance == Provenance(kind="plugin", name="beads")
+    assert merged.source_path == Path("/src/b/foo.md")
+
+
+def test_merged_item_preserves_shared_key_fields() -> None:
+    """dest_relpath, kind and namespace are identical on both by definition of
+    the collision and survive onto the merged item unchanged."""
+    existing = _item("/src/a/foo.md", b"alpha")
+    incoming = _item("/src/b/foo.md", b"beta")
+
+    merged = AppendRulesStrategy().merge(existing, incoming)
+
+    assert merged.dest_relpath == Path("rules/foo.md")
+    assert merged.kind == FileKind.NAMESPACED_MD
+    assert merged.namespace == "rules"

--- a/packages/installer/tests/unit/test_append_rules.py
+++ b/packages/installer/tests/unit/test_append_rules.py
@@ -1,4 +1,4 @@
-"""Unit tests for installer.core.merge.strategies.append_rules (E.2).
+"""Unit tests for installer.core.merge.strategies.append_rules.
 
 Each test pins a coded decision in the append-merge contract for
 ``(NAMESPACED_MD, namespace="rules")`` collisions:

--- a/packages/installer/tests/unit/test_append_rules.py
+++ b/packages/installer/tests/unit/test_append_rules.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from installer.core.merge.base import MergeStrategy
 from installer.core.merge.strategies.append_rules import AppendRulesStrategy
 from installer.core.model import FileKind, Provenance, StagedItem
 
@@ -40,12 +39,6 @@ def _item(
         provenance=provenance or Provenance(kind="tool", name="claude"),
         content=content,
     )
-
-
-def test_strategy_satisfies_merge_strategy_protocol() -> None:
-    """AppendRulesStrategy structurally honours the MergeStrategy contract."""
-    strategy: MergeStrategy = AppendRulesStrategy()
-    assert isinstance(strategy, MergeStrategy)
 
 
 def test_non_empty_bodies_join_existing_then_incoming_with_separator() -> None:

--- a/packages/installer/tests/unit/test_fatal.py
+++ b/packages/installer/tests/unit/test_fatal.py
@@ -1,0 +1,108 @@
+"""Unit tests for installer.core.merge.strategies.fatal (E.3).
+
+``FatalStrategy`` resolves the irreconcilable collisions — ``NAMESPACED_MD``
+in the ``commands`` / ``skills`` / ``agents`` namespaces, and ``DIR`` — by
+*always* raising :class:`CollisionError`. It never returns a ``StagedItem``.
+
+Each test pins a coded decision:
+
+- ``merge`` raises ``CollisionError`` rather than returning (the whole point
+  of the strategy).
+- The raised error names BOTH colliding source paths (the operator must be
+  able to locate each side of the conflict).
+- The error carries both paths as structured attributes (callers assert on
+  data, not prose) — and they come from the two *inputs*, in the right slots.
+- ``FatalStrategy`` structurally satisfies the ``MergeStrategy`` protocol
+  (the contract is method-shape, not inheritance).
+
+Tests that would only verify Python/stdlib semantics are deliberately absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.merge.strategies.fatal import FatalStrategy
+from installer.core.model import FileKind, Provenance, StagedItem
+
+
+def _item(
+    source: str,
+    *,
+    dest: str = "commands/foo.md",
+    kind: FileKind = FileKind.NAMESPACED_MD,
+    namespace: str | None = "commands",
+) -> StagedItem:
+    return StagedItem(
+        source_path=Path(source),
+        dest_relpath=Path(dest),
+        kind=kind,
+        namespace=namespace,
+        provenance=Provenance(kind="tool", name="claude"),
+        content=b"x",
+    )
+
+
+def test_merge_raises_collision_error() -> None:
+    """The fatal strategy NEVER returns a StagedItem — merge always raises
+    CollisionError for the irreconcilable kinds it owns."""
+    strategy = FatalStrategy()
+    existing = _item("/src/a/foo.md")
+    incoming = _item("/src/b/foo.md")
+
+    with pytest.raises(CollisionError):
+        strategy.merge(existing, incoming)
+
+
+def test_merge_error_names_both_source_paths() -> None:
+    """The raised error's message names BOTH colliding source paths so an
+    operator can locate each side of the conflict (HLD lines 70, 180)."""
+    strategy = FatalStrategy()
+    existing = _item("/src/a/foo.md")
+    incoming = _item("/src/b/foo.md")
+
+    with pytest.raises(CollisionError) as exc_info:
+        strategy.merge(existing, incoming)
+
+    text = str(exc_info.value)
+    assert "/src/a/foo.md" in text
+    assert "/src/b/foo.md" in text
+
+
+def test_merge_error_carries_input_source_paths_in_order() -> None:
+    """The error's structured attributes come from the two inputs, with
+    ``existing`` from the existing item and ``incoming`` from the incoming
+    item — not swapped, not the dest paths."""
+    strategy = FatalStrategy()
+    existing = _item("/src/a/foo.md")
+    incoming = _item("/src/b/foo.md")
+
+    with pytest.raises(CollisionError) as exc_info:
+        strategy.merge(existing, incoming)
+
+    assert exc_info.value.existing == Path("/src/a/foo.md")
+    assert exc_info.value.incoming == Path("/src/b/foo.md")
+
+
+def test_merge_raises_for_dir_kind() -> None:
+    """DIR collisions are fatal too — the strategy is namespace-agnostic and
+    raises for the DIR kind exactly as it does for namespaced markdown."""
+    strategy = FatalStrategy()
+    existing = _item("/src/a/skills/x", dest="skills/x", kind=FileKind.DIR, namespace=None)
+    incoming = _item("/src/b/skills/x", dest="skills/x", kind=FileKind.DIR, namespace=None)
+
+    with pytest.raises(CollisionError) as exc_info:
+        strategy.merge(existing, incoming)
+
+    assert exc_info.value.existing == Path("/src/a/skills/x")
+    assert exc_info.value.incoming == Path("/src/b/skills/x")
+
+
+def test_fatal_strategy_satisfies_merge_strategy_protocol() -> None:
+    """FatalStrategy structurally satisfies the MergeStrategy protocol — the
+    contract is method-shape, not inheritance."""
+    strategy: MergeStrategy = FatalStrategy()
+    assert isinstance(strategy, MergeStrategy)

--- a/packages/installer/tests/unit/test_fatal.py
+++ b/packages/installer/tests/unit/test_fatal.py
@@ -1,4 +1,4 @@
-"""Unit tests for installer.core.merge.strategies.fatal (E.3).
+"""Unit tests for installer.core.merge.strategies.fatal.
 
 ``FatalStrategy`` resolves the irreconcilable collisions — ``NAMESPACED_MD``
 in the ``commands`` / ``skills`` / ``agents`` namespaces, and ``DIR`` — by

--- a/packages/installer/tests/unit/test_fatal.py
+++ b/packages/installer/tests/unit/test_fatal.py
@@ -12,8 +12,6 @@ Each test pins a coded decision:
   able to locate each side of the conflict).
 - The error carries both paths as structured attributes (callers assert on
   data, not prose) — and they come from the two *inputs*, in the right slots.
-- ``FatalStrategy`` structurally satisfies the ``MergeStrategy`` protocol
-  (the contract is method-shape, not inheritance).
 
 Tests that would only verify Python/stdlib semantics are deliberately absent.
 """
@@ -24,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.merge.base import CollisionError
 from installer.core.merge.strategies.fatal import FatalStrategy
 from installer.core.model import FileKind, Provenance, StagedItem
 
@@ -99,10 +97,3 @@ def test_merge_raises_for_dir_kind() -> None:
 
     assert exc_info.value.existing == Path("/src/a/skills/x")
     assert exc_info.value.incoming == Path("/src/b/skills/x")
-
-
-def test_fatal_strategy_satisfies_merge_strategy_protocol() -> None:
-    """FatalStrategy structurally satisfies the MergeStrategy protocol — the
-    contract is method-shape, not inheritance."""
-    strategy: MergeStrategy = FatalStrategy()
-    assert isinstance(strategy, MergeStrategy)

--- a/packages/installer/tests/unit/test_json_union.py
+++ b/packages/installer/tests/unit/test_json_union.py
@@ -182,6 +182,14 @@ def test_array_union_handles_negative_int_too_large_for_float() -> None:
     assert _merge({"x": [huge_neg]}, {"x": [1]}) == {"x": [huge_neg, 1]}
 
 
+def test_array_union_keeps_distinct_overflow_ints_sharing_a_sort_key() -> None:
+    """Two distinct ints that both overflow ``float()`` share the same +inf
+    sort key, but they are different full-precision integers that ``json.dumps``
+    preserves. Dedupe must break the sort-key tie by Python value equality so
+    neither is dropped — otherwise the second would be silently lost."""
+    assert _merge({"x": [10**400, 10**401]}, {"x": []}) == {"x": [10**400, 10**401]}
+
+
 def test_array_union_jq_total_order_across_types() -> None:
     """jq's total order ranks types null < false < true < number < string
     < array < object; ``unique`` sorts the unioned array by that order."""

--- a/packages/installer/tests/unit/test_json_union.py
+++ b/packages/installer/tests/unit/test_json_union.py
@@ -1,0 +1,398 @@
+"""Unit tests for installer.core.merge.strategies.json_union (E.4).
+
+Each test pins a coded decision in the deep-union-merge contract for
+``(SETTINGS_JSON, *)`` collisions. The behavioural spec is the jq program
+at ``scripts/install.sh:431-456``; these tests were authored by probing the
+real ``jq-1.8.1`` against the same inputs, so they pin jq-parity, not the
+Python stdlib.
+
+The jq rules being pinned:
+
+- dict + dict at a shared key -> recurse (deep merge);
+- array + array at a shared key -> concatenate, jq-``unique`` (sort by jq's
+  total order, then dedupe by value);
+- scalar conflict at a shared key -> KEEP EXISTING;
+- type mismatch at a shared key (dict-vs-scalar, array-vs-scalar, etc.)
+  -> KEEP EXISTING;
+- key only in incoming -> ADD it; key only in existing -> keep it;
+- top-level non-object operand -> the result is ``existing`` whole;
+- the empty-object quirk: merging two objects whose key-merge yields no
+  keys produces JSON ``null`` (jq ``[] | add == null``);
+- output bytes are canonical ``jq .`` formatting: 2-space indent, single
+  trailing newline, and key order that matches ``jq .`` (which does NOT
+  sort) — the deep-merge skeleton it CONSTRUCTS is sorted, but objects it
+  PASSES THROUGH verbatim keep insertion order;
+- the synthesised item takes provenance + source_path from incoming and
+  preserves the shared key fields.
+
+jq total order pinned in the array-union tests:
+``null < false < true < number < string < array < object``.
+
+Tests that would only verify Python/stdlib semantics (``json.loads`` round
+trips, frozen-dataclass immutability) are deliberately absent.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.merge.strategies.json_union import JsonUnionStrategy
+from installer.core.model import FileKind, Provenance, StagedItem
+
+
+def _item(
+    obj: object | None,
+    *,
+    source: str = "/src/a/settings.json",
+    dest: str = "settings.json",
+    provenance: Provenance | None = None,
+    raw: bytes | None = None,
+) -> StagedItem:
+    """Build a SETTINGS_JSON StagedItem. ``obj`` is serialised to bytes;
+    pass ``raw`` to inject deliberately malformed bytes instead."""
+    if raw is not None:
+        content: bytes | None = raw
+    elif obj is None:
+        content = None
+    else:
+        content = json.dumps(obj).encode("utf-8")
+    return StagedItem(
+        source_path=Path(source),
+        dest_relpath=Path(dest),
+        kind=FileKind.SETTINGS_JSON,
+        namespace=None,
+        provenance=provenance or Provenance(kind="tool", name="claude"),
+        content=content,
+    )
+
+
+def _merge(existing_obj: object, incoming_obj: object) -> object:
+    """Run the strategy and parse the merged bytes back to a Python object."""
+    merged = JsonUnionStrategy().merge(_item(existing_obj), _item(incoming_obj))
+    assert merged.content is not None
+    return json.loads(merged.content)
+
+
+# --- protocol conformance -------------------------------------------------
+
+
+def test_strategy_satisfies_merge_strategy_protocol() -> None:
+    """JsonUnionStrategy structurally honours the MergeStrategy contract."""
+    strategy: MergeStrategy = JsonUnionStrategy()
+    assert isinstance(strategy, MergeStrategy)
+
+
+# --- key presence rules ---------------------------------------------------
+
+
+def test_key_only_in_incoming_is_added() -> None:
+    """A key present only in incoming is added to the merged object."""
+    assert _merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+
+def test_key_only_in_existing_is_kept() -> None:
+    """A key present only in existing survives the merge."""
+    assert _merge({"a": 1}, {"b": 2})["a"] == 1
+
+
+# --- scalar / type-mismatch rules (KEEP EXISTING) -------------------------
+
+
+def test_scalar_conflict_keeps_existing() -> None:
+    """When both sides have a scalar at the same key, existing wins."""
+    assert _merge({"a": 1}, {"a": 99}) == {"a": 1}
+
+
+def test_string_scalar_conflict_keeps_existing() -> None:
+    """Scalar-keep-existing applies to strings, not just numbers."""
+    assert _merge({"a": "old"}, {"a": "new"}) == {"a": "old"}
+
+
+def test_type_mismatch_dict_vs_scalar_keeps_existing_dict() -> None:
+    """Existing dict vs incoming scalar at the same key: keep the dict."""
+    assert _merge({"x": {"deep": 1}}, {"x": 5}) == {"x": {"deep": 1}}
+
+
+def test_type_mismatch_array_vs_scalar_keeps_existing_array() -> None:
+    """Existing array vs incoming scalar at the same key: keep the array."""
+    assert _merge({"x": [1, 2]}, {"x": "str"}) == {"x": [1, 2]}
+
+
+def test_type_mismatch_scalar_vs_dict_keeps_existing_scalar() -> None:
+    """Existing scalar vs incoming dict at the same key: keep the scalar
+    (the recurse/union branches require BOTH sides to match type)."""
+    assert _merge({"x": 5}, {"x": {"deep": 1}}) == {"x": 5}
+
+
+def test_null_is_a_scalar_kept_on_conflict() -> None:
+    """null is treated as an ordinary scalar: existing null beats incoming 2,
+    and existing 1 beats incoming null."""
+    assert _merge({"x": None, "y": 1}, {"x": 2, "y": None}) == {"x": None, "y": 1}
+
+
+# --- recursion rule (dict + dict) -----------------------------------------
+
+
+def test_nested_dicts_recurse_and_union_keys() -> None:
+    """Two dicts at the same key deep-merge: shared scalar keeps existing,
+    disjoint keys from both sides are unioned."""
+    result = _merge({"n": {"x": 1, "y": 2}}, {"n": {"y": 99, "z": 3}})
+    assert result == {"n": {"x": 1, "y": 2, "z": 3}}
+
+
+def test_deeply_nested_dicts_recurse() -> None:
+    """Recursion is unbounded: a scalar conflict three levels deep still
+    keeps existing while sibling keys union."""
+    result = _merge(
+        {"a": {"b": {"c": 1, "keep": "old"}}},
+        {"a": {"b": {"c": 9, "add": "new"}}},
+    )
+    assert result == {"a": {"b": {"c": 1, "keep": "old", "add": "new"}}}
+
+
+# --- array union rule (concatenate + jq unique) ---------------------------
+
+
+def test_scalar_arrays_union_sort_and_dedupe() -> None:
+    """Conflicting scalar arrays concatenate, then jq-``unique`` sorts
+    ascending and removes duplicates."""
+    assert _merge({"arr": [3, 1, 2]}, {"arr": [2, 4, 1]}) == {"arr": [1, 2, 3, 4]}
+
+
+def test_array_union_dedupes_within_a_single_side() -> None:
+    """jq-``unique`` collapses duplicates that already exist within one side
+    as well as across sides."""
+    assert _merge({"x": [1, 1, 2, 2]}, {"x": [2, 3, 3]}) == {"x": [1, 2, 3]}
+
+
+def test_array_union_dedupes_int_and_float_with_same_value() -> None:
+    """jq treats 1 and 1.0 as the same number, so they dedupe to one."""
+    assert _merge({"x": [1]}, {"x": [1.0, 2]}) == {"x": [1, 2]}
+
+
+def test_array_union_jq_total_order_across_types() -> None:
+    """jq's total order ranks types null < false < true < number < string
+    < array < object; ``unique`` sorts the unioned array by that order."""
+    result = _merge(
+        {"x": [3, "b", True, None]},
+        {"x": ["a", False, 2]},
+    )
+    assert result == {"x": [None, False, True, 2, 3, "a", "b"]}
+
+
+def test_array_union_of_objects_sorts_by_keys_then_values() -> None:
+    """Arrays of objects union + dedupe; jq orders objects by sorted-key
+    array first, then by values in key order."""
+    result = _merge(
+        {"perms": [{"k": "v2"}, {"k": "v1"}]},
+        {"perms": [{"k": "v1"}, {"k": "v3"}]},
+    )
+    assert result == {"perms": [{"k": "v1"}, {"k": "v2"}, {"k": "v3"}]}
+
+
+def test_array_union_object_keyset_tiebreak() -> None:
+    """jq object order compares the sorted key-set first: {"a":2} precedes
+    {"a":1,"b":2} (key-set ["a"] < ["a","b"]) which precedes {"b":1}."""
+    result = _merge(
+        {"x": [{"a": 1, "b": 2}, {"a": 2}]},
+        {"x": [{"b": 1}, {"a": 1}]},
+    )
+    assert result == {"x": [{"a": 1}, {"a": 2}, {"a": 1, "b": 2}, {"b": 1}]}
+
+
+def test_array_union_of_nested_arrays_lexicographic_order() -> None:
+    """Nested arrays sort element-wise with a length tiebreak (prefix is
+    less), matching jq's recursive array comparison."""
+    result = _merge({"x": [[1, 2], [1]]}, {"x": [[1, 2], [1, 2, 0]]})
+    assert result == {"x": [[1], [1, 2], [1, 2, 0]]}
+
+
+# --- empty-container edges ------------------------------------------------
+
+
+def test_empty_arrays_union_to_empty_array() -> None:
+    """Two empty arrays at a key union to an empty array, not null."""
+    assert _merge({"x": []}, {"x": []}) == {"x": []}
+
+
+def test_empty_array_unions_with_populated_array() -> None:
+    """An empty array on one side contributes nothing; the other side's
+    elements survive, sorted and deduped."""
+    assert _merge({"x": []}, {"x": [2, 1]}) == {"x": [1, 2]}
+
+
+def test_disjoint_empty_containers_are_preserved() -> None:
+    """Keys carrying empty {} / [] that appear on only one side pass through
+    unchanged (no collision occurs, so no merge rule fires)."""
+    result = _merge({"a": {}, "c": 1}, {"b": [], "d": 2})
+    assert result == {"a": {}, "b": [], "c": 1, "d": 2}
+
+
+def test_merging_two_empty_objects_yields_null_quirk() -> None:
+    """The jq quirk: deep-merging two objects whose key-merge yields no keys
+    runs ``[] | add`` which is null. Two empty top-level objects -> null."""
+    merged = JsonUnionStrategy().merge(_item({}), _item({}))
+    assert merged.content is not None
+    assert json.loads(merged.content) is None
+
+
+def test_nested_two_empty_objects_yield_null_at_that_key() -> None:
+    """The empty-object quirk propagates through recursion: a key holding {}
+    on both sides recurses, the inner key-merge is empty, and the value
+    becomes null."""
+    assert _merge({"x": {}}, {"x": {}}) == {"x": None}
+
+
+# --- top-level type-mismatch rule -----------------------------------------
+
+
+def test_top_level_existing_object_incoming_array_keeps_existing() -> None:
+    """The deep_merge guard requires BOTH operands to be objects; when
+    incoming is a non-object the whole existing value is returned."""
+    merged = JsonUnionStrategy().merge(_item({"a": 1}), _item([1, 2, 3]))
+    assert merged.content is not None
+    assert json.loads(merged.content) == {"a": 1}
+
+
+def test_top_level_existing_array_incoming_object_keeps_existing_array() -> None:
+    """When existing itself is a non-object, deep_merge returns it whole
+    regardless of incoming being an object."""
+    merged = JsonUnionStrategy().merge(_item([1, 2, 3]), _item({"a": 1}))
+    assert merged.content is not None
+    assert json.loads(merged.content) == [1, 2, 3]
+
+
+# --- output formatting (jq-parity bytes) ----------------------------------
+
+
+def test_output_is_two_space_indented_with_sorted_keys_and_trailing_newline() -> None:
+    """Merged bytes match canonical jq formatting: 2-space indent, exactly one
+    trailing newline, and — for keys the deep-merge constructs (as here, where
+    every key comes from both operands) — sorted order. The serializer itself
+    uses ``sort_keys=False``; sorting comes from skeleton construction, so
+    passthrough objects keep insertion order (pinned separately below)."""
+    merged = JsonUnionStrategy().merge(_item({"b": 1, "a": 2}), _item({"c": 3}))
+    assert merged.content == b'{\n  "a": 2,\n  "b": 1,\n  "c": 3\n}\n'
+
+
+def test_output_keys_sorted_codepoint_order_digits_upper_lower() -> None:
+    """jq key order is Unicode codepoint: digits < uppercase < lowercase."""
+    merged = JsonUnionStrategy().merge(_item({"B": 1, "a": 2, "10": 3, "2": 4}), _item({"A": 5}))
+    assert merged.content is not None
+    text = merged.content.decode("utf-8")
+    assert list(json.loads(text).keys()) == ["10", "2", "A", "B", "a"]
+    # Bytes must reflect that order, not insertion order.
+    assert text.index('"10"') < text.index('"2"') < text.index('"A"')
+    assert text.index('"A"') < text.index('"B"') < text.index('"a"')
+
+
+# --- passthrough key-order rule (jq `.` preserves insertion order) --------
+#
+# These pin the distinction `jq .` makes between objects the deep-merge
+# skeleton CONSTRUCTS (via `keys | unique`, which jq sorts) and objects it
+# PASSES THROUGH verbatim (which keep their original insertion order). All
+# expectations were probed against the real jq-1.8.1 deep_merge program from
+# scripts/install.sh:431-454.
+
+
+def test_one_side_only_nested_object_keeps_insertion_key_order() -> None:
+    """A key present on only ONE side whose value is an object is passed
+    through verbatim by jq (branch ``{($k): $a[$k]}`` — no recursion), so its
+    nested keys keep INSERTION order, not sorted order. jq emits ``env`` as
+    ``Z, A, M``; sorted would be ``A, M, Z``."""
+    merged = JsonUnionStrategy().merge(
+        _item({"env": {"Z": 1, "A": 2, "M": 3}}),
+        _item({"other": 1}),
+    )
+    assert merged.content is not None
+    text = merged.content.decode("utf-8")
+    assert text.index('"Z"') < text.index('"A"') < text.index('"M"')
+
+
+def test_object_inside_array_keeps_insertion_key_order() -> None:
+    """An object nested inside an array goes through ``union_arrays`` and is
+    never re-serialised key-by-key, so jq keeps its insertion order. jq emits
+    ``{z, a}``; sorted would be ``{a, z}``."""
+    merged = JsonUnionStrategy().merge(
+        _item({"arr": [{"z": 1, "a": 2}]}),
+        _item({"other": 1}),
+    )
+    assert merged.content is not None
+    text = merged.content.decode("utf-8")
+    assert text.index('"z"') < text.index('"a"')
+
+
+def test_deep_merge_skeleton_keys_stay_sorted_at_every_level() -> None:
+    """The object the deep-merge skeleton CONSTRUCTS (keys merged on both
+    sides, via jq ``keys | unique``) is sorted by jq at every recursion level
+    — including a nested object present on BOTH sides, which recurses. This
+    guards the fix from over-correcting passthrough order onto constructed
+    objects."""
+    merged = JsonUnionStrategy().merge(
+        _item({"n": {"z": 1, "a": 2}, "shared": 1}),
+        _item({"n": {"m": 3, "b": 4}, "extra": 2}),
+    )
+    assert merged.content is not None
+    text = merged.content.decode("utf-8")
+    # top-level constructed keys sorted: extra, n, shared
+    assert text.index('"extra"') < text.index('"n"') < text.index('"shared"')
+    # nested object recursed on both sides -> constructed -> keys sorted
+    assert text.index('"a"') < text.index('"b"') < text.index('"m"') < text.index('"z"')
+
+
+# --- synthesis contract (provenance / source_path / shared key fields) ----
+
+
+def test_merged_item_takes_provenance_and_source_from_incoming() -> None:
+    """The synthesised item attributes the merge to the incoming source."""
+    existing = _item(
+        {"a": 1}, source="/src/a/settings.json", provenance=Provenance(kind="tool", name="claude")
+    )
+    incoming = _item(
+        {"b": 2}, source="/src/b/settings.json", provenance=Provenance(kind="plugin", name="beads")
+    )
+
+    merged = JsonUnionStrategy().merge(existing, incoming)
+
+    assert merged.provenance == Provenance(kind="plugin", name="beads")
+    assert merged.source_path == Path("/src/b/settings.json")
+
+
+def test_merged_item_preserves_shared_key_fields() -> None:
+    """dest_relpath, kind and namespace survive onto the merged item."""
+    merged = JsonUnionStrategy().merge(_item({"a": 1}), _item({"b": 2}))
+
+    assert merged.dest_relpath == Path("settings.json")
+    assert merged.kind == FileKind.SETTINGS_JSON
+    assert merged.namespace is None
+
+
+# --- unparseable / missing content (irreconcilable) -----------------------
+
+
+def test_none_content_raises_collision_error() -> None:
+    """SETTINGS_JSON content is meant to be eager bytes; a None side cannot
+    be parsed as JSON, so the merge is irreconcilable and raises
+    CollisionError naming both source paths."""
+    existing = _item(None, source="/src/a/settings.json")
+    incoming = _item({"b": 2}, source="/src/b/settings.json")
+
+    with pytest.raises(CollisionError) as excinfo:
+        JsonUnionStrategy().merge(existing, incoming)
+
+    assert excinfo.value.existing == Path("/src/a/settings.json")
+    assert excinfo.value.incoming == Path("/src/b/settings.json")
+
+
+def test_malformed_json_raises_collision_error() -> None:
+    """Bytes that are not valid JSON make the merge irreconcilable; the
+    strategy raises CollisionError rather than crashing with a JSONDecodeError."""
+    existing = _item(None, raw=b"{not valid json", source="/src/a/settings.json")
+    incoming = _item({"b": 2}, source="/src/b/settings.json")
+
+    with pytest.raises(CollisionError):
+        JsonUnionStrategy().merge(existing, incoming)

--- a/packages/installer/tests/unit/test_json_union.py
+++ b/packages/installer/tests/unit/test_json_union.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 import pytest
 
-from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.merge.base import CollisionError
 from installer.core.merge.strategies.json_union import JsonUnionStrategy
 from installer.core.model import FileKind, Provenance, StagedItem
 
@@ -75,15 +75,6 @@ def _merge(existing_obj: object, incoming_obj: object) -> object:
     merged = JsonUnionStrategy().merge(_item(existing_obj), _item(incoming_obj))
     assert merged.content is not None
     return json.loads(merged.content)
-
-
-# --- protocol conformance -------------------------------------------------
-
-
-def test_strategy_satisfies_merge_strategy_protocol() -> None:
-    """JsonUnionStrategy structurally honours the MergeStrategy contract."""
-    strategy: MergeStrategy = JsonUnionStrategy()
-    assert isinstance(strategy, MergeStrategy)
 
 
 # --- key presence rules ---------------------------------------------------
@@ -180,6 +171,15 @@ def test_array_union_handles_int_too_large_for_float() -> None:
     loses the value — the exact integer survives in the merged output."""
     huge = 10**400
     assert _merge({"x": [huge]}, {"x": [1]}) == {"x": [1, huge]}
+
+
+def test_array_union_handles_negative_int_too_large_for_float() -> None:
+    """The negative mirror of the overflow guard: a hugely negative integer
+    overflows ``float()`` too; the jq sort key falls back to -inf, so it sorts
+    BELOW every finite number while the exact integer survives — order
+    ``[huge_neg, 1]`` distinguishes the -inf branch from the +inf one."""
+    huge_neg = -(10**400)
+    assert _merge({"x": [huge_neg]}, {"x": [1]}) == {"x": [huge_neg, 1]}
 
 
 def test_array_union_jq_total_order_across_types() -> None:
@@ -404,3 +404,18 @@ def test_malformed_json_raises_collision_error() -> None:
 
     with pytest.raises(CollisionError):
         JsonUnionStrategy().merge(existing, incoming)
+
+
+def test_incoming_side_unparseable_raises_same_collision_error() -> None:
+    """The merge parses BOTH sides; a malformed INCOMING (existing good) is
+    equally irreconcilable and raises the SAME CollisionError — with the paths
+    still in canonical (existing, incoming) order, NOT swapped because the bad
+    side happens to be incoming."""
+    existing = _item({"a": 1}, source="/src/a/settings.json")
+    incoming = _item(None, raw=b"}{ broken", source="/src/b/settings.json")
+
+    with pytest.raises(CollisionError) as excinfo:
+        JsonUnionStrategy().merge(existing, incoming)
+
+    assert excinfo.value.existing == Path("/src/a/settings.json")
+    assert excinfo.value.incoming == Path("/src/b/settings.json")

--- a/packages/installer/tests/unit/test_json_union.py
+++ b/packages/installer/tests/unit/test_json_union.py
@@ -1,4 +1,4 @@
-"""Unit tests for installer.core.merge.strategies.json_union (E.4).
+"""Unit tests for installer.core.merge.strategies.json_union.
 
 Each test pins a coded decision in the deep-union-merge contract for
 ``(SETTINGS_JSON, *)`` collisions. The behavioural spec is the jq program
@@ -172,6 +172,14 @@ def test_array_union_dedupes_within_a_single_side() -> None:
 def test_array_union_dedupes_int_and_float_with_same_value() -> None:
     """jq treats 1 and 1.0 as the same number, so they dedupe to one."""
     assert _merge({"x": [1]}, {"x": [1.0, 2]}) == {"x": [1, 2]}
+
+
+def test_array_union_handles_int_too_large_for_float() -> None:
+    """A 400-digit integer is valid JSON but overflows ``float()``; the jq
+    sort key falls back to +inf for ordering, so the union neither crashes nor
+    loses the value — the exact integer survives in the merged output."""
+    huge = 10**400
+    assert _merge({"x": [huge]}, {"x": [1]}) == {"x": [1, huge]}
 
 
 def test_array_union_jq_total_order_across_types() -> None:

--- a/packages/installer/tests/unit/test_last_wins.py
+++ b/packages/installer/tests/unit/test_last_wins.py
@@ -1,0 +1,121 @@
+"""Unit tests for the last-wins collision strategies (E.5).
+
+Two strategies share the "incoming wins" resolution but differ on whether
+they announce the overwrite:
+
+- ``LastWinsWarnStrategy`` ((JSONC, *) / (TOML, *)) emits a stdlib
+  ``warnings.warn`` whose message names BOTH colliding source paths, then
+  returns the ``incoming`` item unchanged.
+- ``LastWinsSilentStrategy`` ((OTHER, *)) returns ``incoming`` with no warning.
+
+Each test pins a coded decision in that contract. Tests that would only
+exercise Python/stdlib semantics (frozen-dataclass immutability, that
+``warnings.warn`` raises under ``error`` filter, …) are deliberately absent.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from installer.core.merge.base import MergeStrategy
+from installer.core.merge.strategies.last_wins_silent import LastWinsSilentStrategy
+from installer.core.merge.strategies.last_wins_warn import LastWinsWarnStrategy
+from installer.core.model import FileKind, Provenance, StagedItem
+
+
+def _item(source: str, kind: FileKind, dest: str = "config.jsonc") -> StagedItem:
+    return StagedItem(
+        source_path=Path(source),
+        dest_relpath=Path(dest),
+        kind=kind,
+        namespace=None,
+        provenance=Provenance(kind="tool", name="claude"),
+        content=source.encode(),
+    )
+
+
+# --- LastWinsWarnStrategy ----------------------------------------------------
+
+
+def test_warn_strategy_returns_incoming_item() -> None:
+    """Last-wins means the colliding ``incoming`` item is the staged result;
+    the warn variant resolves to ``incoming`` identically (by object identity)."""
+    existing = _item("/src/a/config.jsonc", FileKind.JSONC)
+    incoming = _item("/src/b/config.jsonc", FileKind.JSONC)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = LastWinsWarnStrategy().merge(existing, incoming)
+
+    assert result is incoming
+
+
+def test_warn_strategy_warning_names_both_source_paths() -> None:
+    """The emitted warning must name BOTH source paths so an operator can
+    see exactly which file was overwritten by which."""
+    existing = _item("/src/a/config.jsonc", FileKind.JSONC)
+    incoming = _item("/src/b/config.jsonc", FileKind.JSONC)
+
+    with pytest.warns(UserWarning) as record:
+        LastWinsWarnStrategy().merge(existing, incoming)
+
+    assert len(record) == 1
+    message = str(record[0].message)
+    assert str(existing.source_path) in message
+    assert str(incoming.source_path) in message
+
+
+def test_warn_strategy_warning_emitted_for_toml_kind() -> None:
+    """The warn strategy serves both (JSONC, *) and (TOML, *); a TOML
+    collision warns the same way (kind is not branched on inside merge)."""
+    existing = _item("/src/a/cfg.toml", FileKind.TOML, dest="cfg.toml")
+    incoming = _item("/src/b/cfg.toml", FileKind.TOML, dest="cfg.toml")
+
+    with pytest.warns(UserWarning) as record:
+        result = LastWinsWarnStrategy().merge(existing, incoming)
+
+    assert result is incoming
+    message = str(record[0].message)
+    assert str(existing.source_path) in message
+    assert str(incoming.source_path) in message
+
+
+def test_warn_strategy_satisfies_merge_strategy_protocol() -> None:
+    """The warn strategy structurally satisfies the ``MergeStrategy`` protocol."""
+    strategy: MergeStrategy = LastWinsWarnStrategy()
+    assert isinstance(strategy, MergeStrategy)
+
+
+# --- LastWinsSilentStrategy --------------------------------------------------
+
+
+def test_silent_strategy_returns_incoming_item() -> None:
+    """Last-wins: the silent variant resolves to ``incoming`` by identity."""
+    existing = _item("/src/a/file.txt", FileKind.OTHER, dest="file.txt")
+    incoming = _item("/src/b/file.txt", FileKind.OTHER, dest="file.txt")
+
+    result = LastWinsSilentStrategy().merge(existing, incoming)
+
+    assert result is incoming
+
+
+def test_silent_strategy_emits_no_warning() -> None:
+    """The silent variant overwrites without announcing it — the defining
+    behavioural difference from the warn variant. Any warning is a failure."""
+    existing = _item("/src/a/file.txt", FileKind.OTHER, dest="file.txt")
+    incoming = _item("/src/b/file.txt", FileKind.OTHER, dest="file.txt")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would raise here
+        result = LastWinsSilentStrategy().merge(existing, incoming)
+
+    assert result is incoming
+
+
+def test_silent_strategy_satisfies_merge_strategy_protocol() -> None:
+    """The silent strategy structurally satisfies the ``MergeStrategy`` protocol."""
+    strategy: MergeStrategy = LastWinsSilentStrategy()
+    assert isinstance(strategy, MergeStrategy)

--- a/packages/installer/tests/unit/test_last_wins.py
+++ b/packages/installer/tests/unit/test_last_wins.py
@@ -1,4 +1,4 @@
-"""Unit tests for the last-wins collision strategies (E.5).
+"""Unit tests for the last-wins collision strategies.
 
 Two strategies share the "incoming wins" resolution but differ on whether
 they announce the overwrite:

--- a/packages/installer/tests/unit/test_last_wins.py
+++ b/packages/installer/tests/unit/test_last_wins.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 import pytest
 
-from installer.core.merge.base import MergeStrategy
 from installer.core.merge.strategies.last_wins_silent import LastWinsSilentStrategy
 from installer.core.merge.strategies.last_wins_warn import LastWinsWarnStrategy
 from installer.core.model import FileKind, Provenance, StagedItem
@@ -83,10 +82,18 @@ def test_warn_strategy_warning_emitted_for_toml_kind() -> None:
     assert str(incoming.source_path) in message
 
 
-def test_warn_strategy_satisfies_merge_strategy_protocol() -> None:
-    """The warn strategy structurally satisfies the ``MergeStrategy`` protocol."""
-    strategy: MergeStrategy = LastWinsWarnStrategy()
-    assert isinstance(strategy, MergeStrategy)
+def test_warn_strategy_warning_names_destination() -> None:
+    """The warning names the destination relpath so an operator can see WHERE
+    the overwrite landed. Pinned with a dest that appears in NEITHER source
+    path, so only the dest_relpath interpolation can satisfy the assertion."""
+    existing = _item("/src/a/x.jsonc", FileKind.JSONC, dest="nested/here.jsonc")
+    incoming = _item("/src/b/x.jsonc", FileKind.JSONC, dest="nested/here.jsonc")
+
+    with pytest.warns(UserWarning) as record:
+        LastWinsWarnStrategy().merge(existing, incoming)
+
+    message = str(record[0].message)
+    assert str(incoming.dest_relpath) in message
 
 
 # --- LastWinsSilentStrategy --------------------------------------------------
@@ -113,9 +120,3 @@ def test_silent_strategy_emits_no_warning() -> None:
         result = LastWinsSilentStrategy().merge(existing, incoming)
 
     assert result is incoming
-
-
-def test_silent_strategy_satisfies_merge_strategy_protocol() -> None:
-    """The silent strategy structurally satisfies the ``MergeStrategy`` protocol."""
-    strategy: MergeStrategy = LastWinsSilentStrategy()
-    assert isinstance(strategy, MergeStrategy)

--- a/packages/installer/tests/unit/test_merge_base.py
+++ b/packages/installer/tests/unit/test_merge_base.py
@@ -1,6 +1,6 @@
 """Unit tests for installer.core.merge.base.
 
-Each test pins a coded decision in the merge contract (E.1):
+Each test pins a coded decision in the merge contract:
 
 - ``CollisionError`` names BOTH colliding source paths in its message so the
   fatal strategy can surface an actionable error.

--- a/packages/installer/tests/unit/test_merge_base.py
+++ b/packages/installer/tests/unit/test_merge_base.py
@@ -1,0 +1,80 @@
+"""Unit tests for installer.core.merge.base.
+
+Each test pins a coded decision in the merge contract (E.1):
+
+- ``CollisionError`` names BOTH colliding source paths in its message so the
+  fatal strategy can surface an actionable error.
+- A trivial dummy strategy structurally satisfies the ``MergeStrategy``
+  protocol (the contract is method-shape, not inheritance).
+
+Tests that would only verify Python/stdlib semantics (e.g. that a frozen
+dataclass rejects attribute writes) are deliberately absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.model import FileKind, Provenance, StagedItem
+
+
+def _item(source: str, dest: str = "rules/foo.md") -> StagedItem:
+    return StagedItem(
+        source_path=Path(source),
+        dest_relpath=Path(dest),
+        kind=FileKind.NAMESPACED_MD,
+        namespace="rules",
+        provenance=Provenance(kind="tool", name="claude"),
+        content=b"x",
+    )
+
+
+def test_collision_error_message_names_both_source_paths() -> None:
+    """The constructor takes the two colliding source paths and the message
+    must name BOTH so an operator can locate each side of the conflict."""
+    existing = Path("/src/a/foo.md")
+    incoming = Path("/src/b/foo.md")
+
+    err = CollisionError(existing, incoming)
+
+    text = str(err)
+    assert str(existing) in text
+    assert str(incoming) in text
+
+
+def test_collision_error_exposes_both_paths_as_attributes() -> None:
+    """Structured attributes (not just the message string) so callers and
+    tests assert on data rather than parsing prose."""
+    existing = Path("/src/a/foo.md")
+    incoming = Path("/src/b/foo.md")
+
+    err = CollisionError(existing, incoming)
+
+    assert err.existing == existing
+    assert err.incoming == incoming
+
+
+def test_collision_error_is_runtime_error() -> None:
+    """CollisionError is a RuntimeError subclass — the shared fatal-collision
+    signal, distinct from the registry's lookup-miss error."""
+    assert issubclass(CollisionError, RuntimeError)
+
+
+def test_dummy_strategy_satisfies_merge_strategy_protocol() -> None:
+    """A class with a structurally-correct ``merge`` method is a
+    ``MergeStrategy`` — the contract is method-shape, not inheritance."""
+
+    class DummyStrategy:
+        def merge(
+            self,
+            existing: StagedItem,  # noqa: ARG002  # inert stub
+            incoming: StagedItem,
+        ) -> StagedItem:
+            return incoming
+
+    strategy: MergeStrategy = DummyStrategy()
+    existing = _item("/src/a/foo.md")
+    incoming = _item("/src/b/foo.md")
+
+    assert strategy.merge(existing, incoming) is incoming

--- a/packages/installer/tests/unit/test_merge_registry.py
+++ b/packages/installer/tests/unit/test_merge_registry.py
@@ -26,8 +26,9 @@ from installer.core.model import FileKind, Provenance, StagedItem
 
 
 class _DummyStrategy:
-    """Identity strategy with a label so tests can assert WHICH strategy
-    resolve() returned without comparing object identity alone."""
+    """Minimal MergeStrategy stub. The constructor ``label`` is a readable
+    identifier for debugging; tests assert WHICH strategy resolve() returned
+    via object identity (``is``)."""
 
     def __init__(self, label: str) -> None:
         self.label = label
@@ -70,7 +71,7 @@ def test_namespaced_md_distinct_namespaces_do_not_collide() -> None:
     reg.register(FileKind.NAMESPACED_MD, "rules", rules)
     reg.register(FileKind.NAMESPACED_MD, "commands", commands)
 
-    assert reg.resolve(FileKind.NAMESPACED_MD, "rules").label == "rules"  # type: ignore[attr-defined]
+    assert reg.resolve(FileKind.NAMESPACED_MD, "rules") is rules
 
 
 def test_non_namespaced_kind_ignores_namespace_on_register_and_resolve() -> None:

--- a/packages/installer/tests/unit/test_merge_registry.py
+++ b/packages/installer/tests/unit/test_merge_registry.py
@@ -1,6 +1,6 @@
 """Unit tests for installer.core.merge.registry.
 
-Each test pins a coded dispatch decision in the merge registry (E.1):
+Each test pins a coded dispatch decision in the merge registry:
 
 - A registered ``(kind, namespace)`` key resolves to its strategy.
 - ``NAMESPACED_MD`` dispatches BY namespace — ``"rules"`` and ``"commands"``

--- a/packages/installer/tests/unit/test_merge_registry.py
+++ b/packages/installer/tests/unit/test_merge_registry.py
@@ -1,0 +1,154 @@
+"""Unit tests for installer.core.merge.registry.
+
+Each test pins a coded dispatch decision in the merge registry (E.1):
+
+- A registered ``(kind, namespace)`` key resolves to its strategy.
+- ``NAMESPACED_MD`` dispatches BY namespace — ``"rules"`` and ``"commands"``
+  can map to different strategies.
+- Non-namespaced kinds (SETTINGS_JSON / JSONC / TOML / OTHER / DIR) IGNORE
+  the namespace component: registering under ``None`` resolves for any
+  namespace value passed at lookup time.
+- An unknown ``(kind, namespace)`` key raises a clear lookup error that is
+  NOT ``CollisionError`` (which is reserved for real file collisions).
+
+These pin the dispatch contract, not the stdlib dict that backs it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.merge.base import CollisionError, MergeStrategy
+from installer.core.merge.registry import MergeRegistry, UnknownMergeKeyError
+from installer.core.model import FileKind, Provenance, StagedItem
+
+
+class _DummyStrategy:
+    """Identity strategy with a label so tests can assert WHICH strategy
+    resolve() returned without comparing object identity alone."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def merge(
+        self,
+        existing: StagedItem,  # noqa: ARG002  # inert stub
+        incoming: StagedItem,
+    ) -> StagedItem:
+        return incoming
+
+
+def test_register_then_resolve_returns_the_registered_strategy() -> None:
+    reg = MergeRegistry()
+    strat = _DummyStrategy("toml")
+    reg.register(FileKind.TOML, None, strat)
+
+    assert reg.resolve(FileKind.TOML, None) is strat
+
+
+def test_namespaced_md_dispatches_by_namespace() -> None:
+    """The whole point of keying on (kind, namespace): the SAME FileKind
+    resolves to DIFFERENT strategies depending on the namespace."""
+    reg = MergeRegistry()
+    rules = _DummyStrategy("rules-append")
+    commands = _DummyStrategy("commands-fatal")
+    reg.register(FileKind.NAMESPACED_MD, "rules", rules)
+    reg.register(FileKind.NAMESPACED_MD, "commands", commands)
+
+    assert reg.resolve(FileKind.NAMESPACED_MD, "rules") is rules
+    assert reg.resolve(FileKind.NAMESPACED_MD, "commands") is commands
+
+
+def test_namespaced_md_distinct_namespaces_do_not_collide() -> None:
+    """Registering a second namespace must not overwrite the first —
+    guards against a FileKind-only key silently clobbering entries."""
+    reg = MergeRegistry()
+    rules = _DummyStrategy("rules")
+    commands = _DummyStrategy("commands")
+    reg.register(FileKind.NAMESPACED_MD, "rules", rules)
+    reg.register(FileKind.NAMESPACED_MD, "commands", commands)
+
+    assert reg.resolve(FileKind.NAMESPACED_MD, "rules").label == "rules"  # type: ignore[attr-defined]
+
+
+def test_non_namespaced_kind_ignores_namespace_on_register_and_resolve() -> None:
+    """For SETTINGS_JSON the namespace component is normalized to None:
+    a strategy registered under None resolves even when a (nonsense)
+    namespace is supplied at lookup time."""
+    reg = MergeRegistry()
+    strat = _DummyStrategy("json-union")
+    reg.register(FileKind.SETTINGS_JSON, None, strat)
+
+    assert reg.resolve(FileKind.SETTINGS_JSON, "anything") is strat
+    assert reg.resolve(FileKind.SETTINGS_JSON, None) is strat
+
+
+def test_non_namespaced_kind_register_with_namespace_is_normalized() -> None:
+    """Registering a non-namespaced kind WITH a namespace normalizes it to
+    None, so a later resolve without (or with any) namespace still hits."""
+    reg = MergeRegistry()
+    strat = _DummyStrategy("other")
+    reg.register(FileKind.OTHER, "spurious", strat)
+
+    assert reg.resolve(FileKind.OTHER, None) is strat
+    assert reg.resolve(FileKind.OTHER, "different") is strat
+
+
+def test_resolve_unknown_key_raises_unknown_merge_key_error() -> None:
+    reg = MergeRegistry()
+
+    with pytest.raises(UnknownMergeKeyError):
+        reg.resolve(FileKind.JSONC, None)
+
+
+def test_unknown_key_error_is_not_collision_error() -> None:
+    """A lookup miss is a programmer/wiring error, NOT a file collision.
+    Conflating the two would mislead operators, so the classes are distinct."""
+    reg = MergeRegistry()
+
+    with pytest.raises(UnknownMergeKeyError) as excinfo:
+        reg.resolve(FileKind.NAMESPACED_MD, "unregistered")
+
+    assert not isinstance(excinfo.value, CollisionError)
+
+
+def test_unknown_key_error_message_names_kind_and_namespace() -> None:
+    """The error must identify the missing (kind, namespace) so a wiring
+    gap is diagnosable from the message alone."""
+    reg = MergeRegistry()
+
+    with pytest.raises(UnknownMergeKeyError) as excinfo:
+        reg.resolve(FileKind.NAMESPACED_MD, "ghost")
+
+    text = str(excinfo.value)
+    assert FileKind.NAMESPACED_MD.value in text
+    assert "ghost" in text
+
+
+def test_resolved_strategy_is_usable_as_merge_strategy() -> None:
+    """End-to-end: what resolve() returns honours the MergeStrategy
+    contract — it can merge two colliding items."""
+    reg = MergeRegistry()
+    reg.register(FileKind.TOML, None, _DummyStrategy("toml"))
+
+    strategy: MergeStrategy = reg.resolve(FileKind.TOML, None)
+    existing = StagedItem(
+        source_path=Path("/a/x.toml"),
+        dest_relpath=Path("x.toml"),
+        kind=FileKind.TOML,
+        namespace=None,
+        provenance=Provenance(kind="tool", name="claude"),
+        content=b"a=1",
+    )
+    incoming = StagedItem(
+        source_path=Path("/b/x.toml"),
+        dest_relpath=Path("x.toml"),
+        kind=FileKind.TOML,
+        namespace=None,
+        provenance=Provenance(kind="plugin", name="beads"),
+        content=b"b=2",
+    )
+
+    assert strategy.merge(existing, incoming) is incoming

--- a/packages/installer/tests/unit/test_merge_registry_dispatch.py
+++ b/packages/installer/tests/unit/test_merge_registry_dispatch.py
@@ -1,0 +1,106 @@
+"""Integration tests for ``default_registry()`` — the concrete dispatch table.
+
+The mechanism (``MergeRegistry.register`` / ``resolve``) is unit-tested in
+``test_merge_registry``. THIS file pins the WIRING: which concrete strategy
+``default_registry()`` binds to each ``(FileKind, namespace)`` key. Each test
+asserts the resolved strategy TYPE, pinning a coded routing decision:
+
+- ``NAMESPACED_MD`` dispatches by namespace — ``"rules"`` append-merges while
+  ``"commands"`` / ``"skills"`` / ``"agents"`` are fatal (a coded asymmetry,
+  not an implementation accident).
+- Non-namespaced kinds ignore the namespace component.
+- A key the factory does NOT wire still raises ``UnknownMergeKeyError`` — the
+  factory adds bindings, it does not turn the registry permissive.
+
+These are routing assertions (resolve(key) -> expected type), not re-tests of
+the strategies' merge behaviour (covered per-strategy) nor of the registry's
+normalization mechanism (covered in test_merge_registry).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from installer.core.merge.registry import (
+    MergeRegistry,
+    UnknownMergeKeyError,
+    default_registry,
+)
+from installer.core.merge.strategies.append_rules import AppendRulesStrategy
+from installer.core.merge.strategies.fatal import FatalStrategy
+from installer.core.merge.strategies.json_union import JsonUnionStrategy
+from installer.core.merge.strategies.last_wins_silent import LastWinsSilentStrategy
+from installer.core.merge.strategies.last_wins_warn import LastWinsWarnStrategy
+from installer.core.model import FileKind
+
+
+def test_default_registry_returns_a_merge_registry() -> None:
+    """The factory hands back a populated MergeRegistry instance — callers
+    wire collision resolution off this, so the concrete type matters."""
+    assert isinstance(default_registry(), MergeRegistry)
+
+
+def test_rules_namespace_routes_to_append() -> None:
+    """rules/ collisions are additive — they must route to the append
+    strategy, never the fatal one (the load-bearing namespace asymmetry)."""
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.NAMESPACED_MD, "rules"), AppendRulesStrategy)
+
+
+@pytest.mark.parametrize("namespace", ["commands", "skills", "agents"])
+def test_non_rules_namespaces_route_to_fatal(namespace: str) -> None:
+    """commands/skills/agents collisions are irreconcilable — each must route
+    to FatalStrategy, distinct from the rules append route."""
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.NAMESPACED_MD, namespace), FatalStrategy)
+
+
+def test_rules_and_commands_resolve_to_different_strategies() -> None:
+    """Pins the dispatch-by-namespace contract end to end: the SAME kind
+    with two namespaces yields two DIFFERENT strategy types."""
+    reg = default_registry()
+    assert type(reg.resolve(FileKind.NAMESPACED_MD, "rules")) is not type(
+        reg.resolve(FileKind.NAMESPACED_MD, "commands")
+    )
+
+
+def test_settings_json_routes_to_json_union() -> None:
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.SETTINGS_JSON, None), JsonUnionStrategy)
+
+
+def test_jsonc_routes_to_last_wins_warn() -> None:
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.JSONC, None), LastWinsWarnStrategy)
+
+
+def test_toml_routes_to_last_wins_warn() -> None:
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.TOML, None), LastWinsWarnStrategy)
+
+
+def test_other_routes_to_last_wins_silent() -> None:
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.OTHER, None), LastWinsSilentStrategy)
+
+
+def test_dir_routes_to_fatal() -> None:
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.DIR, None), FatalStrategy)
+
+
+@pytest.mark.parametrize("namespace", [None, "ignored", "whatever"])
+def test_non_namespaced_kinds_ignore_namespace(namespace: str | None) -> None:
+    """SETTINGS_JSON is wired under None; the factory must rely on the
+    registry's normalization so any namespace at lookup still resolves."""
+    reg = default_registry()
+    assert isinstance(reg.resolve(FileKind.SETTINGS_JSON, namespace), JsonUnionStrategy)
+
+
+def test_unwired_namespaced_key_still_raises() -> None:
+    """The factory wires specific namespaces; an un-wired NAMESPACED_MD
+    namespace is a routing gap and must still raise — default_registry()
+    does not make the registry permissive."""
+    reg = default_registry()
+    with pytest.raises(UnknownMergeKeyError):
+        reg.resolve(FileKind.NAMESPACED_MD, "unwired_namespace")


### PR DESCRIPTION
## Summary

Implements **Epic E — the installer merge collision matrix** (`agents-config-w1qls.5`): the `MergeStrategy` protocol, a `(FileKind, namespace)`-keyed registry, and the five collision strategies. This is the Python port of `scripts/install.sh`'s collision dispatch (`install.sh:415-505`), replacing the bash `case`-statement.

**Scope:** new code only, all under `packages/installer/src/installer/core/merge/` + unit tests. No existing modules are modified. Single PR by design (cohesive subsystem); the strategies were implemented in parallel but reviewed and gated as one unit.

## What's built

| Story | Module | Behavior |
|-------|--------|----------|
| E.1 | `base.py`, `registry.py` | `MergeStrategy` protocol, `CollisionError`, `MergeRegistry` keyed on `(FileKind, namespace)` (NAMESPACED_MD dispatches by namespace; non-namespaced kinds normalize namespace to `None`); unknown key → `UnknownMergeKeyError` |
| E.2 | `strategies/append_rules.py` | `(NAMESPACED_MD, "rules")` → concat with `\n---\n` |
| E.3 | `strategies/fatal.py` | `(NAMESPACED_MD, commands/skills/agents)` + `DIR` → `CollisionError` naming both source paths |
| E.4 | `strategies/json_union.py` | `(SETTINGS_JSON)` → deep union; **byte-identical to `jq .`** (sorted constructed skeleton, insertion-order passthrough; jq total-order array union+dedupe; `[] | add` → null quirk reproduced) |
| E.5 | `strategies/last_wins_warn.py`, `last_wins_silent.py` | JSONC/TOML → warn + replace; OTHER → silent replace |

The concrete `(FileKind, namespace) → strategy` table is wired in `registry.py`'s `default_registry()`.

## Ground-truth references

- Behavioral contract: `scripts/install.sh` — collision matrix `415-478`, `classify_file` `486-505`, jq union program `431-456`.
- Design: `docs/architecture/installer/installer-design.md` (Epic E, lines ~65-73, 103-110, 164, 178-181).
- json_union parity was verified empirically byte-for-byte against real `jq-1.8.1` on the production `src/user/.claude/settings.json.template`.

## Test plan

- [x] `make ci-installer` green: ruff, ruff format --check, **mypy --strict** (26 files), pytest, pip-audit, entry-verify
- [x] **258 tests pass**, total coverage 99.88%; **merge package 100% line + branch**
- [x] Behavioral tests only (each pins a coded decision; tautology-screened per package `AGENTS.md`)
- [x] Adversarial review per strategy (caught + fixed a real `json.dumps(sort_keys=True)` parity defect in E.4 before commit)
- [x] `quality-reviewer` pass: approve_with_nits; all findings triaged

## Intentionally out of scope (design-forward)

Surfacing the strategies' side-channels through the engine's `IOPort` belongs to the **consumer** that wires `merge()` into staging (a later story), not to the pure strategy modules — filed as `agents-config-h4015`:
- `last_wins_warn` emits via stdlib `warnings.warn` (the merge signature carries no `IOPort`); the staging consumer must capture + re-emit via `IOPort.warn`.
- `UnknownMergeKeyError` from an un-wired namespace should be surfaced by the caller as an actionable fatal install error.

The json_union number-literal note (jq preserves lexemes like `1e3`; this port canonicalizes to `1000.0`) is **documented, not fixed** — no `settings.json` source carries non-canonical number literals, and the golden-master suite is the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
