### PR TITLE
feat(installer): G.1 path-aware backup placement in core/sync.py

### DIFF
--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -1,15 +1,21 @@
-"""Minimal single-file sync engine (B.2).
+"""Minimal single-file sync engine (B.2 + G.1 backup).
 
 Copies one source file to one destination, resolving both ends through a
 `ToolAdapter`. The smallest slice of the eventual Phase-7 sync described in
 `docs/specs/2026-05-17-python-installer-rewrite.md`: later stories grow it
-to walk a `StagingPlan`, route conflicts through the merge registry, and
-place path-aware backups.
+to walk a `StagingPlan` and route conflicts through the merge registry.
+
+Path-aware backup (G.1) ports the bash installer's ``backup()``
+(`scripts/install.sh:352-388`): before overwriting an existing
+destination, the original is copied to a timestamped backup so a failed
+write leaves it recoverable.
 """
 
 from __future__ import annotations
 
 import hashlib
+import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +26,15 @@ if TYPE_CHECKING:
     from installer.core.io_port import IOPort
     from installer.tools.base import ToolAdapter
 
+# Namespaces whose backups route to a sibling ``<namespace>-backup/`` dir
+# rather than an in-place suffix. Mirrors the bash ``backup()`` case list
+# (`scripts/install.sh:369-379`).
+_SCOPED_NAMESPACES = frozenset({"commands", "skills", "agents", "rules", "formulas"})
+
+# Backup timestamp format, matching ``date +%Y%m%d-%H%M%S`` in
+# `scripts/install.sh:365`.
+_TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
+
 
 def sync(
     adapter: ToolAdapter,
@@ -29,6 +44,7 @@ def sync(
     home: Path,
     io: IOPort,
     dry_run: bool = False,
+    timestamp: str | None = None,
 ) -> Counters:
     """Install one file from the adapter's source tree to its dest tree.
 
@@ -39,8 +55,17 @@ def sync(
     the destination
     already holds matching bytes (sha-256); otherwise writes the source
     bytes — unless ``dry_run`` is set, in which case it previews the
-    would-be write through ``io`` and touches nothing. Returns a
-    `Counters` with exactly one of created / updated / skipped incremented.
+    would-be write through ``io`` and touches nothing.
+
+    When overwriting an existing destination (dest present, bytes differ,
+    not ``dry_run``), the original is backed up *before* the write so a
+    failed write leaves it recoverable (G.1). ``timestamp`` is the
+    backup's ``YYYYMMDD-HHMMSS`` suffix; injected so tests assert exact
+    backup names, it defaults to the current local time at the call
+    boundary.
+
+    Returns a `Counters` with exactly one of created / updated / skipped
+    incremented, plus ``backed_up`` when an overwrite was preserved.
     """
     if not is_safe_relpath(relpath):
         raise ValueError(f"relpath escapes the adapter tree: {relpath}")  # noqa: TRY003  # single call-site; subclass not justified
@@ -60,6 +85,10 @@ def sync(
         verb = "update" if dest_exists else "create"
         io.info(f"would {verb} {dest}")
     else:
+        if dest_exists:
+            ts = timestamp if timestamp is not None else _now_timestamp()
+            _backup(dest, ts)
+            counters.backed_up += 1
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(content)
 
@@ -68,6 +97,31 @@ def sync(
     else:
         counters.created += 1
     return counters
+
+
+def _backup(dest: Path, timestamp: str) -> None:
+    """Copy ``dest`` to a timestamped backup before it is overwritten.
+
+    Ports the routing decision in the bash ``backup()``
+    (`scripts/install.sh:360-388`): a destination whose immediate parent
+    is a scoped namespace is copied to a sibling ``<namespace>-backup/``
+    directory; any other destination gets an in-place
+    ``<name>.backup-<ts>`` sibling. Either way the original bytes are
+    written before the caller overwrites ``dest``.
+    """
+    parent = dest.parent
+    if parent.name in _SCOPED_NAMESPACES:
+        backup_dir = parent.parent / f"{parent.name}-backup"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / f"{dest.name}.backup-{timestamp}"
+    else:
+        backup_path = dest.with_name(f"{dest.name}.backup-{timestamp}")
+    shutil.copy2(dest, backup_path)
+
+
+def _now_timestamp() -> str:
+    # Local wall-clock time, matching bash ``date +%Y%m%d-%H%M%S`` (local TZ).
+    return datetime.now().astimezone().strftime(_TIMESTAMP_FORMAT)
 
 
 def _sha256(data: bytes) -> bytes:

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -14,6 +14,7 @@ write leaves it recoverable.
 from __future__ import annotations
 
 import hashlib
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -34,6 +35,13 @@ _SCOPED_NAMESPACES = frozenset({"commands", "skills", "agents", "rules", "formul
 # Backup timestamp format, matching ``date +%Y%m%d-%H%M%S`` in
 # `scripts/install.sh:365`.
 _TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
+
+# A caller-supplied ``timestamp`` is interpolated raw into the backup
+# filename (`_backup`), so it must match the documented ``YYYYMMDD-HHMMSS``
+# contract exactly — otherwise a value carrying path separators (``../``)
+# would split into Path components and write the backup outside the
+# intended ``<namespace>-backup/`` directory.
+_TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
 
 
 def sync(
@@ -62,7 +70,10 @@ def sync(
     failed write leaves it recoverable (G.1). ``timestamp`` is the
     backup's ``YYYYMMDD-HHMMSS`` suffix; injected so tests assert exact
     backup names, it defaults to the current local time at the call
-    boundary.
+    boundary. A caller-supplied ``timestamp`` that does not match that
+    format is rejected with `ValueError` before any backup is written —
+    it is interpolated raw into the backup path, so an unvalidated value
+    carrying ``..``/path separators would escape the backup directory.
 
     Returns a `Counters` with exactly one of created / updated / skipped
     incremented, plus ``backed_up`` when an overwrite was preserved.
@@ -87,6 +98,8 @@ def sync(
     else:
         if dest_exists:
             ts = timestamp if timestamp is not None else _now_timestamp()
+            if not _TIMESTAMP_RE.match(ts):
+                raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {ts!r}")  # noqa: TRY003  # single call-site; subclass not justified
             _backup(dest, ts)
             counters.backed_up += 1
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -364,3 +364,283 @@ def test_write_to_read_only_destination_surfaces_permission_error(tmp_path: Path
             home=dest_root,
             io=ScriptedIO(),
         )
+
+
+# ─────────────────────── G.1: path-aware backup ───────────────────────
+#
+# These tests pin the path-aware backup contract ported from the bash
+# installer's backup() (scripts/install.sh:352-388): an existing
+# destination that is about to be overwritten is copied to a timestamped
+# backup BEFORE the write. The routing decision is coded — a scoped
+# namespace dir routes to a sibling <ns>-backup/, everything else gets an
+# in-place .backup-<ts> suffix — so each test pins that decision, not
+# Path/shutil semantics.
+
+_FIXED_TS = "20260613-120000"
+
+
+@pytest.mark.parametrize("namespace", ["commands", "skills", "agents", "rules", "formulas"])
+def test_overwrite_in_scoped_namespace_backs_up_to_sibling_dir(
+    tmp_path: Path, namespace: str
+) -> None:
+    """
+    Given an existing destination inside a scoped namespace dir whose
+    bytes differ from the source
+    When sync overwrites it
+    Then the original bytes are copied to a sibling ``<namespace>-backup/``
+    directory under a ``<name>.backup-<ts>`` filename — the coded routing
+    decision for the five prune-managed namespaces.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / namespace).mkdir(parents=True)
+    (dest_root / namespace).mkdir(parents=True)
+    (src_root / namespace / "f.md").write_bytes(b"new\n")
+    (dest_root / namespace / "f.md").write_bytes(b"old\n")
+
+    sync(
+        _IdentityAdapter(),
+        Path(namespace) / "f.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    backup = dest_root / f"{namespace}-backup" / f"f.md.backup-{_FIXED_TS}"
+    assert backup.read_bytes() == b"old\n"
+    assert (dest_root / namespace / "f.md").read_bytes() == b"new\n"
+
+
+def test_overwrite_outside_namespace_backs_up_in_place(tmp_path: Path) -> None:
+    """
+    Given an existing destination NOT inside a scoped namespace dir whose
+    bytes differ from the source
+    When sync overwrites it
+    Then the original bytes are copied alongside the file under a
+    ``<name>.backup-<ts>`` suffix — the coded fallback routing decision.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "AGENTS.md").write_bytes(b"new\n")
+    (dest_root / "AGENTS.md").write_bytes(b"old\n")
+
+    sync(
+        _IdentityAdapter(),
+        Path("AGENTS.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    backup = dest_root / f"AGENTS.md.backup-{_FIXED_TS}"
+    assert backup.read_bytes() == b"old\n"
+    assert (dest_root / "AGENTS.md").read_bytes() == b"new\n"
+
+
+def test_namespace_routing_keys_on_parent_dir_not_path_depth(tmp_path: Path) -> None:
+    """
+    Given a destination whose immediate parent is a scoped namespace dir
+    nested deeper than one level (``commands/sub/f.md``)
+    When sync overwrites it
+    Then routing keys on the immediate parent's name — backup lands in a
+    sibling ``commands-backup/`` beside the ``commands`` dir, mirroring the
+    bash ``basename "$(dirname "$target")"`` decision, not the file's depth.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "commands").mkdir(parents=True)
+    (dest_root / "commands").mkdir(parents=True)
+    (src_root / "commands" / "f.md").write_bytes(b"new\n")
+    (dest_root / "commands" / "f.md").write_bytes(b"old\n")
+
+    sync(
+        _IdentityAdapter(),
+        Path("commands") / "f.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    assert (dest_root / "commands-backup" / f"f.md.backup-{_FIXED_TS}").read_bytes() == b"old\n"
+
+
+def test_namespace_name_as_grandparent_routes_in_place(tmp_path: Path) -> None:
+    """
+    Given a nested file whose immediate parent is NOT a scoped namespace
+    but whose grandparent IS (``skills/foo/SKILL.md`` — the real nested-skill
+    case)
+    When sync overwrites it
+    Then routing falls through to the in-place ``.backup-<ts>`` suffix
+    beside the file — the namespace check keys on the immediate parent
+    (``foo``), not any ancestor, so neither ``foo-backup/`` nor
+    ``skills-backup/`` is created.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "skills" / "foo").mkdir(parents=True)
+    (dest_root / "skills" / "foo").mkdir(parents=True)
+    (src_root / "skills" / "foo" / "SKILL.md").write_bytes(b"new\n")
+    (dest_root / "skills" / "foo" / "SKILL.md").write_bytes(b"old\n")
+
+    sync(
+        _IdentityAdapter(),
+        Path("skills") / "foo" / "SKILL.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    in_place = dest_root / "skills" / "foo" / f"SKILL.md.backup-{_FIXED_TS}"
+    assert in_place.read_bytes() == b"old\n"
+    assert not (dest_root / "skills" / "foo-backup").exists()
+    assert not (dest_root / "skills-backup").exists()
+
+
+def test_overwrite_increments_backed_up_counter(tmp_path: Path) -> None:
+    """
+    Given an existing destination that is overwritten
+    When sync runs
+    Then exactly one backup is counted in the returned summary alongside
+    the update.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()
+    (src_root / "AGENTS.md").write_bytes(b"new\n")
+    (dest_root / "AGENTS.md").write_bytes(b"old\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("AGENTS.md"),
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    assert counters.backed_up == 1
+    assert counters.updated == 1
+
+
+def test_new_file_is_not_backed_up(tmp_path: Path) -> None:
+    """
+    Given a destination that does not yet exist
+    When sync creates it
+    Then no backup file or backup dir is written and nothing is counted as
+    backed up — there was no original to preserve.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "commands").mkdir(parents=True)
+    (src_root / "commands" / "f.md").write_bytes(b"hello\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("commands") / "f.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    assert counters.backed_up == 0
+    assert not (dest_root / "commands-backup").exists()
+
+
+def test_identical_destination_is_not_backed_up(tmp_path: Path) -> None:
+    """
+    Given a destination whose bytes already match the source (a skip)
+    When sync runs
+    Then no backup is taken — backup is coupled to the overwrite branch,
+    not to mere destination existence.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "rules").mkdir(parents=True)
+    (dest_root / "rules").mkdir(parents=True)
+    (src_root / "rules" / "f.md").write_bytes(b"same\n")
+    (dest_root / "rules" / "f.md").write_bytes(b"same\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("rules") / "f.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        timestamp=_FIXED_TS,
+    )
+
+    assert counters.backed_up == 0
+    assert not (dest_root / "rules-backup").exists()
+
+
+def test_dry_run_overwrite_writes_no_backup(tmp_path: Path) -> None:
+    """
+    Given --dry-run and an existing destination that would be overwritten
+    When sync runs
+    Then no backup is written to disk and none is counted — dry-run touches
+    nothing, including backups.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "rules").mkdir(parents=True)
+    (dest_root / "rules").mkdir(parents=True)
+    (src_root / "rules" / "f.md").write_bytes(b"new\n")
+    (dest_root / "rules" / "f.md").write_bytes(b"old\n")
+
+    counters = sync(
+        _IdentityAdapter(),
+        Path("rules") / "f.md",
+        repo_root=src_root,
+        home=dest_root,
+        io=ScriptedIO(),
+        dry_run=True,
+        timestamp=_FIXED_TS,
+    )
+
+    assert counters.backed_up == 0
+    assert not (dest_root / "rules-backup").exists()
+    assert (dest_root / "rules" / "f.md").read_bytes() == b"old\n"
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="root bypasses the 0o444 mode bit, so the write would succeed",
+)
+def test_backup_survives_a_failed_write(tmp_path: Path) -> None:
+    """
+    Given a read-only existing destination whose bytes differ (the write
+    will raise PermissionError)
+    When sync runs
+    Then the timestamped backup of the original bytes already exists on
+    disk — proving the backup is taken BEFORE the write, so a failed write
+    leaves the original recoverable.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "rules").mkdir(parents=True)
+    (dest_root / "rules").mkdir(parents=True)
+    (src_root / "rules" / "f.md").write_bytes(b"new\n")
+    dest = dest_root / "rules" / "f.md"
+    dest.write_bytes(b"old\n")
+    dest.chmod(0o444)
+
+    with pytest.raises(PermissionError):
+        sync(
+            _IdentityAdapter(),
+            Path("rules") / "f.md",
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+            timestamp=_FIXED_TS,
+        )
+
+    backup = dest_root / "rules-backup" / f"f.md.backup-{_FIXED_TS}"
+    assert backup.read_bytes() == b"old\n"

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -444,29 +444,32 @@ def test_overwrite_outside_namespace_backs_up_in_place(tmp_path: Path) -> None:
 def test_namespace_routing_keys_on_parent_dir_not_path_depth(tmp_path: Path) -> None:
     """
     Given a destination whose immediate parent is a scoped namespace dir
-    nested deeper than one level (``commands/sub/f.md``)
+    that is itself nested below the root (``tool_dir/commands/f.md``)
     When sync overwrites it
-    Then routing keys on the immediate parent's name — backup lands in a
-    sibling ``commands-backup/`` beside the ``commands`` dir, mirroring the
-    bash ``basename "$(dirname "$target")"`` decision, not the file's depth.
+    Then routing keys on the immediate parent's name regardless of how deep
+    the namespace sits — backup lands in a sibling ``commands-backup/``
+    beside the nested ``commands`` dir, mirroring the bash
+    ``basename "$(dirname "$target")"`` decision, not the file's depth.
     """
     src_root = tmp_path / "repo"
     dest_root = tmp_path / "home"
-    (src_root / "commands").mkdir(parents=True)
-    (dest_root / "commands").mkdir(parents=True)
-    (src_root / "commands" / "f.md").write_bytes(b"new\n")
-    (dest_root / "commands" / "f.md").write_bytes(b"old\n")
+    rel = Path("tool_dir") / "commands" / "f.md"
+    (src_root / "tool_dir" / "commands").mkdir(parents=True)
+    (dest_root / "tool_dir" / "commands").mkdir(parents=True)
+    (src_root / rel).write_bytes(b"new\n")
+    (dest_root / rel).write_bytes(b"old\n")
 
     sync(
         _IdentityAdapter(),
-        Path("commands") / "f.md",
+        rel,
         repo_root=src_root,
         home=dest_root,
         io=ScriptedIO(),
         timestamp=_FIXED_TS,
     )
 
-    assert (dest_root / "commands-backup" / f"f.md.backup-{_FIXED_TS}").read_bytes() == b"old\n"
+    backup = dest_root / "tool_dir" / "commands-backup" / f"f.md.backup-{_FIXED_TS}"
+    assert backup.read_bytes() == b"old\n"
 
 
 def test_namespace_name_as_grandparent_routes_in_place(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -613,6 +613,48 @@ def test_dry_run_overwrite_writes_no_backup(tmp_path: Path) -> None:
     assert (dest_root / "rules" / "f.md").read_bytes() == b"old\n"
 
 
+@pytest.mark.parametrize(
+    "bad_ts",
+    [
+        "../../evil",  # path separators — would escape <ns>-backup/
+        "2026-06-13",  # wrong shape, no separators, but not %Y%m%d-%H%M%S
+    ],
+)
+def test_malformed_timestamp_is_rejected_before_any_write(tmp_path: Path, bad_ts: str) -> None:
+    """
+    Given an existing destination that would be overwritten and a
+    caller-supplied ``timestamp`` that does not match the documented
+    ``YYYYMMDD-HHMMSS`` contract
+    When sync runs
+    Then a ValueError surfaces BEFORE any filesystem mutation: no backup
+    file or backup dir is created, and the destination keeps its original
+    bytes. Pins the coded guard that blocks a path-traversal timestamp
+    (e.g. ``../../evil``) from escaping the backup directory.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    (src_root / "rules").mkdir(parents=True)
+    (dest_root / "rules").mkdir(parents=True)
+    (src_root / "rules" / "f.md").write_bytes(b"new\n")
+    (dest_root / "rules" / "f.md").write_bytes(b"old\n")
+
+    with pytest.raises(ValueError):
+        sync(
+            _IdentityAdapter(),
+            Path("rules") / "f.md",
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+            timestamp=bad_ts,
+        )
+
+    # Guard fires before _backup writes anything: destination untouched and
+    # no backup landed anywhere under the dest root.
+    assert (dest_root / "rules" / "f.md").read_bytes() == b"old\n"
+    assert not (dest_root / "rules-backup").exists()
+    assert not any(dest_root.rglob("*.backup-*"))
+
+
 @pytest.mark.skipif(
     os.geteuid() == 0,
     reason="root bypasses the 0o444 mode bit, so the write would succeed",


### PR DESCRIPTION
## What G.1 does

Adds path-aware backup to the single-file sync engine. When `sync()` is about to **overwrite** an existing destination (dest present, sha-256 differs, not `dry_run`), it copies the original to a timestamped backup **before** the write — so a failed write leaves the original recoverable.

Routing decision (ported faithfully from bash):
- Dest whose **immediate parent** is a scoped namespace (`commands`, `skills`, `agents`, `rules`, `formulas`) → sibling `<namespace>-backup/<name>.backup-<ts>`.
- Any other dest → in-place `<name>.backup-<ts>` suffix beside the file.
- Timestamp `YYYYMMDD-HHMMSS`, **injectable** via a `timestamp: str | None = None` kwarg defaulted to local wall-clock time at the call boundary (keeps `sync()` deterministic under test; pure-core friendly).

## `install.sh` line ranges ported

Behavioral spec: the bash `backup()` function.
- **`scripts/install.sh:352-388`** — the whole `backup()` function (the port target).
- **:365** — `timestamp="$(date +%Y%m%d-%H%M%S)"` → `_TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"`.
- **:366** — `parent="$(basename "$(dirname "$target")")"` → routing keys on `dest.parent.name` (immediate parent, not depth).
- **:369-379** — the `commands|skills|agents|rules|formulas)` case + `*)` fallback → `_SCOPED_NAMESPACES` membership vs. in-place suffix.
- **:372-373** — `backup_dir="$grandparent/${parent}-backup"` / `backup_path="$backup_dir/${base}.backup-${timestamp}"` → sibling-dir construction.
- **:377** — `backup_path="${target}.backup-${timestamp}"` → in-place fallback.
- **:381-385** — `cp`/`cp -R` copy → `shutil.copy2` (file case; dir backup is out of scope for the single-file B.2 sync).

Intentional divergence: `shutil.copy2` preserves the source mode bits where bash plain `cp` does not — a more faithful backup artifact, observably identical to consumers (nothing inspects backup permissions). Flagged for the future golden-master parity suite so it isn't misread as a regression.

## Acceptance criteria

- [x] Files inside `commands`/`skills`/`agents`/`rules`/`formulas` back up to sibling `<ns>-backup/` dir with timestamp.
- [x] Other files get in-place `.backup-<ts>` suffix.
- [x] Backup created **before** write, recoverable on failed write (proven by `test_backup_survives_a_failed_write` via a real `PermissionError`).
- [x] Timestamp matches `install.sh` format `YYYYMMDD-HHMMSS`.
- [x] `dry_run` → no backup; brand-new file → no backup; identical (skipped) dest → no backup.
- [x] Routing keys on the **immediate parent** (namespace-as-grandparent like `skills/foo/SKILL.md` routes in-place).

## Verification

`make ci-installer` green from the worktree root: ruff check + ruff format --check + mypy --strict (35 files) + pytest **393 passed** + coverage **99.77%** (≥90% floor) + pip-audit (no vulnerabilities) + `install.py --help` entry-verify. 13 new `test_sync.py` tests, all behavioral (tautology-screened).

> Part 1 of 3 — Epic G operations; PR-2 (prune pipeline + --yes) stacks on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)