### PR TITLE
feat(installer): W3 — wire main() default path to a real install (hmxpp.4)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -6,18 +6,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from installer.config import Config, resolve_plugins, resolve_tools
-from installer.core.consent import ConsentRequiredError, require_consent
+from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installer_toml import load_installer_toml
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
-from installer.core.run import prune_pipeline
+from installer.core.run import install_pipeline, prune_pipeline
 from installer.tools.registry import UnknownToolError, get_adapter, known_tools
 
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
-    from installer.core.model import Tool
-    from installer.plugins.base import PluginAdapter
+    from installer.core.model import StagingPlan, Tool
+    from installer.tools.base import ToolAdapter
 
 # The repo root is the agents-config checkout containing ``src/user/.agents`` and
 # ``src/plugins``. ``cli.py`` lives at ``<repo>/packages/installer/src/installer/
@@ -161,78 +161,95 @@ def main(
             return 2
         return 0
 
-    # B.1: instantiation proves Config construction succeeds end-to-end; the
-    # object is intentionally not bound — the full plan-walking install sync is
-    # not wired here yet. When core/sync.py grows to walk a StagingPlan (Epic E),
-    # main() must drive core.orchestrator.stage_and_transform(tools, ...) — NOT
-    # build_plan->sync directly — so adapter post-staging transforms (e.g. the
-    # Gemini frontmatter transform) actually run in real installs, and that sync
-    # is where Config.auto_yes finds its consumer. Today auto_yes reaches the
-    # prune path directly via args.yes below; the Config field is forward-wiring
-    # for when sync() reads it. Tracked as a dedicated story.
-    Config(home=resolved_home, tools=tools, auto_yes=args.yes)
+    config = Config(home=resolved_home, tools=tools, auto_yes=args.yes)
+
+    # Stage once, up front: the same StagingPlan set feeds both the install and
+    # the prune orphan-scan, so --prune is install-then-prune over ONE plan, not
+    # two independent stagings. Staging touches no io channel and is
+    # deterministic, so producing it before the prune-only toml-load below
+    # changes no observable behaviour.
+    adapters = [get_adapter(tool) for tool in tools]
+    plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
+
+    # Default install path (also the install half of --prune): walk each active
+    # tool's StagingPlan to disk via install_pipeline. Skipped only for
+    # --prune-only, which removes retired paths without installing. Slots ahead
+    # of the prune branch so --prune is install-then-prune, mirroring the bash
+    # installer (scripts/install.sh copies before the retire sweep). Driving the
+    # install through stage_and_transform is also what makes adapter post-staging
+    # transforms (e.g. the Gemini frontmatter transform) fire in real installs,
+    # not just --dump-stage / --prune.
+    if not args.prune_only:
+        try:
+            install_pipeline(
+                adapters,
+                plans=plans,
+                home=resolved_home,
+                io=io,
+                dry_run=args.dry_run,
+                auto_yes=config.auto_yes,
+            )
+        except ConsentRequiredError:
+            # A non-interactive run lacking --yes/--dry-run cannot answer the
+            # per-file overwrite prompt; sync_plan's up-front guard raises before
+            # any write. Surface it as the CLI's exit 1 (the prune flow uses the
+            # same convention) rather than an uncaught traceback.
+            return 1
 
     if args.prune or args.prune_only:
         return _run_prune(
-            tools,
+            adapters,
+            plans=plans,
             io=io,
             home=resolved_home,
             repo_root=resolved_repo_root,
             dry_run=args.dry_run,
-            auto_yes=args.yes,
+            auto_yes=config.auto_yes,
             prune_only=args.prune_only,
-            plugins=plugins,
         )
 
     return 0
 
 
 def _run_prune(
-    tools: tuple[Tool, ...],
+    adapters: list[ToolAdapter],
     *,
+    plans: dict[Tool, StagingPlan],
     io: IOPort,
     home: Path,
     repo_root: Path,
     dry_run: bool,
     auto_yes: bool,
     prune_only: bool,
-    plugins: tuple[PluginAdapter, ...],
 ) -> int:
     """Drive the prune pipeline behind --prune / --prune-only.
 
-    Builds the in-memory plans (the prune scan compares the dest tree against
-    them), then runs scan + interactive flow. The install half of --prune is not
-    performed: the plan-walking install sync is not yet wired into main() (see
-    the Config note above), so today --prune performs only its prune half. The
-    sequencing is structured so the install phase slots in ahead of this call
-    when that story lands.
+    Scans each active tool's dest tree against its already-built ``StagingPlan``
+    (``plans``, produced once by ``main`` and shared with the install half), then
+    runs the scan + interactive flow. Consent for ``--prune`` is owned upstream:
+    ``main`` runs ``install_pipeline`` (whose ``sync_plan`` guard refuses a
+    non-interactive run lacking ``--yes``/``--dry-run``) before this call, so the
+    prune step needs no separate consent gate; ``--prune-only`` skips install and
+    relies on the prune flow's own non-interactive hard-fail.
 
-    The prune list is read from ``installer.toml`` under the passed
-    ``repo_root`` (not off ``__file__``), so the config tracks the same root as
-    ``stage_and_transform``. When that file is absent — e.g. a wheel/install
-    that bundles only ``src/installer`` and omits ``installer.toml`` — the load
-    yields an empty prune list, so nothing would be pruned; a warning is emitted
-    naming the missing path so the no-op is explained rather than silent. A
-    *present but type-malformed* ``installer.toml`` makes ``load_installer_toml``
-    raise ``ValueError``; that is caught here and surfaced through ``io`` as a
-    clean error with ``return 2`` (the CLI's config-error exit convention),
-    never an uncaught traceback.
+    The prune list is read from ``installer.toml`` under the passed ``repo_root``
+    (not off ``__file__``), so the config tracks the same root the plans were
+    staged from. When that file is absent — e.g. a wheel/install that bundles
+    only ``src/installer`` and omits ``installer.toml`` — the load yields an empty
+    prune list, so nothing would be pruned; a warning is emitted naming the
+    missing path so the no-op is explained rather than silent. A *present but
+    type-malformed* ``installer.toml`` makes ``load_installer_toml`` raise
+    ``ValueError``; that is caught here and surfaced through ``io`` as a clean
+    error with ``return 2`` (the CLI's config-error exit convention), never an
+    uncaught traceback.
 
-    The active ``plugins`` are resolved by ``main`` (against
-    ``repo_root / "src" / "plugins"``) and passed in, so the ``--plugins``
-    selection reaches the prune scan and ``repo_root`` stays authoritative —
-    config and plugin source resolve against one injected root rather than
-    splitting between the argument and a module-level constant.
+    The ``plans`` reflect the active ``--plugins`` selection (``main`` builds them
+    with the resolved plugin set), so a plugin's overlaid files reach the orphan
+    scan as known entries rather than retired ones.
 
-    Returns 0 on success, 1 when the non-interactive consent guard or the
-    prune-only flow aborts the run, 2 when ``installer.toml`` is malformed.
+    Returns 0 on success, 1 when the prune-only flow aborts the run, 2 when
+    ``installer.toml`` is malformed.
     """
-    if not prune_only:
-        try:
-            require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
-        except ConsentRequiredError:
-            return 1
-
     installer_toml = repo_root / "packages" / "installer" / "installer.toml"
     if not installer_toml.is_file():
         io.warn(
@@ -244,8 +261,6 @@ def _run_prune(
     except ValueError as exc:
         io.err(f"installer: {exc}")
         return 2
-    plans = stage_and_transform(tools, repo_root=repo_root, io=io, plugins=plugins)
-    adapters = [get_adapter(tool) for tool in tools]
 
     try:
         prune_pipeline(

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -165,9 +165,11 @@ def main(
 
     # Stage once, up front: the same StagingPlan set feeds both the install and
     # the prune orphan-scan, so --prune is install-then-prune over ONE plan, not
-    # two independent stagings. Staging touches no io channel and is
-    # deterministic, so producing it before the prune-only toml-load below
-    # changes no observable behaviour.
+    # two independent stagings. Staging is deterministic, writes nothing to disk,
+    # and does not read installer.toml, so producing the plan before the
+    # prune-only toml-load below changes neither the prune outcome nor its error
+    # handling — only a verbose adapter transform notice (e.g. Gemini) may now
+    # precede a toml error, which is immaterial.
     adapters = [get_adapter(tool) for tool in tools]
     plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
 

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -1,15 +1,12 @@
 """Run-orchestration seam: stage every active tool (Phases 1-5), overlay active
 plugins (Phase 6), then apply its post-staging transform pass.
 
-This is the FIRST call site for ``ToolAdapter.post_staging_transforms`` across
-all four adapters. It is deliberately NOT yet invoked from ``cli.main()``: the
-plan-walking sync that would consume these transformed plans does not exist yet
-(``core/sync.py`` is the single-file B.2 slice; plan-walking sync arrives with
-the Epic E merge dispatch). When the full install pipeline is wired into
-``main()``, it MUST route every active tool through this function — not
-``build_plan``->``sync`` directly — or adapter transforms (e.g. the Gemini
-frontmatter transform) will silently never run in real installs. That wiring is
-tracked as its own story.
+This is the call site for ``ToolAdapter.post_staging_transforms`` across all four
+adapters. ``cli.main`` (W3) routes every active tool through this function and
+feeds the transformed plans to ``install_pipeline`` (and the prune scan) — NOT
+``build_plan``->``sync`` directly — so adapter transforms (e.g. the Gemini
+frontmatter transform) run in real installs, not only when materialising the
+stage via ``--dump-stage``.
 
 Phase ordering (epic Plugin Seam Integration Brief): plugin overlay (6) runs
 AFTER base staging; plugin extensions (6.5, F.5 YAML patches) run AFTER the

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -1,19 +1,17 @@
-"""Run-level composition for the prune pipeline (G.5).
+"""Run-level composition for the install and prune pipelines (W1 / G.5).
 
-``prune_pipeline`` is the install-side composition wired behind the ``--prune``
-and ``--prune-only`` CLI flags: scan each active tool's destination tree against
-its in-memory ``StagingPlan`` for orphans (``core/prune.py``), then drive the
+``install_pipeline`` walks each active tool's ``StagingPlan`` to disk via
+``sync_plan``; ``prune_pipeline`` scans each tool's destination tree against its
+in-memory ``StagingPlan`` for orphans (``core/prune.py``), then drives the
 interactive prune flow over the result (``core/prune_flow.py``).
 
-It is kept separate from ``cli.py`` so the scan+flow composition is unit-testable
+Both are kept separate from ``cli.py`` so the compositions are unit-testable
 without argparse, and separate from ``orchestrator.stage_and_transform`` so the
 staging-plan production (which needs ``repo_root`` + plugin resolution) stays in
-the caller. The install half of ``--prune`` (install THEN prune) is not performed
-here: the plan-walking install sync is not yet wired into ``cli.main`` (see
-``cli.py`` and ``orchestrator.py`` notes). The sequencing is structured so that
-install slots in ahead of this call when that story lands; today this performs
-the prune half against the already-built plans, which is correct for
-``--prune-only`` and is the prune half of ``--prune``.
+the caller. ``cli.main`` (W3) stages once and feeds the shared plans to both:
+``install_pipeline`` runs first (the install half of a plain install and of
+``--prune``), then ``prune_pipeline`` runs the prune half against the same
+plans. ``--prune-only`` skips the install half.
 """
 
 from __future__ import annotations

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -80,24 +80,41 @@ def test_main_help_prints_usage(capsys: pytest.CaptureFixture[str]) -> None:
     assert "installer" in captured.out
 
 
-def test_main_no_args_returns_zero_against_hermetic_home_with_settings(
-    tmp_path: Path,
-) -> None:
+def test_main_dry_run_auto_detect_with_claude_signal_returns_zero(tmp_path: Path) -> None:
     """
-    Given a home directory with a file at .claude/settings.json
-    When main([], home=that_home) is invoked
-    Then it returns 0.
+    Given a home with a .claude/settings.json install signal and a hermetic repo,
+    under --dry-run with no --tools
+    When main runs (auto-detect)
+    Then it returns 0 — auto-detection finds claude and proceeds past resolution
+    (the success counterpart to the empty-home exit-2 path), and --dry-run lets
+    the real install path preview without prompting or writing.
+
+    Pins: auto-detect of an installed tool does NOT take the no-tools exit-2
+    guard; the run reaches and completes the (dry-run) install path.
     """
     home = _home_with_claude_settings(tmp_path)
-    assert main([], home=home) == 0
+    repo = _hermetic_repo(tmp_path)
+    assert main(["--dry-run"], home=home, io=ScriptedIO(interactive=False), repo_root=repo) == 0
 
 
-def test_main_tools_claude_returns_zero(tmp_path: Path) -> None:
+def test_main_tools_claude_dry_run_returns_zero_and_writes_nothing(tmp_path: Path) -> None:
     """
-    When main(["--tools=claude"], home=any) is invoked
-    Then it returns 0.
+    When main(["--tools=claude", "--dry-run"]) runs against a hermetic repo
+    Then it returns 0 and writes nothing under ~/.claude — --dry-run previews the
+    install without prompting (waiving consent) and touches no destination.
+
+    Pins: --tools=claude resolves and the install path runs in preview mode; the
+    dry-run write-suppression holds end-to-end through main.
     """
-    assert main(["--tools=claude"], home=tmp_path) == 0
+    repo = _hermetic_repo(tmp_path)
+    rc = main(
+        ["--tools=claude", "--dry-run"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc == 0
+    assert not (tmp_path / ".claude").exists()
 
 
 def test_main_tools_unregistered_returns_2_and_writes_unknown_tool_to_stderr(
@@ -329,10 +346,11 @@ def test_prune_plugin_discovery_honors_injected_repo_root(tmp_path: Path) -> Non
     repo's src/plugins).
 
     Pins: main resolves plugins against the injected repo_root
-    (repo_root / "src" / "plugins"), not the module-level _REPO_ROOT, and passes
-    them to _run_prune, so repo_root is fully authoritative (PR #151 comment
-    3408271853). With a repo_root lacking src/plugins, discover() returns {} —
-    proving the real repo's plugins are not consulted.
+    (repo_root / "src" / "plugins"), not the module-level _REPO_ROOT, builds the
+    staging plans with them, and passes those plans to _run_prune — so repo_root
+    is fully authoritative for plugin discovery (PR #151 comment 3408271853).
+    With a repo_root lacking src/plugins, discover() returns {} — proving the
+    real repo's plugins are not consulted.
     """
     home = _home_with_claude_settings(tmp_path)
 
@@ -367,8 +385,10 @@ def test_plain_prune_non_interactive_without_yes_fails_on_consent_guard(tmp_path
     """
     Given plain --prune (not --prune-only), a non-interactive io, and no --yes
     When main runs
-    Then it returns non-zero — the consent guard refuses a destructive run that
-    cannot prompt (G.7), before any orphan scan.
+    Then it returns non-zero — the install half's consent guard
+    (install_pipeline -> sync_plan -> require_consent) refuses a destructive run
+    that cannot prompt (G.7) before any file is written or orphan scanned, and
+    main surfaces it as exit 1.
     """
     home = _home_with_claude_settings(tmp_path)
     empty_repo = tmp_path / "empty-repo"
@@ -569,10 +589,11 @@ def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
     Then the dest entry is pruned — excluded, nothing stages it, so it is an
     orphan matching the retired glob.
 
-    Pins: the up-front resolved plugins tuple is threaded into _run_prune. Fails
-    while _run_prune re-resolves plugins internally with override_csv=None —
-    which, absent the footprint, excludes widget even under --plugins=widget and
-    prunes the dest.
+    Pins: the resolved plugin set builds the staging plans in main, and those
+    plans are threaded into _run_prune — so the --plugins selection reaches the
+    orphan scan via the plans. Fails if the plans dropped the override (e.g.
+    plugins resolved with override_csv=None): absent the footprint, widget would
+    be unstaged even under --plugins=widget and the dest pruned.
     """
     repo = _repo_with_installer_toml(tmp_path, retired=["claude/rules/widget-rule.md"])
     rule = repo / "src" / "plugins" / "widget" / ".claude" / "rules" / "widget-rule.md"
@@ -603,3 +624,94 @@ def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
     )
     assert rc_excluded == 0
     assert not dest_rule.exists()
+
+
+# ── W3: default-path real install (install_pipeline wired into main) ──
+
+
+def test_main_default_install_writes_staged_plan_to_dest(tmp_path: Path) -> None:
+    """
+    Given a hermetic source repo (a shared template -> a non-empty claude plan),
+    under --tools=claude --yes
+    When main runs (non-interactive io; --yes waives the consent prompt)
+    Then the staged shared template is written to ~/.claude/INSTRUCTIONS.md
+    And main returns 0.
+
+    Pins: the default (no terminal-mode flag) path performs a REAL install — it
+    walks each tool's StagingPlan to disk via install_pipeline, honoring
+    Config.auto_yes. Fails while main builds Config, discards it, and returns 0
+    without installing.
+    """
+    repo = _hermetic_repo(tmp_path)
+
+    rc = main(
+        ["--tools=claude", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (tmp_path / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"
+
+
+def test_main_default_install_non_interactive_without_consent_returns_one(tmp_path: Path) -> None:
+    """
+    Given a hermetic source repo and a non-interactive io, under --tools=claude
+    with neither --yes nor --dry-run
+    When main runs the default install path
+    Then it returns 1 — install_pipeline -> sync_plan's require_consent refuses a
+    destructive run that cannot prompt (G.7);
+    And nothing is written under ~/.claude (the guard fires before any write).
+
+    Pins: the W2 consent contract is enforced at the CLI boundary — main catches
+    ConsentRequiredError from the install and returns 1, rather than letting it
+    escape as an uncaught traceback. Fails (errors out) while the install_pipeline
+    call is unguarded.
+    """
+    repo = _hermetic_repo(tmp_path)
+
+    rc = main(
+        ["--tools=claude"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 1
+    assert not (tmp_path / ".claude" / "INSTRUCTIONS.md").exists()
+
+
+def test_main_prune_installs_then_prunes(tmp_path: Path) -> None:
+    """
+    Given a hermetic repo whose installer.toml retires '*/skills/ralf-it', a home
+    holding that retired orphan, under --prune --yes
+    When main runs (non-interactive io; --yes waives consent)
+    Then the staged shared template is installed at ~/.claude/INSTRUCTIONS.md
+    (install half) AND the retired orphan ~/.claude/skills/ralf-it is removed
+    (prune half), and main returns 0.
+
+    Pins: --prune is install-then-prune over ONE shared staging plan — main
+    installs the plan, then _run_prune scans the same plan for orphans. Fails
+    while --prune skips the install half (the pre-W3 prune-only behaviour of the
+    default branch).
+    """
+    repo = _hermetic_repo(tmp_path)
+    toml_dir = repo / "packages" / "installer"
+    toml_dir.mkdir(parents=True)
+    (toml_dir / "installer.toml").write_text('[prune]\nretired = [\n  "*/skills/ralf-it",\n]\n')
+
+    home = tmp_path / "home"
+    orphan = home / ".claude" / "skills" / "ralf-it"
+    orphan.mkdir(parents=True)
+
+    rc = main(
+        ["--prune", "--yes", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (home / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"
+    assert not orphan.exists()


### PR DESCRIPTION
## What

W3 (`hmxpp.4`) — wire `cli.main()`'s default path to a **real install**, the integration story that ties together W1 (`install_pipeline`), W2 (consent UX), and W4 (`--plugins`). Before this, the default (no terminal-mode flag) path built a `Config` and **discarded it**, returning 0 without installing — a placeholder no-op. Now it walks each active tool's `StagingPlan` to disk via `install_pipeline`, honoring `Config.auto_yes` (`--yes`) and `--dry-run`.

This also fixes a latent correctness gap: the Gemini frontmatter transform (and any adapter post-staging transform) now fires in **real installs**, not only `--dump-stage` / `--prune`.

## Behavior, by mode

- **plain** (`install.py [--tools=…] [--yes|--dry-run]`) → stage + install. The default path is no longer a no-op.
- **`--prune`** → install **then** prune, over **one shared staging plan** (mirrors the bash installer: copy before the retire sweep, `scripts/install.sh`).
- **`--prune-only`** → prune only; install is skipped.
- **non-interactive without `--yes`/`--dry-run`** → `exit 1` (consent refused before any write), surfaced cleanly, not as a traceback.

## Where

`core`/`cli.py`:
- **Stage once, up front.** Build `adapters` + `plans` (`stage_and_transform`) once after `Config`; the same plan set feeds both the install and the prune orphan-scan. Staging touches no io channel and is deterministic, so producing it before the prune-only `installer.toml` load changes no observable behavior.
- **Install when `not --prune-only`**, wrapped in `try/except ConsentRequiredError → return 1` — the W2 consent contract surfaced at the CLI boundary (`install_pipeline → sync_plan` raises it and does not catch it).
- **Thread the shared `plans` (and `adapters`) into `_run_prune`.** `_run_prune` loses (a) its internal `stage_and_transform`, (b) its `plugins` parameter, and (c) its `if not prune_only: require_consent(...)` block.

## Deliberate decision

- **One staging, shared between install and prune (not two independent stagings).** `--prune` is install-then-prune over a single plan — semantically honest and DRY. This is the integration W3 exists to do; W4 threaded `plugins` into `_run_prune` because, at that time, `_run_prune` staged internally. W3 hoists staging to `main()`, so `_run_prune` no longer stages and no longer needs `plugins` — the resolved plugins now build the `plans` in `main()`, and the `plans` (reflecting the plugin selection) are threaded in instead.
- **Removed `_run_prune`'s consent block, not left as defense-in-depth.** Once `install_pipeline` runs first for `--prune`, it owns the consent guard; `_run_prune`'s block only ever fired for `--prune`, so leaving it would be an **unreachable branch** (dead code that also fails the 90% branch-coverage gate). Consent is now owned in exactly one place per mode: install's `require_consent` for plain/`--prune`; the prune flow's own non-interactive hard-fail (`core/prune_flow.run_prune`) for `--prune-only`.

## Out of scope (by design)

- Golden-master parity with `scripts/install.sh` (Epic H) — W3 unblocks it but does not assert it.

## Tests & verification

- **3 new behavioural tests** (`test_cli_smoke.py`):
  - `test_main_default_install_writes_staged_plan_to_dest` — `--tools=claude --yes` writes the staged shared template to `~/.claude/INSTRUCTIONS.md` (RED before wiring: file absent).
  - `test_main_default_install_non_interactive_without_consent_returns_one` — non-interactive, no `--yes`/`--dry-run` → `exit 1`, nothing written (the guard fires before any write).
  - `test_main_prune_installs_then_prunes` — `--prune --yes` both installs the staged file AND prunes the retired orphan, over one plan.
- **2 rewritten** (the prior "returns 0" no-op pins, which now require consent): `test_main_dry_run_auto_detect_with_claude_signal_returns_zero`, `test_main_tools_claude_dry_run_returns_zero_and_writes_nothing`.
- **3 docstrings** updated to the new control flow (consent-guard now install-side; prune plugin tests now thread `plans`, not `plugins`).
- **`make ci-installer` green**: ruff + format + `mypy --strict`, **499 passed**, **99.78% branch coverage** (`cli.py` 100%), pip-audit clean, `install.py --help` entry-verify clean.

## Quality gate

In-house `quality-reviewer` (opus) + `simplify` ran pre-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
