### PR TITLE
feat(installer): wire beads-plugin routes into Python install pipeline (G2)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -12,7 +12,7 @@ from installer.core.dump import dump_plan
 from installer.core.installer_toml import load_installer_toml
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
-from installer.core.run import install_pipeline, prune_pipeline
+from installer.core.run import install_pipeline, install_plugin_routes, prune_pipeline
 from installer.tools.registry import UnknownToolError, get_adapter, known_tools
 
 if TYPE_CHECKING:
@@ -172,6 +172,17 @@ def main(
             install_pipeline(
                 adapters,
                 plans=plans,
+                home=resolved_home,
+                io=io,
+                dry_run=args.dry_run,
+                auto_yes=config.auto_yes,
+            )
+            # Plugin routes (e.g. beads' ~/.beads/formulas + scripts) land outside
+            # any tool tree, so they install in a dedicated pass after the tool
+            # sync — mirroring the bash installer's stage_and_install_beads phase
+            # (scripts/install.sh:948). Same consent gate; --prune-only skips it.
+            install_plugin_routes(
+                plugins,
                 home=resolved_home,
                 io=io,
                 dry_run=args.dry_run,

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from installer.core.model import Counters, Tool
 from installer.core.prune import scan_orphans
 from installer.core.prune_flow import run_prune
-from installer.core.sync import sync_plan
+from installer.core.sync import sync_plan, sync_routes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from installer.core.installer_toml import InstallerToml
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan
+    from installer.plugins.base import PluginAdapter
     from installer.tools.base import ToolAdapter
 
 
@@ -105,3 +106,29 @@ def install_pipeline(
         total.skipped += result.skipped
         total.backed_up += result.backed_up
     return total
+
+
+def install_plugin_routes(
+    plugins: Iterable[PluginAdapter],
+    *,
+    home: Path,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+    timestamp: str | None = None,
+) -> Counters:
+    """Install every active plugin's bespoke routes (e.g. beads' ``~/.beads/...``).
+
+    The plugin-side analog of ``install_pipeline``: it flattens each plugin's
+    ``routes(home)`` and walks them through ``sync_routes``. Generic plugins
+    return no routes, so a routes-free or tool-only plugin set is a clean no-op.
+    ``cli.main`` (W3) calls this after ``install_pipeline`` (gated by
+    ``not --prune-only``), mirroring the bash installer, which runs
+    ``stage_and_install_beads`` after the tool sync (``scripts/install.sh:948``).
+
+    ``dry_run`` and ``auto_yes`` thread into ``sync_routes`` so the consent gate
+    and no-TTY guard apply uniformly with the tool install. Returns the aggregate
+    `Counters` from the route walk.
+    """
+    routes = [route for plugin in plugins for route in plugin.routes(home)]
+    return sync_routes(routes, io=io, dry_run=dry_run, auto_yes=auto_yes, timestamp=timestamp)

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -455,12 +455,16 @@ def _ensure_parent_dir(target: Path, *, dry_run: bool) -> None:
 
 
 def _restore_exec_bit(dest: Path) -> None:
-    """Restore the canonical ``0o755`` mode on a hash-equal dest whose exec bit
-    was lost, without a full rewrite. Route-scoped port of
-    ``scripts/install.sh:1096`` (``[[ -x ]] || chmod +x``): fires only when ALL
-    exec bits are missing, so a file that still carries any exec bit is untouched."""
-    if not dest.stat().st_mode & 0o111:
-        dest.chmod(0o755)
+    """Restore a lost exec bit on a hash-equal dest without a full rewrite.
+    Route-scoped port of ``scripts/install.sh:1096`` (``[[ -x ]] || chmod +x``):
+    fires only when no exec bit is set, and then *adds* the exec bits to the
+    existing mode (``mode | 0o111``) rather than forcing ``0o755`` — so a
+    user-tightened file (e.g. ``0o600``) gains exec without widening its
+    read/write bits, mirroring ``chmod +x``. The any-exec-bit gate matches the
+    differ's executability definition (``_diff.py::_is_executable``)."""
+    mode = dest.stat().st_mode
+    if not mode & 0o111:
+        dest.chmod(mode | 0o111)
 
 
 def _sha256(data: bytes) -> bytes:

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -26,11 +26,12 @@ from installer.core.model import Counters, FileKind
 from installer.core.paths import is_safe_relpath
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
 
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan
+    from installer.plugins.base import PluginRoute
     from installer.tools.base import ToolAdapter
 
 
@@ -204,6 +205,62 @@ def sync_plan(
     return counters
 
 
+def sync_routes(
+    routes: Iterable[PluginRoute],
+    *,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+    timestamp: str | None = None,
+) -> Counters:
+    """Install every plugin route's globbed files at its dest root.
+
+    The in-memory port of the bash installer's ``stage_and_install_beads``
+    (``scripts/install.sh:948-1124``): for each ``PluginRoute``, glob
+    ``source_dir`` for the route's pattern (sorted, files only) and install each
+    match at ``dest_dir/<name>`` with the route's exec bit, reusing the FILE
+    installer's skip / consent / backup contract. A route whose ``source_dir`` is
+    absent contributes nothing (bash ``[[ -d ... ]] || continue``,
+    ``scripts/install.sh:969,1056``). Unlike the tool-file path, a hash-equal skip
+    restores a lost exec bit (``scripts/install.sh:1096``) — route-scoped, since
+    bash carries no general executable reconcile.
+
+    The shared no-TTY guard (`require_consent`) runs once up front, mirroring
+    ``sync_plan``: a non-interactive run with neither ``auto_yes`` nor ``dry_run``
+    hard-fails before any write. ``dest_dir`` is created lazily on the first write
+    (the differ ignores empty dirs); ``timestamp`` is the backup suffix. Returns
+    aggregate `Counters`.
+    """
+    require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
+    counters = Counters()
+    for route in routes:
+        if not route.source_dir.is_dir():
+            continue
+        # ``route.glob`` is a trusted, non-recursive, in-repo adapter pattern
+        # (e.g. ``*.toml``/``*.sh`` from ``beads.py``), so the dest needs no
+        # ``is_safe_relpath`` guard like the tool path: every match is a direct
+        # child of ``source_dir`` and ``src.name`` is a pure basename, so
+        # ``dest_dir / src.name`` cannot escape ``dest_dir``. A future recursive
+        # (``**``) route would break that invariant — add containment validation
+        # before introducing one.
+        for src in sorted(route.source_dir.glob(route.glob)):
+            if not src.is_file():
+                continue
+            _install_file(
+                route.dest_dir / src.name,
+                src.read_bytes(),
+                executable=route.executable,
+                kind=FileKind.OTHER,
+                io=io,
+                dry_run=dry_run,
+                auto_yes=auto_yes,
+                timestamp=timestamp,
+                counters=counters,
+                restore_exec_on_skip=True,
+            )
+    return counters
+
+
 def _install_file(
     dest: Path,
     content: bytes,
@@ -215,6 +272,7 @@ def _install_file(
     auto_yes: bool,
     timestamp: str | None,
     counters: Counters,
+    restore_exec_on_skip: bool = False,
 ) -> None:
     """Install one FILE item: skip an unchanged dest, back up a differing dest
     before the overwrite, and write the bytes with a deterministic mode bit
@@ -231,6 +289,12 @@ def _install_file(
     silently; ``dry_run`` previews without prompting. The gate fires only on an
     existing dest — a first install is not a destructive overwrite.
 
+    ``restore_exec_on_skip`` (default ``False``) opts the *skip* path into
+    restoring a lost exec bit without a rewrite — the plugin-route behaviour at
+    ``scripts/install.sh:1096``. It is off for tool files because bash carries no
+    general executable reconcile (only beads scripts), so enabling it there would
+    diverge from the spec; ``sync_routes`` turns it on.
+
     A dest already occupied by a non-file (a directory) is rejected with
     `ValueError` rather than crashing the walk with a raw ``IsADirectoryError`` —
     matching ``dump``'s type-guard so the CLI surfaces a clean error."""
@@ -240,6 +304,8 @@ def _install_file(
     old = dest.read_bytes() if dest_exists else None
     effective = _effective_content(content, old, kind=kind)
     if old is not None and _is_unchanged(old, effective, kind=kind):
+        if restore_exec_on_skip and executable and not dry_run:
+            _restore_exec_bit(dest)
         counters.skipped += 1
         return
     if (
@@ -386,6 +452,15 @@ def _ensure_parent_dir(target: Path, *, dry_run: bool) -> None:
             break
     if not dry_run:
         target.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _restore_exec_bit(dest: Path) -> None:
+    """Restore the canonical ``0o755`` mode on a hash-equal dest whose exec bit
+    was lost, without a full rewrite. Route-scoped port of
+    ``scripts/install.sh:1096`` (``[[ -x ]] || chmod +x``): fires only when ALL
+    exec bits are missing, so a file that still carries any exec bit is untouched."""
+    if not dest.stat().st_mode & 0o111:
+        dest.chmod(0o755)
 
 
 def _sha256(data: bytes) -> bytes:

--- a/packages/installer/tests/golden_master/test_parity_plugins.py
+++ b/packages/installer/tests/golden_master/test_parity_plugins.py
@@ -26,16 +26,11 @@ _FIXTURE_COLLISION = _FIXTURES / "collision"  # overlay rule colliding with a sh
 _BEADS_ARGS = ["--tools=claude", "--plugins=beads", "--yes"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Plugin routes (~/.beads/formulas + scripts) must be installed; the Python "
-    "pipeline never dispatches PluginRoute.routes(). Not yet wired.",
-)
 def test_plugin_routes(tmp_path: Path) -> None:
     """The fixture beads plugin ships formulas + an executable script, routed to
-    ~/.beads/formulas and ~/.beads/scripts. Bash installs them; the Python port
-    never wires plugin routes, so ~/.beads content is the expected divergence
-    until routes() is dispatched into the pipeline."""
+    ~/.beads/formulas and ~/.beads/scripts. Both installers place them identically,
+    including the script's exec bit — the Python pipeline now dispatches
+    PluginRoute.routes() through install_plugin_routes (G2)."""
     result = run_parity(tmp_path, args=_BEADS_ARGS, plugins_src=_FIXTURE_BASIC)
 
     assert result.bash_returncode == 0, result.bash_stderr

--- a/packages/installer/tests/unit/test_run_plugin_routes.py
+++ b/packages/installer/tests/unit/test_run_plugin_routes.py
@@ -1,0 +1,75 @@
+"""Unit tests for installer.core.run.install_plugin_routes (G2 — plugin-route dispatch).
+
+The bead's core bug: ``PluginRoute.routes()`` had zero call sites; ``core/run.py``
+iterated only tool adapters, never plugin routes, so every Python install with the
+beads plugin silently dropped all ``~/.beads`` content. ``install_plugin_routes``
+is the missing dispatch — the plugin-side analog of ``install_pipeline``, driving
+each active plugin's ``routes(home)`` through ``sync_routes``.
+
+These pin the composition's end-state: real plugin adapters, the real filesystem
+under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.io_port import ScriptedIO
+from installer.core.run import install_plugin_routes
+from installer.plugins.beads import BeadsPlugin
+from installer.plugins.generic import GenericPluginAdapter
+
+_FIXED_TS = "20260613-120000"
+
+
+def _seed_beads_source(src: Path) -> None:
+    formulas = src / ".beads" / "formulas"
+    scripts = src / ".beads" / "scripts"
+    formulas.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    (formulas / "f.toml").write_bytes(b"x = 1\n")
+    (scripts / "s.sh").write_bytes(b"#!/bin/sh\n")
+
+
+def test_install_plugin_routes_dispatches_beads_formulas_and_scripts(tmp_path: Path) -> None:
+    """
+    Given a BeadsPlugin whose source carries a formula and a script
+    When install_plugin_routes runs
+    Then the formula lands at home/.beads/formulas (non-exec) and the script at
+    home/.beads/scripts (exec) — the routes are dispatched, not dropped.
+
+    Pins the fix for the parity BLOCKER: routes(home) is now wired into the
+    install pipeline (was a zero-call-site dead end).
+    """
+    home = tmp_path / "home"
+    src = tmp_path / "plugin-src"
+    _seed_beads_source(src)
+    beads = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
+
+    counters = install_plugin_routes([beads], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    formula = home / ".beads" / "formulas" / "f.toml"
+    script = home / ".beads" / "scripts" / "s.sh"
+    assert formula.read_bytes() == b"x = 1\n"
+    assert script.read_bytes() == b"#!/bin/sh\n"
+    assert script.stat().st_mode & 0o111  # scripts land executable
+    assert formula.stat().st_mode & 0o111 == 0  # formulas do not
+    assert counters.created == 2
+
+
+def test_generic_plugin_contributes_no_routes(tmp_path: Path) -> None:
+    """
+    Given a generic plugin (routes() == ())
+    When install_plugin_routes runs
+    Then nothing is installed — only specialized adapters with bespoke
+    destinations (beads) route content outside a tool tree.
+
+    Pins: the dispatch is route-driven, so a routes-free plugin is a clean no-op.
+    """
+    home = tmp_path / "home"
+    generic = GenericPluginAdapter(name="whatever", source_path=tmp_path / "src")
+
+    counters = install_plugin_routes([generic], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert not (home / ".whatever").exists()
+    assert (counters.created, counters.updated, counters.skipped) == (0, 0, 0)

--- a/packages/installer/tests/unit/test_run_plugin_routes.py
+++ b/packages/installer/tests/unit/test_run_plugin_routes.py
@@ -1,6 +1,6 @@
 """Unit tests for installer.core.run.install_plugin_routes (G2 — plugin-route dispatch).
 
-The bead's core bug: ``PluginRoute.routes()`` had zero call sites; ``core/run.py``
+The core bug this dispatch fixes: ``PluginRoute.routes()`` had zero call sites; ``core/run.py``
 iterated only tool adapters, never plugin routes, so every Python install with the
 beads plugin silently dropped all ``~/.beads`` content. ``install_plugin_routes``
 is the missing dispatch — the plugin-side analog of ``install_pipeline``, driving

--- a/packages/installer/tests/unit/test_sync_routes.py
+++ b/packages/installer/tests/unit/test_sync_routes.py
@@ -131,6 +131,30 @@ def test_route_unchanged_script_is_skipped_but_lost_exec_bit_is_restored(
     assert (counters.skipped, counters.updated) == (1, 0)
 
 
+def test_route_restore_adds_exec_without_widening_existing_rw_bits(tmp_path: Path) -> None:
+    """
+    Given an exec route whose dest holds byte-identical content but was tightened
+    to 0o600 (rw-------, no exec)
+    When sync_routes runs
+    Then exec bits are ADDED on top of the existing mode (0o711), not clobbered to
+    a fixed 0o755 — bash's ``chmod +x`` preserves read/write bits and never widens
+    group/other read.
+
+    Pins faithfulness to ``install.sh:1096`` ``chmod +x`` semantics (add exec,
+    preserve the rest), so a user-tightened file is not silently re-opened.
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    _seed_file(dest / "go.sh", b"#!/bin/sh\n", mode=0o600)  # same bytes, tightened
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "go.sh").stat().st_mode & 0o777 == 0o711  # rw preserved, +x added
+    assert counters.skipped == 1
+
+
 def test_route_unchanged_nonexec_formula_is_not_chmod_executable(tmp_path: Path) -> None:
     """
     Given a non-exec route whose dest already holds byte-identical content (0o644)

--- a/packages/installer/tests/unit/test_sync_routes.py
+++ b/packages/installer/tests/unit/test_sync_routes.py
@@ -1,0 +1,284 @@
+"""Unit tests for installer.core.sync.sync_routes (F.4 / G2 — plugin-route install).
+
+``sync_routes`` is the in-memory port of the bash installer's
+``stage_and_install_beads`` (``scripts/install.sh:948-1124``): it walks a plugin's
+``PluginRoute`` set, globs each route's ``source_dir``, and installs the matched
+files at its ``dest_dir`` with the route's exec bit. Unlike the tool-file path, a
+route restores a *lost* exec bit on a hash-equal skip
+(``scripts/install.sh:1096``) — that restore is route-scoped, since bash carries
+no general executable-file mode reconcile.
+
+Each test pins a coded decision and drives the engine through ``ScriptedIO`` + the
+real filesystem under ``tmp_path``. ``PluginRoute`` carries absolute source/dest
+dirs, so a test controls both ends directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.consent import ConsentRequiredError
+from installer.core.io_port import ScriptedIO
+from installer.core.sync import sync_routes
+from installer.plugins.base import PluginRoute
+
+_FIXED_TS = "20260613-120000"
+
+
+def _seed_file(path: Path, content: bytes, *, mode: int = 0o644) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(mode)
+    return path
+
+
+def test_routes_install_matched_files_with_their_exec_bit(tmp_path: Path) -> None:
+    """
+    Given a non-exec formulas route (*.toml) and an exec scripts route (*.sh),
+    each with one source file
+    When sync_routes runs into fresh dests
+    Then both files land at their dest_dir; the script carries an exec bit and the
+    formula does not; both count as created.
+
+    Pins AC: routes place files at ~/.beads/{formulas,scripts}; the scripts route's
+    exec bit is honored (install.sh:1086 chmod +x), the formulas route's is not.
+    """
+    src = tmp_path / "src"
+    dest_formulas = tmp_path / "home" / ".beads" / "formulas"
+    dest_scripts = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "formulas" / "a.toml", b"x = 1\n")
+    _seed_file(src / "scripts" / "go.sh", b"#!/bin/sh\necho hi\n", mode=0o755)
+    routes = [
+        PluginRoute(src / "formulas", dest_formulas, "*.toml", executable=False),
+        PluginRoute(src / "scripts", dest_scripts, "*.sh", executable=True),
+    ]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest_formulas / "a.toml").read_bytes() == b"x = 1\n"
+    assert (dest_scripts / "go.sh").read_bytes() == b"#!/bin/sh\necho hi\n"
+    assert (dest_formulas / "a.toml").stat().st_mode & 0o111 == 0
+    assert (dest_scripts / "go.sh").stat().st_mode & 0o777 == 0o755
+    assert counters.created == 2
+
+
+def test_routes_install_only_glob_matches(tmp_path: Path) -> None:
+    """
+    Given a route source dir holding a matching *.toml and a non-matching README.md
+    When sync_routes runs with glob *.toml
+    Then only the .toml is installed; the README is left behind.
+
+    Pins: the route glob filters the source dir (install.sh:971 `for ... *.toml`),
+    so unrelated files in the plugin's route dir are not routed.
+    """
+    src = tmp_path / "src" / "formulas"
+    dest = tmp_path / "home" / ".beads" / "formulas"
+    _seed_file(src / "a.toml", b"x = 1\n")
+    _seed_file(src / "README.md", b"not a formula\n")
+    routes = [PluginRoute(src, dest, "*.toml", executable=False)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "a.toml").is_file()
+    assert not (dest / "README.md").exists()
+    assert counters.created == 1
+
+
+def test_route_with_missing_source_dir_installs_nothing(tmp_path: Path) -> None:
+    """
+    Given a route whose source_dir does not exist
+    When sync_routes runs
+    Then nothing is installed, the dest is not created, and no error is raised.
+
+    Pins: bash guards each plugin's route dir with `[[ -d ... ]] || continue`
+    (install.sh:969,1056); a plugin without that subtree contributes no files.
+    """
+    src = tmp_path / "src" / "absent"
+    dest = tmp_path / "home" / ".beads" / "formulas"
+    routes = [PluginRoute(src, dest, "*.toml", executable=False)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert not dest.exists()
+    assert (counters.created, counters.updated, counters.skipped) == (0, 0, 0)
+
+
+def test_route_unchanged_script_is_skipped_but_lost_exec_bit_is_restored(
+    tmp_path: Path,
+) -> None:
+    """
+    Given an exec route whose dest already holds byte-identical content but has
+    lost its exec bit (mode 0o644)
+    When sync_routes runs
+    Then no rewrite/backup happens (content matches), but the exec bit is restored
+    to 0o755 and the item counts as skipped.
+
+    Pins install.sh:1096 — "content matches but exec bit may have been lost;
+    restore it without a full copy" — route-scoped (bash has no general reconcile).
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    _seed_file(dest / "go.sh", b"#!/bin/sh\n", mode=0o644)  # same bytes, no +x
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "go.sh").stat().st_mode & 0o777 == 0o755  # +x restored
+    assert not any(dest.glob("go.sh.backup-*"))  # content matched -> no backup
+    assert (counters.skipped, counters.updated) == (1, 0)
+
+
+def test_route_unchanged_nonexec_formula_is_not_chmod_executable(tmp_path: Path) -> None:
+    """
+    Given a non-exec route whose dest already holds byte-identical content (0o644)
+    When sync_routes runs
+    Then the dest stays non-executable — the +x restore is exec-route-only.
+
+    Pins: the line-1096 restore is gated on the route's exec bit; a formula
+    (executable=False) is never chmod'd +x on a skip.
+    """
+    src = tmp_path / "src" / "formulas"
+    dest = tmp_path / "home" / ".beads" / "formulas"
+    _seed_file(src / "a.toml", b"x = 1\n", mode=0o644)
+    _seed_file(dest / "a.toml", b"x = 1\n", mode=0o644)
+    routes = [PluginRoute(src, dest, "*.toml", executable=False)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "a.toml").stat().st_mode & 0o111 == 0
+    assert counters.skipped == 1
+
+
+def test_route_skips_a_directory_that_matches_the_glob(tmp_path: Path) -> None:
+    """
+    Given a route source dir holding a real a.toml file and a *directory* named
+    sub.toml that also matches the glob
+    When sync_routes runs
+    Then only the file is installed; the glob-matching directory is skipped.
+
+    Pins bash's `[[ -f "$formula" ]] || continue` (install.sh:972) — the glob can
+    match a directory, and only regular files are routed.
+    """
+    src = tmp_path / "src" / "formulas"
+    dest = tmp_path / "home" / ".beads" / "formulas"
+    _seed_file(src / "a.toml", b"x = 1\n")
+    (src / "sub.toml").mkdir(parents=True)  # a dir matching *.toml
+    routes = [PluginRoute(src, dest, "*.toml", executable=False)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "a.toml").is_file()
+    assert not (dest / "sub.toml").exists()
+    assert counters.created == 1
+
+
+def test_route_unchanged_script_with_intact_exec_bit_is_left_as_is(tmp_path: Path) -> None:
+    """
+    Given an exec route whose dest already holds byte-identical content AND still
+    carries its exec bit (0o755)
+    When sync_routes runs
+    Then it is a clean skip — no rewrite, no backup, mode unchanged.
+
+    Pins idempotent reinstall: the line-1096 restore is a no-op when the exec bit
+    is intact (the `[[ -x ]]` guard is already satisfied).
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    _seed_file(dest / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    assert (dest / "go.sh").stat().st_mode & 0o777 == 0o755
+    assert not any(dest.glob("go.sh.backup-*"))
+    assert (counters.skipped, counters.updated) == (1, 0)
+
+
+def test_route_changed_file_is_backed_up_then_overwritten(tmp_path: Path) -> None:
+    """
+    Given an exec route whose dest holds DIFFERENT bytes
+    When sync_routes runs with auto_yes (waiving the per-file confirm)
+    Then the original is backed up under <name>.backup-<ts>, the new bytes are
+    written, the exec bit is set, and the item counts as an update + backup.
+
+    Pins: a changed route file is backed up before overwrite (install.sh:1109-1111
+    backup; cp; chmod +x), matching the tool-file overwrite contract.
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\nnew\n", mode=0o755)
+    _seed_file(dest / "go.sh", b"#!/bin/sh\nold\n", mode=0o755)
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS)
+
+    assert (dest / "go.sh").read_bytes() == b"#!/bin/sh\nnew\n"
+    assert (dest / "go.sh").stat().st_mode & 0o777 == 0o755
+    assert (dest / f"go.sh.backup-{_FIXED_TS}").read_bytes() == b"#!/bin/sh\nold\n"
+    assert (counters.updated, counters.backed_up) == (1, 1)
+
+
+def test_route_dry_run_previews_without_writing(tmp_path: Path) -> None:
+    """
+    Given a fresh exec route and dry_run
+    When sync_routes runs
+    Then nothing is written to disk, but the would-be create is counted.
+
+    Pins: dry_run previews and touches nothing, reusing the file installer's
+    dry-run contract (install.sh:1083 "Would install").
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), dry_run=True, timestamp=_FIXED_TS)
+
+    assert not (dest / "go.sh").exists()
+    assert counters.created == 1
+
+
+def test_route_dry_run_does_not_restore_a_lost_exec_bit(tmp_path: Path) -> None:
+    """
+    Given an exec route whose dest holds byte-identical content but lost its exec
+    bit (0o644), and dry_run
+    When sync_routes runs
+    Then the bit is NOT restored — a dry run mutates nothing, including mode.
+
+    Pins the ``not dry_run`` term of the restore guard, mirroring bash's
+    ``[[ "$DRY_RUN" == true ]] ||`` on the line-1096 restore (install.sh:1096).
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    _seed_file(dest / "go.sh", b"#!/bin/sh\n", mode=0o644)  # same bytes, no +x
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    counters = sync_routes(routes, io=ScriptedIO(), dry_run=True, timestamp=_FIXED_TS)
+
+    assert (dest / "go.sh").stat().st_mode & 0o111 == 0  # dry run left mode alone
+    assert counters.skipped == 1
+
+
+def test_route_non_interactive_without_waiver_raises_before_any_write(tmp_path: Path) -> None:
+    """
+    Given a non-interactive session, not dry_run and not auto_yes
+    When sync_routes is asked to install a route
+    Then it raises ConsentRequiredError up front — before any file lands — reusing
+    the shared no-TTY guard rather than silently overwriting.
+
+    Pins: sync_routes runs require_consent once up front, like sync_plan.
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "go.sh", b"#!/bin/sh\n", mode=0o755)
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+
+    with pytest.raises(ConsentRequiredError):
+        sync_routes(routes, io=ScriptedIO(interactive=False), timestamp=_FIXED_TS)
+
+    assert not (dest / "go.sh").exists()


### PR DESCRIPTION
## Summary

Wave 2 of the Epic H bash→Python installer port closes parity gap **G2** — a P0 BLOCKER: the Python installer silently dropped **all** `~/.beads` content for every install with the beads plugin.

`PluginRoute.routes()` (beads: formulas → `~/.beads/formulas/`, scripts → `~/.beads/scripts/` with `+x`) had **zero call sites**. `core/run.py` iterated only *tool* adapters, never *plugin* routes, so the bespoke `~/.beads/` destinations bash installs via `stage_and_install_beads` (`scripts/install.sh:948-1124`) never landed.

## The fix

A dedicated plugin-route install pass, mirroring the bash phase that runs after the tool sync:

- **`core/sync.py::sync_routes`** — the in-memory port of `stage_and_install_beads`. For each `PluginRoute`, glob `source_dir` for the route's pattern (sorted, files only — bash's `[[ -f ]]` guard), install each match at `dest_dir/<name>` with the route's exec bit, reusing `_install_file`'s skip / consent / backup contract. A route whose `source_dir` is absent contributes nothing (bash `[[ -d ]] || continue`).
- **`core/run.py::install_plugin_routes`** — the plugin-side analog of `install_pipeline`: flattens each active plugin's `routes(home)` and walks them through `sync_routes`. Generic plugins return no routes, so a tool-only set is a clean no-op.
- **`cli.py`** — calls `install_plugin_routes` after `install_pipeline`, inside the same `ConsentRequiredError` guard, gated by `not --prune-only`.

### Route-scoped `+x` restore (the one subtle decision)

Bash restores a lost exec bit on a hash-equal script *without* a rewrite (`scripts/install.sh:1096`). This is ported as a **route-scoped** `restore_exec_on_skip` flag on `_install_file` — ON only for `sync_routes`. It is deliberately **OFF** for the tool-file path: bash's *only* `+x` logic lives in `stage_and_install_beads` (no general executable reconcile), yet tool hook files also carry `executable=True` (`core/staging.py:160`) through the same `_install_file`. A blanket reconcile would make Python restore `+x` on a tool hook that lost its bit where bash would not — a latent parity divergence. Scoping the behavior to routes keeps the port faithful.

## Tests

- **Golden-master**: `test_plugin_routes` xfail → **real green** parity pass (byte-identical `~/.beads/formulas/*` + `~/.beads/scripts/*`, including the script's exec bit).
- **Unit** (`test_sync_routes.py`, `test_run_plugin_routes.py`): fresh install + exec bit, glob filter, missing-source-dir no-op, hash-equal skip **restores** a lost `+x` (install.sh:1096) while leaving a non-exec formula untouched, hash-equal-with-intact-bit clean skip, dir-matching-glob skipped (`[[ -f ]]`), changed file backed-up-then-overwritten, dry-run preview, non-interactive no-TTY guard, and the beads-route dispatch end-state (formulas non-exec, scripts exec; generic plugin → no-op).

## Gate evidence

`make ci-installer` green: ruff lint + format-check, mypy --strict, **548 unit passed** (coverage **99.79%**, floor 90%), golden-master **12 passed / 1 xfailed**, pip-audit clean, entry-verify ok.

The parity net advances one gap: **11 pass/2 xfail → 12 pass/1 xfail**. The lone remaining xfail is reinstall idempotency (G6) — its own Wave 2 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
