### PR TITLE
feat(prgroom): lifecycle stage verbs — _cluster + _fix (local staging) (8.15)

### DIFF
--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -288,11 +288,13 @@ def fix(
     """Dispatch the fix agent per cluster: decide disposition AND implement (local).
 
     A locked verb: ``read → fix_pr → write`` under the §2 ``with_lock`` wrapper.
-    Direct-invocation preconditions (the ``--no-prework`` column, §3.2): no state →
-    ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an all-dispositioned
-    state → no-op exit 0; no clustered-unprocessed items → ``PRECONDITION_NO_CLUSTERS``
-    (no-work exit 0). Fix makes no phase change (end-of-cycle resolution is the run
-    aggregate's job) and sets no ``last_error``. Commits land locally; nothing is pushed here.
+    Direct-invocation preconditions (the ``--no-prework`` column, §3.2), in order:
+    no state → ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an
+    all-dispositioned state (work already done) → idempotent no-op exit 0; items
+    remain but none are clustered-unprocessed → ``PRECONDITION_NO_CLUSTERS``
+    (no-work exit 0, "run cluster first"). Fix makes no phase change (end-of-cycle
+    resolution is the run aggregate's job) and sets no ``last_error``. Commits land
+    locally; nothing is pushed here.
     """
     store: Store = ctx.obj
     try:
@@ -307,6 +309,11 @@ def fix(
             if is_terminal_for_cli(state.phase):
                 return  # terminal-for-CLI: no autonomous work (no-op exit 0)
             if not _has_clusters(state.items):
+                # No clustered-unprocessed work. An all-dispositioned state is the
+                # idempotent "already done" no-op (silent exit 0); only a genuinely
+                # un-clustered state is the NO_CLUSTERS precondition ("run cluster").
+                if state.items and all(item.disposition is not None for item in state.items):
+                    return
                 raise PreconditionError(ErrorCode.PRECONDITION_NO_CLUSTERS, detail=ref.display())
             dispatcher, decided_by = _build_fix_dispatcher()
             sink = _build_sink()

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -17,23 +17,35 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
+from pathlib import Path
 from typing import IO
 
 import typer
 
+from prgroom.agent.contracts import ClusterContract, FixContract
+from prgroom.agent.dispatcher import (
+    ClusterDispatcher,
+    FixDispatcher,
+    ProviderChain,
+    load_chain,
+)
+from prgroom.agent.subprocess_runner import SubprocessAgentRunner
 from prgroom.config import PrgroomConfig
 from prgroom.deps import Deps
 from prgroom.errors import ErrorCode, PreconditionError, PrgroomError, exit_code_for_tier
+from prgroom.escalation import Sink, StderrSink
 from prgroom.gh import GhClient
 from prgroom.gh.client import GhCli
-from prgroom.lifecycle import poll_pr
+from prgroom.git import GitCli, GitClient
+from prgroom.lifecycle import cluster_pr, fix_pr, is_terminal_for_cli, poll_pr
 from prgroom.lifecycle.human_review import derive_human_review, fetch_human_review_inputs
 from prgroom.lifecycle.locking import with_lock
 from prgroom.lifecycle.status import build_status
 from prgroom.proc import SubprocessRunner
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.registry import resolve_store
-from prgroom.prsession.state import PRGroomingState, bootstrap_state
+from prgroom.prsession.state import PRGroomingState, ReviewItem, bootstrap_state
 from prgroom.prsession.store import StateNotFoundError, Store
 
 # Foundation skeletons are not yet implemented; they exit non-zero so a caller
@@ -66,6 +78,66 @@ def _build_gh() -> GhClient:
     tests against ``GhCli``, never through this constructor.
     """
     return GhCli(SubprocessRunner())  # pragma: no cover - production boundary wiring
+
+
+def _build_git() -> GitClient:
+    """Build the production git adapter (real subprocess boundary).
+
+    A seam: tests monkeypatch this to inject a fake ``GitClient``. The one
+    production-wiring line is exercised by the git fit tests against ``GitCli``.
+    """
+    return GitCli(SubprocessRunner())  # pragma: no cover - production boundary wiring
+
+
+def _decided_by(chain: ProviderChain) -> str:
+    """Derive ``decided_by`` from a resolved chain's primary provider (``"<cli> <model>"``).
+
+    The primary (first) provider is the one prgroom prefers; its ``cli`` + ``model``
+    name the deciding agent on every disposition this run stamps (e.g.
+    ``"claude opus[1m]"``). An empty chain (a misconfig the dispatcher would reject
+    on dispatch) degrades to ``"prgroom"`` so the field is never blank.
+    """
+    if not chain.providers:
+        return "prgroom"
+    head = chain.providers[0]
+    return f"{head.cli} {head.model}"
+
+
+def _build_cluster_dispatcher() -> tuple[ClusterContract, str]:
+    """Resolve the cluster provider chain + a dispatcher (flag/env/TOML → default).
+
+    A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
+    ``decided_by``. Production resolves the chain via :func:`load_chain` and wires a
+    :class:`ClusterDispatcher` over the real :class:`SubprocessAgentRunner`.
+    """
+    chain = load_chain("cluster", repo_config=None, model_override=None)  # pragma: no cover
+    dispatcher = ClusterDispatcher(  # pragma: no cover - production wiring
+        runner=SubprocessAgentRunner(), chain=chain
+    )
+    return dispatcher, _decided_by(chain)  # pragma: no cover - production wiring
+
+
+def _build_fix_dispatcher() -> tuple[FixContract, str]:
+    """Resolve the fix provider chain + a dispatcher (flag/env/TOML → default).
+
+    A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
+    ``decided_by``. Production resolves the chain via :func:`load_chain` and wires a
+    :class:`FixDispatcher` over the real :class:`SubprocessAgentRunner`.
+    """
+    chain = load_chain("fix", repo_config=None, model_override=None)  # pragma: no cover
+    dispatcher = FixDispatcher(  # pragma: no cover - production wiring
+        runner=SubprocessAgentRunner(), chain=chain
+    )
+    return dispatcher, _decided_by(chain)  # pragma: no cover - production wiring
+
+
+def _build_sink() -> Sink:
+    """Build the default escalation sink (stderr).
+
+    A seam: tests monkeypatch this to record emitted escalations. The ``--bd-bead``
+    / ``--escalation-file`` adapter selection is a later bead; MVP defaults to stderr.
+    """
+    return StderrSink()  # pragma: no cover - trivial production default
 
 
 @app.callback()
@@ -135,16 +207,126 @@ def poll(
         raise typer.Exit(code=handle_cli_error(err)) from err
 
 
-@app.command()
-def cluster(pr: str = typer.Argument(..., help="PR ref.")) -> None:
-    """Group unprocessed items into fix-bundles for cohesive fix work."""
-    _skeleton("cluster")
+def _read_or_no_state(store: Store, ref: PRRef) -> PRGroomingState:
+    """Read the PR's state, raising ``PRECONDITION_NO_STATE`` if it was never polled.
+
+    Direct invocation does NOT self-heal (the ``--no-prework`` column, §3.2): a
+    missing state is a terminal user error (exit 2), not an auto-run-``poll`` path.
+    The self-heal/prework chaining is the ``run`` aggregate's job (bead 8.10).
+    """
+    try:
+        return store.read(ref)
+    except StateNotFoundError as exc:
+        raise PreconditionError(ErrorCode.PRECONDITION_NO_STATE, detail=ref.display()) from exc
+
+
+def _needs_clustering(items: list[ReviewItem]) -> bool:
+    """True iff any item still needs clustering (unclustered AND unprocessed)."""
+    return any(item.cluster_id == "" and item.disposition is None for item in items)
+
+
+def _has_clusters(items: list[ReviewItem]) -> bool:
+    """True iff any clustered item is still unprocessed (fix has work to do)."""
+    return any(item.cluster_id != "" and item.disposition is None for item in items)
 
 
 @app.command()
-def fix(pr: str = typer.Argument(..., help="PR ref.")) -> None:
-    """Dispatch the fix agent per cluster: decide disposition AND implement."""
-    _skeleton("fix")
+def cluster(
+    ctx: typer.Context,
+    pr: str = typer.Argument(..., help="PR ref: owner/repo#n or a full PR URL."),
+) -> None:
+    """Group unprocessed items into fix-bundles for cohesive fix work.
+
+    A locked verb: ``read → cluster_pr → write`` under the §2 ``with_lock`` wrapper.
+    Direct-invocation preconditions (the ``--no-prework`` column, §3.2): no state →
+    ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an already-clustered
+    state → no-op exit 0; items exist but none need clustering → ``PRECONDITION_NO_ITEMS``
+    (no-work exit 0). Cluster decides no disposition and changes no phase.
+    """
+    store: Store = ctx.obj
+    try:
+        ref = PRRef.parse(pr)
+        gh = _build_gh()
+        git = _build_git()
+        deps = Deps.system()
+        config = PrgroomConfig.load()
+
+        def _cluster() -> None:
+            state = _read_or_no_state(store, ref)
+            if is_terminal_for_cli(state.phase):
+                return  # terminal-for-CLI: no autonomous work (no-op exit 0)
+            if not state.items:
+                raise PreconditionError(ErrorCode.PRECONDITION_NO_ITEMS, detail=ref.display())
+            if not _needs_clustering(state.items):
+                return  # already clustered / all processed → idempotent no-op exit 0
+            dispatcher, decided_by = _build_cluster_dispatcher()
+            with tempfile.TemporaryDirectory(prefix="prgroom-cluster-") as scratch:
+                state = cluster_pr(
+                    state,
+                    ref=ref,
+                    gh=gh,
+                    git=git,
+                    deps=deps,
+                    config=config,
+                    dispatcher=dispatcher,
+                    decided_by=decided_by,
+                    scratch_dir=Path(scratch),
+                )
+            store.write(ref, state)
+
+        with_lock(store, ref, _cluster)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
+
+
+@app.command()
+def fix(
+    ctx: typer.Context,
+    pr: str = typer.Argument(..., help="PR ref: owner/repo#n or a full PR URL."),
+) -> None:
+    """Dispatch the fix agent per cluster: decide disposition AND implement (local).
+
+    A locked verb: ``read → fix_pr → write`` under the §2 ``with_lock`` wrapper.
+    Direct-invocation preconditions (the ``--no-prework`` column, §3.2): no state →
+    ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an all-dispositioned
+    state → no-op exit 0; no clustered-unprocessed items → ``PRECONDITION_NO_CLUSTERS``
+    (no-work exit 0). Fix makes no phase change (end-of-cycle resolution is bead 8.10)
+    and sets no ``last_error``. Commits land locally; nothing is pushed here.
+    """
+    store: Store = ctx.obj
+    try:
+        ref = PRRef.parse(pr)
+        gh = _build_gh()
+        git = _build_git()
+        deps = Deps.system()
+        config = PrgroomConfig.load()
+
+        def _fix() -> None:
+            state = _read_or_no_state(store, ref)
+            if is_terminal_for_cli(state.phase):
+                return  # terminal-for-CLI: no autonomous work (no-op exit 0)
+            if not _has_clusters(state.items):
+                raise PreconditionError(ErrorCode.PRECONDITION_NO_CLUSTERS, detail=ref.display())
+            dispatcher, decided_by = _build_fix_dispatcher()
+            sink = _build_sink()
+            with tempfile.TemporaryDirectory(prefix="prgroom-fix-") as scratch:
+                state = fix_pr(
+                    state,
+                    ref=ref,
+                    gh=gh,
+                    git=git,
+                    deps=deps,
+                    config=config,
+                    dispatcher=dispatcher,
+                    sink=sink,
+                    decided_by=decided_by,
+                    scratch_dir=Path(scratch),
+                )
+            store.write(ref, state)
+
+        with_lock(store, ref, _fix)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
 
 
 @app.command()

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -104,11 +104,15 @@ def _decided_by(chain: ProviderChain) -> str:
 
 
 def _build_cluster_dispatcher() -> tuple[ClusterContract, str]:
-    """Resolve the cluster provider chain + a dispatcher (flag/env/TOML → default).
+    """Resolve the cluster provider chain + a dispatcher.
 
     A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
-    ``decided_by``. Production resolves the chain via :func:`load_chain` and wires a
-    :class:`ClusterDispatcher` over the real :class:`SubprocessAgentRunner`.
+    ``decided_by``. Production wires a :class:`ClusterDispatcher` over the real
+    :class:`SubprocessAgentRunner`. It calls :func:`load_chain` with
+    ``repo_config=None`` / ``model_override=None``, so the shipped DEFAULT chain is
+    used today: no verb resolves the per-repo ``.prgroom.toml`` path yet (poll/status
+    pass ``None`` too — there is no resolver), so ``[agents.cluster]`` overrides and a
+    ``--cluster-model`` flag stay inert pending that cross-verb config-path wiring.
     """
     chain = load_chain("cluster", repo_config=None, model_override=None)  # pragma: no cover
     dispatcher = ClusterDispatcher(  # pragma: no cover - production wiring
@@ -118,11 +122,15 @@ def _build_cluster_dispatcher() -> tuple[ClusterContract, str]:
 
 
 def _build_fix_dispatcher() -> tuple[FixContract, str]:
-    """Resolve the fix provider chain + a dispatcher (flag/env/TOML → default).
+    """Resolve the fix provider chain + a dispatcher.
 
     A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
-    ``decided_by``. Production resolves the chain via :func:`load_chain` and wires a
-    :class:`FixDispatcher` over the real :class:`SubprocessAgentRunner`.
+    ``decided_by``. Production wires a :class:`FixDispatcher` over the real
+    :class:`SubprocessAgentRunner`. It calls :func:`load_chain` with
+    ``repo_config=None`` / ``model_override=None``, so the shipped DEFAULT chain is
+    used today: no verb resolves the per-repo ``.prgroom.toml`` path yet (poll/status
+    pass ``None`` too — there is no resolver), so ``[agents.fix]`` overrides and a
+    ``--fix-model`` flag stay inert pending that cross-verb config-path wiring.
     """
     chain = load_chain("fix", repo_config=None, model_override=None)  # pragma: no cover
     dispatcher = FixDispatcher(  # pragma: no cover - production wiring

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -212,7 +212,7 @@ def _read_or_no_state(store: Store, ref: PRRef) -> PRGroomingState:
 
     Direct invocation does NOT self-heal (the ``--no-prework`` column, §3.2): a
     missing state is a terminal user error (exit 2), not an auto-run-``poll`` path.
-    The self-heal/prework chaining is the ``run`` aggregate's job (bead 8.10).
+    The self-heal/prework chaining is the ``run`` aggregate's job (§3.3).
     """
     try:
         return store.read(ref)
@@ -239,9 +239,10 @@ def cluster(
 
     A locked verb: ``read → cluster_pr → write`` under the §2 ``with_lock`` wrapper.
     Direct-invocation preconditions (the ``--no-prework`` column, §3.2): no state →
-    ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an already-clustered
-    state → no-op exit 0; items exist but none need clustering → ``PRECONDITION_NO_ITEMS``
-    (no-work exit 0). Cluster decides no disposition and changes no phase.
+    ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase, an already-clustered state,
+    or all items already processed → idempotent no-op exit 0; zero items in state →
+    ``PRECONDITION_NO_ITEMS`` (no-work exit 0). Cluster decides no disposition and
+    changes no phase.
     """
     store: Store = ctx.obj
     try:
@@ -290,8 +291,8 @@ def fix(
     Direct-invocation preconditions (the ``--no-prework`` column, §3.2): no state →
     ``PRECONDITION_NO_STATE`` (exit 2); a terminal phase or an all-dispositioned
     state → no-op exit 0; no clustered-unprocessed items → ``PRECONDITION_NO_CLUSTERS``
-    (no-work exit 0). Fix makes no phase change (end-of-cycle resolution is bead 8.10)
-    and sets no ``last_error``. Commits land locally; nothing is pushed here.
+    (no-work exit 0). Fix makes no phase change (end-of-cycle resolution is the run
+    aggregate's job) and sets no ``last_error``. Commits land locally; nothing is pushed here.
     """
     store: Store = ctx.obj
     try:

--- a/packages/prgroom/src/prgroom/git/client.py
+++ b/packages/prgroom/src/prgroom/git/client.py
@@ -52,6 +52,10 @@ class GitClient(Protocol):
 
     def rev_list(self, range_: str) -> list[str]: ...  # pragma: no cover
 
+    def log(self, range_: str) -> str: ...  # pragma: no cover
+
+    def diff_stat(self, range_: str) -> str: ...  # pragma: no cover
+
     def push(self, remote: str, branch: str) -> None: ...  # pragma: no cover
 
     def stash(self) -> None: ...  # pragma: no cover
@@ -86,6 +90,16 @@ class GitCli:
     def rev_list(self, range_: str) -> list[str]:
         out = self._run(["git", "rev-list", range_])
         return out.split()
+
+    def log(self, range_: str) -> str:
+        # Snapshot read (§8.1 branch_state): recent-commits text, passed to the
+        # fix agent verbatim — return it unparsed, the caller dumps it to a file.
+        return self._run(["git", "log", range_])
+
+    def diff_stat(self, range_: str) -> str:
+        # Snapshot read (§8.1 branch_state): the diff-since-base summary. `--stat`
+        # keeps the dump bounded (per-file line counts, not full hunks).
+        return self._run(["git", "diff", "--stat", range_])
 
     def push(self, remote: str, branch: str) -> None:
         self._run(["git", "push", remote, branch])

--- a/packages/prgroom/src/prgroom/lifecycle/__init__.py
+++ b/packages/prgroom/src/prgroom/lifecycle/__init__.py
@@ -17,12 +17,16 @@ The terminal sets distinguish the two notions of "done" (§3.1):
 
 from __future__ import annotations
 
+from prgroom.lifecycle.cluster import cluster_pr
+from prgroom.lifecycle.fix import fix_pr
 from prgroom.lifecycle.poll import poll_pr
 from prgroom.prsession.enums import PRPhase
 
 __all__ = [
     "GRAPH_TERMINAL_PHASES",
     "TERMINAL_FOR_CLI_PHASES",
+    "cluster_pr",
+    "fix_pr",
     "is_graph_terminal",
     "is_terminal_for_cli",
     "poll_pr",

--- a/packages/prgroom/src/prgroom/lifecycle/cluster.py
+++ b/packages/prgroom/src/prgroom/lifecycle/cluster.py
@@ -1,0 +1,119 @@
+"""``cluster_pr`` — the lock-held ``_cluster`` lifecycle internal (§3.2, §5).
+
+``cluster_pr`` is the APPLY side of the cluster path: 8.7's pure
+:func:`~prgroom.agent.cluster.run_cluster` computes the clustering; this internal
+calls it and APPLIES the result by setting each item's ``cluster_id``. It mirrors
+:func:`~prgroom.lifecycle.poll.poll_pr`'s shape — works on a deepcopy of the
+in-memory :class:`PRGroomingState`, never reads/writes the store itself (the
+caller owns ``store.write``), and returns the mutated copy.
+
+Cluster is the cheap grouping pass (§5): it decides **no** disposition and makes
+**no** phase change (the §3.2 cluster row). It operates on items with
+``cluster_id == ""`` that are not yet processed (``disposition is None``), and is
+idempotent — a no-op when every item is already clustered (§3.3 idempotency
+contract).
+
+prgroom does the gh/git legwork for the light PR-context file the cluster
+contract passes (``pr_context_path``): the PR title/body + recent commits + a CI
+summary, written under the caller-provided scratch dir. ``decided_by`` is part of
+the uniform 8.7 signature; clustering decides no disposition, so ``run_cluster``
+ignores it (it is threaded through for signature symmetry with the fix path).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import TYPE_CHECKING
+
+from prgroom.agent.cluster import run_cluster
+from prgroom.agent.contracts import ClusterInput
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.gh.client import GhNotFoundError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from prgroom.agent.contracts import ClusterContract
+    from prgroom.config import PrgroomConfig
+    from prgroom.deps import Deps
+    from prgroom.gh.client import GhClient
+    from prgroom.git.client import GitClient
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState, ReviewItem
+
+_PR_CONTEXT_FILENAME = "pr_context.json"
+
+
+def cluster_pr(
+    state: PRGroomingState,
+    *,
+    ref: PRRef,
+    gh: GhClient,
+    git: GitClient,
+    deps: Deps,
+    config: PrgroomConfig,
+    dispatcher: ClusterContract,
+    decided_by: str,
+    scratch_dir: Path,
+) -> PRGroomingState:
+    """Cluster the unclustered items, applying the assignments to a state copy.
+
+    Caller must hold the per-ref lock (see ``lock()``). Works on a deepcopy of
+    ``state`` so the caller's object is never mutated; returns the copy for the
+    caller to persist. Idempotent: a no-op when every item is already clustered.
+    No disposition, no phase change (§3.2 cluster row).
+    """
+    del config  # cluster reads no config knob today; kept for signature symmetry
+    state = copy.deepcopy(state)
+    pending = _unclustered_unprocessed(state.items)
+    if not pending:
+        return state
+
+    context_path = _write_pr_context(ref, gh, git, scratch_dir)
+    req = ClusterInput(pr=ref, items=pending, pr_context_path=str(context_path))
+    result = run_cluster(req, dispatcher, now=deps.clock.now(), decided_by=decided_by)
+
+    for item in pending:
+        cluster_id = result.assignments.get(item.identity.gh_id)
+        if cluster_id is not None:
+            item.cluster_id = cluster_id
+    return state
+
+
+def _unclustered_unprocessed(items: list[ReviewItem]) -> list[ReviewItem]:
+    """Items eligible for clustering: not yet clustered AND not yet processed (§5).
+
+    Cluster operates on ``cluster_id == ""`` items, but an already-dispositioned
+    item is processed work — never re-cluster it even if its ``cluster_id`` was
+    left empty, so it is excluded here too.
+    """
+    return [item for item in items if item.cluster_id == "" and item.disposition is None]
+
+
+def _write_pr_context(ref: PRRef, gh: GhClient, git: GitClient, scratch_dir: Path) -> Path:
+    """Write the light PR-context file the cluster contract passes (§5).
+
+    A read-only gh GET (PR resource: title/body/base) + a git ``log`` of recent
+    commits over ``origin/<base>..HEAD`` form a compact context the cheap cluster
+    model groups against. Errors from the gh/git adapters propagate unchanged.
+    """
+    try:
+        pr = gh.rest("GET", f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
+    except GhNotFoundError as exc:
+        raise PrgroomError(
+            tier=Tier.RUNTIME_TERMINAL_USER,
+            code=ErrorCode.RUNTIME_GH_TERMINAL,
+            detail=f"PR resource not found: {ref.display()}",
+        ) from exc
+    base_ref = str((pr.get("base") or {}).get("ref") or "")
+    range_ = f"origin/{base_ref}..HEAD" if base_ref else "HEAD"
+    context = {
+        "title": str(pr.get("title") or ""),
+        "body": str(pr.get("body") or ""),
+        "recent_commits": git.log(range_),
+        "ci_state": str((pr.get("statusCheckRollup") or {}).get("state") or ""),
+    }
+    path = scratch_dir / _PR_CONTEXT_FILENAME
+    path.write_text(json.dumps(context, indent=2), encoding="utf-8")
+    return path

--- a/packages/prgroom/src/prgroom/lifecycle/cluster.py
+++ b/packages/prgroom/src/prgroom/lifecycle/cluster.py
@@ -28,8 +28,7 @@ from typing import TYPE_CHECKING
 
 from prgroom.agent.cluster import run_cluster
 from prgroom.agent.contracts import ClusterInput
-from prgroom.errors import ErrorCode, PrgroomError, Tier
-from prgroom.gh.client import GhNotFoundError
+from prgroom.lifecycle.snapshot import gh_get
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -96,16 +95,10 @@ def _write_pr_context(ref: PRRef, gh: GhClient, git: GitClient, scratch_dir: Pat
 
     A read-only gh GET (PR resource: title/body/base) + a git ``log`` of recent
     commits over ``origin/<base>..HEAD`` form a compact context the cheap cluster
-    model groups against. Errors from the gh/git adapters propagate unchanged.
+    model groups against. A 404 (vanished PR/repo) maps to a terminal error via the
+    shared :func:`~prgroom.lifecycle.snapshot.gh_get`; other gh/git errors propagate.
     """
-    try:
-        pr = gh.rest("GET", f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
-    except GhNotFoundError as exc:
-        raise PrgroomError(
-            tier=Tier.RUNTIME_TERMINAL_USER,
-            code=ErrorCode.RUNTIME_GH_TERMINAL,
-            detail=f"PR resource not found: {ref.display()}",
-        ) from exc
+    pr = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
     base_ref = str((pr.get("base") or {}).get("ref") or "")
     range_ = f"origin/{base_ref}..HEAD" if base_ref else "HEAD"
     context = {

--- a/packages/prgroom/src/prgroom/lifecycle/cluster.py
+++ b/packages/prgroom/src/prgroom/lifecycle/cluster.py
@@ -14,10 +14,11 @@ idempotent — a no-op when every item is already clustered (§3.3 idempotency
 contract).
 
 prgroom does the gh/git legwork for the light PR-context file the cluster
-contract passes (``pr_context_path``): the PR title/body + recent commits + a CI
-summary, written under the caller-provided scratch dir. ``decided_by`` is part of
-the uniform 8.7 signature; clustering decides no disposition, so ``run_cluster``
-ignores it (it is threaded through for signature symmetry with the fix path).
+contract passes (``pr_context_path``): the PR title/body + recent commits + the
+poll-derived CI summary, written under the caller-provided scratch dir.
+``decided_by`` is part of the uniform ``run_cluster``/``run_fix`` signature;
+clustering decides no disposition, so ``run_cluster`` ignores it (it is threaded
+through for signature symmetry with the fix path).
 """
 
 from __future__ import annotations
@@ -69,7 +70,7 @@ def cluster_pr(
     if not pending:
         return state
 
-    context_path = _write_pr_context(ref, gh, git, scratch_dir)
+    context_path = _write_pr_context(ref, gh, git, scratch_dir, ci_state=state.quiescence.ci_state)
     req = ClusterInput(pr=ref, items=pending, pr_context_path=str(context_path))
     result = run_cluster(req, dispatcher, now=deps.clock.now(), decided_by=decided_by)
 
@@ -90,13 +91,18 @@ def _unclustered_unprocessed(items: list[ReviewItem]) -> list[ReviewItem]:
     return [item for item in items if item.cluster_id == "" and item.disposition is None]
 
 
-def _write_pr_context(ref: PRRef, gh: GhClient, git: GitClient, scratch_dir: Path) -> Path:
+def _write_pr_context(
+    ref: PRRef, gh: GhClient, git: GitClient, scratch_dir: Path, *, ci_state: str
+) -> Path:
     """Write the light PR-context file the cluster contract passes (§5).
 
     A read-only gh GET (PR resource: title/body/base) + a git ``log`` of recent
-    commits over ``origin/<base>..HEAD`` form a compact context the cheap cluster
-    model groups against. A 404 (vanished PR/repo) maps to a terminal error via the
-    shared :func:`~prgroom.lifecycle.snapshot.gh_get`; other gh/git errors propagate.
+    commits over ``origin/<base>..HEAD`` + the poll-derived ``ci_state`` form a
+    compact context the cheap cluster model groups against. ``ci_state`` is the
+    combined-status poll already resolved into ``state.quiescence.ci_state`` (§4.1),
+    reused here so the context needs no extra gh round-trip. A 404 (vanished
+    PR/repo) maps to a terminal error via the shared
+    :func:`~prgroom.lifecycle.snapshot.gh_get`; other gh/git errors propagate.
     """
     pr = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
     base_ref = str((pr.get("base") or {}).get("ref") or "")
@@ -105,7 +111,7 @@ def _write_pr_context(ref: PRRef, gh: GhClient, git: GitClient, scratch_dir: Pat
         "title": str(pr.get("title") or ""),
         "body": str(pr.get("body") or ""),
         "recent_commits": git.log(range_),
-        "ci_state": str((pr.get("statusCheckRollup") or {}).get("state") or ""),
+        "ci_state": ci_state,
     }
     path = scratch_dir / _PR_CONTEXT_FILENAME
     path.write_text(json.dumps(context, indent=2), encoding="utf-8")

--- a/packages/prgroom/src/prgroom/lifecycle/fix.py
+++ b/packages/prgroom/src/prgroom/lifecycle/fix.py
@@ -81,14 +81,12 @@ def fix_pr(
     if not clusters:
         return state
 
-    by_gh = {item.identity.gh_id: item for item in state.items}
     now = deps.clock.now()
     for cluster_id, cluster_items in clusters.items():
         _fix_one_cluster(
             state,
             cluster_id=cluster_id,
             cluster_items=cluster_items,
-            by_gh=by_gh,
             ref=ref,
             gh=gh,
             git=git,
@@ -107,7 +105,6 @@ def _fix_one_cluster(
     *,
     cluster_id: str,
     cluster_items: list[ReviewItem],
-    by_gh: dict[str, ReviewItem],
     ref: PRRef,
     gh: GhClient,
     git: GitClient,
@@ -138,6 +135,11 @@ def _fix_one_cluster(
     )
     result = run_fix(req, dispatcher, git, now=now, decided_by=decided_by)
 
+    # Apply via a per-cluster map over THIS cluster's items only. run_fix returns
+    # dispositions keyed by gh_id for exactly these items, and the codebase's natural
+    # key is (kind, gh_id) — a state-wide gh_id map could mis-target an item from
+    # another cluster/kind that happens to share a gh_id.
+    by_gh = {item.identity.gh_id: item for item in cluster_items}
     for gh_id, disposition in result.dispositions.items():
         item = by_gh.get(gh_id)
         if item is not None:

--- a/packages/prgroom/src/prgroom/lifecycle/fix.py
+++ b/packages/prgroom/src/prgroom/lifecycle/fix.py
@@ -1,0 +1,170 @@
+"""``fix_pr`` — the lock-held ``_fix`` lifecycle internal (§3.2, §5, §8).
+
+``fix_pr`` is the APPLY side of the fix path and the sharpest expression of the
+8.7 boundary: **8.7 computes; the lifecycle (8.15) applies.** For each cluster it
+assembles the §8.1 complete PR snapshot (via
+:func:`~prgroom.lifecycle.snapshot.assemble_snapshot` — the recurrence map and the
+ephemeral ``memory_dir`` / ``response_outbox_dir` ride on the result), builds the
+:class:`~prgroom.agent.contracts.FixInput`, calls 8.7's pure
+:func:`~prgroom.agent.fix.run_fix`, then APPLIES the :class:`FixRunResult`:
+
+* sets each item's :class:`~prgroom.prsession.state.Disposition` from
+  ``result.dispositions``;
+* emits every returned :class:`~prgroom.escalation.Escalation` via the injected
+  :class:`~prgroom.escalation.Sink`;
+* logs each ``result.unwritten`` path as a soft warning (§8.6 declared-but-missing
+  is bookkeeping drift, not a breach) and logs ``result.deferred_memory`` as
+  deferred (MVP routes only CONTEXTUAL→PR; §8.3).
+
+It mirrors :func:`~prgroom.lifecycle.poll.poll_pr` — works on a deepcopy, never
+touches the store (the caller owns ``store.write``), and returns the mutated copy.
+Clusters are processed **serially** (MVP; §5). It makes **no** phase change
+(§3.2 fix row: phase resolution is end-of-cycle, owned by bead 8.10) and does
+**not** set ``state.last_error`` (FAILED dispositions carry their own rationale;
+the end-of-cycle resolver reads them later). ``result.stashed`` is informational.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+from typing import TYPE_CHECKING
+
+from prgroom.agent.contracts import FixInput
+from prgroom.agent.fix import run_fix
+from prgroom.lifecycle.snapshot import assemble_snapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+    from pathlib import Path
+
+    from prgroom.agent.contracts import FixContract, MemoryEntry
+    from prgroom.config import PrgroomConfig
+    from prgroom.deps import Deps
+    from prgroom.escalation import Sink
+    from prgroom.gh.client import GhClient
+    from prgroom.git.client import GitClient
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState, ReviewItem
+
+
+def _default_warn(message: str) -> None:
+    """Default soft-warning sink: a one-line prgroom stderr notice."""
+    sys.stderr.write(f"prgroom: {message}\n")
+
+
+def fix_pr(
+    state: PRGroomingState,
+    *,
+    ref: PRRef,
+    gh: GhClient,
+    git: GitClient,
+    deps: Deps,
+    config: PrgroomConfig,
+    dispatcher: FixContract,
+    sink: Sink,
+    decided_by: str,
+    scratch_dir: Path,
+    warn: Callable[[str], None] = _default_warn,
+) -> PRGroomingState:
+    """Fix every clustered-unprocessed item, applying dispositions to a state copy.
+
+    Caller must hold the per-ref lock (see ``lock()``). Works on a deepcopy of
+    ``state``; returns the copy for the caller to persist. Idempotent: a no-op
+    when every item is already dispositioned. No phase change (§3.2 fix row), no
+    ``state.last_error``. Clusters are dispatched serially (MVP).
+    """
+    del config  # fix reads no config knob today; kept for signature symmetry
+    state = copy.deepcopy(state)
+    clusters = _group_unprocessed_by_cluster(state.items)
+    if not clusters:
+        return state
+
+    by_gh = {item.identity.gh_id: item for item in state.items}
+    now = deps.clock.now()
+    for cluster_id, cluster_items in clusters.items():
+        _fix_one_cluster(
+            state,
+            cluster_id=cluster_id,
+            cluster_items=cluster_items,
+            by_gh=by_gh,
+            ref=ref,
+            gh=gh,
+            git=git,
+            dispatcher=dispatcher,
+            sink=sink,
+            now=now,
+            decided_by=decided_by,
+            scratch_dir=scratch_dir,
+            warn=warn,
+        )
+    return state
+
+
+def _fix_one_cluster(
+    state: PRGroomingState,
+    *,
+    cluster_id: str,
+    cluster_items: list[ReviewItem],
+    by_gh: dict[str, ReviewItem],
+    ref: PRRef,
+    gh: GhClient,
+    git: GitClient,
+    dispatcher: FixContract,
+    sink: Sink,
+    now: datetime,
+    decided_by: str,
+    scratch_dir: Path,
+    warn: Callable[[str], None],
+) -> None:
+    """Assemble the snapshot, dispatch run_fix, and APPLY the result for one cluster.
+
+    ``now`` is the caller's single clock reading (one timestamp shared across the
+    fix cycle), so every disposition this cycle stamps the same ``decided_at``.
+    """
+    snapshot = assemble_snapshot(
+        state, cluster_items, ref=ref, gh=gh, git=git, scratch_dir=scratch_dir
+    )
+    req = FixInput(
+        pr=ref,
+        cluster_id=cluster_id,
+        item_gh_ids=[item.identity.gh_id for item in cluster_items],
+        items=cluster_items,
+        pr_detail_path=snapshot.pr_detail_path,
+        branch_state_path=snapshot.branch_state_path,
+        memory_dir=snapshot.memory_dir,
+        response_outbox_dir=snapshot.response_outbox_dir,
+    )
+    result = run_fix(req, dispatcher, git, now=now, decided_by=decided_by)
+
+    for gh_id, disposition in result.dispositions.items():
+        item = by_gh.get(gh_id)
+        if item is not None:
+            item.disposition = disposition
+    for escalation in result.escalations:
+        sink.emit(escalation)
+    for path in result.unwritten:
+        warn(f"fix: declared memory path was not written (unwritten): {path}")
+    for entry in result.deferred_memory:
+        warn(_deferred_memory_message(entry))
+
+
+def _deferred_memory_message(entry: MemoryEntry) -> str:
+    """A one-line notice for an accepted-but-deferred non-CONTEXTUAL memory entry (§8.3)."""
+    return f"fix: deferred non-CONTEXTUAL memory entry (classification={entry.classification})"
+
+
+def _group_unprocessed_by_cluster(items: list[ReviewItem]) -> dict[str, list[ReviewItem]]:
+    """Group still-unprocessed clustered items by ``cluster_id``, preserving order.
+
+    A cluster is built from items with ``disposition is None`` AND
+    ``cluster_id != ""``. Unclustered items (``cluster_id == ""``) are left for a
+    future cluster pass; already-dispositioned items are skipped (the idempotency
+    contract). Insertion order is preserved so clusters dispatch deterministically.
+    """
+    groups: dict[str, list[ReviewItem]] = {}
+    for item in items:
+        if item.disposition is None and item.cluster_id != "":
+            groups.setdefault(item.cluster_id, []).append(item)
+    return groups

--- a/packages/prgroom/src/prgroom/lifecycle/fix.py
+++ b/packages/prgroom/src/prgroom/lifecycle/fix.py
@@ -1,8 +1,8 @@
 """``fix_pr`` — the lock-held ``_fix`` lifecycle internal (§3.2, §5, §8).
 
 ``fix_pr`` is the APPLY side of the fix path and the sharpest expression of the
-8.7 boundary: **8.7 computes; the lifecycle (8.15) applies.** For each cluster it
-assembles the §8.1 complete PR snapshot (via
+compute/apply boundary: **the agent layer computes; the lifecycle applies.** For
+each cluster it assembles the §8.1 complete PR snapshot (via
 :func:`~prgroom.lifecycle.snapshot.assemble_snapshot` — the recurrence map and the
 ephemeral ``memory_dir`` / ``response_outbox_dir` ride on the result), builds the
 :class:`~prgroom.agent.contracts.FixInput`, calls 8.7's pure
@@ -19,7 +19,7 @@ ephemeral ``memory_dir`` / ``response_outbox_dir` ride on the result), builds th
 It mirrors :func:`~prgroom.lifecycle.poll.poll_pr` — works on a deepcopy, never
 touches the store (the caller owns ``store.write``), and returns the mutated copy.
 Clusters are processed **serially** (MVP; §5). It makes **no** phase change
-(§3.2 fix row: phase resolution is end-of-cycle, owned by bead 8.10) and does
+(§3.2 fix row: phase resolution is end-of-cycle, owned by the run aggregate verb) and does
 **not** set ``state.last_error`` (FAILED dispositions carry their own rationale;
 the end-of-cycle resolver reads them later). ``result.stashed`` is informational.
 """

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -1,0 +1,319 @@
+"""§8.1 complete-PR-snapshot assembly + §8.2 recurrence derivation.
+
+The fix agent NEVER calls ``gh`` (§8.1: runtime swappability, auth containment,
+rate-limit centralisation, reproducibility). prgroom does the gh/git legwork
+**immediately before each cluster's fix dispatch** (minimising staleness) and
+dumps everything to the two files the fix contract already passes —
+``pr_detail_path`` and ``branch_state_path`` (see :class:`SnapshotPaths`):
+
+* ``pr_detail_path`` (JSON): the PR **description** (with the ``## Decisions``
+  block read verbatim — writing it is bead 8.12, here we only READ it), the PR
+  **labels**, **every review thread with its full reply-chain**, the
+  **prior-round dispositions** for already-processed items (kind / rationale /
+  commits / decided_by, from ``prsession`` state), and the per-item
+  **recurrence** (§8.2).
+* ``branch_state_path`` (text): the recent commits (``git log``) + the
+  diff-since-base summary (``git diff --stat``), scoped to ``origin/<base>..HEAD``
+  where ``<base>`` is the gh PR resource's ``base.ref``.
+
+The two ephemeral working dirs the fix contract needs (``memory_dir`` scratch,
+``response_outbox_dir``) are created here too and carried on the result.
+
+8.2 boundary: prgroom **detects, it does not interpret** (§8.2). The recurrence
+signal is **derived at snapshot time, not persisted** (§2 schema unchanged). The
+MVP §2 schema retains exactly one :class:`~prgroom.prsession.state.Disposition`
+per item and no first-seen-round, so ``attempt_count`` reports the schema floor
+(``1``) and ``first_seen_round`` reports the current round as the only available
+proxy — both sharpen once disposition-history tracking lands (reported as a
+schema gap, not invented here).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from prgroom.agent.recurrence import Recurrence
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.gh.client import GhNotFoundError
+
+if TYPE_CHECKING:
+    from prgroom.gh.client import GhClient
+    from prgroom.git.client import GitClient
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState, ReviewItem
+
+# Sentinel markers prgroom owns the ``## Decisions`` block between (§8.3). Here we
+# only READ the block into the snapshot; writing it is bead 8.12.
+DECISIONS_START = "<!-- prgroom:decisions:start -->"
+DECISIONS_END = "<!-- prgroom:decisions:end -->"
+
+_PR_DETAIL_FILENAME = "pr_detail.json"
+_BRANCH_STATE_FILENAME = "branch_state.txt"
+
+
+class SnapshotPaths:
+    """The assembled snapshot's file paths, ephemeral dirs, and per-item recurrence.
+
+    ``pr_detail_path`` / ``branch_state_path`` are the two files the fix contract
+    passes to the agent; ``memory_dir`` / ``response_outbox_dir`` are the ephemeral
+    working dirs it writes into; ``recurrence`` maps a cluster item's ``gh_id`` to
+    its §8.2 :class:`~prgroom.agent.recurrence.Recurrence` (only items carrying a
+    prior disposition appear).
+    """
+
+    __slots__ = (
+        "branch_state_path",
+        "memory_dir",
+        "pr_detail_path",
+        "recurrence",
+        "response_outbox_dir",
+    )
+
+    def __init__(
+        self,
+        *,
+        pr_detail_path: str,
+        branch_state_path: str,
+        memory_dir: str,
+        response_outbox_dir: str,
+        recurrence: dict[str, Recurrence],
+    ) -> None:
+        self.pr_detail_path = pr_detail_path
+        self.branch_state_path = branch_state_path
+        self.memory_dir = memory_dir
+        self.response_outbox_dir = response_outbox_dir
+        self.recurrence = recurrence
+
+
+def extract_decisions_block(body: str) -> str:
+    """Return the ``## Decisions`` block (between sentinels) verbatim, else ``""``.
+
+    The block is read-only here (writing it is bead 8.3/8.12). A body missing
+    either sentinel — or with them out of order — has no block, so this returns
+    the empty string rather than guessing a boundary.
+    """
+    start = body.find(DECISIONS_START)
+    if start == -1:
+        return ""
+    end = body.find(DECISIONS_END, start)
+    if end == -1:
+        return ""
+    return body[start + len(DECISIONS_START) : end].strip()
+
+
+def derive_recurrence(
+    item: ReviewItem,
+    state: PRGroomingState,
+    *,
+    threads: dict[str, list[dict[str, Any]]],
+) -> Recurrence | None:
+    """Derive the §8.2 recurrence signal for one item, or ``None`` if no prior.
+
+    Returns ``None`` when the item carries no prior disposition (a fresh item has
+    no recurrence). Otherwise builds the signal from what the §2 schema actually
+    retains:
+
+    * ``prior_disposition`` / ``prior_commits`` — from the item's single recorded
+      :class:`~prgroom.prsession.state.Disposition` (schema-backed).
+    * ``reopened`` — true iff a reply on the item's thread is newer than the
+      disposition's ``decided_at`` (deterministic from the snapshot's thread
+      reply-chains).
+    * ``attempt_count`` — ``1`` (the MVP schema retains one disposition; a true
+      count needs history tracking — reported as a schema gap).
+    * ``first_seen_round`` — ``state.round`` (the schema has no first-seen field;
+      the current round is the only available proxy — reported as a schema gap).
+    """
+    disposition = item.disposition
+    if disposition is None:
+        return None
+    reopened = _thread_reopened(item, disposition.decided_at, threads)
+    return Recurrence(
+        reopened=reopened,
+        attempt_count=1,
+        prior_disposition=disposition.kind.value,
+        prior_commits=tuple(disposition.commits),
+        first_seen_round=state.round,
+    )
+
+
+def _thread_reopened(
+    item: ReviewItem, decided_at: datetime, threads: dict[str, list[dict[str, Any]]]
+) -> bool:
+    """True iff the item's thread has a reply newer than its disposition (§8.2)."""
+    thread_id = item.identity.thread_id
+    if not thread_id:
+        return False
+    for comment in threads.get(thread_id, []):
+        raw = comment.get("created_at")
+        if not isinstance(raw, str) or not raw:
+            continue
+        if datetime.fromisoformat(raw.replace("Z", "+00:00")) > decided_at:
+            return True
+    return False
+
+
+def assemble_snapshot(
+    state: PRGroomingState,
+    cluster_items: list[ReviewItem],
+    *,
+    ref: PRRef,
+    gh: GhClient,
+    git: GitClient,
+    scratch_dir: Path,
+) -> SnapshotPaths:
+    """Assemble the §8.1 complete snapshot for one cluster's fix dispatch.
+
+    Reads the PR resource (base ref, body, labels) + review threads via ``gh``
+    (read-only GETs) and the branch state via ``git`` (``log`` + ``diff --stat``
+    over ``origin/<base>..HEAD``), then writes ``pr_detail_path`` (JSON) and
+    ``branch_state_path`` (text) under ``scratch_dir`` and creates the ephemeral
+    ``memory_dir`` / ``response_outbox_dir``. Returns the paths + per-item §8.2
+    recurrence. A 404 on a required read maps to ``RUNTIME_GH_TERMINAL`` (the PR
+    or repo vanished mid-run — a blind retry won't bring it back).
+    """
+    pr = _gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
+    base_ref = str((pr.get("base") or {}).get("ref") or "")
+    body = str(pr.get("body") or "")
+    labels = [str(label.get("name", "")) for label in (pr.get("labels") or [])]
+
+    threads = _fetch_review_threads(gh, ref)
+    recurrence = _build_recurrence(state, cluster_items, threads)
+
+    detail = {
+        "description": body,
+        "decisions": extract_decisions_block(body),
+        "labels": labels,
+        "review_threads": _thread_chains(threads),
+        "prior_dispositions": _prior_dispositions(state),
+        "recurrence": {gh_id: rec.to_dict() for gh_id, rec in recurrence.items()},
+    }
+
+    pr_detail_path = scratch_dir / _PR_DETAIL_FILENAME
+    pr_detail_path.write_text(json.dumps(detail, indent=2), encoding="utf-8")
+
+    branch_state_path = scratch_dir / _BRANCH_STATE_FILENAME
+    branch_state_path.write_text(_branch_state(git, base_ref), encoding="utf-8")
+
+    memory_dir = Path(tempfile.mkdtemp(prefix="memory-", dir=scratch_dir))
+    response_outbox_dir = Path(tempfile.mkdtemp(prefix="outbox-", dir=scratch_dir))
+
+    return SnapshotPaths(
+        pr_detail_path=str(pr_detail_path),
+        branch_state_path=str(branch_state_path),
+        memory_dir=str(memory_dir),
+        response_outbox_dir=str(response_outbox_dir),
+        recurrence=recurrence,
+    )
+
+
+def _build_recurrence(
+    state: PRGroomingState,
+    cluster_items: list[ReviewItem],
+    threads: dict[str, list[dict[str, Any]]],
+) -> dict[str, Recurrence]:
+    """Per-item §8.2 recurrence for the cluster items that carry a prior disposition."""
+    out: dict[str, Recurrence] = {}
+    for item in cluster_items:
+        rec = derive_recurrence(item, state, threads=threads)
+        if rec is not None:
+            out[item.identity.gh_id] = rec
+    return out
+
+
+def _branch_state(git: GitClient, base_ref: str) -> str:
+    """The §8.1 branch-state text: recent commits + diff-since-base.
+
+    Scoped to ``origin/<base>..HEAD``. A PR resource that omitted ``base.ref``
+    (unexpected) degrades to ``HEAD`` so the read never builds a malformed range.
+    """
+    range_ = f"origin/{base_ref}..HEAD" if base_ref else "HEAD"
+    log = git.log(range_)
+    diff_stat = git.diff_stat(range_)
+    return f"## Recent commits ({range_})\n{log}\n\n## Diff stat\n{diff_stat}\n"
+
+
+def _prior_dispositions(state: PRGroomingState) -> list[dict[str, Any]]:
+    """The §8.1 prior-round dispositions for every already-processed item."""
+    out: list[dict[str, Any]] = []
+    for item in state.items:
+        disposition = item.disposition
+        if disposition is None:
+            continue
+        out.append(
+            {
+                "gh_id": item.identity.gh_id,
+                "kind": disposition.kind.value,
+                "rationale": disposition.rationale,
+                "commits": list(disposition.commits),
+                "decided_by": disposition.decided_by,
+            }
+        )
+    return out
+
+
+def _fetch_review_threads(gh: GhClient, ref: PRRef) -> dict[str, list[dict[str, Any]]]:
+    """Group every PR review comment into its thread's full reply-chain (§8.1).
+
+    A top-level inline comment (no ``in_reply_to_id``) anchors a thread keyed by
+    its own id; replies (``in_reply_to_id`` set) attach under their root. The key
+    is a string id so it matches a :class:`Identity`'s ``thread_id`` when present,
+    falling back to the root comment id otherwise.
+    """
+    raw = _gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments")
+    roots: dict[int, list[dict[str, Any]]] = {}
+    by_id: dict[int, int] = {}  # comment id -> its thread root id
+    for entry in raw:
+        cid = int(entry["id"])
+        parent = entry.get("in_reply_to_id")
+        root = int(parent) if parent is not None else cid
+        by_id[cid] = root
+        roots.setdefault(root, [])
+    for entry in raw:
+        cid = int(entry["id"])
+        roots[by_id[cid]].append(entry)
+    return {str(root): comments for root, comments in roots.items()}
+
+
+def _thread_chains(threads: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Render the grouped threads as the snapshot's ``review_threads`` array."""
+    return [
+        {
+            "thread_id": thread_id,
+            "comments": [
+                {
+                    "id": str(c.get("id", "")),
+                    "author": str((c.get("user") or {}).get("login", "")),
+                    "body": str(c.get("body") or ""),
+                    "created_at": str(c.get("created_at") or ""),
+                }
+                for c in comments
+            ],
+        }
+        for thread_id, comments in threads.items()
+    ]
+
+
+def _vanished_pr_terminal(ref: PRRef) -> PrgroomError:
+    """Map a 404 on a required snapshot read to ``RUNTIME_GH_TERMINAL`` (§3.6).
+
+    Mirrors ``poll.py``'s mapping: a mid-run 404 on the PR resource or its
+    comments means the PR/repo vanished — terminal, since a blind retry can't
+    bring it back. (The startup ``PRECONDITION_REPO_UNREACHABLE`` is out of scope.)
+    """
+    return PrgroomError(
+        tier=Tier.RUNTIME_TERMINAL_USER,
+        code=ErrorCode.RUNTIME_GH_TERMINAL,
+        detail=f"PR resource not found: {ref.display()}",
+    )
+
+
+def _gh_get(gh: GhClient, ref: PRRef, path: str) -> Any:
+    """``gh.rest("GET", path)`` with a 404 mapped to terminal (vanished PR/repo)."""
+    try:
+        return gh.rest("GET", path)
+    except GhNotFoundError as exc:
+        raise _vanished_pr_terminal(ref) from exc

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -175,7 +175,7 @@ def assemble_snapshot(
     recurrence. A 404 on a required read maps to ``RUNTIME_GH_TERMINAL`` (the PR
     or repo vanished mid-run — a blind retry won't bring it back).
     """
-    pr = _gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
+    pr = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}")
     base_ref = str((pr.get("base") or {}).get("ref") or "")
     body = str(pr.get("body") or "")
     labels = [str(label.get("name", "")) for label in (pr.get("labels") or [])]
@@ -263,7 +263,7 @@ def _fetch_review_threads(gh: GhClient, ref: PRRef) -> dict[str, list[dict[str, 
     is a string id so it matches a :class:`Identity`'s ``thread_id`` when present,
     falling back to the root comment id otherwise.
     """
-    raw = _gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments")
+    raw = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments")
     roots: dict[int, list[dict[str, Any]]] = {}
     by_id: dict[int, int] = {}  # comment id -> its thread root id
     for entry in raw:
@@ -297,12 +297,14 @@ def _thread_chains(threads: dict[str, list[dict[str, Any]]]) -> list[dict[str, A
     ]
 
 
-def _vanished_pr_terminal(ref: PRRef) -> PrgroomError:
+def vanished_pr_terminal(ref: PRRef) -> PrgroomError:
     """Map a 404 on a required snapshot read to ``RUNTIME_GH_TERMINAL`` (§3.6).
 
     Mirrors ``poll.py``'s mapping: a mid-run 404 on the PR resource or its
     comments means the PR/repo vanished — terminal, since a blind retry can't
     bring it back. (The startup ``PRECONDITION_REPO_UNREACHABLE`` is out of scope.)
+    Public so the sibling ``cluster`` internal — which does the same read-only PR
+    GET for its light context file — shares the one mapping.
     """
     return PrgroomError(
         tier=Tier.RUNTIME_TERMINAL_USER,
@@ -311,9 +313,9 @@ def _vanished_pr_terminal(ref: PRRef) -> PrgroomError:
     )
 
 
-def _gh_get(gh: GhClient, ref: PRRef, path: str) -> Any:
+def gh_get(gh: GhClient, ref: PRRef, path: str) -> Any:
     """``gh.rest("GET", path)`` with a 404 mapped to terminal (vanished PR/repo)."""
     try:
         return gh.rest("GET", path)
     except GhNotFoundError as exc:
-        raise _vanished_pr_terminal(ref) from exc
+        raise vanished_pr_terminal(ref) from exc

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -7,7 +7,7 @@ dumps everything to the two files the fix contract already passes —
 ``pr_detail_path`` and ``branch_state_path`` (see :class:`SnapshotPaths`):
 
 * ``pr_detail_path`` (JSON): the PR **description** (with the ``## Decisions``
-  block read verbatim — writing it is the §8.3 write path, here we only READ it), the PR
+  block read (whitespace-trimmed) — writing it is the §8.3 write path, here we only READ it), the PR
   **labels**, the review threads with their reply-chains, the **prior-round
   dispositions** for already-processed items (kind / rationale / commits /
   decided_by, from ``prsession`` state), and the per-item **recurrence** (§8.2).
@@ -96,11 +96,12 @@ class SnapshotPaths:
 
 
 def extract_decisions_block(body: str) -> str:
-    """Return the ``## Decisions`` block (between sentinels) verbatim, else ``""``.
+    """Return the ``## Decisions`` block (between sentinels), whitespace-trimmed, else ``""``.
 
-    The block is read-only here (writing it is the §8.3 write path). A body missing
-    either sentinel — or with them out of order — has no block, so this returns
-    the empty string rather than guessing a boundary.
+    The block is read-only here (writing it is the §8.3 write path). The inner text
+    is ``.strip()``-ed of surrounding whitespace/newlines before being embedded in
+    the snapshot. A body missing either sentinel — or with them out of order — has
+    no block, so this returns the empty string rather than guessing a boundary.
     """
     start = body.find(DECISIONS_START)
     if start == -1:
@@ -162,7 +163,13 @@ def _thread_reopened(
         raw = comment.get("created_at")
         if not isinstance(raw, str) or not raw:
             continue
-        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            # A malformed (non-ISO) timestamp can't prove a reopen — treat it as
+            # non-evidence and skip rather than crash snapshot assembly (which would
+            # abort `fix`). Real GitHub always emits valid Z-suffixed ISO-8601.
+            continue
         # A naive (offsetless) timestamp can't be compared to the tz-aware
         # decided_at without raising — it can't prove a reopen, so skip it rather
         # than crash. Real GitHub always emits Z-suffixed (aware) timestamps.

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -7,7 +7,7 @@ dumps everything to the two files the fix contract already passes —
 ``pr_detail_path`` and ``branch_state_path`` (see :class:`SnapshotPaths`):
 
 * ``pr_detail_path`` (JSON): the PR **description** (with the ``## Decisions``
-  block read verbatim — writing it is bead 8.12, here we only READ it), the PR
+  block read verbatim — writing it is the §8.3 write path, here we only READ it), the PR
   **labels**, the review threads with their reply-chains, the **prior-round
   dispositions** for already-processed items (kind / rationale / commits /
   decided_by, from ``prsession`` state), and the per-item **recurrence** (§8.2).
@@ -23,7 +23,7 @@ dumps everything to the two files the fix contract already passes —
 The two ephemeral working dirs the fix contract needs (``memory_dir`` scratch,
 ``response_outbox_dir``) are created here too and carried on the result.
 
-8.2 boundary: prgroom **detects, it does not interpret** (§8.2). The recurrence
+Detect/interpret boundary: prgroom **detects, it does not interpret** (§8.2). The recurrence
 signal is **derived at snapshot time, not persisted** (§2 schema unchanged). The
 MVP §2 schema retains exactly one :class:`~prgroom.prsession.state.Disposition`
 per item and no first-seen-round, so ``attempt_count`` reports the schema floor
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from prgroom.prsession.state import PRGroomingState, ReviewItem
 
 # Sentinel markers prgroom owns the ``## Decisions`` block between (§8.3). Here we
-# only READ the block into the snapshot; writing it is bead 8.12.
+# only READ the block into the snapshot; writing it is the §8.3 write path.
 DECISIONS_START = "<!-- prgroom:decisions:start -->"
 DECISIONS_END = "<!-- prgroom:decisions:end -->"
 
@@ -98,7 +98,7 @@ class SnapshotPaths:
 def extract_decisions_block(body: str) -> str:
     """Return the ``## Decisions`` block (between sentinels) verbatim, else ``""``.
 
-    The block is read-only here (writing it is bead 8.3/8.12). A body missing
+    The block is read-only here (writing it is the §8.3 write path). A body missing
     either sentinel — or with them out of order — has no block, so this returns
     the empty string rather than guessing a boundary.
     """

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -8,10 +8,14 @@ dumps everything to the two files the fix contract already passes —
 
 * ``pr_detail_path`` (JSON): the PR **description** (with the ``## Decisions``
   block read verbatim — writing it is bead 8.12, here we only READ it), the PR
-  **labels**, **every review thread with its full reply-chain**, the
-  **prior-round dispositions** for already-processed items (kind / rationale /
-  commits / decided_by, from ``prsession`` state), and the per-item
-  **recurrence** (§8.2).
+  **labels**, the review threads with their reply-chains, the **prior-round
+  dispositions** for already-processed items (kind / rationale / commits /
+  decided_by, from ``prsession`` state), and the per-item **recurrence** (§8.2).
+  **MVP completeness caveat:** §8.1 promises *every* thread with its *full*
+  reply-chain, but the ``gh`` adapter does not paginate yet, so the comments read
+  is capped at the first gh page (~30 comments). On a busy PR the snapshot is
+  page-1-complete, not whole-PR-complete; adding ``gh api --paginate`` to the
+  adapter (and using it here) is a tracked follow-up that spans the gh layer.
 * ``branch_state_path`` (text): the recent commits (``git log``) + the
   diff-since-base summary (``git diff --stat``), scoped to ``origin/<base>..HEAD``
   where ``<base>`` is the gh PR resource's ``base.ref``.
@@ -62,7 +66,9 @@ class SnapshotPaths:
     passes to the agent; ``memory_dir`` / ``response_outbox_dir`` are the ephemeral
     working dirs it writes into; ``recurrence`` maps a cluster item's ``gh_id`` to
     its §8.2 :class:`~prgroom.agent.recurrence.Recurrence` (only items carrying a
-    prior disposition appear).
+    prior disposition appear). The agent reads recurrence from
+    ``pr_detail.json["recurrence"]``; the field is surfaced on the result purely for
+    tests + a forward-compat consumer (e.g. an RCA pass), not read by ``fix_pr``.
     """
 
     __slots__ = (
@@ -120,8 +126,13 @@ def derive_recurrence(
     * ``prior_disposition`` / ``prior_commits`` — from the item's single recorded
       :class:`~prgroom.prsession.state.Disposition` (schema-backed).
     * ``reopened`` — true iff a reply on the item's thread is newer than the
-      disposition's ``decided_at`` (deterministic from the snapshot's thread
-      reply-chains).
+      disposition's ``decided_at``. **MVP floor: this is always ``False`` in the
+      integrated poll→cluster→fix path** — poll's ingest does not yet populate
+      :attr:`Identity.thread_id` (and the snapshot keys threads by root-comment id,
+      a different key-space), so ``_thread_reopened`` finds no thread to match. The
+      derivation is correct and unit-tested with populated identities; wiring poll
+      to set ``thread_id`` (and reconciling the key-space) is a poll-side follow-up,
+      not this bead. Reported as a gap alongside the two counters below.
     * ``attempt_count`` — ``1`` (the MVP schema retains one disposition; a true
       count needs history tracking — reported as a schema gap).
     * ``first_seen_round`` — ``state.round`` (the schema has no first-seen field;
@@ -151,7 +162,11 @@ def _thread_reopened(
         raw = comment.get("created_at")
         if not isinstance(raw, str) or not raw:
             continue
-        if datetime.fromisoformat(raw.replace("Z", "+00:00")) > decided_at:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        # A naive (offsetless) timestamp can't be compared to the tz-aware
+        # decided_at without raising — it can't prove a reopen, so skip it rather
+        # than crash. Real GitHub always emits Z-suffixed (aware) timestamps.
+        if parsed.tzinfo is not None and parsed > decided_at:
             return True
     return False
 
@@ -192,14 +207,18 @@ def assemble_snapshot(
         "recurrence": {gh_id: rec.to_dict() for gh_id, rec in recurrence.items()},
     }
 
-    pr_detail_path = scratch_dir / _PR_DETAIL_FILENAME
+    # Each call gets its own subdir so serial clusters sharing one scratch_dir
+    # don't overwrite each other's detail files — and parallel dispatch (a deferred
+    # MVP item) won't reintroduce the data race. memory/outbox are already isolated.
+    snap_dir = Path(tempfile.mkdtemp(prefix="snap-", dir=scratch_dir))
+    pr_detail_path = snap_dir / _PR_DETAIL_FILENAME
     pr_detail_path.write_text(json.dumps(detail, indent=2), encoding="utf-8")
 
-    branch_state_path = scratch_dir / _BRANCH_STATE_FILENAME
+    branch_state_path = snap_dir / _BRANCH_STATE_FILENAME
     branch_state_path.write_text(_branch_state(git, base_ref), encoding="utf-8")
 
-    memory_dir = Path(tempfile.mkdtemp(prefix="memory-", dir=scratch_dir))
-    response_outbox_dir = Path(tempfile.mkdtemp(prefix="outbox-", dir=scratch_dir))
+    memory_dir = Path(tempfile.mkdtemp(prefix="memory-", dir=snap_dir))
+    response_outbox_dir = Path(tempfile.mkdtemp(prefix="outbox-", dir=snap_dir))
 
     return SnapshotPaths(
         pr_detail_path=str(pr_detail_path),

--- a/packages/prgroom/tests/unit/test_cli_cluster.py
+++ b/packages/prgroom/tests/unit/test_cli_cluster.py
@@ -1,0 +1,197 @@
+"""Tests for the wired ``cluster`` CLI verb (§1, §2, §3.2).
+
+The verb resolves the store + gh/git adapters + a ClusterDispatcher, parses the
+PR ref, then runs ``read → cluster_pr → write`` under the lock wrapper. The
+outward seams — ``_build_store``, ``_build_gh``, ``_build_git``, and
+``_build_cluster_dispatcher`` — are monkeypatched so the verb runs against an
+InMemoryStore + fakes (no real subprocess, no real disk). Preconditions for
+direct invocation: no state → NO_STATE; no items → NO_ITEMS; already-clustered or
+terminal → no-op exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom import cli
+from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
+from prgroom.gh import GhCli
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+
+runner = CliRunner()
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+class FakeGit:
+    def head_sha(self) -> str:  # pragma: no cover - unused
+        return "head"
+
+    def rev_list(self, range_: str) -> list[str]:  # pragma: no cover - unused
+        del range_
+        return []
+
+    def log(self, range_: str) -> str:
+        del range_
+        return "recent commits"
+
+    def diff_stat(self, range_: str) -> str:  # pragma: no cover - unused
+        del range_
+        return ""
+
+    def push(self, remote: str, branch: str) -> None:  # pragma: no cover - unused
+        del remote, branch
+
+    def stash(self) -> None:  # pragma: no cover - unused
+        return None
+
+
+class ClusterDispatcherStub:
+    def __init__(self, clusters: list[ClusterResult]) -> None:
+        self._clusters = clusters
+        self.calls = 0
+
+    def cluster(self, request: ClusterInput) -> ClusterOutput:
+        del request
+        self.calls += 1
+        return ClusterOutput(clusters=self._clusters)
+
+
+def _item(
+    gh_id: str, *, cluster_id: str = "", disposition: Disposition | None = None
+) -> ReviewItem:
+    return ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id=gh_id, thread_id=f"PRT_{gh_id}"),
+        author="copilot",
+        body_excerpt="fix this",
+        seen_at=_T0,
+        cluster_id=cluster_id,
+        disposition=disposition,
+    )
+
+
+def _state(*items: ReviewItem, phase: PRPhase = PRPhase.FIXES_PENDING) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(ci_state="success"),
+        items=list(items),
+    )
+
+
+def _gh() -> GhCli:
+    from tests.fakes import RecordedRunner
+
+    return GhCli(RecordedRunner([_ok({"title": "My PR", "body": "desc", "base": {"ref": "main"}})]))
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch) -> InMemoryStore:
+    store = InMemoryStore()
+    monkeypatch.setattr(cli, "_build_store", lambda _name: store)
+    monkeypatch.setattr(cli, "_build_gh", lambda: _gh())
+    monkeypatch.setattr(cli, "_build_git", lambda: FakeGit())
+    return store
+
+
+def _wire_dispatcher(monkeypatch: pytest.MonkeyPatch, dispatcher: ClusterDispatcherStub) -> None:
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (dispatcher, "ollama gemma4"))
+
+
+def test_cluster_applies_and_persists(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    patched.write(_REF, _state(_item("a"), _item("b")))
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-x", item_gh_ids=["a", "b"], rationale="same area")]
+    )
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    written = patched.read(_REF)
+    assert {it.identity.gh_id: it.cluster_id for it in written.items} == {"a": "c-x", "b": "c-x"}
+
+
+@pytest.mark.usefixtures("patched")
+def test_cluster_no_state_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_dispatcher(monkeypatch, ClusterDispatcherStub([]))
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_NO_STATE" in result.output
+
+
+def test_cluster_no_items_exits_zero_no_work(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    patched.write(_REF, _state())  # state exists but has no items at all
+    _wire_dispatcher(monkeypatch, ClusterDispatcherStub([]))
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 0
+    assert "PRECONDITION_NO_ITEMS" in result.output
+
+
+def test_cluster_already_clustered_is_idempotent_noop(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    patched.write(_REF, _state(_item("a", cluster_id="c-old")))
+    dispatcher = ClusterDispatcherStub([])
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert dispatcher.calls == 0  # nothing to cluster → no dispatch
+    assert patched.read(_REF).items[0].cluster_id == "c-old"
+
+
+def test_cluster_terminal_phase_is_noop(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A merged PR is terminal: cluster is a no-op exit 0 even with unclustered items.
+    patched.write(_REF, _state(_item("a"), phase=PRPhase.MERGED))
+    dispatcher = ClusterDispatcherStub([])
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert dispatcher.calls == 0
+    assert patched.read(_REF).items[0].cluster_id == ""
+
+
+def test_cluster_all_items_dispositioned_is_no_items(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Items exist but all are processed (dispositioned) → nothing needs clustering.
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    patched.write(_REF, _state(_item("a", cluster_id="c1", disposition=disp)))
+    dispatcher = ClusterDispatcherStub([])
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["cluster", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert dispatcher.calls == 0
+
+
+def test_cluster_malformed_ref_exits_two() -> None:
+    result = runner.invoke(cli.app, ["cluster", "not-a-ref"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_BAD_PR_REF" in result.output

--- a/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
+++ b/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
@@ -1,0 +1,43 @@
+"""Tests for the decided-by + soft-warning helpers (§5, §8, §8.15).
+
+``cli._decided_by`` derives the disposition author string from a resolved provider
+chain's primary; ``fix._default_warn`` is the ``fix_pr`` default soft-warning
+stderr sink. Both are small pure-ish helpers; the production dispatcher-build seams
+themselves are boundary wiring (monkeypatched in the verb tests), so these pin the
+logic the seams delegate to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prgroom.agent.dispatcher import ProviderChain
+from prgroom.agent.subprocess_runner import AgentSpec
+from prgroom.cli import _decided_by
+from prgroom.lifecycle.fix import _default_warn
+
+
+def test_decided_by_uses_primary_cli_and_model() -> None:
+    chain = ProviderChain(
+        providers=[
+            AgentSpec(cli="claude", model="opus[1m]"),
+            AgentSpec(cli="codex", model="gpt-5.5"),
+        ],
+        time_budget_s=1.0,
+    )
+    # The primary (first) provider names the deciding agent: "<cli> <model>".
+    assert _decided_by(chain) == "claude opus[1m]"
+
+
+def test_decided_by_empty_chain_degrades_to_prgroom() -> None:
+    # A misconfigured empty chain never yields a blank decided_by.
+    assert _decided_by(ProviderChain(providers=[], time_budget_s=1.0)) == "prgroom"
+
+
+def test_default_warn_writes_a_one_line_prgroom_notice(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The fix verb's default soft-warning sink prefixes "prgroom: " and a newline,
+    # so an operator can grep soft warnings out of stderr.
+    _default_warn("a soft warning")
+    assert capsys.readouterr().err == "prgroom: a soft warning\n"

--- a/packages/prgroom/tests/unit/test_cli_fix.py
+++ b/packages/prgroom/tests/unit/test_cli_fix.py
@@ -1,0 +1,186 @@
+"""Tests for the wired ``fix`` CLI verb (§1, §2, §3.2).
+
+The verb resolves the store + gh/git adapters + a FixDispatcher + a StderrSink,
+parses the PR ref, then runs ``read → fix_pr → write`` under the lock wrapper.
+The outward seams — ``_build_store``, ``_build_gh``, ``_build_git``, and
+``_build_fix_dispatcher`` — are monkeypatched. Direct-invocation preconditions:
+no state → NO_STATE; no clusters → NO_CLUSTERS; all dispositioned or terminal →
+no-op exit 0.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom import cli
+from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput
+from prgroom.gh import GhCli
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+
+runner = CliRunner()
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+class FakeGit:
+    def head_sha(self) -> str:
+        return "head"
+
+    def rev_list(self, range_: str) -> list[str]:
+        del range_
+        return []
+
+    def log(self, range_: str) -> str:
+        del range_
+        return "recent commits"
+
+    def diff_stat(self, range_: str) -> str:
+        del range_
+        return "diff stat"
+
+    def push(self, remote: str, branch: str) -> None:  # pragma: no cover - unused
+        del remote, branch
+
+    def stash(self) -> None:  # pragma: no cover - unused
+        return None
+
+
+class FixDispatcherStub:
+    def __init__(self, output: FixOutput) -> None:
+        self._output = output
+        self.calls = 0
+
+    def fix(self, request: FixInput) -> FixOutput:
+        del request
+        self.calls += 1
+        return self._output
+
+
+def _item(
+    gh_id: str, *, cluster_id: str = "c-1", disposition: Disposition | None = None
+) -> ReviewItem:
+    return ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id=gh_id, thread_id=f"PRT_{gh_id}"),
+        author="copilot",
+        body_excerpt="fix this",
+        seen_at=_T0,
+        cluster_id=cluster_id,
+        disposition=disposition,
+    )
+
+
+def _state(*items: ReviewItem, phase: PRPhase = PRPhase.FIXES_PENDING) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(ci_state="success"),
+        items=list(items),
+    )
+
+
+def _gh() -> GhCli:
+    from tests.fakes import RecordedRunner
+
+    pr_resource = {"body": "desc", "base": {"ref": "main"}, "labels": []}
+    return GhCli(RecordedRunner([_ok(pr_resource), _ok([])]))
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch) -> InMemoryStore:
+    store = InMemoryStore()
+    monkeypatch.setattr(cli, "_build_store", lambda _name: store)
+    monkeypatch.setattr(cli, "_build_gh", lambda: _gh())
+    monkeypatch.setattr(cli, "_build_git", lambda: FakeGit())
+    return store
+
+
+def _wire_dispatcher(monkeypatch: pytest.MonkeyPatch, dispatcher: FixDispatcherStub) -> None:
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (dispatcher, "claude opus[1m]"))
+
+
+def test_fix_applies_and_persists(patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    patched.write(_REF, _state(_item("a")))
+    dispatcher = FixDispatcherStub(
+        FixOutput(
+            items=[FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="ack")]
+        )
+    )
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    written = patched.read(_REF)
+    assert written.items[0].disposition is not None
+    assert written.items[0].disposition.kind is DispositionKind.SKIPPED
+    assert written.items[0].disposition.decided_by == "claude opus[1m]"
+
+
+@pytest.mark.usefixtures("patched")
+def test_fix_no_state_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_dispatcher(monkeypatch, FixDispatcherStub(FixOutput(items=[])))
+    result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_NO_STATE" in result.output
+
+
+def test_fix_no_clusters_exits_zero_no_work(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Items exist but none are clustered (cluster_id == "") → nothing to fix.
+    patched.write(_REF, _state(_item("a", cluster_id="")))
+    _wire_dispatcher(monkeypatch, FixDispatcherStub(FixOutput(items=[])))
+    result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
+    assert result.exit_code == 0
+    assert "PRECONDITION_NO_CLUSTERS" in result.output
+
+
+def test_fix_all_dispositioned_is_idempotent_noop(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    patched.write(_REF, _state(_item("a", disposition=disp)))
+    dispatcher = FixDispatcherStub(FixOutput(items=[]))
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert dispatcher.calls == 0  # nothing to fix → no dispatch
+
+
+def test_fix_terminal_phase_is_noop(
+    patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    patched.write(_REF, _state(_item("a"), phase=PRPhase.MERGED))
+    dispatcher = FixDispatcherStub(FixOutput(items=[]))
+    _wire_dispatcher(monkeypatch, dispatcher)
+    result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert dispatcher.calls == 0
+    assert patched.read(_REF).items[0].disposition is None
+
+
+def test_fix_malformed_ref_exits_two() -> None:
+    result = runner.invoke(cli.app, ["fix", "not-a-ref"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_BAD_PR_REF" in result.output

--- a/packages/prgroom/tests/unit/test_cli_fix.py
+++ b/packages/prgroom/tests/unit/test_cli_fix.py
@@ -166,6 +166,9 @@ def test_fix_all_dispositioned_is_idempotent_noop(
     result = runner.invoke(cli.app, ["fix", "octo/demo#7"])
     assert result.exit_code == 0, result.output
     assert dispatcher.calls == 0  # nothing to fix → no dispatch
+    # All-dispositioned is the idempotent "already done" no-op — NOT the misleading
+    # NO_CLUSTERS "run cluster first" precondition (which also exits 0).
+    assert "PRECONDITION_NO_CLUSTERS" not in result.output
 
 
 def test_fix_terminal_phase_is_noop(

--- a/packages/prgroom/tests/unit/test_cli_smoke.py
+++ b/packages/prgroom/tests/unit/test_cli_smoke.py
@@ -50,11 +50,11 @@ def test_each_verb_has_its_own_help(verb: str) -> None:
 
 # Each single-PR-arg skeleton verb invoked with a positional ref. resolve-escalated
 # has a richer signature and is exercised separately below. ``poll`` is no longer a
-# skeleton (8.9a wired it for real); ``status`` likewise (8.11) — their behavior is
-# covered by test_cli_poll.py / test_cli_status.py.
-_SINGLE_ARG_VERBS = [
-    v for v in MVP_VERBS if v not in {"resolve-escalated", "sweep", "poll", "status"}
-]
+# skeleton (8.9a wired it for real); ``status`` likewise (8.11); ``cluster`` + ``fix``
+# (8.15) — their behavior is covered by test_cli_poll.py / test_cli_status.py /
+# test_cli_cluster.py / test_cli_fix.py.
+_WIRED_VERBS = {"resolve-escalated", "sweep", "poll", "status", "cluster", "fix"}
+_SINGLE_ARG_VERBS = [v for v in MVP_VERBS if v not in _WIRED_VERBS]
 
 
 @pytest.mark.parametrize("verb", _SINGLE_ARG_VERBS)

--- a/packages/prgroom/tests/unit/test_cli_store.py
+++ b/packages/prgroom/tests/unit/test_cli_store.py
@@ -3,7 +3,7 @@
 The store is resolved eagerly in the root callback so an invalid adapter fails
 terminally — rendered 4-line block, exit 2, no traceback — BEFORE any verb body
 runs. A valid `--store file` (or the default) falls through to the verb. The
-probe verb is ``cluster`` (still a foundation skeleton), so these tests exercise
+probe verb is ``push`` (still a foundation skeleton), so these tests exercise
 ONLY the root-callback store resolution, not any verb's own logic. Proves
 `--store` beats `PRGROOM_STORE` via a set env var.
 """
@@ -18,8 +18,9 @@ from prgroom.cli import SKELETON_EXIT_CODE, app
 runner = CliRunner()
 
 # A still-skeleton single-arg verb used purely to probe the root callback. ``poll``
-# is no longer a skeleton (8.9a), so it cannot serve as the fall-through probe.
-_PROBE = "cluster"
+# (8.9a), ``status`` (8.11), and ``cluster`` / ``fix`` (8.15) are wired for real, so
+# ``push`` is the remaining skeleton that serves as the fall-through probe.
+_PROBE = "push"
 
 
 def test_invalid_store_bd_exits_two_with_block_before_verb() -> None:

--- a/packages/prgroom/tests/unit/test_git_fit.py
+++ b/packages/prgroom/tests/unit/test_git_fit.py
@@ -69,6 +69,40 @@ def test_stash_succeeds_returns_none() -> None:
     assert runner.calls[0] == ["git", "stash"]
 
 
+def test_log_returns_raw_output_and_builds_argv() -> None:
+    # `log` is a snapshot read (§8.1 branch_state): the recent-commits text is
+    # passed verbatim to the fix agent, so the adapter returns it unparsed.
+    runner = RecordedRunner([_ok("abc Subject one\ndef Subject two\n")])
+    client = GitCli(runner)
+    assert client.log("origin/main..HEAD") == "abc Subject one\ndef Subject two\n"
+    assert runner.calls[0] == ["git", "log", "origin/main..HEAD"]
+
+
+def test_diff_stat_returns_raw_output_and_builds_argv() -> None:
+    # `diff_stat` is the §8.1 diff-since-base summary; raw text, no parsing.
+    runner = RecordedRunner([_ok(" file.py | 3 +++\n 1 file changed\n")])
+    client = GitCli(runner)
+    assert client.diff_stat("origin/main..HEAD") == " file.py | 3 +++\n 1 file changed\n"
+    assert runner.calls[0] == ["git", "diff", "--stat", "origin/main..HEAD"]
+
+
+def test_log_failure_classifies_as_git_transient() -> None:
+    # A failed snapshot read reuses _run's classification — a non-push local
+    # failure is conservatively transient (the snapshot retries next cadence).
+    runner = RecordedRunner([_fail("fatal: bad revision 'origin/main..HEAD'\n")])
+    client = GitCli(runner)
+    with pytest.raises(PrgroomError) as exc:
+        client.log("origin/main..HEAD")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+
+
+def test_diff_stat_timeout_classifies_as_git_transient() -> None:
+    client = GitCli(TimeoutRunner())
+    with pytest.raises(PrgroomError) as exc:
+        client.diff_stat("origin/main..HEAD")
+    assert exc.value.code is ErrorCode.RUNTIME_GIT_TRANSIENT
+
+
 # ── failure classification ──
 
 

--- a/packages/prgroom/tests/unit/test_lifecycle_cluster.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_cluster.py
@@ -217,9 +217,13 @@ def test_cluster_writes_pr_context_file(tmp_path: Path) -> None:
     assert dispatcher.last_request is not None
     ctx_path = Path(dispatcher.last_request.pr_context_path)
     assert ctx_path.is_file()
-    ctx = ctx_path.read_text(encoding="utf-8")
-    assert "My PR" in ctx  # title from the gh PR resource
-    assert "abc recent commit" in ctx  # recent commits from git
+    ctx = json.loads(ctx_path.read_text(encoding="utf-8"))
+    assert ctx["title"] == "My PR"  # title from the gh PR resource
+    assert "abc recent commit" in ctx["recent_commits"]  # recent commits from git
+    # ci_state comes from the poll-derived state.quiescence.ci_state, NOT a gh field
+    # on the REST PR payload (which carries no statusCheckRollup) — guards the
+    # always-empty dead-field regression.
+    assert ctx["ci_state"] == "success"
 
 
 def test_cluster_404_on_pr_context_read_is_terminal(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_lifecycle_cluster.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_cluster.py
@@ -1,0 +1,219 @@
+"""Tests for ``cluster_pr`` — the lock-held ``_cluster`` lifecycle internal (§3.2, §5).
+
+``cluster_pr`` mirrors ``poll_pr``: it works on a deepcopy of the in-memory
+``PRGroomingState``, calls 8.7's pure ``run_cluster`` compute, and APPLIES the
+returned assignments by setting each item's ``cluster_id``. It decides NO
+disposition and makes NO phase change (the §3.2 cluster row). The dispatcher is a
+small ``ClusterContract`` fake; gh/git are fakes at the boundary; the clock is the
+injected frozen fake. No code we own is mocked (§7.6).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
+from prgroom.config import PrgroomConfig
+from prgroom.deps import Deps
+from prgroom.gh import GhCli
+from prgroom.lifecycle.cluster import cluster_pr
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+from tests.conftest import FixedRandomness, FrozenClock
+from tests.fakes import RecordedRunner
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def _deps() -> Deps:
+    return Deps(clock=FrozenClock(_T0), randomness=FixedRandomness())
+
+
+def _item(
+    gh_id: str, *, cluster_id: str = "", disposition: Disposition | None = None
+) -> ReviewItem:
+    return ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id=gh_id, thread_id=f"PRT_{gh_id}"),
+        author="copilot",
+        body_excerpt="fix this",
+        seen_at=_T0,
+        cluster_id=cluster_id,
+        disposition=disposition,
+    )
+
+
+def _state(*items: ReviewItem, phase: PRPhase = PRPhase.FIXES_PENDING) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(ci_state="success"),
+        items=list(items),
+    )
+
+
+def _gh() -> GhCli:
+    """The light PR-context read: just the PR resource (title/body/CI summary)."""
+    return GhCli(RecordedRunner([_ok({"title": "My PR", "body": "desc", "base": {"ref": "main"}})]))
+
+
+class FakeGit:
+    """A minimal ``GitClient`` fake for the cluster PR-context file's recent commits."""
+
+    def head_sha(self) -> str:  # pragma: no cover - unused
+        return "head"
+
+    def rev_list(self, range_: str) -> list[str]:  # pragma: no cover - unused
+        del range_
+        return []
+
+    def log(self, range_: str) -> str:
+        del range_
+        return "abc recent commit"
+
+    def diff_stat(self, range_: str) -> str:  # pragma: no cover - unused by cluster
+        del range_
+        return ""
+
+    def push(self, remote: str, branch: str) -> None:  # pragma: no cover - unused
+        del remote, branch
+
+    def stash(self) -> None:  # pragma: no cover - unused
+        return None
+
+
+class ClusterDispatcherStub:
+    """A ``ClusterContract`` fake returning a canned clustering of the input items."""
+
+    def __init__(self, clusters: list[ClusterResult]) -> None:
+        self._clusters = clusters
+        self.calls = 0
+        self.last_request: ClusterInput | None = None
+
+    def cluster(self, request: ClusterInput) -> ClusterOutput:
+        self.calls += 1
+        self.last_request = request
+        return ClusterOutput(clusters=self._clusters)
+
+
+def _run(
+    state: PRGroomingState,
+    dispatcher: ClusterDispatcherStub,
+    scratch_dir: Path,
+    *,
+    gh: GhCli | None = None,
+) -> PRGroomingState:
+    return cluster_pr(
+        state,
+        ref=_REF,
+        gh=gh or _gh(),
+        git=FakeGit(),
+        deps=_deps(),
+        config=PrgroomConfig(),
+        dispatcher=dispatcher,
+        decided_by="ollama gemma4",
+        scratch_dir=scratch_dir,
+    )
+
+
+def test_cluster_applies_assignments_to_unclustered_items(tmp_path: Path) -> None:
+    a, b = _item("a"), _item("b")
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-x", item_gh_ids=["a", "b"], rationale="same area")]
+    )
+    out = _run(_state(a, b), dispatcher, tmp_path)
+    assert {it.identity.gh_id: it.cluster_id for it in out.items} == {"a": "c-x", "b": "c-x"}
+    assert dispatcher.calls == 1
+
+
+def test_cluster_no_phase_change_and_no_disposition(tmp_path: Path) -> None:
+    a = _item("a")
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-x", item_gh_ids=["a"], rationale="solo")]
+    )
+    out = _run(_state(a, phase=PRPhase.FIXES_PENDING), dispatcher, tmp_path)
+    assert out.phase is PRPhase.FIXES_PENDING
+    assert out.items[0].disposition is None
+
+
+def test_cluster_idempotent_noop_when_all_already_clustered(tmp_path: Path) -> None:
+    a = _item("a", cluster_id="c-existing")
+    dispatcher = ClusterDispatcherStub([])
+    out = _run(_state(a), dispatcher, tmp_path)
+    # Every item already clustered → no dispatch, cluster_id untouched.
+    assert dispatcher.calls == 0
+    assert out.items[0].cluster_id == "c-existing"
+
+
+def test_cluster_only_clusters_unclustered_items(tmp_path: Path) -> None:
+    done = _item("done", cluster_id="c-old")
+    todo = _item("todo")
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-new", item_gh_ids=["todo"], rationale="new")]
+    )
+    out = _run(_state(done, todo), dispatcher, tmp_path)
+    by_id = {it.identity.gh_id: it.cluster_id for it in out.items}
+    assert by_id == {"done": "c-old", "todo": "c-new"}
+    # Only the unclustered item is sent to the dispatcher.
+    assert dispatcher.last_request is not None
+    assert [it.identity.gh_id for it in dispatcher.last_request.items] == ["todo"]
+
+
+def test_cluster_skips_dispositioned_items_even_if_unclustered(tmp_path: Path) -> None:
+    # A dispositioned-but-unclustered item is already processed; cluster works on
+    # cluster_id == "" items, but an already-dispositioned item must not be re-sent.
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    processed = _item("p", disposition=disp)
+    fresh = _item("f")
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-1", item_gh_ids=["f"], rationale="r")]
+    )
+    out = _run(_state(processed, fresh), dispatcher, tmp_path)
+    assert dispatcher.last_request is not None
+    assert [it.identity.gh_id for it in dispatcher.last_request.items] == ["f"]
+    by_id = {it.identity.gh_id: it.cluster_id for it in out.items}
+    assert by_id["f"] == "c-1"
+    assert by_id["p"] == ""  # processed item is left untouched
+
+
+def test_cluster_does_not_mutate_caller_state(tmp_path: Path) -> None:
+    a = _item("a")
+    state = _state(a)
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-x", item_gh_ids=["a"], rationale="r")]
+    )
+    _run(state, dispatcher, tmp_path)
+    # cluster_pr works on a deepcopy; the caller's object is unchanged.
+    assert state.items[0].cluster_id == ""
+
+
+def test_cluster_writes_pr_context_file(tmp_path: Path) -> None:
+    a = _item("a")
+    dispatcher = ClusterDispatcherStub(
+        [ClusterResult(cluster_id="c-x", item_gh_ids=["a"], rationale="r")]
+    )
+    _run(_state(a), dispatcher, tmp_path)
+    assert dispatcher.last_request is not None
+    ctx_path = Path(dispatcher.last_request.pr_context_path)
+    assert ctx_path.is_file()
+    ctx = ctx_path.read_text(encoding="utf-8")
+    assert "My PR" in ctx  # title from the gh PR resource
+    assert "abc recent commit" in ctx  # recent commits from git

--- a/packages/prgroom/tests/unit/test_lifecycle_cluster.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_cluster.py
@@ -14,9 +14,12 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
 from prgroom.config import PrgroomConfig
 from prgroom.deps import Deps
+from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.gh import GhCli
 from prgroom.lifecycle.cluster import cluster_pr
 from prgroom.proc import CommandResult
@@ -217,3 +220,15 @@ def test_cluster_writes_pr_context_file(tmp_path: Path) -> None:
     ctx = ctx_path.read_text(encoding="utf-8")
     assert "My PR" in ctx  # title from the gh PR resource
     assert "abc recent commit" in ctx  # recent commits from git
+
+
+def test_cluster_404_on_pr_context_read_is_terminal(tmp_path: Path) -> None:
+    # A 404 building the PR-context file means the PR/repo vanished → terminal
+    # RUNTIME_GH_TERMINAL, never a crash or a blind retry.
+    not_found = CommandResult(returncode=1, stdout="{}", stderr="gh: Not Found (HTTP 404)")
+    gh = GhCli(RecordedRunner([not_found]))
+    dispatcher = ClusterDispatcherStub([])
+    with pytest.raises(PrgroomError) as exc:
+        _run(_state(_item("a")), dispatcher, tmp_path, gh=gh)
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert exc.value.tier is Tier.RUNTIME_TERMINAL_USER

--- a/packages/prgroom/tests/unit/test_lifecycle_fix.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix.py
@@ -195,12 +195,8 @@ def test_fix_applies_dispositions_from_result(tmp_path: Path) -> None:
     dispatcher = FixDispatcherStub(
         [
             _out(
-                FixItemResult(
-                    gh_id="a", disposition=DispositionKind.FIXED, commit_shas=["sha1"]
-                ),
-                FixItemResult(
-                    gh_id="b", disposition=DispositionKind.SKIPPED, rationale="ack only"
-                ),
+                FixItemResult(gh_id="a", disposition=DispositionKind.FIXED, commit_shas=["sha1"]),
+                FixItemResult(gh_id="b", disposition=DispositionKind.SKIPPED, rationale="ack only"),
             )
         ]
     )

--- a/packages/prgroom/tests/unit/test_lifecycle_fix.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix.py
@@ -1,0 +1,357 @@
+"""Tests for ``fix_pr`` — the lock-held ``_fix`` lifecycle internal (§3.2, §5, §8).
+
+``fix_pr`` is the APPLY side of the fix path: it assembles the §8.1 snapshot per
+cluster, calls 8.7's pure ``run_fix`` compute, and APPLIES the results to a
+deepcopy of state — setting each ``item.disposition``, emitting each returned
+``Escalation`` via the injected ``Sink``, and logging soft warnings. It makes NO
+phase change (§3.2 fix row: phase resolution is end-of-cycle, bead 8.10) and does
+NOT set ``state.last_error``. The fix dispatcher, gh, git, and sink are fakes at
+the boundaries; the clock is the injected frozen fake. No code we own is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEntry
+from prgroom.agent.dispatcher import AllProvidersFailedError
+from prgroom.config import PrgroomConfig
+from prgroom.deps import Deps
+from prgroom.escalation import Escalation
+from prgroom.gh import GhCli
+from prgroom.lifecycle.fix import fix_pr
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+from tests.conftest import FixedRandomness, FrozenClock
+from tests.fakes import RecordedRunner
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def _deps() -> Deps:
+    return Deps(clock=FrozenClock(_T0), randomness=FixedRandomness())
+
+
+def _item(
+    gh_id: str,
+    *,
+    cluster_id: str = "c-1",
+    disposition: Disposition | None = None,
+) -> ReviewItem:
+    return ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id=gh_id, thread_id=f"PRT_{gh_id}"),
+        author="copilot",
+        body_excerpt="fix this",
+        seen_at=_T0,
+        cluster_id=cluster_id,
+        disposition=disposition,
+    )
+
+
+def _state(*items: ReviewItem, phase: PRPhase = PRPhase.FIXES_PENDING) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(ci_state="success"),
+        items=list(items),
+    )
+
+
+def _gh_per_cluster(n: int) -> GhCli:
+    """Queue the snapshot reads (PR resource + review comments) for ``n`` clusters."""
+    pr_resource = {"body": "desc", "base": {"ref": "main"}, "labels": []}
+    results: list[CommandResult] = []
+    for _ in range(n):
+        results.append(_ok(pr_resource))
+        results.append(_ok([]))  # review comments
+    return GhCli(RecordedRunner(results))
+
+
+class FakeGit:
+    """A ``GitClient`` fake covering both run_fix (head_sha/rev_list) and snapshot.
+
+    ``new_commits`` scripts the ``pre..post`` range run_fix asks for (the commits a
+    cluster's fix produced); the default empty list models the common
+    skipped/wont_fix path. ``head_sha`` returns the same value twice (pre==post),
+    so an empty ``new_commits`` correctly means "no commits produced this cluster".
+    """
+
+    def __init__(self, *, new_commits: list[str] | None = None) -> None:
+        self._new = new_commits or []
+        self.stash_calls = 0
+
+    def head_sha(self) -> str:
+        return "head"
+
+    def rev_list(self, range_: str) -> list[str]:
+        # The bare-pre query yields ancestors (none needed here); the pre..post
+        # range yields this cluster's produced commits.
+        return list(self._new) if ".." in range_ else []
+
+    def log(self, range_: str) -> str:
+        del range_
+        return "recent commits"
+
+    def diff_stat(self, range_: str) -> str:
+        del range_
+        return "diff stat"
+
+    def push(self, remote: str, branch: str) -> None:  # pragma: no cover - unused
+        del remote, branch
+
+    def stash(self) -> None:
+        self.stash_calls += 1
+
+
+class FixDispatcherStub:
+    """A ``FixContract`` fake returning a canned output (or raising) per cluster call."""
+
+    def __init__(self, outcomes: list[FixOutput | Exception]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls = 0
+        self.requests: list[FixInput] = []
+
+    def fix(self, request: FixInput) -> FixOutput:
+        self.calls += 1
+        self.requests.append(request)
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class RecordingSink:
+    """A ``Sink`` fake recording every emitted Escalation."""
+
+    def __init__(self) -> None:
+        self.emitted: list[Escalation] = []
+
+    def emit(self, escalation: Escalation) -> None:
+        self.emitted.append(escalation)
+
+
+def _out(*rows: FixItemResult, **kw: object) -> FixOutput:
+    return FixOutput(items=list(rows), **kw)  # type: ignore[arg-type]
+
+
+def _run(
+    state: PRGroomingState,
+    dispatcher: FixDispatcherStub,
+    scratch_dir: Path,
+    *,
+    gh: GhCli | None = None,
+    git: FakeGit | None = None,
+    sink: RecordingSink | None = None,
+) -> tuple[PRGroomingState, RecordingSink, FakeGit]:
+    sink = sink or RecordingSink()
+    git = git or FakeGit()
+    out = fix_pr(
+        state,
+        ref=_REF,
+        gh=gh or _gh_per_cluster(_count_clusters(state)),
+        git=git,
+        deps=_deps(),
+        config=PrgroomConfig(),
+        dispatcher=dispatcher,
+        sink=sink,
+        decided_by="claude opus[1m]",
+        scratch_dir=scratch_dir,
+    )
+    return out, sink, git
+
+
+def _count_clusters(state: PRGroomingState) -> int:
+    return len(
+        {it.cluster_id for it in state.items if it.disposition is None and it.cluster_id != ""}
+    )
+
+
+# ───────────────────────── apply dispositions ─────────────────────────
+
+
+def test_fix_applies_dispositions_from_result(tmp_path: Path) -> None:
+    a, b = _item("a"), _item("b")
+    # "a" is a clean FIXED claiming a commit the FakeGit reports in pre..post (so
+    # the 8.7 commit audit passes); "b" is a clean SKIPPED (rationale only).
+    dispatcher = FixDispatcherStub(
+        [
+            _out(
+                FixItemResult(
+                    gh_id="a", disposition=DispositionKind.FIXED, commit_shas=["sha1"]
+                ),
+                FixItemResult(
+                    gh_id="b", disposition=DispositionKind.SKIPPED, rationale="ack only"
+                ),
+            )
+        ]
+    )
+    git = FakeGit(new_commits=["sha1"])
+    out, _sink, _git = _run(_state(a, b), dispatcher, tmp_path, git=git)
+    by_id = {it.identity.gh_id: it.disposition for it in out.items}
+    assert by_id["a"] is not None
+    assert by_id["a"].kind is DispositionKind.FIXED
+    assert by_id["a"].decided_by == "claude opus[1m]"
+    assert by_id["b"] is not None
+    assert by_id["b"].kind is DispositionKind.SKIPPED
+
+
+def test_fix_no_phase_change_and_no_last_error(tmp_path: Path) -> None:
+    a = _item("a")
+    dispatcher = FixDispatcherStub(
+        [_out(FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="r"))]
+    )
+    out, _sink, _git = _run(_state(a, phase=PRPhase.FIXES_PENDING), dispatcher, tmp_path)
+    assert out.phase is PRPhase.FIXES_PENDING  # §3.2 fix row: no phase change here
+    assert out.last_error is None  # FAILED dispositions carry their own rationale
+
+
+def test_fix_emits_escalations_via_sink(tmp_path: Path) -> None:
+    a = _item("a")
+    dispatcher = FixDispatcherStub([AllProvidersFailedError(detail="ollama down; opus down")])
+    out, sink, git = _run(_state(a), dispatcher, tmp_path)
+    # both-fail flips the item to FAILED and yields one escalation the sink emits.
+    assert out.items[0].disposition is not None
+    assert out.items[0].disposition.kind is DispositionKind.FAILED
+    assert len(sink.emitted) == 1
+    assert "down" in sink.emitted[0].reason
+    assert git.stash_calls == 0  # both-fail produces nothing → no stash
+
+
+# ───────────────────────── idempotency ─────────────────────────
+
+
+def test_fix_idempotent_noop_when_all_dispositioned(tmp_path: Path) -> None:
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    a = _item("a", disposition=disp)
+    dispatcher = FixDispatcherStub([])
+    out, sink, _git = _run(_state(a), dispatcher, tmp_path, gh=_gh_per_cluster(0))
+    assert dispatcher.calls == 0  # nothing to do → no dispatch
+    assert sink.emitted == []
+    # Value-equal (fix_pr deep-copies state; identity differs, content is preserved).
+    assert out.items[0].disposition == disp
+
+
+def test_fix_skips_unclustered_items(tmp_path: Path) -> None:
+    # An item with cluster_id == "" is not yet clustered → fix does not touch it
+    # (fix groups disposition is None AND cluster_id != "").
+    clustered = _item("c", cluster_id="c-1")
+    unclustered = _item("u", cluster_id="")
+    dispatcher = FixDispatcherStub(
+        [_out(FixItemResult(gh_id="c", disposition=DispositionKind.SKIPPED, rationale="r"))]
+    )
+    out, _sink, _git = _run(_state(clustered, unclustered), dispatcher, tmp_path)
+    by_id = {it.identity.gh_id: it.disposition for it in out.items}
+    assert by_id["c"] is not None
+    assert by_id["u"] is None  # unclustered item left for a future cluster pass
+
+
+# ───────────────────────── serial multi-cluster ─────────────────────────
+
+
+def test_fix_processes_clusters_serially(tmp_path: Path) -> None:
+    a = _item("a", cluster_id="c-1")
+    b = _item("b", cluster_id="c-2")
+    dispatcher = FixDispatcherStub(
+        [
+            _out(FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="r")),
+            _out(FixItemResult(gh_id="b", disposition=DispositionKind.WONT_FIX, rationale="r")),
+        ]
+    )
+    out, _sink, _git = _run(_state(a, b), dispatcher, tmp_path)
+    assert dispatcher.calls == 2  # one dispatch per cluster (MVP serial)
+    # Each dispatch carries exactly its cluster's item.
+    sent = {req.cluster_id: [it.identity.gh_id for it in req.items] for req in dispatcher.requests}
+    assert sent == {"c-1": ["a"], "c-2": ["b"]}
+    by_id = {it.identity.gh_id: it.disposition.kind for it in out.items if it.disposition}
+    assert by_id == {"a": DispositionKind.SKIPPED, "b": DispositionKind.WONT_FIX}
+
+
+# ───────────────────────── soft warnings + deferred memory ─────────────────────────
+
+
+def test_fix_logs_deferred_memory_via_warn_seam(tmp_path: Path) -> None:
+    # A non-CONTEXTUAL memory entry is accepted-but-deferred (§8.3): fix_pr logs it
+    # through the injected warn seam (MVP does not route it) without flipping the
+    # item or escalating. The warn seam is injectable so this is asserted directly,
+    # not by scraping stderr.
+    a = _item("a")
+    out = FixOutput(
+        items=[FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="r")],
+        memory=[MemoryEntry(classification="PROJECT", content="a repo-wide note")],
+    )
+    dispatcher = FixDispatcherStub([out])
+    warnings: list[str] = []
+    state_out = fix_pr(
+        _state(a),
+        ref=_REF,
+        gh=_gh_per_cluster(1),
+        git=FakeGit(),
+        deps=_deps(),
+        config=PrgroomConfig(),
+        dispatcher=dispatcher,
+        sink=RecordingSink(),
+        decided_by="claude opus[1m]",
+        scratch_dir=tmp_path,
+        warn=warnings.append,
+    )
+    assert state_out.items[0].disposition is not None
+    assert state_out.items[0].disposition.kind is DispositionKind.SKIPPED
+    # The deferred memory entry was logged (MVP routes only CONTEXTUAL→PR).
+    assert any("deferred" in w.lower() for w in warnings)
+
+
+def test_fix_logs_unwritten_paths_via_warn_seam(tmp_path: Path) -> None:
+    # A declared-but-unwritten memory_writes path is a soft warning (§8.6): logged,
+    # never a cluster failure. Forced here by passing a known_thread_ids-independent
+    # output; the warn seam records the soft warning.
+    a = _item("a")
+    out = FixOutput(
+        items=[FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="r")],
+    )
+    dispatcher = FixDispatcherStub([out])
+    warnings: list[str] = []
+    fix_pr(
+        _state(a),
+        ref=_REF,
+        gh=_gh_per_cluster(1),
+        git=FakeGit(),
+        deps=_deps(),
+        config=PrgroomConfig(),
+        dispatcher=dispatcher,
+        sink=RecordingSink(),
+        decided_by="claude opus[1m]",
+        scratch_dir=tmp_path,
+        warn=warnings.append,
+    )
+    # MVP audit passes written_paths == declared, so unwritten is empty here — no
+    # spurious soft warning. (The seam is exercised by the deferred-memory test.)
+    assert not any("unwritten" in w.lower() for w in warnings)
+
+
+def test_fix_does_not_mutate_caller_state(tmp_path: Path) -> None:
+    a = _item("a")
+    state = _state(a)
+    dispatcher = FixDispatcherStub(
+        [_out(FixItemResult(gh_id="a", disposition=DispositionKind.SKIPPED, rationale="r"))]
+    )
+    _run(state, dispatcher, tmp_path)
+    assert state.items[0].disposition is None  # caller's object untouched (deepcopy)

--- a/packages/prgroom/tests/unit/test_lifecycle_fix.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix.py
@@ -210,6 +210,38 @@ def test_fix_applies_dispositions_from_result(tmp_path: Path) -> None:
     assert by_id["b"].kind is DispositionKind.SKIPPED
 
 
+def test_fix_applies_per_cluster_not_state_wide_gh_id(tmp_path: Path) -> None:
+    # Two items share gh_id "dup" but differ in kind (the natural key is
+    # (kind, gh_id), not gh_id alone). The clustered-unprocessed one must receive the
+    # disposition; the already-processed sibling sharing the gh_id must be untouched —
+    # a state-wide gh_id map would mis-target the sibling (PR #152 comment 3408284563).
+    target = _item("dup", cluster_id="c-1")  # REVIEW_THREAD, unprocessed
+    prior = Disposition(
+        kind=DispositionKind.SKIPPED, decided_at=_T0, decided_by="x", rationale="kept"
+    )
+    sibling = ReviewItem(
+        kind=ItemKind.ISSUE_COMMENT,
+        identity=Identity(gh_id="dup", issue_comment_id=99),
+        author="copilot",
+        body_excerpt="other",
+        seen_at=_T0,
+        cluster_id="",
+        disposition=prior,
+    )
+    dispatcher = FixDispatcherStub(
+        [_out(FixItemResult(gh_id="dup", disposition=DispositionKind.FIXED, commit_shas=["sha1"]))]
+    )
+    out, _sink, _git = _run(
+        _state(target, sibling), dispatcher, tmp_path, git=FakeGit(new_commits=["sha1"])
+    )
+    rt = next(it for it in out.items if it.kind is ItemKind.REVIEW_THREAD)
+    ic = next(it for it in out.items if it.kind is ItemKind.ISSUE_COMMENT)
+    assert rt.disposition is not None and rt.disposition.kind is DispositionKind.FIXED
+    # the same-gh_id sibling kept its prior disposition; it was NOT clobbered
+    assert ic.disposition is not None and ic.disposition.kind is DispositionKind.SKIPPED
+    assert ic.disposition.rationale == "kept"
+
+
 def test_fix_no_phase_change_and_no_last_error(tmp_path: Path) -> None:
     a = _item("a")
     dispatcher = FixDispatcherStub(

--- a/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
@@ -230,6 +230,17 @@ def test_derive_recurrence_ignores_malformed_reply_timestamp() -> None:
     assert rec.reopened is False
 
 
+def test_derive_recurrence_naive_reply_timestamp_does_not_crash() -> None:
+    # A present-but-naive (offsetless) timestamp can't be compared to the tz-aware
+    # decided_at; it is skipped (can't prove a reopen) rather than raising TypeError.
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    threads = {"PRT_a": [{"created_at": "2026-06-10T12:00:00"}]}  # no offset → naive
+    rec = derive_recurrence(item, _state(item), threads=threads)
+    assert rec is not None
+    assert rec.reopened is False
+
+
 # ───────────────────────── assemble_snapshot ─────────────────────────
 
 

--- a/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
@@ -1,0 +1,304 @@
+"""Tests for §8.1 snapshot assembly + §8.2 recurrence derivation.
+
+The snapshot module does the gh/git legwork the fix agent must NOT do (§8.1):
+it reads the PR resource (base ref, body's ``## Decisions`` block, labels), the
+review threads with full reply-chains, and the git branch state (recent commits +
+diff-since-base), then dumps everything to two files passed to the fix contract.
+
+The single mocked seam is the subprocess boundary: ``GhCli`` is driven by a
+``RecordedRunner`` and ``GitClient`` is a small fake. ``derive_recurrence`` is a
+pure function over a ``ReviewItem`` + state, tested without any boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from prgroom.gh import GhCli
+from prgroom.lifecycle.snapshot import (
+    DECISIONS_END,
+    DECISIONS_START,
+    assemble_snapshot,
+    derive_recurrence,
+    extract_decisions_block,
+)
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+from tests.fakes import RecordedRunner
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_T1 = datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def _item(
+    gh_id: str,
+    *,
+    thread_id: str = "",
+    disposition: Disposition | None = None,
+    cluster_id: str = "c-1",
+    seen_at: datetime = _T0,
+) -> ReviewItem:
+    kind = ItemKind.REVIEW_THREAD if thread_id else ItemKind.ISSUE_COMMENT
+    return ReviewItem(
+        kind=kind,
+        identity=Identity(gh_id=gh_id, thread_id=thread_id),
+        author="copilot",
+        body_excerpt="please fix",
+        seen_at=seen_at,
+        cluster_id=cluster_id,
+        disposition=disposition,
+    )
+
+
+def _state(*items: ReviewItem, round_: int = 2) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=PRPhase.FIXES_PENDING,
+        round=round_,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(ci_state="success"),
+        items=list(items),
+    )
+
+
+class FakeGit:
+    """A minimal ``GitClient`` fake scripting the §8.1 branch-state reads."""
+
+    def __init__(self, *, log: str = "log-text", diff_stat: str = "diff-text") -> None:
+        self._log = log
+        self._diff_stat = diff_stat
+        self.log_calls: list[str] = []
+        self.diff_calls: list[str] = []
+
+    def head_sha(self) -> str:  # pragma: no cover - unused by snapshot
+        return "head"
+
+    def rev_list(self, range_: str) -> list[str]:  # pragma: no cover - unused
+        del range_
+        return []
+
+    def log(self, range_: str) -> str:
+        self.log_calls.append(range_)
+        return self._log
+
+    def diff_stat(self, range_: str) -> str:
+        self.diff_calls.append(range_)
+        return self._diff_stat
+
+    def push(self, remote: str, branch: str) -> None:  # pragma: no cover - unused
+        del remote, branch
+
+    def stash(self) -> None:  # pragma: no cover - unused
+        return None
+
+
+def _gh(
+    *,
+    base_ref: str = "main",
+    body: str = "PR body",
+    labels: list[str] | None = None,
+    review_comments: list[dict[str, object]] | None = None,
+) -> GhCli:
+    """Queue the snapshot's gh reads: PR resource, labels, review comments."""
+    pr_resource = {
+        "body": body,
+        "base": {"ref": base_ref},
+        "labels": [{"name": n} for n in (labels or [])],
+    }
+    results = [
+        _ok(pr_resource),
+        _ok(review_comments or []),
+    ]
+    return GhCli(RecordedRunner(results))
+
+
+# ───────────────────────── derive_recurrence ─────────────────────────
+
+
+def test_derive_recurrence_none_when_no_prior_disposition() -> None:
+    item = _item("a", thread_id="PRT_a")
+    state = _state(item)
+    assert derive_recurrence(item, state, threads={}) is None
+
+
+def test_derive_recurrence_carries_prior_disposition_and_commits() -> None:
+    disp = Disposition(
+        kind=DispositionKind.WONT_FIX,
+        decided_at=_T0,
+        decided_by="claude opus[1m]",
+        rationale="suffix denotes pipeline",
+        commits=["c1", "c2"],
+    )
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    rec = derive_recurrence(item, _state(item), threads={})
+    assert rec is not None
+    assert rec.prior_disposition == "wont_fix"
+    assert rec.prior_commits == ("c1", "c2")
+    assert rec.attempt_count == 1  # MVP floor: schema retains one disposition
+    assert rec.first_seen_round == 2  # MVP proxy: current round (schema has no first-seen)
+    assert rec.reopened is False  # no newer reply than decided_at
+
+
+def test_derive_recurrence_reopened_when_newer_reply_on_thread() -> None:
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    # A reply on the same thread arrived AFTER the disposition was decided.
+    threads = {"PRT_a": [{"created_at": _T1.isoformat()}]}
+    rec = derive_recurrence(item, _state(item), threads=threads)
+    assert rec is not None
+    assert rec.reopened is True
+
+
+def test_derive_recurrence_not_reopened_when_reply_predates_disposition() -> None:
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T1, decided_by="x")
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    threads = {"PRT_a": [{"created_at": _T0.isoformat()}]}  # older than decided_at
+    rec = derive_recurrence(item, _state(item), threads=threads)
+    assert rec is not None
+    assert rec.reopened is False
+
+
+def test_derive_recurrence_omits_prior_commits_when_empty() -> None:
+    disp = Disposition(kind=DispositionKind.SKIPPED, decided_at=_T0, decided_by="x")
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    rec = derive_recurrence(item, _state(item), threads={})
+    assert rec is not None
+    assert rec.prior_commits == ()
+    assert "prior_commits" not in rec.to_dict()
+
+
+# ───────────────────────── extract_decisions_block ─────────────────────────
+
+
+def test_extract_decisions_block_present() -> None:
+    body = f"intro\n\n{DECISIONS_START}\n## Decisions\n- a decision\n{DECISIONS_END}\ntail"
+    extracted = extract_decisions_block(body)
+    assert "## Decisions" in extracted
+    assert "a decision" in extracted
+
+
+def test_extract_decisions_block_absent_returns_empty() -> None:
+    assert extract_decisions_block("a PR body with no decisions section") == ""
+
+
+# ───────────────────────── assemble_snapshot ─────────────────────────
+
+
+def test_assemble_snapshot_writes_both_files(tmp_path: Path) -> None:
+    item = _item("11", thread_id="PRT_11")
+    state = _state(item)
+    gh = _gh(base_ref="main", body="body", labels=["bug", "needs-fix"])
+    git = FakeGit(log="commit log here", diff_stat="2 files changed")
+    snap = assemble_snapshot(
+        state, [item], ref=_REF, gh=gh, git=git, scratch_dir=tmp_path
+    )
+    assert Path(snap.pr_detail_path).is_file()
+    assert Path(snap.branch_state_path).is_file()
+    # The branch-state file carries the git log + diff-stat dump verbatim.
+    branch_text = Path(snap.branch_state_path).read_text(encoding="utf-8")
+    assert "commit log here" in branch_text
+    assert "2 files changed" in branch_text
+    # git reads are scoped to base..HEAD (base ref from the gh PR resource).
+    assert git.log_calls == ["origin/main..HEAD"]
+    assert git.diff_calls == ["origin/main..HEAD"]
+
+
+def test_assemble_snapshot_detail_carries_labels_and_decisions(tmp_path: Path) -> None:
+    body = f"intro\n{DECISIONS_START}\n## Decisions\n- adopted Result<T>\n{DECISIONS_END}"
+    item = _item("11", thread_id="PRT_11")
+    gh = _gh(base_ref="main", body=body, labels=["human-review-required"])
+    snap = assemble_snapshot(
+        _state(item), [item], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+    )
+    detail = json.loads(Path(snap.pr_detail_path).read_text(encoding="utf-8"))
+    assert detail["labels"] == ["human-review-required"]
+    assert "adopted Result<T>" in detail["decisions"]
+    assert detail["description"] == body
+
+
+def test_assemble_snapshot_detail_carries_prior_dispositions(tmp_path: Path) -> None:
+    disp = Disposition(
+        kind=DispositionKind.FIXED,
+        decided_at=_T0,
+        decided_by="claude opus[1m]",
+        commits=["c1"],
+    )
+    done = _item("done", thread_id="PRT_done", disposition=disp)
+    todo = _item("todo", thread_id="PRT_todo")
+    state = _state(done, todo)
+    gh = _gh()
+    snap = assemble_snapshot(
+        state, [todo], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+    )
+    detail = json.loads(Path(snap.pr_detail_path).read_text(encoding="utf-8"))
+    prior = detail["prior_dispositions"]
+    assert len(prior) == 1
+    assert prior[0]["gh_id"] == "done"
+    assert prior[0]["kind"] == "fixed"
+    assert prior[0]["commits"] == ["c1"]
+    assert prior[0]["decided_by"] == "claude opus[1m]"
+
+
+def test_assemble_snapshot_threads_carry_full_reply_chain(tmp_path: Path) -> None:
+    review_comments = [
+        {"id": 1, "in_reply_to_id": None, "body": "top", "created_at": _T0.isoformat()},
+        {"id": 2, "in_reply_to_id": 1, "body": "reply", "created_at": _T1.isoformat()},
+    ]
+    item = _item("11", thread_id="PRT_11")
+    gh = _gh(review_comments=review_comments)
+    snap = assemble_snapshot(
+        _state(item), [item], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+    )
+    detail = json.loads(Path(snap.pr_detail_path).read_text(encoding="utf-8"))
+    chains = detail["review_threads"]
+    # Both the top comment and its reply are present (full reply-chain, §8.1).
+    bodies = [c["body"] for thread in chains for c in thread["comments"]]
+    assert "top" in bodies
+    assert "reply" in bodies
+
+
+def test_assemble_snapshot_returns_ephemeral_dirs(tmp_path: Path) -> None:
+    item = _item("11", thread_id="PRT_11")
+    snap = assemble_snapshot(
+        _state(item), [item], ref=_REF, gh=_gh(), git=FakeGit(), scratch_dir=tmp_path
+    )
+    assert Path(snap.memory_dir).is_dir()
+    assert Path(snap.response_outbox_dir).is_dir()
+
+
+def test_assemble_snapshot_embeds_recurrence_for_prior_disposition_items(
+    tmp_path: Path,
+) -> None:
+    disp = Disposition(kind=DispositionKind.WONT_FIX, decided_at=_T0, decided_by="x")
+    # An item being re-fixed that still carries its prior disposition gets a
+    # recurrence object in the per-item recurrence map (forward-compat seam).
+    reopened = _item("a", thread_id="PRT_a", disposition=disp)
+    snap = assemble_snapshot(
+        _state(reopened), [reopened], ref=_REF, gh=_gh(), git=FakeGit(), scratch_dir=tmp_path
+    )
+    assert "a" in snap.recurrence
+    assert snap.recurrence["a"].prior_disposition == "wont_fix"
+
+
+def test_assemble_snapshot_no_recurrence_for_fresh_items(tmp_path: Path) -> None:
+    fresh = _item("a", thread_id="PRT_a")
+    snap = assemble_snapshot(
+        _state(fresh), [fresh], ref=_REF, gh=_gh(), git=FakeGit(), scratch_dir=tmp_path
+    )
+    assert snap.recurrence == {}

--- a/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
@@ -16,6 +16,9 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.gh import GhCli
 from prgroom.lifecycle.snapshot import (
     DECISIONS_END,
@@ -197,6 +200,36 @@ def test_extract_decisions_block_absent_returns_empty() -> None:
     assert extract_decisions_block("a PR body with no decisions section") == ""
 
 
+def test_extract_decisions_block_start_without_end_returns_empty() -> None:
+    # A start sentinel with no matching end has no parseable boundary → empty,
+    # rather than guessing where the block ends.
+    body = f"intro\n{DECISIONS_START}\n## Decisions\n- dangling"
+    assert extract_decisions_block(body) == ""
+
+
+def test_derive_recurrence_no_thread_id_is_not_reopened() -> None:
+    # An item with no thread_id (e.g. an issue_comment) cannot be "reopened" by a
+    # thread reply — the reopened signal degrades to False.
+    disp = Disposition(kind=DispositionKind.SKIPPED, decided_at=_T0, decided_by="x")
+    item = _item("a", disposition=disp)  # no thread_id → issue_comment kind
+    rec = derive_recurrence(
+        item, _state(item), threads={"PRT_a": [{"created_at": _T1.isoformat()}]}
+    )
+    assert rec is not None
+    assert rec.reopened is False
+
+
+def test_derive_recurrence_ignores_malformed_reply_timestamp() -> None:
+    # A reply with a missing/blank created_at cannot prove a reopen — skipped, not
+    # crashed; with no other newer reply the item is not reopened.
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    item = _item("a", thread_id="PRT_a", disposition=disp)
+    threads = {"PRT_a": [{"created_at": ""}, {"body": "no timestamp at all"}]}
+    rec = derive_recurrence(item, _state(item), threads=threads)
+    assert rec is not None
+    assert rec.reopened is False
+
+
 # ───────────────────────── assemble_snapshot ─────────────────────────
 
 
@@ -205,9 +238,7 @@ def test_assemble_snapshot_writes_both_files(tmp_path: Path) -> None:
     state = _state(item)
     gh = _gh(base_ref="main", body="body", labels=["bug", "needs-fix"])
     git = FakeGit(log="commit log here", diff_stat="2 files changed")
-    snap = assemble_snapshot(
-        state, [item], ref=_REF, gh=gh, git=git, scratch_dir=tmp_path
-    )
+    snap = assemble_snapshot(state, [item], ref=_REF, gh=gh, git=git, scratch_dir=tmp_path)
     assert Path(snap.pr_detail_path).is_file()
     assert Path(snap.branch_state_path).is_file()
     # The branch-state file carries the git log + diff-stat dump verbatim.
@@ -243,9 +274,7 @@ def test_assemble_snapshot_detail_carries_prior_dispositions(tmp_path: Path) -> 
     todo = _item("todo", thread_id="PRT_todo")
     state = _state(done, todo)
     gh = _gh()
-    snap = assemble_snapshot(
-        state, [todo], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
-    )
+    snap = assemble_snapshot(state, [todo], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path)
     detail = json.loads(Path(snap.pr_detail_path).read_text(encoding="utf-8"))
     prior = detail["prior_dispositions"]
     assert len(prior) == 1
@@ -280,6 +309,20 @@ def test_assemble_snapshot_returns_ephemeral_dirs(tmp_path: Path) -> None:
     )
     assert Path(snap.memory_dir).is_dir()
     assert Path(snap.response_outbox_dir).is_dir()
+
+
+def test_assemble_snapshot_404_on_pr_resource_is_terminal(tmp_path: Path) -> None:
+    # A mid-run 404 on the PR resource means the PR/repo vanished → terminal
+    # RUNTIME_GH_TERMINAL (mirrors poll.py), never a crash or a blind retry.
+    item = _item("11", thread_id="PRT_11")
+    not_found = CommandResult(returncode=1, stdout="{}", stderr="gh: Not Found (HTTP 404)")
+    gh = GhCli(RecordedRunner([not_found]))
+    with pytest.raises(PrgroomError) as exc:
+        assemble_snapshot(
+            _state(item), [item], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+        )
+    assert exc.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert exc.value.tier is Tier.RUNTIME_TERMINAL_USER
 
 
 def test_assemble_snapshot_embeds_recurrence_for_prior_disposition_items(

--- a/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
@@ -220,11 +220,19 @@ def test_derive_recurrence_no_thread_id_is_not_reopened() -> None:
 
 
 def test_derive_recurrence_ignores_malformed_reply_timestamp() -> None:
-    # A reply with a missing/blank created_at cannot prove a reopen — skipped, not
-    # crashed; with no other newer reply the item is not reopened.
+    # A reply with a blank/missing created_at OR a truly malformed (non-ISO) string
+    # cannot prove a reopen — each is skipped, not crashed (a non-ISO value would
+    # otherwise raise ValueError out of datetime.fromisoformat and abort `fix`).
+    # With no other newer reply the item is not reopened.
     disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
     item = _item("a", thread_id="PRT_a", disposition=disp)
-    threads = {"PRT_a": [{"created_at": ""}, {"body": "no timestamp at all"}]}
+    threads = {
+        "PRT_a": [
+            {"created_at": ""},
+            {"body": "no timestamp at all"},
+            {"created_at": "not-a-real-timestamp"},  # non-ISO → must be skipped, not crash
+        ]
+    }
     rec = derive_recurrence(item, _state(item), threads=threads)
     assert rec is not None
     assert rec.reopened is False


### PR DESCRIPTION
## Summary

Bead **8.15** (label 8.9b) of the prgroom CLI grinder — milestone **M2** ("it decides what to do"). Implements the `_cluster` and `_fix` **lifecycle stage verbs** and their public CLI verbs. This is the *apply* side of the compute/apply boundary that bead 8.7 (merged in #147) built: 8.7's pure `run_cluster`/`run_fix` compute results; 8.15 assembles their inputs and applies their results to `PRGroomingState`.

**M2 safety line:** read-only *toward GitHub* — the fix agent stages commits on the local worktree branch; **nothing is pushed**. All gh use here is read-only GETs (snapshot assembly).

## What changed

- **`lifecycle/cluster.py`** — `cluster_pr` lock-held internal: deepcopy → `run_cluster` → apply `assignments` to `item.cluster_id`. Idempotent; no disposition; no phase change.
- **`lifecycle/fix.py`** — `fix_pr` lock-held internal: per-cluster (serial) snapshot assembly → `run_fix` → apply `dispositions`, emit `escalations` via the injected `Sink`, soft-warn `unwritten`/`deferred_memory`. Idempotent; no phase change; no `last_error`.
- **`lifecycle/snapshot.py`** — §8.1 complete-PR-snapshot assembly + §8.2 recurrence derivation. Read-only gh (PR resource, review-thread reply-chains) + git (`log`/`diff --stat`); writes `pr_detail_path` (description incl. the read-only `## Decisions` block, labels, threads, prior dispositions, recurrence) and `branch_state_path`; creates per-call-isolated ephemeral `memory_dir`/`response_outbox_dir`.
- **`cli.py`** — public `cluster` + `fix` verbs (mirror `poll`'s lock→read→internal→write), plus dispatcher/sink/git seams. Direct-invocation preconditions only.
- **`git/client.py`** — `GitClient.log` + `diff_stat` reads for the §8.1 branch-state file.

## Ground-truth references

Design doc: §3.2 (phase×verb matrix — cluster/fix rows), §5 (cluster/fix contracts, EscalationSink), §8.1 (snapshot), §8.2 (recurrence), §8.6 (audit severities). HLDs: `c4-l3-lifecycle`, `c4-l3-agent-dispatch`.

## Intentionally OUT OF SCOPE (later beads — do not flag as missing)

- **Self-heal / prework orchestration** (auto-running poll→cluster from `fix`) → the `run` aggregate verb (bead 8.10). This bead implements the direct-invocation (`--no-prework`) precondition column only.
- **End-of-cycle phase resolver** (`resolve_end_of_cycle_phase`) → bead 8.10. Cluster/fix make **no** phase change by design (§3.2).
- **`_push` / `_rereview` / `_resolve`** → bead 8.16.
- **`## Decisions` block *write* path** → bead 8.12 (§8.3). The snapshot only *reads* the block.
- **Full §8.1/§8.2 fidelity** is deliberately floored at MVP and tracked as follow-ups:
  - `recurrence.reopened` is always `False` in the integrated path (poll never populates the GraphQL `Identity.thread_id`; REST↔GraphQL key-space mismatch) — `agents-config-qmoz5`.
  - `attempt_count`/`first_seen_round` report schema floors (§2 retains one disposition, no first-seen-round) — `agents-config-us8da`.
  - Review-thread fetch is page-1-capped (the gh adapter does not paginate) — `agents-config-j8pdq`.
  The recurrence derivation logic itself is correct and unit-tested with populated identities; only the integrated wiring is floored.

## Test plan / evidence

- `make ci-prgroom` **green**: ruff check + format, `mypy --strict` (46 files), **701 passed**, **99.86%** branch coverage (≥90% floor), pip-audit clean, `prgroom --help` entry verified.
- **3-lens adversarial review** (boundary purity / safety+test-quality / deferral legitimacy): two SHIP verdicts + all-deferrals-legit. Fixes applied: `ci_state` now sourced from the poll-derived `state.quiescence.ci_state` (was reading a GraphQL-only field off a REST payload → always empty); precondition docstring corrected; bead-IDs stripped from new docstrings.
- gh-read-only / local-staging-only invariant proven: GET-only via `gh_get`, zero `git.push` callers in this path.

> Stacked on `main` (8.7 merged). **Do not merge without explicit authorization** (stacked-PR-human-merges policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
