### PR TITLE
fix(installer): inline rules for non-Claude tools instead of loose files

### DIFF
--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -63,9 +63,11 @@ _NAMED_RULES_RE = re.compile(r"^<!-- DYNAMIC-INCLUDE-RULES: (.*) -->$")
 # Distinct from ALL-RULES, which reads the staged rules tree.
 _NAMED_RULES_SOURCE_DIR = Path("src/user/.claude/rules")
 
-# Tool-root instruction files that are flattened: ``AGENTS.md.template`` and
-# ``GEMINI.md.template`` — keyed by their ``.template``-stripped dest, which is
-# how the plan stores them.
+# Tool-root instruction files that are flattened, keyed by their
+# ``.template``-stripped dest (how the plan stores them). The dest is per-tool,
+# so ``AGENTS.md`` covers Claude, Codex, AND OpenCode (each installs an
+# ``AGENTS.md``); ``GEMINI.md`` covers Gemini. Only Codex/Gemini/OpenCode carry
+# the ALL-RULES marker — Claude's ``AGENTS.md`` does not, so its rules survive.
 _FLATTENABLE_DESTS: tuple[Path, ...] = (Path("AGENTS.md"), Path("GEMINI.md"))
 
 
@@ -140,25 +142,42 @@ def flatten_template(
 
 def flatten_plan_templates(plan: StagingPlan, *, repo_root: Path, io: IOPort) -> None:
     """Phase 6.5/6.75: flatten the plan's instruction templates, then drop the
-    include-only templates they inline.
+    standalone files they inline.
 
     For each flattenable instruction file present in the plan (``AGENTS.md`` /
     ``GEMINI.md``), replace its content with the DYNAMIC-INCLUDE-flattened text —
     file includes resolved from ``repo_root``, ALL-RULES from the plan's own
-    staged rules — then remove the include-only templates from the plan so they
-    are not also deployed standalone. Mutates ``plan`` in place.
+    staged rules — then remove from the plan whatever that flattening inlined so it
+    is not also deployed standalone: the include-only file templates always, and —
+    when the instruction file carried an ALL-RULES marker — the loose ``rules/``
+    items too. A tool whose instruction file has no ALL-RULES marker (Claude reads
+    a loose ``~/.claude/rules/`` tree natively) keeps its rules. Mutates ``plan``
+    in place.
     """
     include_only: set[Path] = set()
+    inlines_rules = False
     for dest in _FLATTENABLE_DESTS:
         item = plan.items.get(dest)
         if item is None or item.content is None:
             continue
         text = item.content.decode("utf-8")
         include_only |= _file_include_dests(text)
+        inlines_rules |= _text_inlines_rules(text)
         flattened = _flatten_with_plan_rules(text, plan=plan, repo_root=repo_root, io=io)
         plan.items[dest] = replace(item, content=flattened.encode("utf-8"))
     for dest in include_only:
         plan.items.pop(dest, None)
+    if inlines_rules:
+        # The instruction file inlined every rule via ALL-RULES, so the standalone
+        # rules/ files would be redundant copies the tool does not read (codex /
+        # gemini / opencode). Drop exactly what the flatten consumed — file items
+        # (content is not None), mirroring _flatten_with_plan_rules — so a rules/
+        # item that was NOT inlined is never silently discarded.
+        inlined = [
+            d for d, it in plan.items.items() if it.namespace == "rules" and it.content is not None
+        ]
+        for dest in inlined:
+            plan.items.pop(dest, None)
 
 
 def _file_include_dests(text: str) -> set[Path]:
@@ -175,6 +194,15 @@ def _file_include_dests(text: str) -> set[Path]:
     return dests
 
 
+def _text_inlines_rules(text: str) -> bool:
+    """True when ``text`` carries an ALL-RULES marker.
+
+    Flattening such a file inlines every staged rule into it, which makes the
+    standalone ``rules/`` files redundant for that tool.
+    """
+    return any(isinstance(parse_directive(line), AllRulesInclude) for line in text.splitlines())
+
+
 def _flatten_with_plan_rules(text: str, *, plan: StagingPlan, repo_root: Path, io: IOPort) -> str:
     """Flatten ``text``, sourcing ALL-RULES from the plan's staged ``rules/``.
 
@@ -183,10 +211,7 @@ def _flatten_with_plan_rules(text: str, *, plan: StagingPlan, repo_root: Path, i
     they are materialised to a temp dir for ``flatten_template`` to read —
     matching ``find $staging/rules -name '*.md' | sort``.
     """
-    needs_rules = any(
-        isinstance(parse_directive(line), AllRulesInclude) for line in text.splitlines()
-    )
-    if not needs_rules:
+    if not _text_inlines_rules(text):
         return flatten_template(text, base_dir=repo_root, io=io, rules_dir=None)
     with tempfile.TemporaryDirectory() as tmp:
         rules_dir = Path(tmp)

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -43,14 +43,12 @@ class OpenCodeAdapter:
     def post_staging_transforms(
         self,
         plan: StagingPlan,
-        io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCode mutates only the plan
+        io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCode has no transform
     ) -> StagingPlan:
-        """Drop staged rules/ items before sync: OpenCode has no standalone rules/
-        destination. The rules are inlined into the flat AGENTS.md by the
-        DYNAMIC-INCLUDE-ALL-RULES flatten — which runs earlier in
-        stage_and_transform and sources them from these same staged items — so
-        dropping them here prevents a second standalone deploy of the same
-        content."""
-        for relpath in [rp for rp, item in plan.items.items() if item.namespace == "rules"]:
-            del plan.items[relpath]
+        """No-op. OpenCode has no standalone rules/ destination, but the loose
+        rules/ drop is no longer OpenCode-specific: flatten_plan_templates drops
+        the inlined rules from EVERY plan whose instruction file carries the
+        DYNAMIC-INCLUDE-ALL-RULES marker (OpenCode's AGENTS.md does), and that runs
+        earlier in stage_and_transform. Kept as a no-op only to satisfy the
+        ToolAdapter protocol."""
         return plan

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -16,6 +16,7 @@ from installer.core.installignore import InstallIgnore
 from installer.core.io_port import ScriptedIO
 from installer.core.model import StagingPlan, Tool
 from installer.core.staging import build_plan
+from installer.core.templates import flatten_plan_templates
 from installer.tools.opencode import OpenCodeAdapter
 
 
@@ -33,7 +34,11 @@ def _make_opencode_repo(tmp_path: Path) -> Path:
     (shared / "INSTRUCTIONS.md.template").write_bytes(b"# shared root tmpl")
     # opencode tool root — templates + settings, no namespace subdirs
     opencode.mkdir(parents=True)
-    (opencode / "AGENTS.md.template").write_bytes(b"# opencode root tmpl")
+    # Mirror the real OpenCode template: it carries the ALL-RULES marker, so
+    # flatten_plan_templates inlines the staged rules and drops the loose copies.
+    (opencode / "AGENTS.md.template").write_bytes(
+        b"# opencode root tmpl\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n"
+    )
     (opencode / "opencode.jsonc.template").write_bytes(b"{}")
     return repo
 
@@ -94,27 +99,26 @@ def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path, ignore: Insta
     assert Path("opencode.jsonc") in plan.items
 
 
-def test_opencode_post_staging_transforms_drops_rules(
-    tmp_path: Path, ignore: InstallIgnore
-) -> None:
+def test_opencode_flatten_inlines_and_drops_rules(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
     Given an OpenCode plan that still carries shared rules/ items (build_plan keeps
     them so the DYNAMIC-INCLUDE-ALL-RULES flatten can inline them)
-    When OpenCodeAdapter.post_staging_transforms runs
-    Then every rules/ item is dropped, while non-rules items (skills/, templates)
-    survive.
+    When flatten_plan_templates runs
+    Then the rule is inlined into AGENTS.md and every rules/ item is dropped, while
+    non-rules items (skills/, templates) survive.
 
     Pins: OpenCode writes no standalone rules/ namespace — rules live only inline in
-    AGENTS.md. The drop runs post-flatten (mirrors install.sh Phase 7, which stages
-    rules then skips writing the rules/ subdir for opencode), so the inliner still
-    sees the rules but sync does not.
+    AGENTS.md. The loose-rules drop is owned by flatten_plan_templates (keyed on the
+    ALL-RULES marker OpenCode's AGENTS.md carries), NOT a per-adapter transform, so
+    the inliner still sees the rules but sync does not.
     """
     repo = _make_opencode_repo(tmp_path)
     plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)
     assert Path("rules/delegation.md") in plan.items  # precondition: staged for inlining
 
-    result = OpenCodeAdapter().post_staging_transforms(plan, ScriptedIO())
+    flatten_plan_templates(plan, repo_root=repo, io=ScriptedIO())
 
-    assert not any(item.namespace == "rules" for item in result.items.values())
-    assert Path("rules/delegation.md") not in result.items
-    assert Path("skills/shared-skill") in result.items
+    assert b"shared rule" in plan.items[Path("AGENTS.md")].content  # inlined
+    assert not any(item.namespace == "rules" for item in plan.items.values())
+    assert Path("rules/delegation.md") not in plan.items
+    assert Path("skills/shared-skill") in plan.items

--- a/packages/installer/tests/unit/test_templates_flatten_plan.py
+++ b/packages/installer/tests/unit/test_templates_flatten_plan.py
@@ -23,6 +23,19 @@ def _item(relpath: Path, content: bytes, *, namespace: str | None = None) -> Sta
     )
 
 
+def _dir_item(relpath: Path, *, namespace: str) -> StagedItem:
+    """A directory StagedItem (``content is None``) — materialised from its source
+    tree at sync, never inlined."""
+    return StagedItem(
+        source_path=Path("/unused") / relpath,
+        dest_relpath=relpath,
+        kind=FileKind.DIR,
+        namespace=namespace,
+        provenance=Provenance(kind="tool", name="claude"),
+        content=None,
+    )
+
+
 def _plan(*items: StagedItem) -> StagingPlan:
     return StagingPlan(items={i.dest_relpath: i for i in items}, tool=Tool.CLAUDE)
 
@@ -90,3 +103,54 @@ def test_flatten_leaves_other_items_and_markerless_templates_untouched(tmp_path:
 
     assert plan.items[Path("AGENTS.md")].content == b"# no markers here\n"
     assert plan.items[Path("commands/go.md")].content == b"go"
+
+
+def test_all_rules_inline_drops_loose_rules_from_plan(tmp_path: Path) -> None:
+    """When the instruction file inlines every rule via ALL-RULES, the loose
+    rules/ items are dropped from the plan.
+
+    A tool whose instruction file carries the ALL-RULES marker
+    (codex/gemini/opencode) gets every rule inlined into AGENTS.md/GEMINI.md, so
+    deploying the rules/ files standalone would write redundant copies the tool
+    does not read. They are removed exactly like include-only file templates."""
+    gemini_md = _item(Path("GEMINI.md"), b"top\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n")
+    r1 = _item(Path("rules/a-first.md"), b"FIRST", namespace="rules")
+    r2 = _item(Path("rules/b-second.md"), b"SECOND", namespace="rules")
+    plan = _plan(gemini_md, r1, r2)
+
+    flatten_plan_templates(plan, repo_root=tmp_path, io=ScriptedIO())
+
+    assert plan.items[Path("GEMINI.md")].content == b"top\nFIRST\n---\nSECOND"
+    assert Path("rules/a-first.md") not in plan.items
+    assert Path("rules/b-second.md") not in plan.items
+
+
+def test_markerless_instruction_file_keeps_loose_rules(tmp_path: Path) -> None:
+    """When the instruction file does NOT inline ALL-RULES, the rules/ items stay
+    in the plan for standalone deploy.
+
+    Claude reads a loose ~/.claude/rules/ tree natively and its AGENTS.md carries
+    no ALL-RULES marker, so its rules must survive flattening as standalone files —
+    only the inlining tools drop them."""
+    agents_md = _item(Path("AGENTS.md"), b"# claude - no all-rules marker\n")
+    r1 = _item(Path("rules/a-first.md"), b"FIRST", namespace="rules")
+    plan = _plan(agents_md, r1)
+
+    flatten_plan_templates(plan, repo_root=tmp_path, io=ScriptedIO())
+
+    assert plan.items[Path("rules/a-first.md")].content == b"FIRST"
+
+
+def test_all_rules_inline_keeps_a_non_inlined_rules_dir_item(tmp_path: Path) -> None:
+    """The drop mirrors the inliner: only rule FILE items (content is not None) are
+    inlined, so only those are dropped. A rules/ directory item (content None) was
+    never inlined, so dropping it would lose content silently — it must survive."""
+    gemini_md = _item(Path("GEMINI.md"), b"top\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n")
+    rule_file = _item(Path("rules/a-first.md"), b"FIRST", namespace="rules")
+    rule_dir = _dir_item(Path("rules/subpack"), namespace="rules")
+    plan = _plan(gemini_md, rule_file, rule_dir)
+
+    flatten_plan_templates(plan, repo_root=tmp_path, io=ScriptedIO())
+
+    assert Path("rules/a-first.md") not in plan.items  # inlined file dropped
+    assert Path("rules/subpack") in plan.items  # non-inlined dir survives


### PR DESCRIPTION
## What
CodexAdapter/GeminiAdapter installed the `rules` namespace as loose files to `~/.codex/rules/` and `~/.gemini/rules/`, but neither tool reads a `rules/` subdir natively (Claude-only feature). The bash installer inlined rules into AGENTS.md via `DYNAMIC-INCLUDE-ALL-RULES`. This restores that behavior in the Python installer.

## How
In `flatten_plan_templates` (per-tool, on the real install path via `stage_and_transform`), when a plan's instruction file carries the ALL-RULES marker, drop the rules-namespace items it inlined.

**Key insight (spike):** the flattener sources rules *from the plan's staged rules* to inline them, so excluding rules at *staging* time would starve the inliner. The correct layer is **post-inline removal** — mirroring how include-only file templates are already dropped. Claude's `AGENTS.md` has no ALL-RULES marker, so its loose rules survive (its native feature).

## Review-driven changes
This PR went through quality-reviewer **and a codex adversarial pass (gpt-5.5)**:
- **Consolidation:** `OpenCodeAdapter.post_staging_transforms` already dropped rules per-adapter. `flatten_plan_templates` now owns this invariant uniformly for *all* inlining tools (codex/gemini/opencode), so OpenCode's bespoke drop is removed (kept as a Protocol-required no-op); its test migrated to the flatten layer.
- **Robustness:** the drop mirrors the inliner's condition (`content is not None`), so a non-inlined rules/ *directory* item is never silently discarded.

## Tests
- `test_all_rules_inline_drops_loose_rules_from_plan` — inlining tool drops loose rules.
- `test_markerless_instruction_file_keeps_loose_rules` — Claude keeps loose rules.
- `test_all_rules_inline_keeps_a_non_inlined_rules_dir_item` — un-inlined dir survives.
- `test_opencode_flatten_inlines_and_drops_rules` — real `build_plan`→flatten for OpenCode.

## Gate
`make ci-installer` green: 590 tests, 99.81% coverage, mypy strict, lint, format, pip-audit, entry-verify. quality-reviewer + codex (no BLOCKING/CRITICAL) + simplify.

## Deferred
`agents-config-24eo5` — full `stage_and_transform` end-to-end + plugin-rules integration suite (additive confidence; logic verified by two adversarial reviews).

Closes agents-config-q1q6r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)