### PR TITLE
fix(installer): route base-staging collisions through the merge registry (w1qls.8.14)

### DIFF
--- a/docs/specs/2026-06-21-w1qls.8.14-staging-merge-dispatch-design.md
+++ b/docs/specs/2026-06-21-w1qls.8.14-staging-merge-dispatch-design.md
@@ -1,0 +1,114 @@
+# Staging collision → merge-dispatch (not hard-fail)
+
+**Date:** 2026-06-21
+**Status:** approved, implementing
+**Owner:** Epic E (merge registry) — filed under Epic H, owned by merge-strategy work
+
+## Problem
+
+Base staging (Phases 1–5, `core/staging.build_plan`) hard-fails on a
+`dest_relpath` collision: `_add_item` raises `ValueError`. Plugin overlay
+(Phase 6, `core/overlay._place`) already resolves the identical situation
+through the merge registry (`default_registry()`): rules append-merge, settings
+json-union, OTHER last-wins, DIR/commands/skills/agents fatal.
+
+That asymmetry is the defect. The `_add_item` raise is an explicit placeholder
+("collision resolution is Epic E; until then a hard error") and Epic E's
+infrastructure now exists and is tested. Base staging should route collisions
+through the same registry.
+
+### Current trigger census (verify-first)
+
+No real shipped install path triggers a base-staging collision today. The one
+real shared-vs-tool filename overlap, `rules/AGENTS.md`, is filtered by
+`.installignore` before `_add_item` sees it; all other Claude shared-vs-tool
+dest sets are disjoint (`comm -12` empty on skills/agents/rules). Non-Claude
+adapters return an empty `scoped_namespaces()`, so they never stage a Phase-4
+item that could collide with a Phase-2 one.
+
+This work therefore closes an architectural asymmetry and removes a latent
+footgun — a future tool-specific rule sharing a shared rule's basename would
+fatal today, when it should append-merge. It does not fix a live break.
+
+## Decision
+
+- **Registry dispatch only.** Base staging resolves collisions via the merge
+  registry. Carrier-merge (the `shared_carrier` disjoint-DIR file-merge) stays
+  overlay-only: it is a Phase-2-sets-flag → Phase-6-consumes-flag handshake, and
+  no base-staging path produces a disjoint-DIR carrier collision.
+- **Turn on real merges.** Every kind dispatches to its registered strategy:
+  `rules → append`, `settings → json-union`, `OTHER → last-wins-silent`,
+  `DIR/commands/skills/agents → fatal`. The DIR/commands/skills/agents cases stay
+  fatal, but now via `FatalStrategy` rather than the ad-hoc `_add_item` raise.
+
+## Design
+
+### New shared primitive — `core/merge/place.py`
+
+The lookup→resolve→store core is currently inlined in `overlay._place` and
+absent from `_add_item`. Extract it once:
+
+```python
+def place_resolved(plan, incoming, existing, registry) -> None:
+    """Store `incoming` at its dest; if `existing` already occupies it,
+    resolve the collision through the merge registry."""
+    if existing is None:
+        plan.items[incoming.dest_relpath] = incoming
+    else:
+        plan.items[incoming.dest_relpath] = registry.resolve(
+            incoming.kind, incoming.namespace
+        ).merge(existing, incoming)
+```
+
+Both callers fetch `existing` once and pass it in, so every path does a single
+dict lookup (no double-get on the no-collision hot path). The helper lives in
+the merge package so both `staging.py` and `overlay.py` depend downward on
+merge — clean layering, and it avoids deepening the existing overlay→staging
+import.
+
+### `core/staging.py`
+
+- `build_plan` gains a `registry: MergeRegistry` parameter.
+- `_add_item(plan, item, registry)` drops the raise: fetch `existing`, call
+  `place_resolved`. It stays a named wrapper (not inlined at the five phase
+  call sites) to keep the phase loop readable and preserve a seam for any
+  future base-staging pre-resolve hook.
+- Docstring updated; the "hard error until Epic E" note is obsolete.
+
+### `core/overlay.py`
+
+`_place` keeps its carrier-merge tier unchanged. Its non-carrier tail delegates
+to `place_resolved` instead of inlining `registry.resolve(...).merge(...)`. It
+fetches `existing` once, intercepts the carrier case, else calls
+`place_resolved(plan, incoming, existing, registry)`.
+
+### `core/orchestrator.py`
+
+One line: pass the already-built `registry` into `build_plan(...)` (today it
+only reaches `overlay_plugins`).
+
+### Merge order
+
+`MergeStrategy.merge(existing, incoming)` joins existing-then-incoming. In base
+staging the shared item (Phase 2) is staged before the tool item (Phase 4), so
+existing=shared, incoming=tool — shared body first, tool extension appended.
+Symmetric with overlay, where base is existing and the plugin is incoming.
+
+## Testing
+
+- **Rewrite `test_build_plan_raises_on_collision`.** Its forced
+  `rules/delegation.md` shared-vs-tool collision now append-merges. Rewrite to
+  assert the merged content is `shared_body + b"\n---\n" + tool_body`, no raise.
+- **Add: DIR collision still fatal.** Force a same-named skill *directory* in
+  shared (Phase 2) and tool (Phase 4); assert it raises via `FatalStrategy`
+  (match the FatalStrategy message, not the old `"collision"` string). Proves
+  the guard was relocated, not dissolved.
+- **Add: OTHER collision → last-wins-silent.** Two same-dest root templates;
+  assert incoming wins silently.
+- No base-staging settings/json-union test: settings are Phase 5, tool-root,
+  single-source — no second base item can collide on a settings dest. That path
+  is covered by the registry dispatch unit tests.
+- `place_resolved`'s arms are covered by the above plus the existing overlay
+  tests once `_place` delegates to it.
+
+`make ci-installer` (90% branch floor) must pass before done.

--- a/packages/installer/src/installer/core/merge/place.py
+++ b/packages/installer/src/installer/core/merge/place.py
@@ -1,0 +1,42 @@
+"""Shared collision-resolving placement of a StagedItem into a StagingPlan.
+
+``place_resolved`` is the one primitive both base staging (``staging._add_item``,
+Phases 1-5) and plugin overlay (``overlay._place``, Phase 6) use to land an item
+at its destination: store it when the slot is free, else resolve the collision
+through the merge registry. Callers fetch the existing occupant once and hand it
+in, so every path does a single ``plan.items`` lookup.
+
+Overlay's carrier-merge special case (disjoint-DIR file merge for a
+``shared_carrier`` directory) is intercepted by ``_place`` *before* this helper;
+``place_resolved`` is the non-carrier resolution shared by both callers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from installer.core.merge.registry import MergeRegistry
+    from installer.core.model import StagedItem, StagingPlan
+
+
+def place_resolved(
+    plan: StagingPlan,
+    incoming: StagedItem,
+    existing: StagedItem | None,
+    registry: MergeRegistry,
+) -> None:
+    """Store ``incoming`` at its ``dest_relpath`` in ``plan``.
+
+    When ``existing`` is ``None`` the slot is free and ``incoming`` is stored
+    as-is. Otherwise the registry's strategy for ``(incoming.kind,
+    incoming.namespace)`` resolves the collision, joining ``existing`` THEN
+    ``incoming``; the resulting item replaces the slot. A fatal strategy raises
+    instead of returning.
+    """
+    if existing is None:
+        plan.items[incoming.dest_relpath] = incoming
+    else:
+        plan.items[incoming.dest_relpath] = registry.resolve(
+            incoming.kind, incoming.namespace
+        ).merge(existing, incoming)

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -59,7 +59,7 @@ def stage_and_transform(
     plans: dict[Tool, StagingPlan] = {}
     for tool in tools:
         adapter = get_adapter(tool)
-        plan = build_plan(adapter, repo_root=repo_root, ignore=ignore)
+        plan = build_plan(adapter, repo_root=repo_root, ignore=ignore, registry=registry)
         plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry, ignore=ignore)
         plan = apply_extensions(plan, plugins)
         flatten_plan_templates(plan, repo_root=repo_root, io=io)

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -29,6 +29,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from installer.core.merge.place import place_resolved
 from installer.core.model import FileKind, Provenance
 from installer.core.staging import stage_namespace, stage_settings
 
@@ -99,10 +100,7 @@ def _place(
     already-merged (flag-cleared) carrier — routes through the registry, where
     ``FileKind.DIR`` is fatal."""
     existing = plan.items.get(incoming.dest_relpath)
-    if existing is None:
-        plan.items[incoming.dest_relpath] = incoming
-        return
-    if carrier_eligible and _carrier_merge_allowed(existing, incoming):
+    if existing is not None and carrier_eligible and _carrier_merge_allowed(existing, incoming):
         # The carrier dir survives with the plugin's disjoint files merged in.
         # Record those added files' bytes in
         # the dir_overrides side channel (the carrier DIR item has a single
@@ -119,9 +117,7 @@ def _place(
         )
         plan.items[incoming.dest_relpath] = replace(existing, shared_carrier=False)
         return
-    plan.items[incoming.dest_relpath] = registry.resolve(incoming.kind, incoming.namespace).merge(
-        existing, incoming
-    )
+    place_resolved(plan, incoming, existing, registry)
 
 
 def _carrier_merge_allowed(existing: StagedItem, incoming: StagedItem) -> bool:

--- a/packages/installer/src/installer/core/staging.py
+++ b/packages/installer/src/installer/core/staging.py
@@ -15,9 +15,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from installer.core.merge.registry import MergeRegistry
     from installer.tools.base import ToolAdapter
 
 from installer.core.installignore import InstallIgnore
+from installer.core.merge.place import place_resolved
+from installer.core.merge.registry import default_registry
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 
 
@@ -176,21 +179,26 @@ def _mark_carrier(item: StagedItem) -> StagedItem:
     return item
 
 
-def _add_item(plan: StagingPlan, item: StagedItem) -> None:
-    """Insert one item, raising on a duplicate dest_relpath.
+def _add_item(plan: StagingPlan, item: StagedItem, registry: MergeRegistry) -> None:
+    """Insert one item, resolving a duplicate dest_relpath through the registry.
 
     The data model overwrites silently on a duplicate key (see StagingPlan
-    docstring); collision *resolution* (merge dispatch) is Epic E. Until then
-    a collision is a hard error so it can never silently drop content.
+    docstring), so base staging never relies on that: a collision routes through
+    the merge registry exactly as plugin overlay does — rules append, settings
+    json-union, OTHER last-wins, and DIR/commands/skills/agents fatal. Carrier-
+    merge is overlay-only and is not reached here.
     """
-    if item.dest_relpath in plan.items:
-        raise ValueError(  # noqa: TRY003  # single call-site; deferred-feature signal
-            f"staging collision at {item.dest_relpath}; merge dispatch lands in Epic E"
-        )
-    plan.items[item.dest_relpath] = item
+    existing = plan.items.get(item.dest_relpath)
+    place_resolved(plan, item, existing, registry)
 
 
-def build_plan(adapter: ToolAdapter, *, repo_root: Path, ignore: InstallIgnore) -> StagingPlan:
+def build_plan(
+    adapter: ToolAdapter,
+    *,
+    repo_root: Path,
+    ignore: InstallIgnore,
+    registry: MergeRegistry | None = None,
+) -> StagingPlan:
     """Build a StagingPlan for one tool (Phases 1-5).
 
     Stages: shared templates (1), shared skills/agents/rules namespaces (2),
@@ -199,24 +207,29 @@ def build_plan(adapter: ToolAdapter, *, repo_root: Path, ignore: InstallIgnore) 
     is gated by ``adapter.should_install_namespace(ns, source)`` so a tool can
     opt out (e.g. OpenCode skips shared agents). Plugin overlay (Phase 6) and
     DYNAMIC-INCLUDE flatten (Phase 6.5) are later stories.
+
+    A same-dest collision routes through ``registry`` (the orchestrator passes
+    the shared ``default_registry()`` it also hands to the overlay); when omitted
+    a fresh ``default_registry()`` is built, since it is a pure stateless factory.
     """
+    merge_registry = registry if registry is not None else default_registry()
     plan = StagingPlan(items={}, tool=Tool(adapter.name))
     prov = Provenance(kind="tool", name=adapter.name)
     shared_root = repo_root / "src" / "user" / ".agents"
     tool_root = adapter.source_dir(repo_root)
 
     for item in stage_templates(shared_root, provenance=prov):  # Phase 1
-        _add_item(plan, item)
+        _add_item(plan, item, merge_registry)
     for ns in _SHARED_NAMESPACES:  # Phase 2
         if adapter.should_install_namespace(ns, "shared"):
             for item in stage_namespace(shared_root, ns, provenance=prov, ignore=ignore):
-                _add_item(plan, _mark_carrier(item))
+                _add_item(plan, _mark_carrier(item), merge_registry)
     for item in stage_templates(tool_root, provenance=prov):  # Phase 3
-        _add_item(plan, item)
+        _add_item(plan, item, merge_registry)
     for ns in adapter.scoped_namespaces():  # Phase 4
         if adapter.should_install_namespace(ns, "tool"):
             for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
-                _add_item(plan, item)
+                _add_item(plan, item, merge_registry)
     for item in stage_settings(tool_root, provenance=prov):  # Phase 5
-        _add_item(plan, item)
+        _add_item(plan, item, merge_registry)
     return plan

--- a/packages/installer/tests/unit/test_staging_build_plan.py
+++ b/packages/installer/tests/unit/test_staging_build_plan.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from installer.core.installignore import InstallIgnore
+from installer.core.merge.base import CollisionError
 from installer.core.model import FileKind, StagingPlan, Tool
 from installer.core.staging import build_plan
 from installer.tools.claude import ClaudeAdapter
@@ -91,16 +92,46 @@ def test_build_plan_assigns_namespaces_and_kinds(tmp_path: Path, ignore: Install
     assert plan.items[Path("settings.json")].kind == FileKind.SETTINGS_JSON
 
 
-def test_build_plan_raises_on_collision(tmp_path: Path, ignore: InstallIgnore) -> None:
-    """Two sources mapping to the same dest_relpath must raise — merge
-    dispatch is deferred to Epic E, so a silent overwrite is unacceptable."""
+def test_build_plan_appends_colliding_rules(tmp_path: Path, ignore: InstallIgnore) -> None:
+    """A shared rules/ file (Phase 2) and a tool rules/ file (Phase 4) at the
+    same dest_relpath append-merge through the registry: (NAMESPACED_MD, "rules")
+    -> AppendRulesStrategy joins existing (shared) THEN incoming (tool) with the
+    canonical b"\\n---\\n" separator."""
     repo = _make_repo(tmp_path)
-    # Force a collision: a tool-side rules/ file with the SAME name as the shared
-    # rules/ file already in the fixture. rules is in both _SHARED_NAMESPACES
-    # (Phase 2) and ClaudeAdapter.scoped_namespaces() (Phase 4), so both stage to
-    # rules/delegation.md -> identical dest_relpath.
+    # rules is in both _SHARED_NAMESPACES (Phase 2) and scoped_namespaces (Phase 4),
+    # so both stage to rules/delegation.md -> identical dest_relpath.
     (repo / "src" / "user" / ".claude" / "rules").mkdir(parents=True)
-    (repo / "src" / "user" / ".claude" / "rules" / "delegation.md").write_bytes(b"dup")
+    (repo / "src" / "user" / ".claude" / "rules" / "delegation.md").write_bytes(b"tool extension")
 
-    with pytest.raises(ValueError, match="collision"):
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
+
+    assert plan.items[Path("rules/delegation.md")].content == b"shared rule\n---\ntool extension"
+
+
+def test_build_plan_dir_collision_is_fatal(tmp_path: Path, ignore: InstallIgnore) -> None:
+    """A same-named skill DIR in shared (Phase 2) and tool (Phase 4) is an
+    irreconcilable collision: the registry routes (FileKind.DIR) to
+    FatalStrategy, which raises CollisionError. Proves the guard was relocated to
+    the registry, not dissolved."""
+    repo = _make_repo(tmp_path)
+    # shared has skills/shared-skill/ (a DIR); stage the same DIR name tool-side.
+    (repo / "src" / "user" / ".claude" / "skills" / "shared-skill").mkdir(parents=True)
+    (repo / "src" / "user" / ".claude" / "skills" / "shared-skill" / "SKILL.md").write_bytes(b"x")
+
+    with pytest.raises(CollisionError):
         build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
+
+
+def test_build_plan_other_collision_last_wins(tmp_path: Path, ignore: InstallIgnore) -> None:
+    """Two root templates mapping to the same dest (FileKind.OTHER) resolve via
+    LastWinsSilentStrategy: the incoming tool template (Phase 3) silently wins
+    over the shared one (Phase 1)."""
+    repo = _make_repo(tmp_path)
+    # shared INSTRUCTIONS.md.template (Phase 1) -> INSTRUCTIONS.md; add a tool-root
+    # template at the same dest (Phase 3).
+    tool_tmpl = repo / "src" / "user" / ".claude" / "INSTRUCTIONS.md.template"
+    tool_tmpl.write_bytes(b"# tool root tmpl")
+
+    plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
+
+    assert plan.items[Path("INSTRUCTIONS.md")].content == b"# tool root tmpl"


### PR DESCRIPTION
## Summary
- Base staging (`core/staging.py`, Phases 1-5) hard-failed with `ValueError` on a `dest_relpath` collision while plugin overlay (`core/overlay.py`, Phase 6) already merge-dispatched. This closes that Epic-E asymmetry.
- Extracts the shared lookup→resolve→store core into a new `core/merge/place.py::place_resolved`; both `_add_item` (base staging) and `overlay._place` now call it.
- Base-staging collisions resolve via the same `default_registry()`: rules→append, settings→json-union, OTHER→last-wins, DIR/commands/skills/agents→fatal (`CollisionError`). Carrier-merge stays overlay-only by design.
- `build_plan` gains a keyword-only `registry: MergeRegistry | None = None` (defaults to the pure stateless `default_registry()`; the orchestrator passes its shared instance explicitly).

## Scope
- **In scope:** `core/merge/place.py` (new), `core/staging.py`, `core/overlay.py`, `core/orchestrator.py`, `tests/unit/test_staging_build_plan.py`.
- **Out of scope:** the carrier-merge tier (unchanged); no plugin or sync changes.

## Context for reviewers
- **No real install path collides today.** The one real shared-vs-tool filename overlap, `rules/AGENTS.md`, is filtered by `.installignore` before staging sees it; all other Claude dest sets are disjoint. This PR closes an architectural asymmetry and removes a latent footgun (a future tool-specific rule sharing a shared rule's basename would have fataled; now it append-merges) — it does not fix a live break.
- **Merge order:** `MergeStrategy.merge(existing, incoming)` joins existing-then-incoming; base staging stages shared (Phase 2) before tool (Phase 4), so shared body precedes the tool extension — symmetric with overlay.
- **The `None`-default registry is an injected dependency, not a hidden global** — `default_registry()` is a pure stateless factory, so the default is referentially transparent.
- Design doc: `docs/specs/2026-06-21-w1qls.8.14-staging-merge-dispatch-design.md`.

## Test Plan
- [x] `make ci-installer` — 590 passed, 99.81% coverage, mypy --strict clean, pip-audit clean, entry-verify clean.
- [x] Rewrote the synthetic raise-on-collision test into three dispatch tests: rules→append-merge, DIR→`CollisionError` (fatal), OTHER→last-wins-silent.
- [x] Full overlay suite green after `_place` delegates to `place_resolved` (no carrier-path regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)