### PR TITLE
feat(installer): stdout parity oracle + fix surfaced output divergences (8.19)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -125,6 +125,16 @@ def main(
 
         io = TerminalIO(verbose=args.verbose)
 
+    # Run-mode notice, mirroring bash (scripts/install.sh:218-222): a dry-run
+    # announces itself up front; an auto-yes run notes that prompts and diffs are
+    # suppressed — but only when NOT verbose, since verbose already narrates every
+    # file. Emitted before tool/plugin resolution so it leads the transcript, as
+    # the excluded-plugin warning (below) trails it in the bash ordering.
+    if args.dry_run:
+        io.info("DRY RUN -- no changes will be made")
+    elif args.yes and not args.verbose:
+        io.info("Auto-yes mode -- prompts and diffs suppressed")
+
     try:
         tools = resolve_tools(home=resolved_home, override_csv=args.tools)
     except (UnknownToolError, ValueError) as exc:

--- a/packages/installer/src/installer/core/io_port.py
+++ b/packages/installer/src/installer/core/io_port.py
@@ -124,8 +124,13 @@ class TerminalIO:
         stderr: Console | None = None,
         verbose: bool = False,
     ) -> None:
-        self._out = stdout if stdout is not None else Console()
-        self._err = stderr if stderr is not None else Console(stderr=True)
+        # markup=False: the installer emits plain log lines and styles them via the
+        # `style=` argument, never via rich's inline `[tag]` markup. Left on, rich
+        # would parse a literal bracket token like the prune list's `[dir]` / `[file]`
+        # type tag as a (non-existent) markup tag and silently strip it. Disabling
+        # markup keeps every message byte-literal.
+        self._out = stdout if stdout is not None else Console(markup=False)
+        self._err = stderr if stderr is not None else Console(stderr=True, markup=False)
         self._verbose = verbose
 
     # -- output channels --

--- a/packages/installer/src/installer/core/io_port.py
+++ b/packages/installer/src/installer/core/io_port.py
@@ -124,41 +124,43 @@ class TerminalIO:
         stderr: Console | None = None,
         verbose: bool = False,
     ) -> None:
-        # markup=False: the installer emits plain log lines and styles them via the
-        # `style=` argument, never via rich's inline `[tag]` markup. Left on, rich
-        # would parse a literal bracket token like the prune list's `[dir]` / `[file]`
-        # type tag as a (non-existent) markup tag and silently strip it. Disabling
-        # markup keeps every message byte-literal.
-        self._out = stdout if stdout is not None else Console(markup=False)
-        self._err = stderr if stderr is not None else Console(stderr=True, markup=False)
+        self._out = stdout if stdout is not None else Console()
+        self._err = stderr if stderr is not None else Console(stderr=True)
         self._verbose = verbose
 
     # -- output channels --
+    #
+    # Every print passes markup=False: the installer emits plain log lines, styled via
+    # the `style=` argument, never via rich's inline `[tag]` markup. Left on, rich parses
+    # a literal bracket token like the prune list's `[dir]`/`[file]` type tag as a
+    # (non-existent) markup tag and silently strips it. Setting markup=False per call —
+    # not only on the default Console — keeps the guarantee even when a caller injects
+    # its own Console (e.g. a test capturing output).
 
     def info(self, message: str, *, verbose: bool = False) -> None:
         if verbose and not self._verbose:
             return
-        self._out.print(message, style="cyan")
+        self._out.print(message, style="cyan", markup=False)
 
     def ok(self, message: str, *, verbose: bool = False) -> None:
         if verbose and not self._verbose:
             return
-        self._out.print(f"✓ {message}", style="green")
+        self._out.print(f"✓ {message}", style="green", markup=False)
 
     def warn(self, message: str, *, verbose: bool = False) -> None:
         if verbose and not self._verbose:
             return
-        self._out.print(f"⚠ {message}", style="yellow")
+        self._out.print(f"⚠ {message}", style="yellow", markup=False)
 
     def err(self, message: str, *, verbose: bool = False) -> None:
         if verbose and not self._verbose:
             return
-        self._err.print(f"✗ {message}", style="red")
+        self._err.print(f"✗ {message}", style="red", markup=False)
 
     def header(self, message: str, *, verbose: bool = False) -> None:
         if verbose and not self._verbose:
             return
-        self._out.print(message, style="bold")
+        self._out.print(message, style="bold", markup=False)
 
     # -- diff --
 

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -194,11 +194,19 @@ def _back_up_and_delete(
 
 
 def _display(orphans: Sequence[Orphan], io: IOPort) -> None:
-    """Print the orphan list grouped by tool then namespace (bash ``_display_orphans``)."""
-    io.header(f"Orphans detected ({len(orphans)} total)")
+    """Print the orphan list grouped by tool then namespace (bash ``_display_orphans``).
+
+    Framing mirrors the bash function (``scripts/install.sh:1560-1584``): a blank
+    line then the ``-- … --`` header (bash ``header()`` prepends the newline and
+    wraps the text in dashes — ``io.header`` does neither, so both are explicit
+    here), a blank line before each tool block, and a trailing blank line.
+    """
+    io.info("")
+    io.header(f"-- Orphans detected ({len(orphans)} total) --")
     last_tool = last_ns = ""
     for orphan in orphans:
         if orphan.tool != last_tool:
+            io.info("")
             io.header(orphan.tool)
             last_tool = orphan.tool
             last_ns = ""
@@ -206,3 +214,4 @@ def _display(orphans: Sequence[Orphan], io: IOPort) -> None:
             io.info(f"  {orphan.namespace}/")
             last_ns = orphan.namespace
         io.info(f"    [{orphan.kind}] {orphan.path}")
+    io.info("")

--- a/packages/installer/tests/golden_master/_stdout.py
+++ b/packages/installer/tests/golden_master/_stdout.py
@@ -1,0 +1,91 @@
+"""Stdout normalization for golden-master parity tests.
+
+The tree-diff scenarios (``ParityResult.diff()``) compare installed FILE TREES;
+none looks at stdout. Terminal output therefore had no regression net beyond the
+Summary block (``test_parity_summary.py``). This module is the shared normalizer
+that lets a test byte-compare a region of BOTH installers' stdout for MEANINGFUL
+parity — content and structure — without tripping on incidental rendering.
+
+Each rule is a documented, blessed exception. Where bash emits a cosmetic wart
+the Python port need not reproduce (a missing space after a comma, trailing
+whitespace), the wart is normalized away on BOTH sides rather than mirrored into
+the Python output — meaningful-parity, not byte-mimicry.
+
+Normalized (everything else must match line-for-line):
+
+- **ANSI SGR escapes** — bash colorizes via ``${CYAN}``…; the Python ``rich``
+  console strips styling against a captured (non-TTY) pipe. Pure decoration.
+- **Leading status glyph** — bash prints ``i``/``+``/``!`` + two spaces; the
+  Python ``IOPort`` prints ``✓``/``⚠`` + one space (and emits no glyph at all
+  for ``info``/``header``). The glyph CHARACTER divergence is a pre-existing
+  ``IOPort`` property tracked separately; the message text is the parity
+  contract, so the glyph is stripped on both sides. Severity is therefore not
+  asserted by these oracles — a known, accepted limitation.
+- **Volatile install count** — bash counts a prgroom-adjacent file the Python
+  port does not stage, so ``N installed`` / ``Installed:  N`` differ by a small
+  constant. The SHAPE of the line is pinned, not the value. Every OTHER count
+  (backed up / pruned / updated / merged / skipped) is deterministic and is
+  left intact so the oracle still asserts it.
+- **Comma spacing** — bash's count footer omits the space after the comma
+  (``2 backed up,2 pruned``); the Python port emits the (nicer) space. Cosmetic
+  bash wart — comma spacing is canonicalized on both sides.
+- **Temp HOME path** — the two installers write into sibling temp homes
+  (``home_a`` / ``home_b``); the absolute path is replaced with ``<HOME>`` so a
+  path-bearing line (e.g. an orphan entry) compares by structure.
+- **Trailing whitespace** — stripped per line (printf padding can leave it).
+
+Callers MUST pin the rich console width (``COLUMNS`` in ``run_parity(env=…)``)
+so the Python port does not hard-wrap long lines mid-token against the captured
+pipe — a non-TTY artifact whose break point is path-length-volatile.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+# Leading status glyph: bash 'i'/'+'/'!'/'x' + two spaces, or the Python IOPort's
+# '✓'/'⚠'/'✗' + one space. Anchored so only a true status prefix is stripped:
+# namespace ('  skills/'), orphan ('    [dir] …'), header ('-- … --'), and footer
+# ('   claude: …') lines do not start with a glyph+spacing and are left intact.
+_GLYPH = re.compile(r"^(?:[i+!x]  |[✓⚠✗] )")
+# The volatile install count (footer 'N installed' and the verbose 'Installed:' field).
+_INSTALLED_FOOTER = re.compile(r"\b\d+ installed\b")
+_INSTALLED_FIELD = re.compile(r"^(\s*Installed:\s+)\d+$")
+# bash's count footer omits the space after the comma ('2 backed up,2 pruned'); the
+# Python port emits it. The canon is anchored to the count vocabulary (lookahead) so
+# it ONLY ever touches that footer — never a comma inside a path or message body,
+# which would silently mask a real divergence in this regression net.
+_COMMA = re.compile(r",\s*(?=\d+ (?:installed|updated|merged|backed up|pruned|skipped))")
+
+
+def normalize(stdout: str, *, homes: tuple[Path, ...]) -> list[str]:
+    """Canonicalize one installer's stdout to a list of comparable lines."""
+    lines = _ANSI.sub("", stdout).splitlines()
+    out: list[str] = []
+    for raw in lines:
+        line = raw
+        for home in homes:
+            line = line.replace(str(home), "<HOME>")
+        line = _GLYPH.sub("", line)
+        line = _INSTALLED_FIELD.sub(r"\1<count>", line)
+        line = _INSTALLED_FOOTER.sub("<count> installed", line)
+        line = _COMMA.sub(", ", line)
+        out.append(line.rstrip())
+    return out
+
+
+def region_from(lines: list[str], marker: str) -> list[str]:
+    """Slice ``lines`` from the first occurrence of ``marker`` to the end.
+
+    Used to scope a comparison to a region (e.g. the verbose Summary block) when
+    earlier lines legitimately diverge (the verbose per-file install chatter is
+    an accepted, intended divergence). Returns ``[]`` when the marker is absent
+    so the caller's emptiness assertion gives a clear failure.
+    """
+    try:
+        start = lines.index(marker)
+    except ValueError:  # pragma: no cover - absence is an assertion failure in the caller
+        return []
+    return lines[start:]

--- a/packages/installer/tests/golden_master/test_parity_stdout.py
+++ b/packages/installer/tests/golden_master/test_parity_stdout.py
@@ -1,0 +1,127 @@
+"""Golden-master stdout parity beyond the Summary block: bash ``install.sh`` vs
+Python ``install.py``.
+
+``test_parity_summary.py`` pins the verbose Summary region. This module pins the
+output the tree-diff scenarios are blind to in the OTHER modes:
+
+- **default (non-verbose) mode** — the whole transcript: the run-mode notice, the
+  excluded-plugin warning, the trailing ``Done.`` and the per-tool count footer.
+  Non-verbose mode emits no per-file chatter, so the full transcript is a clean
+  parity contract.
+- **prune mode** — the orphan list (header framing, per-namespace grouping, the
+  ``[dir]``/``[file]`` type tags), the ``Pruned`` line, and the count footer.
+
+Both run with the beads fixture and ``--plugins=`` so the excluded-plugin universe
+agrees (bash hardcodes ``ALL_PLUGINS=(beads)``; the Python port discovers from the
+source root — they only agree when beads is present in the plugin source), and with
+a wide ``COLUMNS`` so the Python ``rich`` console does not hard-wrap path-bearing
+lines against the captured pipe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.golden_master._runner import run_parity
+from tests.golden_master._stdout import normalize
+
+pytestmark = pytest.mark.golden_master
+
+# beads-bearing plugin source so both installers agree on the plugin universe
+# (see module docstring). Same fixture the summary / route parity scenarios use.
+_FIXTURE_BASIC = Path(__file__).parent / "fixtures" / "plugins" / "basic"
+
+# Pin the rich console wide enough that no line wraps against the captured pipe.
+_WIDE_ENV = {"COLUMNS": "1000"}
+
+
+def test_default_mode_transcript_is_parity(tmp_path: Path) -> None:
+    """Default (non-verbose) install: the ENTIRE stdout transcript byte-matches
+    the bash installer once the systemic differences are normalized. This is the
+    regression net for the run-mode notice ('Auto-yes mode …'), the excluded-plugin
+    warning, the trailing 'Done.', and the per-tool count footer — none of which a
+    tree-diff scenario can see.
+    """
+    result = run_parity(
+        tmp_path,
+        args=["--tools=claude", "--plugins=", "--yes"],
+        plugins_src=_FIXTURE_BASIC,
+        env=_WIDE_ENV,
+    )
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+
+    homes = (result.home_a, result.home_b)
+    bash = normalize(result.bash_stdout, homes=homes)
+    python = normalize(result.python_stdout, homes=homes)
+
+    # Anchor the systemic-difference assumptions: the run-mode notice and the
+    # excluded-plugin warning are the lines the Python port was missing/diverging
+    # on, so prove they are present in the bash oracle before the line-for-line
+    # compare makes them load-bearing.
+    assert "Auto-yes mode -- prompts and diffs suppressed" in bash
+    assert any("Plugin 'beads' excluded via --plugins=" in line for line in bash)
+    assert bash[-1] == "   claude: <count> installed"
+
+    assert python == bash, (
+        "Default-mode stdout diverged from the bash oracle.\n"
+        f"bash:\n{chr(10).join(bash)}\n\n"
+        f"python:\n{chr(10).join(python)}"
+    )
+
+
+def _seed_orphans(home: Path) -> None:
+    """Seed two retired entries (a skill dir + an agent file) into the Claude tree.
+
+    Both globs are on the bash prune-list and the Python ``installer.toml`` prune
+    list, so a ``--prune-only`` run finds exactly these two orphans on both sides.
+    Mirrors ``test_parity_prune._seed_orphans``.
+    """
+    skills = home / ".claude" / "skills"
+    agents = home / ".claude" / "agents"
+    skills.mkdir(parents=True, exist_ok=True)
+    agents.mkdir(parents=True, exist_ok=True)
+    orphan_skill = skills / "condition-based-waiting"
+    orphan_skill.mkdir()
+    (orphan_skill / "SKILL.md").write_text("# retired skill\n")
+    (agents / "bead-implementor.md").write_text("# retired agent\n")
+
+
+def test_prune_only_transcript_is_parity(tmp_path: Path) -> None:
+    """--prune-only with two seeded orphans: the ENTIRE prune transcript byte-matches
+    the bash installer once systemic differences are normalized. This is the
+    regression net for the orphan-list framing ('-- Orphans detected (N total) --'),
+    the per-namespace grouping, the '[dir]'/'[file]' type tags, the 'Pruned' line,
+    and the count footer — none visible to a tree-diff scenario.
+    """
+    result = run_parity(
+        tmp_path,
+        args=["--tools=claude", "--plugins=", "--yes", "--prune-only"],
+        seed=_seed_orphans,
+        plugins_src=_FIXTURE_BASIC,
+        env=_WIDE_ENV,
+    )
+
+    assert result.bash_returncode == 0, result.bash_stderr
+    assert result.python_returncode == 0, result.python_stderr
+
+    homes = (result.home_a, result.home_b)
+    bash = normalize(result.bash_stdout, homes=homes)
+    python = normalize(result.python_stdout, homes=homes)
+
+    # Anchor: the orphan-list framing + the type tags are exactly what the Python
+    # port diverged on, so prove they are present in the bash oracle before the
+    # line-for-line compare makes them load-bearing.
+    assert "-- Orphans detected (2 total) --" in bash
+    assert any(line.startswith("    [dir] ") for line in bash)
+    assert any(line.startswith("    [file] ") for line in bash)
+    assert "   claude: 2 backed up, 2 pruned" in bash
+
+    assert python == bash, (
+        "Prune-only stdout diverged from the bash oracle.\n"
+        f"bash:\n{chr(10).join(bash)}\n\n"
+        f"python:\n{chr(10).join(python)}"
+    )

--- a/packages/installer/tests/golden_master/test_parity_summary.py
+++ b/packages/installer/tests/golden_master/test_parity_summary.py
@@ -5,20 +5,15 @@ diff()`` over the two HOME dirs); none of them looks at stdout. The install Summ
 block (``scripts/install.sh:1801-1869``) is terminal output, not a file, so without
 a stdout oracle the renderer's byte-parity with bash has no regression net — header
 wrapping, leading blank lines, and field padding could all drift while every
-tree-diff test stayed green. This module is that oracle: it captures BOTH installers'
-stdout, normalizes the *known-systemic* differences, and byte-compares the Summary
-region.
+tree-diff test stayed green. This module is that oracle for the VERBOSE Summary
+region; ``test_parity_stdout.py`` covers the default-mode and prune transcripts.
 
-Two systemic differences are normalized away (everything else must match byte-for-byte):
-
-- **The volatile install count.** ``Installed:  N`` differs by a small constant
-  (bash counts a prgroom-adjacent file the Python port does not yet stage). The
-  count is not what this test pins — the *shape* of the Summary is — so the numeric
-  value on the ``Installed:`` line is canonicalized.
-- **The ``ok()`` glyph.** bash prints ``+  Done.`` and the Python ``TerminalIO.ok``
-  prints ``✓ Done.``. That glyph divergence is a pre-existing ``IOPort`` property
-  (not introduced by the Summary renderer) tracked separately; it is canonicalized
-  on the ``Done.`` line so it does not mask a real Summary regression.
+The comparison is scoped to the ``-- Summary --`` region: in verbose mode the
+pre-Summary per-file install chatter legitimately differs line-for-line (an
+intended divergence of the rewrite). The shared normalizer (``_stdout.normalize``)
+canonicalizes the systemic differences — ANSI styling, the ``ok()`` glyph, and the
+volatile install count (bash counts a prgroom-adjacent file the Python port does
+not stage); see that module for the full, documented rule set.
 
 The beads fixture (``INSTALLER_PLUGINS_SRC`` -> a tree containing ``beads/``) is
 required: bash hardcodes ``ALL_PLUGINS=(beads)`` while the Python port *discovers*
@@ -29,12 +24,12 @@ skipped) --`` footer when beads is actually present in the plugin source tree (r
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
 from tests.golden_master._runner import run_parity
+from tests.golden_master._stdout import normalize, region_from
 
 pytestmark = pytest.mark.golden_master
 
@@ -47,51 +42,27 @@ _FIXTURE_BASIC = Path(__file__).parent / "fixtures" / "plugins" / "basic"
 # '(not detected, skipped)' footers for every other tool and for beads.
 _VERBOSE_ARGS = ["--tools=claude", "--plugins=", "--yes", "--verbose"]
 
-_ANSI = re.compile(r"\x1b\[[0-9;]*m")
-# The volatile install count on the 'Installed:' field line (verbose block).
-_INSTALLED_LINE = re.compile(r"^(\s*Installed:\s+)\d+$")
-# The ok() 'Done.' line, whichever glyph/spacing the IOPort used.
-_DONE_LINE = re.compile(r"^[+✓]\s+Done\.$")
-
-
-def _normalize_summary(stdout: str) -> list[str]:
-    """Reduce raw installer stdout to the Summary region, ANSI-stripped, with the
-    two systemic differences (install count, ok() glyph) canonicalized.
-
-    Returns the Summary lines from the ``-- Summary --`` header onward so the
-    pre-Summary install chatter (which legitimately differs line-for-line) is
-    excluded — this test pins the Summary block's shape, not the whole transcript.
-    """
-    lines = _ANSI.sub("", stdout).splitlines()
-    try:
-        start = lines.index("-- Summary --")
-    except ValueError:  # pragma: no cover - a missing header is an assertion failure below
-        return []
-    normalized: list[str] = []
-    for line in lines[start:]:
-        line = _INSTALLED_LINE.sub(r"\1<count>", line)
-        if _DONE_LINE.match(line):
-            line = "<ok> Done."
-        normalized.append(line)
-    return normalized
+# Pin the rich console wide enough that no line wraps against the captured pipe.
+_WIDE_ENV = {"COLUMNS": "1000"}
 
 
 def test_verbose_summary_stdout_is_byte_parity(tmp_path: Path) -> None:
     """The verbose Summary block printed by the Python renderer byte-matches the
-    bash installer's, once the install count and the pre-existing ok() glyph are
-    canonicalized. This is the load-bearing parity proof for the Summary renderer:
-    header wrapping ('-- Summary --', '-- claude --'), the leading blank line
-    before every block/footer, the six field labels + padding, the
-    '(not detected, skipped)' footers, and the blank line before Done. — any drift
-    in those fails here, where the tree-diff scenarios are blind.
+    bash installer's, once the shared systemic differences are normalized. This is
+    the load-bearing parity proof for the Summary renderer: header wrapping
+    ('-- Summary --', '-- claude --'), the leading blank line before every
+    block/footer, the six field labels + padding, the '(not detected, skipped)'
+    footers, and the blank line before Done. — any drift in those fails here, where
+    the tree-diff scenarios are blind.
     """
-    result = run_parity(tmp_path, args=_VERBOSE_ARGS, plugins_src=_FIXTURE_BASIC)
+    result = run_parity(tmp_path, args=_VERBOSE_ARGS, plugins_src=_FIXTURE_BASIC, env=_WIDE_ENV)
 
     assert result.bash_returncode == 0, result.bash_stderr
     assert result.python_returncode == 0, result.python_stderr
 
-    bash_summary = _normalize_summary(result.bash_stdout)
-    python_summary = _normalize_summary(result.python_stdout)
+    homes = (result.home_a, result.home_b)
+    bash_summary = region_from(normalize(result.bash_stdout, homes=homes), "-- Summary --")
+    python_summary = region_from(normalize(result.python_stdout, homes=homes), "-- Summary --")
 
     assert bash_summary, f"bash emitted no Summary block:\n{result.bash_stdout}"
     assert python_summary, f"python emitted no Summary block:\n{result.python_stdout}"
@@ -99,7 +70,7 @@ def test_verbose_summary_stdout_is_byte_parity(tmp_path: Path) -> None:
     # field rows are present to be compared) and the canonicalized footer/Done.
     assert "-- claude --" in bash_summary
     assert "-- beads (not detected, skipped) --" in bash_summary
-    assert bash_summary[-1] == "<ok> Done."
+    assert bash_summary[-1] == "Done."
     # The load-bearing assertion: the Summary regions match line-for-line.
     assert python_summary == bash_summary, (
         "Summary stdout diverged from bash oracle.\n"

--- a/packages/installer/tests/unit/test_io_port.py
+++ b/packages/installer/tests/unit/test_io_port.py
@@ -206,6 +206,18 @@ def test_terminal_io_info_writes_to_console() -> None:
     assert "hello" in out_buf.getvalue()
 
 
+def test_terminal_io_does_not_interpret_bracket_tokens_as_markup() -> None:
+    """A literal '[dir]' / '[file]' token (the prune list's type tag) must survive
+    verbatim. rich would otherwise parse '[dir]' as inline markup and silently strip
+    it. markup=False is set per print(), so the guarantee holds even here, where the
+    caller injects a markup-enabled Console (rich's default) — not only on the default
+    Console TerminalIO builds for itself."""
+    out_console, out_buf = _capture_console()  # injected Console; markup defaults to True
+    io = TerminalIO(stdout=out_console)
+    io.info("    [dir] /home/.claude/skills/condition-based-waiting")
+    assert "[dir]" in out_buf.getvalue()
+
+
 def test_terminal_io_verbose_suppressed_when_verbose_flag_false() -> None:
     """Pins the default-quiet contract: verbose=True messages do not
     render unless TerminalIO was constructed with verbose=True."""


### PR DESCRIPTION
## Summary

Extends the golden-master parity suite from **Summary-only** stdout parity to **full default-mode and prune-mode transcript** parity, via a shared normalizer (`tests/golden_master/_stdout.py`). Empirical bash-vs-python capture surfaced three real `install.py` output divergences, now fixed.

Closes bead 8.19: before cutover retires `scripts/install.sh`, the bash stdout **is** the oracle — once it's gone there's no source of truth to compare against, so this parity must be captured now.

### Fixes (the oracle made these load-bearing)
- **Run-mode notice** (`cli.py`) — Python never printed the `DRY RUN -- no changes will be made` / `Auto-yes mode -- prompts and diffs suppressed` lines bash emits (`install.sh:218-222`; auto-yes gated on **not** verbose). Now emitted, bash-ordered before the excluded-plugin warning.
- **Prune orphan-list framing** (`prune_flow.py`) — the header was a bare `Orphans detected (N total)`; bash frames it `-- Orphans detected (N total) --` with leading/trailing blanks and a blank before each tool block. Now matches.
- **Eaten `[dir]`/`[file]` tags** (`io_port.py`) — `rich.Console.print` was parsing the prune list's `[dir]`/`[file]` type tag as markup and **silently stripping it**. `Console(markup=False)` makes every message byte-literal. *(A real user-facing output bug, not just a test artifact.)*

### Deliberately no change
- **Excluded-plugin warning** — bash hardcodes `ALL_PLUGINS=(beads)` and warns even when beads has no source; Python *discovers* and warns only on a real universe. Identical text when the universe agrees — the oracle uses the beads fixture for parity. Python's behaviour is the correct one.
- **Verbose per-file chatter** — bash's Phase-numbered, namespace-grouped, relative-path lines vs Python's flat absolute-path lines: the intended rewrite redesign. The verbose case stays scoped to the Summary region (as before).

### Normalizer = meaningful-parity, not byte-mimicry
Canonicalizes systemic + cosmetic differences on **both** sides (ANSI, status glyph, volatile install count, comma-spacing wart, temp-home path, trailing whitespace); callers pin `COLUMNS` so rich doesn't wrap mid-path. Each rule is a documented, blessed exception — where bash emits a wart Python needn't reproduce, it's normalized away, not mirrored into the port.

## ⚠️ Pre-existing CI red (NOT introduced by this PR)
`make ci` includes golden-master, where `test_bare_install_{codex,gemini,opencode}` **already fail on main**: bash inlines a 9-line `# Rules` / "Companion readmes" preamble into the assembled `AGENTS.md` / `GEMINI.md` that Python omits (447 vs 438 lines, single hunk). **Reproduced with all of this PR's changes stashed** → pre-existing, and a separate subsystem (rules `DYNAMIC-INCLUDE` assembly, not stdout). Tracked as bead `agents-config-37sep` (needs a bug-vs-intended ruling: should the installed `AGENTS.md` carry that rules header at all?). The Claude tool is unaffected. This PR's own additions are green.

## Test Plan
- [x] `make lint-installer format-check-installer typecheck-installer` — clean (ruff check, ruff format --check, mypy --strict, 43 files)
- [x] `make cov-installer` — 601 passed, **99.81%** coverage
- [x] golden-master (serial, deterministic) — **25 passed incl. the 3 new stdout oracles**; only the 3 pre-existing rules-assembly tests fail
- [x] `quality-reviewer` — zero CRITICAL/HIGH; 2 LOW (normalizer breadth) — LOW-1 applied, LOW-2 accepted + documented
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pnTdkPJ2gY2dKxAjVFU6p
