### PR TITLE
fix(installer): match bash on invalid settings.json (H.3 blocker)

### DIFF
--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -40,25 +40,36 @@ def _effective_content(content: bytes, old: bytes | None, *, kind: FileKind) -> 
 
     A ``settings.json`` over an existing user file is union-merged into that file
     (bash ``sync_settings_file``) so user values survive; any other kind, or a
-    fresh install, writes the staged content unchanged. An existing settings file
-    that is not valid JSON falls back to overwrite — bash warns and replaces.
+    fresh install, writes the staged content unchanged. The caller guarantees an
+    existing settings file is valid JSON before this runs (an invalid one is
+    skipped with an error — bash ``scripts/install.sh:1299-1304``), so the union
+    never has to reconcile unparseable bytes.
     """
     if kind is not FileKind.SETTINGS_JSON or old is None:
         return content
+    return merge_settings_bytes(existing=old, incoming=content)
+
+
+def _is_valid_json(data: bytes) -> bool:
+    """Whether ``data`` parses as JSON — the guard bash runs as ``jq empty`` before
+    union-merging an existing ``settings.json`` (``scripts/install.sh:1299``)."""
     try:
-        return merge_settings_bytes(existing=old, incoming=content)
-    except ValueError:
-        return content
+        json.loads(data)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return True
 
 
 def _is_unchanged(old: bytes, new: bytes, *, kind: FileKind) -> bool:
     """Settings compare semantically — a reformat is not a change; every other
-    file compares byte-for-byte via sha-256."""
+    file compares byte-for-byte via sha-256.
+
+    For ``SETTINGS_JSON`` both sides are valid JSON when this runs: ``_install_file``
+    skips an invalid existing settings file (``_is_valid_json``) before reaching
+    here, and ``new`` is always a union-merge result. So the parse cannot fail on
+    the guarded path — an unparseable ``old`` would have been skipped upstream."""
     if kind is FileKind.SETTINGS_JSON:
-        try:
-            return bool(json.loads(old) == json.loads(new))
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            return False
+        return bool(json.loads(old) == json.loads(new))
     return _sha256(old) == _sha256(new)
 
 
@@ -281,7 +292,10 @@ def _install_file(
     A ``SETTINGS_JSON`` item is union-merged into an existing user file rather
     than overwritten (``_effective_content``), so user values survive an install;
     the change check is then semantic (``_is_unchanged``), so a pure reformat is a
-    skip, not a spurious backup-and-rewrite.
+    skip, not a spurious backup-and-rewrite. An existing settings file that is not
+    valid JSON is left untouched and reported as an error (it cannot be merged, and
+    a blind overwrite would destroy a recoverable hand-edit), counted as a skip —
+    bash's ``jq empty`` guard (``scripts/install.sh:1299-1304``).
 
     A *changed* dest (present, content differs) passes through the consent gate
     (`_consent_to_overwrite`) before any backup or write: an interactive decline
@@ -302,6 +316,13 @@ def _install_file(
         raise ValueError(f"dest exists but is not a file: {dest}")  # noqa: TRY003  # single call-site; subclass not justified
     dest_exists = dest.is_file()
     old = dest.read_bytes() if dest_exists else None
+    if kind is FileKind.SETTINGS_JSON and old is not None and not _is_valid_json(old):
+        # Refuse to touch an unparseable settings.json: union-merge is impossible
+        # and a blind overwrite would destroy the user's (recoverable) hand-edit.
+        # bash skips with the same guidance (``scripts/install.sh:1299-1304``).
+        io.err(f"{dest} contains invalid JSON. Fix it manually or remove it.")
+        counters.skipped += 1
+        return
     effective = _effective_content(content, old, kind=kind)
     if old is not None and _is_unchanged(old, effective, kind=kind):
         if restore_exec_on_skip and executable and not dry_run:

--- a/packages/installer/tests/golden_master/_diff.py
+++ b/packages/installer/tests/golden_master/_diff.py
@@ -165,9 +165,14 @@ def _is_executable(path: Path) -> bool:
 
 def _files_equal(relpath: str, a: Path, b: Path) -> bool:
     data_a, data_b = a.read_bytes(), b.read_bytes()
+    # Byte-identical is always equal — including two unparseable ``.json`` files
+    # (both installers skipping a malformed settings.json), which
+    # ``json_semantically_equal`` alone would report unequal on its parse failure.
+    if data_a == data_b:
+        return True
     if relpath.endswith(".json"):
         return json_semantically_equal(data_a, data_b)
-    return data_a == data_b
+    return False
 
 
 def diff_trees(root_a: Path, root_b: Path) -> TreeDiff:

--- a/packages/installer/tests/golden_master/test_diff.py
+++ b/packages/installer/tests/golden_master/test_diff.py
@@ -103,6 +103,19 @@ def test_json_compared_semantically_not_bytewise(tmp_path: Path) -> None:
     assert result.is_parity(), result.render()
 
 
+def test_byte_identical_invalid_json_is_parity(tmp_path: Path) -> None:
+    # When both installers refuse to touch a malformed settings.json (invalid-JSON
+    # skip), they leave byte-identical unparseable bytes. The differ must treat
+    # identical bytes as equal even though neither side parses as JSON —
+    # json_semantically_equal alone returns False on a parse failure, so the
+    # byte-equality short-circuit in _files_equal is what keeps this at parity.
+    a, b = tmp_path / "a", tmp_path / "b"
+    _write(a / ".claude/settings.json", b"{ not valid json\n")
+    _write(b / ".claude/settings.json", b"{ not valid json\n")
+    result = diff_trees(a, b)
+    assert result.is_parity(), result.render()
+
+
 def test_non_json_compared_bytewise(tmp_path: Path) -> None:
     a, b = tmp_path / "a", tmp_path / "b"
     _write(a / "note.md", b"alpha")

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -106,6 +106,29 @@ def test_settings_merge_with_overlapping_array(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
 
+def test_pre_existing_invalid_settings_is_preserved(tmp_path: Path) -> None:
+    """A pre-existing settings.json that is NOT valid JSON: both installers refuse
+    to touch it — bash errors and skips (install.sh:1299-1304), and the Python port
+    now matches — leaving the user's malformed file in place rather than clobbering
+    it with the template. Parity holds because neither installer writes the settings
+    file (no overwrite, no backup); the rest of the install proceeds normally."""
+
+    def seed(home: Path) -> None:
+        claude = home / ".claude"
+        claude.mkdir(parents=True, exist_ok=True)
+        (claude / "settings.json").write_text("{ not valid json\n")
+
+    result = run_parity(tmp_path, args=_CLAUDE_ARGS, seed=seed)
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+    diff = result.diff()
+    assert diff.is_parity(), diff.render()
+    # both leave the malformed file exactly as seeded — no overwrite, no backup
+    assert (result.home_b / ".claude" / "settings.json").read_text() == "{ not valid json\n"
+    assert not list((result.home_b / ".claude").glob("settings.json.backup-*"))
+
+
 def test_bare_install_codex(tmp_path: Path) -> None:
     """Single-tool parity for Codex — a dot-dir tool with its own templates."""
     result = run_parity(tmp_path, args=["--tools=codex", "--plugins=", "--yes"])

--- a/packages/installer/tests/unit/test_sync_settings_union.py
+++ b/packages/installer/tests/unit/test_sync_settings_union.py
@@ -78,17 +78,32 @@ def test_sync_settings_backs_up_user_file_before_union(tmp_path: Path) -> None:
     assert json.loads(backups[0].read_bytes()) == {"userKey": "keep-me"}
 
 
-def test_sync_overwrites_when_existing_settings_is_invalid_json(tmp_path: Path) -> None:
-    """A malformed existing settings.json cannot be unioned; the installer falls
-    back to overwrite (bash warns and replaces) rather than crashing."""
+def test_sync_preserves_and_skips_invalid_existing_settings(tmp_path: Path) -> None:
+    """An existing settings.json that is not valid JSON is left untouched and
+    reported as an error, not overwritten — matching bash, which refuses to touch a
+    file it cannot parse (``scripts/install.sh:1299-1304``: err + skip + return, the
+    file left in place). The earlier Python behaviour clobbered it with the template
+    (the user's content survived only in a backup); these assertions pin the
+    skip-and-preserve contract."""
     home = tmp_path / "home"
     home.mkdir()
-    (home / "settings.json").write_text("{ not valid json")
+    invalid = "{ not valid json"
+    (home / "settings.json").write_text(invalid)
     plan = StagingPlan(
         items={Path("settings.json"): _settings_item(b'{"templateKey": 1}')},
         tool=Tool.CLAUDE,
     )
+    io = ScriptedIO()
 
-    sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_TS)
+    counters = sync_plan(_IdentityAdapter(), plan, home=home, io=io, auto_yes=True, timestamp=_TS)
 
-    assert json.loads((home / "settings.json").read_bytes()) == {"templateKey": 1}
+    # the malformed file is preserved verbatim — not overwritten, not backed up
+    assert (home / "settings.json").read_text() == invalid
+    assert not list(home.glob("settings.json.backup-*"))
+    # it is counted as skipped, not updated
+    assert counters.skipped == 1
+    assert counters.updated == 0
+    # an actionable error names the offending file
+    errs = [e for e in io.transcript if e.channel == "err"]
+    assert errs, "expected an error about the invalid settings.json"
+    assert "invalid JSON" in errs[0].message

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -16,3 +16,15 @@
   `claude`; it adds `codex` / `gemini` only when `~/.codex/` / `~/.gemini/`
   exists, or when `--tools=` forces them. Don't describe it as "detecting
   installed CLIs".
+- **Namespace-dir replace is backup-free in bash, backed-up in Python — an
+  intentional divergence.** `sync_directory` replaces a *changed*
+  `commands` / `skills` / `agents` / `rules` / `hooks` item with
+  `rm -rf "$dest_item"; cp -R` and **no `backup()` call** — a user-modified
+  skill/agent/hook is silently destroyed. The Python port (`packages/installer/`)
+  backs the item up to `<namespace>-backup/` before replacing, deliberately
+  fixing that latent data-loss bug. **Consequence for parity comparisons:** a
+  real-home (drifted-state) `install.sh`-vs-`install.py` diff shows Python-only
+  `<namespace>-backup/…` directories and `<namespace>/<file>.backup-*` entries —
+  expected (Python preserving content bash would destroy), **not** a regression.
+  The hermetic golden-master suite never seeds a content-drifted namespace dir,
+  so it does not surface this; a real-home smoke does.


### PR DESCRIPTION
## Summary

Fixes a **parity blocker** found by the H.3 parity-confirmation gate (`agents-config-w1qls.8.3`): a pre-existing `settings.json` that is **not valid JSON** produced *opposite* on-disk outcomes between the two installers.

- **bash** (`scripts/install.sh:1299-1304`, the behavioral spec): `jq empty` fails → errors `"contains invalid JSON. Fix it manually or remove it."`, increments `tool_skipped`, returns — **the user's file is left untouched**.
- **Python** (before this PR, `core/sync.py`): the union-merge raised `ValueError`, which was caught and fell back to **overwrite** — backing up the bad file then clobbering it with the template.

The golden-master suite stayed green only because no scenario seeded invalid JSON, and the `_effective_content` docstring rationalizing the overwrite was **factually wrong** ("bash warns and replaces" — bash skips, it does not replace). This was a porting defect, not a deliberate divergence.

## What changed

- `core/sync.py`: `_install_file` now **skips an unparseable existing `settings.json`** with the byte-for-byte same error as bash, leaving it untouched (no backup, no clobber). Removed the now-unreachable overwrite-fallback in `_effective_content` (a malformed in-repo template now fails loudly instead of silently clobbering a user file) and the dead `except` branch in `_is_unchanged`; documented the preconditions.
- `tests/golden_master/_diff.py`: added a **byte-equality short-circuit** to `_files_equal` so two byte-identical-but-unparseable `.json` files (both installers correctly skipping a malformed file) compare equal — previously `json_semantically_equal` returned `False` on a parse failure even for identical bytes, a false mismatch. (This also closes one of the audit's differ-fidelity findings.)
- Tests: rewrote the wrong-behavior `test_sync_overwrites_when_existing_settings_is_invalid_json` → `test_sync_preserves_and_skips_invalid_existing_settings`; **+1 golden-master scenario** (`test_pre_existing_invalid_settings_is_preserved`, now 16/16); **+1 differ unit test**.

## Scope

Focused bug-fix port-parity correction. The behavioral contract is bash (`scripts/install.sh`); this PR makes Python match it. TDD: both new tests were watched to fail (RED) before the fix, then pass (GREEN).

## Out of scope (filed as follow-up beads, `discovered-from` H.3)

Non-blocker findings from the parity-coverage audit — all latent, cosmetic, or on dead-in-production paths:
- `agents-config-gs83z` — deferred golden-master scenarios (multi-tool combined, carrier-merge, deep-merge depth>1, JSONC/TOML collision, prune literal-glob)
- `agents-config-918hf` — differ + design-doc parity-exception documentation gaps (empty-dir blindness, `.json` compare scope, process-contract divergences)
- `agents-config-qd8ca` — Python prune `beads/formulas` scan hardcodes `staged=set()` (latent divergence from bash)
- `agents-config-8debl` — dead single-file `sync()` path — delete or guard against `SETTINGS_JSON`

## Test plan / evidence

`make ci-installer` fully green:
- [x] ruff check + ruff format --check (105 files)
- [x] mypy --strict (42 source files)
- [x] 558 unit tests @ **99.79%** coverage (`core/sync.py` 0 missed statements)
- [x] **16** golden-master parity scenarios
- [x] pip-audit (no known vulnerabilities) + `install.py --help` entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UE3S6f56KxiyfN3FxWzyUJ
