### PR TITLE
fix(installer): claude always-on in auto-detect — parity gap G5 (8.9)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -119,21 +119,6 @@ def main(
         sys.stderr.write(f"installer: {exc}\n")
         return 2
 
-    if not tools:
-        sys.stderr.write(
-            "installer: no agent tools detected; cannot proceed.\n"
-            "Auto-detection checks each known tool's installation signal:\n"
-        )
-        for known in known_tools():
-            adapter = get_adapter(known)
-            detected_path = resolved_home / adapter.detection_signal
-            sys.stderr.write(f"  {known.value}: {detected_path}\n")
-        sys.stderr.write(
-            f"None of the above were found under {resolved_home}.\n"
-            "To force installation, pass --tools=<csv>, e.g. --tools=claude.\n"
-        )
-        return 2
-
     # Resolve plugins up front (after tools) so an invalid --plugins fails fast
     # on every path — matching the bash installer, which validates --plugins
     # before dispatching any mode (scripts/install.sh:298-307). The resolved set

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -30,7 +30,9 @@ def resolve_tools(*, home: Path, override_csv: str | None) -> tuple[Tool, ...]:
     """Translate the `--tools=` CLI value into the resolved tool tuple.
 
     - `override_csv is None` -> auto-detect: walk known_tools(), keep
-      those whose adapter reports `is_detected(home) is True`.
+      those whose adapter reports `is_detected(home) is True`. claude's
+      adapter is always-on (install.sh's `TOOLS=(claude)` floor), so it is
+      always selected; known_tools() sorts it first, so it also leads.
     - `override_csv == ""` (or whitespace-only) -> ValueError.
     - Otherwise -> split on commas, strip whitespace, validate each via
       `parse_tool_name`, dedupe preserving first occurrence, preserve

--- a/packages/installer/src/installer/tools/base.py
+++ b/packages/installer/src/installer/tools/base.py
@@ -14,12 +14,6 @@ class ToolAdapter(Protocol):
     per `Tool` enum value; registry-wired."""
 
     name: str
-    # Path **relative to home** that signals tool presence
-    # (e.g. ".claude/settings.json"). NOT a `~`-prefixed absolute string —
-    # callers that surface this in diagnostics are responsible for joining it
-    # against the resolved home so the printed path reflects what was probed
-    # (critical when `home` is injected, e.g. in tests).
-    detection_signal: str
 
     def source_dir(self, repo_root: Path) -> Path: ...  # pragma: no cover
 

--- a/packages/installer/src/installer/tools/claude.py
+++ b/packages/installer/src/installer/tools/claude.py
@@ -9,12 +9,12 @@ if TYPE_CHECKING:
 
 
 class ClaudeAdapter:
-    """Adapter for Anthropic's Claude Code. Probes ~/.claude/settings.json
-    as the detection marker — deliberate divergence from install.sh's
-    'always include claude' rule."""
+    """Adapter for Anthropic's Claude Code. Always detected: install.sh treats
+    claude as its unconditional tool (`TOOLS=(claude)` — "claude always; others
+    if ~/.<tool>/ exists"), so auto-detect always selects it, even on a fresh
+    machine with no ~/.claude yet."""
 
     name: str = "claude"
-    detection_signal: str = ".claude/settings.json"
 
     def source_dir(self, repo_root: Path) -> Path:
         return repo_root / "src" / "user" / ".claude"
@@ -22,8 +22,11 @@ class ClaudeAdapter:
     def dest_dir(self, home: Path) -> Path:
         return home / ".claude"
 
-    def is_detected(self, home: Path) -> bool:
-        return (home / ".claude" / "settings.json").is_file()
+    def is_detected(
+        self,
+        home: Path,  # noqa: ARG002  # protocol parameter; claude is unconditionally detected
+    ) -> bool:
+        return True
 
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ("commands", "skills", "agents", "rules", "hooks")

--- a/packages/installer/src/installer/tools/codex.py
+++ b/packages/installer/src/installer/tools/codex.py
@@ -13,7 +13,6 @@ class CodexAdapter:
     mirrors the bash installer's [[ -d "$HOME/.codex" ]] detection."""
 
     name: str = "codex"
-    detection_signal: str = ".codex"
 
     def source_dir(self, repo_root: Path) -> Path:
         return repo_root / "src" / "user" / ".codex"

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -69,7 +69,6 @@ class GeminiAdapter:
     mirrors the bash installer's [[ -d "$HOME/.gemini" ]] detection."""
 
     name: str = "gemini"
-    detection_signal: str = ".gemini"
 
     def source_dir(self, repo_root: Path) -> Path:
         return repo_root / "src" / "user" / ".gemini"

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -18,7 +18,6 @@ class OpenCodeAdapter:
     `command -v opencode || [[ -d ~/.config/opencode ]]`."""
 
     name: str = "opencode"
-    detection_signal: str = ".config/opencode"
 
     def source_dir(self, repo_root: Path) -> Path:
         return repo_root / "src" / "user" / ".opencode"

--- a/packages/installer/tests/golden_master/_runner.py
+++ b/packages/installer/tests/golden_master/_runner.py
@@ -98,6 +98,7 @@ def run_parity(
     seed: SeedFn | None = None,
     plugins_src: Path | None = None,
     repeat: int = 1,
+    env: dict[str, str] | None = None,
 ) -> ParityResult:
     """Run both installers with ``args`` into fresh homes under ``tmp_path``.
 
@@ -111,6 +112,11 @@ def run_parity(
     times into its home; the returned result reflects the *last* run.
     ``repeat=2`` exercises re-install idempotency — the second run lands on a
     tree the first already created.
+
+    ``env`` (optional) overrides extra environment for both installers — e.g. a
+    pinned ``PATH`` that isolates tool auto-detection deterministically. It is
+    applied after ``plugins_src`` (so it can override that too) on top of the
+    ``HOME``/locale pins ``_build_env`` always applies.
     """
     home_a = tmp_path / "home_a"
     home_b = tmp_path / "home_b"
@@ -120,7 +126,11 @@ def run_parity(
         seed(home_a)
         seed(home_b)
 
-    extra_env = {"INSTALLER_PLUGINS_SRC": str(plugins_src)} if plugins_src is not None else None
+    extra_env: dict[str, str] = {}
+    if plugins_src is not None:
+        extra_env["INSTALLER_PLUGINS_SRC"] = str(plugins_src)
+    if env:
+        extra_env.update(env)
     # Run the warm-up rounds for their filesystem effect; capture only the final
     # run's exit/stderr below. A warm-up failure still raises (it must not be
     # masked by a later run). For repeat=1 the loop runs zero times.

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -8,6 +8,8 @@ run them with ``make golden-master-installer``.
 
 from __future__ import annotations
 
+import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -18,6 +20,23 @@ pytestmark = pytest.mark.golden_master
 
 
 _CLAUDE_ARGS = ["--tools=claude", "--plugins=", "--yes"]
+
+
+def _tool_isolated_path(tmp_path: Path) -> str:
+    """A PATH that hides the opencode/gemini/codex CLIs so auto-detect is
+    deterministic — none are found on PATH, and a fresh HOME has none of their
+    config dirs — while keeping the binaries the bash installer needs reachable.
+    A symlink farm holds jq (bash's hard precondition, often Homebrew-only on
+    macOS) plus bash/git; /usr/bin:/bin supplies the coreutils. The third-party
+    tool CLIs are never symlinked and don't live in /usr/bin:/bin, so both
+    ``command -v opencode`` (bash) and ``which("opencode")`` (Python) miss."""
+    farm = tmp_path / "isolated_bin"
+    farm.mkdir()
+    for tool in ("jq", "bash", "git"):
+        resolved = shutil.which(tool)
+        if resolved is not None:
+            (farm / tool).symlink_to(resolved)
+    return os.pathsep.join([str(farm), "/usr/bin", "/bin"])
 
 
 def test_bare_install_single_tool_no_plugins(tmp_path: Path) -> None:
@@ -129,20 +148,23 @@ def test_bare_install_opencode(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Auto-detect must install Claude unconditionally to match bash; the Python "
-    "port requires ~/.claude/settings.json and so detects nothing here. Not yet ported.",
-)
 def test_autodetect_fresh_home(tmp_path: Path) -> None:
-    """No --tools: auto-detect against an empty HOME. Bash treats Claude as
-    always-installed; the Python port requires ~/.claude/settings.json to detect
-    it, so it detects nothing. That asymmetry guarantees a divergence on any
-    host regardless of PATH — no PATH manipulation is needed to keep this xfail
-    deterministic. (When this is wired green, tool-detection must be isolated —
-    opencode/gemini/codex absent — while bash's required binaries, notably jq,
-    stay reachable; a bare PATH=/usr/bin:/bin would starve bash's jq guard.)"""
-    result = run_parity(tmp_path, args=["--plugins=", "--yes"])
+    """No --tools: auto-detect against an empty HOME. Both installers treat
+    Claude as always-on (bash's ``TOOLS=(claude)`` floor; the Python port's
+    ClaudeAdapter is unconditionally detected), so a fresh machine installs
+    exactly Claude and reaches parity.
+
+    Tool-detection is isolated via a pinned PATH (``_tool_isolated_path``):
+    opencode/gemini/codex CLIs are absent so neither installer auto-adds them
+    (which would otherwise drag in still-diverging install paths), while jq
+    stays reachable for bash's hard precondition."""
+    if shutil.which("jq") is None:
+        pytest.skip("bash installer requires jq on PATH")
+    result = run_parity(
+        tmp_path,
+        args=["--plugins=", "--yes"],
+        env={"PATH": _tool_isolated_path(tmp_path)},
+    )
 
     assert result.bash_returncode == 0, result.bash_stderr
     assert result.python_returncode == 0, result.python_stderr

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -162,31 +162,21 @@ def test_main_tools_foo_returns_2(tmp_path: Path) -> None:
     assert main(["--tools=foo"], home=tmp_path) == 2
 
 
-def test_main_no_args_against_empty_home_returns_2_with_detection_diagnostic(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+def test_main_no_args_against_empty_home_auto_selects_claude_returns_zero(
+    tmp_path: Path,
 ) -> None:
     """
-    Given an empty home directory (no agent tools detectable)
-    When main([], home=that_home) is invoked
-    Then it returns 2
-    And stderr names the failure ("no agent tools detected")
-    And stderr lists each known tool by name
-    And stderr lists each tool's detection signal
-    And stderr names the home directory that was probed
-    And stderr suggests the --tools= escape hatch.
+    Given an empty home directory (no install signals) and a hermetic repo,
+    under --dry-run with no --tools
+    When main(["--dry-run"], home=that_home) is invoked
+    Then it returns 0 — auto-detect falls back to claude and proceeds.
 
-    Pins: empty auto-detect must NOT silently succeed — see Codex
-    adversarial review of PR #86 (2026-05-23). Forces operators to
-    either install a recognized tool or pass --tools= explicitly.
+    Pins: a bare home no longer takes a no-tools exit-2 guard; claude is the
+    auto-detect floor, matching install.sh's unconditional `TOOLS=(claude)`.
     """
-    rc = main([], home=tmp_path)
-    assert rc == 2
-    captured = capsys.readouterr()
-    assert "no agent tools detected" in captured.err
-    assert "claude" in captured.err
-    assert "settings.json" in captured.err
-    assert str(tmp_path) in captured.err
-    assert "--tools=" in captured.err
+    repo = _hermetic_repo(tmp_path)
+    rc = main(["--dry-run"], home=tmp_path, io=ScriptedIO(interactive=False), repo_root=repo)
+    assert rc == 0
 
 
 # ── G.5 / G.7: prune flags + --yes wiring ──

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -162,7 +162,7 @@ def test_main_tools_foo_returns_2(tmp_path: Path) -> None:
     assert main(["--tools=foo"], home=tmp_path) == 2
 
 
-def test_main_no_args_against_empty_home_auto_selects_claude_returns_zero(
+def test_main_autodetect_empty_home_dry_run_selects_claude_returns_zero(
     tmp_path: Path,
 ) -> None:
     """

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -37,18 +37,33 @@ def test_autodetect_includes_claude_when_settings_json_exists(
     assert resolve_tools(home=home, override_csv=None) == (Tool.CLAUDE,)
 
 
-def test_autodetect_excludes_claude_when_settings_json_absent(
+def test_autodetect_includes_claude_when_settings_json_absent(
     tmp_path: Path,
 ) -> None:
     """
     Given an empty home directory
     When resolve_tools(home=that_home, override_csv=None) is called
-    Then the result is ().
+    Then the result is (Tool.CLAUDE,).
 
-    Pins: the deliberate divergence from install.sh's unconditional
-    claude inclusion.
+    Pins: claude is unconditionally selected under auto-detect, matching
+    install.sh's `TOOLS=(claude)` ("claude always; others if ~/.<tool>/").
+    A fresh machine with no ~/.claude/settings.json still installs claude.
     """
-    assert resolve_tools(home=tmp_path, override_csv=None) == ()
+    assert resolve_tools(home=tmp_path, override_csv=None) == (Tool.CLAUDE,)
+
+
+def test_autodetect_claude_always_plus_detected_other(tmp_path: Path) -> None:
+    """
+    Given a home with ~/.codex/ (a codex marker) but no ~/.claude/settings.json
+    When resolve_tools(home=that_home, override_csv=None) is called
+    Then the result is (Tool.CLAUDE, Tool.CODEX).
+
+    Pins: the always-on claude rule composes with — does not suppress —
+    detection of other tools, and claude leads (known_tools() sorts it first,
+    matching bash's claude-first auto-detect order).
+    """
+    (tmp_path / ".codex").mkdir()
+    assert resolve_tools(home=tmp_path, override_csv=None) == (Tool.CLAUDE, Tool.CODEX)
 
 
 def test_explicit_tools_claude_is_accepted(tmp_path: Path) -> None:
@@ -59,16 +74,19 @@ def test_explicit_tools_claude_is_accepted(tmp_path: Path) -> None:
     assert resolve_tools(home=tmp_path, override_csv="claude") == (Tool.CLAUDE,)
 
 
-def test_explicit_tools_claude_overrides_empty_autodetect(
+def test_explicit_tools_suppresses_autodetected_others(
     tmp_path: Path,
 ) -> None:
     """
-    Given an empty home directory
+    Given a home with ~/.codex/ (a codex marker)
     When resolve_tools(home=that_home, override_csv="claude") is called
-    Then the result is (Tool.CLAUDE,).
+    Then the result is (Tool.CLAUDE,) — codex is NOT auto-added.
 
-    Pins: override is "I know what I'm doing" — no settings.json gate.
+    Pins: an explicit --tools list is authoritative; it bypasses auto-detect
+    entirely (including the always-on claude rule's sibling detection), so the
+    user gets exactly what they asked for.
     """
+    (tmp_path / ".codex").mkdir()
     assert resolve_tools(home=tmp_path, override_csv="claude") == (Tool.CLAUDE,)
 
 

--- a/packages/installer/tests/unit/test_tools_opencode.py
+++ b/packages/installer/tests/unit/test_tools_opencode.py
@@ -6,9 +6,8 @@ the XDG config dir exists OR `opencode` is on PATH (mirrors the bash
 one branch of that OR. The live PATH probe is global state, so every test
 stubs `shutil.which` explicitly to stay hermetic.
 
-Tautology tests (attribute literals like adapter.name, detection_signal
-string, @runtime_checkable machinery) are absent per the writing-unit-tests
-tautology filter."""
+Tautology tests (attribute literals like adapter.name, @runtime_checkable
+machinery) are absent per the writing-unit-tests tautology filter."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Epic H Wave 2 — closes parity gap **G5** (bead `agents-config-w1qls.8.9`).

`scripts/install.sh` auto-detect always installs Claude (`TOOLS=(claude)` — "claude always; others if `~/.<tool>/` exists"). The Python port's `ClaudeAdapter` required `~/.claude/settings.json` to detect Claude, so a fresh machine auto-detected **nothing** and exited "no agent tools detected" — a deliberate-but-buggy divergence. This makes the Python installer match bash.

### Changes
- **`ClaudeAdapter.is_detected` → always `True`** (`tools/claude.py`). Claude is bash's unconditional tool; auto-detect always selects it. Explicit `--tools=` is unchanged.
- **Removed the unreachable "no agent tools detected" diagnostic** (`cli.py`). With Claude always-on, auto-detect can't be empty, and an empty `--tools=` raises `ValueError` earlier → exit 2. The block was dead; the 90%-branch gate won't tolerate dead+uncovered code.
- **Removed `detection_signal`** from the `ToolAdapter` protocol + 4 adapters — the diagnostic was its sole consumer.
- **`test_autodetect_fresh_home` dropped its `xfail`** and now pins real parity, via a `_tool_isolated_path` symlink-farm PATH (jq/bash/git reachable; opencode/gemini/codex CLIs absent) so auto-detect is deterministic on both ubuntu-CI and a Homebrew Mac while bash's jq precondition stays satisfied. Skips if jq is absent.
- **`run_parity` gains an `env=` seam** for the PATH injection.
- Rewrote the unit tests that pinned the old "fresh home → no tools" behavior to the new "fresh home → claude" contract.

This reverses the PR #86 "empty auto-detect must exit 2" decision in favor of bash parity (the Epic H mandate).

### Parity net
Was 8 green / 5 xfail → now **9 green / 4 xfail**. Remaining gaps: gemini transform (8.17), opencode rules-skip (8.10), reinstall idempotency (8.12), plugin routes (8.8).

### Out of scope (not regressions)
- The 4 remaining xfail scenarios are tracked gaps, not this PR's concern.
- Test-fake adapters still declare `detection_signal` (harmless extra attr on a `@runtime_checkable` Protocol) — deliberately not churned per the simplify "don't refactor test files" rule.

## Test Plan
- [x] `make ci-installer` — ruff, ruff format, mypy --strict (42 files), coverage 99.78%, golden-master 9 passed / 4 xfailed, pip-audit clean, entry-verify
- [x] `quality-reviewer` — clean, 0 blocking findings
- [x] `simplify` — none warranted
- [ ] Copilot review pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
