### PR TITLE
feat(installer): F.2 — Phase 6 plugin overlay + shared_carrier model (w1qls.6.2)

### DIFF
--- a/packages/installer/src/installer/core/model.py
+++ b/packages/installer/src/installer/core/model.py
@@ -88,7 +88,17 @@ class StagedItem:
     `executable` is a sync-phase write attribute (mode bit 0o755 vs 0o644),
     not a merge-dispatch concern — see design doc §3.6. Directories
     ignore `executable`; the sync engine preserves the source tree's
-    mode bits for recursive copies."""
+    mode bits for recursive copies.
+
+    `shared_carrier` is the in-memory replacement for the bash
+    `.carrier-from-user-shared` sentinel file (`scripts/install.sh:517-529`).
+    It is set `True` only on `skills/` and `agents/` `kind==DIR` items first
+    staged from the shared carrier tree (`build_plan` Phase 2). The Phase 6
+    plugin overlay reads it to allow a carrier-merge (a plugin overlaying a
+    disjoint file set into a shared skill/agent dir) while keeping plugin-vs-
+    plugin directory collisions fatal. The overlay clears it after a merge —
+    mirroring the bash `rm -f sentinel` — so a second plugin colliding on the
+    same dir is a true plugin-plugin collision (fatal)."""
 
     source_path: Path
     dest_relpath: Path
@@ -97,6 +107,7 @@ class StagedItem:
     provenance: Provenance
     content: bytes | None = None
     executable: bool = False
+    shared_carrier: bool = False
 
 
 @dataclass(slots=True)

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -1,5 +1,5 @@
-"""Run-orchestration seam: stage every active tool, then apply its
-post-staging transform pass.
+"""Run-orchestration seam: stage every active tool (Phases 1-5), overlay active
+plugins (Phase 6), then apply its post-staging transform pass.
 
 This is the FIRST call site for ``ToolAdapter.post_staging_transforms`` across
 all four adapters. It is deliberately NOT yet invoked from ``cli.main()``: the
@@ -10,33 +10,49 @@ the Epic E merge dispatch). When the full install pipeline is wired into
 ``build_plan``->``sync`` directly — or adapter transforms (e.g. the Gemini
 frontmatter transform) will silently never run in real installs. That wiring is
 tracked as its own story.
+
+Phase ordering (epic Plugin Seam Integration Brief): plugin overlay (6) runs
+AFTER base staging and BEFORE ``post_staging_transforms`` (the Gemini frontmatter
+transform at 6.95), so a plugin-contributed Gemini agent is normalised by the
+same transform as a base agent.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from installer.core.merge.registry import default_registry
+from installer.core.overlay import overlay_plugins
 from installer.core.staging import build_plan
 from installer.tools.registry import get_adapter
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
     from pathlib import Path
 
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan, Tool
+    from installer.plugins.base import PluginAdapter
 
 
 def stage_and_transform(
-    tools: Iterable[Tool], *, repo_root: Path, io: IOPort
+    tools: Iterable[Tool],
+    *,
+    repo_root: Path,
+    io: IOPort,
+    plugins: Sequence[PluginAdapter] = (),
 ) -> dict[Tool, StagingPlan]:
-    """Build a StagingPlan for each active tool (staging Phases 1-5) and run
-    that tool's adapter ``post_staging_transforms`` pass over it. Returns the
-    transformed plan per tool, preserving iteration order.
+    """Build a StagingPlan for each active tool (staging Phases 1-5), overlay the
+    active ``plugins`` onto it (Phase 6, through the merge registry), and run
+    that tool's adapter ``post_staging_transforms`` pass over the result. Returns
+    the transformed plan per tool, preserving iteration order. With no plugins
+    the overlay is a no-op, so existing tool-only callers are unaffected.
     """
+    registry = default_registry()
     plans: dict[Tool, StagingPlan] = {}
     for tool in tools:
         adapter = get_adapter(tool)
         plan = build_plan(adapter, repo_root=repo_root)
+        plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry)
         plans[tool] = adapter.post_staging_transforms(plan, io)
     return plans

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -1,0 +1,121 @@
+"""Phase 6: overlay active plugins onto a base StagingPlan.
+
+After base staging (Phases 1-5, ``staging.build_plan``), each active plugin's
+``.agents/`` (shared scope) and ``.<tool>/`` (tool scope) content is overlaid
+onto the tool's plan. Port of the bash Phase 6 loop
+(``scripts/install.sh:813-847``).
+
+Two invariants from the bash original:
+
+- **Alphabetical plugin order.** Plugins are applied in ascending name order so
+  that last-wins collisions (``OTHER`` / ``JSONC`` / ``TOML``) resolve
+  deterministically. The active set is pre-sorted by the registry's
+  ``discover``; this module sorts again defensively so a caller passing an
+  unsorted sequence still gets deterministic results.
+- **Adapter namespace reuse.** Plugins have no namespace routing of their own in
+  F.2 — the overlay consults the *tool* adapter's
+  ``should_install_namespace(ns, source)`` so a tool's opt-out (e.g. OpenCode
+  skipping shared ``agents/``) applies to plugin content too.
+
+Every ``dest_relpath`` collision with an already-staged item routes through the
+Epic-E merge registry, EXCEPT the shared-carrier skills/agents DIR path: an
+incoming plugin directory colliding with a ``shared_carrier`` DIR carrier-merges
+when the file sets are disjoint (and clears the flag), else falls through to the
+registry's fatal strategy. See ``_place``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from installer.core.model import FileKind, Provenance
+from installer.core.staging import stage_namespace, stage_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from installer.core.merge.registry import MergeRegistry
+    from installer.core.model import StagedItem, StagingPlan
+    from installer.plugins.base import PluginAdapter
+    from installer.tools.base import ToolAdapter
+
+# Plugin namespace staging order, per scope (bash install.sh:820, 837). The tool
+# scope includes commands; the shared scope does not (no shared commands).
+_TOOL_NAMESPACES = ("rules", "commands", "skills", "agents")
+_SHARED_NAMESPACES = ("rules", "skills", "agents")
+
+
+def overlay_plugins(
+    plan: StagingPlan,
+    plugins: Sequence[PluginAdapter],
+    *,
+    adapter: ToolAdapter,
+    registry: MergeRegistry,
+) -> StagingPlan:
+    """Overlay every plugin in ``plugins`` onto ``plan``, in alphabetical name
+    order, mutating and returning ``plan``. Each plugin contributes its
+    ``.<tool>/`` (tool scope) then ``.agents/`` (shared scope) namespace content
+    plus its tool-scope settings, gated by the tool adapter's namespace rules
+    and with collisions resolved by ``_place``.
+    """
+    for plugin in sorted(plugins, key=lambda p: p.name):
+        prov = Provenance(kind="plugin", name=plugin.name)
+        tool_root = plugin.source_path / f".{adapter.name}"
+        shared_root = plugin.source_path / ".agents"
+
+        for ns in _TOOL_NAMESPACES:
+            if adapter.should_install_namespace(ns, "tool"):
+                for item in stage_namespace(tool_root, ns, provenance=prov):
+                    _place(plan, item, registry=registry)
+        for item in stage_settings(tool_root, provenance=prov):
+            _place(plan, item, registry=registry)
+        for ns in _SHARED_NAMESPACES:
+            if adapter.should_install_namespace(ns, "shared"):
+                for item in stage_namespace(shared_root, ns, provenance=prov):
+                    _place(plan, item, registry=registry)
+    return plan
+
+
+def _place(plan: StagingPlan, incoming: StagedItem, *, registry: MergeRegistry) -> None:
+    """Insert ``incoming`` into the plan, resolving a collision if the
+    destination is already occupied.
+
+    The shared-carrier DIR path is intercepted before the registry: when an
+    incoming plugin directory collides with a ``shared_carrier`` DIR and their
+    file sets are disjoint, the two directories carrier-merge (the carrier item
+    is kept with its flag cleared). Every other collision — including a
+    carrier-merge with overlapping files, a DIR collision on a non-carrier item,
+    and a second plugin colliding on an already-merged (flag-cleared) carrier —
+    routes through the registry, where ``FileKind.DIR`` is fatal."""
+    existing = plan.items.get(incoming.dest_relpath)
+    if existing is None:
+        plan.items[incoming.dest_relpath] = incoming
+        return
+    if _carrier_merge_allowed(existing, incoming):
+        # Mirror bash `rm -f sentinel`: the carrier dir survives with the
+        # plugin's disjoint files conceptually merged in; clearing the flag
+        # makes any further plugin collision on this dir a true plugin-plugin
+        # collision (fatal via the registry).
+        plan.items[incoming.dest_relpath] = replace(existing, shared_carrier=False)
+        return
+    plan.items[incoming.dest_relpath] = registry.resolve(incoming.kind, incoming.namespace).merge(
+        existing, incoming
+    )
+
+
+def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:
+    """True when ``incoming`` (a plugin DIR) may carrier-merge into ``existing``
+    (a shared-carrier DIR): both are directories, ``existing`` still carries the
+    shared-carrier flag, and their on-disk file sets are disjoint.
+
+    Port of the bash carrier-merge guard (``scripts/install.sh:550-595``): the
+    disjoint-file-set check is the load-bearing precondition — overlapping names
+    fall through to the registry's fatal strategy."""
+    if not (
+        existing.kind is FileKind.DIR and incoming.kind is FileKind.DIR and existing.shared_carrier
+    ):
+        return False
+    existing_names = {p.name for p in existing.source_path.iterdir()}
+    incoming_names = {p.name for p in incoming.source_path.iterdir()}
+    return existing_names.isdisjoint(incoming_names)

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -27,6 +27,7 @@ registry's fatal strategy. See ``_place``.
 from __future__ import annotations
 
 from dataclasses import replace
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from installer.core.model import FileKind, Provenance
@@ -67,32 +68,40 @@ def overlay_plugins(
         for ns in _TOOL_NAMESPACES:
             if adapter.should_install_namespace(ns, "tool"):
                 for item in stage_namespace(tool_root, ns, provenance=prov):
-                    _place(plan, item, registry=registry)
+                    _place(plan, item, registry=registry, carrier_eligible=False)
         for item in stage_settings(tool_root, provenance=prov):
-            _place(plan, item, registry=registry)
+            _place(plan, item, registry=registry, carrier_eligible=False)
         for ns in _SHARED_NAMESPACES:
             if adapter.should_install_namespace(ns, "shared"):
                 for item in stage_namespace(shared_root, ns, provenance=prov):
-                    _place(plan, item, registry=registry)
+                    _place(plan, item, registry=registry, carrier_eligible=True)
     return plan
 
 
-def _place(plan: StagingPlan, incoming: StagedItem, *, registry: MergeRegistry) -> None:
+def _place(
+    plan: StagingPlan,
+    incoming: StagedItem,
+    *,
+    registry: MergeRegistry,
+    carrier_eligible: bool,
+) -> None:
     """Insert ``incoming`` into the plan, resolving a collision if the
     destination is already occupied.
 
-    The shared-carrier DIR path is intercepted before the registry: when an
-    incoming plugin directory collides with a ``shared_carrier`` DIR and their
+    The shared-carrier DIR path is intercepted before the registry: when a
+    ``carrier_eligible`` incoming directory (one staged from the plugin's
+    ``.agents/`` shared tree) collides with a ``shared_carrier`` DIR and their
     file sets are disjoint, the two directories carrier-merge (the carrier item
-    is kept with its flag cleared). Every other collision — including a
-    carrier-merge with overlapping files, a DIR collision on a non-carrier item,
-    and a second plugin colliding on an already-merged (flag-cleared) carrier —
-    routes through the registry, where ``FileKind.DIR`` is fatal."""
+    is kept with its flag cleared). Every other collision — a tool-scope plugin
+    DIR (``carrier_eligible=False``), a carrier-merge with overlapping files, a
+    DIR collision on a non-carrier item, and a second plugin colliding on an
+    already-merged (flag-cleared) carrier — routes through the registry, where
+    ``FileKind.DIR`` is fatal."""
     existing = plan.items.get(incoming.dest_relpath)
     if existing is None:
         plan.items[incoming.dest_relpath] = incoming
         return
-    if _carrier_merge_allowed(existing, incoming):
+    if carrier_eligible and _carrier_merge_allowed(existing, incoming):
         # Mirror bash `rm -f sentinel`: the carrier dir survives with the
         # plugin's disjoint files conceptually merged in; clearing the flag
         # makes any further plugin collision on this dir a true plugin-plugin
@@ -105,17 +114,27 @@ def _place(plan: StagingPlan, incoming: StagedItem, *, registry: MergeRegistry) 
 
 
 def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:
-    """True when ``incoming`` (a plugin DIR) may carrier-merge into ``existing``
-    (a shared-carrier DIR): both are directories, ``existing`` still carries the
-    shared-carrier flag, and their on-disk file sets are disjoint.
+    """True when ``incoming`` (a plugin ``.agents/`` DIR) may carrier-merge into
+    ``existing`` (a shared-carrier DIR): both are directories, ``existing`` still
+    carries the shared-carrier flag, and their on-disk file sets are disjoint.
+    The ``.agents/``-origin precondition is enforced by the caller via
+    ``carrier_eligible`` — a tool-scope plugin DIR never reaches here.
 
     Port of the bash carrier-merge guard (``scripts/install.sh:550-595``): the
     disjoint-file-set check is the load-bearing precondition — overlapping names
-    fall through to the registry's fatal strategy."""
+    fall through to the registry's fatal strategy. Dotfiles are excluded from the
+    comparison to mirror bash's ``"$dir"/*`` globs, which skip dot-prefixed
+    entries."""
     if not (
         existing.kind is FileKind.DIR and incoming.kind is FileKind.DIR and existing.shared_carrier
     ):
         return False
-    existing_names = {p.name for p in existing.source_path.iterdir()}
-    incoming_names = {p.name for p in incoming.source_path.iterdir()}
+    existing_names = _visible_names(existing.source_path)
+    incoming_names = _visible_names(incoming.source_path)
     return existing_names.isdisjoint(incoming_names)
+
+
+def _visible_names(directory: Path) -> set[str]:
+    """The dot-excluded child names of ``directory`` — the entries a bash
+    ``"$dir"/*`` glob would iterate (dotfiles are skipped without ``dotglob``)."""
+    return {entry.name for entry in directory.iterdir() if not entry.name.startswith(".")}

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -11,6 +11,7 @@ destination.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -158,6 +159,27 @@ def stage_namespace(
 
 _SHARED_NAMESPACES = ("skills", "agents", "rules")  # bash Phase 2 (no commands shared)
 
+# Shared namespaces whose DIR units are carrier dirs (bash install.sh:525) — a
+# plugin may carrier-merge disjoint files into one of these; rules/ holds files,
+# not dirs, so it is excluded.
+_CARRIER_NAMESPACES = frozenset({"skills", "agents"})
+
+
+def _mark_carrier(item: StagedItem) -> StagedItem:
+    """Stamp the shared-carrier flag on a shared skills/agents DIR item.
+
+    Port of the bash ``.carrier-from-user-shared`` sentinel drop
+    (``scripts/install.sh:517-529``). Only ``kind==DIR`` items in the carrier
+    namespaces are marked; every other item passes through unchanged so the
+    flag never spuriously appears on rules files, agent ``*.md`` files, or
+    templates. Mark only during shared (Phase 2) staging — plugin staging must
+    NOT self-mark, which is why this lives in ``build_plan`` and not in the
+    shared ``stage_namespace`` walker.
+    """
+    if item.kind is FileKind.DIR and item.namespace in _CARRIER_NAMESPACES:
+        return replace(item, shared_carrier=True)
+    return item
+
 
 def _add_item(plan: StagingPlan, item: StagedItem) -> None:
     """Insert one item, raising on a duplicate dest_relpath.
@@ -193,7 +215,7 @@ def build_plan(adapter: ToolAdapter, *, repo_root: Path) -> StagingPlan:
     for ns in _SHARED_NAMESPACES:  # Phase 2
         if adapter.should_install_namespace(ns, "shared"):
             for item in stage_namespace(shared_root, ns, provenance=prov):
-                _add_item(plan, item)
+                _add_item(plan, _mark_carrier(item))
     for item in stage_templates(tool_root, provenance=prov):  # Phase 3
         _add_item(plan, item)
     for ns in adapter.scoped_namespaces():  # Phase 4

--- a/packages/installer/src/installer/plugins/registry.py
+++ b/packages/installer/src/installer/plugins/registry.py
@@ -34,7 +34,13 @@ def discover(
     `plugins_root`. Non-directory entries (e.g. `AGENTS.md`) and `.`/`_`-
     prefixed directories are skipped. Each plugin gets a `GenericPluginAdapter`
     unless its name is in `specialized`. Returns a name-keyed mapping; entries
-    are sorted by name for deterministic downstream ordering."""
+    are sorted by name for deterministic downstream ordering.
+
+    A missing `plugins_root` yields `{}` (no plugins to overlay) rather than
+    raising — `src/plugins/` is optional, so the overlay must tolerate its
+    absence (F.1-deferred decision, resolved in F.2)."""
+    if not plugins_root.is_dir():
+        return {}
     discovered: dict[str, PluginAdapter] = {}
     for entry in sorted(plugins_root.iterdir()):
         name = entry.name

--- a/packages/installer/tests/unit/test_orchestrator.py
+++ b/packages/installer/tests/unit/test_orchestrator.py
@@ -9,6 +9,7 @@ single call.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -71,3 +72,53 @@ def test_stage_and_transform_dispatches_correct_adapter_per_tool(tmp_path: Path)
     assert gemini_content is not None
     assert "color" not in _frontmatter(gemini_content)
     assert plans[Tool.CLAUDE].items[_AGENT].content == _CLAUDE_AGENT
+
+
+@dataclass(frozen=True, slots=True)
+class _Plugin:
+    """Minimal active PluginAdapter for the overlay-wiring test."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002  # inert  # pragma: no cover
+        return True
+
+
+def test_stage_and_transform_overlays_active_plugins(tmp_path: Path) -> None:
+    """Phase 6 wiring: an active plugin's content is overlaid onto the tool's
+    plan between base staging and the post-staging transform."""
+    repo = _make_repo(tmp_path)
+    plugin_root = tmp_path / "plugins" / "test-plugin"
+    (plugin_root / ".claude" / "rules").mkdir(parents=True)
+    (plugin_root / ".claude" / "rules" / "plugin-rule.md").write_bytes(b"from plugin")
+
+    plans = stage_and_transform(
+        [Tool.CLAUDE],
+        repo_root=repo,
+        io=ScriptedIO(),
+        plugins=[_Plugin(name="test-plugin", source_path=plugin_root)],
+    )
+
+    assert plans[Tool.CLAUDE].items[Path("rules/plugin-rule.md")].content == b"from plugin"
+
+
+def test_stage_and_transform_overlay_runs_before_gemini_transform(tmp_path: Path) -> None:
+    """A plugin-contributed Gemini agent must still pass through the Gemini
+    frontmatter transform — proving the overlay runs BEFORE post_staging_transforms
+    (brief phase ladder: 6 overlay, then 6.95 Gemini transform)."""
+    repo = _make_repo(tmp_path)
+    plugin_root = tmp_path / "plugins" / "test-plugin"
+    (plugin_root / ".agents" / "agents").mkdir(parents=True)
+    (plugin_root / ".agents" / "agents" / "plug-agent.md").write_bytes(_CLAUDE_AGENT)
+
+    plans = stage_and_transform(
+        [Tool.GEMINI],
+        repo_root=repo,
+        io=ScriptedIO(),
+        plugins=[_Plugin(name="test-plugin", source_path=plugin_root)],
+    )
+
+    content = plans[Tool.GEMINI].items[Path("agents/plug-agent.md")].content
+    assert content is not None
+    assert "color" not in _frontmatter(content)  # transform ran on plugin content

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -316,6 +316,34 @@ def test_non_carrier_dir_collision_is_fatal_even_when_disjoint(tmp_path: Path) -
         overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
 
 
+def test_tool_scope_plugin_dir_cannot_carrier_merge(tmp_path: Path) -> None:
+    """Carrier-merge is eligible ONLY for content from the plugin's .agents/
+    (shared) tree. A tool-scope plugin DIR (.<tool>/skills/...) colliding with a
+    shared_carrier dir is fatal even with a disjoint file set — mirrors the bash
+    guard requiring the incoming src under /src/plugins/<p>/.agents/."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin(tmp_path, "test-plugin")
+    # Tool-scope (.claude/), NOT .agents/ — disjoint file set, but ineligible.
+    tool_skill = plugin.source_path / ".claude" / "skills" / "demo-skill"
+    tool_skill.mkdir(parents=True)
+    (tool_skill / "SKILL.md").write_bytes(b"plugin")
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+
+def test_carrier_merge_ignores_dotfiles_in_disjoint_check(tmp_path: Path) -> None:
+    """Dotfiles are excluded from the disjointness comparison (bash `"$dir"/*`
+    skips them): a shared carrier and an incoming plugin dir that share only a
+    dot-prefixed entry still carrier-merge."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh", ".gitkeep"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", ".gitkeep"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.items[Path("skills/demo-skill")].shared_carrier is False
+
+
 def test_second_plugin_on_merged_carrier_is_fatal(tmp_path: Path) -> None:
     """After one plugin carrier-merges (clearing the flag), a SECOND plugin
     colliding on the same dir is a true plugin-plugin collision and fatal —

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -1,0 +1,412 @@
+"""Phase 6 plugin overlay (core/overlay.py).
+
+Behavioural tests for ``overlay_plugins``: it overlays each active plugin's
+``.agents/`` and ``.<tool>/`` content onto a base ``StagingPlan`` in alphabetical
+plugin order, routing every ``dest_relpath`` collision through the Epic-E merge
+registry, and reusing the tool adapter's namespace rules. Carrier-merge of the
+shared skills/agents DIR-collision path lives here too (Decision B of the epic's
+Plugin Seam Integration Brief).
+
+Each test pins a coded routing/ordering/merge decision, observed on the returned
+plan — never a mock call-count. The merge *strategies* themselves are unit-
+tested in tests/unit/test_{append_rules,json_union,fatal,last_wins}.py; here we
+pin only that the overlay dispatches to them on the right keys.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import pytest
+
+from installer.core.merge.base import CollisionError
+from installer.core.merge.registry import default_registry
+from installer.core.model import (
+    FileKind,
+    Provenance,
+    StagedItem,
+    StagingPlan,
+    Tool,
+)
+from installer.core.overlay import overlay_plugins
+from installer.plugins.generic import GenericPluginAdapter
+from installer.tools.claude import ClaudeAdapter
+from installer.tools.opencode import OpenCodeAdapter
+
+
+@dataclass(frozen=True, slots=True)
+class _Plugin:
+    """Minimal PluginAdapter: a name and an on-disk source tree. Mirrors
+    GenericPluginAdapter's shape without its is_detected probe (the overlay
+    never re-checks detection — the active set is already resolved)."""
+
+    name: str
+    source_path: Path
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002  # inert  # pragma: no cover
+        return True
+
+
+def _empty_plan() -> StagingPlan:
+    return StagingPlan(items={}, tool=Tool.CLAUDE)
+
+
+def _plugin(tmp_path: Path, name: str) -> _Plugin:
+    root = tmp_path / "plugins" / name
+    root.mkdir(parents=True)
+    return _Plugin(name=name, source_path=root)
+
+
+def _write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+
+
+def test_disjoint_plugin_content_is_added_to_the_plan(tmp_path: Path) -> None:
+    """A plugin rule with no base-side collision simply lands in the plan."""
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "rules" / "extra.md", b"plugin rule")
+
+    plan = overlay_plugins(
+        _empty_plan(),
+        [plugin],
+        adapter=ClaudeAdapter(),
+        registry=default_registry(),
+    )
+
+    item = plan.items[Path("rules/extra.md")]
+    assert item.content == b"plugin rule"
+    assert item.provenance == Provenance(kind="plugin", name="test-plugin")
+
+
+def _base_item(
+    dest: str,
+    *,
+    kind: FileKind,
+    namespace: str | None,
+    content: bytes | None,
+    shared_carrier: bool = False,
+) -> StagedItem:
+    """A base-staged (tool-provenance) item to pre-seed a plan with, so an
+    overlaid plugin item collides with it."""
+    return StagedItem(
+        source_path=Path("/base") / dest,
+        dest_relpath=Path(dest),
+        kind=kind,
+        namespace=namespace,
+        provenance=Provenance(kind="tool", name="claude"),
+        content=content,
+        shared_carrier=shared_carrier,
+    )
+
+
+def _seeded_plan(item: StagedItem) -> StagingPlan:
+    return StagingPlan(items={item.dest_relpath: item}, tool=Tool.CLAUDE)
+
+
+def test_plugin_rule_appends_to_base_rule(tmp_path: Path) -> None:
+    """A plugin rules/foo.md colliding with a base rules/foo.md append-merges:
+    the two bodies are joined with the canonical b'\\n---\\n' separator
+    (bead AC #1)."""
+    plan = _seeded_plan(
+        _base_item(
+            "rules/shared.md",
+            kind=FileKind.NAMESPACED_MD,
+            namespace="rules",
+            content=b"base",
+        )
+    )
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "rules" / "shared.md", b"plugin")
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.items[Path("rules/shared.md")].content == b"base\n---\nplugin"
+
+
+def test_plugin_command_same_name_as_base_command_is_fatal(tmp_path: Path) -> None:
+    """A plugin commands/foo.md colliding with a base commands/foo.md is an
+    irreconcilable collision — the registry routes (NAMESPACED_MD, "commands")
+    to the fatal strategy (bead AC #2)."""
+    plan = _seeded_plan(
+        _base_item(
+            "commands/go.md", kind=FileKind.NAMESPACED_MD, namespace="commands", content=b"base"
+        )
+    )
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "commands" / "go.md", b"plugin")
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+
+def test_plugin_settings_deep_union_merges_into_base(tmp_path: Path) -> None:
+    """A plugin settings.json fragment deep-union-merges into the base settings:
+    a base-only key and a plugin-only key both survive (bead AC #3)."""
+    plan = _seeded_plan(
+        _base_item(
+            "settings.json",
+            kind=FileKind.SETTINGS_JSON,
+            namespace=None,
+            content=b'{"base": 1}',
+        )
+    )
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "settings.json.template", b'{"plugin": 2}')
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    merged = json.loads(plan.items[Path("settings.json")].content or b"{}")
+    assert merged == {"base": 1, "plugin": 2}
+
+
+def test_plugin_toml_collision_is_last_wins_with_warning(tmp_path: Path) -> None:
+    """A plugin *.toml colliding with a base *.toml resolves last-wins and warns
+    (the registry routes (TOML, None) to LastWinsWarnStrategy)."""
+    plan = _seeded_plan(
+        _base_item("config.toml", kind=FileKind.TOML, namespace=None, content=b"base=1")
+    )
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "config.toml.template", b"plugin=2")
+
+    with pytest.warns(UserWarning):
+        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.items[Path("config.toml")].content == b"plugin=2"
+
+
+def test_plugins_apply_in_alphabetical_order(tmp_path: Path) -> None:
+    """Two plugins both contribute config.toml; the later (alphabetical) plugin
+    wins the last-wins collision. Passing them in REVERSE order proves the
+    overlay sorts internally rather than honouring caller order (bead AC #4)."""
+    a_plugin = _plugin(tmp_path, "a-plugin")
+    z_plugin = _plugin(tmp_path, "z-plugin")
+    _write(a_plugin.source_path / ".claude" / "config.toml.template", b"who='a'")
+    _write(z_plugin.source_path / ".claude" / "config.toml.template", b"who='z'")
+
+    # Deliberately reversed input order: z first, a second.
+    with pytest.warns(UserWarning):
+        plan = overlay_plugins(
+            _empty_plan(),
+            [z_plugin, a_plugin],
+            adapter=ClaudeAdapter(),
+            registry=default_registry(),
+        )
+
+    # z applied last (alphabetical), so z wins regardless of input order.
+    assert plan.items[Path("config.toml")].content == b"who='z'"
+
+
+def test_overlay_reuses_tool_adapter_namespace_skip(tmp_path: Path) -> None:
+    """The overlay has no namespace routing of its own — it consults the tool
+    adapter's should_install_namespace. OpenCode skips the shared agents/
+    namespace, so a plugin's .agents/agents/ content is dropped while its
+    .agents/skills/ content is kept."""
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".agents" / "agents" / "skipme.md", b"agent")
+    (plugin.source_path / ".agents" / "skills" / "keepme").mkdir(parents=True)
+
+    plan = overlay_plugins(
+        StagingPlan(items={}, tool=Tool.OPENCODE),
+        [plugin],
+        adapter=OpenCodeAdapter(),
+        registry=default_registry(),
+    )
+
+    assert Path("agents/skipme.md") not in plan.items
+    assert Path("skills/keepme") in plan.items
+
+
+@dataclass(frozen=True, slots=True)
+class _CommandsOptOutAdapter:
+    """A tool adapter that opts a TOOL-scope namespace (commands) out. Pins that
+    the overlay gates tool-scope namespaces through should_install_namespace too,
+    not just shared-scope ones — a plugin's .<tool>/commands/ content is dropped
+    when the adapter declines that namespace."""
+
+    name: str = "claude"
+
+    def should_install_namespace(self, namespace: str, source: str) -> bool:
+        return not (namespace == "commands" and source == "tool")
+
+
+def test_overlay_gates_tool_scope_namespaces_via_adapter(tmp_path: Path) -> None:
+    plugin = _plugin(tmp_path, "test-plugin")
+    _write(plugin.source_path / ".claude" / "commands" / "skipme.md", b"cmd")
+    _write(plugin.source_path / ".claude" / "rules" / "keepme.md", b"rule")
+
+    plan = overlay_plugins(
+        _empty_plan(),
+        [plugin],
+        adapter=_CommandsOptOutAdapter(),  # type: ignore[arg-type]  # structural ToolAdapter subset
+        registry=default_registry(),
+    )
+
+    assert Path("commands/skipme.md") not in plan.items
+    assert Path("rules/keepme.md") in plan.items
+
+
+def _carrier_dir_plan(tmp_path: Path, *, files: list[str]) -> StagingPlan:
+    """A plan pre-seeded with a shared_carrier skills/ DIR item whose on-disk
+    source_path holds ``files`` (the carrier-side file set)."""
+    carrier_src = tmp_path / "shared" / "skills" / "demo-skill"
+    carrier_src.mkdir(parents=True)
+    for name in files:
+        (carrier_src / name).write_bytes(b"carrier")
+    item = StagedItem(
+        source_path=carrier_src,
+        dest_relpath=Path("skills/demo-skill"),
+        kind=FileKind.DIR,
+        namespace="skills",
+        provenance=Provenance(kind="tool", name="claude"),
+        content=None,
+        shared_carrier=True,
+    )
+    return _seeded_plan(item)
+
+
+def _plugin_skill_dir(tmp_path: Path, name: str, *, files: list[str]) -> _Plugin:
+    """A plugin whose .agents/skills/demo-skill/ dir holds ``files``."""
+    plugin = _plugin(tmp_path, name)
+    skill_dir = plugin.source_path / ".agents" / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    for fname in files:
+        (skill_dir / fname).write_bytes(b"plugin")
+    return plugin
+
+
+def test_carrier_merge_disjoint_files_succeeds_and_clears_flag(tmp_path: Path) -> None:
+    """A plugin skill dir overlaying a shared_carrier dir with a DISJOINT file
+    set carrier-merges: no fatal error, the carrier item stays, and its
+    shared_carrier flag is cleared (mirrors bash `rm -f sentinel`)."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    merged = plan.items[Path("skills/demo-skill")]
+    assert merged.kind is FileKind.DIR
+    assert merged.shared_carrier is False
+
+
+def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path) -> None:
+    """A plugin skill dir overlaying a shared_carrier dir with an OVERLAPPING
+    file name cannot carrier-merge — it is a real conflict and falls through to
+    the registry's fatal DIR strategy."""
+    plan = _carrier_dir_plan(tmp_path, files=["SKILL.md"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+
+def test_non_carrier_dir_collision_is_fatal_even_when_disjoint(tmp_path: Path) -> None:
+    """A DIR collision on a NON-carrier item is fatal regardless of file-set
+    disjointness — the shared_carrier flag, not the file sets, is what unlocks
+    carrier-merge."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    # Strip the carrier flag: now it is an ordinary DIR item.
+    seeded = plan.items[Path("skills/demo-skill")]
+    plan.items[Path("skills/demo-skill")] = replace(seeded, shared_carrier=False)
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])  # disjoint
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+
+def test_second_plugin_on_merged_carrier_is_fatal(tmp_path: Path) -> None:
+    """After one plugin carrier-merges (clearing the flag), a SECOND plugin
+    colliding on the same dir is a true plugin-plugin collision and fatal —
+    even with a disjoint file set (mirrors bash `rm -f sentinel`)."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    first = _plugin_skill_dir(tmp_path, "a-plugin", files=["SKILL.md"])
+    second = _plugin_skill_dir(tmp_path, "z-plugin", files=["OTHER.md"])  # disjoint from carrier
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(plan, [first, second], adapter=ClaudeAdapter(), registry=default_registry())
+
+
+# ── Against the canonical committed test-plugin fixture ──────────────────────
+
+_SOURCES = Path(__file__).parents[1] / "fixtures" / "sources"
+
+
+def _test_plugin_adapter() -> GenericPluginAdapter:
+    return GenericPluginAdapter(name="test-plugin", source_path=_SOURCES / "test-plugin")
+
+
+def test_fixture_plugin_rule_appends_to_a_colliding_base_rule() -> None:
+    """End-to-end against the committed fixture: its .claude/rules/test-plugin-
+    rule.md append-merges onto a colliding base rule of the same name."""
+    plan = _seeded_plan(
+        _base_item(
+            "rules/test-plugin-rule.md",
+            kind=FileKind.NAMESPACED_MD,
+            namespace="rules",
+            content=b"base body",
+        )
+    )
+
+    overlay_plugins(
+        plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+    )
+
+    merged = plan.items[Path("rules/test-plugin-rule.md")].content
+    assert merged is not None
+    assert merged.startswith(b"base body\n---\n")
+    assert b"test-plugin-rule" in merged
+
+
+def test_fixture_plugin_command_collision_is_fatal() -> None:
+    """The fixture's .claude/commands/test-plugin-command.md is fatal when it
+    collides with a base command of the same name."""
+    plan = _seeded_plan(
+        _base_item(
+            "commands/test-plugin-command.md",
+            kind=FileKind.NAMESPACED_MD,
+            namespace="commands",
+            content=b"base command",
+        )
+    )
+
+    with pytest.raises(CollisionError):
+        overlay_plugins(
+            plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+        )
+
+
+def test_fixture_plugin_settings_union_merges_with_base() -> None:
+    """The fixture's .claude/settings.json.template deep-union-merges with a base
+    settings.json: the base permission survives alongside the plugin's."""
+    plan = _seeded_plan(
+        _base_item(
+            "settings.json",
+            kind=FileKind.SETTINGS_JSON,
+            namespace=None,
+            content=b'{"permissions": {"allow": ["Bash(base:*)"]}}',
+        )
+    )
+
+    overlay_plugins(
+        plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+    )
+
+    merged = json.loads(plan.items[Path("settings.json")].content or b"{}")
+    allow = merged["permissions"]["allow"]
+    assert "Bash(base:*)" in allow
+    assert "Bash(test-plugin:*)" in allow
+
+
+def test_fixture_plugin_skill_overlays_without_collision() -> None:
+    """The fixture's shared-scope .agents/skills/test-plugin-skill/ lands in the
+    plan as a DIR when no base item occupies that destination."""
+    plan = overlay_plugins(
+        _empty_plan(),
+        [_test_plugin_adapter()],
+        adapter=ClaudeAdapter(),
+        registry=default_registry(),
+    )
+
+    assert plan.items[Path("skills/test-plugin-skill")].kind is FileKind.DIR

--- a/packages/installer/tests/unit/test_plugins_registry.py
+++ b/packages/installer/tests/unit/test_plugins_registry.py
@@ -74,6 +74,21 @@ def test_discover_dispatches_to_specialized_class_when_registered(
     assert type(discovered["beads"]) is _FakeSpecialized
 
 
+def test_discover_returns_empty_for_a_missing_plugins_root(tmp_path: Path) -> None:
+    """
+    Given a plugins_root path that does not exist on disk
+    When discover() scans it
+    Then it returns {} rather than raising FileNotFoundError.
+
+    Pins the F.1-deferred decision (resolved in F.2): a missing plugins_root is
+    "no plugins to overlay", not a hard error — `src/plugins/` is optional, and
+    the overlay must tolerate its absence. Resolves the latent unguarded
+    `iterdir()` flagged in the F.1 review.
+    """
+    missing = tmp_path / "does-not-exist"
+    assert discover(missing) == {}
+
+
 def test_unknown_plugin_error_exposes_structured_attributes() -> None:
     """
     When UnknownPluginError("gamma", ("alpha", "beta")) is constructed

--- a/packages/installer/tests/unit/test_staging_shared_carrier.py
+++ b/packages/installer/tests/unit/test_staging_shared_carrier.py
@@ -1,0 +1,67 @@
+"""build_plan Phase 2 marks shared skills/agents DIR items as carrier dirs.
+
+The ``shared_carrier`` flag is the in-memory replacement for the bash
+``.carrier-from-user-shared`` sentinel file (scripts/install.sh:517-529): it
+records that a skills/agents directory was first staged from the shared carrier
+tree, so the Phase 6 plugin overlay can distinguish an allowed carrier-merge
+from a forbidden plugin-plugin directory collision. These tests pin *where*
+Phase 2 sets the flag — only skills/ and agents/ DIR items — not the field's
+default literal (that is the type system's job).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.model import FileKind
+from installer.core.staging import build_plan
+from installer.tools.claude import ClaudeAdapter
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    (shared / "skills" / "shared-skill").mkdir(parents=True)
+    (shared / "agents").mkdir(parents=True)
+    (shared / "agents" / "shared-agent-dir").mkdir()
+    (shared / "agents" / "shared-agent.md").write_bytes(b"agent file")
+    (shared / "rules").mkdir(parents=True)
+    (shared / "rules" / "delegation.md").write_bytes(b"shared rule")
+    (shared / "INSTRUCTIONS.md.template").write_bytes(b"# tmpl")
+    (repo / "src" / "user" / ".claude").mkdir(parents=True)
+    return repo
+
+
+def test_shared_skill_dir_is_marked_carrier(tmp_path: Path) -> None:
+    """A shared skills/ DIR item carries shared_carrier=True so the overlay
+    can carrier-merge a plugin's disjoint additions into it."""
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    item = plan.items[Path("skills/shared-skill")]
+    assert item.kind is FileKind.DIR
+    assert item.shared_carrier is True
+
+
+def test_shared_agent_dir_is_marked_carrier(tmp_path: Path) -> None:
+    """The carrier mark covers agents/ DIR items too, not just skills/."""
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    assert plan.items[Path("agents/shared-agent-dir")].shared_carrier is True
+
+
+def test_shared_non_dir_namespace_item_is_not_carrier(tmp_path: Path) -> None:
+    """A shared rules/*.md file is not a DIR, so it must NOT be marked —
+    carrier-merge applies only to skill/agent directory units."""
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    assert plan.items[Path("rules/delegation.md")].shared_carrier is False
+
+
+def test_shared_agent_md_file_is_not_carrier(tmp_path: Path) -> None:
+    """An agents/*.md file (kind OTHER-of-namespace, not DIR) is not a carrier
+    even though it lives under agents/ — the mark keys on kind==DIR."""
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    assert plan.items[Path("agents/shared-agent.md")].shared_carrier is False
+
+
+def test_shared_template_is_not_carrier(tmp_path: Path) -> None:
+    """A Phase 1 root template is neither skills/ nor agents/, so unmarked."""
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    assert plan.items[Path("INSTRUCTIONS.md")].shared_carrier is False


### PR DESCRIPTION
## Scope

Implements **F.2 — Phase 6 plugin overlay** (`agents-config-w1qls.6.2`), a real-code change under `packages/installer/` (Python, mandatory `make ci-installer` gate). Ports the bash Phase 6 plugin-overlay loop (`scripts/install.sh:813-847`) into the Python installer engine.

After base staging (Phases 1–5, `build_plan`), each **active** plugin's `.agents/` + `.<tool>/` content is overlaid onto that tool's `StagingPlan` in **alphabetical plugin order**, routing every `dest_relpath` collision through the Epic-E merge registry and **reusing the tool adapter's namespace rules** (plugins have no own namespace routing in F.2).

## What changed

- **`core/overlay.py`** (new): `overlay_plugins(plan, plugins, *, adapter, registry)` — the Phase 6 engine. Disjoint plugin content is added; collisions route through `registry.resolve(kind, namespace).merge(...)`.
- **`core/model.py`**: adds `shared_carrier: bool = False` to `StagedItem` (Decision B — on the item, not `Provenance`).
- **`core/staging.py`**: `build_plan` Phase 2 marks shared `skills/`+`agents/` `kind==DIR` items as `shared_carrier=True` (in-memory replacement for the bash `.carrier-from-user-shared` sentinel).
- **`core/orchestrator.py`**: wires Phase 6 between `build_plan` and `post_staging_transforms` (additive `plugins=()` param; no-op when empty, so tool-only callers are unaffected).
- **`plugins/registry.py`**: `discover()` now returns `{}` for a missing `plugins_root` instead of raising `FileNotFoundError` — resolves the F.1-deferred decision (the latent unguarded `iterdir()`). Only the `discover` body is touched; the F.4-owned `_SPECIALIZED` dict is untouched.

### Carrier-merge (Decision B)

An incoming plugin DIR colliding with a `shared_carrier` DIR in `skills/`/`agents/` with **disjoint** on-disk file sets carrier-merges (the carrier item is kept with its flag **cleared** via `dataclasses.replace`); overlapping files, a non-carrier DIR, or a second plugin on an already-merged carrier all fall through to the registry's fatal `(DIR, None)` strategy — mirroring the bash `rm -f sentinel` semantics.

## Tests

Behavioural unit tests drive the engine directly (no mocks). Full collision matrix exercised — including end-to-end against the committed `tests/fixtures/sources/test-plugin/` fixture (append on rules, fatal on commands, json_union on settings, plus skill overlay). Carrier-merge disjoint/overlapping/non-carrier/second-plugin paths all pinned.

- `make ci-installer` green: **296 tests, 99.90% total coverage** (90% branch floor), `ruff check` + `ruff format --check` + `mypy --strict` + `pip-audit` + `install.py --help` all clean.

## Out of scope (intentional — design-forward)

- **Two-source DIR byte materialization for a carrier-merged dir.** F.2 keeps the carrier item (its `source_path` is the shared dir) and validates the disjoint precondition + clears the flag — it does **not** yet represent the plugin's added files for sync. That in-memory two-source representation is **F.3** ("carrier-merge logic via in-memory metadata"). Plan-walking DIR-sync does not exist yet (sync is the B.2 single-file slice), so there is no observable gap today.
- **beads' `~/.beads/` destination + chmod** — **F.4** (parallel worktree; isolated).
- **`dir_overrides` / YAML extension patching** — **F.5**.

Bead: `agents-config-w1qls.6.2` (closed locally on completion). Design-of-record: the epic `agents-config-w1qls.6` *Plugin Seam Integration Brief* and `docs/architecture/installer/installer-design.md` (Epic F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)