### PR TITLE
feat(hooks): global ruff PostToolUse hook + hooks/ installer namespace

### DIFF
--- a/docs/plans/2026-06-13-ruff-postedit-hook.md
+++ b/docs/plans/2026-06-13-ruff-postedit-hook.md
@@ -1,0 +1,426 @@
+# ruff-postedit Hook Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a global Claude Code PostToolUse hook that runs ruff on a just-edited Python file — silently applying safe fixes + formatting, and surfacing only residual unfixable violations — deployed via the active `scripts/install.sh` through a new `hooks/` namespace.
+
+**Architecture:** A self-contained stdlib-only Python script (`ruff-postedit.py`) parses the hook's stdin JSON, gates on a discovered ruff config, runs `ruff check --fix` → `ruff format` → `ruff check`, and maps the final exit code to silent-0 / feedback-2. It is wired into `settings.json.template` (invoked via `python3 <path>`) and deployed by adding `hooks` to `install.sh`'s tool-subdir staging loop.
+
+**Tech Stack:** Python 3 (stdlib), bash (`install.sh`, `*_test.sh` test convention), ruff, Claude Code hooks.
+
+**Spec:** `docs/specs/2026-06-13-ruff-postedit-hook-design.md`
+
+## Scope
+
+**In scope (this plan / branch):** the hook script + tests, the `settings.json.template` wiring, the `project-config.toml` test-glob extension, and the **legacy `scripts/install.sh`** `hooks/` namespace (the active installer — this is what deploys the hook today).
+
+**Out of scope (tracked separately):** the **`packages/installer/` (Python rewrite)** `hooks/` namespace + golden-master coverage. Tracked under **`agents-config-w1qls.8.7`** (Epic H). The Epic H parity harness is the forcing function that surfaces any divergence before cutover; the Python installer is not the active installer today.
+
+## File Structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `src/user/.claude/hooks/ruff-postedit.py` | The hook: parse → gate → run ruff → map exit code | Create |
+| `src/user/.claude/hooks/ruff-postedit_test.sh` | Hermetic tests via a fake `ruff` PATH shim | Create |
+| `src/user/.claude/settings.json.template` | Register the PostToolUse matcher | Modify |
+| `project-config.toml` | Extend the `test` target glob to include `hooks/` | Modify |
+| `scripts/install.sh` | Add `hooks` to the tool-subdir staging loop (line 802) | Modify |
+
+---
+
+### Task 1: Hook script `ruff-postedit.py` (+ hermetic tests)
+
+**Files:**
+- Create: `src/user/.claude/hooks/ruff-postedit.py`
+- Test: `src/user/.claude/hooks/ruff-postedit_test.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/user/.claude/hooks/ruff-postedit_test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Hermetic tests for ruff-postedit.py. A fake `ruff` shim on PATH makes
+# exit-code/gating behavior deterministic without depending on real ruff
+# (ruff's own fix/format behavior is ruff's to test, not ours).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/ruff-postedit.py"
+PASS=0; FAIL=0
+
+assert_rc()       { if [ "$2" -eq "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1 (expected rc=$2, got $3)"; fi; }
+assert_contains() { case "$3" in *"$2"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: $1 (stderr missing '$2')";; esac; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# fake ruff shim: only the final `check --force-exclude` decides the outcome
+BIN="$WORK/bin"; mkdir -p "$BIN"
+cat > "$BIN/ruff" <<'SH'
+#!/bin/sh
+if [ "$1" = "check" ] && [ "$2" = "--force-exclude" ]; then
+  if [ "${FAKE_RUFF_RESIDUAL:-0}" = "1" ]; then
+    echo "bad.py:1:1: F821 Undefined name \`x\`"
+    exit 1
+  fi
+fi
+exit 0
+SH
+chmod +x "$BIN/ruff"
+PATH="$BIN:$PATH"; export PATH
+
+# ruff-configured project fixture (no uv.lock -> hook uses PATH ruff = our shim)
+PROJ="$WORK/proj"; mkdir -p "$PROJ"
+printf '[tool.ruff]\nline-length = 100\n' > "$PROJ/pyproject.toml"
+echo "x = 1" > "$PROJ/clean.py"
+
+run_hook() { ERR="$(printf '%s' "$1" | python3 "$HOOK" 2>&1 >/dev/null)"; RC=${PIPESTATUS[1]}; }
+
+# 1. non-.py -> silent 0
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.txt\"}}"
+assert_rc "non-python file is ignored" 0 "$RC"
+
+# 2. .py with no ruff config in tree -> silent 0
+echo "x=1" > "$WORK/loose.py"
+run_hook "{\"tool_input\":{\"file_path\":\"$WORK/loose.py\"}}"
+assert_rc "no ruff config -> skip" 0 "$RC"
+
+# 3. clean .py in configured project -> silent 0
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}"
+assert_rc "clean file -> exit 0" 0 "$RC"
+
+# 4. residual unfixable -> exit 2 + helpful stderr
+export FAKE_RUFF_RESIDUAL=1
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}"
+assert_rc       "residual -> exit 2" 2 "$RC"
+assert_contains "residual names rule" "F821" "$ERR"
+assert_contains "residual has nudge"  "manual attention" "$ERR"
+unset FAKE_RUFF_RESIDUAL
+
+# 5. malformed JSON -> silent 0
+run_hook "not json at all"
+assert_rc "malformed JSON -> exit 0" 0 "$RC"
+
+# 6. missing file_path -> silent 0
+run_hook "{}"
+assert_rc "missing file_path -> exit 0" 0 "$RC"
+
+# 7. ruff absent (PATH has only python3) -> silent 0
+PYBIN="$WORK/pybin"; mkdir -p "$PYBIN"; ln -s "$(command -v python3)" "$PYBIN/python3"
+ERR="$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}" | PATH="$PYBIN" python3 "$HOOK" 2>&1 >/dev/null)"; RC=$?
+assert_rc "ruff absent -> exit 0" 0 "$RC"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash src/user/.claude/hooks/ruff-postedit_test.sh`
+Expected: FAIL — `python3` cannot open `ruff-postedit.py` (file does not exist yet), so every case reports a non-zero rc and the script exits non-zero.
+
+- [ ] **Step 3: Write the hook script**
+
+Create `src/user/.claude/hooks/ruff-postedit.py`:
+
+```python
+#!/usr/bin/env python3
+"""PostToolUse hook: run ruff on a just-edited Python file.
+
+Applies ruff's safe fixes + formatting silently; exits 2 with the residual
+unfixable violations on stderr. Any internal problem (no ruff, no config,
+crash, timeout, bad input) is a silent exit 0 — the hook is invisible unless
+it has a real, actionable lint result.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PY_SUFFIXES = {".py", ".pyi"}
+CONFIG_FILENAMES = ("ruff.toml", ".ruff.toml")
+TIMEOUT_SECONDS = 10
+
+
+def _read_file_path():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    tool_input = payload.get("tool_input") or {}
+    fp = tool_input.get("file_path")
+    if not fp or not isinstance(fp, str):
+        return None
+    return Path(fp)
+
+
+def _find_config_root(start: Path):
+    """Walk upward for a ruff config; return the directory that holds it."""
+    for d in [start, *start.parents]:
+        for name in CONFIG_FILENAMES:
+            if (d / name).is_file():
+                return d
+        pyproject = d / "pyproject.toml"
+        if pyproject.is_file():
+            try:
+                if "[tool.ruff" in pyproject.read_text(encoding="utf-8", errors="ignore"):
+                    return d
+            except OSError:
+                pass
+    return None
+
+
+def _ruff_argv(config_root: Path):
+    """Prefer the project-pinned ruff (uv, no sync); else PATH ruff."""
+    if (config_root / "uv.lock").is_file() or (config_root / ".venv").is_dir():
+        if shutil.which("uv"):
+            return ["uv", "run", "--no-sync", "ruff"]
+    if shutil.which("ruff"):
+        return ["ruff"]
+    return None
+
+
+def _run(argv, cwd: Path):
+    try:
+        return subprocess.run(
+            argv, cwd=str(cwd), capture_output=True, text=True,
+            timeout=TIMEOUT_SECONDS, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def main() -> int:
+    file_path = _read_file_path()
+    if file_path is None:
+        return 0
+    if file_path.suffix not in PY_SUFFIXES or not file_path.is_file():
+        return 0
+
+    config_root = _find_config_root(file_path.parent)
+    if config_root is None:
+        return 0
+
+    ruff = _ruff_argv(config_root)
+    if ruff is None:
+        return 0
+
+    target = str(file_path)
+    if _run([*ruff, "check", "--fix", "--force-exclude", target], config_root) is None:
+        return 0
+    if _run([*ruff, "format", "--force-exclude", target], config_root) is None:
+        return 0
+    final = _run([*ruff, "check", "--force-exclude", target], config_root)
+    if final is None:
+        return 0
+
+    # ruff check: 0 = clean, 1 = violations remain, 2 = ruff internal error
+    if final.returncode == 1:
+        sys.stderr.write(
+            "ruff auto-fixed what it could; the following need manual attention:\n"
+            + (final.stdout or final.stderr or "")
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Then make it executable:
+
+Run: `chmod +x src/user/.claude/hooks/ruff-postedit.py`
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash src/user/.claude/hooks/ruff-postedit_test.sh`
+Expected: `PASS=8 FAIL=0` and exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/user/.claude/hooks/ruff-postedit.py src/user/.claude/hooks/ruff-postedit_test.sh
+git commit -m "feat(hooks): add ruff-postedit PostToolUse hook + hermetic tests"
+```
+
+---
+
+### Task 2: Include `hooks/` tests in the project test target
+
+**Files:**
+- Modify: `project-config.toml` (the `test` command)
+
+- [ ] **Step 1: Read the current `test` target**
+
+Run: `grep -n 'test ' project-config.toml`
+Expected: a line of the form
+`test = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\" || exit 1' _ {}"`
+
+- [ ] **Step 2: Extend the glob to also scan `src/user/.claude/hooks`**
+
+Change the `find` path list so both roots are scanned. Replace `find src/user/.agents/skills` with `find src/user/.agents/skills src/user/.claude/hooks`:
+
+```toml
+test      = "find src/user/.agents/skills src/user/.claude/hooks -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\" || exit 1' _ {}"
+```
+
+(Keep the rest of the line — the `-print0 | sort -z | xargs -0 …` pipeline — byte-for-byte identical.)
+
+- [ ] **Step 3: Verify the hook test is now collected and green**
+
+Run: `find src/user/.agents/skills src/user/.claude/hooks -name '*_test.sh' | grep ruff-postedit`
+Expected: prints `src/user/.claude/hooks/ruff-postedit_test.sh`
+
+Run: `bash src/user/.claude/hooks/ruff-postedit_test.sh`
+Expected: `PASS=8 FAIL=0`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add project-config.toml
+git commit -m "build(hooks): include src/user/.claude/hooks in the test target"
+```
+
+---
+
+### Task 3: Wire the hook into `settings.json.template`
+
+**Files:**
+- Modify: `src/user/.claude/settings.json.template` (the `hooks.PostToolUse` array)
+
+- [ ] **Step 1: Confirm the current PostToolUse shape**
+
+Run: `python3 -c "import json;print(json.dumps(json.load(open('src/user/.claude/settings.json.template'))['hooks']['PostToolUse'], indent=2))"`
+Expected: a one-element array — the `detect-pr-push.sh` Bash matcher.
+
+- [ ] **Step 2: Append the ruff-postedit matcher**
+
+Add a second object to the `PostToolUse` array (leave the existing `detect-pr-push.sh` entry first, unchanged). The array becomes:
+
+```jsonc
+"PostToolUse": [
+  {
+    "matcher": "Bash",
+    "hooks": [
+      { "type": "command", "command": "~/.claude/skills/wait-for-pr-comments/detect-pr-push.sh", "timeout": 5 }
+    ]
+  },
+  {
+    "matcher": "Write|Edit",
+    "hooks": [
+      { "type": "command", "command": "python3 ~/.claude/hooks/ruff-postedit.py", "timeout": 15 }
+    ]
+  }
+]
+```
+
+- [ ] **Step 3: Verify the template still parses and contains both hooks**
+
+Run:
+```bash
+python3 -c "
+import json
+d=json.load(open('src/user/.claude/settings.json.template'))
+ptu=d['hooks']['PostToolUse']
+cmds=[h['command'] for m in ptu for h in m['hooks']]
+assert any('detect-pr-push' in c for c in cmds), 'lost detect-pr-push hook'
+assert any('ruff-postedit' in c for c in cmds), 'ruff-postedit hook not added'
+print('OK: both PostToolUse hooks present')
+"
+```
+Expected: `OK: both PostToolUse hooks present`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/user/.claude/settings.json.template
+git commit -m "feat(hooks): register ruff-postedit PostToolUse hook in settings template"
+```
+
+---
+
+### Task 4: Stage the `hooks/` namespace in `scripts/install.sh`
+
+**Files:**
+- Modify: `scripts/install.sh:802` (the tool-subdir staging loop)
+
+- [ ] **Step 1: Confirm the staging loop**
+
+Run: `sed -n '800,805p' scripts/install.sh`
+Expected (around line 802):
+```bash
+        for subdir in commands skills agents rules; do
+            stage_content_from_dir "$src_tool" "$staging" "$subdir"
+        done
+```
+`stage_content_from_dir` (line 603) globs every item in `$src_tool/<subdir>/` and stages each via `stage_item`; a `.py` file classifies as `"other"` and copies normally — so no other change is needed to carry the script.
+
+- [ ] **Step 2: Add `hooks` to the loop**
+
+Edit line 802 — append `hooks` to the subdir list:
+```bash
+        for subdir in commands skills agents rules hooks; do
+```
+Leave the `prune_subdirs=(commands skills agents rules)` list at line 1529 **unchanged** — `hooks/` must stay prune-exempt (matches the spec and the orphan-scan comment at `install.sh:1453`).
+
+- [ ] **Step 3: Verify deployment into a throwaway HOME**
+
+Run from the worktree root (uses this branch's `src/`):
+```bash
+TMPHOME="$(mktemp -d)"
+HOME="$TMPHOME" bash scripts/install.sh --yes --tools=claude >/tmp/ruff-hook-install.log 2>&1 || { tail -40 /tmp/ruff-hook-install.log; echo "INSTALL FAILED"; }
+test -f "$TMPHOME/.claude/hooks/ruff-postedit.py" && echo "DEPLOYED: hook script present"
+python3 -c "
+import json
+d=json.load(open('$TMPHOME/.claude/settings.json'))
+ok=any('ruff-postedit' in h.get('command','') for m in d['hooks']['PostToolUse'] for h in m['hooks'])
+print('SETTINGS MERGED:' , ok)
+assert ok
+"
+rm -rf "$TMPHOME"
+```
+Expected: `DEPLOYED: hook script present` and `SETTINGS MERGED: True`.
+
+- [ ] **Step 4: Confirm the deployed script is invocable**
+
+The settings command uses `python3 ~/.claude/hooks/ruff-postedit.py`, so execution does not depend on the deployed file's mode bit. Confirm it nonetheless runs:
+```bash
+echo '{}' | python3 "$TMPHOME/.claude/hooks/ruff-postedit.py"; echo "rc=$?"
+```
+(Run before the `rm -rf "$TMPHOME"` above, or re-stage.) Expected: `rc=0`.
+If the deployed file is **not** executable and you want belt-and-suspenders parity with the source `+x`, note it for follow-up — it is **not** a blocker because invocation is via `python3`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/install.sh
+git commit -m "feat(installer): stage hooks/ namespace in install.sh"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Behavior contract (silent fixes, exit-2 residual, silent-0 on all internal failures) → Task 1 script + test cases 3/4/5/6/7.
+- Auto-fix scope (safe `--fix` + `format`) → Task 1 Step 3 (`ruff check --fix` without `--unsafe-fixes`, then `ruff format`).
+- Activation gate + config-root discovery → Task 1 `_find_config_root` + test case 2.
+- ruff discovery (uv `--no-sync` → PATH ruff → skip) → Task 1 `_ruff_argv` + test case 7.
+- `--force-exclude` → Task 1 Step 3.
+- Hook wiring `python3 <path>`, matcher `Write|Edit` → Task 3.
+- `hooks/` legacy-installer namespace + prune-exemption → Task 4.
+- Test-glob extension → Task 2.
+- Python-installer parity → **out of scope**, tracked in `w1qls.8.7` (stated in Scope).
+
+**Placeholder scan:** none — all code and commands are concrete.
+
+**Type/name consistency:** `_read_file_path`, `_find_config_root`, `_ruff_argv`, `_run`, `main` are consistent across Task 1; `ruff check --fix` / `ruff format` / `ruff check` order matches the spec; matcher `Write|Edit` matches between spec and Task 3.
+
+**Risks the spec flagged, carried into tasks:** legacy exec-bit (Task 4 Step 4 — mitigated by `python3` invocation); settings union-merge append (Task 4 Step 3 verifies the merged result); `uv --no-sync` availability (Task 1 case 7 covers the no-ruff fallback; real-uv behavior validated at integration time).

--- a/docs/specs/2026-06-13-ruff-postedit-hook-design.md
+++ b/docs/specs/2026-06-13-ruff-postedit-hook-design.md
@@ -1,0 +1,132 @@
+# Design: Global `ruff-postedit` PostToolUse hook + `hooks/` installer namespace
+
+**Date:** 2026-06-13
+**Status:** draft (design — awaiting review)
+**Scope:** Adds a global discipline-layer PostToolUse hook that runs ruff on just-edited Python files, plus the `hooks/` installer namespace needed to deploy it.
+
+## Summary
+
+After an agent edits a Python file, run ruff on that one file: silently apply every fix ruff can make (safe lint fixes + formatting), and surface only the residual *unfixable* violations back to the agent. The hook ships to every tool/project via the discipline layer, so it must be **invisible unless it has a real, actionable result**, and must **degrade silently** wherever ruff is absent or unconfigured.
+
+Delivering it requires a new `hooks/` namespace in both installers (legacy `scripts/install.sh` and the Python rewrite at `packages/installer/`), since neither stages a `hooks/` directory today.
+
+## Motivation
+
+Lint/format feedback currently arrives only at `make ci` / pre-push time. A per-edit hook tightens the loop: the agent fixes (or is told about) ruff violations the moment it writes them, not after a full gate run. Auto-applying ruff's fixes keeps the agent's files continuously clean with zero agent effort; reporting the rest keeps the agent honest about what it can't auto-resolve.
+
+## Behavior contract
+
+| Condition | Outcome |
+|---|---|
+| Non-Python file, missing `file_path`, unparseable hook JSON, file no longer exists | **exit 0, silent** |
+| Python file, but no ruff config found walking up the tree | **exit 0, silent** (opt-in gate) |
+| ruff not resolvable (no PATH ruff, no usable `uv` env) | **exit 0, silent** |
+| ruff crash, ruff "abnormal" exit (2), or internal timeout | **exit 0, silent** (never block on our own failure) |
+| ruff applied fixes and nothing remains | **exit 0, silent** (file may have been rewritten) |
+| Unfixable violations remain after fix + format | **exit 2**, residual diagnostics + nudge on **stderr** |
+
+**Invariant:** the hook exits 2 *only* for genuine remaining lint on an in-scope file in a ruff-configured project. Every other path is a silent exit 0.
+
+## Auto-fix scope (accepted tradeoff)
+
+The hook applies `ruff check --fix` **safe fixes only** (never `--unsafe-fixes`) and `ruff format`. This includes import sorting and unused-import removal. Accepted hazard: a safe fix can remove code the agent planned to use across a multi-edit sequence (e.g. an import added in one edit, intended for use two edits later, removed as "unused" in between). This is judged acceptable because:
+
+- The harness file-state guard prevents data loss: after the hook mutates the file, the agent's next `Edit`/`Write` fails with a "modified since read" error, forcing a re-read — so the agent sees the change rather than clobbering blindly.
+- Formatting changes are semantically inert; the agent's understanding of the *code* stays correct even before the re-read.
+- This matches familiar format/fix-on-save editor behavior.
+
+Costs we accept: one wasted edit round-trip per touched file (re-read after the staleness error); whole-file reformat can add diff churn to a one-line edit (mitigated by the opt-in gate — ruff-using repos keep files formatted); benign re-format oscillation if the agent's next op is a stale full `Write`.
+
+## Component 1 — `ruff-postedit.py`
+
+A self-contained Python script (`#!/usr/bin/env python3`, standard library only). Source: `src/user/.claude/hooks/ruff-postedit.py`. Deploys to `~/.claude/hooks/ruff-postedit.py`.
+
+### Algorithm
+
+1. Read stdin JSON. On parse failure → exit 0.
+2. Extract `tool_input.file_path`. Missing → exit 0. (Note: `NotebookEdit` uses `notebook_path`, so notebooks fall out here.)
+3. Resolve to an absolute path. Suffix must be `.py` or `.pyi` and the file must exist → else exit 0.
+4. **Activation gate / config-root discovery.** Walk upward from the file's directory to the filesystem root, looking for the first of:
+   - `pyproject.toml` containing a `[tool.ruff` table (substring check on the file text — avoids a TOML dependency and tolerates `[tool.ruff]` and `[tool.ruff.<subtable>]`),
+   - `ruff.toml`, or `.ruff.toml`.
+
+   None found → exit 0. The directory containing the match is the **config root** (ruff runs with this as CWD so it loads the right config).
+5. **ruff discovery** (first that works, else exit 0):
+   - `uv run --no-sync ruff …` when the config root has a `uv.lock` or `.venv` (use the project-pinned ruff with no install side effects — this is the agents-config dogfood case, where ruff lives in each package's uv env, not on PATH);
+   - otherwise `ruff` on PATH.
+6. **Apply + report** (CWD = config root; each call wrapped in a ~10s timeout):
+   1. `ruff check --fix --force-exclude <file>` — applies safe fixes.
+   2. `ruff format --force-exclude <file>` — formats in place.
+   3. `ruff check --force-exclude <file>` — authoritative residual check.
+
+   `--force-exclude` ensures the project's `exclude`/`extend-exclude` is honored even though we pass an explicit path.
+
+   Interpret the final check's exit code:
+   - `0` → exit 0, silent.
+   - `1` (violations remain) → print the diagnostics + a one-line nudge (`ruff auto-fixed what it could; the following need manual attention:`) to **stderr**, exit 2.
+   - `2` (ruff abnormal/error) → exit 0, silent.
+7. Any unexpected exception, missing binary, or timeout anywhere above → exit 0, silent.
+
+## Component 2 — hook wiring (`src/user/.claude/settings.json.template`)
+
+Append a second matcher object to the existing `PostToolUse` array (the `detect-pr-push.sh` Bash entry is preserved by the settings union-merge):
+
+```jsonc
+{
+  "matcher": "Write|Edit",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "python3 ~/.claude/hooks/ruff-postedit.py",
+      "timeout": 15
+    }
+  ]
+}
+```
+
+- `Write|Edit` matches `Write`, `Edit`, `MultiEdit`, and (harmlessly) `NotebookEdit`; the `.py` filter inside the script is the authoritative gate.
+- Invoked via `python3 <path>` rather than a bare exec path, so deployment does not depend on the executable bit or shebang resolution. The source file still ships `+x` as belt-and-suspenders.
+- `settings.json.template` union-merges into `~/.claude/settings.json` (`staging.py` `classify_file`; legacy `install.sh` `classify_file`); the new array element is appended without disturbing the existing hook.
+
+## Component 3 — `hooks/` installer namespace
+
+Neither installer stages a `hooks/` directory today. Both enumerate a fixed namespace allowlist (`commands | skills | agents | rules`, shared `skills | agents | rules`). This is the bulk of the work and touches the gated `packages/installer`.
+
+This hook is **Claude-specific** — `settings.json` PostToolUse hooks are a Claude Code feature; Codex/Gemini have no equivalent mechanism. So the source lives under `src/user/.claude/hooks/` and deploys to `~/.claude/hooks/`. The installer's `hooks/` namespace support is added generically (any tool source dir may carry a `hooks/`), but in practice only `.claude` populates it.
+
+### Legacy `scripts/install.sh`
+- Add `hooks` to the staged-namespace set so a tool's `hooks/` source dir (here `src/user/.claude/hooks/`) stages to `~/.<tool>/hooks/` (here `~/.claude/hooks/`).
+- Apply `chmod +x` to staged hook scripts, mirroring the existing `scripts/` handling.
+- `hooks/` is already prune-exempt (the orphan scan excludes top-level non-namespace entries), so no prune change is needed on the bash side.
+
+### Python installer (`packages/installer/`)
+- Add `hooks` to namespace staging (alongside the `skills`/`agents`/`rules` handling in `core/staging.py`). Hook files are staged as files (like `rules`/`commands`), not dir-granularity entries (like `skills`/`agents`).
+- Preserve the source executable bit via the existing `executable` mode attribute on the staged-item model (`core/model.py`), so deployed scripts land `0o755`.
+- Ensure the orphan/prune scan (`core/prune.py`) never treats `~/.<tool>/hooks/` entries as prunable orphans.
+- This work is tracked for parity under **`agents-config-w1qls.8.7`** (Epic H); see that bead for the rewrite-side checklist and golden-master coverage.
+
+## Testing
+
+- **`src/user/.claude/hooks/ruff-postedit_test.sh`** — pipes crafted PostToolUse JSON to the script and asserts exit code + stderr against a tmp fixture project (a throwaway `pyproject.toml` with `[tool.ruff]`, plus clean / fixable-dirty / unfixable-dirty `.py` files). Cases:
+  - non-`.py` file → exit 0, file untouched;
+  - `.py` with no ruff config in the tree → exit 0;
+  - clean `.py` → exit 0;
+  - fixable-dirty `.py` (e.g. unsorted imports, reformattable layout) → exit 0 **and the file is rewritten clean**;
+  - unfixable-dirty `.py` (e.g. an undefined name) → exit 2 **and stderr names the rule**;
+  - malformed JSON / missing `file_path` → exit 0;
+  - ruff absent on PATH and no uv env → exit 0.
+- **Extend `project-config.toml`'s `test` target** to also glob `src/user/.claude/hooks/*_test.sh` (today it scans only `src/user/.agents/skills`).
+- **Installer unit tests** for `hooks` namespace staging + exec-bit preservation + prune-exemption, run under `make ci-installer`.
+
+## Out of scope
+
+- Non-Python linters / other tools (this hook is ruff-only).
+- Notebook (`.ipynb`) linting.
+- `--unsafe-fixes`.
+- Project-specific ruff config authoring — the hook consumes whatever config the project already has.
+
+## Risks / verification owed by the plan
+
+- **Legacy-installer exec-bit parity for `hooks/`.** Confirm `install.sh` actually `chmod +x`es a `hooks/` namespace (its current `+x` logic is wired for `scripts/` dirs). Mitigated regardless by invoking via `python3 <path>`.
+- **settings union-merge append semantics.** Confirm the `json_union` merge appends the new matcher object rather than collapsing/deduping it against the existing Bash matcher.
+- **uv `--no-sync` availability** across the uv versions in use.

--- a/project-config.toml
+++ b/project-config.toml
@@ -26,7 +26,7 @@ default-formula = "implement-feature"  # fallback when no formula-* label on bea
 build     = ""   # no build step
 typecheck = ""   # no type checker
 lint      = ""   # no linter
-test      = "find src/user/.agents/skills -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\" || exit 1' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines (find -print0 / sort -z / xargs -0 are common GNU/BSD extensions, not POSIX; portable on macOS + Linux)
+test      = "find src/user/.agents/skills src/user/.claude/hooks -name '*_test.sh' -print0 | sort -z | xargs -0 -I{} sh -c 'echo \"[TEST] $1\"; bash \"$1\" || exit 1' _ {}"   # skill smoke tests (added by abn9.4); null-delimited handles spaces/newlines (find -print0 / sort -z / xargs -0 are common GNU/BSD extensions, not POSIX; portable on macOS + Linux)
 
 # ---------------------------------------------------------------------------
 # [coverage] — code coverage settings

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -799,7 +799,7 @@ stage_and_install_tool() {
             stage_item "$template" "$staging/$(basename "$template")" "other"
         done
 
-        for subdir in commands skills agents rules; do
+        for subdir in commands skills agents rules hooks; do
             stage_content_from_dir "$src_tool" "$staging" "$subdir"
         done
 
@@ -921,7 +921,7 @@ stage_and_install_tool() {
     sync_templates "$staging" "$dest_dir" "staged"
 
     # Sync subdirectories
-    for subdir in rules commands skills agents; do
+    for subdir in rules commands skills agents hooks; do
         # OpenCode: skip agents (frontmatter format differs; see OPENCODE-EXTENSIONS.md)
         # and skip rules (inlined into AGENTS.md via DYNAMIC-INCLUDE-ALL-RULES; OpenCode
         # has no rules/ destination directory)

--- a/src/user/.claude/hooks/ruff-postedit.py
+++ b/src/user/.claude/hooks/ruff-postedit.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 PY_SUFFIXES = {".py", ".pyi"}
 CONFIG_FILENAMES = ("ruff.toml", ".ruff.toml")
-TIMEOUT_SECONDS = 10
+TIMEOUT_SECONDS = 4  # 3 calls × 4s = 12s worst-case, under the 15s outer hook timeout
 
 
 def _read_file_path():
@@ -30,7 +30,7 @@ def _read_file_path():
     fp = tool_input.get("file_path")
     if not fp or not isinstance(fp, str):
         return None
-    return Path(fp)
+    return Path(fp).resolve()
 
 
 def _find_config_root(start: Path):

--- a/src/user/.claude/hooks/ruff-postedit.py
+++ b/src/user/.claude/hooks/ruff-postedit.py
@@ -27,10 +27,15 @@ def _read_file_path():
     if not isinstance(payload, dict):
         return None
     tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return None
     fp = tool_input.get("file_path")
     if not fp or not isinstance(fp, str):
         return None
-    return Path(fp).resolve()
+    try:
+        return Path(fp).resolve()
+    except OSError:
+        return None
 
 
 def _find_config_root(start: Path):

--- a/src/user/.claude/hooks/ruff-postedit.py
+++ b/src/user/.claude/hooks/ruff-postedit.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: run ruff on a just-edited Python file.
+
+Applies ruff's safe fixes + formatting silently; exits 2 with the residual
+unfixable violations on stderr. Any internal problem (no ruff, no config,
+crash, timeout, bad input) is a silent exit 0 — the hook is invisible unless
+it has a real, actionable lint result.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PY_SUFFIXES = {".py", ".pyi"}
+CONFIG_FILENAMES = ("ruff.toml", ".ruff.toml")
+TIMEOUT_SECONDS = 10
+
+
+def _read_file_path():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    tool_input = payload.get("tool_input") or {}
+    fp = tool_input.get("file_path")
+    if not fp or not isinstance(fp, str):
+        return None
+    return Path(fp)
+
+
+def _find_config_root(start: Path):
+    """Walk upward for a ruff config; return the directory that holds it."""
+    for d in [start, *start.parents]:
+        for name in CONFIG_FILENAMES:
+            if (d / name).is_file():
+                return d
+        pyproject = d / "pyproject.toml"
+        if pyproject.is_file():
+            try:
+                if "[tool.ruff" in pyproject.read_text(encoding="utf-8", errors="ignore"):
+                    return d
+            except OSError:
+                pass
+    return None
+
+
+def _ruff_argv(config_root: Path):
+    """Prefer the project-pinned ruff (uv, no sync); else PATH ruff."""
+    if (config_root / "uv.lock").is_file() or (config_root / ".venv").is_dir():
+        if shutil.which("uv"):
+            return ["uv", "run", "--no-sync", "ruff"]
+    if shutil.which("ruff"):
+        return ["ruff"]
+    return None
+
+
+def _run(argv, cwd: Path):
+    try:
+        return subprocess.run(
+            argv, cwd=str(cwd), capture_output=True, text=True,
+            timeout=TIMEOUT_SECONDS, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def main() -> int:
+    file_path = _read_file_path()
+    if file_path is None:
+        return 0
+    if file_path.suffix not in PY_SUFFIXES or not file_path.is_file():
+        return 0
+
+    config_root = _find_config_root(file_path.parent)
+    if config_root is None:
+        return 0
+
+    ruff = _ruff_argv(config_root)
+    if ruff is None:
+        return 0
+
+    target = str(file_path)
+    if _run([*ruff, "check", "--fix", "--force-exclude", target], config_root) is None:
+        return 0
+    if _run([*ruff, "format", "--force-exclude", target], config_root) is None:
+        return 0
+    final = _run([*ruff, "check", "--force-exclude", target], config_root)
+    if final is None:
+        return 0
+
+    # ruff check: 0 = clean, 1 = violations remain, 2 = ruff internal error
+    if final.returncode == 1:
+        sys.stderr.write(
+            "ruff auto-fixed what it could; the following need manual attention:\n"
+            + (final.stdout or final.stderr or "")
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/user/.claude/hooks/ruff-postedit.py
+++ b/src/user/.claude/hooks/ruff-postedit.py
@@ -109,4 +109,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/src/user/.claude/hooks/ruff-postedit_test.sh
+++ b/src/user/.claude/hooks/ruff-postedit_test.sh
@@ -64,6 +64,11 @@ assert_rc "malformed JSON -> exit 0" 0 "$RC"
 run_hook "{}"
 assert_rc "missing file_path -> exit 0" 0 "$RC"
 
+# 6b. tool_input present but not a dict (string) -> silent 0, no traceback
+run_hook "{\"tool_input\":\"oops\"}"
+assert_rc "non-dict tool_input -> exit 0" 0 "$RC"
+case "$ERR" in *Traceback*) FAIL=$((FAIL+1)); echo "FAIL: non-dict tool_input emitted a traceback";; *) PASS=$((PASS+1));; esac
+
 # 7. ruff absent (PATH has only python3) -> silent 0
 PYBIN="$WORK/pybin"; mkdir -p "$PYBIN"; ln -s "$(command -v python3)" "$PYBIN/python3"
 ERR="$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}" | PATH="$PYBIN" python3 "$HOOK" 2>&1 >/dev/null)"; RC=$?

--- a/src/user/.claude/hooks/ruff-postedit_test.sh
+++ b/src/user/.claude/hooks/ruff-postedit_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Hermetic tests for ruff-postedit.py. A fake `ruff` shim on PATH makes
+# exit-code/gating behavior deterministic without depending on real ruff
+# (ruff's own fix/format behavior is ruff's to test, not ours).
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$SCRIPT_DIR/ruff-postedit.py"
+PASS=0; FAIL=0
+
+assert_rc()       { if [ "$2" -eq "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1 (expected rc=$2, got $3)"; fi; }
+assert_contains() { case "$3" in *"$2"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: $1 (stderr missing '$2')";; esac; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+
+# fake ruff shim: only the final `check --force-exclude` decides the outcome
+BIN="$WORK/bin"; mkdir -p "$BIN"
+cat > "$BIN/ruff" <<'SH'
+#!/bin/sh
+if [ "$1" = "check" ] && [ "$2" = "--force-exclude" ]; then
+  if [ "${FAKE_RUFF_RESIDUAL:-0}" = "1" ]; then
+    echo "bad.py:1:1: F821 Undefined name \`x\`"
+    exit 1
+  fi
+fi
+exit 0
+SH
+chmod +x "$BIN/ruff"
+PATH="$BIN:$PATH"; export PATH
+
+# ruff-configured project fixture (no uv.lock -> hook uses PATH ruff = our shim)
+PROJ="$WORK/proj"; mkdir -p "$PROJ"
+printf '[tool.ruff]\nline-length = 100\n' > "$PROJ/pyproject.toml"
+echo "x = 1" > "$PROJ/clean.py"
+
+run_hook() { local _tmp; _tmp=$(mktemp); printf '%s' "$1" | python3 "$HOOK" >"$_tmp" 2>&1; RC=${PIPESTATUS[1]}; ERR=$(<"$_tmp"); rm -f "$_tmp"; }
+
+# 1. non-.py -> silent 0
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.txt\"}}"
+assert_rc "non-python file is ignored" 0 "$RC"
+
+# 2. .py with no ruff config in tree -> silent 0
+echo "x=1" > "$WORK/loose.py"
+run_hook "{\"tool_input\":{\"file_path\":\"$WORK/loose.py\"}}"
+assert_rc "no ruff config -> skip" 0 "$RC"
+
+# 3. clean .py in configured project -> silent 0
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}"
+assert_rc "clean file -> exit 0" 0 "$RC"
+
+# 4. residual unfixable -> exit 2 + helpful stderr
+export FAKE_RUFF_RESIDUAL=1
+run_hook "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}"
+assert_rc       "residual -> exit 2" 2 "$RC"
+assert_contains "residual names rule" "F821" "$ERR"
+assert_contains "residual has nudge"  "manual attention" "$ERR"
+unset FAKE_RUFF_RESIDUAL
+
+# 5. malformed JSON -> silent 0
+run_hook "not json at all"
+assert_rc "malformed JSON -> exit 0" 0 "$RC"
+
+# 6. missing file_path -> silent 0
+run_hook "{}"
+assert_rc "missing file_path -> exit 0" 0 "$RC"
+
+# 7. ruff absent (PATH has only python3) -> silent 0
+PYBIN="$WORK/pybin"; mkdir -p "$PYBIN"; ln -s "$(command -v python3)" "$PYBIN/python3"
+ERR="$(printf '%s' "{\"tool_input\":{\"file_path\":\"$PROJ/clean.py\"}}" | PATH="$PYBIN" python3 "$HOOK" 2>&1 >/dev/null)"; RC=$?
+assert_rc "ruff absent -> exit 0" 0 "$RC"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/src/user/.claude/settings.json.template
+++ b/src/user/.claude/settings.json.template
@@ -40,6 +40,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.claude/hooks/ruff-postedit.py",
+            "timeout": 15
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Adds `src/user/.claude/hooks/ruff-postedit.py`: a stdlib-only PostToolUse hook that silently applies ruff safe fixes + formatting after any Write/Edit to a Python file, and exits 2 with actionable stderr only for residual unfixable violations.
- Adds `src/user/.claude/hooks/ruff-postedit_test.sh`: 9 hermetic assertions using a fake ruff PATH shim (zero real-ruff dependency).
- Extends `project-config.toml` test glob to include `src/user/.claude/hooks/`.
- Wires the hook into `src/user/.claude/settings.json.template` as a second PostToolUse matcher (`Write|Edit`, timeout 15s).
- Adds `hooks` to both subdir loop lists in `scripts/install.sh` (staging loop line 802 + sync loop line 924). The prune list is intentionally unchanged — `hooks/` stays prune-exempt.

## Design notes

- Hook is invisible unless it has a real, actionable result: every internal failure (no ruff, no config, malformed input, timeout, ruff crash) is a silent exit 0.
- Activation gate: walks up from the edited file to find `pyproject.toml` with `[tool.ruff`, `ruff.toml`, or `.ruff.toml`. No config found → skip silently.
- ruff discovery: prefers `uv run --no-sync ruff` when `uv.lock`/`.venv` present (project-pinned); else PATH ruff.
- Per-call timeout: 4s (3 calls × 4s = 12s worst-case, under the 15s outer hook timeout).
- Python-installer (`packages/installer/`) hooks/ parity is explicitly out of scope — tracked in `agents-config-w1qls.8.7`.

## Test plan

- [ ] `bash src/user/.claude/hooks/ruff-postedit_test.sh` → `PASS=9 FAIL=0`
- [ ] Install into a throwaway HOME: `HOME=$(mktemp -d) bash scripts/install.sh --yes --tools=claude` → `~/.claude/hooks/ruff-postedit.py` present, `settings.json` PostToolUse array contains both hooks
- [ ] Invoke deployed hook with empty JSON: `echo '{}' | python3 ~/.claude/hooks/ruff-postedit.py` → rc=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)