### PR TITLE
feat(prgroom): run-loop keystone — run/wait verbs + flush hooks (8.10)

### DIFF
--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -50,6 +50,7 @@ from prgroom.lifecycle import (
 )
 from prgroom.lifecycle.human_review import derive_human_review, fetch_human_review_inputs
 from prgroom.lifecycle.locking import with_lock
+from prgroom.lifecycle.run import Mode, run_lifecycle, wait_lifecycle
 from prgroom.lifecycle.status import build_status
 from prgroom.proc import SubprocessRunner
 from prgroom.prsession.pr_ref import PRRef
@@ -466,9 +467,30 @@ def resolve_escalated(
 
 
 @app.command()
-def wait(pr: str = typer.Argument(..., help="PR ref.")) -> None:
-    """Sleep/poll until SHA changes or quiescence threshold trips."""
-    _skeleton("wait")
+def wait(
+    ctx: typer.Context,
+    pr: str = typer.Argument(..., help="PR ref: owner/repo#n or a full PR URL."),
+) -> None:
+    """Block until the PR's phase moves, quiescence trips, or a signal cancels (§4.2).
+
+    The locking wrapper around ``_wait``: acquires the PR lock once and holds it for
+    the whole blocking poll (no mid-sleep release). Installs SIGINT/SIGTERM handlers so
+    a Ctrl-C / scheduler stop exits 130 / 143 cleanly (never the scheduler-retry 75).
+    Preconditions (§3.2): ``fixes-pending`` → ``PRECONDITION_WAIT_NOT_APPLICABLE`` (exit
+    2, it has actionable work); ``merged`` → no-op; a never-polled PR →
+    ``PRECONDITION_NO_STATE`` (exit 2). The §4.3 cadence knobs (``poll_interval`` /
+    ``idle_threshold`` / reviewer timeouts) resolve from env / ``.prgroom.toml``.
+    """
+    store: Store = ctx.obj
+    try:
+        ref = PRRef.parse(pr)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
+    code = wait_lifecycle(
+        store=store, ref=ref, gh=_build_gh(), deps=Deps.system(), config=PrgroomConfig.load()
+    )
+    if code != 0:
+        raise typer.Exit(code=code)
 
 
 @app.command()
@@ -523,9 +545,58 @@ def status(
 
 
 @app.command()
-def run(pr: str = typer.Argument(..., help="PR ref.")) -> None:
-    """Aggregate: orchestrate the verbs in sequence until quiescent or capped."""
-    _skeleton("run")
+def run(
+    ctx: typer.Context,
+    pr: str = typer.Argument(..., help="PR ref: owner/repo#n or a full PR URL."),
+    interactive: bool = typer.Option(
+        False,
+        "--interactive/--autonomous",
+        help="Interactive returns at awaiting-review/idle (caller owns the wait); "
+        "autonomous (default) blocks through the wait until quiescent or capped.",
+    ),
+    max_rounds: int | None = typer.Option(
+        None, "--max-rounds", help="Hard cap on review-eliciting pushes (§3.5; default 3)."
+    ),
+    no_prework: bool = typer.Option(
+        False,
+        "--no-prework",
+        help="Accepted for parity with the per-verb flag; the run aggregate always "
+        "orchestrates its own prework (§3.2), so this has no effect here.",
+    ),
+) -> None:
+    """Aggregate: orchestrate the verbs under one lock until quiescent or capped (§3.3).
+
+    Acquires the PR lock once and threads ``_poll → _cluster → _fix → [cap] → _push →
+    [_rereview] → _reply → _resolve`` per cycle, blocking in ``_wait`` between cycles
+    (autonomous) until the phase reaches ``quiesced`` / ``human-gated`` / ``merged``,
+    then flushes terminal signals and releases. A concurrent run on the same PR exits
+    75. Exit code is the propagated tier's sysexits value (0 on a clean terminal). The
+    §4.3 cadence knobs resolve from env / ``.prgroom.toml``.
+    """
+    del no_prework  # parity-only; the aggregate always orchestrates its own prework
+    store: Store = ctx.obj
+    try:
+        ref = PRRef.parse(pr)
+    except PrgroomError as err:
+        raise typer.Exit(code=handle_cli_error(err)) from err
+    cluster_dispatcher, cluster_decided_by = _build_cluster_dispatcher()
+    fix_dispatcher, fix_decided_by = _build_fix_dispatcher()
+    code = run_lifecycle(
+        store=store,
+        ref=ref,
+        gh=_build_gh(),
+        git=_build_git(),
+        deps=Deps.system(),
+        config=PrgroomConfig.load(max_rounds_flag=max_rounds),
+        sink=_build_sink(),
+        mode=Mode.INTERACTIVE if interactive else Mode.AUTONOMOUS,
+        cluster_dispatcher=cluster_dispatcher,
+        cluster_decided_by=cluster_decided_by,
+        fix_dispatcher=fix_dispatcher,
+        fix_decided_by=fix_decided_by,
+    )
+    if code != 0:
+        raise typer.Exit(code=code)
 
 
 @app.command()

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -75,6 +75,8 @@ class GhClient(Protocol):
 
     def graphql(self, query: str, variables: JsonObj) -> JsonObj: ...  # pragma: no cover
 
+    def add_label(self, ref: PRRef, label: str) -> None: ...  # pragma: no cover
+
 
 def _classify_gh_failure(stdout: str, stderr: str) -> PrgroomError | GhNotFoundError:
     """Map a failed ``gh`` invocation to its registry error (§3.6/§3.7)."""
@@ -173,6 +175,18 @@ class GhCli:
             )
         data: JsonObj = envelope.get("data") or {}
         return data
+
+    def add_label(self, ref: PRRef, label: str) -> None:
+        # POST to the issue's labels collection with gh's array placeholder syntax
+        # (`labels[]=<name>`). The server treats a label already present as a no-op,
+        # so this is idempotent — §4.7's auto-add re-issues it safely every gating
+        # event. Routed through `rest` so a failure arrives as the registry-tagged
+        # PrgroomError the §4.7 hook swallows (best-effort label add).
+        self.rest(
+            "POST",
+            f"repos/{ref.owner}/{ref.repo}/issues/{ref.number}/labels",
+            fields={"labels[]": label},
+        )
 
     def _run(self, argv: list[str]) -> str:
         try:

--- a/packages/prgroom/src/prgroom/lifecycle/escalation.py
+++ b/packages/prgroom/src/prgroom/lifecycle/escalation.py
@@ -1,0 +1,166 @@
+"""Terminal-signal flush hooks for the run-loop (§3.3, §4.7).
+
+The run-loop emits its terminal signals through two parallel best-effort hooks,
+fired at exactly two dedup-safe sites (the loop-top terminal-for-CLI check and
+immediately before each ``PROPAGATE`` re-raise):
+
+- :func:`escalate_if_needed` — files one :class:`~prgroom.escalation.Sink` event per
+  un-filed ESCALATED/FAILED item plus one lifecycle-tier event for a set
+  ``last_error``, deduped by the per-item ``escalation_filed`` flag and the lifecycle
+  ``lifecycle_escalation_filed`` flag.
+- :func:`request_human_review_if_needed` — adds the GitHub ``human-review-required``
+  label once per gating event (§4.7), deduped by ``human_review_label_added``, and
+  ONLY for review-content gates (cap-trip, ESCALATED/FAILED items) — never for infra
+  gates (auth expiry, state corruption, push rejection).
+
+Both are idempotent and best-effort: a dedup flag is set ONLY after a successful
+emit, and the state is persisted right after, so a failed emit leaves the flag unset
+and the next pass retries — lifecycle progression never blocks on Sink/label
+reachability. A crash between emit and write may double-fire on the next invocation,
+absorbed by the Sink's own idempotency (``gh.add_label`` is server-idempotent; a
+stderr sink accepts one extra log line). This module is git-free and writes state
+through the injected :class:`~prgroom.prsession.store.Store`.
+
+This is the **lifecycle** escalation surface; the top-level
+:mod:`prgroom.escalation` owns the :class:`~prgroom.escalation.Sink` protocol and its
+stderr/file adapters, which this module routes through.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+from prgroom.errors import ErrorCode
+from prgroom.escalation import Escalation, Severity
+from prgroom.lifecycle.quiescence import BLOCKER_DISPOSITIONS
+from prgroom.lifecycle.warn import default_warn
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from prgroom.escalation import Sink
+    from prgroom.gh.client import GhClient
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState
+    from prgroom.prsession.store import Store
+
+# §4.7 literal label string — the GitHub-visible "automation gave up here" marker.
+HUMAN_REVIEW_LABEL = "human-review-required"
+
+
+def escalate_if_needed(
+    state: PRGroomingState,
+    *,
+    sink: Sink,
+    store: Store,
+    ref: PRRef,
+    warn: Callable[[str], None] = default_warn,
+) -> PRGroomingState:
+    """File one Sink event per un-filed blocker item + one per lifecycle gate (§3.3).
+
+    Walks ``state.items`` for ESCALATED/FAILED dispositions whose ``escalation_filed``
+    is still ``False``, and fires one lifecycle-tier event when ``last_error`` is set
+    and ``lifecycle_escalation_filed`` is still ``False``. Each dedup flag is set only
+    after its emit succeeds; a raising Sink is swallowed (best-effort) AND logged via
+    ``warn`` so a persistently-failing Sink is observable rather than silent, leaving
+    the flag unset for the next pass. Persists once if anything changed. Mutates and
+    returns ``state``.
+    """
+    changed = False
+    for item in state.items:
+        disp = item.disposition
+        if disp is None or disp.kind not in BLOCKER_DISPOSITIONS or disp.escalation_filed:
+            continue
+        emitted = _emit(
+            sink,
+            Escalation(
+                pr=ref,
+                reason=f"item {item.identity.gh_id} dispositioned {disp.kind.value}",
+                severity=Severity.BLOCK,
+                item=item,
+            ),
+            warn,
+        )
+        if emitted:
+            item.disposition = dataclasses.replace(disp, escalation_filed=True)
+            changed = True
+
+    if state.last_error is not None and not state.lifecycle_escalation_filed:
+        emitted = _emit(
+            sink,
+            Escalation(
+                pr=ref, reason=f"lifecycle gate: {state.last_error}", severity=Severity.BLOCK
+            ),
+            warn,
+        )
+        if emitted:
+            state.lifecycle_escalation_filed = True
+            changed = True
+
+    if changed:
+        store.write(ref, state)
+    return state
+
+
+def _emit(sink: Sink, escalation: Escalation, warn: Callable[[str], None]) -> bool:
+    """Emit ``escalation``; return whether it succeeded, swallowing any Sink error (§3.3).
+
+    A failed emit (stderr write error, bd-adapter blip) returns ``False`` so the caller
+    leaves the dedup flag unset and the next pass retries — best-effort, never blocking
+    lifecycle progression. The swallowed failure is logged via ``warn`` (symmetric with
+    the §4.7 label-add hook) so a persistently-unreachable Sink surfaces in stderr
+    instead of failing silently.
+    """
+    try:
+        sink.emit(escalation)
+    except Exception as exc:
+        warn(f"escalation sink emit failed: {exc}")
+        return False
+    return True
+
+
+def should_request_human_review(state: PRGroomingState) -> bool:
+    """True iff a review-content gate is active (§4.7): cap-trip or an ESCALATED/FAILED item.
+
+    Deliberately narrower than :func:`escalate_if_needed`'s lifecycle trigger: only the
+    hard-cap ``last_error`` counts here. Infra gates (``RUNTIME_TERMINAL_USER``,
+    ``STATE_CORRUPT``, ``RUNTIME_PUSH_REJECTED``, …) are §4.7 non-triggers — they are
+    operator-infra problems, not review-content problems, so they never add the label.
+    """
+    if state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value:
+        return True
+    return any(
+        item.disposition is not None and item.disposition.kind in BLOCKER_DISPOSITIONS
+        for item in state.items
+    )
+
+
+def request_human_review_if_needed(
+    state: PRGroomingState,
+    *,
+    gh: GhClient,
+    store: Store,
+    ref: PRRef,
+    auto_request: bool,
+    warn: Callable[[str], None] = default_warn,
+) -> PRGroomingState:
+    """Add the ``human-review-required`` label once per gating event (§4.7).
+
+    Short-circuits when auto-request is off, no review-content gate is active, or the
+    label was already added this gating event (which preserves an operator's deliberate
+    label removal — the flag stays ``True`` until the §3.3 reset-on-success path clears
+    it). Best-effort: a failed ``gh.add_label`` is logged via ``warn`` and leaves
+    ``human_review_label_added`` unset so the next pass retries; it never tier-tags,
+    blocks, or propagates. Mutates and returns ``state``.
+    """
+    if not auto_request or not should_request_human_review(state) or state.human_review_label_added:
+        return state
+    try:
+        gh.add_label(ref, HUMAN_REVIEW_LABEL)
+    except Exception as exc:
+        warn(f"failed to add {HUMAN_REVIEW_LABEL} label: {exc}")
+        return state
+    state.human_review_label_added = True
+    store.write(ref, state)
+    return state

--- a/packages/prgroom/src/prgroom/lifecycle/push.py
+++ b/packages/prgroom/src/prgroom/lifecycle/push.py
@@ -57,10 +57,17 @@ def has_queued_fix_commits(gh: GhClient, git: GitClient, ref: PRRef) -> bool:
     field): it reads the authoritative remote HEAD via ``gh.head_ref_oid`` and lists
     local commits ahead of it with ``git.rev_list``. Shared by :func:`push_pr` (its
     no-op guard) and the run-loop's §3.5 pre-push cap check, so the cap decision and
-    the push agree on exactly what "queued" means. May raise the gh adapter's tagged
-    error (or :class:`~prgroom.gh.client.GhNotFoundError`) — callers handle it.
+    the push agree on exactly what "queued" means. A 404 (vanished PR/repo) is mapped
+    to a terminal :class:`~prgroom.errors.PrgroomError` here — never re-raised as a raw
+    :class:`~prgroom.gh.client.GhNotFoundError` — so every caller (including the
+    run-loop's ``_execute_step``, which only catches ``PrgroomError``) handles it
+    through the tagged-error path rather than a stray traceback. Other gh/git failures
+    already arrive as the adapter's registry-tagged ``PrgroomError``.
     """
-    remote_head = gh.head_ref_oid(ref)
+    try:
+        remote_head = gh.head_ref_oid(ref)
+    except GhNotFoundError as exc:
+        raise vanished_pr_terminal(ref) from exc
     return bool(git.rev_list(f"{remote_head}..HEAD"))
 
 

--- a/packages/prgroom/src/prgroom/lifecycle/push.py
+++ b/packages/prgroom/src/prgroom/lifecycle/push.py
@@ -50,6 +50,20 @@ if TYPE_CHECKING:
 _REMOTE = "origin"
 
 
+def has_queued_fix_commits(gh: GhClient, git: GitClient, ref: PRRef) -> bool:
+    """True iff the local PR-branch HEAD has ≥1 commit not yet on the remote (§3.4).
+
+    The remote tip is the source of truth for the commit queue (§3.4 forbids a state
+    field): it reads the authoritative remote HEAD via ``gh.head_ref_oid`` and lists
+    local commits ahead of it with ``git.rev_list``. Shared by :func:`push_pr` (its
+    no-op guard) and the run-loop's §3.5 pre-push cap check, so the cap decision and
+    the push agree on exactly what "queued" means. May raise the gh adapter's tagged
+    error (or :class:`~prgroom.gh.client.GhNotFoundError`) — callers handle it.
+    """
+    remote_head = gh.head_ref_oid(ref)
+    return bool(git.rev_list(f"{remote_head}..HEAD"))
+
+
 def push_pr(
     state: PRGroomingState,
     *,
@@ -81,9 +95,7 @@ def push_pr(
                 detail=f"worktree on '{current}', expected PR head branch '{branch}'",
             )
 
-        remote_head = gh.head_ref_oid(ref)
-        queued = git.rev_list(f"{remote_head}..HEAD")
-        if not queued:
+        if not has_queued_fix_commits(gh, git, ref):
             return state  # nothing queued — idempotent no-op (§3.4)
 
         git.push(_REMOTE, f"HEAD:{branch}")

--- a/packages/prgroom/src/prgroom/lifecycle/reply.py
+++ b/packages/prgroom/src/prgroom/lifecycle/reply.py
@@ -1,0 +1,29 @@
+"""``reply_pr`` — the foundation no-op skeleton for the ``reply`` verb (§3.3).
+
+The run-loop wires the §3.3 pipeline against a **no-op skeleton** of ``_reply`` (the
+pipeline-slotting pin): it occupies the ``_push → _rereview → _reply → _resolve`` slot
+so the loop's ordering and write discipline are exercised end-to-end, but renders and
+posts nothing. The full template-matrix reply (rendering per-item responses and
+posting them via the gh API) lands in the deterministic-verbs bead.
+
+Keeping it a real, idempotent passthrough — rather than omitting the slot — means the
+run-loop's pipeline list and its per-step write discipline need no change when the
+real ``reply`` arrives; only this body is filled in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from prgroom.prsession.state import PRGroomingState
+
+
+def reply_pr(state: PRGroomingState) -> PRGroomingState:
+    """No-op skeleton: return ``state`` unchanged (§3.3 pipeline-slotting pin).
+
+    Caller must hold the per-ref lock (see ``lock()``). Idempotent by construction —
+    every item is left exactly as received, so the run-loop's ``_reply`` slot is a
+    safe passthrough until the deterministic-verbs bead fills it in.
+    """
+    return state

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -501,12 +501,16 @@ def _entry_probe(ctx: RunContext, verbs: Verbs) -> None:
     if ctx.state.phase not in {PRPhase.QUIESCED, PRPhase.HUMAN_GATED}:
         return
     _execute_step(VerbStep("poll", verbs.poll), ctx)
-    # `round >= max_rounds` is checked first so a raised cap short-circuits the gh read.
-    cap_still_trips = ctx.state.round >= ctx.config.max_rounds and verbs.has_queued(ctx)
+    # Probe the cap ONLY when the poll left us still hard-cap-gated. A poll that moved
+    # the PR out of human-gated (external merge, operator fix-push) must NOT trigger the
+    # effectful has_queued gh/git read — it is wasted there and a transient failure would
+    # turn an otherwise-clean terminal run into an error. The phase + cap-error checks
+    # short-circuit before the read; within them, `round >= max_rounds` is checked first
+    # so a raised --max-rounds also short-circuits the read.
     if (
         ctx.state.phase is PRPhase.HUMAN_GATED
         and ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
-        and not cap_still_trips
+        and not (ctx.state.round >= ctx.config.max_rounds and verbs.has_queued(ctx))
     ):
         ctx.state.phase = PRPhase.FIXES_PENDING
         ctx.state.last_error = None

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -381,13 +381,16 @@ def _run(ctx: RunContext, verbs: Verbs) -> PRGroomingState:
         # === FIXES_PENDING: the ordered pipeline ===
         ctx.cycle_start_pushed_sha = ctx.state.last_pushed_head_sha
         ctx.cycle_start_error = ctx.state.last_error
-        capped = False
+        pipeline_terminated = False
         for step in pipeline:
             _execute_step(step, ctx)
             if is_terminal_for_cli(ctx.state.phase):
-                capped = True  # the pre-push cap guard gated this cycle
+                # A step set a terminal-for-CLI phase on a clean return (today only the
+                # pre-push cap guard does — verb errors gate via PROPAGATE, which
+                # re-raises out of the loop). Skip end-of-cycle resolution.
+                pipeline_terminated = True
                 break
-        if not capped:
+        if not pipeline_terminated:
             _resolve_end_of_cycle(ctx, verbs)
         # loop continues; the loop top handles the terminal phase + flush
 

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -497,9 +497,11 @@ def _entry_probe(ctx: RunContext, verbs: Verbs) -> None:
 
     From ``quiesced`` / ``human-gated`` run ``_poll`` once to detect an external merge
     or a manual fix-push that cleared the gate; then, if still hard-cap-gated and the
-    operator has raised ``--max-rounds`` so the cap no longer trips, clear the gate and
-    advance to ``fixes-pending`` for the refused commits to push under the raised cap. A
-    bare re-run with no raise leaves ``round >= max_rounds`` → the cap stays gated.
+    cap no longer trips, clear the gate and advance to ``fixes-pending`` for the refused
+    commits to push. The cap stays gated only while it still trips — ``round >=
+    max_rounds`` AND commits are still queued (the exact inverse of the §3.5 cap-trip).
+    So a bare re-run with the refused commits still queued stays gated, whereas raising
+    ``--max-rounds`` (round now below the cap) OR an emptied queue re-arms.
     """
     if ctx.state.phase not in {PRPhase.QUIESCED, PRPhase.HUMAN_GATED}:
         return

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -1,0 +1,584 @@
+"""``run`` — the aggregate verb that threads the lifecycle under one lock (§3.3).
+
+``run`` is the only verb that acquires the PR lock **once** and drives the lock-held
+internals in sequence (the §3.3 exception to the per-verb locking rule). It is
+long-running and blocking for non-terminal phases; when the phase reaches
+``quiesced`` / ``human-gated`` / ``merged`` it flushes terminal signals and returns,
+releasing the lock so external triggers can act.
+
+The §3.3 pseudocode is an 8x-repeated try/except. This implementation collapses that
+into a **single shared error site** — :func:`_execute_step` — through which every
+verb invocation funnels: it runs the verb, persists state (the per-internal write
+discipline, so a crash leaves the on-disk state at the last completed verb), and on a
+tagged error applies :func:`~prgroom.lifecycle.verb_error.handle_verb_error` and either
+proceeds (``CONTINUE``) or flushes the two terminal signals and re-raises
+(``PROPAGATE``). The cycle is modelled as an ordered ``list`` of :class:`VerbStep`s.
+
+The verbs are injected as a :class:`Verbs` bundle so the orchestration is unit-testable
+without gh/git — production wires :meth:`Verbs.system`; tests pass fakes. The two
+flush hooks (``escalate_if_needed`` + ``request_human_review_if_needed``) fire at
+exactly two dedup-safe sites: the loop-top terminal-for-CLI check, and immediately
+before each ``PROPAGATE`` re-raise.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+
+from prgroom.errors import ErrorCode, PreconditionError, PrgroomError, Tier, exit_code_for_tier
+from prgroom.lifecycle import is_graph_terminal, is_terminal_for_cli
+from prgroom.lifecycle.cluster import cluster_pr
+from prgroom.lifecycle.escalation import escalate_if_needed, request_human_review_if_needed
+from prgroom.lifecycle.fix import fix_pr
+from prgroom.lifecycle.locking import run_locked, with_lock
+from prgroom.lifecycle.poll import poll_pr
+from prgroom.lifecycle.predicates import (
+    has_required_reviewers_to_refresh,
+    new_lifecycle_gate_this_cycle,
+    push_uploaded_commits_this_cycle,
+)
+from prgroom.lifecycle.push import has_queued_fix_commits, push_pr
+from prgroom.lifecycle.quiescence import quiescence_predicate
+from prgroom.lifecycle.reply import reply_pr
+from prgroom.lifecycle.rereview import rereview_pr
+from prgroom.lifecycle.resolve import resolve_pr
+from prgroom.lifecycle.resolver import resolve_end_of_cycle_phase
+from prgroom.lifecycle.verb_error import VerbDisposition, handle_verb_error
+from prgroom.lifecycle.wait import SignalCancelToken, wait_pr
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.state import bootstrap_state
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError, StateNotFoundError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from types import FrameType
+
+    from prgroom.agent.contracts import ClusterContract, FixContract
+    from prgroom.config import PrgroomConfig
+    from prgroom.deps import Deps
+    from prgroom.escalation import Sink
+    from prgroom.gh.client import GhClient
+    from prgroom.git.client import GitClient
+    from prgroom.lifecycle.wait import CancelToken
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState
+    from prgroom.prsession.store import Store
+
+# Phases that drive into the §3.3 cycle (poll-first, then branch). Any other phase is
+# terminal-for-CLI (handled at loop top) — there is no separate "active" enum.
+_WAITING_PHASES: frozenset[PRPhase] = frozenset({PRPhase.IDLE, PRPhase.AWAITING_REVIEW})
+_IDLE_ADVISORY = "prgroom: nothing to do — PR has no commits yet (phase=idle)"
+
+
+class Mode(StrEnum):
+    """Whether ``run`` blocks on ``_wait`` (autonomous) or hands the wait back (interactive)."""
+
+    INTERACTIVE = "interactive"
+    AUTONOMOUS = "autonomous"
+
+
+@dataclass(slots=True)
+class RunContext:
+    """The mutable per-invocation context threaded through the run-loop.
+
+    ``state`` is reassigned by every step; ``cycle_start_pushed_sha`` / ``cycle_start_error``
+    are the per-cycle snapshots the §3.4 cycle-relative predicates read (the spec keeps
+    no stored "prior cycle" field — the loop captures them at cycle entry).
+    """
+
+    store: Store
+    ref: PRRef
+    gh: GhClient
+    git: GitClient
+    deps: Deps
+    config: PrgroomConfig
+    sink: Sink
+    mode: Mode
+    cancel: CancelToken
+    state: PRGroomingState
+    cycle_start_pushed_sha: str = ""
+    cycle_start_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VerbStep:
+    """One step in the run-loop pipeline: a named, optionally-guarded ctx→state call.
+
+    ``run`` mutates and returns ``ctx.state``; ``guard`` (when present) decides whether
+    the step runs at all this cycle (the post-push ``_rereview`` is the only guarded step).
+    """
+
+    name: str
+    run: Callable[[RunContext], PRGroomingState]
+    guard: Callable[[RunContext], bool] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Verbs:
+    """The injected lock-held internals the run-loop drives (§3.3).
+
+    Each is a ``ctx → state`` adapter over a lifecycle verb, except ``has_queued`` (the
+    effectful §3.5 cap read). Injected so the orchestration is testable with fakes;
+    :meth:`system` wires the production verbs.
+    """
+
+    poll: Callable[[RunContext], PRGroomingState]
+    cluster: Callable[[RunContext], PRGroomingState]
+    fix: Callable[[RunContext], PRGroomingState]
+    push: Callable[[RunContext], PRGroomingState]
+    rereview: Callable[[RunContext], PRGroomingState]
+    reply: Callable[[RunContext], PRGroomingState]
+    resolve: Callable[[RunContext], PRGroomingState]
+    wait: Callable[[RunContext], PRGroomingState]
+    has_queued: Callable[[RunContext], bool]
+
+    @classmethod
+    def system(
+        cls,
+        *,
+        cluster_dispatcher: ClusterContract,
+        cluster_decided_by: str,
+        fix_dispatcher: FixContract,
+        fix_decided_by: str,
+    ) -> Verbs:
+        """Wire the production verbs; cluster/fix capture their dispatchers + decided_by."""
+
+        def cluster(ctx: RunContext) -> PRGroomingState:
+            with TemporaryDirectory(prefix="prgroom-cluster-") as scratch:
+                return cluster_pr(
+                    ctx.state,
+                    ref=ctx.ref,
+                    gh=ctx.gh,
+                    git=ctx.git,
+                    deps=ctx.deps,
+                    config=ctx.config,
+                    dispatcher=cluster_dispatcher,
+                    decided_by=cluster_decided_by,
+                    scratch_dir=Path(scratch),
+                )
+
+        def fix(ctx: RunContext) -> PRGroomingState:
+            with TemporaryDirectory(prefix="prgroom-fix-") as scratch:
+                return fix_pr(
+                    ctx.state,
+                    ref=ctx.ref,
+                    gh=ctx.gh,
+                    git=ctx.git,
+                    deps=ctx.deps,
+                    config=ctx.config,
+                    dispatcher=fix_dispatcher,
+                    sink=ctx.sink,
+                    decided_by=fix_decided_by,
+                    scratch_dir=Path(scratch),
+                )
+
+        return cls(
+            poll=_poll,
+            cluster=cluster,
+            fix=fix,
+            push=_push,
+            rereview=_rereview,
+            reply=_reply,
+            resolve=_resolve,
+            wait=_wait,
+            has_queued=_has_queued,
+        )
+
+
+# ── production ctx → verb adapters (no dispatcher capture needed) ────────────
+
+
+def _poll(ctx: RunContext) -> PRGroomingState:
+    return poll_pr(ctx.state, ref=ctx.ref, gh=ctx.gh, deps=ctx.deps, config=ctx.config)
+
+
+def _push(ctx: RunContext) -> PRGroomingState:
+    return push_pr(ctx.state, ref=ctx.ref, gh=ctx.gh, git=ctx.git, config=ctx.config)
+
+
+def _rereview(ctx: RunContext) -> PRGroomingState:
+    return rereview_pr(ctx.state, ref=ctx.ref, gh=ctx.gh, deps=ctx.deps)
+
+
+def _resolve(ctx: RunContext) -> PRGroomingState:
+    return resolve_pr(ctx.state, gh=ctx.gh)
+
+
+def _reply(ctx: RunContext) -> PRGroomingState:
+    return reply_pr(ctx.state)
+
+
+def _has_queued(ctx: RunContext) -> bool:
+    return has_queued_fix_commits(ctx.gh, ctx.git, ctx.ref)
+
+
+def _wait(ctx: RunContext) -> PRGroomingState:
+    return wait_pr(
+        ctx.state,
+        poll=lambda s: poll_pr(s, ref=ctx.ref, gh=ctx.gh, deps=ctx.deps, config=ctx.config),
+        store=ctx.store,
+        ref=ctx.ref,
+        cancel=ctx.cancel,
+        now=ctx.deps.clock.now,
+        poll_interval=ctx.config.poll_interval,
+        idle_threshold=ctx.config.idle_threshold,
+    )
+
+
+# ── the run-loop ────────────────────────────────────────────────────────────
+
+
+def run_lifecycle(
+    *,
+    store: Store,
+    ref: PRRef,
+    gh: GhClient,
+    git: GitClient,
+    deps: Deps,
+    config: PrgroomConfig,
+    sink: Sink,
+    mode: Mode,
+    cluster_dispatcher: ClusterContract,
+    cluster_decided_by: str,
+    fix_dispatcher: FixContract,
+    fix_decided_by: str,
+) -> int:
+    """Run the lifecycle under one lock; return the §3.3 exit code (the CLI entry).
+
+    Installs OS signal handlers (autonomous only — interactive leaves the default
+    Ctrl-C) wiring SIGINT/SIGTERM into the cancel token ``_wait`` honors, acquires the
+    PR lock once via ``run_locked``, and maps any tier-tagged error to its exit code.
+    A ``PRECONDITION_LOCK_HELD`` on acquire (concurrent run) maps to 75.
+    """
+    cancel = SignalCancelToken()
+    ctx = RunContext(
+        store=store,
+        ref=ref,
+        gh=gh,
+        git=git,
+        deps=deps,
+        config=config,
+        sink=sink,
+        mode=mode,
+        cancel=cancel,
+        state=bootstrap_state(ref, now=deps.clock.now()),  # placeholder; _run reads/bootstraps
+    )
+    verbs = Verbs.system(
+        cluster_dispatcher=cluster_dispatcher,
+        cluster_decided_by=cluster_decided_by,
+        fix_dispatcher=fix_dispatcher,
+        fix_decided_by=fix_decided_by,
+    )
+    handlers = _signal_handlers(cancel) if mode is Mode.AUTONOMOUS else nullcontext()
+    with handlers:
+        try:
+            run_locked(store, ref, lambda: _run(ctx, verbs))
+        except PrgroomError as err:
+            return _report(err)
+    return 0
+
+
+def _report(err: PrgroomError) -> int:
+    """Render the §1 what/why/how block to stderr and return the tier's exit code (§3.3).
+
+    ``run`` / ``wait`` own their terminal reporting (they catch the propagated tagged
+    error rather than letting it surface as a raw traceback), so the operator/agent
+    sees the structured failure and the documented sysexits code.
+    """
+    sys.stderr.write(err.render() + "\n")
+    return exit_code_for_tier(err)
+
+
+def wait_lifecycle(
+    *,
+    store: Store,
+    ref: PRRef,
+    gh: GhClient,
+    deps: Deps,
+    config: PrgroomConfig,
+) -> int:
+    """Run the standalone ``wait`` verb under one lock; return its §3.3 exit code.
+
+    Like ``run`` it installs SIGINT/SIGTERM handlers wiring the cancel token ``_wait``
+    honors (a cancelled wait exits 130/143, never the scheduler-retry 75) and acquires
+    the lock once. The §3.2 ``wait`` preconditions gate up front: ``fixes-pending`` has
+    actionable work (→ ``PRECONDITION_WAIT_NOT_APPLICABLE``, exit 2); ``merged`` is a
+    no-op; a never-polled PR → ``PRECONDITION_NO_STATE`` (exit 2).
+    """
+    cancel = SignalCancelToken()
+    with _signal_handlers(cancel):
+        try:
+            with_lock(store, ref, lambda: _wait_verb(store, ref, gh, deps, config, cancel))
+        except PrgroomError as err:
+            return _report(err)
+    return 0
+
+
+def _wait_verb(
+    store: Store,
+    ref: PRRef,
+    gh: GhClient,
+    deps: Deps,
+    config: PrgroomConfig,
+    cancel: SignalCancelToken,
+) -> PRGroomingState:
+    """Lock-held body of the ``wait`` verb: precondition-gate, then block in ``wait_pr``."""
+    try:
+        state = store.read(ref)
+    except StateNotFoundError as exc:
+        raise PreconditionError(ErrorCode.PRECONDITION_NO_STATE, detail=ref.display()) from exc
+    if state.phase is PRPhase.FIXES_PENDING:
+        raise PreconditionError(ErrorCode.PRECONDITION_WAIT_NOT_APPLICABLE, detail=ref.display())
+    if is_graph_terminal(state.phase):
+        return state  # merged is absorbing — nothing to wait on
+    return wait_pr(
+        state,
+        poll=lambda s: poll_pr(s, ref=ref, gh=gh, deps=deps, config=config),
+        store=store,
+        ref=ref,
+        cancel=cancel,
+        now=deps.clock.now,
+        poll_interval=config.poll_interval,
+        idle_threshold=config.idle_threshold,
+    )
+
+
+def _run(ctx: RunContext, verbs: Verbs) -> PRGroomingState:
+    """Drive the §3.3 cycle under the held lock. Caller must hold the per-ref lock."""
+    ctx.state = _read_or_bootstrap(ctx)
+    _entry_probe(ctx, verbs)
+    pipeline = _build_pipeline(verbs)
+
+    while True:
+        if is_terminal_for_cli(ctx.state.phase):  # loop-top flush site
+            _flush_terminal_signals(ctx)
+            return ctx.state
+
+        _execute_step(VerbStep("poll", verbs.poll), ctx)
+        if is_terminal_for_cli(ctx.state.phase):
+            continue  # loop top flushes + returns
+
+        if ctx.state.phase in _WAITING_PHASES:
+            if ctx.mode is Mode.INTERACTIVE:
+                if ctx.state.phase is PRPhase.IDLE:
+                    sys.stderr.write(_IDLE_ADVISORY + "\n")
+                return ctx.state  # interactive: the caller owns the wait
+            # Termination guarantee: the loop has no iteration cap (per §4.2 "no hard
+            # wait-timeout in MVP"); it relies on `_wait` BLOCKING and only returning on
+            # a phase move off `_WAITING_PHASES` or a quiescence trip (→ QUIESCED). A
+            # `_wait` that returned while still in a waiting phase would hot-loop — that
+            # is a `_wait` contract violation, not a condition the loop can recover from.
+            _execute_step(VerbStep("wait", verbs.wait), ctx)
+            continue
+
+        # === FIXES_PENDING: the ordered pipeline ===
+        ctx.cycle_start_pushed_sha = ctx.state.last_pushed_head_sha
+        ctx.cycle_start_error = ctx.state.last_error
+        capped = False
+        for step in pipeline:
+            _execute_step(step, ctx)
+            if is_terminal_for_cli(ctx.state.phase):
+                capped = True  # the pre-push cap guard gated this cycle
+                break
+        if not capped:
+            _resolve_end_of_cycle(ctx, verbs)
+        # loop continues; the loop top handles the terminal phase + flush
+
+
+def _build_pipeline(verbs: Verbs) -> list[VerbStep]:
+    """The ordered FIXES_PENDING pipeline (§3.3): cluster→fix→cap→push→[rereview]→reply→resolve."""
+    return [
+        VerbStep("cluster", verbs.cluster),
+        VerbStep("fix", verbs.fix),
+        VerbStep("cap-guard", _cap_guard_step(verbs)),
+        VerbStep("push", verbs.push),
+        VerbStep("rereview", verbs.rereview, guard=_rereview_guard),
+        VerbStep("reply", verbs.reply),
+        VerbStep("resolve", verbs.resolve),
+    ]
+
+
+def _cap_guard_step(verbs: Verbs) -> Callable[[RunContext], PRGroomingState]:
+    """Build the pre-push hard-cap guard (§3.5): refuse the cap-tripping push.
+
+    When commits are queued AND ``round >= max_rounds``, set ``human-gated`` +
+    ``LIFECYCLE_HARD_CAP_EXCEEDED`` and clear ``lifecycle_escalation_filed`` so the
+    loop-top flush fires exactly one Sink event; the push is then never reached. The
+    effectful ``has_queued`` read can raise (gh transient) — routed through the single
+    error site like any verb.
+    """
+
+    def cap_guard(ctx: RunContext) -> PRGroomingState:
+        if verbs.has_queued(ctx) and ctx.state.round >= ctx.config.max_rounds:
+            ctx.state.phase = PRPhase.HUMAN_GATED
+            ctx.state.last_error = ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+            ctx.state.lifecycle_escalation_filed = False
+        return ctx.state
+
+    return cap_guard
+
+
+def _rereview_guard(ctx: RunContext) -> bool:
+    """True iff this cycle's push uploaded commits AND a required reviewer needs refresh (§3.3)."""
+    return push_uploaded_commits_this_cycle(
+        ctx.state, cycle_start_pushed_sha=ctx.cycle_start_pushed_sha
+    ) and has_required_reviewers_to_refresh(ctx.state)
+
+
+def _execute_step(step: VerbStep, ctx: RunContext) -> None:
+    """Run one step through the single shared error site (§3.3).
+
+    Skips the step when its guard is unmet. On success, persists state (the
+    per-internal write discipline). On a tagged error, applies ``handle_verb_error``
+    (which mutates state in place — the verb's own work is discarded because it
+    raised), persists, then either proceeds (``CONTINUE``) or flushes the two terminal
+    signals and re-raises (``PROPAGATE``).
+    """
+    if step.guard is not None and not step.guard(ctx):
+        return
+    try:
+        ctx.state = step.run(ctx)
+        ctx.store.write(ctx.ref, ctx.state)
+    except PrgroomError as err:
+        disposition = handle_verb_error(err, ctx.state)
+        ctx.store.write(ctx.ref, ctx.state)
+        if disposition is VerbDisposition.PROPAGATE:
+            _flush_terminal_signals(ctx)  # pre-PROPAGATE flush site
+            raise
+
+
+def _flush_terminal_signals(ctx: RunContext) -> None:
+    """Fire both terminal-signal hooks (§3.3, §4.7); each is idempotent + best-effort."""
+    escalate_if_needed(ctx.state, sink=ctx.sink, store=ctx.store, ref=ctx.ref)
+    request_human_review_if_needed(
+        ctx.state,
+        gh=ctx.gh,
+        store=ctx.store,
+        ref=ctx.ref,
+        auto_request=ctx.config.auto_request_human_review,
+    )
+
+
+def _read_or_bootstrap(ctx: RunContext) -> PRGroomingState:
+    """Read the PR's state, bootstrapping a zero-value state on first contact (§3.3).
+
+    Auto-bootstrap is unconditional (absence is a discovery condition, not a
+    precondition failure). A corrupt/unknown-schema read maps to its STATE_* tier so
+    the run exits 78 rather than crashing with a raw ``ValueError``.
+    """
+    try:
+        return ctx.store.read(ctx.ref)
+    except StateNotFoundError:
+        state = bootstrap_state(ctx.ref, now=ctx.deps.clock.now())
+        ctx.store.write(ctx.ref, state)
+        return state
+    except SchemaUnknownError as exc:
+        raise PrgroomError(
+            tier=Tier.STATE_SCHEMA_UNKNOWN, code=ErrorCode.STATE_SCHEMA_UNKNOWN, detail=str(exc)
+        ) from exc
+    except StateCorruptError as exc:
+        raise PrgroomError(
+            tier=Tier.STATE_CORRUPT, code=ErrorCode.STATE_CORRUPT, detail=str(exc)
+        ) from exc
+
+
+def _entry_probe(ctx: RunContext, verbs: Verbs) -> None:
+    """Probe external transitions + re-arm the cap when entering at a terminal phase (§3.3/§3.5).
+
+    From ``quiesced`` / ``human-gated`` run ``_poll`` once to detect an external merge
+    or a manual fix-push that cleared the gate; then, if still hard-cap-gated and the
+    operator has raised ``--max-rounds`` so the cap no longer trips, clear the gate and
+    advance to ``fixes-pending`` for the refused commits to push under the raised cap. A
+    bare re-run with no raise leaves ``round >= max_rounds`` → the cap stays gated.
+    """
+    if ctx.state.phase not in {PRPhase.QUIESCED, PRPhase.HUMAN_GATED}:
+        return
+    _execute_step(VerbStep("poll", verbs.poll), ctx)
+    # `round >= max_rounds` is checked first so a raised cap short-circuits the gh read.
+    cap_still_trips = ctx.state.round >= ctx.config.max_rounds and verbs.has_queued(ctx)
+    if (
+        ctx.state.phase is PRPhase.HUMAN_GATED
+        and ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+        and not cap_still_trips
+    ):
+        ctx.state.phase = PRPhase.FIXES_PENDING
+        ctx.state.last_error = None
+        ctx.state.lifecycle_escalation_filed = False
+        ctx.state.human_review_label_added = False
+        ctx.store.write(ctx.ref, ctx.state)
+
+
+def _resolve_end_of_cycle(ctx: RunContext, verbs: Verbs) -> None:
+    """Apply the §3.2 end-of-cycle phase cascade + the §3.3 reset-on-success (writes state).
+
+    Reads ``has_queued_commits`` honestly (``verbs.has_queued``) rather than assuming it
+    is false. In the normal path the pre-push cap guard already refused any cap-tripping
+    push and a non-capped push consumed the queue, so this is false — but reading it for
+    real keeps the resolver's priority-1 a LIVE safety net: if any pipeline step ever
+    leaves commits queued at the cap (a future commit-producing ``reply``, a partial
+    push), the cap still gates here rather than silently pushing past it. On a
+    non-``human-gated`` resolution the gating error + both dedup flags clear (success); a
+    fresh ``human-gated`` gate clears ``lifecycle_escalation_filed`` once so the loop-top
+    emits a single event.
+    """
+    now = ctx.deps.clock.now()
+    resolved = resolve_end_of_cycle_phase(
+        ctx.state,
+        now=now,
+        max_rounds=ctx.config.max_rounds,
+        has_queued_commits=verbs.has_queued(ctx),
+        pushed_this_cycle=push_uploaded_commits_this_cycle(
+            ctx.state, cycle_start_pushed_sha=ctx.cycle_start_pushed_sha
+        ),
+        quiescent=quiescence_predicate(
+            ctx.state, now=now, idle_threshold=ctx.config.idle_threshold
+        ),
+    )
+    ctx.state.phase = resolved.phase
+    if resolved.last_error is not None:
+        ctx.state.last_error = resolved.last_error
+    if resolved.quiesced_at is not None:
+        ctx.state.quiescence = dataclasses.replace(
+            ctx.state.quiescence, quiesced_at=resolved.quiesced_at
+        )
+
+    if resolved.phase is PRPhase.HUMAN_GATED:
+        if new_lifecycle_gate_this_cycle(ctx.state, previous_error=ctx.cycle_start_error):
+            ctx.state.lifecycle_escalation_filed = False
+    else:
+        # Successful cycle completion clears any prior gating error + dedup flags (§3.3).
+        ctx.state.last_error = None
+        ctx.state.lifecycle_escalation_filed = False
+        ctx.state.human_review_label_added = False
+    ctx.store.write(ctx.ref, ctx.state)
+
+
+@contextmanager
+def _signal_handlers(cancel: SignalCancelToken) -> Iterator[None]:
+    """Route SIGINT/SIGTERM into ``cancel`` for the duration, restoring prior handlers.
+
+    Installed for autonomous runs only (the blocking ``_wait`` honors the token);
+    interactive runs keep the default Ctrl-C. ``signal.signal`` requires the main
+    thread — the CLI entry point satisfies this.
+    """
+    import signal
+
+    def handler(signum: int, _frame: FrameType | None) -> None:
+        cancel.trip(signum)
+
+    signals = (signal.SIGINT, signal.SIGTERM)
+    previous = {sig: signal.getsignal(sig) for sig in signals}
+    for sig in signals:
+        signal.signal(sig, handler)
+    try:
+        yield
+    finally:
+        for sig, prev in previous.items():
+            signal.signal(sig, prev)

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -469,6 +469,28 @@ def _flush_terminal_signals(ctx: RunContext) -> None:
     )
 
 
+def _guarded_has_queued(ctx: RunContext, verbs: Verbs) -> bool:
+    """Read ``has_queued`` (an effectful gh/git read) under the §3.3 error discipline.
+
+    The §3.5 cap re-arm (entry probe) and the end-of-cycle resolver read the queue
+    OUTSIDE the VerbStep pipeline, so they cannot rely on ``_execute_step``. A tagged
+    failure here gets the same treatment a verb error would: ``handle_verb_error``
+    applies its per-tier mutation, the state is persisted, the two terminal signals
+    flush, and the error re-raises to ``run``/``wait``'s reporting wrapper — so a
+    vanished PR (404 → ``RUNTIME_GH_TERMINAL``) or a gh blip never escapes the
+    lifecycle's tagged-error handling. (A gh read only ever yields ``PROPAGATE`` tiers;
+    ``CONTINUE`` is reserved for ``CONTRACT_AUDIT_FAILED``, which this read cannot
+    raise.)
+    """
+    try:
+        return verbs.has_queued(ctx)
+    except PrgroomError as err:
+        handle_verb_error(err, ctx.state)
+        ctx.store.write(ctx.ref, ctx.state)
+        _flush_terminal_signals(ctx)
+        raise
+
+
 def _read_or_bootstrap(ctx: RunContext) -> PRGroomingState:
     """Read the PR's state, bootstrapping a zero-value state on first contact (§3.3).
 
@@ -515,7 +537,7 @@ def _entry_probe(ctx: RunContext, verbs: Verbs) -> None:
     if (
         ctx.state.phase is PRPhase.HUMAN_GATED
         and ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
-        and not (ctx.state.round >= ctx.config.max_rounds and verbs.has_queued(ctx))
+        and not (ctx.state.round >= ctx.config.max_rounds and _guarded_has_queued(ctx, verbs))
     ):
         ctx.state.phase = PRPhase.FIXES_PENDING
         ctx.state.last_error = None
@@ -542,7 +564,7 @@ def _resolve_end_of_cycle(ctx: RunContext, verbs: Verbs) -> None:
         ctx.state,
         now=now,
         max_rounds=ctx.config.max_rounds,
-        has_queued_commits=verbs.has_queued(ctx),
+        has_queued_commits=_guarded_has_queued(ctx, verbs),
         pushed_this_cycle=push_uploaded_commits_this_cycle(
             ctx.state, cycle_start_pushed_sha=ctx.cycle_start_pushed_sha
         ),

--- a/packages/prgroom/src/prgroom/lifecycle/wait.py
+++ b/packages/prgroom/src/prgroom/lifecycle/wait.py
@@ -1,0 +1,139 @@
+"""``wait_pr`` — the lock-held ``_wait`` blocking poll loop (§4.2).
+
+``_wait`` is the ``wait`` verb's lock-assuming internal: it sleeps ``poll_interval``,
+polls, and returns when one of four wake events fires (§4.2 registry):
+
+1. **Signal-cancel** — SIGINT/SIGTERM sets the cancel token; ``_wait`` raises
+   ``RUNTIME_CANCELLED`` (exit 128+signum) at the loop top OR mid-sleep, so the
+   scheduler does NOT resurrect a cancelled wait (distinct from ``RUNTIME_TRANSIENT``).
+2. **Poll error** — an internal poll past its retry budget propagates unchanged.
+3. **Phase moved** — the polled phase left ``{awaiting-review, idle}`` (fix commits
+   arrived, PR merged externally, …); return so the run-loop re-enters the cycle.
+4. **Quiescence trips** — the §4.1 predicate is satisfied; write ``quiesced`` +
+   ``quiesced_at`` and return.
+
+The lock is held continuously (no mid-sleep release): the public ``wait`` wrapper's
+``lock()`` context manager spans the whole call. The sleep is interruptible — the
+cancel token's ``wait`` returns early when a signal arrives — so a Ctrl-C does not
+wait out the full ``poll_interval``. Each poll's state is persisted (resumability: a
+crash mid-wait leaves the last poll on disk; the next ``run`` resumes from it). There
+is no hard wait-timeout in MVP.
+
+The ``poll`` seam is injected (the run-loop binds ``poll_pr`` with its gh/deps/config),
+keeping this loop pure to test, and ``now`` is the injected clock reading.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import signal
+import threading
+from typing import TYPE_CHECKING, Protocol
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.lifecycle.quiescence import quiescence_predicate
+from prgroom.prsession.enums import PRPhase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime, timedelta
+
+    from prgroom.prsession.pr_ref import PRRef
+    from prgroom.prsession.state import PRGroomingState
+    from prgroom.prsession.store import Store
+
+# Phases that keep _wait blocking; observing any other phase is wake event 3 (§4.2).
+_WAITING_PHASES: frozenset[PRPhase] = frozenset({PRPhase.AWAITING_REVIEW, PRPhase.IDLE})
+
+
+class CancelToken(Protocol):
+    """The cancellation seam ``_wait`` honors (§4.2).
+
+    ``signum`` is the captured signal number (2/15) read at error-construction time
+    for the exit-code mapping; ``is_set`` is the loop-top check and ``wait`` is the
+    interruptible sleep (returns ``True`` if cancelled during the wait).
+    """
+
+    signum: int
+
+    def is_set(self) -> bool: ...  # pragma: no cover
+
+    def wait(self, seconds: float) -> bool: ...  # pragma: no cover
+
+
+class SignalCancelToken:
+    """Production cancel token wrapping a :class:`threading.Event`.
+
+    ``trip`` is called from ``run``'s OS signal handler: it records the observed
+    ``signum`` BEFORE setting the event, so a thread waking on the event reads the
+    correct signal number for the §3.7 exit-code mapping. Structurally satisfies
+    :class:`CancelToken`.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self.signum = 0
+
+    def trip(self, signum: int) -> None:
+        self.signum = signum
+        self._event.set()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, seconds: float) -> bool:
+        return self._event.wait(timeout=seconds)
+
+
+def cancelled_error(signum: int) -> PrgroomError:
+    """Build the ``RUNTIME_CANCELLED`` error for ``signum`` (SIGINT→130, SIGTERM→143; §3.7).
+
+    SIGINT (2) maps to ``RUNTIME_CANCELLED_SIGINT``; any other signal (SIGTERM=15 in
+    practice) maps to ``RUNTIME_CANCELLED_SIGTERM``. ``exit_code_for_tier`` reads
+    ``signum`` to produce ``128 + signum``.
+    """
+    code = (
+        ErrorCode.RUNTIME_CANCELLED_SIGINT
+        if signum == signal.SIGINT
+        else ErrorCode.RUNTIME_CANCELLED_SIGTERM
+    )
+    return PrgroomError(tier=Tier.RUNTIME_CANCELLED, code=code, signum=signum)
+
+
+def wait_pr(
+    state: PRGroomingState,
+    *,
+    poll: Callable[[PRGroomingState], PRGroomingState],
+    store: Store,
+    ref: PRRef,
+    cancel: CancelToken,
+    now: Callable[[], datetime],
+    poll_interval: timedelta,
+    idle_threshold: timedelta,
+) -> PRGroomingState:
+    """Sleep+poll until phase moves, quiescence trips, or a signal cancels (§4.2).
+
+    Caller must hold the per-ref lock (see ``lock()``); the lock is NOT released during
+    the sleep. Sleeps first (interruptibly), then polls — the run-loop already polled at
+    cycle top, so this avoids hammering gh. Honors the cancel token at the loop top AND
+    inside the sleep. Persists each poll. Returns the state to re-enter the cycle (phase
+    moved) or to rest at ``quiesced``.
+    """
+    while True:
+        if cancel.is_set():  # wake event 1 — loop-top cancel
+            raise cancelled_error(cancel.signum)
+        if cancel.wait(poll_interval.total_seconds()):  # interruptible sleep; mid-sleep cancel
+            raise cancelled_error(cancel.signum)
+
+        state = poll(state)  # wake event 2 — poll may raise (propagates via the run-loop)
+        store.write(ref, state)
+
+        if state.phase not in _WAITING_PHASES:  # wake event 3 — phase moved off waiting
+            return state
+
+        current = now()
+        if quiescence_predicate(state, now=current, idle_threshold=idle_threshold):  # event 4
+            state.phase = PRPhase.QUIESCED
+            state.quiescence = dataclasses.replace(state.quiescence, quiesced_at=current)
+            store.write(ref, state)
+            return state

--- a/packages/prgroom/tests/unit/test_cli_run.py
+++ b/packages/prgroom/tests/unit/test_cli_run.py
@@ -1,0 +1,116 @@
+"""Tests for the wired ``run`` CLI verb (§3.3).
+
+Two layers: wiring tests monkeypatch ``run_lifecycle`` to assert the command maps
+flags correctly (``--interactive/--autonomous`` → ``Mode``, ``--max-rounds`` → config)
+and propagates the returned exit code; one integration test drives the real
+``run_lifecycle`` + ``Verbs.system`` end-to-end against a fake gh on the simplest
+real path (autonomous run where ``_poll`` observes the PR merged → terminal), proving
+the cli → run_lifecycle → _run → real ``poll_pr`` → flush chain connects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom import cli
+from prgroom.lifecycle.run import Mode
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+
+runner = CliRunner()
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+
+
+class _StubDispatcher:
+    """Unused under a stubbed run_lifecycle; satisfies the build seam's return shape."""
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub every build seam + capture the kwargs the command hands ``run_lifecycle``."""
+    monkeypatch.setattr(cli, "_build_store", lambda _name: InMemoryStore())
+    monkeypatch.setattr(cli, "_build_gh", lambda: object())
+    monkeypatch.setattr(cli, "_build_git", lambda: object())
+    monkeypatch.setattr(cli, "_build_sink", lambda: object())
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    box: dict[str, Any] = {}
+
+    def fake_run_lifecycle(**kwargs: Any) -> int:
+        box.update(kwargs)
+        return box.get("_return_code", 0)
+
+    monkeypatch.setattr(cli, "run_lifecycle", fake_run_lifecycle)
+    return box
+
+
+def test_run_defaults_to_autonomous_mode(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["run", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert captured["mode"] is Mode.AUTONOMOUS
+    assert captured["ref"] == _REF
+    assert captured["config"].max_rounds == 3  # built-in default
+
+
+def test_run_interactive_flag_sets_mode(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["run", "octo/demo#7", "--interactive"])
+    assert result.exit_code == 0, result.output
+    assert captured["mode"] is Mode.INTERACTIVE
+
+
+def test_run_max_rounds_flag_flows_into_config(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["run", "octo/demo#7", "--max-rounds", "6"])
+    assert result.exit_code == 0, result.output
+    assert captured["config"].max_rounds == 6
+
+
+def test_run_propagates_nonzero_exit_code(captured: dict[str, Any]) -> None:
+    captured["_return_code"] = 77  # run_lifecycle's mapped tier code
+    result = runner.invoke(cli.app, ["run", "octo/demo#7"])
+    assert result.exit_code == 77
+
+
+def test_run_bad_ref_exits_2(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["run", "not a ref"])
+    assert result.exit_code == 2  # PRECONDITION_BAD_PR_REF, rendered before run_lifecycle
+    assert "run_lifecycle" not in captured or "mode" not in captured
+
+
+# ── real-seam integration: autonomous run on a merged PR ────────────────────
+
+
+class _MergedGh:
+    """A fake gh where the PR reads as merged and no items/CI exist (real poll_pr path)."""
+
+    def head_ref_oid(self, ref: PRRef) -> str:
+        del ref
+        return "abc123"
+
+    def rest(self, method: str, path: str, *, fields: dict[str, str] | None = None) -> Any:
+        del method, fields
+        if path == "repos/octo/demo/pulls/7":
+            return {"merged_at": "2026-06-09T12:00:00Z"}  # merged close
+        if path.endswith("/status"):
+            return {"state": "success"}
+        return []  # issue comments / reviews / review comments — none
+
+    def add_label(self, ref: PRRef, label: str) -> None:  # pragma: no cover - not a gating run
+        del ref, label
+
+
+def test_run_integration_merged_pr_reaches_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = InMemoryStore()
+    monkeypatch.setattr(cli, "_build_store", lambda _name: store)
+    monkeypatch.setattr(cli, "_build_gh", lambda: _MergedGh())
+    monkeypatch.setattr(cli, "_build_git", lambda: object())  # unused: never reaches push
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    # Drives the REAL run_lifecycle -> _run -> poll_pr -> flush via Verbs.system.
+    result = runner.invoke(cli.app, ["run", "octo/demo#7", "--autonomous"])
+    assert result.exit_code == 0, result.output
+    assert store.read(_REF).phase is PRPhase.MERGED  # poll observed the merge close

--- a/packages/prgroom/tests/unit/test_cli_smoke.py
+++ b/packages/prgroom/tests/unit/test_cli_smoke.py
@@ -51,9 +51,9 @@ def test_each_verb_has_its_own_help(verb: str) -> None:
 # Each single-PR-arg skeleton verb invoked with a positional ref. resolve-escalated
 # has a richer signature and is exercised separately below. ``poll`` is no longer a
 # skeleton (8.9a wired it for real); ``status`` likewise (8.11); ``cluster`` + ``fix``
-# (8.15); ``push`` + ``rereview`` + ``resolve`` (8.16) — their behavior is covered by
-# the per-verb test_cli_*.py suites. The remaining single-arg skeletons are
-# ``reply`` / ``wait`` / ``run``.
+# (8.15); ``push`` + ``rereview`` + ``resolve`` (8.16); ``run`` + ``wait`` (8.10) — their
+# behavior is covered by the per-verb test_cli_*.py suites. The remaining single-arg
+# skeleton is ``reply``.
 _WIRED_VERBS = {
     "resolve-escalated",
     "sweep",
@@ -64,6 +64,8 @@ _WIRED_VERBS = {
     "push",
     "rereview",
     "resolve",
+    "run",
+    "wait",
 }
 _SINGLE_ARG_VERBS = [v for v in MVP_VERBS if v not in _WIRED_VERBS]
 

--- a/packages/prgroom/tests/unit/test_cli_wait.py
+++ b/packages/prgroom/tests/unit/test_cli_wait.py
@@ -1,0 +1,101 @@
+"""Tests for the wired ``wait`` CLI verb (§4.2).
+
+Wiring tests monkeypatch ``wait_lifecycle`` to assert the command parses the ref and
+propagates the exit code. Integration tests drive the real ``wait_lifecycle`` →
+``_wait_verb`` for the non-blocking precondition paths (§3.2): ``fixes-pending`` →
+``PRECONDITION_WAIT_NOT_APPLICABLE``, a never-polled PR → ``PRECONDITION_NO_STATE``,
+``merged`` → no-op. These return before any blocking poll, so no clock is consumed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from prgroom import cli
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import PRGroomingState, QuiescenceState
+
+runner = CliRunner()
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def _state(phase: PRPhase) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(),
+    )
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setattr(cli, "_build_store", lambda _name: InMemoryStore())
+    monkeypatch.setattr(cli, "_build_gh", lambda: object())
+    box: dict[str, Any] = {}
+
+    def fake_wait_lifecycle(**kwargs: Any) -> int:
+        box.update(kwargs)
+        return box.get("_return_code", 0)
+
+    monkeypatch.setattr(cli, "wait_lifecycle", fake_wait_lifecycle)
+    return box
+
+
+def test_wait_parses_ref_and_returns_zero(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["wait", "octo/demo#7"])
+    assert result.exit_code == 0, result.output
+    assert captured["ref"] == _REF
+
+
+def test_wait_propagates_nonzero_exit_code(captured: dict[str, Any]) -> None:
+    captured["_return_code"] = 2  # e.g. PRECONDITION_WAIT_NOT_APPLICABLE
+    result = runner.invoke(cli.app, ["wait", "octo/demo#7"])
+    assert result.exit_code == 2
+
+
+def test_wait_bad_ref_exits_2(captured: dict[str, Any]) -> None:
+    result = runner.invoke(cli.app, ["wait", "not a ref"])
+    assert result.exit_code == 2
+    assert "ref" not in captured  # failed at parse, before wait_lifecycle
+
+
+# ── real-seam integration: non-blocking precondition paths ──────────────────
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch) -> InMemoryStore:
+    store = InMemoryStore()
+    monkeypatch.setattr(cli, "_build_store", lambda _name: store)
+    monkeypatch.setattr(cli, "_build_gh", lambda: object())  # unused on these paths
+    return store
+
+
+def test_wait_fixes_pending_is_not_applicable(patched: InMemoryStore) -> None:
+    patched.write(_REF, _state(PRPhase.FIXES_PENDING))
+    result = runner.invoke(cli.app, ["wait", "octo/demo#7"])
+    assert result.exit_code == 2  # PRECONDITION_WAIT_NOT_APPLICABLE (EX_USAGE)
+    assert "PRECONDITION_WAIT_NOT_APPLICABLE" in result.output
+
+
+def test_wait_no_state_is_precondition_error(patched: InMemoryStore) -> None:
+    assert patched.list_refs() == []  # never polled — no state on disk
+    result = runner.invoke(cli.app, ["wait", "octo/demo#7"])
+    assert result.exit_code == 2
+    assert "PRECONDITION_NO_STATE" in result.output
+
+
+def test_wait_merged_is_noop(patched: InMemoryStore) -> None:
+    patched.write(_REF, _state(PRPhase.MERGED))
+    result = runner.invoke(cli.app, ["wait", "octo/demo#7"])
+    assert result.exit_code == 0, result.output  # merged is absorbing — nothing to wait on

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -100,6 +100,19 @@ def test_rest_with_fields_passes_each_as_field_flag() -> None:
     assert "body=new body" in argv
 
 
+def test_add_label_posts_labels_array_field(ref: PRRef) -> None:
+    # §4.7: the human-review auto-label add. POSTs to the issue's labels collection
+    # with gh's array placeholder syntax (`labels[]=<name>`), which the server treats
+    # idempotently — a label already present is a no-op, never an error.
+    runner = RecordedRunner([_ok('[{"name": "human-review-required"}]')])
+    client = GhCli(runner)
+    assert client.add_label(ref, "human-review-required") is None
+    argv = runner.calls[0]
+    assert argv[:4] == ["gh", "api", "--method", "POST"]
+    assert "repos/octo/demo/issues/7/labels" in argv
+    assert "labels[]=human-review-required" in argv
+
+
 def test_graphql_returns_data() -> None:
     runner = RecordedRunner([_ok(_fixture("graphql_resolve_ok.json"))])
     client = GhCli(runner)

--- a/packages/prgroom/tests/unit/test_lifecycle_escalation.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_escalation.py
@@ -1,0 +1,252 @@
+"""Tests for the run-loop terminal-signal flush hooks (§3.3, §4.7).
+
+Two best-effort hooks fired at the run-loop's two terminal sites:
+``escalate_if_needed`` (one Sink event per un-filed ESCALATED/FAILED item + one per
+lifecycle gate, deduped by ``escalation_filed`` / ``lifecycle_escalation_filed``) and
+``request_human_review_if_needed`` (the §4.7 ``human-review-required`` label add,
+deduped by ``human_review_label_added``). Both swallow Sink/label failures so the
+lifecycle never blocks; a failed emit leaves the dedup flag unset for the next pass.
+
+The Sink is a recording fake (not a mock) — the dedup behavior is asserted by the
+COUNT and content of recorded escalations, and persistence via ``store.read``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from prgroom.errors import ErrorCode
+from prgroom.escalation import Escalation
+from prgroom.lifecycle.escalation import (
+    escalate_if_needed,
+    request_human_review_if_needed,
+    should_request_human_review,
+)
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_LABEL = "human-review-required"
+
+
+class RecordingSink:
+    """A Sink that records every emitted Escalation. Structurally satisfies ``Sink``."""
+
+    def __init__(self) -> None:
+        self.emitted: list[Escalation] = []
+
+    def emit(self, escalation: Escalation) -> None:
+        self.emitted.append(escalation)
+
+
+class RaisingSink:
+    """A Sink whose emit always fails — exercises the best-effort swallow (§3.3)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def emit(self, _escalation: Escalation) -> None:
+        self.calls += 1
+        msg = "sink down"
+        raise OSError(msg)
+
+
+class FakeGh:
+    """Records ``add_label`` calls; optionally raises to drive the §4.7 swallow path."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.added: list[tuple[PRRef, str]] = []
+        self._fail = fail
+
+    def add_label(self, ref: PRRef, label: str) -> None:
+        self.added.append((ref, label))
+        if self._fail:
+            msg = "no triage scope"
+            raise RuntimeError(msg)
+
+
+def _disp(kind: DispositionKind, *, filed: bool = False) -> Disposition:
+    return Disposition(
+        kind=kind, decided_at=_T0, decided_by="claude opus[1m]", escalation_filed=filed
+    )
+
+
+def _item(*, gh_id: str = "1", disposition: Disposition | None = None) -> ReviewItem:
+    return ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id=gh_id, thread_id=f"PRRT_{gh_id}"),
+        author="copilot",
+        body_excerpt="fix this",
+        seen_at=_T0,
+        disposition=disposition,
+    )
+
+
+def _state(
+    *items: ReviewItem,
+    last_error: str | None = None,
+    lifecycle_filed: bool = False,
+    label_added: bool = False,
+    phase: PRPhase = PRPhase.HUMAN_GATED,
+) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=2,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(),
+        items=list(items),
+        last_error=last_error,
+        lifecycle_escalation_filed=lifecycle_filed,
+        human_review_label_added=label_added,
+    )
+
+
+@pytest.fixture
+def store() -> InMemoryStore:
+    return InMemoryStore()
+
+
+# ── escalate_if_needed ──────────────────────────────────────────────────────
+
+
+def test_escalate_emits_one_event_per_unfiled_blocker_item(store: InMemoryStore) -> None:
+    sink = RecordingSink()
+    state = _state(
+        _item(gh_id="1", disposition=_disp(DispositionKind.ESCALATED)),
+        _item(gh_id="2", disposition=_disp(DispositionKind.FAILED)),
+        _item(gh_id="3", disposition=_disp(DispositionKind.FIXED)),  # not a blocker
+    )
+    out = escalate_if_needed(state, sink=sink, store=store, ref=_REF)
+    # One emit each for the ESCALATED + FAILED items; the FIXED item is silent.
+    assert len(sink.emitted) == 2
+    assert {e.item.identity.gh_id for e in sink.emitted if e.item} == {"1", "2"}
+    # Flags set on the emitted items, persisted to the store.
+    assert out.items[0].disposition.escalation_filed is True
+    assert out.items[1].disposition.escalation_filed is True
+    assert store.read(_REF).items[1].disposition.escalation_filed is True
+
+
+def test_escalate_dedups_already_filed_items(store: InMemoryStore) -> None:
+    sink = RecordingSink()
+    state = _state(_item(disposition=_disp(DispositionKind.ESCALATED, filed=True)))
+    escalate_if_needed(state, sink=sink, store=store, ref=_REF)
+    assert sink.emitted == []  # already filed — no re-emit
+
+
+def test_escalate_emits_one_lifecycle_event_for_last_error(store: InMemoryStore) -> None:
+    sink = RecordingSink()
+    state = _state(last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value)
+    out = escalate_if_needed(state, sink=sink, store=store, ref=_REF)
+    assert len(sink.emitted) == 1
+    assert sink.emitted[0].item is None
+    assert ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value in sink.emitted[0].reason
+    assert out.lifecycle_escalation_filed is True
+    assert store.read(_REF).lifecycle_escalation_filed is True
+
+
+def test_escalate_dedups_filed_lifecycle_gate(store: InMemoryStore) -> None:
+    sink = RecordingSink()
+    state = _state(last_error="LIFECYCLE_HARD_CAP_EXCEEDED", lifecycle_filed=True)
+    escalate_if_needed(state, sink=sink, store=store, ref=_REF)
+    assert sink.emitted == []
+
+
+def test_escalate_swallows_sink_failure_and_leaves_flag_unset(store: InMemoryStore) -> None:
+    sink = RaisingSink()
+    warnings: list[str] = []
+    state = _state(_item(disposition=_disp(DispositionKind.FAILED)), last_error="X")
+    # Best-effort: a raising Sink must NOT propagate, and the flags stay unset so the
+    # next pass retries. The item + lifecycle gate are both attempted, and each swallow
+    # is logged via warn so a dead Sink is observable (not silent).
+    out = escalate_if_needed(state, sink=sink, store=store, ref=_REF, warn=warnings.append)
+    assert sink.calls == 2  # item + lifecycle both attempted
+    assert out.items[0].disposition.escalation_filed is False
+    assert out.lifecycle_escalation_filed is False
+    assert len(warnings) == 2  # each swallowed failure surfaced
+
+
+def test_escalate_no_work_does_not_write(store: InMemoryStore) -> None:
+    sink = RecordingSink()
+    state = _state(_item(disposition=_disp(DispositionKind.FIXED)))
+    escalate_if_needed(state, sink=sink, store=store, ref=_REF)
+    assert sink.emitted == []
+    with pytest.raises(Exception, match="demo"):  # nothing written — read raises NotFound
+        store.read(_REF)
+
+
+# ── should_request_human_review ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (_state(last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value), True),
+        (_state(_item(disposition=_disp(DispositionKind.ESCALATED))), True),
+        (_state(_item(disposition=_disp(DispositionKind.FAILED))), True),
+        (_state(last_error=ErrorCode.RUNTIME_GH_TERMINAL.value), False),  # §4.7 non-trigger
+        (_state(_item(disposition=_disp(DispositionKind.FIXED))), False),
+        (_state(), False),
+    ],
+)
+def test_should_request_human_review_matrix(state: PRGroomingState, *, expected: bool) -> None:
+    assert should_request_human_review(state) is expected
+
+
+# ── request_human_review_if_needed ──────────────────────────────────────────
+
+
+def test_request_human_review_adds_label_once(store: InMemoryStore) -> None:
+    gh = FakeGh()
+    state = _state(last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value)
+    out = request_human_review_if_needed(state, gh=gh, store=store, ref=_REF, auto_request=True)
+    assert gh.added == [(_REF, _LABEL)]
+    assert out.human_review_label_added is True
+    assert store.read(_REF).human_review_label_added is True
+
+
+def test_request_human_review_short_circuits_when_disabled(store: InMemoryStore) -> None:
+    gh = FakeGh()
+    state = _state(_item(disposition=_disp(DispositionKind.FAILED)))
+    request_human_review_if_needed(state, gh=gh, store=store, ref=_REF, auto_request=False)
+    assert gh.added == []
+
+
+def test_request_human_review_short_circuits_when_already_added(store: InMemoryStore) -> None:
+    # Operator-removed-label intent: once added this gating event, do not re-add (§4.7).
+    gh = FakeGh()
+    state = _state(_item(disposition=_disp(DispositionKind.FAILED)), label_added=True)
+    request_human_review_if_needed(state, gh=gh, store=store, ref=_REF, auto_request=True)
+    assert gh.added == []
+
+
+def test_request_human_review_no_op_on_non_trigger(store: InMemoryStore) -> None:
+    gh = FakeGh()
+    state = _state(last_error=ErrorCode.RUNTIME_GH_TERMINAL.value)  # infra, not review-content
+    request_human_review_if_needed(state, gh=gh, store=store, ref=_REF, auto_request=True)
+    assert gh.added == []
+
+
+def test_request_human_review_swallows_label_failure(store: InMemoryStore) -> None:
+    gh = FakeGh(fail=True)
+    warnings: list[str] = []
+    state = _state(last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value)
+    out = request_human_review_if_needed(
+        state, gh=gh, store=store, ref=_REF, auto_request=True, warn=warnings.append
+    )
+    # Best-effort: failure is logged, the flag stays unset, nothing propagates.
+    assert out.human_review_label_added is False
+    assert len(warnings) == 1
+    assert _LABEL in warnings[0]

--- a/packages/prgroom/tests/unit/test_lifecycle_push.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_push.py
@@ -16,7 +16,7 @@ import pytest
 from prgroom.config import PrgroomConfig
 from prgroom.errors import ErrorCode, PreconditionError, PrgroomError, Tier
 from prgroom.gh import GhNotFoundError
-from prgroom.lifecycle.push import push_pr
+from prgroom.lifecycle.push import has_queued_fix_commits, push_pr
 from prgroom.prsession.enums import PRPhase, ReviewerKind, ReviewerStatus
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import (
@@ -282,3 +282,13 @@ def test_push_past_the_cap_does_not_re_warn() -> None:
         warn=msgs.append,
     )
     assert msgs == []
+
+
+def test_has_queued_fix_commits_maps_404_to_terminal() -> None:
+    # PR #165 review: a 404 on the remote-HEAD read (vanished PR/repo) maps to a
+    # terminal PrgroomError here, never a raw GhNotFoundError — so the run-loop's
+    # PrgroomError-only handlers (_execute_step / run_lifecycle) catch it.
+    with pytest.raises(PrgroomError) as excinfo:
+        has_queued_fix_commits(VanishedGh(), FakeGit(), _REF)
+    assert excinfo.value.tier is Tier.RUNTIME_TERMINAL_USER
+    assert excinfo.value.code is ErrorCode.RUNTIME_GH_TERMINAL

--- a/packages/prgroom/tests/unit/test_lifecycle_run.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_run.py
@@ -295,6 +295,31 @@ def test_entry_probe_no_rearm_on_bare_rerun() -> None:
     assert ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
 
 
+def test_entry_probe_skips_has_queued_when_poll_exits_gate() -> None:
+    # PR #165 review: a poll that moves the PR out of human-gated (external merge) must
+    # NOT trigger the effectful has_queued read — a transient failure there would corrupt
+    # an otherwise-clean terminal run. has_queued raises here; the probe must not call it.
+    reads: list[int] = []
+
+    def poll(ctx: RunContext) -> PRGroomingState:
+        ctx.state.phase = PRPhase.MERGED  # operator merged externally
+        return ctx.state
+
+    def spy(_ctx: RunContext) -> bool:
+        reads.append(1)
+        return False
+
+    state = _quiescent_state(
+        phase=PRPhase.HUMAN_GATED,
+        round=3,
+        last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value,
+    )
+    ctx = _ctx(state, config=PrgroomConfig(max_rounds=3))
+    _entry_probe(ctx, _verbs([], poll=poll, has_queued_fn=spy))
+    assert ctx.state.phase is PRPhase.MERGED  # left terminal
+    assert reads == []  # has_queued never read after the poll exits the gate
+
+
 # ── _resolve_end_of_cycle ───────────────────────────────────────────────────
 
 

--- a/packages/prgroom/tests/unit/test_lifecycle_run.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_run.py
@@ -364,6 +364,27 @@ def test_resolve_end_of_cycle_caps_when_queue_survives_at_cap() -> None:
     assert ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
 
 
+def test_guarded_has_queued_routes_tagged_error_through_discipline() -> None:
+    # PR #165: the cap re-arm + end-of-cycle reads call has_queued OUTSIDE the VerbStep
+    # pipeline. A tagged failure must still go through handle_verb_error + persist +
+    # flush + re-raise, never escape the lifecycle's error handling.
+    from prgroom.lifecycle.run import _guarded_has_queued
+
+    def boom(_ctx: RunContext) -> bool:
+        raise PrgroomError(tier=Tier.RUNTIME_TERMINAL_USER, code=ErrorCode.RUNTIME_GH_TERMINAL)
+
+    sink = RecordingSink()
+    store = InMemoryStore()
+    store.write(_REF, _quiescent_state(phase=PRPhase.FIXES_PENDING))
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING), store=store, sink=sink)
+    with pytest.raises(PrgroomError) as excinfo:
+        _guarded_has_queued(ctx, _verbs([], has_queued_fn=boom))
+    assert excinfo.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert ctx.state.phase is PRPhase.HUMAN_GATED  # handle_verb_error gated it
+    assert len(sink.emitted) == 1  # flushed before the re-raise
+    assert store.read(_REF).phase is PRPhase.HUMAN_GATED  # persisted
+
+
 # ── full _run scenarios ─────────────────────────────────────────────────────
 
 

--- a/packages/prgroom/tests/unit/test_lifecycle_run.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_run.py
@@ -1,0 +1,627 @@
+"""Tests for the ``run`` aggregate verb — the §3.3 keystone.
+
+The orchestration is driven through the injectable :class:`Verbs` seam: fake verbs
+record their invocation and apply deterministic state transforms, so the loop's
+control flow (poll-first cycle, ordered FIXES_PENDING pipeline, the single
+``handle_verb_error`` site, pre-push cap guard, ``_rereview`` guard, entry-probe +
+cap re-arm, end-of-cycle resolution, both flush sites, per-step write discipline) is
+exercised without any gh/git. Helper functions are unit-tested directly; full ``_run``
+scenarios cover the assembled flow.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from prgroom.config import PrgroomConfig
+from prgroom.deps import Deps
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.escalation import Escalation
+from prgroom.lifecycle.run import (
+    Mode,
+    RunContext,
+    Verbs,
+    VerbStep,
+    _build_pipeline,
+    _cap_guard_step,
+    _entry_probe,
+    _execute_step,
+    _reply,
+    _rereview_guard,
+    _resolve_end_of_cycle,
+    _run,
+    run_lifecycle,
+)
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase, ReviewerKind, ReviewerStatus
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewerState,
+    ReviewItem,
+)
+from prgroom.prsession.store import SchemaUnknownError, StateCorruptError
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_NOW = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_STALE = _NOW - timedelta(hours=1)  # past the idle threshold -> idle gate satisfied
+
+
+class _Clock:
+    def now(self) -> datetime:
+        return _NOW
+
+
+class _Rand:
+    def token_hex(self, n: int = 8) -> str:
+        return "0" * (2 * n)
+
+
+_DEPS = Deps(clock=_Clock(), randomness=_Rand())
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.emitted: list[Escalation] = []
+
+    def emit(self, escalation: Escalation) -> None:
+        self.emitted.append(escalation)
+
+
+class FakeGh:
+    def __init__(self) -> None:
+        self.added: list[tuple[PRRef, str]] = []
+
+    def add_label(self, ref: PRRef, label: str) -> None:
+        self.added.append((ref, label))
+
+
+class CountingStore:
+    """Wraps InMemoryStore and counts writes — verifies the per-step write discipline."""
+
+    def __init__(self) -> None:
+        self._inner = InMemoryStore()
+        self.writes = 0
+
+    def read(self, ref: PRRef) -> PRGroomingState:
+        return self._inner.read(ref)
+
+    def write(self, ref: PRRef, state: PRGroomingState) -> None:
+        self.writes += 1
+        self._inner.write(ref, state)
+
+    def lock(self, ref: PRRef):
+        return self._inner.lock(ref)
+
+
+def _quiescent_state(*, phase: PRPhase = PRPhase.FIXES_PENDING, **kw: object) -> PRGroomingState:
+    """A state that satisfies every quiescence gate (no reviewers/items, green CI, idle)."""
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=kw.get("round", 1),  # type: ignore[arg-type]
+        last_polled_at=_NOW,
+        last_activity_at=_STALE,
+        quiescence=QuiescenceState(ci_state="success"),
+        last_pushed_head_sha=kw.get("last_pushed_head_sha", ""),  # type: ignore[arg-type]
+        reviewers=kw.get("reviewers", {}),  # type: ignore[arg-type]
+        items=kw.get("items", []),  # type: ignore[arg-type]
+        last_error=kw.get("last_error"),  # type: ignore[arg-type]
+        lifecycle_escalation_filed=kw.get("lifecycle_filed", False),  # type: ignore[arg-type]
+        human_review_label_added=kw.get("label_added", False),  # type: ignore[arg-type]
+    )
+
+
+def _ctx(
+    state: PRGroomingState,
+    *,
+    store: object | None = None,
+    gh: object | None = None,
+    sink: object | None = None,
+    mode: Mode = Mode.AUTONOMOUS,
+    config: PrgroomConfig | None = None,
+) -> RunContext:
+    used_store = store if store is not None else InMemoryStore()
+    if store is None:
+        # `_run` reads the initial state from the store (ctx.state is a placeholder it
+        # overwrites). Seed the default store so the store and ctx.state agree; tests
+        # that pass an explicit store own their own seeding (e.g. the empty-store
+        # bootstrap test, or the multi-cycle stores written before _ctx).
+        used_store.write(_REF, state)
+    return RunContext(
+        store=used_store,  # type: ignore[arg-type]
+        ref=_REF,
+        gh=gh if gh is not None else FakeGh(),  # type: ignore[arg-type]
+        git=object(),  # type: ignore[arg-type] - unused by fake verbs
+        deps=_DEPS,
+        config=config if config is not None else PrgroomConfig(),
+        sink=sink if sink is not None else RecordingSink(),  # type: ignore[arg-type]
+        mode=mode,
+        cancel=object(),  # type: ignore[arg-type] - _wait is faked
+        state=state,
+    )
+
+
+def _recorder(name: str, calls: list[str], transform=None):
+    def step(ctx: RunContext) -> PRGroomingState:
+        calls.append(name)
+        if transform is not None:
+            transform(ctx.state)
+        return ctx.state
+
+    return step
+
+
+def _raiser(err: PrgroomError):
+    def step(_ctx: RunContext) -> PRGroomingState:
+        raise err
+
+    return step
+
+
+def _verbs(calls: list[str], *, has_queued: bool = False, **overrides):
+    names = ("poll", "cluster", "fix", "push", "rereview", "reply", "resolve", "wait")
+    built = {n: overrides.get(n, _recorder(n, calls)) for n in names}
+    return Verbs(has_queued=overrides.get("has_queued_fn", lambda _ctx: has_queued), **built)
+
+
+# ── _execute_step: the single handle_verb_error site ────────────────────────
+
+
+def test_execute_step_writes_state_on_success() -> None:
+    store = CountingStore()
+    ctx = _ctx(_quiescent_state(), store=store)
+    _execute_step(VerbStep("poll", _recorder("poll", [])), ctx)
+    assert store.writes == 1  # per-internal write discipline
+
+
+def test_execute_step_skips_when_guard_unmet() -> None:
+    store = CountingStore()
+    calls: list[str] = []
+    ctx = _ctx(_quiescent_state(), store=store)
+    _execute_step(VerbStep("x", _recorder("x", calls), guard=lambda _c: False), ctx)
+    assert calls == []
+    assert store.writes == 0
+
+
+def test_execute_step_continue_on_contract_audit_failed() -> None:
+    # CONTRACT_AUDIT_FAILED -> CONTINUE: no re-raise, state persisted, cycle proceeds.
+    ctx = _ctx(_quiescent_state())
+    err = PrgroomError(tier=Tier.CONTRACT_AUDIT_FAILED, code=ErrorCode.CONTRACT_FIX_AUDIT_FAILED)
+    _execute_step(VerbStep("fix", _raiser(err)), ctx)  # must NOT raise
+    assert ctx.state.last_error is None  # CONTRACT tier does not set last_error
+
+
+def test_execute_step_propagate_flushes_then_raises() -> None:
+    sink = RecordingSink()
+    gh = FakeGh()
+    ctx = _ctx(_quiescent_state(), sink=sink, gh=gh)
+    err = PrgroomError(tier=Tier.RUNTIME_TERMINAL_USER, code=ErrorCode.RUNTIME_GH_TERMINAL)
+    with pytest.raises(PrgroomError) as excinfo:
+        _execute_step(VerbStep("poll", _raiser(err)), ctx)
+    assert excinfo.value.code is ErrorCode.RUNTIME_GH_TERMINAL
+    assert ctx.state.phase is PRPhase.HUMAN_GATED  # handle_verb_error gated it
+    assert len(sink.emitted) == 1  # escalate fired before re-raise (last_error set)
+    assert gh.added == []  # RUNTIME_GH_TERMINAL is a §4.7 non-trigger — no label
+
+
+# ── _cap_guard_step + _rereview_guard ───────────────────────────────────────
+
+
+def test_cap_guard_trips_when_queued_and_at_cap() -> None:
+    ctx = _ctx(_quiescent_state(round=3), config=PrgroomConfig(max_rounds=3))
+    guard = _cap_guard_step(_verbs([], has_queued=True))
+    out = guard(ctx)
+    assert out.phase is PRPhase.HUMAN_GATED
+    assert out.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+    assert out.lifecycle_escalation_filed is False  # cleared so loop-top fires once
+
+
+def test_cap_guard_no_trip_under_cap() -> None:
+    ctx = _ctx(_quiescent_state(round=2), config=PrgroomConfig(max_rounds=3))
+    guard = _cap_guard_step(_verbs([], has_queued=True))
+    out = guard(ctx)
+    assert out.phase is PRPhase.FIXES_PENDING  # unchanged
+
+
+def test_cap_guard_no_trip_without_queued_commits() -> None:
+    ctx = _ctx(_quiescent_state(round=5), config=PrgroomConfig(max_rounds=3))
+    guard = _cap_guard_step(_verbs([], has_queued=False))
+    assert guard(ctx).phase is PRPhase.FIXES_PENDING  # at cap but nothing queued
+
+
+def test_rereview_guard_true_when_pushed_and_reviewer_stale() -> None:
+    reviewers = {
+        "copilot": ReviewerState(
+            identity="copilot",
+            kind=ReviewerKind.BOT,
+            status=ReviewerStatus.NOT_REQUESTED,
+            required=True,
+            last_request_at=_NOW,
+        )
+    }
+    ctx = _ctx(_quiescent_state(last_pushed_head_sha="newsha", reviewers=reviewers))
+    ctx.cycle_start_pushed_sha = "oldsha"  # push advanced it this cycle
+    assert _rereview_guard(ctx) is True
+
+
+def test_rereview_guard_false_when_no_push_this_cycle() -> None:
+    ctx = _ctx(_quiescent_state(last_pushed_head_sha="samesha"))
+    ctx.cycle_start_pushed_sha = "samesha"  # push did not advance HEAD
+    assert _rereview_guard(ctx) is False
+
+
+# ── _entry_probe + cap re-arm ───────────────────────────────────────────────
+
+
+def test_entry_probe_noop_on_non_terminal_phase() -> None:
+    calls: list[str] = []
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING))
+    _entry_probe(ctx, _verbs(calls))
+    assert calls == []  # did not poll — entry probe only runs from terminal-for-CLI
+
+
+def test_entry_probe_cap_rearm_after_raised_max_rounds() -> None:
+    state = _quiescent_state(
+        phase=PRPhase.HUMAN_GATED,
+        round=3,
+        last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value,
+        lifecycle_filed=True,
+        label_added=True,
+    )
+    ctx = _ctx(state, config=PrgroomConfig(max_rounds=6))  # operator raised the cap
+    # round(3) < max(6) -> cap no longer trips -> re-arm to fixes-pending.
+    _entry_probe(ctx, _verbs([], has_queued=True))
+    assert ctx.state.phase is PRPhase.FIXES_PENDING
+    assert ctx.state.last_error is None
+    assert ctx.state.lifecycle_escalation_filed is False
+    assert ctx.state.human_review_label_added is False
+
+
+def test_entry_probe_no_rearm_on_bare_rerun() -> None:
+    state = _quiescent_state(
+        phase=PRPhase.HUMAN_GATED,
+        round=3,
+        last_error=ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value,
+    )
+    ctx = _ctx(state, config=PrgroomConfig(max_rounds=3))  # NOT raised
+    _entry_probe(ctx, _verbs([], has_queued=True))  # round(3) >= max(3) AND queued -> stays gated
+    assert ctx.state.phase is PRPhase.HUMAN_GATED
+    assert ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+
+
+# ── _resolve_end_of_cycle ───────────────────────────────────────────────────
+
+
+def test_resolve_end_of_cycle_quiesces_and_clears_error() -> None:
+    state = _quiescent_state(last_error="STALE")
+    ctx = _ctx(state)
+    ctx.cycle_start_pushed_sha = state.last_pushed_head_sha
+    ctx.cycle_start_error = "STALE"
+    _resolve_end_of_cycle(ctx, _verbs([], has_queued=False))
+    assert ctx.state.phase is PRPhase.QUIESCED
+    assert ctx.state.quiescence.quiesced_at == _NOW
+    assert ctx.state.last_error is None  # success clears the gating error
+
+
+def test_resolve_end_of_cycle_gates_on_failed_item() -> None:
+    item = ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id="1"),
+        author="copilot",
+        body_excerpt="x",
+        seen_at=_NOW,
+        disposition=Disposition(kind=DispositionKind.FAILED, decided_at=_NOW, decided_by="claude"),
+    )
+    state = _quiescent_state(items=[item])
+    ctx = _ctx(state)
+    ctx.cycle_start_pushed_sha = ""
+    ctx.cycle_start_error = None
+    _resolve_end_of_cycle(ctx, _verbs([], has_queued=False))
+    assert ctx.state.phase is PRPhase.HUMAN_GATED  # priority 2
+
+
+def test_resolve_end_of_cycle_caps_when_queue_survives_at_cap() -> None:
+    # H1 safety net: if a pipeline step ever leaves commits queued AT the cap (a future
+    # commit-producing reply, a partial push), the honest has_queued read makes the
+    # resolver's priority-1 gate here rather than silently pushing past the cap.
+    state = _quiescent_state(round=3)
+    ctx = _ctx(state, config=PrgroomConfig(max_rounds=3))
+    ctx.cycle_start_pushed_sha = state.last_pushed_head_sha
+    ctx.cycle_start_error = None
+    _resolve_end_of_cycle(ctx, _verbs([], has_queued=True))  # queue survived
+    assert ctx.state.phase is PRPhase.HUMAN_GATED
+    assert ctx.state.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+
+
+# ── full _run scenarios ─────────────────────────────────────────────────────
+
+
+def test_run_full_cycle_to_quiesced() -> None:
+    calls: list[str] = []
+    store = CountingStore()
+    store.write(_REF, _quiescent_state(phase=PRPhase.FIXES_PENDING))
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING), store=store)
+    out = _run(ctx, _verbs(calls, has_queued=False))
+    # poll-first, then the ordered pipeline; rereview skipped (no push this cycle).
+    assert calls == ["poll", "cluster", "fix", "push", "reply", "resolve"]
+    assert out.phase is PRPhase.QUIESCED
+
+
+def test_run_cap_trip_gates_and_labels() -> None:
+    calls: list[str] = []
+    sink = RecordingSink()
+    gh = FakeGh()
+    store = InMemoryStore()
+    store.write(_REF, _quiescent_state(phase=PRPhase.FIXES_PENDING, round=3))
+    ctx = _ctx(
+        _quiescent_state(phase=PRPhase.FIXES_PENDING, round=3),
+        store=store,
+        sink=sink,
+        gh=gh,
+        config=PrgroomConfig(max_rounds=3),
+    )
+    out = _run(ctx, _verbs(calls, has_queued=True))
+    assert "push" not in calls  # cap guard refused the push
+    assert out.phase is PRPhase.HUMAN_GATED
+    assert out.last_error == ErrorCode.LIFECYCLE_HARD_CAP_EXCEEDED.value
+    assert len(sink.emitted) == 1  # one lifecycle escalation
+    assert gh.added == [(_REF, "human-review-required")]  # §4.7 label added
+
+
+def test_run_rereview_runs_after_push_uploads() -> None:
+    calls: list[str] = []
+    reviewers = {
+        "copilot": ReviewerState(
+            identity="copilot",
+            kind=ReviewerKind.BOT,
+            status=ReviewerStatus.NOT_REQUESTED,
+            required=True,
+            last_request_at=_NOW,
+        )
+    }
+    store = InMemoryStore()
+    store.write(_REF, _quiescent_state(phase=PRPhase.FIXES_PENDING, reviewers=reviewers))
+
+    def push(ctx: RunContext) -> PRGroomingState:
+        calls.append("push")
+        ctx.state.last_pushed_head_sha = "newsha"  # uploaded a commit
+        return ctx.state
+
+    def wait(ctx: RunContext) -> PRGroomingState:
+        # The push resolves the cycle to awaiting-review; end the loop on the next wait.
+        calls.append("wait")
+        ctx.state.phase = PRPhase.MERGED
+        return ctx.state
+
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING, reviewers=reviewers), store=store)
+    _run(ctx, _verbs(calls, has_queued=False, push=push, wait=wait))
+    assert "rereview" in calls  # guard satisfied: pushed + required reviewer stale
+
+
+def test_run_interactive_returns_at_awaiting_review_without_wait() -> None:
+    calls: list[str] = []
+
+    def poll(ctx: RunContext) -> PRGroomingState:
+        calls.append("poll")
+        ctx.state.phase = PRPhase.AWAITING_REVIEW
+        return ctx.state
+
+    ctx = _ctx(_quiescent_state(phase=PRPhase.AWAITING_REVIEW), mode=Mode.INTERACTIVE)
+    out = _run(ctx, _verbs(calls, poll=poll))
+    assert "wait" not in calls  # interactive never waits
+    assert out.phase is PRPhase.AWAITING_REVIEW
+
+
+def test_run_autonomous_waits_at_awaiting_review() -> None:
+    calls: list[str] = []
+
+    def poll(ctx: RunContext) -> PRGroomingState:
+        calls.append("poll")
+        ctx.state.phase = PRPhase.AWAITING_REVIEW
+        return ctx.state
+
+    def wait(ctx: RunContext) -> PRGroomingState:
+        calls.append("wait")
+        ctx.state.phase = PRPhase.MERGED  # end the loop
+        return ctx.state
+
+    ctx = _ctx(_quiescent_state(phase=PRPhase.AWAITING_REVIEW), mode=Mode.AUTONOMOUS)
+    _run(ctx, _verbs(calls, poll=poll, wait=wait))
+    assert calls.count("wait") == 1
+
+
+def test_run_first_invocation_bootstraps() -> None:
+    calls: list[str] = []
+    store = InMemoryStore()  # empty — no state for _REF
+
+    def poll(ctx: RunContext) -> PRGroomingState:
+        calls.append("poll")
+        ctx.state.phase = PRPhase.MERGED  # short-circuit after bootstrap
+        return ctx.state
+
+    ctx = _ctx(_quiescent_state(phase=PRPhase.IDLE), store=store)
+    out = _run(ctx, _verbs(calls, poll=poll))
+    assert out.phase is PRPhase.MERGED
+    assert store.read(_REF).schema_version == 1  # bootstrapped + persisted
+
+
+def test_run_terminal_user_error_gates_and_propagates() -> None:
+    sink = RecordingSink()
+    err = PrgroomError(tier=Tier.RUNTIME_TERMINAL_USER, code=ErrorCode.RUNTIME_GH_TERMINAL)
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING), sink=sink)
+    with pytest.raises(PrgroomError) as excinfo:
+        _run(ctx, _verbs([], poll=_raiser(err)))
+    assert excinfo.value.tier is Tier.RUNTIME_TERMINAL_USER
+    assert ctx.state.phase is PRPhase.HUMAN_GATED
+    assert len(sink.emitted) == 1  # escalate flushed before propagating
+
+
+def test_run_merged_is_absorbing() -> None:
+    calls: list[str] = []
+    ctx = _ctx(_quiescent_state(phase=PRPhase.MERGED))
+    out = _run(ctx, _verbs(calls))
+    assert calls == []  # terminal at loop top — no poll, no pipeline
+    assert out.phase is PRPhase.MERGED
+
+
+def test_run_interactive_idle_emits_advisory(capsys: pytest.CaptureFixture[str]) -> None:
+    # Interactive at idle returns 0 without waiting and emits the one-line advisory so
+    # the caller can tell "nothing to do" from "completed work" (§3.3).
+    ctx = _ctx(_quiescent_state(phase=PRPhase.IDLE), mode=Mode.INTERACTIVE)
+    out = _run(ctx, _verbs([]))  # default poll keeps the phase at idle
+    assert out.phase is PRPhase.IDLE
+    assert "phase=idle" in capsys.readouterr().err
+
+
+class _CorruptStore:
+    """A store whose read raises a parse/schema error — exercises _read_or_bootstrap."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def read(self, _ref: PRRef) -> PRGroomingState:
+        raise self._exc
+
+    def write(self, ref: PRRef, state: PRGroomingState) -> None:  # pragma: no cover - unused
+        del ref, state
+
+
+@pytest.mark.parametrize(
+    ("exc", "tier"),
+    [
+        (StateCorruptError("bad json"), Tier.STATE_CORRUPT),
+        (SchemaUnknownError("v999"), Tier.STATE_SCHEMA_UNKNOWN),
+    ],
+)
+def test_run_maps_unreadable_state_to_state_tier(exc: Exception, tier: Tier) -> None:
+    ctx = _ctx(_quiescent_state(), store=_CorruptStore(exc))
+    with pytest.raises(PrgroomError) as excinfo:
+        _run(ctx, _verbs([]))
+    assert excinfo.value.tier is tier  # § 3.3 read-failure mapping (exit 78)
+
+
+def test_run_drives_real_reply_skeleton_as_noop() -> None:
+    # The §3.3 pipeline-slotting pin: the loop wires the REAL `_reply` (a no-op
+    # skeleton until the deterministic-verbs bead). Drive a cycle through it and assert
+    # it leaves the item untouched (replied stays False) — a safe passthrough.
+    item = ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id="1"),
+        author="copilot",
+        body_excerpt="x",
+        seen_at=_NOW,
+        disposition=Disposition(kind=DispositionKind.FIXED, decided_at=_NOW, decided_by="claude"),
+    )
+    calls: list[str] = []
+    store = InMemoryStore()
+    store.write(_REF, _quiescent_state(phase=PRPhase.FIXES_PENDING, items=[item]))
+    ctx = _ctx(_quiescent_state(phase=PRPhase.FIXES_PENDING, items=[item]), store=store)
+    out = _run(ctx, _verbs(calls, has_queued=False, reply=_reply))  # real reply adapter
+    assert out.phase is PRPhase.QUIESCED
+    assert out.items[0].replied is False  # reply_pr no-op skeleton touched nothing
+
+
+# ── run_lifecycle wrapper ───────────────────────────────────────────────────
+
+
+def test_run_lifecycle_lock_held_returns_75() -> None:
+    store = InMemoryStore()
+    store.write(_REF, _quiescent_state())
+    assert store.try_acquire(_REF) is True  # a live holder owns the lock
+    try:
+        code = run_lifecycle(
+            store=store,
+            ref=_REF,
+            gh=FakeGh(),  # type: ignore[arg-type]
+            git=object(),  # type: ignore[arg-type]
+            deps=_DEPS,
+            config=PrgroomConfig(),
+            sink=RecordingSink(),  # type: ignore[arg-type]
+            mode=Mode.INTERACTIVE,
+            cluster_dispatcher=object(),  # type: ignore[arg-type] - never reached
+            cluster_decided_by="x",
+            fix_dispatcher=object(),  # type: ignore[arg-type]
+            fix_decided_by="x",
+        )
+    finally:
+        store.release(_REF)
+    assert code == 75  # PRECONDITION_LOCK_HELD -> EX_TEMPFAIL
+
+
+def test_verbs_system_adapters_delegate_to_real_verbs(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The production ctx→verb adapters are thin delegations; assert Verbs.system binds
+    # each to the right lifecycle verb (with the dispatchers/sink/scratch threaded)
+    # without needing real gh/git — the underlying verbs are monkeypatched recorders.
+    from prgroom.lifecycle import run as run_mod
+
+    calls: list[str] = []
+
+    def rec(name: str):
+        def fn(state: PRGroomingState, **_kw: object) -> PRGroomingState:
+            calls.append(name)
+            return state
+
+        return fn
+
+    monkeypatch.setattr(run_mod, "poll_pr", rec("poll"))
+    monkeypatch.setattr(run_mod, "cluster_pr", rec("cluster"))
+    monkeypatch.setattr(run_mod, "fix_pr", rec("fix"))
+    monkeypatch.setattr(run_mod, "push_pr", rec("push"))
+    monkeypatch.setattr(run_mod, "rereview_pr", rec("rereview"))
+    monkeypatch.setattr(run_mod, "resolve_pr", rec("resolve"))
+    monkeypatch.setattr(run_mod, "reply_pr", rec("reply"))
+    monkeypatch.setattr(run_mod, "wait_pr", rec("wait"))
+    monkeypatch.setattr(
+        run_mod, "has_queued_fix_commits", lambda *_a: calls.append("has_queued") or True
+    )
+
+    verbs = Verbs.system(
+        cluster_dispatcher=object(),  # type: ignore[arg-type]
+        cluster_decided_by="claude",
+        fix_dispatcher=object(),  # type: ignore[arg-type]
+        fix_decided_by="claude",
+    )
+    ctx = _ctx(_quiescent_state())
+    for adapter in (
+        verbs.poll,
+        verbs.cluster,
+        verbs.fix,
+        verbs.push,
+        verbs.rereview,
+        verbs.reply,
+        verbs.resolve,
+        verbs.wait,
+    ):
+        adapter(ctx)
+    assert verbs.has_queued(ctx) is True
+    assert calls == [
+        "poll",
+        "cluster",
+        "fix",
+        "push",
+        "rereview",
+        "reply",
+        "resolve",
+        "wait",
+        "has_queued",
+    ]
+
+
+def test_build_pipeline_order() -> None:
+    pipeline = _build_pipeline(_verbs([]))
+    assert [s.name for s in pipeline] == [
+        "cluster",
+        "fix",
+        "cap-guard",
+        "push",
+        "rereview",
+        "reply",
+        "resolve",
+    ]
+    assert pipeline[4].guard is _rereview_guard  # only rereview is guarded

--- a/packages/prgroom/tests/unit/test_lifecycle_wait.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_wait.py
@@ -1,0 +1,243 @@
+"""Tests for ``wait_pr`` — the lock-held ``_wait`` blocking poll loop (§4.2).
+
+``_wait`` sleeps ``poll_interval`` (interruptibly), polls, and returns on one of four
+wake events: a signal-cancel (loop-top OR mid-sleep) raising ``RUNTIME_CANCELLED``; the
+polled phase moving off ``{awaiting-review, idle}``; or the quiescence predicate
+tripping (writes ``quiesced`` + ``quiesced_at``). A ``_poll`` error propagates. There is
+no hard wait-timeout in MVP.
+
+The seams are an injected ``poll`` callable (decoupled from gh — pure to drive) and a
+``CancelToken`` fake whose ``is_set`` / ``wait`` are scripted so the loop-top and
+mid-sleep cancel branches are exercised independently. ``poll_interval`` is zero so the
+real ``threading.Event.wait`` (when used) does not sleep.
+"""
+
+from __future__ import annotations
+
+import signal
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from prgroom.errors import ErrorCode, PrgroomError, Tier
+from prgroom.lifecycle.wait import SignalCancelToken, cancelled_error, wait_pr
+from prgroom.prsession.enums import PRPhase
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import PRGroomingState, QuiescenceState
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+_LATER = _T0 + timedelta(hours=1)  # past any idle threshold, so the idle gate is satisfied
+_ZERO = timedelta(0)
+
+
+class FakeCancel:
+    """A scripted cancel token: ``is_set`` and ``wait`` return from queued booleans."""
+
+    def __init__(
+        self, *, is_set: bool = False, wait: bool = False, signum: int = signal.SIGINT
+    ) -> None:
+        self._is_set = is_set
+        self._wait = wait
+        self.signum = signum
+
+    def is_set(self) -> bool:
+        return self._is_set
+
+    def wait(self, _seconds: float) -> bool:
+        return self._wait
+
+
+def _state(
+    *,
+    phase: PRPhase = PRPhase.AWAITING_REVIEW,
+    ci_state: str = "success",
+    last_activity_at: datetime = _T0,
+) -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        round=1,
+        last_polled_at=_T0,
+        last_activity_at=last_activity_at,
+        quiescence=QuiescenceState(ci_state=ci_state),
+    )
+
+
+def _now(value: datetime = _LATER) -> Callable[[], datetime]:
+    return lambda: value
+
+
+@pytest.fixture
+def store() -> InMemoryStore:
+    return InMemoryStore()
+
+
+# ── wake event 1 + the interruptible sleep: signal cancel ───────────────────
+
+
+def test_cancel_at_loop_top_raises_runtime_cancelled(store: InMemoryStore) -> None:
+    polled = []
+
+    def poll(s: PRGroomingState) -> PRGroomingState:
+        polled.append(s)
+        return s
+
+    with pytest.raises(PrgroomError) as excinfo:
+        wait_pr(
+            _state(),
+            poll=poll,
+            store=store,
+            ref=_REF,
+            cancel=FakeCancel(is_set=True, signum=signal.SIGINT),
+            now=_now(),
+            poll_interval=_ZERO,
+            idle_threshold=timedelta(minutes=10),
+        )
+    assert excinfo.value.tier is Tier.RUNTIME_CANCELLED
+    assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGINT
+    assert polled == []  # never reached the poll — cancelled at loop top
+
+
+def test_cancel_during_sleep_raises_before_polling(store: InMemoryStore) -> None:
+    # is_set False at loop-top, but the interruptible sleep returns True (event set
+    # mid-sleep). Must raise without polling — the mid-sleep branch (§4.2).
+    polled = []
+
+    def poll(s: PRGroomingState) -> PRGroomingState:
+        polled.append(s)
+        return s
+
+    with pytest.raises(PrgroomError) as excinfo:
+        wait_pr(
+            _state(),
+            poll=poll,
+            store=store,
+            ref=_REF,
+            cancel=FakeCancel(is_set=False, wait=True, signum=signal.SIGTERM),
+            now=_now(),
+            poll_interval=_ZERO,
+            idle_threshold=timedelta(minutes=10),
+        )
+    assert excinfo.value.code is ErrorCode.RUNTIME_CANCELLED_SIGTERM
+    assert polled == []
+
+
+# ── wake event 3: phase moved off awaiting/idle ─────────────────────────────
+
+
+def test_returns_when_poll_moves_phase_off_waiting(store: InMemoryStore) -> None:
+    def poll(s: PRGroomingState) -> PRGroomingState:
+        s.phase = PRPhase.FIXES_PENDING  # fix commits arrived
+        return s
+
+    out = wait_pr(
+        _state(),
+        poll=poll,
+        store=store,
+        ref=_REF,
+        cancel=FakeCancel(),
+        now=_now(),
+        poll_interval=_ZERO,
+        idle_threshold=timedelta(minutes=10),
+    )
+    assert out.phase is PRPhase.FIXES_PENDING
+    assert store.read(_REF).phase is PRPhase.FIXES_PENDING  # each poll persisted
+
+
+# ── wake event 4: quiescence trips ──────────────────────────────────────────
+
+
+def test_trips_to_quiesced_when_predicate_satisfied(store: InMemoryStore) -> None:
+    # An idle, green-CI, reviewer-free, item-free state satisfies every gate; the idle
+    # timer is satisfied because now() is an hour past last_activity_at.
+    def poll(s: PRGroomingState) -> PRGroomingState:
+        return s  # poll observes no change
+
+    out = wait_pr(
+        _state(ci_state="success", last_activity_at=_T0),
+        poll=poll,
+        store=store,
+        ref=_REF,
+        cancel=FakeCancel(),
+        now=_now(_LATER),
+        poll_interval=_ZERO,
+        idle_threshold=timedelta(minutes=10),
+    )
+    assert out.phase is PRPhase.QUIESCED
+    assert out.quiescence.quiesced_at == _LATER
+    assert store.read(_REF).phase is PRPhase.QUIESCED
+
+
+def test_loops_until_quiescent(store: InMemoryStore) -> None:
+    # First poll leaves CI pending (G_CI fails -> not quiescent -> sleep again); second
+    # poll flips CI to success -> quiescence trips. Exercises the loop-continue path.
+    calls = {"n": 0}
+
+    def poll(s: PRGroomingState) -> PRGroomingState:
+        calls["n"] += 1
+        s.quiescence = QuiescenceState(ci_state="success" if calls["n"] >= 2 else "pending")
+        return s
+
+    out = wait_pr(
+        _state(ci_state="pending"),
+        poll=poll,
+        store=store,
+        ref=_REF,
+        cancel=FakeCancel(),
+        now=_now(_LATER),
+        poll_interval=_ZERO,
+        idle_threshold=timedelta(minutes=10),
+    )
+    assert calls["n"] == 2
+    assert out.phase is PRPhase.QUIESCED
+
+
+# ── wake event 2: a poll error propagates (not swallowed) ───────────────────
+
+
+def test_poll_transient_error_propagates(store: InMemoryStore) -> None:
+    def poll(_s: PRGroomingState) -> PRGroomingState:
+        raise PrgroomError(tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_GH_TRANSIENT)
+
+    with pytest.raises(PrgroomError) as excinfo:
+        wait_pr(
+            _state(),
+            poll=poll,
+            store=store,
+            ref=_REF,
+            cancel=FakeCancel(),
+            now=_now(),
+            poll_interval=_ZERO,
+            idle_threshold=timedelta(minutes=10),
+        )
+    assert excinfo.value.tier is Tier.RUNTIME_TRANSIENT
+
+
+# ── cancelled_error mapping + the real token ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("signum", "code"),
+    [
+        (signal.SIGINT, ErrorCode.RUNTIME_CANCELLED_SIGINT),
+        (signal.SIGTERM, ErrorCode.RUNTIME_CANCELLED_SIGTERM),
+    ],
+)
+def test_cancelled_error_maps_signum_to_code(signum: int, code: ErrorCode) -> None:
+    err = cancelled_error(signum)
+    assert err.tier is Tier.RUNTIME_CANCELLED
+    assert err.code is code
+    assert err.signum == signum  # exit_code_for_tier -> 128 + signum (130 / 143)
+
+
+def test_signal_cancel_token_trip_records_signum_and_sets() -> None:
+    token = SignalCancelToken()
+    assert token.is_set() is False
+    assert token.wait(0.0) is False
+    token.trip(signal.SIGTERM)
+    assert token.is_set() is True
+    assert token.signum == signal.SIGTERM
+    assert token.wait(0.0) is True


### PR DESCRIPTION
## Summary

Implements **bead `agents-config-abn9.8.10`** — the keystone `run` aggregate verb that
ties the already-built prgroom lifecycle verbs together. Spec:
`docs/plans/2026-05-12-prgroom-cli-design.md` §1 / §3.3 / §3.5 / §4.2 / §4.7.

The `_run` cycle acquires the PR lock **once** and threads the verbs as a
`list[VerbStep]` funneled through a **single shared `handle_verb_error` site**
(`_execute_step`) — the bead's mandated refactor of the spec's 8×-repeated try/except.

## What's in scope (this PR)

- **`lifecycle/run.py`** — `_run` (poll-first cycle → ordered fixes-pending pipeline
  `cluster→fix→[cap-guard]→push→[rereview]→reply→resolve` → end-of-cycle resolution),
  `run_lifecycle`/`wait_lifecycle` public wrappers (lock-once, tier→exit mapping,
  signal handlers), entry-probe + §3.5 cap re-arm, the two terminal-signal flush sites,
  and an injectable `Verbs` seam so the orchestration is unit-testable without gh/git.
- **`lifecycle/wait.py`** — `_wait` blocking poll (§4.2): four wake events, signal-cancel
  at loop-top AND mid-sleep, SIGINT→130 / SIGTERM→143, no mid-sleep lock release, no hard
  timeout, quiescence-trip writes `quiesced`+`quiesced_at`.
- **`lifecycle/escalation.py`** — the two flush hooks `escalate_if_needed` (one Sink event
  per un-filed ESCALATED/FAILED item + one per lifecycle gate, dedup-safe, best-effort)
  and `request_human_review_if_needed` (§4.7 `human-review-required` label, review-content
  gates only).
- **`lifecycle/reply.py`** — `reply_pr` no-op skeleton (the §3.3 pipeline-slotting pin;
  full-fidelity reply lands in the deterministic-verbs bead).
- **`gh.add_label`** (needed by §4.7); shared **`has_queued_fix_commits`** extracted in
  `push.py` so the pre-push cap check and `_push` agree on "queued".
- **CLI** — `run` (`--interactive/--autonomous`, `--max-rounds`, `--no-prework`) and
  `wait` verbs wired (replacing the skeletons).

## Intentionally out of scope (other beads)

- `_reply` / `resolve-escalated` business logic — deterministic-verbs bead. `_run` wires
  the pipeline against the **no-op `_reply` skeleton** (verified by a test that drives the
  cycle through the real `reply_pr`).
- `sweep` cross-PR aggregator — deferred (the bead marks it optional / vacuous if dropped).
- `status` verb + merge-gate contract — already built (8.11/8.16).

## Test plan / evidence

- [x] `make ci-prgroom` green: **819 tests, 99.80% coverage** (run.py 99%), `mypy --strict`
      + `ruff` + `pip-audit` clean, `prgroom --help` resolves.
- [x] Orchestration covered via the `Verbs` seam: full cycle→quiesced, cap-trip→human-gated
      +label, rereview guard, entry-probe cap re-arm, success-clears-last_error, both flush
      sites, interactive vs autonomous, bootstrap, terminal-error propagation, merged.
- [x] `_wait` wake events + cancel mapping; escalation dedup + best-effort swallow; CLI
      wiring + a real-seam integration run (autonomous on a merged PR).

## Reviewer notes (in-house review already applied)

A `quality-reviewer` pass ran pre-PR. Addressed: **H1** — `_resolve_end_of_cycle` now reads
`has_queued` honestly so the resolver's priority-1 cap is a live safety net (not a
False-assumption that rots when a future `reply` commits); **H2** — documented the
`_wait`-blocking termination contract; **M4** — Sink-emit failures now surface via `warn`
(symmetric with the label hook). `verb_error.py`'s `case _` handling of precondition tiers
(M1) was left as-is: out of scope for this bead and exit-2 for `WRONG_BRANCH` is a
defensible terminal-user error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
