### PR TITLE
fix(installer): re-install idempotency parity — idempotent dir sync + settings-backup (8.12)

### DIFF
--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -325,6 +325,26 @@ def _install_file(
     _record_write(dest, dest_exists=dest_exists, io=io, dry_run=dry_run, counters=counters)
 
 
+def _dir_is_unchanged(dest: Path, source_path: Path, overrides: Mapping[Path, bytes]) -> bool:
+    """Whether re-materialising ``dest`` from ``source_path`` + ``overrides`` would
+    leave its contents byte-identical — the directory idempotency check.
+
+    Mirrors bash ``sync_directory``'s ``src_hash == dest_hash`` "up to date"
+    branch (`scripts/install.sh:1230`), whose directory hash folds every file's
+    relpath and bytes (`compute_hash`, `scripts/install.sh:402-403`). The
+    expected file map is the source tree with ``overrides`` overlaid (override
+    wins on a name collision — dump-time semantics), compared against the actual
+    dest tree. Bytes are read through symlinks to match ``copytree``'s
+    dereferencing; only files participate, so empty dirs are ignored — matching
+    the golden-master differ."""
+    expected = {
+        p.relative_to(source_path): p.read_bytes() for p in source_path.rglob("*") if p.is_file()
+    }
+    expected.update(overrides)
+    actual = {p.relative_to(dest): p.read_bytes() for p in dest.rglob("*") if p.is_file()}
+    return expected == actual
+
+
 def _install_dir(
     dest: Path,
     source_path: Path,
@@ -340,10 +360,14 @@ def _install_dir(
     copy the ``source_path`` tree, then overlay ``overrides`` (override wins on
     a name collision, matching dump-time semantics). Mutates ``counters``.
 
-    An existing dest passes through the consent gate before the backup/replace:
-    an interactive decline keeps the existing tree and counts a skip; ``auto_yes``
-    accepts silently; ``dry_run`` previews without prompting. A directory has no
-    ``IOPort`` byte-diff, so the change is surfaced as a notice, not a unified diff.
+    An existing dest whose contents already match (`_dir_is_unchanged`) is left
+    untouched and counted as a skip — so a re-install is idempotent and produces
+    no spurious backups (bash ``sync_directory``'s "up to date" branch,
+    `scripts/install.sh:1230`). A changed existing dest passes through the
+    consent gate before the backup/replace: an interactive decline keeps the
+    existing tree and counts a skip; ``auto_yes`` accepts silently; ``dry_run``
+    previews without prompting. A directory has no ``IOPort`` byte-diff, so the
+    change is surfaced as a notice, not a unified diff.
 
     A missing or non-directory ``source_path``, or a dest already occupied by a
     non-directory (a file), is rejected with `ValueError` rather than crashing
@@ -361,6 +385,9 @@ def _install_dir(
         if not is_safe_relpath(inner):
             raise ValueError(f"dir override relpath escapes the dir: {inner}")  # noqa: TRY003  # single call-site; subclass not justified
     dest_exists = dest.exists()
+    if dest_exists and _dir_is_unchanged(dest, source_path, overrides):
+        counters.skipped += 1
+        return
     if (
         dest_exists
         and not dry_run

--- a/packages/installer/tests/golden_master/_diff.py
+++ b/packages/installer/tests/golden_master/_diff.py
@@ -126,6 +126,34 @@ def _index_tree(root: Path) -> dict[str, Path]:
     return index
 
 
+def _is_accepted_settings_backup(
+    relpath: str, index_a: dict[str, Path], index_b: dict[str, Path]
+) -> bool:
+    """Whether a bash-only ``<x>.json.backup-<TS>`` is the accepted artifact of the
+    settings array-order divergence (see ``_order_insensitive``).
+
+    On a re-install, bash's jq ``unique`` sorts ``permissions.deny`` / ``hooks.*``
+    when it re-merges the settings file, so it sees a "change" and backs up the
+    prior copy; Python's order-preserving union is idempotent and writes no backup.
+    That surplus backup is the same accepted divergence leaking onto disk — accept
+    it, but only narrowly: the backup must target a ``.json`` file whose live copy
+    exists on BOTH sides and is semantically equal. A non-``.json`` backup, a
+    missing live counterpart, or a genuinely different target (element added or
+    dropped, not a pure reorder) is not exempt and still flags. The exemption is
+    deliberately one-sided — a Python-only backup means Python itself was
+    non-idempotent, the very regression this scenario guards, so the caller applies
+    this only to ``only_in_a`` (bash)."""
+    if not relpath.endswith(_BACKUP_TS_PLACEHOLDER):
+        return False
+    target = relpath[: -len(_BACKUP_TS_PLACEHOLDER)]
+    if not target.endswith(".json"):
+        return False
+    live_a, live_b = index_a.get(target), index_b.get(target)
+    if live_a is None or live_b is None:
+        return False
+    return json_semantically_equal(live_a.read_bytes(), live_b.read_bytes())
+
+
 def _is_executable(path: Path) -> bool:
     # Any execute bit (owner/group/other), matching POSIX ``test -x`` intent —
     # not just owner-execute. Git stores only 0o644/0o755, so the two agree on
@@ -160,8 +188,15 @@ def diff_trees(root_a: Path, root_b: Path) -> TreeDiff:
         if _is_executable(path_a) != _is_executable(path_b):
             mode_mismatch.append(relpath)
 
+    only_in_a = tuple(
+        sorted(
+            rel
+            for rel in keys_a - keys_b
+            if not _is_accepted_settings_backup(rel, index_a, index_b)
+        )
+    )
     return TreeDiff(
-        only_in_a=tuple(sorted(keys_a - keys_b)),
+        only_in_a=only_in_a,
         only_in_b=tuple(sorted(keys_b - keys_a)),
         content_mismatch=tuple(content_mismatch),
         mode_mismatch=tuple(mode_mismatch),

--- a/packages/installer/tests/golden_master/_diff.py
+++ b/packages/installer/tests/golden_master/_diff.py
@@ -136,17 +136,19 @@ def _is_accepted_settings_backup(
     when it re-merges the settings file, so it sees a "change" and backs up the
     prior copy; Python's order-preserving union is idempotent and writes no backup.
     That surplus backup is the same accepted divergence leaking onto disk — accept
-    it, but only narrowly: the backup must target a ``.json`` file whose live copy
-    exists on BOTH sides and is semantically equal. A non-``.json`` backup, a
-    missing live counterpart, or a genuinely different target (element added or
-    dropped, not a pure reorder) is not exempt and still flags. The exemption is
-    deliberately one-sided — a Python-only backup means Python itself was
-    non-idempotent, the very regression this scenario guards, so the caller applies
-    this only to ``only_in_a`` (bash)."""
+    it, but only narrowly: the backup must target a ``settings.json`` file (the
+    only union-merged file, hence the only one whose array order bash re-sorts)
+    whose live copy exists on BOTH sides and is semantically equal. A backup of any
+    other file (a verbatim-copied ``.json``, a non-JSON file), a missing live
+    counterpart, or a genuinely different target (element added or dropped, not a
+    pure reorder) is not exempt and still flags. The exemption is deliberately
+    one-sided — a Python-only backup means Python itself was non-idempotent, the
+    very regression this scenario guards, so the caller applies this only to
+    ``only_in_a`` (bash)."""
     if not relpath.endswith(_BACKUP_TS_PLACEHOLDER):
         return False
     target = relpath[: -len(_BACKUP_TS_PLACEHOLDER)]
-    if not target.endswith(".json"):
+    if Path(target).name != "settings.json":
         return False
     live_a, live_b = index_a.get(target), index_b.get(target)
     if live_a is None or live_b is None:

--- a/packages/installer/tests/golden_master/test_diff.py
+++ b/packages/installer/tests/golden_master/test_diff.py
@@ -192,12 +192,26 @@ def test_settings_backup_only_in_bash_with_divergent_live_still_flags(tmp_path: 
 
 
 def test_non_json_backup_only_in_bash_still_flags(tmp_path: Path) -> None:
-    # Only `.json` merge backups are the accepted array-order artifact. A non-JSON
-    # backup present on only one side (e.g. a spurious dir/file backup) is not
-    # exempt and must still flag.
+    # Only the union-merged settings file produces the accepted array-order
+    # artifact. A non-JSON backup present on only one side (e.g. a spurious
+    # dir/file backup) is not exempt and must still flag.
     a, b = tmp_path / "a", tmp_path / "b"
     _write(a / ".claude/AGENTS.md", b"x")
     _write(a / ".claude/AGENTS.md.backup-20260619-120000", b"old")
     _write(b / ".claude/AGENTS.md", b"x")
     result = diff_trees(a, b)
     assert ".claude/AGENTS.md.backup-<TS>" in result.only_in_a
+
+
+def test_non_settings_json_backup_only_in_bash_still_flags(tmp_path: Path) -> None:
+    # The exemption is anchored to the union-merged `settings.json` — the only
+    # file whose array order bash's jq re-sorts. A bash-only backup of any OTHER
+    # `.json` (which is copied verbatim, never merged) cannot be that artifact, so
+    # it must still flag even when its live copy matches semantically — otherwise
+    # the oracle would silently swallow an unrelated bash-only backup.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/other.json", b'{"x": [1, 2]}')
+    _write(a / ".claude/other.json.backup-20260619-120000", b'{"x": [2, 1]}')
+    _write(b / ".claude/other.json", b'{"x": [2, 1]}')
+    result = diff_trees(a, b)
+    assert ".claude/other.json.backup-<TS>" in result.only_in_a

--- a/packages/installer/tests/golden_master/test_diff.py
+++ b/packages/installer/tests/golden_master/test_diff.py
@@ -147,3 +147,57 @@ def test_tool_root_instruction_file_is_not_exempt(tmp_path: Path) -> None:
     _write(b / ".claude/AGENTS.md", b"beta")
     result = diff_trees(a, b)
     assert ".claude/AGENTS.md" in result.content_mismatch
+
+
+def test_settings_reinstall_backup_only_in_bash_is_accepted(tmp_path: Path) -> None:
+    # bash's jq `unique` sorts settings arrays on a re-install merge and backs up
+    # the prior file; Python's order-preserving union is idempotent and writes no
+    # backup. The surplus bash backup is the accepted artifact of that array-order
+    # divergence, provided the live settings.json matches on both sides.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/settings.json", b'{"permissions": {"deny": [1, 2]}}')
+    _write(
+        a / ".claude/settings.json.backup-20260619-120000",
+        b'{"permissions": {"deny": [2, 1]}}',
+    )
+    _write(b / ".claude/settings.json", b'{"permissions": {"deny": [2, 1]}}')
+    result = diff_trees(a, b)
+    assert result.is_parity(), result.render()
+
+
+def test_settings_backup_only_in_python_still_flags(tmp_path: Path) -> None:
+    # The exemption is asymmetric: a Python-only settings backup means Python was
+    # non-idempotent on a re-install — exactly the regression this parity scenario
+    # guards — so it must still break parity.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/settings.json", b'{"deny": [1, 2]}')
+    _write(b / ".claude/settings.json", b'{"deny": [1, 2]}')
+    _write(b / ".claude/settings.json.backup-20260619-120000", b'{"deny": [1, 2]}')
+    result = diff_trees(a, b)
+    assert ".claude/settings.json.backup-<TS>" in result.only_in_b
+
+
+def test_settings_backup_only_in_bash_with_divergent_live_still_flags(tmp_path: Path) -> None:
+    # The exemption requires the live target to match on both sides. A backup whose
+    # live settings.json genuinely differs (element added/dropped, not a pure
+    # reorder) is a real divergence — both the surplus backup and the live content
+    # mismatch must flag.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/settings.json", b'{"deny": [1, 2]}')
+    _write(a / ".claude/settings.json.backup-20260619-120000", b'{"deny": [9]}')
+    _write(b / ".claude/settings.json", b'{"deny": [1, 2, 3]}')
+    result = diff_trees(a, b)
+    assert ".claude/settings.json.backup-<TS>" in result.only_in_a
+    assert ".claude/settings.json" in result.content_mismatch
+
+
+def test_non_json_backup_only_in_bash_still_flags(tmp_path: Path) -> None:
+    # Only `.json` merge backups are the accepted array-order artifact. A non-JSON
+    # backup present on only one side (e.g. a spurious dir/file backup) is not
+    # exempt and must still flag.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/AGENTS.md", b"x")
+    _write(a / ".claude/AGENTS.md.backup-20260619-120000", b"old")
+    _write(b / ".claude/AGENTS.md", b"x")
+    result = diff_trees(a, b)
+    assert ".claude/AGENTS.md.backup-<TS>" in result.only_in_a

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -176,15 +176,11 @@ def test_warmup_run_failure_is_surfaced(tmp_path: Path) -> None:
         run_parity(tmp_path, args=["--tools=bogus-tool", "--plugins=", "--yes"], repeat=2)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Re-install must be idempotent: the Python port re-backs-up directories on "
-    "every run, so a second run leaves spurious backups bash does not. Not yet ported.",
-)
 def test_reinstall_is_idempotent(tmp_path: Path) -> None:
     """Running each installer twice into the same HOME must converge to the same
-    tree — no spurious second-run backups. Exercises re-install idempotency
-    (Python re-backs-up directories every run)."""
+    tree. ``_install_dir`` skips an unchanged directory (no spurious second-run
+    backup), and the differ accepts bash's lone settings.json re-merge backup —
+    the on-disk trace of the array-order divergence it already normalises away."""
     result = run_parity(tmp_path, args=_CLAUDE_ARGS, repeat=2)
 
     assert result.bash_returncode == 0, result.bash_stderr

--- a/packages/installer/tests/unit/test_sync_plan.py
+++ b/packages/installer/tests/unit/test_sync_plan.py
@@ -294,6 +294,68 @@ def test_existing_dir_is_backed_up_then_cleanly_replaced(tmp_path: Path) -> None
     assert (counters.updated, counters.backed_up) == (1, 1)
 
 
+def test_unchanged_dir_item_is_skipped_without_backup(tmp_path: Path) -> None:
+    """
+    Given a DIR item already materialised by a prior identical run
+    When sync_plan re-runs into the same dest
+    Then the unchanged dir is skipped — no backup is created and skipped is
+    counted — mirroring bash sync_directory's ``src_hash == dest_hash`` "up to
+    date" branch (scripts/install.sh:1230) so a re-install is idempotent.
+    """
+    src = tmp_path / "src_skill"
+    (src / "sub").mkdir(parents=True)
+    (src / "SKILL.md").write_bytes(b"skill\n")
+    (src / "sub" / "x.md").write_bytes(b"nested\n")
+    home = tmp_path / "home"
+    plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
+
+    first = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+    assert first.created == 1
+
+    second = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert second.skipped == 1
+    assert (second.created, second.updated, second.backed_up) == (0, 0, 0)
+    assert not (home / "skills-backup").exists()
+    assert (home / "skills" / "s" / "SKILL.md").read_bytes() == b"skill\n"
+    assert (home / "skills" / "s" / "sub" / "x.md").read_bytes() == b"nested\n"
+
+
+def test_unchanged_dir_item_with_overrides_is_skipped(tmp_path: Path) -> None:
+    """
+    Given a DIR item plus an override file, already materialised by a prior run
+    When sync_plan re-runs
+    Then the overlaid override is folded into the unchanged comparison, so the
+    dir is recognised as up to date and skipped — the override file in dest is
+    not mistaken for drift that would force a spurious backup/replace.
+    """
+    src = tmp_path / "src_skill"
+    src.mkdir()
+    (src / "shared.md").write_bytes(b"from-source\n")
+    home = tmp_path / "home"
+    plan = StagingPlan(
+        items={Path("skills/s"): _dir_item(Path("skills/s"), src)},
+        tool=Tool.CLAUDE,
+        dir_overrides={Path("skills/s"): {Path("extra.md"): b"added\n"}},
+    )
+
+    sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+    second = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert second.skipped == 1
+    assert second.backed_up == 0
+    assert not (home / "skills-backup").exists()
+    assert (home / "skills" / "s" / "extra.md").read_bytes() == b"added\n"
+
+
 def test_dry_run_does_not_materialize_dir(tmp_path: Path) -> None:
     """
     Given --dry-run and a DIR item whose dest is absent


### PR DESCRIPTION
## Summary

Greens the final Epic H golden-master parity gap: `tests/golden_master/test_parity.py::test_reinstall_is_idempotent` (was `xfail(strict)`). **Parity net 12 → 13 — all gaps green.** This is the Python port of `scripts/install.sh`; bash is the behavioural spec until parity lands.

Two coordinated fixes for a double-install (run the installer twice into the same HOME):

### 1. `_install_dir` was non-idempotent (the named defect)
It unconditionally `_back_up` + `rmtree` + `copytree`'d whenever the dest existed, so a second run left a spurious backup. New `_dir_is_unchanged` builds the expected file map (source tree via `rglob`, overlaid with `overrides`, override-wins-on-collision) and compares it to the actual dest tree; `_install_dir` now **skips** (counts `skipped`, no backup/replace) when unchanged, *before* the consent gate. Mirrors bash `sync_directory`'s `src_hash == dest_hash` 'up to date' branch (`install.sh:1230`); bash's dir hash (`install.sh:402-403`) folds relpath+bytes of every file — exactly a `{relpath: bytes}` dict comparison.

### 2. Parity oracle: accept bash's lone settings.json re-merge backup
After fix #1, the sole remaining divergence was bash writing a `settings.json.backup-<TS>` on run 2 that Python doesn't. **Root cause:** bash's jq `unique` *sorts* `permissions.deny` / `hooks.*` arrays on re-merge (non-idempotent self-merge → 'changed' → backup), while Python's `json_union` preserves first-seen order (idempotent → no backup, and the deliberately *more correct* behaviour — authored hook order is preserved). The differ **already** documents and accepts this array-order divergence (`_order_insensitive`, compares arrays as multisets). `_is_accepted_settings_backup` extends that same acceptance to its on-disk trace.

## Why the oracle change is sound (please scrutinise)
The exemption is **deliberately narrow and asymmetric** — it can never be wider than the array-order divergence the differ already accepts:
- Applies **only to `only_in_a` (bash)**. A *Python*-only backup still flags — that would be a real Python non-idempotency, the exact regression this scenario guards.
- Gated on `.json` suffix **and** `json_semantically_equal` of the live target on **both** sides. A non-`.json` backup, a missing live counterpart, or a genuinely different target (element added/dropped, not a pure reorder) still flags — with the live `content_mismatch` firing independently.

`quality-reviewer` attempted four masking attacks (different live, Python-side backup, non-json, multi-run accumulation) — all defeated. Four new `test_diff.py` tests pin each guard.

## Out of scope (intentional)
- **bash is not modified** — its jq-sort non-idempotency is a reference-spec quirk being retired by this port, not fixed here.
- **`_install_dir` still backs up on dir *change*** (bash `rm -rf`+`cp -R`s without backup) — preserved as the safer behaviour. No parity scenario exercises a *changed* dir, so it is not a parity gap.

## Test Plan
- [x] TDD red→green: 2 new `test_sync_plan.py` tests (unchanged dir skipped, override-aware), 4 new `test_diff.py` tests (accepted case + 3 over-exemption guards)
- [x] `test_reinstall_is_idempotent` xfail removed → passes end-to-end (real bash + Python double-install)
- [x] `make ci-installer` green: ruff, ruff-format, mypy --strict, pytest (556 passed, **99.79%** coverage), 13 golden-master, pip-audit, entry-verify
- [x] No regressions across the full golden-master suite (39 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)