### PR TITLE
refactor(installer): json_union semantic deep-merge, drop jq-byte-parity (lnotj)

### DIFF
--- a/docs/architecture/installer/installer-design.md
+++ b/docs/architecture/installer/installer-design.md
@@ -176,7 +176,7 @@ Pure-function tests against the core engine, exercised through a `FakeToolAdapte
 
 - `core/templates.py` — directive recognition; ALL-RULES join; trailing-newline preservation; Gemini frontmatter strip + tools-list YAML conversion (the conversion lives in `tools/gemini.py` but the test plugs it into the core).
 - `core/merge/strategies/append_rules.py` — empty/non-empty concat; separator placement.
-- `core/merge/strategies/json_union.py` — nested dict precedence; array union+sort; type mismatch; key only in incoming.
+- `core/merge/strategies/json_union.py` — nested dict precedence; array union+dedupe (first-seen order); type mismatch; key only in incoming.
 - `core/merge/strategies/fatal.py` — raises with informative message including filenames.
 - `core/merge/registry.py` — `(FileKind, namespace)` dispatch correctness (NAMESPACED_MD with namespace "rules" vs "commands" dispatches to different strategies; non-namespaced kinds ignore the namespace); unknown `(FileKind, namespace)` key raises.
 - `core/prune.py` — TOML prune-list load; glob matching (`*/skills/foo` vs exact match).

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -1,59 +1,27 @@
 """Deep union-merge strategy for ``(SETTINGS_JSON, *)`` collisions.
 
 When two ``settings.json`` payloads (e.g. a tool's and a plugin's) collide at
-the same destination they are not a conflict — they are combined. This is the
-Python port of the jq program at ``scripts/install.sh:431-456``; the bash
-installer's observable behaviour is the contract this module matches. The merge
-rules and the *structural* output formatting (2-space indent, object key order,
-trailing newline) mirror ``jq .``; lexical number normalisation is the one
-deliberate exception (quirk 3 below):
+the same destination they are not a conflict — they are combined into a single
+semantic deep-merge:
 
 - dict + dict at a shared key -> recurse (deep merge);
-- array + array at a shared key -> concatenate then jq-``unique`` (sort by
-  jq's total order, then dedupe by value);
+- array + array at a shared key -> concatenate, then dedupe by value keeping
+  first-seen order;
 - scalar conflict at a shared key -> KEEP EXISTING;
 - type mismatch at a shared key (dict-vs-scalar, array-vs-scalar, …)
   -> KEEP EXISTING;
 - key only in incoming -> ADD it; key only in existing -> keep it;
-- a top-level operand that is not an object -> the result is ``existing`` whole.
+- a top-level operand that is not an object -> the result is ``existing`` whole;
+- two empty objects merge to ``{}``, never ``null``.
 
-Two jq quirks are reproduced deliberately rather than "fixed":
-
-1. **Empty-object quirk.** jq builds the merged object with ``… | add``; over
-   an empty key-list ``[] | add`` evaluates to ``null``. So deep-merging two
-   objects whose key-merge yields no keys produces JSON ``null`` — including
-   nested ``{}`` + ``{}`` keys, which become ``null`` at that key.
-2. **jq total order.** jq sorts and dedupes arrays by its own total order:
-   ``null < false < true < number < string < array < object``, with arrays
-   compared element-wise (length tiebreak) and objects compared by their
-   sorted key-array first then their values in key order. ``_jq_sort_key``
-   reproduces that ordering.
-
-One jq behaviour is deliberately NOT reproduced:
-
-3. **Number lexemes are not byte-preserved.** jq echoes a number's source form
-   (``1e3`` stays ``1E+3``, ``1.50`` stays ``1.50``); this port round-trips
-   through ``json.loads``/``json.dumps`` and canonicalises them (``1e3`` ->
-   ``1000.0``, ``1.50`` -> ``1.5``). Common-case numbers round-trip faithfully
-   (``1`` vs ``1.0`` stay distinct; integral floats and big ints keep their
-   form). Accepted, not fixed: every ``settings.json`` source is canonical-
-   number JSON — no template carries scientific-notation or trailing-zero
-   literals — and the golden-master parity suite is the backstop should one
-   ever appear.
-
-Output bytes are canonical ``jq .`` formatting: 2-space indent and a single
-trailing newline. ``jq .`` does NOT sort object keys — it preserves each
-object's insertion order. The bash installer emits the merge with ``jq .``
-(``install.sh:456``), not ``jq -S``, so this port matches that: the deep-merge
-skeleton is constructed in sorted-key order by :func:`_deep_merge` (mirroring
-jq's ``($a|keys)+($b|keys)|unique``, which sorts by Unicode codepoint), while
-any object jq passes through verbatim — a key present on only one side whose
-value is an object, or an object nested inside an array — keeps its original
-insertion order.
+Output is canonical JSON: 2-space indent, keys sorted, a single trailing
+newline. Key order and whitespace are not a behavioural contract — every
+consumer parses the file — so the merge optimises for a deterministic, readable
+form rather than reproducing any particular tool's byte layout.
 
 Irreconcilable input (a ``None`` side, or bytes that are not valid JSON) raises
-:class:`CollisionError` naming both source paths, mirroring jq aborting on bad
-input rather than silently fabricating an empty object.
+:class:`CollisionError` naming both source paths, rather than silently
+fabricating an empty object.
 """
 
 from __future__ import annotations
@@ -65,102 +33,33 @@ from typing import Any
 from installer.core.merge.base import CollisionError
 from installer.core.model import StagedItem
 
-# jq total-order type ranks. Lower sorts first. ``bool`` is checked before
-# ``int`` because ``bool`` is a subclass of ``int`` in Python.
-_RANK_NULL = 0
-_RANK_BOOL = 1
-_RANK_NUMBER = 2
-_RANK_STRING = 3
-_RANK_ARRAY = 4
-_RANK_OBJECT = 5
-
-
-def _jq_sort_key(value: Any) -> tuple[Any, ...]:
-    """Map a JSON value to a sortable key reproducing jq's total order.
-
-    Type rank dominates (``null < bool < number < string < array < object``);
-    within a rank values compare naturally. Containers recurse so arrays
-    compare element-wise and objects compare by their sorted key-array first,
-    then by their values in key order — matching jq's ``sort``/``unique``.
-    """
-    if value is None:
-        return (_RANK_NULL,)
-    if isinstance(value, bool):
-        # false < true; rely on int(False)=0 < int(True)=1.
-        return (_RANK_BOOL, int(value))
-    if isinstance(value, (int, float)):
-        try:
-            return (_RANK_NUMBER, float(value))
-        except OverflowError:
-            # A Python int too large for a float (valid JSON, e.g. a 400-digit
-            # integer literal): jq stores numbers as IEEE doubles, so an
-            # out-of-range int collapses to +/-inf. Mirror that here for
-            # ordering only — the element's exact value is preserved in the
-            # output bytes (json.dumps keeps int precision); just this sort key
-            # approximates, which would otherwise crash with OverflowError.
-            return (_RANK_NUMBER, float("inf") if value > 0 else float("-inf"))
-    if isinstance(value, str):
-        return (_RANK_STRING, value)
-    if isinstance(value, list):
-        return (_RANK_ARRAY, [_jq_sort_key(elem) for elem in value])
-    # dict: keys sorted first, then the values in that key order.
-    keys = sorted(value.keys())
-    return (
-        _RANK_OBJECT,
-        [_jq_sort_key(k) for k in keys],
-        [_jq_sort_key(value[k]) for k in keys],
-    )
-
 
 def _union_arrays(existing: list[Any], incoming: list[Any]) -> list[Any]:
-    """jq ``[a, b] | add | unique``: concatenate, sort by jq's total order,
-    then drop adjacent duplicates (values with an equal sort key are jq-equal,
-    which correctly treats ``1`` and ``1.0`` as one while keeping ``true`` and
-    ``1`` distinct)."""
-    # Compute each element's sort key once, then sort + dedupe by it. Sort on
-    # the key alone (``key=`` on the pair's first item): when two keys tie the
-    # raw values must not be compared, since dicts/lists are not orderable.
-    keyed = sorted(
-        ((_jq_sort_key(elem), elem) for elem in (*existing, *incoming)),
-        key=lambda pair: pair[0],
-    )
+    """Concatenate two arrays and dedupe by value, preserving first-seen order.
+
+    Equality is Python ``==``, so ``1`` and ``1.0`` collapse to one (first seen
+    wins) while distinct values — including unhashable ``dict`` and ``list``
+    elements, compared structurally — are each kept once. ``==`` also collapses
+    ``True``/``1`` and ``False``/``0`` across the bool/number boundary; accepted
+    because settings arrays never mix bare booleans with bare numbers."""
     deduped: list[Any] = []
-    last_key: tuple[Any, ...] | None = None
-    last_elem: Any = None
-    for key, elem in keyed:
-        # Dedupe on the sort key, but break ties by Python value equality so a
-        # lossy sort key cannot collapse two distinct values. The overflow
-        # guard in ``_jq_sort_key`` maps every huge positive int to the same
-        # +inf key (and every huge negative int to -inf), so ``10**400`` and
-        # ``10**401`` share a key while being distinct, full-precision integers
-        # that ``json.dumps`` preserves verbatim. Without the value check the
-        # second would be silently dropped, losing data. ``1`` vs ``1.0`` still
-        # dedupe because ``1 == 1.0`` in Python, matching jq.
-        if key != last_key or elem != last_elem:
+    for elem in (*existing, *incoming):
+        if elem not in deduped:
             deduped.append(elem)
-            last_key = key
-            last_elem = elem
     return deduped
 
 
 def _deep_merge(existing: Any, incoming: Any) -> Any:
-    """Port of the jq ``deep_merge`` def. Only object+object recurses; every
-    other top-level shape returns ``existing`` whole. The merged object is
-    built via ``add`` over per-key fragments, so a key-merge yielding no keys
-    collapses to ``None`` (the jq ``[] | add`` quirk)."""
+    """Recursively union two JSON values. Only object+object merges; every
+    other top-level shape returns ``existing`` whole. At a shared key two dicts
+    recurse, two lists union, and anything else (scalar conflict or type
+    mismatch) keeps ``existing``; keys present on only one side are carried
+    through. In-memory key order is irrelevant — :func:`_to_bytes` sorts."""
     if not (isinstance(existing, dict) and isinstance(incoming, dict)):
         return existing
 
-    # jq builds the merged object via ``($a|keys)+($b|keys)|unique|map(…)``,
-    # and ``keys|unique`` sorts the key-set by Unicode codepoint. Building the
-    # dict in sorted-key order here reproduces that: the CONSTRUCTED skeleton
-    # is sorted at every recursion level, while objects passed through verbatim
-    # (one-side-only object values, objects nested inside arrays) are never
-    # rebuilt and so keep their original insertion order — matching ``jq .``,
-    # which sorts only what the program constructs. ``_to_jq_bytes`` therefore
-    # serialises with ``sort_keys=False``.
     merged: dict[str, Any] = {}
-    for key in sorted(set(existing) | set(incoming)):
+    for key in set(existing) | set(incoming):
         in_existing = key in existing
         in_incoming = key in incoming
         if in_existing and in_incoming:
@@ -177,9 +76,6 @@ def _deep_merge(existing: Any, incoming: Any) -> Any:
         else:
             merged[key] = incoming[key]
 
-    # jq ``[] | add`` is null: an object that merged to no keys becomes null.
-    if not merged:
-        return None
     return merged
 
 
@@ -195,21 +91,18 @@ def _parse(content: bytes | None) -> Any:
     return json.loads(content)
 
 
-def _to_jq_bytes(value: Any) -> bytes:
-    """Serialise to canonical ``jq .`` formatting: 2-space indent, single
-    trailing newline, and — crucially — each object's keys in the order it
-    already holds them (``sort_keys=False``). ``jq .`` does NOT sort keys; it
-    preserves every object's insertion order. The deep-merge skeleton is built
-    in sorted order by :func:`_deep_merge` (mirroring jq's ``keys|unique``), so
-    objects jq constructs come out sorted while objects jq passes through
-    verbatim keep their original order. Sorting here would wrongly re-order the
-    latter (e.g. a one-side-only ``env`` block, or an object inside an array)."""
-    text = json.dumps(value, indent=2, sort_keys=False, ensure_ascii=False)
+def _to_bytes(value: Any) -> bytes:
+    """Serialise to canonical JSON: 2-space indent, keys sorted
+    (``sort_keys=True``), single trailing newline. Key order and whitespace are
+    not a behavioural contract — every consumer parses the file — so the merge
+    emits a deterministic, readable form rather than any one tool's byte
+    layout."""
+    text = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False)
     return (text + "\n").encode("utf-8")
 
 
 class JsonUnionStrategy:
-    """Deep union-merge two colliding JSON payloads, jq-parity.
+    """Deep union-merge two colliding JSON payloads.
 
     Honours the ``MergeStrategy`` protocol structurally. The synthesised item
     preserves the shared key fields (``dest_relpath``, ``kind``, ``namespace``
@@ -227,4 +120,4 @@ class JsonUnionStrategy:
         except ValueError as exc:
             raise CollisionError(existing.source_path, incoming.source_path) from exc
         merged = _deep_merge(existing_json, incoming_json)
-        return replace(incoming, content=_to_jq_bytes(merged))
+        return replace(incoming, content=_to_bytes(merged))

--- a/packages/installer/tests/unit/test_json_union.py
+++ b/packages/installer/tests/unit/test_json_union.py
@@ -1,32 +1,21 @@
 """Unit tests for installer.core.merge.strategies.json_union.
 
-Each test pins a coded decision in the deep-union-merge contract for
-``(SETTINGS_JSON, *)`` collisions. The behavioural spec is the jq program
-at ``scripts/install.sh:431-456``; these tests were authored by probing the
-real ``jq-1.8.1`` against the same inputs, so they pin jq-parity, not the
-Python stdlib.
-
-The jq rules being pinned:
+Each test pins a coded decision in the semantic deep-union-merge contract for
+``(SETTINGS_JSON, *)`` collisions:
 
 - dict + dict at a shared key -> recurse (deep merge);
-- array + array at a shared key -> concatenate, jq-``unique`` (sort by jq's
-  total order, then dedupe by value);
+- array + array at a shared key -> concatenate, dedupe by value, keep
+  first-seen order;
 - scalar conflict at a shared key -> KEEP EXISTING;
 - type mismatch at a shared key (dict-vs-scalar, array-vs-scalar, etc.)
   -> KEEP EXISTING;
 - key only in incoming -> ADD it; key only in existing -> keep it;
 - top-level non-object operand -> the result is ``existing`` whole;
-- the empty-object quirk: merging two objects whose key-merge yields no
-  keys produces JSON ``null`` (jq ``[] | add == null``);
-- output bytes are canonical ``jq .`` formatting: 2-space indent, single
-  trailing newline, and key order that matches ``jq .`` (which does NOT
-  sort) — the deep-merge skeleton it CONSTRUCTS is sorted, but objects it
-  PASSES THROUGH verbatim keep insertion order;
+- two empty objects merge to ``{}`` (not null);
+- output bytes are canonical JSON: 2-space indent, keys sorted, single
+  trailing newline;
 - the synthesised item takes provenance + source_path from incoming and
   preserves the shared key fields.
-
-jq total order pinned in the array-union tests:
-``null < false < true < number < string < array < object``.
 
 Tests that would only verify Python/stdlib semantics (``json.loads`` round
 trips, frozen-dataclass immutability) are deliberately absent.
@@ -145,86 +134,61 @@ def test_deeply_nested_dicts_recurse() -> None:
     assert result == {"a": {"b": {"c": 1, "keep": "old", "add": "new"}}}
 
 
-# --- array union rule (concatenate + jq unique) ---------------------------
+# --- array union rule (concatenate + dedupe, first-seen order) ------------
 
 
-def test_scalar_arrays_union_sort_and_dedupe() -> None:
-    """Conflicting scalar arrays concatenate, then jq-``unique`` sorts
-    ascending and removes duplicates."""
-    assert _merge({"arr": [3, 1, 2]}, {"arr": [2, 4, 1]}) == {"arr": [1, 2, 3, 4]}
+def test_scalar_arrays_union_dedupe_first_seen_order() -> None:
+    """Conflicting scalar arrays concatenate, then dedupe by value while
+    preserving first-seen order (NOT sorted)."""
+    assert _merge({"arr": [3, 1, 2]}, {"arr": [2, 4, 1]}) == {"arr": [3, 1, 2, 4]}
 
 
 def test_array_union_dedupes_within_a_single_side() -> None:
-    """jq-``unique`` collapses duplicates that already exist within one side
-    as well as across sides."""
+    """Dedupe collapses duplicates that already exist within one side as well
+    as across sides."""
     assert _merge({"x": [1, 1, 2, 2]}, {"x": [2, 3, 3]}) == {"x": [1, 2, 3]}
 
 
 def test_array_union_dedupes_int_and_float_with_same_value() -> None:
-    """jq treats 1 and 1.0 as the same number, so they dedupe to one."""
+    """Python ``==`` treats 1 and 1.0 as equal, so they dedupe to one — and
+    first-seen wins, so the int ``1`` survives."""
     assert _merge({"x": [1]}, {"x": [1.0, 2]}) == {"x": [1, 2]}
 
 
-def test_array_union_handles_int_too_large_for_float() -> None:
-    """A 400-digit integer is valid JSON but overflows ``float()``; the jq
-    sort key falls back to +inf for ordering, so the union neither crashes nor
-    loses the value — the exact integer survives in the merged output."""
-    huge = 10**400
-    assert _merge({"x": [huge]}, {"x": [1]}) == {"x": [1, huge]}
+def test_array_union_collapses_bool_and_int_accepted_edge() -> None:
+    """``==`` dedupe collapses True/1 (and False/0) across the bool/number
+    boundary — first-seen wins. Accepted: settings arrays never mix bare
+    booleans with bare numbers, so there is no live data-loss path. Pinned so a
+    future change to dedupe semantics must confront the trade-off."""
+    assert _merge({"x": [1]}, {"x": [True, 2]}) == {"x": [1, 2]}
+    assert _merge({"x": [False]}, {"x": [0, 3]}) == {"x": [False, 3]}
 
 
-def test_array_union_handles_negative_int_too_large_for_float() -> None:
-    """The negative mirror of the overflow guard: a hugely negative integer
-    overflows ``float()`` too; the jq sort key falls back to -inf, so it sorts
-    BELOW every finite number while the exact integer survives — order
-    ``[huge_neg, 1]`` distinguishes the -inf branch from the +inf one."""
-    huge_neg = -(10**400)
-    assert _merge({"x": [huge_neg]}, {"x": [1]}) == {"x": [huge_neg, 1]}
-
-
-def test_array_union_keeps_distinct_overflow_ints_sharing_a_sort_key() -> None:
-    """Two distinct ints that both overflow ``float()`` share the same +inf
-    sort key, but they are different full-precision integers that ``json.dumps``
-    preserves. Dedupe must break the sort-key tie by Python value equality so
-    neither is dropped — otherwise the second would be silently lost."""
-    assert _merge({"x": [10**400, 10**401]}, {"x": []}) == {"x": [10**400, 10**401]}
-
-
-def test_array_union_jq_total_order_across_types() -> None:
-    """jq's total order ranks types null < false < true < number < string
-    < array < object; ``unique`` sorts the unioned array by that order."""
+def test_array_union_mixed_types_keep_first_seen_order() -> None:
+    """A mixed-type array concatenates and dedupes by value, keeping
+    first-seen order — no type-rank sorting."""
     result = _merge(
         {"x": [3, "b", True, None]},
         {"x": ["a", False, 2]},
     )
-    assert result == {"x": [None, False, True, 2, 3, "a", "b"]}
+    assert result == {"x": [3, "b", True, None, "a", False, 2]}
 
 
-def test_array_union_of_objects_sorts_by_keys_then_values() -> None:
-    """Arrays of objects union + dedupe; jq orders objects by sorted-key
-    array first, then by values in key order."""
+def test_array_union_of_objects_dedupe_first_seen() -> None:
+    """Arrays of objects concatenate and dedupe by value (==) — unhashable
+    dict elements are compared structurally — keeping first-seen order."""
     result = _merge(
         {"perms": [{"k": "v2"}, {"k": "v1"}]},
         {"perms": [{"k": "v1"}, {"k": "v3"}]},
     )
-    assert result == {"perms": [{"k": "v1"}, {"k": "v2"}, {"k": "v3"}]}
+    assert result == {"perms": [{"k": "v2"}, {"k": "v1"}, {"k": "v3"}]}
 
 
-def test_array_union_object_keyset_tiebreak() -> None:
-    """jq object order compares the sorted key-set first: {"a":2} precedes
-    {"a":1,"b":2} (key-set ["a"] < ["a","b"]) which precedes {"b":1}."""
-    result = _merge(
-        {"x": [{"a": 1, "b": 2}, {"a": 2}]},
-        {"x": [{"b": 1}, {"a": 1}]},
-    )
-    assert result == {"x": [{"a": 1}, {"a": 2}, {"a": 1, "b": 2}, {"b": 1}]}
-
-
-def test_array_union_of_nested_arrays_lexicographic_order() -> None:
-    """Nested arrays sort element-wise with a length tiebreak (prefix is
-    less), matching jq's recursive array comparison."""
+def test_array_union_of_nested_arrays_dedupe_first_seen() -> None:
+    """Nested arrays concatenate and dedupe by value (unhashable list elements
+    compared structurally), keeping first-seen order."""
     result = _merge({"x": [[1, 2], [1]]}, {"x": [[1, 2], [1, 2, 0]]})
-    assert result == {"x": [[1], [1, 2], [1, 2, 0]]}
+    assert result == {"x": [[1, 2], [1], [1, 2, 0]]}
 
 
 # --- empty-container edges ------------------------------------------------
@@ -237,8 +201,8 @@ def test_empty_arrays_union_to_empty_array() -> None:
 
 def test_empty_array_unions_with_populated_array() -> None:
     """An empty array on one side contributes nothing; the other side's
-    elements survive, sorted and deduped."""
-    assert _merge({"x": []}, {"x": [2, 1]}) == {"x": [1, 2]}
+    elements survive in first-seen order."""
+    assert _merge({"x": []}, {"x": [2, 1]}) == {"x": [2, 1]}
 
 
 def test_disjoint_empty_containers_are_preserved() -> None:
@@ -248,19 +212,18 @@ def test_disjoint_empty_containers_are_preserved() -> None:
     assert result == {"a": {}, "b": [], "c": 1, "d": 2}
 
 
-def test_merging_two_empty_objects_yields_null_quirk() -> None:
-    """The jq quirk: deep-merging two objects whose key-merge yields no keys
-    runs ``[] | add`` which is null. Two empty top-level objects -> null."""
+def test_merging_two_empty_objects_yields_empty_object() -> None:
+    """Two empty objects merge to an empty object ``{}`` — the semantic
+    deep-merge does NOT reproduce jq's ``[] | add == null`` wart."""
     merged = JsonUnionStrategy().merge(_item({}), _item({}))
     assert merged.content is not None
-    assert json.loads(merged.content) is None
+    assert json.loads(merged.content) == {}
 
 
-def test_nested_two_empty_objects_yield_null_at_that_key() -> None:
-    """The empty-object quirk propagates through recursion: a key holding {}
-    on both sides recurses, the inner key-merge is empty, and the value
-    becomes null."""
-    assert _merge({"x": {}}, {"x": {}}) == {"x": None}
+def test_nested_two_empty_objects_yield_empty_object_at_that_key() -> None:
+    """A key holding {} on both sides recurses to an empty object, not null —
+    the wart does not propagate through recursion either."""
+    assert _merge({"x": {}}, {"x": {}}) == {"x": {}}
 
 
 # --- top-level type-mismatch rule -----------------------------------------
@@ -282,21 +245,19 @@ def test_top_level_existing_array_incoming_object_keeps_existing_array() -> None
     assert json.loads(merged.content) == [1, 2, 3]
 
 
-# --- output formatting (jq-parity bytes) ----------------------------------
+# --- output formatting (canonical sorted JSON bytes) ----------------------
 
 
 def test_output_is_two_space_indented_with_sorted_keys_and_trailing_newline() -> None:
-    """Merged bytes match canonical jq formatting: 2-space indent, exactly one
-    trailing newline, and — for keys the deep-merge constructs (as here, where
-    every key comes from both operands) — sorted order. The serializer itself
-    uses ``sort_keys=False``; sorting comes from skeleton construction, so
-    passthrough objects keep insertion order (pinned separately below)."""
+    """Merged bytes are canonical JSON: 2-space indent, keys sorted
+    (``sort_keys=True``), exactly one trailing newline."""
     merged = JsonUnionStrategy().merge(_item({"b": 1, "a": 2}), _item({"c": 3}))
     assert merged.content == b'{\n  "a": 2,\n  "b": 1,\n  "c": 3\n}\n'
 
 
 def test_output_keys_sorted_codepoint_order_digits_upper_lower() -> None:
-    """jq key order is Unicode codepoint: digits < uppercase < lowercase."""
+    """``sort_keys=True`` orders keys by Unicode codepoint: digits < uppercase
+    < lowercase."""
     merged = JsonUnionStrategy().merge(_item({"B": 1, "a": 2, "10": 3, "2": 4}), _item({"A": 5}))
     assert merged.content is not None
     text = merged.content.decode("utf-8")
@@ -306,48 +267,42 @@ def test_output_keys_sorted_codepoint_order_digits_upper_lower() -> None:
     assert text.index('"A"') < text.index('"B"') < text.index('"a"')
 
 
-# --- passthrough key-order rule (jq `.` preserves insertion order) --------
+# --- output key order (all objects serialised sorted) ---------------------
 #
-# These pin the distinction `jq .` makes between objects the deep-merge
-# skeleton CONSTRUCTS (via `keys | unique`, which jq sorts) and objects it
-# PASSES THROUGH verbatim (which keep their original insertion order). All
-# expectations were probed against the real jq-1.8.1 deep_merge program from
-# scripts/install.sh:431-454.
+# The semantic merge serialises with ``sort_keys=True``, so EVERY object —
+# whether constructed by the deep-merge or carried through from one side —
+# comes out with keys sorted. There is no insertion-order passthrough special
+# case.
 
 
-def test_one_side_only_nested_object_keeps_insertion_key_order() -> None:
-    """A key present on only ONE side whose value is an object is passed
-    through verbatim by jq (branch ``{($k): $a[$k]}`` — no recursion), so its
-    nested keys keep INSERTION order, not sorted order. jq emits ``env`` as
-    ``Z, A, M``; sorted would be ``A, M, Z``."""
+def test_one_side_only_nested_object_is_sorted() -> None:
+    """A nested object present on only ONE side is serialised with sorted keys
+    like every other object — there is no passthrough/insertion-order special
+    case. ``env`` keys come out ``A, M, Z``."""
     merged = JsonUnionStrategy().merge(
         _item({"env": {"Z": 1, "A": 2, "M": 3}}),
         _item({"other": 1}),
     )
     assert merged.content is not None
     text = merged.content.decode("utf-8")
-    assert text.index('"Z"') < text.index('"A"') < text.index('"M"')
+    assert text.index('"A"') < text.index('"M"') < text.index('"Z"')
 
 
-def test_object_inside_array_keeps_insertion_key_order() -> None:
-    """An object nested inside an array goes through ``union_arrays`` and is
-    never re-serialised key-by-key, so jq keeps its insertion order. jq emits
-    ``{z, a}``; sorted would be ``{a, z}``."""
+def test_object_inside_array_is_sorted() -> None:
+    """An object nested inside an array is serialised with sorted keys too —
+    ``sort_keys=True`` applies recursively, so ``{z, a}`` comes out ``{a, z}``."""
     merged = JsonUnionStrategy().merge(
         _item({"arr": [{"z": 1, "a": 2}]}),
         _item({"other": 1}),
     )
     assert merged.content is not None
     text = merged.content.decode("utf-8")
-    assert text.index('"z"') < text.index('"a"')
+    assert text.index('"a"') < text.index('"z"')
 
 
-def test_deep_merge_skeleton_keys_stay_sorted_at_every_level() -> None:
-    """The object the deep-merge skeleton CONSTRUCTS (keys merged on both
-    sides, via jq ``keys | unique``) is sorted by jq at every recursion level
-    — including a nested object present on BOTH sides, which recurses. This
-    guards the fix from over-correcting passthrough order onto constructed
-    objects."""
+def test_deep_merge_keys_stay_sorted_at_every_level() -> None:
+    """``sort_keys=True`` applies at every recursion level: a nested object
+    merged on BOTH sides comes out sorted, as do the top-level keys."""
     merged = JsonUnionStrategy().merge(
         _item({"n": {"z": 1, "a": 2}, "shared": 1}),
         _item({"n": {"m": 3, "b": 4}, "extra": 2}),


### PR DESCRIPTION
## What

Bead `lnotj` — replace `JsonUnionStrategy`'s jq-output-byte reproduction machinery with a **semantic deep-merge**. The strategy combines two colliding `settings.json` payloads (a tool's + a plugin's). It previously reproduced jq's exact output bytes purely to satisfy a future byte-diff golden-master; this excises ~90 lines of that machinery.

Bundled with a one-field change to bead `w1qls.8.1` (Epic H golden-master) pinning its acceptance to **JSON-semantic comparison** — the decision that makes this safe.

## Why

JSON key order and whitespace are **not a behavioural contract** — every consumer parses the file. The Epic H golden-master (`w1qls.8.1`) now compares `.json` files semantically (parse + deep-equal), never byte-wise, so install.py's `json_union` no longer needs to mimic jq's byte layout. The design doc already blesses this: *"divergence is welcome — particularly when the Python fixes latent install.sh bugs."*

## Changes

**Behavioural divergences (all intentional, each TDD'd RED→GREEN):**
- **Arrays** → concatenate + dedupe by value, **first-seen order** (was: jq total-order sort). `_jq_sort_key` + rank constants + float-overflow handling deleted.
- **Empty-object merge** → yields `{}` (was: `null` — a deliberately-reproduced jq `[] | add == null` wart, now **fixed**).
- **Output** → `json.dumps(sort_keys=True)` (was: `sort_keys=False` + a fragile sorted-skeleton-vs-passthrough invariant). All objects serialise sorted, recursively.

**Unchanged merge rules** (verified preserved): dict+dict recurse; scalar conflict keeps existing; type mismatch keeps existing; key-only-one-side carried through; top-level non-object → existing whole; `CollisionError` on `None`/unparseable input.

## Tests

- **4 tautology tests deleted** — they pinned jq's internal sort machine (two `int_too_large_for_float`, `keeps_distinct_overflow_ints`, `object_keyset_tiebreak`). Once arrays preserve first-seen order there is no sort key, so they tested deleted code, not surviving logic. Mechanically porting them would have re-pinned nothing.
- **Rewrites** pin the new contract (first-seen dedupe, mixed-type order, empty-object→`{}` at top and nested levels, recursive sorted output).
- **New** `test_array_union_collapses_bool_and_int_accepted_edge` documents + locks the accepted `True`/`1` `==`-dedupe collapse (no live path: settings arrays hold only strings or only dicts).
- Suite: **33 tests** on this file (100% line + branch coverage).

## Out of scope (by design)

- The Epic H golden-master harness itself (`w1qls.8.1`) — this PR pins its **comparison semantics** but does not build it.
- Broader `json_union` doc cleanup — owned by `w1qls.8.5`.

## Verification

`make ci-installer` green: ruff + `ruff format --check` + **mypy --strict** + **496 passed** + **99.78% branch coverage** (`json_union.py` 100%) + pip-audit clean + `install.py --help` entry-verify.

**Net −152 lines.** In-house `quality-reviewer` (opus) verdict: "Clean. Ship it." (0 HIGH/MEDIUM; 2 LOW both addressed in-PR). `simplify`: none warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
