### PR TITLE
refactor(installer): consolidate path-traversal relpath guard into is_safe_relpath (ujhdj)

### DIFF
--- a/packages/installer/src/installer/core/paths.py
+++ b/packages/installer/src/installer/core/paths.py
@@ -1,0 +1,24 @@
+"""Shared path-safety helpers.
+
+A single home for the relpath-traversal invariant that several stages rely on
+before joining a caller-supplied path under a trusted base directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_safe_relpath(path: Path) -> bool:
+    """True when ``path`` is safe to join under a trusted base directory.
+
+    Safe means relative *and* free of any ``..`` component: ``base / path``
+    then cannot resolve outside ``base``. Absolute paths (which discard
+    ``base`` entirely) and paths containing a parent-directory component are
+    unsafe. The check is on path *components* (``path.parts``), so a filename
+    that merely contains ``..`` as a substring (e.g. ``foo..bar.md``) is safe.
+
+    Callers keep their own contextual error when this returns ``False`` — the
+    predicate centralises the invariant, not the failure mode.
+    """
+    return not path.is_absolute() and ".." not in path.parts

--- a/packages/installer/src/installer/core/paths.py
+++ b/packages/installer/src/installer/core/paths.py
@@ -12,11 +12,13 @@ from pathlib import Path
 def is_safe_relpath(path: Path) -> bool:
     """True when ``path`` is safe to join under a trusted base directory.
 
-    Safe means relative *and* free of any ``..`` component: ``base / path``
-    then cannot resolve outside ``base``. Absolute paths (which discard
-    ``base`` entirely) and paths containing a parent-directory component are
-    unsafe. The check is on path *components* (``path.parts``), so a filename
-    that merely contains ``..`` as a substring (e.g. ``foo..bar.md``) is safe.
+    Safe means relative *and* free of any ``..`` component, so ``base / path``
+    cannot climb out of ``base`` *lexically*. Absolute paths (which discard
+    ``base`` entirely) and paths with a parent-directory component are unsafe.
+    This is a lexical check on path *components* (``path.parts``); it does not
+    resolve symlinks, so it does not guarantee containment of the *resolved*
+    path. A filename that merely contains ``..`` as a substring (e.g.
+    ``foo..bar.md``) is safe.
 
     Callers keep their own contextual error when this returns ``False`` — the
     predicate centralises the invariant, not the failure mode.

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from installer.core.model import Counters
+from installer.core.paths import is_safe_relpath
 
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
@@ -41,7 +42,7 @@ def sync(
     would-be write through ``io`` and touches nothing. Returns a
     `Counters` with exactly one of created / updated / skipped incremented.
     """
-    if relpath.is_absolute() or ".." in relpath.parts:
+    if not is_safe_relpath(relpath):
         raise ValueError(f"relpath escapes the adapter tree: {relpath}")  # noqa: TRY003  # single call-site; subclass not justified
 
     counters = Counters()

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -125,8 +125,8 @@ def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
     is non-fatal — it warns and resolves to the empty string.
 
     Raises ``ValueError`` for absolute paths or paths containing ``..`` —
-    either would let ``base_dir / rel`` resolve outside ``base_dir`` (the
-    shared ``is_safe_relpath`` guard).
+    either would let ``base_dir / rel`` escape ``base_dir`` (rejected by the
+    shared lexical ``is_safe_relpath`` guard, which does not resolve symlinks).
     """
     if not is_safe_relpath(rel):
         raise ValueError(f"DYNAMIC-INCLUDE path escapes base_dir: {rel}")  # noqa: TRY003  # single call-site; subclass not justified

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, assert_never
 
 from installer.core.model import AllRulesInclude, FileInclude, IncludeDirective
+from installer.core.paths import is_safe_relpath
 
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
@@ -124,10 +125,10 @@ def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
     is non-fatal — it warns and resolves to the empty string.
 
     Raises ``ValueError`` for absolute paths or paths containing ``..`` —
-    either would let ``base_dir / rel`` resolve outside ``base_dir``. Mirrors
-    the traversal guard in ``sync.py``.
+    either would let ``base_dir / rel`` resolve outside ``base_dir`` (the
+    shared ``is_safe_relpath`` guard).
     """
-    if rel.is_absolute() or ".." in rel.parts:
+    if not is_safe_relpath(rel):
         raise ValueError(f"DYNAMIC-INCLUDE path escapes base_dir: {rel}")  # noqa: TRY003  # single call-site; subclass not justified
     target = base_dir / rel
     if not target.is_file():

--- a/packages/installer/src/installer/plugins/extensions.py
+++ b/packages/installer/src/installer/plugins/extensions.py
@@ -35,6 +35,7 @@ import yaml
 
 from installer.core.md_patch import PatchError, Precision, apply_patch
 from installer.core.model import FileKind
+from installer.core.paths import is_safe_relpath
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -120,7 +121,7 @@ def _load_extension(yaml_path: Path) -> _Extension:
             "replace, insert_before, insert_after, prepend, append",
         ) from None
     target_file = Path(fields["target-file"])
-    if target_file.is_absolute() or ".." in target_file.parts:
+    if not is_safe_relpath(target_file):
         raise ExtensionError(
             yaml_path,
             "target-file must be a relative path inside the install root",

--- a/packages/installer/tests/unit/test_paths.py
+++ b/packages/installer/tests/unit/test_paths.py
@@ -23,7 +23,7 @@ from installer.core.paths import is_safe_relpath
 )
 def test_plain_relative_path_is_safe(rel: Path) -> None:
     """A relative path with no parent-dir component joins safely under a base."""
-    assert is_safe_relpath(rel) is True
+    assert is_safe_relpath(rel)
 
 
 @pytest.mark.parametrize(
@@ -35,7 +35,7 @@ def test_plain_relative_path_is_safe(rel: Path) -> None:
 )
 def test_absolute_path_is_unsafe(abs: Path) -> None:
     """An absolute path discards the base on join, so it can never be safe."""
-    assert is_safe_relpath(abs) is False
+    assert not is_safe_relpath(abs)
 
 
 @pytest.mark.parametrize(
@@ -48,7 +48,7 @@ def test_absolute_path_is_unsafe(abs: Path) -> None:
 )
 def test_parent_dir_component_is_unsafe(rel: Path) -> None:
     """Any ``..`` component lets the join climb out of the base — unsafe."""
-    assert is_safe_relpath(rel) is False
+    assert not is_safe_relpath(rel)
 
 
 def test_dotdot_substring_in_filename_is_safe() -> None:
@@ -58,4 +58,4 @@ def test_dotdot_substring_in_filename_is_safe() -> None:
     Pins the membership check against a naive ``".." in str(path)`` rewrite,
     which would wrongly reject this path.
     """
-    assert is_safe_relpath(Path("foo..bar.md")) is True
+    assert is_safe_relpath(Path("foo..bar.md"))

--- a/packages/installer/tests/unit/test_paths.py
+++ b/packages/installer/tests/unit/test_paths.py
@@ -1,4 +1,4 @@
-"""Shared path-safety helper (core/paths.py).
+"""Unit tests for installer.core.paths — the shared path-safety helper.
 
 Behavioural tests for ``is_safe_relpath`` — the single relpath-traversal guard
 consolidated from sync.py, templates.py, and extensions.py. Each test pins one

--- a/packages/installer/tests/unit/test_paths.py
+++ b/packages/installer/tests/unit/test_paths.py
@@ -1,0 +1,61 @@
+"""Shared path-safety helper (core/paths.py).
+
+Behavioural tests for ``is_safe_relpath`` — the single relpath-traversal guard
+consolidated from sync.py, templates.py, and extensions.py. Each test pins one
+safe/unsafe decision; none assert on internals.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.paths import is_safe_relpath
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        Path("file.md"),
+        Path("docs/plans/file.md"),
+    ],
+)
+def test_plain_relative_path_is_safe(rel: Path) -> None:
+    """A relative path with no parent-dir component joins safely under a base."""
+    assert is_safe_relpath(rel) is True
+
+
+@pytest.mark.parametrize(
+    "abs",
+    [
+        Path("/etc/passwd"),
+        Path("/"),
+    ],
+)
+def test_absolute_path_is_unsafe(abs: Path) -> None:
+    """An absolute path discards the base on join, so it can never be safe."""
+    assert is_safe_relpath(abs) is False
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        Path("../escape.md"),  # leading
+        Path("a/../b.md"),  # mid-path — position must not matter
+        Path("a/.."),  # trailing
+    ],
+)
+def test_parent_dir_component_is_unsafe(rel: Path) -> None:
+    """Any ``..`` component lets the join climb out of the base — unsafe."""
+    assert is_safe_relpath(rel) is False
+
+
+def test_dotdot_substring_in_filename_is_safe() -> None:
+    """``..`` inside a single filename is not a parent-dir component: the guard
+    checks ``path.parts``, not the string, so ``foo..bar.md`` stays safe.
+
+    Pins the membership check against a naive ``".." in str(path)`` rewrite,
+    which would wrongly reject this path.
+    """
+    assert is_safe_relpath(Path("foo..bar.md")) is True


### PR DESCRIPTION
## Summary

The relpath-safety invariant `path.is_absolute() or \"..\" in path.parts` was **triplicated** across `core/sync.py`, `core/templates.py`, and `plugins/extensions.py` (F.5 added the third). This extracts a single shared predicate `core.paths.is_safe_relpath(path) -> bool` and routes all three call sites through it.

- **Behavior-preserving.** The helper `return not path.is_absolute() and \"..\" not in path.parts` is the exact De Morgan negation of the three inline guards. Each call site keeps its **own** error wrap — two distinct `ValueError` messages and an `ExtensionError(yaml_path, ..., target_file=...)`. A predicate (not an assert-style raiser) was chosen precisely so each site retains its contextual error.
- A security-relevant guard now has exactly one definition.

## Scope / artifact type

Pure refactor in the `packages/installer/` Python package (real code, gated). No behavior change, no API change, no new dependency. Surfaced by the F.5 simplify reuse review; deferred then to avoid scope creep into untouched modules.

## Out of scope (intentionally)

`is_safe_relpath` is a **lexical** guard — it rejects `..` and absolute paths but does not resolve symlinks, identical to the three inline guards it replaces. Symlink-resolution containment is a separate hardening task, not a regression here.

## Test plan

- [x] New `tests/unit/test_paths.py` — 8 behavioral cases: safe relative paths, absolute rejection, `..` at leading/mid/trailing position, and the `.parts`-vs-substring discriminator (`foo..bar.md` stays safe).
- [x] Existing call-site rejection tests in `test_sync.py` / `test_templates.py` / `test_extensions.py` still pass through the new helper.
- [x] `make ci-installer` green: ruff lint+format, mypy --strict, **380 passed**, **99.77%** branch coverage, pip-audit clean, entry-verify ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)