### PR TITLE
fix(installer): surgical line port of Gemini agent transform for byte parity (8.17)

### DIFF
--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -4,64 +4,73 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import yaml
-
 if TYPE_CHECKING:
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan
 
-_CLAUDE_ONLY_KEYS = ("skills", "color", "memory")
+_CLAUDE_ONLY_FIELDS = ("skills:", "color:", "memory:")
 
 
 def transform_agent_frontmatter(content: bytes) -> bytes:
     """Translate a shared (Claude-style) agent file's YAML frontmatter into the
     form Gemini's agent loader accepts: drop Claude-only keys (skills, color,
-    memory) and convert a comma-separated ``tools:`` string into a YAML
-    sequence. Port of bash ``transform_gemini_agent_frontmatter``
-    (scripts/install.sh:639-684), via a pyyaml round-trip.
+    memory) and rewrite a comma-separated ``tools:`` string into an inline YAML
+    flow sequence.
 
-    Returns ``content`` unchanged when it has no leading ``---``…``---`` block,
-    when that block is unterminated, when it does not parse to a mapping, or
-    when there is nothing to strip or convert (so an already-clean file is
-    never gratuitously reformatted). The body after the closing fence is
-    preserved byte-for-byte.
+    Surgical line port of bash ``transform_gemini_agent_frontmatter``
+    (scripts/install.sh:643-688): a fence-counting state machine that edits only
+    the lines it must and emits every other line verbatim. That verbatim path is
+    why a ``description: |-`` block scalar — and any quoting or spacing — survives
+    byte-for-byte; a pyyaml round-trip would reflow it. The ``tools:`` value is
+    wrapped whole (``tools: [Read, Grep]``), preserving its raw spacing, rather
+    than re-serialised item by item.
+
+    Non-UTF-8 content is returned unchanged (an undecodable agent file must not
+    abort the install). Like awk, every emitted record is newline-terminated.
     """
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError:
         return content
 
-    lines = text.split("\n")
-    if lines[0] != "---":
-        return content
-    closing = next((i for i in range(1, len(lines)) if lines[i] == "---"), None)
-    if closing is None:
-        return content
+    if not text:
+        return content  # awk's main loop never runs on a 0-byte file: empty in, empty out
 
-    try:
-        data = yaml.safe_load("\n".join(lines[1:closing]))
-    except yaml.YAMLError:
-        return content
-    if not isinstance(data, dict):
-        return content
+    # awk reads \n-separated records; a trailing \n is a terminator, not an empty
+    # final record. Drop that artifact so an unchanged file round-trips identically.
+    records = text.split("\n")
+    if text.endswith("\n"):
+        records = records[:-1]
 
-    changed = False
-    for key in _CLAUDE_ONLY_KEYS:
-        if key in data:
-            del data[key]
-            changed = True
-    tools = data.get("tools")
-    if isinstance(tools, str):
-        items = [t.strip() for t in tools.split(",") if t.strip()]
-        if items:
-            data["tools"] = items
-            changed = True
-    if not changed:
-        return content
+    out: list[str] = []
+    fences = 0  # number of '---' lines seen (frontmatter is the span where == 1)
+    skipping = False  # inside a stripped key's indented continuation block
+    for line in records:
+        if line == "---":
+            fences += 1
+            skipping = False
+            out.append(line)
+            continue
+        if fences == 1:
+            if skipping:
+                if not line or line[0].isspace():
+                    continue  # swallow the stripped key's blank/indented block
+                skipping = False
+            # awk's $1 splits on its default FS (space/tab only), so match the
+            # first space/tab-delimited token — not str.split(), which would also
+            # break on \f/\v and strip a key bash would keep.
+            field = line.lstrip(" \t").split(" ", 1)[0].split("\t", 1)[0]
+            if field in _CLAUDE_ONLY_FIELDS:
+                skipping = True
+                continue
+            if line.startswith("tools:"):
+                value = line[len("tools:") :].lstrip()
+                if value and not value.startswith("["):
+                    out.append(f"tools: [{value}]")
+                    continue
+        out.append(line)
 
-    dumped = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
-    body = "\n".join(lines[closing + 1 :])
-    return ("---\n" + dumped + "---\n" + body).encode("utf-8")
+    return "".join(f"{rec}\n" for rec in out).encode("utf-8")
 
 
 class GeminiAdapter:

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -116,13 +116,12 @@ def test_bare_install_codex(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Gemini agent transform must match bash byte-for-byte (inline tools:[...], "
-    "surgical edit); the Python port's pyyaml round-trip reformats it. Not yet ported.",
-)
 def test_bare_install_gemini(tmp_path: Path) -> None:
-    """Single-tool parity for Gemini — another dot-dir tool, flat instruction file."""
+    """Single-tool parity for Gemini — another dot-dir tool, flat instruction
+    file. The agent frontmatter transform is a surgical line port of the bash
+    awk (inline ``tools: [...]`` wrapping the raw value, Claude-only keys
+    stripped, every other line byte-identical), so a real agent's block-scalar
+    ``description`` survives unreflowed."""
     result = run_parity(tmp_path, args=["--tools=gemini", "--plugins=", "--yes"])
 
     assert result.bash_returncode == 0, result.bash_stderr

--- a/packages/installer/tests/unit/test_gemini_frontmatter.py
+++ b/packages/installer/tests/unit/test_gemini_frontmatter.py
@@ -47,9 +47,14 @@ def test_strips_claude_only_keys() -> None:
     assert fm["name"] == "a"
 
 
-def test_converts_csv_tools_to_sequence() -> None:
-    src = b"---\nname: a\ntools: Read, Grep, Glob\n---\nbody\n"
-    assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read", "Grep", "Glob"]
+def test_csv_tools_wrapped_inline_preserving_raw_spacing() -> None:
+    # Bash awk wraps the RAW value string in brackets (printf "tools: [%s]"), so
+    # the source comma-space spacing survives byte-for-byte. A pyyaml round-trip
+    # would instead emit a block sequence — the exact divergence this fixes.
+    src = b"---\nname: a\ntools: Read, Edit, Write, Grep, Glob, Bash\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    assert b"\ntools: [Read, Edit, Write, Grep, Glob, Bash]\n" in out
+    assert b"\n- Read\n" not in out  # never a block sequence
 
 
 def test_single_tool_becomes_one_element_sequence() -> None:
@@ -57,9 +62,33 @@ def test_single_tool_becomes_one_element_sequence() -> None:
     assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read"]
 
 
+def test_already_inline_tools_not_double_wrapped() -> None:
+    # A value already starting with `[` (inline flow sequence) fails the bash
+    # `val !~ /^\[/` guard, so it is left verbatim — never `[[...]]`.
+    src = b"---\nname: a\ntools: [Read, Grep]\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    assert b"\ntools: [Read, Grep]\n" in out
+    assert b"[[" not in out
+
+
 def test_already_sequence_tools_not_double_wrapped() -> None:
     src = b"---\nname: a\ntools:\n  - Read\n  - Grep\n---\nbody\n"
     assert _frontmatter(transform_agent_frontmatter(src))["tools"] == ["Read", "Grep"]
+
+
+def test_description_block_scalar_preserved_while_stripping_and_wrapping() -> None:
+    # The headline parity guarantee: a `description: |-` block scalar survives
+    # byte-for-byte even as color: is stripped and tools: is wrapped. The pyyaml
+    # round-trip reflowed the block (quoting/spacing/style); the line port leaves
+    # every untouched line verbatim. Mirrors install.sh transform_gemini_agent_
+    # frontmatter (the surgical awk).
+    block = "description: |-\n  Line one.\n\n  Line two with: a colon and  weird   spacing.\n"
+    src = ("---\nname: a\n" + block + "tools: Read, Grep\ncolor: purple\n---\nbody\n").encode()
+    out = transform_agent_frontmatter(src).decode("utf-8")
+    assert block in out  # block scalar byte-identical
+    assert "\ntools: [Read, Grep]\n" in out  # tools wrapped inline
+    assert "color:" not in out  # claude-only key stripped
+    assert out.startswith("---\nname: a\n")
 
 
 def test_strips_key_with_indented_block() -> None:
@@ -74,9 +103,27 @@ def test_no_frontmatter_passes_through_byte_identical() -> None:
     assert transform_agent_frontmatter(src) == src
 
 
-def test_unterminated_frontmatter_passes_through() -> None:
+def test_missing_trailing_newline_is_normalized_like_awk() -> None:
+    # awk terminates every record with \n, so a file lacking a final newline
+    # gains one (matching bash). Pins the record-reconstruction decision.
+    src = b"# no frontmatter, no trailing newline"
+    assert transform_agent_frontmatter(src) == src + b"\n"
+
+
+def test_empty_content_returns_empty_like_awk() -> None:
+    # A 0-byte file never enters awk's main loop, so bash emits nothing. Without
+    # the empty guard, record reconstruction would add a stray newline.
+    assert transform_agent_frontmatter(b"") == b""
+
+
+def test_unterminated_frontmatter_still_transforms_like_bash() -> None:
+    # Bash awk has no closing-fence guard: once the opening --- is seen it keeps
+    # transforming every subsequent line. Mirror that — tools: is wrapped even
+    # with no closing ---, and the trailing non-frontmatter line is preserved.
     src = b"---\nname: a\ntools: Read\n(no closing fence)\n"
-    assert transform_agent_frontmatter(src) == src
+    out = transform_agent_frontmatter(src)
+    assert b"\ntools: [Read]\n" in out
+    assert b"(no closing fence)\n" in out
 
 
 def test_unchanged_frontmatter_returns_byte_identical() -> None:
@@ -114,25 +161,38 @@ def test_invalid_utf8_passes_through_unchanged() -> None:
 
 
 def test_malformed_yaml_frontmatter_passes_through_unchanged() -> None:
-    # A YAML typo in one agent file must not abort the whole install — it is
-    # left verbatim rather than raised.
+    # The line port never parses YAML, so a typo can't abort the install: no line
+    # is a Claude-only key or a `tools:` line, so nothing matches and the bytes
+    # survive verbatim.
     src = b'---\nkey: "unterminated\n---\nbody\n'
     assert transform_agent_frontmatter(src) == src
 
 
 def test_non_mapping_frontmatter_passes_through_unchanged() -> None:
-    # Frontmatter that parses to a sequence/scalar (not a mapping) is left as-is.
+    # Sequence/scalar frontmatter has no key=value line to match either, so the
+    # line port leaves it byte-identical (no structural validation happens).
     src = b"---\n- a\n- b\n---\nbody\n"
     assert transform_agent_frontmatter(src) == src
 
 
-def test_empty_tools_string_is_not_converted() -> None:
-    # An empty tools value yields no sequence items, so it is left untouched
-    # (mirrors the bash length>0 guard); other keys still transform.
+def test_quoted_empty_tools_string_is_bracket_wrapped_like_bash() -> None:
+    # Bash's length>0 guard is on the RAW substring after `tools:`, not on parsed
+    # items — so a quoted empty string (`tools: ""`, length 2) is non-empty and
+    # gets wrapped to `tools: [""]`. Only a truly empty value (`tools:` with
+    # nothing after) is left alone. color: is still stripped.
     src = b'---\nname: a\ncolor: red\ntools: ""\n---\nbody\n'
-    fm = _frontmatter(transform_agent_frontmatter(src))
-    assert "color" not in fm
-    assert fm["tools"] == ""
+    out = transform_agent_frontmatter(src)
+    assert b'\ntools: [""]\n' in out
+    assert b"color:" not in out
+
+
+def test_bare_empty_tools_value_left_untouched() -> None:
+    # `tools:` with nothing after it (raw value length 0) fails the bash length>0
+    # guard, so the line is printed verbatim — no `[]` wrapping.
+    src = b"---\nname: a\ntools:\n---\nbody\n"
+    out = transform_agent_frontmatter(src)
+    assert b"\ntools:\n" in out
+    assert b"tools: [" not in out
 
 
 def test_post_staging_transforms_rewrites_agent_items() -> None:


### PR DESCRIPTION
## Summary

Wave 2 of the Epic H bash→Python installer port closes parity gap **G11**: the Gemini agent frontmatter transform must match `install.sh` byte-for-byte.

`tools/gemini.py::transform_agent_frontmatter` round-tripped frontmatter through `yaml.safe_dump`, which emits **block-style** `tools:` sequences and **reflows** `description:` block scalars (quoting, spacing, style). The bash original — `transform_gemini_agent_frontmatter` (`scripts/install.sh:643-688`) — is a surgical awk: it strips `skills:`/`color:`/`memory:` lines, rewrites `tools: X, Y` → inline `tools: [X, Y]`, and leaves every other line untouched. Every real agent carrying `tools:` plus a block scalar (`quality-reviewer`, `pr-comment-fixer-team`, `tech-lead`) diverged in content.

## The fix

Rewrite the transform as a **fence-counting line state machine** that mirrors the awk:

- Count `---` fences; only act inside the frontmatter span.
- Strip `skills:`/`color:`/`memory:` first-field lines and their indented continuation blocks.
- Wrap a raw, non-`[` `tools:` value whole — `tools: [Read, Grep]` — preserving the source spacing, rather than re-serialising item by item.
- Emit every other line **verbatim**, so a `description: |-` block scalar survives byte-for-byte.
- Match awk's default field separator (space/tab only) for the `$1` strip-key test, terminate each record with `\n` like awk, and short-circuit empty input (empty in, empty out).
- Drop the now-unused `import yaml`.

## Tests

- **Golden-master**: `test_bare_install_gemini` xfail → **real green** parity pass.
- **Unit**: parse-based assertions (which can't see block-vs-inline — the whole bug) replaced with **byte-level** ones; the headline test pins that a `description: |-` block scalar is preserved unreflowed while `color:` is stripped and `tools:` is wrapped. Two pre-existing tests that pinned behavior *diverging* from bash were corrected (unterminated frontmatter keeps transforming; `tools: ""` → `tools: [""]`).

## Review hardening (post quality-review)

A pre-merge adversarial review (25+ inputs cross-checked against the live awk) surfaced two latent byte divergences in this parity-contract function, both now closed: empty input no longer emits a stray `\n`, and the `$1` field test matches awk's space/tab FS rather than `str.split()`'s broader whitespace class.

## Gate evidence

`make ci-installer` green: ruff lint + format-check, mypy --strict, **536 unit passed** (coverage **99.78%**, `gemini.py` fully covered), golden-master **11 passed / 2 xfailed**, pip-audit clean, entry-verify ok.

The parity net advances one gap: **10 pass/3 xfail → 11 pass/2 xfail**. Remaining xfails are reinstall idempotency and plugin routes — each its own Wave 2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
