### PR TITLE
docs(installer): repoint dead python-installer-rewrite.md citations to installer-design.md (w1qls.7.8)

### DIFF
--- a/docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-design.md
+++ b/docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-design.md
@@ -4,7 +4,7 @@
 **Parent epic:** `agents-config-w1qls.1` (Epic A — Foundation)
 **Parent feature:** `agents-config-w1qls` (Python installer rewrite)
 **Milestone:** `agents-config-wgclw` (M0 — Discipline-layer rearchitecture)
-**Parent spec:** [`2026-05-17-python-installer-rewrite.md`](./2026-05-17-python-installer-rewrite.md)
+**Parent spec:** [`installer-design.md`](../architecture/installer/installer-design.md)
 **Date:** 2026-05-17
 
 ## Summary

--- a/docs/specs/2026-05-17-w1qls.1.2-model-design.md
+++ b/docs/specs/2026-05-17-w1qls.1.2-model-design.md
@@ -4,7 +4,7 @@
 **Parent epic:** `agents-config-w1qls.1` (Epic A — Foundation)
 **Parent feature:** `agents-config-w1qls` (Python installer rewrite)
 **Milestone:** `agents-config-wgclw` (M0 — Discipline-layer rearchitecture)
-**Parent spec:** [`2026-05-17-python-installer-rewrite.md`](./2026-05-17-python-installer-rewrite.md)
+**Parent spec:** [`installer-design.md`](../architecture/installer/installer-design.md)
 **Date:** 2026-05-17
 
 ## Summary

--- a/docs/specs/2026-05-19-w1qls.1.3-io-port-design.md
+++ b/docs/specs/2026-05-19-w1qls.1.3-io-port-design.md
@@ -4,7 +4,7 @@
 **Parent epic:** `agents-config-w1qls.1` (Epic A — Foundation)
 **Parent feature:** `agents-config-w1qls` (Python installer rewrite)
 **Milestone:** `agents-config-wgclw` (M0 — Discipline-layer rearchitecture)
-**Parent spec:** [`2026-05-17-python-installer-rewrite.md`](./2026-05-17-python-installer-rewrite.md)
+**Parent spec:** [`installer-design.md`](../architecture/installer/installer-design.md)
 **Sibling specs:** [`2026-05-17-w1qls.1.2-model-design.md`](./2026-05-17-w1qls.1.2-model-design.md)
 **Date:** 2026-05-19
 

--- a/packages/installer/README.md
+++ b/packages/installer/README.md
@@ -2,7 +2,7 @@
 
 uv-managed Python package that installs agent configurations into AI coding assistant homes (`~/.claude/`, `~/.codex/`, `~/.gemini/`, OpenCode XDG).
 
-Replaces `scripts/install.sh` (which stays as the parity reference until the golden-master suite goes green; see [`docs/specs/2026-05-17-python-installer-rewrite.md`](../../docs/specs/2026-05-17-python-installer-rewrite.md)).
+Replaces `scripts/install.sh` (which stays as the parity reference until the golden-master suite goes green; see [`docs/architecture/installer/installer-design.md`](../../docs/architecture/installer/installer-design.md)).
 
 ## Local development
 
@@ -17,4 +17,4 @@ First-time setup: `uv` auto-installs Python 3.11 if missing (one-time slow run; 
 
 ## Status
 
-A.1 (this milestone) ships only the package scaffold and the `--help`-printing CLI entry point. No installer behaviour yet. See the [parent spec](../../docs/specs/2026-05-17-python-installer-rewrite.md) for the full Epic A → H sequence.
+A.1 (this milestone) ships only the package scaffold and the `--help`-printing CLI entry point. No installer behaviour yet. See the [design spec](../../docs/architecture/installer/installer-design.md) for the full Epic A → H sequence.

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -2,7 +2,7 @@
 
 Copies one source file to one destination, resolving both ends through a
 `ToolAdapter`. The smallest slice of the eventual Phase-7 sync described in
-`docs/specs/2026-05-17-python-installer-rewrite.md`: later stories grow it
+`docs/architecture/installer/installer-design.md`: later stories grow it
 to walk a `StagingPlan` and route conflicts through the merge registry.
 
 Path-aware backup (G.1) ports the bash installer's ``backup()``

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -1,7 +1,7 @@
 """Unit tests for installer.core.sync (B.2 — minimal single-file sync).
 
 Each test pins a behaviour the B.2 story contract requires
-(docs/specs/2026-05-17-python-installer-rewrite.md, Epic B.2). The sync
+(docs/architecture/installer/installer-design.md, Epic B.2). The sync
 engine is exercised through a minimal identity-pass-through ToolAdapter so
 the tests are independent of any real tool's path layout; the real
 ClaudeAdapter is driven once, end-to-end, in test_sync_claude.py to cover

--- a/scripts/bootstrap-installer-beads.sh
+++ b/scripts/bootstrap-installer-beads.sh
@@ -2,7 +2,7 @@
 # bootstrap-installer-beads.sh
 #
 # Bootstrap the bd work-tracking structure for the Python installer rewrite.
-# See docs/specs/2026-05-17-python-installer-rewrite.md for the full spec
+# See docs/architecture/installer/installer-design.md for the full spec
 # and dependency graph.
 #
 # Creates (in full-run mode):
@@ -38,7 +38,7 @@
 
 set -euo pipefail
 
-SPEC="docs/specs/2026-05-17-python-installer-rewrite.md"
+SPEC="docs/architecture/installer/installer-design.md"
 
 ############################################################
 # CLI parsing


### PR DESCRIPTION
## What

Repoint every **live** citation of the dead spec path
`docs/specs/2026-05-17-python-installer-rewrite.md` to its real location,
`docs/architecture/installer/installer-design.md`.

## Why

The spec was **moved**, not deleted — commit `88e031d`
(*"docs(installer): move spec to architecture folder"*) relocated
`docs/specs/2026-05-17-python-installer-rewrite.md` →
`docs/architecture/installer/installer-design.md`. `git log --follow` on the
target threads cleanly back through that move. So these are **broken links to a
file that moved**, not historical references to a superseded decision — the
correct fix is to repoint, keeping each recorded link true.

Discovered during Epic G wave-2 (PRs #150/#151) and flagged by the
prune-pipeline implementer as a future-agent footgun. Tracked as
`agents-config-w1qls.7.8` (final child of Epic G).

## Scope — 7 files repointed

| File | Citation kind |
|------|---------------|
| `packages/installer/src/installer/core/sync.py` | module docstring |
| `packages/installer/tests/unit/test_sync.py` | module docstring |
| `packages/installer/README.md` (×2) | living doc links |
| `docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-design.md` | `**Parent spec:**` nav link |
| `docs/specs/2026-05-17-w1qls.1.2-model-design.md` | `**Parent spec:**` nav link |
| `docs/specs/2026-05-19-w1qls.1.3-io-port-design.md` | `**Parent spec:**` nav link |
| `scripts/bootstrap-installer-beads.sh` (×2) | header comment + `SPEC` var |

## Intentionally NOT changed (deliberate per-file calls)

- **`docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-plan.md` lines 490/505** —
  these are inside a fenced code-block that *reproduces the README as authored at
  A.1*. A dated plan recording "the README contained X" is a **true historical
  snapshot**; rewriting it to cite a path that did not exist at authoring time
  would record a false history. The distinction drawn throughout: **navigation
  aids get repointed** (their purpose is to resolve), **content reproductions
  stay frozen** (their purpose is to record).
- **`.beads/issues.jsonl`** — bd-owned tracker records, not living docs.
  Hand-editing the ledger is out of scope and wrong; the bead scoped code + docs.

## Verification

- `make ci-installer` green: **460 passed**, 99.82% coverage, no vulnerabilities,
  entry-verify clean.
- All repointed relative links confirmed to resolve to the existing target.
- No logic touched — docstring/comment/markdown/shell-string only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
