### PR TITLE
feat(installer): F.3 — carrier-merge file-carry via dir_overrides (w1qls.6.3)

### DIFF
--- a/packages/installer/src/installer/core/model.py
+++ b/packages/installer/src/installer/core/model.py
@@ -9,7 +9,7 @@ See `docs/specs/2026-05-17-w1qls.1.2-model-design.md` for the rationale
 behind every design decision in this file.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Literal, TypeAlias
@@ -121,10 +121,27 @@ class StagingPlan:
     before assigning and route through the merge registry when the key is
     already present; this dataclass is bare storage, not a collision
     detector. A future helper may absorb the check, but A.2 deliberately
-    holds the engine behaviour out of the data layer."""
+    holds the engine behaviour out of the data layer.
+
+    `dir_overrides` is the side channel for bytes that cannot be expressed
+    through a single-`source_path` DIR `StagedItem`. It is keyed by the DIR
+    item's `dest_relpath`, then by each inner file's relpath (relative to the
+    dir), to that file's bytes. Two producers write here, both targeting an
+    existing DIR item rather than replacing it:
+
+    - the Phase 6 plugin carrier-merge (overlay) records the plugin's disjoint
+      added files, since a DIR item has only one `source_path` and two source
+      dirs land at one destination;
+    - `apply_extensions` (F.5) records YAML-patched file bytes for a skill/agent
+      dir whose opaque DIR item it cannot mutate (`content` stays `None`).
+
+    The future plan-walking DIR-sync emits each carrier DIR's own
+    `source_path` tree first, then overlays `dir_overrides[dest]` on top.
+    Empty by default — the common case stages no override bytes."""
 
     items: dict[Path, StagedItem]
     tool: Tool
+    dir_overrides: dict[Path, dict[Path, bytes]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -154,13 +154,20 @@ def _carry_files(directory: Path) -> dict[Path, bytes]:
     """The plugin DIR's disjoint files, keyed by their relpath under
     ``directory`` to their bytes — the file-carry payload of a carrier-merge.
 
-    Mirrors the bash carrier-merge copy loop (``scripts/install.sh:585-592``):
+    Approximates the bash carrier-merge copy loop (``scripts/install.sh:585-592``):
     ``for sfile in "$src"/*`` iterates the dot-excluded TOP-LEVEL entries, then
-    ``cp -R`` copies a subdir wholesale (its inner dotfiles included). So a
-    top-level dotfile is dropped — matching the same dotfile exclusion the
-    disjoint check applies via ``_visible_names`` — while a dotfile nested under
-    a carried subdir is kept. Keys are relpaths so a nested file lands at
-    ``subdir/file`` under the carrier DIR's destination."""
+    ``cp -R`` descends each subdir. So a top-level dotfile is dropped — matching
+    the same dotfile exclusion the disjoint check applies via ``_visible_names``
+    — while a dotfile nested under a carried subdir is kept. Keys are relpaths so
+    a nested file lands at ``subdir/file`` under the carrier DIR's destination.
+
+    Only files are recorded; ``dir_overrides`` maps relpaths to bytes and so has
+    no representation for a directory entry. A *truly empty* subdir that bash
+    ``cp -R`` would have created is therefore not carried — a deliberate gap, not
+    an oversight: plugin source trees are git-tracked, and git cannot store an
+    empty directory, so an empty subdir cannot reach this function in the first
+    place (an intentional empty dir ships a ``.keep`` placeholder, which IS a
+    file and IS carried)."""
     carried: dict[Path, bytes] = {}
     for entry in sorted(directory.iterdir()):
         if entry.name.startswith("."):

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -108,7 +108,14 @@ def _place(
         # source_path and so cannot itself express a second source tree), then
         # clear the flag so any further plugin collision on this dir is a true
         # plugin-plugin collision (fatal via the registry).
-        plan.dir_overrides[incoming.dest_relpath] = _carry_files(incoming.source_path)
+        #
+        # Merge per inner relpath rather than replacing the dest's whole map:
+        # dir_overrides is shared with the later F.5 patched-bytes producer, so
+        # a contribution it recorded for this dest under a different inner
+        # relpath must survive (last-writer-wins per file, not per directory).
+        plan.dir_overrides.setdefault(incoming.dest_relpath, {}).update(
+            _carry_files(incoming.source_path)
+        )
         plan.items[incoming.dest_relpath] = replace(existing, shared_carrier=False)
         return
     plan.items[incoming.dest_relpath] = registry.resolve(incoming.kind, incoming.namespace).merge(

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -103,9 +103,12 @@ def _place(
         return
     if carrier_eligible and _carrier_merge_allowed(existing, incoming):
         # Mirror bash `rm -f sentinel`: the carrier dir survives with the
-        # plugin's disjoint files conceptually merged in; clearing the flag
-        # makes any further plugin collision on this dir a true plugin-plugin
-        # collision (fatal via the registry).
+        # plugin's disjoint files merged in. Record those added files' bytes in
+        # the dir_overrides side channel (the carrier DIR item has a single
+        # source_path and so cannot itself express a second source tree), then
+        # clear the flag so any further plugin collision on this dir is a true
+        # plugin-plugin collision (fatal via the registry).
+        plan.dir_overrides[incoming.dest_relpath] = _carry_files(incoming.source_path)
         plan.items[incoming.dest_relpath] = replace(existing, shared_carrier=False)
         return
     plan.items[incoming.dest_relpath] = registry.resolve(incoming.kind, incoming.namespace).merge(
@@ -138,3 +141,26 @@ def _visible_names(directory: Path) -> set[str]:
     """The dot-excluded child names of ``directory`` — the entries a bash
     ``"$dir"/*`` glob would iterate (dotfiles are skipped without ``dotglob``)."""
     return {entry.name for entry in directory.iterdir() if not entry.name.startswith(".")}
+
+
+def _carry_files(directory: Path) -> dict[Path, bytes]:
+    """The plugin DIR's disjoint files, keyed by their relpath under
+    ``directory`` to their bytes — the file-carry payload of a carrier-merge.
+
+    Mirrors the bash carrier-merge copy loop (``scripts/install.sh:585-592``):
+    ``for sfile in "$src"/*`` iterates the dot-excluded TOP-LEVEL entries, then
+    ``cp -R`` copies a subdir wholesale (its inner dotfiles included). So a
+    top-level dotfile is dropped — matching the same dotfile exclusion the
+    disjoint check applies via ``_visible_names`` — while a dotfile nested under
+    a carried subdir is kept. Keys are relpaths so a nested file lands at
+    ``subdir/file`` under the carrier DIR's destination."""
+    carried: dict[Path, bytes] = {}
+    for entry in sorted(directory.iterdir()):
+        if entry.name.startswith("."):
+            continue
+        if entry.is_dir():
+            for nested in sorted(p for p in entry.rglob("*") if p.is_file()):
+                carried[nested.relative_to(directory)] = nested.read_bytes()
+        else:
+            carried[Path(entry.name)] = entry.read_bytes()
+    return carried

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -323,6 +323,26 @@ def test_carrier_merge_records_plugin_file_bytes_in_dir_overrides(tmp_path: Path
     assert plan.dir_overrides[dest] == {Path("SKILL.md"): b"plugin"}
 
 
+def test_carrier_merge_preserves_existing_overrides_for_the_same_dest(tmp_path: Path) -> None:
+    """dir_overrides is a shared side channel (carrier-merge now, F.5 patched
+    bytes later). A carrier-merge merges its carried files INTO any existing
+    inner-relpath map for that dest rather than replacing the whole map, so a
+    file a prior producer recorded under a different inner relpath survives —
+    last-writer-wins per inner relpath, not per dest directory."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    dest = Path("skills/demo-skill")
+    # A prior producer (stand-in for F.5) already recorded a file at this dest.
+    plan.dir_overrides[dest] = {Path("PATCHED.md"): b"prior"}
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.dir_overrides[dest] == {
+        Path("PATCHED.md"): b"prior",
+        Path("SKILL.md"): b"plugin",
+    }
+
+
 def test_carrier_merge_carries_every_plugin_file(tmp_path: Path) -> None:
     """A plugin contributing several disjoint files has ALL of them represented
     in dir_overrides, not just the first — the carry iterates the whole added

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -79,6 +79,23 @@ def test_disjoint_plugin_content_is_added_to_the_plan(tmp_path: Path) -> None:
     item = plan.items[Path("rules/extra.md")]
     assert item.content == b"plugin rule"
     assert item.provenance == Provenance(kind="plugin", name="test-plugin")
+    # No carrier-merge happened, so the side channel stays empty.
+    assert plan.dir_overrides == {}
+
+
+def test_skill_dir_overlay_without_collision_records_no_override(tmp_path: Path) -> None:
+    """A plugin skill dir landing on an UNOCCUPIED destination is added as a
+    plain DIR item (its bytes come from source_path at sync); it is not a
+    carrier-merge, so nothing is written to dir_overrides. The channel is only
+    for the second-source-tree case."""
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    plan = overlay_plugins(
+        _empty_plan(), [plugin], adapter=ClaudeAdapter(), registry=default_registry()
+    )
+
+    assert plan.items[Path("skills/demo-skill")].kind is FileKind.DIR
+    assert plan.dir_overrides == {}
 
 
 def _base_item(
@@ -289,6 +306,87 @@ def test_carrier_merge_disjoint_files_succeeds_and_clears_flag(tmp_path: Path) -
     merged = plan.items[Path("skills/demo-skill")]
     assert merged.kind is FileKind.DIR
     assert merged.shared_carrier is False
+
+
+def test_carrier_merge_records_plugin_file_bytes_in_dir_overrides(tmp_path: Path) -> None:
+    """The carrier-merge does not silently drop the plugin's added file: its
+    bytes are recorded in plan.dir_overrides, keyed by the carrier DIR's
+    dest_relpath then the inner file relpath. This is the F.3 file-carry channel
+    that the later plan-walking DIR-sync emits alongside the carrier's own
+    files."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    dest = Path("skills/demo-skill")
+    assert plan.dir_overrides[dest] == {Path("SKILL.md"): b"plugin"}
+
+
+def test_carrier_merge_carries_every_plugin_file(tmp_path: Path) -> None:
+    """A plugin contributing several disjoint files has ALL of them represented
+    in dir_overrides, not just the first — the carry iterates the whole added
+    file set."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", "ref.md", "helper.py"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {
+        Path("SKILL.md"): b"plugin",
+        Path("ref.md"): b"plugin",
+        Path("helper.py"): b"plugin",
+    }
+
+
+def test_carrier_merge_override_holds_only_plugin_files_not_carrier_own(tmp_path: Path) -> None:
+    """The override map holds the PLUGIN's added files only. The carrier's own
+    files (read from its source_path at sync) are not duplicated into the
+    channel — dir_overrides is the second source tree, not the merged whole."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh", "README.md"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    overrides = plan.dir_overrides[Path("skills/demo-skill")]
+    assert overrides == {Path("SKILL.md"): b"plugin"}
+    assert Path("_test.sh") not in overrides
+    assert Path("README.md") not in overrides
+
+
+def test_carrier_merge_does_not_carry_top_level_dotfiles(tmp_path: Path) -> None:
+    """A top-level dotfile in the plugin dir is NOT carried: bash's
+    `for sfile in "$src"/*` skips dot-prefixed entries, so they never reach the
+    copy. This matches the dotfile exclusion the disjoint check already
+    applies — a shared `.gitkeep` does not block the merge AND is not copied."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh", ".gitkeep"])
+    plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", ".gitkeep"])
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("SKILL.md"): b"plugin"}
+
+
+def test_carrier_merge_carries_nested_subdirectory_files(tmp_path: Path) -> None:
+    """A subdirectory in the plugin dir is carried wholesale (bash `cp -R`):
+    each nested file is represented under its relpath (e.g. `lib/util.py`), and
+    a dotfile NESTED under a carried subdir is kept (cp -R copies it) — unlike a
+    top-level dotfile."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin(tmp_path, "test-plugin")
+    skill_dir = plugin.source_path / ".agents" / "skills" / "demo-skill"
+    (skill_dir / "lib").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(b"top")
+    (skill_dir / "lib" / "util.py").write_bytes(b"nested")
+    (skill_dir / "lib" / ".keep").write_bytes(b"dot-nested")
+
+    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {
+        Path("SKILL.md"): b"top",
+        Path("lib/util.py"): b"nested",
+        Path("lib/.keep"): b"dot-nested",
+    }
 
 
 def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path) -> None:


### PR DESCRIPTION
## F.3 — carrier-merge file-carry via `dir_overrides`

Implements story `agents-config-w1qls.6.3`. Completes the plugin carrier-merge
begun in F.2: F.2 validated the merge and cleared the `shared_carrier` flag but
did **not** represent the plugin's added files for sync. This PR adds the channel
that does.

### Stacked PR — retarget after #143
**This PR is stacked on #143** (`feat/w1qls.6.2-plugin-overlay`) and its base is
that branch, so the diff shows only F.3's changes. **After #143 merges, retarget
this PR's base to `main`** (and rebase if needed).

### What changed
- **`core/model.py`** — new `StagingPlan.dir_overrides: dict[Path, dict[Path, bytes]]`
  (`field(default_factory=dict)`; `StagingPlan` stays `@dataclass(slots=True)`).
  Keyed by the DIR item's `dest_relpath`, then by each inner file's relpath, to
  that file's bytes. Docstring documents both producers (carrier-merge now; F.5
  patched bytes later).
- **`core/overlay.py`** — on a successful carrier-merge, `_place` records the
  plugin DIR's disjoint files into `plan.dir_overrides[dest]` via the new
  `_carry_files` helper, then keeps the carrier item with the flag cleared (F.2
  behaviour unchanged). `_carry_files` mirrors the bash copy loop
  (`scripts/install.sh:585-592`): top-level dotfiles dropped (same exclusion as
  the disjoint check), subdirs carried wholesale (`cp -R` parity, including their
  nested dotfiles), keys are relpaths so a nested file lands at `subdir/file`.
- **`tests/unit/test_overlay.py`** — strengthened the carrier test to assert the
  plugin file's bytes are REPRESENTED in `dir_overrides`, plus edge cases:
  multiple plugin files, plugin-only payload (carrier's own files not duplicated),
  top-level-dotfile exclusion, nested-subdir carry, and the negative cases (plain
  disjoint add and no-collision skill overlay record nothing).

### Boundary — plan-level only
`core/sync.py` is still the single-file B.2 slice; the plan-walking DIR-sync that
would emit both the carrier's own tree and `dir_overrides[dest]` does **not**
exist yet and is **not** built here. Correctness is proven at the **plan layer**
(the override map is populated with the right bytes/keys). **Deployment proof is
deferred** to the future DIR-sync story.

### F.5 reuse note
`dir_overrides` is one primitive, two consumers. F.5's `apply_extensions` will
write YAML-patched bytes into this **same** channel for opaque skill/agent DIR
items (`StagedItem.content` stays `None`). The map is keyed by `dest_relpath` →
inner relpath; F.5 should write patched files under the same inner-relpath key
the carrier-merge uses (and be aware both producers may target the same `dest` —
last writer wins on a given inner relpath, which the future DIR-sync resolves by
overlaying `dir_overrides` on top of the source tree).

### Verification
`make ci-installer` green from the repo root: ruff lint + format, `mypy --strict`,
304 tests, **99.90%** coverage (≥90% floor), `pip-audit` clean, entry-verify pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
