### PR TITLE
feat(installer): add --verbose/-v flag with per-file detail at bash parity

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -68,6 +68,12 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show what would be done without making changes.",
     )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Show per-file progress (installed / up-to-date / updated).",
+    )
     # --dump-stage, --prune, and --prune-only are three mutually exclusive
     # terminal modes (dump the staging plan / install-then-prune / prune-only),
     # so any combination is rejected by argparse.
@@ -111,7 +117,7 @@ def main(
     if io is None:
         from installer.core.io_port import TerminalIO
 
-        io = TerminalIO()
+        io = TerminalIO(verbose=args.verbose)
 
     try:
         tools = resolve_tools(home=resolved_home, override_csv=args.tools)

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -276,7 +276,9 @@ def _install_file(
 ) -> None:
     """Install one FILE item: skip an unchanged dest, back up a differing dest
     before the overwrite, and write the bytes with a deterministic mode bit
-    (``0o755`` when ``executable`` else ``0o644``). Mutates ``counters``.
+    (``0o755`` when ``executable`` else ``0o644``). Mutates ``counters``. An
+    unchanged-dest skip emits a verbose-gated "X is up to date" line (bash
+    ``vok``, scripts/install.sh:1166), silent without ``--verbose``.
 
     A ``SETTINGS_JSON`` item is union-merged into an existing user file rather
     than overwritten (``_effective_content``), so user values survive an install;
@@ -306,6 +308,7 @@ def _install_file(
     if old is not None and _is_unchanged(old, effective, kind=kind):
         if restore_exec_on_skip and executable and not dry_run:
             _restore_exec_bit(dest)
+        io.ok(f"{dest} is up to date", verbose=True)
         counters.skipped += 1
         return
     if (
@@ -363,11 +366,13 @@ def _install_dir(
     An existing dest whose contents already match (`_dir_is_unchanged`) is left
     untouched and counted as a skip — so a re-install is idempotent and produces
     no spurious backups (bash ``sync_directory``'s "up to date" branch,
-    `scripts/install.sh:1230`). A changed existing dest passes through the
-    consent gate before the backup/replace: an interactive decline keeps the
-    existing tree and counts a skip; ``auto_yes`` accepts silently; ``dry_run``
-    previews without prompting. A directory has no ``IOPort`` byte-diff, so the
-    change is surfaced as a notice, not a unified diff.
+    `scripts/install.sh:1230`); the skip emits a verbose-gated "X is up to date"
+    line (bash ``vok``, scripts/install.sh:1237), silent without ``--verbose``.
+    A changed existing dest passes through the consent gate before the
+    backup/replace: an interactive decline keeps the existing tree and counts a
+    skip; ``auto_yes`` accepts silently; ``dry_run`` previews without prompting.
+    A directory has no ``IOPort`` byte-diff, so the change is surfaced as a
+    notice, not a unified diff.
 
     A missing or non-directory ``source_path``, or a dest already occupied by a
     non-directory (a file), is rejected with `ValueError` rather than crashing
@@ -386,6 +391,7 @@ def _install_dir(
             raise ValueError(f"dir override relpath escapes the dir: {inner}")  # noqa: TRY003  # single call-site; subclass not justified
     dest_exists = dest.exists()
     if dest_exists and _dir_is_unchanged(dest, source_path, overrides):
+        io.ok(f"{dest} is up to date", verbose=True)
         counters.skipped += 1
         return
     if (
@@ -442,10 +448,15 @@ def _record_write(
     dest: Path, *, dest_exists: bool, io: IOPort, dry_run: bool, counters: Counters
 ) -> None:
     """Preview the would-be write under ``dry_run`` and tally it as a create or
-    update. Shared by the file and dir installers; mutates ``counters``."""
+    update. On a real (non-``dry_run``) write, emit a verbose-gated per-item line
+    ("Installed X" / "Updated X") so ``--verbose`` yields bash ``vok`` per-file
+    detail (scripts/install.sh:1158,1180) while a quiet run stays silent. Shared
+    by the file and dir installers; mutates ``counters``."""
     if dry_run:
         verb = "update" if dest_exists else "create"
         io.info(f"would {verb} {dest}")
+    else:
+        io.ok(f"{'Updated' if dest_exists else 'Installed'} {dest}", verbose=True)
     if dest_exists:
         counters.updated += 1
     else:

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -306,8 +306,8 @@ def _install_file(
     old = dest.read_bytes() if dest_exists else None
     effective = _effective_content(content, old, kind=kind)
     if old is not None and _is_unchanged(old, effective, kind=kind):
-        if restore_exec_on_skip and executable and not dry_run:
-            _restore_exec_bit(dest)
+        if restore_exec_on_skip and executable and not dry_run and _restore_exec_bit(dest):
+            io.info(f"Restored +x on {dest}", verbose=True)
         io.ok(f"{dest} is up to date", verbose=True)
         counters.skipped += 1
         return
@@ -449,14 +449,14 @@ def _record_write(
 ) -> None:
     """Preview the would-be write under ``dry_run`` and tally it as a create or
     update. On a real (non-``dry_run``) write, emit a verbose-gated per-item line
-    ("Installed X" / "Updated X") so ``--verbose`` yields bash ``vok`` per-file
-    detail (scripts/install.sh:1158,1180) while a quiet run stays silent. Shared
-    by the file and dir installers; mutates ``counters``."""
+    ("Installed X (new)" / "Updated X") so ``--verbose`` yields bash ``vok``
+    per-file detail (scripts/install.sh:1158,1180) while a quiet run stays
+    silent. Shared by the file and dir installers; mutates ``counters``."""
     if dry_run:
         verb = "update" if dest_exists else "create"
         io.info(f"would {verb} {dest}")
     else:
-        io.ok(f"{'Updated' if dest_exists else 'Installed'} {dest}", verbose=True)
+        io.ok(f"Updated {dest}" if dest_exists else f"Installed {dest} (new)", verbose=True)
     if dest_exists:
         counters.updated += 1
     else:
@@ -492,17 +492,22 @@ def _ensure_parent_dir(target: Path, *, dry_run: bool) -> None:
         target.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _restore_exec_bit(dest: Path) -> None:
+def _restore_exec_bit(dest: Path) -> bool:
     """Restore a lost exec bit on a hash-equal dest without a full rewrite.
     Route-scoped port of ``scripts/install.sh:1096`` (``[[ -x ]] || chmod +x``):
     fires only when no exec bit is set, and then *adds* the exec bits to the
     existing mode (``mode | 0o111``) rather than forcing ``0o755`` — so a
     user-tightened file (e.g. ``0o600``) gains exec without widening its
     read/write bits, mirroring ``chmod +x``. The any-exec-bit gate matches the
-    differ's executability definition (``_diff.py::_is_executable``)."""
+    differ's executability definition (``_diff.py::_is_executable``). Returns
+    ``True`` when the mode was changed (so the caller can announce the repair
+    under ``--verbose``, mirroring bash ``vinfo "Restored +x ..."``,
+    scripts/install.sh:1096), ``False`` when the exec bit was already set."""
     mode = dest.stat().st_mode
-    if not mode & 0o111:
-        dest.chmod(mode | 0o111)
+    if mode & 0o111:
+        return False
+    dest.chmod(mode | 0o111)
+    return True
 
 
 def _sha256(data: bytes) -> bytes:

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -616,6 +616,108 @@ def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
     assert not dest_rule.exists()
 
 
+# ── 8.13: --verbose/-v flag parsing + plumbing into the IOPort ──
+
+
+@pytest.mark.parametrize("flag", ["--verbose", "-v"])
+def test_verbose_flag_constructs_terminal_io_verbose(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    """
+    Given --verbose (or its -v alias) and no injected io
+    When main builds the default TerminalIO
+    Then TerminalIO is constructed with verbose=True.
+
+    Pins: args.verbose is parsed (both spellings) and threaded into the
+    TerminalIO construction in main — the plumbing the bash installer's
+    VERBOSE=true wiring (scripts/install.sh:110) ports to. A spy on the lazily
+    imported TerminalIO captures the kwarg without touching a real terminal.
+    Fails while the flag is unparsed (argparse SystemExit) or constructed with a
+    hard-coded verbose=False.
+    """
+    import installer.core.io_port as io_port_mod
+
+    captured: dict[str, bool] = {}
+
+    def _spy(*, verbose: bool = False, **_kwargs: object) -> ScriptedIO:
+        captured["verbose"] = verbose
+        return ScriptedIO(interactive=False)
+
+    monkeypatch.setattr(io_port_mod, "TerminalIO", _spy)
+    repo = _hermetic_repo(tmp_path)
+
+    main([flag, "--tools=claude", "--dry-run"], home=tmp_path, repo_root=repo)
+
+    assert captured == {"verbose": True}
+
+
+def test_no_verbose_flag_constructs_terminal_io_quiet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given NO --verbose flag and no injected io
+    When main builds the default TerminalIO
+    Then TerminalIO is constructed with verbose=False — the default-quiet
+    contract, so per-file detail stays suppressed.
+
+    Pins: the absence of --verbose yields verbose=False, the other direction of
+    the plumbing.
+    """
+    import installer.core.io_port as io_port_mod
+
+    captured: dict[str, bool] = {}
+
+    def _spy(*, verbose: bool = False, **_kwargs: object) -> ScriptedIO:
+        captured["verbose"] = verbose
+        return ScriptedIO(interactive=False)
+
+    monkeypatch.setattr(io_port_mod, "TerminalIO", _spy)
+    repo = _hermetic_repo(tmp_path)
+
+    main(["--tools=claude", "--dry-run"], home=tmp_path, repo_root=repo)
+
+    assert captured == {"verbose": False}
+
+
+def test_verbose_install_renders_per_file_detail_quiet_install_does_not(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    Given a hermetic repo (one shared template -> a non-empty claude plan),
+    under --tools=claude --yes
+    When main runs a REAL install with --verbose vs without it (default io)
+    Then --verbose renders a per-file line naming the installed dest on stdout,
+    while the quiet run renders no such per-file line.
+
+    End-to-end parity assertion: the flag reaches the file-operation sites and
+    its presence/absence flips per-file chatter on/off, matching bash vok. The
+    install_pipeline emits the staged template's dest under ~/.claude on the
+    verbose run only. Uses the real default TerminalIO (no injected io) so the
+    whole flag->IOPort->emission chain is exercised; stdout is captured by
+    capsys.
+    """
+    dest = tmp_path / ".claude" / "INSTRUCTIONS.md"
+
+    repo_v = _hermetic_repo(tmp_path / "v")
+    home_v = tmp_path
+    rc_v = main(["--tools=claude", "--yes", "--verbose"], home=home_v, repo_root=repo_v)
+    assert rc_v == 0
+    verbose_out = capsys.readouterr().out
+    assert "INSTRUCTIONS.md" in verbose_out
+
+    # Quiet re-install into a fresh home: the same install produces no per-file
+    # line on stdout (the default-quiet contract).
+    repo_q = _hermetic_repo(tmp_path / "q")
+    home_q = tmp_path / "qhome"
+    home_q.mkdir()
+    rc_q = main(["--tools=claude", "--yes"], home=home_q, repo_root=repo_q)
+    assert rc_q == 0
+    quiet_out = capsys.readouterr().out
+    assert "INSTRUCTIONS.md" not in quiet_out
+    # sanity: the verbose dest path is the one we expect main to have installed.
+    assert dest.exists()
+
+
 # ── W3: default-path real install (install_pipeline wired into main) ──
 
 

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -703,7 +703,10 @@ def test_verbose_install_renders_per_file_detail_quiet_install_does_not(
     rc_v = main(["--tools=claude", "--yes", "--verbose"], home=home_v, repo_root=repo_v)
     assert rc_v == 0
     verbose_out = capsys.readouterr().out
-    assert "INSTRUCTIONS.md" in verbose_out
+    # Collapse whitespace before asserting: terminals in CI wrap long paths at
+    # ~80 chars, splitting "INSTRUCTIONS.md" across lines and breaking naive
+    # substring checks.
+    assert "INSTRUCTIONS.md" in "".join(verbose_out.split())
 
     # Quiet re-install into a fresh home: the same install produces no per-file
     # line on stdout (the default-quiet contract).
@@ -713,7 +716,7 @@ def test_verbose_install_renders_per_file_detail_quiet_install_does_not(
     rc_q = main(["--tools=claude", "--yes"], home=home_q, repo_root=repo_q)
     assert rc_q == 0
     quiet_out = capsys.readouterr().out
-    assert "INSTRUCTIONS.md" not in quiet_out
+    assert "INSTRUCTIONS.md" not in "".join(quiet_out.split())
     # sanity: the verbose dest path is the one we expect main to have installed.
     assert dest.exists()
 

--- a/packages/installer/tests/unit/test_sync_plan.py
+++ b/packages/installer/tests/unit/test_sync_plan.py
@@ -736,7 +736,10 @@ def test_created_file_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
     sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
 
     detail = _verbose_lines(io)
-    assert any(str(home / "f.md") in e.message for e in detail)
+    assert any(
+        str(home / "f.md") in e.message and "Installed" in e.message and "(new)" in e.message
+        for e in detail
+    )
 
 
 def test_updated_file_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
@@ -758,7 +761,10 @@ def test_updated_file_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
     sync_plan(_IdentityAdapter(), plan, home=home, io=io, auto_yes=True, timestamp=_FIXED_TS)
 
     detail = _verbose_lines(io)
-    assert any(str(home / "f.md") in e.message for e in detail)
+    assert any(
+        str(home / "f.md") in e.message and "Updated" in e.message and "(new)" not in e.message
+        for e in detail
+    )
 
 
 def test_skipped_file_emits_verbose_up_to_date_detail(tmp_path: Path) -> None:
@@ -803,7 +809,12 @@ def test_created_dir_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
     sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
 
     detail = _verbose_lines(io)
-    assert any(str(home / "skills" / "s") in e.message for e in detail)
+    assert any(
+        str(home / "skills" / "s") in e.message
+        and "Installed" in e.message
+        and "(new)" in e.message
+        for e in detail
+    )
 
 
 def test_skipped_dir_emits_verbose_up_to_date_detail(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_sync_plan.py
+++ b/packages/installer/tests/unit/test_sync_plan.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 
 from installer.core.consent import ConsentRequiredError
-from installer.core.io_port import IOPort, ScriptedIO
+from installer.core.io_port import IOPort, ScriptedIO, TranscriptEntry
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 from installer.core.sync import sync_plan
 
@@ -698,6 +698,138 @@ def test_interactive_decline_keeps_existing_file_and_counts_skipped(tmp_path: Pa
     assert (home / "AGENTS.md").read_bytes() == b"old\n"  # decline keeps existing
     assert not any(home.glob("AGENTS.md.backup-*"))  # no backup on decline
     assert (counters.skipped, counters.updated, counters.backed_up) == (1, 0, 0)
+
+
+# ── 8.13: verbose per-file detail (bash parity) ──
+#
+# The bash installer emits per-file chatter via ``vok`` at the real-install
+# outcomes — "Installed X (new)" / "X is up to date" / "Updated X"
+# (scripts/install.sh:1158,1166,1180,1224,1237,1255). The Python port routes
+# these through the IOPort with ``verbose=True`` so ``TerminalIO`` suppresses
+# them unless constructed with ``verbose=True`` — matching ``vok``'s
+# silent-unless-``--verbose`` contract (scripts/install.sh:166-168). These tests
+# assert the emission AND its ``verbose=True`` tag at the ScriptedIO transcript
+# boundary; the suppression direction itself is pinned in test_io_port.py.
+
+
+def _verbose_lines(io: ScriptedIO) -> list[TranscriptEntry]:
+    """Output entries tagged verbose=True — the per-file detail that is silent
+    without --verbose."""
+    return [e for e in io.transcript if e.channel in ("info", "ok", "warn") and e.verbose]
+
+
+def test_created_file_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
+    """
+    Given a NEW FILE item (dest absent) installed for real (not dry-run)
+    When sync_plan walks it
+    Then a verbose-tagged per-file line naming the dest is emitted — the parity
+    equivalent of bash ``vok "Installed X (new)"`` — and it carries verbose=True
+    so a default (quiet) TerminalIO suppresses it.
+
+    Pins: the real-install create path emits per-file detail behind the verbose
+    gate. Fails while the Python port stays silent on a real install.
+    """
+    home = tmp_path / "home"
+    io = ScriptedIO()
+    plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"hi\n")}, tool=Tool.CLAUDE)
+
+    sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    detail = _verbose_lines(io)
+    assert any(str(home / "f.md") in e.message for e in detail)
+
+
+def test_updated_file_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
+    """
+    Given a CHANGED FILE item overwritten for real under --yes
+    When sync_plan walks it
+    Then a verbose-tagged per-file line naming the dest is emitted — the parity
+    equivalent of bash ``vok "Updated X"``.
+
+    Pins: the real-install update path emits per-file detail behind the verbose
+    gate, distinct from the create path.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "f.md").write_bytes(b"old\n")
+    io = ScriptedIO()
+    plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"new\n")}, tool=Tool.CLAUDE)
+
+    sync_plan(_IdentityAdapter(), plan, home=home, io=io, auto_yes=True, timestamp=_FIXED_TS)
+
+    detail = _verbose_lines(io)
+    assert any(str(home / "f.md") in e.message for e in detail)
+
+
+def test_skipped_file_emits_verbose_up_to_date_detail(tmp_path: Path) -> None:
+    """
+    Given an UNCHANGED FILE item whose dest already holds matching bytes
+    When sync_plan walks it
+    Then a verbose-tagged per-file "up to date" line naming the dest is emitted —
+    the parity equivalent of bash ``vok "X is up to date"``.
+
+    Pins: the skip path is NOT silent under verbose — bash announces up-to-date
+    files. Fails while the Python skip path emits nothing.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "f.md").write_bytes(b"same\n")
+    io = ScriptedIO()
+    plan = StagingPlan(items={Path("f.md"): _file_item(Path("f.md"), b"same\n")}, tool=Tool.CLAUDE)
+
+    sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    detail = _verbose_lines(io)
+    assert any(str(home / "f.md") in e.message and "up to date" in e.message for e in detail)
+
+
+def test_created_dir_emits_verbose_detail_naming_dest(tmp_path: Path) -> None:
+    """
+    Given a NEW DIR item materialised for real
+    When sync_plan walks it
+    Then a verbose-tagged per-dir line naming the dest is emitted — the parity
+    equivalent of bash ``vok "Installed dir/item (new)"``.
+
+    Pins: the DIR install path emits per-item detail behind the verbose gate too,
+    not just the FILE path.
+    """
+    src = tmp_path / "src_skill"
+    src.mkdir()
+    (src / "SKILL.md").write_bytes(b"skill\n")
+    home = tmp_path / "home"
+    io = ScriptedIO()
+    plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
+
+    sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    detail = _verbose_lines(io)
+    assert any(str(home / "skills" / "s") in e.message for e in detail)
+
+
+def test_skipped_dir_emits_verbose_up_to_date_detail(tmp_path: Path) -> None:
+    """
+    Given an UNCHANGED DIR item already materialised by a prior identical run
+    When sync_plan re-runs into the same dest
+    Then a verbose-tagged per-dir "up to date" line naming the dest is emitted —
+    the parity equivalent of bash ``vok "dir/item is up to date"``.
+
+    Pins: the DIR skip path announces up-to-date items under verbose, mirroring
+    the FILE skip path.
+    """
+    src = tmp_path / "src_skill"
+    src.mkdir()
+    (src / "SKILL.md").write_bytes(b"skill\n")
+    home = tmp_path / "home"
+    plan = StagingPlan(items={Path("skills/s"): _dir_item(Path("skills/s"), src)}, tool=Tool.CLAUDE)
+    sync_plan(_IdentityAdapter(), plan, home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+
+    io = ScriptedIO()
+    sync_plan(_IdentityAdapter(), plan, home=home, io=io, timestamp=_FIXED_TS)
+
+    detail = _verbose_lines(io)
+    assert any(
+        str(home / "skills" / "s") in e.message and "up to date" in e.message for e in detail
+    )
 
 
 def test_interactive_accept_shows_diff_then_overwrites_with_backup(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_sync_routes.py
+++ b/packages/installer/tests/unit/test_sync_routes.py
@@ -131,6 +131,41 @@ def test_route_unchanged_script_is_skipped_but_lost_exec_bit_is_restored(
     assert (counters.skipped, counters.updated) == (1, 0)
 
 
+def test_route_lost_exec_restore_emits_verbose_detail_but_clean_skip_does_not(
+    tmp_path: Path,
+) -> None:
+    """
+    Given two exec routes that both hash-skip — one whose dest lost its exec bit
+    (0o644 -> repaired) and one whose dest already carries it (0o755 -> untouched)
+    When sync_routes runs
+    Then ONLY the repaired one emits a verbose-tagged "Restored +x" line — the
+    parity equivalent of bash ``vinfo "Restored +x on scripts/X"``
+    (scripts/install.sh:1096), which fires only when the repair actually happens.
+
+    Pins: the exec-bit repair on a hash-equal skip is announced under --verbose
+    (and silent without it), and a skip that does no repair stays quiet on that
+    line — so the "up to date" message is never misleadingly preceded by a
+    phantom restore. Fails if the restore is silent or fires unconditionally.
+    """
+    src = tmp_path / "src" / "scripts"
+    dest = tmp_path / "home" / ".beads" / "scripts"
+    _seed_file(src / "lost.sh", b"#!/bin/sh\n", mode=0o755)
+    _seed_file(dest / "lost.sh", b"#!/bin/sh\n", mode=0o644)  # same bytes, no +x
+    _seed_file(src / "kept.sh", b"#!/bin/sh\necho ok\n", mode=0o755)
+    _seed_file(dest / "kept.sh", b"#!/bin/sh\necho ok\n", mode=0o755)  # same bytes, +x intact
+    routes = [PluginRoute(src, dest, "*.sh", executable=True)]
+    io = ScriptedIO()
+
+    sync_routes(routes, io=io, timestamp=_FIXED_TS)
+
+    restored = [e for e in io.transcript if e.verbose and "Restored +x" in e.message]
+    assert len(restored) == 1
+    assert str(dest / "lost.sh") in restored[0].message
+    assert not any(
+        str(dest / "kept.sh") in e.message and "Restored +x" in e.message for e in io.transcript
+    )
+
+
 def test_route_restore_adds_exec_without_widening_existing_rw_bits(tmp_path: Path) -> None:
     """
     Given an exec route whose dest holds byte-identical content but was tightened


### PR DESCRIPTION
## What changed

Adds a `--verbose`/`-v` flag to the Python installer CLI, reaching parity with the bash installer (`scripts/install.sh`), which has long supported `-v`/`--verbose` and emits per-file progress. Before this change the Python port had no such flag, so all per-file detail was silently suppressed.

- `cli.py`: add `--verbose`/`-v` to `_build_parser()`; construct `TerminalIO(verbose=args.verbose)` in `main()`.
- `core/sync.py`: emit verbose-gated (`verbose=True`) per-file lines at the shared sync outcome sites:
  - create/update → `_record_write`: "Installed X (new)" / "Updated X"
  - skip (up-to-date) → `_install_file` + `_install_dir`: "X is up to date"
  - plugin-route exec-bit repair on a hash-equal skip → "Restored +x on X" (`_restore_exec_bit` now reports whether it changed the mode)

  Because `sync_routes` (beads formulas/scripts) also routes through `_install_file`, plugin-route installs get the same per-file detail with no separate emission site — a DRY refinement over bash, which duplicates `vok` across four loops.

## Why

Closes the verbose-output parity gap (bead 8.13). Operators running the Python installer could not get the per-file progress the bash installer provides.

## Parity reference

`scripts/install.sh` — `vok`/`vinfo` helpers (~166-168, silent unless `VERBOSE=true`); "Installed X (new)"/"X is up to date"/"Updated X" at ~1158/1166/1180 (files) and ~1224/1237/1255 (dirs); "Restored +x" at ~1096.

## Scope

- IN: the flag, its plumbing into `TerminalIO`, verbose per-file emission at the create/update/skip/exec-restore sites, and behavioral tests.
- OUT: the pre-existing non-verbose dry-run "would create/update" preview is intentionally left unchanged (separate pre-existing behavior); no phase-header or "(auto-yes)" prompt-echo parity (not per-file detail).

## Verification

- `make ci-installer` GREEN: 567 unit + 15 golden-master tests, coverage 99.79% (90% floor), `pip-audit` clean, entry-verify clean. Without `--verbose`, output is unchanged (verbose suppressed); with it, per-file detail renders — both directions covered by tests at the IOPort/CLI boundary.

## Adversarial review

Codex `gpt-5.5` adversarial review was run (read-only, via the companion runtime) against the branch diff. Verdict: **NO BLOCKING FINDINGS** (0 blocker, 0 major, 3 minor). All three minors were folded in: the `(new)` create marker, the "Restored +x" route line, and stronger verb/marker assertions in the create/update/route tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
