### PR TITLE
feat(installer): Epic G PR-2 — prune pipeline + --yes auto-accept (G.2–G.5, G.7)

### DIFF
--- a/packages/installer/installer.toml
+++ b/packages/installer/installer.toml
@@ -1,0 +1,30 @@
+# installer.toml — structured installer configuration for the Python installer.
+#
+# Replaces the legacy scripts/prune-list text file (read by install.sh during
+# the side-by-side window). See core/installer_toml.py for the loader and
+# core/prune.py for glob-matching semantics.
+
+[prune]
+# Retired paths this repo previously installed and has since removed.
+# Format: tool/namespace/basename  OR  */namespace/basename  (all tools).
+# Add an entry here when removing a skill/agent/command/rule from src/user/.
+retired = [
+  # superpowers audit — condition-based-waiting removed
+  "*/skills/condition-based-waiting",
+  # superpowers audit — testing-anti-patterns removed
+  "*/skills/testing-anti-patterns",
+  # bead-implementor mega-agent split into five role-named workers
+  "*/agents/bead-implementor.md",
+  # deprecated ralf-it skill
+  "*/skills/ralf-it",
+  # renamed to claude-sandbox.md
+  "claude/rules/git-commits.md",
+  # renamed to claude-to-codex-routing.md
+  "claude/rules/codex-routing.md",
+  # renamed big-picture -> where-does-this-fit
+  "*/skills/big-picture",
+]
+
+[tools]
+# Optional per-tool dest-dir overrides — leave commented to use built-in adapters.
+# claude.dest = "~/.claude"

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 # Repo root is four parents up from this file:
 # packages/installer/src/installer/cli.py -> repo root.
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-# Bundled installer config (prune list + tool overrides) and plugin source root.
-_INSTALLER_TOML = _REPO_ROOT / "packages" / "installer" / "installer.toml"
+# Plugin source root. (The bundled installer.toml path is derived per-run inside
+# _run_prune from the injected repo_root, so the config tracks the same root as
+# staging — and the missing-file case stays testable.)
 _PLUGINS_ROOT = _REPO_ROOT / "src" / "plugins"
 
 
@@ -150,6 +151,13 @@ def _run_prune(
     sequencing is structured so the install phase slots in ahead of this call
     when that story lands.
 
+    The prune list is read from ``installer.toml`` under the passed
+    ``repo_root`` (not off ``__file__``), so the config tracks the same root as
+    ``stage_and_transform``. When that file is absent — e.g. a wheel/install
+    that bundles only ``src/installer`` and omits ``installer.toml`` — the load
+    yields an empty prune list, so nothing would be pruned; a warning is emitted
+    naming the missing path so the no-op is explained rather than silent.
+
     Returns 0 on success, 1 when the non-interactive consent guard or the
     prune-only flow aborts the run.
     """
@@ -159,7 +167,13 @@ def _run_prune(
         except ConsentRequiredError:
             return 1
 
-    config = load_installer_toml(_INSTALLER_TOML)
+    installer_toml = repo_root / "packages" / "installer" / "installer.toml"
+    if not installer_toml.is_file():
+        io.warn(
+            f"installer.toml not found at {installer_toml}; the prune list is "
+            "empty, so nothing will be pruned."
+        )
+    config = load_installer_toml(installer_toml)
     plugins = resolve_plugins(home=home, plugins_root=_PLUGINS_ROOT, override_csv=None)
     plans = stage_and_transform(tools, repo_root=repo_root, io=io, plugins=plugins)
     adapters = [get_adapter(tool) for tool in tools]

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 
 # Repo root is four parents up from this file:
 # packages/installer/src/installer/cli.py -> repo root.
+# Both the bundled installer.toml path and the plugin source root are derived
+# per-run inside _run_prune from the injected repo_root (default: _REPO_ROOT),
+# so config + plugin discovery track the same root as staging — keeping
+# repo_root fully authoritative and the missing-path cases testable.
 _REPO_ROOT = Path(__file__).resolve().parents[4]
-# Plugin source root. (The bundled installer.toml path is derived per-run inside
-# _run_prune from the injected repo_root, so the config tracks the same root as
-# staging — and the missing-file case stays testable.)
-_PLUGINS_ROOT = _REPO_ROOT / "src" / "plugins"
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -156,10 +156,19 @@ def _run_prune(
     ``stage_and_transform``. When that file is absent — e.g. a wheel/install
     that bundles only ``src/installer`` and omits ``installer.toml`` — the load
     yields an empty prune list, so nothing would be pruned; a warning is emitted
-    naming the missing path so the no-op is explained rather than silent.
+    naming the missing path so the no-op is explained rather than silent. A
+    *present but type-malformed* ``installer.toml`` makes ``load_installer_toml``
+    raise ``ValueError``; that is caught here and surfaced through ``io`` as a
+    clean error with ``return 2`` (the CLI's config-error exit convention),
+    never an uncaught traceback.
+
+    Plugin discovery is likewise rooted at the passed ``repo_root``
+    (``repo_root / "src" / "plugins"``), so ``repo_root`` is fully
+    authoritative — config and plugins resolve against one injected root rather
+    than splitting between the argument and a module-level constant.
 
     Returns 0 on success, 1 when the non-interactive consent guard or the
-    prune-only flow aborts the run.
+    prune-only flow aborts the run, 2 when ``installer.toml`` is malformed.
     """
     if not prune_only:
         try:
@@ -173,8 +182,13 @@ def _run_prune(
             f"installer.toml not found at {installer_toml}; the prune list is "
             "empty, so nothing will be pruned."
         )
-    config = load_installer_toml(installer_toml)
-    plugins = resolve_plugins(home=home, plugins_root=_PLUGINS_ROOT, override_csv=None)
+    try:
+        config = load_installer_toml(installer_toml)
+    except ValueError as exc:
+        io.err(f"installer: {exc}")
+        return 2
+    plugins_root = repo_root / "src" / "plugins"
+    plugins = resolve_plugins(home=home, plugins_root=plugins_root, override_csv=None)
     plans = stage_and_transform(tools, repo_root=repo_root, io=io, plugins=plugins)
     adapters = [get_adapter(tool) for tool in tools]
 

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -3,9 +3,26 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from installer.config import Config, resolve_tools
+from installer.config import Config, resolve_plugins, resolve_tools
+from installer.core.consent import ConsentRequiredError, require_consent
+from installer.core.installer_toml import load_installer_toml
+from installer.core.orchestrator import stage_and_transform
+from installer.core.prune_flow import PruneAbortedError
+from installer.core.run import prune_pipeline
 from installer.tools.registry import UnknownToolError, get_adapter, known_tools
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+    from installer.core.model import Tool
+
+# Repo root is four parents up from this file:
+# packages/installer/src/installer/cli.py -> repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+# Bundled installer config (prune list + tool overrides) and plugin source root.
+_INSTALLER_TOML = _REPO_ROOT / "packages" / "installer" / "installer.toml"
+_PLUGINS_ROOT = _REPO_ROOT / "src" / "plugins"
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -23,12 +40,50 @@ def _build_parser() -> argparse.ArgumentParser:
             "Default: auto-detect against $HOME."
         ),
     )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Auto-accept all prompts (the scripted-install path).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes.",
+    )
+    # --prune and --prune-only are mutually exclusive. This group is the seam a
+    # later story extends to add the --dump-stage ⊥ --prune exclusion (the
+    # --dump-stage flag lands in a sibling PR); keep prune flags grouped so that
+    # integration only has to widen the group, not restructure the parser.
+    prune_group = parser.add_mutually_exclusive_group()
+    prune_group.add_argument(
+        "--prune",
+        action="store_true",
+        help="After install, remove retired paths from installer.toml (with backup).",
+    )
+    prune_group.add_argument(
+        "--prune-only",
+        action="store_true",
+        help="Skip install; scan + remove retired paths from installer.toml.",
+    )
     return parser
 
 
-def main(argv: list[str] | None = None, *, home: Path | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    home: Path | None = None,
+    io: IOPort | None = None,
+    repo_root: Path | None = None,
+) -> int:
     args = _build_parser().parse_args(argv)
     resolved_home = home if home is not None else Path.home()
+    resolved_repo_root = repo_root if repo_root is not None else _REPO_ROOT
+
+    if io is None:
+        from installer.core.io_port import TerminalIO
+
+        io = TerminalIO()
 
     try:
         tools = resolve_tools(home=resolved_home, override_csv=args.tools)
@@ -51,11 +106,72 @@ def main(argv: list[str] | None = None, *, home: Path | None = None) -> int:
         )
         return 2
 
-    # B.1: instantiation proves Config construction succeeds end-to-end.
-    # The full install pipeline is not wired here yet. When core/sync.py grows
-    # to walk a StagingPlan (Epic E), main() must drive
+    # B.1: instantiation proves Config construction succeeds end-to-end. The
+    # full plan-walking install sync is not wired here yet. When core/sync.py
+    # grows to walk a StagingPlan (Epic E), main() must drive
     # core.orchestrator.stage_and_transform(tools, ...) — NOT build_plan->sync
     # directly — so adapter post-staging transforms (e.g. the Gemini frontmatter
     # transform) actually run in real installs. Tracked as a dedicated story.
-    Config(home=resolved_home, tools=tools)
+    Config(home=resolved_home, tools=tools, auto_yes=args.yes)
+
+    if args.prune or args.prune_only:
+        return _run_prune(
+            tools,
+            io=io,
+            home=resolved_home,
+            repo_root=resolved_repo_root,
+            dry_run=args.dry_run,
+            auto_yes=args.yes,
+            prune_only=args.prune_only,
+        )
+
+    return 0
+
+
+def _run_prune(
+    tools: tuple[Tool, ...],
+    *,
+    io: IOPort,
+    home: Path,
+    repo_root: Path,
+    dry_run: bool,
+    auto_yes: bool,
+    prune_only: bool,
+) -> int:
+    """Drive the prune pipeline behind --prune / --prune-only.
+
+    Builds the in-memory plans (the prune scan compares the dest tree against
+    them), then runs scan + interactive flow. The install half of --prune is not
+    performed: the plan-walking install sync is not yet wired into main() (see
+    the Config note above), so today --prune performs only its prune half. The
+    sequencing is structured so the install phase slots in ahead of this call
+    when that story lands.
+
+    Returns 0 on success, 1 when the non-interactive consent guard or the
+    prune-only flow aborts the run.
+    """
+    if not prune_only:
+        try:
+            require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
+        except ConsentRequiredError:
+            return 1
+
+    config = load_installer_toml(_INSTALLER_TOML)
+    plugins = resolve_plugins(home=home, plugins_root=_PLUGINS_ROOT, override_csv=None)
+    plans = stage_and_transform(tools, repo_root=repo_root, io=io, plugins=plugins)
+    adapters = [get_adapter(tool) for tool in tools]
+
+    try:
+        prune_pipeline(
+            adapters,
+            plans=plans,
+            home=home,
+            config=config,
+            io=io,
+            dry_run=dry_run,
+            auto_yes=auto_yes,
+            prune_only=prune_only,
+        )
+    except PruneAbortedError:
+        return 1
     return 0

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -106,12 +106,15 @@ def main(
         )
         return 2
 
-    # B.1: instantiation proves Config construction succeeds end-to-end. The
-    # full plan-walking install sync is not wired here yet. When core/sync.py
-    # grows to walk a StagingPlan (Epic E), main() must drive
-    # core.orchestrator.stage_and_transform(tools, ...) — NOT build_plan->sync
-    # directly — so adapter post-staging transforms (e.g. the Gemini frontmatter
-    # transform) actually run in real installs. Tracked as a dedicated story.
+    # B.1: instantiation proves Config construction succeeds end-to-end; the
+    # object is intentionally not bound — the full plan-walking install sync is
+    # not wired here yet. When core/sync.py grows to walk a StagingPlan (Epic E),
+    # main() must drive core.orchestrator.stage_and_transform(tools, ...) — NOT
+    # build_plan->sync directly — so adapter post-staging transforms (e.g. the
+    # Gemini frontmatter transform) actually run in real installs, and that sync
+    # is where Config.auto_yes finds its consumer. Today auto_yes reaches the
+    # prune path directly via args.yes below; the Config field is forward-wiring
+    # for when sync() reads it. Tracked as a dedicated story.
     Config(home=resolved_home, tools=tools, auto_yes=args.yes)
 
     if args.prune or args.prune_only:

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -12,11 +12,17 @@ from installer.tools.registry import get_adapter, known_tools, parse_tool_name
 @dataclass(frozen=True, slots=True)
 class Config:
     """Resolved installer configuration. Frozen so the engine can pass it
-    freely without defensive copies. B.1 scope: only fields needed for
-    tool selection. Later stories add fields as their behaviour requires."""
+    freely without defensive copies. Later stories add fields as their
+    behaviour requires.
+
+    ``auto_yes`` (G.7) carries the ``--yes`` / ``-y`` flag: it waives the
+    non-interactive consent guard (``core/consent.py``) and is the intended
+    scripted-install path. Defaults ``False`` so existing constructions are
+    unaffected."""
 
     home: Path
     tools: tuple[Tool, ...]
+    auto_yes: bool = False
 
 
 def resolve_tools(*, home: Path, override_csv: str | None) -> tuple[Tool, ...]:

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -62,11 +62,18 @@ def _backup_path_for(target: Path, timestamp: str) -> Path:
 def back_up(target: Path, timestamp: str) -> Path:
     """Copy ``target`` (file or directory) to its timestamped backup; return the path.
 
+    Validates ``timestamp`` against the ``YYYYMMDD-HHMMSS`` contract before any
+    I/O (``ValueError`` otherwise): the value is interpolated raw into the backup
+    path, so this guard is the path-traversal security boundary — safe by default
+    rather than relying on every caller to pre-validate.
+
     Routes via ``_backup_path_for`` (scoped namespace -> sibling
     ``<namespace>-backup/``; else in-place), creating the backup dir as needed.
     Directories are copied recursively (``shutil.copytree``), files via
     ``shutil.copy2`` — mirroring the bash ``cp -R`` / ``cp`` split.
     """
+    if not valid_timestamp(timestamp):
+        raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {timestamp!r}")  # noqa: TRY003  # single call-site
     dest = _backup_path_for(target, timestamp)
     dest.parent.mkdir(parents=True, exist_ok=True)
     if target.is_dir():

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -1,0 +1,75 @@
+"""Path-aware timestamped backup placement (shared by sync and prune).
+
+Single home for the bash ``backup()`` routing decision
+(``scripts/install.sh:352-388``): a target whose immediate parent is one of the
+prune-managed namespaces is copied to a sibling ``<namespace>-backup/`` dir
+under the grandparent; any other target gets an in-place ``<name>.backup-<ts>``
+sibling. Handles both files (``shutil.copy2``) and directories
+(``shutil.copytree``), mirroring the bash ``cp`` / ``cp -R`` split.
+
+The ``timestamp`` is interpolated raw into the backup path, so callers MUST
+pass a value matching the ``YYYYMMDD-HHMMSS`` contract; ``new_timestamp``
+produces one and ``valid_timestamp`` validates a caller-supplied value before
+it reaches the filesystem (a value carrying ``../`` would otherwise escape the
+backup directory).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+# Namespaces whose backups route to a sibling ``<namespace>-backup/`` dir rather
+# than an in-place suffix (bash ``backup()`` case list, scripts/install.sh:369-379).
+_SCOPED_NAMESPACES = frozenset({"commands", "skills", "agents", "rules", "formulas"})
+
+# Backup timestamp format, matching ``date +%Y%m%d-%H%M%S`` (scripts/install.sh:365).
+_TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
+
+# A caller-supplied timestamp is interpolated raw into the backup filename, so it
+# must match the documented YYYYMMDD-HHMMSS contract exactly — otherwise a value
+# carrying path separators (``../``) would split into Path components and write
+# the backup outside the intended directory.
+_TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
+
+
+def new_timestamp() -> str:
+    """Current local wall-clock time as ``YYYYMMDD-HHMMSS`` (bash local-TZ ``date``)."""
+    return datetime.now().astimezone().strftime(_TIMESTAMP_FORMAT)
+
+
+def valid_timestamp(timestamp: str) -> bool:
+    """True when ``timestamp`` matches the ``YYYYMMDD-HHMMSS`` backup contract."""
+    return _TIMESTAMP_RE.match(timestamp) is not None
+
+
+def backup_path_for(target: Path, timestamp: str) -> Path:
+    """Resolve the backup destination for ``target`` (no I/O).
+
+    A target whose parent is a scoped namespace routes to
+    ``<grandparent>/<namespace>-backup/<name>.backup-<ts>``; any other target
+    gets an in-place ``<name>.backup-<ts>`` sibling.
+    """
+    parent = target.parent
+    if parent.name in _SCOPED_NAMESPACES:
+        backup_dir = parent.parent / f"{parent.name}-backup"
+        return backup_dir / f"{target.name}.backup-{timestamp}"
+    return target.with_name(f"{target.name}.backup-{timestamp}")
+
+
+def back_up(target: Path, timestamp: str) -> Path:
+    """Copy ``target`` (file or directory) to its timestamped backup; return the path.
+
+    Creates the sibling ``<namespace>-backup/`` directory when routing there.
+    Directories are copied recursively (``shutil.copytree``), files via
+    ``shutil.copy2`` — mirroring the bash ``cp -R`` / ``cp`` split.
+    """
+    dest = backup_path_for(target, timestamp)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if target.is_dir():
+        shutil.copytree(target, dest)
+    else:
+        shutil.copy2(target, dest)
+    return dest

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -45,7 +45,7 @@ def valid_timestamp(timestamp: str) -> bool:
     return _TIMESTAMP_RE.match(timestamp) is not None
 
 
-def backup_path_for(target: Path, timestamp: str) -> Path:
+def _backup_path_for(target: Path, timestamp: str) -> Path:
     """Resolve the backup destination for ``target`` (no I/O).
 
     A target whose parent is a scoped namespace routes to
@@ -62,11 +62,12 @@ def backup_path_for(target: Path, timestamp: str) -> Path:
 def back_up(target: Path, timestamp: str) -> Path:
     """Copy ``target`` (file or directory) to its timestamped backup; return the path.
 
-    Creates the sibling ``<namespace>-backup/`` directory when routing there.
+    Routes via ``_backup_path_for`` (scoped namespace -> sibling
+    ``<namespace>-backup/``; else in-place), creating the backup dir as needed.
     Directories are copied recursively (``shutil.copytree``), files via
     ``shutil.copy2`` — mirroring the bash ``cp -R`` / ``cp`` split.
     """
-    dest = backup_path_for(target, timestamp)
+    dest = _backup_path_for(target, timestamp)
     dest.parent.mkdir(parents=True, exist_ok=True)
     if target.is_dir():
         shutil.copytree(target, dest)

--- a/packages/installer/src/installer/core/consent.py
+++ b/packages/installer/src/installer/core/consent.py
@@ -1,0 +1,43 @@
+"""Non-interactive consent guard (G.7).
+
+The Python installer makes a destructive run impossible to start without a way to
+confirm it: when stdin is not a TTY (no prompt can be answered) and neither
+``--yes`` nor ``--dry-run`` waives confirmation, the run hard-fails up front with
+a clear error rather than silently overwriting files.
+
+This is design-forward relative to ``scripts/install.sh``, whose per-prompt
+``confirm()`` merely *skips* in non-interactive mode (``scripts/install.sh:177``)
+— the Python installer promotes that to a single explicit precondition so a
+scripted caller learns immediately that it must pass ``--yes``. ``--yes`` is the
+intended scripted-install path; ``--dry-run`` writes nothing, so both waive the
+guard.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from installer.core.io_port import IOPort
+
+
+class ConsentRequiredError(RuntimeError):
+    """Raised when a destructive run cannot obtain interactive consent.
+
+    The session is non-interactive and neither ``--yes`` nor ``--dry-run`` was
+    supplied, so there is no way to confirm the writes — the run must not
+    proceed silently.
+    """
+
+
+def require_consent(io: IOPort, *, dry_run: bool, auto_yes: bool) -> None:
+    """Raise ``ConsentRequiredError`` if a destructive run lacks any consent path.
+
+    Returns ``None`` (no-op) when the session is interactive, or when ``dry_run``
+    / ``auto_yes`` waives the requirement. Raises only in the genuinely unsafe
+    case: non-interactive AND not dry-run AND not auto-yes.
+    """
+    if io.is_interactive() or dry_run or auto_yes:
+        return
+    io.err("non-interactive run requires --yes or --dry-run")
+    raise ConsentRequiredError("non-interactive run requires --yes or --dry-run")  # noqa: TRY003  # single call-site

--- a/packages/installer/src/installer/core/installer_toml.py
+++ b/packages/installer/src/installer/core/installer_toml.py
@@ -52,18 +52,22 @@ def load_installer_toml(path: Path) -> InstallerToml:
     no error — absence of installer-level config is a valid state, not a
     failure. A present file with no ``[prune]`` section likewise yields an empty
     prune list; the section is optional. The ``[tools]`` table is read as a
-    flat ``{tool: dest}`` mapping from each ``<tool>.dest`` entry.
+    flat ``{tool: dest}`` mapping from each ``<tool>.dest`` entry; each ``dest``
+    must be a string.
 
     Raises ``ValueError`` when the file is present but type-malformed: ``prune``
-    or ``tools`` decoded to a non-table, or ``prune.retired`` decoded to
-    anything other than a list of strings. Catching these at load time turns a
-    silent corruption — ``retired = "*/foo"`` would otherwise ``list()``-shred
-    into single-character globs — into a clear configuration error.
+    or ``tools`` decoded to a non-table, ``prune.retired`` decoded to anything
+    other than a list of strings, or a ``[tools]`` ``dest`` decoded to a
+    non-string. Catching these at load time turns a silent corruption —
+    ``retired = "*/foo"`` would otherwise ``list()``-shred into single-character
+    globs — into a clear configuration error.
     """
     if not path.is_file():
         return InstallerToml()
 
-    data = tomllib.loads(path.read_text())
+    # TOML is defined as UTF-8; read explicitly rather than rely on the
+    # locale-dependent platform default (matches the rest of the installer).
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
 
     prune_section = data.get("prune", {})
     if not isinstance(prune_section, dict):
@@ -82,10 +86,15 @@ def load_installer_toml(path: Path) -> InstallerToml:
         got = type(tools_section).__name__
         msg = f"installer.toml: [tools] must be a table, got {got}"
         raise ValueError(msg)  # noqa: TRY004  # ValueError is the documented config-error contract
-    tool_dest_overrides = {
-        tool: table["dest"]
-        for tool, table in tools_section.items()
-        if isinstance(table, dict) and "dest" in table
-    }
+    tool_dest_overrides: dict[str, str] = {}
+    for tool, table in tools_section.items():
+        if not (isinstance(table, dict) and "dest" in table):
+            continue
+        dest = table["dest"]
+        if not isinstance(dest, str):
+            got = type(dest).__name__
+            msg = f"installer.toml: [tools] {tool}.dest must be a string, got {got}"
+            raise ValueError(msg)  # noqa: TRY004  # ValueError is the documented config-error contract
+        tool_dest_overrides[tool] = dest
 
     return InstallerToml(prune_globs=prune_globs, tool_dest_overrides=tool_dest_overrides)

--- a/packages/installer/src/installer/core/installer_toml.py
+++ b/packages/installer/src/installer/core/installer_toml.py
@@ -53,6 +53,12 @@ def load_installer_toml(path: Path) -> InstallerToml:
     failure. A present file with no ``[prune]`` section likewise yields an empty
     prune list; the section is optional. The ``[tools]`` table is read as a
     flat ``{tool: dest}`` mapping from each ``<tool>.dest`` entry.
+
+    Raises ``ValueError`` when the file is present but type-malformed: ``prune``
+    or ``tools`` decoded to a non-table, or ``prune.retired`` decoded to
+    anything other than a list of strings. Catching these at load time turns a
+    silent corruption — ``retired = "*/foo"`` would otherwise ``list()``-shred
+    into single-character globs — into a clear configuration error.
     """
     if not path.is_file():
         return InstallerToml()
@@ -60,9 +66,22 @@ def load_installer_toml(path: Path) -> InstallerToml:
     data = tomllib.loads(path.read_text())
 
     prune_section = data.get("prune", {})
-    prune_globs = list(prune_section.get("retired", []))
+    if not isinstance(prune_section, dict):
+        got = type(prune_section).__name__
+        msg = f"installer.toml: [prune] must be a table, got {got}"
+        raise ValueError(msg)  # noqa: TRY004  # ValueError is the documented config-error contract
+
+    retired = prune_section.get("retired", [])
+    if not isinstance(retired, list) or not all(isinstance(g, str) for g in retired):
+        msg = "installer.toml: [prune] retired must be a list of strings (glob patterns)"
+        raise ValueError(msg)
+    prune_globs = list(retired)
 
     tools_section = data.get("tools", {})
+    if not isinstance(tools_section, dict):
+        got = type(tools_section).__name__
+        msg = f"installer.toml: [tools] must be a table, got {got}"
+        raise ValueError(msg)  # noqa: TRY004  # ValueError is the documented config-error contract
     tool_dest_overrides = {
         tool: table["dest"]
         for tool, table in tools_section.items()

--- a/packages/installer/src/installer/core/installer_toml.py
+++ b/packages/installer/src/installer/core/installer_toml.py
@@ -31,7 +31,15 @@ class InstallerToml:
     happens in ``core/prune.py``). ``tool_dest_overrides`` maps a tool name to
     a dest-dir override string; empty unless a ``[tools]`` table declares one.
     Both default empty so the missing-file path constructs a valid, inert
-    config without special-casing at every call site."""
+    config without special-casing at every call site.
+
+    ``tool_dest_overrides`` is parsed and surfaced but NOT yet consumed: dest
+    resolution still goes through ``adapter.dest_dir(home)`` everywhere
+    (including the prune scan), so a declared override is currently inert.
+    Threading the override into dest resolution is a deliberate later story —
+    the schema ships now (it is documented in the design doc) so the loader is
+    forward-compatible. Until a consumer lands, a ``[tools]`` ``dest`` entry has
+    no runtime effect."""
 
     prune_globs: list[str] = field(default_factory=list)
     tool_dest_overrides: dict[str, str] = field(default_factory=dict)

--- a/packages/installer/src/installer/core/installer_toml.py
+++ b/packages/installer/src/installer/core/installer_toml.py
@@ -1,0 +1,64 @@
+"""Loader for ``installer.toml`` — the structured replacement for the legacy
+``scripts/prune-list`` text file.
+
+Replaces the bash ``_load_prune_list`` (``scripts/install.sh:1471-1483``), which
+read one glob per non-comment line out of ``scripts/prune-list``. The Python
+installer instead reads a ``[prune] retired`` array from
+``packages/installer/installer.toml`` (schema in
+``docs/architecture/installer/installer-design.md`` §"Configuration —
+installer.toml"). An optional ``[tools]`` table carries per-tool dest-dir
+overrides.
+
+Pure: takes a ``Path``, returns parsed data. A missing file is the no-op
+default (empty prune list, no overrides) — mirroring the bash
+``[[ -f "$list_file" ]] || return 0`` early-out — so callers never have to
+guard the absent-config case. Glob *matching* lives in ``core/prune.py``; this
+module only retains the patterns as strings.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class InstallerToml:
+    """Parsed ``installer.toml`` contents the engine consumes.
+
+    ``prune_globs`` are retired-path glob patterns retained verbatim (matching
+    happens in ``core/prune.py``). ``tool_dest_overrides`` maps a tool name to
+    a dest-dir override string; empty unless a ``[tools]`` table declares one.
+    Both default empty so the missing-file path constructs a valid, inert
+    config without special-casing at every call site."""
+
+    prune_globs: list[str] = field(default_factory=list)
+    tool_dest_overrides: dict[str, str] = field(default_factory=dict)
+
+
+def load_installer_toml(path: Path) -> InstallerToml:
+    """Parse ``installer.toml`` at ``path``; return an ``InstallerToml``.
+
+    A missing file yields an empty config (no prune globs, no overrides) with
+    no error — absence of installer-level config is a valid state, not a
+    failure. A present file with no ``[prune]`` section likewise yields an empty
+    prune list; the section is optional. The ``[tools]`` table is read as a
+    flat ``{tool: dest}`` mapping from each ``<tool>.dest`` entry.
+    """
+    if not path.is_file():
+        return InstallerToml()
+
+    data = tomllib.loads(path.read_text())
+
+    prune_section = data.get("prune", {})
+    prune_globs = list(prune_section.get("retired", []))
+
+    tools_section = data.get("tools", {})
+    tool_dest_overrides = {
+        tool: table["dest"]
+        for tool, table in tools_section.items()
+        if isinstance(table, dict) and "dest" in table
+    }
+
+    return InstallerToml(prune_globs=prune_globs, tool_dest_overrides=tool_dest_overrides)

--- a/packages/installer/src/installer/core/prune.py
+++ b/packages/installer/src/installer/core/prune.py
@@ -1,0 +1,152 @@
+"""Orphan scan — identify retired dest entries to prune.
+
+Pure port of the bash orphan scan (``scripts/install.sh:1505-1543``). An orphan
+is a top-level entry directly inside a tool's scoped namespace dir
+(``commands``/``skills``/``agents``/``rules``) or ``~/.beads/formulas`` that:
+
+1. is NOT present in this run's ``StagingPlan`` (nothing staged it), AND
+2. matches a prune-list glob keyed ``tool/namespace/basename``.
+
+Item granularity is the top-level entry — the scan does not recurse into nested
+skill directories (bash note at ``scripts/install.sh:1446-1448``). Legacy
+``*.backup-*`` entries (in-place backups from older ``backup()``
+implementations) are skipped so they are never treated as orphans
+(``scripts/install.sh:1512``). Sibling ``<namespace>-backup/`` dirs live at the
+grandparent level and are never visited by this scan.
+
+``~/.beads/formulas`` is scanned whenever pruning runs, regardless of beads
+plugin detection: if beads is not an active plugin, no plan staged any formula,
+so every dest formula registers as an orphan — consistent with strict mode
+(``scripts/install.sh:1537-1541``).
+
+Matching is ``fnmatch`` on the ``tool/namespace/basename`` key, mirroring the
+bash ``case "$key" in ($entry)`` glob match (``scripts/install.sh:1485-1499``).
+Pure: it reads the destination filesystem and the in-memory plans, and returns
+``list[Orphan]`` without mutating anything.
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from installer.core.model import Orphan, Tool
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from installer.core.installer_toml import InstallerToml
+    from installer.core.model import StagingPlan
+    from installer.tools.base import ToolAdapter
+
+# Tool-tree namespaces scanned for orphans (bash ``prune_subdirs``,
+# ``scripts/install.sh:1529``). Narrower than ``adapter.scoped_namespaces()``
+# only incidentally — kept explicit so the scan set is the bash set, not
+# whatever an adapter happens to expose.
+_PRUNE_SUBDIRS = ("commands", "skills", "agents", "rules")
+
+# Beads' formulas live outside any tool tree; scanned unconditionally under a
+# fixed ``beads/formulas`` key (``scripts/install.sh:1541``).
+_BEADS_TOOL = "beads"
+_BEADS_NAMESPACE = "formulas"
+
+
+def _staged_basenames(plan: StagingPlan | None, namespace: str) -> set[str]:
+    """Top-level entry names the plan stages under ``namespace``.
+
+    The plan keys items by ``dest_relpath`` (e.g. ``skills/foo``); the
+    first-level child name under ``namespace`` is what a dest entry is compared
+    against. A ``None`` plan (e.g. a namespace no plan targets) stages nothing.
+    """
+    if plan is None:
+        return set()
+    return {
+        item.dest_relpath.parts[1]
+        for item in plan.items.values()
+        if len(item.dest_relpath.parts) >= 2 and item.dest_relpath.parts[0] == namespace
+    }
+
+
+def _scan_namespace(
+    *,
+    tool: str,
+    namespace: str,
+    dest: Path,
+    staged: set[str],
+    prune_globs: Iterable[str],
+) -> list[Orphan]:
+    """Collect orphans in one dest namespace dir (bash ``_scan_namespace``).
+
+    An entry is an orphan when it is not a legacy ``*.backup-*`` file, is not
+    staged, and its ``tool/namespace/basename`` key matches a prune glob.
+    """
+    if not dest.is_dir():
+        return []
+
+    globs = list(prune_globs)
+    orphans: list[Orphan] = []
+    for entry in sorted(dest.iterdir()):
+        base = entry.name
+        if ".backup-" in base:
+            continue
+        if base in staged:
+            continue
+        key = f"{tool}/{namespace}/{base}"
+        if not any(fnmatch(key, pattern) for pattern in globs):
+            continue
+        orphans.append(
+            Orphan(
+                tool=tool,
+                namespace=namespace,
+                path=entry,
+                kind="dir" if entry.is_dir() else "file",
+            )
+        )
+    return orphans
+
+
+def scan_orphans(
+    adapters: Iterable[ToolAdapter],
+    *,
+    plans: dict[Tool, StagingPlan],
+    home: Path,
+    config: InstallerToml,
+) -> list[Orphan]:
+    """Scan every active tool's namespaces plus ``~/.beads/formulas`` for orphans.
+
+    For each adapter, walk the prune subdirs under its ``dest_dir(home)``,
+    comparing each top-level entry against the tool's plan and the prune globs.
+    Then scan ``~/.beads/formulas`` once with a fixed ``beads`` tool bucket
+    (strict mode: nothing in the per-tool plans stages a beads formula, so an
+    unmatched-by-plan formula is an orphan when a glob matches). Returns all
+    orphans in tool-then-namespace iteration order; an empty prune list yields
+    no orphans.
+    """
+    prune_globs = config.prune_globs
+    orphans: list[Orphan] = []
+
+    for adapter in adapters:
+        plan = plans.get(Tool(adapter.name))
+        dest_root = adapter.dest_dir(home)
+        for namespace in _PRUNE_SUBDIRS:
+            orphans.extend(
+                _scan_namespace(
+                    tool=adapter.name,
+                    namespace=namespace,
+                    dest=dest_root / namespace,
+                    staged=_staged_basenames(plan, namespace),
+                    prune_globs=prune_globs,
+                )
+            )
+
+    orphans.extend(
+        _scan_namespace(
+            tool=_BEADS_TOOL,
+            namespace=_BEADS_NAMESPACE,
+            dest=home / ".beads" / _BEADS_NAMESPACE,
+            staged=set(),
+            prune_globs=prune_globs,
+        )
+    )
+    return orphans

--- a/packages/installer/src/installer/core/prune.py
+++ b/packages/installer/src/installer/core/prune.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 from installer.core.model import Orphan, Tool
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
     from installer.core.installer_toml import InstallerToml
     from installer.core.model import StagingPlan
@@ -74,7 +74,7 @@ def _scan_namespace(
     namespace: str,
     dest: Path,
     staged: set[str],
-    prune_globs: Iterable[str],
+    prune_globs: Sequence[str],
 ) -> list[Orphan]:
     """Collect orphans in one dest namespace dir (bash ``_scan_namespace``).
 
@@ -84,7 +84,6 @@ def _scan_namespace(
     if not dest.is_dir():
         return []
 
-    globs = list(prune_globs)
     orphans: list[Orphan] = []
     for entry in sorted(dest.iterdir()):
         base = entry.name
@@ -93,7 +92,7 @@ def _scan_namespace(
         if base in staged:
             continue
         key = f"{tool}/{namespace}/{base}"
-        if not any(fnmatch(key, pattern) for pattern in globs):
+        if not any(fnmatch(key, pattern) for pattern in prune_globs):
             continue
         orphans.append(
             Orphan(

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -157,10 +157,16 @@ def _back_up_and_delete(orphan: Orphan, *, io: IOPort, timestamp: str, counters:
     dest = back_up(orphan.path, timestamp)
     counters.backed_up += 1
     io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
-    if orphan.path.is_dir():
-        shutil.rmtree(orphan.path)
-    else:
+    # A symlink (to a dir OR a file) is removed with ``unlink``, which deletes
+    # the link itself, never its target. ``rmtree`` is reserved for real
+    # directories: ``Path.is_dir()`` follows symlinks, so a dir-symlink would
+    # otherwise reach ``rmtree`` — which refuses a symlink and raises OSError.
+    # The bash original used ``rm -rf``, which handles symlinks fine; this keeps
+    # port parity.
+    if orphan.path.is_symlink() or not orphan.path.is_dir():
         orphan.path.unlink()
+    else:
+        shutil.rmtree(orphan.path)
     counters.pruned += 1
 
 

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import shutil
 from typing import TYPE_CHECKING
 
-from installer.core.backup import back_up, new_timestamp, valid_timestamp
+from installer.core.backup import back_up, new_timestamp
 from installer.core.model import Counters
 
 if TYPE_CHECKING:
@@ -71,9 +71,10 @@ def run_prune(
        deletes nothing.
 
     ``timestamp`` is the ``YYYYMMDD-HHMMSS`` backup suffix; injected so tests
-    assert exact backup names, it defaults to the current local time. A
-    caller-supplied value that does not match the format raises ``ValueError``
-    before any backup is written.
+    assert exact backup names, it defaults to the current local time. It is only
+    resolved on paths that may delete, so a ``dry_run`` never computes one; on a
+    deleting path a malformed value raises ``ValueError`` from ``back_up`` (the
+    validation boundary) before any backup is written.
     """
     if not io.is_interactive() and not dry_run and not auto_yes:
         if prune_only:
@@ -86,15 +87,16 @@ def run_prune(
         io.info("No orphans detected.")
         return Counters()
 
-    ts = timestamp if timestamp is not None else new_timestamp()
-    if not valid_timestamp(ts):
-        raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {ts!r}")  # noqa: TRY003  # single call-site
-
     _display(orphans, io)
 
     if dry_run:
         io.info(f"Dry-run: {len(orphans)} orphan(s) listed above; no changes made.")
         return Counters()
+
+    # Resolve the backup suffix only on paths that may actually delete; the
+    # dry-run early-return above never needs it. ``back_up`` validates the value
+    # at the filesystem boundary, so no explicit ``valid_timestamp`` check here.
+    ts = timestamp if timestamp is not None else new_timestamp()
 
     if auto_yes:
         return _delete_all(orphans, io=io, timestamp=ts)

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -1,0 +1,177 @@
+"""Interactive prune flow — confirm and perform orphan deletion.
+
+Port of the bash ``prune_orphans`` (``scripts/install.sh:1602-1687``). Takes the
+orphan list from ``core/prune.py`` and an ``IOPort``, drives the three-way
+prompt (all / one-by-one / cancel) and the one-by-one per-item drill-down, and
+backs up then deletes every confirmed orphan. ALL prompts route through the
+``IOPort`` so the flow is unit-testable through ``ScriptedIO``.
+
+Deletion is always preceded by a path-aware backup (``core/backup.py``) so
+``--yes`` is never a data-loss path — the bash ``_delete_orphan`` likewise calls
+``backup`` before ``rm -rf`` (``scripts/install.sh:1580-1588``).
+
+Guard ordering mirrors the bash function exactly: the non-interactive guard runs
+FIRST, before the empty-orphan fast path, so ``--prune-only`` without auth
+hard-fails regardless of orphan count (``scripts/install.sh:1602-1615``).
+``--dry-run`` and ``--yes`` are themselves the authorization, so they are exempt.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+from installer.core.backup import back_up, new_timestamp, valid_timestamp
+from installer.core.model import Counters
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from installer.core.io_port import IOPort
+    from installer.core.model import Orphan
+
+# Three-way prompt answer tokens (bash ``[a]ll, [o]ne-by-one, [c]ancel``).
+_ALL = "a"
+_ONE_BY_ONE = "o"
+_CANCEL = "c"
+
+
+class PruneAbortedError(RuntimeError):
+    """Raised when a non-interactive ``--prune-only`` run lacks authorization.
+
+    Mirrors the bash hard-fail (``scripts/install.sh:1608-1610``): the caller
+    asked for an action (prune-only) with no way to confirm it and no ``--yes``
+    / ``--dry-run`` standing in for consent, so the intent cannot be fulfilled.
+    """
+
+
+def run_prune(
+    orphans: Sequence[Orphan],
+    *,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+    prune_only: bool = False,
+    timestamp: str | None = None,
+) -> Counters:
+    """Confirm and delete orphans; return a ``Counters`` of the work done.
+
+    Guard order (bash ``prune_orphans``):
+
+    1. **Non-interactive guard first.** When the session is non-interactive and
+       neither ``dry_run`` nor ``auto_yes`` supplies consent: a ``prune_only``
+       run raises ``PruneAbortedError`` (action demanded, no auth); a plain
+       ``--prune`` run warns and returns having deleted nothing.
+    2. **Empty fast path.** No orphans -> return immediately.
+    3. **Display** the orphan list.
+    4. **dry_run** -> display only, no deletes.
+    5. **auto_yes** -> back up + delete every orphan, no prompt.
+    6. **Interactive** -> three-way prompt; ``all`` deletes everything,
+       ``one-by-one`` drills down per item (``quit`` stops the rest), ``cancel``
+       deletes nothing.
+
+    ``timestamp`` is the ``YYYYMMDD-HHMMSS`` backup suffix; injected so tests
+    assert exact backup names, it defaults to the current local time. A
+    caller-supplied value that does not match the format raises ``ValueError``
+    before any backup is written.
+    """
+    if not io.is_interactive() and not dry_run and not auto_yes:
+        if prune_only:
+            io.err("prune-only requires --yes or --dry-run in non-interactive mode")
+            raise PruneAbortedError("prune-only requires --yes or --dry-run")  # noqa: TRY003  # single call-site
+        io.warn("prune phase requires confirmation, skipping")
+        return Counters()
+
+    if not orphans:
+        io.info("No orphans detected.")
+        return Counters()
+
+    ts = timestamp if timestamp is not None else new_timestamp()
+    if not valid_timestamp(ts):
+        raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {ts!r}")  # noqa: TRY003  # single call-site
+
+    _display(orphans, io)
+
+    if dry_run:
+        io.info(f"Dry-run: {len(orphans)} orphan(s) listed above; no changes made.")
+        return Counters()
+
+    if auto_yes:
+        return _delete_all(orphans, io=io, timestamp=ts)
+
+    return _prompt_and_delete(orphans, io=io, timestamp=ts)
+
+
+def _prompt_and_delete(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+    """Three-way prompt then act (bash interactive branch, install.sh:1636-1686)."""
+    choice = io.confirm_three_way(
+        "Action? [a]ll, [o]ne-by-one, [c]ancel",
+        choices=(_ALL, _ONE_BY_ONE, _CANCEL),
+        default=_CANCEL,
+    )
+    if choice == _ALL:
+        return _delete_all(orphans, io=io, timestamp=timestamp)
+    if choice == _ONE_BY_ONE:
+        return _delete_one_by_one(orphans, io=io, timestamp=timestamp)
+    io.info("Cancelled. No changes made.")
+    return Counters()
+
+
+def _delete_one_by_one(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+    """Per-item drill-down (bash ``o|O`` branch, install.sh:1650-1676).
+
+    A per-item ``quit`` leaves every un-answered orphan in place; an orphan the
+    user did not keep (decision ``True``) is deleted. Orphans the user never
+    reached (the dict is incomplete on quit) are skipped.
+    """
+    result = io.confirm_per_item(
+        "Delete each orphan? [y/N/q]",
+        items=[str(o.path) for o in orphans],
+    )
+    counters = Counters()
+    for orphan in orphans:
+        if result.decisions.get(str(orphan.path)):
+            _back_up_and_delete(orphan, io=io, timestamp=timestamp, counters=counters)
+    if result.quit:
+        io.info("Quit per-item loop; remaining orphans left in place.")
+    return counters
+
+
+def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+    """Back up + delete every orphan (bash ``_delete_all_orphans``, install.sh:1592-1600)."""
+    counters = Counters()
+    for orphan in orphans:
+        _back_up_and_delete(orphan, io=io, timestamp=timestamp, counters=counters)
+    io.ok(f"Pruned {counters.pruned} orphan(s).")
+    return counters
+
+
+def _back_up_and_delete(orphan: Orphan, *, io: IOPort, timestamp: str, counters: Counters) -> None:
+    """Back up an orphan, then remove it (bash ``_delete_orphan``, install.sh:1580-1588).
+
+    Backup ALWAYS precedes deletion so the original bytes are recoverable even
+    if the delete is interrupted.
+    """
+    dest = back_up(orphan.path, timestamp)
+    counters.backed_up += 1
+    io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
+    if orphan.path.is_dir():
+        shutil.rmtree(orphan.path)
+    else:
+        orphan.path.unlink()
+    counters.pruned += 1
+
+
+def _display(orphans: Sequence[Orphan], io: IOPort) -> None:
+    """Print the orphan list grouped by tool then namespace (bash ``_display_orphans``)."""
+    io.header(f"Orphans detected ({len(orphans)} total)")
+    last_tool = last_ns = ""
+    for orphan in orphans:
+        if orphan.tool != last_tool:
+            io.header(orphan.tool)
+            last_tool = orphan.tool
+            last_ns = ""
+        if orphan.namespace != last_ns:
+            io.info(f"  {orphan.namespace}/")
+            last_ns = orphan.namespace
+        io.info(f"    [{orphan.kind}] {orphan.path}")

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -151,12 +151,18 @@ def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Cou
 def _back_up_and_delete(orphan: Orphan, *, io: IOPort, timestamp: str, counters: Counters) -> None:
     """Back up an orphan, then remove it (bash ``_delete_orphan``, install.sh:1580-1588).
 
-    Backup ALWAYS precedes deletion so the original bytes are recoverable even
-    if the delete is interrupted.
+    Backup precedes deletion so the original bytes are recoverable even if the
+    delete is interrupted — but only when there is something to back up. A broken
+    symlink (or a path that vanished mid-run) has nothing recoverable: ``exists()``
+    follows the dead link to a missing target and returns False, so ``back_up``
+    would fall through to ``copy2``/``copytree`` and raise, aborting the whole run.
+    Mirror the bash ``backup()`` ``[[ -e "$target" ]]`` no-op — skip the backup but
+    still remove the link below (``rm -rf`` deletes a broken link unconditionally).
     """
-    dest = back_up(orphan.path, timestamp)
-    counters.backed_up += 1
-    io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
+    if orphan.path.exists():
+        dest = back_up(orphan.path, timestamp)
+        counters.backed_up += 1
+        io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
     # A symlink (to a dir OR a file) is removed with ``unlink``, which deletes
     # the link itself, never its target. ``rmtree`` is reserved for real
     # directories: ``Path.is_dir()`` follows symlinks, so a dir-symlink would

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -1,0 +1,62 @@
+"""Run-level composition for the prune pipeline (G.5).
+
+``prune_pipeline`` is the install-side composition wired behind the ``--prune``
+and ``--prune-only`` CLI flags: scan each active tool's destination tree against
+its in-memory ``StagingPlan`` for orphans (``core/prune.py``), then drive the
+interactive prune flow over the result (``core/prune_flow.py``).
+
+It is kept separate from ``cli.py`` so the scan+flow composition is unit-testable
+without argparse, and separate from ``orchestrator.stage_and_transform`` so the
+staging-plan production (which needs ``repo_root`` + plugin resolution) stays in
+the caller. The install half of ``--prune`` (install THEN prune) is not performed
+here: the plan-walking install sync is not yet wired into ``cli.main`` (see
+``cli.py`` and ``orchestrator.py`` notes). The sequencing is structured so that
+install slots in ahead of this call when that story lands; today this performs
+the prune half against the already-built plans, which is correct for
+``--prune-only`` and is the prune half of ``--prune``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from installer.core.prune import scan_orphans
+from installer.core.prune_flow import run_prune
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from installer.core.installer_toml import InstallerToml
+    from installer.core.io_port import IOPort
+    from installer.core.model import Counters, StagingPlan, Tool
+    from installer.tools.base import ToolAdapter
+
+
+def prune_pipeline(
+    adapters: Iterable[ToolAdapter],
+    *,
+    plans: dict[Tool, StagingPlan],
+    home: Path,
+    config: InstallerToml,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+    prune_only: bool = False,
+    timestamp: str | None = None,
+) -> Counters:
+    """Scan ``adapters`` for orphans against ``plans``, then run the prune flow.
+
+    ``prune_only`` is threaded to the flow so its non-interactive guard
+    distinguishes a hard-fail (prune-only without consent) from a warn+skip
+    (plain ``--prune``). Returns the flow's ``Counters`` (pruned / backed_up).
+    """
+    orphans = scan_orphans(adapters, plans=plans, home=home, config=config)
+    return run_prune(
+        orphans,
+        io=io,
+        dry_run=dry_run,
+        auto_yes=auto_yes,
+        prune_only=prune_only,
+        timestamp=timestamp,
+    )

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -8,40 +8,24 @@ to walk a `StagingPlan` and route conflicts through the merge registry.
 Path-aware backup (G.1) ports the bash installer's ``backup()``
 (`scripts/install.sh:352-388`): before overwriting an existing
 destination, the original is copied to a timestamped backup so a failed
-write leaves it recoverable.
+write leaves it recoverable. The routing decision and timestamp contract
+live in `core/backup.py`, shared with the prune flow (G.4).
 """
 
 from __future__ import annotations
 
 import hashlib
-import re
-import shutil
-from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING
 
+from installer.core.backup import back_up, new_timestamp, valid_timestamp
 from installer.core.model import Counters
 from installer.core.paths import is_safe_relpath
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from installer.core.io_port import IOPort
     from installer.tools.base import ToolAdapter
-
-# Namespaces whose backups route to a sibling ``<namespace>-backup/`` dir
-# rather than an in-place suffix. Mirrors the bash ``backup()`` case list
-# (`scripts/install.sh:369-379`).
-_SCOPED_NAMESPACES = frozenset({"commands", "skills", "agents", "rules", "formulas"})
-
-# Backup timestamp format, matching ``date +%Y%m%d-%H%M%S`` in
-# `scripts/install.sh:365`.
-_TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
-
-# A caller-supplied ``timestamp`` is interpolated raw into the backup
-# filename (`_backup`), so it must match the documented ``YYYYMMDD-HHMMSS``
-# contract exactly — otherwise a value carrying path separators (``../``)
-# would split into Path components and write the backup outside the
-# intended ``<namespace>-backup/`` directory.
-_TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
 
 
 def sync(
@@ -97,10 +81,10 @@ def sync(
         io.info(f"would {verb} {dest}")
     else:
         if dest_exists:
-            ts = timestamp if timestamp is not None else _now_timestamp()
-            if not _TIMESTAMP_RE.match(ts):
+            ts = timestamp if timestamp is not None else new_timestamp()
+            if not valid_timestamp(ts):
                 raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {ts!r}")  # noqa: TRY003  # single call-site; subclass not justified
-            _backup(dest, ts)
+            back_up(dest, ts)
             counters.backed_up += 1
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(content)
@@ -110,31 +94,6 @@ def sync(
     else:
         counters.created += 1
     return counters
-
-
-def _backup(dest: Path, timestamp: str) -> None:
-    """Copy ``dest`` to a timestamped backup before it is overwritten.
-
-    Ports the routing decision in the bash ``backup()``
-    (`scripts/install.sh:360-388`): a destination whose immediate parent
-    is a scoped namespace is copied to a sibling ``<namespace>-backup/``
-    directory; any other destination gets an in-place
-    ``<name>.backup-<ts>`` sibling. Either way the original bytes are
-    written before the caller overwrites ``dest``.
-    """
-    parent = dest.parent
-    if parent.name in _SCOPED_NAMESPACES:
-        backup_dir = parent.parent / f"{parent.name}-backup"
-        backup_dir.mkdir(parents=True, exist_ok=True)
-        backup_path = backup_dir / f"{dest.name}.backup-{timestamp}"
-    else:
-        backup_path = dest.with_name(f"{dest.name}.backup-{timestamp}")
-    shutil.copy2(dest, backup_path)
-
-
-def _now_timestamp() -> str:
-    # Local wall-clock time, matching bash ``date +%Y%m%d-%H%M%S`` (local TZ).
-    return datetime.now().astimezone().strftime(_TIMESTAMP_FORMAT)
 
 
 def _sha256(data: bytes) -> bytes:

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -1,0 +1,59 @@
+"""Unit tests for installer.core.backup.
+
+Each test pins a coded decision in ``back_up`` / ``valid_timestamp``, the shared
+path-aware backup placement used by both sync and prune. The focus here is the
+safe-by-default validation boundary: ``back_up`` rejects a malformed timestamp
+itself, so a caller cannot interpolate a path-traversing value into the backup
+path by forgetting to pre-validate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.backup import back_up
+
+_TS = "20250101-120000"
+
+
+def test_back_up_rejects_malformed_timestamp_before_any_io(tmp_path: Path) -> None:
+    """
+    Given a target file and a timestamp that escapes the YYYYMMDD-HHMMSS format
+    When back_up is called directly
+    Then it raises ValueError and writes no backup (safe-by-default boundary).
+
+    Pins the security guard at the API boundary: the timestamp is interpolated
+    raw into the backup path, so a path-separator-bearing value (``../``) must be
+    rejected by back_up itself, not left to caller-side validation.
+    """
+    target = tmp_path / ".claude" / "skills" / "a"
+    target.parent.mkdir(parents=True)
+    target.write_text("precious")
+
+    with pytest.raises(ValueError, match="YYYYMMDD-HHMMSS"):
+        back_up(target, "../evil")
+
+    # No backup escaped into the parent tree.
+    assert list(tmp_path.glob("**/*.backup-*")) == []
+    assert not (tmp_path / "evil").exists()
+
+
+def test_back_up_with_valid_timestamp_writes_recoverable_copy(tmp_path: Path) -> None:
+    """
+    Given a scoped-namespace target file and a well-formed timestamp
+    When back_up is called directly
+    Then a recoverable copy lands in the sibling <namespace>-backup/ directory.
+
+    Anchors the happy path so the rejection test above is not vacuously green
+    (a back_up that raised on every input would also pass the guard test).
+    """
+    target = tmp_path / ".claude" / "skills" / "retired"
+    target.parent.mkdir(parents=True)
+    target.write_text("precious")
+
+    dest = back_up(target, _TS)
+
+    assert dest == tmp_path / ".claude" / "skills-backup" / f"retired.backup-{_TS}"
+    assert dest.read_text() == "precious"

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from installer.cli import main
+from installer.core.io_port import ScriptedIO
 from installer.core.model import Tool
 from installer.tools import registry
 
@@ -134,3 +135,71 @@ def test_main_no_args_against_empty_home_returns_2_with_detection_diagnostic(
     assert "settings.json" in captured.err
     assert str(tmp_path) in captured.err
     assert "--tools=" in captured.err
+
+
+# ── G.5 / G.7: prune flags + --yes wiring ──
+
+
+def test_prune_and_prune_only_together_is_mutually_exclusive_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    When main(["--prune", "--prune-only"]) is invoked
+    Then argparse exits 2 (mutually exclusive group rejects both).
+
+    Pins: --prune and --prune-only cannot be combined (installer-design.md G.5).
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--prune", "--prune-only"], home=tmp_path)
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "not allowed with" in captured.err
+
+
+def test_prune_only_against_empty_source_prunes_unstaged_dest_entry(tmp_path: Path) -> None:
+    """
+    Given a home with a claude skills/ entry matching the bundled prune list and
+    an empty source repo (nothing staged), under --prune-only --yes
+    When main runs (non-interactive io)
+    Then the unstaged, retired entry is removed.
+
+    Pins: --prune-only scans + prunes against the in-memory plan without an
+    install half, and --yes waives the non-interactive guard.
+    """
+    home = _home_with_claude_settings(tmp_path)
+    # "*/skills/ralf-it" is in the bundled installer.toml prune list.
+    retired = home / ".claude" / "skills" / "ralf-it"
+    retired.mkdir(parents=True)
+    empty_repo = tmp_path / "empty-repo"
+    empty_repo.mkdir()
+
+    rc = main(
+        ["--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=empty_repo,
+    )
+
+    assert rc == 0
+    assert not retired.exists()
+
+
+def test_prune_only_non_interactive_without_yes_fails(tmp_path: Path) -> None:
+    """
+    Given --prune-only with a matching orphan, a non-interactive io, and no --yes
+    When main runs
+    Then it returns a non-zero status (the prune flow's hard-fail guard).
+    """
+    home = _home_with_claude_settings(tmp_path)
+    (home / ".claude" / "skills" / "ralf-it").mkdir(parents=True)
+    empty_repo = tmp_path / "empty-repo"
+    empty_repo.mkdir()
+
+    rc = main(
+        ["--prune-only", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=empty_repo,
+    )
+
+    assert rc != 0

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -23,6 +23,18 @@ def _home_with_claude_settings(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _repo_with_installer_toml(tmp_path: Path, *, retired: list[str]) -> Path:
+    """Create a repo_root whose packages/installer/installer.toml carries the
+    given prune list — mirroring where _run_prune now derives the config path
+    (off the injected repo_root, not __file__)."""
+    repo = tmp_path / "repo"
+    toml_dir = repo / "packages" / "installer"
+    toml_dir.mkdir(parents=True)
+    retired_lines = "\n".join(f'  "{glob}",' for glob in retired)
+    (toml_dir / "installer.toml").write_text(f"[prune]\nretired = [\n{retired_lines}\n]\n")
+    return repo
+
+
 def test_main_help_exits_with_status_zero() -> None:
     """
     When main(["--help"]) is invoked
@@ -167,21 +179,64 @@ def test_prune_only_against_empty_source_prunes_unstaged_dest_entry(tmp_path: Pa
     install half, and --yes waives the non-interactive guard.
     """
     home = _home_with_claude_settings(tmp_path)
-    # "*/skills/ralf-it" is in the bundled installer.toml prune list.
     retired = home / ".claude" / "skills" / "ralf-it"
     retired.mkdir(parents=True)
-    empty_repo = tmp_path / "empty-repo"
-    empty_repo.mkdir()
+    # Source repo is empty (nothing staged) but carries an installer.toml whose
+    # prune list matches the orphan, so _run_prune loads a non-empty list.
+    repo = _repo_with_installer_toml(tmp_path, retired=["*/skills/ralf-it"])
+    io = ScriptedIO(interactive=False)
 
     rc = main(
         ["--prune-only", "--yes", "--tools=claude"],
         home=home,
-        io=ScriptedIO(interactive=False),
-        repo_root=empty_repo,
+        io=io,
+        repo_root=repo,
     )
 
     assert rc == 0
     assert not retired.exists()
+    # Companion to the missing-config case: when installer.toml IS present, the
+    # missing-config warning is not emitted.
+    assert not any(
+        e.channel == "warn" and "installer.toml not found" in e.message for e in io.transcript
+    )
+
+
+def test_prune_only_warns_and_exits_clean_when_installer_toml_absent(tmp_path: Path) -> None:
+    """
+    Given a repo_root whose packages/installer/installer.toml does NOT exist,
+    under --prune-only --yes
+    When main runs (non-interactive io)
+    Then a warning naming the missing path is emitted through io and the run
+    still exits cleanly (0) — an absent prune list deletes nothing (fail-safe),
+    so the no-op is explained rather than silent.
+
+    Pins: _run_prune derives the config path from repo_root and warns on the
+    missing-file case (PR #151 comment 3408241642).
+    """
+    home = _home_with_claude_settings(tmp_path)
+    # An orphan that WOULD match the bundled prune list, to prove it is the
+    # empty list (not a non-match) that spares it from pruning.
+    retired = home / ".claude" / "skills" / "ralf-it"
+    retired.mkdir(parents=True)
+    empty_repo = tmp_path / "no-toml-repo"
+    empty_repo.mkdir()  # no packages/installer/installer.toml underneath
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=io,
+        repo_root=empty_repo,
+    )
+
+    assert rc == 0
+    assert retired.exists()  # empty prune list => nothing pruned
+    warnings = [
+        e for e in io.transcript if e.channel == "warn" and "installer.toml not found" in e.message
+    ]
+    assert len(warnings) == 1
+    assert str(empty_repo / "packages" / "installer" / "installer.toml") in warnings[0].message
 
 
 def test_prune_only_non_interactive_without_yes_fails(tmp_path: Path) -> None:
@@ -192,14 +247,13 @@ def test_prune_only_non_interactive_without_yes_fails(tmp_path: Path) -> None:
     """
     home = _home_with_claude_settings(tmp_path)
     (home / ".claude" / "skills" / "ralf-it").mkdir(parents=True)
-    empty_repo = tmp_path / "empty-repo"
-    empty_repo.mkdir()
+    repo = _repo_with_installer_toml(tmp_path, retired=["*/skills/ralf-it"])
 
     rc = main(
         ["--prune-only", "--tools=claude"],
         home=home,
         io=ScriptedIO(interactive=False),
-        repo_root=empty_repo,
+        repo_root=repo,
     )
 
     assert rc != 0

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -35,6 +35,17 @@ def _repo_with_installer_toml(tmp_path: Path, *, retired: list[str]) -> Path:
     return repo
 
 
+def _repo_with_malformed_installer_toml(tmp_path: Path) -> Path:
+    """Create a repo_root whose installer.toml is type-malformed: prune.retired
+    is a bare string, which load_installer_toml rejects with ValueError (it would
+    otherwise list()-shred into single-character globs)."""
+    repo = tmp_path / "repo"
+    toml_dir = repo / "packages" / "installer"
+    toml_dir.mkdir(parents=True)
+    (toml_dir / "installer.toml").write_text('[prune]\nretired = "*/skills/ralf-it"\n')
+    return repo
+
+
 def test_main_help_exits_with_status_zero() -> None:
     """
     When main(["--help"]) is invoked
@@ -257,6 +268,87 @@ def test_prune_only_non_interactive_without_yes_fails(tmp_path: Path) -> None:
     )
 
     assert rc != 0
+
+
+def test_prune_only_with_malformed_installer_toml_returns_2_and_errs_through_io(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a repo_root whose packages/installer/installer.toml is type-malformed
+    (prune.retired is a string, not a list), under --prune-only --yes
+    When main runs (non-interactive io)
+    Then it returns 2 (the config-error exit convention)
+    And the malformed-config message is surfaced through io's err channel
+    And no uncaught traceback escapes.
+
+    Pins: _run_prune catches the ValueError that load_installer_toml raises on a
+    type-malformed installer.toml and fails cleanly via io.err + return 2 rather
+    than crashing the CLI (PR #151 comment 3408271848).
+    """
+    home = _home_with_claude_settings(tmp_path)
+    repo = _repo_with_malformed_installer_toml(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    errs = [
+        e
+        for e in io.transcript
+        if e.channel == "err" and "retired must be a list of strings" in e.message
+    ]
+    assert len(errs) == 1
+
+
+def test_prune_plugin_discovery_honors_injected_repo_root(tmp_path: Path) -> None:
+    """
+    Given two repo_roots — one whose src/plugins/ contains a plugin directory and
+    one lacking src/plugins entirely — each with a valid installer.toml,
+    under --prune-only --yes
+    When main runs against each (non-interactive io)
+    Then plugin discovery resolves against the *injected* repo_root: the run
+    completes cleanly (0) in both cases, and the run whose repo_root lacks
+    src/plugins discovers nothing (no plugin staging is attempted off the real
+    repo's src/plugins).
+
+    Pins: _run_prune derives plugins_root from the injected repo_root
+    (repo_root / "src" / "plugins"), not the module-level _REPO_ROOT, so
+    repo_root is fully authoritative (PR #151 comment 3408271853). With a
+    repo_root lacking src/plugins, discover() returns {} — proving the real
+    repo's plugins are not consulted.
+    """
+    home = _home_with_claude_settings(tmp_path)
+
+    # repo_root WITH a plugin under src/plugins/: discovery has something to find
+    # there, and the run must not error reaching for the real repo's plugins.
+    repo_with_plugins = _repo_with_installer_toml(tmp_path / "with", retired=[])
+    (repo_with_plugins / "src" / "plugins" / "beads").mkdir(parents=True)
+    rc_with = main(
+        ["--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo_with_plugins,
+    )
+    assert rc_with == 0
+
+    # repo_root WITHOUT src/plugins: discover() returns {} for the injected root.
+    # If discovery had ignored repo_root and used the real _REPO_ROOT/src/plugins,
+    # this assertion could not distinguish the two — the injected empty root is
+    # what makes "no plugins" observable.
+    repo_no_plugins = _repo_with_installer_toml(tmp_path / "without", retired=[])
+    assert not (repo_no_plugins / "src" / "plugins").exists()
+    rc_without = main(
+        ["--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo_no_plugins,
+    )
+    assert rc_without == 0
 
 
 def test_plain_prune_non_interactive_without_yes_fails_on_consent_guard(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -203,3 +203,24 @@ def test_prune_only_non_interactive_without_yes_fails(tmp_path: Path) -> None:
     )
 
     assert rc != 0
+
+
+def test_plain_prune_non_interactive_without_yes_fails_on_consent_guard(tmp_path: Path) -> None:
+    """
+    Given plain --prune (not --prune-only), a non-interactive io, and no --yes
+    When main runs
+    Then it returns non-zero — the consent guard refuses a destructive run that
+    cannot prompt (G.7), before any orphan scan.
+    """
+    home = _home_with_claude_settings(tmp_path)
+    empty_repo = tmp_path / "empty-repo"
+    empty_repo.mkdir()
+
+    rc = main(
+        ["--prune", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=empty_repo,
+    )
+
+    assert rc != 0

--- a/packages/installer/tests/unit/test_consent.py
+++ b/packages/installer/tests/unit/test_consent.py
@@ -1,0 +1,62 @@
+"""Unit tests for installer.core.consent (G.7 — non-interactive consent guard).
+
+Pins the installer-level guard the Python rewrite adds: a run that cannot prompt
+(stdin not a TTY) and has not been waived by ``--yes`` or ``--dry-run`` must hard
+fail with a clear error rather than silently make destructive changes. ``--yes``
+or ``--dry-run`` stand in for consent, so the guard does not trigger then.
+
+The guard is driven through ``ScriptedIO`` (its ``is_interactive`` flag is the
+TTY probe) and asserted on its raise/no-raise behaviour — the actual coded
+decision, not the stdlib ``sys.stdin.isatty``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from installer.core.consent import ConsentRequiredError, require_consent
+
+
+def test_non_interactive_without_waiver_raises() -> None:
+    """
+    Given a non-interactive session, not dry_run, not auto_yes
+    When require_consent runs
+    Then it raises ConsentRequiredError (no way to confirm destructive writes).
+    """
+    from installer.core.io_port import ScriptedIO
+
+    with pytest.raises(ConsentRequiredError):
+        require_consent(ScriptedIO(interactive=False), dry_run=False, auto_yes=False)
+
+
+def test_non_interactive_with_auto_yes_does_not_raise() -> None:
+    """
+    Given a non-interactive session waived by auto_yes
+    When require_consent runs
+    Then it returns without raising (the scripted-install path).
+    """
+    from installer.core.io_port import ScriptedIO
+
+    require_consent(ScriptedIO(interactive=False), dry_run=False, auto_yes=True)
+
+
+def test_non_interactive_with_dry_run_does_not_raise() -> None:
+    """
+    Given a non-interactive session waived by dry_run
+    When require_consent runs
+    Then it returns without raising (dry-run touches nothing).
+    """
+    from installer.core.io_port import ScriptedIO
+
+    require_consent(ScriptedIO(interactive=False), dry_run=True, auto_yes=False)
+
+
+def test_interactive_session_does_not_raise() -> None:
+    """
+    Given an interactive session (a TTY can answer prompts)
+    When require_consent runs with no waiver
+    Then it returns without raising.
+    """
+    from installer.core.io_port import ScriptedIO
+
+    require_consent(ScriptedIO(interactive=True), dry_run=False, auto_yes=False)

--- a/packages/installer/tests/unit/test_installer_toml.py
+++ b/packages/installer/tests/unit/test_installer_toml.py
@@ -1,0 +1,87 @@
+"""Unit tests for installer.core.installer_toml (G.2 — TOML config loader).
+
+Each test pins a coded decision in ``load_installer_toml``:
+- a present ``[prune] retired`` list is surfaced verbatim,
+- a missing file is a no-op default (empty prune list), not an error,
+- a present file with no ``[prune]`` section yields an empty prune list,
+- optional ``[tools]`` dest overrides are surfaced when present, empty when not.
+
+Tautology tests (asserting tomllib parses TOML, asserting a dataclass is frozen)
+are deliberately absent — the loader's *defaulting* and *section-selection*
+decisions are the behaviour under test, not stdlib TOML parsing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.installer_toml import load_installer_toml
+
+
+def test_present_prune_section_surfaces_retired_globs_in_order(tmp_path: Path) -> None:
+    """
+    Given an installer.toml with a [prune] retired list of two globs
+    When the loader reads it
+    Then both globs are returned as strings in file order.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text(
+        '[prune]\nretired = [\n  "*/skills/foo",\n  "claude/rules/bar.md",\n]\n',
+    )
+
+    config = load_installer_toml(toml)
+
+    assert config.prune_globs == ["*/skills/foo", "claude/rules/bar.md"]
+
+
+def test_missing_file_yields_empty_prune_list_without_error(tmp_path: Path) -> None:
+    """
+    Given a path to an installer.toml that does not exist
+    When the loader reads it
+    Then it returns an empty prune list (absence is not an error).
+    """
+    config = load_installer_toml(tmp_path / "does-not-exist.toml")
+
+    assert config.prune_globs == []
+
+
+def test_present_file_without_prune_section_yields_empty_prune_list(tmp_path: Path) -> None:
+    """
+    Given an installer.toml present but carrying no [prune] section
+    When the loader reads it
+    Then the prune list is empty (section-optional, not section-required).
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('[tools]\n# claude.dest = "~/.claude"\n')
+
+    config = load_installer_toml(toml)
+
+    assert config.prune_globs == []
+
+
+def test_tool_dest_override_surfaced_when_present(tmp_path: Path) -> None:
+    """
+    Given a [tools] section declaring a per-tool dest override
+    When the loader reads it
+    Then the override is surfaced keyed by tool name.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('[tools]\nclaude.dest = "~/somewhere/.claude"\n')
+
+    config = load_installer_toml(toml)
+
+    assert config.tool_dest_overrides == {"claude": "~/somewhere/.claude"}
+
+
+def test_tool_dest_overrides_empty_when_tools_section_absent(tmp_path: Path) -> None:
+    """
+    Given an installer.toml with only a [prune] section
+    When the loader reads it
+    Then tool dest overrides default to an empty mapping.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('[prune]\nretired = ["*/skills/foo"]\n')
+
+    config = load_installer_toml(toml)
+
+    assert config.tool_dest_overrides == {}

--- a/packages/installer/tests/unit/test_installer_toml.py
+++ b/packages/installer/tests/unit/test_installer_toml.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from installer.core.installer_toml import load_installer_toml
 
 
@@ -85,3 +87,55 @@ def test_tool_dest_overrides_empty_when_tools_section_absent(tmp_path: Path) -> 
     config = load_installer_toml(toml)
 
     assert config.tool_dest_overrides == {}
+
+
+def test_prune_not_a_table_raises_value_error(tmp_path: Path) -> None:
+    """
+    Given a type-malformed [prune] (a scalar, not a table)
+    When the loader reads it
+    Then a ValueError is raised rather than an AttributeError on .get().
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('prune = "x"\n')
+
+    with pytest.raises(ValueError, match=r"\[prune\] must be a table"):
+        load_installer_toml(toml)
+
+
+def test_retired_as_string_raises_value_error(tmp_path: Path) -> None:
+    """
+    Given retired declared as a bare string instead of a list
+    When the loader reads it
+    Then a ValueError is raised — guarding the list("*/foo") single-char shred.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('[prune]\nretired = "*/skills/foo"\n')
+
+    with pytest.raises(ValueError, match=r"retired must be a list of strings"):
+        load_installer_toml(toml)
+
+
+def test_retired_with_non_string_elements_raises_value_error(tmp_path: Path) -> None:
+    """
+    Given a retired list whose elements are not strings
+    When the loader reads it
+    Then a ValueError is raised rather than passing ints downstream to fnmatch.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text("[prune]\nretired = [1, 2]\n")
+
+    with pytest.raises(ValueError, match=r"retired must be a list of strings"):
+        load_installer_toml(toml)
+
+
+def test_tools_not_a_table_raises_value_error(tmp_path: Path) -> None:
+    """
+    Given a type-malformed [tools] (a scalar, not a table)
+    When the loader reads it
+    Then a ValueError is raised rather than silently iterating a non-dict.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('tools = "x"\n')
+
+    with pytest.raises(ValueError, match=r"\[tools\] must be a table"):
+        load_installer_toml(toml)

--- a/packages/installer/tests/unit/test_installer_toml.py
+++ b/packages/installer/tests/unit/test_installer_toml.py
@@ -139,3 +139,32 @@ def test_tools_not_a_table_raises_value_error(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match=r"\[tools\] must be a table"):
         load_installer_toml(toml)
+
+
+def test_tool_dest_non_string_raises_value_error(tmp_path: Path) -> None:
+    """
+    Given a [tools] entry whose dest leaf is a non-string (an int)
+    When the loader reads it
+    Then a ValueError is raised — the dest leaf is validated, not just the
+    container shape, so a non-string never reaches a later string consumer.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text("[tools]\nclaude.dest = 123\n")
+
+    with pytest.raises(ValueError, match=r"claude\.dest must be a string"):
+        load_installer_toml(toml)
+
+
+def test_tool_entry_without_dest_key_is_skipped_not_an_error(tmp_path: Path) -> None:
+    """
+    Given a [tools] entry that declares no dest key (only some other field)
+    When the loader reads it
+    Then the entry is silently skipped (no override surfaced, no error) —
+    only <tool>.dest entries contribute to the override mapping.
+    """
+    toml = tmp_path / "installer.toml"
+    toml.write_text('[tools]\nclaude.other = "x"\n')
+
+    config = load_installer_toml(toml)
+
+    assert config.tool_dest_overrides == {}

--- a/packages/installer/tests/unit/test_prune.py
+++ b/packages/installer/tests/unit/test_prune.py
@@ -180,6 +180,24 @@ def test_tool_scoped_glob_does_not_match_other_tool(tmp_path: Path) -> None:
     assert orphans == []
 
 
+def test_adapter_with_no_plan_entry_still_scans_dest(tmp_path: Path) -> None:
+    """
+    Given an adapter active for the run but absent from the plans mapping
+    When scan_orphans runs
+    Then its dest tree is still scanned (a missing plan stages nothing, so a
+    matching dest entry is an orphan).
+
+    Pins the ``plan is None`` branch: an active tool with no built plan must not
+    suppress its orphan scan.
+    """
+    _make_dest_dir(tmp_path, "skills", "retired-skill")
+    config = InstallerToml(prune_globs=["*/skills/retired-skill"])
+
+    orphans = scan_orphans([_ClaudeLikeAdapter()], plans={}, home=tmp_path, config=config)
+
+    assert [o.path.name for o in orphans] == ["retired-skill"]
+
+
 def test_beads_formulas_scanned_with_no_beads_plan(tmp_path: Path) -> None:
     """
     Given a ~/.beads/formulas entry and no beads content in any plan

--- a/packages/installer/tests/unit/test_prune.py
+++ b/packages/installer/tests/unit/test_prune.py
@@ -1,0 +1,200 @@
+"""Unit tests for installer.core.prune (G.3 — orphan scan).
+
+Each test pins a coded decision in ``scan_orphans``, the port of the bash
+orphan scan (``scripts/install.sh:1505-1543``):
+- a dest entry absent from the plan AND matching a prune glob is an orphan,
+- a dest entry absent from the plan but matching NO glob is left alone,
+- a dest entry present in the plan is never an orphan (even if a glob matches),
+- ``*.backup-*`` legacy entries are skipped,
+- dir vs file kind is classified from the filesystem entry,
+- a ``*/...`` glob matches across tools; a ``claude/...`` glob is tool-scoped,
+- ``~/.beads/formulas`` is scanned even with no beads plan present (strict mode).
+
+The fnmatch semantics themselves are stdlib and not under test; what is pinned
+is the key shape (``tool/namespace/basename``), the plan-membership exclusion,
+the backup skip, and the kind classification.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.installer_toml import InstallerToml
+from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
+from installer.core.prune import scan_orphans
+
+
+class _ClaudeLikeAdapter:
+    """Minimal ToolAdapter double: dest_dir is ``home/.claude`` and the scoped
+    namespaces match Claude. The scan only consults ``name``, ``dest_dir``, and
+    ``scoped_namespaces``; the rest are inert."""
+
+    name: str = "claude"
+    detection_signal: str = ".claude/settings.json"
+
+    def source_dir(self, repo_root: Path) -> Path:
+        return repo_root
+
+    def dest_dir(self, home: Path) -> Path:
+        return home / ".claude"
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002  # inert stub
+        return True
+
+    def scoped_namespaces(self) -> tuple[str, ...]:
+        return ("commands", "skills", "agents", "rules")
+
+    def should_install_namespace(self, namespace: str, source: str) -> bool:  # noqa: ARG002
+        return True
+
+    def post_staging_transforms(self, plan: StagingPlan, io: object) -> StagingPlan:  # noqa: ARG002
+        return plan
+
+
+def _empty_plan() -> StagingPlan:
+    return StagingPlan(items={}, tool=Tool.CLAUDE)
+
+
+def _staged_dir(namespace: str, name: str) -> StagedItem:
+    return StagedItem(
+        source_path=Path("/src") / namespace / name,
+        dest_relpath=Path(namespace) / name,
+        kind=FileKind.DIR,
+        namespace=namespace,
+        provenance=Provenance(kind="tool", name="claude"),
+    )
+
+
+def _make_dest_dir(home: Path, namespace: str, name: str) -> Path:
+    d = home / ".claude" / namespace / name
+    d.mkdir(parents=True)
+    return d
+
+
+def test_unstaged_entry_matching_glob_is_orphan(tmp_path: Path) -> None:
+    """
+    Given a dest skills/ entry absent from the plan and matching a prune glob
+    When scan_orphans runs
+    Then exactly that entry is returned as a dir orphan tagged claude/skills.
+    """
+    _make_dest_dir(tmp_path, "skills", "retired-skill")
+    config = InstallerToml(prune_globs=["*/skills/retired-skill"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert [(o.tool, o.namespace, o.path.name, o.kind) for o in orphans] == [
+        ("claude", "skills", "retired-skill", "dir")
+    ]
+
+
+def test_unstaged_entry_not_matching_any_glob_is_not_orphan(tmp_path: Path) -> None:
+    """
+    Given a dest entry absent from the plan but matching no prune glob
+    When scan_orphans runs
+    Then it is not reported (a non-listed extra is left in place).
+    """
+    _make_dest_dir(tmp_path, "skills", "some-other-skill")
+    config = InstallerToml(prune_globs=["*/skills/retired-skill"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert orphans == []
+
+
+def test_staged_entry_is_never_orphan_even_when_glob_matches(tmp_path: Path) -> None:
+    """
+    Given a dest entry that IS in the plan and would match a glob
+    When scan_orphans runs
+    Then it is not reported — plan membership wins over the glob.
+    """
+    _make_dest_dir(tmp_path, "skills", "kept-skill")
+    plan = _empty_plan()
+    plan.items[Path("skills/kept-skill")] = _staged_dir("skills", "kept-skill")
+    config = InstallerToml(prune_globs=["*/skills/kept-skill"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: plan}, home=tmp_path, config=config
+    )
+
+    assert orphans == []
+
+
+def test_legacy_backup_entry_is_skipped(tmp_path: Path) -> None:
+    """
+    Given a dest entry whose name carries the legacy .backup- marker
+    When scan_orphans runs
+    Then it is skipped even though it is unstaged and would match a glob.
+    """
+    _make_dest_dir(tmp_path, "skills", "old-skill.backup-20250101-000000")
+    config = InstallerToml(prune_globs=["*/skills/*"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert orphans == []
+
+
+def test_file_entry_classified_as_file_kind(tmp_path: Path) -> None:
+    """
+    Given an unstaged dest rules/ FILE matching a glob
+    When scan_orphans runs
+    Then the orphan's kind is "file", not "dir".
+    """
+    (tmp_path / ".claude" / "rules").mkdir(parents=True)
+    (tmp_path / ".claude" / "rules" / "git-commits.md").write_text("x")
+    config = InstallerToml(prune_globs=["claude/rules/git-commits.md"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert [o.kind for o in orphans] == ["file"]
+
+
+def test_tool_scoped_glob_does_not_match_other_tool(tmp_path: Path) -> None:
+    """
+    Given a claude/-prefixed glob and a dest entry under the claude tree
+    When scan_orphans runs for an adapter whose name is NOT claude
+    Then the entry is not matched (the glob is tool-scoped by its first segment).
+    """
+
+    class _CodexLikeAdapter(_ClaudeLikeAdapter):
+        name: str = "codex"
+
+        def dest_dir(self, home: Path) -> Path:
+            return home / ".codex"
+
+    (tmp_path / ".codex" / "rules").mkdir(parents=True)
+    (tmp_path / ".codex" / "rules" / "git-commits.md").write_text("x")
+    config = InstallerToml(prune_globs=["claude/rules/git-commits.md"])
+
+    orphans = scan_orphans(
+        [_CodexLikeAdapter()], plans={Tool.CODEX: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert orphans == []
+
+
+def test_beads_formulas_scanned_with_no_beads_plan(tmp_path: Path) -> None:
+    """
+    Given a ~/.beads/formulas entry and no beads content in any plan
+    When scan_orphans runs
+    Then the formula is flagged as a beads/formulas orphan (strict mode):
+    nothing staged it, so it is an orphan if a glob matches.
+    """
+    (tmp_path / ".beads" / "formulas").mkdir(parents=True)
+    (tmp_path / ".beads" / "formulas" / "stale.toml").write_text("x")
+    config = InstallerToml(prune_globs=["beads/formulas/*"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert [(o.tool, o.namespace, o.path.name) for o in orphans] == [
+        ("beads", "formulas", "stale.toml")
+    ]

--- a/packages/installer/tests/unit/test_prune.py
+++ b/packages/installer/tests/unit/test_prune.py
@@ -51,8 +51,8 @@ class _ClaudeLikeAdapter:
         return plan
 
 
-def _empty_plan() -> StagingPlan:
-    return StagingPlan(items={}, tool=Tool.CLAUDE)
+def _empty_plan(tool: Tool = Tool.CLAUDE) -> StagingPlan:
+    return StagingPlan(items={}, tool=tool)
 
 
 def _staged_dir(namespace: str, name: str) -> StagedItem:
@@ -174,7 +174,10 @@ def test_tool_scoped_glob_does_not_match_other_tool(tmp_path: Path) -> None:
     config = InstallerToml(prune_globs=["claude/rules/git-commits.md"])
 
     orphans = scan_orphans(
-        [_CodexLikeAdapter()], plans={Tool.CODEX: _empty_plan()}, home=tmp_path, config=config
+        [_CodexLikeAdapter()],
+        plans={Tool.CODEX: _empty_plan(Tool.CODEX)},
+        home=tmp_path,
+        config=config,
     )
 
     assert orphans == []

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -1,0 +1,234 @@
+"""Unit tests for installer.core.prune_flow (G.4 — interactive prune flow).
+
+Each test pins a coded decision in ``run_prune``, the port of the bash
+``prune_orphans`` (``scripts/install.sh:1602-1687``). The engine is driven
+through ``ScriptedIO`` and asserted against real filesystem end-state plus the
+returned ``Counters`` — never against which IOPort method was called.
+
+Covered decisions:
+- three-way "all" -> every orphan backed up then deleted,
+- three-way "one-by-one" -> per-item y deletes, n/default skips, q stops the rest,
+- three-way "cancel" -> nothing deleted,
+- non-interactive + prune_only + not auto_yes + not dry_run -> hard fail,
+- non-interactive + plain prune (not prune_only) -> warn + skip, no deletes,
+- auto_yes -> delete all without prompting,
+- dry_run -> display only, no deletes,
+- empty orphan list -> no prompt, no deletes,
+- backup precedes delete (a sibling <namespace>-backup/ copy survives the rm),
+- directory orphans are backed up recursively.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.io_port import PerItemResult, ScriptedIO
+from installer.core.model import Orphan
+from installer.core.prune_flow import PruneAbortedError, run_prune
+
+_TS = "20250101-120000"
+
+
+def _file_orphan(home: Path, tool: str, namespace: str, name: str, body: str = "x") -> Orphan:
+    d = home / f".{tool}" / namespace
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / name
+    path.write_text(body)
+    return Orphan(tool=tool, namespace=namespace, path=path, kind="file")
+
+
+def _dir_orphan(home: Path, tool: str, namespace: str, name: str) -> Orphan:
+    d = home / f".{tool}" / namespace / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "inner.md").write_text("inner")
+    return Orphan(tool=tool, namespace=namespace, path=d, kind="dir")
+
+
+def test_three_way_all_deletes_every_orphan(tmp_path: Path) -> None:
+    """
+    Given two orphans and an interactive answer of "all"
+    When run_prune executes
+    Then both paths are gone and pruned == 2.
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    o2 = _file_orphan(tmp_path, "claude", "skills", "b")
+    io = ScriptedIO(three_ways=["a"])
+
+    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+
+    assert not o1.path.exists()
+    assert not o2.path.exists()
+    assert counters.pruned == 2
+
+
+def test_three_way_one_by_one_respects_per_item_choices(tmp_path: Path) -> None:
+    """
+    Given two orphans, "one-by-one", and per-item decisions keep-a / drop-b
+    When run_prune executes
+    Then only b is deleted and pruned == 1.
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    o2 = _file_orphan(tmp_path, "claude", "skills", "b")
+    io = ScriptedIO(
+        three_ways=["o"],
+        per_items=[PerItemResult(decisions={str(o1.path): False, str(o2.path): True}, quit=False)],
+    )
+
+    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+
+    assert o1.path.exists()
+    assert not o2.path.exists()
+    assert counters.pruned == 1
+
+
+def test_three_way_one_by_one_quit_leaves_remaining(tmp_path: Path) -> None:
+    """
+    Given two orphans, "one-by-one", and a quit after answering only the first
+    When run_prune executes
+    Then the un-answered orphan is left in place (quit stops the loop).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    o2 = _file_orphan(tmp_path, "claude", "skills", "b")
+    io = ScriptedIO(
+        three_ways=["o"],
+        per_items=[PerItemResult(decisions={str(o1.path): True}, quit=True)],
+    )
+
+    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+
+    assert not o1.path.exists()
+    assert o2.path.exists()
+    assert counters.pruned == 1
+
+
+def test_three_way_cancel_deletes_nothing(tmp_path: Path) -> None:
+    """
+    Given an orphan and an interactive answer of "cancel"
+    When run_prune executes
+    Then nothing is deleted and pruned == 0.
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(three_ways=["c"])
+
+    counters = run_prune([o1], io=io, timestamp=_TS)
+
+    assert o1.path.exists()
+    assert counters.pruned == 0
+
+
+def test_non_interactive_prune_only_without_auth_raises(tmp_path: Path) -> None:
+    """
+    Given a non-interactive session, prune_only, no auto_yes, no dry_run
+    When run_prune executes
+    Then it raises PruneAbortedError (intent unfulfilled: action with no auth).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(interactive=False)
+
+    with pytest.raises(PruneAbortedError):
+        run_prune([o1], io=io, prune_only=True, timestamp=_TS)
+
+    assert o1.path.exists()
+
+
+def test_non_interactive_plain_prune_skips_without_deleting(tmp_path: Path) -> None:
+    """
+    Given a non-interactive session and plain prune (not prune_only), no auth
+    When run_prune executes
+    Then it returns having deleted nothing (warn + skip, not a hard fail).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([o1], io=io, prune_only=False, timestamp=_TS)
+
+    assert o1.path.exists()
+    assert counters.pruned == 0
+
+
+def test_auto_yes_deletes_all_without_prompting(tmp_path: Path) -> None:
+    """
+    Given auto_yes and an empty prompt queue
+    When run_prune executes
+    Then all orphans are deleted with no prompt popped (ScriptedIO not drained).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    o2 = _file_orphan(tmp_path, "claude", "skills", "b")
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([o1, o2], io=io, auto_yes=True, timestamp=_TS)
+
+    assert not o1.path.exists()
+    assert not o2.path.exists()
+    assert counters.pruned == 2
+
+
+def test_dry_run_displays_without_deleting(tmp_path: Path) -> None:
+    """
+    Given dry_run
+    When run_prune executes
+    Then nothing is deleted and pruned == 0 (no prompt is consulted).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([o1], io=io, dry_run=True, timestamp=_TS)
+
+    assert o1.path.exists()
+    assert counters.pruned == 0
+
+
+def test_empty_orphan_list_is_noop() -> None:
+    """
+    Given no orphans and a passing guard (interactive session)
+    When run_prune executes
+    Then it returns pruned == 0 without consulting any prompt.
+
+    Note: the empty fast-path sits AFTER the non-interactive guard (bash
+    ordering, scripts/install.sh:1603-1620), so this exercises the empty path
+    only once the guard has been cleared — see
+    test_non_interactive_prune_only_without_auth_raises for the guard-first case.
+    """
+    io = ScriptedIO(interactive=True)
+
+    counters = run_prune([], io=io, prune_only=True, timestamp=_TS)
+
+    assert counters.pruned == 0
+
+
+def test_backup_precedes_delete_into_sibling_namespace_dir(tmp_path: Path) -> None:
+    """
+    Given a skills/ file orphan deleted under auto_yes
+    When run_prune executes
+    Then a recoverable copy survives in the sibling skills-backup/ directory
+    and backed_up == 1.
+
+    Pins the path-aware routing reuse: a scoped-namespace orphan's backup lands
+    in <grandparent>/<namespace>-backup/, not in-place (scripts/install.sh:369).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "retired", body="precious")
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([o1], io=io, auto_yes=True, timestamp=_TS)
+
+    backup = tmp_path / ".claude" / "skills-backup" / f"retired.backup-{_TS}"
+    assert backup.read_text() == "precious"
+    assert counters.backed_up == 1
+
+
+def test_directory_orphan_backed_up_recursively(tmp_path: Path) -> None:
+    """
+    Given a skills/ directory orphan deleted under auto_yes
+    When run_prune executes
+    Then the backup is a recursive copy (inner file present) and the dir is gone.
+    """
+    o1 = _dir_orphan(tmp_path, "claude", "skills", "retired-dir")
+    io = ScriptedIO(interactive=False)
+
+    run_prune([o1], io=io, auto_yes=True, timestamp=_TS)
+
+    backup_inner = tmp_path / ".claude" / "skills-backup" / f"retired-dir.backup-{_TS}" / "inner.md"
+    assert backup_inner.read_text() == "inner"
+    assert not o1.path.exists()

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -17,7 +17,9 @@ Covered decisions:
 - backup precedes delete (a sibling <namespace>-backup/ copy survives the rm),
 - directory orphans are backed up recursively,
 - a malformed timestamp under a deleting path (auto_yes) raises before any delete,
-- a malformed timestamp under dry_run does NOT raise (no timestamp is resolved).
+- a malformed timestamp under dry_run does NOT raise (no timestamp is resolved),
+- a symlink-to-directory orphan is unlinked (not rmtree'd): the link is removed,
+  its target directory survives, and the flow completes without raising.
 """
 
 from __future__ import annotations
@@ -274,3 +276,36 @@ def test_malformed_timestamp_under_dry_run_does_not_raise(tmp_path: Path) -> Non
     assert o1.path.exists()
     assert counters.pruned == 0
     assert counters.backed_up == 0
+
+
+def test_symlink_to_directory_orphan_unlinked_not_rmtree(tmp_path: Path) -> None:
+    """
+    Given a skills/ orphan that is a symlink pointing at a real directory
+    When run_prune deletes it under auto_yes
+    Then the link is removed via unlink, its target directory survives, and the
+    flow completes without raising.
+
+    Pins the symlink branch in ``_back_up_and_delete``: ``Path.is_dir()`` follows
+    symlinks, so a dir-symlink would reach ``shutil.rmtree`` — which refuses a
+    symlink and raises OSError. The ``is_symlink()`` guard routes it to
+    ``unlink`` (deletes the link, not the target), matching the bash ``rm -rf``.
+    """
+    target_dir = tmp_path / "real-target"
+    target_dir.mkdir()
+    (target_dir / "keep.md").write_text("survives")
+
+    ns_dir = tmp_path / ".claude" / "skills"
+    ns_dir.mkdir(parents=True)
+    link = ns_dir / "linked"
+    link.symlink_to(target_dir, target_is_directory=True)
+    orphan = Orphan(tool="claude", namespace="skills", path=link, kind="dir")
+
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
+
+    assert not link.exists()  # the symlink itself is gone
+    assert not link.is_symlink()
+    assert target_dir.is_dir()  # the link target is untouched
+    assert (target_dir / "keep.md").read_text() == "survives"
+    assert counters.pruned == 1

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -232,3 +232,21 @@ def test_directory_orphan_backed_up_recursively(tmp_path: Path) -> None:
     backup_inner = tmp_path / ".claude" / "skills-backup" / f"retired-dir.backup-{_TS}" / "inner.md"
     assert backup_inner.read_text() == "inner"
     assert not o1.path.exists()
+
+
+def test_malformed_timestamp_rejected_before_any_delete(tmp_path: Path) -> None:
+    """
+    Given an orphan and a caller-supplied timestamp that escapes the format
+    When run_prune executes
+    Then it raises ValueError and the orphan is untouched.
+
+    Pins the guardrail: the timestamp is interpolated raw into the backup path,
+    so a path-separator-bearing value must be rejected before any I/O.
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(interactive=False)
+
+    with pytest.raises(ValueError, match="YYYYMMDD-HHMMSS"):
+        run_prune([o1], io=io, auto_yes=True, timestamp="../evil")
+
+    assert o1.path.exists()

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -15,7 +15,9 @@ Covered decisions:
 - dry_run -> display only, no deletes,
 - empty orphan list -> no prompt, no deletes,
 - backup precedes delete (a sibling <namespace>-backup/ copy survives the rm),
-- directory orphans are backed up recursively.
+- directory orphans are backed up recursively,
+- a malformed timestamp under a deleting path (auto_yes) raises before any delete,
+- a malformed timestamp under dry_run does NOT raise (no timestamp is resolved).
 """
 
 from __future__ import annotations
@@ -234,14 +236,16 @@ def test_directory_orphan_backed_up_recursively(tmp_path: Path) -> None:
     assert not o1.path.exists()
 
 
-def test_malformed_timestamp_rejected_before_any_delete(tmp_path: Path) -> None:
+def test_malformed_timestamp_under_auto_yes_rejected_before_any_delete(tmp_path: Path) -> None:
     """
-    Given an orphan and a caller-supplied timestamp that escapes the format
+    Given a non-empty orphan list, auto_yes, and a timestamp that escapes the format
     When run_prune executes
     Then it raises ValueError and the orphan is untouched.
 
-    Pins the guardrail: the timestamp is interpolated raw into the backup path,
-    so a path-separator-bearing value must be rejected before any I/O.
+    Pins the guardrail on a *deleting* path: the timestamp is interpolated raw
+    into the backup path, so a path-separator-bearing value must be rejected
+    before any I/O. The raise now originates at the ``back_up`` boundary
+    (safe-by-default), not from an explicit check in ``run_prune``.
     """
     o1 = _file_orphan(tmp_path, "claude", "skills", "a")
     io = ScriptedIO(interactive=False)
@@ -250,3 +254,23 @@ def test_malformed_timestamp_rejected_before_any_delete(tmp_path: Path) -> None:
         run_prune([o1], io=io, auto_yes=True, timestamp="../evil")
 
     assert o1.path.exists()
+
+
+def test_malformed_timestamp_under_dry_run_does_not_raise(tmp_path: Path) -> None:
+    """
+    Given a non-empty orphan list, dry_run, and a timestamp that escapes the format
+    When run_prune executes
+    Then it lists the orphan, returns empty Counters, and does NOT raise.
+
+    Pins the dry-run skip: a dry-run performs no backup, so it must never resolve
+    or validate a timestamp it will not use. A malformed value is irrelevant on
+    this path (mirrors sync.py, which validates only on the actual-write path).
+    """
+    o1 = _file_orphan(tmp_path, "claude", "skills", "a")
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([o1], io=io, dry_run=True, timestamp="../evil")
+
+    assert o1.path.exists()
+    assert counters.pruned == 0
+    assert counters.backed_up == 0

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -19,7 +19,10 @@ Covered decisions:
 - a malformed timestamp under a deleting path (auto_yes) raises before any delete,
 - a malformed timestamp under dry_run does NOT raise (no timestamp is resolved),
 - a symlink-to-directory orphan is unlinked (not rmtree'd): the link is removed,
-  its target directory survives, and the flow completes without raising.
+  its target directory survives, and the flow completes without raising,
+- a broken-symlink orphan (link present, target missing) is unlinked WITHOUT a
+  backup: ``exists()`` is False so backup is skipped (backed_up == 0), the link
+  is still removed (pruned == 1), and the flow does not raise.
 """
 
 from __future__ import annotations
@@ -308,4 +311,35 @@ def test_symlink_to_directory_orphan_unlinked_not_rmtree(tmp_path: Path) -> None
     assert not link.is_symlink()
     assert target_dir.is_dir()  # the link target is untouched
     assert (target_dir / "keep.md").read_text() == "survives"
+    assert counters.pruned == 1
+
+
+def test_broken_symlink_orphan_unlinked_without_backup(tmp_path: Path) -> None:
+    """
+    Given a skills/ orphan that is a symlink whose target does not exist
+    When run_prune deletes it under auto_yes
+    Then the backup is skipped (backed_up == 0), the dangling link is still
+    removed (pruned == 1), and the flow completes without raising.
+
+    Pins the existence guard in ``_back_up_and_delete``: ``Path.exists()`` follows
+    the link to a missing target and returns False, so ``back_up`` (which would
+    fall through to ``copy2`` on the dead link and raise ``FileNotFoundError``,
+    aborting the whole prune run) must be skipped — mirroring the bash
+    ``backup()`` ``[[ -e ]]`` no-op. The broken link is still unlinked, matching
+    ``rm -rf`` removing a dangling symlink.
+    """
+    ns_dir = tmp_path / ".claude" / "skills"
+    ns_dir.mkdir(parents=True)
+    link = ns_dir / "dangling"
+    link.symlink_to(tmp_path / "does-not-exist")
+    assert link.is_symlink()
+    assert not link.exists()  # broken: target is missing
+    orphan = Orphan(tool="claude", namespace="skills", path=link, kind="file")
+
+    io = ScriptedIO(interactive=False)
+
+    counters = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
+
+    assert not link.is_symlink()  # the dangling link is gone
+    assert counters.backed_up == 0  # nothing to back up
     assert counters.pruned == 1

--- a/packages/installer/tests/unit/test_run_prune_pipeline.py
+++ b/packages/installer/tests/unit/test_run_prune_pipeline.py
@@ -1,0 +1,108 @@
+"""Unit tests for installer.core.run.prune_pipeline (G.5 — scan + flow composition).
+
+``prune_pipeline`` is the install-side composition that G.5 wires behind the
+``--prune`` / ``--prune-only`` flags: scan the active tools' dest trees against
+their in-memory plans for orphans, then drive the interactive prune flow. These
+tests pin the composition's end-state, driving it through ``ScriptedIO`` and the
+real filesystem — not the call sequence.
+
+Covered decisions:
+- an unstaged, glob-matched dest entry is scanned AND pruned (scan -> flow),
+- an empty staging plan with an excluded-plugin file flags + prunes that file
+  (strict mode: nothing staged it),
+- a no-orphan tree is a clean no-op.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.installer_toml import InstallerToml
+from installer.core.io_port import ScriptedIO
+from installer.core.model import StagingPlan, Tool
+from installer.core.run import prune_pipeline
+from installer.tools.registry import get_adapter
+
+_TS = "20250101-120000"
+
+
+def _claude_home_with_settings(tmp_path: Path) -> Path:
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text("{}")
+    return tmp_path
+
+
+def test_unstaged_matched_entry_is_scanned_and_pruned(tmp_path: Path) -> None:
+    """
+    Given a claude skills/ entry absent from the plan and matching a glob
+    When prune_pipeline runs under auto_yes
+    Then it is deleted (the scan feeds the flow) and pruned == 1.
+    """
+    home = _claude_home_with_settings(tmp_path)
+    retired = home / ".claude" / "skills" / "retired-skill"
+    retired.mkdir(parents=True)
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+    config = InstallerToml(prune_globs=["*/skills/retired-skill"])
+
+    counters = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        home=home,
+        config=config,
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert not retired.exists()
+    assert counters.pruned == 1
+
+
+def test_empty_plan_with_excluded_plugin_file_flags_it(tmp_path: Path) -> None:
+    """
+    Given a ~/.beads/formulas file and an empty plan set (plugin excluded)
+    When prune_pipeline runs under auto_yes with a matching glob
+    Then the formula is pruned (strict mode: excluded plugin -> all its files
+    are orphans).
+    """
+    home = _claude_home_with_settings(tmp_path)
+    formula = home / ".beads" / "formulas" / "stale.toml"
+    formula.parent.mkdir(parents=True)
+    formula.write_text("x")
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+    config = InstallerToml(prune_globs=["beads/formulas/*"])
+
+    counters = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        home=home,
+        config=config,
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert not formula.exists()
+    assert counters.pruned == 1
+
+
+def test_no_orphans_is_clean_noop(tmp_path: Path) -> None:
+    """
+    Given a dest tree with nothing matching the prune globs
+    When prune_pipeline runs
+    Then pruned == 0 (no scan hit, flow no-ops on empty list).
+    """
+    home = _claude_home_with_settings(tmp_path)
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+    config = InstallerToml(prune_globs=["*/skills/never-matches"])
+
+    counters = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        home=home,
+        config=config,
+        io=ScriptedIO(interactive=True),
+        timestamp=_TS,
+    )
+
+    assert counters.pruned == 0


### PR DESCRIPTION
## Scope

PR-2 of installer **Epic G** — the prune pipeline plus the `--yes` auto-accept path. Five stories on one branch, in dependency order (G.2 → G.3 → G.4 → G.5; G.7 alongside).

**Artifact type:** Python installer engine code (`packages/installer/`) — real code with a real quality gate, not the prose config under `src/`.

**Ground-truth references:**
- `docs/architecture/installer/installer-design.md` — Epic G (~line 297); `installer.toml` schema (~lines 128–145).
- `scripts/install.sh` is the behavioural spec. Ported line ranges (cited in code comments): `352-388` (backup routing), `1471-1499` (prune-list load + glob match), `1505-1543` (orphan scan), `1602-1687` (interactive prune flow), `170-185` (`confirm()`).

## Stories

| Story | What landed | Bash spec |
|---|---|---|
| **G.2** | `core/installer_toml.py` + `installer.toml` — stdlib-`tomllib` loader for a `[prune] retired` glob array (+ optional `[tools]` overrides). Missing file → empty config, no error. | `install.sh:1471-1483` |
| **G.3** | `core/prune.py` — orphan scan against the in-memory `StagingPlan`(s). A top-level dest entry under a scoped namespace (or `~/.beads/formulas`) that is absent from the plan **and** matches a `tool/namespace/basename` prune glob (`fnmatch`) is an `Orphan`. `*.backup-*` skipped; beads/formulas scanned unconditionally (strict mode). Pure function. | `install.sh:1505-1543` |
| **G.4** | `core/prune_flow.py` — three-way prompt (all / one-by-one / cancel) + per-item drill-down with quit-mid-loop, routed entirely through `IOPort`. Backup **always** precedes delete (file or dir) so `--yes` is never data-loss. Non-interactive guard runs first. | `install.sh:1602-1687` |
| **G.5** | `cli.py` + `core/run.py` — `--prune` / `--prune-only` (argparse `mutually_exclusive_group`), `--yes`/`-y`, `--dry-run`. `core/run.py::prune_pipeline` composes the scan (G.3) with the flow (G.4). | `install.sh:106-141` |
| **G.7** | `config.py` (`Config.auto_yes`) + `core/consent.py` — a non-interactive run that is neither `--yes` nor `--dry-run` raises `ConsentRequiredError` rather than overwriting silently. | `install.sh:170-185` |

**Refactor (carried in G.4):** extracted the path-aware backup routing + timestamp contract out of `core/sync.py` (G.1) into a shared `core/backup.py`, now directory-capable (`shutil.copytree`). `sync.py` delegates — no behaviour change; the sync tests still pass unchanged.

## Architectural decisions & gaps (read before reviewing)

These are **deliberate** and structured for the future stories that complete them. Please do not flag them as defects.

1. **Plan-walking install sync is NOT wired into `main()`** (pre-existing — see the notes in `cli.py` and `orchestrator.py`). Consequence: `--prune` ("install then prune") cannot perform the install half today. The prune scan + flow run against the in-memory `StagingPlan`(s) from `stage_and_transform`; the sequencing in `_run_prune` is structured so the install phase slots in ahead of the prune call when that story lands. `--prune-only` is fully correct today (it skips install by design).

2. **G.7's `sync.py` diff/confirm bypass is deferred.** `core/sync.py` currently writes-on-hash-differ and has **no interactive diff/confirm path to bypass**. So `auto_yes` is threaded at the `Config` + consent-guard layer (the genuinely testable new behaviour) rather than as a no-op parameter on `sync()` (which would pin nothing — a tautology). Backup always runs; the confirm-path bypass lands with the plan-walking sync story. `Config.auto_yes` is forward-wiring for that consumer (commented at its construction site).

3. **`tool_dest_overrides` (G.2) is parsed and surfaced but NOT yet consumed.** Dest resolution still goes through `adapter.dest_dir(home)` everywhere, including the prune scan — a declared `[tools].<tool>.dest` override is currently inert. The schema ships now (it is in the design doc) so the loader is forward-compatible; threading the override into dest resolution is a later story. Made explicit in the loader docstring (raised by the quality reviewer; resolved as documented deferral).

4. **Cross-PR `--dump-stage ⊥ --prune` mutual exclusion is deferred to integration.** A sibling PR-3 concurrently adds `--dump-stage` to `cli.py`. The prune flags are deliberately grouped in a `mutually_exclusive_group` as the seam a later integration widens — this branch does not reference `--dump-stage` (it doesn't exist here). A `cli.py` merge conflict at integration time is expected.

## Quality gate

`make ci-installer` is **green**: ruff lint + format, `mypy --strict` (41 source files), `pytest` **431 passed / 99.81% coverage** (90% branch floor; all new modules at 100% — the 2 misses are pre-existing `staging.py`/`extensions.py`), `pip-audit` clean, `install.py --help` entry-verify passing.

## Review notes (from the in-house quality reviewer)

A `quality-reviewer` pass found **no CRITICAL/HIGH correctness or security bugs**. Resolved/deferred:
- **Finding 1 (HIGH-decision):** `tool_dest_overrides` unconsumed → documented as intentional deferral (decision #3 above).
- **Finding 2 (suggestion):** discarded `Config(...)` → comment sharpened to note the field is forward-wiring.
- **Finding 3 (suggestion):** symlink-following on directory backup — **parity-preserving with bash** `cp -R`/`rm -rf`, low likelihood (requires an attacker-planted symlink already inside `~/.<tool>/skills/`). Deferred; a future `is_symlink()` defence-in-depth check would be *more* correct than bash.
- **Finding 4 (suggestion):** three near-identical namespace tuples (`_PRUNE_SUBDIRS`, `_SCOPED_NAMESPACES`, per-adapter `scoped_namespaces()`). Reviewer endorsed keeping them distinct (the scan set is a fixed contract, not adapter-derived); noted as a watch-item for when a fifth namespace is added.

## Testing

TDD throughout (red → green per story, vertical slices). Tests are behavioural — driven through `ScriptedIO`, asserted against real filesystem end-state and returned `Counters`, screened against the tautology filter (no tests of `tomllib`/`fnmatch`/regex/enum literals). New test modules: `test_installer_toml.py`, `test_prune.py`, `test_prune_flow.py`, `test_consent.py`, `test_run_prune_pipeline.py`, plus additions to `test_cli_smoke.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
