### PR TITLE
feat(installer): F.1 — plugin protocol, registry, and test-plugin fixture (w1qls.6.1)

### DIFF
--- a/docs/plans/2026-06-07-w1qls.6.1-plugin-registry.md
+++ b/docs/plans/2026-06-07-w1qls.6.1-plugin-registry.md
@@ -49,10 +49,18 @@ class PluginAdapter(Protocol):
     concerns on a future specialized adapter. They are added to this protocol
     additively when a consumer exists."""
 
-    name: str
+    # Read-only members (declared as properties) so a frozen dataclass adapter
+    # — `GenericPluginAdapter`, and any future specialized adapter — structurally
+    # satisfies this protocol. A plain `name: str` annotation is a *settable*
+    # protocol member, which a `frozen=True` dataclass cannot match under
+    # mypy --strict ("expected settable variable, got read-only attribute").
+    @property
+    def name(self) -> str: ...  # pragma: no cover
+
     # Absolute path to the plugin's source tree, set by the registry at
     # discovery time (e.g. `<repo>/src/plugins/beads`).
-    source_path: Path
+    @property
+    def source_path(self) -> Path: ...  # pragma: no cover
 
     def is_detected(self, home: Path) -> bool: ...  # pragma: no cover
 ```

--- a/docs/plans/2026-06-07-w1qls.6.1-plugin-registry.md
+++ b/docs/plans/2026-06-07-w1qls.6.1-plugin-registry.md
@@ -1,0 +1,666 @@
+# F.1 — Plugin protocol, registry, and test-plugin fixture — Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add plugin support scaffolding to the Python installer — a `PluginAdapter` protocol, a string-keyed registry that discovers plugins dynamically, the `--plugins=` selection-resolution policy, and a synthetic `test-plugin` source fixture.
+
+**Architecture:** A new `src/installer/plugins/` package mirrors `tools/`: `base.py` holds the protocol, `generic.py` the convention-detected default adapter, `registry.py` the dynamic `discover()`. Selection-resolution policy (`resolve_plugins`) lives in `config.py` beside `resolve_tools`. Plugins auto-detect on a home footprint (`~/.<name>/`); specialization (beads, F.4) attaches via a name→factory map that is empty here.
+
+**Tech Stack:** Python ≥3.11, `typing.Protocol` (`@runtime_checkable`), frozen dataclasses, `pytest`, mypy `--strict`, ruff (line-length 100), 90% branch coverage.
+
+All paths below are relative to `packages/installer/`. Commands run from the repo root unless noted. Spec: `docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md`.
+
+---
+
+### Task 1: `plugins/` package + `PluginAdapter` protocol
+
+**Files:**
+- Create: `packages/installer/src/installer/plugins/__init__.py`
+- Create: `packages/installer/src/installer/plugins/base.py`
+
+No unit test: a `...`-bodied `Protocol` has no behaviour to pin — asserting its existence or `@runtime_checkable` machinery is a tautology (see the `writing-unit-tests` tautology filter and the absence of a `tools/base.py` test). The protocol is exercised structurally by Tasks 2, 4, 5.
+
+- [ ] **Step 1: Create the empty package marker**
+
+`packages/installer/src/installer/plugins/__init__.py` — empty file (mirrors `tools/__init__.py`, which is empty).
+
+- [ ] **Step 2: Write the protocol**
+
+`packages/installer/src/installer/plugins/base.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PluginAdapter(Protocol):
+    """Plugin-specific behaviour the engine consults. Unlike `ToolAdapter`,
+    plugins are not enumerated — they are discovered by scanning a plugins
+    root and registered by name string, so the registry knows each plugin's
+    source directory at discovery time and the adapter carries it as
+    `source_path` rather than reconstructing it from `repo_root`.
+
+    F.1 needs exactly these three members. Namespace routing, destinations,
+    and chmod are out of scope: the F.2 overlay reuses the *tool* adapter's
+    namespace rules, and beads' `~/.beads/` destination + `chmod +x` are F.4
+    concerns on a future specialized adapter. They are added to this protocol
+    additively when a consumer exists."""
+
+    name: str
+    # Absolute path to the plugin's source tree, set by the registry at
+    # discovery time (e.g. `<repo>/src/plugins/beads`).
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool: ...  # pragma: no cover
+```
+
+The `# pragma: no cover` is load-bearing: with `--cov-branch`, coverage.py counts the inter-declaration branch on a `...`-bodied Protocol method (per `packages/installer/AGENTS.md`).
+
+- [ ] **Step 3: Verify types and lint**
+
+Run: `cd packages/installer && uv run mypy --strict src/installer/plugins/base.py && uv run ruff check src/installer/plugins/`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/installer/src/installer/plugins/
+git commit -m "feat(installer): F.1 PluginAdapter protocol (w1qls.6.1)"
+```
+
+---
+
+### Task 2: `GenericPluginAdapter` — convention-based detection
+
+**Files:**
+- Create: `packages/installer/src/installer/plugins/generic.py`
+- Test: `packages/installer/tests/unit/test_plugins_generic.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`packages/installer/tests/unit/test_plugins_generic.py`:
+
+```python
+"""Unit tests for installer.plugins.generic.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md). Tests for
+dataclass/frozen/slots machinery and pathlib semantics are deliberately
+absent — they test stdlib, not coded decisions. See the writing-unit-tests
+tautology filter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.plugins.generic import GenericPluginAdapter
+
+
+def test_is_detected_true_when_home_footprint_directory_exists(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home directory containing a directory named `.myplugin`
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns True.
+
+    Pins: the home-footprint auto-detect convention `~/.<name>/`.
+    """
+    (tmp_path / ".myplugin").mkdir()
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is True
+
+
+def test_is_detected_false_when_home_footprint_absent(tmp_path: Path) -> None:
+    """
+    Given an empty home directory
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns False.
+    """
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is False
+
+
+def test_is_detected_false_when_footprint_is_a_file_not_a_directory(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home directory containing a *file* named `.myplugin`
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns False.
+
+    Pins: the convention is `.is_dir()`, not `.exists()` — a config footprint
+    is a directory, and a same-named stray file must not trip detection.
+    """
+    (tmp_path / ".myplugin").write_text("not a directory")
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_plugins_generic.py -q`
+Expected: collection/import error — `ModuleNotFoundError: installer.plugins.generic`.
+
+- [ ] **Step 3: Write the implementation**
+
+`packages/installer/src/installer/plugins/generic.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class GenericPluginAdapter:
+    """Default `PluginAdapter` for a discovered plugin with no specialized
+    class. Auto-detects on its home footprint: `~/.<name>/` present as a
+    directory. A specialized adapter (e.g. beads in F.4) overrides
+    `is_detected` to add probes the generic convention cannot express, such
+    as `shutil.which("bd")`."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / f".{self.name}").is_dir()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_plugins_generic.py -q`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/plugins/generic.py packages/installer/tests/unit/test_plugins_generic.py
+git commit -m "feat(installer): F.1 GenericPluginAdapter convention detection (w1qls.6.1)"
+```
+
+---
+
+### Task 3: `test-plugin` source fixture
+
+**Files:**
+- Create: `packages/installer/tests/fixtures/sources/test-plugin/.agents/skills/test-plugin-skill/SKILL.md`
+- Create: `packages/installer/tests/fixtures/sources/test-plugin/.claude/rules/test-plugin-rule.md`
+- Create: `packages/installer/tests/fixtures/sources/test-plugin/.claude/commands/test-plugin-command.md`
+- Create: `packages/installer/tests/fixtures/sources/test-plugin/.claude/settings.json.template`
+
+No standalone test; the fixture's discoverability is asserted in Task 4. The four files cover one item per collision class so downstream stories (F.2 overlay, F.3 carrier-merge, F.5 extensions) need not retrofit it.
+
+- [ ] **Step 1: Create the shared skill (`.agents/` scope)**
+
+`.../test-plugin/.agents/skills/test-plugin-skill/SKILL.md`:
+
+```markdown
+---
+name: test-plugin-skill
+description: Synthetic skill shipped by the test-plugin fixture for installer plugin-overlay exercise.
+---
+
+# test-plugin-skill
+
+Canonical shared-scope skill used by installer plugin-overlay tests. Installed
+to every active tool.
+```
+
+- [ ] **Step 2: Create the rule (append-merge collision class)**
+
+`.../test-plugin/.claude/rules/test-plugin-rule.md`:
+
+```markdown
+# test-plugin-rule
+
+Synthetic rule contributed by the test-plugin fixture. Exercises the
+append-merge collision class — `rules/*.md` joined with a `\n---\n` separator.
+```
+
+- [ ] **Step 3: Create the command (fatal-collision class)**
+
+`.../test-plugin/.claude/commands/test-plugin-command.md`:
+
+```markdown
+---
+description: Synthetic command from the test-plugin fixture (fatal-collision namespace).
+---
+
+# /test-plugin-command
+
+Canonical command-namespace entry used by installer collision-matrix tests.
+```
+
+- [ ] **Step 4: Create the settings template (json-union collision class)**
+
+`.../test-plugin/.claude/settings.json.template`:
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(test-plugin:*)"]
+  }
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/tests/fixtures/sources/test-plugin/
+git commit -m "test(installer): F.1 canonical test-plugin source fixture (w1qls.6.1)"
+```
+
+---
+
+### Task 4: `registry.discover()` + `UnknownPluginError`
+
+**Files:**
+- Create: `packages/installer/src/installer/plugins/registry.py`
+- Test: `packages/installer/tests/unit/test_plugins_registry.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`packages/installer/tests/unit/test_plugins_registry.py`:
+
+```python
+"""Unit tests for installer.plugins.registry.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md). isinstance /
+@runtime_checkable machinery and attribute-literal assertions are
+deliberately absent — see the writing-unit-tests tautology filter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from installer.plugins.registry import UnknownPluginError, discover
+
+_SOURCES = Path(__file__).parents[1] / "fixtures" / "sources"
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSpecialized:
+    """Stand-in for a future specialized adapter (e.g. beads, F.4). Same
+    construction shape as GenericPluginAdapter: (name, source_path)."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:  # pragma: no cover
+        return True
+
+
+def test_discover_finds_the_canonical_test_plugin_fixture() -> None:
+    """
+    Given the committed tests/fixtures/sources/ tree
+    When discover() scans it
+    Then `test-plugin` is discovered with source_path pointing at its dir.
+
+    Pins: the canonical exercise fixture exists and is discoverable.
+    """
+    discovered = discover(_SOURCES)
+    assert "test-plugin" in discovered
+    assert discovered["test-plugin"].source_path == _SOURCES / "test-plugin"
+
+
+def test_discover_returns_only_plugin_directories(tmp_path: Path) -> None:
+    """
+    Given a plugins root with a plugin dir, a loose file, a dot-dir, and an
+    underscore-dir
+    When discover() scans it
+    Then only the plain plugin directory is returned.
+
+    Pins: discovery scans direct subdirectories, skipping non-directory
+    entries (e.g. AGENTS.md) and `.`/`_`-prefixed directories.
+    """
+    (tmp_path / "myplugin").mkdir()
+    (tmp_path / "notes.md").write_text("loose file")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / "_scratch").mkdir()
+    discovered = discover(tmp_path)
+    assert set(discovered) == {"myplugin"}
+    assert discovered["myplugin"].source_path == tmp_path / "myplugin"
+
+
+def test_discover_dispatches_to_specialized_class_when_registered(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a plugin name present in the injected `specialized` map
+    When discover() builds its adapter
+    Then the adapter is an instance of the specialized class, not the generic.
+
+    Pins: the name->factory dispatch that F.4 uses to register BeadsAdapter.
+    """
+    (tmp_path / "beads").mkdir()
+    discovered = discover(tmp_path, specialized={"beads": _FakeSpecialized})
+    assert type(discovered["beads"]) is _FakeSpecialized
+
+
+def test_unknown_plugin_error_exposes_structured_attributes() -> None:
+    """
+    When UnknownPluginError("gamma", ("alpha", "beta")) is constructed
+    Then .name == "gamma" and .valid == ("alpha", "beta").
+
+    Pins: structured-exception contract — callers assert on data, not the
+    message string (mirrors UnknownToolError).
+    """
+    err = UnknownPluginError("gamma", ("alpha", "beta"))
+    assert err.name == "gamma"
+    assert err.valid == ("alpha", "beta")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_plugins_registry.py -q`
+Expected: import error — `cannot import name 'discover' from 'installer.plugins.registry'`.
+
+- [ ] **Step 3: Write the implementation**
+
+`packages/installer/src/installer/plugins/registry.py`:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+from installer.plugins.base import PluginAdapter
+from installer.plugins.generic import GenericPluginAdapter
+
+# name -> factory for plugins needing behaviour the generic adapter cannot
+# express. Empty in F.1; beads registers its specialized adapter here in F.4.
+# A factory is `(name, source_path) -> PluginAdapter` — a concrete class whose
+# __init__ matches that shape satisfies it (typing it as `type[PluginAdapter]`
+# would wrongly imply instantiating the Protocol).
+_SPECIALIZED: dict[str, Callable[[str, Path], PluginAdapter]] = {}
+
+
+class UnknownPluginError(ValueError):
+    """Raised when a `--plugins=` element names a plugin absent from the
+    discovered set. Structured attrs (.name, .valid) so callers and tests
+    assert on data, not the message string."""
+
+    def __init__(self, name: str, valid: tuple[str, ...]) -> None:
+        super().__init__(f"Unknown plugin: {name!r} (valid: {', '.join(valid)})")
+        self.name = name
+        self.valid = valid
+
+
+def discover(
+    plugins_root: Path,
+    *,
+    specialized: Mapping[str, Callable[[str, Path], PluginAdapter]] = _SPECIALIZED,
+) -> dict[str, PluginAdapter]:
+    """Discover plugins by scanning the direct subdirectories of
+    `plugins_root`. Non-directory entries (e.g. `AGENTS.md`) and `.`/`_`-
+    prefixed directories are skipped. Each plugin gets a `GenericPluginAdapter`
+    unless its name is in `specialized`. Returns a name-keyed mapping; entries
+    are sorted by name for deterministic downstream ordering."""
+    discovered: dict[str, PluginAdapter] = {}
+    for entry in sorted(plugins_root.iterdir()):
+        name = entry.name
+        if not entry.is_dir() or name.startswith((".", "_")):
+            continue
+        factory: Callable[[str, Path], PluginAdapter] = specialized.get(
+            name, GenericPluginAdapter
+        )
+        discovered[name] = factory(name, entry)
+    return discovered
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_plugins_registry.py -q`
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/plugins/registry.py packages/installer/tests/unit/test_plugins_registry.py
+git commit -m "feat(installer): F.1 plugin registry discover() (w1qls.6.1)"
+```
+
+---
+
+### Task 5: `config.resolve_plugins()` — `--plugins=` resolution
+
+**Files:**
+- Modify: `packages/installer/src/installer/config.py` (add `resolve_plugins`; add imports)
+- Test: `packages/installer/tests/unit/test_config_plugins.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+`packages/installer/tests/unit/test_config_plugins.py`:
+
+```python
+"""Unit tests for installer.config.resolve_plugins.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.config import resolve_plugins
+from installer.plugins.registry import UnknownPluginError
+
+
+def _sources_with_two_plugins(tmp_path: Path) -> Path:
+    """A plugins root containing two discoverable plugin dirs: alpha, beta."""
+    root = tmp_path / "plugins"
+    (root / "alpha").mkdir(parents=True)
+    (root / "beta").mkdir()
+    return root
+
+
+def _names(adapters: tuple[object, ...]) -> tuple[str, ...]:
+    return tuple(a.name for a in adapters)  # type: ignore[attr-defined]
+
+
+def test_autodetect_includes_only_plugins_with_a_home_footprint(
+    tmp_path: Path,
+) -> None:
+    """
+    Given alpha has a home footprint (~/.alpha) and beta does not
+    When resolve_plugins(override_csv=None) is called
+    Then only alpha is resolved.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    (home / ".alpha").mkdir(parents=True)
+    result = resolve_plugins(home=home, plugins_root=root, override_csv=None)
+    assert _names(result) == ("alpha",)
+
+
+def test_autodetect_empty_when_no_footprints(tmp_path: Path) -> None:
+    """
+    Given no plugin has a home footprint
+    When resolve_plugins(override_csv=None) is called
+    Then the result is empty.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    assert resolve_plugins(home=home, plugins_root=root, override_csv=None) == ()
+
+
+def test_empty_override_installs_no_plugins(tmp_path: Path) -> None:
+    """
+    Given an empty --plugins= value (and a whitespace-only value)
+    When resolve_plugins is called
+    Then the result is empty — the deliberate asymmetry with resolve_tools,
+    which raises on empty --tools= (install.sh:298-300).
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    assert resolve_plugins(home=home, plugins_root=root, override_csv="") == ()
+    assert resolve_plugins(home=home, plugins_root=root, override_csv="   ") == ()
+
+
+def test_explicit_override_selects_named_plugins_in_order(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="beta,alpha") is called
+    Then the result preserves the user-supplied order (beta, alpha),
+    independent of any home footprint.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    result = resolve_plugins(home=home, plugins_root=root, override_csv="beta,alpha")
+    assert _names(result) == ("beta", "alpha")
+
+
+def test_explicit_override_dedupes_preserving_first_occurrence(
+    tmp_path: Path,
+) -> None:
+    """
+    When resolve_plugins(override_csv="alpha, beta ,alpha") is called
+    Then duplicates collapse to first occurrence and whitespace is stripped.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    result = resolve_plugins(
+        home=home, plugins_root=root, override_csv="alpha, beta ,alpha"
+    )
+    assert _names(result) == ("alpha", "beta")
+
+
+def test_unknown_plugin_name_raises_with_valid_set(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="gamma") names an undiscovered plugin
+    Then UnknownPluginError is raised with .name and the sorted .valid set.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    with pytest.raises(UnknownPluginError) as exc:
+        resolve_plugins(home=home, plugins_root=root, override_csv="gamma")
+    assert exc.value.name == "gamma"
+    assert exc.value.valid == ("alpha", "beta")
+
+
+def test_stray_empty_element_raises_value_error(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="alpha,,beta") contains a stray empty
+    element among real names
+    Then ValueError is raised (mirrors resolve_tools' stray-comma guard).
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    with pytest.raises(ValueError):
+        resolve_plugins(home=home, plugins_root=root, override_csv="alpha,,beta")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_config_plugins.py -q`
+Expected: import error — `cannot import name 'resolve_plugins' from 'installer.config'`.
+
+- [ ] **Step 3: Add the implementation to `config.py`**
+
+Add these imports to the top of `packages/installer/src/installer/config.py` (alongside the existing imports):
+
+```python
+from installer.plugins.base import PluginAdapter
+from installer.plugins.registry import UnknownPluginError, discover
+```
+
+Append this function to `packages/installer/src/installer/config.py`:
+
+```python
+def resolve_plugins(
+    *, home: Path, plugins_root: Path, override_csv: str | None
+) -> tuple[PluginAdapter, ...]:
+    """Translate the `--plugins=` CLI value into the resolved plugin tuple.
+
+    - `override_csv is None` -> auto-detect: discovered adapters whose
+      `is_detected(home)` is True.
+    - `override_csv == ""` (or whitespace-only) -> () (install no plugins).
+      Deliberate asymmetry with `resolve_tools`, which raises on empty
+      `--tools=`: "no plugins" is a valid choice, "no tools" is a no-op error.
+      Matches scripts/install.sh:298-300 (PLUGINS_FLAG_SET + empty value).
+    - Otherwise -> split on commas, strip whitespace, validate each via the
+      discovered set, dedupe preserving first occurrence, preserve order.
+    """
+    discovered = discover(plugins_root)
+
+    if override_csv is None:
+        return tuple(a for a in discovered.values() if a.is_detected(home))
+
+    if override_csv.strip() == "":
+        return ()
+
+    valid = tuple(discovered.keys())
+    seen: dict[str, None] = {}
+    for raw in override_csv.split(","):
+        name = raw.strip()
+        if not name:
+            raise ValueError("--plugins= contains an empty plugin name (check for stray commas)")  # noqa: TRY003  # single call-site; subclass not justified
+        if name not in discovered:
+            raise UnknownPluginError(name, valid)
+        seen.setdefault(name, None)
+    return tuple(discovered[name] for name in seen)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_config_plugins.py -q`
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/config.py packages/installer/tests/unit/test_config_plugins.py
+git commit -m "feat(installer): F.1 resolve_plugins --plugins= resolution (w1qls.6.1)"
+```
+
+---
+
+### Task 6: Full quality gate
+
+**Files:** none (verification only — no new code expected).
+
+- [ ] **Step 1: Run the canonical gate**
+
+Run: `make ci-installer` (from repo root).
+Expected: ruff check, ruff format --check, mypy --strict, pytest --cov (≥90% branch), pip-audit, and `install.py --help` all pass.
+
+- [ ] **Step 2: Fix any gate findings**
+
+If `ruff format --check` reports diffs, run `cd packages/installer && uv run ruff format` and re-stage. If coverage on the new modules is below 90% branch, inspect `--cov-report=term-missing` for the uncovered branch and add the pinning test (do not lower the floor). Re-run the gate until green.
+
+- [ ] **Step 3: Final commit (only if Step 2 changed anything)**
+
+```bash
+git add -A
+git commit -m "chore(installer): F.1 gate fixups (w1qls.6.1)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- `PluginAdapter` protocol → Task 1.
+- `GenericPluginAdapter` convention detection (`.is_dir()`) → Task 2.
+- `discover()` (subdirs only, skip non-dir/dot/underscore, specialized dispatch) → Task 4.
+- `resolve_plugins` (auto-detect / empty-means-none / CSV select+dedupe / unknown / stray-empty) → Task 5.
+- `UnknownPluginError` structured attrs → Task 4.
+- `test-plugin` fixture (one item per collision class) → Task 3; discoverability asserted in Task 4.
+- The `resolve_tools` asymmetry, documented inline → Task 5, Step 3.
+- 90% branch / mypy strict / ruff → Task 6.
+
+**Placeholder scan:** none — every code step shows complete code.
+
+**Type consistency:** `discover(plugins_root, *, specialized=…) -> dict[str, PluginAdapter]`, `GenericPluginAdapter(name, source_path)`, `UnknownPluginError(name, valid)`, `resolve_plugins(*, home, plugins_root, override_csv) -> tuple[PluginAdapter, ...]` — names and signatures are identical across the plan and the spec. The specialized-factory type `Callable[[str, Path], PluginAdapter]` matches both `GenericPluginAdapter` and the `_FakeSpecialized` test double's `(name, source_path)` shape.

--- a/docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md
+++ b/docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md
@@ -1,0 +1,166 @@
+# F.1 — Plugin protocol, registry, and test-plugin fixture
+
+**Story:** w1qls.6.1 (Epic F — Plugins) · **Status:** design approved
+**Parent design:** `docs/architecture/installer/installer-design.md` (Epic F)
+
+## Purpose
+
+Establish the foundation for plugin support in the Python installer: a
+`PluginAdapter` protocol, a string-keyed registry that discovers plugins
+dynamically, the selection-resolution policy honouring `--plugins=`, and a
+synthetic `test-plugin` source fixture that downstream stories (overlay,
+carrier-merge, extensions) exercise against.
+
+This story stops at "plugins are discovered, detected, and resolved — and it is
+tested." It does **not** install plugin content; that is the F.2 overlay.
+
+## Why plugins differ from tools
+
+Tools are a closed set (`Tool` enum) with fixed source locations and rich
+per-tool namespace rules; one hand-written adapter per tool, registered in a
+`Tool`-keyed map. Plugins are open-ended: they are discovered by scanning a
+plugins root, registered by name string, and an installer should gain a plugin
+by dropping a directory under `src/plugins/`, not by editing `model.py`. Per
+the parent design's "Data model highlights", plugin origin is tracked via
+`Provenance(kind="plugin", name=…)`; F.1 introduces no new model types.
+
+## Module layout
+
+```
+src/installer/plugins/
+├── __init__.py
+├── base.py        PluginAdapter protocol  (protocol-only, mirrors tools/base.py)
+├── generic.py     GenericPluginAdapter    (convention-detected default)
+└── registry.py    discover() + UnknownPluginError + _SPECIALIZED map
+```
+
+`resolve_plugins()` is added to `config.py`, sibling to the existing
+`resolve_tools()`, so selection-resolution policy for both tools and plugins
+lives in one place. The fixture lives at `tests/fixtures/sources/test-plugin/`.
+
+## `PluginAdapter` protocol
+
+Three members — the minimum F.1 needs. The overlay (F.2) and beads' bespoke
+destination (F.4) extend the protocol additively when they have a consumer.
+
+```python
+@runtime_checkable
+class PluginAdapter(Protocol):
+    name: str
+    source_path: Path                       # absolute; set by the registry at discovery
+    def is_detected(self, home: Path) -> bool: ...
+```
+
+`source_path` is an attribute, not a `source_dir(repo_root)` method (as on
+`ToolAdapter`), because discovery already knows the exact directory — the
+adapter carries it rather than reconstructing it. Namespace routing,
+destinations, and `chmod` are deliberately absent: the overlay reuses the
+*tool* adapter's namespace rules, and `~/.beads/` + `chmod +x` are F.4 concerns
+on a future `BeadsAdapter`.
+
+## `GenericPluginAdapter` — convention-based detection
+
+```python
+@dataclass(frozen=True, slots=True)
+class GenericPluginAdapter:
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / f".{self.name}").is_dir()
+```
+
+A discovered plugin auto-detects on its home footprint — `~/.<name>/` exists as
+a directory (`~/.beads`, `~/.test-plugin`). `.is_dir()` (not `.exists()`)
+because a plugin's footprint is a config directory, and a same-named stray file
+should not trip detection. `beads.py` (F.4) overrides `is_detected` to *also*
+check `shutil.which("bd")`; that PATH probe is beads-specific and does not
+belong in the generic convention.
+
+## `registry.discover()`
+
+```python
+_SPECIALIZED: dict[str, type[PluginAdapter]] = {}   # beads registers here in F.4
+
+def discover(plugins_root: Path, *, specialized=_SPECIALIZED) -> dict[str, PluginAdapter]:
+    ...
+```
+
+- Scans **direct subdirectories** of `plugins_root`. Skips non-directory
+  entries (e.g. `src/plugins/AGENTS.md`) and names beginning with `.` or `_`.
+- For each plugin directory, builds a `GenericPluginAdapter(name, dir)` unless
+  `name` is in `specialized`, in which case it constructs the specialized class
+  with the same `(name, source_path)` shape.
+- Returns a `dict[str, PluginAdapter]` keyed by plugin name.
+
+The injectable `specialized=` parameter lets a unit test exercise the
+specialized-dispatch branch without waiting for F.4's `BeadsAdapter`, keeping
+the 90% branch-coverage gate honest. Real runs pass `repo_root/src/plugins`;
+tests pass `tests/fixtures/sources/`.
+
+## `config.resolve_plugins()`
+
+```python
+def resolve_plugins(
+    *, home: Path, plugins_root: Path, override_csv: str | None
+) -> tuple[PluginAdapter, ...]:
+    ...
+```
+
+| `override_csv`            | Behaviour                                                              |
+|---------------------------|-----------------------------------------------------------------------|
+| `None` (flag absent)      | Auto-detect: discovered adapters where `is_detected(home)` is `True`.  |
+| `""` / whitespace-only    | Empty tuple — install no plugins.                                     |
+| CSV of names              | Split, strip, validate each against discovered names, dedupe (first occurrence wins), preserve order. |
+
+Validation raises `UnknownPluginError(name, valid)` — structured `.name` /
+`.valid` attributes so callers and tests assert on data, not message strings
+(mirrors `UnknownToolError`). A genuinely empty element among others (e.g.
+`"a,,b"`) raises; an all-empty value means "no plugins" and does not.
+
+### Deliberate asymmetry with `resolve_tools`
+
+`resolve_tools` raises on an empty `--tools=`; `resolve_plugins` treats an empty
+`--plugins=` as "install no plugins." This matches `scripts/install.sh:298-300`
+(`PLUGINS_FLAG_SET` set with an empty value yields zero plugins). The asymmetry
+is correct: "install no tools" is a no-op error, whereas "install no plugins"
+is a valid, common choice. Documented inline at the call site.
+
+## `test-plugin` fixture
+
+The canonical exercise plugin, built with one item per collision class so
+downstream stories need not retrofit it:
+
+```
+tests/fixtures/sources/test-plugin/
+├── .agents/skills/test-plugin-skill/SKILL.md   shared → installed to all active tools
+└── .claude/
+    ├── rules/test-plugin-rule.md               append-merge collision class
+    ├── commands/test-plugin-command.md         fatal-collision class
+    └── settings.json.template                  json-union collision class
+```
+
+Content is minimal and self-describing; collision *behaviour* is asserted by
+the F.2 overlay tests, not by this fixture's mere existence.
+
+## Test plan
+
+Each test pins a coded decision (not language/stdlib behaviour):
+
+- **discovery** — finds `test-plugin` under `tests/fixtures/sources/`; skips the
+  non-directory `AGENTS.md` sibling and `.`/`_`-prefixed directories; dispatches
+  to a specialized class when one is injected via `specialized=`.
+- **detection** — `GenericPluginAdapter.is_detected` is `True` only when
+  `home/.<name>/` exists as a directory; `False` for absent and for a same-named
+  file.
+- **resolution** — auto-detect includes only detected plugins; `--plugins=`
+  empty yields none; an explicit CSV selects and dedupes preserving order; an
+  unknown name raises `UnknownPluginError` carrying `.name`/`.valid`; a stray
+  empty element raises.
+
+## Scope boundaries (explicitly out of F.1)
+
+- No `--plugins` CLI flag wiring — there is no consumer until the F.2 overlay;
+  wiring it to discard the result would be dead code.
+- No `Config.plugins` field — added when a consumer (overlay) needs it.
+- No plugin overlay, no `beads.py`, no destination or `chmod` logic.

--- a/docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md
+++ b/docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md
@@ -46,8 +46,13 @@ destination (F.4) extend the protocol additively when they have a consumer.
 ```python
 @runtime_checkable
 class PluginAdapter(Protocol):
-    name: str
-    source_path: Path                       # absolute; set by the registry at discovery
+    # Read-only members (properties) so a frozen dataclass adapter satisfies
+    # the protocol under mypy --strict (a plain `name: str` is a settable
+    # member a frozen field cannot match).
+    @property
+    def name(self) -> str: ...
+    @property
+    def source_path(self) -> Path: ...      # absolute; set by the registry at discovery
     def is_detected(self, home: Path) -> bool: ...
 ```
 
@@ -80,9 +85,15 @@ belong in the generic convention.
 ## `registry.discover()`
 
 ```python
-_SPECIALIZED: dict[str, type[PluginAdapter]] = {}   # beads registers here in F.4
+# name -> factory `(name, source_path) -> PluginAdapter`. Typed as a Callable,
+# not `type[PluginAdapter]`, which would wrongly imply instantiating the Protocol.
+_SPECIALIZED: dict[str, Callable[[str, Path], PluginAdapter]] = {}   # beads registers here in F.4
 
-def discover(plugins_root: Path, *, specialized=_SPECIALIZED) -> dict[str, PluginAdapter]:
+def discover(
+    plugins_root: Path,
+    *,
+    specialized: Mapping[str, Callable[[str, Path], PluginAdapter]] = _SPECIALIZED,
+) -> dict[str, PluginAdapter]:
     ...
 ```
 

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -55,7 +55,8 @@ def resolve_plugins(
     - `override_csv == ""` (or whitespace-only) -> () (install no plugins).
       Deliberate asymmetry with `resolve_tools`, which raises on empty
       `--tools=`: "no plugins" is a valid choice, "no tools" is a no-op error.
-      Matches scripts/install.sh:298-300 (PLUGINS_FLAG_SET + empty value).
+      Matches scripts/install.sh's plugin-detection block, where a set
+      `--plugins=` flag with an empty value yields no plugins.
     - Otherwise -> split on commas, strip whitespace, validate each via the
       discovered set, dedupe preserving first occurrence, preserve order.
     """

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from installer.core.model import Tool
+from installer.plugins.base import PluginAdapter
+from installer.plugins.registry import UnknownPluginError, discover
 from installer.tools.registry import get_adapter, known_tools, parse_tool_name
 
 
@@ -41,3 +43,37 @@ def resolve_tools(*, home: Path, override_csv: str | None) -> tuple[Tool, ...]:
         tool = parse_tool_name(name)
         seen.setdefault(tool, None)
     return tuple(seen.keys())
+
+
+def resolve_plugins(
+    *, home: Path, plugins_root: Path, override_csv: str | None
+) -> tuple[PluginAdapter, ...]:
+    """Translate the `--plugins=` CLI value into the resolved plugin tuple.
+
+    - `override_csv is None` -> auto-detect: discovered adapters whose
+      `is_detected(home)` is True.
+    - `override_csv == ""` (or whitespace-only) -> () (install no plugins).
+      Deliberate asymmetry with `resolve_tools`, which raises on empty
+      `--tools=`: "no plugins" is a valid choice, "no tools" is a no-op error.
+      Matches scripts/install.sh:298-300 (PLUGINS_FLAG_SET + empty value).
+    - Otherwise -> split on commas, strip whitespace, validate each via the
+      discovered set, dedupe preserving first occurrence, preserve order.
+    """
+    discovered = discover(plugins_root)
+
+    if override_csv is None:
+        return tuple(a for a in discovered.values() if a.is_detected(home))
+
+    if override_csv.strip() == "":
+        return ()
+
+    valid = tuple(discovered.keys())
+    seen: dict[str, None] = {}
+    for raw in override_csv.split(","):
+        name = raw.strip()
+        if not name:
+            raise ValueError("--plugins= contains an empty plugin name (check for stray commas)")  # noqa: TRY003  # single call-site; subclass not justified
+        if name not in discovered:
+            raise UnknownPluginError(name, valid)
+        seen.setdefault(name, None)
+    return tuple(discovered[name] for name in seen)

--- a/packages/installer/src/installer/plugins/base.py
+++ b/packages/installer/src/installer/plugins/base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class PluginAdapter(Protocol):
+    """Plugin-specific behaviour the engine consults. Unlike `ToolAdapter`,
+    plugins are not enumerated — they are discovered by scanning a plugins
+    root and registered by name string, so the registry knows each plugin's
+    source directory at discovery time and the adapter carries it as
+    `source_path` rather than reconstructing it from `repo_root`.
+
+    F.1 needs exactly these three members. Namespace routing, destinations,
+    and chmod are out of scope: the F.2 overlay reuses the *tool* adapter's
+    namespace rules, and beads' `~/.beads/` destination + `chmod +x` are F.4
+    concerns on a future specialized adapter. They are added to this protocol
+    additively when a consumer exists."""
+
+    name: str
+    # Absolute path to the plugin's source tree, set by the registry at
+    # discovery time (e.g. `<repo>/src/plugins/beads`).
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool: ...  # pragma: no cover

--- a/packages/installer/src/installer/plugins/base.py
+++ b/packages/installer/src/installer/plugins/base.py
@@ -18,9 +18,17 @@ class PluginAdapter(Protocol):
     concerns on a future specialized adapter. They are added to this protocol
     additively when a consumer exists."""
 
-    name: str
+    # Read-only members (declared as properties) so a frozen dataclass adapter
+    # — `GenericPluginAdapter`, and any future specialized adapter — structurally
+    # satisfies this protocol. A plain `name: str` annotation is a *settable*
+    # protocol member, which a `frozen=True` dataclass cannot match under
+    # mypy --strict ("expected settable variable, got read-only attribute").
+    @property
+    def name(self) -> str: ...  # pragma: no cover
+
     # Absolute path to the plugin's source tree, set by the registry at
     # discovery time (e.g. `<repo>/src/plugins/beads`).
-    source_path: Path
+    @property
+    def source_path(self) -> Path: ...  # pragma: no cover
 
     def is_detected(self, home: Path) -> bool: ...  # pragma: no cover

--- a/packages/installer/src/installer/plugins/generic.py
+++ b/packages/installer/src/installer/plugins/generic.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class GenericPluginAdapter:
+    """Default `PluginAdapter` for a discovered plugin with no specialized
+    class. Auto-detects on its home footprint: `~/.<name>/` present as a
+    directory. A specialized adapter (e.g. beads in F.4) overrides
+    `is_detected` to add probes the generic convention cannot express, such
+    as `shutil.which("bd")`."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:
+        return (home / f".{self.name}").is_dir()

--- a/packages/installer/src/installer/plugins/registry.py
+++ b/packages/installer/src/installer/plugins/registry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+from installer.plugins.base import PluginAdapter
+from installer.plugins.generic import GenericPluginAdapter
+
+# name -> factory for plugins needing behaviour the generic adapter cannot
+# express. Empty in F.1; beads registers its specialized adapter here in F.4.
+# A factory is `(name, source_path) -> PluginAdapter` — a concrete class whose
+# __init__ matches that shape satisfies it (typing it as `type[PluginAdapter]`
+# would wrongly imply instantiating the Protocol).
+_SPECIALIZED: dict[str, Callable[[str, Path], PluginAdapter]] = {}
+
+
+class UnknownPluginError(ValueError):
+    """Raised when a `--plugins=` element names a plugin absent from the
+    discovered set. Structured attrs (.name, .valid) so callers and tests
+    assert on data, not the message string."""
+
+    def __init__(self, name: str, valid: tuple[str, ...]) -> None:
+        super().__init__(f"Unknown plugin: {name!r} (valid: {', '.join(valid)})")
+        self.name = name
+        self.valid = valid
+
+
+def discover(
+    plugins_root: Path,
+    *,
+    specialized: Mapping[str, Callable[[str, Path], PluginAdapter]] = _SPECIALIZED,
+) -> dict[str, PluginAdapter]:
+    """Discover plugins by scanning the direct subdirectories of
+    `plugins_root`. Non-directory entries (e.g. `AGENTS.md`) and `.`/`_`-
+    prefixed directories are skipped. Each plugin gets a `GenericPluginAdapter`
+    unless its name is in `specialized`. Returns a name-keyed mapping; entries
+    are sorted by name for deterministic downstream ordering."""
+    discovered: dict[str, PluginAdapter] = {}
+    for entry in sorted(plugins_root.iterdir()):
+        name = entry.name
+        if not entry.is_dir() or name.startswith((".", "_")):
+            continue
+        factory: Callable[[str, Path], PluginAdapter] = specialized.get(name, GenericPluginAdapter)
+        discovered[name] = factory(name, entry)
+    return discovered

--- a/packages/installer/tests/fixtures/sources/test-plugin/.agents/skills/test-plugin-skill/SKILL.md
+++ b/packages/installer/tests/fixtures/sources/test-plugin/.agents/skills/test-plugin-skill/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: test-plugin-skill
+description: Synthetic skill shipped by the test-plugin fixture for installer plugin-overlay exercise.
+---
+
+# test-plugin-skill
+
+Canonical shared-scope skill used by installer plugin-overlay tests. Installed
+to every active tool.

--- a/packages/installer/tests/fixtures/sources/test-plugin/.claude/commands/test-plugin-command.md
+++ b/packages/installer/tests/fixtures/sources/test-plugin/.claude/commands/test-plugin-command.md
@@ -1,0 +1,7 @@
+---
+description: Synthetic command from the test-plugin fixture (fatal-collision namespace).
+---
+
+# /test-plugin-command
+
+Canonical command-namespace entry used by installer collision-matrix tests.

--- a/packages/installer/tests/fixtures/sources/test-plugin/.claude/rules/test-plugin-rule.md
+++ b/packages/installer/tests/fixtures/sources/test-plugin/.claude/rules/test-plugin-rule.md
@@ -1,0 +1,4 @@
+# test-plugin-rule
+
+Synthetic rule contributed by the test-plugin fixture. Exercises the
+append-merge collision class — `rules/*.md` joined with a `\n---\n` separator.

--- a/packages/installer/tests/fixtures/sources/test-plugin/.claude/settings.json.template
+++ b/packages/installer/tests/fixtures/sources/test-plugin/.claude/settings.json.template
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(test-plugin:*)"]
+  }
+}

--- a/packages/installer/tests/unit/test_config_plugins.py
+++ b/packages/installer/tests/unit/test_config_plugins.py
@@ -1,0 +1,115 @@
+"""Unit tests for installer.config.resolve_plugins.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.config import resolve_plugins
+from installer.plugins.registry import UnknownPluginError
+
+
+def _sources_with_two_plugins(tmp_path: Path) -> Path:
+    """A plugins root containing two discoverable plugin dirs: alpha, beta."""
+    root = tmp_path / "plugins"
+    (root / "alpha").mkdir(parents=True)
+    (root / "beta").mkdir()
+    return root
+
+
+def _names(adapters: tuple[object, ...]) -> tuple[str, ...]:
+    return tuple(a.name for a in adapters)  # type: ignore[attr-defined]
+
+
+def test_autodetect_includes_only_plugins_with_a_home_footprint(
+    tmp_path: Path,
+) -> None:
+    """
+    Given alpha has a home footprint (~/.alpha) and beta does not
+    When resolve_plugins(override_csv=None) is called
+    Then only alpha is resolved.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    (home / ".alpha").mkdir(parents=True)
+    result = resolve_plugins(home=home, plugins_root=root, override_csv=None)
+    assert _names(result) == ("alpha",)
+
+
+def test_autodetect_empty_when_no_footprints(tmp_path: Path) -> None:
+    """
+    Given no plugin has a home footprint
+    When resolve_plugins(override_csv=None) is called
+    Then the result is empty.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    assert resolve_plugins(home=home, plugins_root=root, override_csv=None) == ()
+
+
+def test_empty_override_installs_no_plugins(tmp_path: Path) -> None:
+    """
+    Given an empty --plugins= value (and a whitespace-only value)
+    When resolve_plugins is called
+    Then the result is empty — the deliberate asymmetry with resolve_tools,
+    which raises on empty --tools= (install.sh:298-300).
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    assert resolve_plugins(home=home, plugins_root=root, override_csv="") == ()
+    assert resolve_plugins(home=home, plugins_root=root, override_csv="   ") == ()
+
+
+def test_explicit_override_selects_named_plugins_in_order(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="beta,alpha") is called
+    Then the result preserves the user-supplied order (beta, alpha),
+    independent of any home footprint.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    result = resolve_plugins(home=home, plugins_root=root, override_csv="beta,alpha")
+    assert _names(result) == ("beta", "alpha")
+
+
+def test_explicit_override_dedupes_preserving_first_occurrence(
+    tmp_path: Path,
+) -> None:
+    """
+    When resolve_plugins(override_csv="alpha, beta ,alpha") is called
+    Then duplicates collapse to first occurrence and whitespace is stripped.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    result = resolve_plugins(home=home, plugins_root=root, override_csv="alpha, beta ,alpha")
+    assert _names(result) == ("alpha", "beta")
+
+
+def test_unknown_plugin_name_raises_with_valid_set(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="gamma") names an undiscovered plugin
+    Then UnknownPluginError is raised with .name and the sorted .valid set.
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    with pytest.raises(UnknownPluginError) as exc:
+        resolve_plugins(home=home, plugins_root=root, override_csv="gamma")
+    assert exc.value.name == "gamma"
+    assert exc.value.valid == ("alpha", "beta")
+
+
+def test_stray_empty_element_raises_value_error(tmp_path: Path) -> None:
+    """
+    When resolve_plugins(override_csv="alpha,,beta") contains a stray empty
+    element among real names
+    Then ValueError is raised (mirrors resolve_tools' stray-comma guard).
+    """
+    root = _sources_with_two_plugins(tmp_path)
+    home = tmp_path / "home"
+    with pytest.raises(ValueError):
+        resolve_plugins(home=home, plugins_root=root, override_csv="alpha,,beta")

--- a/packages/installer/tests/unit/test_plugins_generic.py
+++ b/packages/installer/tests/unit/test_plugins_generic.py
@@ -1,0 +1,54 @@
+"""Unit tests for installer.plugins.generic.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md). Tests for
+dataclass/frozen/slots machinery and pathlib semantics are deliberately
+absent — they test stdlib, not coded decisions. See the writing-unit-tests
+tautology filter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.plugins.generic import GenericPluginAdapter
+
+
+def test_is_detected_true_when_home_footprint_directory_exists(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home directory containing a directory named `.myplugin`
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns True.
+
+    Pins: the home-footprint auto-detect convention `~/.<name>/`.
+    """
+    (tmp_path / ".myplugin").mkdir()
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is True
+
+
+def test_is_detected_false_when_home_footprint_absent(tmp_path: Path) -> None:
+    """
+    Given an empty home directory
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns False.
+    """
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is False
+
+
+def test_is_detected_false_when_footprint_is_a_file_not_a_directory(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home directory containing a *file* named `.myplugin`
+    When the adapter for `myplugin` is asked is_detected(home)
+    Then it returns False.
+
+    Pins: the convention is `.is_dir()`, not `.exists()` — a config footprint
+    is a directory, and a same-named stray file must not trip detection.
+    """
+    (tmp_path / ".myplugin").write_text("not a directory")
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.is_detected(tmp_path) is False

--- a/packages/installer/tests/unit/test_plugins_registry.py
+++ b/packages/installer/tests/unit/test_plugins_registry.py
@@ -1,0 +1,87 @@
+"""Unit tests for installer.plugins.registry.
+
+Each test pins a design decision from the F.1 spec
+(docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md). isinstance /
+@runtime_checkable machinery and attribute-literal assertions are
+deliberately absent — see the writing-unit-tests tautology filter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from installer.plugins.registry import UnknownPluginError, discover
+
+_SOURCES = Path(__file__).parents[1] / "fixtures" / "sources"
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSpecialized:
+    """Stand-in for a future specialized adapter (e.g. beads, F.4). Same
+    construction shape as GenericPluginAdapter: (name, source_path)."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002  # inert stub  # pragma: no cover
+        return True
+
+
+def test_discover_finds_the_canonical_test_plugin_fixture() -> None:
+    """
+    Given the committed tests/fixtures/sources/ tree
+    When discover() scans it
+    Then `test-plugin` is discovered with source_path pointing at its dir.
+
+    Pins: the canonical exercise fixture exists and is discoverable.
+    """
+    discovered = discover(_SOURCES)
+    assert "test-plugin" in discovered
+    assert discovered["test-plugin"].source_path == _SOURCES / "test-plugin"
+
+
+def test_discover_returns_only_plugin_directories(tmp_path: Path) -> None:
+    """
+    Given a plugins root with a plugin dir, a loose file, a dot-dir, and an
+    underscore-dir
+    When discover() scans it
+    Then only the plain plugin directory is returned.
+
+    Pins: discovery scans direct subdirectories, skipping non-directory
+    entries (e.g. AGENTS.md) and `.`/`_`-prefixed directories.
+    """
+    (tmp_path / "myplugin").mkdir()
+    (tmp_path / "notes.md").write_text("loose file")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / "_scratch").mkdir()
+    discovered = discover(tmp_path)
+    assert set(discovered) == {"myplugin"}
+    assert discovered["myplugin"].source_path == tmp_path / "myplugin"
+
+
+def test_discover_dispatches_to_specialized_class_when_registered(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a plugin name present in the injected `specialized` map
+    When discover() builds its adapter
+    Then the adapter is an instance of the specialized class, not the generic.
+
+    Pins: the name->factory dispatch that F.4 uses to register BeadsAdapter.
+    """
+    (tmp_path / "beads").mkdir()
+    discovered = discover(tmp_path, specialized={"beads": _FakeSpecialized})
+    assert type(discovered["beads"]) is _FakeSpecialized
+
+
+def test_unknown_plugin_error_exposes_structured_attributes() -> None:
+    """
+    When UnknownPluginError("gamma", ("alpha", "beta")) is constructed
+    Then .name == "gamma" and .valid == ("alpha", "beta").
+
+    Pins: structured-exception contract — callers assert on data, not the
+    message string (mirrors UnknownToolError).
+    """
+    err = UnknownPluginError("gamma", ("alpha", "beta"))
+    assert err.name == "gamma"
+    assert err.valid == ("alpha", "beta")


### PR DESCRIPTION
## Summary

F.1 of Epic F (Plugins) for the Python installer (`packages/installer/`). Establishes plugin support **scaffolding** — discovery, detection, and `--plugins=` resolution — without yet installing any plugin content.

- **`plugins/base.py`** — `PluginAdapter` Protocol. Members are read-only `@property` declarations so a `frozen=True` dataclass adapter structurally satisfies it under `mypy --strict` (a plain `name: str` annotation is a *settable* protocol member, which a frozen field cannot match). `# pragma: no cover` on the declarations is load-bearing for branch coverage.
- **`plugins/generic.py`** — `GenericPluginAdapter`, auto-detects on its home footprint `~/.<name>/` via `.is_dir()`.
- **`plugins/registry.py`** — `discover()` scans the direct subdirectories of a plugins root (skips non-dirs like `AGENTS.md` and `.`/`_`-prefixed dirs), dispatching to a name→factory specialized map (empty here; beads registers in F.4) or `GenericPluginAdapter`. Plus structured `UnknownPluginError`.
- **`config.py`** — adds `resolve_plugins()`, the `--plugins=` policy. **Deliberate asymmetry** with `resolve_tools`: an empty `--plugins=` returns `()` (install no plugins), it does *not* raise — matching the bash installer's plugin-detection block where "no plugins" is a valid choice.
- **`tests/fixtures/sources/test-plugin/`** — the canonical synthetic exercise plugin, one file per collision class (shared skill, append-merge rule, fatal-collision command, json-union settings template).

## Scope / artifact type

Real Python package code with a mandatory quality gate. The PR also includes the approved design spec (`docs/specs/2026-06-07-w1qls.6.1-plugin-registry-design.md`) and implementation plan (`docs/plans/2026-06-07-w1qls.6.1-plugin-registry.md`).

## Intentionally out of scope (deferred to later Epic-F stories — not omissions)

- **No `--plugins` CLI flag wiring / no `Config.plugins` field** — there is no consumer until the F.2 overlay; wiring it now to discard the result would be dead code.
- **No plugin overlay, no `beads.py`, no destination/`chmod` logic** — F.2 (overlay) and F.4 (`BeadsAdapter`, `~/.beads/` destination) respectively. The protocol is intentionally three-member-minimal; it extends additively when those consumers land.
- **`discover()` does not guard a missing `plugins_root`** (`iterdir()` would raise `FileNotFoundError`). Latent only — no live caller in F.1, and `src/plugins/` always exists in-repo. The empty-vs-error decision is deferred to F.2 where wiring creates a live caller (recorded on bead `w1qls.6.2`); a guard with no consumer would be untested dead code lowering branch coverage.

## Ground-truth references

- Behavioural spec being ported: `scripts/install.sh` plugin-detection block.
- Package standards: `packages/installer/AGENTS.md`.

## Test plan

- [x] `make ci-installer` green: `ruff check` + `ruff format --check` + `mypy --strict` (30 files) + `pytest --cov` (**272 passed, 99.89% coverage**, floor 90%) + `pip-audit` (clean) + `install.py --help` entry-verify.
- [x] 14 new unit tests pin coded decisions (`.is_dir()` vs `.exists()`, subdir-only discovery with skip rules, specialized dispatch via injected map, dedupe-first-occurrence, empty-vs-stray-comma, structured error attrs) — no tautologies.
- [x] In-house review: `quality-reviewer` ("ship it", no Critical/High/Medium) + `simplify` (none warranted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
