### PR TITLE
feat(installer): own prgroom CLI install lifecycle — uv tool install/uninstall on PATH (8.6)

### DIFF
--- a/packages/installer/tests/golden_master/_runner.py
+++ b/packages/installer/tests/golden_master/_runner.py
@@ -62,6 +62,13 @@ def _build_env(home: Path, extra_env: dict[str, str] | None) -> dict[str, str]:
         "LC_ALL": "C",
         "LANG": "C",
         "INSTALLER_PLUGINS_SRC": "",
+        # install.sh owns a prgroom `uv tool install` step that install.py has no
+        # counterpart for (design §7.2). Left on, only the bash side would create
+        # a uv-managed `prgroom` console script under home_a's uv tool-bin dir — a
+        # spurious parity divergence — and it would need a real (slow, networked)
+        # wheel build, breaking hermeticity. The master toggle pins it off for
+        # BOTH installers (inert for install.py, which has no prgroom step).
+        "INSTALLER_PRGROOM": "0",
     }
     if extra_env:
         env.update(extra_env)

--- a/packages/installer/tests/golden_master/test_prgroom_install.py
+++ b/packages/installer/tests/golden_master/test_prgroom_install.py
@@ -115,16 +115,25 @@ def test_install_invokes_uv_tool_install_force(tmp_path: Path) -> None:
     assert str(REPO_ROOT / "packages" / "prgroom") in invocations, invocations
 
 
-def _path_without_uv() -> str | None:
-    """Ambient PATH with uv's directory removed, or None if it can't be isolated.
+def _core_tools_present(path: str) -> bool:
+    """True if the bash installer's core tools all resolve under ``path``."""
+    return all(shutil.which(t, path=path) is not None for t in ("bash", "jq", "git"))
 
-    Returns None (caller skips) when uv is absent already (nothing to test) or
-    when stripping uv's dir would also drop a core tool the bash installer needs
-    — i.e. uv shares a directory with bash/jq/git and can't be isolated cleanly.
+
+def _path_without_uv() -> str | None:
+    """A PATH on which uv is absent but the installer's core tools resolve, or
+    None when that can't be arranged.
+
+    When uv is already absent, the ambient PATH already satisfies the condition —
+    return it so the graceful-skip branch is exercised exactly where it matters
+    most (a host with no uv), rather than skipping the test there. When uv is
+    present, strip its directory; return None only if uv stays reachable via
+    another entry or stripping it would also drop a core tool.
     """
     uv = shutil.which("uv")
     if uv is None:
-        return None
+        ambient = os.environ.get("PATH", "")
+        return ambient if _core_tools_present(ambient) else None
     uv_dir = Path(uv).parent.resolve()
     kept = [
         e for e in os.environ.get("PATH", "").split(os.pathsep) if e and Path(e).resolve() != uv_dir
@@ -132,7 +141,7 @@ def _path_without_uv() -> str | None:
     reduced = os.pathsep.join(kept)
     if shutil.which("uv", path=reduced) is not None:
         return None  # uv reachable via another PATH entry — can't isolate
-    if any(shutil.which(t, path=reduced) is None for t in ("bash", "jq", "git")):
+    if not _core_tools_present(reduced):
         return None  # core tool shared uv's dir — isolating uv would break install
     return reduced
 

--- a/packages/installer/tests/golden_master/test_prgroom_install.py
+++ b/packages/installer/tests/golden_master/test_prgroom_install.py
@@ -1,0 +1,221 @@
+"""install.sh prgroom-CLI install/uninstall behavior (bash installer only).
+
+Unlike the parity suite, these scenarios assert behavior that install.sh owns
+*alone*: install.py performs no prgroom step (design §7.2 makes install.sh the
+sole owner of the ``uv tool install`` lifecycle). So there is nothing to compare
+against — these drive install.sh directly and assert what command it decided to
+hand to ``uv`` at the system boundary.
+
+``uv`` is the system boundary here, so it is replaced by a fake stub that records
+its argv to a log file and exits 0 — no real wheel build, no network, hermetic.
+Marked ``golden_master`` because it spawns the bash installer (slow, no src
+coverage), so it runs under ``make golden-master-installer``, not the fast gate.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.golden_master._runner import _BASH, _INSTALL_SH, REPO_ROOT
+
+pytestmark = pytest.mark.golden_master
+
+_CLAUDE_ARGS = ["--tools=claude", "--plugins=", "--yes"]
+_RUN_TIMEOUT_S = 120
+
+
+def _write_fake_uv(bin_dir: Path, log: Path) -> None:
+    """Write a fake ``uv`` that logs its full argv and fakes ``tool list``.
+
+    ``tool list`` prints a prgroom entry so install.sh's prune-uninstall guard
+    (which greps ``uv tool list`` for an installed prgroom) sees it as present.
+    Every invocation appends its argv to ``log`` and exits 0 — the stub never
+    builds or fetches anything.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    uv = bin_dir / "uv"
+    uv.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> "{log}"\n'
+        'if [ "$1" = "tool" ] && [ "$2" = "list" ]; then\n'
+        "  printf 'prgroom v0.1.0\\n- prgroom\\n'\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    uv.chmod(0o755)
+
+
+def _run_install_sh(
+    home: Path,
+    *,
+    args: list[str],
+    extra_env: dict[str, str] | None = None,
+    uv_dir: Path | None = None,
+    path_override: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run scripts/install.sh into ``home`` with a hermetic, pinned env.
+
+    ``uv_dir`` (when given) is prepended to PATH so the fake ``uv`` there shadows
+    any real uv. ``path_override`` replaces the base PATH entirely (used to run
+    with uv stripped from PATH). Mirrors the parity runner's env pins (HOME /
+    locale / INSTALLER_PLUGINS_SRC) so a leaked ambient value can't make a run
+    non-hermetic.
+    """
+    path = path_override if path_override is not None else os.environ.get("PATH", "")
+    if uv_dir is not None:
+        path = f"{uv_dir}{os.pathsep}{path}"
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": path,
+        "LC_ALL": "C",
+        "LANG": "C",
+        "INSTALLER_PLUGINS_SRC": "",
+        # These tests exercise the prgroom paths, so pin the master toggle ON —
+        # otherwise a leaked ambient INSTALLER_PRGROOM=0 (the value the parity
+        # harness exports) would disable the very code under test and let the
+        # dry-run assertion pass for the wrong reason.
+        "INSTALLER_PRGROOM": "1",
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(  # noqa: S603 — fixed argv, no shell, hermetic env
+        [_BASH, str(_INSTALL_SH), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_S,
+        check=False,
+    )
+
+
+def test_install_invokes_uv_tool_install_force(tmp_path: Path) -> None:
+    """A normal install (uv present, package in source tree) hands
+    ``tool install --force <packages/prgroom>`` to uv — the §7.2 install path."""
+    if shutil.which("jq") is None:
+        pytest.skip("bash installer requires jq on PATH")
+    home = tmp_path / "home"
+    home.mkdir()
+    log = tmp_path / "uv.log"
+    _write_fake_uv(tmp_path / "bin", log)
+
+    result = _run_install_sh(home, args=_CLAUDE_ARGS, uv_dir=tmp_path / "bin")
+
+    assert result.returncode == 0, result.stderr
+    assert log.exists(), "fake uv was never invoked — install.sh skipped prgroom"
+    invocations = log.read_text()
+    assert "tool install --force" in invocations, invocations
+    assert str(REPO_ROOT / "packages" / "prgroom") in invocations, invocations
+
+
+def _path_without_uv() -> str | None:
+    """Ambient PATH with uv's directory removed, or None if it can't be isolated.
+
+    Returns None (caller skips) when uv is absent already (nothing to test) or
+    when stripping uv's dir would also drop a core tool the bash installer needs
+    — i.e. uv shares a directory with bash/jq/git and can't be isolated cleanly.
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        return None
+    uv_dir = Path(uv).parent.resolve()
+    kept = [
+        e for e in os.environ.get("PATH", "").split(os.pathsep) if e and Path(e).resolve() != uv_dir
+    ]
+    reduced = os.pathsep.join(kept)
+    if shutil.which("uv", path=reduced) is not None:
+        return None  # uv reachable via another PATH entry — can't isolate
+    if any(shutil.which(t, path=reduced) is None for t in ("bash", "jq", "git")):
+        return None  # core tool shared uv's dir — isolating uv would break install
+    return reduced
+
+
+def test_uv_absent_skips_gracefully(tmp_path: Path) -> None:
+    """With uv off PATH, install.sh skips the prgroom CLI install and still exits
+    0 — the §7.2 ``uv``-present guard, graceful-skip branch."""
+    reduced = _path_without_uv()
+    if reduced is None:
+        pytest.skip("cannot isolate uv from PATH on this host")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_install_sh(home, args=_CLAUDE_ARGS, path_override=reduced)
+
+    assert result.returncode == 0, result.stderr
+    # Pin the actual skip branch, not any incidental mention of "uv" — the notice
+    # is "prgroom: uv not found on PATH -- skipping CLI install ...".
+    assert "uv not found" in result.stdout.lower(), result.stdout
+    assert not (home / ".local" / "bin" / "prgroom").exists(), (
+        "no prgroom binary should be installed when uv is absent"
+    )
+
+
+def test_prune_uninstalls_when_package_left_source_tree(tmp_path: Path) -> None:
+    """``--prune`` with the prgroom package gone from the source tree hands
+    ``tool uninstall prgroom`` to uv — the §7.2 orphan-removal branch.
+
+    The absent source tree is simulated by pointing INSTALLER_PRGROOM_SRC at a
+    path that does not exist; the fake uv's ``tool list`` reports prgroom as
+    installed so the uninstall guard fires."""
+    if shutil.which("jq") is None:
+        pytest.skip("bash installer requires jq on PATH")
+    home = tmp_path / "home"
+    home.mkdir()
+    log = tmp_path / "uv.log"
+    _write_fake_uv(tmp_path / "bin", log)
+
+    result = _run_install_sh(
+        home,
+        args=[*_CLAUDE_ARGS, "--prune"],
+        uv_dir=tmp_path / "bin",
+        extra_env={"INSTALLER_PRGROOM_SRC": str(tmp_path / "no-such-prgroom")},
+    )
+
+    assert result.returncode == 0, result.stderr
+    invocations = log.read_text() if log.exists() else ""
+    assert "tool uninstall prgroom" in invocations, invocations
+    # Source absent => install must NOT have fired.
+    assert "tool install" not in invocations, invocations
+
+
+def test_prune_keeps_prgroom_when_still_in_source_tree(tmp_path: Path) -> None:
+    """``--prune`` while the prgroom package is still in the source tree must NOT
+    uninstall it — the orphan guard's keep branch. Guards against nuking an
+    installed CLI on a routine prune."""
+    if shutil.which("jq") is None:
+        pytest.skip("bash installer requires jq on PATH")
+    home = tmp_path / "home"
+    home.mkdir()
+    log = tmp_path / "uv.log"
+    _write_fake_uv(tmp_path / "bin", log)
+
+    result = _run_install_sh(home, args=[*_CLAUDE_ARGS, "--prune"], uv_dir=tmp_path / "bin")
+
+    assert result.returncode == 0, result.stderr
+    invocations = log.read_text() if log.exists() else ""
+    assert "tool uninstall" not in invocations, invocations
+    # Package present => the install path still ran, proving this wasn't a no-op.
+    assert "tool install --force" in invocations, invocations
+
+
+def test_dry_run_does_not_invoke_uv(tmp_path: Path) -> None:
+    """``--dry-run`` announces the prgroom install but invokes no uv command —
+    dry-run must mutate nothing."""
+    if shutil.which("jq") is None:
+        pytest.skip("bash installer requires jq on PATH")
+    home = tmp_path / "home"
+    home.mkdir()
+    log = tmp_path / "uv.log"
+    _write_fake_uv(tmp_path / "bin", log)
+
+    result = _run_install_sh(home, args=[*_CLAUDE_ARGS, "--dry-run"], uv_dir=tmp_path / "bin")
+
+    assert result.returncode == 0, result.stderr
+    assert not log.exists(), "dry-run must not invoke uv"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -203,6 +203,12 @@ SRC_SHARED="$SRC_USER/.agents"
 # unset => the repo's src/plugins, identical to before. The Python installer
 # carries the symmetric override (installer.config.resolve_plugins_root).
 SRC_PLUGINS="${INSTALLER_PLUGINS_SRC:-$PROJECT_ROOT/src/plugins}"
+# prgroom package source — same default-inert override idiom as SRC_PLUGINS.
+# Unset => the repo's packages/prgroom. A test may point this at an ABSENT path
+# to exercise the "package dropped from the source tree" prune-uninstall branch
+# (_prune_prgroom). install.py owns no prgroom step — design §7.2 makes
+# install.sh the sole owner of the `uv tool install` lifecycle.
+SRC_PRGROOM="${INSTALLER_PRGROOM_SRC:-$PROJECT_ROOT/packages/prgroom}"
 
 if [[ ! -d "$SRC_SHARED" ]]; then
     err "Shared source directory not found: $SRC_SHARED"
@@ -1690,6 +1696,71 @@ prune_orphans() {
     done
 }
 
+# ── prgroom CLI install/uninstall (uv-managed tool) ───────────────────────────
+#
+# install.sh is the sole owner of the prgroom install lifecycle (design §7.2):
+# it installs the `prgroom` console-script on PATH via `uv tool install` and,
+# under --prune, uninstalls it once the package leaves the source tree. The
+# INSTALLER_PRGROOM master toggle (default 1) lets the golden-master parity
+# harness disable BOTH paths — install.py performs no prgroom step, so the
+# hermetic homes must match with prgroom handling switched off entirely.
+
+# Master toggle (default on). One home for the default so the two callers can't
+# drift apart.
+_prgroom_enabled() { [[ "${INSTALLER_PRGROOM:-1}" == "1" ]]; }
+
+_install_prgroom() {
+    _prgroom_enabled || return 0
+    if [[ ! -d "$SRC_PRGROOM" ]]; then
+        vinfo "prgroom: package not in source tree ($SRC_PRGROOM) -- skipping install"
+        return 0
+    fi
+    if ! command -v uv >/dev/null 2>&1; then
+        warn "prgroom: uv not found on PATH -- skipping CLI install (install uv to enable the 'prgroom' command)"
+        return 0
+    fi
+    if [[ "$DRY_RUN" == true ]]; then
+        info "Dry-run: would install prgroom CLI via 'uv tool install --force $SRC_PRGROOM'"
+        return 0
+    fi
+    info "Installing prgroom CLI (uv tool install)..."
+    # --force makes re-runs idempotent and doubles as the upgrade path (§7.3:
+    # upgrades land by re-running the installer, which re-runs `uv tool install
+    # --force`). A failure is non-fatal -- config deployment already succeeded;
+    # surface it loudly rather than aborting the whole installer for one CLI.
+    if uv tool install --force "$SRC_PRGROOM"; then
+        if command -v prgroom >/dev/null 2>&1; then
+            ok "prgroom CLI installed."
+        else
+            warn "prgroom installed but not on PATH -- add uv's tool bin dir (see 'uv tool dir --bin') to PATH."
+        fi
+    else
+        warn "prgroom: 'uv tool install' failed -- the prgroom CLI is unavailable."
+    fi
+}
+
+_prune_prgroom() {
+    _prgroom_enabled || return 0
+    # Only an orphan once the package has left the source tree, mirroring how
+    # --prune removes other orphaned deploy outputs. Still in source => not an
+    # orphan; uv absent or prgroom not installed => nothing to remove.
+    [[ -d "$SRC_PRGROOM" ]] && return 0
+    command -v uv >/dev/null 2>&1 || return 0
+    # uv tool list prints "<name> <version>" at column 0; the trailing space
+    # anchors an exact package match (not a 'prgroom-extra' prefix).
+    uv tool list 2>/dev/null | grep -q '^prgroom ' || return 0
+    if [[ "$DRY_RUN" == true ]]; then
+        info "Dry-run: would uninstall prgroom CLI via 'uv tool uninstall prgroom' (package left the source tree)"
+        return 0
+    fi
+    info "Pruning prgroom CLI (uv tool uninstall) -- package no longer in source tree..."
+    if uv tool uninstall prgroom; then
+        ok "prgroom CLI uninstalled."
+    else
+        warn "prgroom: 'uv tool uninstall' failed."
+    fi
+}
+
 # ── Staging directory (cleaned up on exit) ────────────────────────────────────
 
 STAGING_DIR="$(mktemp -d /tmp/agents-config-install-XXXXXX)"
@@ -1714,10 +1785,17 @@ if plugin_enabled "beads" || prune_active; then
     stage_and_install_beads
 fi
 
+# Install the prgroom CLI (uv-managed tool). Part of the install phase, so it is
+# skipped under --prune-only (which runs no install); see _install_prgroom.
+if [[ "$PRUNE_ONLY" != true ]]; then
+    _install_prgroom
+fi
+
 # Prune phase (post-install) — only when --prune or --prune-only is active
 if prune_active; then
     scan_orphans
     prune_orphans
+    _prune_prgroom
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Wires `scripts/install.sh` to own the **prgroom CLI install lifecycle** — the §6.1 "installable first" gate that every prgroom skill-thinning depends on. Closes bead `agents-config-abn9.8.6`. Per `docs/plans/2026-05-12-prgroom-cli-design.md` §7.2.

`install.sh` had **zero** uv references before this; prgroom is the first `uv tool install` it performs.

## Scope (what to review against)

**In scope** — `scripts/install.sh` only (plus the test harness):
- `_install_prgroom`: `uv tool install --force "$SRC_PRGROOM"` — idempotent and the upgrade path (§7.3); guarded by a `uv`-present check; **non-fatal** graceful skip when uv is absent; `--dry-run` announces without mutating; post-install `command -v prgroom` PATH check.
- `_prune_prgroom`: `uv tool uninstall prgroom` **only once the package has left the source tree** (orphan model), wired into the `--prune` block.
- Two default-inert env seams mirroring the existing `INSTALLER_PLUGINS_SRC` idiom:
  - `INSTALLER_PRGROOM_SRC` — package source path (lets a test point at an absent path to exercise the prune-uninstall branch).
  - `INSTALLER_PRGROOM` — master toggle (default on); the golden-master harness pins it `0`.

**Intentionally out of scope (do NOT flag):**
- `scripts/install.py` is deliberately untouched — design §7.2 makes `install.sh` the **sole owner** until the Python port catches up. Adding prgroom logic to install.py would violate the contract.
- monitor-pr skill, Skill A retirement, hook/rule repointing — those belong to the Phase-1 cutover bead (`abn9.8.13`), not this one.

## The parity trap, and how it's handled

The golden-master suite runs install.sh **and** install.py into temp HOMEs and byte-diffs the full trees. A real `uv tool install` in install.sh (but not install.py) would (a) drop a bash-only console script → parity break and (b) need a networked wheel build → break hermeticity. The `INSTALLER_PRGROOM` master toggle, pinned `0` in the harness's `_build_env`, disables both prgroom paths so the hermetic homes stay identical. **`_diff.py` is untouched** — no new accepted-divergence rules. A separate toggle (not the source seam) is required because "source absent" means *skip* to install but *act* to prune.

## Tests

New `golden_master`-marked module `test_prgroom_install.py` drives install.sh with a **fake `uv` stub** (logs argv, no network — uv is the system boundary). Five behavioral scenarios, each TDD red→green: install-fires, uv-absent graceful skip, prune-uninstall-on-absent, prune-keep-on-present, dry-run no-op.

## Evidence

`make ci-installer` green: lint, format-check, mypy --strict, **557 unit @ 99.79% coverage**, 20 golden-master (15 existing parity — zero regression — + 5 new), pip-audit clean, entry-verify. `bash -n scripts/install.sh` clean. `make verify-entry-prgroom` resolves.

Reviewed via `quality-reviewer` (1 HIGH env-pinning hole + 3 Low, all addressed) and the `simplify` pass (toggle-guard extracted to `_prgroom_enabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01548S2z8LGzwvp2D3wY2yK8