### PR TITLE
feat(prgroom): store selector + schema-migration seam + error-model delta (8.3)

### DIFF
--- a/docs/plans/2026-06-09-prgroom-8.3-store-errors.md
+++ b/docs/plans/2026-06-09-prgroom-8.3-store-errors.md
@@ -1,0 +1,612 @@
+# prgroom 8.3 — Store Residuals + Runtime Error Model Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the store-adapter selector, schema-migration seam, and the `BlockingErrorCodes` constant to the prgroom CLI — the genuine delta on top of the 8.1 foundation, which already shipped the full `Tier`/`ErrorCode`/`exit_code_for_tier` error model.
+
+**Architecture:** Three small, pure-ish units plus thin CLI wiring. `prsession/registry.py` resolves a `--store`/`PRGROOM_STORE` name to a concrete `Store` constructor (flag > env > default `file`). `prsession/migrations.py` holds an (empty in MVP) `dict[int, Migrator]`; `FileStore.read` gains a migration branch keyed on `schema_version` mismatch. `errors.py` gains one new precondition code (`PRECONDITION_STORE_UNAVAILABLE`) and the `BlockingErrorCodes` frozenset. The CLI root callback eagerly resolves the store so an invalid adapter fails terminally (rendered 4-line block, exit 2) before any verb runs.
+
+**Tech Stack:** Python 3.11+, typer, mypy --strict, ruff, pytest + coverage (90% branch). Reuses the existing `PrgroomError`/`PreconditionError`/`FileStore`/`write_atomic` foundation verbatim.
+
+**Reconciliation note:** 8.1 over-delivered the error model. This bead does NOT re-declare any `Tier` member, any existing `ErrorCode`, `exit_code_for_tier`, `_NO_WORK_CODES`, `precondition_tier()`, or `PrgroomError` (which IS the bead's "TaggedError"). `lifecycle/errors.py` is deferred — zero consumers today. The §3.7 registry was diffed against the shipped enum and is complete; only the new store code + `BlockingErrorCodes` are added.
+
+---
+
+## File Structure
+
+- **Modify** `src/prgroom/errors.py` — add `PRECONDITION_STORE_UNAVAILABLE` enum member + registry entry; add `BlockingErrorCodes` frozenset.
+- **Create** `src/prgroom/prsession/migrations.py` — `Migrator` type alias + empty `MIGRATIONS` dict.
+- **Modify** `src/prgroom/prsession/file.py` — `FileStore.__init__(migrations=...)`; migration branch in `read()`.
+- **Create** `src/prgroom/prsession/registry.py` — `StoreName` enum + `resolve_store()`.
+- **Modify** `src/prgroom/cli.py` — root callback `--store` eager resolution.
+- **Test** `tests/unit/test_errors.py` (extend), `tests/unit/test_registry.py` (new), `tests/integration/test_file_store_migrations.py` (new), `tests/unit/test_cli_store.py` (new).
+
+---
+
+## Task 1: New error code + BlockingErrorCodes in errors.py
+
+**Files:**
+- Modify: `src/prgroom/errors.py`
+- Test: `tests/unit/test_errors.py`
+
+- [ ] **Step 1: Write failing tests** — append to `tests/unit/test_errors.py`:
+
+```python
+from prgroom.errors import BlockingErrorCodes
+
+
+def test_store_unavailable_is_user_error_tier() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="bd")
+    assert err.tier == Tier.PRECONDITION_USER_ERROR
+    assert exit_code_for_tier(err) == 2
+
+
+def test_store_unavailable_carries_detail_in_message() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="frobnicate")
+    assert "frobnicate" in str(err)
+
+
+def test_blocking_error_codes_is_the_exact_documented_set() -> None:
+    # §3.2 / §3.6: resolve-escalated cannot clear these. Exact-set equality so a
+    # stray addition or omission fails here, not silently downstream.
+    assert BlockingErrorCodes == frozenset(
+        {
+            ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+            ErrorCode.STATE_CORRUPT,
+            ErrorCode.STATE_SCHEMA_UNKNOWN,
+            ErrorCode.RUNTIME_GH_TERMINAL,
+            ErrorCode.RUNTIME_PUSH_REJECTED,
+        }
+    )
+
+
+@pytest.mark.parametrize("absent", ["STATE_LOCK_STALE", "NOTICE_LOCK_STALE_CLEANED"])
+def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
+    # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
+    # death). Their presence would signal a regression to an fcntl-style protocol.
+    assert absent not in ErrorCode.__members__
+
+
+def test_every_tier_maps_to_a_concrete_exit_code() -> None:
+    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
+    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
+    for tier in Tier:
+        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
+        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
+        code = exit_code_for_tier(err)
+        assert isinstance(code, int)
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`AttributeError` on `BlockingErrorCodes`, missing enum member).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_errors.py -q`
+
+- [ ] **Step 3: Implement** — in `src/prgroom/errors.py`, add the enum member in the `PRECONDITION_*` block:
+
+```python
+    PRECONDITION_STORE_UNAVAILABLE = "PRECONDITION_STORE_UNAVAILABLE"
+```
+
+Add its registry entry to `_REGISTRY`:
+
+```python
+    ErrorCode.PRECONDITION_STORE_UNAVAILABLE: RegistryEntry(
+        what="the requested store adapter is unavailable",
+        why="--store/PRGROOM_STORE named an adapter not usable in this build",
+        how="use --store file (the default); 'bd' is deferred to a later release",
+    ),
+```
+
+Add the constant after `_REGISTRY` (it references `ErrorCode`):
+
+```python
+# Codes that gate `resolve-escalated` re-entry (§3.2, §3.6): an operator flipping
+# an escalated disposition cannot clear any of these — they require the recovery
+# paths in §3.6/§3.7 (cap re-arm, state-file inspection, gh/git reconciliation).
+BlockingErrorCodes: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+        ErrorCode.STATE_CORRUPT,
+        ErrorCode.STATE_SCHEMA_UNKNOWN,
+        ErrorCode.RUNTIME_GH_TERMINAL,
+        ErrorCode.RUNTIME_PUSH_REJECTED,
+    }
+)
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit** (deferred to end-of-bead single commit).
+
+---
+
+## Task 2: migrations.py registry
+
+**Files:**
+- Create: `src/prgroom/prsession/migrations.py`
+- Test: covered via Task 3 (the migration branch exercises `MIGRATIONS`); a direct
+  smoke assertion lives in the integration test.
+
+- [ ] **Step 1: Create the module:**
+
+```python
+"""Schema-migration registry for persisted state (§2, §3.7).
+
+A migrator upgrades a serialized state blob from one ``schema_version`` to the
+current one. The registry is keyed by the **from** version. It is EMPTY in the
+MVP — ``schema_version`` is 1 and there is nothing older to upgrade — but the
+seam exists so a future schema bump ships its upgrade path here without touching
+the read path. :meth:`~prgroom.prsession.file.FileStore.read` consults this dict
+on a version mismatch: a registered migrator runs and the file is rewritten in
+place; an absent one trips ``STATE_SCHEMA_UNKNOWN`` (exit 78).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Upgrades a raw JSON state blob from the keyed (from-)version toward the current
+# SCHEMA_VERSION. Must be pure w.r.t. the filesystem — the caller owns the atomic
+# rewrite. A migrator that cannot convert MUST raise (never return corrupt bytes);
+# the read path maps the raise to STATE_CORRUPT.
+Migrator = Callable[[bytes], bytes]
+
+# Keyed by the from-version. EMPTY in MVP (schema_version == 1, nothing older).
+MIGRATIONS: dict[int, Migrator] = {}
+```
+
+- [ ] **Step 2: Verify import** — `cd packages/prgroom && uv run python -c "from prgroom.prsession.migrations import MIGRATIONS, Migrator; assert MIGRATIONS == {}"`
+
+---
+
+## Task 3: FileStore migration branch
+
+**Files:**
+- Modify: `src/prgroom/prsession/file.py`
+- Test: `tests/integration/test_file_store_migrations.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/integration/test_file_store_migrations.py`:
+
+```python
+"""Integration tests for FileStore's schema-migration read branch (§2, §3.7).
+
+Real filesystem, real atomic rewrite, a synthetic migrator injected via the
+constructor seam (no global monkeypatching). Pins three coded decisions: a
+registered migrator upgrades + rewrites the file in place and the read proceeds;
+no migrator trips STATE_SCHEMA_UNKNOWN; a raising migrator surfaces STATE_CORRUPT
+and leaves the on-disk file byte-identical (write_atomic runs only on success).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.migrations import Migrator
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState, QuiescenceState
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError
+
+_T = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_OLD = SCHEMA_VERSION - 1
+
+
+def _current_state(ref: PRRef) -> PRGroomingState:
+    return PRGroomingState(
+        pr=ref,
+        phase=PRPhase.IDLE,
+        round=1,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+    )
+
+
+def _write_old_schema_file(path: Path, ref: PRRef) -> bytes:
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = _OLD
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    return raw
+
+
+def _bump_to_current() -> Migrator:
+    def migrate(raw: bytes) -> bytes:
+        obj = json.loads(raw)
+        obj["schema_version"] = SCHEMA_VERSION
+        return json.dumps(obj).encode("utf-8")
+
+    return migrate
+
+
+def test_registered_migrator_upgrades_and_rewrites_in_place(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    _write_old_schema_file(state_path, ref)
+    migrations: Mapping[int, Migrator] = {_OLD: _bump_to_current()}
+    store = FileStore(state_dir=tmp_path, migrations=migrations)
+
+    read_back = store.read(ref)
+
+    assert read_back.phase == PRPhase.IDLE
+    # File rewritten in place at the current version (write_atomic ran on success).
+    on_disk = json.loads(state_path.read_bytes())
+    assert on_disk["schema_version"] == SCHEMA_VERSION
+
+
+def test_no_migrator_for_unknown_version_trips_schema_unknown(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    _write_old_schema_file(tmp_path / f"{ref.slug()}.json", ref)
+    store = FileStore(state_dir=tmp_path, migrations={})  # empty: no migrator
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)
+
+
+def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
+    tmp_path: Path,
+) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _boom(_raw: bytes) -> bytes:
+        raise ValueError("migrator cannot convert")  # noqa: TRY003
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _boom})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+
+    # HARD requirement: a failed migration never rewrites the file.
+    assert state_path.read_bytes() == original
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`FileStore.__init__` has no `migrations` kwarg).
+
+Run: `cd packages/prgroom && uv run pytest tests/integration/test_file_store_migrations.py -q`
+
+- [ ] **Step 3: Implement** — edit `src/prgroom/prsession/file.py`.
+
+Add import near the existing imports:
+
+```python
+from collections.abc import Iterator, Mapping
+```
+(merge with the existing `from collections.abc import Iterator` line)
+
+Add the migrations import:
+
+```python
+from prgroom.prsession.migrations import MIGRATIONS, Migrator
+```
+
+Change `__init__`:
+
+```python
+    def __init__(
+        self,
+        *,
+        state_dir: Path | None = None,
+        migrations: Mapping[int, Migrator] | None = None,
+    ) -> None:
+        self._dir = state_dir if state_dir is not None else resolve_state_dir()
+        self._migrations: Mapping[int, Migrator] = (
+            migrations if migrations is not None else MIGRATIONS
+        )
+```
+
+Replace the version-check block in `read()`:
+
+```python
+        version = payload.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raw, payload = self._migrate(path, raw, version)
+        return PRGroomingState.from_dict(payload)
+```
+
+Add the `_migrate` helper as a method on `FileStore`:
+
+```python
+    def _migrate(
+        self, path: Path, raw: bytes, from_version: object
+    ) -> tuple[bytes, dict[str, object]]:
+        """Apply a registered migrator for ``from_version`` or trip schema-unknown.
+
+        On a registered migrator: run it on the raw bytes, rewrite the file in
+        place via ``write_atomic`` (only on success — a raising migrator leaves
+        the file byte-identical), then re-parse. A raising migrator maps to
+        :class:`StateCorruptError` (its registry ``how`` — move aside, rebuild —
+        fits a failed migration). No migrator: :class:`SchemaUnknownError`.
+        """
+        migrator = (
+            self._migrations.get(from_version) if isinstance(from_version, int) else None
+        )
+        if migrator is None:
+            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; names the file + version
+                f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
+            )
+        try:
+            migrated = migrator(raw)
+        except Exception as exc:  # migrator failure must never corrupt on-disk state
+            raise StateCorruptError(f"{path}: migration from {from_version!r} failed: {exc}") from exc  # noqa: TRY003
+        write_atomic(path, migrated)
+        return migrated, json.loads(migrated)
+```
+
+Note: `json.loads(migrated)` may itself raise `json.JSONDecodeError` if a buggy migrator returns non-JSON; that is a programming error in the migrator and surfaces as an uncaught decode error — acceptable (a registered migrator is trusted code, not external input). The empty-MVP registry means this path is exercised only by injected test migrators.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+---
+
+## Task 4: registry.py store selector
+
+**Files:**
+- Create: `src/prgroom/prsession/registry.py`
+- Test: `tests/unit/test_registry.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/unit/test_registry.py`:
+
+```python
+"""Tests for the store-adapter selector (§2 "Selection at runtime").
+
+Pins the coded decisions: name resolution and precedence (flag > env > default
+file), the concrete adapter each name yields, and the terminal user-error for
+the deferred `bd` adapter and any unknown name. Uses the real FileStore (a fake
+would not prove the file branch returns the production adapter).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prgroom.errors import ErrorCode, PreconditionError, Tier
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.registry import StoreName, resolve_store
+
+
+def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
+    store = resolve_store("file", env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_default_when_no_flag_no_env_is_file(tmp_path: Path) -> None:
+    store = resolve_store(None, env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_env_selects_when_no_flag(tmp_path: Path) -> None:
+    store = resolve_store(None, env={"PRGROOM_STORE": "file"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_flag_beats_env(tmp_path: Path) -> None:
+    # Flag says file, env says bd: flag wins, so we get a FileStore (no error).
+    store = resolve_store("file", env={"PRGROOM_STORE": "bd"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_bd_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("bd", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert exc.value.tier == Tier.PRECONDITION_USER_ERROR
+    assert "bd" in str(exc.value)
+
+
+def test_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("frobnicate", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert "frobnicate" in str(exc.value)
+
+
+def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError):
+        resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
+
+
+def test_store_name_enum_values() -> None:
+    # Consumer-boundary pin: these strings are the user-facing --store / env
+    # vocabulary, so they are pinned where a drift would break the CLI surface.
+    assert StoreName.FILE.value == "file"
+    assert StoreName.BD.value == "bd"
+```
+
+- [ ] **Step 2: Run — expect FAIL** (no module `registry`).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_registry.py -q`
+
+- [ ] **Step 3: Implement** — new file `src/prgroom/prsession/registry.py`:
+
+```python
+"""Store-adapter selector (§2 "Selection at runtime").
+
+Resolves a ``--store`` flag value (or the ``PRGROOM_STORE`` env var, or the
+built-in default ``file``) to a concrete :class:`~prgroom.prsession.store.Store`.
+Precedence is **flag > env > default** — the flag is consulted first and only
+falls through to the env when unset. ``file`` yields the production
+:class:`~prgroom.prsession.file.FileStore`; ``bd`` is deferred (v2) and any
+unknown name is a user error — both surface as a terminal
+``PRECONDITION_STORE_UNAVAILABLE`` (exit 2, rendered 4-line block, no traceback).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import Path
+
+from prgroom.errors import ErrorCode, PreconditionError
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.store import Store
+
+ENV_VAR = "PRGROOM_STORE"
+DEFAULT_STORE = "file"
+
+
+class StoreName(StrEnum):
+    """The user-facing ``--store`` / ``PRGROOM_STORE`` vocabulary."""
+
+    FILE = "file"
+    BD = "bd"
+
+
+def resolve_store(
+    name: str | None,
+    *,
+    env: Mapping[str, str] | None = None,
+    state_dir: Path | None = None,
+) -> Store:
+    """Resolve a store name to a concrete adapter (flag > env > default ``file``).
+
+    ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
+    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
+    unrecognized name raise :class:`PreconditionError` tagged
+    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    """
+    environ = env if env is not None else {}
+    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    if resolved == StoreName.FILE:
+        return FileStore(state_dir=state_dir)
+    raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+---
+
+## Task 5: CLI --store wiring (eager root-callback resolution)
+
+**Files:**
+- Modify: `src/prgroom/cli.py`
+- Test: `tests/unit/test_cli_store.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/unit/test_cli_store.py`:
+
+```python
+"""Tests for the CLI `--store` root-callback wiring (§1, §2).
+
+The store is resolved eagerly in the root callback so an invalid adapter fails
+terminally — rendered 4-line block, exit 2, no traceback — BEFORE any verb body
+runs. A valid `--store file` (or the default) falls through to the verb skeleton.
+Proves `--store` beats `PRGROOM_STORE` via a set env var.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom.cli import SKELETON_EXIT_CODE, app
+
+runner = CliRunner()
+
+
+def test_invalid_store_bd_exits_two_with_block_before_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "bd", "poll", "123"])
+    assert result.exit_code == 2
+    assert "error: PRECONDITION_STORE_UNAVAILABLE" in result.output
+    assert "how:" in result.output
+    # Terminal store error pre-empts the skeleton notice.
+    assert "not yet implemented" not in result.output
+    assert result.exception is None  # no traceback surfaced
+
+
+def test_unknown_store_name_exits_two() -> None:
+    result = runner.invoke(app, ["--store", "frobnicate", "poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+
+
+def test_valid_store_file_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+    assert "not yet implemented" in result.output
+
+
+def test_default_store_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # env says bd (would error); flag says file (valid) -> flag wins -> skeleton.
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_env_bd_with_no_flag_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`--store` is not a known option; exit 2 from typer's own usage error, but with no registry block — assertions on the rendered block fail).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_cli_store.py -q`
+
+- [ ] **Step 3: Implement** — edit `src/prgroom/cli.py`.
+
+Add imports:
+
+```python
+import os
+
+from prgroom.prsession.registry import resolve_store
+```
+
+Add a root callback (typer invokes it before any subcommand). The callback resolves the store eagerly; a `PreconditionError` propagates to `main()`'s existing handler (rendered block + exit 2). Resolution is order-independent of the env read because `resolve_store` is passed `os.environ`:
+
+```python
+@app.callback()
+def _root(
+    store: str | None = typer.Option(
+        None,
+        "--store",
+        help="State store adapter: file (default) or bd (deferred).",
+        envvar=None,  # env precedence is handled in resolve_store, not by typer
+    ),
+) -> None:
+    """Resolve the state store eagerly so an invalid --store fails before any verb."""
+    # Resolution is discarded here (verbs are skeletons); its sole purpose in the
+    # foundation is to fail terminally on an invalid adapter. Later beads keep the
+    # resolved Store on a context object for the verbs to consume.
+    resolve_store(store, env=os.environ)
+```
+
+Note: `envvar=None` keeps typer from reading `PRGROOM_STORE` itself — precedence (flag > env) lives in `resolve_store`, the single source of truth, so the CLI and a direct `resolve_store` caller behave identically.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Re-run the existing CLI smoke suite** to confirm the new callback did not break verb discovery (the root callback adds an option but `no_args_is_help` + per-verb help must still work):
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_cli_smoke.py tests/unit/test_cli_errors.py -q`
+Expected: PASS (all existing CLI tests green).
+
+---
+
+## Task 6: Full gate
+
+- [ ] **Step 1:** `make -C <worktree-root> ci-prgroom` → expect green (ruff, ruff format --check, mypy --strict, pytest --cov ≥90% branch, pip-audit, entry verify).
+- [ ] **Step 2:** Completion gate — `quality-reviewer` → address → `simplify` → address → `verify-checklist`.
+- [ ] **Step 3:** Single semantic commit on the worktree branch.
+
+---
+
+## Self-Review
+
+**Spec coverage:** registry (Task 4) ✓; migrations module (Task 2) + read branch (Task 3) ✓; BlockingErrorCodes + new code (Task 1) ✓; CLI wiring (Task 5) ✓; Tier-exhaustiveness + STATE_LOCK_STALE absence tests (Task 1) ✓. No lifecycle/errors.py, no TaggedError — deferred per decision #2.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `Migrator` (migrations.py) used identically in file.py + tests; `resolve_store(name, *, env, state_dir)` signature consistent across registry.py, tests, and the CLI callback; `PreconditionError(code, detail=...)` matches the foundation's existing constructor.

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -14,12 +14,14 @@ Verb names with underscores in the function name render as hyphenated commands
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import IO
 
 import typer
 
 from prgroom.errors import PreconditionError, PrgroomError, exit_code_for_tier
+from prgroom.prsession.registry import resolve_store
 
 # Foundation skeletons are not yet implemented; they exit non-zero so a caller
 # never mistakes a skeleton's silence for a successful no-op. EX_UNAVAILABLE
@@ -32,6 +34,33 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+@app.callback()
+def _root(
+    store: str | None = typer.Option(
+        None,
+        "--store",
+        help="State store adapter: file (default) or bd (deferred).",
+        envvar=None,  # env precedence is owned by resolve_store, not typer
+    ),
+) -> None:
+    """Resolve the state store eagerly so an invalid --store fails before any verb.
+
+    The resolved Store is discarded here (verbs are skeletons); its sole purpose
+    in the foundation is to fail terminally on an invalid adapter. An invalid
+    ``--store`` renders the canonical 4-line block via :func:`handle_cli_error`
+    and exits with the tier code (2, no traceback) right here — so the behavior
+    is identical whether the app is driven through :func:`main` or directly (e.g.
+    typer's ``CliRunner``). Later beads keep the resolved Store on a context
+    object for the verbs to consume. Precedence (flag > env > default) lives in
+    :func:`resolve_store`, the single source of truth, so the CLI and a direct
+    ``resolve_store`` caller behave identically.
+    """
+    try:
+        resolve_store(store, env=os.environ)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
 
 
 def _skeleton(verb: str) -> None:

--- a/packages/prgroom/src/prgroom/errors.py
+++ b/packages/prgroom/src/prgroom/errors.py
@@ -77,6 +77,7 @@ class ErrorCode(StrEnum):
     PRECONDITION_NO_ESCALATIONS = "PRECONDITION_NO_ESCALATIONS"
     PRECONDITION_WAIT_NOT_APPLICABLE = "PRECONDITION_WAIT_NOT_APPLICABLE"
     PRECONDITION_LOCK_HELD = "PRECONDITION_LOCK_HELD"
+    PRECONDITION_STORE_UNAVAILABLE = "PRECONDITION_STORE_UNAVAILABLE"
     # RUNTIME_*
     RUNTIME_GH_TRANSIENT = "RUNTIME_GH_TRANSIENT"
     RUNTIME_GH_TERMINAL = "RUNTIME_GH_TERMINAL"
@@ -181,6 +182,11 @@ _REGISTRY: dict[ErrorCode, RegistryEntry] = {
         why="the concurrency model is one-at-a-time per PR",
         how="wait for the other invocation; the scheduler retries on next cadence",
     ),
+    ErrorCode.PRECONDITION_STORE_UNAVAILABLE: RegistryEntry(
+        what="the requested store adapter is unavailable",
+        why="--store/PRGROOM_STORE named an adapter not usable in this build",
+        how="use --store file (the default); 'bd' is deferred to a later release",
+    ),
     ErrorCode.RUNTIME_GH_TRANSIENT: RegistryEntry(
         what="gh API returned 5xx or rate-limited with Retry-After",
         why="the external service is degraded",
@@ -272,6 +278,20 @@ _REGISTRY: dict[ErrorCode, RegistryEntry] = {
         how="resolve escalations; raise --max-rounds and re-run, or hand off to human review",
     ),
 }
+
+
+# Codes that gate `resolve-escalated` re-entry (§3.2, §3.6): an operator flipping
+# an escalated disposition cannot clear any of these — they require the recovery
+# paths in §3.6/§3.7 (cap re-arm, state-file inspection, gh/git reconciliation).
+BlockingErrorCodes: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+        ErrorCode.STATE_CORRUPT,
+        ErrorCode.STATE_SCHEMA_UNKNOWN,
+        ErrorCode.RUNTIME_GH_TERMINAL,
+        ErrorCode.RUNTIME_PUSH_REJECTED,
+    }
+)
 
 
 class PrgroomError(Exception):

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -144,9 +144,16 @@ class FileStore:
             raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
                 f"{path}: migration from {from_version!r} produced non-object JSON"
             )
+        new_version = decoded.get("schema_version")
+        if not (_is_int_version(new_version) and new_version == SCHEMA_VERSION):
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + result version
+                f"{path}: migration from {from_version!r} did not reach "
+                f"schema_version {SCHEMA_VERSION} (got {new_version!r})"
+            )
         # Validate-before-commit: write_atomic runs ONLY after the migrated bytes
-        # are confirmed parseable AND a JSON object, so a migrator that returns
-        # garbage without raising can never overwrite good on-disk state.
+        # are confirmed parseable, a JSON object, AND at the current schema_version,
+        # so a migrator that returns garbage or an unmigrated payload without raising
+        # can never overwrite good on-disk state.
         write_atomic(path, migrated)
         parsed: dict[str, object] = decoded
         return parsed

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -204,7 +204,10 @@ def _ref_from_state_file(path: Path) -> PRRef | None:
         payload = json.loads(path.read_bytes())
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("schema_version")
+    if not (_is_int_version(version) and version == SCHEMA_VERSION):
         return None
     pr = payload.get("pr")
     if not isinstance(pr, dict):

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -131,14 +131,24 @@ class FileStore:
             raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
                 f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
             )
+        # Both the migrator call and the parse sit inside the try: a raising OR an
+        # invalid-JSON migrator must not corrupt on-disk state.
         try:
             migrated = migrator(raw)
-        except Exception as exc:  # a migrator failure must never corrupt on-disk state
+            decoded = json.loads(migrated)
+        except Exception as exc:
             raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
                 f"{path}: migration from {from_version!r} failed: {exc}"
             ) from exc
+        if not isinstance(decoded, dict):
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
+                f"{path}: migration from {from_version!r} produced non-object JSON"
+            )
+        # Validate-before-commit: write_atomic runs ONLY after the migrated bytes
+        # are confirmed parseable AND a JSON object, so a migrator that returns
+        # garbage without raising can never overwrite good on-disk state.
         write_atomic(path, migrated)
-        parsed: dict[str, object] = json.loads(migrated)
+        parsed: dict[str, object] = decoded
         return parsed
 
     def write(self, ref: PRRef, state: PRGroomingState) -> None:

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -18,6 +18,7 @@ import tempfile
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TypeGuard
 
 from prgroom.prsession.migrations import MIGRATIONS, Migrator
 from prgroom.prsession.pr_ref import PRRef
@@ -59,6 +60,19 @@ def write_atomic(path: Path, data: bytes) -> None:
         raise
 
 
+def _is_int_version(version: object) -> TypeGuard[int]:
+    """True only for a genuine ``int`` schema version.
+
+    ``bool`` subclasses ``int`` (``True == 1``) and ``float`` compares equal
+    (``1.0 == 1``), so a naive ``== SCHEMA_VERSION`` gate would silently accept
+    ``schema_version: true`` / ``1.0`` as healthy v1 state — and ``bool`` would
+    even alias an integer key in the ``MIGRATIONS`` lookup (``hash(True) ==
+    hash(1)``). ``type(...) is int`` excludes both, routing malformed versions to
+    the migrate-or-reject path instead of masquerading as current.
+    """
+    return type(version) is int
+
+
 class FileStore:
     """Production Store adapter. Structurally satisfies ``Store``."""
 
@@ -92,7 +106,7 @@ class FileStore:
         except json.JSONDecodeError as exc:
             raise StateCorruptError(f"{path}: {exc}") from exc  # noqa: TRY003  # single call-site; message names the offending file
         version = payload.get("schema_version")
-        if version != SCHEMA_VERSION:
+        if not (_is_int_version(version) and version == SCHEMA_VERSION):
             payload = self._migrate(path, raw, version)
         return PRGroomingState.from_dict(payload)
 
@@ -105,8 +119,14 @@ class FileStore:
         A raising migrator maps to :class:`StateCorruptError` (its registry
         ``how`` — move aside, rebuild — fits a failed migration). No migrator:
         :class:`SchemaUnknownError` (the §3.7 ``STATE_SCHEMA_UNKNOWN`` path).
+
+        NOTE for the status/locking beads: this rewrites the file in place, so
+        ``read`` is no longer side-effect-free once a migrator is registered. The
+        lock-free ``status`` reader (§3.3 carve-out) must either migrate in memory
+        without writing, or take the lock before a migrating read — do not ship an
+        unlocked migrating reader. (Latent today: ``MIGRATIONS`` is empty.)
         """
-        migrator = self._migrations.get(from_version) if isinstance(from_version, int) else None
+        migrator = self._migrations.get(from_version) if _is_int_version(from_version) else None
         if migrator is None:
             raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
                 f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -15,10 +15,11 @@ import fcntl
 import json
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
+from prgroom.prsession.migrations import MIGRATIONS, Migrator
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState
 from prgroom.prsession.store import (
@@ -61,8 +62,16 @@ def write_atomic(path: Path, data: bytes) -> None:
 class FileStore:
     """Production Store adapter. Structurally satisfies ``Store``."""
 
-    def __init__(self, *, state_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        state_dir: Path | None = None,
+        migrations: Mapping[int, Migrator] | None = None,
+    ) -> None:
         self._dir = state_dir if state_dir is not None else resolve_state_dir()
+        self._migrations: Mapping[int, Migrator] = (
+            migrations if migrations is not None else MIGRATIONS
+        )
 
     def _state_path(self, ref: PRRef) -> Path:
         return self._dir / f"{ref.slug()}.json"
@@ -84,10 +93,33 @@ class FileStore:
             raise StateCorruptError(f"{path}: {exc}") from exc  # noqa: TRY003  # single call-site; message names the offending file
         version = payload.get("schema_version")
         if version != SCHEMA_VERSION:
-            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
-                f"{path}: schema_version {version!r} != {SCHEMA_VERSION}"
-            )
+            payload = self._migrate(path, raw, version)
         return PRGroomingState.from_dict(payload)
+
+    def _migrate(self, path: Path, raw: bytes, from_version: object) -> dict[str, object]:
+        """Apply a registered migrator for ``from_version`` or trip schema-unknown.
+
+        On a registered migrator: run it on the raw bytes, rewrite the file in
+        place via ``write_atomic`` (only on success — a raising migrator leaves
+        the file byte-identical), then re-parse and return the upgraded payload.
+        A raising migrator maps to :class:`StateCorruptError` (its registry
+        ``how`` — move aside, rebuild — fits a failed migration). No migrator:
+        :class:`SchemaUnknownError` (the §3.7 ``STATE_SCHEMA_UNKNOWN`` path).
+        """
+        migrator = self._migrations.get(from_version) if isinstance(from_version, int) else None
+        if migrator is None:
+            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
+                f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
+            )
+        try:
+            migrated = migrator(raw)
+        except Exception as exc:  # a migrator failure must never corrupt on-disk state
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
+                f"{path}: migration from {from_version!r} failed: {exc}"
+            ) from exc
+        write_atomic(path, migrated)
+        parsed: dict[str, object] = json.loads(migrated)
+        return parsed
 
     def write(self, ref: PRRef, state: PRGroomingState) -> None:
         data = json.dumps(state.to_dict(), indent=2, sort_keys=True).encode("utf-8")

--- a/packages/prgroom/src/prgroom/prsession/migrations.py
+++ b/packages/prgroom/src/prgroom/prsession/migrations.py
@@ -1,0 +1,23 @@
+"""Schema-migration registry for persisted state (§2, §3.7).
+
+A migrator upgrades a serialized state blob from one ``schema_version`` to the
+current one. The registry is keyed by the **from** version. It is EMPTY in the
+MVP — ``schema_version`` is 1 and there is nothing older to upgrade — but the
+seam exists so a future schema bump ships its upgrade path here without touching
+the read path. :meth:`~prgroom.prsession.file.FileStore.read` consults this dict
+on a version mismatch: a registered migrator runs and the file is rewritten in
+place; an absent one trips ``STATE_SCHEMA_UNKNOWN`` (exit 78).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Upgrades a raw JSON state blob from the keyed (from-)version toward the current
+# SCHEMA_VERSION. Must be pure w.r.t. the filesystem — the caller owns the atomic
+# rewrite. A migrator that cannot convert MUST raise (never return corrupt bytes);
+# the read path maps the raise to STATE_CORRUPT.
+Migrator = Callable[[bytes], bytes]
+
+# Keyed by the from-version. EMPTY in MVP (schema_version == 1, nothing older).
+MIGRATIONS: dict[int, Migrator] = {}

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -1,0 +1,50 @@
+"""Store-adapter selector (§2 "Selection at runtime").
+
+Resolves a ``--store`` flag value (or the ``PRGROOM_STORE`` env var, or the
+built-in default ``file``) to a concrete :class:`~prgroom.prsession.store.Store`.
+Precedence is **flag > env > default** — the flag is consulted first and only
+falls through to the env when unset. ``file`` yields the production
+:class:`~prgroom.prsession.file.FileStore`; ``bd`` is deferred (v2) and any
+unknown name is a user error — both surface as a terminal
+``PRECONDITION_STORE_UNAVAILABLE`` (exit 2, rendered 4-line block, no traceback).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import Path
+
+from prgroom.errors import ErrorCode, PreconditionError
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.store import Store
+
+ENV_VAR = "PRGROOM_STORE"
+DEFAULT_STORE = "file"
+
+
+class StoreName(StrEnum):
+    """The user-facing ``--store`` / ``PRGROOM_STORE`` vocabulary."""
+
+    FILE = "file"
+    BD = "bd"
+
+
+def resolve_store(
+    name: str | None,
+    *,
+    env: Mapping[str, str] | None = None,
+    state_dir: Path | None = None,
+) -> Store:
+    """Resolve a store name to a concrete adapter (flag > env > default ``file``).
+
+    ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
+    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
+    unrecognized name raise :class:`PreconditionError` tagged
+    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    """
+    environ = env if env is not None else {}
+    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    if resolved == StoreName.FILE:
+        return FileStore(state_dir=state_dir)
+    raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -39,12 +39,14 @@ def resolve_store(
     """Resolve a store name to a concrete adapter (flag > env > default ``file``).
 
     ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
-    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
-    unrecognized name raise :class:`PreconditionError` tagged
-    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    ``env[PRGROOM_STORE]`` then the ``file`` default. A **blank** env var is
+    treated as unset (POSIX convention, mirroring ``resolve_state_dir``); a blank
+    ``--store ''`` flag is, by contrast, an explicit user mistake and errors.
+    ``bd`` (deferred) and any unrecognized name raise :class:`PreconditionError`
+    tagged ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
     """
     environ = env if env is not None else {}
-    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    resolved = name if name is not None else (environ.get(ENV_VAR) or DEFAULT_STORE)
     if resolved == StoreName.FILE:
         return FileStore(state_dir=state_dir)
     raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/tests/integration/test_file_store.py
+++ b/packages/prgroom/tests/integration/test_file_store.py
@@ -167,6 +167,10 @@ def test_list_refs_skips_files_that_are_not_current_prgroom_state(tmp_path: Path
     (tmp_path / "future-schema.json").write_text(
         json.dumps({"schema_version": SCHEMA_VERSION + 1, "pr": valid_pr})
     )  # foreign / future schema
+    # bool/float schema_version (True==1, 1.0==1) must NOT enumerate as current —
+    # enumeration stays consistent with read()'s type-strict gate.
+    (tmp_path / "bool-schema.json").write_text(json.dumps({"schema_version": True, "pr": valid_pr}))
+    (tmp_path / "float-schema.json").write_text(json.dumps({"schema_version": 1.0, "pr": valid_pr}))
     (tmp_path / "pr-not-object.json").write_text(
         json.dumps({"schema_version": SCHEMA_VERSION, "pr": "nope"})
     )  # `pr` is not a dict

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -94,3 +94,21 @@ def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
 
     # HARD requirement: a failed migration never rewrites the file.
     assert state_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
+def test_non_int_schema_version_is_rejected_not_loaded_as_current(
+    tmp_path: Path, bogus_version: object
+) -> None:
+    # bool subclasses int (True == 1) and 1.0 == 1, so a naive `!= SCHEMA_VERSION`
+    # gate would silently accept these as a healthy v1 state. A schema_version that
+    # is not a genuine int must route to the migrate-or-reject path (here: no
+    # migrator -> STATE_SCHEMA_UNKNOWN), never load as current.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = bogus_version
+    state_path.write_bytes(json.dumps(payload).encode("utf-8"))
+    store = FileStore(state_dir=tmp_path, migrations={})
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -96,6 +96,38 @@ def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
     assert state_path.read_bytes() == original
 
 
+def test_migrator_returning_invalid_json_does_not_corrupt_the_file(tmp_path: Path) -> None:
+    # A migrator that returns unparseable bytes WITHOUT raising must not overwrite
+    # the good file: validation happens before the atomic write.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _garbage(_raw: bytes) -> bytes:
+        return b"not valid json{{{"
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _garbage})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
+def test_migrator_returning_non_object_json_does_not_corrupt_the_file(tmp_path: Path) -> None:
+    # Parseable but non-object JSON (e.g. a bare number) is not valid state; it
+    # must be rejected before the write, leaving the good file byte-identical.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _scalar(_raw: bytes) -> bytes:
+        return b"5"
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _scalar})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
 @pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
 def test_non_int_schema_version_is_rejected_not_loaded_as_current(
     tmp_path: Path, bogus_version: object

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -1,0 +1,96 @@
+"""Integration tests for FileStore's schema-migration read branch (§2, §3.7).
+
+Real filesystem, real atomic rewrite, a synthetic migrator injected via the
+constructor seam (no global monkeypatching). Pins three coded decisions: a
+registered migrator upgrades + rewrites the file in place and the read proceeds;
+no migrator trips STATE_SCHEMA_UNKNOWN; a raising migrator surfaces STATE_CORRUPT
+and leaves the on-disk file byte-identical (write_atomic runs only on success).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.migrations import Migrator
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState, QuiescenceState
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError
+
+_T = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_OLD = SCHEMA_VERSION - 1
+
+
+def _current_state(ref: PRRef) -> PRGroomingState:
+    return PRGroomingState(
+        pr=ref,
+        phase=PRPhase.IDLE,
+        round=1,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+    )
+
+
+def _write_old_schema_file(path: Path, ref: PRRef) -> bytes:
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = _OLD
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    return raw
+
+
+def _bump_to_current() -> Migrator:
+    def migrate(raw: bytes) -> bytes:
+        obj = json.loads(raw)
+        obj["schema_version"] = SCHEMA_VERSION
+        return json.dumps(obj).encode("utf-8")
+
+    return migrate
+
+
+def test_registered_migrator_upgrades_and_rewrites_in_place(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    _write_old_schema_file(state_path, ref)
+    migrations: Mapping[int, Migrator] = {_OLD: _bump_to_current()}
+    store = FileStore(state_dir=tmp_path, migrations=migrations)
+
+    read_back = store.read(ref)
+
+    assert read_back.phase == PRPhase.IDLE
+    # File rewritten in place at the current version (write_atomic ran on success).
+    on_disk = json.loads(state_path.read_bytes())
+    assert on_disk["schema_version"] == SCHEMA_VERSION
+
+
+def test_no_migrator_for_unknown_version_trips_schema_unknown(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    _write_old_schema_file(tmp_path / f"{ref.slug()}.json", ref)
+    store = FileStore(state_dir=tmp_path, migrations={})  # empty: no migrator
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)
+
+
+def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
+    tmp_path: Path,
+) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _boom(_raw: bytes) -> bytes:
+        raise ValueError("migrator cannot convert")  # noqa: TRY003
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _boom})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+
+    # HARD requirement: a failed migration never rewrites the file.
+    assert state_path.read_bytes() == original

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -128,6 +128,24 @@ def test_migrator_returning_non_object_json_does_not_corrupt_the_file(tmp_path: 
     assert state_path.read_bytes() == original
 
 
+def test_migrator_not_reaching_current_version_is_rejected(tmp_path: Path) -> None:
+    # A migrator that returns valid state but fails to bump schema_version to the
+    # current version is a FAILED migration (the single-step _migrate expects the
+    # result to be current). It must surface STATE_CORRUPT and not be committed,
+    # else `from_dict` (which accepts any schema_version) would silently load it.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _forgot_to_bump(raw: bytes) -> bytes:
+        return raw  # valid object, but still at the OLD schema_version
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _forgot_to_bump})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
 @pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
 def test_non_int_schema_version_is_rejected_not_loaded_as_current(
     tmp_path: Path, bogus_version: object

--- a/packages/prgroom/tests/unit/test_cli_store.py
+++ b/packages/prgroom/tests/unit/test_cli_store.py
@@ -1,0 +1,61 @@
+"""Tests for the CLI `--store` root-callback wiring (§1, §2).
+
+The store is resolved eagerly in the root callback so an invalid adapter fails
+terminally — rendered 4-line block, exit 2, no traceback — BEFORE any verb body
+runs. A valid `--store file` (or the default) falls through to the verb skeleton.
+Proves `--store` beats `PRGROOM_STORE` via a set env var.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom.cli import SKELETON_EXIT_CODE, app
+
+runner = CliRunner()
+
+
+def test_invalid_store_bd_exits_two_with_block_before_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "bd", "poll", "123"])
+    assert result.exit_code == 2
+    assert "error: PRECONDITION_STORE_UNAVAILABLE" in result.output
+    assert "how:" in result.output
+    # Terminal store error pre-empts the skeleton notice.
+    assert "not yet implemented" not in result.output
+    # A clean typer.Exit (SystemExit), not an uncaught PrgroomError traceback: the
+    # error was caught and rendered, not propagated raw. CliRunner records the
+    # raw exception when a command raises something other than SystemExit, so a
+    # PrgroomError leaking here would NOT be a SystemExit.
+    assert isinstance(result.exception, SystemExit)
+
+
+def test_unknown_store_name_exits_two() -> None:
+    result = runner.invoke(app, ["--store", "frobnicate", "poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+
+
+def test_valid_store_file_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+    assert "not yet implemented" in result.output
+
+
+def test_default_store_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # env says bd (would error); flag says file (valid) -> flag wins -> skeleton.
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_env_bd_with_no_flag_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output

--- a/packages/prgroom/tests/unit/test_errors.py
+++ b/packages/prgroom/tests/unit/test_errors.py
@@ -137,13 +137,3 @@ def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
     # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
     # death). Their presence would signal a regression to an fcntl-style protocol.
     assert absent not in ErrorCode.__members__
-
-
-def test_every_tier_maps_to_a_concrete_exit_code() -> None:
-    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
-    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
-    for tier in Tier:
-        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
-        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
-        code = exit_code_for_tier(err)
-        assert isinstance(code, int)

--- a/packages/prgroom/tests/unit/test_errors.py
+++ b/packages/prgroom/tests/unit/test_errors.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from prgroom.errors import (
+    BlockingErrorCodes,
     ErrorCode,
     PreconditionError,
     PrgroomError,
@@ -104,3 +105,45 @@ def test_precondition_tier_rejects_a_non_precondition_code() -> None:
     # on a runtime code is a programming error, surfaced as ValueError.
     with pytest.raises(ValueError, match="not a PRECONDITION"):
         ErrorCode.RUNTIME_GH_TERMINAL.precondition_tier()
+
+
+def test_store_unavailable_is_user_error_tier() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="bd")
+    assert err.tier == Tier.PRECONDITION_USER_ERROR
+    assert exit_code_for_tier(err) == 2
+
+
+def test_store_unavailable_carries_detail_in_message() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="frobnicate")
+    assert "frobnicate" in str(err)
+
+
+def test_blocking_error_codes_is_the_exact_documented_set() -> None:
+    # §3.2 / §3.6: resolve-escalated cannot clear these. Exact-set equality so a
+    # stray addition or omission fails here, not silently downstream.
+    assert BlockingErrorCodes == frozenset(
+        {
+            ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+            ErrorCode.STATE_CORRUPT,
+            ErrorCode.STATE_SCHEMA_UNKNOWN,
+            ErrorCode.RUNTIME_GH_TERMINAL,
+            ErrorCode.RUNTIME_PUSH_REJECTED,
+        }
+    )
+
+
+@pytest.mark.parametrize("absent", ["STATE_LOCK_STALE", "NOTICE_LOCK_STALE_CLEANED"])
+def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
+    # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
+    # death). Their presence would signal a regression to an fcntl-style protocol.
+    assert absent not in ErrorCode.__members__
+
+
+def test_every_tier_maps_to_a_concrete_exit_code() -> None:
+    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
+    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
+    for tier in Tier:
+        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
+        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
+        code = exit_code_for_tier(err)
+        assert isinstance(code, int)

--- a/packages/prgroom/tests/unit/test_registry.py
+++ b/packages/prgroom/tests/unit/test_registry.py
@@ -14,7 +14,7 @@ import pytest
 
 from prgroom.errors import ErrorCode, PreconditionError, Tier
 from prgroom.prsession.file import FileStore
-from prgroom.prsession.registry import StoreName, resolve_store
+from prgroom.prsession.registry import resolve_store
 
 
 def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
@@ -58,8 +58,18 @@ def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
         resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
 
 
-def test_store_name_enum_values() -> None:
-    # Consumer-boundary pin: these strings are the user-facing --store / env
-    # vocabulary, so they are pinned where a drift would break the CLI surface.
-    assert StoreName.FILE.value == "file"
-    assert StoreName.BD.value == "bd"
+def test_blank_env_falls_back_to_default_file(tmp_path: Path) -> None:
+    # A blank PRGROOM_STORE is treated as unset (POSIX env convention, mirroring
+    # resolve_state_dir's blank-XDG_STATE_HOME handling), not as an explicit
+    # invalid selection — a stray `export PRGROOM_STORE=` must not break every run.
+    store = resolve_store(None, env={"PRGROOM_STORE": ""}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_blank_flag_is_an_explicit_error_not_a_fallback(tmp_path: Path) -> None:
+    # Deliberately distinct from a blank env: an explicit empty `--store ''` is a
+    # user mistake (an explicit selection of nothing), so it surfaces the terminal
+    # user-error rather than silently defaulting.
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE

--- a/packages/prgroom/tests/unit/test_registry.py
+++ b/packages/prgroom/tests/unit/test_registry.py
@@ -1,0 +1,65 @@
+"""Tests for the store-adapter selector (§2 "Selection at runtime").
+
+Pins the coded decisions: name resolution and precedence (flag > env > default
+file), the concrete adapter each name yields, and the terminal user-error for
+the deferred `bd` adapter and any unknown name. Uses the real FileStore (a fake
+would not prove the file branch returns the production adapter).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prgroom.errors import ErrorCode, PreconditionError, Tier
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.registry import StoreName, resolve_store
+
+
+def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
+    store = resolve_store("file", env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_default_when_no_flag_no_env_is_file(tmp_path: Path) -> None:
+    store = resolve_store(None, env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_env_selects_when_no_flag(tmp_path: Path) -> None:
+    store = resolve_store(None, env={"PRGROOM_STORE": "file"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_flag_beats_env(tmp_path: Path) -> None:
+    # Flag says file, env says bd: flag wins, so we get a FileStore (no error).
+    store = resolve_store("file", env={"PRGROOM_STORE": "bd"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_bd_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("bd", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert exc.value.tier == Tier.PRECONDITION_USER_ERROR
+    assert "bd" in str(exc.value)
+
+
+def test_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("frobnicate", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert "frobnicate" in str(exc.value)
+
+
+def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError):
+        resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
+
+
+def test_store_name_enum_values() -> None:
+    # Consumer-boundary pin: these strings are the user-facing --store / env
+    # vocabulary, so they are pinned where a drift would break the CLI surface.
+    assert StoreName.FILE.value == "file"
+    assert StoreName.BD.value == "bd"


### PR DESCRIPTION
## Scope

Bead **8.3** — store-layer residuals + the runtime error model, the second bead of the prgroom CLI (stacked on the merged 8.1 foundation).

## Reconciliation (read this first)

The 8.1 foundation **over-delivered the error model**: it already shipped the complete `Tier` enum, the entire §3.7 `ErrorCode` registry (what/why/how), `exit_code_for_tier` (with the `assert_never` guard), the `_NO_WORK_CODES` set, `precondition_tier()`, and `PrgroomError(tier, code, signum, detail)` — which **is** the "TaggedError" the bead text names. So 8.3 builds **only the genuine delta** and re-declares none of that. `TaggedError` and a separate `lifecycle/errors.py` were **deferred** — forward-references for the later lifecycle beads (8.8+) with zero consumers today; building them now would be speculative dead code.

## What's in this PR

- **`prsession/registry.py`** — `resolve_store(name, env, state_dir)` selector. Precedence **flag > `PRGROOM_STORE` env > default `file`**; `file`→`FileStore`; `bd` (deferred) and unknown names → terminal `PreconditionError(PRECONDITION_STORE_UNAVAILABLE)` (exit 2, rendered 4-line block, no traceback).
- **`prsession/migrations.py` + `FileStore` read-path branch** — `MIGRATIONS: dict[int, Migrator]` (empty MVP seam), constructor-injected for tests. Schema mismatch + registered migrator → apply + `write_atomic` rewrite-in-place (only on success) + reparse; no migrator → `STATE_SCHEMA_UNKNOWN` (exit 78); raising migrator → `STATE_CORRUPT` with the on-disk file **byte-identical**.
- **`errors.py`** — new `PRECONDITION_STORE_UNAVAILABLE` code (+ registry entry; auto-resolves to USER_ERROR) and the `BlockingErrorCodes` frozenset.
- **`cli.py`** — `--store` root callback resolving the store eagerly (invalid adapter errors before any verb).

## In-house adversarial review (already applied)

A three-lens review (spec-alignment / correctness-safety / test-quality) ran before this PR. Findings fixed in `1ead651`:
- **bool/float schema-version trap** — `schema_version: true`/`1.0` (both `== 1`) silently loaded as healthy v1, defeating the STATE_SCHEMA_UNKNOWN contract. Now a `type(v) is int` predicate gates both the read check and the `MIGRATIONS` lookup (bool also aliases int keys via `hash(True)==hash(1)`).
- **blank `PRGROOM_STORE=""`** now falls back to `file` (matching `resolve_state_dir`'s POSIX convention); explicit empty `--store ''` still errors.
- Removed two definition-site tautology tests; exhaustiveness stays covered by the exact-value tier parametrize + the `assert_never` guard.

## Ground-truth references
Design `docs/plans/2026-05-12-prgroom-cli-design.md` §2 (Store), §3.6 (tiers), §3.7 (error registry).

## Intentionally out of scope / deferred
- Verb business logic; real gh/git integration.
- `TaggedError` + `lifecycle/errors.py` (forward-refs; land with their consumers in 8.8+).
- **Known deferred seam:** `FileStore.read` now has a write side-effect (in-place migration), so the §3.3 *lock-free* `status` reader must migrate-in-memory or take the lock — documented at `file.py` and recorded on bead 8.11. Latent today (`MIGRATIONS` empty).

## Test Plan
- [x] `make ci-prgroom` — exit 0: ruff ✓, format ✓, mypy --strict ✓ (17 files), **207 tests / 100% branch coverage**, pip-audit ✓, `prgroom --help` ✓.
- [ ] Copilot review of this PR.

**Stacking:** branched off `main` (post-8.1-merge); base = `main`. Bottom of the M1 stack — merge after Copilot clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
