### PR TITLE
refactor(installer): scrub stale bash-parity comments from installer src/

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -31,11 +31,10 @@ if TYPE_CHECKING:
 # ``src/plugins``. ``cli.py`` lives at ``<repo>/packages/installer/src/installer/
 # cli.py``, so the fourth parent is the repo root. ``uv`` installs this package
 # editable, so ``__file__`` stays inside the source tree and this resolution holds
-# at runtime; tests inject ``repo_root`` directly. Mirrors the bash installer's
-# ``PROJECT_ROOT="$SCRIPT_DIR/.."`` (scripts/install.sh:197-198). The bundled
-# installer.toml path and the plugin source root are derived per-run from the
-# injected repo_root (default: _REPO_ROOT), keeping repo_root fully authoritative
-# for staging, config, and plugin discovery alike.
+# at runtime; tests inject ``repo_root`` directly. The bundled installer.toml path
+# and the plugin source root are derived per-run from the injected repo_root
+# (default: _REPO_ROOT), keeping repo_root fully authoritative for staging,
+# config, and plugin discovery alike.
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
@@ -126,11 +125,10 @@ def main(
 
         io = TerminalIO(verbose=args.verbose)
 
-    # Run-mode notice, mirroring bash (scripts/install.sh:218-222): a dry-run
-    # announces itself up front; an auto-yes run notes that prompts and diffs are
-    # suppressed — but only when NOT verbose, since verbose already narrates every
-    # file. Emitted before tool/plugin resolution so it leads the transcript, as
-    # the excluded-plugin warning (below) trails it in the bash ordering.
+    # Run-mode notice: a dry-run announces itself up front; an auto-yes run notes
+    # that prompts and diffs are suppressed — but only when NOT verbose, since
+    # verbose already narrates every file. Emitted before tool/plugin resolution
+    # so it leads the transcript.
     if args.dry_run:
         io.info("DRY RUN -- no changes will be made")
     elif args.yes and not args.verbose:
@@ -143,9 +141,7 @@ def main(
         return 2
 
     # Resolve plugins up front (after tools) so an invalid --plugins fails fast
-    # on every path — matching the bash installer, which validates --plugins
-    # before dispatching any mode (scripts/install.sh:298-307). The resolved set
-    # feeds both --dump-stage and --prune below.
+    # on every path. The resolved set feeds both --dump-stage and --prune below.
     try:
         plugins = resolve_plugins(
             home=resolved_home,
@@ -158,11 +154,10 @@ def main(
         sys.stderr.write(f"installer: {exc}\n")
         return 2
 
-    # Warn about plugins an EXPLICIT --plugins= override dropped (bash gates this on
-    # PLUGINS_FLAG_SET, scripts/install.sh:308 — auto-detect dropping an undetected
-    # plugin is normal, not warn-worthy). Routed through io.warn after resolution and
-    # before any mode dispatch so it fires on every path (plain / --dump-stage /
-    # --prune / --prune-only) the override reaches.
+    # Warn about plugins an EXPLICIT --plugins= override dropped (auto-detect
+    # dropping an undetected plugin is normal, not warn-worthy). Routed through
+    # io.warn after resolution and before any mode dispatch so it fires on every
+    # path (plain / --dump-stage / --prune / --prune-only) the override reaches.
     if args.plugins is not None:
         _warn_excluded_plugins(
             resolved=plugins,
@@ -171,12 +166,11 @@ def main(
             prune_active=args.prune or args.prune_only,
         )
 
-    # Load the shared exclusion manifest up front, mirroring the bash installer's
-    # early fail-fast. An absent, unreadable, or non-UTF-8 .installignore is a hard
-    # error (exit 2) rather than a silent empty-exclusion install — the manifest is
-    # load-bearing policy, and a missing one would re-leak dead-docs identically on
-    # both installers (shared wrongness the parity oracle cannot see). UnicodeDecodeError
-    # is a ValueError (not an OSError), so it is caught explicitly here.
+    # Load the shared exclusion manifest up front. An absent, unreadable, or
+    # non-UTF-8 .installignore is a hard error (exit 2) rather than a silent
+    # empty-exclusion install — the manifest is load-bearing policy, and a missing
+    # one would re-leak dead-docs silently. UnicodeDecodeError is a ValueError
+    # (not an OSError), so it is caught explicitly here.
     try:
         ignore = load_installignore(resolved_repo_root / ".installignore")
     except (OSError, UnicodeDecodeError) as exc:
@@ -213,16 +207,14 @@ def main(
 
     # Default install path (also the install half of --prune): walk each active
     # tool's StagingPlan to disk via install_pipeline. Skipped only for
-    # --prune-only, which removes retired paths without installing. Slots ahead
-    # of the prune branch so --prune is install-then-prune, mirroring the bash
-    # installer (scripts/install.sh copies before the retire sweep). Driving the
-    # install through stage_and_transform is also what makes adapter post-staging
+    # --prune-only, which removes retired paths without installing. Slots ahead of
+    # the prune branch so --prune is install-then-prune. Driving the install
+    # through stage_and_transform is also what makes adapter post-staging
     # transforms (e.g. the Gemini frontmatter transform) fire in real installs,
     # not just --dump-stage / --prune.
     # Per-target tallies accumulate across the install and prune halves so the
     # summary reports each tool/plugin's full activity merged (a tool that both
-    # installs files and has orphans pruned shows both). Keyed by target name,
-    # mirroring the bash per-tool counter arrays (scripts/install.sh:349-357).
+    # installs files and has orphans pruned shows both). Keyed by target name.
     counters: dict[str, Counters] = {}
 
     if not args.prune_only:
@@ -240,8 +232,7 @@ def main(
             )
             # Plugin routes (e.g. beads' ~/.beads/formulas + scripts) land outside
             # any tool tree, so they install in a dedicated pass after the tool
-            # sync — mirroring the bash installer's stage_and_install_beads phase
-            # (scripts/install.sh:948). Same consent gate; --prune-only skips it.
+            # sync. Same consent gate; --prune-only skips it.
             _merge_into(
                 counters,
                 install_plugin_routes(
@@ -274,10 +265,9 @@ def main(
         if rc != 0:
             return rc
 
-    # Render the install / prune summary once at the end, mirroring the bash
-    # installer's terminal Summary block (scripts/install.sh:1801-1869). ALL_TOOLS
-    # is the closed tool universe (known_tools); ALL_PLUGINS is the discovered
-    # plugin set — both feed the '(not detected, skipped)' verbose footers.
+    # Render the install / prune summary once at the end. ALL_TOOLS is the closed
+    # tool universe (known_tools); ALL_PLUGINS is the discovered plugin set — both
+    # feed the '(not detected, skipped)' verbose footers.
     render_summary(
         counters,
         tools=[t.value for t in tools],
@@ -316,12 +306,12 @@ def _warn_excluded_plugins(
 ) -> None:
     """Warn about each discovered plugin an explicit ``--plugins=`` override dropped.
 
-    Mirrors bash ``scripts/install.sh:317-328``: for every plugin in the discovered
-    set absent from the resolved selection, emit a warning naming it. The wording
-    branches on whether a prune phase is active — under ``--prune``/``--prune-only``
-    the excluded plugin's already-installed files become orphans that may be removed
-    (strict mode); otherwise they are left in place. Caller gates this on an explicit
-    override, so an auto-detected exclusion stays silent.
+    For every plugin in the discovered set absent from the resolved selection, emit
+    a warning naming it. The wording branches on whether a prune phase is active —
+    under ``--prune``/``--prune-only`` the excluded plugin's already-installed files
+    become orphans that may be removed (strict mode); otherwise they are left in
+    place. Caller gates this on an explicit override, so an auto-detected exclusion
+    stays silent.
     """
     resolved_names = {adapter.name for adapter in resolved}
     discovered = discover(resolve_plugins_root(repo_root, os.environ))

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -31,8 +31,8 @@ def resolve_tools(*, home: Path, override_csv: str | None) -> tuple[Tool, ...]:
 
     - `override_csv is None` -> auto-detect: walk known_tools(), keep
       those whose adapter reports `is_detected(home) is True`. claude's
-      adapter is always-on (install.sh's `TOOLS=(claude)` floor), so it is
-      always selected; known_tools() sorts it first, so it also leads.
+      adapter is always-on (always selected); known_tools() sorts it first,
+      so it also leads.
     - `override_csv == ""` (or whitespace-only) -> ValueError.
     - Otherwise -> split on commas, strip whitespace, validate each via
       `parse_tool_name`, dedupe preserving first occurrence, preserve
@@ -64,8 +64,6 @@ def resolve_plugins(
     - `override_csv == ""` (or whitespace-only) -> () (install no plugins).
       Deliberate asymmetry with `resolve_tools`, which raises on empty
       `--tools=`: "no plugins" is a valid choice, "no tools" is a no-op error.
-      Matches scripts/install.sh's plugin-detection block, where a set
-      `--plugins=` flag with an empty value yields no plugins.
     - Otherwise -> split on commas, strip whitespace, validate each via the
       discovered set, dedupe preserving first occurrence, preserve order.
     """
@@ -94,10 +92,9 @@ def resolve_plugins_root(repo_root: Path, env: Mapping[str, str]) -> Path:
 
     Defaults to ``repo_root/src/plugins``. The ``INSTALLER_PLUGINS_SRC`` env var
     overrides it — a default-inert seam used only by the golden-master parity
-    harness to point both installers at a fixture plugin tree. The bash
-    installer carries the symmetric ``${INSTALLER_PLUGINS_SRC:-...}`` override
-    (scripts/install.sh). An unset *or empty* value falls back to the default,
-    so an exported-but-empty var can never collapse the root to ``Path('')``.
+    harness to point both installers at a fixture plugin tree. An unset *or
+    empty* value falls back to the default, so an exported-but-empty var can
+    never collapse the root to ``Path('')``.
     """
     override = env.get("INSTALLER_PLUGINS_SRC")
     return Path(override) if override else repo_root / "src" / "plugins"

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -34,7 +34,7 @@ _TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
 
 
 def new_timestamp() -> str:
-    """Current local wall-clock time as ``YYYYMMDD-HHMMSS`` (bash local-TZ ``date``)."""
+    """Current local wall-clock time as ``YYYYMMDD-HHMMSS``."""
     return datetime.now().astimezone().strftime(_TIMESTAMP_FORMAT)
 
 

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -1,11 +1,9 @@
 """Path-aware timestamped backup placement (shared by sync and prune).
 
-Single home for the bash ``backup()`` routing decision
-(``scripts/install.sh:352-388``): a target whose immediate parent is one of the
-prune-managed namespaces is copied to a sibling ``<namespace>-backup/`` dir
-under the grandparent; any other target gets an in-place ``<name>.backup-<ts>``
-sibling. Handles both files (``shutil.copy2``) and directories
-(``shutil.copytree``), mirroring the bash ``cp`` / ``cp -R`` split.
+A target whose immediate parent is one of the prune-managed namespaces is
+copied to a sibling ``<namespace>-backup/`` dir under the grandparent; any
+other target gets an in-place ``<name>.backup-<ts>`` sibling. Handles both
+files (``shutil.copy2``) and directories (``shutil.copytree``).
 
 The ``timestamp`` is interpolated raw into the backup path, so callers MUST
 pass a value matching the ``YYYYMMDD-HHMMSS`` contract; ``new_timestamp``
@@ -22,10 +20,10 @@ from datetime import datetime
 from pathlib import Path
 
 # Namespaces whose backups route to a sibling ``<namespace>-backup/`` dir rather
-# than an in-place suffix (bash ``backup()`` case list, scripts/install.sh:369-379).
+# than an in-place suffix.
 _SCOPED_NAMESPACES = frozenset({"commands", "skills", "agents", "rules", "formulas"})
 
-# Backup timestamp format, matching ``date +%Y%m%d-%H%M%S`` (scripts/install.sh:365).
+# Backup timestamp format: YYYYMMDD-HHMMSS.
 _TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
 
 # A caller-supplied timestamp is interpolated raw into the backup filename, so it
@@ -70,7 +68,7 @@ def back_up(target: Path, timestamp: str) -> Path:
     Routes via ``_backup_path_for`` (scoped namespace -> sibling
     ``<namespace>-backup/``; else in-place), creating the backup dir as needed.
     Directories are copied recursively (``shutil.copytree``), files via
-    ``shutil.copy2`` — mirroring the bash ``cp -R`` / ``cp`` split.
+    ``shutil.copy2``.
     """
     if not valid_timestamp(timestamp):
         raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {timestamp!r}")  # noqa: TRY003  # single call-site

--- a/packages/installer/src/installer/core/consent.py
+++ b/packages/installer/src/installer/core/consent.py
@@ -5,12 +5,10 @@ confirm it: when stdin is not a TTY (no prompt can be answered) and neither
 ``--yes`` nor ``--dry-run`` waives confirmation, the run hard-fails up front with
 a clear error rather than silently overwriting files.
 
-This is design-forward relative to ``scripts/install.sh``, whose per-prompt
-``confirm()`` merely *skips* in non-interactive mode (``scripts/install.sh:177``)
-— the Python installer promotes that to a single explicit precondition so a
-scripted caller learns immediately that it must pass ``--yes``. ``--yes`` is the
-intended scripted-install path; ``--dry-run`` writes nothing, so both waive the
-guard.
+The non-interactive guard is an explicit up-front precondition: a scripted
+caller learns immediately that it must pass ``--yes`` rather than discovering
+it mid-run when a prompt cannot be answered. ``--yes`` is the intended
+scripted-install path; ``--dry-run`` writes nothing, so both waive the guard.
 """
 
 from __future__ import annotations

--- a/packages/installer/src/installer/core/installer_toml.py
+++ b/packages/installer/src/installer/core/installer_toml.py
@@ -1,19 +1,14 @@
-"""Loader for ``installer.toml`` — the structured replacement for the legacy
-``scripts/prune-list`` text file.
+"""Loader for ``installer.toml`` — the prune-list configuration.
 
-Replaces the bash ``_load_prune_list`` (``scripts/install.sh:1471-1483``), which
-read one glob per non-comment line out of ``scripts/prune-list``. The Python
-installer instead reads a ``[prune] retired`` array from
-``packages/installer/installer.toml`` (schema in
-``docs/architecture/installer/installer-design.md`` §"Configuration —
-installer.toml"). An optional ``[tools]`` table carries per-tool dest-dir
+Reads a ``[prune] retired`` array from ``packages/installer/installer.toml``
+(schema in ``docs/architecture/installer/installer-design.md`` §"Configuration
+— installer.toml"). An optional ``[tools]`` table carries per-tool dest-dir
 overrides.
 
 Pure: takes a ``Path``, returns parsed data. A missing file is the no-op
-default (empty prune list, no overrides) — mirroring the bash
-``[[ -f "$list_file" ]] || return 0`` early-out — so callers never have to
-guard the absent-config case. Glob *matching* lives in ``core/prune.py``; this
-module only retains the patterns as strings.
+default (empty prune list, no overrides), so callers never have to guard the
+absent-config case. Glob *matching* lives in ``core/prune.py``; this module
+only retains the patterns as strings.
 """
 
 from __future__ import annotations

--- a/packages/installer/src/installer/core/merge/strategies/json_union.py
+++ b/packages/installer/src/installer/core/merge/strategies/json_union.py
@@ -107,10 +107,9 @@ def merge_settings_bytes(existing: bytes, incoming: bytes) -> bytes:
     The reusable core of the union: parse both, deep-merge (``existing`` wins on a
     scalar conflict, arrays union, keys present on only one side carried through),
     and serialise canonically. The sync engine uses it to union a staged
-    settings.json into the user's existing dest file (bash ``sync_settings_file``,
-    ``scripts/install.sh:1268-1335``), so user values survive an install. Raises
-    ``ValueError`` if either side is not valid JSON — the caller decides how to
-    recover.
+    settings.json into the user's existing dest file so user values survive an
+    install. Raises ``ValueError`` if either side is not valid JSON — the caller
+    decides how to recover.
     """
     return _to_bytes(_deep_merge(json.loads(existing), json.loads(incoming)))
 

--- a/packages/installer/src/installer/core/model.py
+++ b/packages/installer/src/installer/core/model.py
@@ -26,8 +26,7 @@ class Tool(StrEnum):
 
 
 class FileKind(StrEnum):
-    """Merge-dispatch discriminator. Mirrors the bash `classify_file()` at
-    `scripts/install.sh:486-505`. Namespace context for `NAMESPACED_MD`
+    """Merge-dispatch discriminator. Namespace context for `NAMESPACED_MD`
     lives on `StagedItem.namespace`, not in the enum, so merge dispatch
     keys on (kind, namespace) cleanly."""
 
@@ -74,8 +73,8 @@ class NamedRulesInclude:
     from the fixed ``src/user/.claude/rules/`` source dir and preserves the
     author's ordering. ``names`` holds the verbatim sed capture (the raw
     comma-list text); splitting, trimming, and empty-entry skipping happen at
-    flatten time in `core/templates.py`, mirroring the bash ``tr ',' '\\n'`` +
-    per-name trim loop."""
+    flatten time in `core/templates.py` (split on comma, trim each name, skip
+    empties)."""
 
     names: str
 
@@ -104,15 +103,15 @@ class StagedItem:
     ignore `executable`; the sync engine preserves the source tree's
     mode bits for recursive copies.
 
-    `shared_carrier` is the in-memory replacement for the bash
-    `.carrier-from-user-shared` sentinel file (`scripts/install.sh:517-529`).
-    It is set `True` only on `skills/` and `agents/` `kind==DIR` items first
+    `shared_carrier` is the in-memory carrier flag (replaces the on-disk
+    `.carrier-from-user-shared` sentinel). It is set `True` only on `skills/`
+    and `agents/` `kind==DIR` items first
     staged from the shared carrier tree (`build_plan` Phase 2). The Phase 6
     plugin overlay reads it to allow a carrier-merge (a plugin overlaying a
     disjoint file set into a shared skill/agent dir) while keeping plugin-vs-
-    plugin directory collisions fatal. The overlay clears it after a merge —
-    mirroring the bash `rm -f sentinel` — so a second plugin colliding on the
-    same dir is a true plugin-plugin collision (fatal)."""
+    plugin directory collisions fatal. The overlay clears it after a merge so
+    a second plugin colliding on the same dir is a true plugin-plugin collision
+    (fatal)."""
 
     source_path: Path
     dest_relpath: Path
@@ -126,7 +125,7 @@ class StagedItem:
 
 @dataclass(slots=True)
 class StagingPlan:
-    """The in-memory replacement for the bash installer's temp-dir staging.
+    """The in-memory staging plan.
 
     Built incrementally during the staging phase; consumed by sync and
     prune. `items` is a plain `dict` and therefore **silently overwrites**
@@ -162,8 +161,7 @@ class StagingPlan:
 class Orphan:
     """One destination-side entry not present in this run's staging plan.
 
-    Replaces the four parallel arrays at `scripts/install.sh:1456-1467`
-    with a single record per orphan. `tool` is `str` rather than `Tool`
+    One record per orphan. `tool` is `str` rather than `Tool`
     because the orphan bucket includes plugin namespaces (e.g. ``beads``)
     that are not tools."""
 

--- a/packages/installer/src/installer/core/model.py
+++ b/packages/installer/src/installer/core/model.py
@@ -91,12 +91,11 @@ every call site rather than silently passing through."""
 class StagedItem:
     """In-memory record of one entry destined for a tool's install root.
 
-    `content` is `None` when `kind == FileKind.DIR` (the bash installer
-    treats top-level skill / agent directories as single staged units;
-    their bytes are derived from `source_path` at sync time, not carried
-    in the data model). For every other `kind`, `content` is the file's
-    bytes (eager — read at staging time so the sync-phase hash-compare
-    has no extra I/O).
+    `content` is `None` when `kind == FileKind.DIR` — top-level skill /
+    agent directories are staged as single units; their bytes are derived
+    from `source_path` at sync time, not carried in the data model. For
+    every other `kind`, `content` is the file's bytes (eager — read at
+    staging time so the sync-phase hash-compare has no extra I/O).
 
     `executable` is a sync-phase write attribute (mode bit 0o755 vs 0o644),
     not a merge-dispatch concern — see design doc §3.6. Directories

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -2,8 +2,7 @@
 
 After base staging (Phases 1-5, ``staging.build_plan``), each active plugin's
 ``.agents/`` (shared scope) and ``.<tool>/`` (tool scope) content is overlaid
-onto the tool's plan. Port of the bash Phase 6 loop
-(``scripts/install.sh:813-847``).
+onto the tool's plan.
 
 Two invariants from the bash original:
 
@@ -42,8 +41,8 @@ if TYPE_CHECKING:
     from installer.plugins.base import PluginAdapter
     from installer.tools.base import ToolAdapter
 
-# Plugin namespace staging order, per scope (bash install.sh:820, 837). The tool
-# scope includes commands; the shared scope does not (no shared commands).
+# Plugin namespace staging order, per scope. The tool scope includes commands;
+# the shared scope does not (no shared commands).
 _TOOL_NAMESPACES = ("rules", "commands", "skills", "agents")
 _SHARED_NAMESPACES = ("rules", "skills", "agents")
 
@@ -132,11 +131,9 @@ def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:
     The ``.agents/``-origin precondition is enforced by the caller via
     ``carrier_eligible`` — a tool-scope plugin DIR never reaches here.
 
-    Port of the bash carrier-merge guard (``scripts/install.sh:550-595``): the
-    disjoint-file-set check is the load-bearing precondition — overlapping names
-    fall through to the registry's fatal strategy. Dotfiles are excluded from the
-    comparison to mirror bash's ``"$dir"/*`` globs, which skip dot-prefixed
-    entries."""
+    The disjoint-file-set check is the load-bearing precondition — overlapping
+    names fall through to the registry's fatal strategy. Dotfiles are excluded
+    from the comparison (dot-prefixed entries are skipped)."""
     if not (
         existing.kind is FileKind.DIR and incoming.kind is FileKind.DIR and existing.shared_carrier
     ):
@@ -156,12 +153,11 @@ def _carry_files(directory: Path) -> dict[Path, bytes]:
     """The plugin DIR's disjoint files, keyed by their relpath under
     ``directory`` to their bytes — the file-carry payload of a carrier-merge.
 
-    Approximates the bash carrier-merge copy loop (``scripts/install.sh:585-592``):
-    ``for sfile in "$src"/*`` iterates the dot-excluded TOP-LEVEL entries, then
-    ``cp -R`` descends each subdir. So a top-level dotfile is dropped — matching
-    the same dotfile exclusion the disjoint check applies via ``_visible_names``
-    — while a dotfile nested under a carried subdir is kept. Keys are relpaths so
-    a nested file lands at ``subdir/file`` under the carrier DIR's destination.
+    Iterates dot-excluded TOP-LEVEL entries, recursing into subdirs. A top-level
+    dotfile is dropped — matching the same dotfile exclusion the disjoint check
+    applies via ``_visible_names`` — while a dotfile nested under a carried
+    subdir is kept. Keys are relpaths so a nested file lands at
+    ``subdir/file`` under the carrier DIR's destination.
 
     Only files are recorded; ``dir_overrides`` maps relpaths to bytes and so has
     no representation for a directory entry. A *truly empty* subdir that bash

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -103,8 +103,8 @@ def _place(
         plan.items[incoming.dest_relpath] = incoming
         return
     if carrier_eligible and _carrier_merge_allowed(existing, incoming):
-        # The carrier dir survives: with the
-        # plugin's disjoint files merged in. Record those added files' bytes in
+        # The carrier dir survives with the plugin's disjoint files merged in.
+        # Record those added files' bytes in
         # the dir_overrides side channel (the carrier DIR item has a single
         # source_path and so cannot itself express a second source tree), then
         # clear the flag so any further plugin collision on this dir is a true

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -144,7 +144,10 @@ def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:
 
 
 def _visible_names(directory: Path) -> set[str]:
-    """The dot-excluded child names of ``directory`` — entries a plain glob would iterate (dotfiles excluded)."""
+    """The dot-excluded child names of ``directory``.
+
+    Entries a plain glob would iterate (dotfiles excluded).
+    """
     return {entry.name for entry in directory.iterdir() if not entry.name.startswith(".")}
 
 

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -4,7 +4,7 @@ After base staging (Phases 1-5, ``staging.build_plan``), each active plugin's
 ``.agents/`` (shared scope) and ``.<tool>/`` (tool scope) content is overlaid
 onto the tool's plan.
 
-Two invariants from the bash original:
+Two ordering invariants:
 
 - **Alphabetical plugin order.** Plugins are applied in ascending name order so
   that last-wins collisions (``OTHER`` / ``JSONC`` / ``TOML``) resolve
@@ -103,7 +103,7 @@ def _place(
         plan.items[incoming.dest_relpath] = incoming
         return
     if carrier_eligible and _carrier_merge_allowed(existing, incoming):
-        # Mirror bash `rm -f sentinel`: the carrier dir survives with the
+        # The carrier dir survives: with the
         # plugin's disjoint files merged in. Record those added files' bytes in
         # the dir_overrides side channel (the carrier DIR item has a single
         # source_path and so cannot itself express a second source tree), then
@@ -144,8 +144,7 @@ def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:
 
 
 def _visible_names(directory: Path) -> set[str]:
-    """The dot-excluded child names of ``directory`` — the entries a bash
-    ``"$dir"/*`` glob would iterate (dotfiles are skipped without ``dotglob``)."""
+    """The dot-excluded child names of ``directory`` — entries a plain glob would iterate (dotfiles excluded)."""
     return {entry.name for entry in directory.iterdir() if not entry.name.startswith(".")}
 
 
@@ -160,7 +159,7 @@ def _carry_files(directory: Path) -> dict[Path, bytes]:
     ``subdir/file`` under the carrier DIR's destination.
 
     Only files are recorded; ``dir_overrides`` maps relpaths to bytes and so has
-    no representation for a directory entry. A *truly empty* subdir that bash
+    no representation for a directory entry. A *truly empty* subdir that
     ``cp -R`` would have created is therefore not carried — a deliberate gap, not
     an oversight: plugin source trees are git-tracked, and git cannot store an
     empty directory, so an empty subdir cannot reach this function in the first

--- a/packages/installer/src/installer/core/prune.py
+++ b/packages/installer/src/installer/core/prune.py
@@ -71,7 +71,7 @@ def _scan_namespace(
     staged: set[str],
     prune_globs: Sequence[str],
 ) -> list[Orphan]:
-    """Collect orphans in one dest namespace dir (bash ``_scan_namespace``).
+    """Collect orphans in one dest namespace dir.
 
     An entry is an orphan when it is not a legacy ``*.backup-*`` file, is not
     staged, and its ``tool/namespace/basename`` key matches a prune glob.

--- a/packages/installer/src/installer/core/prune.py
+++ b/packages/installer/src/installer/core/prune.py
@@ -1,28 +1,24 @@
 """Orphan scan — identify retired dest entries to prune.
 
-Pure port of the bash orphan scan (``scripts/install.sh:1505-1543``). An orphan
-is a top-level entry directly inside a tool's scoped namespace dir
+An orphan is a top-level entry directly inside a tool's scoped namespace dir
 (``commands``/``skills``/``agents``/``rules``) or ``~/.beads/formulas`` that:
 
 1. is NOT present in this run's ``StagingPlan`` (nothing staged it), AND
 2. matches a prune-list glob keyed ``tool/namespace/basename``.
 
 Item granularity is the top-level entry — the scan does not recurse into nested
-skill directories (bash note at ``scripts/install.sh:1446-1448``). Legacy
-``*.backup-*`` entries (in-place backups from older ``backup()``
-implementations) are skipped so they are never treated as orphans
-(``scripts/install.sh:1512``). Sibling ``<namespace>-backup/`` dirs live at the
-grandparent level and are never visited by this scan.
+skill directories. Legacy ``*.backup-*`` entries (in-place backups from older
+``backup()`` implementations) are skipped so they are never treated as orphans.
+Sibling ``<namespace>-backup/`` dirs live at the grandparent level and are never
+visited by this scan.
 
 ``~/.beads/formulas`` is scanned whenever pruning runs, regardless of beads
 plugin detection: if beads is not an active plugin, no plan staged any formula,
-so every dest formula registers as an orphan — consistent with strict mode
-(``scripts/install.sh:1537-1541``).
+so every dest formula registers as an orphan (strict mode).
 
-Matching is ``fnmatch`` on the ``tool/namespace/basename`` key, mirroring the
-bash ``case "$key" in ($entry)`` glob match (``scripts/install.sh:1485-1499``).
-Pure: it reads the destination filesystem and the in-memory plans, and returns
-``list[Orphan]`` without mutating anything.
+Matching is ``fnmatch`` on the ``tool/namespace/basename`` key. Pure: it reads
+the destination filesystem and the in-memory plans, and returns ``list[Orphan]``
+without mutating anything.
 """
 
 from __future__ import annotations
@@ -40,14 +36,13 @@ if TYPE_CHECKING:
     from installer.core.model import StagingPlan
     from installer.tools.base import ToolAdapter
 
-# Tool-tree namespaces scanned for orphans (bash ``prune_subdirs``,
-# ``scripts/install.sh:1529``). Narrower than ``adapter.scoped_namespaces()``
-# only incidentally — kept explicit so the scan set is the bash set, not
-# whatever an adapter happens to expose.
+# Tool-tree namespaces scanned for orphans. Narrower than
+# ``adapter.scoped_namespaces()`` only incidentally — kept explicit so the scan
+# set is independent of adapter changes.
 _PRUNE_SUBDIRS = ("commands", "skills", "agents", "rules")
 
 # Beads' formulas live outside any tool tree; scanned unconditionally under a
-# fixed ``beads/formulas`` key (``scripts/install.sh:1541``).
+# fixed ``beads/formulas`` key.
 _BEADS_TOOL = "beads"
 _BEADS_NAMESPACE = "formulas"
 

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -1,19 +1,17 @@
 """Interactive prune flow — confirm and perform orphan deletion.
 
-Port of the bash ``prune_orphans`` (``scripts/install.sh:1602-1687``). Takes the
-orphan list from ``core/prune.py`` and an ``IOPort``, drives the three-way
-prompt (all / one-by-one / cancel) and the one-by-one per-item drill-down, and
-backs up then deletes every confirmed orphan. ALL prompts route through the
-``IOPort`` so the flow is unit-testable through ``ScriptedIO``.
+Takes the orphan list from ``core/prune.py`` and an ``IOPort``, drives the
+three-way prompt (all / one-by-one / cancel) and the one-by-one per-item
+drill-down, and backs up then deletes every confirmed orphan. ALL prompts route
+through the ``IOPort`` so the flow is unit-testable through ``ScriptedIO``.
 
 Deletion is always preceded by a path-aware backup (``core/backup.py``) so
-``--yes`` is never a data-loss path — the bash ``_delete_orphan`` likewise calls
-``backup`` before ``rm -rf`` (``scripts/install.sh:1580-1588``).
+``--yes`` is never a data-loss path.
 
-Guard ordering mirrors the bash function exactly: the non-interactive guard runs
-FIRST, before the empty-orphan fast path, so ``--prune-only`` without auth
-hard-fails regardless of orphan count (``scripts/install.sh:1602-1615``).
-``--dry-run`` and ``--yes`` are themselves the authorization, so they are exempt.
+Guard ordering: the non-interactive guard runs FIRST, before the empty-orphan
+fast path, so ``--prune-only`` without auth hard-fails regardless of orphan
+count. ``--dry-run`` and ``--yes`` are themselves the authorization, so they
+are exempt.
 """
 
 from __future__ import annotations
@@ -39,9 +37,9 @@ _CANCEL = "c"
 class PruneAbortedError(RuntimeError):
     """Raised when a non-interactive ``--prune-only`` run lacks authorization.
 
-    Mirrors the bash hard-fail (``scripts/install.sh:1608-1610``): the caller
-    asked for an action (prune-only) with no way to confirm it and no ``--yes``
-    / ``--dry-run`` standing in for consent, so the intent cannot be fulfilled.
+    The caller asked for an action (prune-only) with no way to confirm it and
+    no ``--yes`` / ``--dry-run`` standing in for consent, so the intent cannot
+    be fulfilled.
     """
 
 
@@ -113,7 +111,7 @@ def run_prune(
 def _prompt_and_delete(
     orphans: Sequence[Orphan], *, io: IOPort, timestamp: str
 ) -> dict[str, Counters]:
-    """Three-way prompt then act (bash interactive branch, install.sh:1636-1686)."""
+    """Three-way prompt then act."""
     choice = io.confirm_three_way(
         "Action? [a]ll, [o]ne-by-one, [c]ancel",
         choices=(_ALL, _ONE_BY_ONE, _CANCEL),
@@ -130,7 +128,7 @@ def _prompt_and_delete(
 def _delete_one_by_one(
     orphans: Sequence[Orphan], *, io: IOPort, timestamp: str
 ) -> dict[str, Counters]:
-    """Per-item drill-down (bash ``o|O`` branch, install.sh:1650-1676).
+    """Per-item drill-down.
 
     A per-item ``quit`` leaves every un-answered orphan in place; an orphan the
     user did not keep (decision ``True``) is deleted. Orphans the user never
@@ -150,7 +148,7 @@ def _delete_one_by_one(
 
 
 def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> dict[str, Counters]:
-    """Back up + delete every orphan (bash ``_delete_all_orphans``, install.sh:1592-1600)."""
+    """Back up + delete every orphan."""
     per_tool: dict[str, Counters] = {}
     for orphan in orphans:
         _back_up_and_delete(orphan, io=io, timestamp=timestamp, per_tool=per_tool)
@@ -162,7 +160,7 @@ def _delete_all(orphans: Sequence[Orphan], *, io: IOPort, timestamp: str) -> dic
 def _back_up_and_delete(
     orphan: Orphan, *, io: IOPort, timestamp: str, per_tool: dict[str, Counters]
 ) -> None:
-    """Back up an orphan, then remove it (bash ``_delete_orphan``, install.sh:1580-1588).
+    """Back up an orphan, then remove it.
 
     Tallies into the ``per_tool[orphan.tool]`` bucket (created on first sight) so
     pruned/backed_up land under the orphan's own tool or plugin namespace.
@@ -194,12 +192,11 @@ def _back_up_and_delete(
 
 
 def _display(orphans: Sequence[Orphan], io: IOPort) -> None:
-    """Print the orphan list grouped by tool then namespace (bash ``_display_orphans``).
+    """Print the orphan list grouped by tool then namespace.
 
-    Framing mirrors the bash function (``scripts/install.sh:1560-1584``): a blank
-    line then the ``-- … --`` header (bash ``header()`` prepends the newline and
-    wraps the text in dashes — ``io.header`` does neither, so both are explicit
-    here), a blank line before each tool block, and a trailing blank line.
+    A blank line then the ``-- … --`` header (``io.header`` does not prepend the
+    newline or wrap in dashes, so both are explicit here), a blank line before
+    each tool block, and a trailing blank line.
     """
     io.info("")
     io.header(f"-- Orphans detected ({len(orphans)} total) --")

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from installer.core.io_port import IOPort
     from installer.core.model import Orphan
 
-# Three-way prompt answer tokens (bash ``[a]ll, [o]ne-by-one, [c]ancel``).
+# Three-way prompt answer tokens: ``[a]ll, [o]ne-by-one, [c]ancel``.
 _ALL = "a"
 _ONE_BY_ONE = "o"
 _CANCEL = "c"
@@ -56,11 +56,11 @@ def run_prune(
 
     The mapping is keyed by ``Orphan.tool`` — each tool or plugin namespace whose
     orphans were pruned gets its own bucket (pruned / backed_up), so the install
-    summary can report a plugin pruned outside the active tool set (bash AC#19).
+    summary can report a plugin pruned outside the active tool set (AC#19).
     Every no-deletion path (guard skip, empty list, dry-run, cancel) returns an
     empty mapping.
 
-    Guard order (bash ``prune_orphans``):
+    Guard order:
 
     1. **Non-interactive guard first.** When the session is non-interactive and
        neither ``dry_run`` nor ``auto_yes`` supplies consent: a ``prune_only``
@@ -170,8 +170,9 @@ def _back_up_and_delete(
     symlink (or a path that vanished mid-run) has nothing recoverable: ``exists()``
     follows the dead link to a missing target and returns False, so ``back_up``
     would fall through to ``copy2``/``copytree`` and raise, aborting the whole run.
-    Mirror the bash ``backup()`` ``[[ -e "$target" ]]`` no-op — skip the backup but
-    still remove the link below (``rm -rf`` deletes a broken link unconditionally).
+    Skip the backup for a broken symlink — ``exists()`` returns False on a dead
+    link so ``back_up`` would raise — but still remove the link below (``unlink``
+    deletes a broken link unconditionally).
     """
     counters = per_tool.setdefault(orphan.tool, Counters())
     if orphan.path.exists():
@@ -182,8 +183,7 @@ def _back_up_and_delete(
     # the link itself, never its target. ``rmtree`` is reserved for real
     # directories: ``Path.is_dir()`` follows symlinks, so a dir-symlink would
     # otherwise reach ``rmtree`` — which refuses a symlink and raises OSError.
-    # The bash original used ``rm -rf``, which handles symlinks fine; this keeps
-    # port parity.
+    # ``unlink`` removes the symlink itself; ``rmtree`` handles real directories.
     if orphan.path.is_symlink() or not orphan.path.is_dir():
         orphan.path.unlink()
     else:

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -53,7 +53,7 @@ def prune_pipeline(
     (plain ``--prune``). Returns the flow's per-target ``Counters`` (pruned /
     backed_up) keyed by ``Orphan.tool`` — each tool or plugin namespace whose
     orphans were pruned gets its own bucket so the install summary can report a
-    plugin pruned outside the active tool set (bash AC#19). An empty / no-op
+    plugin pruned outside the active tool set (AC#19). An empty / no-op
     prune yields an empty mapping.
     """
     orphans = scan_orphans(adapters, plans=plans, home=home, config=config)

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -84,9 +84,8 @@ def install_pipeline(
     looked up by its tool (``Tool(adapter.name)``) and written under
     ``adapter.dest_dir(home)``. Returns a per-tool mapping keyed by
     ``adapter.name`` (each tool's own `Counters`) rather than one aggregate, so
-    the install summary can render a separate block per tool at bash parity
-    (``scripts/install.sh:1818-1826``). A summed total would throw the per-tool
-    distinction away.
+    the install summary can render a separate block per tool. A summed total
+    would throw the per-tool distinction away.
 
     ``dry_run`` and ``auto_yes`` are forwarded verbatim into every ``sync_plan``
     call, so the W2 consent gate and the shared no-TTY guard apply uniformly
@@ -125,13 +124,11 @@ def install_plugin_routes(
     The plugin-side analog of ``install_pipeline``: it walks each plugin's
     ``routes(home)`` through ``sync_routes`` and returns a per-plugin mapping
     keyed by ``plugin.name`` (each plugin's own `Counters`). Per-plugin rather
-    than one aggregate so the install summary renders a block per plugin at bash
-    parity. A routes-free generic plugin still gets an all-zero bucket — present
-    so a verbose summary can print its (empty) block — so a tool-only plugin set
-    is a no-op on disk, not on the mapping. ``cli.main`` (W3) calls this after
-    ``install_pipeline`` (gated by ``not --prune-only``), mirroring the bash
-    installer, which runs ``stage_and_install_beads`` after the tool sync
-    (``scripts/install.sh:948``).
+    than one aggregate so the install summary renders a block per plugin. A
+    routes-free generic plugin still gets an all-zero bucket — present so a
+    verbose summary can print its (empty) block — so a tool-only plugin set is a
+    no-op on disk, not on the mapping. ``cli.main`` (W3) calls this after
+    ``install_pipeline`` (gated by ``not --prune-only``).
 
     ``dry_run`` and ``auto_yes`` thread into ``sync_routes`` so the consent gate
     and no-TTY guard apply uniformly with the tool install.

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -1,7 +1,6 @@
 """Staging-phase construction of a StagingPlan from source files.
 
-Pure builders mirroring the bash installer's Phase 1-5 staging
-(``scripts/install.sh``): ``classify_file`` assigns a ``FileKind``;
+Phase 1-5 pure builders: ``classify_file`` assigns a ``FileKind``;
 ``stage_namespace`` walks one namespace subdir (skills/agents/rules/commands);
 ``stage_templates`` and ``stage_settings`` collect tool-root instruction
 templates and settings; ``build_plan`` drives all five phases for one tool.
@@ -37,12 +36,10 @@ def strip_template_suffix(path: Path) -> Path:
 def classify_file(path: Path, namespace: str | None) -> FileKind:
     """Merge-dispatch classification of a source path.
 
-    Port of the bash ``classify_file`` (``scripts/install.sh:486-505``).
     ``namespace`` is the parent namespace dir name (``skills``/``rules``/…)
     or ``None`` for tool-root files; it promotes a ``*.md`` file to
-    ``NAMESPACED_MD`` exactly as the bash ``-n "$parent_dir"`` guard does.
-    The directory check is first, mirroring the bash ordering, so a
-    directory named ``foo.toml`` still classifies as ``DIR``.
+    ``NAMESPACED_MD``. The directory check is first, so a directory named
+    ``foo.toml`` still classifies as ``DIR``.
     """
     if path.is_dir():
         return FileKind.DIR
@@ -81,19 +78,18 @@ def stage_templates(source_root: Path, *, provenance: Provenance) -> list[Staged
     ]
 
 
-# Three explicit globs in bash Phase 5 order (install.sh:806) — keep them
-# separate; collapsing into one brace pattern would lose the staging order.
+# Three explicit globs — keep them separate; collapsing into one brace pattern
+# would lose the staging order (Phase 5: json, jsonc, toml).
 _SETTINGS_GLOBS = ("*.json.template", "*.jsonc.template", "*.toml.template")
 
 
 def stage_settings(source_root: Path, *, provenance: Provenance) -> list[StagedItem]:
     """Stage tool-root settings templates (bash Phase 5).
 
-    Globs the JSON/JSONC/TOML template forms (each glob sorted, in the bash
-    order), classifies via ``classify_file``, strips ``.template``, and stages
-    each as a root-level item with no namespace. Shared settings are
-    intentionally never staged (bash note at install.sh:791-792). A missing
-    ``source_root`` yields ``[]``.
+    Globs the JSON/JSONC/TOML template forms (each glob sorted, in order),
+    classifies via ``classify_file``, strips ``.template``, and stages each as a
+    root-level item with no namespace. Shared settings are intentionally never
+    staged. A missing ``source_root`` yields ``[]``.
     """
     if not source_root.is_dir():
         return []
@@ -122,8 +118,8 @@ def stage_namespace(
 ) -> list[StagedItem]:
     """Stage one namespace subdir into StagedItems.
 
-    Port of bash ``stage_content_from_dir`` (``scripts/install.sh``). Walks
-    ``source_root/namespace/*`` in sorted order; each direct child whose name is
+    Walks ``source_root/namespace/*`` in sorted order; each direct child whose
+    name is
     excluded by ``ignore`` (a file basename or a directory name from
     ``.installignore``) is skipped. Surviving entries are classified, suffix-
     stripped, and turned into ``StagedItem``s. A missing namespace dir yields
@@ -159,24 +155,22 @@ def stage_namespace(
     return items
 
 
-_SHARED_NAMESPACES = ("skills", "agents", "rules")  # bash Phase 2 (no commands shared)
+_SHARED_NAMESPACES = ("skills", "agents", "rules")  # no commands shared (Phase 2)
 
-# Shared namespaces whose DIR units are carrier dirs (bash install.sh:525) — a
-# plugin may carrier-merge disjoint files into one of these; rules/ holds files,
-# not dirs, so it is excluded.
+# Shared namespaces whose DIR units are carrier dirs — a plugin may
+# carrier-merge disjoint files into one of these; rules/ holds files, not dirs,
+# so it is excluded.
 _CARRIER_NAMESPACES = frozenset({"skills", "agents"})
 
 
 def _mark_carrier(item: StagedItem) -> StagedItem:
     """Stamp the shared-carrier flag on a shared skills/agents DIR item.
 
-    Port of the bash ``.carrier-from-user-shared`` sentinel drop
-    (``scripts/install.sh:517-529``). Only ``kind==DIR`` items in the carrier
-    namespaces are marked; every other item passes through unchanged so the
-    flag never spuriously appears on rules files, agent ``*.md`` files, or
-    templates. Mark only during shared (Phase 2) staging — plugin staging must
-    NOT self-mark, which is why this lives in ``build_plan`` and not in the
-    shared ``stage_namespace`` walker.
+    Only ``kind==DIR`` items in the carrier namespaces are marked; every other
+    item passes through unchanged so the flag never spuriously appears on rules
+    files, agent ``*.md`` files, or templates. Marked only during shared
+    (Phase 2) staging — plugin staging must NOT self-mark, which is why this
+    lives in ``build_plan`` and not in the shared ``stage_namespace`` walker.
     """
     if item.kind is FileKind.DIR and item.namespace in _CARRIER_NAMESPACES:
         return replace(item, shared_carrier=True)
@@ -198,10 +192,10 @@ def _add_item(plan: StagingPlan, item: StagedItem) -> None:
 
 
 def build_plan(adapter: ToolAdapter, *, repo_root: Path, ignore: InstallIgnore) -> StagingPlan:
-    """Build a StagingPlan for one tool (bash Phases 1-5).
+    """Build a StagingPlan for one tool (Phases 1-5).
 
-    Stages, in bash order: shared templates (1), shared skills/agents/rules
-    namespaces (2), tool-root templates (3), tool namespaces from
+    Stages: shared templates (1), shared skills/agents/rules namespaces (2),
+    tool-root templates (3), tool namespaces from
     ``adapter.scoped_namespaces()`` (4), and tool settings (5). Each namespace
     is gated by ``adapter.should_install_namespace(ns, source)`` so a tool can
     opt out (e.g. OpenCode skips shared agents). Plugin overlay (Phase 6) and

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -56,7 +56,7 @@ def classify_file(path: Path, namespace: str | None) -> FileKind:
 
 
 def stage_templates(source_root: Path, *, provenance: Provenance) -> list[StagedItem]:
-    """Stage tool-root instruction templates (bash Phases 1 & 3).
+    """Stage tool-root instruction templates (Phases 1 & 3).
 
     Globs ``source_root/*.md.template`` (sorted), strips the ``.template``
     suffix, and stages each as a root-level ``FileKind.OTHER`` item with no
@@ -84,7 +84,7 @@ _SETTINGS_GLOBS = ("*.json.template", "*.jsonc.template", "*.toml.template")
 
 
 def stage_settings(source_root: Path, *, provenance: Provenance) -> list[StagedItem]:
-    """Stage tool-root settings templates (bash Phase 5).
+    """Stage tool-root settings templates (Phase 5).
 
     Globs the JSON/JSONC/TOML template forms (each glob sorted, in order),
     classifies via ``classify_file``, strips ``.template``, and stages each as a
@@ -145,10 +145,10 @@ def stage_namespace(
                 namespace=namespace,
                 provenance=provenance,
                 content=entry.read_bytes() if is_file else None,
-                # Preserve the source mode bit so hook scripts land +x (sync
-                # writes 0o755 vs 0o644 from this). Mirrors bash ``cp``, which
-                # carries the executable bit through staging. Any execute bit
-                # (owner/group/other) counts, matching POSIX ``test -x`` intent.
+                # Preserves the source mode bit so hook scripts land +x (sync
+                # writes 0o755 vs 0o644 from this), which carries the executable
+                # bit through staging. Any execute bit (owner/group/other) counts,
+                # matching POSIX ``test -x`` intent.
                 executable=is_file and bool(entry.stat().st_mode & 0o111),
             )
         )

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -119,8 +119,7 @@ def stage_namespace(
     """Stage one namespace subdir into StagedItems.
 
     Walks ``source_root/namespace/*`` in sorted order; each direct child whose
-    name is
-    excluded by ``ignore`` (a file basename or a directory name from
+    name is excluded by ``ignore`` (a file basename or a directory name from
     ``.installignore``) is skipped. Surviving entries are classified, suffix-
     stripped, and turned into ``StagedItem``s. A missing namespace dir yields
     ``[]``. Matching runs on direct children pre-``.template``-strip, so the real

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -1,6 +1,5 @@
-"""Install / prune summary renderer (8.18 — bash parity).
+"""Install / prune summary renderer.
 
-Pure in-memory port of the bash install Summary (``scripts/install.sh:1801-1869``).
 ``cli.main`` merges the per-target ``Counters`` from the three pipelines
 (``install_pipeline`` tools, ``install_plugin_routes`` plugins,
 ``prune_pipeline`` orphans-by-tool) and hands them here with the active tool /
@@ -8,22 +7,19 @@ plugin lists, the ALL_* universes, and the verbose flag. The renderer decides
 *what* to print and routes every line through the injected ``IOPort`` — it owns
 no terminal, so it is unit-testable through ``ScriptedIO``.
 
-Two shapes, branching on ``verbose`` exactly as bash does:
+Two shapes, branching on ``verbose``:
 
-- **verbose** (``scripts/install.sh:1815-1842``): a '-- Summary --' header, then
-  one '-- <target> --' block per report target listing the six fields in fixed bash
-  order (Installed / Updated / Merged / Backed up / Pruned / Skipped), then a DIM
-  '(not detected, skipped)' footer for every ALL_* target absent from the report
-  set;
-- **quiet** (``scripts/install.sh:1843-1869``): one line per target with non-zero
-  *changes* (installed + updated + merged + pruned; a pure skip is not a change),
-  or the single em-dash 'All files up to date' line when nothing changed
-  anywhere.
+- **verbose**: a '-- Summary --' header, then one '-- <target> --' block per
+  report target listing the six fields in fixed order (Installed / Updated /
+  Merged / Backed up / Pruned / Skipped), then a DIM '(not detected, skipped)'
+  footer for every ALL_* target absent from the report set;
+- **quiet**: one line per target with non-zero *changes* (installed + updated +
+  merged + pruned; a pure skip is not a change), or the single 'All files up to
+  date' line when nothing changed anywhere.
 
-The report-target set mirrors bash ``REPORT_TARGETS`` (``:1807-1813``): active
-tools, then active plugins, then any ALL_* plugin that pruned outside the active
-set (bash AC#19) — keyed off the report set so such a plugin gets a real block,
-not a skipped footer.
+The report-target set: active tools, then active plugins, then any ALL_* plugin
+that pruned outside the active set (AC#19) — keyed off the report set so such a
+plugin gets a real block, not a skipped footer.
 """
 
 from __future__ import annotations
@@ -37,9 +33,8 @@ if TYPE_CHECKING:
 
     from installer.core.io_port import IOPort
 
-# Field rows in the verbose block: (label, Counters attribute). The order is the
-# bash field order (``scripts/install.sh:1820-1825``); 'Installed' maps to the
-# model's ``created`` (the rename lives here in the renderer, not the model).
+# Field rows in the verbose block: (label, Counters attribute). 'Installed' maps
+# to the model's ``created`` (the rename lives here in the renderer, not the model).
 _FIELDS: tuple[tuple[str, str], ...] = (
     ("Installed", "created"),
     ("Updated", "updated"),
@@ -54,7 +49,7 @@ _FIELDS: tuple[tuple[str, str], ...] = (
 _VALUE_COLUMN = max(len(label) for label, _ in _FIELDS) + len(":  ")
 
 # Quiet-line parts: (Counters attribute, suffix). A part is shown only when its
-# value is non-zero (``scripts/install.sh:1852-1856``).
+# value is non-zero.
 _QUIET_PARTS: tuple[tuple[str, str], ...] = (
     ("created", "installed"),
     ("updated", "updated"),
@@ -67,8 +62,8 @@ _QUIET_PARTS: tuple[tuple[str, str], ...] = (
 def _is_changed(counters: Counters) -> bool:
     """Whether a target counts as *changed* for the quiet summary.
 
-    A pure skip is not a change — only installed/updated/merged/pruned count
-    (``scripts/install.sh:1848``). ``backed_up`` rides along a change but never
+    A pure skip is not a change — only installed/updated/merged/pruned count.
+    ``backed_up`` rides along a change but never
     constitutes one on its own (a backup only happens alongside an overwrite or a
     prune), so it is intentionally excluded from this predicate.
     """
@@ -82,11 +77,11 @@ def _report_targets(
     plugins: Sequence[str],
     all_plugins: Sequence[str],
 ) -> list[str]:
-    """Ordered report-target set (bash ``REPORT_TARGETS``, ``:1807-1813``).
+    """Ordered report-target set.
 
     Active tools, then active plugins, then any ALL_* plugin that is not already
     a report target but accumulated prune activity — so a plugin pruned outside
-    the active set (bash AC#19) is reported once, as a real block.
+    the active set (AC#19) is reported once, as a real block.
     """
     targets = [*tools, *plugins]
     seen = set(targets)
@@ -109,7 +104,7 @@ def render_summary(
     verbose: bool,
     io: IOPort,
 ) -> None:
-    """Render the install / prune summary through ``io`` (bash ``:1801-1869``).
+    """Render the install / prune summary through ``io``.
 
     ``counters`` is the merged per-target tally (a target absent from the map is
     treated as all-zero). ``tools`` / ``plugins`` are the active sets in report
@@ -132,16 +127,14 @@ def _render_verbose(
     all_plugins: Sequence[str],
     io: IOPort,
 ) -> None:
-    """Per-target block form (``scripts/install.sh:1815-1842``).
+    """Per-target block form.
 
-    Every block header byte-matches bash ``header()``
-    (``scripts/install.sh:162``), which is ``printf "\\n-- %s --\\n"``: a leading
-    blank line, then the name wrapped in ``-- ... --``. The renderer reproduces
-    that here (a blank ``io.info("")`` then the wrapped name) rather than relying
-    on ``IOPort.header``, whose contract prints the message verbatim with no
+    Each block header is ``\\n-- <name> --\\n``: a leading blank line, then the
+    name wrapped in ``-- ... --``. The renderer produces this explicitly (a blank
+    ``io.info("")`` then the wrapped name) rather than relying on
+    ``IOPort.header``, whose contract prints the message verbatim with no
     wrapping and no leading newline (and is shared with non-Summary callers that
-    pass already-formed text). The trailing ``echo ""`` before ``Done.``
-    (``scripts/install.sh:1844``) is reproduced the same way.
+    pass already-formed text). A trailing blank line precedes ``Done.``.
     """
     io.info("")
     io.header("-- Summary --")
@@ -168,7 +161,7 @@ def _render_quiet(
     *,
     io: IOPort,
 ) -> None:
-    """One-line-per-changed-target form (``scripts/install.sh:1843-1869``)."""
+    """One-line-per-changed-target form."""
     lines: list[str] = []
     for target in targets:
         c = counters.get(target, Counters())
@@ -178,8 +171,7 @@ def _render_quiet(
             f"{getattr(c, attr)} {suffix}" for attr, suffix in _QUIET_PARTS if getattr(c, attr)
         ]
         lines.append(f"{target}: {', '.join(parts)}")
-    # bash emits one blank line before the up-to-date / Done branch
-    # (``scripts/install.sh:1859``), regardless of which branch fires.
+    # One blank line before the up-to-date / Done branch, regardless of which fires.
     io.info("")
     if not lines:
         io.ok("All files up to date — no changes made.")

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -44,8 +44,8 @@ _FIELDS: tuple[tuple[str, str], ...] = (
     ("Skipped", "skipped"),
 )
 
-# Column at which each field's value is printed, matching the bash printf padding
-# (e.g. ``"  Installed:  %s"``). Computed once so a label rename keeps alignment.
+# Column at which each field's value is printed; computed so a label rename
+# keeps alignment.
 _VALUE_COLUMN = max(len(label) for label, _ in _FIELDS) + len(":  ")
 
 # Quiet-line parts: (Counters attribute, suffix). A part is shown only when its

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -15,7 +15,7 @@ Two shapes, branching on ``verbose``:
   footer for every ALL_* target absent from the report set;
 - **quiet**: one line per target with non-zero *changes* (installed + updated +
   merged + pruned; a pure skip is not a change), or the single 'All files up to
-  date' line when nothing changed anywhere.
+  date — no changes made.' line when nothing changed anywhere.
 
 The report-target set: active tools, then active plugins, then any ALL_* plugin
 that pruned outside the active set (AC#19) — keyed off the report set so such a

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -5,11 +5,10 @@ Copies one source file to one destination, resolving both ends through a
 `docs/architecture/installer/installer-design.md`: later stories grow it
 to walk a `StagingPlan` and route conflicts through the merge registry.
 
-Path-aware backup (G.1) ports the bash installer's ``backup()``
-(`scripts/install.sh:352-388`): before overwriting an existing
-destination, the original is copied to a timestamped backup so a failed
-write leaves it recoverable. The routing decision and timestamp contract
-live in `core/backup.py`, shared with the prune flow (G.4).
+Path-aware backup (G.1): before overwriting an existing destination, the
+original is copied to a timestamped backup so a failed write leaves it
+recoverable. The routing decision and timestamp contract live in
+`core/backup.py`, shared with the prune flow (G.4).
 """
 
 from __future__ import annotations
@@ -39,10 +38,9 @@ def _effective_content(content: bytes, old: bytes | None, *, kind: FileKind) -> 
     """The bytes to actually write for one item.
 
     A ``settings.json`` over an existing user file is union-merged into that file
-    (bash ``sync_settings_file``) so user values survive; any other kind, or a
-    fresh install, writes the staged content unchanged. The caller guarantees an
-    existing settings file is valid JSON before this runs (an invalid one is
-    skipped with an error — bash ``scripts/install.sh:1299-1304``), so the union
+    so user values survive; any other kind, or a fresh install, writes the staged
+    content unchanged. The caller guarantees an existing settings file is valid
+    JSON before this runs (an invalid one is skipped with an error), so the union
     never has to reconcile unparseable bytes.
     """
     if kind is not FileKind.SETTINGS_JSON or old is None:
@@ -51,8 +49,8 @@ def _effective_content(content: bytes, old: bytes | None, *, kind: FileKind) -> 
 
 
 def _is_valid_json(data: bytes) -> bool:
-    """Whether ``data`` parses as JSON — the guard bash runs as ``jq empty`` before
-    union-merging an existing ``settings.json`` (``scripts/install.sh:1299``)."""
+    """Whether ``data`` parses as JSON — the guard before union-merging an existing
+    ``settings.json``."""
     try:
         json.loads(data)
     except (json.JSONDecodeError, UnicodeDecodeError):
@@ -226,20 +224,17 @@ def sync_routes(
 ) -> Counters:
     """Install every plugin route's globbed files at its dest root.
 
-    The in-memory port of the bash installer's ``stage_and_install_beads``
-    (``scripts/install.sh:948-1124``): for each ``PluginRoute``, glob
-    ``source_dir`` for the route's pattern (sorted, files only) and install each
-    match at ``dest_dir/<name>`` with the route's exec bit, reusing the FILE
-    installer's skip / consent / backup contract. A route whose ``source_dir`` is
-    absent contributes nothing (bash ``[[ -d ... ]] || continue``,
-    ``scripts/install.sh:969,1056``). Unlike the tool-file path, a hash-equal skip
-    restores a lost exec bit (``scripts/install.sh:1096``) — route-scoped, since
-    bash carries no general executable reconcile.
+    For each ``PluginRoute``, glob ``source_dir`` for the route's pattern
+    (sorted, files only) and install each match at ``dest_dir/<name>`` with the
+    route's exec bit, reusing the FILE installer's skip / consent / backup
+    contract. A route whose ``source_dir`` is absent contributes nothing.
+    Unlike the tool-file path, a hash-equal skip restores a lost exec bit —
+    route-scoped, since exec-bit restore applies only to plugin routes.
 
-    The shared no-TTY guard (`require_consent`) runs once up front, mirroring
-    ``sync_plan``: a non-interactive run with neither ``auto_yes`` nor ``dry_run``
-    hard-fails before any write. ``dest_dir`` is created lazily on the first write
-    (the differ ignores empty dirs); ``timestamp`` is the backup suffix. Returns
+    The shared no-TTY guard (`require_consent`) runs once up front: a
+    non-interactive run with neither ``auto_yes`` nor ``dry_run`` hard-fails
+    before any write. ``dest_dir`` is created lazily on the first write (the
+    differ ignores empty dirs); ``timestamp`` is the backup suffix. Returns
     aggregate `Counters`.
     """
     require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
@@ -288,16 +283,15 @@ def _install_file(
     """Install one FILE item: skip an unchanged dest, back up a differing dest
     before the overwrite, and write the bytes with a deterministic mode bit
     (``0o755`` when ``executable`` else ``0o644``). Mutates ``counters``. An
-    unchanged-dest skip emits a verbose-gated "X is up to date" line (bash
-    ``vok``, scripts/install.sh:1166), silent without ``--verbose``.
+    unchanged-dest skip emits a verbose-gated "X is up to date" line, silent
+    without ``--verbose``.
 
     A ``SETTINGS_JSON`` item is union-merged into an existing user file rather
     than overwritten (``_effective_content``), so user values survive an install;
     the change check is then semantic (``_is_unchanged``), so a pure reformat is a
     skip, not a spurious backup-and-rewrite. An existing settings file that is not
     valid JSON is left untouched and reported as an error (it cannot be merged, and
-    a blind overwrite would destroy a recoverable hand-edit), counted as a skip —
-    bash's ``jq empty`` guard (``scripts/install.sh:1299-1304``).
+    a blind overwrite would destroy a recoverable hand-edit), counted as a skip.
 
     A *changed* dest (present, content differs) passes through the consent gate
     (`_consent_to_overwrite`) before any backup or write: an interactive decline
@@ -306,10 +300,9 @@ def _install_file(
     existing dest — a first install is not a destructive overwrite.
 
     ``restore_exec_on_skip`` (default ``False``) opts the *skip* path into
-    restoring a lost exec bit without a rewrite — the plugin-route behaviour at
-    ``scripts/install.sh:1096``. It is off for tool files because bash carries no
-    general executable reconcile (only beads scripts), so enabling it there would
-    diverge from the spec; ``sync_routes`` turns it on.
+    restoring a lost exec bit without a rewrite — route-scoped, since exec-bit
+    restore applies only to plugin routes (e.g. beads scripts). Off for tool files
+    by default; ``sync_routes`` turns it on.
 
     A dest already occupied by a non-file (a directory) is rejected with
     `ValueError` rather than crashing the walk with a raw ``IsADirectoryError`` —
@@ -321,7 +314,6 @@ def _install_file(
     if kind is FileKind.SETTINGS_JSON and old is not None and not _is_valid_json(old):
         # Refuse to touch an unparseable settings.json: union-merge is impossible
         # and a blind overwrite would destroy the user's (recoverable) hand-edit.
-        # bash skips with the same guidance (``scripts/install.sh:1299-1304``).
         io.err(f"{dest} contains invalid JSON. Fix it manually or remove it.")
         counters.skipped += 1
         return
@@ -347,10 +339,8 @@ def _install_file(
         dest.write_bytes(effective)
         dest.chmod(0o755 if executable else 0o644)
     # A changed settings.json union over an EXISTING dest is a merge, not a plain
-    # update — bash tallies ``tool_merged`` (not ``tool_updated``) on that branch
-    # (scripts/install.sh:1358 dry-run / 1366 applied). A fresh settings.json (no
-    # existing dest) is a plain create (scripts/install.sh:1303), so the merge tally
-    # is gated on ``dest_exists``.
+    # update. A fresh settings.json (no existing dest) is a plain create, so the
+    # merge tally is gated on ``dest_exists``.
     is_merge = kind is FileKind.SETTINGS_JSON and dest_exists
     _record_write(
         dest, dest_exists=dest_exists, io=io, dry_run=dry_run, counters=counters, merged=is_merge
@@ -361,10 +351,7 @@ def _dir_is_unchanged(dest: Path, source_path: Path, overrides: Mapping[Path, by
     """Whether re-materialising ``dest`` from ``source_path`` + ``overrides`` would
     leave its contents byte-identical — the directory idempotency check.
 
-    Mirrors bash ``sync_directory``'s ``src_hash == dest_hash`` "up to date"
-    branch (`scripts/install.sh:1230`), whose directory hash folds every file's
-    relpath and bytes (`compute_hash`, `scripts/install.sh:402-403`). The
-    expected file map is the source tree with ``overrides`` overlaid (override
+    The expected file map is the source tree with ``overrides`` overlaid (override
     wins on a name collision — dump-time semantics), compared against the actual
     dest tree. Bytes are read through symlinks to match ``copytree``'s
     dereferencing; only files participate, so empty dirs are ignored — matching
@@ -394,9 +381,8 @@ def _install_dir(
 
     An existing dest whose contents already match (`_dir_is_unchanged`) is left
     untouched and counted as a skip — so a re-install is idempotent and produces
-    no spurious backups (bash ``sync_directory``'s "up to date" branch,
-    `scripts/install.sh:1230`); the skip emits a verbose-gated "X is up to date"
-    line (bash ``vok``, scripts/install.sh:1237), silent without ``--verbose``.
+    no spurious backups; the skip emits a verbose-gated "X is up to date" line,
+    silent without ``--verbose``.
     A changed existing dest passes through the consent gate before the
     backup/replace: an interactive decline keeps the existing tree and counts a
     skip; ``auto_yes`` accepts silently; ``dry_run`` previews without prompting.
@@ -484,16 +470,14 @@ def _record_write(
 ) -> None:
     """Preview the would-be write under ``dry_run`` and tally it as a create,
     update, or merge. On a real (non-``dry_run``) write, emit a verbose-gated
-    per-item line ("Installed X (new)" / "Updated X" / "Merged X") so ``--verbose``
-    yields bash ``vok`` per-file detail (scripts/install.sh:1158,1180,1365) while a
-    quiet run stays silent.
+    per-item line ("Installed X (new)" / "Updated X" / "Merged X"); a quiet run
+    stays silent.
 
     ``merged`` is True only for a changed settings.json union over an existing dest
-    (``_install_file``): bash tallies that as ``tool_merged`` rather than
-    ``tool_updated`` (scripts/install.sh:1358 dry-run / 1366 applied). It is
-    mutually exclusive with the create branch — a merge always overwrites an
-    existing dest — so ``merged`` is only ever set alongside ``dest_exists``. Shared
-    by the file and dir installers; mutates ``counters``."""
+    (``_install_file``): tallied as ``merged``, not ``updated``. Mutually exclusive
+    with the create branch — a merge always overwrites an existing dest — so
+    ``merged`` is only ever set alongside ``dest_exists``. Shared by the file and
+    dir installers; mutates ``counters``."""
     if dry_run:
         verb = "merge" if merged else "update" if dest_exists else "create"
         io.info(f"would {verb} {dest}")
@@ -540,15 +524,14 @@ def _ensure_parent_dir(target: Path, *, dry_run: bool) -> None:
 
 def _restore_exec_bit(dest: Path) -> bool:
     """Restore a lost exec bit on a hash-equal dest without a full rewrite.
-    Route-scoped port of ``scripts/install.sh:1096`` (``[[ -x ]] || chmod +x``):
-    fires only when no exec bit is set, and then *adds* the exec bits to the
-    existing mode (``mode | 0o111``) rather than forcing ``0o755`` — so a
-    user-tightened file (e.g. ``0o600``) gains exec without widening its
-    read/write bits, mirroring ``chmod +x``. The any-exec-bit gate matches the
-    differ's executability definition (``_diff.py::_is_executable``). Returns
-    ``True`` when the mode was changed (so the caller can announce the repair
-    under ``--verbose``, mirroring bash ``vinfo "Restored +x ..."``,
-    scripts/install.sh:1096), ``False`` when the exec bit was already set."""
+
+    Fires only when no exec bit is set, then *adds* the exec bits to the existing
+    mode (``mode | 0o111``) rather than forcing ``0o755`` — so a user-tightened
+    file (e.g. ``0o600``) gains exec without widening its read/write bits,
+    matching ``chmod +x`` semantics. The any-exec-bit gate matches the differ's
+    executability definition (``_diff.py::_is_executable``). Returns ``True`` when
+    the mode was changed (so the caller can announce the repair under
+    ``--verbose``), ``False`` when the exec bit was already set."""
     mode = dest.stat().st_mode
     if mode & 0o111:
         return False

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -151,8 +151,7 @@ def sync_plan(
 ) -> Counters:
     """Walk a ``StagingPlan`` and install every item under the adapter's dest root.
 
-    The plan-walking install sync (W1): the in-memory replacement for the bash
-    installer's temp-dir-to-home copy. For each item:
+    The plan-walking install sync (W1). For each item:
 
     - a FILE item (eager ``content``) is hash-compared against the dest; an
       unchanged dest is skipped, a differing dest is backed up *before* the
@@ -171,8 +170,8 @@ def sync_plan(
     a whole-plan precondition. Path containment is **lexical** — like
     ``sync``/``dump``, symlinked dest *parents* are not resolved, so the guard
     is not resolved-path safety. The walk is **non-transactional**: a failure on
-    item N leaves items 1..N-1 **already installed** (matching the bash streaming
-    installer; no rollback of earlier items). Returns aggregate `Counters`.
+    item N leaves items 1..N-1 **already installed** (no rollback of earlier
+    items). Returns aggregate `Counters`.
 
     The shared no-TTY guard (`require_consent`) runs once up front: a
     non-interactive run with neither ``auto_yes`` nor ``dry_run`` cannot answer a

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -32,8 +32,6 @@ listed** (not lexicographic), each resolved as ``<name>.md`` from the fixed
 skipped; a missing rule warns and is skipped (the separator only advances on a
 successful inline). An empty list passes through as prose.
 
-The behavioural reference is the bash installer's ``flatten_agents_md``
-(``scripts/install.sh``).
 """
 
 from __future__ import annotations
@@ -61,14 +59,13 @@ _FILE_INCLUDE_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE: (.*) -->$")
 _ALL_RULES_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE-ALL-RULES -->$")
 _NAMED_RULES_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE-RULES: (.*) -->$")
 
-# Fixed source dir the named-RULES subset resolves from, relative to base_dir —
-# mirrors the bash ``$project_root/src/user/.claude/rules/$rule_name.md``
-# (install.sh:718). Distinct from ALL-RULES, which reads the staged rules tree.
+# Fixed source dir the named-RULES subset resolves from, relative to base_dir.
+# Distinct from ALL-RULES, which reads the staged rules tree.
 _NAMED_RULES_SOURCE_DIR = Path("src/user/.claude/rules")
 
-# Tool-root instruction files the bash installer flattens (install.sh:854):
-# ``AGENTS.md.template`` and ``GEMINI.md.template`` — here keyed by their
-# ``.template``-stripped dest, which is how the plan stores them.
+# Tool-root instruction files that are flattened: ``AGENTS.md.template`` and
+# ``GEMINI.md.template`` — keyed by their ``.template``-stripped dest, which is
+# how the plan stores them.
 _FLATTENABLE_DESTS: tuple[Path, ...] = (Path("AGENTS.md"), Path("GEMINI.md"))
 
 
@@ -146,8 +143,7 @@ def flatten_plan_templates(plan: StagingPlan, *, repo_root: Path, io: IOPort) ->
     """Phase 6.5/6.75: flatten the plan's instruction templates, then drop the
     include-only templates they inline.
 
-    Mirrors the bash installer (``scripts/install.sh:849-890``): for each
-    flattenable instruction file present in the plan (``AGENTS.md`` /
+    For each flattenable instruction file present in the plan (``AGENTS.md`` /
     ``GEMINI.md``), replace its content with the DYNAMIC-INCLUDE-flattened text —
     file includes resolved from ``repo_root``, ALL-RULES from the plan's own
     staged rules — then remove the include-only templates from the plan so they
@@ -206,9 +202,8 @@ def _resolve_all_rules(*, rules_dir: Path | None, io: IOPort) -> str:
     files in ``rules_dir``, sorted lexicographically by filename, joined with
     ``\\n---\\n`` between adjacent rules.
 
-    Mirrors the bash installer's ALL-RULES handler (``scripts/install.sh:730-745``):
-    ``find ... | LC_ALL=C sort`` over rule files, cat each, ``printf '\\n---\\n'``
-    between them, warn if the collection is empty.
+    All ``*.md`` files in ``rules_dir``, sorted lexicographically, joined with
+    ``\\n---\\n`` between them; warns if the collection is empty.
     """
     rule_files: list[Path] = []
     if rules_dir is not None and rules_dir.is_dir():
@@ -222,10 +217,9 @@ def _resolve_all_rules(*, rules_dir: Path | None, io: IOPort) -> str:
 def _resolve_named_rules(names: str, *, base_dir: Path, io: IOPort) -> str:
     """Expand the named-RULES subset directive to the listed rules, in order.
 
-    Mirrors the bash installer's named-RULES handler (``scripts/install.sh:710-731``):
-    split the comma-list, trim each name, skip empties, resolve each as
-    ``<name>.md`` under ``base_dir/src/user/.claude/rules/``, ``cat`` the ones
-    that exist joined by ``\\n---\\n``, and ``warn`` + skip the ones that do not.
+    Split the comma-list, trim each name, skip empties, resolve each as
+    ``<name>.md`` under ``base_dir/src/user/.claude/rules/``, joining the ones
+    that exist with ``\\n---\\n``, and warning + skipping the ones that do not.
     The separator only sits between successful inlines, so a leading missing rule
     produces no leading separator. Unlike ALL-RULES there is no aggregate
     "nothing found" warning — each missing name warns individually.

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -73,9 +73,8 @@ def parse_directive(line: str) -> IncludeDirective | None:
     """Recognise a DYNAMIC-INCLUDE directive on a single line.
 
     The line must match a marker form exactly — no leading or trailing
-    whitespace — mirroring the anchored ``^...$`` patterns in the bash
-    installer. A file marker with an empty path, or a named-RULES marker with an
-    empty list, is rejected — matching the bash ``-n`` guards — so the line
+    whitespace. A file marker with an empty path, or a named-RULES marker with an
+    empty list, is rejected — matching the non-empty guards — so the line
     passes through as prose. Returns the matching directive dataclass, or None
     for any line that is not a directive.
     """
@@ -179,7 +178,7 @@ def _file_include_dests(text: str) -> set[Path]:
 def _flatten_with_plan_rules(text: str, *, plan: StagingPlan, repo_root: Path, io: IOPort) -> str:
     """Flatten ``text``, sourcing ALL-RULES from the plan's staged ``rules/``.
 
-    The bash installer reads ALL-RULES from the on-disk staging tree; the Python
+    The on-disk staging tree is the source for ALL-RULES in the original design; the Python
     installer stages in memory, so when (and only when) the template needs rules
     they are materialised to a temp dir for ``flatten_template`` to read —
     matching ``find $staging/rules -name '*.md' | sort``.
@@ -240,7 +239,7 @@ def _resolve_named_rules(names: str, *, base_dir: Path, io: IOPort) -> str:
 def _resolve_file_include(rel: Path, *, base_dir: Path, io: IOPort) -> str:
     """Read the verbatim text of an included file, or warn and return ''.
 
-    Mirrors the bash ``[[ -f ... ]]`` guard: a missing target *or* a directory
+    A missing target *or* a directory
     is non-fatal — it warns and resolves to the empty string.
 
     Raises ``ValueError`` for absolute paths or paths containing ``..`` —

--- a/packages/installer/src/installer/tools/claude.py
+++ b/packages/installer/src/installer/tools/claude.py
@@ -9,10 +9,8 @@ if TYPE_CHECKING:
 
 
 class ClaudeAdapter:
-    """Adapter for Anthropic's Claude Code. Always detected: install.sh treats
-    claude as its unconditional tool (`TOOLS=(claude)` — "claude always; others
-    if ~/.<tool>/ exists"), so auto-detect always selects it, even on a fresh
-    machine with no ~/.claude yet."""
+    """Adapter for Anthropic's Claude Code. Always detected: auto-detect always
+    selects it, even on a fresh machine with no ~/.claude yet."""
 
     name: str = "claude"
 

--- a/packages/installer/src/installer/tools/codex.py
+++ b/packages/installer/src/installer/tools/codex.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
 
 
 class CodexAdapter:
-    """Adapter for OpenAI's Codex CLI. Probes ~/.codex/ as a directory —
-    mirrors the bash installer's [[ -d "$HOME/.codex" ]] detection."""
+    """Adapter for OpenAI's Codex CLI. Detected when ~/.codex/ exists."""
 
     name: str = "codex"
 

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -73,8 +73,7 @@ def transform_agent_frontmatter(content: bytes) -> bytes:
 
 
 class GeminiAdapter:
-    """Adapter for Google's Gemini CLI. Probes ~/.gemini/ as a directory —
-    mirrors the bash installer's [[ -d "$HOME/.gemini" ]] detection."""
+    """Adapter for Google's Gemini CLI. Detected when ~/.gemini/ exists."""
 
     name: str = "gemini"
 

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -17,9 +17,8 @@ def transform_agent_frontmatter(content: bytes) -> bytes:
     memory) and rewrite a comma-separated ``tools:`` string into an inline YAML
     flow sequence.
 
-    Surgical line port of bash ``transform_gemini_agent_frontmatter``
-    (scripts/install.sh:643-688): a fence-counting state machine that edits only
-    the lines it must and emits every other line verbatim. That verbatim path is
+    A fence-counting state machine that edits only the lines it must and emits
+    every other line verbatim. That verbatim path is
     why a ``description: |-`` block scalar — and any quoting or spacing — survives
     byte-for-byte; a pyyaml round-trip would reflow it. The ``tools:`` value is
     wrapped whole (``tools: [Read, Grep]``), preserving its raw spacing, rather
@@ -100,9 +99,9 @@ class GeminiAdapter:
 
     def post_staging_transforms(self, plan: StagingPlan, io: IOPort) -> StagingPlan:
         """Apply the Claude→Gemini agent frontmatter transform to every staged
-        ``agents/`` file. Mirrors bash Phase 6.6 (scripts/install.sh:892-897):
-        emits one verbose phase line when agent files are present, then rewrites
-        each in place. Non-agent items and directory entries are left untouched.
+        ``agents/`` file: emits one verbose phase line when agent files are
+        present, then rewrites each in place. Non-agent items and directory
+        entries are left untouched.
         """
         logged = False
         for relpath, item in list(plan.items.items()):

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -14,8 +14,7 @@ class OpenCodeAdapter:
     it installs under the XDG config dir (~/.config/opencode/, not ~/.opencode/),
     and it skips the shared agents/ namespace (frontmatter format differs;
     see OPENCODE-EXTENSIONS.md). Detected when opencode is on PATH OR the XDG
-    config dir exists — mirrors the bash
-    `command -v opencode || [[ -d ~/.config/opencode ]]`."""
+    config dir (~/.config/opencode) exists."""
 
     name: str = "opencode"
 
@@ -23,9 +22,8 @@ class OpenCodeAdapter:
         return repo_root / "src" / "user" / ".opencode"
 
     def dest_dir(self, home: Path) -> Path:
-        # XDG config dir, not a dot-dir — mirrors the bash tool_dest_dir()
-        # special-case for opencode. NOT $XDG_CONFIG_HOME-aware by design
-        # (the bash installer hardcodes ~/.config/opencode); keep parity.
+        # XDG config dir, not a dot-dir. NOT $XDG_CONFIG_HOME-aware by design
+        # (hardcoded to ~/.config/opencode to match the install destination).
         return home / ".config" / "opencode"
 
     def is_detected(self, home: Path) -> bool:

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -39,8 +39,7 @@ class OpenCodeAdapter:
 
     def should_install_namespace(self, namespace: str, source: str) -> bool:
         # Skip the shared agents/ namespace: OpenCode's agent frontmatter format
-        # differs from the shared format (see OPENCODE-EXTENSIONS.md). Mirrors the
-        # bash installer's Phase 2 `[[ "$tool" != "opencode" ]]` agents guard.
+        # differs from the shared format (see OPENCODE-EXTENSIONS.md).
         return not (namespace == "agents" and source == "shared")
 
     def post_staging_transforms(
@@ -50,10 +49,10 @@ class OpenCodeAdapter:
     ) -> StagingPlan:
         """Drop staged rules/ items before sync: OpenCode has no standalone rules/
         destination. The rules are inlined into the flat AGENTS.md by the
-        DYNAMIC-INCLUDE-ALL-RULES flatten — which runs earlier in stage_and_transform
-        and sources them from these same staged items — so dropping them here mirrors
-        install.sh Phase 7, which stages rules then skips writing the rules/ subdir
-        for opencode (scripts/install.sh:928-934)."""
+        DYNAMIC-INCLUDE-ALL-RULES flatten — which runs earlier in
+        stage_and_transform and sources them from these same staged items — so
+        dropping them here prevents a second standalone deploy of the same
+        content."""
         for relpath in [rp for rp, item in plan.items.items() if item.namespace == "rules"]:
             del plan.items[relpath]
         return plan


### PR DESCRIPTION
## Summary

- Remove all `install.sh:NNN` line-number citations and `Port of the bash` / `Mirrors bash` attributions from `packages/installer/src/`
- The bash implementation is retired (H.4); these provenance comments are now dead weight that misleads future readers who won't have the original bash context
- Behavioral invariants (ordering requirements, skip logic, exec-bit scope) are kept but rephrased to stand alone without the bash reference

## Scope

- **In scope:** All 18 `packages/installer/src/` files containing bash-provenance comments
- **Out of scope:** Test files (parity-oracle tests keep their references — they're the ground truth for correctness, not dead docs); `docs/specs/` and `docs/plans/` (dated point-in-time, frozen); `installer-design.md` bash refs that describe the current exec-stub architecture (still accurate)

## What changed

Per-file breakdown of the ~106 bash-provenance comment lines removed:
- `staging.py`, `sync.py`, `summary.py`, `cli.py` — heaviest cleanup (module docstrings + inline comments)
- `prune.py`, `prune_flow.py`, `overlay.py`, `templates.py`, `backup.py` — moderate
- `model.py`, `config.py`, `consent.py`, `installer_toml.py`, `json_union.py`, `run.py` — light
- `tools/claude.py`, `tools/gemini.py`, `tools/opencode.py` — light

## Test Plan

- [x] `make ci-installer` passes: 588 tests, 99.81% coverage, 0 audit findings (baseline unchanged)
- [x] Zero remaining `install.sh:NNN` / `port of the bash` / `mirroring bash` references in `src/`
- [x] Behavioral comments preserved — only attribution stripped

Closes bead `agents-config-w1qls.8.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013G7x6xrFrEme6bBXi8cMac