### PR TITLE
fix(installer): OpenCode drops staged rules/ items post-flatten (8.10)

### DIFF
--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -46,6 +46,14 @@ class OpenCodeAdapter:
     def post_staging_transforms(
         self,
         plan: StagingPlan,
-        io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCodeAdapter accepts uniformly
+        io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCode mutates only the plan
     ) -> StagingPlan:
+        """Drop staged rules/ items before sync: OpenCode has no standalone rules/
+        destination. The rules are inlined into the flat AGENTS.md by the
+        DYNAMIC-INCLUDE-ALL-RULES flatten — which runs earlier in stage_and_transform
+        and sources them from these same staged items — so dropping them here mirrors
+        install.sh Phase 7, which stages rules then skips writing the rules/ subdir
+        for opencode (scripts/install.sh:928-934)."""
+        for relpath in [rp for rp, item in plan.items.items() if item.namespace == "rules"]:
+            del plan.items[relpath]
         return plan

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -131,15 +131,11 @@ def test_bare_install_gemini(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="OpenCode must not install a standalone rules/ namespace (bash inlines rules "
-    "into AGENTS.md); the Python adapter still stages rules/ files. Not yet ported.",
-)
 def test_bare_install_opencode(tmp_path: Path) -> None:
     """Single-tool parity for OpenCode — the XDG (~/.config/opencode) tool that
-    skips shared agents/ and flattens rules into AGENTS.md. Confirms the Python
-    adapter wrongly installs a standalone rules/ namespace."""
+    skips shared agents/ and inlines rules into AGENTS.md (no standalone rules/
+    namespace; the adapter drops rules from the plan after the ALL-RULES flatten,
+    mirroring install.sh Phase 7's rules/-subdir sync skip)."""
     result = run_parity(tmp_path, args=["--tools=opencode", "--plugins=", "--yes"])
 
     assert result.bash_returncode == 0, result.bash_stderr

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.io_port import ScriptedIO
 from installer.core.model import StagingPlan, Tool
 from installer.core.staging import build_plan
 from installer.tools.opencode import OpenCodeAdapter
@@ -88,3 +89,27 @@ def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path) -> None:
     plan = build_plan(OpenCodeAdapter(), repo_root=repo)
 
     assert Path("opencode.jsonc") in plan.items
+
+
+def test_opencode_post_staging_transforms_drops_rules(tmp_path: Path) -> None:
+    """
+    Given an OpenCode plan that still carries shared rules/ items (build_plan keeps
+    them so the DYNAMIC-INCLUDE-ALL-RULES flatten can inline them)
+    When OpenCodeAdapter.post_staging_transforms runs
+    Then every rules/ item is dropped, while non-rules items (skills/, templates)
+    survive.
+
+    Pins: OpenCode writes no standalone rules/ namespace — rules live only inline in
+    AGENTS.md. The drop runs post-flatten (mirrors install.sh Phase 7, which stages
+    rules then skips writing the rules/ subdir for opencode), so the inliner still
+    sees the rules but sync does not.
+    """
+    repo = _make_opencode_repo(tmp_path)
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+    assert Path("rules/delegation.md") in plan.items  # precondition: staged for inlining
+
+    result = OpenCodeAdapter().post_staging_transforms(plan, ScriptedIO())
+
+    assert not any(item.namespace == "rules" for item in result.items.values())
+    assert Path("rules/delegation.md") not in result.items
+    assert Path("skills/shared-skill") in result.items


### PR DESCRIPTION
## Summary

Wave 2 of the Epic H bash→Python installer port closes parity gap **G3**: OpenCode must not install a standalone `rules/` namespace.

OpenCode has no `rules/` destination directory — the rules are inlined into its flat `AGENTS.md` via the `DYNAMIC-INCLUDE-ALL-RULES` marker. The Python adapter, however, staged the shared `rules/` files and synced them as a standalone namespace, diverging from `install.sh`, which stages rules then **skips writing** the `rules/` subdir for opencode (Phase 7, `scripts/install.sh:928-934`).

## The fix

Add `OpenCodeAdapter.post_staging_transforms` to drop `rules/` items from the plan **after** the ALL-RULES flatten has already consumed them — mirroring the bash `stage → inline → skip-write` ordering.

The seam matters: the flatten (`flatten_plan_templates`) sources its rule bodies from the staged `rules/` plan items, and it runs *before* `post_staging_transforms` in `stage_and_transform`. Gating rules out of the plan earlier (the naive `should_install_namespace` route) would **starve the inliner** and produce an `AGENTS.md` missing its rules. So the drop must run post-flatten.

## Tests

- **Golden-master**: `test_bare_install_opencode` xfail → **real green** parity pass (byte-identical `AGENTS.md` vs bash, no orphan `rules/*.md`).
- **Unit**: new `test_opencode_post_staging_transforms_drops_rules` pins the post-flatten drop — asserts the staged-for-inlining precondition, then that every `rules/` item is gone while non-rules items (`skills/`) survive.

## Gate evidence

`make ci-installer` green: ruff lint + format-check, mypy --strict, **530 unit passed** (coverage **99.78%**, floor 90%), golden-master **9 passed / 4 xfailed**, pip-audit clean, entry-verify ok.

The parity net flips one gap green: **8 pass/5 xfail → 9 pass/4 xfail**. Remaining xfails are the still-open gaps (gemini transform format, reinstall idempotency, two plugin-route scenarios), each a separate Wave 2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
