### PR TITLE
feat(installer): W4 — add the --plugins CLI flag (hmxpp.2)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -17,6 +17,7 @@ from installer.tools.registry import UnknownToolError, get_adapter, known_tools
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
     from installer.core.model import Tool
+    from installer.plugins.base import PluginAdapter
 
 # The repo root is the agents-config checkout containing ``src/user/.agents`` and
 # ``src/plugins``. ``cli.py`` lives at ``<repo>/packages/installer/src/installer/
@@ -43,6 +44,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "Comma-separated tool list to install "
             f"(valid: {', '.join(t.value for t in known_tools())}). "
             "Default: auto-detect against $HOME."
+        ),
+    )
+    parser.add_argument(
+        "--plugins",
+        metavar="CSV",
+        default=None,
+        help=(
+            "Comma-separated plugin list to install (discovered under "
+            "src/plugins). Default: auto-detect against $HOME. "
+            "Pass --plugins= (empty) to install no plugins."
         ),
     )
     parser.add_argument(
@@ -122,12 +133,23 @@ def main(
         )
         return 2
 
-    if args.dump_stage is not None:
+    # Resolve plugins up front (after tools) so an invalid --plugins fails fast
+    # on every path — matching the bash installer, which validates --plugins
+    # before dispatching any mode (scripts/install.sh:298-307). The resolved set
+    # feeds both --dump-stage and --prune below.
+    try:
         plugins = resolve_plugins(
             home=resolved_home,
             plugins_root=resolved_repo_root / "src" / "plugins",
-            override_csv=None,
+            override_csv=args.plugins,
         )
+    except ValueError as exc:
+        # UnknownPluginError (unknown name) and the stray-comma ValueError both
+        # subclass ValueError; surface cleanly with exit 2, mirroring resolve_tools.
+        sys.stderr.write(f"installer: {exc}\n")
+        return 2
+
+    if args.dump_stage is not None:
         plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
         try:
             dump_plan(plans, args.dump_stage, io=io)
@@ -159,6 +181,7 @@ def main(
             dry_run=args.dry_run,
             auto_yes=args.yes,
             prune_only=args.prune_only,
+            plugins=plugins,
         )
 
     return 0
@@ -173,6 +196,7 @@ def _run_prune(
     dry_run: bool,
     auto_yes: bool,
     prune_only: bool,
+    plugins: tuple[PluginAdapter, ...],
 ) -> int:
     """Drive the prune pipeline behind --prune / --prune-only.
 
@@ -194,10 +218,11 @@ def _run_prune(
     clean error with ``return 2`` (the CLI's config-error exit convention),
     never an uncaught traceback.
 
-    Plugin discovery is likewise rooted at the passed ``repo_root``
-    (``repo_root / "src" / "plugins"``), so ``repo_root`` is fully
-    authoritative — config and plugins resolve against one injected root rather
-    than splitting between the argument and a module-level constant.
+    The active ``plugins`` are resolved by ``main`` (against
+    ``repo_root / "src" / "plugins"``) and passed in, so the ``--plugins``
+    selection reaches the prune scan and ``repo_root`` stays authoritative —
+    config and plugin source resolve against one injected root rather than
+    splitting between the argument and a module-level constant.
 
     Returns 0 on success, 1 when the non-interactive consent guard or the
     prune-only flow aborts the run, 2 when ``installer.toml`` is malformed.
@@ -219,8 +244,6 @@ def _run_prune(
     except ValueError as exc:
         io.err(f"installer: {exc}")
         return 2
-    plugins_root = repo_root / "src" / "plugins"
-    plugins = resolve_plugins(home=home, plugins_root=plugins_root, override_csv=None)
     plans = stage_and_transform(tools, repo_root=repo_root, io=io, plugins=plugins)
     adapters = [get_adapter(tool) for tool in tools]
 

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -510,10 +510,12 @@ def test_dump_stage_honors_plugins_override_over_footprint_autodetect(tmp_path: 
     And when --dump-stage runs WITH an empty --plugins=
     Then the plugin's rule is absent.
 
-    Pins: args.plugins flows to the dump-stage resolve_plugins call. An empty
-    --plugins= installs no plugins (resolve_plugins '' -> ()), overriding the
-    footprint auto-detect. Fails while the call site hardcodes override_csv=None
-    — the empty value would be ignored and widget staged regardless.
+    Pins: args.plugins reaches plugin resolution and feeds the --dump-stage
+    plan. main() resolves plugins once up front (resolve_plugins '' -> ()) and
+    passes the resolved tuple into stage_and_transform, so an empty --plugins=
+    installs no plugins, overriding the footprint auto-detect. Fails if
+    --plugins is unregistered or its value is dropped (e.g. resolve_plugins
+    pinned to override_csv=None) — widget would then be staged regardless.
     """
     repo = _repo_with_widget_plugin(tmp_path)
     home = _home_with_claude_settings(tmp_path)

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -328,11 +328,11 @@ def test_prune_plugin_discovery_honors_injected_repo_root(tmp_path: Path) -> Non
     src/plugins discovers nothing (no plugin staging is attempted off the real
     repo's src/plugins).
 
-    Pins: _run_prune derives plugins_root from the injected repo_root
-    (repo_root / "src" / "plugins"), not the module-level _REPO_ROOT, so
-    repo_root is fully authoritative (PR #151 comment 3408271853). With a
-    repo_root lacking src/plugins, discover() returns {} — proving the real
-    repo's plugins are not consulted.
+    Pins: main resolves plugins against the injected repo_root
+    (repo_root / "src" / "plugins"), not the module-level _REPO_ROOT, and passes
+    them to _run_prune, so repo_root is fully authoritative (PR #151 comment
+    3408271853). With a repo_root lacking src/plugins, discover() returns {} —
+    proving the real repo's plugins are not consulted.
     """
     home = _home_with_claude_settings(tmp_path)
 
@@ -485,3 +485,119 @@ def test_dump_stage_and_prune_together_is_mutually_exclusive_error(
         main(["--dump-stage", str(tmp_path / "out"), "--prune"], home=tmp_path)
     assert exc_info.value.code == 2
     assert "not allowed with" in capsys.readouterr().err
+
+
+# ── W4: --plugins flag wiring ──
+
+
+def _repo_with_widget_plugin(tmp_path: Path) -> Path:
+    """A hermetic repo plus a discoverable 'widget' plugin whose overlay
+    contributes a Claude rules file. The rule lands in the Claude plan only
+    when the widget plugin is active for the run."""
+    repo = _hermetic_repo(tmp_path)
+    rule = repo / "src" / "plugins" / "widget" / ".claude" / "rules" / "widget-rule.md"
+    rule.parent.mkdir(parents=True)
+    rule.write_bytes(b"widget rule\n")
+    return repo
+
+
+def test_dump_stage_honors_plugins_override_over_footprint_autodetect(tmp_path: Path) -> None:
+    """
+    Given a discoverable 'widget' plugin (overlaying claude rules/widget-rule.md)
+    and a home carrying the ~/.widget footprint plugin auto-detection keys on
+    When --dump-stage runs WITHOUT --plugins
+    Then the plugin's rule is staged (auto-detect includes the footprint plugin);
+    And when --dump-stage runs WITH an empty --plugins=
+    Then the plugin's rule is absent.
+
+    Pins: args.plugins flows to the dump-stage resolve_plugins call. An empty
+    --plugins= installs no plugins (resolve_plugins '' -> ()), overriding the
+    footprint auto-detect. Fails while the call site hardcodes override_csv=None
+    — the empty value would be ignored and widget staged regardless.
+    """
+    repo = _repo_with_widget_plugin(tmp_path)
+    home = _home_with_claude_settings(tmp_path)
+    (home / ".widget").mkdir()
+    staged = Path("claude") / "rules" / "widget-rule.md"
+
+    auto_out = tmp_path / "auto"
+    assert main([f"--dump-stage={auto_out}", "--tools=claude"], home=home, repo_root=repo) == 0
+    assert (auto_out / staged).exists()
+
+    empty_out = tmp_path / "empty"
+    rc = main(
+        [f"--dump-stage={empty_out}", "--tools=claude", "--plugins="],
+        home=home,
+        repo_root=repo,
+    )
+    assert rc == 0
+    assert not (empty_out / staged).exists()
+
+
+def test_unknown_plugin_value_returns_2_and_names_it(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    Given a repo whose discoverable plugin set does not include 'bogus'
+    When main(["--plugins=bogus", "--tools=claude"]) runs a plain install
+    Then it returns 2
+    And stderr names the unknown plugin ("Unknown plugin: 'bogus'").
+
+    Pins: --plugins is validated up front on every path — not only --dump-stage
+    and --prune — so a bad value fails fast and cleanly (exit 2) rather than
+    being silently ignored or crashing with a traceback. Mirrors the --tools=
+    guard. Fails on the plain path while plugins are resolved only inside the
+    --dump-stage / --prune branches.
+    """
+    repo = _repo_with_widget_plugin(tmp_path)
+    rc = main(["--plugins=bogus", "--tools=claude"], home=tmp_path, repo_root=repo)
+    assert rc == 2
+    assert "Unknown plugin: 'bogus'" in capsys.readouterr().err
+
+
+def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
+    """
+    Given a 'widget' plugin overlaying claude rules/widget-rule.md, a dest entry
+    ~/.claude/rules/widget-rule.md, an installer.toml retiring that key, and NO
+    ~/.widget footprint (so auto-detect alone would exclude widget)
+    When --prune-only --yes runs with --plugins=widget
+    Then the dest entry is spared — an active plugin stages that basename, so the
+    orphan scan treats it as known rather than retired;
+    And when the same dest is run again with an empty --plugins=
+    Then the dest entry is pruned — excluded, nothing stages it, so it is an
+    orphan matching the retired glob.
+
+    Pins: the up-front resolved plugins tuple is threaded into _run_prune. Fails
+    while _run_prune re-resolves plugins internally with override_csv=None —
+    which, absent the footprint, excludes widget even under --plugins=widget and
+    prunes the dest.
+    """
+    repo = _repo_with_installer_toml(tmp_path, retired=["claude/rules/widget-rule.md"])
+    rule = repo / "src" / "plugins" / "widget" / ".claude" / "rules" / "widget-rule.md"
+    rule.parent.mkdir(parents=True)
+    rule.write_bytes(b"widget rule\n")
+
+    home = _home_with_claude_settings(tmp_path)
+    dest_rule = home / ".claude" / "rules" / "widget-rule.md"
+    dest_rule.parent.mkdir(parents=True)
+    dest_rule.write_bytes(b"installed widget rule\n")
+
+    # Active via explicit override (no footprint) -> staged -> spared.
+    rc_active = main(
+        ["--prune-only", "--yes", "--tools=claude", "--plugins=widget"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc_active == 0
+    assert dest_rule.exists()
+
+    # Excluded via empty override -> unstaged -> pruned.
+    rc_excluded = main(
+        ["--prune-only", "--yes", "--tools=claude", "--plugins="],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc_excluded == 0
+    assert not dest_rule.exists()


### PR DESCRIPTION
## What

W4 (`hmxpp.2`) — register the missing **`--plugins` CSV flag** in the Python installer CLI and wire it to plugin resolution. The flag was advertised in `AGENTS.md` and the bash installer (`scripts/install.sh:71,112,298-307`) but absent from `cli._build_parser`, and both `resolve_plugins(...)` call sites hardcoded `override_csv=None` — so `--plugins` was impossible to express and a passed value was silently dropped.

Contract (mirrors the bash installer's `--plugins=` handling and the existing `resolve_plugins` semantics):

- **`--plugins=alpha,beta`** → install exactly those plugins (validated against the discovered set).
- **`--plugins=`** (empty) → install **no** plugins (the deliberate asymmetry with `--tools=`, which errors on empty).
- **flag absent** → auto-detect by home footprint (unchanged default).
- **unknown name / stray comma** → clean `exit 2` with a message naming the problem, not a traceback.

## Where

- **`core`/`cli.py`** — register `--plugins`; resolve plugins **once up front** in `main()` (right after `resolve_tools`) behind a `try/except ValueError → return 2` guard; feed that single resolved tuple to both consumers (`--dump-stage` and `_run_prune`). `_run_prune` loses its internal `resolve_plugins(override_csv=None)` and receives `plugins` as a parameter.

## Deliberate decision

- **One up-front resolve, not two threaded call sites.** DRY (a single resolve + single catch) and bash-faithful: the bash installer validates `--plugins` *before* dispatching any mode (`scripts/install.sh:298-307`), so a bad value now fails fast on **every** path (plain, `--dump-stage`, `--prune`) rather than only inside the mode that happens to resolve plugins. This removes duplication rather than adding it, and closes a latent "bad `--plugins` silently ignored / uncaught crash" gap.
- **`except ValueError` (not `(UnknownPluginError, ValueError)`).** `UnknownPluginError` subclasses `ValueError`, so the narrower spelling would trip ruff's redundant-exception lint (B014). `discover()` raises `OSError`, not `ValueError`, so the catch is not over-broad.

## Out of scope (by design)

- **Wiring `cli.main()`'s plain-install path to a real plan-walking sync** → story **W3** (`hmxpp.4`). This PR only registers + routes the flag; the plain path remains the existing no-op (it now *validates* `--plugins` but installs nothing).

## Tests & verification

- **3 new behavioural tests** (`test_cli_smoke.py`), each value-sensitive (would fail if the flag were unregistered or re-hardcoded to `None`):
  - `test_dump_stage_honors_plugins_override_over_footprint_autodetect` — a footprint-detected plugin is staged under auto-detect but excluded under `--plugins=`.
  - `test_unknown_plugin_value_returns_2_and_names_it` — `--plugins=bogus` on the plain path → `exit 2` naming the unknown plugin (proves up-front validation on every path).
  - `test_prune_only_honors_plugins_override` — a plugin overlaying a rules file *spares* the matching dest entry from pruning when active via `--plugins=<name>` (no home footprint), but the entry is pruned under `--plugins=` (proves the resolved tuple reaches `_run_prune`; staged basenames are prune-exempt, `core/prune.py:92`).
- **1 docstring accuracy fix** on `test_prune_plugin_discovery_honors_injected_repo_root` — the repo_root-authority invariant it pins now holds via `main()` resolving and passing plugins to `_run_prune` (the test still passes unchanged).
- **`make ci-installer` green**: 496 passed, **99.78% branch coverage** (`cli.py` fully covered), `mypy --strict` clean, `ruff` + format clean, `pip-audit` no vulnerabilities, `install.py --help` entry-verify clean.

## Quality gate

In-house `quality-reviewer` agent + `simplify` skill ran pre-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
