### PR TITLE
feat(installer): prune-exclusion warning + merged counter at bash parity

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -13,11 +13,15 @@ from installer.core.installer_toml import load_installer_toml
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
 from installer.core.run import install_pipeline, install_plugin_routes, prune_pipeline
+from installer.plugins.registry import discover
 from installer.tools.registry import UnknownToolError, get_adapter, known_tools
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan, Tool
+    from installer.plugins.base import PluginAdapter
     from installer.tools.base import ToolAdapter
 
 # The repo root is the agents-config checkout containing ``src/user/.agents`` and
@@ -141,6 +145,19 @@ def main(
         sys.stderr.write(f"installer: {exc}\n")
         return 2
 
+    # Warn about plugins an EXPLICIT --plugins= override dropped (bash gates this on
+    # PLUGINS_FLAG_SET, scripts/install.sh:308 — auto-detect dropping an undetected
+    # plugin is normal, not warn-worthy). Routed through io.warn after resolution and
+    # before any mode dispatch so it fires on every path (plain / --dump-stage /
+    # --prune / --prune-only) the override reaches.
+    if args.plugins is not None:
+        _warn_excluded_plugins(
+            resolved=plugins,
+            repo_root=resolved_repo_root,
+            io=io,
+            prune_active=args.prune or args.prune_only,
+        )
+
     if args.dump_stage is not None:
         plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
         try:
@@ -214,6 +231,40 @@ def main(
         )
 
     return 0
+
+
+def _warn_excluded_plugins(
+    *,
+    resolved: Iterable[PluginAdapter],
+    repo_root: Path,
+    io: IOPort,
+    prune_active: bool,
+) -> None:
+    """Warn about each discovered plugin an explicit ``--plugins=`` override dropped.
+
+    Mirrors bash ``scripts/install.sh:317-328``: for every plugin in the discovered
+    set absent from the resolved selection, emit a warning naming it. The wording
+    branches on whether a prune phase is active — under ``--prune``/``--prune-only``
+    the excluded plugin's already-installed files become orphans that may be removed
+    (strict mode); otherwise they are left in place. Caller gates this on an explicit
+    override, so an auto-detected exclusion stays silent.
+    """
+    resolved_names = {adapter.name for adapter in resolved}
+    discovered = discover(resolve_plugins_root(repo_root, os.environ))
+    for name in discovered:
+        if name in resolved_names:
+            continue
+        if prune_active:
+            io.warn(
+                f"Plugin '{name}' excluded via --plugins= — under --prune, "
+                "previously-installed files become orphans and may be removed."
+            )
+        else:
+            io.warn(
+                f"Plugin '{name}' excluded via --plugins= — files already installed "
+                "are not removed (use --prune or --prune-only to remove orphans "
+                "under strict mode)."
+            )
 
 
 def _run_prune(

--- a/packages/installer/src/installer/core/model.py
+++ b/packages/installer/src/installer/core/model.py
@@ -181,6 +181,7 @@ class Counters:
     staged: int = 0
     created: int = 0
     updated: int = 0
+    merged: int = 0
     skipped: int = 0
     pruned: int = 0
     backed_up: int = 0

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -79,7 +79,7 @@ def install_pipeline(
     ahead of the prune step to perform the real install. Each adapter's plan is
     looked up by its tool (``Tool(adapter.name)``) and written under
     ``adapter.dest_dir(home)``. Returns the aggregate `Counters`
-    (created / updated / skipped / backed_up summed across tools).
+    (created / updated / merged / skipped / backed_up summed across tools).
 
     ``dry_run`` and ``auto_yes`` are forwarded verbatim into every ``sync_plan``
     call, so the W2 consent gate and the shared no-TTY guard apply uniformly
@@ -103,6 +103,7 @@ def install_pipeline(
         )
         total.created += result.created
         total.updated += result.updated
+        total.merged += result.merged
         total.skipped += result.skipped
         total.backed_up += result.backed_up
     return total

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -346,7 +346,15 @@ def _install_file(
             _back_up(dest, timestamp, counters)
         dest.write_bytes(effective)
         dest.chmod(0o755 if executable else 0o644)
-    _record_write(dest, dest_exists=dest_exists, io=io, dry_run=dry_run, counters=counters)
+    # A changed settings.json union over an EXISTING dest is a merge, not a plain
+    # update — bash tallies ``tool_merged`` (not ``tool_updated``) on that branch
+    # (scripts/install.sh:1358 dry-run / 1366 applied). A fresh settings.json (no
+    # existing dest) is a plain create (scripts/install.sh:1303), so the merge tally
+    # is gated on ``dest_exists``.
+    is_merge = kind is FileKind.SETTINGS_JSON and dest_exists
+    _record_write(
+        dest, dest_exists=dest_exists, io=io, dry_run=dry_run, counters=counters, merged=is_merge
+    )
 
 
 def _dir_is_unchanged(dest: Path, source_path: Path, overrides: Mapping[Path, bytes]) -> bool:
@@ -466,19 +474,36 @@ def _consent_to_overwrite(
 
 
 def _record_write(
-    dest: Path, *, dest_exists: bool, io: IOPort, dry_run: bool, counters: Counters
+    dest: Path,
+    *,
+    dest_exists: bool,
+    io: IOPort,
+    dry_run: bool,
+    counters: Counters,
+    merged: bool = False,
 ) -> None:
-    """Preview the would-be write under ``dry_run`` and tally it as a create or
-    update. On a real (non-``dry_run``) write, emit a verbose-gated per-item line
-    ("Installed X (new)" / "Updated X") so ``--verbose`` yields bash ``vok``
-    per-file detail (scripts/install.sh:1158,1180) while a quiet run stays
-    silent. Shared by the file and dir installers; mutates ``counters``."""
+    """Preview the would-be write under ``dry_run`` and tally it as a create,
+    update, or merge. On a real (non-``dry_run``) write, emit a verbose-gated
+    per-item line ("Installed X (new)" / "Updated X" / "Merged X") so ``--verbose``
+    yields bash ``vok`` per-file detail (scripts/install.sh:1158,1180,1365) while a
+    quiet run stays silent.
+
+    ``merged`` is True only for a changed settings.json union over an existing dest
+    (``_install_file``): bash tallies that as ``tool_merged`` rather than
+    ``tool_updated`` (scripts/install.sh:1358 dry-run / 1366 applied). It is
+    mutually exclusive with the create branch — a merge always overwrites an
+    existing dest — so ``merged`` is only ever set alongside ``dest_exists``. Shared
+    by the file and dir installers; mutates ``counters``."""
     if dry_run:
-        verb = "update" if dest_exists else "create"
+        verb = "merge" if merged else "update" if dest_exists else "create"
         io.info(f"would {verb} {dest}")
+    elif merged:
+        io.ok(f"Merged {dest}", verbose=True)
     else:
         io.ok(f"Updated {dest}" if dest_exists else f"Installed {dest} (new)", verbose=True)
-    if dest_exists:
+    if merged:
+        counters.merged += 1
+    elif dest_exists:
         counters.updated += 1
     else:
         counters.created += 1

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -567,6 +567,91 @@ def test_unknown_plugin_value_returns_2_and_names_it(
     assert "Unknown plugin: 'bogus'" in capsys.readouterr().err
 
 
+# ── 8.15: prune-exclusion warning when --plugins= excludes a discovered plugin ──
+
+
+def test_explicit_plugins_override_warns_about_excluded_plugin(tmp_path: Path) -> None:
+    """
+    Given a discoverable 'widget' plugin and an explicit --plugins= that excludes it
+    When main runs a plain install (no --prune)
+    Then a warning naming 'widget' and the non-prune guidance is emitted.
+
+    Pins: an explicit --plugins= override that drops a discovered plugin warns the
+    operator the already-installed files are NOT removed — bash
+    scripts/install.sh:325. Fails while the Python installer drops excluded plugins
+    silently (resolve_plugins returns the resolved set with no exclusion warning).
+    """
+    repo = _repo_with_widget_plugin(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--tools=claude", "--plugins=", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    warns = [e.message for e in io.transcript if e.channel == "warn"]
+    assert any("widget" in m and "excluded via --plugins=" in m for m in warns), warns
+    # non-prune wording: files already installed are not removed
+    assert any("not removed" in m for m in warns), warns
+
+
+def test_explicit_plugins_override_with_prune_warns_orphan_wording(tmp_path: Path) -> None:
+    """
+    Given a discoverable 'widget' plugin excluded via --plugins= AND --prune-only
+    When main runs
+    Then the exclusion warning uses the prune wording (excluded files become
+    orphans and may be removed) — bash scripts/install.sh:323.
+
+    Pins: the wording branches on whether a prune phase is active. Fails if the
+    warning is unconditional (always the non-prune text) or absent under --prune.
+    --prune-only is used so the run needs no installer.toml-present install half.
+    """
+    repo = _repo_with_widget_plugin(tmp_path)
+    # _run_prune reads installer.toml off repo_root; give it an (empty) prune list
+    # so the prune phase is a clean no-op rather than a missing-file warning.
+    toml_dir = repo / "packages" / "installer"
+    toml_dir.mkdir(parents=True, exist_ok=True)
+    (toml_dir / "installer.toml").write_text("[prune]\nretired = []\n")
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--tools=claude", "--plugins=", "--prune-only", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    warns = [e.message for e in io.transcript if e.channel == "warn"]
+    assert any("widget" in m and "become orphans" in m for m in warns), warns
+
+
+def test_autodetect_does_not_warn_about_excluded_plugins(tmp_path: Path) -> None:
+    """
+    Given a discoverable 'widget' plugin with NO ~/.widget footprint (so
+    auto-detect excludes it) and NO explicit --plugins=
+    When main runs a plain install
+    Then NO exclusion warning is emitted.
+
+    Pins: the exclusion warning fires only under an EXPLICIT --plugins= override
+    (bash gates it on PLUGINS_FLAG_SET, scripts/install.sh:308). Auto-detect
+    dropping an undetected plugin is normal, not warn-worthy. Fails if the warning
+    keys on the discovered-vs-resolved delta regardless of how plugins were
+    resolved.
+    """
+    repo = _repo_with_widget_plugin(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(["--tools=claude", "--yes"], home=tmp_path, io=io, repo_root=repo)
+
+    assert rc == 0
+    warns = [e.message for e in io.transcript if e.channel == "warn"]
+    assert not any("excluded via --plugins=" in m for m in warns), warns
+
+
 def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
     """
     Given a 'widget' plugin overlaying claude rules/widget-rule.md, a dest entry

--- a/packages/installer/tests/unit/test_run_install_pipeline.py
+++ b/packages/installer/tests/unit/test_run_install_pipeline.py
@@ -31,6 +31,17 @@ def _file_item(relpath: Path, content: bytes, *, tool: str = "claude") -> Staged
     )
 
 
+def _settings_item(content: bytes, *, tool: str = "claude") -> StagedItem:
+    return StagedItem(
+        source_path=Path("/unused/settings.json"),
+        dest_relpath=Path("settings.json"),
+        kind=FileKind.SETTINGS_JSON,
+        namespace=None,
+        provenance=Provenance(kind="tool", name=tool),
+        content=content,
+    )
+
+
 def test_install_pipeline_aggregates_counters_across_tools(tmp_path: Path) -> None:
     """
     Given two adapters — one installing a new file, one whose dest file already
@@ -86,3 +97,34 @@ def test_install_pipeline_forwards_auto_yes_to_each_sync_plan(tmp_path: Path) ->
 
     assert (claude.dest_dir(home) / "a.md").read_bytes() == b"new\n"
     assert (counters.updated, counters.backed_up) == (1, 1)
+
+
+def test_install_pipeline_aggregates_merged_counter(tmp_path: Path) -> None:
+    """
+    Given a tool whose dest already holds a settings.json that a staged
+    settings.json union would change (a merge, not a plain update)
+    When install_pipeline runs with --yes
+    Then the aggregate Counters carry merged=1 (and updated=0).
+
+    Pins: install_pipeline sums each sync_plan's ``merged`` field into the
+    returned total — the field the 'Merged' summary line reports. Fails while the
+    aggregation drops ``merged`` (sums only created/updated/skipped/backed_up), so
+    a real merge never reaches the summary.
+    """
+    home = tmp_path / "home"
+    claude = get_adapter(Tool.CLAUDE)
+    claude.dest_dir(home).mkdir(parents=True)
+    (claude.dest_dir(home) / "settings.json").write_bytes(b'{"userKey": "keep-me"}\n')
+    plans = {
+        Tool.CLAUDE: StagingPlan(
+            items={Path("settings.json"): _settings_item(b'{"templateKey": 1}')},
+            tool=Tool.CLAUDE,
+        ),
+    }
+
+    counters = install_pipeline(
+        [claude], plans=plans, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
+    )
+
+    assert counters.merged == 1
+    assert counters.updated == 0

--- a/packages/installer/tests/unit/test_sync_settings_union.py
+++ b/packages/installer/tests/unit/test_sync_settings_union.py
@@ -78,6 +78,54 @@ def test_sync_settings_backs_up_user_file_before_union(tmp_path: Path) -> None:
     assert json.loads(backups[0].read_bytes()) == {"userKey": "keep-me"}
 
 
+def test_sync_settings_union_over_existing_counts_merged_not_updated(tmp_path: Path) -> None:
+    """A settings.json union that changes an existing user file is tallied as a
+    *merge*, not a plain update — bash increments ``tool_merged`` (not
+    ``tool_updated``) when ``sync_settings_file`` applies a changed union over an
+    existing dest (``scripts/install.sh:1366``). The 'Merged' summary line counts
+    exactly these. Pins: the changed-existing settings path increments
+    ``Counters.merged`` and leaves created/updated at zero. Fails while the merge
+    path tallies through ``_record_write`` (created/updated) and ``merged`` stays 0."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "settings.json").write_text('{"userKey": "keep-me"}\n')
+    plan = StagingPlan(
+        items={Path("settings.json"): _settings_item(b'{"templateKey": 1}')},
+        tool=Tool.CLAUDE,
+    )
+
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_TS
+    )
+
+    assert counters.merged == 1
+    assert counters.updated == 0
+    assert counters.created == 0
+
+
+def test_sync_fresh_settings_counts_created_not_merged(tmp_path: Path) -> None:
+    """A first settings.json install (no existing dest) is a plain create, not a
+    merge — bash increments ``tool_installed`` on the new-file branch
+    (``scripts/install.sh:1303``), never ``tool_merged``. Pins: the no-existing-dest
+    settings path increments ``created`` and leaves ``merged`` at zero. Fails if the
+    merge tally fires on a fresh install (e.g. keyed on kind alone, not on an
+    existing dest)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    plan = StagingPlan(
+        items={Path("settings.json"): _settings_item(b'{"templateKey": 1}')},
+        tool=Tool.CLAUDE,
+    )
+
+    counters = sync_plan(
+        _IdentityAdapter(), plan, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_TS
+    )
+
+    assert counters.created == 1
+    assert counters.merged == 0
+    assert counters.updated == 0
+
+
 def test_sync_preserves_and_skips_invalid_existing_settings(tmp_path: Path) -> None:
     """An existing settings.json that is not valid JSON is left untouched and
     reported as an error, not overwritten — matching bash, which refuses to touch a


### PR DESCRIPTION
## What changed

Two CLI-output parity fixes between the Python installer (`packages/installer`) and the bash reference (`scripts/install.sh`). Bead `agents-config-w1qls.8.15`. **No installed bytes change** — this is observable-output parity only.

### G7 — prune-exclusion warning (user-visible)

When an **explicit** `--plugins=` override drops a discovered plugin, the installer now warns, naming the excluded plugin. Two wordings, keyed on whether a prune phase is active:

- plain install: *"… files already installed are not removed (use --prune or --prune-only to remove orphans under strict mode)."*
- `--prune`/`--prune-only`: *"… under --prune, previously-installed files become orphans and may be removed."*

Gated on an explicit override (bash `PLUGINS_FLAG_SET`, `install.sh:308`); an auto-detected exclusion stays silent. Wording matches `install.sh:317-325`. Routed through `IOPort.warn` in `cli.py` after plugin resolution and before any mode dispatch, so it fires on every path the override reaches (plain / `--dump-stage` / `--prune` / `--prune-only`).

### G8 — `merged` counter (tracking only; NOT yet user-visible)

Adds a `merged` field to `Counters` (`core/model.py`), increments it at the settings-merge-over-existing site in `core/sync.py` (`_install_file` → `_record_write`), and aggregates it in `core/run.py` `install_pipeline`. The increment fires at **exactly** the bash-equivalent site: a *changed* `settings.json` union over an **existing** dest (`install.sh:1358` dry-run / `1366` applied), including dry-run; a fresh `settings.json` install is a plain create (`install.sh:1303`), not a merge. A verbose per-file `Merged <dest>` line is also emitted (matching bash `vok`, `install.sh:1365`).

**Important honesty note:** the `merged` counter is correctly tracked and aggregated but is **not yet surfaced in an aggregate install summary**, because the Python installer renders **no install summary block at all** — `cli.main` discards the `Counters` it receives. No Epic story currently owns that renderer. Building it (per-tool `Merged:` block + quiet `N merged` one-liner, `install.sh:1815-1869`) is tracked as follow-up bead **`agents-config-w1qls.8.18`** and is **out of scope here**. This PR makes the counter correct and ready to print so 8.18 is a pure rendering change.

## Bash parity reference
- exclusion warning: `scripts/install.sh:308-328`
- merged counter increment: `scripts/install.sh:1284-1372` (esp. 1303 / 1358 / 1366)
- summary printing (deferred to 8.18): `scripts/install.sh:1815-1869`

## Scope
- IN: G7 exclusion warning; G8 `merged` tracking (model + sync increment + run aggregation) + verbose per-file `Merged` line.
- OUT: the aggregate install-summary renderer (no summary exists for ANY counter today) — deferred to `agents-config-w1qls.8.18`.

## Tests
TDD throughout. New behavioral tests pin the contract at the right boundary (Counters fields / IOPort transcript), not tautologies:
- `test_sync_settings_union.py`: merge-over-existing → `merged==1` (not updated); fresh settings → `created==1` (not merged).
- `test_run_install_pipeline.py`: `install_pipeline` aggregates `merged`.
- `test_cli_smoke.py`: explicit `--plugins=` exclusion warns (non-prune wording); `--prune-only` exclusion warns (orphan wording); auto-detect exclusion does NOT warn.

`make ci` (full, both packages) green: installer ruff/format/mypy --strict clean, 582 unit + 25 golden-master pass (cov 99.80%), pip-audit clean, entry-verify + actionlint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)