### PR TITLE
fix(installer): exit 130 on Ctrl-C instead of KeyboardInterrupt traceback

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -116,6 +116,25 @@ def main(
     io: IOPort | None = None,
     repo_root: Path | None = None,
 ) -> int:
+    """CLI entry point. Runs the installer, catching Ctrl-C at the boundary so an
+    interactive abort (e.g. at an overwrite prompt) exits cleanly with code 130 and
+    a short ``Aborted.`` notice instead of dumping a ``KeyboardInterrupt`` traceback.
+    Every other exit — argparse's ``SystemExit``, the guarded config-error returns —
+    passes through unchanged."""
+    try:
+        return _run(argv, home=home, io=io, repo_root=repo_root)
+    except KeyboardInterrupt:
+        sys.stderr.write("\nAborted.\n")
+        return 130
+
+
+def _run(
+    argv: list[str] | None = None,
+    *,
+    home: Path | None = None,
+    io: IOPort | None = None,
+    repo_root: Path | None = None,
+) -> int:
     args = _build_parser().parse_args(argv)
     resolved_home = home if home is not None else Path.home()
     resolved_repo_root = repo_root if repo_root is not None else _REPO_ROOT

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -1054,3 +1054,30 @@ def test_module_entry_point_propagates_nonzero_exit() -> None:
         capture_output=True,
     )
     assert result.returncode == 2
+
+
+def test_keyboard_interrupt_exits_130_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Ctrl-C during a run aborts cleanly: exit 130, a short message, no traceback.
+
+    Pins the CLI boundary contract: a ``KeyboardInterrupt`` raised anywhere inside
+    ``main`` (in practice, at an interactive overwrite prompt) is caught at the entry
+    point and converted to a graceful ``Aborted.`` on stderr with exit code 130 —
+    not a raw ``KeyboardInterrupt`` traceback. ``resolve_tools`` stands in as the deep
+    collaborator that raises, exercising the outermost handler.
+    """
+
+    def _interrupt(**_kwargs: object) -> object:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("installer.cli.resolve_tools", _interrupt)
+
+    rc = main(["--dry-run"], home=tmp_path, repo_root=tmp_path)
+
+    assert rc == 130
+    captured = capsys.readouterr()
+    assert "Aborted." in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## What
Hitting Ctrl-C during an interactive installer prompt dumped a full `KeyboardInterrupt` traceback. Now it exits cleanly: a short `Aborted.` on stderr and exit code 130 (128 + SIGINT), no traceback.

## How
Split `cli.main` into a thin entry wrapper + `_run` body. `main` wraps `_run` in `try/except KeyboardInterrupt`. Scoped to `KeyboardInterrupt` **only** — argparse's `SystemExit` and the guarded config-error returns (`return 1`/`return 2`) pass through unchanged, so no real failure is swallowed.

## Test
`test_keyboard_interrupt_exits_130_without_traceback` pins the three load-bearing decisions: exit 130, `Aborted.` on stderr, no `Traceback`. Injects the interrupt via a monkeypatched `resolve_tools` (reached unconditionally before any mode dispatch).

## Gate
`make ci-installer` green: 590 tests, 99.81% coverage, mypy strict, lint, format, pip-audit, entry-verify. quality-reviewer + simplify: no findings.

Closes agents-config-8h89b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)