### PR TITLE
test(installer): hooks/ namespace parity coverage (8.7)

### DIFF
--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -49,6 +49,31 @@ def test_bare_install_single_tool_no_plugins(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
 
+def test_hooks_namespace_staged_with_exec_bit(tmp_path: Path) -> None:
+    """The real ``src/user/.claude/hooks/`` namespace installs to ``~/.claude/hooks/``
+    at parity, preserving each script's source mode bit: ``ruff-postedit.py`` is
+    git-tracked 100755 and must land executable, while ``ruff-postedit_test.sh`` is
+    100644 and must land non-executable. The bare-install scenario already compares
+    the exec bit tree-wide; this pins the hooks/ namespace explicitly (8.7 parity
+    with install.sh's hooks/ subdir staging + cp mode preservation), so a future
+    regression in either installer surfaces here by name rather than as an opaque
+    tree diff."""
+    result = run_parity(tmp_path, args=_CLAUDE_ARGS)
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+    diff = result.diff()
+    assert diff.is_parity(), diff.render()
+
+    hooks_b = result.home_b / ".claude" / "hooks"
+    exec_hook = hooks_b / "ruff-postedit.py"
+    plain_hook = hooks_b / "ruff-postedit_test.sh"
+    assert exec_hook.is_file(), "hook script must install to ~/.claude/hooks/"
+    assert plain_hook.is_file(), "non-exec hook sibling must install to ~/.claude/hooks/"
+    assert exec_hook.stat().st_mode & 0o111, "executable source hook must land +x"
+    assert not (plain_hook.stat().st_mode & 0o111), "non-executable source hook must stay -x"
+
+
 def test_pre_existing_settings_merge(tmp_path: Path) -> None:
     """A pre-existing user settings.json is union-merged by both installers. The
     bash side uses jq, the Python side json_union — the differ compares JSON

--- a/packages/installer/tests/golden_master/test_parity.py
+++ b/packages/installer/tests/golden_master/test_parity.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.golden_master._runner import run_parity
+from tests.golden_master._runner import REPO_ROOT, run_parity
 
 pytestmark = pytest.mark.golden_master
 
@@ -51,13 +51,24 @@ def test_bare_install_single_tool_no_plugins(tmp_path: Path) -> None:
 
 def test_hooks_namespace_staged_with_exec_bit(tmp_path: Path) -> None:
     """The real ``src/user/.claude/hooks/`` namespace installs to ``~/.claude/hooks/``
-    at parity, preserving each script's source mode bit: ``ruff-postedit.py`` is
-    git-tracked 100755 and must land executable, while ``ruff-postedit_test.sh`` is
-    100644 and must land non-executable. The bare-install scenario already compares
-    the exec bit tree-wide; this pins the hooks/ namespace explicitly (8.7 parity
-    with install.sh's hooks/ subdir staging + cp mode preservation), so a future
-    regression in either installer surfaces here by name rather than as an opaque
-    tree diff."""
+    at parity, preserving each script's source mode bit: an executable source hook
+    must land +x and a non-executable one must stay -x. The bare-install scenario
+    already compares the exec bit tree-wide; this pins the hooks/ namespace
+    explicitly (8.7 parity with install.sh's hooks/ subdir staging + cp mode
+    preservation), so a future regression surfaces here by name rather than as an
+    opaque tree diff.
+
+    The two probe files are derived from the real source tree by mode bit (not
+    hardcoded by name), so the test follows a hook rename and only requires that
+    ``src/user/.claude/hooks/`` keep at least one executable and one
+    non-executable script."""
+    src_hooks = REPO_ROOT / "src" / "user" / ".claude" / "hooks"
+    src_files = sorted(f for f in src_hooks.iterdir() if f.is_file())
+    exec_name = next((f.name for f in src_files if f.stat().st_mode & 0o111), None)
+    plain_name = next((f.name for f in src_files if not (f.stat().st_mode & 0o111)), None)
+    assert exec_name is not None, "fixture invariant: an executable source hook must exist"
+    assert plain_name is not None, "fixture invariant: a non-executable source hook must exist"
+
     result = run_parity(tmp_path, args=_CLAUDE_ARGS)
 
     assert result.bash_returncode == 0, result.bash_stderr
@@ -66,9 +77,9 @@ def test_hooks_namespace_staged_with_exec_bit(tmp_path: Path) -> None:
     assert diff.is_parity(), diff.render()
 
     hooks_b = result.home_b / ".claude" / "hooks"
-    exec_hook = hooks_b / "ruff-postedit.py"
-    plain_hook = hooks_b / "ruff-postedit_test.sh"
-    assert exec_hook.is_file(), "hook script must install to ~/.claude/hooks/"
+    exec_hook = hooks_b / exec_name
+    plain_hook = hooks_b / plain_name
+    assert exec_hook.is_file(), "executable hook must install to ~/.claude/hooks/"
     assert plain_hook.is_file(), "non-exec hook sibling must install to ~/.claude/hooks/"
     assert exec_hook.stat().st_mode & 0o111, "executable source hook must land +x"
     assert not (plain_hook.stat().st_mode & 0o111), "non-executable source hook must stay -x"

--- a/packages/installer/tests/golden_master/test_parity_prune.py
+++ b/packages/installer/tests/golden_master/test_parity_prune.py
@@ -72,6 +72,38 @@ def test_prune_yes_removes_orphans(tmp_path: Path) -> None:
     ), "agents-backup must hold a timestamped backup of the pruned agent"
 
 
+def _seed_hooks_orphan(home: Path) -> None:
+    """Place an unmanaged file into the Claude ``hooks/`` tree under a name that an
+    aggressive prune glob would match. ``hooks/`` is prune-EXEMPT, so this file
+    must survive a ``--prune`` run untouched on both installers."""
+    hooks = home / ".claude" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    (hooks / "user-local-hook.py").write_text("# user-managed hook, not from src\n")
+
+
+def test_hooks_orphan_survives_prune(tmp_path: Path) -> None:
+    """--prune --yes with a stray ``hooks/`` file present: ``hooks/`` is outside the
+    pruned namespace set (bash ``prune_subdirs`` = commands/skills/agents/rules;
+    Python ``_PRUNE_SUBDIRS`` mirrors it), so the stray file must remain after the
+    install-then-prune pass on BOTH installers. Parity proves bash and Python agree
+    that hooks/ is never pruned; the explicit existence check proves the exemption
+    actually held rather than the file having been removed identically by both."""
+    result = run_parity(tmp_path, args=[*_CLAUDE_ARGS, "--prune"], seed=_seed_hooks_orphan)
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+    diff = result.diff()
+    assert diff.is_parity(), diff.render()
+    # The exemption held: the stray hook is still there, not pruned.
+    assert (result.home_b / ".claude" / "hooks" / "user-local-hook.py").is_file(), (
+        "hooks/ is prune-exempt - the stray hook must survive --prune"
+    )
+    # And it was never backed up (no prune action touched it at all).
+    assert not (result.home_b / ".claude" / "hooks-backup").exists(), (
+        "no hooks-backup dir - prune must never visit the hooks/ namespace"
+    )
+
+
 def test_prune_only_removes_orphans(tmp_path: Path) -> None:
     """--prune-only --yes: Phase 7 install is skipped; orphaned retired files are
     backed up and removed.  Both installers must produce identical homes containing

--- a/packages/installer/tests/golden_master/test_parity_prune.py
+++ b/packages/installer/tests/golden_master/test_parity_prune.py
@@ -105,6 +105,11 @@ def test_hooks_orphan_survives_prune(tmp_path: Path) -> None:
     assert (result.home_b / ".claude" / "hooks" / "user-local-hook.py").is_file(), (
         "an unmanaged hooks/ file must survive --prune"
     )
+    assert (
+        result.home_b / ".claude" / "hooks" / "user-local-hook.py"
+    ).read_text() == "# user-managed hook, not from src\n", (
+        "hooks/ orphan content must be untouched — install must not overwrite an unmanaged hook"
+    )
     # And it was never backed up (no prune action touched the hooks/ namespace).
     assert not (result.home_b / ".claude" / "hooks-backup").exists(), (
         "no hooks-backup dir - prune must not back up anything under hooks/"

--- a/packages/installer/tests/golden_master/test_parity_prune.py
+++ b/packages/installer/tests/golden_master/test_parity_prune.py
@@ -73,34 +73,41 @@ def test_prune_yes_removes_orphans(tmp_path: Path) -> None:
 
 
 def _seed_hooks_orphan(home: Path) -> None:
-    """Place an unmanaged file into the Claude ``hooks/`` tree under a name that an
-    aggressive prune glob would match. ``hooks/`` is prune-EXEMPT, so this file
-    must survive a ``--prune`` run untouched on both installers."""
+    """Place an unmanaged file into the Claude ``hooks/`` tree. It is not staged by
+    either installer (no such source hook) and not in any prune list, so a correct
+    ``--prune`` run leaves it untouched on both sides."""
     hooks = home / ".claude" / "hooks"
     hooks.mkdir(parents=True, exist_ok=True)
     (hooks / "user-local-hook.py").write_text("# user-managed hook, not from src\n")
 
 
 def test_hooks_orphan_survives_prune(tmp_path: Path) -> None:
-    """--prune --yes with a stray ``hooks/`` file present: ``hooks/`` is outside the
-    pruned namespace set (bash ``prune_subdirs`` = commands/skills/agents/rules;
-    Python ``_PRUNE_SUBDIRS`` mirrors it), so the stray file must remain after the
-    install-then-prune pass on BOTH installers. Parity proves bash and Python agree
-    that hooks/ is never pruned; the explicit existence check proves the exemption
-    actually held rather than the file having been removed identically by both."""
+    """--prune --yes with a stray ``hooks/`` file present: an unmanaged file in
+    ``hooks/`` is left in place by BOTH installers, end to end, and neither side
+    creates a ``hooks-backup`` dir.
+
+    Scope of this end-to-end check: it proves bash and Python AGREE on the
+    observable outcome through the real ``--prune`` pipeline. It does NOT, on its
+    own, isolate the ``hooks``-vs-``_PRUNE_SUBDIRS`` exemption: the real prune
+    lists ship no ``hooks`` glob, so the orphan scan would skip this file on the
+    glob gate even if ``hooks`` were (wrongly) added to the scanned namespace set.
+    The mutation guard for the exemption is the unit test
+    ``test_prune.py::test_hooks_namespace_is_never_pruned``, which supplies its own
+    ``hooks``-matching globs so the namespace-set choice is the only thing under
+    test. This scenario is the parity/integration complement to that unit guard."""
     result = run_parity(tmp_path, args=[*_CLAUDE_ARGS, "--prune"], seed=_seed_hooks_orphan)
 
     assert result.bash_returncode == 0, result.bash_stderr
     assert result.python_returncode == 0, result.python_stderr
     diff = result.diff()
     assert diff.is_parity(), diff.render()
-    # The exemption held: the stray hook is still there, not pruned.
+    # The stray hook is still there, left in place by the prune pass on both sides.
     assert (result.home_b / ".claude" / "hooks" / "user-local-hook.py").is_file(), (
-        "hooks/ is prune-exempt - the stray hook must survive --prune"
+        "an unmanaged hooks/ file must survive --prune"
     )
-    # And it was never backed up (no prune action touched it at all).
+    # And it was never backed up (no prune action touched the hooks/ namespace).
     assert not (result.home_b / ".claude" / "hooks-backup").exists(), (
-        "no hooks-backup dir - prune must never visit the hooks/ namespace"
+        "no hooks-backup dir - prune must not back up anything under hooks/"
     )
 
 

--- a/packages/installer/tests/unit/test_prune.py
+++ b/packages/installer/tests/unit/test_prune.py
@@ -201,6 +201,31 @@ def test_adapter_with_no_plan_entry_still_scans_dest(tmp_path: Path) -> None:
     assert [o.path.name for o in orphans] == ["retired-skill"]
 
 
+def test_hooks_namespace_is_never_pruned(tmp_path: Path) -> None:
+    """
+    Given an unstaged dest ``hooks/`` entry that matches an aggressive prune glob
+    When scan_orphans runs
+    Then it is NOT reported - ``hooks`` is outside the scanned namespace set.
+
+    Parity: bash scans only ``commands/skills/agents/rules`` for orphans
+    (``scripts/install.sh`` ``prune_subdirs``); ``hooks/`` is prune-EXEMPT by
+    omission. This pins the Python ``_PRUNE_SUBDIRS`` choice - adding ``hooks``
+    to it (the regression this guards) would make a glob-matched hook script
+    deletable, diverging from bash. Contrast with
+    ``test_unstaged_entry_matching_glob_is_orphan``: the same setup shape under a
+    scanned namespace yields an orphan; under ``hooks`` it must not.
+    """
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    (tmp_path / ".claude" / "hooks" / "ruff-postedit.py").write_text("x")
+    config = InstallerToml(prune_globs=["*/hooks/*", "claude/hooks/ruff-postedit.py"])
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()], plans={Tool.CLAUDE: _empty_plan()}, home=tmp_path, config=config
+    )
+
+    assert orphans == []
+
+
 def test_beads_formulas_scanned_with_no_beads_plan(tmp_path: Path) -> None:
     """
     Given a ~/.beads/formulas entry and no beads content in any plan


### PR DESCRIPTION
## What changed

Adds the behavioral test coverage required by bead agents-config-w1qls.8.7 for the Python installer's `hooks/` namespace parity with the bash installer. **Test-only** — the production wiring landed in prior commits (see below).

Three tests, +101/-1:

1. `tests/unit/test_prune.py::test_hooks_namespace_is_never_pruned` — seeds a `hooks/` dest entry matching aggressive prune globs and asserts `scan_orphans(...) == []`. This is the **mutation guard** for the exemption: adding `hooks` to `core/prune.py::_PRUNE_SUBDIRS` makes it fail (verified).
2. `tests/golden_master/test_parity.py::test_hooks_namespace_staged_with_exec_bit` — runs both installers against the real `src/` tree, asserts parity, then asserts an executable source hook lands +x and a non-executable one stays -x. Probe files are derived from source mode bits (not hardcoded), so the test follows a hook rename.
3. `tests/golden_master/test_parity_prune.py::test_hooks_orphan_survives_prune` — end-to-end: a stray `hooks/` file is left in place by both installers under `--prune`, with no `hooks-backup` created. Scoped as the parity/integration complement to the unit guard (see Codex MAJOR below).

## Why

The bash installer stages `hooks/` (file-granularity, +x preserved) and excludes it from the orphan scan. The Python port already wired this in prior commits but lacked the explicit prune-exemption unit test and the golden-master hooks scenarios the bead's acceptance criteria require. Without them, a regression (e.g. someone adds `hooks` to `_PRUNE_SUBDIRS`, or breaks exec-bit preservation) would not be caught.

## Parity reference

`scripts/install.sh` hooks handling: subdir staging loop (~812) and sync loop (~934) both include `hooks`; the orphan scan's `prune_subdirs` (~1529, around the 1453-1543 block) lists only `commands skills agents rules`, so `hooks/` is prune-exempt by omission. The Python port mirrors this exactly: `tools/claude.py` declares `hooks` in `scoped_namespaces()`; `core/staging.py` reads the source mode bit; `core/sync.py` writes 0o755/0o644; `core/prune.py::_PRUNE_SUBDIRS` omits `hooks`.

## Already wired (prior commits, not this PR)

`core/staging.py` exec-bit read, `tools/claude.py` `hooks` namespace, `core/sync.py` mode write, `core/prune.py` exemption, plus existing unit tests for staging exec-bit and `build_plan` hooks staging.

## Scope / out-of-scope

- **In scope:** prune-exemption unit test + two golden-master hooks scenarios; `make ci-installer` green.
- **Out of scope (discovered):** bash stages `hooks/` generically for *every* tool, but only `src/user/.claude/hooks/` exists today; the codex/gemini/opencode adapters return empty `scoped_namespaces()`, so they would not stage a hooks dir if one were ever added. No present-tree divergence (no non-Claude hooks source exists). Flagged for a follow-up if non-Claude hooks are ever introduced — not addressed here to avoid speculative scope-creep.

## Codex adversarial review (gpt-5.5, companion runtime)

**Verdict: no blocking findings.**
- **MAJOR (folded):** the golden prune scenario over-claimed to guard the `_PRUNE_SUBDIRS` mutation, but the real prune lists ship no `hooks` glob, so it would survive even a broken namespace set (the glob gate would skip it). Rewrote its docstring/assertions to scope it as the parity/integration complement and pointed the mutation-guard responsibility at the unit test (which supplies its own `hooks`-matching globs).
- **MINOR (folded):** exec-bit golden test hardcoded hook filenames; now derives the executable/non-executable probe from `src/user/.claude/hooks/` by mode bit.
- **MINOR (deferred):** non-Claude hooks parity — see out-of-scope above.

## Verification

`make ci-installer` green: ruff check + ruff format --check clean, mypy --strict clean (42 files), 558 unit tests passed (99.79% coverage, floor 90%), 22 golden-master scenarios passed, pip-audit clean, `install.py --help` entry-verify OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)