### PR TITLE
fix(wait-for-pr-comments): raise re-review hard cap from 3 to 6 rounds

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -346,7 +346,7 @@ Abort.
 
 5. **If** a new review arrives, return to **Phase 3 (round +1)**.
 
-**Hard cap**: when round >= 3 AND Phase 6 detects a new review, do **one
+**Hard cap**: when round >= 6 AND Phase 6 detects a new review, do **one
 final Phase 3 inventory pull** (no Phase 4). Classify the round-N+1 items
 normally (FIX/SKIP/ESCALATE per the usual rules). Then mark **only** the
 FIX-classified round-N+1 items as
@@ -923,7 +923,7 @@ process.
 | "I'll keep polling past the re-review window" | Phase 6 uses a fixed 80s max window (20s pre-sleep + 6 × 10s polls). Do not extend ad-hoc. If Copilot has not started by then, exit Phase 6 normally and proceed to Phase 7. |
 | "I'll merge while the polling script is still running" | Don't. Issue the guard warning; the review could arrive any moment. |
 | "I'll classify already-addressed items as their own bucket" | Already-addressed is NOT a classification. Classify FIX; the per-comment subagent returns `fix_outcome="already_addressed"` with the existing commit SHA. |
-| "Round 4 of re-review is fine, Copilot's just being thorough" | Hard cap fires when round >= 3 AND a new review arrives. Mark FIX-classified round-N+1 items as `ESCALATE` with rationale `"exceeded re-review round cap"`. |
+| "Round 7 of re-review is fine, Copilot's just being thorough" | Hard cap fires when round >= 6 AND a new review arrives. Mark FIX-classified round-N+1 items as `ESCALATE` with rationale `"exceeded re-review round cap"`. |
 | "I'll inline `--mode autonomous` from the hook text" | The hook does not pass `--mode`. Autonomous mode is set ONLY by formulas (which also pass `--bead-id`). If you're invoking from chat, leave it interactive. |
 | "Skill B failed but I'll unlink the inventory anyway" | No. On Skill B failure, leave the inventory in place. Skill A only unlinks after Phase 9 final check passes and `write-inventory.sh --state complete --phase 9-final-check-done --output <path>` succeeds. |
 | "I'll keep the squashed commits clean — combine all subagent fixes into one" | Each subagent's commit stands alone. **No squashing.** Commit message format pinned: `fix(<scope>): <summary> (PR #<n> comment <comment_id>)`. |


### PR DESCRIPTION
## Summary

Raises the `wait-for-pr-comments` re-review **hard cap** from `round >= 3` to `round >= 6`. The 3-round ceiling was forcing premature `ESCALATE` (rationale `"exceeded re-review round cap"`) on PRs that legitimately needed more Copilot re-review iterations to converge.

Two literal edits in `src/user/.agents/skills/wait-for-pr-comments/SKILL.md`:
- **Phase 6 hard-cap definition** (~L349): `round >= 3` → `round >= 6`
- **Rationalizations table row** (~L926): `round >= 3` → `round >= 6`, and the human-readable label `"Round 4 of re-review is fine"` → `"Round 7 of re-review is fine"` (round+1 of the new cap, so the rebuttal still names the round being prevented).

## Scope / artifact type

Source template for a Claude skill (prose + agent instructions), not application code. Edit is in `src/` per repo convention; it stages into `~/.claude/` on the next `install.sh` run.

## Deliberately out of scope (design-forward)

- The `"exceeded re-review round cap"` magic string in `reply-and-resolve-pr-threads` (`render-reply-bodies.sh` + SKILL.md + tests) carries **no number** — it keys off the rationale string, not the cap value — so it correctly needs no change.
- `round-N+1` references in the same section are **symbolic** (`N`) and stay correct at any cap.
- This is an **interim prose tune**. Lifting the threshold into code/config is tracked separately under the prgroom CLI epic (a child bead is being filed); this PR intentionally does not introduce config plumbing.

## Test Plan

- [x] Census confirms no stale `round >= 3` / `Round 4 of re-review` remains in the skill.
- [x] Diff is exactly the two intended lines (`2 insertions, 2 deletions`).
- [ ] No SKILL.md prose tests exist; behavior is exercised implicitly the next time `wait-for-pr-comments` runs a re-review loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
