### PR TITLE
feat(installer): shared .installignore exclusion manifest (replaces DEAD_MARKERS)

### DIFF
--- a/.installignore
+++ b/.installignore
@@ -17,5 +17,7 @@ CLAUDE.md
 GEMINI.md
 README.md
 SESSION-PRIMER-README.md
-# Source-only rationale directories (never installed):
+# Defensive directory coverage. The current rules-readmes/ dirs live at tool
+# roots (siblings of rules/), which are never staged, so they need no entry —
+# this guards the hypothetical case of a namespace-level rules-readmes/ child.
 rules-readmes/

--- a/.installignore
+++ b/.installignore
@@ -1,0 +1,21 @@
+# .installignore — source files excluded from the install fileset.
+#
+# Consumed by BOTH installers (scripts/install.sh and packages/installer) at the
+# staging step, on the DIRECT CHILDREN of each staged namespace subdir, BEFORE
+# any .template suffix is stripped.
+#
+# Grammar (simple subset; identical in bash and Python): one entry per line;
+# '#' comment lines and blank lines are ignored; an exact basename matches a
+# FILE; a trailing-'/' name matches a DIRECTORY. No globs, no '**', no negation,
+# no anchoring.
+#
+# The real tool-root instruction files are *.md.template and are NOT matched by
+# these bare basenames. Live leaker today: rules/AGENTS.md. The other entries are
+# class coverage (defensive; see the design spec's audit table).
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+README.md
+SESSION-PRIMER-README.md
+# Source-only rationale directories (never installed):
+rules-readmes/

--- a/docs/plans/2026-06-20-installignore-exclusion-manifest.md
+++ b/docs/plans/2026-06-20-installignore-exclusion-manifest.md
@@ -1,0 +1,1075 @@
+# Shared `.installignore` Exclusion Manifest — Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Python-only hardcoded `DEAD_MARKERS` with a single repo-root `.installignore` manifest that both installers consume at staging, killing the bash↔python exclusion divergence and closing the three RED golden-master tests.
+
+**Architecture:** A trivial-grammar manifest (exact basenames + `name/` directories; no globs) is loaded once and threaded into `stage_namespace` — the single Python chokepoint for base *and* plugin staging — and into a sourceable bash matcher lib used by `install.sh`. Missing/unreadable manifest is fail-fast on both installers. The golden-master oracle's dead-marker skip is deleted (pure tree parity); a hardcoded Python invariant test + a cross-language matcher-parity test backstop correctness.
+
+**Tech Stack:** Python 3.11+ (`uv`, `pytest`, `mypy --strict`, `ruff`), Bash 4+ (`scripts/install.sh`). Gate: `make ci-installer` from repo root.
+
+**Design spec:** `docs/specs/2026-06-20-installignore-exclusion-manifest-design.md`
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `.installignore` | Create | Repo-root manifest; the single source of truth for excluded dev-docs. |
+| `packages/installer/src/installer/core/installignore.py` | Create | `InstallIgnore` model + `load_installignore` (fail-fast on missing). |
+| `packages/installer/tests/unit/test_installignore.py` | Create | Loader/model unit tests. |
+| `packages/installer/tests/unit/conftest.py` | Modify | Add a shared `ignore` fixture for staging tests. |
+| `packages/installer/src/installer/core/staging.py` | Modify | Drop `DEAD_MARKERS`; thread `ignore` into `stage_namespace` + `build_plan`. |
+| `packages/installer/src/installer/core/overlay.py` | Modify | Thread `ignore` into `overlay_plugins` → `stage_namespace`. |
+| `packages/installer/src/installer/core/orchestrator.py` | Modify | Thread `ignore` into `stage_and_transform`. |
+| `packages/installer/src/installer/cli.py` | Modify | Load manifest up-front (fail-fast → exit 2); pass `ignore` to both call sites. |
+| `packages/installer/tests/unit/test_staging*.py`, `test_orchestrator.py`, `test_overlay.py`, `test_run_plugin_routes.py` | Modify | Pass the `ignore` fixture to changed call sites. |
+| `scripts/lib/installignore.sh` | Create | Sourceable bash matcher: `load_installignore` + `is_installignored` (fail-fast). |
+| `scripts/lib/installignore_test.sh` | Create | Bash unit test for the matcher + fail-fast. |
+| `scripts/install.sh` | Modify | Source the lib; load+fail-fast early; filter in `stage_content_from_dir`. |
+| `packages/installer/tests/golden_master/_diff.py` | Modify | Delete the dead-marker skip (pure parity). |
+| `packages/installer/tests/golden_master/test_diff.py` | Modify | Drop/replace any test pinning the deleted skip. |
+| `packages/installer/tests/unit/test_installignore_invariant.py` | Create | Hardcoded "known leakers never staged" guard against the real repo. |
+| `packages/installer/tests/unit/test_installignore_parity.py` | Create | Cross-language matcher-parity (bash lib vs Python). |
+| `packages/installer/tests/unit/test_cli_installignore.py` | Create | CLI fail-fast on missing manifest → exit 2. |
+
+---
+
+## Task 1: Create the `.installignore` manifest
+
+**Files:**
+- Create: `.installignore` (repo root)
+
+- [ ] **Step 1: Write the manifest**
+
+Create `/.installignore` (at the repository root, alongside `AGENTS.md`):
+
+```
+# .installignore — source files excluded from the install fileset.
+#
+# Consumed by BOTH installers (scripts/install.sh and packages/installer) at the
+# staging step, on the DIRECT CHILDREN of each staged namespace subdir, BEFORE
+# any .template suffix is stripped.
+#
+# Grammar (simple subset; identical in bash and Python): one entry per line;
+# '#' comment lines and blank lines are ignored; an exact basename matches a
+# FILE; a trailing-'/' name matches a DIRECTORY. No globs, no '**', no negation,
+# no anchoring.
+#
+# The real tool-root instruction files are *.md.template and are NOT matched by
+# these bare basenames. Live leaker today: rules/AGENTS.md. The other entries are
+# class coverage (defensive; see the design spec's audit table).
+AGENTS.md
+CLAUDE.md
+GEMINI.md
+README.md
+SESSION-PRIMER-README.md
+# Source-only rationale directories (never installed):
+rules-readmes/
+```
+
+- [ ] **Step 2: Verify it is at the repo root and not under `src/`**
+
+Run: `ls -1 .installignore && git -C . check-ignore .installignore; echo "exit=$?"`
+Expected: prints `.installignore`; `check-ignore` exits non-zero (the file itself is tracked, not git-ignored).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .installignore
+git commit -m "feat(installer): add .installignore exclusion manifest"
+```
+
+---
+
+## Task 2: Python loader + model (`core/installignore.py`)
+
+**Files:**
+- Create: `packages/installer/src/installer/core/installignore.py`
+- Test: `packages/installer/tests/unit/test_installignore.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/installer/tests/unit/test_installignore.py`:
+
+```python
+"""Unit tests for installer.core.installignore — the shared exclusion manifest
+loader. Each test pins a coded decision: basename vs directory parsing, comment
+and blank-line skipping, and the fail-fast contract on a missing/unreadable file
+(load-bearing policy, unlike the inert-default installer.toml loader)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.installignore import InstallIgnore, load_installignore
+
+
+def test_basename_and_directory_entries_are_partitioned(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("AGENTS.md\nrules-readmes/\nREADME.md\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md", "README.md"})
+    assert ignore.dirnames == frozenset({"rules-readmes"})
+
+
+def test_comments_and_blank_lines_are_ignored(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("# a comment\n\nAGENTS.md\n   \n# trailing\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md"})
+    assert ignore.dirnames == frozenset()
+
+
+def test_surrounding_whitespace_is_trimmed(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("  AGENTS.md  \n\trules-readmes/\t\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md"})
+    assert ignore.dirnames == frozenset({"rules-readmes"})
+
+
+def test_excludes_matches_files_against_basenames(tmp_path: Path) -> None:
+    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+
+    assert ignore.excludes("AGENTS.md", is_dir=False) is True
+    assert ignore.excludes("AGENTS.md.template", is_dir=False) is False  # never the real file
+    assert ignore.excludes("rules-readmes", is_dir=False) is False  # dir entry, file query
+
+
+def test_excludes_matches_directories_against_dirnames(tmp_path: Path) -> None:
+    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+
+    assert ignore.excludes("rules-readmes", is_dir=True) is True
+    assert ignore.excludes("AGENTS.md", is_dir=True) is False  # basename entry, dir query
+
+
+def test_missing_manifest_is_fail_fast(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"\.installignore not found"):
+        load_installignore(tmp_path / ".installignore")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_installignore.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'installer.core.installignore'`.
+
+- [ ] **Step 3: Implement the loader + model**
+
+Create `packages/installer/src/installer/core/installignore.py`:
+
+```python
+"""Loader for ``.installignore`` — the shared source-file exclusion manifest
+consumed by BOTH installers at the staging step.
+
+Unlike ``load_installer_toml`` (a missing file is an inert default), a missing or
+unreadable ``.installignore`` is a HARD ERROR: the manifest encodes load-bearing
+exclusion policy, so silently treating absence as "exclude nothing" would
+re-leak namespace dev-docs identically on both installers — the shared-wrongness
+case the golden-master parity oracle cannot see. Fail-fast turns every
+missing/wrong-root/absent-in-fixture mode into a loud error.
+
+Grammar (simple subset, identical to the bash matcher in
+``scripts/lib/installignore.sh``): one entry per line; ``#`` comment lines and
+blank lines ignored; an exact basename matches a file; a trailing-``/`` name
+matches a directory. No globs, no ``**``, no negation, no anchoring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class InstallIgnore:
+    """Parsed manifest: the set of excluded file basenames and directory names.
+
+    ``excludes`` is the single match primitive both staging and the parity test
+    consult; a file is tested against ``basenames``, a directory against
+    ``dirnames``, so the same name can never accidentally cross kinds.
+    """
+
+    basenames: frozenset[str] = field(default_factory=frozenset)
+    dirnames: frozenset[str] = field(default_factory=frozenset)
+
+    def excludes(self, name: str, *, is_dir: bool) -> bool:
+        return name in (self.dirnames if is_dir else self.basenames)
+
+
+def load_installignore(path: Path) -> InstallIgnore:
+    """Parse ``.installignore`` at ``path``; return an ``InstallIgnore``.
+
+    Raises ``FileNotFoundError`` when the file is absent (fail-fast — see module
+    docstring). A present-but-unreadable file raises naturally from ``read_text``
+    (``PermissionError`` / ``OSError``). Both are surfaced cleanly by the CLI as
+    exit 2.
+    """
+    if not path.is_file():
+        msg = f".installignore not found at {path}; refusing to install with exclusions disabled"
+        raise FileNotFoundError(msg)
+
+    basenames: set[str] = set()
+    dirnames: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("/"):
+            dirnames.add(line[:-1])
+        else:
+            basenames.add(line)
+    return InstallIgnore(basenames=frozenset(basenames), dirnames=frozenset(dirnames))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_installignore.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/installer/src/installer/core/installignore.py packages/installer/tests/unit/test_installignore.py
+git commit -m "feat(installer): add .installignore loader with fail-fast on missing manifest"
+```
+
+---
+
+## Task 3: Add the shared `ignore` test fixture
+
+**Files:**
+- Modify: `packages/installer/tests/unit/conftest.py`
+
+- [ ] **Step 1: Add the fixture**
+
+Append to `packages/installer/tests/unit/conftest.py` (add the import near the other imports at the top of the file):
+
+```python
+import pytest
+
+from installer.core.installignore import InstallIgnore
+
+
+@pytest.fixture
+def ignore() -> InstallIgnore:
+    """The canonical .installignore content as an in-memory object, for staging
+    tests that must pass an exclusion set without touching a manifest file."""
+    return InstallIgnore(
+        basenames=frozenset(
+            {"AGENTS.md", "CLAUDE.md", "GEMINI.md", "README.md", "SESSION-PRIMER-README.md"}
+        ),
+        dirnames=frozenset({"rules-readmes"}),
+    )
+```
+
+- [ ] **Step 2: Verify the fixture imports cleanly**
+
+Run: `cd packages/installer && uv run python -c "import tests.unit.conftest"`
+Expected: no output, exit 0. (If `conftest` is not importable as a module, instead run `uv run pytest tests/unit/test_installignore.py -q` to confirm collection still works.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/installer/tests/unit/conftest.py
+git commit -m "test(installer): add shared ignore fixture for staging tests"
+```
+
+---
+
+## Task 4: Thread the manifest through the Python staging chain
+
+This is the central change. `stage_namespace` gains a required `ignore` param; every caller up the chain (`build_plan`, `overlay_plugins`, `stage_and_transform`, `cli.main`) threads it. `mypy --strict` enforces that no call site is missed.
+
+**Files:**
+- Modify: `packages/installer/src/installer/core/staging.py`
+- Modify: `packages/installer/src/installer/core/overlay.py`
+- Modify: `packages/installer/src/installer/core/orchestrator.py`
+- Modify: `packages/installer/src/installer/cli.py`
+- Modify: `packages/installer/tests/unit/test_staging.py` (and other staging/overlay/orchestrator test files — Step 9)
+
+- [ ] **Step 1: Update the `stage_namespace` dead-marker test to use the manifest, and add a directory-exclusion test**
+
+In `packages/installer/tests/unit/test_staging.py`, replace `test_stage_namespace_filters_top_level_marker_files` (around line 120) with the manifest-driven version, and add a directory test. (The `ignore` fixture comes from conftest; add it as a parameter.)
+
+```python
+def test_stage_namespace_filters_top_level_marker_files(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """In-repo AGENTS.md/CLAUDE.md/GEMINI.md at the top of a namespace dir are
+    dead files; the .installignore matcher drops them while keeping real content."""
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    (skills / "AGENTS.md").write_bytes(b"dev doc")
+    (skills / "real-skill").mkdir()
+
+    items = stage_namespace(tmp_path, "skills", provenance=_prov(), ignore=ignore)
+
+    names = {i.dest_relpath.name for i in items}
+    assert names == {"real-skill"}
+
+
+def test_stage_namespace_filters_excluded_directory(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """A directory whose name is a .installignore directory entry (rules-readmes)
+    is dropped whole, not partially staged."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "rules-readmes").mkdir()
+    (rules / "rules-readmes" / "foo-readme.md").write_bytes(b"rationale")
+    (rules / "real-rule.md").write_bytes(b"rule")
+
+    items = stage_namespace(tmp_path, "rules", provenance=_prov(), ignore=ignore)
+
+    names = {i.dest_relpath.name for i in items}
+    assert names == {"real-rule.md"}
+```
+
+Add `InstallIgnore` to the imports at the top of `test_staging.py`:
+
+```python
+from installer.core.installignore import InstallIgnore
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_staging.py -q`
+Expected: FAIL — `stage_namespace() got an unexpected keyword argument 'ignore'`.
+
+- [ ] **Step 3: Change `stage_namespace` and `build_plan` in `staging.py`**
+
+In `packages/installer/src/installer/core/staging.py`:
+
+(a) Add the import after the existing model import (line 21):
+
+```python
+from installer.core.installignore import InstallIgnore
+from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
+```
+
+(b) Delete the `DEAD_MARKERS` frozenset and its docstring (lines 60-64).
+
+(c) Change `stage_namespace` (replace its signature and the filter line). New signature and body head:
+
+```python
+def stage_namespace(
+    source_root: Path,
+    namespace: str,
+    *,
+    provenance: Provenance,
+    ignore: InstallIgnore,
+) -> list[StagedItem]:
+    """Stage one namespace subdir into StagedItems.
+
+    Port of bash ``stage_content_from_dir`` (``scripts/install.sh``). Walks
+    ``source_root/namespace/*`` in sorted order; each direct child whose name is
+    excluded by ``ignore`` (a file basename or a directory name from
+    ``.installignore``) is skipped. Surviving entries are classified, suffix-
+    stripped, and turned into ``StagedItem``s. A missing namespace dir yields
+    ``[]``. Matching runs on direct children pre-``.template``-strip, so the real
+    tool-root ``AGENTS.md.template`` is never matched by a bare ``AGENTS.md``.
+    """
+    src_dir = source_root / namespace
+    if not src_dir.is_dir():
+        return []
+
+    items: list[StagedItem] = []
+    for entry in sorted(src_dir.iterdir()):
+        if ignore.excludes(entry.name, is_dir=entry.is_dir()):
+            continue
+        kind = classify_file(entry, namespace)
+        # ... (rest of the loop body is UNCHANGED from the current implementation)
+```
+
+Leave the remainder of the loop body (the `StagedItem(...)` construction with `kind`, `dest_name`, `is_file`, `executable`) exactly as it is today.
+
+(d) Change `build_plan` to accept and forward `ignore`. New signature line and the two `stage_namespace` calls:
+
+```python
+def build_plan(adapter: ToolAdapter, *, repo_root: Path, ignore: InstallIgnore) -> StagingPlan:
+```
+
+Update its two `stage_namespace` calls (Phase 2 and Phase 4) to pass `ignore=ignore`:
+
+```python
+            for item in stage_namespace(shared_root, ns, provenance=prov, ignore=ignore):
+```
+```python
+            for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
+```
+
+- [ ] **Step 4: Change `overlay_plugins` in `overlay.py`**
+
+In `packages/installer/src/installer/core/overlay.py`:
+
+(a) Add `InstallIgnore` to the `TYPE_CHECKING` block (the file uses `from __future__ import annotations`, so a type-only import suffices):
+
+```python
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from installer.core.installignore import InstallIgnore
+    from installer.core.merge.registry import MergeRegistry
+    from installer.core.model import StagedItem, StagingPlan
+    from installer.plugins.base import PluginAdapter
+    from installer.tools.base import ToolAdapter
+```
+
+(b) Add `ignore` to `overlay_plugins`' signature:
+
+```python
+def overlay_plugins(
+    plan: StagingPlan,
+    plugins: Sequence[PluginAdapter],
+    *,
+    adapter: ToolAdapter,
+    registry: MergeRegistry,
+    ignore: InstallIgnore,
+) -> StagingPlan:
+```
+
+(c) Pass `ignore=ignore` to its two `stage_namespace` calls:
+
+```python
+                for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
+```
+```python
+                for item in stage_namespace(shared_root, ns, provenance=prov, ignore=ignore):
+```
+
+- [ ] **Step 5: Change `stage_and_transform` in `orchestrator.py`**
+
+In `packages/installer/src/installer/core/orchestrator.py`:
+
+(a) Add `InstallIgnore` to the `TYPE_CHECKING` block:
+
+```python
+    from installer.core.installignore import InstallIgnore
+    from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan, Tool
+    from installer.plugins.base import PluginAdapter
+```
+
+(b) Add `ignore` to the signature and forward it to `build_plan` and `overlay_plugins`:
+
+```python
+def stage_and_transform(
+    tools: Iterable[Tool],
+    *,
+    repo_root: Path,
+    io: IOPort,
+    ignore: InstallIgnore,
+    plugins: Sequence[PluginAdapter] = (),
+) -> dict[Tool, StagingPlan]:
+```
+```python
+        plan = build_plan(adapter, repo_root=repo_root, ignore=ignore)
+        plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry, ignore=ignore)
+```
+
+- [ ] **Step 6: Load the manifest + fail-fast in `cli.main`**
+
+In `packages/installer/src/installer/cli.py`:
+
+(a) Add the import near the other core imports (around line 14):
+
+```python
+from installer.core.installignore import load_installignore
+```
+
+(b) After the excluded-plugins warning block (immediately before `if args.dump_stage is not None:` near line 173), insert the up-front load with fail-fast:
+
+```python
+    # Load the shared exclusion manifest up front, mirroring the bash installer's
+    # early fail-fast. Absent or unreadable .installignore is a hard error (exit 2)
+    # rather than a silent empty-exclusion install — the manifest is load-bearing
+    # policy, and a missing one would re-leak dead-docs identically on both
+    # installers (shared wrongness the parity oracle cannot see).
+    try:
+        ignore = load_installignore(resolved_repo_root / ".installignore")
+    except OSError as exc:
+        sys.stderr.write(f"installer: {exc}\n")
+        return 2
+```
+
+(c) Pass `ignore=ignore` to BOTH `stage_and_transform` call sites (lines 174 and 195):
+
+```python
+        plans = stage_and_transform(
+            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+        )
+```
+
+(both occurrences).
+
+- [ ] **Step 7: Run mypy to find every remaining call site**
+
+Run: `cd packages/installer && uv run mypy --strict src`
+Expected: errors ONLY where a `stage_namespace` / `build_plan` / `overlay_plugins` / `stage_and_transform` call still lacks `ignore`. If clean, proceed; if not, fix each reported src call site by adding `ignore=ignore` (all production call sites are covered by Steps 3-6, so a clean run is expected).
+
+- [ ] **Step 8: Run the staging test to verify Step 1 passes**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_staging.py -q`
+Expected: PASS.
+
+- [ ] **Step 9: Update the remaining test call sites**
+
+Enumerate every test that calls a changed function:
+
+Run: `cd packages/installer && grep -rn -E 'stage_namespace\(|build_plan\(|overlay_plugins\(|stage_and_transform\(' tests/unit | grep -v 'def '`
+
+For each call site: add `ignore: InstallIgnore` (the conftest fixture) to the enclosing test function's parameters, add `from installer.core.installignore import InstallIgnore` to that test module's imports if absent, and pass `ignore=ignore` into the call. Expected files (confirm against the grep): `test_staging.py`, `test_staging_build_plan.py`, `test_staging_codex.py`, `test_staging_gemini.py`, `test_staging_opencode.py`, `test_staging_shared_carrier.py`, `test_orchestrator.py`, `test_overlay.py`, `test_run_plugin_routes.py`.
+
+Concrete example — `test_staging_build_plan.py` (its `build_plan` call, ~line 60):
+
+```python
+# before:
+#   plan = build_plan(adapter, repo_root=tmp_path)
+# after:
+def test_build_plan_filters_namespace_dead_markers(tmp_path: Path, ignore: InstallIgnore) -> None:
+    ...
+    plan = build_plan(adapter, repo_root=tmp_path, ignore=ignore)
+```
+
+- [ ] **Step 10: Run the full unit suite**
+
+Run: `cd packages/installer && uv run pytest tests/unit -q`
+Expected: PASS (all unit tests green).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/installer/src/installer/core/staging.py \
+        packages/installer/src/installer/core/overlay.py \
+        packages/installer/src/installer/core/orchestrator.py \
+        packages/installer/src/installer/cli.py \
+        packages/installer/tests/unit
+git commit -m "feat(installer): consume .installignore in Python staging, drop DEAD_MARKERS"
+```
+
+---
+
+## Task 5: Bash matcher library (`scripts/lib/installignore.sh`)
+
+**Files:**
+- Create: `scripts/lib/installignore.sh`
+- Test: `scripts/lib/installignore_test.sh`
+
+- [ ] **Step 1: Write the failing bash test**
+
+Create `scripts/lib/installignore_test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Unit test for scripts/lib/installignore.sh — the bash exclusion matcher.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/installignore.sh"
+fail=0
+
+assert() { # $1=desc  $2=expected  $3=actual
+    if [[ "$2" != "$3" ]]; then echo "FAIL: $1 (expected '$2', got '$3')" >&2; fail=1
+    else echo "ok: $1"; fi
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+manifest="$work/.installignore"
+printf '%s\n' '# comment' '' 'AGENTS.md' 'rules-readmes/' > "$manifest"
+
+# shellcheck source=/dev/null
+source "$LIB"
+load_installignore "$manifest"
+
+is_installignored "AGENTS.md" false && r=drop || r=keep
+assert "file basename excluded" "drop" "$r"
+is_installignored "AGENTS.md.template" false && r=drop || r=keep
+assert "template not excluded" "keep" "$r"
+is_installignored "rules-readmes" true && r=drop || r=keep
+assert "dir name excluded" "drop" "$r"
+is_installignored "rules-readmes" false && r=drop || r=keep
+assert "dir entry does not match a file query" "keep" "$r"
+
+# Fail-fast on a missing manifest (run in a subshell so its exit does not kill us).
+( source "$LIB"; load_installignore "$work/nope" ) 2>/dev/null && r=0 || r=$?
+assert "missing manifest fail-fast (nonzero exit)" "1" "$r"
+
+exit "$fail"
+```
+
+Make it executable:
+
+```bash
+chmod +x scripts/lib/installignore_test.sh
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/lib/installignore_test.sh; echo "exit=$?"`
+Expected: FAIL — lib not found / functions undefined; non-zero exit.
+
+- [ ] **Step 3: Implement the lib**
+
+Create `scripts/lib/installignore.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Shared exclusion matcher for the install fileset — bash side of .installignore.
+# Sourced by scripts/install.sh and by installignore_test.sh. Grammar matches the
+# Python loader (installer.core.installignore): one entry per line; '#' comments
+# and blank lines ignored; an exact basename matches a file; a trailing-'/' name
+# matches a directory. No globs, no '**', no negation, no anchoring.
+#
+# Requires bash 4+ associative arrays (install.sh already guards the version and
+# uses `declare -A`). Do NOT `set -e` here — this file only defines functions.
+
+declare -A _INSTALLIGNORE_BASENAMES
+declare -A _INSTALLIGNORE_DIRNAMES
+
+# load_installignore <path>: populate the matcher from the manifest. A missing or
+# unreadable file is a HARD ERROR (fail-fast) — mirrors the Python loader.
+load_installignore() {
+    local file="$1" line
+    if [[ ! -r "$file" ]]; then
+        echo "Error: .installignore not found at $file; refusing to install with exclusions disabled" >&2
+        exit 1
+    fi
+    _INSTALLIGNORE_BASENAMES=()
+    _INSTALLIGNORE_DIRNAMES=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line#"${line%%[![:space:]]*}"}"   # ltrim
+        line="${line%"${line##*[![:space:]]}"}"    # rtrim
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        if [[ "$line" == */ ]]; then
+            _INSTALLIGNORE_DIRNAMES["${line%/}"]=1
+        else
+            _INSTALLIGNORE_BASENAMES["$line"]=1
+        fi
+    done < "$file"
+}
+
+# is_installignored <name> <is_dir:true|false>: succeed (0) if excluded.
+is_installignored() {
+    if [[ "$2" == true ]]; then
+        [[ -n "${_INSTALLIGNORE_DIRNAMES[$1]:-}" ]]
+    else
+        [[ -n "${_INSTALLIGNORE_BASENAMES[$1]:-}" ]]
+    fi
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bash scripts/lib/installignore_test.sh; echo "exit=$?"`
+Expected: all `ok:` lines, `exit=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/lib/installignore.sh scripts/lib/installignore_test.sh
+git commit -m "feat(installer): add sourceable bash .installignore matcher with fail-fast"
+```
+
+---
+
+## Task 6: Wire `scripts/install.sh` to the manifest
+
+**Files:**
+- Modify: `scripts/install.sh`
+
+- [ ] **Step 1: Source the lib and load the manifest with fail-fast**
+
+In `scripts/install.sh`, just after the `PROJECT_ROOT` / `SRC_*` block (after line ~205), source the lib and load the manifest (this runs at startup, before any staging, so a missing manifest aborts the whole run):
+
+```bash
+INSTALLIGNORE_FILE="$PROJECT_ROOT/.installignore"
+# shellcheck source=lib/installignore.sh
+source "$SCRIPT_DIR/lib/installignore.sh"
+load_installignore "$INSTALLIGNORE_FILE"
+```
+
+- [ ] **Step 2: Filter excluded entries in `stage_content_from_dir`**
+
+In `stage_content_from_dir` (lines 613-632), add the exclusion check at the top of the per-item loop. Replace:
+
+```bash
+    for item in "$src_dir"/*; do
+        [[ -e "$item" ]] || continue
+        item_name="$(basename "$item")"
+        file_type="$(classify_file "$item" "$dir_name")"
+        stage_item "$item" "$staging_dir/$item_name" "$file_type"
+    done
+```
+
+with:
+
+```bash
+    for item in "$src_dir"/*; do
+        [[ -e "$item" ]] || continue
+        item_name="$(basename "$item")"
+        if [[ -d "$item" ]]; then is_dir=true; else is_dir=false; fi
+        if is_installignored "$item_name" "$is_dir"; then
+            vinfo "  .installignore: skipping $dir_name/$item_name"
+            continue
+        fi
+        file_type="$(classify_file "$item" "$dir_name")"
+        stage_item "$item" "$staging_dir/$item_name" "$file_type"
+    done
+```
+
+(Declare `is_dir` alongside the existing `local item_name file_type` line: `local item_name file_type is_dir`.)
+
+- [ ] **Step 3: Smoke-check the script parses and the help path still runs**
+
+Run: `bash -n scripts/install.sh && echo "syntax ok"`
+Expected: `syntax ok`.
+
+Run: `bash scripts/install.sh --help >/dev/null 2>&1; echo "exit=$?"`
+Expected: `exit=0` (help path does not stage, but the early `load_installignore` runs — confirms the manifest is found from `PROJECT_ROOT`). If the `--help` path short-circuits before the load, this still exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/install.sh
+git commit -m "feat(installer): consume .installignore in install.sh staging with fail-fast"
+```
+
+---
+
+## Task 7: Delete the golden-master dead-marker skip
+
+**Files:**
+- Modify: `packages/installer/tests/golden_master/_diff.py`
+- Modify: `packages/installer/tests/golden_master/test_diff.py`
+
+- [ ] **Step 1: Remove the skip from `_diff.py`**
+
+In `packages/installer/tests/golden_master/_diff.py`:
+
+(a) Delete the `_DEAD_MARKER_NAMES` / `_NAMESPACE_DIRS` constants and their comment (lines 91-97) and the `_is_namespace_dead_marker` function (lines 100-102).
+
+(b) In `_index_tree`, delete the skip and update the docstring. Replace:
+
+```python
+def _index_tree(root: Path) -> dict[str, Path]:
+    """Map every file under ``root`` to its normalised POSIX relpath.
+
+    Namespace-level dead markers are skipped — see ``_is_namespace_dead_marker``.
+    """
+    index: dict[str, Path] = {}
+    for path in root.rglob("*"):
+        if path.is_file():
+            rel = normalize_relpath(path.relative_to(root).as_posix())
+            if _is_namespace_dead_marker(rel):
+                continue
+            if rel in index:
+```
+
+with:
+
+```python
+def _index_tree(root: Path) -> dict[str, Path]:
+    """Map every file under ``root`` to its normalised POSIX relpath.
+
+    No path is skipped: both installers now exclude .installignore dev-docs at
+    staging, so neither tree contains them and a plain tree comparison is exact.
+    A dead-doc reappearing on only one side is a real divergence and must surface.
+    """
+    index: dict[str, Path] = {}
+    for path in root.rglob("*"):
+        if path.is_file():
+            rel = normalize_relpath(path.relative_to(root).as_posix())
+            if rel in index:
+```
+
+- [ ] **Step 2: Drop/replace any test that pins the deleted skip**
+
+Run: `cd packages/installer && grep -n -E '_is_namespace_dead_marker|dead_marker|DEAD_MARKER' tests/golden_master/test_diff.py`
+
+If a test asserts the skip behaviour (e.g. that a namespace `AGENTS.md` is ignored by `diff_trees`), delete that test — the behaviour is intentionally gone. If no such test exists, no change here.
+
+- [ ] **Step 3: Run the diff unit tests**
+
+Run: `cd packages/installer && uv run pytest tests/golden_master/test_diff.py -q`
+Expected: PASS (with the skip-pinning test removed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/installer/tests/golden_master/_diff.py packages/installer/tests/golden_master/test_diff.py
+git commit -m "test(installer): delete golden-master dead-marker skip (pure tree parity)"
+```
+
+---
+
+## Task 8: Python invariant test — known leakers never staged
+
+**Files:**
+- Create: `packages/installer/tests/unit/test_installignore_invariant.py`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/installer/tests/unit/test_installignore_invariant.py`:
+
+```python
+"""Invariant guard: the known confirmed dev-doc leakers never appear in the
+Python installer's staged output, using the REAL repo-root .installignore.
+
+The leaker paths are HARDCODED here, deliberately NOT sourced from .installignore:
+a manifest-sourced check would go blind to the exact regression it must catch —
+someone deleting an entry from .installignore. This test goes red on a manifest
+mis-edit OR a staging-logic regression, and survives the parity gate (it tests
+Python, the permanent installer, not the bash↔python comparison)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.installignore import load_installignore
+from installer.core.model import Tool
+from installer.core.staging import build_plan
+from installer.tools.registry import get_adapter
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Confirmed live leakers (design spec audit table). Their relpaths must never
+# survive base staging into any tool's plan.
+_FORBIDDEN_RELPATHS = (
+    Path("rules/AGENTS.md"),
+    Path("skills/AGENTS.md"),
+)
+_NAMESPACE_DIRS = {"skills", "agents", "rules", "commands", "hooks"}
+_MARKER_BASENAMES = {"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
+
+
+def test_known_dead_docs_are_never_staged() -> None:
+    ignore = load_installignore(_REPO_ROOT / ".installignore")
+
+    for tool in Tool:
+        adapter = get_adapter(tool)
+        plan = build_plan(adapter, repo_root=_REPO_ROOT, ignore=ignore)
+
+        for forbidden in _FORBIDDEN_RELPATHS:
+            assert forbidden not in plan.items, f"{forbidden} leaked into {tool} plan"
+        # No namespace-level AGENTS.md/CLAUDE.md/GEMINI.md under a staged subdir.
+        for dest in plan.items:
+            parts = dest.parts
+            if len(parts) >= 2 and parts[-1] in _MARKER_BASENAMES:
+                assert parts[-2] not in _NAMESPACE_DIRS, (
+                    f"namespace dead-doc {dest} leaked into {tool} plan"
+                )
+```
+
+Notes for the implementer: `build_plan` is IO-free (no `ScriptedIO` needed) and stages the known leakers, which live in the shared `rules/` and `skills/` namespaces (Phase 2). `Tool` is an enum, so `for tool in Tool` iterates all adapters; a tool with no tool-specific source dir simply yields no extra items. Confirm `get_adapter` is importable from `installer.tools.registry` (it is used in `cli.py`).
+
+- [ ] **Step 2: Run to verify it passes against the real manifest**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_installignore_invariant.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Prove it catches a manifest mis-edit (manual red check)**
+
+Run:
+```bash
+cd packages/installer
+cp ../../.installignore /tmp/installignore.bak
+grep -v '^AGENTS.md$' ../../.installignore > /tmp/ii && cp /tmp/ii ../../.installignore
+uv run pytest tests/unit/test_installignore_invariant.py -q; echo "exit=$?"
+cp /tmp/installignore.bak ../../.installignore
+```
+Expected: the middle pytest FAILS (a leaker reappears), then the manifest is restored. Re-run `uv run pytest tests/unit/test_installignore_invariant.py -q` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/installer/tests/unit/test_installignore_invariant.py
+git commit -m "test(installer): guard that known dead-docs never stage (real manifest)"
+```
+
+---
+
+## Task 9: Matcher-parity test — bash lib vs Python
+
+**Files:**
+- Create: `packages/installer/tests/unit/test_installignore_parity.py`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/installer/tests/unit/test_installignore_parity.py`:
+
+```python
+"""Cross-language matcher parity: the bash matcher (scripts/lib/installignore.sh)
+and the Python matcher (installer.core.installignore) must agree on every fixture
+path. Guards the only duplicated logic in the two-installer world. Retires with
+bash at the parity gate."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from installer.core.installignore import load_installignore
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_LIB = _REPO_ROOT / "scripts" / "lib" / "installignore.sh"
+
+# (name, is_dir, expected) — keep/drop verdicts the two matchers must share.
+_CASES = [
+    ("AGENTS.md", False, "drop"),
+    ("CLAUDE.md", False, "drop"),
+    ("GEMINI.md", False, "drop"),
+    ("README.md", False, "drop"),
+    ("SESSION-PRIMER-README.md", False, "drop"),
+    ("AGENTS.md.template", False, "keep"),  # the real instruction file
+    ("brainstorming.md", False, "keep"),  # ordinary content
+    ("rules-readmes", True, "drop"),
+    ("rules-readmes", False, "keep"),  # dir entry must not match a file query
+    ("real-skill", True, "keep"),
+]
+
+
+def _bash_verdict(manifest: Path, name: str, is_dir: bool) -> str:
+    flag = "true" if is_dir else "false"
+    script = (
+        f'source "{_LIB}"; load_installignore "{manifest}"; '
+        f'if is_installignored "{name}" {flag}; then echo drop; else echo keep; fi'
+    )
+    out = subprocess.run(  # noqa: S603 — fixed argv, no shell injection (paths are test-local)
+        ["bash", "-c", script], capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+@pytest.mark.parametrize(("name", "is_dir", "expected"), _CASES)
+def test_bash_and_python_matchers_agree(
+    tmp_path: Path, name: str, is_dir: bool, expected: str
+) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text(
+        "AGENTS.md\nCLAUDE.md\nGEMINI.md\nREADME.md\nSESSION-PRIMER-README.md\nrules-readmes/\n",
+        encoding="utf-8",
+    )
+    ignore = load_installignore(manifest)
+
+    python_verdict = "drop" if ignore.excludes(name, is_dir=is_dir) else "keep"
+    bash_verdict = _bash_verdict(manifest, name, is_dir)
+
+    assert python_verdict == expected
+    assert bash_verdict == expected
+    assert python_verdict == bash_verdict
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_installignore_parity.py -q`
+Expected: PASS (10 cases). If `bash` is not on PATH in CI, mark the module `pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="bash unavailable")` — but the golden-master suite already requires bash, so it is present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/installer/tests/unit/test_installignore_parity.py
+git commit -m "test(installer): bash/python .installignore matcher parity"
+```
+
+---
+
+## Task 10: CLI fail-fast on a missing manifest
+
+**Files:**
+- Create: `packages/installer/tests/unit/test_cli_installignore.py`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/installer/tests/unit/test_cli_installignore.py`:
+
+```python
+"""The CLI fails fast (exit 2, clear stderr) when .installignore is absent from
+the resolved repo root, rather than silently installing with exclusions off."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.cli import main
+
+
+def test_missing_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # tmp_path is a repo root with NO .installignore. Point main() at it and a
+    # throwaway HOME so nothing real is touched.
+    home = tmp_path / "home"
+    home.mkdir()
+
+    rc = main(["--yes"], home=home, repo_root=tmp_path)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert ".installignore not found" in err
+```
+
+Notes for the implementer: confirm `main`'s parameter names (`home`, `repo_root`) and that `--yes` is a valid flag (see `cli.py` `_build_parser`); if a different non-interactive flag is required to avoid prompting, use it. The load+fail-fast inserted in Task 4 Step 6 runs before any tool dispatch, so no tool/plugin source is needed in `tmp_path`.
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_installignore.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/installer/tests/unit/test_cli_installignore.py
+git commit -m "test(installer): CLI fail-fast on missing .installignore"
+```
+
+---
+
+## Task 11: Full gate + golden-master green
+
+**Files:** none (verification + final confirmation)
+
+- [ ] **Step 1: Run the golden-master parity suite**
+
+Run: `cd packages/installer && uv run pytest tests/golden_master -q`
+Expected: PASS — including `test_bare_install_codex`, `test_bare_install_gemini`, `test_bare_install_opencode` (previously RED) and `test_bare_install_single_tool` (claude).
+
+- [ ] **Step 2: Prove the RED→GREEN transition is real (optional spot-check)**
+
+Run: `cd packages/installer && git stash && uv run pytest tests/golden_master/test_parity.py -k 'bare_install and (codex or gemini or opencode)' -q; echo "exit=$?"; git stash pop`
+Expected: the stashed (pre-change) run FAILS the three; after `git stash pop` the working tree is restored. (Skip if a partial stash would be unsafe; the design spec already documents the pre-change RED state.)
+
+- [ ] **Step 3: Run the full installer gate**
+
+Run (from repo root): `make ci-installer`
+Expected: PASS — ruff lint, ruff format-check, mypy --strict, pytest --cov (≥90% branch), pip-audit, entry-verify all green. If coverage on `core/installignore.py` is below the floor, add the missing branch case (empty file, unreadable file) to `test_installignore.py`.
+
+- [ ] **Step 4: Run the bash matcher test once more**
+
+Run: `bash scripts/lib/installignore_test.sh; echo "exit=$?"`
+Expected: `exit=0`.
+
+- [ ] **Step 5: Final commit (if any gate fixups were needed)**
+
+```bash
+git add -A
+git commit -m "chore(installer): gate fixups for .installignore manifest"
+```
+
+---
+
+## Self-Review (run before handing off)
+
+- **Spec coverage:** manifest (Task 1) ✓; grammar + bare-basename + dir entry (Tasks 1,2,5) ✓; dual consumption single-chokepoint per installer (Tasks 4,6) ✓; fail-closed/fail-fast (Tasks 2,4,5,6,10) ✓; oracle simplified to pure parity (Task 7) ✓; hardcoded invariant test (Task 8) ✓; matcher-parity test (Task 9) ✓; audit table → manifest entries (Task 1) ✓; non-editable-wheel caveat is documented in the spec (no task — it is a future risk, not current work).
+- **Placeholder scan:** none — every code step carries complete code; the only "confirm X" notes point at exact call sites with the grep to find them.
+- **Type consistency:** `InstallIgnore` / `load_installignore` / `excludes(name, *, is_dir)` used identically across loader, staging, overlay, orchestrator, cli, and all tests; bash `load_installignore` / `is_installignored <name> <is_dir>` consistent across lib, install.sh, and both bash/parity tests.

--- a/docs/specs/2026-06-20-installignore-exclusion-manifest-design.md
+++ b/docs/specs/2026-06-20-installignore-exclusion-manifest-design.md
@@ -41,6 +41,14 @@ The root cause *is* "the same rule implemented (or not) twice." Re-encoding it a
 
 **Only `AGENTS.md` is a live leaker.** The other five are the rest of the *class*, listed so the next dev-doc dropped into a staged subdir cannot leak. The audit table is the spec's record of the bead's "audit README/rules-readmes reachability" requirement: real leaker folded in, non-leakers documented as already-excluded-by-namespace-scoping.
 
+### Loading & failure semantics (fail-closed)
+
+The manifest now encodes load-bearing exclusion policy, so a *missing* manifest must never silently mean "exclude nothing" — that would re-enable the exact leaks this work removes, **identically on both installers** (the shared-wrongness case the parity oracle cannot see).
+
+- **Absent or unreadable** `/.installignore` → **fail-fast**: both installers abort with a clear error (e.g. "`.installignore` not found at `<resolved repo root>`; refusing to install with exclusions disabled") rather than proceeding. This converts every "missing / wrong-root / absent-in-fixture" mode from a silent leak into a loud error.
+- **Present but empty** (no entries) → allowed; it is an explicit choice, and is backstopped by the Python invariant test (a known leaker slipping through turns that test red).
+- Both installers resolve the manifest relative to their own location-derived repo root (bash: `PROJECT_ROOT` from `$0`; Python: `repo_root` from `__file__`, or the test-injected `repo_root`) — the same root used to resolve `src/`, so the manifest travels with the source it governs.
+
 ## Application model — why bare basenames are safe
 
 The matcher is consulted **at the staging choke point, on the direct children of each staged subdir, before any `.template` suffix is stripped** — exactly where Python's `DEAD_MARKERS` runs today.
@@ -57,10 +65,12 @@ Because the matcher runs over **direct children only**:
 ### Python (`packages/installer/`)
 - Load the manifest **once** in `stage_and_transform` (`core/orchestrator.py`), thread it down into `stage_namespace` (`core/staging.py`).
 - **Replace** the hardcoded `DEAD_MARKERS` frozenset and its file-name check with manifest membership: skip a direct-child entry when it is a file whose basename is in the manifest's basename set, or a directory whose name is in the manifest's directory set.
+- **Fail-fast** if the manifest is absent or unreadable (see "Loading & failure semantics") — never default to an empty exclusion set.
 - This single point already fans out to both deploy (`install_pipeline`) and prune (`scan_orphans`) — no second integration needed.
 
 ### Bash (`scripts/install.sh`)
 - Consult the manifest inside `stage_content_from_dir` (the universal per-subdir staging helper): inside its `for item in "$src_dir"/*` loop, skip any direct child whose basename (for files) or name (for directories) is in the manifest.
+- **Fail-fast** if `$PROJECT_ROOT/.installignore` is absent or unreadable — abort before staging, never proceed with exclusions disabled.
 - This is **upstream of both leaks**: excluded files never enter staging, so the DYNAMIC-INCLUDE-ALL-RULES `find` over `$staging/.../rules` cannot inline them, and `sync_directory` cannot deploy them.
 - **Single-point sufficiency (verified):** plain `.md` files reach deploy *only* through staged subdirs (`sync_directory`). `sync_templates` handles `*.md.template` only and never touches plain `.md`. So filtering at `stage_content_from_dir` covers both the staging loop and the sync loop, because both operate on already-staged content. (Do **not** move the filter to the sync layer — the two bash subdir loops, staging and sync, are separate, and a sync-layer filter would have to patch both.)
 - Bash effort is **not** throwaway: `install.sh` retirement is **parity-gated** (it collapses to a thin `uv run` wrapper only once the golden-master suite goes green), with no version date. The RED tests are red *because* bash and Python disagree, so the manifest must land in both simultaneously to close them.
@@ -91,6 +101,14 @@ A fixture set of `(path, expect: keep | drop)` run through **both** the bash mat
 
 This guards the only duplicated logic (the two trivial parsers/matchers). It retires with bash at the parity gate.
 
+## Missing-manifest tests (fail-closed proof)
+
+Explicit tests in **both** installer paths assert that an absent (or unreadable) manifest causes a **hard abort**, not a silent empty-exclusion install:
+- **Python:** invoke the installer with a `repo_root` lacking `.installignore` → assert it exits non-zero / raises before staging, and that no namespace dead-doc is written.
+- **Bash:** run `install.sh` against a `PROJECT_ROOT` lacking `.installignore` → assert non-zero exit and that nothing was staged.
+
+No test-only "empty denylist" opt-out flag is introduced: the missing-manifest test asserts the abort directly, and the matcher-parity test supplies its own fixture manifest content rather than depending on the repo-root file.
+
 ## Outcome
 
 - `test_bare_install_codex`, `test_bare_install_gemini`, `test_bare_install_opencode` go **green** — bash stops inlining `rules/AGENTS.md`, matching Python's (correct) omission.
@@ -106,7 +124,7 @@ This guards the only duplicated logic (the two trivial parsers/matchers). It ret
 
 ## Risks / verification owed by the plan
 
-- **Manifest path resolution in both runtimes.** Confirm both installers resolve `/.installignore` relative to the project root in all invocation modes (direct, dry-run, prune-only) and degrade sanely (treat as empty) if the file is absent.
+- **Manifest path resolution & packaging.** Both installers resolve `/.installignore` from their own location-derived repo root (verified: bash `PROJECT_ROOT` from `$0`; Python `repo_root` from `__file__` / test-injected), so it is co-located with `src/` in all current modes (editable / `uv run`). Confirm fail-fast fires in all invocation modes (direct, dry-run, prune-only). **Caveat:** the manifest lives at repo-root, *outside* both `src/` and `packages/installer/`; if the Python installer is ever distributed as a *non-editable* wheel, repo-root `.installignore` would not be bundled. Fail-fast turns that into a loud error, not a silent leak — but if non-editable packaging is introduced, bundle the manifest as package data or relocate it inside the packaged tree.
 - **Bash single-point sufficiency.** Re-confirm at implementation time that no path other than `stage_content_from_dir` stages plain `.md` files into a deployable location (the audit says only `sync_directory` does, fed from staging; verify no regression path via plugin loops).
 - **Directory-exclusion semantics in bash.** `stage_content_from_dir` iterates `"$src_dir"/*`; ensure a directory entry (`rules-readmes/`) is matched by *name* and the whole subtree is skipped (it is staged via `stage_item` as a recursive copy today), not partially copied.
 - **Coverage of the deleted skip.** Confirm deleting `_is_namespace_dead_marker` does not silently drop coverage that some other test relied on; the matcher-parity test and the Python invariant test together must cover what the skip's removal exposes.

--- a/docs/specs/2026-06-20-installignore-exclusion-manifest-design.md
+++ b/docs/specs/2026-06-20-installignore-exclusion-manifest-design.md
@@ -1,0 +1,113 @@
+# Design: Shared `.installignore` exclusion manifest
+
+**Date:** 2026-06-20
+**Status:** draft (design — awaiting review)
+**Scope:** Introduce a single repo-root `.installignore` manifest consumed by *both* installers (legacy `scripts/install.sh` and the Python rewrite at `packages/installer/`) at the staging choke point, replacing the Python-only hardcoded `DEAD_MARKERS` frozenset. Kills the bash↔python "which source files are excluded" divergence at its root, closing the three RED golden-master parity tests.
+
+## Summary
+
+Bash and Python disagree on which source files are **excluded** from the install fileset. Python has a hardcoded staging filter `DEAD_MARKERS = {AGENTS.md, CLAUDE.md, GEMINI.md}` (`core/staging.py`); bash has **no equivalent**. So a folder-doc marker like `src/user/.agents/rules/AGENTS.md` leaks on the bash side two ways: its prose gets **inlined** into the assembled per-tool instruction file (content-leak), and the file itself gets **deployed** standalone into the installed tree (file-leak).
+
+The fix is a single source of truth — a gitignore-flavored (not gitignore-complete) `.installignore` at the repo root — that **both** installers consult at the one staging step that sits upstream of both leak surfaces. Python's hardcoded `DEAD_MARKERS` is removed in favor of it. The grammar is a deliberately trivial subset (exact basenames + directory names; no globs, no `**`, no negation, no anchoring) so the two implementations are provably equivalent and can be parity-tested against each other.
+
+## Motivation / root cause
+
+The divergence is not a one-off bug; it is a **class**. Today's symptom is `rules/AGENTS.md` (added in the recent rules-rightsizing work, #186), but the underlying defect is that exclusion lives in two places with two different fidelities: a hardcoded list in Python and *nothing* in bash. Every future namespace dev-doc someone adds re-opens the same leak on the bash side.
+
+A shared manifest collapses the two-implementation drift into one reviewable data file. The trivial grammar keeps the per-installer matcher to a few lines each, and a matcher-parity test pins them together.
+
+### Why a manifest rather than codifying the rule in code
+
+The root cause *is* "the same rule implemented (or not) twice." Re-encoding it as logic in both bash and Python recreates the exact drift being killed. Only a shared data file consulted by both structurally prevents it. The trivial grammar means the two *parsers* are the only duplicated logic, and they are parity-tested.
+
+## The manifest
+
+- **Location:** repo-root `/.installignore`. Outside `src/`, so it never stages itself. Patterns are basenames/dirnames, so location is about discoverability, not anchoring.
+- **Grammar (simple subset):**
+  - One entry per line. `#` starts a comment line; blank lines ignored.
+  - **Basename entry** — an exact filename (e.g. `AGENTS.md`). Matches a file whose basename equals it.
+  - **Directory entry** — a name with a trailing `/` (e.g. `rules-readmes/`). Matches a directory whose name equals it (sans slash).
+  - **No** `*`/`?` globs, **no** `**`, **no** negation (`!`), **no** path anchoring. Equality only.
+- **Entries (the full known set), with reachability provenance from the source audit:**
+
+| Entry | Kind | Leaks **today**? | Evidence |
+|---|---|---|---|
+| `AGENTS.md` | basename | **YES** | `src/user/.agents/rules/AGENTS.md` → content-leak (DYNAMIC-INCLUDE-ALL-RULES inlines it) **+** file-leak; `src/user/.agents/skills/AGENTS.md` and `src/user/.claude/rules/AGENTS.md` → file-leak. Python drops via `DEAD_MARKERS`; bash does not. This is the RED. |
+| `CLAUDE.md` | basename | defensive | Mirrors `DEAD_MARKERS`. No plain `CLAUDE.md` sits inside a staged subdir today (only `src/user/.claude/CLAUDE.md` at a namespace root, which is never staged). |
+| `GEMINI.md` | basename | defensive | Mirrors `DEAD_MARKERS`. No plain `GEMINI.md` in a staged subdir today. |
+| `README.md` | basename | defensive | All five (`.agents`, `.claude`, `.codex`, `.gemini`, `.opencode`) sit at namespace roots → never staged (bash copies only `*.md.template` globs + enumerated subdirs, never wholesale tool dirs). |
+| `SESSION-PRIMER-README.md` | basename | defensive | At `.agents/` root → never staged. |
+| `rules-readmes/` | directory | defensive | Sibling of `rules/`; never appears in any staged-subdir enumeration, including the plugin staging loops. |
+
+**Only `AGENTS.md` is a live leaker.** The other five are the rest of the *class*, listed so the next dev-doc dropped into a staged subdir cannot leak. The audit table is the spec's record of the bead's "audit README/rules-readmes reachability" requirement: real leaker folded in, non-leakers documented as already-excluded-by-namespace-scoping.
+
+## Application model — why bare basenames are safe
+
+The matcher is consulted **at the staging choke point, on the direct children of each staged subdir, before any `.template` suffix is stripped** — exactly where Python's `DEAD_MARKERS` runs today.
+
+The same basename is both a thing-to-exclude (the namespace dev-doc `AGENTS.md`) and a thing-to-keep (the tool-root instruction file). Bare basenames are nonetheless safe because in *source* the instruction file is named `AGENTS.md.template`, and equality matching never hits `AGENTS.md.template` — so no namespace-anchoring (`*/AGENTS.md`) is needed.
+
+Because the matcher runs over **direct children only**:
+- `rules/AGENTS.md`, `skills/AGENTS.md` (direct children of staged subdirs) → matched, excluded.
+- A nested file such as `skills/<skill>/README.md` is *not* a direct child of `skills/`; it is staged as part of the skill folder's content and is **not** matched. This is correct — it is skill content, not a namespace dev-doc. (No such file exists today; the rule simply does not reach into folder content.)
+- The real instruction files are staged via separate `*.md.template` globs, never through the matched subdir iteration, so they are untouched.
+
+## Dual consumption — one choke point each
+
+### Python (`packages/installer/`)
+- Load the manifest **once** in `stage_and_transform` (`core/orchestrator.py`), thread it down into `stage_namespace` (`core/staging.py`).
+- **Replace** the hardcoded `DEAD_MARKERS` frozenset and its file-name check with manifest membership: skip a direct-child entry when it is a file whose basename is in the manifest's basename set, or a directory whose name is in the manifest's directory set.
+- This single point already fans out to both deploy (`install_pipeline`) and prune (`scan_orphans`) — no second integration needed.
+
+### Bash (`scripts/install.sh`)
+- Consult the manifest inside `stage_content_from_dir` (the universal per-subdir staging helper): inside its `for item in "$src_dir"/*` loop, skip any direct child whose basename (for files) or name (for directories) is in the manifest.
+- This is **upstream of both leaks**: excluded files never enter staging, so the DYNAMIC-INCLUDE-ALL-RULES `find` over `$staging/.../rules` cannot inline them, and `sync_directory` cannot deploy them.
+- **Single-point sufficiency (verified):** plain `.md` files reach deploy *only* through staged subdirs (`sync_directory`). `sync_templates` handles `*.md.template` only and never touches plain `.md`. So filtering at `stage_content_from_dir` covers both the staging loop and the sync loop, because both operate on already-staged content. (Do **not** move the filter to the sync layer — the two bash subdir loops, staging and sync, are separate, and a sync-layer filter would have to patch both.)
+- Bash effort is **not** throwaway: `install.sh` retirement is **parity-gated** (it collapses to a thin `uv run` wrapper only once the golden-master suite goes green), with no version date. The RED tests are red *because* bash and Python disagree, so the manifest must land in both simultaneously to close them.
+
+## Oracle — simplify, don't extend
+
+The golden-master oracle's job is purely "does bash's installed tree equal Python's installed tree?" (`ParityResult.diff()` → `diff_trees(home_a, home_b)`). Today it carries `_is_namespace_dead_marker` (`tests/golden_master/_diff.py`), which **skips** dead markers on **both** trees before comparing — a band-aid that hides the known bash-installs/Python-omits divergence so the suite stays green.
+
+**Delete `_is_namespace_dead_marker` and the skip entirely.** Once both installers exclude the dead-docs, neither tree contains them, so a plain tree comparison passes with zero special-casing. No `.installignore` awareness is threaded into the harness; the post-strip namespace-anchoring problem never arises because the oracle stops trying to reason about dead markers at all.
+
+This is also **stronger** than today. The skip currently masks the *file-leak* on both sides — including on `test_bare_install_single_tool` (claude), which is **falsely green** today because its `~/.claude/rules/AGENTS.md` file-leak is hidden. Deleting the skip turns that test red for the right reason; the fix turns it (and the three flat-tool tests) green.
+
+### What pure parity cannot see — and where that invariant goes instead
+
+A parity comparison catches *divergence*, never *shared wrongness*. If both installers ever leak the **same** dead-doc **identically** — most realistically via a `.installignore` mis-edit that drops an entry — the trees still match and the suite stays green while both are wrong.
+
+That invariant ("no dead-doc is ever installed") therefore lives **not** in the cross-installer oracle but as a small **Python unit test** against Python's own installed/staged output:
+- Assert the **known confirmed leakers** (`src/user/.agents/rules/AGENTS.md`, `src/user/.agents/skills/AGENTS.md`) never appear in Python's installed tree.
+- **Hardcode** these specific paths in the test — do **not** source them from `.installignore`. A manifest-sourced check goes blind to the exact manifest mis-edit it should catch.
+- Rationale for this home: it tests the consumer of the manifest directly; it guards the realistic regression path; it keeps the oracle dumb; and it **survives the parity gate** (once `install.sh` is a wrapper, the parity oracle tests nothing about dead-docs, but this unit test still does).
+
+## Matcher-parity test
+
+A fixture set of `(path, expect: keep | drop)` run through **both** the bash matcher and the Python matcher, asserting they agree. Cases must include the asymmetry and edge points:
+- `rules/AGENTS.md` → drop; `AGENTS.md.template` → keep (suffix mismatch); a tool-root `AGENTS.md` context → keep (not a staged-subdir direct child).
+- `rules-readmes/` (directory) → drop; a nested `skills/<skill>/README.md` → keep (not a direct child).
+- A comment line and a blank line in the manifest → ignored by both parsers.
+
+This guards the only duplicated logic (the two trivial parsers/matchers). It retires with bash at the parity gate.
+
+## Outcome
+
+- `test_bare_install_codex`, `test_bare_install_gemini`, `test_bare_install_opencode` go **green** — bash stops inlining `rules/AGENTS.md`, matching Python's (correct) omission.
+- `test_bare_install_single_tool` (claude) stays green *for the right reason* after the skip is deleted (the previously-masked file-leak is now genuinely absent on both sides).
+- **Gate:** `make ci-installer` (lint, format-check, typecheck, coverage, audit, entry-verify) must pass before push, plus the golden-master suite.
+
+## Out of scope / non-goals
+
+- **No gitignore semantics** — no `*`/`**` globs, negation, anchoring, or per-directory cascade. (If a future need for `*` globs appears, it is a separate, parity-tested grammar extension.)
+- **No per-namespace cascade** — one root manifest only.
+- **Not** removing `install.sh` — its retirement is parity-gated and tracked separately.
+- **No change to which directories count as staged namespaces** — this work filters *within* the existing staged set, it does not add or remove namespaces.
+
+## Risks / verification owed by the plan
+
+- **Manifest path resolution in both runtimes.** Confirm both installers resolve `/.installignore` relative to the project root in all invocation modes (direct, dry-run, prune-only) and degrade sanely (treat as empty) if the file is absent.
+- **Bash single-point sufficiency.** Re-confirm at implementation time that no path other than `stage_content_from_dir` stages plain `.md` files into a deployable location (the audit says only `sync_directory` does, fed from staging; verify no regression path via plugin loops).
+- **Directory-exclusion semantics in bash.** `stage_content_from_dir` iterates `"$src_dir"/*`; ensure a directory entry (`rules-readmes/`) is matched by *name* and the whole subtree is skipped (it is staged via `stage_item` as a recursive copy today), not partially copied.
+- **Coverage of the deleted skip.** Confirm deleting `_is_namespace_dead_marker` does not silently drop coverage that some other test relied on; the matcher-parity test and the Python invariant test together must cover what the skip's removal exposes.
+- **`make ci-installer` coverage floor** on the changed Python (`staging.py`, `orchestrator.py`, the new manifest loader/matcher, the new tests).

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -172,13 +172,14 @@ def main(
         )
 
     # Load the shared exclusion manifest up front, mirroring the bash installer's
-    # early fail-fast. Absent or unreadable .installignore is a hard error (exit 2)
-    # rather than a silent empty-exclusion install — the manifest is load-bearing
-    # policy, and a missing one would re-leak dead-docs identically on both
-    # installers (shared wrongness the parity oracle cannot see).
+    # early fail-fast. An absent, unreadable, or non-UTF-8 .installignore is a hard
+    # error (exit 2) rather than a silent empty-exclusion install — the manifest is
+    # load-bearing policy, and a missing one would re-leak dead-docs identically on
+    # both installers (shared wrongness the parity oracle cannot see). UnicodeDecodeError
+    # is a ValueError (not an OSError), so it is caught explicitly here.
     try:
         ignore = load_installignore(resolved_repo_root / ".installignore")
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         sys.stderr.write(f"installer: {exc}\n")
         return 2
 

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -10,6 +10,7 @@ from installer.config import Config, resolve_plugins, resolve_plugins_root, reso
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installer_toml import load_installer_toml
+from installer.core.installignore import load_installignore
 from installer.core.model import Counters
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
@@ -170,8 +171,21 @@ def main(
             prune_active=args.prune or args.prune_only,
         )
 
+    # Load the shared exclusion manifest up front, mirroring the bash installer's
+    # early fail-fast. Absent or unreadable .installignore is a hard error (exit 2)
+    # rather than a silent empty-exclusion install — the manifest is load-bearing
+    # policy, and a missing one would re-leak dead-docs identically on both
+    # installers (shared wrongness the parity oracle cannot see).
+    try:
+        ignore = load_installignore(resolved_repo_root / ".installignore")
+    except OSError as exc:
+        sys.stderr.write(f"installer: {exc}\n")
+        return 2
+
     if args.dump_stage is not None:
-        plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
+        plans = stage_and_transform(
+            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+        )
         try:
             dump_plan(plans, args.dump_stage, io=io)
         except ValueError as exc:
@@ -192,7 +206,9 @@ def main(
     # handling — only a verbose adapter transform notice (e.g. Gemini) may now
     # precede a toml error, which is immaterial.
     adapters = [get_adapter(tool) for tool in tools]
-    plans = stage_and_transform(tools, repo_root=resolved_repo_root, io=io, plugins=plugins)
+    plans = stage_and_transform(
+        tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+    )
 
     # Default install path (also the install half of --prune): walk each active
     # tool's StagingPlan to disk via install_pipeline. Skipped only for

--- a/packages/installer/src/installer/core/installignore.py
+++ b/packages/installer/src/installer/core/installignore.py
@@ -1,0 +1,61 @@
+"""Loader for ``.installignore`` — the shared source-file exclusion manifest
+consumed by BOTH installers at the staging step.
+
+Unlike ``load_installer_toml`` (a missing file is an inert default), a missing or
+unreadable ``.installignore`` is a HARD ERROR: the manifest encodes load-bearing
+exclusion policy, so silently treating absence as "exclude nothing" would
+re-leak namespace dev-docs identically on both installers — the shared-wrongness
+case the golden-master parity oracle cannot see. Fail-fast turns every
+missing/wrong-root/absent-in-fixture mode into a loud error.
+
+Grammar (simple subset, identical to the bash matcher in
+``scripts/lib/installignore.sh``): one entry per line; ``#`` comment lines and
+blank lines ignored; an exact basename matches a file; a trailing-``/`` name
+matches a directory. No globs, no ``**``, no negation, no anchoring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class InstallIgnore:
+    """Parsed manifest: the set of excluded file basenames and directory names.
+
+    ``excludes`` is the single match primitive both staging and the parity test
+    consult; a file is tested against ``basenames``, a directory against
+    ``dirnames``, so the same name can never accidentally cross kinds.
+    """
+
+    basenames: frozenset[str] = field(default_factory=frozenset)
+    dirnames: frozenset[str] = field(default_factory=frozenset)
+
+    def excludes(self, name: str, *, is_dir: bool) -> bool:
+        return name in (self.dirnames if is_dir else self.basenames)
+
+
+def load_installignore(path: Path) -> InstallIgnore:
+    """Parse ``.installignore`` at ``path``; return an ``InstallIgnore``.
+
+    Raises ``FileNotFoundError`` when the file is absent (fail-fast — see module
+    docstring). A present-but-unreadable file raises naturally from ``read_text``
+    (``PermissionError`` / ``OSError``). Both are surfaced cleanly by the CLI as
+    exit 2.
+    """
+    if not path.is_file():
+        msg = f".installignore not found at {path}; refusing to install with exclusions disabled"
+        raise FileNotFoundError(msg)
+
+    basenames: set[str] = set()
+    dirnames: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("/"):
+            dirnames.add(line[:-1])
+        else:
+            basenames.add(line)
+    return InstallIgnore(basenames=frozenset(basenames), dirnames=frozenset(dirnames))

--- a/packages/installer/src/installer/core/installignore.py
+++ b/packages/installer/src/installer/core/installignore.py
@@ -41,8 +41,9 @@ def load_installignore(path: Path) -> InstallIgnore:
 
     Raises ``FileNotFoundError`` when the file is absent (fail-fast — see module
     docstring). A present-but-unreadable file raises naturally from ``read_text``
-    (``PermissionError`` / ``OSError``). Both are surfaced cleanly by the CLI as
-    exit 2.
+    (``PermissionError`` / ``OSError``); a non-UTF-8 file raises
+    ``UnicodeDecodeError`` (a ``ValueError``, not an ``OSError``). The CLI catches
+    both ``OSError`` and ``UnicodeDecodeError`` and surfaces them as exit 2.
     """
     if not path.is_file():
         msg = f".installignore not found at {path}; refusing to install with exclusions disabled"

--- a/packages/installer/src/installer/core/installignore.py
+++ b/packages/installer/src/installer/core/installignore.py
@@ -55,7 +55,9 @@ def load_installignore(path: Path) -> InstallIgnore:
         if not line or line.startswith("#"):
             continue
         if line.endswith("/"):
-            dirnames.add(line[:-1])
+            name = line[:-1]
+            if name:  # a bare "/" has no directory name; skip it (parity with bash)
+                dirnames.add(name)
         else:
             basenames.add(line)
     return InstallIgnore(basenames=frozenset(basenames), dirnames=frozenset(dirnames))

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from pathlib import Path
 
+    from installer.core.installignore import InstallIgnore
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan, Tool
     from installer.plugins.base import PluginAdapter
@@ -43,6 +44,7 @@ def stage_and_transform(
     *,
     repo_root: Path,
     io: IOPort,
+    ignore: InstallIgnore,
     plugins: Sequence[PluginAdapter] = (),
 ) -> dict[Tool, StagingPlan]:
     """Build a StagingPlan for each active tool (staging Phases 1-5), overlay the
@@ -57,8 +59,8 @@ def stage_and_transform(
     plans: dict[Tool, StagingPlan] = {}
     for tool in tools:
         adapter = get_adapter(tool)
-        plan = build_plan(adapter, repo_root=repo_root)
-        plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry)
+        plan = build_plan(adapter, repo_root=repo_root, ignore=ignore)
+        plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry, ignore=ignore)
         plan = apply_extensions(plan, plugins)
         flatten_plan_templates(plan, repo_root=repo_root, io=io)
         plans[tool] = adapter.post_staging_transforms(plan, io)

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -36,6 +36,7 @@ from installer.core.staging import stage_namespace, stage_settings
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from installer.core.installignore import InstallIgnore
     from installer.core.merge.registry import MergeRegistry
     from installer.core.model import StagedItem, StagingPlan
     from installer.plugins.base import PluginAdapter
@@ -53,6 +54,7 @@ def overlay_plugins(
     *,
     adapter: ToolAdapter,
     registry: MergeRegistry,
+    ignore: InstallIgnore,
 ) -> StagingPlan:
     """Overlay every plugin in ``plugins`` onto ``plan``, in alphabetical name
     order, mutating and returning ``plan``. Each plugin contributes its
@@ -67,13 +69,13 @@ def overlay_plugins(
 
         for ns in _TOOL_NAMESPACES:
             if adapter.should_install_namespace(ns, "tool"):
-                for item in stage_namespace(tool_root, ns, provenance=prov):
+                for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
                     _place(plan, item, registry=registry, carrier_eligible=False)
         for item in stage_settings(tool_root, provenance=prov):
             _place(plan, item, registry=registry, carrier_eligible=False)
         for ns in _SHARED_NAMESPACES:
             if adapter.should_install_namespace(ns, "shared"):
-                for item in stage_namespace(shared_root, ns, provenance=prov):
+                for item in stage_namespace(shared_root, ns, provenance=prov, ignore=ignore):
                     _place(plan, item, registry=registry, carrier_eligible=True)
     return plan
 

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from installer.tools.base import ToolAdapter
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 
 
@@ -55,13 +56,6 @@ def classify_file(path: Path, namespace: str | None) -> FileKind:
     if name.endswith(".md") and namespace:
         return FileKind.NAMESPACED_MD
     return FileKind.OTHER
-
-
-DEAD_MARKERS = frozenset({"AGENTS.md", "CLAUDE.md", "GEMINI.md"})
-"""In-repo host-instruction filenames. Hosts inject only the tree-root
-~/.<tool>/AGENTS.md as system context, never per-namespace copies, so these
-are dead files when found inside a namespace dir. Tool-root *.md.template
-files are NOT in this set (different name) and are staged via stage_templates."""
 
 
 def stage_templates(source_root: Path, *, provenance: Provenance) -> list[StagedItem]:
@@ -124,15 +118,17 @@ def stage_namespace(
     namespace: str,
     *,
     provenance: Provenance,
+    ignore: InstallIgnore,
 ) -> list[StagedItem]:
     """Stage one namespace subdir into StagedItems.
 
-    Port of bash ``stage_content_from_dir`` (``scripts/install.sh:603-622``).
-    Walks ``source_root/namespace/*`` in sorted order; each entry is
-    classified, dead-marker-filtered, and turned into a ``StagedItem`` whose
-    ``dest_relpath`` is ``namespace/<name>`` with any ``.template`` suffix
-    stripped. Directory entries (skills/agents) carry ``content=None``;
-    file entries carry eager bytes. A missing namespace dir yields ``[]``.
+    Port of bash ``stage_content_from_dir`` (``scripts/install.sh``). Walks
+    ``source_root/namespace/*`` in sorted order; each direct child whose name is
+    excluded by ``ignore`` (a file basename or a directory name from
+    ``.installignore``) is skipped. Surviving entries are classified, suffix-
+    stripped, and turned into ``StagedItem``s. A missing namespace dir yields
+    ``[]``. Matching runs on direct children pre-``.template``-strip, so the real
+    tool-root ``AGENTS.md.template`` is never matched by a bare ``AGENTS.md``.
     """
     src_dir = source_root / namespace
     if not src_dir.is_dir():
@@ -140,7 +136,7 @@ def stage_namespace(
 
     items: list[StagedItem] = []
     for entry in sorted(src_dir.iterdir()):
-        if entry.is_file() and entry.name in DEAD_MARKERS:
+        if ignore.excludes(entry.name, is_dir=entry.is_dir()):
             continue
         kind = classify_file(entry, namespace)
         dest_name = strip_template_suffix(Path(entry.name))
@@ -201,7 +197,7 @@ def _add_item(plan: StagingPlan, item: StagedItem) -> None:
     plan.items[item.dest_relpath] = item
 
 
-def build_plan(adapter: ToolAdapter, *, repo_root: Path) -> StagingPlan:
+def build_plan(adapter: ToolAdapter, *, repo_root: Path, ignore: InstallIgnore) -> StagingPlan:
     """Build a StagingPlan for one tool (bash Phases 1-5).
 
     Stages, in bash order: shared templates (1), shared skills/agents/rules
@@ -220,13 +216,13 @@ def build_plan(adapter: ToolAdapter, *, repo_root: Path) -> StagingPlan:
         _add_item(plan, item)
     for ns in _SHARED_NAMESPACES:  # Phase 2
         if adapter.should_install_namespace(ns, "shared"):
-            for item in stage_namespace(shared_root, ns, provenance=prov):
+            for item in stage_namespace(shared_root, ns, provenance=prov, ignore=ignore):
                 _add_item(plan, _mark_carrier(item))
     for item in stage_templates(tool_root, provenance=prov):  # Phase 3
         _add_item(plan, item)
     for ns in adapter.scoped_namespaces():  # Phase 4
         if adapter.should_install_namespace(ns, "tool"):
-            for item in stage_namespace(tool_root, ns, provenance=prov):
+            for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
                 _add_item(plan, item)
     for item in stage_settings(tool_root, provenance=prov):  # Phase 5
         _add_item(plan, item)

--- a/packages/installer/tests/golden_master/_diff.py
+++ b/packages/installer/tests/golden_master/_diff.py
@@ -88,31 +88,17 @@ class TreeDiff:
         return "tree diff:\n" + "\n".join(lines)
 
 
-# Bash deploys AGENTS.md/CLAUDE.md/GEMINI.md found inside a namespace dir
-# (source-dir dev-docs); the Python installer correctly omits them via its
-# DEAD_MARKERS rule. They are never a real parity divergence, so the harness
-# drops them on both sides. The tool-root instruction file (parent is the tool
-# dir, not a namespace) is not matched and still compares.
-_DEAD_MARKER_NAMES = frozenset({"AGENTS.md", "CLAUDE.md", "GEMINI.md"})
-_NAMESPACE_DIRS = frozenset({"skills", "agents", "rules", "commands", "hooks"})
-
-
-def _is_namespace_dead_marker(relpath: str) -> bool:
-    parts = relpath.split("/")
-    return len(parts) >= 2 and parts[-1] in _DEAD_MARKER_NAMES and parts[-2] in _NAMESPACE_DIRS
-
-
 def _index_tree(root: Path) -> dict[str, Path]:
     """Map every file under ``root`` to its normalised POSIX relpath.
 
-    Namespace-level dead markers are skipped — see ``_is_namespace_dead_marker``.
+    No path is skipped: both installers now exclude .installignore dev-docs at
+    staging, so neither tree contains them and a plain tree comparison is exact.
+    A dead-doc reappearing on only one side is a real divergence and must surface.
     """
     index: dict[str, Path] = {}
     for path in root.rglob("*"):
         if path.is_file():
             rel = normalize_relpath(path.relative_to(root).as_posix())
-            if _is_namespace_dead_marker(rel):
-                continue
             if rel in index:
                 # Two real files collapsed to one key (e.g. two backups of the
                 # same name). Surfacing loudly beats silently dropping one and

--- a/packages/installer/tests/golden_master/test_diff.py
+++ b/packages/installer/tests/golden_master/test_diff.py
@@ -141,18 +141,6 @@ def test_executable_bit_mismatch_is_detected(tmp_path: Path) -> None:
     assert "hooks/h.py" in result.mode_mismatch
 
 
-def test_namespace_dead_marker_only_in_a_is_exempt(tmp_path: Path) -> None:
-    # Class 2: bash deploys a namespace-level AGENTS.md (source-dir dev docs);
-    # the Python installer correctly omits it (DEAD_MARKERS). The harness must
-    # not flag bash's known-spurious surplus.
-    a, b = tmp_path / "a", tmp_path / "b"
-    _write(a / ".claude/skills/AGENTS.md", b"dev docs for the skills source dir")
-    _write(a / ".claude/skills/real-skill.md", b"x")
-    _write(b / ".claude/skills/real-skill.md", b"x")
-    result = diff_trees(a, b)
-    assert result.is_parity(), result.render()
-
-
 def test_tool_root_instruction_file_is_not_exempt(tmp_path: Path) -> None:
     # Guard against over-exempting: the real tool-root AGENTS.md still compares.
     a, b = tmp_path / "a", tmp_path / "b"

--- a/packages/installer/tests/unit/conftest.py
+++ b/packages/installer/tests/unit/conftest.py
@@ -19,7 +19,21 @@ from __future__ import annotations
 
 import pytest
 
+from installer.core.installignore import InstallIgnore
+
 
 @pytest.fixture(autouse=True)
 def _neutralize_opencode_path_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("installer.tools.opencode.which", lambda _cmd: None)
+
+
+@pytest.fixture
+def ignore() -> InstallIgnore:
+    """The canonical .installignore content as an in-memory object, for staging
+    tests that must pass an exclusion set without touching a manifest file."""
+    return InstallIgnore(
+        basenames=frozenset(
+            {"AGENTS.md", "CLAUDE.md", "GEMINI.md", "README.md", "SESSION-PRIMER-README.md"}
+        ),
+        dirnames=frozenset({"rules-readmes"}),
+    )

--- a/packages/installer/tests/unit/test_cli_installignore.py
+++ b/packages/installer/tests/unit/test_cli_installignore.py
@@ -1,0 +1,21 @@
+"""The CLI fails fast (exit 2, clear stderr) when .installignore is absent from
+the resolved repo root, rather than silently installing with exclusions off."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.cli import main
+
+
+def test_missing_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # tmp_path is a repo root with NO .installignore. Point main() at it and a
+    # throwaway HOME so nothing real is touched.
+    home = tmp_path / "home"
+    home.mkdir()
+
+    rc = main(["--yes"], home=home, repo_root=tmp_path)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert ".installignore not found" in err

--- a/packages/installer/tests/unit/test_cli_installignore.py
+++ b/packages/installer/tests/unit/test_cli_installignore.py
@@ -1,5 +1,6 @@
-"""The CLI fails fast (exit 2, clear stderr) when .installignore is absent from
-the resolved repo root, rather than silently installing with exclusions off."""
+"""The CLI fails fast (exit 2, clear stderr) when .installignore is absent or
+unparseable at the resolved repo root, rather than silently installing with
+exclusions off or crashing with a traceback."""
 
 from __future__ import annotations
 
@@ -19,3 +20,18 @@ def test_missing_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  #
     assert rc == 2
     err = capsys.readouterr().err
     assert ".installignore not found" in err
+
+
+def test_non_utf8_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # A present-but-non-UTF-8 manifest raises UnicodeDecodeError (a ValueError,
+    # not an OSError). The CLI must still fail fast (exit 2) with a clean message,
+    # not crash with an uncaught traceback.
+    home = tmp_path / "home"
+    home.mkdir()
+    (tmp_path / ".installignore").write_bytes(b"\xff\xfe\x00bad bytes\n")
+
+    rc = main(["--yes"], home=home, repo_root=tmp_path)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "installer:" in err

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -23,6 +23,17 @@ def _home_with_claude_settings(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _write_installignore(repo: Path) -> None:
+    """Mirror the real repo-root .installignore so cli.main's up-front fail-fast
+    load finds it. main() refuses to run without one (exit 2), so every hermetic
+    repo a CLI smoke test points main() at must carry the manifest."""
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".installignore").write_text(
+        "AGENTS.md\nCLAUDE.md\nGEMINI.md\nREADME.md\nSESSION-PRIMER-README.md\nrules-readmes/\n",
+        encoding="utf-8",
+    )
+
+
 def _repo_with_installer_toml(tmp_path: Path, *, retired: list[str]) -> Path:
     """Create a repo_root whose packages/installer/installer.toml carries the
     given prune list — mirroring where _run_prune now derives the config path
@@ -32,6 +43,7 @@ def _repo_with_installer_toml(tmp_path: Path, *, retired: list[str]) -> Path:
     toml_dir.mkdir(parents=True)
     retired_lines = "\n".join(f'  "{glob}",' for glob in retired)
     (toml_dir / "installer.toml").write_text(f"[prune]\nretired = [\n{retired_lines}\n]\n")
+    _write_installignore(repo)
     return repo
 
 
@@ -43,6 +55,7 @@ def _repo_with_malformed_installer_toml(tmp_path: Path) -> Path:
     toml_dir = repo / "packages" / "installer"
     toml_dir.mkdir(parents=True)
     (toml_dir / "installer.toml").write_text('[prune]\nretired = "*/skills/ralf-it"\n')
+    _write_installignore(repo)
     return repo
 
 
@@ -55,6 +68,7 @@ def _hermetic_repo(tmp_path: Path) -> Path:
     (shared / "INSTRUCTIONS.md.template").write_bytes(b"shared laws\n")
     for tool in ("claude", "codex", "gemini", "opencode"):
         (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
+    _write_installignore(repo)
     return repo
 
 
@@ -251,6 +265,7 @@ def test_prune_only_warns_and_exits_clean_when_installer_toml_absent(tmp_path: P
     retired.mkdir(parents=True)
     empty_repo = tmp_path / "no-toml-repo"
     empty_repo.mkdir()  # no packages/installer/installer.toml underneath
+    _write_installignore(empty_repo)  # but the exclusion manifest is required to run
     io = ScriptedIO(interactive=False)
 
     rc = main(
@@ -383,6 +398,7 @@ def test_plain_prune_non_interactive_without_yes_fails_on_consent_guard(tmp_path
     home = _home_with_claude_settings(tmp_path)
     empty_repo = tmp_path / "empty-repo"
     empty_repo.mkdir()
+    _write_installignore(empty_repo)  # required to reach the consent guard this test pins
 
     rc = main(
         ["--prune", "--tools=claude"],

--- a/packages/installer/tests/unit/test_extensions_pipeline.py
+++ b/packages/installer/tests/unit/test_extensions_pipeline.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.io_port import ScriptedIO
 from installer.core.model import Tool
 from installer.core.orchestrator import stage_and_transform
@@ -26,7 +27,9 @@ SKILL_BASE = "# Demo\n\n## Usage\nbase usage\n\n## Reference\nsee docs\n"
 CHEAT_BLOCK = "### Beads cheats\n- bd ready\n- bd show <id>"
 
 
-def test_extension_round_trip_injects_content_at_logical_position(tmp_path: Path) -> None:
+def test_extension_round_trip_injects_content_at_logical_position(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """Round-trip equivalence (AC #9 analog): the resolved SKILL.md bytes
     contain the injected block at the targeted position; every other byte of
     the base document is unchanged."""
@@ -43,7 +46,7 @@ def test_extension_round_trip_injects_content_at_logical_position(tmp_path: Path
     plugin = GenericPluginAdapter(name="demo-plugin", source_path=plugin_root)
 
     plans = stage_and_transform(
-        [Tool.CLAUDE, Tool.CODEX], repo_root=repo, io=ScriptedIO(), plugins=[plugin]
+        [Tool.CLAUDE, Tool.CODEX], repo_root=repo, io=ScriptedIO(), ignore=ignore, plugins=[plugin]
     )
 
     for tool in (Tool.CLAUDE, Tool.CODEX):  # shared scope reaches every tool
@@ -54,7 +57,9 @@ def test_extension_round_trip_injects_content_at_logical_position(tmp_path: Path
         assert patched == expected
 
 
-def test_extension_targets_a_carrier_merged_plugin_file(tmp_path: Path) -> None:
+def test_extension_targets_a_carrier_merged_plugin_file(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """Phase ordering pin: apply_extensions runs AFTER overlay_plugins, so an
     extension can patch a file the plugin itself carrier-merged into a shared
     skill dir in the same run."""
@@ -71,7 +76,9 @@ def test_extension_targets_a_carrier_merged_plugin_file(tmp_path: Path) -> None:
     )
     plugin = GenericPluginAdapter(name="demo-plugin", source_path=plugin_root)
 
-    plans = stage_and_transform([Tool.CLAUDE], repo_root=repo, io=ScriptedIO(), plugins=[plugin])
+    plans = stage_and_transform(
+        [Tool.CLAUDE], repo_root=repo, io=ScriptedIO(), ignore=ignore, plugins=[plugin]
+    )
 
     patched = plans[Tool.CLAUDE].dir_overrides[Path("skills/demo")][Path("cheats.md")]
     assert patched == b"## Cheats\nraw\nappended-after-merge\n"

--- a/packages/installer/tests/unit/test_installignore.py
+++ b/packages/installer/tests/unit/test_installignore.py
@@ -1,0 +1,62 @@
+"""Unit tests for installer.core.installignore — the shared exclusion manifest
+loader. Each test pins a coded decision: basename vs directory parsing, comment
+and blank-line skipping, and the fail-fast contract on a missing/unreadable file
+(load-bearing policy, unlike the inert-default installer.toml loader)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.installignore import InstallIgnore, load_installignore
+
+
+def test_basename_and_directory_entries_are_partitioned(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("AGENTS.md\nrules-readmes/\nREADME.md\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md", "README.md"})
+    assert ignore.dirnames == frozenset({"rules-readmes"})
+
+
+def test_comments_and_blank_lines_are_ignored(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("# a comment\n\nAGENTS.md\n   \n# trailing\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md"})
+    assert ignore.dirnames == frozenset()
+
+
+def test_surrounding_whitespace_is_trimmed(tmp_path: Path) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("  AGENTS.md  \n\trules-readmes/\t\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"AGENTS.md"})
+    assert ignore.dirnames == frozenset({"rules-readmes"})
+
+
+def test_excludes_matches_files_against_basenames(tmp_path: Path) -> None:
+    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+
+    assert ignore.excludes("AGENTS.md", is_dir=False) is True
+    assert ignore.excludes("AGENTS.md.template", is_dir=False) is False  # never the real file
+    assert ignore.excludes("rules-readmes", is_dir=False) is False  # dir entry, file query
+
+
+def test_excludes_matches_directories_against_dirnames(tmp_path: Path) -> None:
+    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+
+    assert ignore.excludes("rules-readmes", is_dir=True) is True
+    assert ignore.excludes("AGENTS.md", is_dir=True) is False  # basename entry, dir query
+
+
+def test_missing_manifest_is_fail_fast(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"\.installignore not found"):
+        load_installignore(tmp_path / ".installignore")

--- a/packages/installer/tests/unit/test_installignore.py
+++ b/packages/installer/tests/unit/test_installignore.py
@@ -42,16 +42,20 @@ def test_surrounding_whitespace_is_trimmed(tmp_path: Path) -> None:
     assert ignore.dirnames == frozenset({"rules-readmes"})
 
 
-def test_excludes_matches_files_against_basenames(tmp_path: Path) -> None:
-    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+def test_excludes_matches_files_against_basenames() -> None:
+    ignore = InstallIgnore(
+        basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"})
+    )
 
     assert ignore.excludes("AGENTS.md", is_dir=False) is True
     assert ignore.excludes("AGENTS.md.template", is_dir=False) is False  # never the real file
     assert ignore.excludes("rules-readmes", is_dir=False) is False  # dir entry, file query
 
 
-def test_excludes_matches_directories_against_dirnames(tmp_path: Path) -> None:
-    ignore = InstallIgnore(basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"}))
+def test_excludes_matches_directories_against_dirnames() -> None:
+    ignore = InstallIgnore(
+        basenames=frozenset({"AGENTS.md"}), dirnames=frozenset({"rules-readmes"})
+    )
 
     assert ignore.excludes("rules-readmes", is_dir=True) is True
     assert ignore.excludes("AGENTS.md", is_dir=True) is False  # basename entry, dir query

--- a/packages/installer/tests/unit/test_installignore.py
+++ b/packages/installer/tests/unit/test_installignore.py
@@ -64,3 +64,44 @@ def test_excludes_matches_directories_against_dirnames() -> None:
 def test_missing_manifest_is_fail_fast(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match=r"\.installignore not found"):
         load_installignore(tmp_path / ".installignore")
+
+
+def test_bare_slash_line_is_skipped(tmp_path: Path) -> None:
+    """A degenerate ``/`` line (empty directory name after the trailing-slash
+    strip) is dropped, not stored as an empty-string dirname — matching the bash
+    matcher, which would otherwise hit a fatal ``bad array subscript``."""
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("/\nAGENTS.md\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.dirnames == frozenset()
+    assert ignore.basenames == frozenset({"AGENTS.md"})
+    assert ignore.excludes("", is_dir=True) is False
+
+
+def test_same_name_as_file_and_directory_partitions_by_kind(tmp_path: Path) -> None:
+    """A manifest carrying both ``foo`` and ``foo/`` records the name under BOTH
+    kinds, and ``excludes`` resolves each query against the matching kind only."""
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("foo\nfoo/\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset({"foo"})
+    assert ignore.dirnames == frozenset({"foo"})
+    assert ignore.excludes("foo", is_dir=False) is True
+    assert ignore.excludes("foo", is_dir=True) is True
+
+
+def test_empty_manifest_excludes_nothing(tmp_path: Path) -> None:
+    """An all-comment/blank manifest is valid (not a fail-fast) and excludes
+    nothing — present-but-empty is allowed; only absence/unreadability aborts."""
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("# only a comment\n\n", encoding="utf-8")
+
+    ignore = load_installignore(manifest)
+
+    assert ignore.basenames == frozenset()
+    assert ignore.dirnames == frozenset()
+    assert ignore.excludes("AGENTS.md", is_dir=False) is False

--- a/packages/installer/tests/unit/test_installignore_invariant.py
+++ b/packages/installer/tests/unit/test_installignore_invariant.py
@@ -1,0 +1,46 @@
+"""Invariant guard: the known confirmed dev-doc leakers never appear in the
+Python installer's staged output, using the REAL repo-root .installignore.
+
+The leaker paths are HARDCODED here, deliberately NOT sourced from .installignore:
+a manifest-sourced check would go blind to the exact regression it must catch —
+someone deleting an entry from .installignore. This test goes red on a manifest
+mis-edit OR a staging-logic regression, and survives the parity gate (it tests
+Python, the permanent installer, not the bash↔python comparison)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.installignore import load_installignore
+from installer.core.model import Tool
+from installer.core.staging import build_plan
+from installer.tools.registry import get_adapter
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Confirmed live leakers (design spec audit table). Their relpaths must never
+# survive base staging into any tool's plan.
+_FORBIDDEN_RELPATHS = (
+    Path("rules/AGENTS.md"),
+    Path("skills/AGENTS.md"),
+)
+_NAMESPACE_DIRS = {"skills", "agents", "rules", "commands", "hooks"}
+_MARKER_BASENAMES = {"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
+
+
+def test_known_dead_docs_are_never_staged() -> None:
+    ignore = load_installignore(_REPO_ROOT / ".installignore")
+
+    for tool in Tool:
+        adapter = get_adapter(tool)
+        plan = build_plan(adapter, repo_root=_REPO_ROOT, ignore=ignore)
+
+        for forbidden in _FORBIDDEN_RELPATHS:
+            assert forbidden not in plan.items, f"{forbidden} leaked into {tool} plan"
+        # No namespace-level AGENTS.md/CLAUDE.md/GEMINI.md under a staged subdir.
+        for dest in plan.items:
+            parts = dest.parts
+            if len(parts) >= 2 and parts[-1] in _MARKER_BASENAMES:
+                assert parts[-2] not in _NAMESPACE_DIRS, (
+                    f"namespace dead-doc {dest} leaked into {tool} plan"
+                )

--- a/packages/installer/tests/unit/test_installignore_parity.py
+++ b/packages/installer/tests/unit/test_installignore_parity.py
@@ -1,0 +1,65 @@
+"""Cross-language matcher parity: the bash matcher (scripts/lib/installignore.sh)
+and the Python matcher (installer.core.installignore) must agree on every fixture
+path. Guards the only duplicated logic in the two-installer world. Retires with
+bash at the parity gate."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from installer.core.installignore import load_installignore
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_LIB = _REPO_ROOT / "scripts" / "lib" / "installignore.sh"
+# Resolve bash to a full path so the subprocess call carries no partial executable
+# path (S607). The golden-master suite already requires bash on PATH.
+_BASH = shutil.which("bash") or "bash"
+
+# (name, is_dir, expected) — keep/drop verdicts the two matchers must share.
+_CASES = [
+    ("AGENTS.md", False, "drop"),
+    ("CLAUDE.md", False, "drop"),
+    ("GEMINI.md", False, "drop"),
+    ("README.md", False, "drop"),
+    ("SESSION-PRIMER-README.md", False, "drop"),
+    ("AGENTS.md.template", False, "keep"),  # the real instruction file
+    ("brainstorming.md", False, "keep"),  # ordinary content
+    ("rules-readmes", True, "drop"),
+    ("rules-readmes", False, "keep"),  # dir entry must not match a file query
+    ("real-skill", True, "keep"),
+]
+
+
+def _bash_verdict(manifest: Path, name: str, is_dir: bool) -> str:
+    flag = "true" if is_dir else "false"
+    script = (
+        f'source "{_LIB}"; load_installignore "{manifest}"; '
+        f'if is_installignored "{name}" {flag}; then echo drop; else echo keep; fi'
+    )
+    out = subprocess.run(  # noqa: S603 — fixed argv, no shell injection (paths are test-local)
+        [_BASH, "-c", script], capture_output=True, text=True, check=True
+    )
+    return out.stdout.strip()
+
+
+@pytest.mark.parametrize(("name", "is_dir", "expected"), _CASES)
+def test_bash_and_python_matchers_agree(
+    tmp_path: Path, name: str, is_dir: bool, expected: str
+) -> None:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text(
+        "AGENTS.md\nCLAUDE.md\nGEMINI.md\nREADME.md\nSESSION-PRIMER-README.md\nrules-readmes/\n",
+        encoding="utf-8",
+    )
+    ignore = load_installignore(manifest)
+
+    python_verdict = "drop" if ignore.excludes(name, is_dir=is_dir) else "keep"
+    bash_verdict = _bash_verdict(manifest, name, is_dir)
+
+    assert python_verdict == expected
+    assert bash_verdict == expected
+    assert python_verdict == bash_verdict

--- a/packages/installer/tests/unit/test_installignore_parity.py
+++ b/packages/installer/tests/unit/test_installignore_parity.py
@@ -16,8 +16,14 @@ from installer.core.installignore import load_installignore
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _LIB = _REPO_ROOT / "scripts" / "lib" / "installignore.sh"
 # Resolve bash to a full path so the subprocess call carries no partial executable
-# path (S607). The golden-master suite already requires bash on PATH.
-_BASH = shutil.which("bash") or "bash"
+# path (S607). If bash is absent, skip the whole module rather than fall back to a
+# partial "bash" (which would defeat S607 and crash with FileNotFoundError); the
+# golden-master suite already requires bash, so this skip never fires in CI.
+_BASH = shutil.which("bash")
+
+pytestmark = pytest.mark.skipif(
+    _BASH is None, reason="bash not on PATH; matcher parity requires it"
+)
 
 # (name, is_dir, expected) — keep/drop verdicts the two matchers must share.
 _CASES = [
@@ -35,6 +41,7 @@ _CASES = [
 
 
 def _bash_verdict(manifest: Path, name: str, is_dir: bool) -> str:
+    assert _BASH is not None  # guarded by the module-level skipif
     flag = "true" if is_dir else "false"
     script = (
         f'source "{_LIB}"; load_installignore "{manifest}"; '

--- a/packages/installer/tests/unit/test_orchestrator.py
+++ b/packages/installer/tests/unit/test_orchestrator.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import yaml
 
+from installer.core.installignore import InstallIgnore
 from installer.core.io_port import ScriptedIO
 from installer.core.model import Tool
 from installer.core.orchestrator import stage_and_transform
@@ -38,8 +39,12 @@ def _frontmatter(content: bytes) -> dict[str, object]:
     return parsed
 
 
-def test_stage_and_transform_gemini_rewrites_agent_frontmatter(tmp_path: Path) -> None:
-    plans = stage_and_transform([Tool.GEMINI], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+def test_stage_and_transform_gemini_rewrites_agent_frontmatter(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    plans = stage_and_transform(
+        [Tool.GEMINI], repo_root=_make_repo(tmp_path), io=ScriptedIO(), ignore=ignore
+    )
     content = plans[Tool.GEMINI].items[_AGENT].content
     assert content is not None
     fm = _frontmatter(content)
@@ -47,26 +52,38 @@ def test_stage_and_transform_gemini_rewrites_agent_frontmatter(tmp_path: Path) -
     assert fm["tools"] == ["Read", "Grep"]
 
 
-def test_stage_and_transform_claude_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
+def test_stage_and_transform_claude_leaves_agent_frontmatter_unchanged(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     io = ScriptedIO()
-    plans = stage_and_transform([Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=io)
+    plans = stage_and_transform([Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=io, ignore=ignore)
     assert plans[Tool.CLAUDE].items[_AGENT].content == _CLAUDE_AGENT
     assert not any("frontmatter" in e.message.lower() for e in io.transcript)
 
 
-def test_stage_and_transform_codex_leaves_agent_frontmatter_unchanged(tmp_path: Path) -> None:
-    plans = stage_and_transform([Tool.CODEX], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+def test_stage_and_transform_codex_leaves_agent_frontmatter_unchanged(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    plans = stage_and_transform(
+        [Tool.CODEX], repo_root=_make_repo(tmp_path), io=ScriptedIO(), ignore=ignore
+    )
     assert plans[Tool.CODEX].items[_AGENT].content == _CLAUDE_AGENT
 
 
-def test_stage_and_transform_opencode_skips_shared_agents(tmp_path: Path) -> None:
-    plans = stage_and_transform([Tool.OPENCODE], repo_root=_make_repo(tmp_path), io=ScriptedIO())
+def test_stage_and_transform_opencode_skips_shared_agents(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    plans = stage_and_transform(
+        [Tool.OPENCODE], repo_root=_make_repo(tmp_path), io=ScriptedIO(), ignore=ignore
+    )
     assert _AGENT not in plans[Tool.OPENCODE].items
 
 
-def test_stage_and_transform_dispatches_correct_adapter_per_tool(tmp_path: Path) -> None:
+def test_stage_and_transform_dispatches_correct_adapter_per_tool(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     plans = stage_and_transform(
-        [Tool.GEMINI, Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=ScriptedIO()
+        [Tool.GEMINI, Tool.CLAUDE], repo_root=_make_repo(tmp_path), io=ScriptedIO(), ignore=ignore
     )
     gemini_content = plans[Tool.GEMINI].items[_AGENT].content
     assert gemini_content is not None
@@ -85,7 +102,7 @@ class _Plugin:
         return True
 
 
-def test_stage_and_transform_overlays_active_plugins(tmp_path: Path) -> None:
+def test_stage_and_transform_overlays_active_plugins(tmp_path: Path, ignore: InstallIgnore) -> None:
     """Phase 6 wiring: an active plugin's content is overlaid onto the tool's
     plan between base staging and the post-staging transform."""
     repo = _make_repo(tmp_path)
@@ -97,13 +114,16 @@ def test_stage_and_transform_overlays_active_plugins(tmp_path: Path) -> None:
         [Tool.CLAUDE],
         repo_root=repo,
         io=ScriptedIO(),
+        ignore=ignore,
         plugins=[_Plugin(name="test-plugin", source_path=plugin_root)],
     )
 
     assert plans[Tool.CLAUDE].items[Path("rules/plugin-rule.md")].content == b"from plugin"
 
 
-def test_stage_and_transform_overlay_runs_before_gemini_transform(tmp_path: Path) -> None:
+def test_stage_and_transform_overlay_runs_before_gemini_transform(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin-contributed Gemini agent must still pass through the Gemini
     frontmatter transform — proving the overlay runs BEFORE post_staging_transforms
     (brief phase ladder: 6 overlay, then 6.95 Gemini transform)."""
@@ -116,6 +136,7 @@ def test_stage_and_transform_overlay_runs_before_gemini_transform(tmp_path: Path
         [Tool.GEMINI],
         repo_root=repo,
         io=ScriptedIO(),
+        ignore=ignore,
         plugins=[_Plugin(name="test-plugin", source_path=plugin_root)],
     )
 

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from installer.core.installignore import InstallIgnore
 from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import default_registry
 from installer.core.model import (
@@ -64,7 +65,9 @@ def _write(path: Path, content: bytes) -> None:
     path.write_bytes(content)
 
 
-def test_disjoint_plugin_content_is_added_to_the_plan(tmp_path: Path) -> None:
+def test_disjoint_plugin_content_is_added_to_the_plan(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin rule with no base-side collision simply lands in the plan."""
     plugin = _plugin(tmp_path, "test-plugin")
     _write(plugin.source_path / ".claude" / "rules" / "extra.md", b"plugin rule")
@@ -74,6 +77,7 @@ def test_disjoint_plugin_content_is_added_to_the_plan(tmp_path: Path) -> None:
         [plugin],
         adapter=ClaudeAdapter(),
         registry=default_registry(),
+        ignore=ignore,
     )
 
     item = plan.items[Path("rules/extra.md")]
@@ -83,7 +87,9 @@ def test_disjoint_plugin_content_is_added_to_the_plan(tmp_path: Path) -> None:
     assert plan.dir_overrides == {}
 
 
-def test_skill_dir_overlay_without_collision_records_no_override(tmp_path: Path) -> None:
+def test_skill_dir_overlay_without_collision_records_no_override(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin skill dir landing on an UNOCCUPIED destination is added as a
     plain DIR item (its bytes come from source_path at sync); it is not a
     carrier-merge, so nothing is written to dir_overrides. The channel is only
@@ -91,7 +97,7 @@ def test_skill_dir_overlay_without_collision_records_no_override(tmp_path: Path)
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
     plan = overlay_plugins(
-        _empty_plan(), [plugin], adapter=ClaudeAdapter(), registry=default_registry()
+        _empty_plan(), [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
     )
 
     assert plan.items[Path("skills/demo-skill")].kind is FileKind.DIR
@@ -123,7 +129,7 @@ def _seeded_plan(item: StagedItem) -> StagingPlan:
     return StagingPlan(items={item.dest_relpath: item}, tool=Tool.CLAUDE)
 
 
-def test_plugin_rule_appends_to_base_rule(tmp_path: Path) -> None:
+def test_plugin_rule_appends_to_base_rule(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin rules/foo.md colliding with a base rules/foo.md append-merges:
     the two bodies are joined with the canonical b'\\n---\\n' separator
     (bead AC #1)."""
@@ -138,12 +144,16 @@ def test_plugin_rule_appends_to_base_rule(tmp_path: Path) -> None:
     plugin = _plugin(tmp_path, "test-plugin")
     _write(plugin.source_path / ".claude" / "rules" / "shared.md", b"plugin")
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.items[Path("rules/shared.md")].content == b"base\n---\nplugin"
 
 
-def test_plugin_command_same_name_as_base_command_is_fatal(tmp_path: Path) -> None:
+def test_plugin_command_same_name_as_base_command_is_fatal(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin commands/foo.md colliding with a base commands/foo.md is an
     irreconcilable collision — the registry routes (NAMESPACED_MD, "commands")
     to the fatal strategy (bead AC #2)."""
@@ -156,10 +166,12 @@ def test_plugin_command_same_name_as_base_command_is_fatal(tmp_path: Path) -> No
     _write(plugin.source_path / ".claude" / "commands" / "go.md", b"plugin")
 
     with pytest.raises(CollisionError):
-        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+        )
 
 
-def test_plugin_settings_deep_union_merges_into_base(tmp_path: Path) -> None:
+def test_plugin_settings_deep_union_merges_into_base(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin settings.json fragment deep-union-merges into the base settings:
     a base-only key and a plugin-only key both survive (bead AC #3)."""
     plan = _seeded_plan(
@@ -173,13 +185,17 @@ def test_plugin_settings_deep_union_merges_into_base(tmp_path: Path) -> None:
     plugin = _plugin(tmp_path, "test-plugin")
     _write(plugin.source_path / ".claude" / "settings.json.template", b'{"plugin": 2}')
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     merged = json.loads(plan.items[Path("settings.json")].content or b"{}")
     assert merged == {"base": 1, "plugin": 2}
 
 
-def test_plugin_toml_collision_is_last_wins_with_warning(tmp_path: Path) -> None:
+def test_plugin_toml_collision_is_last_wins_with_warning(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin *.toml colliding with a base *.toml resolves last-wins and warns
     (the registry routes (TOML, None) to LastWinsWarnStrategy)."""
     plan = _seeded_plan(
@@ -189,12 +205,14 @@ def test_plugin_toml_collision_is_last_wins_with_warning(tmp_path: Path) -> None
     _write(plugin.source_path / ".claude" / "config.toml.template", b"plugin=2")
 
     with pytest.warns(UserWarning):
-        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+        )
 
     assert plan.items[Path("config.toml")].content == b"plugin=2"
 
 
-def test_plugins_apply_in_alphabetical_order(tmp_path: Path) -> None:
+def test_plugins_apply_in_alphabetical_order(tmp_path: Path, ignore: InstallIgnore) -> None:
     """Two plugins both contribute config.toml; the later (alphabetical) plugin
     wins the last-wins collision. Passing them in REVERSE order proves the
     overlay sorts internally rather than honouring caller order (bead AC #4)."""
@@ -210,13 +228,14 @@ def test_plugins_apply_in_alphabetical_order(tmp_path: Path) -> None:
             [z_plugin, a_plugin],
             adapter=ClaudeAdapter(),
             registry=default_registry(),
+            ignore=ignore,
         )
 
     # z applied last (alphabetical), so z wins regardless of input order.
     assert plan.items[Path("config.toml")].content == b"who='z'"
 
 
-def test_overlay_reuses_tool_adapter_namespace_skip(tmp_path: Path) -> None:
+def test_overlay_reuses_tool_adapter_namespace_skip(tmp_path: Path, ignore: InstallIgnore) -> None:
     """The overlay has no namespace routing of its own — it consults the tool
     adapter's should_install_namespace. OpenCode skips the shared agents/
     namespace, so a plugin's .agents/agents/ content is dropped while its
@@ -230,6 +249,7 @@ def test_overlay_reuses_tool_adapter_namespace_skip(tmp_path: Path) -> None:
         [plugin],
         adapter=OpenCodeAdapter(),
         registry=default_registry(),
+        ignore=ignore,
     )
 
     assert Path("agents/skipme.md") not in plan.items
@@ -249,7 +269,9 @@ class _CommandsOptOutAdapter:
         return not (namespace == "commands" and source == "tool")
 
 
-def test_overlay_gates_tool_scope_namespaces_via_adapter(tmp_path: Path) -> None:
+def test_overlay_gates_tool_scope_namespaces_via_adapter(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     plugin = _plugin(tmp_path, "test-plugin")
     _write(plugin.source_path / ".claude" / "commands" / "skipme.md", b"cmd")
     _write(plugin.source_path / ".claude" / "rules" / "keepme.md", b"rule")
@@ -259,6 +281,7 @@ def test_overlay_gates_tool_scope_namespaces_via_adapter(tmp_path: Path) -> None
         [plugin],
         adapter=_CommandsOptOutAdapter(),  # type: ignore[arg-type]  # structural ToolAdapter subset
         registry=default_registry(),
+        ignore=ignore,
     )
 
     assert Path("commands/skipme.md") not in plan.items
@@ -294,21 +317,27 @@ def _plugin_skill_dir(tmp_path: Path, name: str, *, files: list[str]) -> _Plugin
     return plugin
 
 
-def test_carrier_merge_disjoint_files_succeeds_and_clears_flag(tmp_path: Path) -> None:
+def test_carrier_merge_disjoint_files_succeeds_and_clears_flag(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A plugin skill dir overlaying a shared_carrier dir with a DISJOINT file
     set carrier-merges: no fatal error, the carrier item stays, and its
     shared_carrier flag is cleared (mirrors bash `rm -f sentinel`)."""
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     merged = plan.items[Path("skills/demo-skill")]
     assert merged.kind is FileKind.DIR
     assert merged.shared_carrier is False
 
 
-def test_carrier_merge_records_plugin_file_bytes_in_dir_overrides(tmp_path: Path) -> None:
+def test_carrier_merge_records_plugin_file_bytes_in_dir_overrides(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """The carrier-merge does not silently drop the plugin's added file: its
     bytes are recorded in plan.dir_overrides, keyed by the carrier DIR's
     dest_relpath then the inner file relpath. This is the F.3 file-carry channel
@@ -317,13 +346,17 @@ def test_carrier_merge_records_plugin_file_bytes_in_dir_overrides(tmp_path: Path
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     dest = Path("skills/demo-skill")
     assert plan.dir_overrides[dest] == {Path("SKILL.md"): b"plugin"}
 
 
-def test_carrier_merge_preserves_existing_overrides_for_the_same_dest(tmp_path: Path) -> None:
+def test_carrier_merge_preserves_existing_overrides_for_the_same_dest(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """dir_overrides is a shared side channel (carrier-merge now, F.5 patched
     bytes later). A carrier-merge merges its carried files INTO any existing
     inner-relpath map for that dest rather than replacing the whole map, so a
@@ -335,7 +368,9 @@ def test_carrier_merge_preserves_existing_overrides_for_the_same_dest(tmp_path: 
     plan.dir_overrides[dest] = {Path("PATCHED.md"): b"prior"}
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.dir_overrides[dest] == {
         Path("PATCHED.md"): b"prior",
@@ -343,14 +378,16 @@ def test_carrier_merge_preserves_existing_overrides_for_the_same_dest(tmp_path: 
     }
 
 
-def test_carrier_merge_carries_every_plugin_file(tmp_path: Path) -> None:
+def test_carrier_merge_carries_every_plugin_file(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin contributing several disjoint files has ALL of them represented
     in dir_overrides, not just the first — the carry iterates the whole added
     file set."""
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", "ref.md", "helper.py"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.dir_overrides[Path("skills/demo-skill")] == {
         Path("SKILL.md"): b"plugin",
@@ -359,14 +396,18 @@ def test_carrier_merge_carries_every_plugin_file(tmp_path: Path) -> None:
     }
 
 
-def test_carrier_merge_override_holds_only_plugin_files_not_carrier_own(tmp_path: Path) -> None:
+def test_carrier_merge_override_holds_only_plugin_files_not_carrier_own(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """The override map holds the PLUGIN's added files only. The carrier's own
     files (read from its source_path at sync) are not duplicated into the
     channel — dir_overrides is the second source tree, not the merged whole."""
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh", "README.md"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     overrides = plan.dir_overrides[Path("skills/demo-skill")]
     assert overrides == {Path("SKILL.md"): b"plugin"}
@@ -374,7 +415,9 @@ def test_carrier_merge_override_holds_only_plugin_files_not_carrier_own(tmp_path
     assert Path("README.md") not in overrides
 
 
-def test_carrier_merge_does_not_carry_top_level_dotfiles(tmp_path: Path) -> None:
+def test_carrier_merge_does_not_carry_top_level_dotfiles(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A top-level dotfile in the plugin dir is NOT carried: bash's
     `for sfile in "$src"/*` skips dot-prefixed entries, so they never reach the
     copy. This matches the dotfile exclusion the disjoint check already
@@ -382,12 +425,16 @@ def test_carrier_merge_does_not_carry_top_level_dotfiles(tmp_path: Path) -> None
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh", ".gitkeep"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", ".gitkeep"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("SKILL.md"): b"plugin"}
 
 
-def test_carrier_merge_carries_nested_subdirectory_files(tmp_path: Path) -> None:
+def test_carrier_merge_carries_nested_subdirectory_files(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A subdirectory in the plugin dir is carried wholesale (bash `cp -R`):
     each nested file is represented under its relpath (e.g. `lib/util.py`), and
     a dotfile NESTED under a carried subdir is kept (cp -R copies it) — unlike a
@@ -400,7 +447,9 @@ def test_carrier_merge_carries_nested_subdirectory_files(tmp_path: Path) -> None
     (skill_dir / "lib" / "util.py").write_bytes(b"nested")
     (skill_dir / "lib" / ".keep").write_bytes(b"dot-nested")
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.dir_overrides[Path("skills/demo-skill")] == {
         Path("SKILL.md"): b"top",
@@ -409,7 +458,7 @@ def test_carrier_merge_carries_nested_subdirectory_files(tmp_path: Path) -> None
     }
 
 
-def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path) -> None:
+def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin skill dir overlaying a shared_carrier dir with an OVERLAPPING
     file name cannot carrier-merge — it is a real conflict and falls through to
     the registry's fatal DIR strategy."""
@@ -417,10 +466,14 @@ def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path) -> None:
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])
 
     with pytest.raises(CollisionError):
-        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+        )
 
 
-def test_non_carrier_dir_collision_is_fatal_even_when_disjoint(tmp_path: Path) -> None:
+def test_non_carrier_dir_collision_is_fatal_even_when_disjoint(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A DIR collision on a NON-carrier item is fatal regardless of file-set
     disjointness — the shared_carrier flag, not the file sets, is what unlocks
     carrier-merge."""
@@ -431,10 +484,12 @@ def test_non_carrier_dir_collision_is_fatal_even_when_disjoint(tmp_path: Path) -
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md"])  # disjoint
 
     with pytest.raises(CollisionError):
-        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+        )
 
 
-def test_tool_scope_plugin_dir_cannot_carrier_merge(tmp_path: Path) -> None:
+def test_tool_scope_plugin_dir_cannot_carrier_merge(tmp_path: Path, ignore: InstallIgnore) -> None:
     """Carrier-merge is eligible ONLY for content from the plugin's .agents/
     (shared) tree. A tool-scope plugin DIR (.<tool>/skills/...) colliding with a
     shared_carrier dir is fatal even with a disjoint file set — mirrors the bash
@@ -447,22 +502,28 @@ def test_tool_scope_plugin_dir_cannot_carrier_merge(tmp_path: Path) -> None:
     (tool_skill / "SKILL.md").write_bytes(b"plugin")
 
     with pytest.raises(CollisionError):
-        overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+        )
 
 
-def test_carrier_merge_ignores_dotfiles_in_disjoint_check(tmp_path: Path) -> None:
+def test_carrier_merge_ignores_dotfiles_in_disjoint_check(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """Dotfiles are excluded from the disjointness comparison (bash `"$dir"/*`
     skips them): a shared carrier and an incoming plugin dir that share only a
     dot-prefixed entry still carrier-merge."""
     plan = _carrier_dir_plan(tmp_path, files=["_test.sh", ".gitkeep"])
     plugin = _plugin_skill_dir(tmp_path, "test-plugin", files=["SKILL.md", ".gitkeep"])
 
-    overlay_plugins(plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry())
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
 
     assert plan.items[Path("skills/demo-skill")].shared_carrier is False
 
 
-def test_second_plugin_on_merged_carrier_is_fatal(tmp_path: Path) -> None:
+def test_second_plugin_on_merged_carrier_is_fatal(tmp_path: Path, ignore: InstallIgnore) -> None:
     """After one plugin carrier-merges (clearing the flag), a SECOND plugin
     colliding on the same dir is a true plugin-plugin collision and fatal —
     even with a disjoint file set (mirrors bash `rm -f sentinel`)."""
@@ -471,7 +532,13 @@ def test_second_plugin_on_merged_carrier_is_fatal(tmp_path: Path) -> None:
     second = _plugin_skill_dir(tmp_path, "z-plugin", files=["OTHER.md"])  # disjoint from carrier
 
     with pytest.raises(CollisionError):
-        overlay_plugins(plan, [first, second], adapter=ClaudeAdapter(), registry=default_registry())
+        overlay_plugins(
+            plan,
+            [first, second],
+            adapter=ClaudeAdapter(),
+            registry=default_registry(),
+            ignore=ignore,
+        )
 
 
 # ── Against the canonical committed test-plugin fixture ──────────────────────
@@ -483,7 +550,7 @@ def _test_plugin_adapter() -> GenericPluginAdapter:
     return GenericPluginAdapter(name="test-plugin", source_path=_SOURCES / "test-plugin")
 
 
-def test_fixture_plugin_rule_appends_to_a_colliding_base_rule() -> None:
+def test_fixture_plugin_rule_appends_to_a_colliding_base_rule(ignore: InstallIgnore) -> None:
     """End-to-end against the committed fixture: its .claude/rules/test-plugin-
     rule.md append-merges onto a colliding base rule of the same name."""
     plan = _seeded_plan(
@@ -496,7 +563,11 @@ def test_fixture_plugin_rule_appends_to_a_colliding_base_rule() -> None:
     )
 
     overlay_plugins(
-        plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+        plan,
+        [_test_plugin_adapter()],
+        adapter=ClaudeAdapter(),
+        registry=default_registry(),
+        ignore=ignore,
     )
 
     merged = plan.items[Path("rules/test-plugin-rule.md")].content
@@ -505,7 +576,7 @@ def test_fixture_plugin_rule_appends_to_a_colliding_base_rule() -> None:
     assert b"test-plugin-rule" in merged
 
 
-def test_fixture_plugin_command_collision_is_fatal() -> None:
+def test_fixture_plugin_command_collision_is_fatal(ignore: InstallIgnore) -> None:
     """The fixture's .claude/commands/test-plugin-command.md is fatal when it
     collides with a base command of the same name."""
     plan = _seeded_plan(
@@ -519,11 +590,15 @@ def test_fixture_plugin_command_collision_is_fatal() -> None:
 
     with pytest.raises(CollisionError):
         overlay_plugins(
-            plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+            plan,
+            [_test_plugin_adapter()],
+            adapter=ClaudeAdapter(),
+            registry=default_registry(),
+            ignore=ignore,
         )
 
 
-def test_fixture_plugin_settings_union_merges_with_base() -> None:
+def test_fixture_plugin_settings_union_merges_with_base(ignore: InstallIgnore) -> None:
     """The fixture's .claude/settings.json.template deep-union-merges with a base
     settings.json: the base permission survives alongside the plugin's."""
     plan = _seeded_plan(
@@ -536,7 +611,11 @@ def test_fixture_plugin_settings_union_merges_with_base() -> None:
     )
 
     overlay_plugins(
-        plan, [_test_plugin_adapter()], adapter=ClaudeAdapter(), registry=default_registry()
+        plan,
+        [_test_plugin_adapter()],
+        adapter=ClaudeAdapter(),
+        registry=default_registry(),
+        ignore=ignore,
     )
 
     merged = json.loads(plan.items[Path("settings.json")].content or b"{}")
@@ -545,7 +624,7 @@ def test_fixture_plugin_settings_union_merges_with_base() -> None:
     assert "Bash(test-plugin:*)" in allow
 
 
-def test_fixture_plugin_skill_overlays_without_collision() -> None:
+def test_fixture_plugin_skill_overlays_without_collision(ignore: InstallIgnore) -> None:
     """The fixture's shared-scope .agents/skills/test-plugin-skill/ lands in the
     plan as a DIR when no base item occupies that destination."""
     plan = overlay_plugins(
@@ -553,6 +632,7 @@ def test_fixture_plugin_skill_overlays_without_collision() -> None:
         [_test_plugin_adapter()],
         adapter=ClaudeAdapter(),
         registry=default_registry(),
+        ignore=ignore,
     )
 
     assert plan.items[Path("skills/test-plugin-skill")].kind is FileKind.DIR

--- a/packages/installer/tests/unit/test_staging.py
+++ b/packages/installer/tests/unit/test_staging.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import FileKind, Provenance
 from installer.core.staging import (
     stage_namespace,
@@ -84,14 +85,14 @@ def _prov() -> Provenance:
     return Provenance(kind="tool", name="claude")
 
 
-def test_stage_namespace_md_files_are_namespaced(tmp_path: Path) -> None:
+def test_stage_namespace_md_files_are_namespaced(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A .md file in a namespace dir becomes a NAMESPACED_MD item whose
     dest_relpath is <namespace>/<name> and whose bytes are read eagerly."""
     rules = tmp_path / "rules"
     rules.mkdir()
     (rules / "style.md").write_bytes(b"# style\n")
 
-    items = stage_namespace(tmp_path, "rules", provenance=_prov())
+    items = stage_namespace(tmp_path, "rules", provenance=_prov(), ignore=ignore)
 
     assert len(items) == 1
     item = items[0]
@@ -102,14 +103,16 @@ def test_stage_namespace_md_files_are_namespaced(tmp_path: Path) -> None:
     assert item.provenance == _prov()
 
 
-def test_stage_namespace_directory_is_dir_with_no_content(tmp_path: Path) -> None:
+def test_stage_namespace_directory_is_dir_with_no_content(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A skill directory is staged as a single DIR unit; content is None
     (bytes derived from source_path at sync time)."""
     skills = tmp_path / "skills"
     (skills / "my-skill").mkdir(parents=True)
     (skills / "my-skill" / "SKILL.md").write_bytes(b"x")
 
-    items = stage_namespace(tmp_path, "skills", provenance=_prov())
+    items = stage_namespace(tmp_path, "skills", provenance=_prov(), ignore=ignore)
 
     assert len(items) == 1
     assert items[0].kind == FileKind.DIR
@@ -117,49 +120,68 @@ def test_stage_namespace_directory_is_dir_with_no_content(tmp_path: Path) -> Non
     assert items[0].dest_relpath == Path("skills/my-skill")
 
 
-def test_stage_namespace_filters_top_level_marker_files(tmp_path: Path) -> None:
-    """In-repo AGENTS.md/CLAUDE.md/GEMINI.md at the top of a namespace dir
-    are dead files with no host-runtime meaning and are dropped."""
+def test_stage_namespace_filters_top_level_marker_files(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """In-repo AGENTS.md/CLAUDE.md/GEMINI.md at the top of a namespace dir are
+    dead files; the .installignore matcher drops them while keeping real content."""
     skills = tmp_path / "skills"
     skills.mkdir()
     (skills / "AGENTS.md").write_bytes(b"dev doc")
     (skills / "real-skill").mkdir()
 
-    items = stage_namespace(tmp_path, "skills", provenance=_prov())
+    items = stage_namespace(tmp_path, "skills", provenance=_prov(), ignore=ignore)
 
     names = {i.dest_relpath.name for i in items}
     assert names == {"real-skill"}
 
 
-def test_stage_namespace_strips_template_suffix(tmp_path: Path) -> None:
+def test_stage_namespace_filters_excluded_directory(tmp_path: Path, ignore: InstallIgnore) -> None:
+    """A directory whose name is a .installignore directory entry (rules-readmes)
+    is dropped whole, not partially staged."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    (rules / "rules-readmes").mkdir()
+    (rules / "rules-readmes" / "foo-readme.md").write_bytes(b"rationale")
+    (rules / "real-rule.md").write_bytes(b"rule")
+
+    items = stage_namespace(tmp_path, "rules", provenance=_prov(), ignore=ignore)
+
+    names = {i.dest_relpath.name for i in items}
+    assert names == {"real-rule.md"}
+
+
+def test_stage_namespace_strips_template_suffix(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A namespace .md.template entry lands with the suffix stripped."""
     cmds = tmp_path / "commands"
     cmds.mkdir()
     (cmds / "go.md.template").write_bytes(b"go")
 
-    items = stage_namespace(tmp_path, "commands", provenance=_prov())
+    items = stage_namespace(tmp_path, "commands", provenance=_prov(), ignore=ignore)
 
     assert items[0].dest_relpath == Path("commands/go.md")
 
 
-def test_stage_namespace_missing_dir_returns_empty(tmp_path: Path) -> None:
+def test_stage_namespace_missing_dir_returns_empty(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A namespace dir that does not exist yields no items (bash `return 0`)."""
-    assert stage_namespace(tmp_path, "agents", provenance=_prov()) == []
+    assert stage_namespace(tmp_path, "agents", provenance=_prov(), ignore=ignore) == []
 
 
-def test_stage_namespace_is_deterministically_ordered(tmp_path: Path) -> None:
+def test_stage_namespace_is_deterministically_ordered(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """Entries are returned sorted by name for reproducible plans."""
     rules = tmp_path / "rules"
     rules.mkdir()
     for n in ("c.md", "a.md", "b.md"):
         (rules / n).write_bytes(b"x")
 
-    items = stage_namespace(tmp_path, "rules", provenance=_prov())
+    items = stage_namespace(tmp_path, "rules", provenance=_prov(), ignore=ignore)
 
     assert [i.dest_relpath.name for i in items] == ["a.md", "b.md", "c.md"]
 
 
-def test_stage_namespace_preserves_executable_bit(tmp_path: Path) -> None:
+def test_stage_namespace_preserves_executable_bit(tmp_path: Path, ignore: InstallIgnore) -> None:
     """An executable source file (a hook script) stages with executable=True; a
     non-executable sibling stages with executable=False. The sync engine writes
     0o755 vs 0o644 from this bit, so hook scripts must land +x (8.7 parity)."""
@@ -172,7 +194,10 @@ def test_stage_namespace_preserves_executable_bit(tmp_path: Path) -> None:
     plain.write_bytes(b"x")
     plain.chmod(0o644)
 
-    items = {i.dest_relpath.name: i for i in stage_namespace(tmp_path, "hooks", provenance=_prov())}
+    items = {
+        i.dest_relpath.name: i
+        for i in stage_namespace(tmp_path, "hooks", provenance=_prov(), ignore=ignore)
+    }
 
     assert items["ruff-postedit.py"].executable is True
     assert items["notes.md"].executable is False

--- a/packages/installer/tests/unit/test_staging_build_plan.py
+++ b/packages/installer/tests/unit/test_staging_build_plan.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import FileKind, StagingPlan, Tool
 from installer.core.staging import build_plan
 from installer.tools.claude import ClaudeAdapter
@@ -46,10 +47,10 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_build_plan_includes_shared_and_tool_phases(tmp_path: Path) -> None:
+def test_build_plan_includes_shared_and_tool_phases(tmp_path: Path, ignore: InstallIgnore) -> None:
     repo = _make_repo(tmp_path)
 
-    plan = build_plan(ClaudeAdapter(), repo_root=repo)
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
 
     assert isinstance(plan, StagingPlan)
     assert plan.tool == Tool.CLAUDE
@@ -63,24 +64,26 @@ def test_build_plan_includes_shared_and_tool_phases(tmp_path: Path) -> None:
     assert Path("settings.json") in dests  # tool settings
 
 
-def test_build_plan_filters_namespace_marker_file(tmp_path: Path) -> None:
+def test_build_plan_filters_namespace_marker_file(tmp_path: Path, ignore: InstallIgnore) -> None:
     repo = _make_repo(tmp_path)
-    plan = build_plan(ClaudeAdapter(), repo_root=repo)
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
     assert Path("skills/AGENTS.md") not in plan.items
 
 
-def test_build_plan_stages_hooks_namespace_with_exec_bit(tmp_path: Path) -> None:
+def test_build_plan_stages_hooks_namespace_with_exec_bit(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """The Claude installer stages src/user/.claude/hooks/ -> hooks/ and preserves
     the +x bit on hook scripts (8.7 parity with install.sh's hooks/ support)."""
     repo = _make_repo(tmp_path)
-    plan = build_plan(ClaudeAdapter(), repo_root=repo)
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
     assert Path("hooks/ruff-postedit.py") in plan.items
     assert plan.items[Path("hooks/ruff-postedit.py")].executable is True
 
 
-def test_build_plan_assigns_namespaces_and_kinds(tmp_path: Path) -> None:
+def test_build_plan_assigns_namespaces_and_kinds(tmp_path: Path, ignore: InstallIgnore) -> None:
     repo = _make_repo(tmp_path)
-    plan = build_plan(ClaudeAdapter(), repo_root=repo)
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
 
     assert plan.items[Path("rules/delegation.md")].kind == FileKind.NAMESPACED_MD
     assert plan.items[Path("rules/delegation.md")].namespace == "rules"
@@ -88,7 +91,7 @@ def test_build_plan_assigns_namespaces_and_kinds(tmp_path: Path) -> None:
     assert plan.items[Path("settings.json")].kind == FileKind.SETTINGS_JSON
 
 
-def test_build_plan_raises_on_collision(tmp_path: Path) -> None:
+def test_build_plan_raises_on_collision(tmp_path: Path, ignore: InstallIgnore) -> None:
     """Two sources mapping to the same dest_relpath must raise — merge
     dispatch is deferred to Epic E, so a silent overwrite is unacceptable."""
     repo = _make_repo(tmp_path)
@@ -100,4 +103,4 @@ def test_build_plan_raises_on_collision(tmp_path: Path) -> None:
     (repo / "src" / "user" / ".claude" / "rules" / "delegation.md").write_bytes(b"dup")
 
     with pytest.raises(ValueError, match="collision"):
-        build_plan(ClaudeAdapter(), repo_root=repo)
+        build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)

--- a/packages/installer/tests/unit/test_staging_codex.py
+++ b/packages/installer/tests/unit/test_staging_codex.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import StagingPlan, Tool
 from installer.core.staging import build_plan
 from installer.tools.codex import CodexAdapter
@@ -34,7 +35,7 @@ def _make_codex_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_codex_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
+def test_codex_build_plan_stages_shared_namespaces(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given a repo with shared rules/skills/agents content
     When build_plan runs with CodexAdapter
@@ -45,7 +46,7 @@ def test_codex_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
     """
     repo = _make_codex_repo(tmp_path)
 
-    plan = build_plan(CodexAdapter(), repo_root=repo)
+    plan = build_plan(CodexAdapter(), repo_root=repo, ignore=ignore)
 
     assert isinstance(plan, StagingPlan)
     assert plan.tool == Tool.CODEX
@@ -56,7 +57,7 @@ def test_codex_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
     assert Path("AGENTS.md") in dests  # tool template (Phase 3), suffix stripped
 
 
-def test_codex_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
+def test_codex_build_plan_stages_no_tool_namespaces(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given CodexAdapter.scoped_namespaces() returns ()
     When build_plan runs
@@ -67,6 +68,6 @@ def test_codex_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
     """
     repo = _make_codex_repo(tmp_path)
 
-    plan = build_plan(CodexAdapter(), repo_root=repo)
+    plan = build_plan(CodexAdapter(), repo_root=repo, ignore=ignore)
 
     assert not any(i.namespace == "commands" for i in plan.items.values())

--- a/packages/installer/tests/unit/test_staging_gemini.py
+++ b/packages/installer/tests/unit/test_staging_gemini.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import StagingPlan, Tool
 from installer.core.staging import build_plan
 from installer.tools.gemini import GeminiAdapter
@@ -34,7 +35,7 @@ def _make_gemini_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_gemini_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
+def test_gemini_build_plan_stages_shared_namespaces(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given a repo with shared rules/skills/agents content
     When build_plan runs with GeminiAdapter
@@ -45,7 +46,7 @@ def test_gemini_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
     """
     repo = _make_gemini_repo(tmp_path)
 
-    plan = build_plan(GeminiAdapter(), repo_root=repo)
+    plan = build_plan(GeminiAdapter(), repo_root=repo, ignore=ignore)
 
     assert isinstance(plan, StagingPlan)
     assert plan.tool == Tool.GEMINI
@@ -56,7 +57,7 @@ def test_gemini_build_plan_stages_shared_namespaces(tmp_path: Path) -> None:
     assert Path("GEMINI.md") in dests  # tool template (Phase 3), suffix stripped
 
 
-def test_gemini_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
+def test_gemini_build_plan_stages_no_tool_namespaces(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given GeminiAdapter.scoped_namespaces() returns ()
     When build_plan runs
@@ -67,6 +68,6 @@ def test_gemini_build_plan_stages_no_tool_namespaces(tmp_path: Path) -> None:
     """
     repo = _make_gemini_repo(tmp_path)
 
-    plan = build_plan(GeminiAdapter(), repo_root=repo)
+    plan = build_plan(GeminiAdapter(), repo_root=repo, ignore=ignore)
 
     assert not any(i.namespace == "commands" for i in plan.items.values())

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.io_port import ScriptedIO
 from installer.core.model import StagingPlan, Tool
 from installer.core.staging import build_plan
@@ -37,7 +38,7 @@ def _make_opencode_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_opencode_build_plan_skips_shared_agents(tmp_path: Path) -> None:
+def test_opencode_build_plan_skips_shared_agents(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given a repo with shared agents/ content
     When build_plan runs with OpenCodeAdapter
@@ -48,13 +49,15 @@ def test_opencode_build_plan_skips_shared_agents(tmp_path: Path) -> None:
     """
     repo = _make_opencode_repo(tmp_path)
 
-    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)
 
     assert not any(item.namespace == "agents" for item in plan.items.values())
     assert Path("agents/shared-agent.md") not in plan.items
 
 
-def test_opencode_build_plan_keeps_shared_skills_and_rules(tmp_path: Path) -> None:
+def test_opencode_build_plan_keeps_shared_skills_and_rules(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """
     Given a repo with shared skills/ and rules/ content
     When build_plan runs with OpenCodeAdapter
@@ -65,7 +68,7 @@ def test_opencode_build_plan_keeps_shared_skills_and_rules(tmp_path: Path) -> No
     """
     repo = _make_opencode_repo(tmp_path)
 
-    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)
 
     assert isinstance(plan, StagingPlan)
     assert plan.tool == Tool.OPENCODE
@@ -74,7 +77,7 @@ def test_opencode_build_plan_keeps_shared_skills_and_rules(tmp_path: Path) -> No
     assert Path("AGENTS.md") in plan.items  # tool template (Phase 3), suffix stripped
 
 
-def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path) -> None:
+def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given src/user/.opencode/opencode.jsonc.template
     When build_plan runs with OpenCodeAdapter
@@ -86,12 +89,14 @@ def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path) -> None:
     """
     repo = _make_opencode_repo(tmp_path)
 
-    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)
 
     assert Path("opencode.jsonc") in plan.items
 
 
-def test_opencode_post_staging_transforms_drops_rules(tmp_path: Path) -> None:
+def test_opencode_post_staging_transforms_drops_rules(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """
     Given an OpenCode plan that still carries shared rules/ items (build_plan keeps
     them so the DYNAMIC-INCLUDE-ALL-RULES flatten can inline them)
@@ -105,7 +110,7 @@ def test_opencode_post_staging_transforms_drops_rules(tmp_path: Path) -> None:
     sees the rules but sync does not.
     """
     repo = _make_opencode_repo(tmp_path)
-    plan = build_plan(OpenCodeAdapter(), repo_root=repo)
+    plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)
     assert Path("rules/delegation.md") in plan.items  # precondition: staged for inlining
 
     result = OpenCodeAdapter().post_staging_transforms(plan, ScriptedIO())

--- a/packages/installer/tests/unit/test_staging_shared_carrier.py
+++ b/packages/installer/tests/unit/test_staging_shared_carrier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from installer.core.installignore import InstallIgnore
 from installer.core.model import FileKind
 from installer.core.staging import build_plan
 from installer.tools.claude import ClaudeAdapter
@@ -32,36 +33,38 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_shared_skill_dir_is_marked_carrier(tmp_path: Path) -> None:
+def test_shared_skill_dir_is_marked_carrier(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A shared skills/ DIR item carries shared_carrier=True so the overlay
     can carrier-merge a plugin's disjoint additions into it."""
-    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path), ignore=ignore)
     item = plan.items[Path("skills/shared-skill")]
     assert item.kind is FileKind.DIR
     assert item.shared_carrier is True
 
 
-def test_shared_agent_dir_is_marked_carrier(tmp_path: Path) -> None:
+def test_shared_agent_dir_is_marked_carrier(tmp_path: Path, ignore: InstallIgnore) -> None:
     """The carrier mark covers agents/ DIR items too, not just skills/."""
-    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path), ignore=ignore)
     assert plan.items[Path("agents/shared-agent-dir")].shared_carrier is True
 
 
-def test_shared_non_dir_namespace_item_is_not_carrier(tmp_path: Path) -> None:
+def test_shared_non_dir_namespace_item_is_not_carrier(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
     """A shared rules/*.md file is not a DIR, so it must NOT be marked —
     carrier-merge applies only to skill/agent directory units."""
-    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path), ignore=ignore)
     assert plan.items[Path("rules/delegation.md")].shared_carrier is False
 
 
-def test_shared_agent_md_file_is_not_carrier(tmp_path: Path) -> None:
+def test_shared_agent_md_file_is_not_carrier(tmp_path: Path, ignore: InstallIgnore) -> None:
     """An agents/*.md file (kind OTHER-of-namespace, not DIR) is not a carrier
     even though it lives under agents/ — the mark keys on kind==DIR."""
-    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path), ignore=ignore)
     assert plan.items[Path("agents/shared-agent.md")].shared_carrier is False
 
 
-def test_shared_template_is_not_carrier(tmp_path: Path) -> None:
+def test_shared_template_is_not_carrier(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A Phase 1 root template is neither skills/ nor agents/, so unmarked."""
-    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path))
+    plan = build_plan(ClaudeAdapter(), repo_root=_make_repo(tmp_path), ignore=ignore)
     assert plan.items[Path("INSTRUCTIONS.md")].shared_carrier is False

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,11 @@ SRC_PLUGINS="${INSTALLER_PLUGINS_SRC:-$PROJECT_ROOT/src/plugins}"
 # install.sh the sole owner of the `uv tool install` lifecycle.
 SRC_PRGROOM="${INSTALLER_PRGROOM_SRC:-$PROJECT_ROOT/packages/prgroom}"
 
+INSTALLIGNORE_FILE="$PROJECT_ROOT/.installignore"
+# shellcheck source=lib/installignore.sh
+source "$SCRIPT_DIR/lib/installignore.sh"
+load_installignore "$INSTALLIGNORE_FILE"
+
 if [[ ! -d "$SRC_SHARED" ]]; then
     err "Shared source directory not found: $SRC_SHARED"
     exit 1
@@ -622,10 +627,15 @@ stage_content_from_dir() {
 
     mkdir -p "$staging_dir"
 
-    local item_name file_type
+    local item_name file_type is_dir
     for item in "$src_dir"/*; do
         [[ -e "$item" ]] || continue
         item_name="$(basename "$item")"
+        if [[ -d "$item" ]]; then is_dir=true; else is_dir=false; fi
+        if is_installignored "$item_name" "$is_dir"; then
+            vinfo "  .installignore: skipping $dir_name/$item_name"
+            continue
+        fi
         file_type="$(classify_file "$item" "$dir_name")"
         stage_item "$item" "$staging_dir/$item_name" "$file_type"
     done

--- a/scripts/lib/installignore.sh
+++ b/scripts/lib/installignore.sh
@@ -16,7 +16,7 @@ declare -A _INSTALLIGNORE_DIRNAMES
 load_installignore() {
     local file="$1" line name
     if [[ ! -r "$file" ]]; then
-        echo "Error: .installignore not found at $file; refusing to install with exclusions disabled" >&2
+        echo "Error: .installignore missing or unreadable at $file; refusing to install with exclusions disabled" >&2
         exit 1
     fi
     _INSTALLIGNORE_BASENAMES=()

--- a/scripts/lib/installignore.sh
+++ b/scripts/lib/installignore.sh
@@ -14,7 +14,7 @@ declare -A _INSTALLIGNORE_DIRNAMES
 # load_installignore <path>: populate the matcher from the manifest. A missing or
 # unreadable file is a HARD ERROR (fail-fast) — mirrors the Python loader.
 load_installignore() {
-    local file="$1" line
+    local file="$1" line name
     if [[ ! -r "$file" ]]; then
         echo "Error: .installignore not found at $file; refusing to install with exclusions disabled" >&2
         exit 1
@@ -26,7 +26,8 @@ load_installignore() {
         line="${line%"${line##*[![:space:]]}"}"    # rtrim
         [[ -z "$line" || "$line" == \#* ]] && continue
         if [[ "$line" == */ ]]; then
-            _INSTALLIGNORE_DIRNAMES["${line%/}"]=1
+            name="${line%/}"
+            [[ -n "$name" ]] && _INSTALLIGNORE_DIRNAMES["$name"]=1   # skip a bare "/" (parity with Python)
         else
             _INSTALLIGNORE_BASENAMES["$line"]=1
         fi

--- a/scripts/lib/installignore.sh
+++ b/scripts/lib/installignore.sh
@@ -5,8 +5,9 @@
 # and blank lines ignored; an exact basename matches a file; a trailing-'/' name
 # matches a directory. No globs, no '**', no negation, no anchoring.
 #
-# Requires bash 4+ associative arrays (install.sh already guards the version and
-# uses `declare -A`). Do NOT `set -e` here — this file only defines functions.
+# Requires a shell with associative arrays — zsh or bash 4+. install.sh re-execs
+# into zsh (preferred) or bash 4+ before sourcing this, and both support the
+# `declare -A` used here. Do NOT `set -e` here — this file only defines functions.
 
 declare -A _INSTALLIGNORE_BASENAMES
 declare -A _INSTALLIGNORE_DIRNAMES
@@ -27,9 +28,12 @@ load_installignore() {
         [[ -z "$line" || "$line" == \#* ]] && continue
         if [[ "$line" == */ ]]; then
             name="${line%/}"
-            [[ -n "$name" ]] && _INSTALLIGNORE_DIRNAMES["$name"]=1   # skip a bare "/" (parity with Python)
+            # Unquoted subscript: a quoted ["$name"] embeds literal quotes in the
+            # key under zsh (but not bash), breaking lookups when install.sh re-execs
+            # into zsh. The lookup side uses [$1] unquoted, so the store must too.
+            [[ -n "$name" ]] && _INSTALLIGNORE_DIRNAMES[$name]=1   # skip a bare "/" (parity with Python)
         else
-            _INSTALLIGNORE_BASENAMES["$line"]=1
+            _INSTALLIGNORE_BASENAMES[$line]=1
         fi
     done < "$file"
 }

--- a/scripts/lib/installignore.sh
+++ b/scripts/lib/installignore.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Shared exclusion matcher for the install fileset — bash side of .installignore.
+# Sourced by scripts/install.sh and by installignore_test.sh. Grammar matches the
+# Python loader (installer.core.installignore): one entry per line; '#' comments
+# and blank lines ignored; an exact basename matches a file; a trailing-'/' name
+# matches a directory. No globs, no '**', no negation, no anchoring.
+#
+# Requires bash 4+ associative arrays (install.sh already guards the version and
+# uses `declare -A`). Do NOT `set -e` here — this file only defines functions.
+
+declare -A _INSTALLIGNORE_BASENAMES
+declare -A _INSTALLIGNORE_DIRNAMES
+
+# load_installignore <path>: populate the matcher from the manifest. A missing or
+# unreadable file is a HARD ERROR (fail-fast) — mirrors the Python loader.
+load_installignore() {
+    local file="$1" line
+    if [[ ! -r "$file" ]]; then
+        echo "Error: .installignore not found at $file; refusing to install with exclusions disabled" >&2
+        exit 1
+    fi
+    _INSTALLIGNORE_BASENAMES=()
+    _INSTALLIGNORE_DIRNAMES=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line#"${line%%[![:space:]]*}"}"   # ltrim
+        line="${line%"${line##*[![:space:]]}"}"    # rtrim
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        if [[ "$line" == */ ]]; then
+            _INSTALLIGNORE_DIRNAMES["${line%/}"]=1
+        else
+            _INSTALLIGNORE_BASENAMES["$line"]=1
+        fi
+    done < "$file"
+}
+
+# is_installignored <name> <is_dir:true|false>: succeed (0) if excluded.
+is_installignored() {
+    if [[ "$2" == true ]]; then
+        [[ -n "${_INSTALLIGNORE_DIRNAMES[$1]:-}" ]]
+    else
+        [[ -n "${_INSTALLIGNORE_BASENAMES[$1]:-}" ]]
+    fi
+}

--- a/scripts/lib/installignore_test.sh
+++ b/scripts/lib/installignore_test.sh
@@ -29,6 +29,13 @@ assert "dir name excluded" "drop" "$r"
 is_installignored "rules-readmes" false && r=drop || r=keep
 assert "dir entry does not match a file query" "keep" "$r"
 
+# A degenerate "/" line must not abort the loader. Run under `set -e` (as install.sh
+# does): the unguarded code would assign to an empty array key (`bad array subscript`)
+# and abort; the guard skips it, matching the Python loader.
+printf '%s\n' '/' 'AGENTS.md' > "$work/slash"
+( set -e; source "$LIB"; load_installignore "$work/slash" ) 2>/dev/null && r=0 || r=$?
+assert "bare slash line does not abort under set -e" "0" "$r"
+
 # Fail-fast on a missing manifest (run in a subshell so its exit does not kill us).
 ( source "$LIB"; load_installignore "$work/nope" ) 2>/dev/null && r=0 || r=$?
 assert "missing manifest fail-fast (nonzero exit)" "1" "$r"

--- a/scripts/lib/installignore_test.sh
+++ b/scripts/lib/installignore_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Unit test for scripts/lib/installignore.sh — the bash exclusion matcher.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/installignore.sh"
+fail=0
+
+assert() { # $1=desc  $2=expected  $3=actual
+    if [[ "$2" != "$3" ]]; then echo "FAIL: $1 (expected '$2', got '$3')" >&2; fail=1
+    else echo "ok: $1"; fi
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+manifest="$work/.installignore"
+printf '%s\n' '# comment' '' 'AGENTS.md' 'rules-readmes/' > "$manifest"
+
+# shellcheck source=/dev/null
+source "$LIB"
+load_installignore "$manifest"
+
+is_installignored "AGENTS.md" false && r=drop || r=keep
+assert "file basename excluded" "drop" "$r"
+is_installignored "AGENTS.md.template" false && r=drop || r=keep
+assert "template not excluded" "keep" "$r"
+is_installignored "rules-readmes" true && r=drop || r=keep
+assert "dir name excluded" "drop" "$r"
+is_installignored "rules-readmes" false && r=drop || r=keep
+assert "dir entry does not match a file query" "keep" "$r"
+
+# Fail-fast on a missing manifest (run in a subshell so its exit does not kill us).
+( source "$LIB"; load_installignore "$work/nope" ) 2>/dev/null && r=0 || r=$?
+assert "missing manifest fail-fast (nonzero exit)" "1" "$r"
+
+exit "$fail"

--- a/scripts/lib/installignore_test.sh
+++ b/scripts/lib/installignore_test.sh
@@ -40,4 +40,23 @@ assert "bare slash line does not abort under set -e" "0" "$r"
 ( source "$LIB"; load_installignore "$work/nope" ) 2>/dev/null && r=0 || r=$?
 assert "missing manifest fail-fast (nonzero exit)" "1" "$r"
 
+# Cross-shell regression: install.sh re-execs into zsh (preferred) before sourcing
+# this lib, so the matcher MUST work under zsh too — not just the bash this test
+# runs under. A quoted store subscript (["$key"]) silently embeds the quotes in the
+# key under zsh while the lookup uses [$1], so every match misses and exclusions
+# vanish. Source + load + query under zsh and assert the verdicts when zsh exists.
+if command -v zsh >/dev/null 2>&1; then
+    zverdicts="$(zsh -c '
+        source "$1"
+        load_installignore "$2"
+        for q in "AGENTS.md:false" "AGENTS.md.template:false" "rules-readmes:true"; do
+            n="${q%:*}"; d="${q#*:}"
+            if is_installignored "$n" "$d"; then printf "drop "; else printf "keep "; fi
+        done
+    ' zsh_matcher_test "$LIB" "$manifest")"
+    assert "matcher works under zsh (drop/keep/drop)" "drop keep drop " "$zverdicts"
+else
+    echo "ok: zsh unavailable — cross-shell check skipped"
+fi
+
 exit "$fail"


### PR DESCRIPTION
## Summary

Replaces the Python-only hardcoded `DEAD_MARKERS` frozenset with a single repo-root **`.installignore`** manifest that **both** installers (`scripts/install.sh` and `packages/installer/`) consume at the staging chokepoint — killing the bash↔python exclusion divergence that left three golden-master parity tests RED.

Previously bash leaked `src/user/.agents/rules/AGENTS.md` two ways (inlined into assembled instruction files **and** deployed standalone) while Python silently omitted it. Now a shared, gitignore-flavored manifest is the single source of truth.

Implements bead `agents-config-37sep`.

### What changed
- **`.installignore`** (repo root) — the manifest. Simple-subset grammar (identical in both installers): one entry per line; `#`/blank lines skipped; a bare basename matches a **file**, a trailing-`/` name matches a **directory**. No globs/negation/anchoring. Matching runs on direct children of each staged namespace, **pre-`.template`-strip**, so a bare `AGENTS.md` never matches the real `AGENTS.md.template`.
- **`installer/core/installignore.py`** — `InstallIgnore` model + `load_installignore`. **Fail-closed:** a missing/unreadable manifest is a hard error, never a silent "exclude nothing".
- **`scripts/lib/installignore.sh`** — sourceable bash matcher mirroring the Python grammar, same fail-fast.
- **Threading** — `ignore` is a required kwarg through `stage_namespace` → `build_plan`/`overlay_plugins` → `stage_and_transform` → `cli.main`; `mypy --strict` enforces no call site is missed. `install.sh` sources the lib, loads the manifest at startup (fail-fast), and filters in `stage_content_from_dir`.
- **Oracle simplified** — the golden-master `_diff.py` dead-marker skip is **deleted**: both trees now exclude dead-docs at staging, so a pure tree comparison is exact and a one-sided dead-doc is a real divergence that must surface.
- **Backstops** — a hardcoded invariant test (catches a manifest mis-edit — the shared-wrongness case the parity oracle is blind to), a cross-language matcher-parity test, and a CLI fail-fast test.

### Why fail-closed
A missing manifest treated as "empty" would re-leak dead-docs *identically* on both installers — shared wrongness the parity oracle cannot see. So absence aborts both installers (Python exit 2, bash exit 1).

## Test Plan
- [x] `make ci-installer` — **623 unit passed, 99.81% coverage** (floor 90%), `mypy --strict` clean, ruff lint+format clean, `pip-audit` no vulnerabilities, `install.py --help` entry-verify ok
- [x] `uv run pytest tests/golden_master` — **55 passed**, incl. the three previously-RED parity tests (`codex`/`gemini`/`opencode`) now GREEN
- [x] `bash scripts/lib/installignore_test.sh` — exit 0 (incl. bare-`/` parity guard under `set -e`)
- [x] `quality-reviewer` (verdict: ship it) + `simplify` (none warranted) completion gate

Follow-up test-hardening nits tracked in `agents-config-ufy4c` (discovered-from `agents-config-37sep`); none block this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
