### PR TITLE
feat(prgroom): gh/git Protocol adapter layer + failure classification (8.5)

### DIFF
--- a/docs/plans/2026-06-09-prgroom-8.3-store-errors.md
+++ b/docs/plans/2026-06-09-prgroom-8.3-store-errors.md
@@ -1,0 +1,612 @@
+# prgroom 8.3 — Store Residuals + Runtime Error Model Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the store-adapter selector, schema-migration seam, and the `BlockingErrorCodes` constant to the prgroom CLI — the genuine delta on top of the 8.1 foundation, which already shipped the full `Tier`/`ErrorCode`/`exit_code_for_tier` error model.
+
+**Architecture:** Three small, pure-ish units plus thin CLI wiring. `prsession/registry.py` resolves a `--store`/`PRGROOM_STORE` name to a concrete `Store` constructor (flag > env > default `file`). `prsession/migrations.py` holds an (empty in MVP) `dict[int, Migrator]`; `FileStore.read` gains a migration branch keyed on `schema_version` mismatch. `errors.py` gains one new precondition code (`PRECONDITION_STORE_UNAVAILABLE`) and the `BlockingErrorCodes` frozenset. The CLI root callback eagerly resolves the store so an invalid adapter fails terminally (rendered 4-line block, exit 2) before any verb runs.
+
+**Tech Stack:** Python 3.11+, typer, mypy --strict, ruff, pytest + coverage (90% branch). Reuses the existing `PrgroomError`/`PreconditionError`/`FileStore`/`write_atomic` foundation verbatim.
+
+**Reconciliation note:** 8.1 over-delivered the error model. This bead does NOT re-declare any `Tier` member, any existing `ErrorCode`, `exit_code_for_tier`, `_NO_WORK_CODES`, `precondition_tier()`, or `PrgroomError` (which IS the bead's "TaggedError"). `lifecycle/errors.py` is deferred — zero consumers today. The §3.7 registry was diffed against the shipped enum and is complete; only the new store code + `BlockingErrorCodes` are added.
+
+---
+
+## File Structure
+
+- **Modify** `src/prgroom/errors.py` — add `PRECONDITION_STORE_UNAVAILABLE` enum member + registry entry; add `BlockingErrorCodes` frozenset.
+- **Create** `src/prgroom/prsession/migrations.py` — `Migrator` type alias + empty `MIGRATIONS` dict.
+- **Modify** `src/prgroom/prsession/file.py` — `FileStore.__init__(migrations=...)`; migration branch in `read()`.
+- **Create** `src/prgroom/prsession/registry.py` — `StoreName` enum + `resolve_store()`.
+- **Modify** `src/prgroom/cli.py` — root callback `--store` eager resolution.
+- **Test** `tests/unit/test_errors.py` (extend), `tests/unit/test_registry.py` (new), `tests/integration/test_file_store_migrations.py` (new), `tests/unit/test_cli_store.py` (new).
+
+---
+
+## Task 1: New error code + BlockingErrorCodes in errors.py
+
+**Files:**
+- Modify: `src/prgroom/errors.py`
+- Test: `tests/unit/test_errors.py`
+
+- [ ] **Step 1: Write failing tests** — append to `tests/unit/test_errors.py`:
+
+```python
+from prgroom.errors import BlockingErrorCodes
+
+
+def test_store_unavailable_is_user_error_tier() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="bd")
+    assert err.tier == Tier.PRECONDITION_USER_ERROR
+    assert exit_code_for_tier(err) == 2
+
+
+def test_store_unavailable_carries_detail_in_message() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="frobnicate")
+    assert "frobnicate" in str(err)
+
+
+def test_blocking_error_codes_is_the_exact_documented_set() -> None:
+    # §3.2 / §3.6: resolve-escalated cannot clear these. Exact-set equality so a
+    # stray addition or omission fails here, not silently downstream.
+    assert BlockingErrorCodes == frozenset(
+        {
+            ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+            ErrorCode.STATE_CORRUPT,
+            ErrorCode.STATE_SCHEMA_UNKNOWN,
+            ErrorCode.RUNTIME_GH_TERMINAL,
+            ErrorCode.RUNTIME_PUSH_REJECTED,
+        }
+    )
+
+
+@pytest.mark.parametrize("absent", ["STATE_LOCK_STALE", "NOTICE_LOCK_STALE_CLEANED"])
+def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
+    # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
+    # death). Their presence would signal a regression to an fcntl-style protocol.
+    assert absent not in ErrorCode.__members__
+
+
+def test_every_tier_maps_to_a_concrete_exit_code() -> None:
+    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
+    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
+    for tier in Tier:
+        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
+        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
+        code = exit_code_for_tier(err)
+        assert isinstance(code, int)
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`AttributeError` on `BlockingErrorCodes`, missing enum member).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_errors.py -q`
+
+- [ ] **Step 3: Implement** — in `src/prgroom/errors.py`, add the enum member in the `PRECONDITION_*` block:
+
+```python
+    PRECONDITION_STORE_UNAVAILABLE = "PRECONDITION_STORE_UNAVAILABLE"
+```
+
+Add its registry entry to `_REGISTRY`:
+
+```python
+    ErrorCode.PRECONDITION_STORE_UNAVAILABLE: RegistryEntry(
+        what="the requested store adapter is unavailable",
+        why="--store/PRGROOM_STORE named an adapter not usable in this build",
+        how="use --store file (the default); 'bd' is deferred to a later release",
+    ),
+```
+
+Add the constant after `_REGISTRY` (it references `ErrorCode`):
+
+```python
+# Codes that gate `resolve-escalated` re-entry (§3.2, §3.6): an operator flipping
+# an escalated disposition cannot clear any of these — they require the recovery
+# paths in §3.6/§3.7 (cap re-arm, state-file inspection, gh/git reconciliation).
+BlockingErrorCodes: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+        ErrorCode.STATE_CORRUPT,
+        ErrorCode.STATE_SCHEMA_UNKNOWN,
+        ErrorCode.RUNTIME_GH_TERMINAL,
+        ErrorCode.RUNTIME_PUSH_REJECTED,
+    }
+)
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Commit** (deferred to end-of-bead single commit).
+
+---
+
+## Task 2: migrations.py registry
+
+**Files:**
+- Create: `src/prgroom/prsession/migrations.py`
+- Test: covered via Task 3 (the migration branch exercises `MIGRATIONS`); a direct
+  smoke assertion lives in the integration test.
+
+- [ ] **Step 1: Create the module:**
+
+```python
+"""Schema-migration registry for persisted state (§2, §3.7).
+
+A migrator upgrades a serialized state blob from one ``schema_version`` to the
+current one. The registry is keyed by the **from** version. It is EMPTY in the
+MVP — ``schema_version`` is 1 and there is nothing older to upgrade — but the
+seam exists so a future schema bump ships its upgrade path here without touching
+the read path. :meth:`~prgroom.prsession.file.FileStore.read` consults this dict
+on a version mismatch: a registered migrator runs and the file is rewritten in
+place; an absent one trips ``STATE_SCHEMA_UNKNOWN`` (exit 78).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Upgrades a raw JSON state blob from the keyed (from-)version toward the current
+# SCHEMA_VERSION. Must be pure w.r.t. the filesystem — the caller owns the atomic
+# rewrite. A migrator that cannot convert MUST raise (never return corrupt bytes);
+# the read path maps the raise to STATE_CORRUPT.
+Migrator = Callable[[bytes], bytes]
+
+# Keyed by the from-version. EMPTY in MVP (schema_version == 1, nothing older).
+MIGRATIONS: dict[int, Migrator] = {}
+```
+
+- [ ] **Step 2: Verify import** — `cd packages/prgroom && uv run python -c "from prgroom.prsession.migrations import MIGRATIONS, Migrator; assert MIGRATIONS == {}"`
+
+---
+
+## Task 3: FileStore migration branch
+
+**Files:**
+- Modify: `src/prgroom/prsession/file.py`
+- Test: `tests/integration/test_file_store_migrations.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/integration/test_file_store_migrations.py`:
+
+```python
+"""Integration tests for FileStore's schema-migration read branch (§2, §3.7).
+
+Real filesystem, real atomic rewrite, a synthetic migrator injected via the
+constructor seam (no global monkeypatching). Pins three coded decisions: a
+registered migrator upgrades + rewrites the file in place and the read proceeds;
+no migrator trips STATE_SCHEMA_UNKNOWN; a raising migrator surfaces STATE_CORRUPT
+and leaves the on-disk file byte-identical (write_atomic runs only on success).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.migrations import Migrator
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState, QuiescenceState
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError
+
+_T = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_OLD = SCHEMA_VERSION - 1
+
+
+def _current_state(ref: PRRef) -> PRGroomingState:
+    return PRGroomingState(
+        pr=ref,
+        phase=PRPhase.IDLE,
+        round=1,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+    )
+
+
+def _write_old_schema_file(path: Path, ref: PRRef) -> bytes:
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = _OLD
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    return raw
+
+
+def _bump_to_current() -> Migrator:
+    def migrate(raw: bytes) -> bytes:
+        obj = json.loads(raw)
+        obj["schema_version"] = SCHEMA_VERSION
+        return json.dumps(obj).encode("utf-8")
+
+    return migrate
+
+
+def test_registered_migrator_upgrades_and_rewrites_in_place(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    _write_old_schema_file(state_path, ref)
+    migrations: Mapping[int, Migrator] = {_OLD: _bump_to_current()}
+    store = FileStore(state_dir=tmp_path, migrations=migrations)
+
+    read_back = store.read(ref)
+
+    assert read_back.phase == PRPhase.IDLE
+    # File rewritten in place at the current version (write_atomic ran on success).
+    on_disk = json.loads(state_path.read_bytes())
+    assert on_disk["schema_version"] == SCHEMA_VERSION
+
+
+def test_no_migrator_for_unknown_version_trips_schema_unknown(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    _write_old_schema_file(tmp_path / f"{ref.slug()}.json", ref)
+    store = FileStore(state_dir=tmp_path, migrations={})  # empty: no migrator
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)
+
+
+def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
+    tmp_path: Path,
+) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _boom(_raw: bytes) -> bytes:
+        raise ValueError("migrator cannot convert")  # noqa: TRY003
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _boom})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+
+    # HARD requirement: a failed migration never rewrites the file.
+    assert state_path.read_bytes() == original
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`FileStore.__init__` has no `migrations` kwarg).
+
+Run: `cd packages/prgroom && uv run pytest tests/integration/test_file_store_migrations.py -q`
+
+- [ ] **Step 3: Implement** — edit `src/prgroom/prsession/file.py`.
+
+Add import near the existing imports:
+
+```python
+from collections.abc import Iterator, Mapping
+```
+(merge with the existing `from collections.abc import Iterator` line)
+
+Add the migrations import:
+
+```python
+from prgroom.prsession.migrations import MIGRATIONS, Migrator
+```
+
+Change `__init__`:
+
+```python
+    def __init__(
+        self,
+        *,
+        state_dir: Path | None = None,
+        migrations: Mapping[int, Migrator] | None = None,
+    ) -> None:
+        self._dir = state_dir if state_dir is not None else resolve_state_dir()
+        self._migrations: Mapping[int, Migrator] = (
+            migrations if migrations is not None else MIGRATIONS
+        )
+```
+
+Replace the version-check block in `read()`:
+
+```python
+        version = payload.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raw, payload = self._migrate(path, raw, version)
+        return PRGroomingState.from_dict(payload)
+```
+
+Add the `_migrate` helper as a method on `FileStore`:
+
+```python
+    def _migrate(
+        self, path: Path, raw: bytes, from_version: object
+    ) -> tuple[bytes, dict[str, object]]:
+        """Apply a registered migrator for ``from_version`` or trip schema-unknown.
+
+        On a registered migrator: run it on the raw bytes, rewrite the file in
+        place via ``write_atomic`` (only on success — a raising migrator leaves
+        the file byte-identical), then re-parse. A raising migrator maps to
+        :class:`StateCorruptError` (its registry ``how`` — move aside, rebuild —
+        fits a failed migration). No migrator: :class:`SchemaUnknownError`.
+        """
+        migrator = (
+            self._migrations.get(from_version) if isinstance(from_version, int) else None
+        )
+        if migrator is None:
+            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; names the file + version
+                f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
+            )
+        try:
+            migrated = migrator(raw)
+        except Exception as exc:  # migrator failure must never corrupt on-disk state
+            raise StateCorruptError(f"{path}: migration from {from_version!r} failed: {exc}") from exc  # noqa: TRY003
+        write_atomic(path, migrated)
+        return migrated, json.loads(migrated)
+```
+
+Note: `json.loads(migrated)` may itself raise `json.JSONDecodeError` if a buggy migrator returns non-JSON; that is a programming error in the migrator and surfaces as an uncaught decode error — acceptable (a registered migrator is trusted code, not external input). The empty-MVP registry means this path is exercised only by injected test migrators.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+---
+
+## Task 4: registry.py store selector
+
+**Files:**
+- Create: `src/prgroom/prsession/registry.py`
+- Test: `tests/unit/test_registry.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/unit/test_registry.py`:
+
+```python
+"""Tests for the store-adapter selector (§2 "Selection at runtime").
+
+Pins the coded decisions: name resolution and precedence (flag > env > default
+file), the concrete adapter each name yields, and the terminal user-error for
+the deferred `bd` adapter and any unknown name. Uses the real FileStore (a fake
+would not prove the file branch returns the production adapter).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prgroom.errors import ErrorCode, PreconditionError, Tier
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.registry import StoreName, resolve_store
+
+
+def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
+    store = resolve_store("file", env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_default_when_no_flag_no_env_is_file(tmp_path: Path) -> None:
+    store = resolve_store(None, env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_env_selects_when_no_flag(tmp_path: Path) -> None:
+    store = resolve_store(None, env={"PRGROOM_STORE": "file"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_flag_beats_env(tmp_path: Path) -> None:
+    # Flag says file, env says bd: flag wins, so we get a FileStore (no error).
+    store = resolve_store("file", env={"PRGROOM_STORE": "bd"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_bd_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("bd", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert exc.value.tier == Tier.PRECONDITION_USER_ERROR
+    assert "bd" in str(exc.value)
+
+
+def test_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("frobnicate", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert "frobnicate" in str(exc.value)
+
+
+def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError):
+        resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
+
+
+def test_store_name_enum_values() -> None:
+    # Consumer-boundary pin: these strings are the user-facing --store / env
+    # vocabulary, so they are pinned where a drift would break the CLI surface.
+    assert StoreName.FILE.value == "file"
+    assert StoreName.BD.value == "bd"
+```
+
+- [ ] **Step 2: Run — expect FAIL** (no module `registry`).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_registry.py -q`
+
+- [ ] **Step 3: Implement** — new file `src/prgroom/prsession/registry.py`:
+
+```python
+"""Store-adapter selector (§2 "Selection at runtime").
+
+Resolves a ``--store`` flag value (or the ``PRGROOM_STORE`` env var, or the
+built-in default ``file``) to a concrete :class:`~prgroom.prsession.store.Store`.
+Precedence is **flag > env > default** — the flag is consulted first and only
+falls through to the env when unset. ``file`` yields the production
+:class:`~prgroom.prsession.file.FileStore`; ``bd`` is deferred (v2) and any
+unknown name is a user error — both surface as a terminal
+``PRECONDITION_STORE_UNAVAILABLE`` (exit 2, rendered 4-line block, no traceback).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import Path
+
+from prgroom.errors import ErrorCode, PreconditionError
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.store import Store
+
+ENV_VAR = "PRGROOM_STORE"
+DEFAULT_STORE = "file"
+
+
+class StoreName(StrEnum):
+    """The user-facing ``--store`` / ``PRGROOM_STORE`` vocabulary."""
+
+    FILE = "file"
+    BD = "bd"
+
+
+def resolve_store(
+    name: str | None,
+    *,
+    env: Mapping[str, str] | None = None,
+    state_dir: Path | None = None,
+) -> Store:
+    """Resolve a store name to a concrete adapter (flag > env > default ``file``).
+
+    ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
+    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
+    unrecognized name raise :class:`PreconditionError` tagged
+    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    """
+    environ = env if env is not None else {}
+    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    if resolved == StoreName.FILE:
+        return FileStore(state_dir=state_dir)
+    raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)
+```
+
+- [ ] **Step 4: Run — expect PASS.**
+
+---
+
+## Task 5: CLI --store wiring (eager root-callback resolution)
+
+**Files:**
+- Modify: `src/prgroom/cli.py`
+- Test: `tests/unit/test_cli_store.py`
+
+- [ ] **Step 1: Write failing tests** — new file `tests/unit/test_cli_store.py`:
+
+```python
+"""Tests for the CLI `--store` root-callback wiring (§1, §2).
+
+The store is resolved eagerly in the root callback so an invalid adapter fails
+terminally — rendered 4-line block, exit 2, no traceback — BEFORE any verb body
+runs. A valid `--store file` (or the default) falls through to the verb skeleton.
+Proves `--store` beats `PRGROOM_STORE` via a set env var.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom.cli import SKELETON_EXIT_CODE, app
+
+runner = CliRunner()
+
+
+def test_invalid_store_bd_exits_two_with_block_before_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "bd", "poll", "123"])
+    assert result.exit_code == 2
+    assert "error: PRECONDITION_STORE_UNAVAILABLE" in result.output
+    assert "how:" in result.output
+    # Terminal store error pre-empts the skeleton notice.
+    assert "not yet implemented" not in result.output
+    assert result.exception is None  # no traceback surfaced
+
+
+def test_unknown_store_name_exits_two() -> None:
+    result = runner.invoke(app, ["--store", "frobnicate", "poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+
+
+def test_valid_store_file_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+    assert "not yet implemented" in result.output
+
+
+def test_default_store_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # env says bd (would error); flag says file (valid) -> flag wins -> skeleton.
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_env_bd_with_no_flag_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`--store` is not a known option; exit 2 from typer's own usage error, but with no registry block — assertions on the rendered block fail).
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_cli_store.py -q`
+
+- [ ] **Step 3: Implement** — edit `src/prgroom/cli.py`.
+
+Add imports:
+
+```python
+import os
+
+from prgroom.prsession.registry import resolve_store
+```
+
+Add a root callback (typer invokes it before any subcommand). The callback resolves the store eagerly; a `PreconditionError` propagates to `main()`'s existing handler (rendered block + exit 2). Resolution is order-independent of the env read because `resolve_store` is passed `os.environ`:
+
+```python
+@app.callback()
+def _root(
+    store: str | None = typer.Option(
+        None,
+        "--store",
+        help="State store adapter: file (default) or bd (deferred).",
+        envvar=None,  # env precedence is handled in resolve_store, not by typer
+    ),
+) -> None:
+    """Resolve the state store eagerly so an invalid --store fails before any verb."""
+    # Resolution is discarded here (verbs are skeletons); its sole purpose in the
+    # foundation is to fail terminally on an invalid adapter. Later beads keep the
+    # resolved Store on a context object for the verbs to consume.
+    resolve_store(store, env=os.environ)
+```
+
+Note: `envvar=None` keeps typer from reading `PRGROOM_STORE` itself — precedence (flag > env) lives in `resolve_store`, the single source of truth, so the CLI and a direct `resolve_store` caller behave identically.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Re-run the existing CLI smoke suite** to confirm the new callback did not break verb discovery (the root callback adds an option but `no_args_is_help` + per-verb help must still work):
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_cli_smoke.py tests/unit/test_cli_errors.py -q`
+Expected: PASS (all existing CLI tests green).
+
+---
+
+## Task 6: Full gate
+
+- [ ] **Step 1:** `make -C <worktree-root> ci-prgroom` → expect green (ruff, ruff format --check, mypy --strict, pytest --cov ≥90% branch, pip-audit, entry verify).
+- [ ] **Step 2:** Completion gate — `quality-reviewer` → address → `simplify` → address → `verify-checklist`.
+- [ ] **Step 3:** Single semantic commit on the worktree branch.
+
+---
+
+## Self-Review
+
+**Spec coverage:** registry (Task 4) ✓; migrations module (Task 2) + read branch (Task 3) ✓; BlockingErrorCodes + new code (Task 1) ✓; CLI wiring (Task 5) ✓; Tier-exhaustiveness + STATE_LOCK_STALE absence tests (Task 1) ✓. No lifecycle/errors.py, no TaggedError — deferred per decision #2.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `Migrator` (migrations.py) used identically in file.py + tests; `resolve_store(name, *, env, state_dir)` signature consistent across registry.py, tests, and the CLI callback; `PreconditionError(code, detail=...)` matches the foundation's existing constructor.

--- a/docs/plans/2026-06-09-prgroom-gh-git-adapters.md
+++ b/docs/plans/2026-06-09-prgroom-gh-git-adapters.md
@@ -1,0 +1,100 @@
+# prgroom gh/git Protocol Adapter Layer — Implementation Plan (bead 8.5)
+
+> **For agentic workers:** Implement task-by-task using `test-driven-development` (red-green-refactor per task). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Build the gh and git boundary-adapter layer — two `@runtime_checkable` Protocols with structurally-satisfying subprocess CLI adapters that map gh/git failures to the existing `ErrorCode` registry, plus recorded-response fakes and per-adapter fit-tests.
+
+**Architecture:** A shared `CommandRunner` Protocol (mirrors the `Clock`/`Randomness`/`Deps` seam) is the single injection point — the system boundary is `subprocess.run`, wrapped by `SubprocessRunner` in production and a `RecordedRunner` fake in tests. `GhCli` and `GitCli` adapters route every external call through the injected runner and classify failures into existing `PrgroomError(tier, code)` pairs. 404 from gh surfaces as a typed `GhNotFoundError` (the out-of-scope verb owns the precondition decision per spec §3.7); non-404 4xx → `RUNTIME_GH_TERMINAL`.
+
+**Tech Stack:** Python 3.11+, stdlib `subprocess`, typer (runtime), pytest + mypy --strict (dev). No new dependencies.
+
+---
+
+## Reconciliation pins (from spec §3.6/§3.7 + errors.py)
+
+- gh 5xx OR rate-limit (403/429 with `Retry-After` / `X-RateLimit-Remaining: 0`) → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GH_TRANSIENT`
+- gh 4xx ≠ 404 ≠ rate → `Tier.RUNTIME_TERMINAL_USER` + `ErrorCode.RUNTIME_GH_TERMINAL`
+- gh 404 → `GhNotFoundError` (typed signal; NOT a PrgroomError — caller's startup precondition owns `PRECONDITION_REPO_UNREACHABLE`)
+- gh GraphQL: exit 0 but `errors[]` present in JSON → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GRAPHQL_FAILED`
+- git push rejected (`! [rejected]`, `non-fast-forward`, `protected branch`, hook decline) → `Tier.RUNTIME_TERMINAL_USER` + `ErrorCode.RUNTIME_PUSH_REJECTED`
+- git network failure (`subprocess.TimeoutExpired`, `Could not resolve host`, `Connection timed out`, `Connection reset`) → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GIT_TRANSIENT`
+- Adapters structurally satisfy their Protocol (no inheritance); `mypy --strict` proves the fit.
+
+## File structure
+
+- Create `src/prgroom/proc.py` — `CommandResult`, `CommandRunner` Protocol, `SubprocessRunner`.
+- Create `src/prgroom/gh/__init__.py` — re-export `GhClient`, `GhCli`, `GhNotFoundError`.
+- Create `src/prgroom/gh/client.py` — Protocol + adapter + `_classify_gh_failure`.
+- Create `src/prgroom/git/__init__.py` — re-export `GitClient`, `GitCli`.
+- Create `src/prgroom/git/client.py` — Protocol + adapter + `_classify_git_failure`.
+- Create `tests/fakes.py` — `RecordedRunner` (matches argv → recorded `CommandResult`).
+- Create `tests/unit/test_proc.py` — `SubprocessRunner` boundary test (monkeypatch `subprocess.run`).
+- Create `tests/unit/test_gh_fit.py` — gh adapter surface + every classification arm vs `RecordedRunner`.
+- Create `tests/unit/test_git_fit.py` — git adapter surface + every classification arm vs `RecordedRunner`.
+- Create `tests/fixtures/gh/*`, `tests/fixtures/git/*` — recorded stdout/stderr fixtures.
+
+---
+
+### Task 1: Shared CommandRunner seam (`proc.py`)
+
+**Files:**
+- Create: `src/prgroom/proc.py`
+- Create: `tests/fakes.py`
+- Test: `tests/unit/test_proc.py`
+
+- [ ] Step 1: Write `tests/fakes.py` with `RecordedRunner` — a `CommandRunner` fake that pops a queued `CommandResult` per call (FIFO) and records the argv it saw; raises if the queue empties. Also support a `TimeoutRunner` that raises `subprocess.TimeoutExpired`.
+- [ ] Step 2: Write failing `tests/unit/test_proc.py`: `SubprocessRunner().run([...])` returns a `CommandResult` whose fields come from a monkeypatched `subprocess.run` (boundary mock). Assert `text=True`, `capture_output=True`, `check=False`, and that `input`/`timeout` are forwarded. Run → FAIL (module missing).
+- [ ] Step 3: Implement `proc.py`: `@dataclass(frozen=True, slots=True) CommandResult(returncode, stdout, stderr)`; `@runtime_checkable CommandRunner(Protocol)` with `run(argv, *, input=None, timeout=None) -> CommandResult`; `SubprocessRunner` wrapping `subprocess.run(list(argv), capture_output=True, text=True, check=False, input=input, timeout=timeout)`.
+- [ ] Step 4: Run → PASS.
+- [ ] Step 5: Commit `feat(prgroom): CommandRunner subprocess seam (8.5)`.
+
+### Task 2: gh adapter + classification (`gh/client.py`)
+
+**Files:**
+- Create: `src/prgroom/gh/client.py`, `src/prgroom/gh/__init__.py`
+- Test: `tests/unit/test_gh_fit.py`
+- Fixtures: `tests/fixtures/gh/`
+
+- [ ] Step 1: Write failing `test_gh_fit.py` covering the full public surface against `RecordedRunner`:
+  - `head_ref_oid(ref)` parses `{"headRefOid": "abc"}` stdout.
+  - `rest("GET", path)` returns parsed JSON on success.
+  - `graphql(query, variables)` returns `data` on success; raises `PrgroomError(RUNTIME_GRAPHQL_FAILED, RUNTIME_TRANSIENT)` when stdout JSON has `errors[]`.
+  - classification arms: 503 stderr `gh: ... (HTTP 503)` → `RUNTIME_GH_TRANSIENT`; 429 with rate-limit → `RUNTIME_GH_TRANSIENT`; 422 → `RUNTIME_GH_TERMINAL`; 404 → `GhNotFoundError`.
+  - structural fit: `isinstance(GhCli(RecordedRunner()), GhClient)`.
+- [ ] Step 2: Run → FAIL.
+- [ ] Step 3: Implement `gh/client.py`: `GhNotFoundError(Exception)`; `@runtime_checkable GhClient(Protocol)` with `head_ref_oid`, `rest`, `graphql`; `GhCli(runner)` adapter; `_classify_gh_failure(result)` parsing `(HTTP NNN)` from stderr, rate-limit via stderr/`Retry-After`, raising the mapped error. GraphQL success-with-errors detected by inspecting parsed JSON.
+- [ ] Step 4: Run → PASS.
+- [ ] Step 5: Commit `feat(prgroom): gh subprocess adapter + failure classification (8.5)`.
+
+### Task 3: git adapter + classification (`git/client.py`)
+
+**Files:**
+- Create: `src/prgroom/git/client.py`, `src/prgroom/git/__init__.py`
+- Test: `tests/unit/test_git_fit.py`
+- Fixtures: `tests/fixtures/git/`
+
+- [ ] Step 1: Write failing `test_git_fit.py`:
+  - `head_sha()` returns stripped stdout SHA.
+  - `rev_list(range_)` splits stdout lines into a list (empty stdout → `[]`).
+  - `push(remote, branch)` returns None on success.
+  - `stash()` returns None on success.
+  - classification: push `! [rejected] ... (non-fast-forward)` → `RUNTIME_PUSH_REJECTED`; `protected branch` → `RUNTIME_PUSH_REJECTED`; `Could not resolve host` → `RUNTIME_GIT_TRANSIENT`; `TimeoutRunner` → `RUNTIME_GIT_TRANSIENT`.
+  - structural fit: `isinstance(GitCli(RecordedRunner()), GitClient)`.
+- [ ] Step 2: Run → FAIL.
+- [ ] Step 3: Implement `git/client.py`: `@runtime_checkable GitClient(Protocol)`; `GitCli(runner)`; `_classify_git_failure(result_or_timeout)` mapping rejection vs transient.
+- [ ] Step 4: Run → PASS.
+- [ ] Step 5: Commit `feat(prgroom): git subprocess adapter + push/transient classification (8.5)`.
+
+### Task 4: Integration tier — real git on a fixture repo
+
+**Files:**
+- Test: `tests/integration/test_git_real.py`
+
+- [ ] Step 1: Write a test using a `tmp_path` git repo (real `SubprocessRunner`): init, commit twice, assert `head_sha()` is 40 hex chars and `rev_list("HEAD~1..HEAD")` has length 1. Skip if `git` not on PATH.
+- [ ] Step 2: Run → may FAIL until paths align; Step 3 fix; Step 4 PASS.
+- [ ] Step 5: Commit `test(prgroom): real-git integration for the git adapter (8.5)`.
+
+### Task 5: Coverage close-out + completion gate
+
+- [ ] `make -C <worktree> ci-prgroom` green (90% branch).
+- [ ] quality-reviewer → address → simplify → address → verify-checklist.

--- a/docs/plans/2026-06-09-prgroom-gh-git-adapters.md
+++ b/docs/plans/2026-06-09-prgroom-gh-git-adapters.md
@@ -12,7 +12,7 @@
 
 ## Reconciliation pins (from spec §3.6/§3.7 + errors.py)
 
-- gh 5xx OR rate-limit (403/429 with `Retry-After` / `X-RateLimit-Remaining: 0`) → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GH_TRANSIENT`
+- gh 5xx, OR a rate limit (HTTP 429, or a 4xx whose `gh` stderr contains `rate limit exceeded`) → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GH_TRANSIENT` (the gh CLI surfaces rate limiting via stderr text, not parsed HTTP headers)
 - gh 4xx ≠ 404 ≠ rate → `Tier.RUNTIME_TERMINAL_USER` + `ErrorCode.RUNTIME_GH_TERMINAL`
 - gh 404 → `GhNotFoundError` (typed signal; NOT a PrgroomError — caller's startup precondition owns `PRECONDITION_REPO_UNREACHABLE`)
 - gh GraphQL: exit 0 but `errors[]` present in JSON → `Tier.RUNTIME_TRANSIENT` + `ErrorCode.RUNTIME_GRAPHQL_FAILED`
@@ -62,7 +62,7 @@
   - classification arms: 503 stderr `gh: ... (HTTP 503)` → `RUNTIME_GH_TRANSIENT`; 429 with rate-limit → `RUNTIME_GH_TRANSIENT`; 422 → `RUNTIME_GH_TERMINAL`; 404 → `GhNotFoundError`.
   - structural fit: `isinstance(GhCli(RecordedRunner()), GhClient)`.
 - [ ] Step 2: Run → FAIL.
-- [ ] Step 3: Implement `gh/client.py`: `GhNotFoundError(Exception)`; `@runtime_checkable GhClient(Protocol)` with `head_ref_oid`, `rest`, `graphql`; `GhCli(runner)` adapter; `_classify_gh_failure(result)` parsing `(HTTP NNN)` from stderr, rate-limit via stderr/`Retry-After`, raising the mapped error. GraphQL success-with-errors detected by inspecting parsed JSON.
+- [ ] Step 3: Implement `gh/client.py`: `GhNotFoundError(Exception)`; `@runtime_checkable GhClient(Protocol)` with `head_ref_oid`, `rest`, `graphql`; `GhCli(runner)` adapter; `_classify_gh_failure(result)` parsing the trailing `(HTTP NNN)` from stderr, rate-limit via the `rate limit exceeded` stderr phrase (429 unconditionally), raising the mapped error. GraphQL success-with-errors detected by inspecting parsed JSON.
 - [ ] Step 4: Run → PASS.
 - [ ] Step 5: Commit `feat(prgroom): gh subprocess adapter + failure classification (8.5)`.
 

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -14,12 +14,14 @@ Verb names with underscores in the function name render as hyphenated commands
 
 from __future__ import annotations
 
+import os
 import sys
 from typing import IO
 
 import typer
 
 from prgroom.errors import PreconditionError, PrgroomError, exit_code_for_tier
+from prgroom.prsession.registry import resolve_store
 
 # Foundation skeletons are not yet implemented; they exit non-zero so a caller
 # never mistakes a skeleton's silence for a successful no-op. EX_UNAVAILABLE
@@ -32,6 +34,33 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+
+
+@app.callback()
+def _root(
+    store: str | None = typer.Option(
+        None,
+        "--store",
+        help="State store adapter: file (default) or bd (deferred).",
+        envvar=None,  # env precedence is owned by resolve_store, not typer
+    ),
+) -> None:
+    """Resolve the state store eagerly so an invalid --store fails before any verb.
+
+    The resolved Store is discarded here (verbs are skeletons); its sole purpose
+    in the foundation is to fail terminally on an invalid adapter. An invalid
+    ``--store`` renders the canonical 4-line block via :func:`handle_cli_error`
+    and exits with the tier code (2, no traceback) right here — so the behavior
+    is identical whether the app is driven through :func:`main` or directly (e.g.
+    typer's ``CliRunner``). Later beads keep the resolved Store on a context
+    object for the verbs to consume. Precedence (flag > env > default) lives in
+    :func:`resolve_store`, the single source of truth, so the CLI and a direct
+    ``resolve_store`` caller behave identically.
+    """
+    try:
+        resolve_store(store, env=os.environ)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
 
 
 def _skeleton(verb: str) -> None:

--- a/packages/prgroom/src/prgroom/errors.py
+++ b/packages/prgroom/src/prgroom/errors.py
@@ -77,6 +77,7 @@ class ErrorCode(StrEnum):
     PRECONDITION_NO_ESCALATIONS = "PRECONDITION_NO_ESCALATIONS"
     PRECONDITION_WAIT_NOT_APPLICABLE = "PRECONDITION_WAIT_NOT_APPLICABLE"
     PRECONDITION_LOCK_HELD = "PRECONDITION_LOCK_HELD"
+    PRECONDITION_STORE_UNAVAILABLE = "PRECONDITION_STORE_UNAVAILABLE"
     # RUNTIME_*
     RUNTIME_GH_TRANSIENT = "RUNTIME_GH_TRANSIENT"
     RUNTIME_GH_TERMINAL = "RUNTIME_GH_TERMINAL"
@@ -181,6 +182,11 @@ _REGISTRY: dict[ErrorCode, RegistryEntry] = {
         why="the concurrency model is one-at-a-time per PR",
         how="wait for the other invocation; the scheduler retries on next cadence",
     ),
+    ErrorCode.PRECONDITION_STORE_UNAVAILABLE: RegistryEntry(
+        what="the requested store adapter is unavailable",
+        why="--store/PRGROOM_STORE named an adapter not usable in this build",
+        how="use --store file (the default); 'bd' is deferred to a later release",
+    ),
     ErrorCode.RUNTIME_GH_TRANSIENT: RegistryEntry(
         what="gh API returned 5xx or rate-limited with Retry-After",
         why="the external service is degraded",
@@ -272,6 +278,20 @@ _REGISTRY: dict[ErrorCode, RegistryEntry] = {
         how="resolve escalations; raise --max-rounds and re-run, or hand off to human review",
     ),
 }
+
+
+# Codes that gate `resolve-escalated` re-entry (§3.2, §3.6): an operator flipping
+# an escalated disposition cannot clear any of these — they require the recovery
+# paths in §3.6/§3.7 (cap re-arm, state-file inspection, gh/git reconciliation).
+BlockingErrorCodes: frozenset[ErrorCode] = frozenset(
+    {
+        ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+        ErrorCode.STATE_CORRUPT,
+        ErrorCode.STATE_SCHEMA_UNKNOWN,
+        ErrorCode.RUNTIME_GH_TERMINAL,
+        ErrorCode.RUNTIME_PUSH_REJECTED,
+    }
+)
 
 
 class PrgroomError(Exception):

--- a/packages/prgroom/src/prgroom/gh/__init__.py
+++ b/packages/prgroom/src/prgroom/gh/__init__.py
@@ -1,0 +1,7 @@
+"""The gh adapter package (§1, §3). GitHub access via the ``gh`` subprocess."""
+
+from __future__ import annotations
+
+from prgroom.gh.client import GhCli, GhClient, GhNotFoundError
+
+__all__ = ["GhCli", "GhClient", "GhNotFoundError"]

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -5,7 +5,8 @@
 :class:`~prgroom.proc.CommandRunner` boundary, and maps failures onto the
 existing :class:`~prgroom.errors.ErrorCode` registry:
 
-* 5xx / rate-limit (403|429 naming a rate limit) -> ``RUNTIME_GH_TRANSIENT``
+* 5xx, or rate-limit (429 always; 403 only when stderr names a rate limit)
+  -> ``RUNTIME_GH_TRANSIENT``
 * other 4xx (not 404, not rate-limit)            -> ``RUNTIME_GH_TERMINAL``
 * 404                                            -> :class:`GhNotFoundError`
   (a typed signal; the caller's startup precondition owns

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -68,8 +68,8 @@ class GhClient(Protocol):
     def head_ref_oid(self, ref: PRRef) -> str: ...  # pragma: no cover
 
     def rest(
-        self, method: str, path: str, *, fields: JsonObj | None = None
-    ) -> JsonObj: ...  # pragma: no cover
+        self, method: str, path: str, *, fields: dict[str, str] | None = None
+    ) -> Any: ...  # pragma: no cover  # gh api returns object|array|primitive; caller narrows
 
     def graphql(self, query: str, variables: JsonObj) -> JsonObj: ...  # pragma: no cover
 
@@ -126,13 +126,15 @@ class GhCli:
         parsed: JsonObj = json.loads(out)
         return str(parsed["headRefOid"])
 
-    def rest(self, method: str, path: str, *, fields: JsonObj | None = None) -> JsonObj:
+    def rest(self, method: str, path: str, *, fields: dict[str, str] | None = None) -> Any:
         argv = ["gh", "api", "--method", method, path]
         for key, value in (fields or {}).items():
             argv += ["-f", f"{key}={value}"]
         out = self._run(argv)
-        parsed: JsonObj = json.loads(out) if out.strip() else {}
-        return parsed
+        # gh api returns a JSON object, array, or primitive depending on the
+        # endpoint — the caller (which knows the endpoint) narrows. An empty body
+        # (e.g. a 204) normalizes to {}.
+        return json.loads(out) if out.strip() else {}
 
     def graphql(self, query: str, variables: JsonObj) -> JsonObj:
         argv = ["gh", "api", "graphql", "-f", f"query={query}"]

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -1,0 +1,138 @@
+"""The gh adapter — GitHub access via the ``gh`` subprocess (§1, §3, §7.6).
+
+``GhCli`` shells out to ``gh`` (REST via ``gh api``, GraphQL via
+``gh api graphql``, head-OID via ``gh pr view``) through the injected
+:class:`~prgroom.proc.CommandRunner` boundary, and maps failures onto the
+existing :class:`~prgroom.errors.ErrorCode` registry:
+
+* 5xx / rate-limit (403|429 naming a rate limit) -> ``RUNTIME_GH_TRANSIENT``
+* other 4xx (not 404, not rate-limit)            -> ``RUNTIME_GH_TERMINAL``
+* 404                                            -> :class:`GhNotFoundError`
+  (a typed signal; the caller's startup precondition owns
+  ``PRECONDITION_REPO_UNREACHABLE`` per §3.7 — the adapter does not guess)
+* GraphQL request returns 200 but carries ``errors[]`` -> ``RUNTIME_GRAPHQL_FAILED``
+
+It **structurally satisfies** :class:`GhClient` (no inheritance); ``mypy
+--strict`` checks the fit, mirroring ``FileStore`` vs ``Store``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Protocol, runtime_checkable
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.proc import CommandRunner
+from prgroom.prsession.pr_ref import PRRef
+
+JsonObj = dict[str, Any]
+
+# gh prints `gh: <message> (HTTP NNN)` to stderr on an API error; the exit code is
+# always 1, so the status token in stderr is the only classification signal.
+_HTTP_STATUS = re.compile(r"\(HTTP (\d{3})\)")
+
+
+class GhNotFoundError(Exception):
+    """A gh API 404. A typed signal, NOT a :class:`PrgroomError` (§3.7).
+
+    404 is ambiguous at the boundary — repo-unreachable (a startup precondition,
+    ``PRECONDITION_REPO_UNREACHABLE``) versus a PR/thread that vanished mid-run.
+    The adapter reports the HTTP fact and lets the (out-of-scope) verb decide
+    which precondition/runtime code applies.
+    """
+
+
+@runtime_checkable
+class GhClient(Protocol):
+    """The GitHub access surface the lifecycle verbs depend on (§3)."""
+
+    def head_ref_oid(self, ref: PRRef) -> str: ...  # pragma: no cover
+
+    def rest(
+        self, method: str, path: str, *, fields: JsonObj | None = None
+    ) -> JsonObj: ...  # pragma: no cover
+
+    def graphql(self, query: str, variables: JsonObj) -> JsonObj: ...  # pragma: no cover
+
+
+def _classify_gh_failure(stdout: str, stderr: str) -> PrgroomError | GhNotFoundError:
+    """Map a failed ``gh`` invocation to its registry error (§3.6/§3.7)."""
+    match = _HTTP_STATUS.search(stderr)
+    if match is None:
+        # No parseable status: cannot prove transient, so treat as terminal
+        # rather than invite an unbounded scheduler retry loop.
+        return PrgroomError(
+            tier=Tier.RUNTIME_TERMINAL_USER,
+            code=ErrorCode.RUNTIME_GH_TERMINAL,
+            detail=stderr.strip() or stdout.strip(),
+        )
+    status = int(match.group(1))
+    detail = stderr.strip()
+    if status == 404:  # HTTP status literal is self-documenting
+        return GhNotFoundError(detail)
+    # 429 is definitionally rate-limited; 403 is ambiguous (permissions vs
+    # secondary rate limit) so it only counts as transient when the message
+    # names a rate limit. 5xx is always a degraded-service transient.
+    is_rate_limit = status == 429 or (  # Too Many Requests
+        status == 403 and "rate limit" in stderr.lower()  # Forbidden
+    )
+    if status >= 500 or is_rate_limit:  # 5xx server-error band
+        return PrgroomError(
+            tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_GH_TRANSIENT, detail=detail
+        )
+    return PrgroomError(
+        tier=Tier.RUNTIME_TERMINAL_USER, code=ErrorCode.RUNTIME_GH_TERMINAL, detail=detail
+    )
+
+
+class GhCli:
+    """gh adapter. Structurally satisfies :class:`GhClient`."""
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    def head_ref_oid(self, ref: PRRef) -> str:
+        out = self._run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(ref.number),
+                "--repo",
+                f"{ref.owner}/{ref.repo}",
+                "--json",
+                "headRefOid",
+            ]
+        )
+        parsed: JsonObj = json.loads(out)
+        return str(parsed["headRefOid"])
+
+    def rest(self, method: str, path: str, *, fields: JsonObj | None = None) -> JsonObj:
+        argv = ["gh", "api", "--method", method, path]
+        for key, value in (fields or {}).items():
+            argv += ["-f", f"{key}={value}"]
+        out = self._run(argv)
+        parsed: JsonObj = json.loads(out) if out.strip() else {}
+        return parsed
+
+    def graphql(self, query: str, variables: JsonObj) -> JsonObj:
+        argv = ["gh", "api", "graphql", "-f", f"query={query}"]
+        for key, value in variables.items():
+            argv += ["-F", f"{key}={value}"]
+        out = self._run(argv)
+        envelope: JsonObj = json.loads(out)
+        if envelope.get("errors"):
+            raise PrgroomError(
+                tier=Tier.RUNTIME_TRANSIENT,
+                code=ErrorCode.RUNTIME_GRAPHQL_FAILED,
+                detail=json.dumps(envelope["errors"]),
+            )
+        data: JsonObj = envelope.get("data") or {}
+        return data
+
+    def _run(self, argv: list[str]) -> str:
+        result = self._runner.run(argv)
+        if result.returncode != 0:
+            raise _classify_gh_failure(result.stdout, result.stderr)
+        return result.stdout

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -7,11 +7,20 @@ existing :class:`~prgroom.errors.ErrorCode` registry:
 
 * 5xx, or rate-limit (429 always; 403 only when stderr names a rate limit)
   -> ``RUNTIME_GH_TRANSIENT``
+* a hung call (``subprocess.TimeoutExpired``)     -> ``RUNTIME_GH_TRANSIENT``
+  (symmetric with the git adapter; retry on the next cadence)
 * other 4xx (not 404, not rate-limit)            -> ``RUNTIME_GH_TERMINAL``
+* a missing ``gh`` binary (``OSError``)           -> ``RUNTIME_GH_TERMINAL``
+  (a local config gap a retry won't fix)
 * 404                                            -> :class:`GhNotFoundError`
   (a typed signal; the caller's startup precondition owns
   ``PRECONDITION_REPO_UNREACHABLE`` per §3.7 — the adapter does not guess)
 * GraphQL request returns 200 but carries ``errors[]`` -> ``RUNTIME_GRAPHQL_FAILED``
+
+Every call passes a bounded ``DEFAULT_SUBPROCESS_TIMEOUT`` so a hung ``gh``
+cannot block forever while holding the PR lock. Callers only ever see a
+registry-tagged :class:`~prgroom.errors.PrgroomError` or
+:class:`GhNotFoundError` — no raw subprocess exception escapes ``_run``.
 
 It **structurally satisfies** :class:`GhClient` (no inheritance); ``mypy
 --strict`` checks the fit, mirroring ``FileStore`` vs ``Store``.
@@ -21,17 +30,25 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from typing import Any, Protocol, runtime_checkable
 
 from prgroom.errors import ErrorCode, PrgroomError, Tier
-from prgroom.proc import CommandRunner
+from prgroom.proc import DEFAULT_SUBPROCESS_TIMEOUT, CommandRunner
 from prgroom.prsession.pr_ref import PRRef
 
 JsonObj = dict[str, Any]
 
 # gh prints `gh: <message> (HTTP NNN)` to stderr on an API error; the exit code is
-# always 1, so the status token in stderr is the only classification signal.
+# always 1, so the status token in stderr is the only classification signal. gh's
+# own status token is trailing, so we anchor on the LAST match — an upstream
+# status echoed earlier in the message must not win.
 _HTTP_STATUS = re.compile(r"\(HTTP (\d{3})\)")
+
+# gh's actual secondary-rate-limit phrasing. Scoped tightly so a permissions 403
+# whose human message merely contains the words "rate limit" is not mistaken for
+# a throttle.
+_RATE_LIMIT_PHRASE = "rate limit exceeded"
 
 
 class GhNotFoundError(Exception):
@@ -59,8 +76,8 @@ class GhClient(Protocol):
 
 def _classify_gh_failure(stdout: str, stderr: str) -> PrgroomError | GhNotFoundError:
     """Map a failed ``gh`` invocation to its registry error (§3.6/§3.7)."""
-    match = _HTTP_STATUS.search(stderr)
-    if match is None:
+    matches = _HTTP_STATUS.findall(stderr)
+    if not matches:
         # No parseable status: cannot prove transient, so treat as terminal
         # rather than invite an unbounded scheduler retry loop.
         return PrgroomError(
@@ -68,15 +85,15 @@ def _classify_gh_failure(stdout: str, stderr: str) -> PrgroomError | GhNotFoundE
             code=ErrorCode.RUNTIME_GH_TERMINAL,
             detail=stderr.strip() or stdout.strip(),
         )
-    status = int(match.group(1))
+    status = int(matches[-1])  # gh's own status token is trailing
     detail = stderr.strip()
     if status == 404:  # HTTP status literal is self-documenting
         return GhNotFoundError(detail)
     # 429 is definitionally rate-limited; 403 is ambiguous (permissions vs
-    # secondary rate limit) so it only counts as transient when the message
-    # names a rate limit. 5xx is always a degraded-service transient.
+    # secondary rate limit) so it only counts as transient when gh's actual
+    # rate-limit phrasing is present. 5xx is always a degraded-service transient.
     is_rate_limit = status == 429 or (  # Too Many Requests
-        status == 403 and "rate limit" in stderr.lower()  # Forbidden
+        status == 403 and _RATE_LIMIT_PHRASE in stderr.lower()  # Forbidden
     )
     if status >= 500 or is_rate_limit:  # 5xx server-error band
         return PrgroomError(
@@ -133,7 +150,25 @@ class GhCli:
         return data
 
     def _run(self, argv: list[str]) -> str:
-        result = self._runner.run(argv)
+        try:
+            result = self._runner.run(argv, timeout=DEFAULT_SUBPROCESS_TIMEOUT)
+        except subprocess.TimeoutExpired as exc:
+            # A hung gh call is transient — symmetric with the git adapter; retry
+            # on the next scheduler cadence.
+            raise PrgroomError(
+                tier=Tier.RUNTIME_TRANSIENT,
+                code=ErrorCode.RUNTIME_GH_TRANSIENT,
+                detail=f"gh timed out: {' '.join(argv)}",
+            ) from exc
+        except OSError as exc:
+            # A missing `gh` binary (or other PATH/exec failure) raises OSError
+            # before any command runs. A retry won't fix a local config gap, so
+            # it is terminal.
+            raise PrgroomError(
+                tier=Tier.RUNTIME_TERMINAL_USER,
+                code=ErrorCode.RUNTIME_GH_TERMINAL,
+                detail=f"gh not runnable: {exc}",
+            ) from exc
         if result.returncode != 0:
             raise _classify_gh_failure(result.stdout, result.stderr)
         return result.stdout

--- a/packages/prgroom/src/prgroom/git/__init__.py
+++ b/packages/prgroom/src/prgroom/git/__init__.py
@@ -1,0 +1,7 @@
+"""The git adapter package (§3.4). Worktree plumbing via the ``git`` subprocess."""
+
+from __future__ import annotations
+
+from prgroom.git.client import GitCli, GitClient
+
+__all__ = ["GitCli", "GitClient"]

--- a/packages/prgroom/src/prgroom/git/client.py
+++ b/packages/prgroom/src/prgroom/git/client.py
@@ -1,0 +1,99 @@
+"""The git adapter — worktree plumbing via the ``git`` subprocess (§3.4, §7.6).
+
+``GitCli`` shells out to ``git`` (rev-parse, rev-list, push, stash) through the
+injected :class:`~prgroom.proc.CommandRunner` boundary and maps failures onto
+the existing :class:`~prgroom.errors.ErrorCode` registry. The registry defines
+exactly two git outcomes, so the classification is a clean dichotomy:
+
+* a recognized **push rejection** (non-fast-forward, protected branch, hook
+  decline) -> ``RUNTIME_PUSH_REJECTED`` (terminal — a blind retry is futile)
+* **any other** non-zero exit or a boundary ``TimeoutExpired`` (network blip,
+  transient lock) -> ``RUNTIME_GIT_TRANSIENT`` (retry on the next cadence)
+
+There is deliberately no third "git-terminal" code in the registry; the
+non-rejection branch is the registry's only non-rejection git code, so unknown
+failures fall to transient rather than inventing a code.
+
+``GitCli`` **structurally satisfies** :class:`GitClient` (no inheritance);
+``mypy --strict`` checks the fit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Protocol, runtime_checkable
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.proc import CommandRunner
+
+# Substrings git emits when a push is rejected by the remote. These are terminal
+# (manual reconciliation required); everything else non-zero is transient.
+_PUSH_REJECTED_MARKERS = (
+    "[rejected]",
+    "[remote rejected]",
+    "non-fast-forward",
+    "protected branch",
+    "hook declined",
+    "failed to push",
+)
+
+
+@runtime_checkable
+class GitClient(Protocol):
+    """The worktree-git surface the lifecycle verbs depend on (§3.4)."""
+
+    def head_sha(self) -> str: ...  # pragma: no cover
+
+    def rev_list(self, range_: str) -> list[str]: ...  # pragma: no cover
+
+    def push(self, remote: str, branch: str) -> None: ...  # pragma: no cover
+
+    def stash(self) -> None: ...  # pragma: no cover
+
+
+def _transient(detail: str) -> PrgroomError:
+    return PrgroomError(
+        tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_GIT_TRANSIENT, detail=detail
+    )
+
+
+def _classify_git_failure(stderr: str) -> PrgroomError:
+    """Map a failed ``git`` invocation to its registry error (§3.6/§3.7)."""
+    if any(marker in stderr for marker in _PUSH_REJECTED_MARKERS):
+        return PrgroomError(
+            tier=Tier.RUNTIME_TERMINAL_USER,
+            code=ErrorCode.RUNTIME_PUSH_REJECTED,
+            detail=stderr.strip(),
+        )
+    return _transient(stderr.strip())
+
+
+class GitCli:
+    """git adapter. Structurally satisfies :class:`GitClient`."""
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    def head_sha(self) -> str:
+        return self._run(["git", "rev-parse", "HEAD"]).strip()
+
+    def rev_list(self, range_: str) -> list[str]:
+        out = self._run(["git", "rev-list", range_])
+        return out.split()
+
+    def push(self, remote: str, branch: str) -> None:
+        self._run(["git", "push", remote, branch])
+
+    def stash(self) -> None:
+        self._run(["git", "stash"])
+
+    def _run(self, argv: list[str]) -> str:
+        try:
+            result = self._runner.run(argv)
+        except subprocess.TimeoutExpired as exc:
+            # A hung network op never returns a code; it is unambiguously transient.
+            detail = f"git timed out: {' '.join(argv)}"
+            raise _transient(detail) from exc
+        if result.returncode != 0:
+            raise _classify_git_failure(result.stderr)
+        return result.stdout

--- a/packages/prgroom/src/prgroom/git/client.py
+++ b/packages/prgroom/src/prgroom/git/client.py
@@ -7,12 +7,18 @@ exactly two git outcomes, so the classification is a clean dichotomy:
 
 * a recognized **push rejection** (non-fast-forward, protected branch, hook
   decline) -> ``RUNTIME_PUSH_REJECTED`` (terminal — a blind retry is futile)
-* **any other** non-zero exit or a boundary ``TimeoutExpired`` (network blip,
-  transient lock) -> ``RUNTIME_GIT_TRANSIENT`` (retry on the next cadence)
+* **any other** non-zero exit, a boundary ``TimeoutExpired``, or a missing
+  ``git`` binary (``OSError``) -> ``RUNTIME_GIT_TRANSIENT`` (retry next cadence)
 
 There is deliberately no third "git-terminal" code in the registry; the
 non-rejection branch is the registry's only non-rejection git code, so unknown
-failures fall to transient rather than inventing a code.
+failures (including a missing binary) fall to transient rather than inventing a
+code — that gap is tracked for the verb bead.
+
+Every call passes a bounded ``DEFAULT_SUBPROCESS_TIMEOUT`` so a hung ``git``
+cannot block forever while holding the PR lock. Callers only ever see a
+registry-tagged :class:`~prgroom.errors.PrgroomError` — no raw subprocess
+exception escapes ``_run``.
 
 ``GitCli`` **structurally satisfies** :class:`GitClient` (no inheritance);
 ``mypy --strict`` checks the fit.
@@ -24,7 +30,7 @@ import subprocess
 from typing import Protocol, runtime_checkable
 
 from prgroom.errors import ErrorCode, PrgroomError, Tier
-from prgroom.proc import CommandRunner
+from prgroom.proc import DEFAULT_SUBPROCESS_TIMEOUT, CommandRunner
 
 # Substrings git emits when a push is rejected by the remote. These are terminal
 # (manual reconciliation required); everything else non-zero is transient.
@@ -89,10 +95,16 @@ class GitCli:
 
     def _run(self, argv: list[str]) -> str:
         try:
-            result = self._runner.run(argv)
+            result = self._runner.run(argv, timeout=DEFAULT_SUBPROCESS_TIMEOUT)
         except subprocess.TimeoutExpired as exc:
             # A hung network op never returns a code; it is unambiguously transient.
             detail = f"git timed out: {' '.join(argv)}"
+            raise _transient(detail) from exc
+        except OSError as exc:
+            # A missing `git` binary (or other PATH/exec failure) raises OSError
+            # before any command runs. The registry has no git-terminal code, so
+            # it maps to transient (the gap is tracked for the verb bead).
+            detail = f"git not runnable: {exc}"
             raise _transient(detail) from exc
         if result.returncode != 0:
             raise _classify_git_failure(result.stderr)

--- a/packages/prgroom/src/prgroom/proc.py
+++ b/packages/prgroom/src/prgroom/proc.py
@@ -1,0 +1,73 @@
+"""The subprocess-runner injection seam (§7.6).
+
+The gh and git adapters do not call :func:`subprocess.run` directly. Every
+external command goes through the :class:`CommandRunner` Protocol, so the single
+system boundary is injectable: production wires :class:`SubprocessRunner`; tests
+inject a recorded-response fake. This mirrors the ``Clock`` / ``Randomness``
+seams in :mod:`prgroom.deps` — the concrete runner **structurally satisfies**
+the Protocol (no inheritance); ``mypy --strict`` checks the fit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """The captured outcome of one external command — the boundary's data shape."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@runtime_checkable
+class CommandRunner(Protocol):
+    """Runs one external command and returns its captured result.
+
+    The adapters depend on this, never on :mod:`subprocess` directly, so the
+    boundary is a single injectable seam.
+    """
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        input: str | None = None,  # noqa: A002  # stdlib name; matches subprocess.run's keyword
+        timeout: float | None = None,
+    ) -> CommandResult: ...  # pragma: no cover
+
+
+class SubprocessRunner:
+    """Production runner. Wraps :func:`subprocess.run`; the real system boundary.
+
+    Always non-raising on a non-zero exit (``check=False``) — the adapters
+    classify failures from the returncode + stderr themselves, mapping to the
+    structured :class:`~prgroom.errors.ErrorCode` registry rather than letting a
+    raw ``CalledProcessError`` escape.
+    """
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        input: str | None = None,  # noqa: A002  # stdlib name; matches subprocess.run's keyword
+        timeout: float | None = None,
+    ) -> CommandResult:
+        completed = subprocess.run(
+            list(argv),
+            capture_output=True,
+            text=True,
+            check=False,
+            input=input,
+            timeout=timeout,
+        )
+        return CommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )

--- a/packages/prgroom/src/prgroom/proc.py
+++ b/packages/prgroom/src/prgroom/proc.py
@@ -68,8 +68,10 @@ class SubprocessRunner:
         argv: Sequence[str],
         *,
         input: str | None = None,  # stdlib name; matches subprocess.run's keyword
-        timeout: float | None = None,
+        timeout: float | None = DEFAULT_SUBPROCESS_TIMEOUT,
     ) -> CommandResult:
+        # Fail-safe: bound by default so a caller that omits `timeout` cannot hang
+        # forever holding the PR lock. Pass `timeout=None` explicitly to opt out.
         env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
         completed = subprocess.run(  # noqa: S603  # argv is internally built (gh/git verb + typed args), never shell-interpolated user input; this IS the sanctioned boundary
             list(argv),

--- a/packages/prgroom/src/prgroom/proc.py
+++ b/packages/prgroom/src/prgroom/proc.py
@@ -72,7 +72,10 @@ class SubprocessRunner:
     ) -> CommandResult:
         # Fail-safe: bound by default so a caller that omits `timeout` cannot hang
         # forever holding the PR lock. Pass `timeout=None` explicitly to opt out.
-        env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
+        # LANGUAGE takes precedence over LC_ALL/LANG for gettext message
+        # translation (git/gh use gettext), so it must be pinned too — otherwise a
+        # box with LANGUAGE set would still localize stderr and break classification.
+        env = {**os.environ, "LC_ALL": "C", "LANG": "C", "LANGUAGE": "C"}
         completed = subprocess.run(  # noqa: S603  # argv is internally built (gh/git verb + typed args), never shell-interpolated user input; this IS the sanctioned boundary
             list(argv),
             capture_output=True,

--- a/packages/prgroom/src/prgroom/proc.py
+++ b/packages/prgroom/src/prgroom/proc.py
@@ -37,7 +37,7 @@ class CommandRunner(Protocol):
         self,
         argv: Sequence[str],
         *,
-        input: str | None = None,  # noqa: A002  # stdlib name; matches subprocess.run's keyword
+        input: str | None = None,  # stdlib name; matches subprocess.run's keyword
         timeout: float | None = None,
     ) -> CommandResult: ...  # pragma: no cover
 
@@ -55,10 +55,10 @@ class SubprocessRunner:
         self,
         argv: Sequence[str],
         *,
-        input: str | None = None,  # noqa: A002  # stdlib name; matches subprocess.run's keyword
+        input: str | None = None,  # stdlib name; matches subprocess.run's keyword
         timeout: float | None = None,
     ) -> CommandResult:
-        completed = subprocess.run(
+        completed = subprocess.run(  # noqa: S603  # argv is internally built (gh/git verb + typed args), never shell-interpolated user input; this IS the sanctioned boundary
             list(argv),
             capture_output=True,
             text=True,

--- a/packages/prgroom/src/prgroom/proc.py
+++ b/packages/prgroom/src/prgroom/proc.py
@@ -10,10 +10,17 @@ the Protocol (no inheritance); ``mypy --strict`` checks the fit.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+
+# Default wall-clock budget for one external gh/git call. Bounds a hung
+# subprocess so it cannot block forever while holding the PR lock. A later
+# config bead may make this per-call or operator-overridable; for now it is a
+# single conservative default shared by both adapters.
+DEFAULT_SUBPROCESS_TIMEOUT = 30.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +56,11 @@ class SubprocessRunner:
     classify failures from the returncode + stderr themselves, mapping to the
     structured :class:`~prgroom.errors.ErrorCode` registry rather than letting a
     raw ``CalledProcessError`` escape.
+
+    Runs every command under a pinned ``C`` locale. Failure classification
+    matches English stderr substrings (git push-rejection markers, gh ``(HTTP
+    NNN)`` tokens); a localized stderr from an operator's non-C locale would
+    silently break that match and misclassify a terminal failure as transient.
     """
 
     def run(
@@ -58,6 +70,7 @@ class SubprocessRunner:
         input: str | None = None,  # stdlib name; matches subprocess.run's keyword
         timeout: float | None = None,
     ) -> CommandResult:
+        env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
         completed = subprocess.run(  # noqa: S603  # argv is internally built (gh/git verb + typed args), never shell-interpolated user input; this IS the sanctioned boundary
             list(argv),
             capture_output=True,
@@ -65,6 +78,7 @@ class SubprocessRunner:
             check=False,
             input=input,
             timeout=timeout,
+            env=env,
         )
         return CommandResult(
             returncode=completed.returncode,

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -144,9 +144,16 @@ class FileStore:
             raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
                 f"{path}: migration from {from_version!r} produced non-object JSON"
             )
+        new_version = decoded.get("schema_version")
+        if not (_is_int_version(new_version) and new_version == SCHEMA_VERSION):
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + result version
+                f"{path}: migration from {from_version!r} did not reach "
+                f"schema_version {SCHEMA_VERSION} (got {new_version!r})"
+            )
         # Validate-before-commit: write_atomic runs ONLY after the migrated bytes
-        # are confirmed parseable AND a JSON object, so a migrator that returns
-        # garbage without raising can never overwrite good on-disk state.
+        # are confirmed parseable, a JSON object, AND at the current schema_version,
+        # so a migrator that returns garbage or an unmigrated payload without raising
+        # can never overwrite good on-disk state.
         write_atomic(path, migrated)
         parsed: dict[str, object] = decoded
         return parsed

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -204,7 +204,10 @@ def _ref_from_state_file(path: Path) -> PRRef | None:
         payload = json.loads(path.read_bytes())
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("schema_version")
+    if not (_is_int_version(version) and version == SCHEMA_VERSION):
         return None
     pr = payload.get("pr")
     if not isinstance(pr, dict):

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -131,14 +131,24 @@ class FileStore:
             raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
                 f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
             )
+        # Both the migrator call and the parse sit inside the try: a raising OR an
+        # invalid-JSON migrator must not corrupt on-disk state.
         try:
             migrated = migrator(raw)
-        except Exception as exc:  # a migrator failure must never corrupt on-disk state
+            decoded = json.loads(migrated)
+        except Exception as exc:
             raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
                 f"{path}: migration from {from_version!r} failed: {exc}"
             ) from exc
+        if not isinstance(decoded, dict):
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
+                f"{path}: migration from {from_version!r} produced non-object JSON"
+            )
+        # Validate-before-commit: write_atomic runs ONLY after the migrated bytes
+        # are confirmed parseable AND a JSON object, so a migrator that returns
+        # garbage without raising can never overwrite good on-disk state.
         write_atomic(path, migrated)
-        parsed: dict[str, object] = json.loads(migrated)
+        parsed: dict[str, object] = decoded
         return parsed
 
     def write(self, ref: PRRef, state: PRGroomingState) -> None:

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -18,6 +18,7 @@ import tempfile
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TypeGuard
 
 from prgroom.prsession.migrations import MIGRATIONS, Migrator
 from prgroom.prsession.pr_ref import PRRef
@@ -59,6 +60,19 @@ def write_atomic(path: Path, data: bytes) -> None:
         raise
 
 
+def _is_int_version(version: object) -> TypeGuard[int]:
+    """True only for a genuine ``int`` schema version.
+
+    ``bool`` subclasses ``int`` (``True == 1``) and ``float`` compares equal
+    (``1.0 == 1``), so a naive ``== SCHEMA_VERSION`` gate would silently accept
+    ``schema_version: true`` / ``1.0`` as healthy v1 state — and ``bool`` would
+    even alias an integer key in the ``MIGRATIONS`` lookup (``hash(True) ==
+    hash(1)``). ``type(...) is int`` excludes both, routing malformed versions to
+    the migrate-or-reject path instead of masquerading as current.
+    """
+    return type(version) is int
+
+
 class FileStore:
     """Production Store adapter. Structurally satisfies ``Store``."""
 
@@ -92,7 +106,7 @@ class FileStore:
         except json.JSONDecodeError as exc:
             raise StateCorruptError(f"{path}: {exc}") from exc  # noqa: TRY003  # single call-site; message names the offending file
         version = payload.get("schema_version")
-        if version != SCHEMA_VERSION:
+        if not (_is_int_version(version) and version == SCHEMA_VERSION):
             payload = self._migrate(path, raw, version)
         return PRGroomingState.from_dict(payload)
 
@@ -105,8 +119,14 @@ class FileStore:
         A raising migrator maps to :class:`StateCorruptError` (its registry
         ``how`` — move aside, rebuild — fits a failed migration). No migrator:
         :class:`SchemaUnknownError` (the §3.7 ``STATE_SCHEMA_UNKNOWN`` path).
+
+        NOTE for the status/locking beads: this rewrites the file in place, so
+        ``read`` is no longer side-effect-free once a migrator is registered. The
+        lock-free ``status`` reader (§3.3 carve-out) must either migrate in memory
+        without writing, or take the lock before a migrating read — do not ship an
+        unlocked migrating reader. (Latent today: ``MIGRATIONS`` is empty.)
         """
-        migrator = self._migrations.get(from_version) if isinstance(from_version, int) else None
+        migrator = self._migrations.get(from_version) if _is_int_version(from_version) else None
         if migrator is None:
             raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
                 f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"

--- a/packages/prgroom/src/prgroom/prsession/file.py
+++ b/packages/prgroom/src/prgroom/prsession/file.py
@@ -15,10 +15,11 @@ import fcntl
 import json
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
+from prgroom.prsession.migrations import MIGRATIONS, Migrator
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState
 from prgroom.prsession.store import (
@@ -61,8 +62,16 @@ def write_atomic(path: Path, data: bytes) -> None:
 class FileStore:
     """Production Store adapter. Structurally satisfies ``Store``."""
 
-    def __init__(self, *, state_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        state_dir: Path | None = None,
+        migrations: Mapping[int, Migrator] | None = None,
+    ) -> None:
         self._dir = state_dir if state_dir is not None else resolve_state_dir()
+        self._migrations: Mapping[int, Migrator] = (
+            migrations if migrations is not None else MIGRATIONS
+        )
 
     def _state_path(self, ref: PRRef) -> Path:
         return self._dir / f"{ref.slug()}.json"
@@ -84,10 +93,33 @@ class FileStore:
             raise StateCorruptError(f"{path}: {exc}") from exc  # noqa: TRY003  # single call-site; message names the offending file
         version = payload.get("schema_version")
         if version != SCHEMA_VERSION:
-            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
-                f"{path}: schema_version {version!r} != {SCHEMA_VERSION}"
-            )
+            payload = self._migrate(path, raw, version)
         return PRGroomingState.from_dict(payload)
+
+    def _migrate(self, path: Path, raw: bytes, from_version: object) -> dict[str, object]:
+        """Apply a registered migrator for ``from_version`` or trip schema-unknown.
+
+        On a registered migrator: run it on the raw bytes, rewrite the file in
+        place via ``write_atomic`` (only on success — a raising migrator leaves
+        the file byte-identical), then re-parse and return the upgraded payload.
+        A raising migrator maps to :class:`StateCorruptError` (its registry
+        ``how`` — move aside, rebuild — fits a failed migration). No migrator:
+        :class:`SchemaUnknownError` (the §3.7 ``STATE_SCHEMA_UNKNOWN`` path).
+        """
+        migrator = self._migrations.get(from_version) if isinstance(from_version, int) else None
+        if migrator is None:
+            raise SchemaUnknownError(  # noqa: TRY003  # single call-site; message names the file + version mismatch
+                f"{path}: schema_version {from_version!r} != {SCHEMA_VERSION}"
+            )
+        try:
+            migrated = migrator(raw)
+        except Exception as exc:  # a migrator failure must never corrupt on-disk state
+            raise StateCorruptError(  # noqa: TRY003  # single call-site; names the file + from-version
+                f"{path}: migration from {from_version!r} failed: {exc}"
+            ) from exc
+        write_atomic(path, migrated)
+        parsed: dict[str, object] = json.loads(migrated)
+        return parsed
 
     def write(self, ref: PRRef, state: PRGroomingState) -> None:
         data = json.dumps(state.to_dict(), indent=2, sort_keys=True).encode("utf-8")

--- a/packages/prgroom/src/prgroom/prsession/migrations.py
+++ b/packages/prgroom/src/prgroom/prsession/migrations.py
@@ -1,0 +1,23 @@
+"""Schema-migration registry for persisted state (§2, §3.7).
+
+A migrator upgrades a serialized state blob from one ``schema_version`` to the
+current one. The registry is keyed by the **from** version. It is EMPTY in the
+MVP — ``schema_version`` is 1 and there is nothing older to upgrade — but the
+seam exists so a future schema bump ships its upgrade path here without touching
+the read path. :meth:`~prgroom.prsession.file.FileStore.read` consults this dict
+on a version mismatch: a registered migrator runs and the file is rewritten in
+place; an absent one trips ``STATE_SCHEMA_UNKNOWN`` (exit 78).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+# Upgrades a raw JSON state blob from the keyed (from-)version toward the current
+# SCHEMA_VERSION. Must be pure w.r.t. the filesystem — the caller owns the atomic
+# rewrite. A migrator that cannot convert MUST raise (never return corrupt bytes);
+# the read path maps the raise to STATE_CORRUPT.
+Migrator = Callable[[bytes], bytes]
+
+# Keyed by the from-version. EMPTY in MVP (schema_version == 1, nothing older).
+MIGRATIONS: dict[int, Migrator] = {}

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -1,0 +1,50 @@
+"""Store-adapter selector (§2 "Selection at runtime").
+
+Resolves a ``--store`` flag value (or the ``PRGROOM_STORE`` env var, or the
+built-in default ``file``) to a concrete :class:`~prgroom.prsession.store.Store`.
+Precedence is **flag > env > default** — the flag is consulted first and only
+falls through to the env when unset. ``file`` yields the production
+:class:`~prgroom.prsession.file.FileStore`; ``bd`` is deferred (v2) and any
+unknown name is a user error — both surface as a terminal
+``PRECONDITION_STORE_UNAVAILABLE`` (exit 2, rendered 4-line block, no traceback).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from pathlib import Path
+
+from prgroom.errors import ErrorCode, PreconditionError
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.store import Store
+
+ENV_VAR = "PRGROOM_STORE"
+DEFAULT_STORE = "file"
+
+
+class StoreName(StrEnum):
+    """The user-facing ``--store`` / ``PRGROOM_STORE`` vocabulary."""
+
+    FILE = "file"
+    BD = "bd"
+
+
+def resolve_store(
+    name: str | None,
+    *,
+    env: Mapping[str, str] | None = None,
+    state_dir: Path | None = None,
+) -> Store:
+    """Resolve a store name to a concrete adapter (flag > env > default ``file``).
+
+    ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
+    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
+    unrecognized name raise :class:`PreconditionError` tagged
+    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    """
+    environ = env if env is not None else {}
+    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    if resolved == StoreName.FILE:
+        return FileStore(state_dir=state_dir)
+    raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -39,12 +39,14 @@ def resolve_store(
     """Resolve a store name to a concrete adapter (flag > env > default ``file``).
 
     ``name`` is the ``--store`` flag value (``None`` when unset). Falls back to
-    ``env[PRGROOM_STORE]`` then the ``file`` default. ``bd`` (deferred) and any
-    unrecognized name raise :class:`PreconditionError` tagged
-    ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
+    ``env[PRGROOM_STORE]`` then the ``file`` default. A **blank** env var is
+    treated as unset (POSIX convention, mirroring ``resolve_state_dir``); a blank
+    ``--store ''`` flag is, by contrast, an explicit user mistake and errors.
+    ``bd`` (deferred) and any unrecognized name raise :class:`PreconditionError`
+    tagged ``PRECONDITION_STORE_UNAVAILABLE`` (terminal user-error, exit 2).
     """
     environ = env if env is not None else {}
-    resolved = name if name is not None else environ.get(ENV_VAR, DEFAULT_STORE)
+    resolved = name if name is not None else (environ.get(ENV_VAR) or DEFAULT_STORE)
     if resolved == StoreName.FILE:
         return FileStore(state_dir=state_dir)
     raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/tests/fakes.py
+++ b/packages/prgroom/tests/fakes.py
@@ -30,16 +30,18 @@ class RecordedRunner:
         self._results = list(results)
         self.calls: list[list[str]] = []
         self.inputs: list[str | None] = []
+        self.timeouts: list[float | None] = []
 
     def run(
         self,
         argv: Sequence[str],
         *,
         input: str | None = None,  # matches the Protocol's keyword name
-        timeout: float | None = None,  # noqa: ARG002  # recorded runner ignores timeout
+        timeout: float | None = None,
     ) -> CommandResult:
         self.calls.append(list(argv))
         self.inputs.append(input)
+        self.timeouts.append(timeout)
         if not self._results:
             msg = f"RecordedRunner exhausted: unexpected call {list(argv)!r}"
             raise AssertionError(msg)
@@ -49,8 +51,8 @@ class RecordedRunner:
 class TimeoutRunner:
     """A :class:`CommandRunner` fake that always raises ``TimeoutExpired``.
 
-    Models the network-timeout boundary failure the git adapter must classify
-    as ``RUNTIME_GIT_TRANSIENT`` (and the gh adapter could see too).
+    Models the hung-call boundary failure both adapters must classify as their
+    transient code (``RUNTIME_GIT_TRANSIENT`` / ``RUNTIME_GH_TRANSIENT``).
     """
 
     def __init__(self) -> None:
@@ -65,3 +67,25 @@ class TimeoutRunner:
     ) -> CommandResult:  # pragma: no cover - never returns; raises below
         self.calls.append(list(argv))
         raise subprocess.TimeoutExpired(cmd=list(argv), timeout=timeout or 0.0)
+
+
+class MissingBinaryRunner:
+    """A :class:`CommandRunner` fake that always raises ``FileNotFoundError``.
+
+    Models a missing ``gh`` / ``git`` binary on ``PATH`` — the OSError the real
+    boundary raises before any command runs. Each adapter must map this to a
+    registry error rather than leak the raw traceback.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        input: str | None = None,  # noqa: ARG002  # part of the Protocol signature; unused here
+        timeout: float | None = None,  # noqa: ARG002  # part of the Protocol signature; unused here
+    ) -> CommandResult:  # pragma: no cover - never returns; raises below
+        self.calls.append(list(argv))
+        raise FileNotFoundError(2, "No such file or directory", argv[0])

--- a/packages/prgroom/tests/fakes.py
+++ b/packages/prgroom/tests/fakes.py
@@ -1,0 +1,67 @@
+"""Test fakes for the subprocess boundary (§7.6).
+
+The gh/git adapters reach the outside world through a single seam — the
+:class:`~prgroom.proc.CommandRunner` Protocol. These fakes structurally satisfy
+that Protocol so adapter tests inject recorded responses instead of mocking code
+we own. This is the spec's "mock only at the system boundary" discipline: the
+boundary is the subprocess call, and a runner is the smallest honest stand-in
+for it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+from prgroom.proc import CommandResult
+
+
+class RecordedRunner:
+    """A :class:`CommandRunner` fake that replays queued results in FIFO order.
+
+    Each :meth:`run` pops the next recorded :class:`CommandResult` and records
+    the argv it was called with, so a test can both feed a recorded
+    gh/git response and assert the adapter built the right command line. Running
+    dry (more calls than recorded results) raises — a silent empty result would
+    mask an adapter issuing an unexpected extra call.
+    """
+
+    def __init__(self, results: Sequence[CommandResult]) -> None:
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+        self.inputs: list[str | None] = []
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        input: str | None = None,  # noqa: A002  # matches the Protocol's keyword name
+        timeout: float | None = None,  # noqa: ARG002  # recorded runner ignores timeout
+    ) -> CommandResult:
+        self.calls.append(list(argv))
+        self.inputs.append(input)
+        if not self._results:
+            msg = f"RecordedRunner exhausted: unexpected call {list(argv)!r}"
+            raise AssertionError(msg)
+        return self._results.pop(0)
+
+
+class TimeoutRunner:
+    """A :class:`CommandRunner` fake that always raises ``TimeoutExpired``.
+
+    Models the network-timeout boundary failure the git adapter must classify
+    as ``RUNTIME_GIT_TRANSIENT`` (and the gh adapter could see too).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        input: str | None = None,  # noqa: A002  # matches the Protocol's keyword name
+        timeout: float | None = None,
+    ) -> CommandResult:  # pragma: no cover - never returns; raises below
+        self.calls.append(list(argv))
+        raise subprocess.TimeoutExpired(cmd=list(argv), timeout=timeout or 0.0)

--- a/packages/prgroom/tests/fakes.py
+++ b/packages/prgroom/tests/fakes.py
@@ -35,7 +35,7 @@ class RecordedRunner:
         self,
         argv: Sequence[str],
         *,
-        input: str | None = None,  # noqa: A002  # matches the Protocol's keyword name
+        input: str | None = None,  # matches the Protocol's keyword name
         timeout: float | None = None,  # noqa: ARG002  # recorded runner ignores timeout
     ) -> CommandResult:
         self.calls.append(list(argv))
@@ -60,7 +60,7 @@ class TimeoutRunner:
         self,
         argv: Sequence[str],
         *,
-        input: str | None = None,  # noqa: A002  # matches the Protocol's keyword name
+        input: str | None = None,  # noqa: ARG002  # part of the Protocol signature; unused here
         timeout: float | None = None,
     ) -> CommandResult:  # pragma: no cover - never returns; raises below
         self.calls.append(list(argv))

--- a/packages/prgroom/tests/fixtures/gh/graphql_errors.json
+++ b/packages/prgroom/tests/fixtures/gh/graphql_errors.json
@@ -1,0 +1,1 @@
+{"data": null, "errors": [{"type": "NOT_FOUND", "message": "Could not resolve to a node with the global id of 'PRRT_bad'."}]}

--- a/packages/prgroom/tests/fixtures/gh/graphql_resolve_ok.json
+++ b/packages/prgroom/tests/fixtures/gh/graphql_resolve_ok.json
@@ -1,0 +1,1 @@
+{"data": {"resolveReviewThread": {"thread": {"id": "PRRT_kwDOABC123", "isResolved": true}}}}

--- a/packages/prgroom/tests/fixtures/gh/pr_view_head_oid.json
+++ b/packages/prgroom/tests/fixtures/gh/pr_view_head_oid.json
@@ -1,0 +1,1 @@
+{"headRefOid": "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4"}

--- a/packages/prgroom/tests/integration/test_file_store.py
+++ b/packages/prgroom/tests/integration/test_file_store.py
@@ -167,6 +167,10 @@ def test_list_refs_skips_files_that_are_not_current_prgroom_state(tmp_path: Path
     (tmp_path / "future-schema.json").write_text(
         json.dumps({"schema_version": SCHEMA_VERSION + 1, "pr": valid_pr})
     )  # foreign / future schema
+    # bool/float schema_version (True==1, 1.0==1) must NOT enumerate as current —
+    # enumeration stays consistent with read()'s type-strict gate.
+    (tmp_path / "bool-schema.json").write_text(json.dumps({"schema_version": True, "pr": valid_pr}))
+    (tmp_path / "float-schema.json").write_text(json.dumps({"schema_version": 1.0, "pr": valid_pr}))
     (tmp_path / "pr-not-object.json").write_text(
         json.dumps({"schema_version": SCHEMA_VERSION, "pr": "nope"})
     )  # `pr` is not a dict

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -94,3 +94,21 @@ def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
 
     # HARD requirement: a failed migration never rewrites the file.
     assert state_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
+def test_non_int_schema_version_is_rejected_not_loaded_as_current(
+    tmp_path: Path, bogus_version: object
+) -> None:
+    # bool subclasses int (True == 1) and 1.0 == 1, so a naive `!= SCHEMA_VERSION`
+    # gate would silently accept these as a healthy v1 state. A schema_version that
+    # is not a genuine int must route to the migrate-or-reject path (here: no
+    # migrator -> STATE_SCHEMA_UNKNOWN), never load as current.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = bogus_version
+    state_path.write_bytes(json.dumps(payload).encode("utf-8"))
+    store = FileStore(state_dir=tmp_path, migrations={})
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -96,6 +96,38 @@ def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
     assert state_path.read_bytes() == original
 
 
+def test_migrator_returning_invalid_json_does_not_corrupt_the_file(tmp_path: Path) -> None:
+    # A migrator that returns unparseable bytes WITHOUT raising must not overwrite
+    # the good file: validation happens before the atomic write.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _garbage(_raw: bytes) -> bytes:
+        return b"not valid json{{{"
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _garbage})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
+def test_migrator_returning_non_object_json_does_not_corrupt_the_file(tmp_path: Path) -> None:
+    # Parseable but non-object JSON (e.g. a bare number) is not valid state; it
+    # must be rejected before the write, leaving the good file byte-identical.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _scalar(_raw: bytes) -> bytes:
+        return b"5"
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _scalar})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
 @pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
 def test_non_int_schema_version_is_rejected_not_loaded_as_current(
     tmp_path: Path, bogus_version: object

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -1,0 +1,96 @@
+"""Integration tests for FileStore's schema-migration read branch (§2, §3.7).
+
+Real filesystem, real atomic rewrite, a synthetic migrator injected via the
+constructor seam (no global monkeypatching). Pins three coded decisions: a
+registered migrator upgrades + rewrites the file in place and the read proceeds;
+no migrator trips STATE_SCHEMA_UNKNOWN; a raising migrator surfaces STATE_CORRUPT
+and leaves the on-disk file byte-identical (write_atomic runs only on success).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.migrations import Migrator
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import SCHEMA_VERSION, PRGroomingState, QuiescenceState
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError
+
+_T = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_OLD = SCHEMA_VERSION - 1
+
+
+def _current_state(ref: PRRef) -> PRGroomingState:
+    return PRGroomingState(
+        pr=ref,
+        phase=PRPhase.IDLE,
+        round=1,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+    )
+
+
+def _write_old_schema_file(path: Path, ref: PRRef) -> bytes:
+    payload = _current_state(ref).to_dict()
+    payload["schema_version"] = _OLD
+    raw = json.dumps(payload).encode("utf-8")
+    path.write_bytes(raw)
+    return raw
+
+
+def _bump_to_current() -> Migrator:
+    def migrate(raw: bytes) -> bytes:
+        obj = json.loads(raw)
+        obj["schema_version"] = SCHEMA_VERSION
+        return json.dumps(obj).encode("utf-8")
+
+    return migrate
+
+
+def test_registered_migrator_upgrades_and_rewrites_in_place(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    _write_old_schema_file(state_path, ref)
+    migrations: Mapping[int, Migrator] = {_OLD: _bump_to_current()}
+    store = FileStore(state_dir=tmp_path, migrations=migrations)
+
+    read_back = store.read(ref)
+
+    assert read_back.phase == PRPhase.IDLE
+    # File rewritten in place at the current version (write_atomic ran on success).
+    on_disk = json.loads(state_path.read_bytes())
+    assert on_disk["schema_version"] == SCHEMA_VERSION
+
+
+def test_no_migrator_for_unknown_version_trips_schema_unknown(tmp_path: Path) -> None:
+    ref = PRRef("octo", "demo", 7)
+    _write_old_schema_file(tmp_path / f"{ref.slug()}.json", ref)
+    store = FileStore(state_dir=tmp_path, migrations={})  # empty: no migrator
+    with pytest.raises(SchemaUnknownError):
+        store.read(ref)
+
+
+def test_raising_migrator_surfaces_corrupt_and_leaves_file_byte_identical(
+    tmp_path: Path,
+) -> None:
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _boom(_raw: bytes) -> bytes:
+        raise ValueError("migrator cannot convert")  # noqa: TRY003
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _boom})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+
+    # HARD requirement: a failed migration never rewrites the file.
+    assert state_path.read_bytes() == original

--- a/packages/prgroom/tests/integration/test_file_store_migrations.py
+++ b/packages/prgroom/tests/integration/test_file_store_migrations.py
@@ -128,6 +128,24 @@ def test_migrator_returning_non_object_json_does_not_corrupt_the_file(tmp_path: 
     assert state_path.read_bytes() == original
 
 
+def test_migrator_not_reaching_current_version_is_rejected(tmp_path: Path) -> None:
+    # A migrator that returns valid state but fails to bump schema_version to the
+    # current version is a FAILED migration (the single-step _migrate expects the
+    # result to be current). It must surface STATE_CORRUPT and not be committed,
+    # else `from_dict` (which accepts any schema_version) would silently load it.
+    ref = PRRef("octo", "demo", 7)
+    state_path = tmp_path / f"{ref.slug()}.json"
+    original = _write_old_schema_file(state_path, ref)
+
+    def _forgot_to_bump(raw: bytes) -> bytes:
+        return raw  # valid object, but still at the OLD schema_version
+
+    store = FileStore(state_dir=tmp_path, migrations={_OLD: _forgot_to_bump})
+    with pytest.raises(StateCorruptError):
+        store.read(ref)
+    assert state_path.read_bytes() == original
+
+
 @pytest.mark.parametrize("bogus_version", [True, 1.0, "1"])
 def test_non_int_schema_version_is_rejected_not_loaded_as_current(
     tmp_path: Path, bogus_version: object

--- a/packages/prgroom/tests/integration/test_git_real.py
+++ b/packages/prgroom/tests/integration/test_git_real.py
@@ -3,8 +3,11 @@
 The unit fit-test proves classification against recorded boundary output; this
 narrower integration test proves the happy-path adapter actually drives real
 ``git`` correctly — ``head_sha`` and ``rev_list`` parse genuine git output, not
-just our hand-recorded fixtures. Uses ``SubprocessRunner`` (the real boundary)
-on a throwaway ``tmp_path`` repo.
+just our hand-recorded fixtures. Drives real ``git`` on a throwaway ``tmp_path``
+repo via ``SubprocessRunner`` (the ``git --version`` smoke) and a cwd-pinned
+``_CwdRunner`` mirror of it (the push-rejection case, which needs the repo as the
+working directory). ``_CwdRunner`` replicates the production C-locale + timeout
+behavior so the assertions stay faithful.
 """
 
 from __future__ import annotations
@@ -40,12 +43,21 @@ class _CwdRunner:
         self,
         argv: list[str],
         *,
-        input: str | None = None,  # noqa: ARG002  # Protocol signature; unused here
-        timeout: float | None = None,  # noqa: ARG002  # Protocol signature; unused here
+        input: str | None = None,  # noqa: ARG002  # git commands here take no stdin
+        timeout: float | None = None,
     ) -> CommandResult:
-        env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
+        # Faithful mirror of production SubprocessRunner: pin LANGUAGE too (gettext
+        # precedence over LC_ALL) and honor the bounded timeout GitCli forwards, so
+        # this real-git path can't localize stderr or hang.
+        env = {**os.environ, "LC_ALL": "C", "LANG": "C", "LANGUAGE": "C"}
         completed = subprocess.run(  # noqa: S603  # internally-built git argv on a tmp fixture repo
-            argv, capture_output=True, text=True, check=False, cwd=self._cwd, env=env
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=self._cwd,
+            env=env,
+            timeout=timeout,
         )
         return CommandResult(completed.returncode, completed.stdout, completed.stderr)
 

--- a/packages/prgroom/tests/integration/test_git_real.py
+++ b/packages/prgroom/tests/integration/test_git_real.py
@@ -1,0 +1,89 @@
+"""Integration test: the git adapter against real ``git`` on a fixture repo (§7.6).
+
+The unit fit-test proves classification against recorded boundary output; this
+narrower integration test proves the happy-path adapter actually drives real
+``git`` correctly — ``head_sha`` and ``rev_list`` parse genuine git output, not
+just our hand-recorded fixtures. Uses ``SubprocessRunner`` (the real boundary)
+on a throwaway ``tmp_path`` repo.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from prgroom.git import GitCli
+from prgroom.proc import CommandResult, CommandRunner, SubprocessRunner
+
+_HAS_GIT = shutil.which("git") is not None
+pytestmark = pytest.mark.skipif(not _HAS_GIT, reason="git not on PATH")
+
+
+class _CwdRunner:
+    """A SubprocessRunner pinned to a working directory (so the test repo is the cwd)."""
+
+    def __init__(self, cwd: Path) -> None:
+        self._cwd = cwd
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        input: str | None = None,  # noqa: ARG002  # Protocol signature; unused here
+        timeout: float | None = None,  # noqa: ARG002  # Protocol signature; unused here
+    ) -> CommandResult:
+        completed = subprocess.run(  # noqa: S603  # internally-built git argv on a tmp fixture repo
+            argv, capture_output=True, text=True, check=False, cwd=self._cwd
+        )
+        return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(  # noqa: S603  # test-only fixture-repo setup
+        ["git", *args],  # noqa: S607  # `git` on PATH is fine in a test fixture
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "a.txt").write_text("one\n")
+    _git(tmp_path, "add", "a.txt")
+    _git(tmp_path, "commit", "-m", "first")
+    (tmp_path / "b.txt").write_text("two\n")
+    _git(tmp_path, "add", "b.txt")
+    _git(tmp_path, "commit", "-m", "second")
+    return tmp_path
+
+
+def test_cwd_runner_satisfies_protocol(tmp_path: Path) -> None:
+    assert isinstance(_CwdRunner(tmp_path), CommandRunner)
+
+
+def test_head_sha_against_real_git(repo: Path) -> None:
+    client = GitCli(_CwdRunner(repo))
+    sha = client.head_sha()
+    assert len(sha) == 40
+    assert all(c in "0123456789abcdef" for c in sha)
+
+
+def test_rev_list_counts_real_commits(repo: Path) -> None:
+    client = GitCli(_CwdRunner(repo))
+    assert len(client.rev_list("HEAD~1..HEAD")) == 1
+    assert len(client.rev_list("HEAD")) == 2
+
+
+def test_subprocess_runner_runs_real_git_version() -> None:
+    # The production runner itself drives a real binary end-to-end.
+    result = SubprocessRunner().run(["git", "--version"])
+    assert result.returncode == 0
+    assert result.stdout.startswith("git version")

--- a/packages/prgroom/tests/integration/test_git_real.py
+++ b/packages/prgroom/tests/integration/test_git_real.py
@@ -9,12 +9,14 @@ on a throwaway ``tmp_path`` repo.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from prgroom.errors import ErrorCode, PrgroomError
 from prgroom.git import GitCli
 from prgroom.proc import CommandResult, CommandRunner, SubprocessRunner
 
@@ -23,7 +25,13 @@ pytestmark = pytest.mark.skipif(not _HAS_GIT, reason="git not on PATH")
 
 
 class _CwdRunner:
-    """A SubprocessRunner pinned to a working directory (so the test repo is the cwd)."""
+    """A SubprocessRunner pinned to a working directory (so the test repo is the cwd).
+
+    Mirrors the production :class:`SubprocessRunner` C-locale pinning so the
+    push-rejection assertion is a faithful ground-truth anchor for both the
+    English marker-matching AND the locale fix — the installed git's real stderr
+    under ``C`` must contain a recognized rejection marker.
+    """
 
     def __init__(self, cwd: Path) -> None:
         self._cwd = cwd
@@ -35,8 +43,9 @@ class _CwdRunner:
         input: str | None = None,  # noqa: ARG002  # Protocol signature; unused here
         timeout: float | None = None,  # noqa: ARG002  # Protocol signature; unused here
     ) -> CommandResult:
+        env = {**os.environ, "LC_ALL": "C", "LANG": "C"}
         completed = subprocess.run(  # noqa: S603  # internally-built git argv on a tmp fixture repo
-            argv, capture_output=True, text=True, check=False, cwd=self._cwd
+            argv, capture_output=True, text=True, check=False, cwd=self._cwd, env=env
         )
         return CommandResult(completed.returncode, completed.stdout, completed.stderr)
 
@@ -87,3 +96,43 @@ def test_subprocess_runner_runs_real_git_version() -> None:
     result = SubprocessRunner().run(["git", "--version"])
     assert result.returncode == 0
     assert result.stdout.startswith("git version")
+
+
+def _clone_with_identity(origin: Path, dest: Path) -> None:
+    _git(dest.parent, "clone", str(origin), dest.name)
+    _git(dest, "config", "user.email", "test@example.com")
+    _git(dest, "config", "user.name", "Test")
+
+
+def test_push_rejection_against_real_git(tmp_path: Path) -> None:
+    # Ground-truth anchor: drive the installed git to emit a REAL non-fast-forward
+    # rejection (no network — a bare file:// origin) and assert GitCli classifies
+    # it terminal. A future git stderr reword would fail HERE rather than silently
+    # misclassifying in production. Doubles as the locale fix's anchor (C locale).
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", "-b", "main", "origin.git")
+
+    clone_a = tmp_path / "a"
+    _clone_with_identity(origin, clone_a)
+    (clone_a / "f.txt").write_text("a1\n")
+    _git(clone_a, "add", "f.txt")
+    _git(clone_a, "commit", "-m", "a1")
+    _git(clone_a, "push", "origin", "main")
+
+    # Clone B starts from the same origin tip, then both diverge.
+    clone_b = tmp_path / "b"
+    _clone_with_identity(origin, clone_b)
+
+    (clone_a / "f.txt").write_text("a2\n")
+    _git(clone_a, "add", "f.txt")
+    _git(clone_a, "commit", "-m", "a2")
+    _git(clone_a, "push", "origin", "main")  # origin now ahead of B
+
+    (clone_b / "g.txt").write_text("b1\n")
+    _git(clone_b, "add", "g.txt")
+    _git(clone_b, "commit", "-m", "b1")
+
+    client = GitCli(_CwdRunner(clone_b))
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "main")  # non-fast-forward -> rejected
+    assert exc.value.code is ErrorCode.RUNTIME_PUSH_REJECTED

--- a/packages/prgroom/tests/unit/test_cli_store.py
+++ b/packages/prgroom/tests/unit/test_cli_store.py
@@ -1,0 +1,61 @@
+"""Tests for the CLI `--store` root-callback wiring (§1, §2).
+
+The store is resolved eagerly in the root callback so an invalid adapter fails
+terminally — rendered 4-line block, exit 2, no traceback — BEFORE any verb body
+runs. A valid `--store file` (or the default) falls through to the verb skeleton.
+Proves `--store` beats `PRGROOM_STORE` via a set env var.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom.cli import SKELETON_EXIT_CODE, app
+
+runner = CliRunner()
+
+
+def test_invalid_store_bd_exits_two_with_block_before_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "bd", "poll", "123"])
+    assert result.exit_code == 2
+    assert "error: PRECONDITION_STORE_UNAVAILABLE" in result.output
+    assert "how:" in result.output
+    # Terminal store error pre-empts the skeleton notice.
+    assert "not yet implemented" not in result.output
+    # A clean typer.Exit (SystemExit), not an uncaught PrgroomError traceback: the
+    # error was caught and rendered, not propagated raw. CliRunner records the
+    # raw exception when a command raises something other than SystemExit, so a
+    # PrgroomError leaking here would NOT be a SystemExit.
+    assert isinstance(result.exception, SystemExit)
+
+
+def test_unknown_store_name_exits_two() -> None:
+    result = runner.invoke(app, ["--store", "frobnicate", "poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output
+
+
+def test_valid_store_file_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+    assert "not yet implemented" in result.output
+
+
+def test_default_store_falls_through_to_skeleton() -> None:
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # env says bd (would error); flag says file (valid) -> flag wins -> skeleton.
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["--store", "file", "poll", "123"])
+    assert result.exit_code == SKELETON_EXIT_CODE
+
+
+def test_env_bd_with_no_flag_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRGROOM_STORE", "bd")
+    result = runner.invoke(app, ["poll", "123"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_STORE_UNAVAILABLE" in result.output

--- a/packages/prgroom/tests/unit/test_errors.py
+++ b/packages/prgroom/tests/unit/test_errors.py
@@ -137,13 +137,3 @@ def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
     # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
     # death). Their presence would signal a regression to an fcntl-style protocol.
     assert absent not in ErrorCode.__members__
-
-
-def test_every_tier_maps_to_a_concrete_exit_code() -> None:
-    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
-    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
-    for tier in Tier:
-        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
-        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
-        code = exit_code_for_tier(err)
-        assert isinstance(code, int)

--- a/packages/prgroom/tests/unit/test_errors.py
+++ b/packages/prgroom/tests/unit/test_errors.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from prgroom.errors import (
+    BlockingErrorCodes,
     ErrorCode,
     PreconditionError,
     PrgroomError,
@@ -104,3 +105,45 @@ def test_precondition_tier_rejects_a_non_precondition_code() -> None:
     # on a runtime code is a programming error, surfaced as ValueError.
     with pytest.raises(ValueError, match="not a PRECONDITION"):
         ErrorCode.RUNTIME_GH_TERMINAL.precondition_tier()
+
+
+def test_store_unavailable_is_user_error_tier() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="bd")
+    assert err.tier == Tier.PRECONDITION_USER_ERROR
+    assert exit_code_for_tier(err) == 2
+
+
+def test_store_unavailable_carries_detail_in_message() -> None:
+    err = PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail="frobnicate")
+    assert "frobnicate" in str(err)
+
+
+def test_blocking_error_codes_is_the_exact_documented_set() -> None:
+    # §3.2 / §3.6: resolve-escalated cannot clear these. Exact-set equality so a
+    # stray addition or omission fails here, not silently downstream.
+    assert BlockingErrorCodes == frozenset(
+        {
+            ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED,
+            ErrorCode.STATE_CORRUPT,
+            ErrorCode.STATE_SCHEMA_UNKNOWN,
+            ErrorCode.RUNTIME_GH_TERMINAL,
+            ErrorCode.RUNTIME_PUSH_REJECTED,
+        }
+    )
+
+
+@pytest.mark.parametrize("absent", ["STATE_LOCK_STALE", "NOTICE_LOCK_STALE_CLEANED"])
+def test_removed_lock_codes_are_not_in_the_registry(absent: str) -> None:
+    # §3.7: these were removed to match the flock(2) mechanism (kernel-released on
+    # death). Their presence would signal a regression to an fcntl-style protocol.
+    assert absent not in ErrorCode.__members__
+
+
+def test_every_tier_maps_to_a_concrete_exit_code() -> None:
+    # Recovers the exhaustiveness StrEnum lacks: every Tier member must resolve to
+    # a non-None int via exit_code_for_tier (RUNTIME_CANCELLED needs signum).
+    for tier in Tier:
+        signum = 2 if tier == Tier.RUNTIME_CANCELLED else 0
+        err = PrgroomError(tier=tier, code=ErrorCode.STATE_CORRUPT, signum=signum)
+        code = exit_code_for_tier(err)
+        assert isinstance(code, int)

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -1,0 +1,198 @@
+"""Fit-test for the gh adapter (§7.6).
+
+Exercises the full public surface of ``GhCli`` against a ``RecordedRunner`` —
+the subprocess boundary is the only mock point. Each failure-classification arm
+(transient / terminal / not-found / graphql) is driven by a recorded
+``CommandResult`` that reproduces what real ``gh`` writes, so the mapping to the
+existing ``ErrorCode`` registry is exercised, not asserted at the definition
+site.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.gh import GhCli, GhClient, GhNotFoundError
+from prgroom.proc import CommandResult
+from prgroom.prsession.pr_ref import PRRef
+from tests.fakes import RecordedRunner
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures" / "gh"
+
+
+def _fixture(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+@pytest.fixture
+def ref() -> PRRef:
+    return PRRef(owner="octo", repo="demo", number=7)
+
+
+def _ok(stdout: str) -> CommandResult:
+    return CommandResult(returncode=0, stdout=stdout, stderr="")
+
+
+def _gh_http_error(status: int, message: str) -> CommandResult:
+    # Reproduces gh's real shape: JSON body on stdout, `gh: <msg> (HTTP NNN)` on stderr.
+    body = json.dumps({"message": message, "status": str(status)})
+    return CommandResult(returncode=1, stdout=body, stderr=f"gh: {message} (HTTP {status})")
+
+
+# ── structural fit ──
+
+
+def test_gh_cli_structurally_satisfies_protocol() -> None:
+    assert isinstance(GhCli(RecordedRunner([])), GhClient)
+
+
+# ── happy paths ──
+
+
+def test_head_ref_oid_parses_json(ref: PRRef) -> None:
+    runner = RecordedRunner([_ok(_fixture("pr_view_head_oid.json"))])
+    client = GhCli(runner)
+    assert client.head_ref_oid(ref) == "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4"
+    # The adapter issued a `gh pr view <n> --json headRefOid` against the repo.
+    argv = runner.calls[0]
+    assert argv[:3] == ["gh", "pr", "view"]
+    assert "headRefOid" in argv
+    assert "octo/demo" in argv
+
+
+def test_rest_returns_parsed_json() -> None:
+    runner = RecordedRunner([_ok('{"login": "octocat"}')])
+    client = GhCli(runner)
+    assert client.rest("GET", "user") == {"login": "octocat"}
+    assert runner.calls[0][:3] == ["gh", "api", "--method"]
+
+
+def test_rest_with_fields_passes_each_as_field_flag() -> None:
+    runner = RecordedRunner([_ok("{}")])
+    client = GhCli(runner)
+    client.rest("PATCH", "repos/octo/demo/pulls/7", fields={"body": "new body"})
+    argv = runner.calls[0]
+    assert "-f" in argv
+    assert "body=new body" in argv
+
+
+def test_graphql_returns_data() -> None:
+    runner = RecordedRunner([_ok(_fixture("graphql_resolve_ok.json"))])
+    client = GhCli(runner)
+    data = client.graphql("mutation {...}", {"threadId": "PRRT_kwDOABC123"})
+    assert data["resolveReviewThread"]["thread"]["isResolved"] is True
+    argv = runner.calls[0]
+    assert argv[:3] == ["gh", "api", "graphql"]
+
+
+# ── failure classification ──
+
+
+def test_graphql_errors_raise_graphql_failed() -> None:
+    runner = RecordedRunner([_ok(_fixture("graphql_errors.json"))])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.graphql("mutation {...}", {"threadId": "PRRT_bad"})
+    assert exc.value.code is ErrorCode.RUNTIME_GRAPHQL_FAILED
+    assert exc.value.tier is Tier.RUNTIME_TRANSIENT
+
+
+def test_500_classifies_as_gh_transient() -> None:
+    runner = RecordedRunner([_gh_http_error(500, "Internal Server Error")])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TRANSIENT
+    assert exc.value.tier is Tier.RUNTIME_TRANSIENT
+
+
+def test_503_classifies_as_gh_transient() -> None:
+    runner = RecordedRunner([_gh_http_error(503, "Service Unavailable")])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TRANSIENT
+
+
+def test_rate_limit_403_classifies_as_gh_transient() -> None:
+    # gh's rate-limit message names "rate limit"; status is 403.
+    runner = RecordedRunner(
+        [
+            CommandResult(
+                returncode=1,
+                stdout='{"message": "API rate limit exceeded", "status": "403"}',
+                stderr="gh: API rate limit exceeded for user ID 1. (HTTP 403)",
+            )
+        ]
+    )
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TRANSIENT
+
+
+def test_429_classifies_as_gh_transient() -> None:
+    runner = RecordedRunner([_gh_http_error(429, "Too Many Requests")])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TRANSIENT
+
+
+def test_422_classifies_as_gh_terminal() -> None:
+    runner = RecordedRunner([_gh_http_error(422, "Validation Failed")])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("POST", "repos/octo/demo/issues")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert exc.value.tier is Tier.RUNTIME_TERMINAL_USER
+
+
+def test_401_classifies_as_gh_terminal() -> None:
+    runner = RecordedRunner([_gh_http_error(401, "Bad credentials")])
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+
+
+def test_403_without_rate_limit_classifies_as_gh_terminal() -> None:
+    # A plain permissions 403 (no rate-limit wording) is terminal, not transient.
+    runner = RecordedRunner(
+        [
+            CommandResult(
+                returncode=1,
+                stdout='{"message": "Resource not accessible by integration", "status": "403"}',
+                stderr="gh: Resource not accessible by integration (HTTP 403)",
+            )
+        ]
+    )
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("POST", "repos/octo/demo/issues/1/labels")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+
+
+def test_404_raises_typed_not_found_not_a_prgroom_error(ref: PRRef) -> None:
+    # 404 is the caller's precondition (PRECONDITION_REPO_UNREACHABLE), so the
+    # adapter surfaces a distinct typed signal and does NOT pre-classify it.
+    runner = RecordedRunner([_gh_http_error(404, "Not Found")])
+    client = GhCli(runner)
+    with pytest.raises(GhNotFoundError):
+        client.head_ref_oid(ref)
+
+
+def test_unparseable_error_falls_back_to_gh_terminal() -> None:
+    # A failure with no parseable `(HTTP NNN)` token is treated as terminal —
+    # we cannot prove it transient, so we do not invite an infinite retry loop.
+    runner = RecordedRunner(
+        [CommandResult(returncode=1, stdout="", stderr="gh: command failed unexpectedly")]
+    )
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -71,6 +71,15 @@ def test_rest_returns_parsed_json() -> None:
     assert runner.calls[0][:3] == ["gh", "api", "--method"]
 
 
+def test_rest_returns_array_for_list_endpoints() -> None:
+    # gh api on a collection endpoint returns a JSON array, not an object — rest()
+    # returns it as-is (the return type is Any; the caller narrows). The old
+    # JsonObj annotation was a lie for these endpoints.
+    runner = RecordedRunner([_ok('[{"number": 1}, {"number": 2}]')])
+    client = GhCli(runner)
+    assert client.rest("GET", "repos/octo/demo/pulls") == [{"number": 1}, {"number": 2}]
+
+
 def test_rest_with_fields_passes_each_as_field_flag() -> None:
     runner = RecordedRunner([_ok("{}")])
     client = GhCli(runner)

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -19,7 +19,7 @@ from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.gh import GhCli, GhClient, GhNotFoundError
 from prgroom.proc import CommandResult
 from prgroom.prsession.pr_ref import PRRef
-from tests.fakes import RecordedRunner
+from tests.fakes import MissingBinaryRunner, RecordedRunner, TimeoutRunner
 
 _FIXTURES = Path(__file__).parent.parent / "fixtures" / "gh"
 
@@ -196,3 +196,84 @@ def test_unparseable_error_falls_back_to_gh_terminal() -> None:
     with pytest.raises(PrgroomError) as exc:
         client.rest("GET", "user")
     assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+
+
+# ── timeout / binary-missing boundary failures ──
+
+
+def test_gh_forwards_a_bounded_timeout_to_the_runner() -> None:
+    runner = RecordedRunner([_ok("{}")])
+    GhCli(runner).rest("GET", "user")
+    assert runner.timeouts[0] is not None
+    assert runner.timeouts[0] > 0
+
+
+def test_gh_subprocess_timeout_classifies_as_gh_transient() -> None:
+    # A hung gh call surfaces as TimeoutExpired from the boundary; symmetric with
+    # the git adapter, it maps to the transient code (retry on next cadence).
+    client = GhCli(TimeoutRunner())
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TRANSIENT
+    assert exc.value.tier is Tier.RUNTIME_TRANSIENT
+
+
+def test_gh_missing_binary_classifies_as_gh_terminal() -> None:
+    # A missing `gh` binary surfaces as OSError; the adapter maps it to a registry
+    # error rather than leaking a raw traceback. gh-missing is a local config
+    # problem a retry won't fix, so it is terminal.
+    client = GhCli(MissingBinaryRunner())
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("GET", "user")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert exc.value.tier is Tier.RUNTIME_TERMINAL_USER
+
+
+# ── parse hardening (last-match, scoped rate-limit phrase) ──
+
+
+def test_classification_anchors_on_the_last_http_token() -> None:
+    # gh's own status token is trailing; an upstream status echoed earlier in the
+    # message must not win. Earlier (HTTP 503) decoy, real trailing (HTTP 422).
+    runner = RecordedRunner(
+        [
+            CommandResult(
+                returncode=1,
+                stdout="{}",
+                stderr="gh: upstream said (HTTP 503) but validation failed (HTTP 422)",
+            )
+        ]
+    )
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("POST", "repos/octo/demo/issues")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+
+
+def test_permissions_403_mentioning_rate_limit_stays_terminal() -> None:
+    # A genuine permissions 403 whose human message merely contains the words
+    # "rate limit" must NOT be mistaken for a throttle; only gh's actual
+    # secondary-rate-limit phrasing ("rate limit exceeded") counts as transient.
+    runner = RecordedRunner(
+        [
+            CommandResult(
+                returncode=1,
+                stdout='{"message": "You cannot change the rate limit policy", "status": "403"}',
+                stderr="gh: You cannot change the rate limit policy (HTTP 403)",
+            )
+        ]
+    )
+    client = GhCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.rest("PATCH", "repos/octo/demo")
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+
+
+# ── REST empty-body (204) ──
+
+
+def test_rest_empty_body_returns_empty_dict() -> None:
+    # A 204 No Content (e.g. DELETE) returns an empty stdout; rest() must yield {}.
+    runner = RecordedRunner([_ok("")])
+    client = GhCli(runner)
+    assert client.rest("DELETE", "repos/octo/demo/issues/1/labels/wontfix") == {}

--- a/packages/prgroom/tests/unit/test_git_fit.py
+++ b/packages/prgroom/tests/unit/test_git_fit.py
@@ -14,7 +14,7 @@ import pytest
 from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.git import GitCli, GitClient
 from prgroom.proc import CommandResult
-from tests.fakes import RecordedRunner, TimeoutRunner
+from tests.fakes import MissingBinaryRunner, RecordedRunner, TimeoutRunner
 
 
 def _ok(stdout: str) -> CommandResult:
@@ -147,6 +147,25 @@ def test_unclassifiable_git_failure_falls_back_to_git_transient() -> None:
     # would gate a PR on a possibly-flaky local condition.
     runner = RecordedRunner([_fail("fatal: some unexpected git error\n")])
     client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+
+
+def test_git_forwards_a_bounded_timeout_to_the_runner() -> None:
+    # A hung git call must not block forever holding the PR lock; the adapter
+    # passes a bounded default timeout to the boundary on every call.
+    runner = RecordedRunner([_ok("")])
+    GitCli(runner).head_sha()
+    assert runner.timeouts[0] is not None
+    assert runner.timeouts[0] > 0
+
+
+def test_git_missing_binary_classifies_as_git_transient() -> None:
+    # A missing `git` binary surfaces as OSError from the boundary; the adapter
+    # must map it to a registry error, never let a raw traceback escape. The
+    # registry has no git-terminal code, so it maps to transient (tracked).
+    client = GitCli(MissingBinaryRunner())
     with pytest.raises(PrgroomError) as exc:
         client.push("origin", "feature")
     assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT

--- a/packages/prgroom/tests/unit/test_git_fit.py
+++ b/packages/prgroom/tests/unit/test_git_fit.py
@@ -1,0 +1,152 @@
+"""Fit-test for the git adapter (§7.6).
+
+Exercises the full public surface of ``GitCli`` against a ``RecordedRunner`` /
+``TimeoutRunner`` — the subprocess boundary is the only mock point. Each
+failure-classification arm (push-rejected vs git-transient) is driven by a
+recorded ``CommandResult`` reproducing real git stderr, so the mapping to the
+existing ``ErrorCode`` registry is exercised, not pinned at the definition site.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.git import GitCli, GitClient
+from prgroom.proc import CommandResult
+from tests.fakes import RecordedRunner, TimeoutRunner
+
+
+def _ok(stdout: str) -> CommandResult:
+    return CommandResult(returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr: str) -> CommandResult:
+    return CommandResult(returncode=1, stdout="", stderr=stderr)
+
+
+# ── structural fit ──
+
+
+def test_git_cli_structurally_satisfies_protocol() -> None:
+    assert isinstance(GitCli(RecordedRunner([])), GitClient)
+
+
+# ── happy paths ──
+
+
+def test_head_sha_strips_output() -> None:
+    runner = RecordedRunner([_ok("a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4\n")])
+    client = GitCli(runner)
+    assert client.head_sha() == "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4"
+    assert runner.calls[0] == ["git", "rev-parse", "HEAD"]
+
+
+def test_rev_list_splits_lines() -> None:
+    runner = RecordedRunner([_ok("sha1\nsha2\nsha3\n")])
+    client = GitCli(runner)
+    assert client.rev_list("origin/main..HEAD") == ["sha1", "sha2", "sha3"]
+    assert runner.calls[0] == ["git", "rev-list", "origin/main..HEAD"]
+
+
+def test_rev_list_empty_output_is_empty_list() -> None:
+    runner = RecordedRunner([_ok("\n")])
+    client = GitCli(runner)
+    assert client.rev_list("origin/main..HEAD") == []
+
+
+def test_push_succeeds_returns_none() -> None:
+    runner = RecordedRunner([_ok("")])
+    client = GitCli(runner)
+    assert client.push("origin", "feature-branch") is None
+    assert runner.calls[0] == ["git", "push", "origin", "feature-branch"]
+
+
+def test_stash_succeeds_returns_none() -> None:
+    runner = RecordedRunner([_ok("Saved working directory")])
+    client = GitCli(runner)
+    assert client.stash() is None
+    assert runner.calls[0] == ["git", "stash"]
+
+
+# ── failure classification ──
+
+
+def test_push_non_fast_forward_classifies_as_push_rejected() -> None:
+    stderr = (
+        "To github.com:octo/demo.git\n"
+        " ! [rejected]        feature-branch -> feature-branch (non-fast-forward)\n"
+        "error: failed to push some refs to 'github.com:octo/demo.git'\n"
+    )
+    runner = RecordedRunner([_fail(stderr)])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature-branch")
+    assert exc.value.code is ErrorCode.RUNTIME_PUSH_REJECTED
+    assert exc.value.tier is Tier.RUNTIME_TERMINAL_USER
+
+
+def test_push_protected_branch_classifies_as_push_rejected() -> None:
+    stderr = (
+        " ! [remote rejected] main -> main (protected branch hook declined)\n"
+        "error: failed to push some refs\n"
+    )
+    runner = RecordedRunner([_fail(stderr)])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "main")
+    assert exc.value.code is ErrorCode.RUNTIME_PUSH_REJECTED
+
+
+def test_push_hook_declined_classifies_as_push_rejected() -> None:
+    stderr = " ! [remote rejected] feature -> feature (pre-receive hook declined)\n"
+    runner = RecordedRunner([_fail(stderr)])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_PUSH_REJECTED
+
+
+def test_push_network_failure_classifies_as_git_transient() -> None:
+    stderr = (
+        "fatal: unable to access 'https://github.com/octo/demo.git/': "
+        "Could not resolve host: github.com\n"
+    )
+    runner = RecordedRunner([_fail(stderr)])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+    assert exc.value.tier is Tier.RUNTIME_TRANSIENT
+
+
+def test_push_connection_timeout_classifies_as_git_transient() -> None:
+    stderr = (
+        "fatal: unable to access 'https://github.com/octo/demo.git/': "
+        "Failed to connect to github.com port 443: Connection timed out\n"
+    )
+    runner = RecordedRunner([_fail(stderr)])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+
+
+def test_subprocess_timeout_classifies_as_git_transient() -> None:
+    # A hung network op surfaces as TimeoutExpired from the boundary, not a
+    # non-zero return; the adapter must still map it to RUNTIME_GIT_TRANSIENT.
+    client = GitCli(TimeoutRunner())
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+
+
+def test_unclassifiable_git_failure_falls_back_to_git_transient() -> None:
+    # A non-push, non-network local failure is conservatively transient: a
+    # retry on the next cadence is harmless, whereas wrongly marking it terminal
+    # would gate a PR on a possibly-flaky local condition.
+    runner = RecordedRunner([_fail("fatal: some unexpected git error\n")])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.push("origin", "feature")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT

--- a/packages/prgroom/tests/unit/test_proc.py
+++ b/packages/prgroom/tests/unit/test_proc.py
@@ -39,6 +39,30 @@ def test_subprocess_runner_forwards_args_and_shapes_result(monkeypatch: Any) -> 
     assert kwargs["timeout"] == 5.0
 
 
+def test_subprocess_runner_forces_c_locale(monkeypatch: Any) -> None:
+    # Failure classification matches English stderr substrings; a non-C locale
+    # would localize git/gh stderr and break that match. The runner must pin
+    # LC_ALL=C / LANG=C so the classified output is always English.
+    captured: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setenv("LC_ALL", "fr_FR.UTF-8")
+    monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    SubprocessRunner().run(["git", "push"])
+
+    env = captured["env"]
+    assert env is not None
+    assert env["LC_ALL"] == "C"
+    assert env["LANG"] == "C"
+    # The rest of the parent environment is preserved (e.g. PATH so the binary resolves).
+    assert "PATH" in env
+
+
 def test_subprocess_runner_structurally_satisfies_protocol() -> None:
     assert isinstance(SubprocessRunner(), CommandRunner)
 

--- a/packages/prgroom/tests/unit/test_proc.py
+++ b/packages/prgroom/tests/unit/test_proc.py
@@ -1,0 +1,71 @@
+"""Boundary test for the CommandRunner seam (§7.6).
+
+``SubprocessRunner`` is the one place we call ``subprocess.run`` — the system
+boundary. We mock ONLY there (monkeypatch ``subprocess.run``) and assert the
+wrapper forwards args and shapes the result. The fakes used everywhere else
+(``RecordedRunner``) are validated by their structural fit to the Protocol.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+from prgroom.proc import CommandResult, CommandRunner, SubprocessRunner
+from tests.fakes import RecordedRunner, TimeoutRunner
+
+
+def test_subprocess_runner_forwards_args_and_shapes_result(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="out", stderr="err")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = SubprocessRunner().run(["gh", "api", "x"], input="body", timeout=5.0)
+
+    assert result == CommandResult(returncode=0, stdout="out", stderr="err")
+    assert captured["argv"] == ["gh", "api", "x"]
+    kwargs = captured["kwargs"]
+    assert kwargs["capture_output"] is True
+    assert kwargs["text"] is True
+    assert kwargs["check"] is False
+    assert kwargs["input"] == "body"
+    assert kwargs["timeout"] == 5.0
+
+
+def test_subprocess_runner_structurally_satisfies_protocol() -> None:
+    assert isinstance(SubprocessRunner(), CommandRunner)
+
+
+def test_recorded_runner_satisfies_protocol_and_records_calls() -> None:
+    runner = RecordedRunner([CommandResult(0, "x", "")])
+    assert isinstance(runner, CommandRunner)
+    result = runner.run(["git", "rev-parse", "HEAD"], input="i")
+    assert result.stdout == "x"
+    assert runner.calls == [["git", "rev-parse", "HEAD"]]
+    assert runner.inputs == ["i"]
+
+
+def test_recorded_runner_raises_when_exhausted() -> None:
+    runner = RecordedRunner([])
+    try:
+        runner.run(["gh", "api", "x"])
+    except AssertionError as exc:
+        assert "exhausted" in str(exc)
+    else:  # pragma: no cover - the call above must raise
+        raise AssertionError("expected RecordedRunner to raise when exhausted")
+
+
+def test_timeout_runner_raises_timeout_expired() -> None:
+    runner = TimeoutRunner()
+    assert isinstance(runner, CommandRunner)
+    try:
+        runner.run(["git", "push"], timeout=1.0)
+    except subprocess.TimeoutExpired:
+        pass
+    else:  # pragma: no cover - the call above must raise
+        raise AssertionError("expected TimeoutRunner to raise TimeoutExpired")

--- a/packages/prgroom/tests/unit/test_proc.py
+++ b/packages/prgroom/tests/unit/test_proc.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
+import pytest
+
 from prgroom.proc import CommandResult, CommandRunner, SubprocessRunner
 from tests.fakes import RecordedRunner, TimeoutRunner
 
@@ -52,20 +54,12 @@ def test_recorded_runner_satisfies_protocol_and_records_calls() -> None:
 
 def test_recorded_runner_raises_when_exhausted() -> None:
     runner = RecordedRunner([])
-    try:
+    with pytest.raises(AssertionError, match="exhausted"):
         runner.run(["gh", "api", "x"])
-    except AssertionError as exc:
-        assert "exhausted" in str(exc)
-    else:  # pragma: no cover - the call above must raise
-        raise AssertionError("expected RecordedRunner to raise when exhausted")
 
 
 def test_timeout_runner_raises_timeout_expired() -> None:
     runner = TimeoutRunner()
     assert isinstance(runner, CommandRunner)
-    try:
+    with pytest.raises(subprocess.TimeoutExpired):
         runner.run(["git", "push"], timeout=1.0)
-    except subprocess.TimeoutExpired:
-        pass
-    else:  # pragma: no cover - the call above must raise
-        raise AssertionError("expected TimeoutRunner to raise TimeoutExpired")

--- a/packages/prgroom/tests/unit/test_proc.py
+++ b/packages/prgroom/tests/unit/test_proc.py
@@ -13,7 +13,12 @@ from typing import Any
 
 import pytest
 
-from prgroom.proc import CommandResult, CommandRunner, SubprocessRunner
+from prgroom.proc import (
+    DEFAULT_SUBPROCESS_TIMEOUT,
+    CommandResult,
+    CommandRunner,
+    SubprocessRunner,
+)
 from tests.fakes import RecordedRunner, TimeoutRunner
 
 
@@ -61,6 +66,22 @@ def test_subprocess_runner_forces_c_locale(monkeypatch: Any) -> None:
     assert env["LANG"] == "C"
     # The rest of the parent environment is preserved (e.g. PATH so the binary resolves).
     assert "PATH" in env
+
+
+def test_subprocess_runner_defaults_to_bounded_timeout(monkeypatch: Any) -> None:
+    # Fail-safe: a caller that omits `timeout` must still get the bounded default,
+    # never an unbounded subprocess that could hang forever while holding the PR
+    # lock. The adapters pass it explicitly, but the seam itself must be safe too.
+    captured: dict[str, Any] = {}
+
+    def fake_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    SubprocessRunner().run(["git", "--version"])  # no explicit timeout
+
+    assert captured["timeout"] == DEFAULT_SUBPROCESS_TIMEOUT
 
 
 def test_subprocess_runner_structurally_satisfies_protocol() -> None:

--- a/packages/prgroom/tests/unit/test_proc.py
+++ b/packages/prgroom/tests/unit/test_proc.py
@@ -56,6 +56,9 @@ def test_subprocess_runner_forces_c_locale(monkeypatch: Any) -> None:
 
     monkeypatch.setenv("LC_ALL", "fr_FR.UTF-8")
     monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    # LANGUAGE overrides LC_ALL/LANG for gettext message translation (git uses
+    # gettext), so it must be pinned too or stderr would still localize under C.
+    monkeypatch.setenv("LANGUAGE", "fr_FR")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     SubprocessRunner().run(["git", "push"])
@@ -64,6 +67,7 @@ def test_subprocess_runner_forces_c_locale(monkeypatch: Any) -> None:
     assert env is not None
     assert env["LC_ALL"] == "C"
     assert env["LANG"] == "C"
+    assert env["LANGUAGE"] == "C"
     # The rest of the parent environment is preserved (e.g. PATH so the binary resolves).
     assert "PATH" in env
 

--- a/packages/prgroom/tests/unit/test_registry.py
+++ b/packages/prgroom/tests/unit/test_registry.py
@@ -14,7 +14,7 @@ import pytest
 
 from prgroom.errors import ErrorCode, PreconditionError, Tier
 from prgroom.prsession.file import FileStore
-from prgroom.prsession.registry import StoreName, resolve_store
+from prgroom.prsession.registry import resolve_store
 
 
 def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
@@ -58,8 +58,18 @@ def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
         resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
 
 
-def test_store_name_enum_values() -> None:
-    # Consumer-boundary pin: these strings are the user-facing --store / env
-    # vocabulary, so they are pinned where a drift would break the CLI surface.
-    assert StoreName.FILE.value == "file"
-    assert StoreName.BD.value == "bd"
+def test_blank_env_falls_back_to_default_file(tmp_path: Path) -> None:
+    # A blank PRGROOM_STORE is treated as unset (POSIX env convention, mirroring
+    # resolve_state_dir's blank-XDG_STATE_HOME handling), not as an explicit
+    # invalid selection — a stray `export PRGROOM_STORE=` must not break every run.
+    store = resolve_store(None, env={"PRGROOM_STORE": ""}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_blank_flag_is_an_explicit_error_not_a_fallback(tmp_path: Path) -> None:
+    # Deliberately distinct from a blank env: an explicit empty `--store ''` is a
+    # user mistake (an explicit selection of nothing), so it surfaces the terminal
+    # user-error rather than silently defaulting.
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE

--- a/packages/prgroom/tests/unit/test_registry.py
+++ b/packages/prgroom/tests/unit/test_registry.py
@@ -1,0 +1,65 @@
+"""Tests for the store-adapter selector (§2 "Selection at runtime").
+
+Pins the coded decisions: name resolution and precedence (flag > env > default
+file), the concrete adapter each name yields, and the terminal user-error for
+the deferred `bd` adapter and any unknown name. Uses the real FileStore (a fake
+would not prove the file branch returns the production adapter).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prgroom.errors import ErrorCode, PreconditionError, Tier
+from prgroom.prsession.file import FileStore
+from prgroom.prsession.registry import StoreName, resolve_store
+
+
+def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
+    store = resolve_store("file", env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_default_when_no_flag_no_env_is_file(tmp_path: Path) -> None:
+    store = resolve_store(None, env={}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_env_selects_when_no_flag(tmp_path: Path) -> None:
+    store = resolve_store(None, env={"PRGROOM_STORE": "file"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_flag_beats_env(tmp_path: Path) -> None:
+    # Flag says file, env says bd: flag wins, so we get a FileStore (no error).
+    store = resolve_store("file", env={"PRGROOM_STORE": "bd"}, state_dir=tmp_path)
+    assert isinstance(store, FileStore)
+
+
+def test_bd_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("bd", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert exc.value.tier == Tier.PRECONDITION_USER_ERROR
+    assert "bd" in str(exc.value)
+
+
+def test_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError) as exc:
+        resolve_store("frobnicate", env={}, state_dir=tmp_path)
+    assert exc.value.code == ErrorCode.PRECONDITION_STORE_UNAVAILABLE
+    assert "frobnicate" in str(exc.value)
+
+
+def test_env_unknown_name_is_a_terminal_user_error(tmp_path: Path) -> None:
+    with pytest.raises(PreconditionError):
+        resolve_store(None, env={"PRGROOM_STORE": "nope"}, state_dir=tmp_path)
+
+
+def test_store_name_enum_values() -> None:
+    # Consumer-boundary pin: these strings are the user-facing --store / env
+    # vocabulary, so they are pinned where a drift would break the CLI surface.
+    assert StoreName.FILE.value == "file"
+    assert StoreName.BD.value == "bd"


### PR DESCRIPTION
## Scope

Bead **8.5** — the `gh`/`git` Protocol adapter layer: the subprocess boundary every lifecycle verb will call. Third bead of the prgroom CLI.

**Stacked on 8.3** (base branch = `worktree-prgroom-8.3-store-errors`, PR #136). This PR's diff is *only* 8.5's adapter work; merge **after** 8.3. GitHub will retarget this to `main` once 8.3 merges.

## What's in this PR

- **`proc.py`** — the subprocess injection seam: `@runtime_checkable CommandRunner` Protocol + `SubprocessRunner` (wraps `subprocess.run`, `check=False` so adapters classify; pins `LC_ALL=C`/`LANG=C`; bounds calls with `DEFAULT_SUBPROCESS_TIMEOUT=30s`).
- **`gh/`** — `@runtime_checkable GhClient` Protocol + `GhCli` adapter (shells out to `gh api` / `gh pr view`; **not** a vendored client). Surface: `head_ref_oid`, `rest`, `graphql`.
- **`git/`** — `@runtime_checkable GitClient` Protocol + `GitCli` adapter (`head_sha`, `rev_list`, `push`, `stash`).
- All adapters **structurally satisfy** their Protocol (no inheritance; `mypy --strict` proves the fit).
- Recorded-response fakes (`tests/fakes.py`) + recorded gh fixtures; the **only** mocked surface is the subprocess boundary. Real-git-on-fixture-repo integration tier.

## Failure → §3.7 code mapping (maps to existing 8.1 codes; re-declares none)
- gh 5xx / 429 / 403-rate → `RUNTIME_GH_TRANSIENT`; gh 4xx (≠404, ≠rate) → `RUNTIME_GH_TERMINAL`; GraphQL `errors[]` → `RUNTIME_GRAPHQL_FAILED`; **404 → typed `GhNotFoundError`** (not a `PrgroomError` — §3.7 puts 404 on the startup precondition check, a verb concern).
- git push-rejection → `RUNTIME_PUSH_REJECTED`; git timeout / other → `RUNTIME_GIT_TRANSIENT`.

## In-house adversarial review (3-lens + mutation testing) — applied before this PR

Verdict GO_WITH_FIXES; 7 findings fixed (`b11e92b`, `eac191e`), each TDD red→green:
- **Locale (med):** push-rejection markers are English substrings → a localized git would misclassify a terminal rejection as transient (unbounded retry). Fixed by pinning `LC_ALL=C`. Anchored against real git's C-locale stderr (`! [rejected] … (fetch first)` + `failed to push`).
- **Timeout (med):** the timeout seam was never wired → a hung call would block forever holding the PR lock. Now bounded at 30s; `TimeoutExpired` classified on both adapters.
- **Boundary totality (med):** a missing `gh`/`git` binary escaped as a raw traceback. Now `OSError` → registry-tagged (gh TERMINAL, git TRANSIENT).
- gh stderr-parse hardening (last-token anchor + `rate limit exceeded` phrase); `rest()` empty-204-body test; real-git push-rejection integration test.

## Ground-truth references
Design `docs/plans/2026-05-12-prgroom-cli-design.md` §7.6 (test discipline), §3 (verb I/O), §3.7 (error registry).

## Intentionally out of scope / deferred
- Verb bodies that call these adapters; the agent/claude subprocess runner (separate beads).
- **Known registry gap:** there is no general git-*terminal* code, so a permanent non-rejection git failure (corrupt repo, missing binary) maps to `RUNTIME_GIT_TRANSIENT`. Tracked on bead 8.9c (where git-push handling lands) — do not flag as a defect here.

## Test Plan
- [x] `make ci-prgroom` — exit 0: ruff ✓, format ✓, mypy --strict ✓ (22 files), **257 tests / 100% branch coverage**, pip-audit ✓, `prgroom --help` ✓.
- [ ] Copilot review of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
