### PR TITLE
feat(prgroom): agent dispatch — Cluster/Fix contracts, subprocess wrapper, provider-chain fallback (8.4)

### DIFF
--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -165,15 +165,22 @@ def load_chain(
     """Resolve the provider chain for ``contract`` (TOML section, else default).
 
     Reads ``[agents.<contract>]`` from the per-repo ``.prgroom.toml`` via the
-    foundation loader; an absent section (or file) yields the shipped default
-    chain. ``model_override`` (``--cluster-model`` / ``--fix-model``) swaps the
-    **primary** provider's model only, leaving its cli and the rest of the chain
-    intact — "same provider, this model".
+    foundation loader; a truly **absent** section (or file) yields the shipped
+    default chain, while a **present** section — even an empty one — must define
+    ``primary`` (else it is rejected). ``model_override`` (``--cluster-model`` /
+    ``--fix-model``) swaps the **primary** provider's model only, leaving its cli
+    and the rest of the chain intact — "same provider, this model".
     """
     table = _read_toml(repo_config)
     agents = _subtable(table, "agents")
-    section = _subtable(agents, contract)
-    specs = _chain_from_toml(contract, section) if section else list(_DEFAULT_CHAINS[contract])
+    # Distinguish key-PRESENT from value-EMPTY by membership, not truthiness: an
+    # empty-but-present [agents.<contract>] table is still a present section, so it
+    # must route through _chain_from_toml (where the missing-primary check fires).
+    # Only a truly ABSENT key falls through to the shipped default chain.
+    if contract in agents:
+        specs = _chain_from_toml(contract, _subtable(agents, contract))
+    else:
+        specs = list(_DEFAULT_CHAINS[contract])
     if model_override is not None and specs:
         head = specs[0]
         specs[0] = AgentSpec(cli=head.cli, model=model_override, extra=dict(head.extra))

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -29,6 +29,7 @@ or-fall-through; it parses the output shape but does not validate its invariants
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -235,12 +236,17 @@ class _Dispatcher:
         runner: AgentRunner,
         chain: ProviderChain,
         prompt: PromptTemplate | None = None,
+        cancel: threading.Event | None = None,
     ) -> None:
         self._runner = runner
         self._chain = chain
         # The prompt template is loaded once (§5 "loaded once at startup"); a caller
         # may inject one to avoid disk I/O in a tight test.
         self._prompt = prompt if prompt is not None else load_prompt(self._contract)
+        # The cancel token is forwarded to EVERY runner invocation, so the lifecycle
+        # (or the run verb's SIGTERM handler) can abort an in-flight dispatch — the
+        # contract surfaces (cluster()/fix()) carry no parameter for it.
+        self._cancel = cancel
 
     def _run_chain(self, payload: dict[str, Any], parse: Callable[[str], T]) -> T:
         """Try each provider; return the first parseable output, else raise both-fail.
@@ -275,6 +281,7 @@ class _Dispatcher:
                 render_data={"contract_version": str(payload.get("contract_version", 1))},
                 contract_payload=payload,
                 time_budget_s=self._chain.time_budget_s,
+                cancel=self._cancel,
             )
         except AgentTimeoutError as exc:
             return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}")

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -117,17 +117,19 @@ class AllProvidersFailedError(PrgroomError):
         )
 
 
-def _spec_from_toml(raw: Mapping[str, Any]) -> AgentSpec:
-    """Build an :class:`AgentSpec` from one TOML provider table.
+def _spec_from_toml(raw: Mapping[str, Any], *, path: str) -> AgentSpec:
+    """Build an :class:`AgentSpec` from one TOML provider table at ``path``.
 
     ``cli`` + ``model`` are required structural fields; every other key (``effort``,
     ``write``, …) flows into ``extra`` so the per-invoker shapes can read them
-    without this loader knowing each CLI's options.
+    without this loader knowing each CLI's options. ``path`` is the provider's full
+    ``agents.<contract>.<key>`` path, named in the error so a user sees which entry
+    is malformed.
     """
     cli = raw.get("cli")
     model = raw.get("model")
     if not isinstance(cli, str) or not isinstance(model, str):
-        msg = f"agent provider needs string cli + model, got {raw!r}"
+        msg = f"{path} needs string cli + model, got {raw!r}"
         raise ValueError(msg)  # noqa: TRY004  # config-domain validation; ValueError is the loader's uniform type
     extra = {k: v for k, v in raw.items() if k not in _STRUCTURAL_KEYS}
     return AgentSpec(cli=cli, model=model, extra=extra)
@@ -149,10 +151,13 @@ def _chain_from_toml(contract: ContractName, section: Mapping[str, Any]) -> list
         raw = section.get(key)
         if raw is None:
             continue
+        # Name the full .prgroom.toml path (agents.<contract>.<key>) so a user
+        # debugging their config sees the real key, not a bare agents.<key>.
+        path = f"agents.{contract}.{key}"
         if not isinstance(raw, dict):
-            msg = f"agents.{key} must be a table, got {raw!r}"
+            msg = f"{path} must be a table, got {raw!r}"
             raise ValueError(msg)  # noqa: TRY004  # config-domain validation; ValueError is the loader's uniform type
-        specs.append(_spec_from_toml(raw))
+        specs.append(_spec_from_toml(raw, path=path))
     return specs
 
 

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -183,7 +183,13 @@ def load_chain(
     # must route through _chain_from_toml (where the missing-primary check fires).
     # Only a truly ABSENT key falls through to the shipped default chain.
     if contract in agents:
-        specs = _chain_from_toml(contract, _subtable(agents, contract))
+        section = agents[contract]
+        if not isinstance(section, dict):
+            # Name the full agents.<contract> path (not _subtable's bare key) so the
+            # error matches the per-provider agents.<contract>.<key> errors below.
+            msg = f"agents.{contract} must be a table, got {section!r}"
+            raise ValueError(msg)
+        specs = _chain_from_toml(contract, section)
     else:
         specs = list(_DEFAULT_CHAINS[contract])
     if model_override is not None and specs:

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -17,7 +17,7 @@ maps to a ``failed`` disposition + ``EscalationSink`` event (§5), never a crash
 
 The chain is resolved by :func:`load_chain` from the per-repo ``.prgroom.toml``
 ``[agents.cluster]`` / ``[agents.fix]`` sections — read through the foundation TOML
-loader (:func:`prgroom.config._read_toml`) so the agent config shares the one
+loader (:func:`prgroom.config.read_toml`) so the agent config shares the one
 ``.prgroom.toml`` parse path — falling back to the shipped default chains. A
 ``--cluster-model`` / ``--fix-model`` override swaps the primary provider's model.
 
@@ -51,7 +51,7 @@ from prgroom.agent.subprocess_runner import (
     AgentTimeoutError,
 )
 from prgroom.agent.usage import UsageRecord
-from prgroom.config import _read_toml, _subtable
+from prgroom.config import read_toml, subtable
 from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.prsession.pr_ref import PRRef
 
@@ -204,8 +204,8 @@ def load_chain(
     ``--fix-model``) swaps the **primary** provider's model only, leaving its cli
     and the rest of the chain intact — "same provider, this model".
     """
-    table = _read_toml(repo_config)
-    agents = _subtable(table, "agents")
+    table = read_toml(repo_config)
+    agents = subtable(table, "agents")
     # Distinguish key-PRESENT from value-EMPTY by membership, not truthiness: an
     # empty-but-present [agents.<contract>] table is still a present section, so it
     # must route through _chain_from_toml (where the missing-primary check fires).
@@ -213,7 +213,7 @@ def load_chain(
     if contract in agents:
         section = agents[contract]
         if not isinstance(section, dict):
-            # Name the full agents.<contract> path (not _subtable's bare key) so the
+            # Name the full agents.<contract> path (not subtable's bare key) so the
             # error matches the per-provider agents.<contract>.<key> errors below.
             msg = f"agents.{contract} must be a table, got {section!r}"
             raise ValueError(msg)

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -1,0 +1,267 @@
+"""Provider-chain dispatch + fallback ladder (§5 agent-CLI config & fallback).
+
+A :class:`ClusterDispatcher` / :class:`FixDispatcher` is the concrete
+implementation of the foundation's ``ClusterContract`` / ``FixContract`` Protocol.
+It resolves a per-contract **provider chain** (§5) — a primary plus ordered
+fallbacks — tries the primary, and on a fallback-triggering failure falls to the
+next link:
+
+* the agent binary is not on ``PATH`` (``FileNotFoundError`` from the spawn);
+* the agent exits non-zero (quota / auth / network — the runner reports the code);
+* the agent exceeds its per-contract time budget (``AgentTimeoutError``);
+* the agent exits 0 but emits JSON that fails to parse into the contract output.
+
+If **every** link fails, the dispatcher raises :class:`AllProvidersFailedError` —
+a ``RUNTIME_AGENT_UNAVAILABLE`` :class:`~prgroom.errors.PrgroomError` the lifecycle
+maps to a ``failed`` disposition + ``EscalationSink`` event (§5), never a crash.
+
+The chain is resolved by :func:`load_chain` from the per-repo ``.prgroom.toml``
+``[agents.cluster]`` / ``[agents.fix]`` sections — read through the foundation TOML
+loader (:func:`prgroom.config._read_toml`) so the agent config shares the one
+``.prgroom.toml`` parse path — falling back to the shipped default chains. A
+``--cluster-model`` / ``--fix-model`` override swaps the primary provider's model.
+
+Audits (cluster coverage, fix commit/disposition checks) are deliberately NOT
+here — they are the agent-audits bead's job. This layer owns only get-valid-JSON-
+or-fall-through; it parses the output shape but does not validate its invariants.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, TypeVar
+
+from prgroom.agent.contracts import (
+    ClusterInput,
+    ClusterOutput,
+    FixInput,
+    FixOutput,
+)
+from prgroom.agent.prompt_loader import PromptTemplate, load_prompt
+from prgroom.agent.subprocess_runner import (
+    AgentRunner,
+    AgentSpec,
+    AgentTimeoutError,
+)
+from prgroom.config import _read_toml, _subtable
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+
+ContractName = Literal["cluster", "fix"]
+
+# The contract output type the fallback ladder parses (ClusterOutput / FixOutput).
+T = TypeVar("T")
+
+# Default per-contract wall-clock budget for one agent invocation (one cluster /
+# the whole cluster set). Conservative; a later config knob may make it per-chain.
+DEFAULT_CLUSTER_BUDGET_S = 120.0
+DEFAULT_FIX_BUDGET_S = 1800.0
+
+# The shipped default provider chains (§5). Each entry is (cli, model, extra).
+_DEFAULT_CHAINS: dict[ContractName, list[AgentSpec]] = {
+    "cluster": [
+        AgentSpec(cli="ollama", model="gemma4"),
+        AgentSpec(cli="claude", model="haiku", extra={"effort": "high"}),
+        AgentSpec(cli="codex", model="gpt-5.4-mini"),
+    ],
+    "fix": [
+        AgentSpec(cli="claude", model="opus[1m]", extra={"effort": "xhigh"}),
+        AgentSpec(cli="codex", model="gpt-5.5", extra={"write": True}),
+    ],
+}
+
+_DEFAULT_BUDGETS: dict[ContractName, float] = {
+    "cluster": DEFAULT_CLUSTER_BUDGET_S,
+    "fix": DEFAULT_FIX_BUDGET_S,
+}
+
+# The ordered TOML keys that form a chain in `[agents.<contract>]`. `primary` is
+# required when the section is present; the fallbacks are optional and consumed in
+# this fixed order so chain ordering is deterministic, not dict-iteration order.
+_CHAIN_KEYS = ("primary", "fallback", "fallback2", "fallback3")
+
+# TOML provider keys that are NOT part of `extra` — they are the structural fields.
+_STRUCTURAL_KEYS = frozenset({"cli", "model"})
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderChain:
+    """An ordered provider chain plus the shared per-contract time budget."""
+
+    providers: list[AgentSpec]
+    time_budget_s: float
+
+
+class AllProvidersFailedError(PrgroomError):
+    """Every provider in the chain failed (§5 both-fail).
+
+    A ``RUNTIME_AGENT_UNAVAILABLE`` error the lifecycle maps to a ``failed``
+    disposition + escalation. ``detail`` chains each link's failure so the
+    escalation names what was tried and why each was rejected.
+    """
+
+    def __init__(self, *, detail: str) -> None:
+        # §3.7 pins RUNTIME_AGENT_UNAVAILABLE to RUNTIME_TRANSIENT (exit 75): the
+        # scheduler retries on the next cadence, preserving §3.6 restart-safety for
+        # the un-dispositioned items. A terminal tier would human-gate and break it.
+        super().__init__(
+            tier=Tier.RUNTIME_TRANSIENT,
+            code=ErrorCode.RUNTIME_AGENT_UNAVAILABLE,
+            detail=detail,
+        )
+
+
+def _spec_from_toml(raw: Mapping[str, Any]) -> AgentSpec:
+    """Build an :class:`AgentSpec` from one TOML provider table.
+
+    ``cli`` + ``model`` are required structural fields; every other key (``effort``,
+    ``write``, …) flows into ``extra`` so the per-invoker shapes can read them
+    without this loader knowing each CLI's options.
+    """
+    cli = raw.get("cli")
+    model = raw.get("model")
+    if not isinstance(cli, str) or not isinstance(model, str):
+        msg = f"agent provider needs string cli + model, got {raw!r}"
+        raise ValueError(msg)  # noqa: TRY004  # config-domain validation; ValueError is the loader's uniform type
+    extra = {k: v for k, v in raw.items() if k not in _STRUCTURAL_KEYS}
+    return AgentSpec(cli=cli, model=model, extra=extra)
+
+
+def _chain_from_toml(section: Mapping[str, Any]) -> list[AgentSpec]:
+    """Read ``primary`` … ``fallback3`` from an ``[agents.<contract>]`` section."""
+    specs: list[AgentSpec] = []
+    for key in _CHAIN_KEYS:
+        raw = section.get(key)
+        if raw is None:
+            continue
+        if not isinstance(raw, dict):
+            msg = f"agents.{key} must be a table, got {raw!r}"
+            raise ValueError(msg)  # noqa: TRY004  # config-domain validation; ValueError is the loader's uniform type
+        specs.append(_spec_from_toml(raw))
+    return specs
+
+
+def load_chain(
+    contract: ContractName,
+    *,
+    repo_config: Path | None,
+    model_override: str | None,
+) -> ProviderChain:
+    """Resolve the provider chain for ``contract`` (TOML section, else default).
+
+    Reads ``[agents.<contract>]`` from the per-repo ``.prgroom.toml`` via the
+    foundation loader; an absent section (or file) yields the shipped default
+    chain. ``model_override`` (``--cluster-model`` / ``--fix-model``) swaps the
+    **primary** provider's model only, leaving its cli and the rest of the chain
+    intact — "same provider, this model".
+    """
+    table = _read_toml(repo_config)
+    agents = _subtable(table, "agents")
+    section = _subtable(agents, contract)
+    specs = _chain_from_toml(section) if section else list(_DEFAULT_CHAINS[contract])
+    if model_override is not None and specs:
+        head = specs[0]
+        specs[0] = AgentSpec(cli=head.cli, model=model_override, extra=dict(head.extra))
+    return ProviderChain(providers=specs, time_budget_s=_DEFAULT_BUDGETS[contract])
+
+
+@dataclass(frozen=True, slots=True)
+class _LinkFailure:
+    """One chain link's failure, recorded for the both-fail escalation detail."""
+
+    spec: AgentSpec
+    reason: str
+
+
+class _Dispatcher:
+    """Shared fallback-ladder engine. Subclasses bind the contract name + output parser.
+
+    The ladder is generic over the contract output type ``T``: :meth:`_run_chain`
+    runs each provider in order, parses the first 0-exit-and-well-formed stdout via
+    the subclass ``parse`` callable, and falls through every other outcome. The only
+    per-contract difference is the parser, so the loop lives here once.
+    """
+
+    _contract: ContractName
+
+    def __init__(
+        self,
+        *,
+        runner: AgentRunner,
+        chain: ProviderChain,
+        prompt: PromptTemplate | None = None,
+    ) -> None:
+        self._runner = runner
+        self._chain = chain
+        # The prompt template is loaded once (§5 "loaded once at startup"); a caller
+        # may inject one to avoid disk I/O in a tight test.
+        self._prompt = prompt if prompt is not None else load_prompt(self._contract)
+
+    def _run_chain(self, payload: dict[str, Any], parse: Callable[[str], T]) -> T:
+        """Try each provider; return the first parseable output, else raise both-fail.
+
+        Per-link failures — binary absent, non-zero exit (quota/auth/network),
+        budget timeout, or 0-exit-but-unparseable output — fall through to the next
+        link. An exhausted chain raises :class:`AllProvidersFailedError` naming every
+        link's rejection (§5 both-fail → failed disposition + escalation).
+        """
+        failures: list[_LinkFailure] = []
+        for spec in self._chain.providers:
+            outcome = self._try_one(spec, payload)
+            if isinstance(outcome, _LinkFailure):
+                failures.append(outcome)
+                continue
+            try:
+                return parse(outcome)
+            except (KeyError, TypeError, ValueError) as exc:
+                # ValueError subsumes json.JSONDecodeError AND an out-of-enum
+                # DispositionKind (StrEnum raises ValueError): a model emitting bogus
+                # JSON or a bogus disposition is THIS provider's malformed output —
+                # fall through to the next link, never crash the whole dispatch.
+                failures.append(_LinkFailure(spec, f"malformed output: {exc}"))
+        raise AllProvidersFailedError(detail=_render_failures(self._contract, failures))
+
+    def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> str | _LinkFailure:
+        """Run one provider; return its stdout on a 0-exit, else a :class:`_LinkFailure`."""
+        try:
+            result = self._runner.run(
+                spec,
+                prompt_template=self._prompt,
+                render_data={"contract_version": str(payload.get("contract_version", 1))},
+                contract_payload=payload,
+                time_budget_s=self._chain.time_budget_s,
+            )
+        except AgentTimeoutError as exc:
+            return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}")
+        except FileNotFoundError:
+            return _LinkFailure(spec, "binary not on PATH")
+        if result.returncode != 0:
+            reason = f"exit {result.returncode}: {result.stderr.strip()[:120]}"
+            return _LinkFailure(spec, reason)
+        return result.stdout
+
+
+class ClusterDispatcher(_Dispatcher):
+    """Concrete ``ClusterContract``: dispatch the cluster chain, parse the output."""
+
+    _contract: ContractName = "cluster"
+
+    def cluster(self, request: ClusterInput) -> ClusterOutput:
+        return self._run_chain(request.to_dict(), lambda s: ClusterOutput.from_dict(json.loads(s)))
+
+
+class FixDispatcher(_Dispatcher):
+    """Concrete ``FixContract``: dispatch the fix chain, parse the output."""
+
+    _contract: ContractName = "fix"
+
+    def fix(self, request: FixInput) -> FixOutput:
+        return self._run_chain(request.to_dict(), lambda s: FixOutput.from_dict(json.loads(s)))
+
+
+def _render_failures(contract: ContractName, failures: list[_LinkFailure]) -> str:
+    """A one-line summary of every link's rejection for the escalation detail."""
+    parts = [f"{f.spec.cli}:{f.spec.model} ({f.reason})" for f in failures]
+    return f"{contract} chain exhausted: " + "; ".join(parts)

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -92,8 +92,11 @@ _CHAIN_KEYS = ("primary", "fallback", "fallback2", "fallback3")
 _STRUCTURAL_KEYS = frozenset({"cli", "model", "timeout"})
 
 # Cap on a single link's failure reason in the escalation detail (post-collapse),
-# so a verbose agent stderr cannot bloat the one-line summary.
+# so a verbose agent stderr cannot bloat the one-line summary. Capping keeps the
+# head AND the tail (tracebacks and CLI stderr put the actual error LAST).
 _REASON_MAX_CHARS = 120
+_REASON_HEAD_CHARS = 40
+_REASON_ELLIPSIS = " ... "
 
 
 @dataclass(frozen=True, slots=True)
@@ -245,9 +248,14 @@ class _LinkFailure:
 
     def __post_init__(self) -> None:
         # Collapse all whitespace (one-line guarantee), then cap so a huge agent
-        # stderr cannot bloat the escalation detail. Both apply to every source.
+        # stderr cannot bloat the escalation detail. The cap keeps head AND tail:
+        # the informative line of a traceback is the LAST one, so head-only
+        # truncation would keep boilerplate and drop the cause.
         collapsed = " ".join(self.reason.split())
-        object.__setattr__(self, "reason", collapsed[:_REASON_MAX_CHARS])
+        if len(collapsed) > _REASON_MAX_CHARS:
+            tail_chars = _REASON_MAX_CHARS - _REASON_HEAD_CHARS - len(_REASON_ELLIPSIS)
+            collapsed = collapsed[:_REASON_HEAD_CHARS] + _REASON_ELLIPSIS + collapsed[-tail_chars:]
+        object.__setattr__(self, "reason", collapsed)
 
 
 class _Dispatcher:
@@ -367,10 +375,47 @@ class _Dispatcher:
             return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}", kind="timeout")
         except FileNotFoundError:
             return _LinkFailure(spec, "binary not on PATH", kind="unavailable")
+        except OSError as exc:
+            # Present-but-unspawnable (non-executable binary, exec-format error) is
+            # the same provider-unavailable trigger as a missing one — fall through.
+            return _LinkFailure(spec, f"spawn failed: {exc}", kind="unavailable")
         if result.returncode != 0:
             # _LinkFailure normalizes whitespace + caps length centrally.
             return _LinkFailure(spec, f"exit {result.returncode}: {result.stderr}", kind="error")
         return result.stdout
+
+
+def _loads_lenient(stdout: str) -> Any:
+    """Parse agent stdout as JSON, tolerating banner noise around the object.
+
+    Strict parse first (the §5 contract: pure JSON on stdout). On failure, scan the
+    text for complete top-level JSON objects and return the LAST one — real CLIs
+    decorate stdout with progress lines and timing banners, and exhausting a whole
+    chain over decoration is worse than reading the object out of it. No parseable
+    object at all raises :class:`ValueError`, so the attempt becomes this link's
+    malformed-output failure and falls through.
+    """
+    try:
+        return json.loads(stdout)
+    except ValueError:
+        pass
+    decoder = json.JSONDecoder()
+    found = False
+    last: Any = None
+    idx = stdout.find("{")
+    while idx != -1:
+        try:
+            obj, end = decoder.raw_decode(stdout, idx)
+        except ValueError:
+            idx = stdout.find("{", idx + 1)
+            continue
+        found = True
+        last = obj
+        idx = stdout.find("{", end)
+    if not found:
+        msg = "no JSON object in agent stdout"
+        raise ValueError(msg)
+    return last
 
 
 class ClusterDispatcher(_Dispatcher):
@@ -379,7 +424,9 @@ class ClusterDispatcher(_Dispatcher):
     _contract: ContractName = "cluster"
 
     def cluster(self, request: ClusterInput) -> ClusterOutput:
-        return self._run_chain(request.to_dict(), lambda s: ClusterOutput.from_dict(json.loads(s)))
+        return self._run_chain(
+            request.to_dict(), lambda s: ClusterOutput.from_dict(_loads_lenient(s))
+        )
 
 
 class FixDispatcher(_Dispatcher):
@@ -388,7 +435,7 @@ class FixDispatcher(_Dispatcher):
     _contract: ContractName = "fix"
 
     def fix(self, request: FixInput) -> FixOutput:
-        return self._run_chain(request.to_dict(), lambda s: FixOutput.from_dict(json.loads(s)))
+        return self._run_chain(request.to_dict(), lambda s: FixOutput.from_dict(_loads_lenient(s)))
 
 
 def _render_failures(contract: ContractName, failures: list[_LinkFailure]) -> str:

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -84,7 +84,7 @@ _DEFAULT_BUDGETS: dict[ContractName, float] = {
 _CHAIN_KEYS = ("primary", "fallback", "fallback2", "fallback3")
 
 # TOML provider keys that are NOT part of `extra` — they are the structural fields.
-_STRUCTURAL_KEYS = frozenset({"cli", "model"})
+_STRUCTURAL_KEYS = frozenset({"cli", "model", "timeout"})
 
 # Cap on a single link's failure reason in the escalation detail (post-collapse),
 # so a verbose agent stderr cannot bloat the one-line summary.
@@ -93,7 +93,13 @@ _REASON_MAX_CHARS = 120
 
 @dataclass(frozen=True, slots=True)
 class ProviderChain:
-    """An ordered provider chain plus the shared per-contract time budget."""
+    """An ordered provider chain plus the shared per-contract time budget.
+
+    ``time_budget_s`` applies **per chain link**, not per dispatch: each provider
+    gets the full budget (unless its own ``timeout`` TOML key overrides it), so the
+    worst-case wall-clock for one dispatch is budget x chain length — all while the
+    per-PR lock is held.
+    """
 
     providers: list[AgentSpec]
     time_budget_s: float
@@ -121,19 +127,32 @@ class AllProvidersFailedError(PrgroomError):
 def _spec_from_toml(raw: Mapping[str, Any], *, path: str) -> AgentSpec:
     """Build an :class:`AgentSpec` from one TOML provider table at ``path``.
 
-    ``cli`` + ``model`` are required structural fields; every other key (``effort``,
-    ``write``, …) flows into ``extra`` so the per-invoker shapes can read them
-    without this loader knowing each CLI's options. ``path`` is the provider's full
-    ``agents.<contract>.<key>`` path, named in the error so a user sees which entry
-    is malformed.
+    ``cli`` + ``model`` are required structural fields; an optional ``timeout``
+    (positive seconds) overrides the contract's per-link budget for this provider.
+    Every other key (``effort``, ``write``, …) flows into ``extra`` so the
+    per-invoker shapes can read them without this loader knowing each CLI's
+    options. ``path`` is the provider's full ``agents.<contract>.<key>`` path,
+    named in the error so a user sees which entry is malformed.
     """
     cli = raw.get("cli")
     model = raw.get("model")
     if not isinstance(cli, str) or not isinstance(model, str):
         msg = f"{path} needs string cli + model, got {raw!r}"
         raise ValueError(msg)  # noqa: TRY004  # config-domain validation; ValueError is the loader's uniform type
+    budget: float | None = None
+    raw_timeout = raw.get("timeout")
+    if raw_timeout is not None:
+        # bool is an int subclass — `timeout = true` must not become a 1s budget.
+        if (
+            isinstance(raw_timeout, bool)
+            or not isinstance(raw_timeout, int | float)
+            or raw_timeout <= 0
+        ):
+            msg = f"{path}.timeout must be a positive number (seconds), got {raw_timeout!r}"
+            raise ValueError(msg)
+        budget = float(raw_timeout)
     extra = {k: v for k, v in raw.items() if k not in _STRUCTURAL_KEYS}
-    return AgentSpec(cli=cli, model=model, extra=extra)
+    return AgentSpec(cli=cli, model=model, extra=extra, time_budget_s=budget)
 
 
 def _chain_from_toml(contract: ContractName, section: Mapping[str, Any]) -> list[AgentSpec]:
@@ -280,7 +299,14 @@ class _Dispatcher:
                 prompt_template=self._prompt,
                 render_data={"contract_version": str(payload.get("contract_version", 1))},
                 contract_payload=payload,
-                time_budget_s=self._chain.time_budget_s,
+                # Per-link: the provider's own `timeout` override, else the
+                # contract default (see ProviderChain — budget x chain length
+                # is the worst-case dispatch wall-clock).
+                time_budget_s=(
+                    spec.time_budget_s
+                    if spec.time_budget_s is not None
+                    else self._chain.time_budget_s
+                ),
                 cancel=self._cancel,
             )
         except AgentTimeoutError as exc:

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 
 import json
 import threading
+import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 
@@ -43,12 +45,15 @@ from prgroom.agent.contracts import (
 )
 from prgroom.agent.prompt_loader import PromptTemplate, load_prompt
 from prgroom.agent.subprocess_runner import (
+    AgentCancelledError,
     AgentRunner,
     AgentSpec,
     AgentTimeoutError,
 )
+from prgroom.agent.usage import UsageRecord
 from prgroom.config import _read_toml, _subtable
 from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.prsession.pr_ref import PRRef
 
 ContractName = Literal["cluster", "fix"]
 
@@ -218,6 +223,10 @@ def load_chain(
     return ProviderChain(providers=specs, time_budget_s=_DEFAULT_BUDGETS[contract])
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
 @dataclass(frozen=True, slots=True)
 class _LinkFailure:
     """One chain link's failure, recorded for the both-fail escalation detail.
@@ -225,11 +234,14 @@ class _LinkFailure:
     ``reason`` is normalized to a single line at construction: every source (an
     agent stderr, a timeout ``detail``, a parse exception message) may contain
     interior newlines, but the escalation ``detail`` is documented as a one-line
-    summary — so collapse all whitespace once, centrally, here.
+    summary — so collapse all whitespace once, centrally, here. ``kind`` is the
+    usage-telemetry outcome tag for the failed attempt (``timeout`` /
+    ``unavailable`` / ``error`` / ``malformed``).
     """
 
     spec: AgentSpec
     reason: str
+    kind: str
 
     def __post_init__(self) -> None:
         # Collapse all whitespace (one-line guarantee), then cap so a huge agent
@@ -256,6 +268,9 @@ class _Dispatcher:
         chain: ProviderChain,
         prompt: PromptTemplate | None = None,
         cancel: threading.Event | None = None,
+        usage_hook: Callable[[UsageRecord], None] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        now: Callable[[], str] = _utc_now_iso,
     ) -> None:
         self._runner = runner
         self._chain = chain
@@ -266,6 +281,13 @@ class _Dispatcher:
         # (or the run verb's SIGTERM handler) can abort an in-flight dispatch — the
         # contract surfaces (cluster()/fix()) carry no parameter for it.
         self._cancel = cancel
+        # §5 usage logging: one UsageRecord per ATTEMPT (failed links included) is
+        # pushed through this hook — the lifecycle wires it to usage.append_usage.
+        # Token counts stay None until a usage-line parser exists. `clock` (monotonic,
+        # durations) and `now` (wall, the ts field) are injectable so tests never sleep.
+        self._usage_hook = usage_hook
+        self._clock = clock
+        self._now = now
 
     def _run_chain(self, payload: dict[str, Any], parse: Callable[[str], T]) -> T:
         """Try each provider; return the first parseable output, else raise both-fail.
@@ -277,19 +299,51 @@ class _Dispatcher:
         """
         failures: list[_LinkFailure] = []
         for spec in self._chain.providers:
-            outcome = self._try_one(spec, payload)
+            started = self._clock()
+            try:
+                outcome = self._try_one(spec, payload)
+            except AgentCancelledError:
+                # The abort-everything path still leaves a telemetry trace of the
+                # attempt before propagating past the ladder.
+                self._emit_usage(spec, payload, started=started, outcome="cancelled")
+                raise
             if isinstance(outcome, _LinkFailure):
+                self._emit_usage(spec, payload, started=started, outcome=outcome.kind)
                 failures.append(outcome)
                 continue
             try:
-                return parse(outcome)
+                parsed = parse(outcome)
             except (KeyError, TypeError, ValueError) as exc:
                 # ValueError subsumes json.JSONDecodeError AND an out-of-enum
                 # DispositionKind (StrEnum raises ValueError): a model emitting bogus
                 # JSON or a bogus disposition is THIS provider's malformed output —
                 # fall through to the next link, never crash the whole dispatch.
-                failures.append(_LinkFailure(spec, f"malformed output: {exc}"))
+                self._emit_usage(spec, payload, started=started, outcome="malformed")
+                failures.append(_LinkFailure(spec, f"malformed output: {exc}", kind="malformed"))
+                continue
+            self._emit_usage(spec, payload, started=started, outcome="success")
+            return parsed
         raise AllProvidersFailedError(detail=_render_failures(self._contract, failures))
+
+    def _emit_usage(
+        self, spec: AgentSpec, payload: dict[str, Any], *, started: float, outcome: str
+    ) -> None:
+        """Push one per-attempt :class:`UsageRecord` through the hook, if wired."""
+        if self._usage_hook is None:
+            return
+        self._usage_hook(
+            UsageRecord(
+                ts=self._now(),
+                pr=PRRef.from_dict(payload["pr"]),
+                contract=self._contract,
+                provider=spec.cli,
+                model=spec.model,
+                input_tokens=None,
+                output_tokens=None,
+                duration_ms=int((self._clock() - started) * 1000),
+                outcome=outcome,
+            )
+        )
 
     def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> str | _LinkFailure:
         """Run one provider; return its stdout on a 0-exit, else a :class:`_LinkFailure`."""
@@ -310,12 +364,12 @@ class _Dispatcher:
                 cancel=self._cancel,
             )
         except AgentTimeoutError as exc:
-            return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}")
+            return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}", kind="timeout")
         except FileNotFoundError:
-            return _LinkFailure(spec, "binary not on PATH")
+            return _LinkFailure(spec, "binary not on PATH", kind="unavailable")
         if result.returncode != 0:
             # _LinkFailure normalizes whitespace + caps length centrally.
-            return _LinkFailure(spec, f"exit {result.returncode}: {result.stderr}")
+            return _LinkFailure(spec, f"exit {result.returncode}: {result.stderr}", kind="error")
         return result.stdout
 
 

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -85,6 +85,10 @@ _CHAIN_KEYS = ("primary", "fallback", "fallback2", "fallback3")
 # TOML provider keys that are NOT part of `extra` — they are the structural fields.
 _STRUCTURAL_KEYS = frozenset({"cli", "model"})
 
+# Cap on a single link's failure reason in the escalation detail (post-collapse),
+# so a verbose agent stderr cannot bloat the one-line summary.
+_REASON_MAX_CHARS = 120
+
 
 @dataclass(frozen=True, slots=True)
 class ProviderChain:
@@ -178,10 +182,22 @@ def load_chain(
 
 @dataclass(frozen=True, slots=True)
 class _LinkFailure:
-    """One chain link's failure, recorded for the both-fail escalation detail."""
+    """One chain link's failure, recorded for the both-fail escalation detail.
+
+    ``reason`` is normalized to a single line at construction: every source (an
+    agent stderr, a timeout ``detail``, a parse exception message) may contain
+    interior newlines, but the escalation ``detail`` is documented as a one-line
+    summary — so collapse all whitespace once, centrally, here.
+    """
 
     spec: AgentSpec
     reason: str
+
+    def __post_init__(self) -> None:
+        # Collapse all whitespace (one-line guarantee), then cap so a huge agent
+        # stderr cannot bloat the escalation detail. Both apply to every source.
+        collapsed = " ".join(self.reason.split())
+        object.__setattr__(self, "reason", collapsed[:_REASON_MAX_CHARS])
 
 
 class _Dispatcher:
@@ -247,8 +263,8 @@ class _Dispatcher:
         except FileNotFoundError:
             return _LinkFailure(spec, "binary not on PATH")
         if result.returncode != 0:
-            reason = f"exit {result.returncode}: {result.stderr.strip()[:120]}"
-            return _LinkFailure(spec, reason)
+            # _LinkFailure normalizes whitespace + caps length centrally.
+            return _LinkFailure(spec, f"exit {result.returncode}: {result.stderr}")
         return result.stdout
 
 

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -129,8 +129,17 @@ def _spec_from_toml(raw: Mapping[str, Any]) -> AgentSpec:
     return AgentSpec(cli=cli, model=model, extra=extra)
 
 
-def _chain_from_toml(section: Mapping[str, Any]) -> list[AgentSpec]:
-    """Read ``primary`` … ``fallback3`` from an ``[agents.<contract>]`` section."""
+def _chain_from_toml(contract: ContractName, section: Mapping[str, Any]) -> list[AgentSpec]:
+    """Read ``primary`` … ``fallback3`` from a present ``[agents.<contract>]`` section.
+
+    A present section MUST define ``primary``: a fallback-only section would build a
+    chain with fallback-as-head, and a key-less one an empty chain that later raises
+    a contentless both-fail. Both are baffling misconfigs, so reject them with the
+    loader's uniform ``ValueError`` rather than silently honoring them.
+    """
+    if "primary" not in section:
+        msg = f"agents.{contract} needs a 'primary' provider"
+        raise ValueError(msg)
     specs: list[AgentSpec] = []
     for key in _CHAIN_KEYS:
         raw = section.get(key)
@@ -160,7 +169,7 @@ def load_chain(
     table = _read_toml(repo_config)
     agents = _subtable(table, "agents")
     section = _subtable(agents, contract)
-    specs = _chain_from_toml(section) if section else list(_DEFAULT_CHAINS[contract])
+    specs = _chain_from_toml(contract, section) if section else list(_DEFAULT_CHAINS[contract])
     if model_override is not None and specs:
         head = specs[0]
         specs[0] = AgentSpec(cli=head.cli, model=model_override, extra=dict(head.extra))

--- a/packages/prgroom/src/prgroom/agent/prompt_loader.py
+++ b/packages/prgroom/src/prgroom/agent/prompt_loader.py
@@ -38,8 +38,10 @@ class UnresolvedPlaceholderError(KeyError):
     """A template referenced a ``{placeholder}`` the render data did not supply.
 
     Subclasses :class:`KeyError` because that is what ``str.format_map`` raises on
-    a missing key; the dispatcher catches this distinct type to fail the dispatch
-    loudly rather than send a half-filled prompt to the agent.
+    a missing key. This is a shipped-template/packaging bug, not a runtime input
+    error, so it is **not** caught by the dispatcher's per-provider fallback ladder:
+    it propagates out of the runner and aborts the dispatch loudly, rather than
+    silently falling through to the next provider with a half-filled prompt.
     """
 
 

--- a/packages/prgroom/src/prgroom/agent/prompt_loader.py
+++ b/packages/prgroom/src/prgroom/agent/prompt_loader.py
@@ -1,0 +1,98 @@
+"""Prompt-template loader (§5 prompt templates).
+
+Each contract's prompt lives in ``agent/prompts/<contract>.tmpl`` as a template
+file with ``{placeholder}`` fields, rendered against a flat ``str -> str`` map
+(the contract-specific data, flattened by the dispatcher). A power user may
+override a shipped template by dropping a same-named file in ``PRGROOM_PROMPTS_DIR``
+— that override wins per-filename and falls through to the shipped template when
+the override dir lacks it. Override is for experimentation, not the default path.
+
+Rendering is stdlib ``str.format_map`` over a strict mapping that raises on a
+missing key, so an unresolved ``{placeholder}`` is a loud
+:class:`UnresolvedPlaceholderError` rather than a silent hole shipped to the
+agent. ``{{``/``}}`` escape to literal braces (the format-spec native rule), so a
+template can embed literal JSON.
+
+This is a deliberately minimal loader, not a templating engine: §5 names a single
+shared engine "the same one used for reply rendering", but that reply renderer
+does not exist in the foundation yet (the ``reply`` verb is still a skeleton).
+Rather than invent a heavyweight dependency or a Protocol the foundation does not
+own, this ships the smallest honest mechanism; when the reply renderer lands, its
+bead may lift this into a shared module.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Final
+
+PROMPTS_DIR_ENV: Final = "PRGROOM_PROMPTS_DIR"
+_TEMPLATE_SUFFIX: Final = ".tmpl"
+_PROMPTS_PACKAGE: Final = "prgroom.agent.prompts"
+
+
+class UnresolvedPlaceholderError(KeyError):
+    """A template referenced a ``{placeholder}`` the render data did not supply.
+
+    Subclasses :class:`KeyError` because that is what ``str.format_map`` raises on
+    a missing key; the dispatcher catches this distinct type to fail the dispatch
+    loudly rather than send a half-filled prompt to the agent.
+    """
+
+
+class _StrictMapping(dict[str, str]):
+    """A ``format_map`` backing dict that turns a missing key into a clear error."""
+
+    def __missing__(self, key: str) -> str:
+        msg = f"prompt placeholder {{{key}}} has no value in the render data"
+        raise UnresolvedPlaceholderError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptTemplate:
+    """A loaded prompt template. ``render`` substitutes a flat ``str -> str`` map."""
+
+    name: str
+    text: str
+
+    def render(self, data: dict[str, str]) -> str:
+        """Substitute ``{placeholder}`` fields from ``data`` (strict on missing keys).
+
+        ``{{``/``}}`` collapse to literal braces. A placeholder with no matching
+        ``data`` key raises :class:`UnresolvedPlaceholderError` — never a silent
+        ``{hole}`` in the prompt handed to the agent.
+        """
+        return self.text.format_map(_StrictMapping(data))
+
+
+def _override_path(name: str) -> Path | None:
+    """The ``PRGROOM_PROMPTS_DIR/<name>.tmpl`` override path if it exists, else ``None``.
+
+    A blank env value is treated as unset (POSIX convention, mirroring the Store's
+    ``XDG_STATE_HOME`` handling). A dir that exists but lacks ``<name>.tmpl`` falls
+    through to the shipped template — the override is per-filename, not all-or-nothing.
+    """
+    raw = os.environ.get(PROMPTS_DIR_ENV)
+    if not raw:
+        return None
+    candidate = Path(raw) / f"{name}{_TEMPLATE_SUFFIX}"
+    return candidate if candidate.is_file() else None
+
+
+def load_prompt(name: str) -> PromptTemplate:
+    """Load the ``<name>`` contract template (override dir wins, else shipped).
+
+    ``name`` is the contract stem (``cluster`` / ``fix``). The override dir
+    (``PRGROOM_PROMPTS_DIR``) is consulted first per-filename; otherwise the
+    template ships inside the ``prgroom.agent.prompts`` package and is read via
+    :mod:`importlib.resources` so it resolves from an installed wheel, not just a
+    source checkout.
+    """
+    override = _override_path(name)
+    if override is not None:
+        return PromptTemplate(name=name, text=override.read_text(encoding="utf-8"))
+    resource = resources.files(_PROMPTS_PACKAGE).joinpath(f"{name}{_TEMPLATE_SUFFIX}")
+    return PromptTemplate(name=name, text=resource.read_text(encoding="utf-8"))

--- a/packages/prgroom/src/prgroom/agent/prompts/__init__.py
+++ b/packages/prgroom/src/prgroom/agent/prompts/__init__.py
@@ -1,0 +1,6 @@
+"""Shipped prompt templates for the cluster and fix contracts (§5).
+
+A package (not a bare data dir) so :mod:`importlib.resources` resolves the
+``.tmpl`` files from an installed wheel, not just a source checkout. The template
+text lives in the sibling ``.tmpl`` files; this module carries no code.
+"""

--- a/packages/prgroom/src/prgroom/agent/prompts/cluster.tmpl
+++ b/packages/prgroom/src/prgroom/agent/prompts/cluster.tmpl
@@ -4,9 +4,7 @@ Your ONE job is to GROUP related review items into fix-bundles. You do NOT decid
 how to handle any item, you do NOT implement anything, and you do NOT call `gh` or
 any other tool that touches GitHub. Grouping intent is not decisional work.
 
-Read the cluster-contract input (contract_version {contract_version}) from this file:
-
-  {input_path}
+Read the cluster-contract input (contract_version {contract_version}) {input_section}
 
 It is a JSON object of the shape:
 

--- a/packages/prgroom/src/prgroom/agent/prompts/cluster.tmpl
+++ b/packages/prgroom/src/prgroom/agent/prompts/cluster.tmpl
@@ -1,0 +1,40 @@
+You are the CLUSTER agent for prgroom, a deterministic PR-grooming tool.
+
+Your ONE job is to GROUP related review items into fix-bundles. You do NOT decide
+how to handle any item, you do NOT implement anything, and you do NOT call `gh` or
+any other tool that touches GitHub. Grouping intent is not decisional work.
+
+Read the cluster-contract input (contract_version {contract_version}) from this file:
+
+  {input_path}
+
+It is a JSON object of the shape:
+
+  {{
+    "contract_version": {contract_version},
+    "pr": {{ "owner": "...", "repo": "...", "number": 0 }},
+    "items": [ /* full ReviewItem entries needing clustering */ ],
+    "pr_context_path": "<file: PR title, body, recent commits, CI summary>",
+    "memory_path": "<file: prior-round PR memory, if any>"
+  }}
+
+Group the `items` into clusters of items that should be fixed together because
+they share a root cause, a file, a pattern, or a single reviewer concern.
+
+Output EXACTLY this JSON shape to stdout and nothing else:
+
+  {{
+    "clusters": [
+      {{
+        "cluster_id": "c-<short-unique-id>",
+        "item_gh_ids": ["<gh_id>", "<gh_id>"],
+        "rationale": "<short why-these-belong-together>"
+      }}
+    ]
+  }}
+
+Hard requirements (these are audited; violations fail the contract):
+- EVERY input item appears in EXACTLY ONE cluster — none dropped, none duplicated.
+- Every `cluster_id` is unique.
+- Every cluster has a non-empty `rationale`.
+- When in doubt, prefer a singleton cluster over forcing an unrelated grouping.

--- a/packages/prgroom/src/prgroom/agent/prompts/fix.tmpl
+++ b/packages/prgroom/src/prgroom/agent/prompts/fix.tmpl
@@ -6,9 +6,8 @@ For the ONE cluster described in the fix-contract input (contract_version
 warranted. You run in the operator's worktree and make your own `git commit`s.
 
 You do NOT call `gh`. Everything you need is already dumped to files for you
-(runtime swappability, auth containment, reproducibility). Read the input from:
-
-  {input_path}
+(runtime swappability, auth containment, reproducibility). Read the fix-contract
+input {input_section}
 
 It is a JSON object of the shape:
 

--- a/packages/prgroom/src/prgroom/agent/prompts/fix.tmpl
+++ b/packages/prgroom/src/prgroom/agent/prompts/fix.tmpl
@@ -1,0 +1,56 @@
+You are the FIX agent for prgroom, a deterministic PR-grooming tool. You are an
+orchestrator: you may choose your own skills and sub-agents to do the work.
+
+For the ONE cluster described in the fix-contract input (contract_version
+{contract_version}), decide each item's disposition AND implement the work where
+warranted. You run in the operator's worktree and make your own `git commit`s.
+
+You do NOT call `gh`. Everything you need is already dumped to files for you
+(runtime swappability, auth containment, reproducibility). Read the input from:
+
+  {input_path}
+
+It is a JSON object of the shape:
+
+  {{
+    "contract_version": {contract_version},
+    "pr": {{ "owner": "...", "repo": "...", "number": 0 }},
+    "cluster_id": "c-...",
+    "item_gh_ids": ["<gh_id>", "..."],
+    "items": [ /* full ReviewItem entries; items with a prior disposition also
+                  carry a `recurrence` object — read it, do NOT re-litigate a
+                  decision already recorded in the `## Decisions` block */ ],
+    "pr_detail_path": "<file: COMPLETE PR snapshot — description incl. `## Decisions`,
+                        labels, every review thread with full reply-chains, and
+                        prior-round dispositions>",
+    "branch_state_path": "<file: recent commits + diff-since-base>",
+    "memory_dir": "<dir: ephemeral within-run scratch for your sub-agents; NOT
+                    cross-round memory — that lives in the PR + dispositions>",
+    "response_outbox_dir": "<dir: write per-item reply text files here>"
+  }}
+
+Output EXACTLY this JSON shape to stdout and nothing else:
+
+  {{
+    "contract_version": {contract_version},
+    "items": [
+      {{
+        "gh_id": "<id>",
+        "disposition": "fixed | already_addressed | skipped | deferred | wont_fix | escalated | failed",
+        "commit_shas": ["<sha>"],
+        "response_path": "<file in response_outbox_dir>",
+        "rationale": "<text>",
+        "recommended_gate": "full | lite"
+      }}
+    ]
+  }}
+
+Hard requirements (these are audited; violations flip the item to `failed`):
+- `fixed` REQUIRES at least one `commit_shas` entry, each reachable on the branch;
+  `recommended_gate` is required for `fixed`.
+- `already_addressed` REQUIRES `commit_shas` that predate this cluster's baseline.
+- `skipped | deferred | wont_fix | escalated | failed` REQUIRE a non-empty `rationale`.
+- Every commit you make on the branch MUST be claimed by some item's `commit_shas`
+  (no orphan commits).
+- Honor prior decisions in the `## Decisions` block; apply established patterns so
+  this round stays consistent with earlier rounds.

--- a/packages/prgroom/src/prgroom/agent/recurrence.py
+++ b/packages/prgroom/src/prgroom/agent/recurrence.py
@@ -1,0 +1,47 @@
+"""The §8.2 ``recurrence`` signal — a per-item derived input to the fix agent.
+
+prgroom **detects, it does not interpret** (§8.2): for an item carrying a prior
+disposition it computes a deterministic recurrence value the fix agent reads to
+decide how to respond (widen the sweep, reaffirm, escalate). The value is
+**derived from disposition history at snapshot-assembly time, NOT a persisted
+state field** — so it lives here in the agent dispatch layer (a contract-input
+shape), not in :mod:`prgroom.prsession.state`'s on-disk schema.
+
+The actual derivation from disposition history and its embedding into the fix
+snapshot is the lifecycle/snapshot-assembly bead's job; this module owns only
+the data shape and its wire serialization (the field set and the "omit empty
+``prior_commits``" rule §8.2 specifies inline).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Recurrence:
+    """One item's recurrence signal (§8.2). Frozen + slots: a hashable value type."""
+
+    reopened: bool
+    """A prior disposition exists AND a new reviewer reply arrived on the thread."""
+    attempt_count: int
+    """How many times this item has been dispositioned (``1`` == first pass)."""
+    prior_disposition: str
+    """The most recent prior ``DispositionKind`` value (its wire string)."""
+    prior_commits: list[str]
+    """SHAs from the most recent prior disposition. Omitted from JSON when empty."""
+    first_seen_round: int
+    """The round the item was first observed."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for the fix snapshot. ``prior_commits`` omitted when empty (§8.2)."""
+        d: dict[str, Any] = {
+            "reopened": self.reopened,
+            "attempt_count": self.attempt_count,
+            "prior_disposition": self.prior_disposition,
+            "first_seen_round": self.first_seen_round,
+        }
+        if self.prior_commits:
+            d["prior_commits"] = list(self.prior_commits)
+        return d

--- a/packages/prgroom/src/prgroom/agent/recurrence.py
+++ b/packages/prgroom/src/prgroom/agent/recurrence.py
@@ -29,8 +29,9 @@ class Recurrence:
     """How many times this item has been dispositioned (``1`` == first pass)."""
     prior_disposition: str
     """The most recent prior ``DispositionKind`` value (its wire string)."""
-    prior_commits: list[str]
-    """SHAs from the most recent prior disposition. Omitted from JSON when empty."""
+    prior_commits: tuple[str, ...]
+    """SHAs from the most recent prior disposition (a tuple so the frozen value type
+    stays immutable + hashable). Serializes as a JSON list; omitted when empty."""
     first_seen_round: int
     """The round the item was first observed."""
 

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -165,8 +165,11 @@ def _invocation_for_codex(spec: AgentSpec, prompt: str) -> AgentInvocation:
     # `codex exec` is the non-interactive entry point; the config `write = true`
     # grants edit permission via the sandbox POLICY (`--sandbox workspace-write`),
     # not a bare flag. Read-only specs leave the default sandbox in place.
+    # Gate on the literal boolean `true`, NOT truthiness: a mistyped string like
+    # write = "false" is truthy and would silently grant edit rights — a
+    # config-driven privilege escalation. `is True` accepts only the TOML boolean.
     argv = ["codex", "exec", "--model", spec.model]
-    if spec.extra.get("write"):
+    if spec.extra.get("write") is True:
         argv += ["--sandbox", "workspace-write"]
     argv += [prompt]
     return AgentInvocation(argv=argv)

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -21,6 +21,7 @@ job — keeping that policy out of the boundary keeps this layer a pure mechanis
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -222,8 +223,12 @@ class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handl
 
     def send_stdin(self, data: str) -> None:
         assert self._proc.stdin is not None  # noqa: S101  # only called when stdin=PIPE was opened
-        self._proc.stdin.write(data)
-        self._proc.stdin.close()
+        # Close the pipe even if the write throws (child exited first → BrokenPipe),
+        # so the fd never leaks; the caller swallows BrokenPipeError as best-effort.
+        try:
+            self._proc.stdin.write(data)
+        finally:
+            self._proc.stdin.close()
 
     def terminate(self) -> None:
         self._proc.terminate()
@@ -319,8 +324,12 @@ class SubprocessAgentRunner:
         proc = self._spawn(invocation.argv, stdin=invocation.stdin)
         # Deliver stdin (and close the pipe) immediately so a stdin-reading child
         # (ollama) can make progress; without this it blocks until the budget.
+        # Best-effort: a child that already exited (e.g. ollama erroring out before
+        # reading stdin) makes the write hit a closed pipe — swallow it so the child
+        # is reported via its returncode/stderr and falls through, not a crash.
         if invocation.stdin is not None:
-            proc.send_stdin(invocation.stdin)
+            with contextlib.suppress(BrokenPipeError):
+                proc.send_stdin(invocation.stdin)
         while True:
             if cancel is not None and cancel.is_set():
                 self._terminate(proc)

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -134,8 +134,10 @@ class ProcessHandle(Protocol):
 
     Beyond poll/terminate/kill, the wrapper needs to (a) DELIVER stdin to the child
     (``send_stdin`` — ollama reads the prompt there; without it the child blocks
-    forever), and (b) REAP a signalled child (``wait`` / ``communicate``) so no
-    zombie lingers and no PIPE fd leaks.
+    forever), (b) REAP a signalled child and collect its captured output
+    (``wait`` / ``communicate``), and (c) ``cleanup`` any capture scratch (the real
+    handle redirects stdout/stderr to temp files to avoid a pipe-buffer deadlock —
+    see :class:`_PopenHandle`). ``cleanup`` is called on every exit path.
     """
 
     def poll(self) -> int | None: ...  # pragma: no cover
@@ -144,6 +146,7 @@ class ProcessHandle(Protocol):
     def kill(self) -> None: ...  # pragma: no cover
     def wait(self, timeout: float | None = None) -> int: ...  # pragma: no cover
     def communicate(self) -> tuple[str, str]: ...  # pragma: no cover
+    def cleanup(self) -> None: ...  # pragma: no cover
 
 
 # A spawn function: given argv + optional stdin, start the process and return a
@@ -212,14 +215,21 @@ def build_invocation(spec: AgentSpec, *, prompt: str) -> AgentInvocation:
 class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handle
     """Adapts ``subprocess.Popen`` to :class:`ProcessHandle`.
 
-    ``send_stdin`` writes the prompt to the child and CLOSES the pipe (an ollama
-    child blocks on an open-but-unwritten stdin); ``communicate`` (called with no
-    further input) then drains stdout/stderr and reaps. Not unit-tested — it is the
-    OS boundary the ``spawn`` seam exists to keep out of the tested path.
+    The child's stdout/stderr are redirected to **temp files**, NOT pipes. A pipe
+    has a bounded OS buffer (~64KB); a chatty agent that writes more than that while
+    the runner is still polling (not yet draining) would block on the full pipe and
+    never exit — a false budget timeout on a job that would succeed. Files never
+    block the writer, so the poll-until-exit loop stays deadlock-free. ``stdin``
+    stays a pipe (``send_stdin`` writes the prompt and closes it). ``communicate``
+    reaps the child then reads the two files; ``cleanup`` unlinks them and is called
+    by the runner on every exit path. Not unit-tested — it IS the OS boundary the
+    ``spawn`` seam keeps out of the tested path.
     """
 
-    def __init__(self, proc: subprocess.Popen[str]) -> None:
+    def __init__(self, proc: subprocess.Popen[bytes], *, out_path: Path, err_path: Path) -> None:
         self._proc = proc
+        self._out_path = out_path
+        self._err_path = err_path
 
     def poll(self) -> int | None:
         return self._proc.poll()
@@ -229,7 +239,7 @@ class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handl
         # Close the pipe even if the write throws (child exited first → BrokenPipe),
         # so the fd never leaks; the caller swallows BrokenPipeError as best-effort.
         try:
-            self._proc.stdin.write(data)
+            self._proc.stdin.write(data.encode())
         finally:
             self._proc.stdin.close()
 
@@ -243,23 +253,42 @@ class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handl
         return self._proc.wait(timeout=timeout)
 
     def communicate(self) -> tuple[str, str]:
-        return self._proc.communicate()
+        # Reap the child, then read what it wrote to the capture files. The child's
+        # stdout/stderr fds are closed on exit, so the files are complete here.
+        self._proc.wait()
+        out = self._out_path.read_text(encoding="utf-8", errors="replace")
+        err = self._err_path.read_text(encoding="utf-8", errors="replace")
+        return out, err
+
+    def cleanup(self) -> None:
+        self._out_path.unlink(missing_ok=True)
+        self._err_path.unlink(missing_ok=True)
 
 
 def _popen_spawn(argv: Sequence[str], *, stdin: str | None) -> ProcessHandle:  # pragma: no cover
     """Production spawn: start a real child via ``subprocess.Popen``.
 
+    stdout/stderr are redirected to temp files (deadlock-free capture — see
+    :class:`_PopenHandle`); stdin stays a pipe only when there is input to deliver.
     Not covered by unit tests — it IS the OS boundary the ``spawn`` seam exists to
     keep out of the tested code path; tests inject a fake handle instead.
     """
-    proc = subprocess.Popen(  # noqa: S603  # argv is internally built per-invoker, never shell-interpolated user input
-        list(argv),
-        stdin=subprocess.PIPE if stdin is not None else None,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    return _PopenHandle(proc)
+    out_fd, out_name = tempfile.mkstemp(suffix=".out", prefix="prgroom-agent-")
+    err_fd, err_name = tempfile.mkstemp(suffix=".err", prefix="prgroom-agent-")
+    out_path, err_path = Path(out_name), Path(err_name)
+    try:
+        with os.fdopen(out_fd, "wb") as out_fh, os.fdopen(err_fd, "wb") as err_fh:
+            proc = subprocess.Popen(  # noqa: S603  # argv is internally built per-invoker, never shell-interpolated user input
+                list(argv),
+                stdin=subprocess.PIPE if stdin is not None else None,
+                stdout=out_fh,
+                stderr=err_fh,
+            )
+    except BaseException:
+        out_path.unlink(missing_ok=True)
+        err_path.unlink(missing_ok=True)
+        raise
+    return _PopenHandle(proc, out_path=out_path, err_path=err_path)
 
 
 class SubprocessAgentRunner:
@@ -325,14 +354,29 @@ class SubprocessAgentRunner:
         start = time.monotonic()
         deadline = start + time_budget_s
         proc = self._spawn(invocation.argv, stdin=invocation.stdin)
-        # Deliver stdin (and close the pipe) immediately so a stdin-reading child
-        # (ollama) can make progress; without this it blocks until the budget.
-        # Best-effort: a child that already exited (e.g. ollama erroring out before
-        # reading stdin) makes the write hit a closed pipe — swallow it so the child
-        # is reported via its returncode/stderr and falls through, not a crash.
-        if invocation.stdin is not None:
-            with contextlib.suppress(BrokenPipeError):
-                proc.send_stdin(invocation.stdin)
+        # cleanup() unlinks the handle's stdout/stderr capture files; run it on EVERY
+        # exit path (success, timeout, cancel, exception), so the scratch never leaks.
+        try:
+            # Deliver stdin (and close the pipe) immediately so a stdin-reading child
+            # (ollama) can make progress; without this it blocks until the budget.
+            # Best-effort: a child that already exited (e.g. ollama erroring out before
+            # reading stdin) makes the write hit a closed pipe — swallow it so the child
+            # is reported via its returncode/stderr and falls through, not a crash.
+            if invocation.stdin is not None:
+                with contextlib.suppress(BrokenPipeError):
+                    proc.send_stdin(invocation.stdin)
+            return self._poll_until_done(proc, start=start, deadline=deadline, cancel=cancel)
+        finally:
+            proc.cleanup()
+
+    def _poll_until_done(
+        self,
+        proc: ProcessHandle,
+        *,
+        start: float,
+        deadline: float,
+        cancel: threading.Event | None,
+    ) -> AgentRunResult:
         while True:
             if cancel is not None and cancel.is_set():
                 self._terminate(proc)
@@ -356,7 +400,7 @@ class SubprocessAgentRunner:
                 raise AgentTimeoutError(
                     tier=Tier.RUNTIME_TRANSIENT,
                     code=ErrorCode.RUNTIME_AGENT_TIMEOUT,
-                    detail=f"agent exceeded its {time_budget_s}s time budget",
+                    detail=f"agent exceeded its {deadline - start:.0f}s time budget",
                 )
             if self._poll_interval_s:
                 time.sleep(self._poll_interval_s)

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -1,0 +1,370 @@
+"""Subprocess lifecycle wrapper for agent dispatch (§5 subprocess wrapper).
+
+Owns the ``subprocess`` plumbing for the four agent CLIs (``claude -p`` /
+``codex exec`` / ``opencode run`` / ``ollama``): it writes the contract JSON to a
+temp file passed **by path** (§5 "JSON, written to a file passed by path"), builds
+the per-invoker argv/stdin shape, enforces a per-contract wall-clock budget
+(kills the child and raises a timeout-tagged error on overrun), and terminates the
+child when a :class:`threading.Event` cancel-token is set.
+
+The single OS seam is the :class:`ProcessHandle` Protocol — a thin ``Popen``
+facade — injected as the ``spawn`` callable. Production wires :func:`_popen_spawn`;
+tests inject a fake that returns recorded behavior, so kill-on-timeout and
+kill-on-cancel are proven without spawning a real CLI. This mirrors the
+foundation's ``CommandRunner`` seam (recorded fakes, not mocks).
+
+The runner is intentionally **classification-free**: it reports the child's
+returncode + stderr faithfully and raises only for timeout/cancel. Mapping a
+non-zero exit (quota/auth/network) onto the fallback ladder is the dispatcher's
+job — keeping that policy out of the boundary keeps this layer a pure mechanism.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from prgroom.agent.prompt_loader import PromptTemplate
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+
+# Default poll cadence while waiting on a child: tight enough that a cancel-token
+# or budget overrun is noticed promptly, loose enough not to busy-spin. Tests
+# inject 0.0 to make the wait deterministic and instant.
+DEFAULT_POLL_INTERVAL_S = 0.1
+
+# Grace given to a SIGTERMed child to exit (flush buffers, release its
+# .git/index.lock) before escalating to SIGKILL. Tests inject 0.0 for an instant,
+# deterministic escalation.
+DEFAULT_SIGTERM_GRACE_S = 5.0
+
+# The render-data key the runner injects: the temp input-file path. The contract
+# prompt templates name this placeholder; only the runner knows the real path
+# (it owns the temp file), so it fills this last, after writing the payload.
+INPUT_PATH_KEY = "input_path"
+
+# The four agent CLIs §5 names. The value is the cli token in TOML config.
+_KNOWN_CLIS = frozenset({"claude", "codex", "opencode", "ollama"})
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpec:
+    """One provider's config: which CLI, which model, and CLI-specific extras.
+
+    ``extra`` carries the per-provider TOML knobs that are not universal —
+    ``effort`` (claude), ``write`` (codex). Unknown keys for a given CLI are
+    ignored by its invoker, so the config surface can grow without breaking.
+    """
+
+    cli: str
+    model: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentInvocation:
+    """A built command: the argv to spawn and the optional stdin to feed it."""
+
+    argv: list[str]
+    stdin: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunResult:
+    """The captured outcome of one agent invocation."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+class AgentTimeoutError(PrgroomError):
+    """The agent exceeded its per-contract time budget (``RUNTIME_AGENT_TIMEOUT``).
+
+    A budget overrun on one provider is a **fallback trigger**: the dispatcher
+    catches this and tries the next link in the chain (§5). It is distinct from
+    :class:`AgentCancelledError` precisely so the dispatcher can route the two
+    differently — try-next vs. abort-all.
+    """
+
+
+class AgentCancelledError(PrgroomError):
+    """A cancel-token (operator/scheduler shutdown) killed the agent mid-run.
+
+    Carries ``RUNTIME_CANCELLED_SIGTERM``. Unlike a timeout, this is **not** a
+    per-provider failure — it propagates past the dispatcher's fallback ladder to
+    abort the whole dispatch, since shutdown means "stop", not "try another model".
+    """
+
+
+@runtime_checkable
+class AgentRunner(Protocol):
+    """The single-invocation surface the dispatcher depends on (§5).
+
+    :class:`SubprocessAgentRunner` is the production implementation; tests inject a
+    recorded-outcome fake. Typing the dispatcher against this Protocol (not the
+    concrete class) keeps the dispatcher's fallback-ladder tests free of real
+    subprocess machinery — the same fakes-not-mocks discipline as ``CommandRunner``.
+    """
+
+    def run(
+        self,
+        spec: AgentSpec,
+        *,
+        prompt_template: PromptTemplate,
+        render_data: dict[str, str],
+        contract_payload: dict[str, Any],
+        time_budget_s: float,
+        cancel: threading.Event | None = ...,
+    ) -> AgentRunResult: ...  # pragma: no cover
+
+
+@runtime_checkable
+class ProcessHandle(Protocol):
+    """A thin ``subprocess.Popen`` facade — the single OS seam this wrapper needs.
+
+    Beyond poll/terminate/kill, the wrapper needs to (a) DELIVER stdin to the child
+    (``send_stdin`` — ollama reads the prompt there; without it the child blocks
+    forever), and (b) REAP a signalled child (``wait`` / ``communicate``) so no
+    zombie lingers and no PIPE fd leaks.
+    """
+
+    def poll(self) -> int | None: ...  # pragma: no cover
+    def send_stdin(self, data: str) -> None: ...  # pragma: no cover
+    def terminate(self) -> None: ...  # pragma: no cover
+    def kill(self) -> None: ...  # pragma: no cover
+    def wait(self, timeout: float | None = None) -> int: ...  # pragma: no cover
+    def communicate(self) -> tuple[str, str]: ...  # pragma: no cover
+
+
+# A spawn function: given argv + optional stdin, start the process and return a
+# handle. The seam the runner depends on instead of `subprocess.Popen` directly.
+SpawnFn = Callable[..., ProcessHandle]
+
+
+def _invocation_for_claude(spec: AgentSpec, prompt: str) -> AgentInvocation:
+    # `claude -p <prompt>` runs headless. The contract input path is already inside
+    # `prompt` (the agent reads the file) — claude has no --input-file flag.
+    argv = ["claude", "-p", prompt, "--model", spec.model]
+    effort = spec.extra.get("effort")
+    if effort:
+        argv += ["--effort", str(effort)]
+    return AgentInvocation(argv=argv)
+
+
+def _invocation_for_codex(spec: AgentSpec, prompt: str) -> AgentInvocation:
+    # `codex exec` is the non-interactive entry point; the config `write = true`
+    # grants edit permission via the sandbox POLICY (`--sandbox workspace-write`),
+    # not a bare flag. Read-only specs leave the default sandbox in place.
+    argv = ["codex", "exec", "--model", spec.model]
+    if spec.extra.get("write"):
+        argv += ["--sandbox", "workspace-write"]
+    argv += [prompt]
+    return AgentInvocation(argv=argv)
+
+
+def _invocation_for_opencode(spec: AgentSpec, prompt: str) -> AgentInvocation:
+    return AgentInvocation(argv=["opencode", "run", "--model", spec.model, prompt])
+
+
+def _invocation_for_ollama(spec: AgentSpec, prompt: str) -> AgentInvocation:
+    # ollama reads the prompt on STDIN (`ollama run <model>`), so the prompt — which
+    # carries the input path — is fed on stdin, not as an argv positional.
+    return AgentInvocation(argv=["ollama", "run", spec.model], stdin=prompt)
+
+
+_INVOKERS: dict[str, Callable[[AgentSpec, str], AgentInvocation]] = {
+    "claude": _invocation_for_claude,
+    "codex": _invocation_for_codex,
+    "opencode": _invocation_for_opencode,
+    "ollama": _invocation_for_ollama,
+}
+
+
+def build_invocation(spec: AgentSpec, *, prompt: str) -> AgentInvocation:
+    """Build the argv/stdin shape for ``spec.cli`` (§5 per-invoker shapes).
+
+    ``prompt`` is the fully-rendered prompt that already names the contract input
+    file by path (none of the four CLIs has an ``--input-file`` flag — the agent
+    reads the path out of the prompt). Raises :class:`ValueError` for a cli outside
+    the four §5 runtimes — a config typo must fail loudly at dispatch, not silently
+    pick a default.
+    """
+    invoker = _INVOKERS.get(spec.cli)
+    if invoker is None:
+        msg = f"unknown agent cli: {spec.cli!r} (expected one of {sorted(_KNOWN_CLIS)})"
+        raise ValueError(msg)
+    return invoker(spec, prompt)
+
+
+class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handle
+    """Adapts ``subprocess.Popen`` to :class:`ProcessHandle`.
+
+    ``send_stdin`` writes the prompt to the child and CLOSES the pipe (an ollama
+    child blocks on an open-but-unwritten stdin); ``communicate`` (called with no
+    further input) then drains stdout/stderr and reaps. Not unit-tested — it is the
+    OS boundary the ``spawn`` seam exists to keep out of the tested path.
+    """
+
+    def __init__(self, proc: subprocess.Popen[str]) -> None:
+        self._proc = proc
+
+    def poll(self) -> int | None:
+        return self._proc.poll()
+
+    def send_stdin(self, data: str) -> None:
+        assert self._proc.stdin is not None  # noqa: S101  # only called when stdin=PIPE was opened
+        self._proc.stdin.write(data)
+        self._proc.stdin.close()
+
+    def terminate(self) -> None:
+        self._proc.terminate()
+
+    def kill(self) -> None:
+        self._proc.kill()
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self._proc.wait(timeout=timeout)
+
+    def communicate(self) -> tuple[str, str]:
+        return self._proc.communicate()
+
+
+def _popen_spawn(argv: Sequence[str], *, stdin: str | None) -> ProcessHandle:  # pragma: no cover
+    """Production spawn: start a real child via ``subprocess.Popen``.
+
+    Not covered by unit tests — it IS the OS boundary the ``spawn`` seam exists to
+    keep out of the tested code path; tests inject a fake handle instead.
+    """
+    proc = subprocess.Popen(  # noqa: S603  # argv is internally built per-invoker, never shell-interpolated user input
+        list(argv),
+        stdin=subprocess.PIPE if stdin is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return _PopenHandle(proc)
+
+
+class SubprocessAgentRunner:
+    """Runs one agent invocation under a budget + cancel-token. Owns the temp-file dance."""
+
+    def __init__(
+        self,
+        *,
+        spawn: SpawnFn = _popen_spawn,
+        scratch_dir: Path | None = None,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        sigterm_grace_s: float = DEFAULT_SIGTERM_GRACE_S,
+    ) -> None:
+        self._spawn = spawn
+        self._scratch_dir = scratch_dir
+        self._poll_interval_s = poll_interval_s
+        self._sigterm_grace_s = sigterm_grace_s
+
+    def run(
+        self,
+        spec: AgentSpec,
+        *,
+        prompt_template: PromptTemplate,
+        render_data: dict[str, str],
+        contract_payload: dict[str, Any],
+        time_budget_s: float,
+        cancel: threading.Event | None = None,
+    ) -> AgentRunResult:
+        """Dispatch ``spec`` against ``contract_payload``, returning the captured result.
+
+        Writes ``contract_payload`` to a temp ``.json`` file, renders
+        ``prompt_template`` with ``render_data`` plus the temp path (under
+        :data:`INPUT_PATH_KEY`), builds the per-invoker argv, spawns the child,
+        delivers any stdin, and waits — polling the cancel-token and the wall-clock
+        deadline. A budget overrun raises :class:`AgentTimeoutError`; a cancel-token
+        set raises :class:`AgentCancelledError`; both stop and reap the child first.
+        The temp input file is always cleaned up. The runner owns the temp path, so
+        it is the only place that can fill the prompt's ``{input_path}`` placeholder.
+        """
+        input_path = self._write_payload(contract_payload)
+        try:
+            prompt = prompt_template.render({**render_data, INPUT_PATH_KEY: str(input_path)})
+            invocation = build_invocation(spec, prompt=prompt)
+            return self._spawn_and_wait(invocation, time_budget_s=time_budget_s, cancel=cancel)
+        finally:
+            input_path.unlink(missing_ok=True)
+
+    def _write_payload(self, payload: dict[str, Any]) -> Path:
+        fd, name = tempfile.mkstemp(suffix=".json", prefix="prgroom-agent-", dir=self._scratch_dir)
+        os.close(fd)
+        path = Path(name)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+        return path
+
+    def _spawn_and_wait(
+        self,
+        invocation: AgentInvocation,
+        *,
+        time_budget_s: float,
+        cancel: threading.Event | None,
+    ) -> AgentRunResult:
+        start = time.monotonic()
+        deadline = start + time_budget_s
+        proc = self._spawn(invocation.argv, stdin=invocation.stdin)
+        # Deliver stdin (and close the pipe) immediately so a stdin-reading child
+        # (ollama) can make progress; without this it blocks until the budget.
+        if invocation.stdin is not None:
+            proc.send_stdin(invocation.stdin)
+        while True:
+            if cancel is not None and cancel.is_set():
+                self._terminate(proc)
+                raise AgentCancelledError(
+                    tier=Tier.RUNTIME_CANCELLED,
+                    code=ErrorCode.RUNTIME_CANCELLED_SIGTERM,
+                    signum=15,
+                    detail="agent dispatch cancelled via cancel-token",
+                )
+            returncode = proc.poll()
+            if returncode is not None:
+                stdout, stderr = proc.communicate()
+                return AgentRunResult(
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=stderr,
+                    duration_ms=_elapsed_ms(start),
+                )
+            if time.monotonic() >= deadline:
+                self._terminate(proc)
+                raise AgentTimeoutError(
+                    tier=Tier.RUNTIME_TRANSIENT,
+                    code=ErrorCode.RUNTIME_AGENT_TIMEOUT,
+                    detail=f"agent exceeded its {time_budget_s}s time budget",
+                )
+            if self._poll_interval_s:
+                time.sleep(self._poll_interval_s)
+
+    def _terminate(self, proc: ProcessHandle) -> None:
+        """Stop and REAP a child: SIGTERM, grace, SIGKILL-on-survival, then reap.
+
+        SIGTERM first, giving the child ``sigterm_grace_s`` to exit cleanly (flush
+        buffers, release its ``.git/index.lock``). Only if it ignores SIGTERM do we
+        SIGKILL. Either way a final ``communicate`` drains the stdout/stderr/stdin
+        pipes and reaps the child, so no zombie lingers and no PIPE fd leaks before
+        the error propagates.
+        """
+        proc.terminate()
+        try:
+            proc.wait(timeout=self._sigterm_grace_s)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        proc.communicate()
+
+
+def _elapsed_ms(start: float) -> int:
+    return int((time.monotonic() - start) * 1000)

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -407,11 +407,11 @@ class SubprocessAgentRunner:
 
     def _write_payload(self, payload: dict[str, Any]) -> Path:
         fd, name = tempfile.mkstemp(suffix=".json", prefix="prgroom-agent-", dir=self._scratch_dir)
-        os.close(fd)
-        path = Path(name)
-        with path.open("w", encoding="utf-8") as fh:
+        # Write through the fd mkstemp returned: reopening by path would leave a
+        # TOCTOU window where the path could be swapped between close and open.
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(payload, fh)
-        return path
+        return Path(name)
 
     def _spawn_and_wait(
         self,

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -410,9 +410,9 @@ class SubprocessAgentRunner:
 
         SIGTERM first, giving the child ``sigterm_grace_s`` to exit cleanly (flush
         buffers, release its ``.git/index.lock``). Only if it ignores SIGTERM do we
-        SIGKILL. Either way a final ``communicate`` drains the stdout/stderr/stdin
-        pipes and reaps the child, so no zombie lingers and no PIPE fd leaks before
-        the error propagates.
+        SIGKILL. Either way a final ``communicate`` reaps the child and reads its
+        stdout/stderr capture files (stdin was already closed in ``send_stdin``), so
+        no zombie lingers before the error propagates; ``cleanup`` unlinks the files.
         """
         proc.terminate()
         try:

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -413,12 +413,19 @@ class SubprocessAgentRunner:
         SIGKILL. Either way a final ``communicate`` reaps the child and reads its
         stdout/stderr capture files (stdin was already closed in ``send_stdin``), so
         no zombie lingers before the error propagates; ``cleanup`` unlinks the files.
+
+        Both signals are best-effort: a child that already exited between the poll
+        loop and here (a fast-failure race) makes ``terminate``/``kill`` raise
+        ``ProcessLookupError``. There is nothing left to signal, so we suppress it and
+        let ``communicate`` reap — keeping the timeout/cancel error deterministic.
         """
-        proc.terminate()
+        with contextlib.suppress(ProcessLookupError):
+            proc.terminate()
         try:
             proc.wait(timeout=self._sigterm_grace_s)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
         proc.communicate()
 
 

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -2,7 +2,9 @@
 
 Owns the ``subprocess`` plumbing for the four agent CLIs (``claude -p`` /
 ``codex exec`` / ``opencode run`` / ``ollama``): it writes the contract JSON to a
-temp file passed **by path** (§5 "JSON, written to a file passed by path"), builds
+temp file passed **by path** (§5 "JSON, written to a file passed by path") for the
+file-capable CLIs — a tool-less ``ollama run`` child instead gets the payload and
+referenced file contents INLINE in its prompt (see :func:`_input_section`) — builds
 the per-invoker argv/stdin shape, enforces a per-contract wall-clock budget
 (kills the child and raises a timeout-tagged error on overrun), and terminates the
 child when a :class:`threading.Event` cancel-token is set.
@@ -46,10 +48,11 @@ DEFAULT_POLL_INTERVAL_S = 0.1
 # deterministic escalation.
 DEFAULT_SIGTERM_GRACE_S = 5.0
 
-# The render-data key the runner injects: the temp input-file path. The contract
-# prompt templates name this placeholder; only the runner knows the real path
-# (it owns the temp file), so it fills this last, after writing the payload.
-INPUT_PATH_KEY = "input_path"
+# The render-data key the runner injects: the per-invoker payload-delivery section.
+# The contract prompt templates name this placeholder; only the runner knows the
+# delivery mode (file path for file-capable CLIs, inline content for ollama — see
+# _input_section), so it fills this last, after writing the payload.
+INPUT_SECTION_KEY = "input_section"
 
 # The four agent CLIs §5 names. The value is the cli token in TOML config.
 _KNOWN_CLIS = frozenset({"claude", "codex", "opencode", "ollama"})
@@ -152,6 +155,42 @@ class ProcessHandle(Protocol):
 # A spawn function: given argv + optional stdin, start the process and return a
 # handle. The seam the runner depends on instead of `subprocess.Popen` directly.
 SpawnFn = Callable[..., ProcessHandle]
+
+
+def _input_section(cli: str, *, input_path: Path, payload: dict[str, Any]) -> str:
+    """The per-invoker payload-delivery section rendered into the prompt template.
+
+    File-capable CLIs (claude/codex/opencode spawn tool-using agents) get the §5
+    pass-by-path shape: the section names the temp input file and the agent reads
+    it. A bare ``ollama run`` child is a tool-less text generator that cannot open
+    ANY file, so its section carries the content INLINE — the contract JSON plus
+    the contents of every ``*_path`` file the payload references — and never
+    instructs the model to read a path. (The HLD's "each invoker owns its own
+    stdin/stdout serialisation" is what licenses the per-invoker delivery mode.)
+    """
+    if cli != "ollama":
+        return f"from this file:\n\n  {input_path}"
+    parts = [
+        "inline below. You CANNOT read files — every file's content you need is",
+        "already included in this prompt; any *_path values in the JSON are",
+        "labels for the inline blocks that follow, not paths for you to open:",
+        "",
+        "```json",
+        json.dumps(payload, indent=2),
+        "```",
+    ]
+    for key, value in payload.items():
+        # Inline each referenced document. Best-effort: a missing/unreadable file
+        # (snapshot not assembled yet) is skipped, not a crash — the agent still
+        # gets the contract JSON and can act on what is present.
+        if not key.endswith("_path") or not isinstance(value, str):
+            continue
+        try:
+            content = Path(value).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        parts += ["", f"Contents of {key} ({value}):", "```", content, "```"]
+    return "\n".join(parts)
 
 
 def _invocation_for_claude(spec: AgentSpec, prompt: str) -> AgentInvocation:
@@ -320,17 +359,21 @@ class SubprocessAgentRunner:
         """Dispatch ``spec`` against ``contract_payload``, returning the captured result.
 
         Writes ``contract_payload`` to a temp ``.json`` file, renders
-        ``prompt_template`` with ``render_data`` plus the temp path (under
-        :data:`INPUT_PATH_KEY`), builds the per-invoker argv, spawns the child,
-        delivers any stdin, and waits — polling the cancel-token and the wall-clock
-        deadline. A budget overrun raises :class:`AgentTimeoutError`; a cancel-token
-        set raises :class:`AgentCancelledError`; both stop and reap the child first.
-        The temp input file is always cleaned up. The runner owns the temp path, so
-        it is the only place that can fill the prompt's ``{input_path}`` placeholder.
+        ``prompt_template`` with ``render_data`` plus the per-invoker payload
+        delivery section (under :data:`INPUT_SECTION_KEY` — pass-by-path for the
+        file-capable CLIs, inline content for ollama), builds the per-invoker argv,
+        spawns the child, delivers any stdin, and waits — polling the cancel-token
+        and the wall-clock deadline. A budget overrun raises
+        :class:`AgentTimeoutError`; a cancel-token set raises
+        :class:`AgentCancelledError`; both stop and reap the child first. The temp
+        input file is always cleaned up. The runner owns the temp path and the
+        delivery mode, so it is the only place that can fill the prompt's
+        ``{input_section}`` placeholder.
         """
         input_path = self._write_payload(contract_payload)
         try:
-            prompt = prompt_template.render({**render_data, INPUT_PATH_KEY: str(input_path)})
+            section = _input_section(spec.cli, input_path=input_path, payload=contract_payload)
+            prompt = prompt_template.render({**render_data, INPUT_SECTION_KEY: section})
             invocation = build_invocation(spec, prompt=prompt)
             return self._spawn_and_wait(invocation, time_budget_s=time_budget_s, cancel=cancel)
         finally:

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -240,7 +240,8 @@ def _invocation_for_opencode(spec: AgentSpec, prompt: str) -> AgentInvocation:
 
 def _invocation_for_ollama(spec: AgentSpec, prompt: str) -> AgentInvocation:
     # ollama reads the prompt on STDIN (`ollama run <model>`), so the prompt — which
-    # carries the input path — is fed on stdin, not as an argv positional.
+    # carries the contract payload INLINE (see _input_section; a tool-less ollama
+    # child cannot open files) — is fed on stdin, not as an argv positional.
     return AgentInvocation(argv=["ollama", "run", spec.model], stdin=prompt)
 
 
@@ -255,11 +256,12 @@ _INVOKERS: dict[str, Callable[[AgentSpec, str], AgentInvocation]] = {
 def build_invocation(spec: AgentSpec, *, prompt: str) -> AgentInvocation:
     """Build the argv/stdin shape for ``spec.cli`` (§5 per-invoker shapes).
 
-    ``prompt`` is the fully-rendered prompt that already names the contract input
-    file by path (none of the four CLIs has an ``--input-file`` flag — the agent
-    reads the path out of the prompt). Raises :class:`ValueError` for a cli outside
-    the four §5 runtimes — a config typo must fail loudly at dispatch, not silently
-    pick a default.
+    ``prompt`` is the fully-rendered prompt whose payload-delivery section was
+    already filled per-invoker (path for file-capable CLIs, inline content for
+    ollama — none of the four CLIs has an ``--input-file`` flag, so delivery lives
+    in the prompt). Raises :class:`ValueError` for a cli outside the four §5
+    runtimes — a config typo must fail loudly at dispatch, not silently pick a
+    default.
     """
     invoker = _INVOKERS.get(spec.cli)
     if invoker is None:

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import subprocess
 import tempfile
@@ -57,19 +58,35 @@ INPUT_SECTION_KEY = "input_section"
 # The four agent CLIs §5 names. The value is the cli token in TOML config.
 _KNOWN_CLIS = frozenset({"claude", "codex", "opencode", "ollama"})
 
+# The `extra` keys each invoker actually consumes. Anything else in a provider
+# table is warned about (a typo like `effrot` must not vanish silently) but NOT
+# rejected — `extra` is a deliberate growth surface.
+_RECOGNIZED_EXTRA: dict[str, frozenset[str]] = {
+    "claude": frozenset({"effort"}),
+    "codex": frozenset({"write"}),
+    "opencode": frozenset(),
+    "ollama": frozenset(),
+}
+
+_logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True, slots=True)
 class AgentSpec:
     """One provider's config: which CLI, which model, and CLI-specific extras.
 
-    ``extra`` carries the per-provider TOML knobs that are not universal —
-    ``effort`` (claude), ``write`` (codex). Unknown keys for a given CLI are
-    ignored by its invoker, so the config surface can grow without breaking.
+    ``time_budget_s`` is the provider-level ``timeout`` TOML key: when set it
+    overrides the contract's default budget for THIS chain link only; ``None``
+    means "use the contract default". ``extra`` carries the per-provider TOML
+    knobs that are not universal — ``effort`` (claude), ``write`` (codex).
+    Unknown keys for a given CLI are warned about and ignored by its invoker,
+    so the config surface can grow without breaking.
     """
 
     cli: str
     model: str
     extra: dict[str, Any] = field(default_factory=dict)
+    time_budget_s: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -248,6 +265,13 @@ def build_invocation(spec: AgentSpec, *, prompt: str) -> AgentInvocation:
     if invoker is None:
         msg = f"unknown agent cli: {spec.cli!r} (expected one of {sorted(_KNOWN_CLIS)})"
         raise ValueError(msg)
+    unrecognized = sorted(set(spec.extra) - _RECOGNIZED_EXTRA[spec.cli])
+    if unrecognized:
+        _logger.warning(
+            "ignoring unrecognized config keys for cli %r: %s",
+            spec.cli,
+            ", ".join(unrecognized),
+        )
     return invoker(spec, prompt)
 
 

--- a/packages/prgroom/src/prgroom/agent/usage.py
+++ b/packages/prgroom/src/prgroom/agent/usage.py
@@ -34,11 +34,15 @@ class UsageRecord:
     provider: str
     """The agent CLI that ran (``claude`` / ``codex`` / ``opencode`` / ``ollama``)."""
     model: str
-    input_tokens: int
-    output_tokens: int
+    input_tokens: int | None
+    """Prompt tokens from the agent CLI's usage line; ``None`` until a usage-line
+    parser exists to extract them (serializes as JSON null)."""
+    output_tokens: int | None
     duration_ms: int
     outcome: str
-    """``success`` / ``timeout`` / ``error`` — the invocation's terminal disposition."""
+    """``success`` / ``timeout`` / ``unavailable`` / ``error`` / ``malformed`` /
+    ``cancelled`` — the attempt's terminal disposition, one record per chain link
+    tried (the dispatcher emits these through its usage hook)."""
 
     def to_dict(self) -> dict[str, Any]:
         """The flat JSONL line. ``pr`` renders as the ``owner/repo#n`` shorthand."""

--- a/packages/prgroom/src/prgroom/agent/usage.py
+++ b/packages/prgroom/src/prgroom/agent/usage.py
@@ -1,0 +1,71 @@
+"""Per-invocation token-usage JSONL emitter (§5 token-usage logging).
+
+The CLI logs **per-contract token usage** to ``$XDG_STATE_HOME/prgroom/usage.jsonl``
+when the agent CLI emits a usage line (Claude and Codex CLIs both do). This is
+**MVP baseline-capture only** — one JSON line per invocation, no aggregation, no
+analysis — so future cost-optimization work has data to start from.
+
+The XDG state directory is resolved through :func:`prgroom.prsession.file.resolve_state_dir`,
+the single source of truth for ``$XDG_STATE_HOME/prgroom`` (shared with the file
+Store), so usage data and state land in the same place under the same env rule.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from prgroom.prsession.file import resolve_state_dir
+from prgroom.prsession.pr_ref import PRRef
+
+USAGE_FILENAME = "usage.jsonl"
+
+
+@dataclass(frozen=True, slots=True)
+class UsageRecord:
+    """One agent invocation's usage record. The §5 JSONL line schema verbatim."""
+
+    ts: str
+    """ISO-8601 timestamp of the invocation (from the injected clock, by the caller)."""
+    pr: PRRef
+    contract: str
+    """``cluster`` or ``fix`` — which contract dispatched."""
+    provider: str
+    """The agent CLI that ran (``claude`` / ``codex`` / ``opencode`` / ``ollama``)."""
+    model: str
+    input_tokens: int
+    output_tokens: int
+    duration_ms: int
+    outcome: str
+    """``success`` / ``timeout`` / ``error`` — the invocation's terminal disposition."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """The flat JSONL line. ``pr`` renders as the ``owner/repo#n`` shorthand."""
+        return {
+            "ts": self.ts,
+            "pr": self.pr.display(),
+            "contract": self.contract,
+            "provider": self.provider,
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "duration_ms": self.duration_ms,
+            "outcome": self.outcome,
+        }
+
+
+def append_usage(record: UsageRecord | None) -> None:
+    """Append one usage line to ``$XDG_STATE_HOME/prgroom/usage.jsonl``.
+
+    A ``None`` record is a **no-op, not an error** (§5): the agent CLI emitted no
+    parseable usage line, so there is nothing to log — the file is not even
+    created. A real record is appended (never truncates prior lines); parent dirs
+    are created on first write so the very first invocation succeeds.
+    """
+    if record is None:
+        return
+    path = resolve_state_dir() / USAGE_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record.to_dict()) + "\n")

--- a/packages/prgroom/src/prgroom/config.py
+++ b/packages/prgroom/src/prgroom/config.py
@@ -148,8 +148,8 @@ class PrgroomConfig:
         auto_request_human_review_flag: bool | None = None,
     ) -> PrgroomConfig:
         """Resolve config with CLI > env > TOML > default precedence (§3.5, §4.3)."""
-        table = _read_toml(repo_config)
-        quiescence = _subtable(table, _QUIESCENCE_TABLE)
+        table = read_toml(repo_config)
+        quiescence = subtable(table, _QUIESCENCE_TABLE)
 
         return cls(
             max_rounds=cls._resolve_max_rounds(table, max_rounds_flag),
@@ -206,14 +206,19 @@ class PrgroomConfig:
         return DEFAULT_MAX_ROUNDS
 
 
-def _read_toml(path: Path | None) -> dict[str, Any]:
+def read_toml(path: Path | None) -> dict[str, Any]:
+    """Parse the per-repo ``.prgroom.toml`` (missing file -> ``{}``).
+
+    The single parse path for the config file — :class:`PrgroomConfig` and the
+    agent chain loader both read through here, so the file is interpreted one way.
+    """
     if path is None or not path.is_file():
         return {}
     with path.open("rb") as fh:
         return tomllib.load(fh)
 
 
-def _subtable(table: dict[str, Any], key: str) -> dict[str, Any]:
+def subtable(table: dict[str, Any], key: str) -> dict[str, Any]:
     """Return the named sub-table; ``{}`` if absent, raise if present-but-not-a-table.
 
     An absent key falls through to per-setting defaults. A present-but-wrong-typed key

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -267,6 +267,57 @@ def test_absent_section_still_falls_through_to_the_default(tmp_path: Path) -> No
     ]
 
 
+def test_provider_timeout_key_overrides_that_links_budget(tmp_path: Path) -> None:
+    # The HLD names per-provider TOML config for model + timeout: a provider-level
+    # `timeout` (seconds) overrides the contract default for THAT link only; links
+    # without one keep the contract default. The key is structural, not `extra`.
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "[agents.cluster]",
+                'primary = { cli = "ollama", model = "gemma4", timeout = 300 }',
+                'fallback = { cli = "claude", model = "haiku" }',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    chain = load_chain("cluster", repo_config=cfg, model_override=None)
+    assert chain.providers[0].time_budget_s == 300.0
+    assert "timeout" not in chain.providers[0].extra
+    assert chain.providers[1].time_budget_s is None  # falls back to the contract budget
+
+
+def test_dispatcher_honors_a_per_link_timeout_override() -> None:
+    # The per-link override must actually reach the runner; the un-overridden link
+    # still gets the chain's contract default.
+    runner = FakeAgentRunner([TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(
+            AgentSpec("ollama", "gemma4", time_budget_s=7.0), AgentSpec("claude", "haiku")
+        ),
+    )
+    dispatcher.cluster(_cluster_input())
+    assert runner.calls[0]["time_budget_s"] == 7.0  # the link's own override
+    assert runner.calls[1]["time_budget_s"] == 5.0  # the chain default
+
+
+def test_provider_timeout_must_be_a_positive_number(tmp_path: Path) -> None:
+    # Invalid timeouts are rejected naming the full agents.<contract>.<key>.timeout
+    # path — never silently swallowed into `extra` (the pre-fix behavior).
+    for bad in ('"5m"', "-3", "0", "true"):
+        cfg = tmp_path / ".prgroom.toml"
+        cfg.write_text(
+            f'[agents.cluster]\nprimary = {{ cli = "ollama", model = "g", timeout = {bad} }}\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(
+            ValueError, match=r"agents\.cluster\.primary\.timeout must be a positive number"
+        ):
+            load_chain("cluster", repo_config=cfg, model_override=None)
+
+
 def test_model_override_replaces_the_primary_model_only() -> None:
     # --cluster-model / --fix-model swaps the primary provider's model, keeping its
     # cli + the rest of the chain (operator wants "the same provider, this model").

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -14,8 +14,10 @@ proven in ``test_agent_subprocess_runner``; here we prove the LADDER logic.
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -27,6 +29,7 @@ from prgroom.agent.dispatcher import (
     ProviderChain,
     load_chain,
 )
+from prgroom.agent.prompt_loader import PromptTemplate
 from prgroom.agent.subprocess_runner import (
     AgentCancelledError,
     AgentRunResult,
@@ -69,14 +72,41 @@ class BinaryMissing(_Outcome):
 
 
 class FakeAgentRunner:
-    """Replays one queued :class:`_Outcome` per ``run`` call, recording the specs tried."""
+    """Replays one queued :class:`_Outcome` per ``run`` call, recording every call.
+
+    The signature mirrors the ``AgentRunner`` Protocol EXACTLY — no ``**kwargs``
+    swallowing — so a dispatcher that drops or misnames a forwarded argument fails
+    loudly here instead of staying green. ``calls`` records each invocation's
+    kwargs so tests pin the dispatcher→runner contract (per-link budget, prompt
+    template, render data, cancel token), not just which specs were tried.
+    """
 
     def __init__(self, outcomes: Sequence[_Outcome]) -> None:
         self._outcomes = list(outcomes)
         self.specs_tried: list[AgentSpec] = []
+        self.calls: list[dict[str, Any]] = []
 
-    def run(self, spec: AgentSpec, **_kwargs: object) -> AgentRunResult:
+    def run(
+        self,
+        spec: AgentSpec,
+        *,
+        prompt_template: PromptTemplate,
+        render_data: dict[str, str],
+        contract_payload: dict[str, Any],
+        time_budget_s: float,
+        cancel: threading.Event | None = None,
+    ) -> AgentRunResult:
         self.specs_tried.append(spec)
+        self.calls.append(
+            {
+                "spec": spec,
+                "prompt_template": prompt_template,
+                "render_data": render_data,
+                "contract_payload": contract_payload,
+                "time_budget_s": time_budget_s,
+                "cancel": cancel,
+            }
+        )
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Succeeds):
             return AgentRunResult(returncode=0, stdout=outcome.stdout, stderr="", duration_ms=1)
@@ -89,6 +119,10 @@ class FakeAgentRunner:
                 tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_AGENT_TIMEOUT
             )
         if isinstance(outcome, Cancelled):
+            # Cancellation is only reachable in production when the dispatcher
+            # forwards a SET cancel token — enforce it so this fake cannot pin a
+            # code path the real plumbing does not have.
+            assert cancel is not None and cancel.is_set(), "cancel token not forwarded"
             raise AgentCancelledError(
                 tier=Tier.RUNTIME_CANCELLED, code=ErrorCode.RUNTIME_CANCELLED_SIGTERM, signum=15
             )
@@ -286,15 +320,40 @@ def test_primary_quota_exit_falls_to_fallback() -> None:
 def test_cancel_token_aborts_the_chain_without_trying_the_fallback() -> None:
     # A cancel-token kill is operator/scheduler shutdown — it must NOT be treated as
     # a per-provider failure and fall through to the next link. It propagates out,
-    # aborting the whole dispatch, and the fallback is never touched.
+    # aborting the whole dispatch, and the fallback is never touched. The token is
+    # REAL plumbing: the dispatcher must forward its own Event to every runner call
+    # (the fake refuses to cancel unless it received a set token).
+    cancel = threading.Event()
+    cancel.set()
     runner = FakeAgentRunner([Cancelled(), Succeeds(CLUSTER_OK)])
     dispatcher = ClusterDispatcher(
-        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku")),
+        cancel=cancel,
     )
     with pytest.raises(AgentCancelledError) as excinfo:
         dispatcher.cluster(_cluster_input())
     assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGTERM
+    assert runner.calls[0]["cancel"] is cancel  # the dispatcher's OWN event reached the runner
     assert [s.cli for s in runner.specs_tried] == ["ollama"]  # fallback never tried
+
+
+def test_dispatcher_forwards_the_runner_contract_kwargs() -> None:
+    # The dispatcher→runner seam pinned end to end: the per-link budget, the loaded
+    # prompt template, the contract_version render datum, and the cancel token must
+    # all reach the runner — a dropped kwarg is a silent regression otherwise.
+    cancel = threading.Event()
+    prompt = PromptTemplate(name="t", text="x")
+    runner = FakeAgentRunner([Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")), prompt=prompt, cancel=cancel
+    )
+    dispatcher.cluster(_cluster_input())
+    call = runner.calls[0]
+    assert call["time_budget_s"] == 5.0  # the chain's per-link budget
+    assert call["prompt_template"] is prompt
+    assert call["render_data"] == {"contract_version": "1"}
+    assert call["cancel"] is cancel
 
 
 def test_all_providers_fail_raises_caller_mappable_error() -> None:

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -186,6 +186,16 @@ def test_non_table_provider_names_the_full_contract_key_path(tmp_path: Path) -> 
         load_chain("cluster", repo_config=cfg, model_override=None)
 
 
+def test_non_table_section_names_the_full_agents_contract_path(tmp_path: Path) -> None:
+    # A present [agents.<contract>] that is not a table at all (e.g. agents.cluster =
+    # "...") must name the full agents.<contract> path — consistent with the
+    # per-provider errors — not the foundation _subtable's bare-key message.
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text('[agents]\ncluster = "ollama"\n', encoding="utf-8")
+    with pytest.raises(ValueError, match=r"agents\.cluster must be a table"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
 def test_present_section_without_primary_is_a_config_error(tmp_path: Path) -> None:
     # A present [agents.cluster] that omits `primary` must be rejected, not silently
     # accepted with fallback-as-head (or an empty chain that later raises a

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -72,6 +72,10 @@ class BinaryMissing(_Outcome):
     """The agent binary was not on PATH (FileNotFoundError) — a fallback trigger."""
 
 
+class SpawnOSError(_Outcome):
+    """Spawn failed with a non-FileNotFound OSError (present but not executable)."""
+
+
 class FakeAgentRunner:
     """Replays one queued :class:`_Outcome` per ``run`` call, recording every call.
 
@@ -127,6 +131,8 @@ class FakeAgentRunner:
             raise AgentCancelledError(
                 tier=Tier.RUNTIME_CANCELLED, code=ErrorCode.RUNTIME_CANCELLED_SIGTERM, signum=15
             )
+        if isinstance(outcome, SpawnOSError):
+            raise PermissionError(13, "Permission denied", spec.cli)
         raise FileNotFoundError(2, "No such file or directory", spec.cli)
 
 
@@ -463,6 +469,75 @@ def test_multiline_stderr_collapses_to_a_single_line_detail() -> None:
     detail = excinfo.value.detail
     assert "\n" not in detail
     assert "Traceback" in detail and "RuntimeError: boom" in detail  # content preserved
+
+
+def test_spawn_oserror_falls_through_like_binary_missing() -> None:
+    # A present-but-non-executable binary (PermissionError, exec-format error) is
+    # morally the same provider-unavailable trigger as a missing one — it must fall
+    # through to the next link, never crash the whole dispatch.
+    runner = FakeAgentRunner([SpawnOSError(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+def test_spawn_oserror_detail_names_the_failure() -> None:
+    runner = FakeAgentRunner([SpawnOSError()])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    assert "spawn failed" in excinfo.value.detail
+    assert "Permission denied" in excinfo.value.detail
+
+
+def test_long_failure_reason_keeps_the_informative_tail() -> None:
+    # Tracebacks and CLI stderr put the real error LAST — head-only truncation kept
+    # pure boilerplate and dropped the cause. The cap must keep head AND tail.
+    long_stderr = (
+        "Traceback (most recent call last):\n"
+        + "\n".join(f'  File "/x/mod{i}.py", line {i}, in step{i}' for i in range(10))
+        + "\nRuntimeError: the actual cause"
+    )
+    runner = FakeAgentRunner([ExitsWith(1, long_stderr)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    detail = excinfo.value.detail
+    assert "Traceback" in detail  # the head survives
+    assert "RuntimeError: the actual cause" in detail  # the tail survives the cap
+
+
+# ── lenient stdout parsing: banner noise must not exhaust the chain ──
+
+
+def test_banner_wrapped_json_still_parses() -> None:
+    # Real CLIs decorate stdout (progress lines, timing banners). The contract
+    # object inside the noise must parse rather than exhausting the whole chain.
+    noisy = "Loading model gemma4...\n" + CLUSTER_OK + "\nDone in 3.2s"
+    runner = FakeAgentRunner([Succeeds(noisy)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    out = dispatcher.cluster(_cluster_input())
+    assert out.clusters == []
+
+
+def test_stray_brace_in_banner_noise_is_skipped() -> None:
+    # A "{" that does not start a valid JSON object (shell prompt art, progress
+    # format strings) must be skipped over, not abort the scan.
+    noisy = "progress {percent} done " + CLUSTER_OK
+    runner = FakeAgentRunner([Succeeds(noisy)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    out = dispatcher.cluster(_cluster_input())
+    assert out.clusters == []
+
+
+def test_last_json_object_wins_when_stdout_carries_several() -> None:
+    noisy = '{"progress": "warming up"} chatter ' + CLUSTER_OK
+    runner = FakeAgentRunner([Succeeds(noisy)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    out = dispatcher.cluster(_cluster_input())
+    assert out.clusters == []  # the LAST object is the contract output
 
 
 def test_fix_dispatcher_parses_fix_output() -> None:

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -230,7 +230,7 @@ def test_non_table_provider_names_the_full_contract_key_path(tmp_path: Path) -> 
 def test_non_table_section_names_the_full_agents_contract_path(tmp_path: Path) -> None:
     # A present [agents.<contract>] that is not a table at all (e.g. agents.cluster =
     # "...") must name the full agents.<contract> path — consistent with the
-    # per-provider errors — not the foundation _subtable's bare-key message.
+    # per-provider errors — not the foundation subtable's bare-key message.
     cfg = tmp_path / ".prgroom.toml"
     cfg.write_text('[agents]\ncluster = "ollama"\n', encoding="utf-8")
     with pytest.raises(ValueError, match=r"agents\.cluster must be a table"):

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -300,6 +300,20 @@ def test_all_providers_fail_detail_names_each_link_and_its_reason() -> None:
     assert "exit 7" in detail and "quota exceeded" in detail
 
 
+def test_multiline_stderr_collapses_to_a_single_line_detail() -> None:
+    # The detail is documented as a one-line summary; a multi-line agent stderr
+    # (traceback, multi-line quota notice) must not smuggle interior newlines into
+    # it. .strip() alone would leave them — the reason must collapse all whitespace.
+    multiline = "Traceback (most recent call last):\n  File x\nRuntimeError: boom"
+    runner = FakeAgentRunner([ExitsWith(1, multiline)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    detail = excinfo.value.detail
+    assert "\n" not in detail
+    assert "Traceback" in detail and "RuntimeError: boom" in detail  # content preserved
+
+
 def test_fix_dispatcher_parses_fix_output() -> None:
     runner = FakeAgentRunner([Succeeds(FIX_OK)])
     dispatcher = FixDispatcher(runner=runner, chain=_chain(AgentSpec("claude", "opus[1m]")))

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -173,13 +173,6 @@ def test_provider_missing_cli_or_model_is_a_config_error(tmp_path: Path) -> None
         load_chain("cluster", repo_config=cfg, model_override=None)
 
 
-def test_non_table_provider_is_a_config_error(tmp_path: Path) -> None:
-    cfg = tmp_path / ".prgroom.toml"
-    cfg.write_text('[agents.cluster]\nprimary = "claude"\n', encoding="utf-8")
-    with pytest.raises(ValueError, match="must be a table"):
-        load_chain("cluster", repo_config=cfg, model_override=None)
-
-
 def test_present_section_without_primary_is_a_config_error(tmp_path: Path) -> None:
     # A present [agents.cluster] that omits `primary` must be rejected, not silently
     # accepted with fallback-as-head (or an empty chain that later raises a
@@ -191,6 +184,30 @@ def test_present_section_without_primary_is_a_config_error(tmp_path: Path) -> No
     )
     with pytest.raises(ValueError, match="needs a 'primary' provider"):
         load_chain("cluster", repo_config=cfg, model_override=None)
+
+
+def test_present_but_empty_section_is_a_config_error(tmp_path: Path) -> None:
+    # A present-but-empty [agents.cluster] is key-present, so it must route through
+    # the missing-primary check — NOT fall through to the shipped default. (Truthiness
+    # of the returned subtable can't tell empty-present from absent; key membership can.)
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text("[agents.cluster]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="needs a 'primary' provider"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
+def test_absent_section_still_falls_through_to_the_default(tmp_path: Path) -> None:
+    # A config file with NO [agents.cluster] key (only an unrelated section) must
+    # still yield the shipped default chain — only a truly absent section, not an
+    # empty one, gets the default.
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text('[agents.fix]\nprimary = { cli = "claude", model = "opus" }\n', encoding="utf-8")
+    chain = load_chain("cluster", repo_config=cfg, model_override=None)
+    assert [(p.cli, p.model) for p in chain.providers] == [
+        ("ollama", "gemma4"),
+        ("claude", "haiku"),
+        ("codex", "gpt-5.4-mini"),
+    ]
 
 
 def test_model_override_replaces_the_primary_model_only() -> None:

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -1,0 +1,337 @@
+"""Provider-chain dispatch + fallback ladder (§5 agent-CLI config & fallback).
+
+The dispatcher resolves a per-contract provider chain (from TOML, with a
+``--cluster-model`` / ``--fix-model`` override), tries the primary, and on a
+fallback-triggering failure (binary absent, quota/auth/network exit, or timeout)
+falls to the next link. If the whole chain fails it raises a single
+caller-mappable error so the lifecycle can file a ``failed`` disposition +
+escalate rather than crash.
+
+Tests use a recorded-outcome fake agent runner (one queued outcome per chain
+link), never a real subprocess — the runner's own timeout/cancel behavior is
+proven in ``test_agent_subprocess_runner``; here we prove the LADDER logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from prgroom.agent.contracts import ClusterContract, ClusterInput, FixContract, FixInput
+from prgroom.agent.dispatcher import (
+    AllProvidersFailedError,
+    ClusterDispatcher,
+    FixDispatcher,
+    ProviderChain,
+    load_chain,
+)
+from prgroom.agent.subprocess_runner import (
+    AgentCancelledError,
+    AgentRunResult,
+    AgentSpec,
+    AgentTimeoutError,
+)
+from prgroom.errors import ErrorCode, PrgroomError, Tier, exit_code_for_tier
+from prgroom.prsession.pr_ref import PRRef
+
+# ── recorded-outcome runner fake (one outcome per chain link) ──
+
+
+class _Outcome:
+    """Base sentinel; subclasses encode the chain link's outcome."""
+
+
+class Succeeds(_Outcome):
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+class ExitsWith(_Outcome):
+    """A non-zero process exit (quota/auth/network) — a fallback trigger."""
+
+    def __init__(self, returncode: int, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class TimesOut(_Outcome):
+    """The runner raised AgentTimeoutError (budget overrun) — a fallback trigger."""
+
+
+class Cancelled(_Outcome):
+    """The runner raised AgentCancelledError (cancel-token) — aborts the whole chain."""
+
+
+class BinaryMissing(_Outcome):
+    """The agent binary was not on PATH (FileNotFoundError) — a fallback trigger."""
+
+
+class FakeAgentRunner:
+    """Replays one queued :class:`_Outcome` per ``run`` call, recording the specs tried."""
+
+    def __init__(self, outcomes: Sequence[_Outcome]) -> None:
+        self._outcomes = list(outcomes)
+        self.specs_tried: list[AgentSpec] = []
+
+    def run(self, spec: AgentSpec, **_kwargs: object) -> AgentRunResult:
+        self.specs_tried.append(spec)
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Succeeds):
+            return AgentRunResult(returncode=0, stdout=outcome.stdout, stderr="", duration_ms=1)
+        if isinstance(outcome, ExitsWith):
+            return AgentRunResult(
+                returncode=outcome.returncode, stdout="", stderr=outcome.stderr, duration_ms=1
+            )
+        if isinstance(outcome, TimesOut):
+            raise AgentTimeoutError(
+                tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_AGENT_TIMEOUT
+            )
+        if isinstance(outcome, Cancelled):
+            raise AgentCancelledError(
+                tier=Tier.RUNTIME_CANCELLED, code=ErrorCode.RUNTIME_CANCELLED_SIGTERM, signum=15
+            )
+        raise FileNotFoundError(2, "No such file or directory", spec.cli)
+
+
+PR = PRRef(owner="octo", repo="demo", number=7)
+CLUSTER_OK = '{"clusters": []}'
+FIX_OK = '{"contract_version": 1, "items": []}'
+
+
+def _cluster_input() -> ClusterInput:
+    return ClusterInput(pr=PR, items=[], pr_context_path="/ctx")
+
+
+def _fix_input() -> FixInput:
+    return FixInput(
+        pr=PR,
+        cluster_id="c-1",
+        item_gh_ids=[],
+        items=[],
+        pr_detail_path="/detail",
+        branch_state_path="/branch",
+        memory_dir="/mem",
+        response_outbox_dir="/out",
+    )
+
+
+def _chain(*specs: AgentSpec) -> ProviderChain:
+    return ProviderChain(providers=list(specs), time_budget_s=5.0)
+
+
+# ── chain loading: defaults, TOML, overrides ──
+
+
+def test_default_cluster_chain_is_ollama_then_claude_haiku_then_codex() -> None:
+    chain = load_chain("cluster", repo_config=None, model_override=None)
+    assert [(p.cli, p.model) for p in chain.providers] == [
+        ("ollama", "gemma4"),
+        ("claude", "haiku"),
+        ("codex", "gpt-5.4-mini"),
+    ]
+    assert chain.providers[1].extra.get("effort") == "high"
+
+
+def test_default_fix_chain_is_opus_then_codex_write() -> None:
+    chain = load_chain("fix", repo_config=None, model_override=None)
+    assert [(p.cli, p.model) for p in chain.providers] == [
+        ("claude", "opus[1m]"),
+        ("codex", "gpt-5.5"),
+    ]
+    assert chain.providers[0].extra.get("effort") == "xhigh"
+    assert chain.providers[1].extra.get("write") is True
+
+
+def test_toml_overrides_the_default_chain(tmp_path: Path) -> None:
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "[agents.cluster]",
+                'primary = { cli = "claude", model = "haiku", effort = "low" }',
+                'fallback = { cli = "ollama", model = "tinyllama" }',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    chain = load_chain("cluster", repo_config=cfg, model_override=None)
+    assert [(p.cli, p.model) for p in chain.providers] == [
+        ("claude", "haiku"),
+        ("ollama", "tinyllama"),
+    ]
+
+
+def test_provider_missing_cli_or_model_is_a_config_error(tmp_path: Path) -> None:
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text(
+        '[agents.cluster]\nprimary = { model = "haiku" }\n',  # no cli
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="string cli \\+ model"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
+def test_non_table_provider_is_a_config_error(tmp_path: Path) -> None:
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text('[agents.cluster]\nprimary = "claude"\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a table"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
+def test_model_override_replaces_the_primary_model_only() -> None:
+    # --cluster-model / --fix-model swaps the primary provider's model, keeping its
+    # cli + the rest of the chain (operator wants "the same provider, this model").
+    chain = load_chain("fix", repo_config=None, model_override="opus")
+    assert chain.providers[0].cli == "claude"
+    assert chain.providers[0].model == "opus"
+    # the fallback link is untouched
+    assert chain.providers[1].model == "gpt-5.5"
+
+
+# ── ladder behavior (table-driven over the acceptance scenarios) ──
+
+
+def test_primary_success_uses_first_provider_only() -> None:
+    runner = FakeAgentRunner([Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    out = dispatcher.cluster(_cluster_input())
+    assert out.clusters == []
+    assert [s.cli for s in runner.specs_tried] == ["ollama"]  # fallback never touched
+
+
+def test_primary_binary_absent_falls_to_fallback() -> None:
+    runner = FakeAgentRunner([BinaryMissing(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+def test_primary_timeout_falls_to_fallback() -> None:
+    runner = FakeAgentRunner([TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+def test_primary_quota_exit_falls_to_fallback() -> None:
+    runner = FakeAgentRunner([ExitsWith(1, "quota exceeded"), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+def test_cancel_token_aborts_the_chain_without_trying_the_fallback() -> None:
+    # A cancel-token kill is operator/scheduler shutdown — it must NOT be treated as
+    # a per-provider failure and fall through to the next link. It propagates out,
+    # aborting the whole dispatch, and the fallback is never touched.
+    runner = FakeAgentRunner([Cancelled(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with pytest.raises(AgentCancelledError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGTERM
+    assert [s.cli for s in runner.specs_tried] == ["ollama"]  # fallback never tried
+
+
+def test_all_providers_fail_raises_caller_mappable_error() -> None:
+    runner = FakeAgentRunner([BinaryMissing(), TimesOut()])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    # caller-mappable: an AGENT_UNAVAILABLE PrgroomError the lifecycle turns into a
+    # failed disposition + escalation (not a crash, not a bare exception).
+    assert isinstance(excinfo.value, PrgroomError)
+    assert excinfo.value.code is ErrorCode.RUNTIME_AGENT_UNAVAILABLE
+
+
+def test_all_providers_fail_is_transient_exit_75() -> None:
+    # §3.7 registry pins RUNTIME_AGENT_UNAVAILABLE to RUNTIME_TRANSIENT (exit 75):
+    # the scheduler retries on the next cadence, preserving restart-safety for the
+    # un-dispositioned items. A terminal tier (77) would human-gate and break that.
+    runner = FakeAgentRunner([BinaryMissing(), TimesOut()])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    assert excinfo.value.tier is Tier.RUNTIME_TRANSIENT
+    assert exit_code_for_tier(excinfo.value) == 75
+
+
+def test_all_providers_fail_detail_names_each_link_and_its_reason() -> None:
+    # _render_failures + the _LinkFailure reasons exist to build the operator-facing
+    # escalation payload — so the detail must name BOTH providers AND both reasons.
+    runner = FakeAgentRunner([BinaryMissing(), ExitsWith(7, "quota exceeded")])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    detail = excinfo.value.detail
+    assert "ollama" in detail and "gemma4" in detail
+    assert "claude" in detail and "haiku" in detail
+    assert "binary not on PATH" in detail
+    assert "exit 7" in detail and "quota exceeded" in detail
+
+
+def test_fix_dispatcher_parses_fix_output() -> None:
+    runner = FakeAgentRunner([Succeeds(FIX_OK)])
+    dispatcher = FixDispatcher(runner=runner, chain=_chain(AgentSpec("claude", "opus[1m]")))
+    out = dispatcher.fix(_fix_input())
+    assert out.items == []
+
+
+def test_fix_out_of_enum_disposition_falls_through_not_crashes() -> None:
+    # A 0-exit provider emitting valid JSON whose `disposition` is out-of-enum makes
+    # FixOutput.from_dict -> DispositionKind(...) raise ValueError. That must be a
+    # per-link failure (fall through to the next provider), not an escaped crash.
+    bad = '{"contract_version": 1, "items": [{"gh_id": "a", "disposition": "garbage"}]}'
+    runner = FakeAgentRunner([Succeeds(bad), Succeeds(FIX_OK)])
+    dispatcher = FixDispatcher(
+        runner=runner, chain=_chain(AgentSpec("claude", "opus[1m]"), AgentSpec("codex", "gpt-5.5"))
+    )
+    out = dispatcher.fix(_fix_input())
+    assert out.items == []  # the second provider's good output was parsed
+    assert [s.cli for s in runner.specs_tried] == ["claude", "codex"]  # fell through
+
+
+def test_malformed_agent_json_falls_through_to_the_next_provider() -> None:
+    # A provider that exits 0 but emits unparseable JSON is a failure of THAT
+    # provider — fall through, do not abort the whole dispatch.
+    runner = FakeAgentRunner([Succeeds("not json at all"), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+# ── structural fit: the concrete dispatchers satisfy the foundation Protocols ──
+
+
+def test_cluster_dispatcher_satisfies_cluster_contract() -> None:
+    runner = FakeAgentRunner([Succeeds(CLUSTER_OK)])
+    dispatcher: ClusterContract = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"))
+    )
+    assert isinstance(dispatcher, ClusterContract)
+
+
+def test_fix_dispatcher_satisfies_fix_contract() -> None:
+    runner = FakeAgentRunner([Succeeds(FIX_OK)])
+    chain = _chain(AgentSpec("claude", "opus[1m]"))
+    dispatcher: FixContract = FixDispatcher(runner=runner, chain=chain)
+    assert isinstance(dispatcher, FixContract)

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -163,13 +163,26 @@ def test_toml_overrides_the_default_chain(tmp_path: Path) -> None:
     ]
 
 
-def test_provider_missing_cli_or_model_is_a_config_error(tmp_path: Path) -> None:
+def test_provider_missing_cli_or_model_names_the_full_path(tmp_path: Path) -> None:
     cfg = tmp_path / ".prgroom.toml"
     cfg.write_text(
         '[agents.cluster]\nprimary = { model = "haiku" }\n',  # no cli
         encoding="utf-8",
     )
-    with pytest.raises(ValueError, match="string cli \\+ model"):
+    # Names the full agents.<contract>.<key> path so the user sees which entry.
+    with pytest.raises(ValueError, match=r"agents\.cluster\.primary needs string cli \+ model"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
+def test_non_table_provider_names_the_full_contract_key_path(tmp_path: Path) -> None:
+    # The error must name the real .prgroom.toml path (agents.<contract>.<key>), not
+    # a bare agents.<key>, so a user debugging their config sees the right key.
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text(
+        '[agents.cluster]\nprimary = { cli = "ollama", model = "g" }\nfallback = "claude"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match=r"agents\.cluster\.fallback must be a table"):
         load_chain("cluster", repo_config=cfg, model_override=None)
 
 

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -180,6 +180,19 @@ def test_non_table_provider_is_a_config_error(tmp_path: Path) -> None:
         load_chain("cluster", repo_config=cfg, model_override=None)
 
 
+def test_present_section_without_primary_is_a_config_error(tmp_path: Path) -> None:
+    # A present [agents.cluster] that omits `primary` must be rejected, not silently
+    # accepted with fallback-as-head (or an empty chain that later raises a
+    # contentless both-fail). An absent section still falls through to the default.
+    cfg = tmp_path / ".prgroom.toml"
+    cfg.write_text(
+        '[agents.cluster]\nfallback = { cli = "ollama", model = "tinyllama" }\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="needs a 'primary' provider"):
+        load_chain("cluster", repo_config=cfg, model_override=None)
+
+
 def test_model_override_replaces_the_primary_model_only() -> None:
     # --cluster-model / --fix-model swaps the primary provider's model, keeping its
     # cli + the rest of the chain (operator wants "the same provider, this model").

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -36,6 +36,7 @@ from prgroom.agent.subprocess_runner import (
     AgentSpec,
     AgentTimeoutError,
 )
+from prgroom.agent.usage import UsageRecord
 from prgroom.errors import ErrorCode, PrgroomError, Tier, exit_code_for_tier
 from prgroom.prsession.pr_ref import PRRef
 
@@ -494,6 +495,73 @@ def test_malformed_agent_json_falls_through_to_the_next_provider() -> None:
     )
     dispatcher.cluster(_cluster_input())
     assert [s.cli for s in runner.specs_tried] == ["ollama", "claude"]
+
+
+# ── usage telemetry: one record per attempt escapes the dispatcher ──
+
+
+def test_usage_hook_emits_one_record_per_attempt_across_the_ladder() -> None:
+    # Per-invocation telemetry must escape the dispatcher — one record per attempt,
+    # failed links included — or the fallback ladder is invisible to the lifecycle
+    # and the §5 usage log can never be correct.
+    records: list[UsageRecord] = []
+    ticks = iter(range(100))
+    runner = FakeAgentRunner([TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku")),
+        usage_hook=records.append,
+        clock=lambda: float(next(ticks)),  # 1s per clock pair -> 1000ms durations
+        now=lambda: "2026-06-12T00:00:00+00:00",
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [(r.provider, r.outcome) for r in records] == [
+        ("ollama", "timeout"),
+        ("claude", "success"),
+    ]
+    first = records[0]
+    assert first.contract == "cluster"
+    assert first.model == "gemma4"
+    assert first.pr == PR  # rebuilt from the contract payload
+    assert first.ts == "2026-06-12T00:00:00+00:00"  # injected wall clock
+    assert first.duration_ms == 1000  # injected monotonic clock
+    assert first.input_tokens is None and first.output_tokens is None  # no parser yet
+
+
+def test_usage_hook_tags_unavailable_error_and_malformed_attempts() -> None:
+    records: list[UsageRecord] = []
+    runner = FakeAgentRunner(
+        [BinaryMissing(), ExitsWith(1, "quota"), Succeeds("not json"), Succeeds(CLUSTER_OK)]
+    )
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(
+            AgentSpec("ollama", "g"),
+            AgentSpec("claude", "h"),
+            AgentSpec("codex", "m"),
+            AgentSpec("opencode", "o"),
+        ),
+        usage_hook=records.append,
+    )
+    dispatcher.cluster(_cluster_input())
+    assert [r.outcome for r in records] == ["unavailable", "error", "malformed", "success"]
+
+
+def test_usage_hook_records_a_cancelled_attempt_before_the_abort() -> None:
+    # Even the abort-everything path leaves a telemetry trace of the attempt.
+    records: list[UsageRecord] = []
+    cancel = threading.Event()
+    cancel.set()
+    runner = FakeAgentRunner([Cancelled()])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "gemma4")),
+        cancel=cancel,
+        usage_hook=records.append,
+    )
+    with pytest.raises(AgentCancelledError):
+        dispatcher.cluster(_cluster_input())
+    assert [r.outcome for r in records] == ["cancelled"]
 
 
 # ── structural fit: the concrete dispatchers satisfy the foundation Protocols ──

--- a/packages/prgroom/tests/unit/test_agent_prompt_loader.py
+++ b/packages/prgroom/tests/unit/test_agent_prompt_loader.py
@@ -1,0 +1,94 @@
+"""Prompt-template loader (§5 prompt templates).
+
+Each contract's prompt lives in ``agent/prompts/<contract>.tmpl``, rendered with
+a flat string mapping. ``PRGROOM_PROMPTS_DIR`` lets a power user override a
+shipped template per-filename. The tests pin: shipped templates load and render
+with no leftover placeholders, the override dir wins when it carries a matching
+filename (and falls through to shipped when it does not), and an unresolved
+placeholder is a loud error rather than a silent ``{hole}`` in the prompt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prgroom.agent.prompt_loader import (
+    PROMPTS_DIR_ENV,
+    PromptTemplate,
+    UnresolvedPlaceholderError,
+    load_prompt,
+)
+
+
+def test_loads_shipped_cluster_template() -> None:
+    tmpl = load_prompt("cluster")
+    assert isinstance(tmpl, PromptTemplate)
+    assert tmpl.text  # shipped template is non-empty
+
+
+def test_loads_shipped_fix_template() -> None:
+    assert load_prompt("fix").text
+
+
+_INPUT = "/var/run/prgroom/in.json"
+
+
+def test_shipped_cluster_template_renders_with_every_placeholder_filled() -> None:
+    # The shipped template embeds literal JSON ({{ }} -> { }), so braces survive
+    # by design. The invariant §5 cares about is that no NAMED {placeholder} is
+    # left unresolved — render must not raise and must substitute the field values.
+    rendered = load_prompt("cluster").render({"contract_version": "1", "input_path": _INPUT})
+    assert "{contract_version}" not in rendered
+    assert "{input_path}" not in rendered
+    assert _INPUT in rendered
+
+
+def test_shipped_fix_template_renders_with_every_placeholder_filled() -> None:
+    rendered = load_prompt("fix").render({"contract_version": "1", "input_path": _INPUT})
+    assert "{contract_version}" not in rendered
+    assert "{input_path}" not in rendered
+    assert _INPUT in rendered
+
+
+def test_override_dir_wins_for_matching_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    override = tmp_path / "prompts"
+    override.mkdir()
+    (override / "cluster.tmpl").write_text("OVERRIDDEN {input_path}", encoding="utf-8")
+    monkeypatch.setenv(PROMPTS_DIR_ENV, str(override))
+
+    rendered = load_prompt("cluster").render({"input_path": "/x"})
+    assert rendered == "OVERRIDDEN /x"
+
+
+def test_override_dir_falls_through_to_shipped_when_filename_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An override dir that does NOT carry fix.tmpl must not hide the shipped one.
+    override = tmp_path / "prompts"
+    override.mkdir()
+    (override / "cluster.tmpl").write_text("only cluster here {input_path}", encoding="utf-8")
+    monkeypatch.setenv(PROMPTS_DIR_ENV, str(override))
+
+    assert load_prompt("fix").text  # shipped fix template still resolves
+
+
+def test_render_raises_on_unresolved_placeholder() -> None:
+    tmpl = PromptTemplate(name="t", text="hello {missing}")
+    with pytest.raises(UnresolvedPlaceholderError):
+        tmpl.render({"present": "x"})
+
+
+def test_render_substitutes_provided_placeholders() -> None:
+    tmpl = PromptTemplate(name="t", text="a={a} b={b}")
+    assert tmpl.render({"a": "1", "b": "2"}) == "a=1 b=2"
+
+
+def test_literal_braces_are_escaped_and_survive_render() -> None:
+    # A template that needs a literal brace (e.g. showing JSON) doubles it; the
+    # render must collapse {{ -> { without treating it as a placeholder.
+    tmpl = PromptTemplate(name="t", text='json: {{ "k": {v} }}')
+    assert tmpl.render({"v": "1"}) == 'json: { "k": 1 }'

--- a/packages/prgroom/tests/unit/test_agent_prompt_loader.py
+++ b/packages/prgroom/tests/unit/test_agent_prompt_loader.py
@@ -32,24 +32,25 @@ def test_loads_shipped_fix_template() -> None:
     assert load_prompt("fix").text
 
 
-_INPUT = "/var/run/prgroom/in.json"
+# The runner-built payload-delivery section (file mode here; ollama gets inline).
+_SECTION = "from this file:\n\n  /var/run/prgroom/in.json"
 
 
 def test_shipped_cluster_template_renders_with_every_placeholder_filled() -> None:
     # The shipped template embeds literal JSON ({{ }} -> { }), so braces survive
     # by design. The invariant §5 cares about is that no NAMED {placeholder} is
     # left unresolved — render must not raise and must substitute the field values.
-    rendered = load_prompt("cluster").render({"contract_version": "1", "input_path": _INPUT})
+    rendered = load_prompt("cluster").render({"contract_version": "1", "input_section": _SECTION})
     assert "{contract_version}" not in rendered
-    assert "{input_path}" not in rendered
-    assert _INPUT in rendered
+    assert "{input_section}" not in rendered
+    assert _SECTION in rendered
 
 
 def test_shipped_fix_template_renders_with_every_placeholder_filled() -> None:
-    rendered = load_prompt("fix").render({"contract_version": "1", "input_path": _INPUT})
+    rendered = load_prompt("fix").render({"contract_version": "1", "input_section": _SECTION})
     assert "{contract_version}" not in rendered
-    assert "{input_path}" not in rendered
-    assert _INPUT in rendered
+    assert "{input_section}" not in rendered
+    assert _SECTION in rendered
 
 
 def test_override_dir_wins_for_matching_filename(

--- a/packages/prgroom/tests/unit/test_agent_recurrence.py
+++ b/packages/prgroom/tests/unit/test_agent_recurrence.py
@@ -16,9 +16,11 @@ def test_recurrence_serializes_all_fields_when_commits_present() -> None:
         reopened=True,
         attempt_count=2,
         prior_disposition="wont_fix",
-        prior_commits=["abc123", "def456"],
+        prior_commits=("abc123", "def456"),
         first_seen_round=1,
     )
+    # prior_commits is a tuple internally (immutable value type) but serializes as a
+    # JSON list for the wire shape.
     assert rec.to_dict() == {
         "reopened": True,
         "attempt_count": 2,
@@ -26,33 +28,31 @@ def test_recurrence_serializes_all_fields_when_commits_present() -> None:
         "prior_commits": ["abc123", "def456"],
         "first_seen_round": 1,
     }
+    assert isinstance(rec.to_dict()["prior_commits"], list)
 
 
-def test_recurrence_to_dict_copies_prior_commits_defensively() -> None:
-    # The serialized list must be a copy, not the dataclass's own list — a consumer
-    # mutating the JSON payload must not corrupt the Recurrence. Removing the
-    # list(...) wrapper in to_dict should fail this test.
+def test_recurrence_is_hashable() -> None:
+    # The docstring promises a hashable value type; the tuple field makes it true.
     rec = Recurrence(
         reopened=True,
         attempt_count=2,
         prior_disposition="fixed",
-        prior_commits=["abc123"],
+        prior_commits=("abc123",),
         first_seen_round=1,
     )
-    serialized = rec.to_dict()
-    assert serialized["prior_commits"] is not rec.prior_commits
-    serialized["prior_commits"].append("mutated")
-    assert rec.prior_commits == ["abc123"]  # source untouched
+    assert hash(rec) == hash(rec)  # does not raise; stable
+    assert len({rec, rec}) == 1  # usable as a set member
 
 
 def test_recurrence_omits_prior_commits_when_empty() -> None:
     # §8.2: prior_commits is "omitted from JSON when empty" — a wont_fix/skipped
-    # prior disposition carries no SHAs, so the key must not appear at all.
+    # prior disposition carries no SHAs, so the key must not appear at all (an empty
+    # tuple is falsy, so the omit-empty rule still holds).
     rec = Recurrence(
         reopened=False,
         attempt_count=1,
         prior_disposition="skipped",
-        prior_commits=[],
+        prior_commits=(),
         first_seen_round=3,
     )
     assert "prior_commits" not in rec.to_dict()

--- a/packages/prgroom/tests/unit/test_agent_recurrence.py
+++ b/packages/prgroom/tests/unit/test_agent_recurrence.py
@@ -1,0 +1,64 @@
+"""Recurrence — the §8.2 derived per-item recurrence signal.
+
+These tests pin the JSON wire shape the fix agent reads: the five fields §8.2
+names, and the "omit ``prior_commits`` when empty" rule the spec calls out
+inline. The dataclass is derived data (never persisted state), so the only
+contract worth pinning is its serialization.
+"""
+
+from __future__ import annotations
+
+from prgroom.agent.recurrence import Recurrence
+
+
+def test_recurrence_serializes_all_fields_when_commits_present() -> None:
+    rec = Recurrence(
+        reopened=True,
+        attempt_count=2,
+        prior_disposition="wont_fix",
+        prior_commits=["abc123", "def456"],
+        first_seen_round=1,
+    )
+    assert rec.to_dict() == {
+        "reopened": True,
+        "attempt_count": 2,
+        "prior_disposition": "wont_fix",
+        "prior_commits": ["abc123", "def456"],
+        "first_seen_round": 1,
+    }
+
+
+def test_recurrence_to_dict_copies_prior_commits_defensively() -> None:
+    # The serialized list must be a copy, not the dataclass's own list — a consumer
+    # mutating the JSON payload must not corrupt the Recurrence. Removing the
+    # list(...) wrapper in to_dict should fail this test.
+    rec = Recurrence(
+        reopened=True,
+        attempt_count=2,
+        prior_disposition="fixed",
+        prior_commits=["abc123"],
+        first_seen_round=1,
+    )
+    serialized = rec.to_dict()
+    assert serialized["prior_commits"] is not rec.prior_commits
+    serialized["prior_commits"].append("mutated")
+    assert rec.prior_commits == ["abc123"]  # source untouched
+
+
+def test_recurrence_omits_prior_commits_when_empty() -> None:
+    # §8.2: prior_commits is "omitted from JSON when empty" — a wont_fix/skipped
+    # prior disposition carries no SHAs, so the key must not appear at all.
+    rec = Recurrence(
+        reopened=False,
+        attempt_count=1,
+        prior_disposition="skipped",
+        prior_commits=[],
+        first_seen_round=3,
+    )
+    assert "prior_commits" not in rec.to_dict()
+    assert rec.to_dict() == {
+        "reopened": False,
+        "attempt_count": 1,
+        "prior_disposition": "skipped",
+        "first_seen_round": 3,
+    }

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -62,12 +62,14 @@ class FakeProcess:
         stderr: str = "",
         finishes_after: int | None = 0,
         survives_sigterm: bool = False,
+        stdin_raises: bool = False,
     ) -> None:
         self._returncode = returncode
         self._stdout = stdout
         self._stderr = stderr
         self._finishes_after = finishes_after
         self._survives_sigterm = survives_sigterm
+        self._stdin_raises = stdin_raises
         self._polls = 0
         self.terminated = False
         self.killed = False
@@ -87,6 +89,10 @@ class FakeProcess:
         return None
 
     def send_stdin(self, data: str) -> None:
+        # Models a child that exited before reading stdin: the write hits a closed
+        # pipe. The real _PopenHandle closes its pipe in finally regardless.
+        if self._stdin_raises:
+            raise BrokenPipeError(32, "Broken pipe")
         self.delivered_stdin = data
 
     def terminate(self) -> None:
@@ -249,6 +255,27 @@ def test_non_stdin_cli_delivers_no_stdin(tmp_path: Path) -> None:
         time_budget_s=5.0,
     )
     assert proc.delivered_stdin is None
+
+
+def test_stdin_broken_pipe_does_not_crash_and_falls_through(tmp_path: Path) -> None:
+    # A child (e.g. ollama) that exits before reading stdin makes the write hit a
+    # closed pipe (BrokenPipeError). Delivery is best-effort: the runner must NOT
+    # crash — it surfaces the child's returncode + stderr so the dispatcher's ladder
+    # turns it into a _LinkFailure and falls through to the next provider.
+    proc = FakeProcess(returncode=1, stderr="model not found", stdin_raises=True)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = runner.run(
+        _spec("ollama", "gemma4"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={},
+        time_budget_s=5.0,
+    )
+    assert result.returncode == 1  # surfaced, not raised
+    assert "model not found" in result.stderr
 
 
 def test_run_polls_repeatedly_until_a_slow_child_finishes(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -74,6 +74,7 @@ class FakeProcess:
         self.terminated = False
         self.killed = False
         self.reaped = False
+        self.cleaned_up = False
         self.delivered_stdin: str | None = None
         self._signalled = False
 
@@ -114,6 +115,11 @@ class FakeProcess:
     def communicate(self) -> tuple[str, str]:
         self.reaped = True
         return self._stdout, self._stderr
+
+    def cleanup(self) -> None:
+        # The real handle unlinks its stdout/stderr temp files here; the runner must
+        # call this on EVERY exit path (success, timeout, cancel, exception).
+        self.cleaned_up = True
 
 
 def _spec(cli: str = "claude", model: str = "haiku", **extra: object) -> AgentSpec:
@@ -343,6 +349,23 @@ def test_successful_run_returns_result_with_duration_and_returncode(tmp_path: Pa
     assert result.stdout == "OK"
     assert result.duration_ms >= 0
     assert proc.reaped  # normal completion reaps the child (no zombie / leaked pipes)
+    assert proc.cleaned_up  # output temp files removed on the success path
+
+
+def test_large_captured_output_flows_through(tmp_path: Path) -> None:
+    # A chatty fix agent emits far more than a pipe buffer (~64KB). Captured via temp
+    # files (not an undrained PIPE), large output flows through intact without the
+    # child blocking on a full pipe — the deadlock this design prevents.
+    big = "x" * 200_000
+    proc = FakeProcess(returncode=0, stdout=big, stderr="warn\n" * 5000)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_ok(runner)
+    assert result.stdout == big
+    assert result.stderr == "warn\n" * 5000
+    assert proc.cleaned_up
 
 
 def test_nonzero_exit_is_returned_not_raised(tmp_path: Path) -> None:
@@ -380,6 +403,7 @@ def test_timeout_escalates_sigterm_to_sigkill_and_reaps(tmp_path: Path) -> None:
         )
     assert proc.terminated and proc.killed  # SIGTERM first, then SIGKILL on survival
     assert proc.reaped  # reaped before the error propagates
+    assert proc.cleaned_up  # output temp files removed even on the timeout path
     assert excinfo.value.code is ErrorCode.RUNTIME_AGENT_TIMEOUT
 
 
@@ -424,6 +448,7 @@ def test_cancel_token_terminates_and_reaps_child(tmp_path: Path) -> None:
         )
     assert proc.terminated
     assert proc.reaped  # cancel path reaps too — no leaked child
+    assert proc.cleaned_up  # output temp files removed even on the cancel path
     assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGTERM
 
 

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -33,9 +33,9 @@ from prgroom.agent.subprocess_runner import (
 )
 from prgroom.errors import ErrorCode
 
-# A prompt template whose only placeholder is the runner-injected input path, so a
-# test can assert the runner filled in the real temp-file path.
-_PROMPT = PromptTemplate(name="t", text="process the input at {input_path}")
+# A prompt template whose only placeholder is the runner-injected input section, so
+# a test can assert the runner filled in the per-invoker payload-delivery shape.
+_PROMPT = PromptTemplate(name="t", text="process the input {input_section}")
 
 
 class FakeProcess:
@@ -209,10 +209,10 @@ def test_runner_writes_contract_json_to_a_temp_file_and_names_it_in_the_prompt(
 
     def spawn(argv: Sequence[str], *, stdin: str | None) -> FakeProcess:  # noqa: ARG001
         # The rendered prompt (a claude positional) names the real temp path; that
-        # path is the argv token that exists as a file on disk.
-        prompt = next(t for t in argv if "input at" in t)
-        path = prompt.removeprefix("process the input at ")
-        captured["path"] = path
+        # path is the last token of the file-delivery section and exists on disk.
+        prompt = next(t for t in argv if "process the input" in t)
+        path = prompt.split()[-1]
+        captured["prompt"] = prompt
         captured["content"] = Path(path).read_text(encoding="utf-8")
         return FakeProcess(returncode=0, stdout='{"clusters": []}')
 
@@ -225,6 +225,8 @@ def test_runner_writes_contract_json_to_a_temp_file_and_names_it_in_the_prompt(
         time_budget_s=5.0,
     )
     assert json.loads(captured["content"]) == {"contract_version": 1, "items": []}
+    # File-capable CLIs get pass-by-path ONLY — the payload is never inlined.
+    assert '"items"' not in captured["prompt"]
     assert result.stdout == '{"clusters": []}'
 
 
@@ -232,8 +234,8 @@ def test_runner_cleans_up_the_temp_input_file(tmp_path: Path) -> None:
     seen: dict[str, Path] = {}
 
     def spawn(argv: Sequence[str], *, stdin: str | None) -> FakeProcess:  # noqa: ARG001
-        prompt = next(t for t in argv if "input at" in t)
-        seen["path"] = Path(prompt.removeprefix("process the input at "))
+        prompt = next(t for t in argv if "process the input" in t)
+        seen["path"] = Path(prompt.split()[-1])
         return FakeProcess(returncode=0, stdout="{}")
 
     runner = SubprocessAgentRunner(spawn=spawn, scratch_dir=tmp_path)
@@ -261,7 +263,51 @@ def test_ollama_run_delivers_the_rendered_prompt_to_the_child_stdin(tmp_path: Pa
         time_budget_s=5.0,
     )
     assert proc.delivered_stdin is not None
-    assert "process the input at " in proc.delivered_stdin
+    assert "process the input" in proc.delivered_stdin
+
+
+def test_ollama_stdin_inlines_payload_and_referenced_file_contents(tmp_path: Path) -> None:
+    # A bare `ollama run` child is a tool-less text generator — it cannot open any
+    # file. Its prompt must carry the contract JSON AND the contents of the payload's
+    # *_path files INLINE, and must not instruct the model to read a file.
+    ctx = tmp_path / "pr-context.txt"
+    ctx.write_text("PR-CONTEXT-SENTINEL", encoding="utf-8")
+    proc = FakeProcess(returncode=0, stdout="{}")
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    runner.run(
+        _spec("ollama", "gemma4"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={"contract_version": 1, "pr_context_path": str(ctx)},
+        time_budget_s=5.0,
+    )
+    assert proc.delivered_stdin is not None
+    assert '"contract_version": 1' in proc.delivered_stdin  # contract JSON inlined
+    assert "PR-CONTEXT-SENTINEL" in proc.delivered_stdin  # referenced file inlined
+    # No read-this-file instruction: the file-delivery phrasing must not appear.
+    assert "from this file" not in proc.delivered_stdin
+
+
+def test_ollama_inline_skips_unreadable_path_values(tmp_path: Path) -> None:
+    # A *_path value that does not exist (or cannot be read) is skipped, not a
+    # crash: the contract JSON still goes inline and the dispatch proceeds.
+    proc = FakeProcess(returncode=0, stdout="{}")
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    runner.run(
+        _spec("ollama", "gemma4"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={"contract_version": 1, "memory_path": "/does/not/exist"},
+        time_budget_s=5.0,
+    )
+    assert proc.delivered_stdin is not None
+    assert '"contract_version": 1' in proc.delivered_stdin
 
 
 def test_non_stdin_cli_delivers_no_stdin(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -63,6 +63,7 @@ class FakeProcess:
         finishes_after: int | None = 0,
         survives_sigterm: bool = False,
         stdin_raises: bool = False,
+        signal_raises: bool = False,
     ) -> None:
         self._returncode = returncode
         self._stdout = stdout
@@ -70,6 +71,9 @@ class FakeProcess:
         self._finishes_after = finishes_after
         self._survives_sigterm = survives_sigterm
         self._stdin_raises = stdin_raises
+        # signal_raises models the poll/signal race: the child already exited, so
+        # terminate()/kill() raise ProcessLookupError (no such process).
+        self._signal_raises = signal_raises
         self._polls = 0
         self.terminated = False
         self.killed = False
@@ -97,10 +101,14 @@ class FakeProcess:
         self.delivered_stdin = data
 
     def terminate(self) -> None:
+        if self._signal_raises:
+            raise ProcessLookupError(3, "No such process")
         self.terminated = True
         self._signalled = True
 
     def kill(self) -> None:
+        if self._signal_raises:
+            raise ProcessLookupError(3, "No such process")
         self.killed = True
         self._signalled = True
 
@@ -422,6 +430,33 @@ def test_timeout_lets_a_well_behaved_child_die_on_sigterm_alone(tmp_path: Path) 
         )
     assert proc.terminated and not proc.killed
     assert proc.reaped
+
+
+def test_terminate_suppresses_process_lookup_error_when_child_already_exited(
+    tmp_path: Path,
+) -> None:
+    # Race: the child exits between the last poll() and the terminate()/kill() signal,
+    # so BOTH signals raise ProcessLookupError. The runner must SUPPRESS that (nothing
+    # left to signal), still reap via communicate(), and surface the intended
+    # AgentTimeoutError — never leak the ProcessLookupError as an unexpected error.
+    proc = FakeProcess(finishes_after=None, survives_sigterm=True, signal_raises=True)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+        sigterm_grace_s=0.0,
+    )
+    with pytest.raises(AgentTimeoutError) as excinfo:
+        runner.run(
+            _spec(),
+            prompt_template=_PROMPT,
+            render_data={},
+            contract_payload={},
+            time_budget_s=0.0,
+        )
+    assert proc.reaped  # communicate() still reaps the already-dead child
+    assert proc.cleaned_up  # output temp files removed even when signalling raced
+    assert excinfo.value.code is ErrorCode.RUNTIME_AGENT_TIMEOUT
 
 
 # ── cancel-token: terminate, grace, reap when the Event is set ──

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -151,6 +151,17 @@ def test_codex_read_only_omits_sandbox_write() -> None:
     assert "workspace-write" not in inv.argv
 
 
+def test_codex_workspace_write_requires_boolean_true_not_truthy() -> None:
+    # Config-driven privilege: workspace-write must be gated on the literal TOML
+    # boolean `true`, not any truthy value. A mistyped write = "false" (a non-empty,
+    # truthy STRING) or write = 1 must NOT silently grant the agent edit rights.
+    for truthy_non_bool in ("false", "true", "yes", 1):
+        inv = build_invocation(_spec("codex", "m", write=truthy_non_bool), prompt="P")
+        assert "workspace-write" not in inv.argv
+    # Only the real boolean True enables it.
+    assert "workspace-write" in build_invocation(_spec("codex", "m", write=True), prompt="P").argv
+
+
 def test_opencode_invocation_shape() -> None:
     inv = build_invocation(_spec("opencode", "some-model"), prompt="read /x")
     assert inv.argv[0] == "opencode"

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -1,0 +1,428 @@
+"""Subprocess lifecycle wrapper for agent dispatch (§5 subprocess wrapper).
+
+The wrapper owns the plumbing for ``claude -p`` / ``codex exec`` / ``opencode run``
+/ ``ollama``: it writes the contract JSON to a temp file passed by path, builds
+the per-invoker argv, enforces a per-contract wall-clock budget (kills the child
+and raises a timeout-tagged error on overrun), and terminates the child when a
+``threading.Event`` cancel-token is set.
+
+The single OS seam is the :class:`~prgroom.agent.subprocess_runner.ProcessHandle`
+Protocol — a thin Popen facade. Tests inject a recorded-behavior fake so
+kill-on-timeout and kill-on-cancel are proven without spawning a real CLI. This
+mirrors the foundation's ``CommandRunner`` seam (recorded fakes, not mocks).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from prgroom.agent.prompt_loader import PromptTemplate
+from prgroom.agent.subprocess_runner import (
+    AgentCancelledError,
+    AgentRunResult,
+    AgentSpec,
+    AgentTimeoutError,
+    SubprocessAgentRunner,
+    build_invocation,
+)
+from prgroom.errors import ErrorCode
+
+# A prompt template whose only placeholder is the runner-injected input path, so a
+# test can assert the runner filled in the real temp-file path.
+_PROMPT = PromptTemplate(name="t", text="process the input at {input_path}")
+
+
+class FakeProcess:
+    """A :class:`ProcessHandle` fake that records the full child lifecycle.
+
+    ``finishes_after`` polls return ``None`` (running) before the process
+    "completes" with ``returncode`` and the recorded ``stdout`` / ``stderr``. A
+    ``finishes_after`` of ``None`` means it NEVER completes on its own — only a
+    ``terminate``/``kill`` ends it (models a hung agent for the timeout/cancel
+    paths). ``survives_sigterm`` makes :meth:`wait` raise ``TimeoutExpired`` on the
+    SIGTERM-grace wait so the escalation-to-SIGKILL path is exercised.
+
+    The fake records: the stdin delivered (:attr:`delivered_stdin`), whether the
+    child was reaped (:attr:`reaped` — a ``communicate``/``wait`` after exit), and
+    the ``terminate``/``kill`` signals — so tests pin delivery, reaping, and the
+    SIGTERM-then-SIGKILL escalation, not just that a kwarg was passed.
+    """
+
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+        finishes_after: int | None = 0,
+        survives_sigterm: bool = False,
+    ) -> None:
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._finishes_after = finishes_after
+        self._survives_sigterm = survives_sigterm
+        self._polls = 0
+        self.terminated = False
+        self.killed = False
+        self.reaped = False
+        self.delivered_stdin: str | None = None
+        self._signalled = False
+
+    def poll(self) -> int | None:
+        if self._signalled:
+            return self._returncode
+        if self._finishes_after is None:
+            self._polls += 1
+            return None
+        if self._polls >= self._finishes_after:
+            return self._returncode
+        self._polls += 1
+        return None
+
+    def send_stdin(self, data: str) -> None:
+        self.delivered_stdin = data
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self._signalled = True
+
+    def kill(self) -> None:
+        self.killed = True
+        self._signalled = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        # The SIGTERM grace wait: a child that survives SIGTERM forces the caller to
+        # escalate to SIGKILL. A timeout-less wait (the final reap) always succeeds.
+        if timeout is not None and self._survives_sigterm and not self.killed:
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout)
+        self.reaped = True
+        return self._returncode
+
+    def communicate(self) -> tuple[str, str]:
+        self.reaped = True
+        return self._stdout, self._stderr
+
+
+def _spec(cli: str = "claude", model: str = "haiku", **extra: object) -> AgentSpec:
+    return AgentSpec(cli=cli, model=model, extra=extra)
+
+
+# ── argv / stdin shapes per invoker (build_invocation) ──
+#
+# The contract input path lives in the PROMPT (the agent reads the file), never as
+# an argv flag — none of the four real CLIs has an --input-file option. So each
+# invoker carries the prompt as its message and the path is already inside it.
+
+
+def test_claude_invocation_shape() -> None:
+    inv = build_invocation(_spec("claude", "opus[1m]", effort="xhigh"), prompt="read /x")
+    assert inv.argv[0] == "claude"
+    assert "-p" in inv.argv
+    assert "--model" in inv.argv and "opus[1m]" in inv.argv
+    assert "--effort" in inv.argv and "xhigh" in inv.argv
+    assert "read /x" in inv.argv  # prompt (carrying the path) is a positional
+
+
+def test_codex_invocation_shape_maps_write_to_workspace_sandbox() -> None:
+    inv = build_invocation(_spec("codex", "gpt-5.5", write=True), prompt="read /x")
+    assert inv.argv[0] == "codex"
+    assert "exec" in inv.argv
+    assert "--model" in inv.argv and "gpt-5.5" in inv.argv
+    # write=true grants edit permission via the sandbox policy, not a bare flag.
+    assert "--sandbox" in inv.argv and "workspace-write" in inv.argv
+    assert "read /x" in inv.argv
+
+
+def test_codex_read_only_omits_sandbox_write() -> None:
+    inv = build_invocation(_spec("codex", "gpt-5.4-mini"), prompt="P")
+    assert "workspace-write" not in inv.argv
+
+
+def test_opencode_invocation_shape() -> None:
+    inv = build_invocation(_spec("opencode", "some-model"), prompt="read /x")
+    assert inv.argv[0] == "opencode"
+    assert "run" in inv.argv
+    assert "--model" in inv.argv and "some-model" in inv.argv
+    assert "read /x" in inv.argv
+
+
+def test_ollama_invocation_shape_pipes_prompt_on_stdin() -> None:
+    inv = build_invocation(_spec("ollama", "gemma4"), prompt="PROMPT-BODY")
+    assert inv.argv[0] == "ollama"
+    assert "run" in inv.argv
+    assert "gemma4" in inv.argv
+    # ollama reads the prompt on stdin, not as an argv positional.
+    assert inv.stdin == "PROMPT-BODY"
+    assert "PROMPT-BODY" not in inv.argv
+
+
+def test_unknown_cli_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown agent cli"):
+        build_invocation(_spec("borg", "model"), prompt="P")
+
+
+# ── JSON-input-by-path ──
+
+
+def test_runner_writes_contract_json_to_a_temp_file_and_names_it_in_the_prompt(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def spawn(argv: Sequence[str], *, stdin: str | None) -> FakeProcess:  # noqa: ARG001
+        # The rendered prompt (a claude positional) names the real temp path; that
+        # path is the argv token that exists as a file on disk.
+        prompt = next(t for t in argv if "input at" in t)
+        path = prompt.removeprefix("process the input at ")
+        captured["path"] = path
+        captured["content"] = Path(path).read_text(encoding="utf-8")
+        return FakeProcess(returncode=0, stdout='{"clusters": []}')
+
+    runner = SubprocessAgentRunner(spawn=spawn, scratch_dir=tmp_path)
+    result = runner.run(
+        _spec(),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={"contract_version": 1, "items": []},
+        time_budget_s=5.0,
+    )
+    assert json.loads(captured["content"]) == {"contract_version": 1, "items": []}
+    assert result.stdout == '{"clusters": []}'
+
+
+def test_runner_cleans_up_the_temp_input_file(tmp_path: Path) -> None:
+    seen: dict[str, Path] = {}
+
+    def spawn(argv: Sequence[str], *, stdin: str | None) -> FakeProcess:  # noqa: ARG001
+        prompt = next(t for t in argv if "input at" in t)
+        seen["path"] = Path(prompt.removeprefix("process the input at "))
+        return FakeProcess(returncode=0, stdout="{}")
+
+    runner = SubprocessAgentRunner(spawn=spawn, scratch_dir=tmp_path)
+    runner.run(
+        _spec(), prompt_template=_PROMPT, render_data={}, contract_payload={}, time_budget_s=5.0
+    )
+    assert not seen["path"].exists()  # temp input is removed after the run
+
+
+def test_ollama_run_delivers_the_rendered_prompt_to_the_child_stdin(tmp_path: Path) -> None:
+    # ollama reads the prompt on stdin; the runner must actually WRITE it to the
+    # child (close the pipe), not merely carry it on the invocation. The fake
+    # records what was delivered — without delivery a real ollama child blocks on an
+    # unwritten stdin and dies at the budget (the default cluster primary DOA bug).
+    proc = FakeProcess(returncode=0, stdout="{}")
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    runner.run(
+        _spec("ollama", "gemma4"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={},
+        time_budget_s=5.0,
+    )
+    assert proc.delivered_stdin is not None
+    assert "process the input at " in proc.delivered_stdin
+
+
+def test_non_stdin_cli_delivers_no_stdin(tmp_path: Path) -> None:
+    # claude/codex/opencode carry the prompt as an argv positional, so the runner
+    # must NOT try to write to a child stdin that was never opened.
+    proc = FakeProcess(returncode=0, stdout="OK")
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    runner.run(
+        _spec("claude", "haiku"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={},
+        time_budget_s=5.0,
+    )
+    assert proc.delivered_stdin is None
+
+
+def test_run_polls_repeatedly_until_a_slow_child_finishes(tmp_path: Path) -> None:
+    # A child that needs two polls before completing exercises the poll-sleep-repoll
+    # loop with a real (tiny) non-zero interval — not just the first-poll-done path.
+    proc = FakeProcess(returncode=0, stdout="DONE", finishes_after=3)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.001,
+    )
+    result = runner.run(
+        _spec(), prompt_template=_PROMPT, render_data={}, contract_payload={}, time_budget_s=30.0
+    )
+    assert result.stdout == "DONE"
+    assert not proc.killed and not proc.terminated  # finished on its own, no signal
+
+
+def test_run_loops_without_sleeping_when_poll_interval_is_zero(tmp_path: Path) -> None:
+    # A slow child with a 0.0 poll interval loops back immediately (the sleep is
+    # skipped) — the "no-sleep" edge of the poll loop, distinct from the timeout
+    # path which also runs at 0.0 but raises before completing.
+    proc = FakeProcess(returncode=0, stdout="DONE", finishes_after=2)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+    )
+    result = runner.run(
+        _spec(), prompt_template=_PROMPT, render_data={}, contract_payload={}, time_budget_s=30.0
+    )
+    assert result.stdout == "DONE"
+
+
+# ── success path returns a structured result ──
+
+
+def _run_ok(runner: SubprocessAgentRunner) -> AgentRunResult:
+    return runner.run(
+        _spec(), prompt_template=_PROMPT, render_data={}, contract_payload={}, time_budget_s=5.0
+    )
+
+
+def test_successful_run_returns_result_with_duration_and_returncode(tmp_path: Path) -> None:
+    proc = FakeProcess(returncode=0, stdout="OK")
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_ok(runner)
+    assert isinstance(result, AgentRunResult)
+    assert result.returncode == 0
+    assert result.stdout == "OK"
+    assert result.duration_ms >= 0
+    assert proc.reaped  # normal completion reaps the child (no zombie / leaked pipes)
+
+
+def test_nonzero_exit_is_returned_not_raised(tmp_path: Path) -> None:
+    # The runner does NOT classify exit codes — the dispatcher's fallback ladder
+    # does. The runner reports the returncode + stderr faithfully.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=7, stderr="quota exceeded"),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_ok(runner)
+    assert result.returncode == 7
+    assert "quota" in result.stderr
+
+
+# ── timeout: SIGTERM-grace-then-SIGKILL, reap, raise timeout-tagged error ──
+
+
+def test_timeout_escalates_sigterm_to_sigkill_and_reaps(tmp_path: Path) -> None:
+    # A budget overrun on a child that IGNORES SIGTERM must escalate to SIGKILL and
+    # then reap — never leave a zombie / leaked pipes.
+    proc = FakeProcess(finishes_after=None, survives_sigterm=True)
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+        sigterm_grace_s=0.0,
+    )
+    with pytest.raises(AgentTimeoutError) as excinfo:
+        runner.run(
+            _spec(),
+            prompt_template=_PROMPT,
+            render_data={},
+            contract_payload={},
+            time_budget_s=0.0,
+        )
+    assert proc.terminated and proc.killed  # SIGTERM first, then SIGKILL on survival
+    assert proc.reaped  # reaped before the error propagates
+    assert excinfo.value.code is ErrorCode.RUNTIME_AGENT_TIMEOUT
+
+
+def test_timeout_lets_a_well_behaved_child_die_on_sigterm_alone(tmp_path: Path) -> None:
+    # A child that exits on SIGTERM within the grace window is NOT SIGKILLed — the
+    # grace gives the fix agent a chance to flush / release its .git/index.lock.
+    proc = FakeProcess(finishes_after=None)  # survives_sigterm=False → SIGTERM suffices
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+    )
+    with pytest.raises(AgentTimeoutError):
+        runner.run(
+            _spec(), prompt_template=_PROMPT, render_data={}, contract_payload={}, time_budget_s=0.0
+        )
+    assert proc.terminated and not proc.killed
+    assert proc.reaped
+
+
+# ── cancel-token: terminate, grace, reap when the Event is set ──
+
+
+def test_cancel_token_terminates_and_reaps_child(tmp_path: Path) -> None:
+    proc = FakeProcess(finishes_after=None)
+    cancel = threading.Event()
+    cancel.set()  # already cancelled before the first poll
+
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+    )
+    with pytest.raises(AgentCancelledError) as excinfo:
+        runner.run(
+            _spec(),
+            prompt_template=_PROMPT,
+            render_data={},
+            contract_payload={},
+            time_budget_s=30.0,
+            cancel=cancel,
+        )
+    assert proc.terminated
+    assert proc.reaped  # cancel path reaps too — no leaked child
+    assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGTERM
+
+
+def test_cancel_escalates_to_sigkill_when_child_survives_sigterm(tmp_path: Path) -> None:
+    proc = FakeProcess(finishes_after=None, survives_sigterm=True)
+    cancel = threading.Event()
+    cancel.set()
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: proc,  # noqa: ARG005
+        scratch_dir=tmp_path,
+        poll_interval_s=0.0,
+        sigterm_grace_s=0.0,
+    )
+    with pytest.raises(AgentCancelledError):
+        runner.run(
+            _spec(),
+            prompt_template=_PROMPT,
+            render_data={},
+            contract_payload={},
+            time_budget_s=30.0,
+            cancel=cancel,
+        )
+    assert proc.terminated and proc.killed and proc.reaped
+
+
+def test_run_builds_the_argv_for_the_specs_cli(tmp_path: Path) -> None:
+    seen_argv: list[Sequence[str]] = []
+
+    def spawn(argv: Sequence[str], *, stdin: str | None) -> FakeProcess:  # noqa: ARG001
+        seen_argv.append(argv)
+        return FakeProcess(returncode=0, stdout="{}")
+
+    runner = SubprocessAgentRunner(spawn=spawn, scratch_dir=tmp_path)
+    runner.run(
+        _spec("claude", "haiku"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={},
+        time_budget_s=5.0,
+    )
+    assert seen_argv[0][0] == "claude"

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -199,6 +199,25 @@ def test_unknown_cli_is_rejected() -> None:
         build_invocation(_spec("borg", "model"), prompt="P")
 
 
+def test_unrecognized_extra_keys_warn_but_do_not_fail(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # `extra` is a deliberate growth surface, so unknown keys are NOT an error —
+    # but a typo (`effrot`, `timout`) must not vanish without trace either. The
+    # invoker warns, names the keys, and proceeds.
+    with caplog.at_level("WARNING"):
+        inv = build_invocation(_spec("claude", "haiku", effrot="high"), prompt="P")
+    assert inv.argv[0] == "claude"  # invocation still built
+    assert "effrot" in caplog.text and "claude" in caplog.text
+
+
+def test_recognized_extra_keys_do_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        build_invocation(_spec("claude", "haiku", effort="high"), prompt="P")
+        build_invocation(_spec("codex", "gpt-5.5", write=True), prompt="P")
+    assert not caplog.records
+
+
 # ── JSON-input-by-path ──
 
 

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -279,8 +279,9 @@ def test_stdin_broken_pipe_does_not_crash_and_falls_through(tmp_path: Path) -> N
 
 
 def test_run_polls_repeatedly_until_a_slow_child_finishes(tmp_path: Path) -> None:
-    # A child that needs two polls before completing exercises the poll-sleep-repoll
-    # loop with a real (tiny) non-zero interval — not just the first-poll-done path.
+    # finishes_after=3 → poll() returns running (None) three times before the code,
+    # exercising the poll-sleep-repoll loop with a real (tiny) non-zero interval —
+    # not just the first-poll-done path.
     proc = FakeProcess(returncode=0, stdout="DONE", finishes_after=3)
     runner = SubprocessAgentRunner(
         spawn=lambda argv, *, stdin: proc,  # noqa: ARG005

--- a/packages/prgroom/tests/unit/test_agent_usage.py
+++ b/packages/prgroom/tests/unit/test_agent_usage.py
@@ -69,6 +69,32 @@ def test_append_creates_parent_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert (tmp_path / "deep" / "nested" / "prgroom" / "usage.jsonl").is_file()
 
 
+def test_none_token_counts_serialize_as_null(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No usage-line parser exists yet, so the dispatcher emits records with unknown
+    # token counts — those must serialize as JSON null, not crash or be dropped.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    record = UsageRecord(
+        ts="2026-06-12T00:00:00+00:00",
+        pr=PRRef(owner="octo", repo="demo", number=7),
+        contract="cluster",
+        provider="ollama",
+        model="gemma4",
+        input_tokens=None,
+        output_tokens=None,
+        duration_ms=10,
+        outcome="timeout",
+    )
+    append_usage(record)
+
+    usage_file = tmp_path / "prgroom" / "usage.jsonl"
+    line = json.loads(usage_file.read_text(encoding="utf-8").splitlines()[0])
+    assert line["input_tokens"] is None
+    assert line["output_tokens"] is None
+    assert line["outcome"] == "timeout"
+
+
 def test_absent_usage_is_a_noop_not_an_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/prgroom/tests/unit/test_agent_usage.py
+++ b/packages/prgroom/tests/unit/test_agent_usage.py
@@ -1,0 +1,81 @@
+"""Token-usage JSONL emitter (§5 token-usage logging).
+
+MVP baseline-capture only: one JSON line per agent invocation appended to
+``$XDG_STATE_HOME/prgroom/usage.jsonl``. No aggregation. The tests pin the §5
+record schema, the XDG path resolution, the append (not truncate) semantics, and
+the "absent usage line is a no-op, not an error" rule.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prgroom.agent.usage import UsageRecord, append_usage
+from prgroom.prsession.pr_ref import PRRef
+
+
+def _record() -> UsageRecord:
+    return UsageRecord(
+        ts="2026-06-10T12:00:00+00:00",
+        pr=PRRef(owner="octo", repo="demo", number=7),
+        contract="cluster",
+        provider="ollama",
+        model="gemma4",
+        input_tokens=1200,
+        output_tokens=80,
+        duration_ms=1450,
+        outcome="success",
+    )
+
+
+def test_append_writes_schema_line_to_xdg_state_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    append_usage(_record())
+
+    usage_file = tmp_path / "prgroom" / "usage.jsonl"
+    lines = usage_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {
+        "ts": "2026-06-10T12:00:00+00:00",
+        "pr": "octo/demo#7",
+        "contract": "cluster",
+        "provider": "ollama",
+        "model": "gemma4",
+        "input_tokens": 1200,
+        "output_tokens": 80,
+        "duration_ms": 1450,
+        "outcome": "success",
+    }
+
+
+def test_append_is_additive_not_truncating(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    append_usage(_record())
+    append_usage(_record())
+
+    usage_file = tmp_path / "prgroom" / "usage.jsonl"
+    assert len(usage_file.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_append_creates_parent_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "deep" / "nested"))
+    append_usage(_record())
+
+    assert (tmp_path / "deep" / "nested" / "prgroom" / "usage.jsonl").is_file()
+
+
+def test_absent_usage_is_a_noop_not_an_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # §5: "logs per-contract token usage WHEN the agent CLI emits a usage line".
+    # A None record (no usage parsed from the agent output) writes nothing and
+    # does not raise — the file must not even be created.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    append_usage(None)
+
+    assert not (tmp_path / "prgroom" / "usage.jsonl").exists()


### PR DESCRIPTION
## Summary

Bead **agents-config-abn9.8.4** — the prgroom **agent-dispatch arm**. This ships the dispatch *logic* against the Cluster/Fix contract Protocols that the foundation bead (8.1) already merged; it does **not** redefine those Protocols.

New modules under `packages/prgroom/src/prgroom/agent/`:

- **`subprocess_runner.py`** — subprocess lifecycle wrapper: JSON-input-by-path, per-contract wall-clock budget, cancel-token (`threading.Event`) kill with a **SIGTERM grace interval → SIGKILL escalation → child reap**, per-invoker argv/stdin shapes for claude / codex / opencode / ollama (ollama's prompt is delivered on the child's stdin).
- **`dispatcher.py`** — provider-chain fallback ladder. Cluster default `ollama → claude haiku → codex-mini`; fix default `opus[1m] → codex gpt-5.5 (write)`; both overridable via `--cluster-model` / `--fix-model`. A cancel aborts the chain; a per-provider failure/timeout/unparseable-output falls through; an exhausted chain raises a **transient** (`RUNTIME_TRANSIENT`, exit 75 — scheduler-retryable) `AllProvidersFailedError` whose detail names each link and why it was rejected.
- **`usage.py`** — per-invocation token-usage JSONL emitter to `$XDG_STATE_HOME/prgroom/usage.jsonl` (baseline capture; no aggregation).
- **`prompt_loader.py`** + **`prompts/{cluster,fix}.tmpl`** — contract prompt templates, strict `format_map` render (raises on unresolved placeholder), `PRGROOM_PROMPTS_DIR` override.
- **`recurrence.py`** — the `Recurrence` derived-data shape (design §8.2); foundation owns no such type, so it lives in the agent layer that consumes it.

Design refs (source of truth): `docs/plans/2026-05-12-prgroom-cli-design.md` §5 (agent dispatch) + §8.2 (recurrence); HLD `docs/architecture/prgroom/c4-l3-agent-dispatch.md`.

## Intentionally out of scope (please do not flag as missing)

- **Cluster/Fix audits + validators** → agent-audits bead (8.7).
- **Lifecycle wiring of `_cluster`/`_fix`**, snapshot assembly, recurrence *derivation*, gh legwork → lifecycle bead (8.15).
- **`append_usage` is not yet called and the cancel-token is not yet threaded** from a verb — that orchestration is the lifecycle layer's job (8.15), per the `c4-l3-agent-dispatch` line-54 layering rule ("agent dispatch does not read/write `prsession.Store`; lifecycle is the sole consumer"). These are deliberate deferrals, not gaps.

## Stack position

Bottom of the **M2** stack (`8.4 → 8.7 → 8.15`); base is `main` (foundation 8.1 is already merged). Stacked siblings target this branch.

## Quality gate

- `make ci-prgroom` green: ruff check + format, **mypy --strict**, pytest at **100% line / 100% branch** (gate floor 90% branch), pip-audit clean, `prgroom --help` entry verify.
- Passed an in-house **3-lens adversarial review** (spec / correctness / test-quality) with per-finding verification; 8 confirmed findings were fixed before this PR — notably the ollama-stdin-delivery blocker, the all-providers-fail tier correction (77→75), and a fix-ladder `ValueError` fall-through (a hallucinated disposition string no longer crashes dispatch).

## Test Plan

- [ ] `make ci-prgroom` green from the worktree root.
- [ ] Provider-chain fall-through: first provider fails → next is tried; all fail → transient escalation naming each link.
- [ ] ollama prompt body reaches the child's stdin.
- [ ] Cancel propagates (aborts chain); timeout falls through; both reap the child.
- [ ] Out-of-enum fix disposition falls through rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
