### PR TITLE
feat(rules): promote cross-project memories to installable rules

### DIFF
--- a/src/user/.agents/rules-readmes/bash-scripting-readme.md
+++ b/src/user/.agents/rules-readmes/bash-scripting-readme.md
@@ -1,0 +1,20 @@
+# Bash Effectful Operations — Context
+
+## The trap
+
+```bash
+# WRONG — under set -e, the redirect failure is silently swallowed:
+[ -n "$cid" ] && printf '%s\n' "$cid" >> "$STATE_FILE"
+
+# RIGHT:
+if [ -n "$cid" ]; then
+  if ! printf '%s\n' "$cid" >> "$STATE_FILE"; then
+    echo "WARNING: state-write failed" >&2
+    any_failed=1
+  fi
+fi
+```
+
+## When it matters
+
+Read-only/pure tests on the RHS are fine — the rule applies when the RHS has a side effect an invariant depends on (idempotency record, audit log, anti-duplicate sidecar, network call).

--- a/src/user/.agents/rules-readmes/beads-readme.md
+++ b/src/user/.agents/rules-readmes/beads-readme.md
@@ -1,0 +1,34 @@
+# Beads CLI — Context
+
+## Parentage: edge vs. dotted ID
+
+`bd list --parent X` matches the dotted ID string (`X.n`); removing the dependency edge via `bd dep remove` orphans the bead for edge-walking tools (whats-next shows blank parent) but `bd list --parent` still returns it. There is no deferred/hidden state — `bd close` + a reason is the only honest park.
+
+## Sync pattern
+
+```bash
+bd dolt commit -m "session close"
+bd dolt push
+# Successful push = not behind. Investigate only if push rejects.
+```
+
+## label remove
+
+```bash
+# WRONG — labelA parsed as a second issue ID:
+bd label remove BEAD-1 labelA labelB
+
+# RIGHT — one label per call:
+bd label remove BEAD-1 labelA
+bd label remove BEAD-1 labelB
+```
+
+## Close-walk verification
+
+```bash
+bd close <last-child>
+bd show <parent-epic>          # verify status == closed
+# If still open with all children closed:
+bd dep list <epic> --direction up   # enumerate true children (edge, not dotted ID)
+bd close <parent-epic>
+```

--- a/src/user/.agents/rules-readmes/pr-authoring-readme.md
+++ b/src/user/.agents/rules-readmes/pr-authoring-readme.md
@@ -1,0 +1,13 @@
+# PR Authoring for Bot Review — Context
+
+## Good PR body structure
+
+1. **Scope** — what the change IS and IS NOT (files in scope, files intentionally untouched)
+2. **Artifact nature** — code vs. design doc; current-state vs. desired-state
+3. **Ground truth** — specific files/types the reviewer should check claims against
+4. **Intentional gaps** — what is design-forward, placeholder, or out-of-scope so the bot does not flag it as missing
+5. **Constraints** — house style, citation rules, conventions to honor
+
+## Desired-state doc behavior
+
+A design doc depicting the target architecture (components not yet built, adapters not yet wired) is doing its job. An automated reviewer flagging those elements as "contradicts current code" is also doing its job — but that class of finding is not a defect. Triage by class: contradiction → fix; "not yet built" → acknowledge in thread, resolve, stop.

--- a/src/user/.agents/rules-readmes/premises-and-scope-readme.md
+++ b/src/user/.agents/rules-readmes/premises-and-scope-readme.md
@@ -1,0 +1,13 @@
+# Premises and Scope — Context
+
+## Absence is not a state
+
+`bd list` truncates at 50 by default; a bead not in the list may simply be past the limit, not closed. Always `bd show <id>` for authoritative state. Same pattern applies to `gh api` without `--paginate` and any other paginated CLI.
+
+## Premise collapse exit
+
+When a sub-design proposes "invert X to use model Y," read the cited architecture documents before exploring design options. If the premise collapses (e.g. the architecture it assumed doesn't exist or works the opposite way), surface that as the brainstorm's first finding and exit with a rejection rationale instead of spending a session designing the rework.
+
+## Census before estimate
+
+Opening sections of a doc or codebase are often atypical (already clean, already converted). Run `grep -c <target-pattern> <file>` for each key signal before stating a number.

--- a/src/user/.agents/rules-readmes/stacked-prs-readme.md
+++ b/src/user/.agents/rules-readmes/stacked-prs-readme.md
@@ -1,0 +1,24 @@
+# Stacked PR Squash Merges — Context
+
+## Why retargeted PRs conflict
+
+Lower-bead review-fixes committed after the upper branch forked land in main's squash commit but not in the upper branch. The three-way merge sees main's fixed lines vs. the upper branch's stale lines → conflict markers. Fix in-place; do NOT `git checkout --ours <file>` — that drops auto-merged hunks of the lower fix.
+
+## Oracle
+
+Green `make ci-<pkg>` at the coverage floor proves the resolution is correct.
+
+## Full procedure per upper PR (bottom-up)
+
+```bash
+gh pr edit N --base main
+git merge origin/main           # in the bead's worktree
+# resolve conflicts in editor — keep-ours for the bead's own evolved files
+git add <resolved-files>        # MUST add — editing alone leaves status U
+make ci-<pkg>                   # oracle
+git commit --no-edit
+git push
+gh pr merge N --squash --admin
+gh pr view N --json state       # verify "MERGED"
+git show --stat origin/main     # confirm landed diff is scoped to this bead only
+```

--- a/src/user/.agents/rules-readmes/testing-principles-readme.md
+++ b/src/user/.agents/rules-readmes/testing-principles-readme.md
@@ -1,0 +1,18 @@
+# Testing Principles — Context
+
+## Tautology categories
+
+1. **Language/compiler/stdlib** — `isinstance`, `FrozenInstanceError`, `Path.is_dir()` semantics test the runtime, not your code. Delete.
+2. **Uncalled methods** — no verified production connection yet. Use `# pragma: no cover  # exercised by <consumer-story>` and add a removal note to the consumer story's AC.
+3. **Attribute literals** — `assert adapter.name == "claude"` when `name = "claude"` is in the source pins a literal, not a decision. Delete; test at the consumer boundary instead.
+
+## Consumer-side enum example
+
+```python
+# Bad: pins the producer
+assert Tool.CLAUDE.value == "claude"
+
+# Good: exercises the contract the user actually crosses
+result = parse_cli_args(["--tools=claude"])
+assert result.tools == [Tool.CLAUDE]
+```

--- a/src/user/.agents/rules/AGENTS.md
+++ b/src/user/.agents/rules/AGENTS.md
@@ -1,0 +1,7 @@
+# Rules
+
+Rules in this directory are installed as always-on constraints for all supported tools.
+
+## Companion readmes
+
+Longer rationale, incident history, and examples live in `rules-readmes/` under the same base name (e.g. `beads.md` → `rules-readmes/beads-readme.md`). Readmes are source-level documentation only — they are not installed. Rule files are self-contained.

--- a/src/user/.agents/rules/bash-scripting.md
+++ b/src/user/.agents/rules/bash-scripting.md
@@ -1,0 +1,3 @@
+# Bash Effectful Operations
+
+Under `set -e`, a command on the RHS of `&&` is NOT caught by the error trap — bash treats the whole list as "tested." When the RHS has a side effect that an invariant depends on (file write, state append, audit log), use an explicit `if`-block with failure handling instead.

--- a/src/user/.agents/rules/beads.md
+++ b/src/user/.agents/rules/beads.md
@@ -1,0 +1,6 @@
+# Beads CLI
+
+- A bead's parent is the dependency edge, not its dotted ID. There is no deferred/hidden state — `bd close` is the only way to remove a bead from active queues.
+- `bd dolt pull` fails with "cannot merge with uncommitted changes." Sync via `bd dolt commit` then `bd dolt push` — a successful push proves you were not behind.
+- `bd label remove` signature: `[issue-ids...] [label]` — label is the last arg, one label per call.
+- After `bd close <last-child>`, always `bd show <parent-epic>` to confirm; close-walk auto-close is unreliable. Close the epic manually if all children are closed and it is still open.

--- a/src/user/.agents/rules/brainstorm-quality.md
+++ b/src/user/.agents/rules/brainstorm-quality.md
@@ -1,0 +1,4 @@
+# Brainstorm and Clarification Quality
+
+- Ask clarifying or approval questions only when choices have genuinely different risk/cost/benefit tradeoffs. Make the obvious call yourself; pause only when user context is truly required.
+- Reserve the Visual Companion for content where seeing matters (mockups, diagrams, spatial comparisons). Text A/B/C tradeoffs belong in the terminal.

--- a/src/user/.agents/rules/crit.md
+++ b/src/user/.agents/rules/crit.md
@@ -1,0 +1,3 @@
+# Crit Review Output
+
+`crit` writes review output to `~/.crit/reviews/<id>/review.json` — not `<repo>/.crit.json`. Find the freshest review with `ls -t ~/.crit/reviews/ | head -1`.

--- a/src/user/.agents/rules/git-hygiene.md
+++ b/src/user/.agents/rules/git-hygiene.md
@@ -1,0 +1,3 @@
+# Git Staging
+
+Run `git status` before `git add -A` or `git add .`; stage explicit paths when unexpected files are present (build artifacts, tool output, nested-agent strays).

--- a/src/user/.agents/rules/github-cli.md
+++ b/src/user/.agents/rules/github-cli.md
@@ -1,0 +1,5 @@
+# GitHub CLI Gotchas
+
+- `gh api .../pulls/N/comments` silently truncates at the first page; always pass `--paginate` when verifying recent activity or specific reply IDs.
+- `gh pr merge` may exit 0 while printing a rejection message; always verify with `gh pr view <n> --json state` — expected value `"MERGED"`.
+- Remove the local git worktree before `gh pr merge --delete-branch`; the API merge succeeds but local branch deletion fails when a worktree has it checked out.

--- a/src/user/.agents/rules/graphify.md
+++ b/src/user/.agents/rules/graphify.md
@@ -1,0 +1,3 @@
+# Graphify Discipline
+
+Never run `graphify update .` from inside a git worktree and commit the result on a feature branch. The output is keyed to the cwd and non-portable; it floods the diff and breaks graphify for others. Run only from the main repo root; keep graphify-out off feature branches.

--- a/src/user/.agents/rules/merge-guard.md
+++ b/src/user/.agents/rules/merge-guard.md
@@ -1,0 +1,3 @@
+# Merge Guard Comment Counting
+
+`merge-guard` counts all inline PR review comments including your own reply comments. If it false-blocks with `unseen_comments` after triaging all reviewer threads, verify the extras are your own replies, then re-run with `--comments-seen` equal to the total comment count (reviewer comments + your replies).

--- a/src/user/.agents/rules/pr-authoring.md
+++ b/src/user/.agents/rules/pr-authoring.md
@@ -1,0 +1,5 @@
+# PR Authoring for Bot Review
+
+A bot reviewer's only context is the PR description. Write it as a reviewer brief: scope (in/out), artifact nature (code vs design doc; current vs desired state), ground-truth files, intentional gaps/placeholders, and constraints.
+
+When an automated reviewer flags a desired-state artifact for depicting unbuilt target components, that is the artifact working correctly — hold firm and explain rather than caveating or triggering another review round.

--- a/src/user/.agents/rules/premises-and-scope.md
+++ b/src/user/.agents/rules/premises-and-scope.md
@@ -1,0 +1,6 @@
+# Premises and Scope Estimation
+
+- Before designing architectural rework, verify cited motivations against the actual architecture (diagrams, specs, code) — a collapsed premise is an early exit, not a design question.
+- Before stating a scope estimate for any conversion or refactor, run a grep census of key signals; never estimate from reading the opening sections.
+- Never state what a tool returned until the result is in context. Assert nothing from output you have not received.
+- Treat absence or null from an aggregate query as "re-check via the authoritative single-record source" — never as a state value. Aggregate CLIs silently truncate at default limits.

--- a/src/user/.agents/rules/stacked-prs.md
+++ b/src/user/.agents/rules/stacked-prs.md
@@ -1,0 +1,5 @@
+# Stacked PR Squash Merges
+
+- GitHub retargets upper PRs only when the lower branch is deleted; without `--delete-branch`, manually run `gh pr edit N --base main`.
+- Retargeted PRs conflict when lower-bead review-fixes landed in main's squash but not in the upper branch; resolve in-place with the three-way merge — do NOT `git checkout --ours`.
+- Use `make ci-<pkg>` as the conflict-resolution oracle; green at coverage floor proves the resolution.

--- a/src/user/.agents/rules/testing-principles.md
+++ b/src/user/.agents/rules/testing-principles.md
@@ -1,0 +1,5 @@
+# Testing Principles
+
+For every proposed test ask: "What coded decision does this pin?" Delete tautologies: tests for language/compiler behavior, uncalled methods, or attribute literals add no signal and constrain growth without catching bugs.
+
+Test enum string values at CLI/config/provenance consumer boundaries, not at the enum definition — the consumer-side test catches wrong values AND wrong parsing.

--- a/src/user/.claude/rules-readmes/worktree-safety-readme.md
+++ b/src/user/.claude/rules-readmes/worktree-safety-readme.md
@@ -1,0 +1,35 @@
+# Worktree Safety — Context
+
+## Verifying isolation by path
+
+```bash
+# Insufficient — branch can be correct while main folder gets switched:
+git branch --show-current
+
+# Correct — worktree path proves isolation:
+git rev-parse --show-toplevel   # must contain .claude/worktrees/
+```
+
+## Write/Edit path trap
+
+`Bash` cwd protects shell commands only. `Write`/`Edit` use the absolute path you pass regardless of cwd — a path like `<repo>/docs/plan.md` writes to the main tree even when every shell command runs correctly in the worktree. Always build `Write`/`Edit` paths under the worktree root.
+
+## Parallel isolated subagents pattern
+
+```
+EnterWorktree(name: "worker-A")
+→ spawn subagentA (no isolation arg)
+→ ExitWorktree(keep)
+EnterWorktree(name: "worker-B")
+→ spawn subagentB (no isolation arg)
+→ ExitWorktree(keep)
+```
+Subagents inherit orchestrator cwd at spawn — entering the worktree first means the subagent starts there.
+
+## Agent(isolation: "worktree") is broken
+
+Bug #33045: silently ignored for named/team agents; agents land at repo root on main. `Workflow agent(isolation: "worktree")` is a distinct runtime that works correctly. Do not rely on the Agent tool's isolation flag.
+
+## Phantom-cwd
+
+Deleting a worktree while a subagent's shell holds the inode: `pwd` still reports the old path but writes become non-deterministic (some land in the stale inode, some fall through). Always `ExitWorktree(keep)` before removing; only remove after all occupying subagents complete.

--- a/src/user/.claude/rules-readmes/worktree-safety-readme.md
+++ b/src/user/.claude/rules-readmes/worktree-safety-readme.md
@@ -19,10 +19,10 @@ git rev-parse --show-toplevel   # must contain .claude/worktrees/
 ```
 EnterWorktree(name: "worker-A")
 → spawn subagentA (no isolation arg)
-→ ExitWorktree(keep)
+→ ExitWorktree  # keep; do not remove worktree
 EnterWorktree(name: "worker-B")
 → spawn subagentB (no isolation arg)
-→ ExitWorktree(keep)
+→ ExitWorktree  # keep; do not remove worktree
 ```
 Subagents inherit orchestrator cwd at spawn — entering the worktree first means the subagent starts there.
 
@@ -32,4 +32,4 @@ Bug #33045: silently ignored for named/team agents; agents land at repo root on 
 
 ## Phantom-cwd
 
-Deleting a worktree while a subagent's shell holds the inode: `pwd` still reports the old path but writes become non-deterministic (some land in the stale inode, some fall through). Always `ExitWorktree(keep)` before removing; only remove after all occupying subagents complete.
+Deleting a worktree while a subagent's shell holds the inode: `pwd` still reports the old path but writes become non-deterministic (some land in the stale inode, some fall through). Always exit the worktree without removing it before proceeding; only remove after all occupying subagents complete.

--- a/src/user/.claude/rules/AGENTS.md
+++ b/src/user/.claude/rules/AGENTS.md
@@ -1,0 +1,7 @@
+# Claude-Specific Rules
+
+Rules in this directory are Claude Code-specific and are installed into `~/.claude/rules/`. They append-merge with same-named plugin files.
+
+## Companion readmes
+
+Longer rationale, incident history, and examples live in `rules-readmes/` under the same base name (e.g. `worktree-safety.md` → `rules-readmes/worktree-safety-readme.md`). Readmes are source-level documentation only — they are not installed. Rule files are self-contained.

--- a/src/user/.claude/rules/headless-claude.md
+++ b/src/user/.claude/rules/headless-claude.md
@@ -1,0 +1,3 @@
+# Headless Claude Dispatch
+
+`claude -p` with no `--permission-mode` silently queues all tool calls and exits 0 having done nothing. For headless dispatch use both: `--permission-mode dontAsk` (fail-closed; denies unlisted tools instead of hanging) and `--allowedTools` listing every needed tool in CLI space-form (`Bash(git *)`, not `Bash(git:*)`).

--- a/src/user/.claude/rules/skill-model-pinning.md
+++ b/src/user/.claude/rules/skill-model-pinning.md
@@ -1,0 +1,3 @@
+# Skill Model Pinning
+
+Do not pin a small model (e.g. `model: haiku`) in a skill's frontmatter — skills run inside the parent conversation context, so a context larger than the model's window causes `ContextLimitExceeded`. Small models belong on agents (fresh context). Default: `model: sonnet[1m]`.

--- a/src/user/.claude/rules/tool-output-reliability.md
+++ b/src/user/.claude/rules/tool-output-reliability.md
@@ -1,0 +1,4 @@
+# Tool Output Reliability
+
+- After context compaction, `Read`/`Edit` may serve a pre-compaction snapshot while `Bash` sees real disk. When they diverge, `Bash` (`grep -n`, `git show HEAD:<path>`) is ground truth; apply edits via Bash if `Edit` won't match.
+- Hook-injected context (`system-reminder`, `UserPromptSubmit`, `PreToolUse`) mid-task is ambient — absorb silently; do not stop, acknowledge, or pause work in progress.

--- a/src/user/.claude/rules/tool-output-reliability.md
+++ b/src/user/.claude/rules/tool-output-reliability.md
@@ -1,4 +1,4 @@
 # Tool Output Reliability
 
-- After context compaction, `Read`/`Edit` may serve a pre-compaction snapshot while `Bash` sees real disk. When they diverge, `Bash` (`grep -n`, `git show HEAD:<path>`) is ground truth; apply edits via Bash if `Edit` won't match.
+- After context compaction, `Read`/`Edit` may serve a pre-compaction snapshot while `Bash` sees real disk. When they diverge, `Bash` (`grep -n`) is ground truth; apply edits via Bash if `Edit` won't match.
 - Hook-injected context (`system-reminder`, `UserPromptSubmit`, `PreToolUse`) mid-task is ambient — absorb silently; do not stop, acknowledge, or pause work in progress.

--- a/src/user/.claude/rules/worktree-safety.md
+++ b/src/user/.claude/rules/worktree-safety.md
@@ -2,7 +2,7 @@
 
 - Verify isolation by path (`git rev-parse --show-toplevel` contains `.claude/worktrees/`), not just branch name — the branch can be correct while the main folder gets switched.
 - `Write`/`Edit` act on absolute paths, not shell cwd — build all file paths under the worktree root, never the main repo root.
-- Subagents inherit the orchestrator's cwd at spawn. Pattern for isolated parallel workers: orchestrator `EnterWorktree` → spawn subagent (no isolation arg) → `ExitWorktree(keep)` → repeat.
+- Subagents inherit the orchestrator's cwd at spawn. Pattern for isolated parallel workers: orchestrator `EnterWorktree` → spawn subagent (no isolation arg) → `ExitWorktree` (keep action, do not remove) → repeat.
 - `Agent(isolation: "worktree")` is silently ignored for named/team agents. Do not rely on it.
 - Before `EnterWorktree`, run an unscoped `git status` in the main tree — unstaged files and deletions do not carry over to the new worktree.
 - Never `git worktree remove` a worktree while a subagent occupies it; writes become non-deterministic (phantom-cwd via stale inode).

--- a/src/user/.claude/rules/worktree-safety.md
+++ b/src/user/.claude/rules/worktree-safety.md
@@ -1,0 +1,8 @@
+# Worktree Safety
+
+- Verify isolation by path (`git rev-parse --show-toplevel` contains `.claude/worktrees/`), not just branch name — the branch can be correct while the main folder gets switched.
+- `Write`/`Edit` act on absolute paths, not shell cwd — build all file paths under the worktree root, never the main repo root.
+- Subagents inherit the orchestrator's cwd at spawn. Pattern for isolated parallel workers: orchestrator `EnterWorktree` → spawn subagent (no isolation arg) → `ExitWorktree(keep)` → repeat.
+- `Agent(isolation: "worktree")` is silently ignored for named/team agents. Do not rely on it.
+- Before `EnterWorktree`, run an unscoped `git status` in the main tree — unstaged files and deletions do not carry over to the new worktree.
+- Never `git worktree remove` a worktree while a subagent occupies it; writes become non-deterministic (phantom-cwd via stale inode).


### PR DESCRIPTION
## Summary

- Extracts ~30 cross-project behavioral rules from the project-scoped auto-memory and promotes them to installable rule files in `src/user/`
- 12 general rules under `src/user/.agents/rules/` (installed for all tools); 4 Claude-specific rules under `src/user/.claude/rules/`
- Rule files are minimal (avg 4 lines, max 8 lines — significantly below the existing 14-line average)
- Fuller rationale, incident history, and code examples live in companion `rules-readmes/` directories (source-level only, not installed by installer)
- `AGENTS.md` in each rules directory explains the companion readme pattern

## What's new

**`.agents/rules/` (general):** `git-hygiene`, `github-cli`, `stacked-prs`, `pr-authoring`, `bash-scripting`, `premises-and-scope`, `brainstorm-quality`, `testing-principles`, `graphify`, `beads`, `merge-guard`, `crit`

**`.claude/rules/` (Claude-specific):** `tool-output-reliability`, `headless-claude`, `skill-model-pinning`, `worktree-safety`

**Companion readmes (source only):** stacked-prs, bash-scripting, premises-and-scope, testing-principles, beads, pr-authoring (in `.agents/`); worktree-safety (in `.claude/`)

## Scope

- **In scope:** New rule files and readmes only. No changes to existing rules, installer, or templates.
- **Not in scope:** Cleanup of the project memory files (separate follow-up).
- **Not in scope:** Installer changes — `rules-readmes/` is intentionally NOT in the installer's staging namespace (`commands skills agents rules hooks`), so it stays source-only.

## Review notes

Rule files reference no bead IDs, PR numbers, session IDs, or stale line numbers — those details live exclusively in the readme companions where they belong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01DGqqD7trfsunxx1wnLUEJC