### PR TITLE
fix(installer): guard sync() against SETTINGS_JSON sources

### DIFF
--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -23,6 +23,7 @@ from installer.core.consent import require_consent
 from installer.core.merge.strategies.json_union import merge_settings_bytes
 from installer.core.model import Counters, FileKind
 from installer.core.paths import is_safe_relpath
+from installer.core.staging import classify_file
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -111,6 +112,18 @@ def sync(
     counters = Counters()
     source = adapter.source_dir(repo_root) / relpath
     dest = adapter.dest_dir(home) / relpath
+
+    # sync is a raw byte-copy with no settings-merge branch, so a SETTINGS_JSON
+    # source would clobber the user's settings.json instead of the union-merge
+    # the plan path performs. Refuse it before any read/write so the merge-aware
+    # path (sync_plan) cannot be bypassed by a future caller.
+    # namespace only affects NAMESPACED_MD promotion; the SETTINGS_JSON branch
+    # keys solely on the filename, so None is the correct argument here.
+    if classify_file(source, namespace=None) is FileKind.SETTINGS_JSON:
+        raise ValueError(  # noqa: TRY003  # single call-site; subclass not justified
+            f"sync cannot install a settings.json source ({relpath}); "
+            "route settings through sync_plan for merge-aware install"
+        )
 
     content = source.read_bytes()
     dest_exists = dest.is_file()

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -689,3 +689,33 @@ def test_backup_survives_a_failed_write(tmp_path: Path) -> None:
 
     backup = dest_root / "rules-backup" / f"f.md.backup-{_FIXED_TS}"
     assert backup.read_bytes() == b"old\n"
+
+
+def test_settings_json_source_is_rejected_before_any_write(tmp_path: Path) -> None:
+    """
+    Given a source that classifies as FileKind.SETTINGS_JSON
+    When sync runs
+    Then it raises ValueError before reading or writing — never clobbering a
+    settings.json.
+
+    sync is a raw byte-copy with no settings-merge branch; a settings.json
+    routed through it would byte-overwrite the user's file instead of the
+    union-merge the plan path (sync_plan) performs. The guard refuses the
+    operation so the merge-aware path cannot be bypassed by a future caller.
+    """
+    src_root = tmp_path / "repo"
+    dest_root = tmp_path / "home"
+    src_root.mkdir()
+    dest_root.mkdir()  # exists, so the no-write assertion is non-trivial
+    (src_root / "settings.json.template").write_bytes(b'{"a": 1}\n')
+
+    with pytest.raises(ValueError, match="settings"):
+        sync(
+            _IdentityAdapter(),
+            Path("settings.json.template"),
+            repo_root=src_root,
+            home=dest_root,
+            io=ScriptedIO(),
+        )
+
+    assert not (dest_root / "settings.json.template").exists()


### PR DESCRIPTION
## What
The standalone `sync()` (old B.2 single-file path) is a raw byte-copy with **no settings-merge branch** and **no production callers** — `sync_plan` (the live path) reimplements via `_install_file`. A settings.json routed through `sync()` would byte-clobber the user's file instead of the union-merge `sync_plan` performs. This guards the latent footgun.

## How
Reject a source that classifies as `FileKind.SETTINGS_JSON` (via the canonical `classify_file`) **before any read or write**, so the merge-aware path can't be bypassed by a future caller.

## Guard vs. delete
Chose **guard**. `sync()` is dead production code, but it's the only exerciser of `back_up()`'s namespace backup-routing across its 28 tests — and `back_up()` is shared **live-path** logic. Deleting `sync()` + tests would regress that coverage for disproportionate effort on a P3.

## Test
`test_settings_json_source_is_rejected_before_any_write` pins: a SETTINGS_JSON source raises `ValueError` before any write, leaving the (existing) dest dir untouched. Real coded decision, not a tautology.

## Gate
`make ci-installer` green: 590 tests, 99.81% coverage, mypy strict, lint, format, pip-audit, entry-verify. quality-reviewer (no blocking; 2 polish items applied) + simplify (none warranted).

## Discovered work (not in this PR)
The settings-source sentinel name lives in `classify_file` (staging.py); long-term it would belong in `model.py` so both staging and sync import it without a layering dependency. Out of scope for this P3.

Closes agents-config-8debl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)