### PR TITLE
feat(installer): F.4 — BeadsPlugin adapter (~/.beads/ routing + chmod) (w1qls.6.4)

### DIFF
--- a/packages/installer/src/installer/plugins/base.py
+++ b/packages/installer/src/installer/plugins/base.py
@@ -1,7 +1,30 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class PluginRoute:
+    """One bespoke source→destination route for a plugin whose content does
+    NOT overlay into a tool tree.
+
+    Generic plugins have no routes — their content installs through the
+    per-tool namespace overlay (F.2). A specialized adapter like beads, whose
+    formulas and scripts land outside any tool tree (`~/.beads/`), declares its
+    destinations here so the sync engine can place files without embedding
+    plugin-specific knowledge.
+
+    `source_dir` and `dest_dir` are absolute (the adapter joins `source_path`
+    and `home` respectively). `glob` selects the files to route from
+    `source_dir` (e.g. `*.toml`). `executable` requests the 0o755 mode bit on
+    each written file — beads scripts need it, formulas do not."""
+
+    source_dir: Path
+    dest_dir: Path
+    glob: str
+    executable: bool
 
 
 @runtime_checkable
@@ -12,11 +35,11 @@ class PluginAdapter(Protocol):
     source directory at discovery time and the adapter carries it as
     `source_path` rather than reconstructing it from `repo_root`.
 
-    F.1 needs exactly these three members. Namespace routing, destinations,
-    and chmod are out of scope: the F.2 overlay reuses the *tool* adapter's
-    namespace rules, and beads' `~/.beads/` destination + `chmod +x` are F.4
-    concerns on a future specialized adapter. They are added to this protocol
-    additively when a consumer exists."""
+    `name` / `source_path` / `is_detected` are the F.1 core. `routes` was added
+    additively in F.4 for plugins (beads) whose content lands at a bespoke
+    destination outside any tool tree. Namespace overlay into tool trees stays
+    a separate concern (F.2): it reuses the *tool* adapter's namespace rules and
+    does not flow through `routes`."""
 
     # Read-only members (declared as properties) so a frozen dataclass adapter
     # — `GenericPluginAdapter`, and any future specialized adapter — structurally
@@ -32,3 +55,9 @@ class PluginAdapter(Protocol):
     def source_path(self) -> Path: ...  # pragma: no cover
 
     def is_detected(self, home: Path) -> bool: ...  # pragma: no cover
+
+    # Bespoke source→destination routes for content that does NOT overlay into
+    # a tool tree. Empty for generic plugins; beads returns its `~/.beads/`
+    # formulas and scripts routes. `home` is injected so destinations resolve
+    # against the caller's home (critical under test).
+    def routes(self, home: Path) -> tuple[PluginRoute, ...]: ...  # pragma: no cover

--- a/packages/installer/src/installer/plugins/beads.py
+++ b/packages/installer/src/installer/plugins/beads.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from installer.plugins.base import PluginRoute
+
+
+@dataclass(frozen=True, slots=True)
+class BeadsPlugin:
+    """Specialized `PluginAdapter` for the beads issue tracker.
+
+    Beads is unlike a generic plugin in two ways the protocol now expresses
+    additively:
+
+    * **Detection** — beads is present if `bd` is on PATH *or* `~/.beads/`
+      exists as a directory. The generic convention checks only the home
+      footprint; the PATH probe is beads-specific (a user with `bd` installed
+      but no `~/.beads/` yet still wants the formulas).
+    * **Destination** — beads' formulas and scripts do not overlay into a tool
+      tree. They route to `~/.beads/formulas/` and `~/.beads/scripts/`, the
+      latter with the executable bit set. `routes()` returns those bespoke
+      destinations; the sync engine reads them without beads-specific code.
+
+    `which` is injected (default `shutil.which`) so the PATH probe is testable
+    without depending on whether `bd` happens to be installed on the runner.
+    """
+
+    name: str
+    source_path: Path
+    which: Callable[[str], str | None] = field(default=shutil.which)
+
+    def is_detected(self, home: Path) -> bool:
+        return self.which("bd") is not None or (home / ".beads").is_dir()
+
+    def routes(self, home: Path) -> tuple[PluginRoute, ...]:
+        beads_src = self.source_path / ".beads"
+        beads_dest = home / ".beads"
+        return (
+            PluginRoute(
+                source_dir=beads_src / "formulas",
+                dest_dir=beads_dest / "formulas",
+                glob="*.toml",
+                executable=False,
+            ),
+            PluginRoute(
+                source_dir=beads_src / "scripts",
+                dest_dir=beads_dest / "scripts",
+                glob="*.sh",
+                executable=True,
+            ),
+        )

--- a/packages/installer/src/installer/plugins/generic.py
+++ b/packages/installer/src/installer/plugins/generic.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from installer.plugins.base import PluginRoute
+
 
 @dataclass(frozen=True, slots=True)
 class GenericPluginAdapter:
@@ -17,3 +19,11 @@ class GenericPluginAdapter:
 
     def is_detected(self, home: Path) -> bool:
         return (home / f".{self.name}").is_dir()
+
+    def routes(
+        self,
+        home: Path,  # noqa: ARG002  # protocol parameter; generic plugins route nothing bespoke
+    ) -> tuple[PluginRoute, ...]:
+        # A generic plugin's content installs through the per-tool namespace
+        # overlay (F.2), not bespoke destinations. No routes to declare.
+        return ()

--- a/packages/installer/src/installer/plugins/registry.py
+++ b/packages/installer/src/installer/plugins/registry.py
@@ -4,14 +4,14 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 
 from installer.plugins.base import PluginAdapter
+from installer.plugins.beads import BeadsPlugin
 from installer.plugins.generic import GenericPluginAdapter
 
 # name -> factory for plugins needing behaviour the generic adapter cannot
-# express. Empty in F.1; beads registers its specialized adapter here in F.4.
-# A factory is `(name, source_path) -> PluginAdapter` — a concrete class whose
-# __init__ matches that shape satisfies it (typing it as `type[PluginAdapter]`
-# would wrongly imply instantiating the Protocol).
-_SPECIALIZED: dict[str, Callable[[str, Path], PluginAdapter]] = {}
+# express. A factory is `(name, source_path) -> PluginAdapter` — a concrete
+# class whose __init__ matches that shape satisfies it (typing it as
+# `type[PluginAdapter]` would wrongly imply instantiating the Protocol).
+_SPECIALIZED: dict[str, Callable[[str, Path], PluginAdapter]] = {"beads": BeadsPlugin}
 
 
 class UnknownPluginError(ValueError):

--- a/packages/installer/tests/unit/test_plugins_beads.py
+++ b/packages/installer/tests/unit/test_plugins_beads.py
@@ -1,0 +1,142 @@
+"""Unit tests for installer.plugins.beads.
+
+Each test pins a coded decision from F.4 (the bead acceptance criteria and
+docs/architecture/installer/installer-design.md Epic F: beads owns the
+~/.beads/ destination and chmod +x on scripts). Tests for dataclass/frozen
+machinery and pathlib/shutil semantics are deliberately absent — they test
+stdlib, not coded decisions. See the writing-unit-tests tautology filter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.plugins.beads import BeadsPlugin
+from installer.plugins.registry import discover
+
+
+def _route_by_glob(adapter: BeadsPlugin, home: Path, glob: str) -> object:
+    """Pick the single route whose glob matches; raises if not exactly one."""
+    matches = [r for r in adapter.routes(home) if r.glob == glob]
+    assert len(matches) == 1, f"expected one {glob!r} route, got {len(matches)}"
+    return matches[0]
+
+
+def test_is_detected_true_when_bd_is_on_path(tmp_path: Path) -> None:
+    """
+    Given a home with no ~/.beads/ directory
+    But `bd` resolvable on PATH (injected probe returns a path)
+    When the beads adapter is asked is_detected(home)
+    Then it returns True.
+
+    Pins: beads detection probes bd-on-PATH (install.sh:321), not just the
+    home footprint the generic convention checks.
+    """
+    adapter = BeadsPlugin(
+        name="beads",
+        source_path=tmp_path / "src",
+        which=lambda _cmd: "/usr/local/bin/bd",
+    )
+    assert adapter.is_detected(tmp_path) is True
+
+
+def test_is_detected_true_when_home_footprint_exists_and_bd_absent(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home containing a ~/.beads/ directory
+    But `bd` not resolvable on PATH (injected probe returns None)
+    When the beads adapter is asked is_detected(home)
+    Then it returns True.
+
+    Pins: the home-footprint half of the OR (install.sh:321) — a user who has
+    run beads before but lacks bd on PATH is still detected.
+    """
+    (tmp_path / ".beads").mkdir()
+    adapter = BeadsPlugin(
+        name="beads",
+        source_path=tmp_path / "src",
+        which=lambda _cmd: None,
+    )
+    assert adapter.is_detected(tmp_path) is True
+
+
+def test_is_detected_false_when_neither_bd_nor_home_footprint(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a home with no ~/.beads/ directory
+    And `bd` not resolvable on PATH
+    When the beads adapter is asked is_detected(home)
+    Then it returns False.
+
+    Pins: detection requires at least one positive probe; absent both, beads
+    is not installed.
+    """
+    adapter = BeadsPlugin(
+        name="beads",
+        source_path=tmp_path / "src",
+        which=lambda _cmd: None,
+    )
+    assert adapter.is_detected(tmp_path) is False
+
+
+def test_routes_formulas_land_in_home_beads_formulas_without_exec_bit(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a beads adapter with source_path <src>
+    When routes(home) is consulted
+    Then the formulas route reads <src>/.beads/formulas, writes
+    home/.beads/formulas, globs *.toml, and is NOT executable.
+
+    Pins AC: "Formulas land at ~/.beads/formulas/." Formulas are data, not
+    scripts — no exec bit (install.sh stages them as 'toml', never chmods).
+    """
+    home = tmp_path / "home"
+    src = tmp_path / "src"
+    adapter = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
+
+    route = _route_by_glob(adapter, home, "*.toml")
+
+    assert route.source_dir == src / ".beads" / "formulas"
+    assert route.dest_dir == home / ".beads" / "formulas"
+    assert route.executable is False
+
+
+def test_routes_scripts_land_in_home_beads_scripts_with_exec_bit(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a beads adapter with source_path <src>
+    When routes(home) is consulted
+    Then the scripts route reads <src>/.beads/scripts, writes
+    home/.beads/scripts, globs *.sh, and IS executable.
+
+    Pins AC: "Scripts land at ~/.beads/scripts/ with mode 0755." The exec bit
+    is what distinguishes scripts from formulas (install.sh chmods +x only on
+    scripts).
+    """
+    home = tmp_path / "home"
+    src = tmp_path / "src"
+    adapter = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
+
+    route = _route_by_glob(adapter, home, "*.sh")
+
+    assert route.source_dir == src / ".beads" / "scripts"
+    assert route.dest_dir == home / ".beads" / "scripts"
+    assert route.executable is True
+
+
+def test_registry_dispatches_beads_name_to_beads_plugin(tmp_path: Path) -> None:
+    """
+    Given a plugins root containing a `beads/` directory
+    When discover() builds adapters using the real default _SPECIALIZED map
+    Then the `beads` adapter is a BeadsPlugin (the F.4 registration).
+
+    Pins: beads is wired into the registry's default specialized map — the
+    contract F.1 reserved the slot for. Uses the real default (no injection)
+    so this fails if the _SPECIALIZED entry is missing.
+    """
+    (tmp_path / "beads").mkdir()
+    discovered = discover(tmp_path)
+    assert type(discovered["beads"]) is BeadsPlugin

--- a/packages/installer/tests/unit/test_plugins_beads.py
+++ b/packages/installer/tests/unit/test_plugins_beads.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.plugins.base import PluginRoute
 from installer.plugins.beads import BeadsPlugin
 from installer.plugins.registry import discover
 
 
-def _route_by_glob(adapter: BeadsPlugin, home: Path, glob: str) -> object:
+def _route_by_glob(adapter: BeadsPlugin, home: Path, glob: str) -> PluginRoute:
     """Pick the single route whose glob matches; raises if not exactly one."""
     matches = [r for r in adapter.routes(home) if r.glob == glob]
     assert len(matches) == 1, f"expected one {glob!r} route, got {len(matches)}"

--- a/packages/installer/tests/unit/test_plugins_generic.py
+++ b/packages/installer/tests/unit/test_plugins_generic.py
@@ -52,3 +52,18 @@ def test_is_detected_false_when_footprint_is_a_file_not_a_directory(
     (tmp_path / ".myplugin").write_text("not a directory")
     adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
     assert adapter.is_detected(tmp_path) is False
+
+
+def test_generic_plugin_has_no_bespoke_routes(tmp_path: Path) -> None:
+    """
+    Given a generic plugin adapter
+    When routes(home) is consulted
+    Then it returns an empty tuple.
+
+    Pins: a generic plugin's content installs through the per-tool namespace
+    overlay (F.2), not through bespoke destination routes — only specialized
+    adapters (beads) route outside a tool tree. Empty here means "no special
+    routing; overlay handles me."
+    """
+    adapter = GenericPluginAdapter(name="myplugin", source_path=tmp_path / "src")
+    assert adapter.routes(tmp_path) == ()


### PR DESCRIPTION
## Summary

Implements **F.4** (story `agents-config-w1qls.6.4`, Epic F — Plugins): the `BeadsPlugin` specialized adapter for the Python installer, plus the additive protocol member that lets a plugin route content to a bespoke destination outside any tool tree.

**Scope:** the beads adapter + its `~/.beads/` routing + registration, unit-tested in isolation. This is **not** the Phase-6 plugin overlay loop (that is F.2, running concurrently). No `core/` files are touched.

### What changed

- **`plugins/beads.py` (new)** — `BeadsPlugin` frozen-dataclass adapter:
  - `is_detected(home)`: True when `bd` is on PATH (`shutil.which`, injected for testability) **OR** `~/.beads/` exists as a directory — matching `install.sh:321`.
  - `routes(home)`: two `PluginRoute`s — formulas (`<src>/.beads/formulas` → `~/.beads/formulas/`, `*.toml`, no exec bit) and scripts (`<src>/.beads/scripts` → `~/.beads/scripts/`, `*.sh`, **executable / 0o755**).
- **`plugins/base.py` (additive)** — extends the `PluginAdapter` protocol with `routes(home) -> tuple[PluginRoute, ...]` and adds the `PluginRoute` descriptor (`source_dir`, `dest_dir`, `glob`, `executable`). Frozen-dataclass / read-only-property pattern intact; `# pragma: no cover` on the Protocol `...` body preserved.
- **`plugins/generic.py` (additive)** — `GenericPluginAdapter.routes()` returns `()`; generic plugins overlay via tool namespaces (F.2), they have no bespoke destination.
- **`plugins/registry.py`** — registers `{"beads": BeadsPlugin}` in `_SPECIALIZED` (the slot F.1 reserved).

### Design notes

- The `~/.beads/` destination + chmod knowledge lives **inside the beads adapter** (via `PluginRoute` descriptors) per the design doc ("beads.py — Owns ~/.beads/ destination, chmod +x on scripts"). The future sync consumer (F.2) reads `routes()` generically with no beads-specific code.
- The `executable` bit was already modeled on `core/model.py`'s `StagedItem` (F.2 territory, untouched) — no `model.py` change was needed.

## Test Plan

- [x] `make ci-installer` green: ruff check + format, `mypy --strict src`, pytest+coverage **99.89%** (≥90% floor), pip-audit clean, `install.py --help` entry-verify.
- [x] 7 new behavioral unit tests (detection OR-branches, formulas/scripts routing + exec bit, registry dispatch via real `_SPECIALIZED`, generic-empty-routes). All four changed `src/installer/plugins/` modules at 100% coverage.
- [x] No `core/` files touched (parallel-safe with concurrent F.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)