### PR TITLE
feat(installer): W2 — interactive install consent gate (hmxpp.3)

### DIFF
--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -71,6 +71,7 @@ def install_pipeline(
     home: Path,
     io: IOPort,
     dry_run: bool = False,
+    auto_yes: bool = False,
     timestamp: str | None = None,
 ) -> Counters:
     """Walk each adapter's ``StagingPlan`` to disk via ``sync_plan``; sum the totals.
@@ -80,6 +81,11 @@ def install_pipeline(
     looked up by its tool (``Tool(adapter.name)``) and written under
     ``adapter.dest_dir(home)``. Returns the aggregate `Counters`
     (created / updated / skipped / backed_up summed across tools).
+
+    ``dry_run`` and ``auto_yes`` are forwarded verbatim into every ``sync_plan``
+    call, so the W2 consent gate and the shared no-TTY guard apply uniformly
+    across tools (``auto_yes`` auto-accepts changed-item overwrites; ``dry_run``
+    previews without prompting).
 
     Unlike ``scan_orphans``'s tolerant ``.get``, the per-tool plan is indexed
     strictly — an adapter without a staged plan is an orchestrator bug (a loud
@@ -93,6 +99,7 @@ def install_pipeline(
             home=home,
             io=io,
             dry_run=dry_run,
+            auto_yes=auto_yes,
             timestamp=timestamp,
         )
         total.created += result.created

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -19,6 +19,7 @@ import shutil
 from typing import TYPE_CHECKING
 
 from installer.core.backup import back_up, new_timestamp, valid_timestamp
+from installer.core.consent import require_consent
 from installer.core.model import Counters
 from installer.core.paths import is_safe_relpath
 
@@ -106,6 +107,7 @@ def sync_plan(
     home: Path,
     io: IOPort,
     dry_run: bool = False,
+    auto_yes: bool = False,
     timestamp: str | None = None,
 ) -> Counters:
     """Walk a ``StagingPlan`` and install every item under the adapter's dest root.
@@ -132,7 +134,14 @@ def sync_plan(
     is not resolved-path safety. The walk is **non-transactional**: a failure on
     item N leaves items 1..N-1 **already installed** (matching the bash streaming
     installer; no rollback of earlier items). Returns aggregate `Counters`.
+
+    The shared no-TTY guard (`require_consent`) runs once up front: a
+    non-interactive run with neither ``auto_yes`` nor ``dry_run`` cannot answer a
+    per-item prompt, so it hard-fails before any write rather than silently
+    overwriting. ``auto_yes`` auto-accepts every changed-item prompt (still backing
+    up first); ``dry_run`` previews without prompting.
     """
+    require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
     counters = Counters()
     dest_dir = adapter.dest_dir(home)
     for item in plan.items.values():
@@ -147,6 +156,7 @@ def sync_plan(
                 plan.dir_overrides.get(item.dest_relpath, {}),
                 io=io,
                 dry_run=dry_run,
+                auto_yes=auto_yes,
                 timestamp=timestamp,
                 counters=counters,
             )
@@ -157,6 +167,7 @@ def sync_plan(
                 executable=item.executable,
                 io=io,
                 dry_run=dry_run,
+                auto_yes=auto_yes,
                 timestamp=timestamp,
                 counters=counters,
             )
@@ -170,6 +181,7 @@ def _install_file(
     executable: bool,
     io: IOPort,
     dry_run: bool,
+    auto_yes: bool,
     timestamp: str | None,
     counters: Counters,
 ) -> None:
@@ -177,13 +189,28 @@ def _install_file(
     dest before the overwrite, and write the bytes with a deterministic mode
     bit (``0o755`` when ``executable`` else ``0o644``). Mutates ``counters``.
 
+    A *changed* dest (present, bytes differ) passes through the consent gate
+    (`_consent_to_overwrite`) before any backup or write: an interactive decline
+    keeps the existing bytes and counts the item as skipped; ``auto_yes`` accepts
+    silently; ``dry_run`` previews without prompting. The gate fires only on an
+    existing dest — a first install is not a destructive overwrite.
+
     A dest already occupied by a non-file (a directory) is rejected with
     `ValueError` rather than crashing the walk with a raw ``IsADirectoryError`` —
     matching ``dump``'s type-guard so the CLI surfaces a clean error."""
     if dest.exists() and not dest.is_file():
         raise ValueError(f"dest exists but is not a file: {dest}")  # noqa: TRY003  # single call-site; subclass not justified
     dest_exists = dest.is_file()
-    if dest_exists and _sha256(dest.read_bytes()) == _sha256(content):
+    old = dest.read_bytes() if dest_exists else None
+    if old is not None and _sha256(old) == _sha256(content):
+        counters.skipped += 1
+        return
+    if (
+        old is not None
+        and not dry_run
+        and not _consent_to_overwrite(dest, diff=(old, content), io=io, auto_yes=auto_yes)
+    ):
+        io.warn(f"skipped {dest}")
         counters.skipped += 1
         return
     _ensure_parent_dir(dest, dry_run=dry_run)
@@ -202,12 +229,18 @@ def _install_dir(
     *,
     io: IOPort,
     dry_run: bool,
+    auto_yes: bool,
     timestamp: str | None,
     counters: Counters,
 ) -> None:
     """Materialise one DIR item: back up then cleanly replace an existing dest,
     copy the ``source_path`` tree, then overlay ``overrides`` (override wins on
     a name collision, matching dump-time semantics). Mutates ``counters``.
+
+    An existing dest passes through the consent gate before the backup/replace:
+    an interactive decline keeps the existing tree and counts a skip; ``auto_yes``
+    accepts silently; ``dry_run`` previews without prompting. A directory has no
+    ``IOPort`` byte-diff, so the change is surfaced as a notice, not a unified diff.
 
     A missing or non-directory ``source_path``, or a dest already occupied by a
     non-directory (a file), is rejected with `ValueError` rather than crashing
@@ -225,6 +258,14 @@ def _install_dir(
         if not is_safe_relpath(inner):
             raise ValueError(f"dir override relpath escapes the dir: {inner}")  # noqa: TRY003  # single call-site; subclass not justified
     dest_exists = dest.exists()
+    if (
+        dest_exists
+        and not dry_run
+        and not _consent_to_overwrite(dest, diff=None, io=io, auto_yes=auto_yes)
+    ):
+        io.warn(f"skipped {dest}")
+        counters.skipped += 1
+        return
     _ensure_parent_dir(dest, dry_run=dry_run)
     if not dry_run:
         if dest_exists:
@@ -236,6 +277,35 @@ def _install_dir(
             _ensure_parent_dir(inner_dest, dry_run=dry_run)
             inner_dest.write_bytes(inner_content)
     _record_write(dest, dest_exists=dest_exists, io=io, dry_run=dry_run, counters=counters)
+
+
+def _consent_to_overwrite(
+    dest: Path,
+    *,
+    diff: tuple[bytes, bytes] | None,
+    io: IOPort,
+    auto_yes: bool,
+) -> bool:
+    """Decide whether a changed dest may be overwritten — the install consent gate.
+
+    ``auto_yes`` short-circuits to ``True`` without prompting (the scripted-install
+    path); the caller still backs up before the write, so ``--yes`` is never a
+    data-loss path. Otherwise the change is surfaced and an interactive y/N confirm
+    decides: a FILE item (``diff`` carries its old/new bytes) is shown a unified
+    diff; a DIR item (``diff`` is ``None`` — a directory tree has no ``IOPort``
+    byte-diff primitive) gets a plain 'changed' notice. A decline returns ``False``
+    and the caller keeps the existing dest untouched.
+
+    Reached only after `require_consent` has guaranteed the run can prompt when
+    ``auto_yes`` is ``False`` — so the session is interactive here by construction.
+    """
+    if auto_yes:
+        return True
+    if diff is not None:
+        io.show_diff(str(dest), *diff)
+    else:
+        io.warn(f"{dest} changed (directory will be replaced)")
+    return io.confirm(f"Overwrite {dest}?", default=False)
 
 
 def _record_write(

--- a/packages/installer/tests/unit/test_run_install_pipeline.py
+++ b/packages/installer/tests/unit/test_run_install_pipeline.py
@@ -60,3 +60,29 @@ def test_install_pipeline_aggregates_counters_across_tools(tmp_path: Path) -> No
 
     assert (claude.dest_dir(home) / "a.md").read_bytes() == b"A\n"
     assert (counters.created, counters.skipped) == (1, 1)
+
+
+def test_install_pipeline_forwards_auto_yes_to_each_sync_plan(tmp_path: Path) -> None:
+    """
+    Given a tool whose dest already holds different bytes than its plan, and --yes
+    When install_pipeline runs with NO queued confirm answers
+    Then the overwrite proceeds without prompting — install_pipeline forwards
+    auto_yes into each sync_plan call (the default would otherwise trip the W2
+    consent gate and raise ScriptExhaustedError on the empty confirm queue).
+    """
+    home = tmp_path / "home"
+    claude = get_adapter(Tool.CLAUDE)
+    claude.dest_dir(home).mkdir(parents=True)
+    (claude.dest_dir(home) / "a.md").write_bytes(b"old\n")
+    plans = {
+        Tool.CLAUDE: StagingPlan(
+            items={Path("a.md"): _file_item(Path("a.md"), b"new\n")}, tool=Tool.CLAUDE
+        ),
+    }
+
+    counters = install_pipeline(
+        [claude], plans=plans, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert (claude.dest_dir(home) / "a.md").read_bytes() == b"new\n"
+    assert (counters.updated, counters.backed_up) == (1, 1)

--- a/packages/installer/tests/unit/test_sync_plan.py
+++ b/packages/installer/tests/unit/test_sync_plan.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from installer.core.consent import ConsentRequiredError
 from installer.core.io_port import IOPort, ScriptedIO
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 from installer.core.sync import sync_plan
@@ -143,7 +144,10 @@ def test_changed_file_item_is_backed_up_before_overwrite(tmp_path: Path) -> None
         items={Path("AGENTS.md"): _file_item(Path("AGENTS.md"), b"new\n")}, tool=Tool.CLAUDE
     )
 
-    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+    # auto_yes bypasses the W2 consent gate so this pins the backup/overwrite mechanics
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
 
     assert (home / f"AGENTS.md.backup-{_FIXED_TS}").read_bytes() == b"old\n"
     assert (home / "AGENTS.md").read_bytes() == b"new\n"
@@ -278,7 +282,10 @@ def test_existing_dir_is_backed_up_then_cleanly_replaced(tmp_path: Path) -> None
     (existing / "stale.md").write_bytes(b"stale\n")
     plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
 
-    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+    # auto_yes bypasses the W2 consent gate so this pins the backup-then-clean-replace
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
 
     backup = home / "skills-backup" / f"s.backup-{_FIXED_TS}"
     assert (backup / "stale.md").read_bytes() == b"stale\n"
@@ -476,7 +483,10 @@ def test_overwrite_with_malformed_timestamp_is_rejected_before_any_write(tmp_pat
     plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"new\n")}, tool=Tool.CLAUDE)
 
     with pytest.raises(ValueError, match="YYYYMMDD"):
-        sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), timestamp="../evil")
+        # auto_yes bypasses the W2 consent gate so the timestamp guard is what trips
+        sync_plan(
+            _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp="../evil"
+        )
 
     assert (home / "f.md").read_bytes() == b"old\n"
     assert not any(home.glob("*.backup-*"))
@@ -494,7 +504,8 @@ def test_overwrite_without_a_timestamp_backs_up_with_a_generated_suffix(tmp_path
     (home / "f.md").write_bytes(b"old\n")
     plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"new\n")}, tool=Tool.CLAUDE)
 
-    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO())
+    # auto_yes bypasses the W2 consent gate so this pins the generated-suffix backup
+    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True)
 
     assert (home / "f.md").read_bytes() == b"new\n"
     assert counters.backed_up == 1
@@ -572,3 +583,182 @@ def test_walk_is_non_transactional_earlier_items_survive_a_later_failure(tmp_pat
         sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
 
     assert (home / "good.md").read_bytes() == b"good\n"  # earlier item survived
+
+
+# ── W2: interactive install consent ──────────────────────────────────────────
+# sync_plan gains a per-changed-item diff+confirm gate (full parity with the
+# bash installer's confirm()). The shared no-TTY guard (consent.require_consent)
+# runs once up front; auto_yes / dry_run waive the per-item prompt.
+
+
+def test_non_interactive_run_without_waiver_raises_before_any_write(tmp_path: Path) -> None:
+    """
+    Given a non-interactive session (no TTY to answer a prompt), not dry_run and
+    not auto_yes
+    When sync_plan is asked to install a plan
+    Then it raises ConsentRequiredError up front — before any item lands —
+    reusing the shared no-TTY guard rather than silently overwriting.
+    """
+    home = tmp_path / "home"
+    plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"hi\n")}, tool=Tool.CLAUDE)
+
+    with pytest.raises(ConsentRequiredError):
+        sync_plan(
+            _IdentityAdapter(),
+            plan,
+            home=home,
+            io=ScriptedIO(interactive=False),
+            timestamp=_FIXED_TS,
+        )
+
+    assert not (home / "f.md").exists()
+
+
+def test_interactive_decline_keeps_existing_file_and_counts_skipped(tmp_path: Path) -> None:
+    """
+    Given a changed FILE item whose dest holds different bytes, and an
+    interactive user who declines the overwrite
+    When sync_plan reaches the per-file consent gate
+    Then the dest keeps its ORIGINAL bytes, no backup is taken, and the item is
+    counted as skipped — decline keeps existing (parity with bash confirm()).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "AGENTS.md").write_bytes(b"old\n")
+    plan = StagingPlan(
+        items={Path("AGENTS.md"): _file_item(Path("AGENTS.md"), b"new\n")}, tool=Tool.CLAUDE
+    )
+
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(confirms=[False]), timestamp=_FIXED_TS
+    )
+
+    assert (home / "AGENTS.md").read_bytes() == b"old\n"  # decline keeps existing
+    assert not any(home.glob("AGENTS.md.backup-*"))  # no backup on decline
+    assert (counters.skipped, counters.updated, counters.backed_up) == (1, 0, 0)
+
+
+def test_interactive_accept_shows_diff_then_overwrites_with_backup(tmp_path: Path) -> None:
+    """
+    Given a changed FILE item and an interactive user who accepts the overwrite
+    When sync_plan reaches the per-file consent gate
+    Then the user is shown a diff before confirming, the original is backed up,
+    the dest holds the NEW bytes, and updated + backed_up are counted.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "AGENTS.md").write_bytes(b"old\n")
+    io = ScriptedIO(confirms=[True])
+    plan = StagingPlan(
+        items={Path("AGENTS.md"): _file_item(Path("AGENTS.md"), b"new\n")}, tool=Tool.CLAUDE
+    )
+
+    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    assert (home / "AGENTS.md").read_bytes() == b"new\n"
+    assert (home / f"AGENTS.md.backup-{_FIXED_TS}").read_bytes() == b"old\n"
+    assert (counters.updated, counters.backed_up) == (1, 1)
+    # the change was surfaced as a diff carrying the old/new bytes before the prompt
+    diffs = [e for e in io.transcript if e.channel == "diff"]
+    assert diffs and diffs[0].payload == (b"old\n", b"new\n")
+
+
+def test_auto_yes_overwrites_changed_file_without_prompting(tmp_path: Path) -> None:
+    """
+    Given --yes and a changed FILE item
+    When sync_plan runs (with NO queued confirm answers)
+    Then the overwrite proceeds without consuming a prompt — auto_yes suppresses
+    the gate — yet the original is STILL backed up first (--yes is never a
+    data-loss path), and no confirm/diff is recorded.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "AGENTS.md").write_bytes(b"old\n")
+    io = ScriptedIO()  # empty queues: a prompt would raise ScriptExhaustedError
+    plan = StagingPlan(
+        items={Path("AGENTS.md"): _file_item(Path("AGENTS.md"), b"new\n")}, tool=Tool.CLAUDE
+    )
+
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=io, auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert (home / "AGENTS.md").read_bytes() == b"new\n"
+    assert (home / f"AGENTS.md.backup-{_FIXED_TS}").read_bytes() == b"old\n"  # still backed up
+    assert (counters.updated, counters.backed_up) == (1, 1)
+    assert not [e for e in io.transcript if e.channel in ("confirm", "diff")]
+
+
+def test_interactive_new_file_installs_without_a_prompt(tmp_path: Path) -> None:
+    """
+    Given a NEW FILE item (dest absent) and an interactive session with NO queued
+    confirm answers
+    When sync_plan runs
+    Then the file installs without any prompt — a first install is not a
+    destructive overwrite, so the consent gate fires only on existing dests.
+    """
+    home = tmp_path / "home"
+    io = ScriptedIO()  # a prompt would raise ScriptExhaustedError
+    plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"hi\n")}, tool=Tool.CLAUDE)
+
+    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    assert (home / "f.md").read_bytes() == b"hi\n"
+    assert counters.created == 1
+    assert not [e for e in io.transcript if e.channel == "confirm"]
+
+
+def test_interactive_decline_keeps_existing_dir_tree(tmp_path: Path) -> None:
+    """
+    Given a DIR item whose dest already exists, and an interactive user who
+    declines the replace
+    When sync_plan reaches the per-dir consent gate
+    Then the existing tree is left untouched (its stale file survives, no backup
+    taken), nothing from the source lands, and the item is counted as skipped.
+    A directory has no IOPort byte-diff, so the change is surfaced as a notice,
+    not a unified diff.
+    """
+    src = tmp_path / "src_skill"
+    src.mkdir()
+    (src / "new.md").write_bytes(b"new\n")
+    home = tmp_path / "home"
+    existing = home / "skills" / "s"
+    existing.mkdir(parents=True)
+    (existing / "stale.md").write_bytes(b"stale\n")
+    io = ScriptedIO(confirms=[False])
+    plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
+
+    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    assert (existing / "stale.md").read_bytes() == b"stale\n"  # untouched
+    assert not (existing / "new.md").exists()  # source not copied in
+    assert not (home / "skills-backup").exists()  # no backup on decline
+    assert (counters.skipped, counters.updated, counters.backed_up) == (1, 0, 0)
+    assert not [e for e in io.transcript if e.channel == "diff"]  # notice, not a byte-diff
+
+
+def test_auto_yes_replaces_existing_dir_without_prompting(tmp_path: Path) -> None:
+    """
+    Given --yes and a DIR item whose dest already exists
+    When sync_plan runs with NO queued confirm answers
+    Then the dir is backed up and cleanly replaced without consuming a prompt —
+    auto_yes suppresses the gate for directories too.
+    """
+    src = tmp_path / "src_skill"
+    src.mkdir()
+    (src / "new.md").write_bytes(b"new\n")
+    home = tmp_path / "home"
+    existing = home / "skills" / "s"
+    existing.mkdir(parents=True)
+    (existing / "stale.md").write_bytes(b"stale\n")
+    io = ScriptedIO()  # a prompt would raise ScriptExhaustedError
+    plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
+
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=io, auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert (home / "skills" / "s" / "new.md").read_bytes() == b"new\n"
+    assert not (home / "skills" / "s" / "stale.md").exists()  # clean replace
+    assert (counters.updated, counters.backed_up) == (1, 1)
+    assert not [e for e in io.transcript if e.channel == "confirm"]


### PR DESCRIPTION
## What

W2 (`hmxpp.3`) — the **interactive install consent gate** for the plan-walking install sync (W1's `sync_plan`). This is the per-file diff-and-confirm UX the Python installer was missing; `consent.py` previously only guarded *non-interactive starts*. Behavioural spec is the bash installer's `confirm()` (`scripts/install.sh:170-185`) and its per-item diff-then-confirm install blocks.

Contract:

- **Changed dest** (present, bytes differ): the change is surfaced, then `io.confirm` decides. A **decline keeps the existing dest byte-for-byte** — no backup, no write — and counts a skip (parity with bash `confirm()` returning non-zero).
- **`--yes`** (`auto_yes`): auto-accepts without prompting, but **still backs up first** — `--yes` is never a data-loss path.
- **`--dry-run`**: previews through `IOPort`, never prompts, never writes.
- **First install** (dest absent): never prompts — a new file is not a destructive overwrite.
- The shared **no-TTY guard** (`consent.require_consent`) runs **once up front** in `sync_plan`: a non-interactive run with neither `--yes` nor `--dry-run` hard-fails *before any write* rather than silently overwriting.

## Where

- **`core/sync.py`** — `sync_plan` gains an `auto_yes` param + the up-front `require_consent` call; the gate is inlined into both `_install_file` and `_install_dir` ahead of the backup/write, via a shared `_consent_to_overwrite` helper.
- **`core/run.py`** — `install_pipeline` threads `auto_yes` (and the existing `dry_run`) verbatim into every per-tool `sync_plan` call, so the gate applies uniformly across tools.

## Deliberate decisions (flagged in code docstrings)

- **Inlined gate, not a separate pre-pass** — matches the established `core/prune_flow.py` pattern (inlines `io.confirm_*`, runs its non-interactive guard first). Single walk; the hash-compare that detects "changed" sits right where the diff bytes are, so there's no duplicated change-detection.
- **DIR items get a 'changed' notice, not a byte-diff** — `IOPort.show_diff` is `(old: bytes, new: bytes)`; a directory tree has no such primitive. Bash's `diff -rq` (recursive file listing) has no `IOPort` equivalent; building one is out of scope here and flagged for the golden-master parity pass (Epic H).
- **Override-relpath and dest-type validation stay up-front** in `_install_dir` — they run *before* the consent gate, so an invalid plan is a hard `ValueError` regardless of consent and an existing dest is never touched on a malformed item.
- **`require_consent` lives in `sync_plan`** (the engine entrypoint), so every install path is guarded; `install_pipeline` only forwards the flag.

## Out of scope (by design — do not flag as missing)

- **`cli.main()` wiring** (a bare `install.py` doing a real install) → story **W3** (`hmxpp.4`).
- **`--plugins` CLI flag** → story **W4** (`hmxpp.2`).
- **Directory-level recursive diff display** → golden-master parity pass (Epic H).
- The dead single-file `sync()` remains untouched (superseded by `sync_plan`; removal deferred to W3).

## Tests & verification

- **8 new behavioural tests** (`test_sync_plan.py`, `test_run_install_pipeline.py`): up-front no-TTY raise; file decline-keeps-existing; file accept-shows-diff-then-backs-up-and-overwrites; `--yes` overwrites-without-prompt-but-still-backs-up; new-file-installs-without-prompt; dir decline-keeps-tree; `--yes` replaces-dir-without-prompt; pipeline forwards `auto_yes`. Each pins a coded decision (no tautologies).
- **4 pre-existing W1 overwrite tests** gained `auto_yes=True` — they pin post-consent backup/timestamp/clean-replace *mechanics*, not the gate; `auto_yes=True` is the faithful "consent granted" expression now that the gate exists.
- **`make ci-installer` green**: 493 passed, **99.78% branch coverage** (new code fully covered), `mypy --strict` clean, `ruff` + format clean, `pip-audit` no vulnerabilities, `install.py --help` entry-verify clean.

## Quality gate

In-house `quality-reviewer` agent + `simplify` skill ran pre-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
