### PR TITLE
feat(installer): install summary renderer at bash parity (8.18)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -10,14 +10,16 @@ from installer.config import Config, resolve_plugins, resolve_plugins_root, reso
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installer_toml import load_installer_toml
+from installer.core.model import Counters
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
 from installer.core.run import install_pipeline, install_plugin_routes, prune_pipeline
+from installer.core.summary import render_summary
 from installer.plugins.registry import discover
 from installer.tools.registry import UnknownToolError, get_adapter, known_tools
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan, Tool
@@ -190,26 +192,38 @@ def main(
     # install through stage_and_transform is also what makes adapter post-staging
     # transforms (e.g. the Gemini frontmatter transform) fire in real installs,
     # not just --dump-stage / --prune.
+    # Per-target tallies accumulate across the install and prune halves so the
+    # summary reports each tool/plugin's full activity merged (a tool that both
+    # installs files and has orphans pruned shows both). Keyed by target name,
+    # mirroring the bash per-tool counter arrays (scripts/install.sh:349-357).
+    counters: dict[str, Counters] = {}
+
     if not args.prune_only:
         try:
-            install_pipeline(
-                adapters,
-                plans=plans,
-                home=resolved_home,
-                io=io,
-                dry_run=args.dry_run,
-                auto_yes=config.auto_yes,
+            _merge_into(
+                counters,
+                install_pipeline(
+                    adapters,
+                    plans=plans,
+                    home=resolved_home,
+                    io=io,
+                    dry_run=args.dry_run,
+                    auto_yes=config.auto_yes,
+                ),
             )
             # Plugin routes (e.g. beads' ~/.beads/formulas + scripts) land outside
             # any tool tree, so they install in a dedicated pass after the tool
             # sync — mirroring the bash installer's stage_and_install_beads phase
             # (scripts/install.sh:948). Same consent gate; --prune-only skips it.
-            install_plugin_routes(
-                plugins,
-                home=resolved_home,
-                io=io,
-                dry_run=args.dry_run,
-                auto_yes=config.auto_yes,
+            _merge_into(
+                counters,
+                install_plugin_routes(
+                    plugins,
+                    home=resolved_home,
+                    io=io,
+                    dry_run=args.dry_run,
+                    auto_yes=config.auto_yes,
+                ),
             )
         except ConsentRequiredError:
             # A non-interactive run lacking --yes/--dry-run cannot answer the
@@ -219,7 +233,7 @@ def main(
             return 1
 
     if args.prune or args.prune_only:
-        return _run_prune(
+        rc = _run_prune(
             adapters,
             plans=plans,
             io=io,
@@ -228,9 +242,42 @@ def main(
             dry_run=args.dry_run,
             auto_yes=config.auto_yes,
             prune_only=args.prune_only,
+            counters=counters,
         )
+        if rc != 0:
+            return rc
 
+    # Render the install / prune summary once at the end, mirroring the bash
+    # installer's terminal Summary block (scripts/install.sh:1801-1869). ALL_TOOLS
+    # is the closed tool universe (known_tools); ALL_PLUGINS is the discovered
+    # plugin set — both feed the '(not detected, skipped)' verbose footers.
+    render_summary(
+        counters,
+        tools=[t.value for t in tools],
+        plugins=[p.name for p in plugins],
+        all_tools=[t.value for t in known_tools()],
+        all_plugins=list(discover(resolve_plugins_root(resolved_repo_root, os.environ))),
+        verbose=args.verbose,
+        io=io,
+    )
     return 0
+
+
+def _merge_into(target: dict[str, Counters], source: Mapping[str, Counters]) -> None:
+    """Field-wise accumulate ``source`` into ``target`` per target name.
+
+    A name may appear in more than one pipeline (e.g. a tool that installs files
+    AND has orphans pruned), so each field is summed into the existing bucket
+    rather than overwriting it — the merged tally is what the summary reports.
+    """
+    for name, c in source.items():
+        bucket = target.setdefault(name, Counters())
+        bucket.created += c.created
+        bucket.updated += c.updated
+        bucket.merged += c.merged
+        bucket.skipped += c.skipped
+        bucket.pruned += c.pruned
+        bucket.backed_up += c.backed_up
 
 
 def _warn_excluded_plugins(
@@ -277,6 +324,7 @@ def _run_prune(
     dry_run: bool,
     auto_yes: bool,
     prune_only: bool,
+    counters: dict[str, Counters],
 ) -> int:
     """Drive the prune pipeline behind --prune / --prune-only.
 
@@ -303,6 +351,10 @@ def _run_prune(
     with the resolved plugin set), so a plugin's overlaid files reach the orphan
     scan as known entries rather than retired ones.
 
+    The prune flow's per-tool ``Counters`` (pruned / backed_up, keyed by
+    ``Orphan.tool``) are merged into ``counters`` so the install summary reports
+    the prune activity alongside the install tally.
+
     Returns 0 on success, 1 when the prune-only flow aborts the run, 2 when
     ``installer.toml`` is malformed.
     """
@@ -319,15 +371,18 @@ def _run_prune(
         return 2
 
     try:
-        prune_pipeline(
-            adapters,
-            plans=plans,
-            home=home,
-            config=config,
-            io=io,
-            dry_run=dry_run,
-            auto_yes=auto_yes,
-            prune_only=prune_only,
+        _merge_into(
+            counters,
+            prune_pipeline(
+                adapters,
+                plans=plans,
+                home=home,
+                config=config,
+                io=io,
+                dry_run=dry_run,
+                auto_yes=auto_yes,
+                prune_only=prune_only,
+            ),
         )
     except PruneAbortedError:
         return 1

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -53,8 +53,14 @@ def run_prune(
     auto_yes: bool = False,
     prune_only: bool = False,
     timestamp: str | None = None,
-) -> Counters:
-    """Confirm and delete orphans; return a ``Counters`` of the work done.
+) -> dict[str, Counters]:
+    """Confirm and delete orphans; return per-target ``Counters`` of the work done.
+
+    The mapping is keyed by ``Orphan.tool`` — each tool or plugin namespace whose
+    orphans were pruned gets its own bucket (pruned / backed_up), so the install
+    summary can report a plugin pruned outside the active tool set (bash AC#19).
+    Every no-deletion path (guard skip, empty list, dry-run, cancel) returns an
+    empty mapping.
 
     Guard order (bash ``prune_orphans``):
 
@@ -81,17 +87,17 @@ def run_prune(
             io.err("prune-only requires --yes or --dry-run in non-interactive mode")
             raise PruneAbortedError("prune-only requires --yes or --dry-run")  # noqa: TRY003  # single call-site
         io.warn("prune phase requires confirmation, skipping")
-        return Counters()
+        return {}
 
     if not orphans:
         io.info("No orphans detected.")
-        return Counters()
+        return {}
 
     _display(orphans, io)
 
     if dry_run:
         io.info(f"Dry-run: {len(orphans)} orphan(s) listed above; no changes made.")
-        return Counters()
+        return {}
 
     # Resolve the backup suffix only on paths that may actually delete; the
     # dry-run early-return above never needs it. ``back_up`` validates the value
@@ -104,7 +110,9 @@ def run_prune(
     return _prompt_and_delete(orphans, io=io, timestamp=ts)
 
 
-def _prompt_and_delete(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+def _prompt_and_delete(
+    orphans: Sequence[Orphan], *, io: IOPort, timestamp: str
+) -> dict[str, Counters]:
     """Three-way prompt then act (bash interactive branch, install.sh:1636-1686)."""
     choice = io.confirm_three_way(
         "Action? [a]ll, [o]ne-by-one, [c]ancel",
@@ -116,10 +124,12 @@ def _prompt_and_delete(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str)
     if choice == _ONE_BY_ONE:
         return _delete_one_by_one(orphans, io=io, timestamp=timestamp)
     io.info("Cancelled. No changes made.")
-    return Counters()
+    return {}
 
 
-def _delete_one_by_one(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+def _delete_one_by_one(
+    orphans: Sequence[Orphan], *, io: IOPort, timestamp: str
+) -> dict[str, Counters]:
     """Per-item drill-down (bash ``o|O`` branch, install.sh:1650-1676).
 
     A per-item ``quit`` leaves every un-answered orphan in place; an orphan the
@@ -130,26 +140,32 @@ def _delete_one_by_one(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str)
         "Delete each orphan? [y/N/q]",
         items=[str(o.path) for o in orphans],
     )
-    counters = Counters()
+    per_tool: dict[str, Counters] = {}
     for orphan in orphans:
         if result.decisions.get(str(orphan.path)):
-            _back_up_and_delete(orphan, io=io, timestamp=timestamp, counters=counters)
+            _back_up_and_delete(orphan, io=io, timestamp=timestamp, per_tool=per_tool)
     if result.quit:
         io.info("Quit per-item loop; remaining orphans left in place.")
-    return counters
+    return per_tool
 
 
-def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> Counters:
+def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> dict[str, Counters]:
     """Back up + delete every orphan (bash ``_delete_all_orphans``, install.sh:1592-1600)."""
-    counters = Counters()
+    per_tool: dict[str, Counters] = {}
     for orphan in orphans:
-        _back_up_and_delete(orphan, io=io, timestamp=timestamp, counters=counters)
-    io.ok(f"Pruned {counters.pruned} orphan(s).")
-    return counters
+        _back_up_and_delete(orphan, io=io, timestamp=timestamp, per_tool=per_tool)
+    pruned = sum(c.pruned for c in per_tool.values())
+    io.ok(f"Pruned {pruned} orphan(s).")
+    return per_tool
 
 
-def _back_up_and_delete(orphan: Orphan, *, io: IOPort, timestamp: str, counters: Counters) -> None:
+def _back_up_and_delete(
+    orphan: Orphan, *, io: IOPort, timestamp: str, per_tool: dict[str, Counters]
+) -> None:
     """Back up an orphan, then remove it (bash ``_delete_orphan``, install.sh:1580-1588).
+
+    Tallies into the ``per_tool[orphan.tool]`` bucket (created on first sight) so
+    pruned/backed_up land under the orphan's own tool or plugin namespace.
 
     Backup precedes deletion so the original bytes are recoverable even if the
     delete is interrupted — but only when there is something to back up. A broken
@@ -159,6 +175,7 @@ def _back_up_and_delete(orphan: Orphan, *, io: IOPort, timestamp: str, counters:
     Mirror the bash ``backup()`` ``[[ -e "$target" ]]`` no-op — skip the backup but
     still remove the link below (``rm -rf`` deletes a broken link unconditionally).
     """
+    counters = per_tool.setdefault(orphan.tool, Counters())
     if orphan.path.exists():
         dest = back_up(orphan.path, timestamp)
         counters.backed_up += 1

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -45,12 +45,16 @@ def prune_pipeline(
     auto_yes: bool = False,
     prune_only: bool = False,
     timestamp: str | None = None,
-) -> Counters:
+) -> dict[str, Counters]:
     """Scan ``adapters`` for orphans against ``plans``, then run the prune flow.
 
     ``prune_only`` is threaded to the flow so its non-interactive guard
     distinguishes a hard-fail (prune-only without consent) from a warn+skip
-    (plain ``--prune``). Returns the flow's ``Counters`` (pruned / backed_up).
+    (plain ``--prune``). Returns the flow's per-target ``Counters`` (pruned /
+    backed_up) keyed by ``Orphan.tool`` — each tool or plugin namespace whose
+    orphans were pruned gets its own bucket so the install summary can report a
+    plugin pruned outside the active tool set (bash AC#19). An empty / no-op
+    prune yields an empty mapping.
     """
     orphans = scan_orphans(adapters, plans=plans, home=home, config=config)
     return run_prune(
@@ -72,14 +76,17 @@ def install_pipeline(
     dry_run: bool = False,
     auto_yes: bool = False,
     timestamp: str | None = None,
-) -> Counters:
-    """Walk each adapter's ``StagingPlan`` to disk via ``sync_plan``; sum the totals.
+) -> dict[str, Counters]:
+    """Walk each adapter's ``StagingPlan`` to disk via ``sync_plan``, per tool.
 
     The install-side analog of ``prune_pipeline``: ``cli.main`` (W3) calls this
     ahead of the prune step to perform the real install. Each adapter's plan is
     looked up by its tool (``Tool(adapter.name)``) and written under
-    ``adapter.dest_dir(home)``. Returns the aggregate `Counters`
-    (created / updated / merged / skipped / backed_up summed across tools).
+    ``adapter.dest_dir(home)``. Returns a per-tool mapping keyed by
+    ``adapter.name`` (each tool's own `Counters`) rather than one aggregate, so
+    the install summary can render a separate block per tool at bash parity
+    (``scripts/install.sh:1818-1826``). A summed total would throw the per-tool
+    distinction away.
 
     ``dry_run`` and ``auto_yes`` are forwarded verbatim into every ``sync_plan``
     call, so the W2 consent gate and the shared no-TTY guard apply uniformly
@@ -90,9 +97,8 @@ def install_pipeline(
     strictly — an adapter without a staged plan is an orchestrator bug (a loud
     `KeyError`), not a silent no-op.
     """
-    total = Counters()
-    for adapter in adapters:
-        result = sync_plan(
+    return {
+        adapter.name: sync_plan(
             adapter,
             plans[Tool(adapter.name)],
             home=home,
@@ -101,12 +107,8 @@ def install_pipeline(
             auto_yes=auto_yes,
             timestamp=timestamp,
         )
-        total.created += result.created
-        total.updated += result.updated
-        total.merged += result.merged
-        total.skipped += result.skipped
-        total.backed_up += result.backed_up
-    return total
+        for adapter in adapters
+    }
 
 
 def install_plugin_routes(
@@ -117,19 +119,30 @@ def install_plugin_routes(
     dry_run: bool = False,
     auto_yes: bool = False,
     timestamp: str | None = None,
-) -> Counters:
+) -> dict[str, Counters]:
     """Install every active plugin's bespoke routes (e.g. beads' ``~/.beads/...``).
 
-    The plugin-side analog of ``install_pipeline``: it flattens each plugin's
-    ``routes(home)`` and walks them through ``sync_routes``. Generic plugins
-    return no routes, so a routes-free or tool-only plugin set is a clean no-op.
-    ``cli.main`` (W3) calls this after ``install_pipeline`` (gated by
-    ``not --prune-only``), mirroring the bash installer, which runs
-    ``stage_and_install_beads`` after the tool sync (``scripts/install.sh:948``).
+    The plugin-side analog of ``install_pipeline``: it walks each plugin's
+    ``routes(home)`` through ``sync_routes`` and returns a per-plugin mapping
+    keyed by ``plugin.name`` (each plugin's own `Counters`). Per-plugin rather
+    than one aggregate so the install summary renders a block per plugin at bash
+    parity. A routes-free generic plugin still gets an all-zero bucket — present
+    so a verbose summary can print its (empty) block — so a tool-only plugin set
+    is a no-op on disk, not on the mapping. ``cli.main`` (W3) calls this after
+    ``install_pipeline`` (gated by ``not --prune-only``), mirroring the bash
+    installer, which runs ``stage_and_install_beads`` after the tool sync
+    (``scripts/install.sh:948``).
 
     ``dry_run`` and ``auto_yes`` thread into ``sync_routes`` so the consent gate
-    and no-TTY guard apply uniformly with the tool install. Returns the aggregate
-    `Counters` from the route walk.
+    and no-TTY guard apply uniformly with the tool install.
     """
-    routes = [route for plugin in plugins for route in plugin.routes(home)]
-    return sync_routes(routes, io=io, dry_run=dry_run, auto_yes=auto_yes, timestamp=timestamp)
+    return {
+        plugin.name: sync_routes(
+            plugin.routes(home),
+            io=io,
+            dry_run=dry_run,
+            auto_yes=auto_yes,
+            timestamp=timestamp,
+        )
+        for plugin in plugins
+    }

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -70,7 +70,7 @@ def _is_changed(counters: Counters) -> bool:
     A pure skip is not a change — only installed/updated/merged/pruned count
     (``scripts/install.sh:1848``). ``backed_up`` rides along a change but never
     constitutes one on its own (a backup only happens alongside an overwrite or a
-    prune), so it is intentionally absent from this test.
+    prune), so it is intentionally excluded from this predicate.
     """
     return bool(counters.created or counters.updated or counters.merged or counters.pruned)
 

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -10,8 +10,8 @@ no terminal, so it is unit-testable through ``ScriptedIO``.
 
 Two shapes, branching on ``verbose`` exactly as bash does:
 
-- **verbose** (``scripts/install.sh:1815-1842``): a 'Summary' header, then one
-  '-- <target> --' block per report target listing the six fields in fixed bash
+- **verbose** (``scripts/install.sh:1815-1842``): a '-- Summary --' header, then
+  one '-- <target> --' block per report target listing the six fields in fixed bash
   order (Installed / Updated / Merged / Backed up / Pruned / Skipped), then a DIM
   '(not detected, skipped)' footer for every ALL_* target absent from the report
   set;
@@ -132,10 +132,22 @@ def _render_verbose(
     all_plugins: Sequence[str],
     io: IOPort,
 ) -> None:
-    """Per-target block form (``scripts/install.sh:1815-1842``)."""
-    io.header("Summary")
+    """Per-target block form (``scripts/install.sh:1815-1842``).
+
+    Every block header byte-matches bash ``header()``
+    (``scripts/install.sh:162``), which is ``printf "\\n-- %s --\\n"``: a leading
+    blank line, then the name wrapped in ``-- ... --``. The renderer reproduces
+    that here (a blank ``io.info("")`` then the wrapped name) rather than relying
+    on ``IOPort.header``, whose contract prints the message verbatim with no
+    wrapping and no leading newline (and is shared with non-Summary callers that
+    pass already-formed text). The trailing ``echo ""`` before ``Done.``
+    (``scripts/install.sh:1844``) is reproduced the same way.
+    """
+    io.info("")
+    io.header("-- Summary --")
     for target in targets:
         c = counters.get(target, Counters())
+        io.info("")
         io.header(f"-- {target} --")
         for label, attr in _FIELDS:
             value = getattr(c, attr)
@@ -144,7 +156,9 @@ def _render_verbose(
     reported = set(targets)
     for absent in [*all_tools, *all_plugins]:
         if absent not in reported:
+            io.info("")
             io.info(f"-- {absent} (not detected, skipped) --")
+    io.info("")
     io.ok("Done.")
 
 
@@ -164,6 +178,9 @@ def _render_quiet(
             f"{getattr(c, attr)} {suffix}" for attr, suffix in _QUIET_PARTS if getattr(c, attr)
         ]
         lines.append(f"{target}: {', '.join(parts)}")
+    # bash emits one blank line before the up-to-date / Done branch
+    # (``scripts/install.sh:1859``), regardless of which branch fires.
+    io.info("")
     if not lines:
         io.ok("All files up to date — no changes made.")
         return

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -1,0 +1,172 @@
+"""Install / prune summary renderer (8.18 — bash parity).
+
+Pure in-memory port of the bash install Summary (``scripts/install.sh:1801-1869``).
+``cli.main`` merges the per-target ``Counters`` from the three pipelines
+(``install_pipeline`` tools, ``install_plugin_routes`` plugins,
+``prune_pipeline`` orphans-by-tool) and hands them here with the active tool /
+plugin lists, the ALL_* universes, and the verbose flag. The renderer decides
+*what* to print and routes every line through the injected ``IOPort`` — it owns
+no terminal, so it is unit-testable through ``ScriptedIO``.
+
+Two shapes, branching on ``verbose`` exactly as bash does:
+
+- **verbose** (``scripts/install.sh:1815-1842``): a 'Summary' header, then one
+  '-- <target> --' block per report target listing the six fields in fixed bash
+  order (Installed / Updated / Merged / Backed up / Pruned / Skipped), then a DIM
+  '(not detected, skipped)' footer for every ALL_* target absent from the report
+  set;
+- **quiet** (``scripts/install.sh:1843-1869``): one line per target with non-zero
+  *changes* (installed + updated + merged + pruned; a pure skip is not a change),
+  or the single em-dash 'All files up to date' line when nothing changed
+  anywhere.
+
+The report-target set mirrors bash ``REPORT_TARGETS`` (``:1807-1813``): active
+tools, then active plugins, then any ALL_* plugin that pruned outside the active
+set (bash AC#19) — keyed off the report set so such a plugin gets a real block,
+not a skipped footer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from installer.core.model import Counters
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from installer.core.io_port import IOPort
+
+# Field rows in the verbose block: (label, Counters attribute). The order is the
+# bash field order (``scripts/install.sh:1820-1825``); 'Installed' maps to the
+# model's ``created`` (the rename lives here in the renderer, not the model).
+_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Installed", "created"),
+    ("Updated", "updated"),
+    ("Merged", "merged"),
+    ("Backed up", "backed_up"),
+    ("Pruned", "pruned"),
+    ("Skipped", "skipped"),
+)
+
+# Column at which each field's value is printed, matching the bash printf padding
+# (e.g. ``"  Installed:  %s"``). Computed once so a label rename keeps alignment.
+_VALUE_COLUMN = max(len(label) for label, _ in _FIELDS) + len(":  ")
+
+# Quiet-line parts: (Counters attribute, suffix). A part is shown only when its
+# value is non-zero (``scripts/install.sh:1852-1856``).
+_QUIET_PARTS: tuple[tuple[str, str], ...] = (
+    ("created", "installed"),
+    ("updated", "updated"),
+    ("merged", "merged"),
+    ("backed_up", "backed up"),
+    ("pruned", "pruned"),
+)
+
+
+def _is_changed(counters: Counters) -> bool:
+    """Whether a target counts as *changed* for the quiet summary.
+
+    A pure skip is not a change — only installed/updated/merged/pruned count
+    (``scripts/install.sh:1848``). ``backed_up`` rides along a change but never
+    constitutes one on its own (a backup only happens alongside an overwrite or a
+    prune), so it is intentionally absent from this test.
+    """
+    return bool(counters.created or counters.updated or counters.merged or counters.pruned)
+
+
+def _report_targets(
+    counters: Mapping[str, Counters],
+    *,
+    tools: Sequence[str],
+    plugins: Sequence[str],
+    all_plugins: Sequence[str],
+) -> list[str]:
+    """Ordered report-target set (bash ``REPORT_TARGETS``, ``:1807-1813``).
+
+    Active tools, then active plugins, then any ALL_* plugin that is not already
+    a report target but accumulated prune activity — so a plugin pruned outside
+    the active set (bash AC#19) is reported once, as a real block.
+    """
+    targets = [*tools, *plugins]
+    seen = set(targets)
+    for plugin in all_plugins:
+        if plugin in seen:
+            continue
+        c = counters.get(plugin)
+        if c is not None and (c.pruned or c.backed_up):
+            targets.append(plugin)
+    return targets
+
+
+def render_summary(
+    counters: Mapping[str, Counters],
+    *,
+    tools: Sequence[str],
+    plugins: Sequence[str],
+    all_tools: Sequence[str],
+    all_plugins: Sequence[str],
+    verbose: bool,
+    io: IOPort,
+) -> None:
+    """Render the install / prune summary through ``io`` (bash ``:1801-1869``).
+
+    ``counters`` is the merged per-target tally (a target absent from the map is
+    treated as all-zero). ``tools`` / ``plugins`` are the active sets in report
+    order; ``all_tools`` / ``all_plugins`` are the ALL_* universes used to emit
+    the '(not detected, skipped)' footers. ``verbose`` selects the per-tool block
+    form over the one-line quiet form.
+    """
+    targets = _report_targets(counters, tools=tools, plugins=plugins, all_plugins=all_plugins)
+    if verbose:
+        _render_verbose(counters, targets, all_tools=all_tools, all_plugins=all_plugins, io=io)
+    else:
+        _render_quiet(counters, targets, io=io)
+
+
+def _render_verbose(
+    counters: Mapping[str, Counters],
+    targets: Sequence[str],
+    *,
+    all_tools: Sequence[str],
+    all_plugins: Sequence[str],
+    io: IOPort,
+) -> None:
+    """Per-target block form (``scripts/install.sh:1815-1842``)."""
+    io.header("Summary")
+    for target in targets:
+        c = counters.get(target, Counters())
+        io.header(f"-- {target} --")
+        for label, attr in _FIELDS:
+            value = getattr(c, attr)
+            pad = " " * (_VALUE_COLUMN - len(label) - len(":"))
+            io.info(f"  {label}:{pad}{value}")
+    reported = set(targets)
+    for absent in [*all_tools, *all_plugins]:
+        if absent not in reported:
+            io.info(f"-- {absent} (not detected, skipped) --")
+    io.ok("Done.")
+
+
+def _render_quiet(
+    counters: Mapping[str, Counters],
+    targets: Sequence[str],
+    *,
+    io: IOPort,
+) -> None:
+    """One-line-per-changed-target form (``scripts/install.sh:1843-1869``)."""
+    lines: list[str] = []
+    for target in targets:
+        c = counters.get(target, Counters())
+        if not _is_changed(c):
+            continue
+        parts = [
+            f"{getattr(c, attr)} {suffix}" for attr, suffix in _QUIET_PARTS if getattr(c, attr)
+        ]
+        lines.append(f"{target}: {', '.join(parts)}")
+    if not lines:
+        io.ok("All files up to date — no changes made.")
+        return
+    io.ok("Done.")
+    for line in lines:
+        io.info(f"   {line}")

--- a/packages/installer/tests/golden_master/_runner.py
+++ b/packages/installer/tests/golden_master/_runner.py
@@ -40,6 +40,8 @@ class ParityResult:
     python_returncode: int
     bash_stderr: str
     python_stderr: str
+    bash_stdout: str
+    python_stdout: str
 
     def diff(self) -> TreeDiff:
         return diff_trees(self.home_a, self.home_b)
@@ -157,4 +159,6 @@ def run_parity(
         python_returncode=python.returncode,
         bash_stderr=bash.stderr,
         python_stderr=python.stderr,
+        bash_stdout=bash.stdout,
+        python_stdout=python.stdout,
     )

--- a/packages/installer/tests/golden_master/test_parity_summary.py
+++ b/packages/installer/tests/golden_master/test_parity_summary.py
@@ -1,0 +1,108 @@
+"""Golden-master Summary-stdout parity: bash ``install.sh`` vs Python ``install.py``.
+
+The other golden-master scenarios compare the installed FILE TREES (``ParityResult.
+diff()`` over the two HOME dirs); none of them looks at stdout. The install Summary
+block (``scripts/install.sh:1801-1869``) is terminal output, not a file, so without
+a stdout oracle the renderer's byte-parity with bash has no regression net — header
+wrapping, leading blank lines, and field padding could all drift while every
+tree-diff test stayed green. This module is that oracle: it captures BOTH installers'
+stdout, normalizes the *known-systemic* differences, and byte-compares the Summary
+region.
+
+Two systemic differences are normalized away (everything else must match byte-for-byte):
+
+- **The volatile install count.** ``Installed:  N`` differs by a small constant
+  (bash counts a prgroom-adjacent file the Python port does not yet stage). The
+  count is not what this test pins — the *shape* of the Summary is — so the numeric
+  value on the ``Installed:`` line is canonicalized.
+- **The ``ok()`` glyph.** bash prints ``+  Done.`` and the Python ``TerminalIO.ok``
+  prints ``✓ Done.``. That glyph divergence is a pre-existing ``IOPort`` property
+  (not introduced by the Summary renderer) tracked separately; it is canonicalized
+  on the ``Done.`` line so it does not mask a real Summary regression.
+
+The beads fixture (``INSTALLER_PLUGINS_SRC`` -> a tree containing ``beads/``) is
+required: bash hardcodes ``ALL_PLUGINS=(beads)`` while the Python port *discovers*
+plugins from the source root, so the two only agree on the ``-- beads (not detected,
+skipped) --`` footer when beads is actually present in the plugin source tree (real
+``src/plugins/beads`` is archived out, mirroring ``test_parity_plugins.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.golden_master._runner import run_parity
+
+pytestmark = pytest.mark.golden_master
+
+# A beads-bearing plugin source so both installers agree on the plugin universe
+# (bash's hardcoded ALL_PLUGINS=(beads) vs the Python port's discovery). Same
+# fixture the route/overlay plugin-parity scenarios use.
+_FIXTURE_BASIC = Path(__file__).parent / "fixtures" / "plugins" / "basic"
+
+# claude only, no active plugins, verbose -> the full per-tool block form with
+# '(not detected, skipped)' footers for every other tool and for beads.
+_VERBOSE_ARGS = ["--tools=claude", "--plugins=", "--yes", "--verbose"]
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# The volatile install count on the 'Installed:' field line (verbose block).
+_INSTALLED_LINE = re.compile(r"^(\s*Installed:\s+)\d+$")
+# The ok() 'Done.' line, whichever glyph/spacing the IOPort used.
+_DONE_LINE = re.compile(r"^[+✓]\s+Done\.$")
+
+
+def _normalize_summary(stdout: str) -> list[str]:
+    """Reduce raw installer stdout to the Summary region, ANSI-stripped, with the
+    two systemic differences (install count, ok() glyph) canonicalized.
+
+    Returns the Summary lines from the ``-- Summary --`` header onward so the
+    pre-Summary install chatter (which legitimately differs line-for-line) is
+    excluded — this test pins the Summary block's shape, not the whole transcript.
+    """
+    lines = _ANSI.sub("", stdout).splitlines()
+    try:
+        start = lines.index("-- Summary --")
+    except ValueError:  # pragma: no cover - a missing header is an assertion failure below
+        return []
+    normalized: list[str] = []
+    for line in lines[start:]:
+        line = _INSTALLED_LINE.sub(r"\1<count>", line)
+        if _DONE_LINE.match(line):
+            line = "<ok> Done."
+        normalized.append(line)
+    return normalized
+
+
+def test_verbose_summary_stdout_is_byte_parity(tmp_path: Path) -> None:
+    """The verbose Summary block printed by the Python renderer byte-matches the
+    bash installer's, once the install count and the pre-existing ok() glyph are
+    canonicalized. This is the load-bearing parity proof for the Summary renderer:
+    header wrapping ('-- Summary --', '-- claude --'), the leading blank line
+    before every block/footer, the six field labels + padding, the
+    '(not detected, skipped)' footers, and the blank line before Done. — any drift
+    in those fails here, where the tree-diff scenarios are blind.
+    """
+    result = run_parity(tmp_path, args=_VERBOSE_ARGS, plugins_src=_FIXTURE_BASIC)
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+
+    bash_summary = _normalize_summary(result.bash_stdout)
+    python_summary = _normalize_summary(result.python_stdout)
+
+    assert bash_summary, f"bash emitted no Summary block:\n{result.bash_stdout}"
+    assert python_summary, f"python emitted no Summary block:\n{result.python_stdout}"
+    # Anchor the systemic-difference assumptions: a per-tool block (proving the
+    # field rows are present to be compared) and the canonicalized footer/Done.
+    assert "-- claude --" in bash_summary
+    assert "-- beads (not detected, skipped) --" in bash_summary
+    assert bash_summary[-1] == "<ok> Done."
+    # The load-bearing assertion: the Summary regions match line-for-line.
+    assert python_summary == bash_summary, (
+        "Summary stdout diverged from bash oracle.\n"
+        f"bash:\n{chr(10).join(bash_summary)}\n\n"
+        f"python:\n{chr(10).join(python_summary)}"
+    )

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -895,3 +895,125 @@ def test_main_prune_installs_then_prunes(tmp_path: Path) -> None:
     assert rc == 0
     assert (home / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"
     assert not orphan.exists()
+
+
+# ── 8.18: install summary renderer wired into main ──
+
+
+def test_main_quiet_install_renders_summary_line_for_changed_tool(tmp_path: Path) -> None:
+    """
+    Given a hermetic repo (one shared template -> a claude create), under
+    --tools=claude --yes (quiet)
+    When main runs a real install
+    Then a quiet summary line names claude and its install count is emitted
+    through io — the per-tool counters from install_pipeline reach the renderer.
+
+    Pins: main binds install_pipeline's per-tool return and feeds it to
+    render_summary. Fails while main discards the counters and prints no summary.
+    """
+    repo = _hermetic_repo(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(["--tools=claude", "--yes"], home=tmp_path, io=io, repo_root=repo)
+
+    assert rc == 0
+    oks = [e.message for e in io.transcript if e.channel == "ok"]
+    infos = [e.message for e in io.transcript if e.channel == "info"]
+    assert any(m == "Done." for m in oks), oks
+    assert any("claude:" in m and "installed" in m for m in infos), infos
+
+
+def test_main_quiet_reinstall_renders_all_up_to_date(tmp_path: Path) -> None:
+    """
+    Given a home where the claude plan is already installed (a second run), under
+    --tools=claude --yes (quiet)
+    When main runs again
+    Then it emits exactly the em-dash 'All files up to date — no changes made.'
+    line — every item is a skip, so nothing changed (scripts/install.sh:1863).
+
+    Pins: the all-zero quiet branch reaches the renderer from a real re-install.
+    """
+    repo = _hermetic_repo(tmp_path)
+    first = ScriptedIO(interactive=False)
+    assert main(["--tools=claude", "--yes"], home=tmp_path, io=first, repo_root=repo) == 0
+
+    second = ScriptedIO(interactive=False)
+    rc = main(["--tools=claude", "--yes"], home=tmp_path, io=second, repo_root=repo)
+
+    assert rc == 0
+    oks = [e.message for e in second.transcript if e.channel == "ok"]
+    assert any(m == "All files up to date — no changes made." for m in oks), oks
+
+
+def test_main_verbose_install_renders_per_tool_block_and_skipped_footer(tmp_path: Path) -> None:
+    """
+    Given --tools=claude --yes --verbose against a hermetic repo
+    When main runs
+    Then the verbose summary emits a '-- claude --' block AND a
+    '(not detected, skipped)' footer for an inactive ALL_TOOLS tool (e.g. codex),
+    proving the active set and the ALL_* universe both reach the renderer.
+
+    Pins: main passes known_tools() as ALL_TOOLS and the active tool list to
+    render_summary under verbose.
+    """
+    repo = _hermetic_repo(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(["--tools=claude", "--yes", "--verbose"], home=tmp_path, io=io, repo_root=repo)
+
+    assert rc == 0
+    headers = [e.message for e in io.transcript if e.channel == "header"]
+    msgs = [e.message for e in io.transcript]
+    assert any("-- claude --" in h for h in headers), headers
+    assert any("not detected, skipped" in m for m in msgs), msgs
+
+
+def test_main_prune_summary_reports_pruned_counts(tmp_path: Path) -> None:
+    """
+    Given a hermetic repo retiring '*/skills/ralf-it' and a home holding that
+    orphan, under --prune --yes (quiet)
+    When main runs (install-then-prune)
+    Then the quiet summary's claude line reports the prune (and the orphan is
+    gone) — the prune_pipeline's per-tool counters reach the renderer merged with
+    the install counters.
+
+    Pins: main merges install + prune per-target counters before rendering, so a
+    --prune run's pruned tally surfaces in the summary.
+    """
+    repo = _hermetic_repo(tmp_path)
+    toml_dir = repo / "packages" / "installer"
+    toml_dir.mkdir(parents=True)
+    (toml_dir / "installer.toml").write_text('[prune]\nretired = [\n  "*/skills/ralf-it",\n]\n')
+    home = tmp_path / "home"
+    orphan = home / ".claude" / "skills" / "ralf-it"
+    orphan.mkdir(parents=True)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(["--prune", "--yes", "--tools=claude"], home=home, io=io, repo_root=repo)
+
+    assert rc == 0
+    assert not orphan.exists()
+    infos = [e.message for e in io.transcript if e.channel == "info"]
+    assert any("claude:" in m and "pruned" in m for m in infos), infos
+
+
+def test_main_dry_run_summary_reports_would_be_installs(tmp_path: Path) -> None:
+    """
+    Given --tools=claude --dry-run against a hermetic repo (a claude create)
+    When main runs in preview mode
+    Then the summary still reports the would-be install — bash tallies counters
+    on a dry-run too (e.g. scripts/install.sh:1154-1160 increments
+    tool_installed inside the DRY_RUN branch) and renders the Summary
+    unconditionally at the end. The quiet 'claude: N installed' line appears.
+
+    Pins: the summary renders on a dry-run with the previewed counts, matching
+    bash — it is NOT gated to real writes only.
+    """
+    repo = _hermetic_repo(tmp_path)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(["--tools=claude", "--dry-run"], home=tmp_path, io=io, repo_root=repo)
+
+    assert rc == 0
+    infos = [e.message for e in io.transcript if e.channel == "info"]
+    assert any("claude:" in m and "installed" in m for m in infos), infos

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -3,7 +3,9 @@
 Each test pins a coded decision in ``run_prune``, the port of the bash
 ``prune_orphans`` (``scripts/install.sh:1602-1687``). The engine is driven
 through ``ScriptedIO`` and asserted against real filesystem end-state plus the
-returned ``Counters`` — never against which IOPort method was called.
+returned per-target ``dict[str, Counters]`` (keyed by ``Orphan.tool``) — never
+against which IOPort method was called. A no-deletion path returns ``{}``; a
+deleting path returns one bucket per pruned orphan's tool.
 
 Covered decisions:
 - three-way "all" -> every orphan backed up then deleted,
@@ -63,11 +65,11 @@ def test_three_way_all_deletes_every_orphan(tmp_path: Path) -> None:
     o2 = _file_orphan(tmp_path, "claude", "skills", "b")
     io = ScriptedIO(three_ways=["a"])
 
-    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+    per_tool = run_prune([o1, o2], io=io, timestamp=_TS)
 
     assert not o1.path.exists()
     assert not o2.path.exists()
-    assert counters.pruned == 2
+    assert per_tool["claude"].pruned == 2
 
 
 def test_three_way_one_by_one_respects_per_item_choices(tmp_path: Path) -> None:
@@ -83,11 +85,11 @@ def test_three_way_one_by_one_respects_per_item_choices(tmp_path: Path) -> None:
         per_items=[PerItemResult(decisions={str(o1.path): False, str(o2.path): True}, quit=False)],
     )
 
-    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+    per_tool = run_prune([o1, o2], io=io, timestamp=_TS)
 
     assert o1.path.exists()
     assert not o2.path.exists()
-    assert counters.pruned == 1
+    assert per_tool["claude"].pruned == 1
 
 
 def test_three_way_one_by_one_quit_leaves_remaining(tmp_path: Path) -> None:
@@ -103,11 +105,11 @@ def test_three_way_one_by_one_quit_leaves_remaining(tmp_path: Path) -> None:
         per_items=[PerItemResult(decisions={str(o1.path): True}, quit=True)],
     )
 
-    counters = run_prune([o1, o2], io=io, timestamp=_TS)
+    per_tool = run_prune([o1, o2], io=io, timestamp=_TS)
 
     assert not o1.path.exists()
     assert o2.path.exists()
-    assert counters.pruned == 1
+    assert per_tool["claude"].pruned == 1
 
 
 def test_three_way_cancel_deletes_nothing(tmp_path: Path) -> None:
@@ -119,10 +121,10 @@ def test_three_way_cancel_deletes_nothing(tmp_path: Path) -> None:
     o1 = _file_orphan(tmp_path, "claude", "skills", "a")
     io = ScriptedIO(three_ways=["c"])
 
-    counters = run_prune([o1], io=io, timestamp=_TS)
+    per_tool = run_prune([o1], io=io, timestamp=_TS)
 
     assert o1.path.exists()
-    assert counters.pruned == 0
+    assert per_tool == {}
 
 
 def test_non_interactive_prune_only_without_auth_raises(tmp_path: Path) -> None:
@@ -149,10 +151,10 @@ def test_non_interactive_plain_prune_skips_without_deleting(tmp_path: Path) -> N
     o1 = _file_orphan(tmp_path, "claude", "skills", "a")
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([o1], io=io, prune_only=False, timestamp=_TS)
+    per_tool = run_prune([o1], io=io, prune_only=False, timestamp=_TS)
 
     assert o1.path.exists()
-    assert counters.pruned == 0
+    assert per_tool == {}
 
 
 def test_auto_yes_deletes_all_without_prompting(tmp_path: Path) -> None:
@@ -165,11 +167,11 @@ def test_auto_yes_deletes_all_without_prompting(tmp_path: Path) -> None:
     o2 = _file_orphan(tmp_path, "claude", "skills", "b")
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([o1, o2], io=io, auto_yes=True, timestamp=_TS)
+    per_tool = run_prune([o1, o2], io=io, auto_yes=True, timestamp=_TS)
 
     assert not o1.path.exists()
     assert not o2.path.exists()
-    assert counters.pruned == 2
+    assert per_tool["claude"].pruned == 2
 
 
 def test_dry_run_displays_without_deleting(tmp_path: Path) -> None:
@@ -181,10 +183,10 @@ def test_dry_run_displays_without_deleting(tmp_path: Path) -> None:
     o1 = _file_orphan(tmp_path, "claude", "skills", "a")
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([o1], io=io, dry_run=True, timestamp=_TS)
+    per_tool = run_prune([o1], io=io, dry_run=True, timestamp=_TS)
 
     assert o1.path.exists()
-    assert counters.pruned == 0
+    assert per_tool == {}
 
 
 def test_empty_orphan_list_is_noop() -> None:
@@ -200,9 +202,9 @@ def test_empty_orphan_list_is_noop() -> None:
     """
     io = ScriptedIO(interactive=True)
 
-    counters = run_prune([], io=io, prune_only=True, timestamp=_TS)
+    per_tool = run_prune([], io=io, prune_only=True, timestamp=_TS)
 
-    assert counters.pruned == 0
+    assert per_tool == {}
 
 
 def test_backup_precedes_delete_into_sibling_namespace_dir(tmp_path: Path) -> None:
@@ -218,11 +220,11 @@ def test_backup_precedes_delete_into_sibling_namespace_dir(tmp_path: Path) -> No
     o1 = _file_orphan(tmp_path, "claude", "skills", "retired", body="precious")
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([o1], io=io, auto_yes=True, timestamp=_TS)
+    per_tool = run_prune([o1], io=io, auto_yes=True, timestamp=_TS)
 
     backup = tmp_path / ".claude" / "skills-backup" / f"retired.backup-{_TS}"
     assert backup.read_text() == "precious"
-    assert counters.backed_up == 1
+    assert per_tool["claude"].backed_up == 1
 
 
 def test_directory_orphan_backed_up_recursively(tmp_path: Path) -> None:
@@ -274,11 +276,11 @@ def test_malformed_timestamp_under_dry_run_does_not_raise(tmp_path: Path) -> Non
     o1 = _file_orphan(tmp_path, "claude", "skills", "a")
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([o1], io=io, dry_run=True, timestamp="../evil")
+    per_tool = run_prune([o1], io=io, dry_run=True, timestamp="../evil")
 
     assert o1.path.exists()
-    assert counters.pruned == 0
-    assert counters.backed_up == 0
+    # Dry-run resolves no timestamp and deletes nothing -> empty mapping.
+    assert per_tool == {}
 
 
 def test_symlink_to_directory_orphan_unlinked_not_rmtree(tmp_path: Path) -> None:
@@ -305,13 +307,13 @@ def test_symlink_to_directory_orphan_unlinked_not_rmtree(tmp_path: Path) -> None
 
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
+    per_tool = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
 
     assert not link.exists()  # the symlink itself is gone
     assert not link.is_symlink()
     assert target_dir.is_dir()  # the link target is untouched
     assert (target_dir / "keep.md").read_text() == "survives"
-    assert counters.pruned == 1
+    assert per_tool["claude"].pruned == 1
 
 
 def test_broken_symlink_orphan_unlinked_without_backup(tmp_path: Path) -> None:
@@ -338,8 +340,8 @@ def test_broken_symlink_orphan_unlinked_without_backup(tmp_path: Path) -> None:
 
     io = ScriptedIO(interactive=False)
 
-    counters = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
+    per_tool = run_prune([orphan], io=io, auto_yes=True, timestamp=_TS)
 
     assert not link.is_symlink()  # the dangling link is gone
-    assert counters.backed_up == 0  # nothing to back up
-    assert counters.pruned == 1
+    assert per_tool["claude"].backed_up == 0  # nothing to back up
+    assert per_tool["claude"].pruned == 1

--- a/packages/installer/tests/unit/test_run_install_pipeline.py
+++ b/packages/installer/tests/unit/test_run_install_pipeline.py
@@ -42,13 +42,18 @@ def _settings_item(content: bytes, *, tool: str = "claude") -> StagedItem:
     )
 
 
-def test_install_pipeline_aggregates_counters_across_tools(tmp_path: Path) -> None:
+def test_install_pipeline_keeps_per_tool_counters_separate(tmp_path: Path) -> None:
     """
-    Given two adapters — one installing a new file, one whose dest file already
-    matches its plan (a skip)
+    Given two adapters — one installing a new file (claude), one whose dest file
+    already matches its plan (codex, a skip)
     When install_pipeline runs
-    Then each tool's dest tree reflects its plan and the returned Counters sum
-    the per-tool results (a create from one tool, a skip from the other).
+    Then each tool's dest tree reflects its plan and the returned mapping keeps
+    the per-tool results in SEPARATE buckets (claude.created==1, codex.skipped==1)
+    rather than summing them into one Counters.
+
+    Pins the 8.18 per-tool plumbing change: the summary renderer needs each
+    tool's own tally, so install_pipeline returns a name-keyed mapping, not an
+    aggregate. Fails while it sums every sync_plan result into one Counters.
     """
     home = tmp_path / "home"
     claude = get_adapter(Tool.CLAUDE)
@@ -65,12 +70,16 @@ def test_install_pipeline_aggregates_counters_across_tools(tmp_path: Path) -> No
         ),
     }
 
-    counters = install_pipeline(
+    per_tool = install_pipeline(
         [claude, codex], plans=plans, home=home, io=ScriptedIO(), timestamp=_FIXED_TS
     )
 
     assert (claude.dest_dir(home) / "a.md").read_bytes() == b"A\n"
-    assert (counters.created, counters.skipped) == (1, 1)
+    # The create landed in claude's bucket, the skip in codex's — not summed.
+    assert per_tool["claude"].created == 1
+    assert per_tool["claude"].skipped == 0
+    assert per_tool["codex"].created == 0
+    assert per_tool["codex"].skipped == 1
 
 
 def test_install_pipeline_forwards_auto_yes_to_each_sync_plan(tmp_path: Path) -> None:
@@ -91,12 +100,12 @@ def test_install_pipeline_forwards_auto_yes_to_each_sync_plan(tmp_path: Path) ->
         ),
     }
 
-    counters = install_pipeline(
+    per_tool = install_pipeline(
         [claude], plans=plans, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
     )
 
     assert (claude.dest_dir(home) / "a.md").read_bytes() == b"new\n"
-    assert (counters.updated, counters.backed_up) == (1, 1)
+    assert (per_tool["claude"].updated, per_tool["claude"].backed_up) == (1, 1)
 
 
 def test_install_pipeline_aggregates_merged_counter(tmp_path: Path) -> None:
@@ -122,9 +131,9 @@ def test_install_pipeline_aggregates_merged_counter(tmp_path: Path) -> None:
         ),
     }
 
-    counters = install_pipeline(
+    per_tool = install_pipeline(
         [claude], plans=plans, home=home, io=ScriptedIO(), auto_yes=True, timestamp=_FIXED_TS
     )
 
-    assert counters.merged == 1
-    assert counters.updated == 0
+    assert per_tool["claude"].merged == 1
+    assert per_tool["claude"].updated == 0

--- a/packages/installer/tests/unit/test_run_plugin_routes.py
+++ b/packages/installer/tests/unit/test_run_plugin_routes.py
@@ -46,7 +46,7 @@ def test_install_plugin_routes_dispatches_beads_formulas_and_scripts(tmp_path: P
     _seed_beads_source(src)
     beads = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
 
-    counters = install_plugin_routes([beads], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+    per_plugin = install_plugin_routes([beads], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
 
     formula = home / ".beads" / "formulas" / "f.toml"
     script = home / ".beads" / "scripts" / "s.sh"
@@ -54,7 +54,8 @@ def test_install_plugin_routes_dispatches_beads_formulas_and_scripts(tmp_path: P
     assert script.read_bytes() == b"#!/bin/sh\n"
     assert script.stat().st_mode & 0o111  # scripts land executable
     assert formula.stat().st_mode & 0o111 == 0  # formulas do not
-    assert counters.created == 2
+    # Per-plugin bucket keyed by the plugin name (8.18 summary plumbing).
+    assert per_plugin["beads"].created == 2
 
 
 def test_generic_plugin_contributes_no_routes(tmp_path: Path) -> None:
@@ -69,7 +70,11 @@ def test_generic_plugin_contributes_no_routes(tmp_path: Path) -> None:
     home = tmp_path / "home"
     generic = GenericPluginAdapter(name="whatever", source_path=tmp_path / "src")
 
-    counters = install_plugin_routes([generic], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
+    per_plugin = install_plugin_routes([generic], home=home, io=ScriptedIO(), timestamp=_FIXED_TS)
 
     assert not (home / ".whatever").exists()
-    assert (counters.created, counters.updated, counters.skipped) == (0, 0, 0)
+    # A routes-free plugin installs nothing, so it contributes an all-zero bucket
+    # (still keyed by name so a verbose summary can print its block).
+    assert per_plugin["whatever"].created == 0
+    assert per_plugin["whatever"].updated == 0
+    assert per_plugin["whatever"].skipped == 0

--- a/packages/installer/tests/unit/test_run_prune_pipeline.py
+++ b/packages/installer/tests/unit/test_run_prune_pipeline.py
@@ -44,7 +44,7 @@ def test_unstaged_matched_entry_is_scanned_and_pruned(tmp_path: Path) -> None:
     plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
     config = InstallerToml(prune_globs=["*/skills/retired-skill"])
 
-    counters = prune_pipeline(
+    per_tool = prune_pipeline(
         [get_adapter(Tool.CLAUDE)],
         plans=plans,
         home=home,
@@ -55,7 +55,46 @@ def test_unstaged_matched_entry_is_scanned_and_pruned(tmp_path: Path) -> None:
     )
 
     assert not retired.exists()
-    assert counters.pruned == 1
+    assert per_tool["claude"].pruned == 1
+
+
+def test_prune_pipeline_groups_counters_by_orphan_tool(tmp_path: Path) -> None:
+    """
+    Given a claude skills/ orphan AND a ~/.beads/formulas orphan, both matching
+    the prune globs
+    When prune_pipeline runs under auto_yes
+    Then the returned mapping buckets each pruned orphan under its OWN
+    Orphan.tool — claude.pruned==1 and beads.pruned==1 — rather than summing both
+    into one tool's tally.
+
+    Pins the 8.18 prune plumbing change: the beads bucket carries a plugin
+    namespace (not a Tool) and must surface separately so the summary can report
+    a plugin pruned outside the active tool set (bash AC#19). Fails while
+    run_prune returns a single aggregate Counters.
+    """
+    home = _claude_home_with_settings(tmp_path)
+    claude_orphan = home / ".claude" / "skills" / "retired-skill"
+    claude_orphan.mkdir(parents=True)
+    beads_orphan = home / ".beads" / "formulas" / "stale.toml"
+    beads_orphan.parent.mkdir(parents=True)
+    beads_orphan.write_text("x")
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+    config = InstallerToml(prune_globs=["*/skills/retired-skill", "beads/formulas/*"])
+
+    per_tool = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        home=home,
+        config=config,
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert not claude_orphan.exists()
+    assert not beads_orphan.exists()
+    assert per_tool["claude"].pruned == 1
+    assert per_tool["beads"].pruned == 1
 
 
 def test_empty_plan_with_excluded_plugin_file_flags_it(tmp_path: Path) -> None:
@@ -72,7 +111,7 @@ def test_empty_plan_with_excluded_plugin_file_flags_it(tmp_path: Path) -> None:
     plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
     config = InstallerToml(prune_globs=["beads/formulas/*"])
 
-    counters = prune_pipeline(
+    per_tool = prune_pipeline(
         [get_adapter(Tool.CLAUDE)],
         plans=plans,
         home=home,
@@ -83,7 +122,7 @@ def test_empty_plan_with_excluded_plugin_file_flags_it(tmp_path: Path) -> None:
     )
 
     assert not formula.exists()
-    assert counters.pruned == 1
+    assert per_tool["beads"].pruned == 1
 
 
 def test_no_orphans_is_clean_noop(tmp_path: Path) -> None:
@@ -96,7 +135,7 @@ def test_no_orphans_is_clean_noop(tmp_path: Path) -> None:
     plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
     config = InstallerToml(prune_globs=["*/skills/never-matches"])
 
-    counters = prune_pipeline(
+    per_tool = prune_pipeline(
         [get_adapter(Tool.CLAUDE)],
         plans=plans,
         home=home,
@@ -105,4 +144,5 @@ def test_no_orphans_is_clean_noop(tmp_path: Path) -> None:
         timestamp=_TS,
     )
 
-    assert counters.pruned == 0
+    # No orphans -> a clean no-op -> no per-tool buckets at all.
+    assert per_tool == {}

--- a/packages/installer/tests/unit/test_summary.py
+++ b/packages/installer/tests/unit/test_summary.py
@@ -20,10 +20,9 @@ Covered decisions (bash spec line refs in each test):
 
 from __future__ import annotations
 
-from installer.core.summary import render_summary
-
 from installer.core.io_port import ScriptedIO, TranscriptEntry
 from installer.core.model import Counters
+from installer.core.summary import render_summary
 
 
 def _messages(io: ScriptedIO) -> list[str]:
@@ -248,6 +247,104 @@ def test_quiet_reports_pruned_and_backed_up_parts() -> None:
 
     msgs = _messages(io)
     assert any("beads:" in m and "3 pruned" in m and "3 backed up" in m for m in msgs), msgs
+
+
+def test_verbose_summary_header_is_dash_wrapped_with_leading_blank() -> None:
+    """
+    Given any verbose run
+    When render_summary runs
+    Then the 'Summary' header byte-matches bash header() — wrapped '-- Summary --'
+    (NOT bare 'Summary') and preceded by a blank line (scripts/install.sh:162,1816).
+    A bare 'Summary' or a missing leading blank is a parity regression.
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    assert "-- Summary --" in msgs, msgs
+    assert "Summary" not in msgs, msgs  # never the unwrapped form
+    summary_idx = msgs.index("-- Summary --")
+    assert summary_idx > 0 and msgs[summary_idx - 1] == "", msgs
+
+
+def test_verbose_block_and_footer_headers_are_dash_wrapped_with_leading_blank() -> None:
+    """
+    Given an active tool and an inactive ALL_* tool, under verbose
+    When render_summary runs
+    Then each per-tool block header and each '(not detected, skipped)' footer is
+    '-- ... --' wrapped and immediately preceded by a blank line, byte-matching
+    bash's leading-'\\n' printf (scripts/install.sh:1819,1833).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude", "codex"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    block_idx = msgs.index("-- claude --")
+    assert msgs[block_idx - 1] == "", msgs
+    footer = "-- codex (not detected, skipped) --"
+    footer_idx = msgs.index(footer)
+    assert msgs[footer_idx - 1] == "", msgs
+
+
+def test_verbose_emits_blank_line_before_done() -> None:
+    """
+    Given any verbose run
+    When render_summary runs
+    Then the final 'Done.' is immediately preceded by a blank line, matching
+    bash's ``echo ""`` before ``ok "Done."`` (scripts/install.sh:1844-1845).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    done_idx = next(i for i, e in enumerate(io.transcript) if e.channel == "ok")
+    assert io.transcript[done_idx].message == "Done."
+    assert io.transcript[done_idx - 1].message == "", _messages(io)
+
+
+def test_quiet_emits_blank_line_before_outcome() -> None:
+    """
+    Given a quiet run that changed nothing
+    When render_summary runs
+    Then a blank line precedes the 'up to date' line, matching bash's ``echo ""``
+    ahead of the quiet outcome branch (scripts/install.sh:1859).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(skipped=2)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=False,
+        io=io,
+    )
+
+    outcome_idx = next(i for i, e in enumerate(io.transcript) if e.channel == "ok")
+    assert io.transcript[outcome_idx - 1].message == "", _messages(io)
 
 
 def test_entries_carry_a_transcript_record() -> None:

--- a/packages/installer/tests/unit/test_summary.py
+++ b/packages/installer/tests/unit/test_summary.py
@@ -1,0 +1,268 @@
+"""Unit tests for installer.core.summary.render_summary (8.18 — install summary).
+
+The renderer is the in-memory port of the bash install Summary
+(``scripts/install.sh:1801-1869``). It is pure: it takes the per-target merged
+``Counters``, the active tool/plugin lists, the ALL_* universes, and a verbose
+flag, and emits through the injected ``IOPort``. These tests drive it with
+``ScriptedIO`` and assert the recorded transcript STRINGS and the per-target
+grouping decisions — never which method fired, and never a Counters default.
+
+Covered decisions (bash spec line refs in each test):
+- verbose per-tool block with the six fields in bash order,
+- the DIM '(not detected, skipped)' footer for an ALL_* target absent from the
+  active/report set,
+- a plugin pruned outside the active set is reported (bash AC#19),
+- quiet one-line-per-target, only for targets with non-zero changes,
+- quiet all-zero prints exactly the em-dash 'up to date' line,
+- a zero-change target is omitted from the quiet summary but still printed
+  (all-zeros) in the verbose block.
+"""
+
+from __future__ import annotations
+
+from installer.core.summary import render_summary
+
+from installer.core.io_port import ScriptedIO, TranscriptEntry
+from installer.core.model import Counters
+
+
+def _messages(io: ScriptedIO) -> list[str]:
+    return [e.message for e in io.transcript]
+
+
+def test_verbose_block_lists_six_fields_in_bash_order() -> None:
+    """
+    Given a single active tool with a created+updated+merged+pruned+backed_up+
+    skipped spread, under verbose
+    When render_summary runs
+    Then its block lists the six fields in EXACT bash order — Installed, Updated,
+    Merged, Backed up, Pruned, Skipped (scripts/install.sh:1820-1825) — with
+    'Installed' sourced from Counters.created.
+    """
+    io = ScriptedIO()
+    counters = {
+        "claude": Counters(created=3, updated=2, merged=1, skipped=5, pruned=4, backed_up=6)
+    }
+
+    render_summary(
+        counters,
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    # The six field lines, in order, immediately follow the per-tool header.
+    field_lines = [
+        m
+        for m in msgs
+        if m.strip().split(":")[0]
+        in {"Installed", "Updated", "Merged", "Backed up", "Pruned", "Skipped"}
+    ]
+    labels = [m.strip().split(":")[0] for m in field_lines]
+    assert labels == ["Installed", "Updated", "Merged", "Backed up", "Pruned", "Skipped"]
+    # 'Installed' carries created's value, not a coincidental zero.
+    assert any(m.strip() == "Installed:  3" for m in msgs), msgs
+    assert any(m.strip() == "Pruned:     4" for m in msgs), msgs
+
+
+def test_verbose_names_the_target_in_its_block_header() -> None:
+    """
+    Given an active tool, under verbose
+    When render_summary runs
+    Then a header naming the tool ('-- claude --') is emitted before its fields
+    (scripts/install.sh:1819).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude", "codex"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    headers = [e.message for e in io.transcript if e.channel == "header"]
+    assert any("claude" in h for h in headers), headers
+
+
+def test_verbose_emits_not_detected_footer_for_inactive_all_tool() -> None:
+    """
+    Given ALL_TOOLS={claude,codex} but only claude active, under verbose
+    When render_summary runs
+    Then a DIM '-- codex (not detected, skipped) --' footer is emitted for the
+    inactive tool (scripts/install.sh:1832-1834) and claude gets a real block.
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude", "codex"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    assert any("codex" in m and "not detected, skipped" in m for m in msgs), msgs
+    # claude is active -> it gets a real block, NOT a skipped footer.
+    assert not any("claude" in m and "not detected, skipped" in m for m in msgs), msgs
+
+
+def test_verbose_plugin_pruned_outside_active_set_gets_real_block_not_footer() -> None:
+    """
+    Given beads NOT in the active plugin set but carrying pruned activity, under
+    verbose
+    When render_summary runs
+    Then beads gets a real '-- beads --' block (its pruned tally), NOT a
+    '(not detected, skipped)' footer — bash AC#19 (scripts/install.sh:1808-1812,
+    keyed off REPORT_TARGETS so it is not double-printed).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1), "beads": Counters(pruned=2, backed_up=2)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=["beads"],
+        verbose=True,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    headers = [e.message for e in io.transcript if e.channel == "header"]
+    assert any("beads" in h for h in headers), headers
+    assert not any("beads" in m and "not detected, skipped" in m for m in msgs), msgs
+
+
+def test_quiet_one_line_per_nonzero_target() -> None:
+    """
+    Given two active tools, one with changes (claude) and one all-zero (codex),
+    under quiet (verbose=False)
+    When render_summary runs
+    Then claude gets a one-line summary naming its non-zero parts and codex is
+    omitted (scripts/install.sh:1847-1858).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=2, updated=1), "codex": Counters(skipped=4)},
+        tools=["claude", "codex"],
+        plugins=[],
+        all_tools=["claude", "codex"],
+        all_plugins=[],
+        verbose=False,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    assert any("claude:" in m and "2 installed" in m and "1 updated" in m for m in msgs), msgs
+    # codex changed nothing (only skips) -> no quiet line for it.
+    assert not any(m.startswith("codex:") for m in msgs), msgs
+
+
+def test_quiet_all_zero_prints_up_to_date_em_dash_line() -> None:
+    """
+    Given every active target all-zero (only skips), under quiet
+    When render_summary runs
+    Then it prints exactly 'All files up to date — no changes made.' (note the
+    em-dash) and no per-target lines (scripts/install.sh:1862-1863).
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(skipped=9)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=False,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    assert any(m == "All files up to date — no changes made." for m in msgs), msgs
+    assert not any(m.startswith("claude:") for m in msgs), msgs
+
+
+def test_quiet_skipped_is_not_a_change_but_verbose_still_prints_the_block() -> None:
+    """
+    Given an all-skips target, comparing quiet vs verbose
+    When render_summary runs each way
+    Then quiet omits it from the per-target lines (skips are not 'changes':
+    installed+updated+merged+pruned == 0, scripts/install.sh:1848) BUT verbose
+    still prints its full all-but-skipped block (scripts/install.sh:1818 iterates
+    every REPORT_TARGET regardless of activity).
+    """
+    counters = {"claude": Counters(skipped=7)}
+
+    quiet_io = ScriptedIO()
+    render_summary(
+        counters,
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=False,
+        io=quiet_io,
+    )
+    assert not any(m.startswith("claude:") for m in _messages(quiet_io))
+
+    verbose_io = ScriptedIO()
+    render_summary(
+        counters,
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=True,
+        io=verbose_io,
+    )
+    vmsgs = _messages(verbose_io)
+    assert any("claude" in e.message for e in verbose_io.transcript if e.channel == "header")
+    assert any(m.strip() == "Skipped:    7" for m in vmsgs), vmsgs
+
+
+def test_quiet_reports_pruned_and_backed_up_parts() -> None:
+    """
+    Given a target whose only activity is a prune (pruned + backed_up), under quiet
+    When render_summary runs
+    Then its one-line summary names 'pruned' and 'backed up' (pruned counts as a
+    change; scripts/install.sh:1855-1856) so a --prune run surfaces in the quiet
+    summary.
+    """
+    io = ScriptedIO()
+    render_summary(
+        {"beads": Counters(pruned=3, backed_up=3)},
+        tools=[],
+        plugins=["beads"],
+        all_tools=[],
+        all_plugins=["beads"],
+        verbose=False,
+        io=io,
+    )
+
+    msgs = _messages(io)
+    assert any("beads:" in m and "3 pruned" in m and "3 backed up" in m for m in msgs), msgs
+
+
+def test_entries_carry_a_transcript_record() -> None:
+    """A sanity guard that the renderer routes through IOPort (records a
+    transcript) rather than printing — so the pure-core/injected-IO contract
+    holds. Pins the seam, not a Counters default."""
+    io = ScriptedIO()
+    render_summary(
+        {"claude": Counters(created=1)},
+        tools=["claude"],
+        plugins=[],
+        all_tools=["claude"],
+        all_plugins=[],
+        verbose=True,
+        io=io,
+    )
+    assert io.transcript
+    assert all(isinstance(e, TranscriptEntry) for e in io.transcript)


### PR DESCRIPTION
SCOPE — Render an install/prune summary (Installed/Updated/Merged/Backed up/Pruned/Skipped) from `cli.main` at parity with the bash installer Summary block, closing the gap where `cli.main` bound none of the pipelines return values and emitted no summary.

## Ground truth

- Bash Summary spec: `scripts/install.sh:1801-1869` (verbose per-tool block `:1815-1842`; quiet one-line-per-target `:1843-1869`; the beads-pruned-outside-active-set inclusion rule `:1779-1784` / `:1807-1813`).
- Six fields in EXACT bash order: Installed (=`created`), Updated, Merged, Backed up, Pruned, Skipped (`:1820-1825`). The `created`->`Installed` rename lives in the renderer, not the model.
- Pre-existing gap: `cli.main` called `install_pipeline` / `install_plugin_routes` / `prune_pipeline` but bound none of their returns; bash prints a full per-tool Summary.

## The plumbing blocker (why this is bigger than it reads)

`run.py` returned an AGGREGATE `Counters`, summing every adapter into one — the per-tool distinction was thrown away, so a faithful per-tool block could not be rendered.

STEP 1 — per-tool plumbing:
- `install_pipeline` / `install_plugin_routes` now return `dict[str, Counters]` keyed by tool/plugin name (no summing).
- `run_prune` / `prune_pipeline` now return `dict[str, Counters]` grouped by `Orphan.tool` (so a plugin namespace like `beads` pruned outside the active tool set gets its own bucket — bash AC#19). No-deletion paths return `{}`.
- Existing pipeline + prune-flow unit tests updated from the old aggregate shape to the per-target mapping.

STEP 2 — renderer + wiring:
- New pure `core/summary.py::render_summary` takes the merged per-target `Counters` + active tool/plugin lists + the ALL_* universes + `verbose`, and routes every line through the existing `IOPort` (no new protocol methods).
- `cli.main` merges the three pipelines field-wise (`_merge_into`) into one per-target tally and renders once at the end (verbose block-per-tool with the `(not detected, skipped)` DIM footers, or the quiet one-line-per-changed-target form / the em-dash `All files up to date — no changes made.` line).

## Intentionally OUT OF SCOPE

- No `sync`/merge-core changes — only the pipeline return shape and a new renderer + cli wiring.
- The dead `staged` counter STAYS dead (set nowhere in src; omitted from the renderer and the merge).
- Deferred sibling beads 8.6 / 8.14 / 8.16 are untouched.
- No `installer.toml` / `[tools]` dest-knob changes.

## Parity evidence

- `make golden-master-installer`: **25/25 parity scenarios pass** (the bash-vs-python byte-parity backstop — it diffs the two installed HOME trees; this change adds no disk divergence).
- `make ci-installer`: ruff check + ruff format --check + mypy --strict all clean; **582 unit tests pass at 99.80% coverage** (floor 90%); entry-verify (`install.py --help`) passes.
- `pip-audit` flags ONE pre-existing transitive advisory (`msgpack 1.1.2`, GHSA-6v7p-g79w-8964) — not introduced here: `pyproject.toml` and `uv.lock` are untouched by this PR. Out of scope for 8.18.

## Tests

`test_summary.py` (9) pins the renderer decisions (six-field order, the `(not detected, skipped)` footer, plugin-pruned-outside-active-set, quiet non-zero-only, em-dash all-zero, zero-change omitted-from-quiet-but-printed-in-verbose). `test_cli_smoke.py` adds transcript assertions for the wired end-to-end paths (quiet install line, all-up-to-date re-install, verbose block + footer, prune counts, dry-run would-be counts). All behavioral — no Counters-default / StrEnum-value tautologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)