### PR TITLE
fix(installer): protect active plugin formulas from the prune scan (qd8ca)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -272,6 +272,7 @@ def _run(
     if args.prune or args.prune_only:
         rc = _run_prune(
             adapters,
+            plugins=plugins,
             plans=plans,
             io=io,
             home=resolved_home,
@@ -353,6 +354,7 @@ def _warn_excluded_plugins(
 def _run_prune(
     adapters: list[ToolAdapter],
     *,
+    plugins: Iterable[PluginAdapter],
     plans: dict[Tool, StagingPlan],
     io: IOPort,
     home: Path,
@@ -385,7 +387,10 @@ def _run_prune(
 
     The ``plans`` reflect the active ``--plugins`` selection (``main`` builds them
     with the resolved plugin set), so a plugin's overlaid files reach the orphan
-    scan as known entries rather than retired ones.
+    scan as known entries rather than retired ones. ``plugins`` is forwarded
+    likewise so a route-based plugin's bespoke dest (beads' ``~/.beads/formulas``)
+    gets its staged baseline from the active routes — a still-shipped formula is
+    protected, not pruned.
 
     The prune flow's per-tool ``Counters`` (pruned / backed_up, keyed by
     ``Orphan.tool``) are merged into ``counters`` so the install summary reports
@@ -411,6 +416,7 @@ def _run_prune(
             counters,
             prune_pipeline(
                 adapters,
+                plugins=plugins,
                 plans=plans,
                 home=home,
                 config=config,

--- a/packages/installer/src/installer/core/prune.py
+++ b/packages/installer/src/installer/core/prune.py
@@ -12,9 +12,12 @@ skill directories. Legacy ``*.backup-*`` entries (in-place backups from older
 Sibling ``<namespace>-backup/`` dirs live at the grandparent level and are never
 visited by this scan.
 
-``~/.beads/formulas`` is scanned whenever pruning runs, regardless of beads
-plugin detection: if beads is not an active plugin, no plan staged any formula,
-so every dest formula registers as an orphan (strict mode).
+``~/.beads/formulas`` is scanned whenever pruning runs. The active plugins'
+``routes()`` supply its staged baseline: a formula an active plugin still ships
+(its route would re-install it) is staged and so never an orphan, exactly as a
+plan-staged tool entry is protected. When beads is not in the active plugin set,
+nothing stages a formula, so every glob-matching dest formula is an orphan
+(strict mode).
 
 Matching is ``fnmatch`` on the ``tool/namespace/basename`` key. Pure: it reads
 the destination filesystem and the in-memory plans, and returns ``list[Orphan]``
@@ -34,6 +37,7 @@ if TYPE_CHECKING:
 
     from installer.core.installer_toml import InstallerToml
     from installer.core.model import StagingPlan
+    from installer.plugins.base import PluginAdapter
     from installer.tools.base import ToolAdapter
 
 # Tool-tree namespaces scanned for orphans. Narrower than
@@ -61,6 +65,28 @@ def _staged_basenames(plan: StagingPlan | None, namespace: str) -> set[str]:
         for item in plan.items.values()
         if len(item.dest_relpath.parts) >= 2 and item.dest_relpath.parts[0] == namespace
     }
+
+
+def _routed_staged_basenames(
+    plugins: Iterable[PluginAdapter], *, home: Path, dest_dir: Path
+) -> set[str]:
+    """Basenames the active plugins would install at ``dest_dir`` via ``routes()``.
+
+    Mirrors ``sync_routes``: a route contributes the names of the files its
+    ``source_dir`` glob would place at ``dest_dir`` — exactly what a real install
+    stages there. A formula an active plugin still ships is therefore staged, so
+    the scan never treats it as an orphan, matching the plan-membership exclusion
+    that protects actively-staged tool entries. A plugin that does not route to
+    ``dest_dir`` — or is inactive, hence absent from ``plugins`` — contributes
+    nothing, so an empty plugin set preserves strict mode.
+    """
+    staged: set[str] = set()
+    for plugin in plugins:
+        for route in plugin.routes(home):
+            if route.dest_dir != dest_dir or not route.source_dir.is_dir():
+                continue
+            staged |= {src.name for src in route.source_dir.glob(route.glob) if src.is_file()}
+    return staged
 
 
 def _scan_namespace(
@@ -103,6 +129,7 @@ def _scan_namespace(
 def scan_orphans(
     adapters: Iterable[ToolAdapter],
     *,
+    plugins: Iterable[PluginAdapter] = (),
     plans: dict[Tool, StagingPlan],
     home: Path,
     config: InstallerToml,
@@ -111,11 +138,12 @@ def scan_orphans(
 
     For each adapter, walk the prune subdirs under its ``dest_dir(home)``,
     comparing each top-level entry against the tool's plan and the prune globs.
-    Then scan ``~/.beads/formulas`` once with a fixed ``beads`` tool bucket
-    (strict mode: nothing in the per-tool plans stages a beads formula, so an
-    unmatched-by-plan formula is an orphan when a glob matches). Returns all
-    orphans in tool-then-namespace iteration order; an empty prune list yields
-    no orphans.
+    Then scan ``~/.beads/formulas`` once with a fixed ``beads`` tool bucket,
+    using the active ``plugins``' routes as the staged baseline: a formula an
+    active plugin still ships is protected; with no beads plugin active the
+    baseline is empty, so a glob-matching formula is an orphan (strict mode).
+    Returns all orphans in tool-then-namespace iteration order; an empty prune
+    list yields no orphans.
     """
     prune_globs = config.prune_globs
     orphans: list[Orphan] = []
@@ -134,12 +162,13 @@ def scan_orphans(
                 )
             )
 
+    beads_formulas_dest = home / ".beads" / _BEADS_NAMESPACE
     orphans.extend(
         _scan_namespace(
             tool=_BEADS_TOOL,
             namespace=_BEADS_NAMESPACE,
-            dest=home / ".beads" / _BEADS_NAMESPACE,
-            staged=set(),
+            dest=beads_formulas_dest,
+            staged=_routed_staged_basenames(plugins, home=home, dest_dir=beads_formulas_dest),
             prune_globs=prune_globs,
         )
     )

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 def prune_pipeline(
     adapters: Iterable[ToolAdapter],
     *,
+    plugins: Iterable[PluginAdapter] = (),
     plans: dict[Tool, StagingPlan],
     home: Path,
     config: InstallerToml,
@@ -48,15 +49,17 @@ def prune_pipeline(
 ) -> dict[str, Counters]:
     """Scan ``adapters`` for orphans against ``plans``, then run the prune flow.
 
-    ``prune_only`` is threaded to the flow so its non-interactive guard
-    distinguishes a hard-fail (prune-only without consent) from a warn+skip
-    (plain ``--prune``). Returns the flow's per-target ``Counters`` (pruned /
-    backed_up) keyed by ``Orphan.tool`` — each tool or plugin namespace whose
-    orphans were pruned gets its own bucket so the install summary can report a
-    plugin pruned outside the active tool set (AC#19). An empty / no-op
-    prune yields an empty mapping.
+    ``plugins`` is the active plugin set; it supplies the ``~/.beads/formulas``
+    staged baseline so a formula a still-active plugin ships is protected from
+    the glob (see ``scan_orphans``). ``prune_only`` is threaded to the flow so
+    its non-interactive guard distinguishes a hard-fail (prune-only without
+    consent) from a warn+skip (plain ``--prune``). Returns the flow's per-target
+    ``Counters`` (pruned / backed_up) keyed by ``Orphan.tool`` — each tool or
+    plugin namespace whose orphans were pruned gets its own bucket so the install
+    summary can report a plugin pruned outside the active tool set (AC#19). An
+    empty / no-op prune yields an empty mapping.
     """
-    orphans = scan_orphans(adapters, plans=plans, home=home, config=config)
+    orphans = scan_orphans(adapters, plugins=plugins, plans=plans, home=home, config=config)
     return run_prune(
         orphans,
         io=io,

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -248,6 +248,42 @@ def test_prune_only_against_empty_source_prunes_unstaged_dest_entry(tmp_path: Pa
     )
 
 
+def test_prune_only_keeps_active_plugin_shipped_formula(tmp_path: Path) -> None:
+    """
+    Given --plugins=beads --prune-only --yes, a repo whose beads plugin still
+    ships current.toml, and a home ~/.beads/formulas holding current.toml AND a
+    genuinely retired.toml, both matching a beads/formulas/* prune glob
+    When main runs (non-interactive io)
+    Then retired.toml is removed but current.toml survives — the CLI threads the
+    active plugin set into the prune scan, so a formula the active plugin still
+    ships is not an orphan.
+
+    Pins the end-to-end wiring (_run -> _run_prune -> prune_pipeline ->
+    scan_orphans). Without it, strict mode deletes the live formula next to the
+    retired one.
+    """
+    repo = _repo_with_installer_toml(tmp_path, retired=["beads/formulas/*"])
+    beads_src = repo / "src" / "plugins" / "beads" / ".beads" / "formulas"
+    beads_src.mkdir(parents=True)
+    (beads_src / "current.toml").write_text("shipped")
+    home = _home_with_claude_settings(tmp_path)
+    formulas = home / ".beads" / "formulas"
+    formulas.mkdir(parents=True)
+    (formulas / "current.toml").write_text("shipped")
+    (formulas / "retired.toml").write_text("stale")
+
+    rc = main(
+        ["--plugins=beads", "--prune-only", "--yes", "--tools=claude"],
+        home=home,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (formulas / "current.toml").exists()
+    assert not (formulas / "retired.toml").exists()
+
+
 def test_prune_only_warns_and_exits_clean_when_installer_toml_absent(tmp_path: Path) -> None:
     """
     Given a repo_root whose packages/installer/installer.toml does NOT exist,

--- a/packages/installer/tests/unit/test_prune.py
+++ b/packages/installer/tests/unit/test_prune.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from installer.core.installer_toml import InstallerToml
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 from installer.core.prune import scan_orphans
+from installer.plugins.beads import BeadsPlugin
 
 
 class _ClaudeLikeAdapter:
@@ -243,4 +244,38 @@ def test_beads_formulas_scanned_with_no_beads_plan(tmp_path: Path) -> None:
 
     assert [(o.tool, o.namespace, o.path.name) for o in orphans] == [
         ("beads", "formulas", "stale.toml")
+    ]
+
+
+def test_active_plugin_shipped_formula_is_not_orphan(tmp_path: Path) -> None:
+    """
+    Given an active beads plugin still shipping current.toml, and a
+    ~/.beads/formulas dir holding current.toml AND retired.toml, both matching a
+    prune glob
+    When scan_orphans runs with that plugin in the active set
+    Then only retired.toml is an orphan — a formula the active plugin still ships
+    is staged (the route would re-install it), so it is protected from the glob
+    exactly as a plan-staged tool entry is. Without this, strict mode would
+    delete the live formula sitting next to the retired one.
+    """
+    src = tmp_path / "src" / "plugins" / "beads"
+    (src / ".beads" / "formulas").mkdir(parents=True)
+    (src / ".beads" / "formulas" / "current.toml").write_text("shipped")
+    dest_formulas = tmp_path / ".beads" / "formulas"
+    dest_formulas.mkdir(parents=True)
+    (dest_formulas / "current.toml").write_text("shipped")
+    (dest_formulas / "retired.toml").write_text("stale")
+    config = InstallerToml(prune_globs=["beads/formulas/*"])
+    beads = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
+
+    orphans = scan_orphans(
+        [_ClaudeLikeAdapter()],
+        plugins=[beads],
+        plans={Tool.CLAUDE: _empty_plan()},
+        home=tmp_path,
+        config=config,
+    )
+
+    assert [(o.tool, o.namespace, o.path.name) for o in orphans] == [
+        ("beads", "formulas", "retired.toml")
     ]

--- a/packages/installer/tests/unit/test_run_prune_pipeline.py
+++ b/packages/installer/tests/unit/test_run_prune_pipeline.py
@@ -21,6 +21,7 @@ from installer.core.installer_toml import InstallerToml
 from installer.core.io_port import ScriptedIO
 from installer.core.model import StagingPlan, Tool
 from installer.core.run import prune_pipeline
+from installer.plugins.beads import BeadsPlugin
 from installer.tools.registry import get_adapter
 
 _TS = "20250101-120000"
@@ -122,6 +123,45 @@ def test_empty_plan_with_excluded_plugin_file_flags_it(tmp_path: Path) -> None:
     )
 
     assert not formula.exists()
+    assert per_tool["beads"].pruned == 1
+
+
+def test_active_plugin_formula_survives_prune(tmp_path: Path) -> None:
+    """
+    Given an active beads plugin still shipping current.toml, and a
+    ~/.beads/formulas dir holding current.toml + retired.toml, both glob-matched
+    When prune_pipeline runs with that plugin active under auto_yes
+    Then retired.toml is pruned but current.toml survives — prune_pipeline
+    forwards the active plugins so the scan protects a still-shipped formula.
+
+    Pins the wiring: without the plugins forwarding, strict mode would delete
+    current.toml alongside retired.toml.
+    """
+    home = _claude_home_with_settings(tmp_path)
+    src = tmp_path / "src" / "plugins" / "beads"
+    (src / ".beads" / "formulas").mkdir(parents=True)
+    (src / ".beads" / "formulas" / "current.toml").write_text("shipped")
+    formulas = home / ".beads" / "formulas"
+    formulas.mkdir(parents=True)
+    (formulas / "current.toml").write_text("shipped")
+    (formulas / "retired.toml").write_text("stale")
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+    config = InstallerToml(prune_globs=["beads/formulas/*"])
+    beads = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
+
+    per_tool = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plugins=[beads],
+        plans=plans,
+        home=home,
+        config=config,
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert (formulas / "current.toml").exists()
+    assert not (formulas / "retired.toml").exists()
     assert per_tool["beads"].pruned == 1
 
 


### PR DESCRIPTION
protect a still-shipped beads formula from being pruned.

## Summary
- `core/prune.py::scan_orphans` hardcoded `staged=set()` for the `~/.beads/formulas` namespace. Under a `beads/formulas/*` prune glob, **every** matching dest formula was treated as an orphan — including formulas the active beads plugin still ships. Strict mode is correct when beads is *inactive* (leftover formulas are genuinely stale), but wrong when beads is *active*: a live formula gets deleted next to a retired one.
- Fix: thread the active plugin set through `_run → _run_prune → prune_pipeline → scan_orphans`; derive the formulas staged baseline from the active plugins' `routes()` via a new pure helper `_routed_staged_basenames`, which **mirrors `core/sync.py::sync_routes` exactly** (`source_dir.glob(route.glob)`, files only, by `.name`). A still-shipped formula is staged and therefore protected; an empty plugin set preserves strict mode byte-for-byte.

## Why now / scope note
- **Latent, not active.** No `*/formulas/*` glob exists in `installer.toml` or the prune list today, so nothing matches and nothing is mis-pruned in production. This hardens against the footgun before such a glob is ever added.
- The bead was originally filed as a **bash-parity** divergence (vs `install.sh:1545,971-975`). That bash logic is **retired** — `scripts/install.sh` is now a 6-line `uv`-exec stub — so the parity framing is moot. The fix stands on its own as a latent-correctness fix; the bead title/description were updated to drop the dead bash framing.

## Contract
- `scan_orphans` / `prune_pipeline` get `plugins` as a keyword-only arg **defaulting to `()`** (safe standalone use → strict mode; backward-compatible call sites).
- `_run_prune` takes `plugins` as a **required** kwarg — the bug was a silent drop, so the default that would permit one is forbidden at the wiring seam.

## Test plan
- 3 new behavioral tests (all RED→GREEN, mutation-verified by the reviewer):
  - `test_prune.py::test_active_plugin_shipped_formula_is_not_orphan` — unit, the core decision.
  - `test_run_prune_pipeline.py::test_active_plugin_formula_survives_prune` — pipeline forwarding.
  - `test_cli_smoke.py::test_prune_only_keeps_active_plugin_shipped_formula` — end-to-end `--plugins=beads --prune-only`; reproduces the bug (live formula deleted) pre-fix, passes post-fix.
- Full gate green: `make ci-installer` → **598 passed, 99.81% coverage**, mypy --strict clean, ruff lint+format clean, pip-audit clean, both entry points verify.

## Out of scope (noted, not addressed)
- The beads plugin also ships a `scripts` route (`~/.beads/scripts`). Prune does **not** scan that dir at all, so there is no bug there today — but if scanning is ever added, it would inherit this same defect. Flagged for a follow-up decision, deliberately not widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)