### PR TITLE
feat(prgroom): populate Identity.thread_id via GraphQL node-id map (qmoz5)

### DIFF
--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -139,7 +139,12 @@ class GhCli:
     def graphql(self, query: str, variables: JsonObj) -> JsonObj:
         argv = ["gh", "api", "graphql", "-f", f"query={query}"]
         for key, value in variables.items():
-            argv += ["-F", f"{key}={value}"]
+            # -F coerces typed scalars (int->Int, bool->Boolean); -f keeps the value a
+            # literal string. Route by Python type so a String!-typed variable whose
+            # value looks numeric (e.g. a purely-numeric owner/repo name) is never
+            # coerced to Int and rejected against String!. (bool is an int subclass → -F.)
+            flag = "-F" if isinstance(value, int) else "-f"
+            argv += [flag, f"{key}={value}"]
         out = self._run(argv)
         envelope: JsonObj = json.loads(out)
         if envelope.get("errors"):

--- a/packages/prgroom/src/prgroom/gh/review_threads.py
+++ b/packages/prgroom/src/prgroom/gh/review_threads.py
@@ -1,0 +1,57 @@
+"""Shared REST→GraphQL review-thread key bridge (§8.1, §8.2).
+
+poll and snapshot both ingest review comments over REST, which exposes only each
+comment's ``databaseId``. But a review item's ``Identity.thread_id`` is defined as
+the GraphQL ``reviewThreads`` node id (``PRRT_*``) — the same id ``resolveReviewThread``
+consumes — and the snapshot must key threads by it for §8.2 recurrence to match.
+:func:`fetch_thread_id_map` runs the one GraphQL query that bridges the key-spaces:
+it returns each thread's node id with its comments' ``databaseId``s, inverted into
+``{str(databaseId) -> node id}``. Both callers map their REST comment ids through it.
+
+Pagination: ``first:100`` on threads and on each thread's comments. A comment beyond
+that cap is simply absent from the map, degrading to ``thread_id == ""`` (the §8.2
+floor) rather than mis-keying — lifting the cap (``gh api --paginate`` / GraphQL
+cursors) is a tracked cross-layer follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from prgroom.gh.client import GhClient
+    from prgroom.prsession.pr_ref import PRRef
+
+_THREAD_ID_QUERY = """
+query($owner:String!,$repo:String!,$pr:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){
+        nodes{ id comments(first:100){ nodes{ databaseId } } }
+      }
+    }
+  }
+}
+"""
+
+
+def fetch_thread_id_map(gh: GhClient, ref: PRRef) -> dict[str, str]:
+    """Map each REST review-comment ``databaseId`` (str) to its GraphQL thread node id.
+
+    One GraphQL ``reviewThreads`` read. A degenerate/empty response yields an empty
+    map (the callers degrade ``thread_id`` to ``""``); GraphQL transport/`errors[]`
+    failures surface from the adapter as ``RUNTIME_GRAPHQL_FAILED`` before reaching here.
+    """
+    data = gh.graphql(_THREAD_ID_QUERY, {"owner": ref.owner, "repo": ref.repo, "pr": ref.number})
+    pr = (data.get("repository") or {}).get("pullRequest") or {}
+    nodes = (pr.get("reviewThreads") or {}).get("nodes") or []
+    out: dict[str, str] = {}
+    for thread in nodes:
+        node_id = str(thread["id"])  # reviewThreads.id is ID! (non-null)
+        for comment in thread["comments"]["nodes"]:
+            # databaseId is nullable in GraphQL (e.g. a pending review comment has no
+            # REST representation) — such a comment contributes no key to the map.
+            database_id = comment.get("databaseId")
+            if database_id is not None:
+                out[str(database_id)] = node_id
+    return out

--- a/packages/prgroom/src/prgroom/gh/review_threads.py
+++ b/packages/prgroom/src/prgroom/gh/review_threads.py
@@ -43,11 +43,16 @@ def fetch_thread_id_map(gh: GhClient, ref: PRRef) -> dict[str, str]:
     failures surface from the adapter as ``RUNTIME_GRAPHQL_FAILED`` before reaching here.
     """
     data = gh.graphql(_THREAD_ID_QUERY, {"owner": ref.owner, "repo": ref.repo, "pr": ref.number})
+    # Envelope levels are guarded because a 200 can carry a hollow data block (a
+    # vanished PR returns a null pullRequest). Per-thread fields below are indexed
+    # directly: the query pins them non-null (reviewThreads.id is ID!, comments is a
+    # non-null connection), and an errors[] payload is already mapped to
+    # RUNTIME_GRAPHQL_FAILED upstream before reaching here.
     pr = (data.get("repository") or {}).get("pullRequest") or {}
     nodes = (pr.get("reviewThreads") or {}).get("nodes") or []
     out: dict[str, str] = {}
     for thread in nodes:
-        node_id = str(thread["id"])  # reviewThreads.id is ID! (non-null)
+        node_id = str(thread["id"])
         for comment in thread["comments"]["nodes"]:
             # databaseId is nullable in GraphQL (e.g. a pending review comment has no
             # REST representation) — such a comment contributes no key to the map.

--- a/packages/prgroom/src/prgroom/lifecycle/poll.py
+++ b/packages/prgroom/src/prgroom/lifecycle/poll.py
@@ -6,7 +6,7 @@ copy (the caller owns ``store.write``). It is **read-only over GitHub** — ever
 call is a REST ``GET`` via the injected :class:`~prgroom.gh.client.GhClient`; no
 push, no review re-request, no resolve.
 
-One poll issues six reads in this fixed order:
+One poll issues six REST reads in this fixed order (plus one conditional GraphQL read):
 
 1. ``head_ref_oid`` — the remote HEAD SHA. Drives the §3.4 bootstrap / attribution
    / push-detection math. An empty HEAD short-circuits the rest (a PR with no
@@ -18,6 +18,11 @@ One poll issues six reads in this fixed order:
 3. issue comments, 4. reviews, 5. review (inline) comments — ingested into
    :class:`ReviewItem`s (natural key ``(kind, gh_id)``; never re-appended) and used
    to flip reviewer engagement (§4.1).
+5a. **GraphQL ``reviewThreads`` thread-id map** — issued only when step 5 returned
+   inline comments. It resolves each review-thread item's :attr:`Identity.thread_id`
+   to its ``PRRT_*`` node id (the id ``resolveReviewThread`` consumes and §8.2
+   recurrence keys on); REST exposes only comment databaseIds, so this one GraphQL
+   read bridges the key-space. A comment absent from the map degrades to ``""``.
 6. CI combined-status for the head SHA — mapped to ``success | pending | failure |
    absent`` for ``quiescence.ci_state``. A 404 there means no CI configured →
    ``absent`` (not an error).
@@ -36,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 
 from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.gh.client import GhNotFoundError
+from prgroom.gh.review_threads import fetch_thread_id_map
 from prgroom.lifecycle.predicates import flip_stale_required_reviews
 from prgroom.lifecycle.quiescence import evaluate_reviewer_timeouts
 from prgroom.prsession.enums import ItemKind, PRPhase, ReviewerStatus
@@ -185,6 +191,9 @@ def _ingest_items(
     raw_issue = _gh_get(gh, ref, f"{base}/issues/{ref.number}/comments")
     raw_reviews = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/reviews")
     raw_review_comments = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/comments")
+    # Only review-thread items carry a thread_id, so the bridging GraphQL read is
+    # skipped entirely when this PR surfaced no inline comments (most polls).
+    thread_id_map = fetch_thread_id_map(gh, ref) if raw_review_comments else {}
 
     new: list[ReviewItem] = []
     for kind, raw, ts_field in (
@@ -193,7 +202,7 @@ def _ingest_items(
         (ItemKind.REVIEW_THREAD, raw_review_comments, "created_at"),
     ):
         for entry in raw:
-            item = _to_item(kind, entry, ts_field, now=now)
+            item = _to_item(kind, entry, ts_field, now=now, thread_id_map=thread_id_map)
             if (item.kind, item.identity.gh_id) not in seen:
                 seen.add((item.kind, item.identity.gh_id))
                 new.append(item)
@@ -215,17 +224,34 @@ def _terminal_review_verdicts(raw_reviews: Any, *, now: datetime) -> dict[str, d
     return verdicts
 
 
-def _to_item(kind: ItemKind, entry: dict[str, Any], ts_field: str, *, now: datetime) -> ReviewItem:
-    """Build a :class:`ReviewItem` from one gh comment/review payload."""
+def _to_item(
+    kind: ItemKind,
+    entry: dict[str, Any],
+    ts_field: str,
+    *,
+    now: datetime,
+    thread_id_map: dict[str, str],
+) -> ReviewItem:
+    """Build a :class:`ReviewItem` from one gh comment/review payload.
+
+    ``thread_id_map`` ({REST comment databaseId -> GraphQL ``PRRT_*`` node id})
+    populates a review-thread item's ``thread_id``; a comment absent from the map
+    (or any non-thread kind) leaves it ``""``.
+    """
     gh_id = str(entry["id"])
     identity = Identity(gh_id=gh_id)
     if kind is ItemKind.REVIEW_THREAD:
         # GitHub's pulls/{n}/comments exposes the PARENT comment id as
         # `in_reply_to_id` (present only on replies); a top-level inline comment
-        # has no parent → 0. The comment's own id lives in `gh_id`.
+        # has no parent → 0. The comment's own id lives in `gh_id`. The GraphQL
+        # node id (thread_id) comes from the bridging map, keyed by that same gh_id.
         parent = entry.get("in_reply_to_id")
         reply_to = int(parent) if parent is not None else 0
-        identity = Identity(gh_id=gh_id, reply_to_comment_id=reply_to)
+        identity = Identity(
+            gh_id=gh_id,
+            reply_to_comment_id=reply_to,
+            thread_id=thread_id_map.get(gh_id, ""),
+        )
     body = str(entry.get("body") or "")
     return ReviewItem(
         kind=kind,

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -289,7 +289,10 @@ def _fetch_review_threads(gh: GhClient, ref: PRRef) -> dict[str, list[dict[str, 
     node id** (via :func:`~prgroom.gh.review_threads.fetch_thread_id_map`) so the key
     matches an :class:`Identity`'s ``thread_id`` and §8.2 ``_thread_reopened`` lookups
     hit. A root absent from the map (e.g. beyond the GraphQL page cap) degrades to its
-    REST root-comment id — harmless, since that thread's items also carry no node id.
+    REST root-comment id. poll fetches its own map separately, so at the pagination
+    boundary a thread can be mapped at poll time yet unmapped here; that fails safe —
+    ``_thread_reopened`` then misses and reports ``reopened == False`` (a missed reopen,
+    never a false one), pending the tracked pagination follow-up.
     """
     raw = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments")
     roots: dict[int, list[dict[str, Any]]] = {}

--- a/packages/prgroom/src/prgroom/lifecycle/snapshot.py
+++ b/packages/prgroom/src/prgroom/lifecycle/snapshot.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 from prgroom.agent.recurrence import Recurrence
 from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.gh.client import GhNotFoundError
+from prgroom.gh.review_threads import fetch_thread_id_map
 
 if TYPE_CHECKING:
     from prgroom.gh.client import GhClient
@@ -127,13 +128,11 @@ def derive_recurrence(
     * ``prior_disposition`` / ``prior_commits`` — from the item's single recorded
       :class:`~prgroom.prsession.state.Disposition` (schema-backed).
     * ``reopened`` — true iff a reply on the item's thread is newer than the
-      disposition's ``decided_at``. **MVP floor: this is always ``False`` in the
-      integrated poll→cluster→fix path** — poll's ingest does not yet populate
-      :attr:`Identity.thread_id` (and the snapshot keys threads by root-comment id,
-      a different key-space), so ``_thread_reopened`` finds no thread to match. The
-      derivation is correct and unit-tested with populated identities; wiring poll
-      to set ``thread_id`` (and reconciling the key-space) is a poll-side follow-up,
-      not this bead. Reported as a gap alongside the two counters below.
+      disposition's ``decided_at``. The item's :attr:`Identity.thread_id` (the GraphQL
+      ``PRRT_*`` node id poll populates) is matched against the snapshot's threads,
+      which :func:`_fetch_review_threads` keys by that same node id. A comment beyond
+      the GraphQL page cap carries no node id, so its item degrades to
+      ``reopened == False`` rather than mis-matching.
     * ``attempt_count`` — ``1`` (the MVP schema retains one disposition; a true
       count needs history tracking — reported as a schema gap).
     * ``first_seen_round`` — ``state.round`` (the schema has no first-seen field;
@@ -284,10 +283,13 @@ def _prior_dispositions(state: PRGroomingState) -> list[dict[str, Any]]:
 def _fetch_review_threads(gh: GhClient, ref: PRRef) -> dict[str, list[dict[str, Any]]]:
     """Group every PR review comment into its thread's full reply-chain (§8.1).
 
-    A top-level inline comment (no ``in_reply_to_id``) anchors a thread keyed by
-    its own id; replies (``in_reply_to_id`` set) attach under their root. The key
-    is a string id so it matches a :class:`Identity`'s ``thread_id`` when present,
-    falling back to the root comment id otherwise.
+    A top-level inline comment (no ``in_reply_to_id``) anchors a thread; replies
+    (``in_reply_to_id`` set) attach under their root. The grouping is built over the
+    REST root-comment id, then each thread is **re-keyed by its GraphQL ``PRRT_*``
+    node id** (via :func:`~prgroom.gh.review_threads.fetch_thread_id_map`) so the key
+    matches an :class:`Identity`'s ``thread_id`` and §8.2 ``_thread_reopened`` lookups
+    hit. A root absent from the map (e.g. beyond the GraphQL page cap) degrades to its
+    REST root-comment id — harmless, since that thread's items also carry no node id.
     """
     raw = gh_get(gh, ref, f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments")
     roots: dict[int, list[dict[str, Any]]] = {}
@@ -301,7 +303,10 @@ def _fetch_review_threads(gh: GhClient, ref: PRRef) -> dict[str, list[dict[str, 
     for entry in raw:
         cid = int(entry["id"])
         roots[by_id[cid]].append(entry)
-    return {str(root): comments for root, comments in roots.items()}
+    if not roots:
+        return {}
+    thread_id_map = fetch_thread_id_map(gh, ref)
+    return {thread_id_map.get(str(root), str(root)): comments for root, comments in roots.items()}
 
 
 def _thread_chains(threads: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -98,6 +98,22 @@ def test_graphql_returns_data() -> None:
     assert argv[:3] == ["gh", "api", "graphql"]
 
 
+def test_graphql_string_variables_use_literal_flag_ints_use_typed() -> None:
+    # gh's -F does typed coercion (numbers->Int, true/false->Boolean); -f keeps the
+    # value a literal string. A String!-typed variable whose value looks numeric (a
+    # purely-numeric owner/repo name) must go via -f, or gh coerces it to Int and the
+    # server rejects it against String! — an unfixable transient that retries forever.
+    runner = RecordedRunner([_ok(_fixture("graphql_resolve_ok.json"))])
+    client = GhCli(runner)
+    client.graphql("query {...}", {"owner": "octo", "repo": "365", "pr": 7})
+    argv = runner.calls[0]
+    # String variables ride -f (literal): a repo literally named "365" stays a string.
+    assert argv[argv.index("owner=octo") - 1] == "-f"
+    assert argv[argv.index("repo=365") - 1] == "-f"
+    # Int variables ride -F (typed) so they satisfy Int! (e.g. $pr).
+    assert argv[argv.index("pr=7") - 1] == "-F"
+
+
 # ── failure classification ──
 
 

--- a/packages/prgroom/tests/unit/test_gh_review_threads.py
+++ b/packages/prgroom/tests/unit/test_gh_review_threads.py
@@ -1,0 +1,73 @@
+"""Tests for ``fetch_thread_id_map`` — the shared REST→GraphQL thread key bridge.
+
+poll and snapshot both ingest review comments over REST (which exposes only the
+comment ``databaseId``) but must key threads by the GraphQL ``reviewThreads`` node
+id (``PRRT_*``) that ``Identity.thread_id`` is defined as and ``resolveReviewThread``
+consumes. ``fetch_thread_id_map`` runs the one GraphQL query that bridges the two
+key-spaces. The only mock point is the subprocess boundary (``RecordedRunner``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from prgroom.gh import GhCli
+from prgroom.gh.review_threads import fetch_thread_id_map
+from prgroom.proc import CommandResult
+from prgroom.prsession.pr_ref import PRRef
+from tests.fakes import RecordedRunner
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+
+
+def _graphql(nodes: list[dict[str, object]]) -> CommandResult:
+    """A gh-api-graphql success envelope carrying ``reviewThreads.nodes``."""
+    envelope = {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}}
+    return CommandResult(returncode=0, stdout=json.dumps(envelope), stderr="")
+
+
+def test_maps_every_comment_database_id_to_its_thread_node_id() -> None:
+    # Two threads; the first has a root comment + a reply. Every comment's
+    # databaseId must resolve to ITS thread's node id (siblings share a node id).
+    nodes = [
+        {"id": "PRRT_a", "comments": {"nodes": [{"databaseId": 101}, {"databaseId": 102}]}},
+        {"id": "PRRT_b", "comments": {"nodes": [{"databaseId": 201}]}},
+    ]
+    gh = GhCli(RecordedRunner([_graphql(nodes)]))
+    assert fetch_thread_id_map(gh, _REF) == {
+        "101": "PRRT_a",
+        "102": "PRRT_a",
+        "201": "PRRT_b",
+    }
+
+
+def test_empty_map_when_pr_has_no_threads() -> None:
+    gh = GhCli(RecordedRunner([_graphql([])]))
+    assert fetch_thread_id_map(gh, _REF) == {}
+
+
+def test_skips_comments_without_a_database_id() -> None:
+    # databaseId is nullable in GraphQL (e.g. a pending review comment has no REST
+    # representation) — such a comment contributes no key, but its siblings still do.
+    nodes = [{"id": "PRRT_a", "comments": {"nodes": [{"databaseId": None}, {"databaseId": 102}]}}]
+    gh = GhCli(RecordedRunner([_graphql(nodes)]))
+    assert fetch_thread_id_map(gh, _REF) == {"102": "PRRT_a"}
+
+
+def test_empty_map_when_response_shape_is_degenerate() -> None:
+    # A 200 with a hollow data envelope (no repository/pullRequest) yields an empty
+    # map rather than crashing — the guard branches must short-circuit cleanly.
+    result = CommandResult(returncode=0, stdout=json.dumps({"data": {}}), stderr="")
+    gh = GhCli(RecordedRunner([result]))
+    assert fetch_thread_id_map(gh, _REF) == {}
+
+
+def test_issues_a_graphql_query_against_the_pr() -> None:
+    runner = RecordedRunner([_graphql([])])
+    fetch_thread_id_map(GhCli(runner), _REF)
+    argv = runner.calls[0]
+    assert argv[:3] == ["gh", "api", "graphql"]
+    # The PR coordinates ride as typed GraphQL variables (-F coerces pr to Int).
+    assert "owner=octo" in argv
+    assert "repo=demo" in argv
+    assert "pr=7" in argv

--- a/packages/prgroom/tests/unit/test_lifecycle_poll.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_poll.py
@@ -61,9 +61,16 @@ def _gh(
     issue_comments: list[dict[str, object]] | None = None,
     reviews: list[dict[str, object]] | None = None,
     review_comments: list[dict[str, object]] | None = None,
+    thread_nodes: list[dict[str, object]] | None = None,
     ci: str = "success",
 ) -> GhCli:
-    """Build a GhCli queuing the six poll reads in the order ``poll_pr`` issues them."""
+    """Build a GhCli queuing the poll reads in the order ``poll_pr`` issues them.
+
+    When ``review_comments`` is non-empty, ``poll_pr`` issues an extra GraphQL
+    ``reviewThreads`` read (the thread-id map) between the review-comments REST read
+    and the CI read; ``thread_nodes`` supplies that envelope's nodes (default empty
+    → every review-thread item degrades to ``thread_id == ""``).
+    """
     pr = (
         {"state": "closed", "merged_at": "2026-06-09T10:00:00Z"}
         if pr_merged
@@ -75,8 +82,10 @@ def _gh(
         _ok(issue_comments or []),
         _ok(reviews or []),
         _ok(review_comments or []),
-        _ok({"state": ci}),
     ]
+    if review_comments:
+        results.append(_thread_map_ok(thread_nodes or []))
+    results.append(_ok({"state": ci}))
     return GhCli(RecordedRunner(results))
 
 
@@ -332,6 +341,56 @@ def test_reply_review_comment_carries_parent_in_reply_to_id() -> None:
     thread = next(i for i in state.items if i.kind is ItemKind.REVIEW_THREAD)
     assert thread.identity.gh_id == "32"  # the reply's own id
     assert thread.identity.reply_to_comment_id == 31  # the parent it replies to
+
+
+def _thread_map_ok(nodes: list[dict[str, object]]) -> CommandResult:
+    """A gh-api-graphql reviewThreads success envelope (the thread-id map read)."""
+    return _ok({"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}})
+
+
+def test_review_thread_item_gets_graphql_node_id_as_thread_id() -> None:
+    # The core qmoz5 fix: a review-thread item's thread_id is the GraphQL PRRT_*
+    # node id its comment maps to — not "" (the old floor) and not the REST id.
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    gh = GhCli(
+        RecordedRunner(
+            [
+                _ok({"headRefOid": "same"}),
+                _ok({"state": "open", "merged_at": None}),
+                _ok([]),  # issue comments
+                _ok([]),  # reviews
+                _ok([_review_comment(31)]),  # review comments (REST databaseId 31)
+                _thread_map_ok([{"id": "PRRT_x", "comments": {"nodes": [{"databaseId": 31}]}}]),
+                _ok({"state": "success"}),  # CI status
+            ]
+        )
+    )
+    state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
+    thread = next(i for i in state.items if i.kind is ItemKind.REVIEW_THREAD)
+    assert thread.identity.gh_id == "31"
+    assert thread.identity.thread_id == "PRRT_x"
+
+
+def test_review_thread_thread_id_empty_when_unmapped() -> None:
+    # A comment absent from the GraphQL map (e.g. beyond the page cap) degrades to
+    # "" rather than mis-keying — the §8.2 floor, applied per-item.
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    gh = GhCli(
+        RecordedRunner(
+            [
+                _ok({"headRefOid": "same"}),
+                _ok({"state": "open", "merged_at": None}),
+                _ok([]),
+                _ok([]),
+                _ok([_review_comment(31)]),
+                _thread_map_ok([]),  # empty map → no node id for comment 31
+                _ok({"state": "success"}),
+            ]
+        )
+    )
+    state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
+    thread = next(i for i in state.items if i.kind is ItemKind.REVIEW_THREAD)
+    assert thread.identity.thread_id == ""
 
 
 # ── reviewer engagement (§4.1) ──

--- a/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_snapshot.py
@@ -48,6 +48,11 @@ def _ok(payload: object) -> CommandResult:
     return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
 
 
+def _thread_map_ok(nodes: list[dict[str, object]]) -> CommandResult:
+    """A gh-api-graphql reviewThreads success envelope (the thread-id map read)."""
+    return _ok({"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}})
+
+
 def _item(
     gh_id: str,
     *,
@@ -117,8 +122,15 @@ def _gh(
     body: str = "PR body",
     labels: list[str] | None = None,
     review_comments: list[dict[str, object]] | None = None,
+    thread_nodes: list[dict[str, object]] | None = None,
 ) -> GhCli:
-    """Queue the snapshot's gh reads: PR resource, labels, review comments."""
+    """Queue the snapshot's gh reads: PR resource, review comments, thread-id map.
+
+    When ``review_comments`` is non-empty, ``_fetch_review_threads`` issues an extra
+    GraphQL ``reviewThreads`` read after the REST comments read; ``thread_nodes``
+    supplies that envelope's nodes (default empty → threads degrade to their REST
+    root-comment id key).
+    """
     pr_resource = {
         "body": body,
         "base": {"ref": base_ref},
@@ -128,6 +140,8 @@ def _gh(
         _ok(pr_resource),
         _ok(review_comments or []),
     ]
+    if review_comments:
+        results.append(_thread_map_ok(thread_nodes or []))
     return GhCli(RecordedRunner(results))
 
 
@@ -319,6 +333,42 @@ def test_assemble_snapshot_threads_carry_full_reply_chain(tmp_path: Path) -> Non
     bodies = [c["body"] for thread in chains for c in thread["comments"]]
     assert "top" in bodies
     assert "reply" in bodies
+
+
+def test_assemble_snapshot_keys_threads_by_graphql_node_id(tmp_path: Path) -> None:
+    # The snapshot keys each thread by its GraphQL PRRT_* node id (the key-space
+    # Identity.thread_id and resolveReviewThread use) — NOT the REST root-comment id.
+    review_comments = [
+        {"id": 11, "in_reply_to_id": None, "body": "top", "created_at": _T0.isoformat()},
+    ]
+    thread_nodes = [{"id": "PRRT_x", "comments": {"nodes": [{"databaseId": 11}]}}]
+    item = _item("11", thread_id="PRRT_x")
+    gh = _gh(review_comments=review_comments, thread_nodes=thread_nodes)
+    snap = assemble_snapshot(
+        _state(item), [item], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+    )
+    detail = json.loads(Path(snap.pr_detail_path).read_text(encoding="utf-8"))
+    assert [t["thread_id"] for t in detail["review_threads"]] == ["PRRT_x"]
+
+
+def test_assemble_snapshot_recurrence_reopened_via_graphql_keyed_threads(tmp_path: Path) -> None:
+    # The payoff: an item carrying its GraphQL node id (set by a prior poll) is
+    # flagged reopened when a newer reply lands — because the snapshot now keys
+    # threads by that same PRRT_* node id, so _thread_reopened's lookup hits.
+    disp = Disposition(kind=DispositionKind.FIXED, decided_at=_T0, decided_by="x")
+    item = _item("11", thread_id="PRRT_x", disposition=disp)
+    review_comments = [
+        {"id": 11, "in_reply_to_id": None, "body": "top", "created_at": _T0.isoformat()},
+        {"id": 12, "in_reply_to_id": 11, "body": "ping", "created_at": _T1.isoformat()},
+    ]
+    thread_nodes = [
+        {"id": "PRRT_x", "comments": {"nodes": [{"databaseId": 11}, {"databaseId": 12}]}}
+    ]
+    gh = _gh(review_comments=review_comments, thread_nodes=thread_nodes)
+    snap = assemble_snapshot(
+        _state(item), [item], ref=_REF, gh=gh, git=FakeGit(), scratch_dir=tmp_path
+    )
+    assert snap.recurrence["11"].reopened is True
 
 
 def test_assemble_snapshot_returns_ephemeral_dirs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Populates `Identity.thread_id` (the GraphQL `PRRT_*` review-thread node id) in the integrated poll→cluster→fix path, and reconciles the snapshot's thread key-space to the same id.

Before this change, `poll._to_item` never set `thread_id`, and `snapshot._fetch_review_threads` keyed threads by the REST root-comment id — a different key-space than the GraphQL node id that `thread_id` is contractually defined as (and that `resolveReviewThread` consumes). Net effect: §8.2 `recurrence.reopened` was always `False`, and `agent/fix.py::_resolve_thread_ids` built an empty `known_thread_ids` set (degrading CONTEXTUAL memory `target_hint` routing).

**Change shape:**
- New shared helper `gh/review_threads.py::fetch_thread_id_map(gh, ref)` — one GraphQL `reviewThreads` query → `{comment databaseId : PRRT_* node id}`.
- `poll` sets `thread_id` from the map (conditional GraphQL read: only when the PR returned inline comments).
- `snapshot` keys its threads dict by the `PRRT_*` node id via the same helper.
- Drive-by safety fix (this is the first GraphQL caller passing variables): `GhCli.graphql` now routes string variables via `-f` and int/bool via `-F`, so a purely-numeric owner/repo name can't be coerced to `Int` and rejected against `String!`.

No state-schema change. No `GhClient` Protocol change (`graphql` already existed).

## Scope / ground truth

- Artifact: implementation in `packages/prgroom/` (greenfield CLI; gate = `make ci-prgroom`).
- Contracts: `thread_id` is the GraphQL node id; `gh_id` is the REST databaseId; `(kind, gh_id)` is the natural key — these are deliberately distinct.
- Design refs: prgroom CLI design §8.1 (snapshot), §8.2 (recurrence).

## Intentionally out of scope (do not flag as defects)

- **Pagination** — the GraphQL query uses `first:100` on threads and comments; a comment beyond the cap degrades to `thread_id == ""` (the §8.2 floor), which fails safe (a missed reopen, never a false one). Lifting the cap is a tracked cross-layer follow-up.
- **Per-cluster snapshot redundancy** — `assemble_snapshot` re-reads PR-level data (now incl. the thread-id map) once per cluster; this is a pre-existing, deliberate staleness-minimization pattern. Hoisting it to once-per-cycle is filed as separate discovered work.

## Test plan

- [x] `make ci-prgroom` green: 712 passed, 99.86% branch coverage, ruff + `mypy --strict` + pip-audit + entry-verify clean.
- [x] New helper at 100% line+branch coverage.
- [x] Mutation-revert verified: reverting either production change fails the new tests (real regression guards, not theater).
- [x] Recurrence `reopened` now fires end-to-end through `assemble_snapshot` (the §8.2 payoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
