### PR TITLE
fix(installer): parity & test-hardening — close abn9.37.2 (h4015, 7gd9w, ufy4c)

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -198,19 +198,27 @@ def _run(
         sys.stderr.write(f"installer: {exc}\n")
         return 2
 
+    # Stage once, up front, for EVERY path (--dump-stage, install, --prune): the
+    # same StagingPlan set feeds the dump, the install, and the prune orphan-scan,
+    # so --prune is install-then-prune over ONE plan. Staging is deterministic,
+    # writes nothing to disk, and does not read installer.toml, so producing the
+    # plan here changes neither the prune outcome nor its error handling — only a
+    # verbose adapter transform notice (e.g. Gemini) may now precede a toml error,
+    # which is immaterial. A fatal staging error — a registry wiring miss
+    # (UnknownMergeKeyError) or an irreconcilable file collision (CollisionError) —
+    # surfaces as an actionable exit 1 (matching the ConsentRequiredError
+    # convention and bash's `err … exit 1`), not an uncaught traceback; the
+    # exception message names the offending key / paths. This single guard covers
+    # both the --dump-stage and install paths.
+    try:
+        plans = stage_and_transform(
+            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+        )
+    except (UnknownMergeKeyError, CollisionError) as exc:
+        sys.stderr.write(f"installer: {exc}\n")
+        return 1
+
     if args.dump_stage is not None:
-        try:
-            plans = stage_and_transform(
-                tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
-            )
-        except (UnknownMergeKeyError, CollisionError) as exc:
-            # A registry wiring miss (UnknownMergeKeyError) or an irreconcilable
-            # file collision (CollisionError) cannot be staged; surface it as an
-            # actionable fatal (exit 1, matching the ConsentRequiredError
-            # convention and bash's `err … exit 1`) rather than an uncaught
-            # traceback. Both carry a message naming the offending key / paths.
-            sys.stderr.write(f"installer: {exc}\n")
-            return 1
         try:
             dump_plan(plans, args.dump_stage, io=io)
         except ValueError as exc:
@@ -222,24 +230,7 @@ def _run(
         return 0
 
     config = Config(home=resolved_home, tools=tools, auto_yes=args.yes)
-
-    # Stage once, up front: the same StagingPlan set feeds both the install and
-    # the prune orphan-scan, so --prune is install-then-prune over ONE plan, not
-    # two independent stagings. Staging is deterministic, writes nothing to disk,
-    # and does not read installer.toml, so producing the plan before the
-    # prune-only toml-load below changes neither the prune outcome nor its error
-    # handling — only a verbose adapter transform notice (e.g. Gemini) may now
-    # precede a toml error, which is immaterial.
     adapters = [get_adapter(tool) for tool in tools]
-    try:
-        plans = stage_and_transform(
-            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
-        )
-    except (UnknownMergeKeyError, CollisionError) as exc:
-        # Same fatal-staging guard as the --dump-stage path above: surface a
-        # wiring miss or irreconcilable collision as exit 1, not a traceback.
-        sys.stderr.write(f"installer: {exc}\n")
-        return 1
 
     # Default install path (also the install half of --prune): walk each active
     # tool's StagingPlan to disk via install_pipeline. Skipped only for

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -11,6 +11,8 @@ from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installer_toml import load_installer_toml
 from installer.core.installignore import load_installignore
+from installer.core.merge.base import CollisionError
+from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.model import Counters
 from installer.core.orchestrator import stage_and_transform
 from installer.core.prune_flow import PruneAbortedError
@@ -197,9 +199,18 @@ def _run(
         return 2
 
     if args.dump_stage is not None:
-        plans = stage_and_transform(
-            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
-        )
+        try:
+            plans = stage_and_transform(
+                tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+            )
+        except (UnknownMergeKeyError, CollisionError) as exc:
+            # A registry wiring miss (UnknownMergeKeyError) or an irreconcilable
+            # file collision (CollisionError) cannot be staged; surface it as an
+            # actionable fatal (exit 1, matching the ConsentRequiredError
+            # convention and bash's `err … exit 1`) rather than an uncaught
+            # traceback. Both carry a message naming the offending key / paths.
+            sys.stderr.write(f"installer: {exc}\n")
+            return 1
         try:
             dump_plan(plans, args.dump_stage, io=io)
         except ValueError as exc:
@@ -220,9 +231,15 @@ def _run(
     # handling — only a verbose adapter transform notice (e.g. Gemini) may now
     # precede a toml error, which is immaterial.
     adapters = [get_adapter(tool) for tool in tools]
-    plans = stage_and_transform(
-        tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
-    )
+    try:
+        plans = stage_and_transform(
+            tools, repo_root=resolved_repo_root, io=io, ignore=ignore, plugins=plugins
+        )
+    except (UnknownMergeKeyError, CollisionError) as exc:
+        # Same fatal-staging guard as the --dump-stage path above: surface a
+        # wiring miss or irreconcilable collision as exit 1, not a traceback.
+        sys.stderr.write(f"installer: {exc}\n")
+        return 1
 
     # Default install path (also the install half of --prune): walk each active
     # tool's StagingPlan to disk via install_pipeline. Skipped only for

--- a/packages/installer/src/installer/core/installignore.py
+++ b/packages/installer/src/installer/core/installignore.py
@@ -8,10 +8,10 @@ re-leak namespace dev-docs identically on both installers — the shared-wrongne
 case the golden-master parity oracle cannot see. Fail-fast turns every
 missing/wrong-root/absent-in-fixture mode into a loud error.
 
-Grammar (simple subset, identical to the bash matcher in
-``scripts/lib/installignore.sh``): one entry per line; ``#`` comment lines and
-blank lines ignored; an exact basename matches a file; a trailing-``/`` name
-matches a directory. No globs, no ``**``, no negation, no anchoring.
+Grammar (simple subset; see the ``.installignore`` header for the canonical
+spec): one entry per line; ``#`` comment lines and blank lines ignored; an exact
+basename matches a file; a trailing-``/`` name matches a directory. No globs, no
+``**``, no negation, no anchoring.
 """
 
 from __future__ import annotations

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -20,6 +20,7 @@ frontmatter transform at 6.95), so a transform sees flattened content.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 from installer.core.merge.registry import default_registry
@@ -59,8 +60,21 @@ def stage_and_transform(
     plans: dict[Tool, StagingPlan] = {}
     for tool in tools:
         adapter = get_adapter(tool)
-        plan = build_plan(adapter, repo_root=repo_root, ignore=ignore, registry=registry)
-        plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry, ignore=ignore)
+        # The merge strategies (LastWinsWarnStrategy for JSONC/TOML) announce a
+        # last-wins overwrite via stdlib warnings.warn — their pure signature
+        # carries no IOPort. Capture those here, the consumer that holds the io,
+        # and re-route them through io.warn so the notice reaches the user.
+        # record=True + simplefilter("always") defeats any ambient -W filter that
+        # would otherwise silence it. Scoped to the two merge sites (build_plan,
+        # overlay_plugins); only UserWarning is re-emitted, so an unrelated
+        # library warning is not surfaced as installer output.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            plan = build_plan(adapter, repo_root=repo_root, ignore=ignore, registry=registry)
+            plan = overlay_plugins(plan, plugins, adapter=adapter, registry=registry, ignore=ignore)
+        for entry in caught:
+            if issubclass(entry.category, UserWarning):
+                io.warn(str(entry.message))
         plan = apply_extensions(plan, plugins)
         flatten_plan_templates(plan, repo_root=repo_root, io=io)
         plans[tool] = adapter.post_staging_transforms(plan, io)

--- a/packages/installer/src/installer/core/orchestrator.py
+++ b/packages/installer/src/installer/core/orchestrator.py
@@ -66,8 +66,12 @@ def stage_and_transform(
         # and re-route them through io.warn so the notice reaches the user.
         # record=True + simplefilter("always") defeats any ambient -W filter that
         # would otherwise silence it. Scoped to the two merge sites (build_plan,
-        # overlay_plugins); only UserWarning is re-emitted, so an unrelated
-        # library warning is not surfaced as installer output.
+        # overlay_plugins). Only UserWarning is re-emitted; any other category
+        # raised inside this scope is dropped — acceptable because staging is pure
+        # dict/path work that emits only the merge UserWarning today.
+        # catch_warnings mutates process-global filter state and is not
+        # thread-safe: safe only while tools stage sequentially (revisit if
+        # staging is ever parallelised).
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             plan = build_plan(adapter, repo_root=repo_root, ignore=ignore, registry=registry)

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -71,6 +71,12 @@ def overlay_plugins(
             if adapter.should_install_namespace(ns, "tool"):
                 for item in stage_namespace(tool_root, ns, provenance=prov, ignore=ignore):
                     _place(plan, item, registry=registry, carrier_eligible=False)
+        # stage_settings globs all settings forms (json/jsonc/toml). For plugins
+        # this is an intentional, currently-inert superset — no plugin ships
+        # jsonc/toml settings, so the staged set equals json-only today. Not
+        # narrowed: stage_settings is the SHARED Phase 5 builder (staging.py),
+        # where the multi-form glob is the contract; a plugin-only narrow would
+        # fork the builder for no live benefit.
         for item in stage_settings(tool_root, provenance=prov):
             _place(plan, item, registry=registry, carrier_eligible=False)
         for ns in _SHARED_NAMESPACES:
@@ -168,8 +174,16 @@ def _carry_files(directory: Path) -> dict[Path, bytes]:
     for entry in sorted(directory.iterdir()):
         if entry.name.startswith("."):
             continue
+        if entry.is_symlink():
+            # Bash `cp -R` (macOS) copies a symlink as a link, not its target's
+            # bytes; dir_overrides maps relpaths to bytes and has no
+            # representation for a link. Skip it rather than dereference — both
+            # a top-level link-to-file (read-through under the link name) and a
+            # link-to-dir (rglob descends from the link) would otherwise carry
+            # bytes from outside the plugin tree, diverging from bash.
+            continue
         if entry.is_dir():
-            for nested in sorted(p for p in entry.rglob("*") if p.is_file()):
+            for nested in sorted(p for p in entry.rglob("*") if p.is_file() and not p.is_symlink()):
                 carried[nested.relative_to(directory)] = nested.read_bytes()
         else:
             carried[Path(entry.name)] = entry.read_bytes()

--- a/packages/installer/src/installer/core/overlay.py
+++ b/packages/installer/src/installer/core/overlay.py
@@ -181,8 +181,18 @@ def _carry_files(directory: Path) -> dict[Path, bytes]:
             # a top-level link-to-file (read-through under the link name) and a
             # link-to-dir (rglob descends from the link) would otherwise carry
             # bytes from outside the plugin tree, diverging from bash.
+            #
+            # Deliberate asymmetry with the disjoint precondition: _visible_names
+            # (feeding _carrier_merge_allowed) counts a symlink BY NAME, so a
+            # symlink whose name collides with a carrier file still fails loud
+            # (fatal), while a name-disjoint symlink reaches here and is dropped.
+            # Do NOT "fix" _visible_names to also skip symlinks — that would turn
+            # a real name collision into a silent drop.
             continue
         if entry.is_dir():
+            # rglob does not descend symlinked DIRECTORIES, so a nested link-to-dir
+            # is already excluded here; the per-file `not p.is_symlink()` guards
+            # the remaining case — a link-to-FILE nested in a real subdir.
             for nested in sorted(p for p in entry.rglob("*") if p.is_file() and not p.is_symlink()):
                 carried[nested.relative_to(directory)] = nested.read_bytes()
         else:

--- a/packages/installer/tests/unit/conftest.py
+++ b/packages/installer/tests/unit/conftest.py
@@ -33,8 +33,9 @@ def _neutralize_opencode_path_probe(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def ignore() -> InstallIgnore:
-    """The canonical .installignore content as an in-memory object, for staging
-    tests that must pass an exclusion set without touching a manifest file.
+    """The canonical .installignore content as an in-memory object, so a staging
+    test gets the real exclusion set without needing a manifest file inside its
+    temporary repo under test.
 
     Sourced from the REAL repo-root manifest via load_installignore rather than a
     hand-copied literal, so a new exclusion class added to .installignore cannot

--- a/packages/installer/tests/unit/conftest.py
+++ b/packages/installer/tests/unit/conftest.py
@@ -17,9 +17,13 @@ stdlib module, so only OpenCode detection is affected and no unrelated
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from installer.core.installignore import InstallIgnore
+from installer.core.installignore import InstallIgnore, load_installignore
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 @pytest.fixture(autouse=True)
@@ -30,10 +34,9 @@ def _neutralize_opencode_path_probe(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def ignore() -> InstallIgnore:
     """The canonical .installignore content as an in-memory object, for staging
-    tests that must pass an exclusion set without touching a manifest file."""
-    return InstallIgnore(
-        basenames=frozenset(
-            {"AGENTS.md", "CLAUDE.md", "GEMINI.md", "README.md", "SESSION-PRIMER-README.md"}
-        ),
-        dirnames=frozenset({"rules-readmes"}),
-    )
+    tests that must pass an exclusion set without touching a manifest file.
+
+    Sourced from the REAL repo-root manifest via load_installignore rather than a
+    hand-copied literal, so a new exclusion class added to .installignore cannot
+    silently drift away from the set these staging tests exercise."""
+    return load_installignore(_REPO_ROOT / ".installignore")

--- a/packages/installer/tests/unit/test_cli_installignore.py
+++ b/packages/installer/tests/unit/test_cli_installignore.py
@@ -4,7 +4,10 @@ exclusions off or crashing with a traceback."""
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from installer.cli import main
 
@@ -35,3 +38,40 @@ def test_non_utf8_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  
     assert rc == 2
     err = capsys.readouterr().err
     assert "installer:" in err
+
+
+def test_unreadable_manifest_aborts_with_exit_2(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # A present-but-unreadable manifest (chmod 000) raises PermissionError, an
+    # OSError subclass. cli.main catches (OSError, UnicodeDecodeError) -> exit 2;
+    # this pins that the except is broad enough to include PermissionError, not
+    # just the missing-file FileNotFoundError. Skipped where chmod cannot make
+    # the file unreadable (root, or a filesystem that ignores mode bits).
+    home = tmp_path / "home"
+    home.mkdir()
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("AGENTS.md\n", encoding="utf-8")
+    manifest.chmod(0o000)
+    try:
+        if os.access(manifest, os.R_OK):
+            pytest.skip("manifest still readable after chmod (root or mode-less fs)")
+        rc = main(["--yes"], home=home, repo_root=tmp_path)
+        assert rc == 2
+        assert "installer:" in capsys.readouterr().err
+    finally:
+        manifest.chmod(0o644)
+
+
+def test_dump_stage_missing_manifest_aborts_before_dump(tmp_path: Path, capsys) -> None:  # type: ignore[no-untyped-def]
+    # The up-front manifest load precedes the --dump-stage branch, so a missing
+    # manifest aborts (exit 2) BEFORE anything is staged or written — pinning that
+    # ordering rather than relying on the transitive exit-2 coverage. The output
+    # path must not be created.
+    home = tmp_path / "home"
+    home.mkdir()
+    out = tmp_path / "stage-out"
+
+    rc = main(["--dump-stage", str(out), "--tools=claude"], home=home, repo_root=tmp_path)
+
+    assert rc == 2
+    assert ".installignore not found" in capsys.readouterr().err
+    assert not out.exists()

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -1117,3 +1117,65 @@ def test_keyboard_interrupt_exits_130_without_traceback(
     captured = capsys.readouterr()
     assert "Aborted." in captured.err
     assert "Traceback" not in captured.err
+
+
+def _repo_with_agent_collision(tmp_path: Path) -> Path:
+    """A hermetic repo where a shared agent and a tool-root agent collide on the
+    same dest (agents/dup.md, NAMESPACED_MD/'agents'); the registry routes that
+    to the fatal strategy, so build_plan raises CollisionError during staging."""
+    repo = _hermetic_repo(tmp_path)
+    shared_agents = repo / "src" / "user" / ".agents" / "agents"
+    shared_agents.mkdir(parents=True)
+    (shared_agents / "dup.md").write_bytes(b"---\nname: dup\n---\nshared\n")
+    claude_agents = repo / "src" / "user" / ".claude" / "agents"
+    claude_agents.mkdir(parents=True)
+    (claude_agents / "dup.md").write_bytes(b"---\nname: dup\n---\ntool\n")
+    return repo
+
+
+def test_main_collision_error_exits_1_not_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An irreconcilable merge collision during staging is surfaced as an
+    actionable fatal install error (exit 1, 'installer:' on stderr), not an
+    uncaught traceback out of stage_and_transform at the CLI boundary."""
+    repo = _repo_with_agent_collision(tmp_path)
+
+    rc = main(
+        ["--tools=claude", "--dry-run"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 1
+    assert "installer:" in capsys.readouterr().err
+
+
+def test_main_unknown_merge_key_exits_1_not_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An UnknownMergeKeyError — a registry wiring miss (no strategy for a
+    (kind, namespace)) — is surfaced as an actionable fatal (exit 1, 'installer:'
+    on stderr) rather than an uncaught traceback. Fault-injected at the staging
+    seam because the complete default_registry cannot produce this from real
+    inputs; mirrors the resolve_tools fault-injection test above."""
+    from installer.core.merge.registry import UnknownMergeKeyError
+    from installer.core.model import FileKind
+
+    def _raise(*_args: object, **_kwargs: object) -> object:
+        raise UnknownMergeKeyError(FileKind.NAMESPACED_MD, "weird-ns")
+
+    monkeypatch.setattr("installer.cli.stage_and_transform", _raise)
+
+    rc = main(
+        ["--tools=claude", "--dry-run"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=_hermetic_repo(tmp_path),
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "installer:" in err
+    assert "weird-ns" in err

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -25,14 +25,17 @@ def _home_with_claude_settings(tmp_path: Path) -> Path:
     return tmp_path
 
 
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
 def _write_installignore(repo: Path) -> None:
     """Mirror the real repo-root .installignore so cli.main's up-front fail-fast
     load finds it. main() refuses to run without one (exit 2), so every hermetic
-    repo a CLI smoke test points main() at must carry the manifest."""
+    repo a CLI smoke test points main() at must carry the manifest. The content
+    is copied from the REAL manifest (not retyped) so it cannot drift from it."""
     repo.mkdir(parents=True, exist_ok=True)
     (repo / ".installignore").write_text(
-        "AGENTS.md\nCLAUDE.md\nGEMINI.md\nREADME.md\nSESSION-PRIMER-README.md\nrules-readmes/\n",
-        encoding="utf-8",
+        (_REPO_ROOT / ".installignore").read_text(encoding="utf-8"), encoding="utf-8"
     )
 
 

--- a/packages/installer/tests/unit/test_installignore.py
+++ b/packages/installer/tests/unit/test_installignore.py
@@ -5,6 +5,7 @@ and blank-line skipping, and the fail-fast contract on a missing/unreadable file
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,26 @@ def test_excludes_matches_directories_against_dirnames() -> None:
 def test_missing_manifest_is_fail_fast(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match=r"\.installignore not found"):
         load_installignore(tmp_path / ".installignore")
+
+
+def test_present_but_unreadable_manifest_is_not_swallowed(tmp_path: Path) -> None:
+    """A present-but-unreadable manifest is NOT silently treated as
+    exclude-nothing: load_installignore lets the PermissionError (an OSError
+    subclass) from read_text propagate, preserving the module's fail-fast
+    contract. This is the regression guard against someone wrapping the read in a
+    try/except that would re-enable the dead-docs leak the manifest prevents.
+    Skipped when chmod cannot make the file unreadable (running as root, or a
+    filesystem that ignores mode bits)."""
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("AGENTS.md\n", encoding="utf-8")
+    manifest.chmod(0o000)
+    try:
+        if os.access(manifest, os.R_OK):
+            pytest.skip("manifest still readable after chmod (root or mode-less fs)")
+        with pytest.raises(PermissionError):
+            load_installignore(manifest)
+    finally:
+        manifest.chmod(0o644)
 
 
 def test_bare_slash_line_is_skipped(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_orchestrator.py
+++ b/packages/installer/tests/unit/test_orchestrator.py
@@ -121,6 +121,35 @@ def test_stage_and_transform_overlays_active_plugins(tmp_path: Path, ignore: Ins
     assert plans[Tool.CLAUDE].items[Path("rules/plugin-rule.md")].content == b"from plugin"
 
 
+def test_stage_and_transform_toml_collision_surfaces_warning_via_ioport(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """A TOML last-wins collision during staging emits a stdlib UserWarning from
+    the merge strategy. The orchestrator — the consumer that holds the IOPort —
+    captures it and re-emits via io.warn so the notice reaches the user instead
+    of vanishing into the warnings system (where a -W filter could silence it)."""
+    repo = _make_repo(tmp_path)
+    # Base claude tool-root ships a TOML settings template (Phase 5)...
+    (repo / "src" / "user" / ".claude" / "config.toml.template").write_bytes(b"base = 1")
+    # ...and an active plugin ships a colliding one: TOML resolves last-wins+warn.
+    plugin_root = tmp_path / "plugins" / "test-plugin"
+    (plugin_root / ".claude").mkdir(parents=True)
+    (plugin_root / ".claude" / "config.toml.template").write_bytes(b"plugin = 2")
+    io = ScriptedIO()
+
+    stage_and_transform(
+        [Tool.CLAUDE],
+        repo_root=repo,
+        io=io,
+        ignore=ignore,
+        plugins=[_Plugin(name="test-plugin", source_path=plugin_root)],
+    )
+
+    warns = [e for e in io.transcript if e.channel == "warn"]
+    assert len(warns) == 1
+    assert "config.toml" in warns[0].message
+
+
 def test_stage_and_transform_overlay_runs_before_gemini_transform(
     tmp_path: Path, ignore: InstallIgnore
 ) -> None:

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -458,6 +458,55 @@ def test_carrier_merge_carries_nested_subdirectory_files(
     }
 
 
+def test_carrier_merge_skips_top_level_symlinked_file(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """A top-level symlink in the plugin dir is NOT dereferenced. Bash `cp -R`
+    (macOS) copies a symlink as a link, not its target's bytes, and dir_overrides
+    has no representation for a link — so _carry_files skips it rather than
+    materialising the target's bytes under the link's name (carrier-merge
+    parity)."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin(tmp_path, "test-plugin")
+    skill_dir = plugin.source_path / ".agents" / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(b"real")
+    # A symlink whose target lives OUTSIDE the carried dir, with distinct bytes.
+    target = tmp_path / "outside.txt"
+    target.write_bytes(b"target-bytes")
+    (skill_dir / "link.md").symlink_to(target)
+
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("SKILL.md"): b"real"}
+
+
+def test_carrier_merge_does_not_descend_symlinked_subdir(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """A top-level symlink to a DIRECTORY is not descended. Bash `cp -R` copies
+    the link itself; the port must not walk through it and carry the linked
+    directory's files (which would both diverge from bash and risk pulling bytes
+    from outside the plugin tree)."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin(tmp_path, "test-plugin")
+    skill_dir = plugin.source_path / ".agents" / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(b"real")
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir()
+    (outside_dir / "leaked.py").write_bytes(b"leak")
+    (skill_dir / "linkdir").symlink_to(outside_dir, target_is_directory=True)
+
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("SKILL.md"): b"real"}
+
+
 def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin skill dir overlaying a shared_carrier dir with an OVERLAPPING
     file name cannot carrier-merge — it is a real conflict and falls through to

--- a/packages/installer/tests/unit/test_overlay.py
+++ b/packages/installer/tests/unit/test_overlay.py
@@ -507,6 +507,30 @@ def test_carrier_merge_does_not_descend_symlinked_subdir(
     assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("SKILL.md"): b"real"}
 
 
+def test_carrier_merge_skips_symlinked_file_nested_in_real_subdir(
+    tmp_path: Path, ignore: InstallIgnore
+) -> None:
+    """A symlink nested inside a REAL carried subdir is skipped too: the rglob
+    walk filters symlinked files, so `lib/link.py -> outside` does not read the
+    target's bytes into dir_overrides under `lib/link.py`. This pins the deeper
+    guard the two top-level symlink tests never reach — they short-circuit at the
+    top-level is_symlink check before the rglob ever runs."""
+    plan = _carrier_dir_plan(tmp_path, files=["_test.sh"])
+    plugin = _plugin(tmp_path, "test-plugin")
+    skill_dir = plugin.source_path / ".agents" / "skills" / "demo-skill"
+    (skill_dir / "lib").mkdir(parents=True)
+    (skill_dir / "lib" / "real.py").write_bytes(b"real")
+    target = tmp_path / "outside.txt"
+    target.write_bytes(b"leak")
+    (skill_dir / "lib" / "link.py").symlink_to(target)
+
+    overlay_plugins(
+        plan, [plugin], adapter=ClaudeAdapter(), registry=default_registry(), ignore=ignore
+    )
+
+    assert plan.dir_overrides[Path("skills/demo-skill")] == {Path("lib/real.py"): b"real"}
+
+
 def test_carrier_merge_overlapping_files_is_fatal(tmp_path: Path, ignore: InstallIgnore) -> None:
     """A plugin skill dir overlaying a shared_carrier dir with an OVERLAPPING
     file name cannot carrier-merge — it is a real conflict and falls through to


### PR DESCRIPTION
## Summary

Closes the three live children of epic **abn9.37.2** (installer parity & test hardening). Each is a separate commit (TDD red→green per bead); one follow-up commit addresses the review pass.

- **h4015** (P2) — surface merge-engine signals at the consumer: JSONC/TOML last-wins `UserWarning`s are captured at the orchestrator and re-emitted via `IOPort.warn` (they previously warned into the void, silenceable by `-W`); `UnknownMergeKeyError`/`CollisionError` are caught at the CLI staging boundary → `installer: …` + exit 1 instead of an uncaught traceback.
- **7gd9w** (P3) — carrier-merge symlink parity: `_carry_files` no longer dereferences symlinks (bash `cp -R` copies the link; `dir_overrides` can't represent one), preventing out-of-tree byte leaks. L2 settings-glob superset is documented (not narrowed — `stage_settings` is the shared Phase-5 builder).
- **ufy4c** (P3) — `.installignore` test-hardening: dedup two drifted fixtures onto the real manifest, add present-but-unreadable (chmod 000) coverage at loader + CLI, pin the dump-stage-missing ordering, fix a stale `scripts/lib/installignore.sh` docstring.

## Commits (map to beads)
- `9b0367d` 7gd9w — symlink skip in `_carry_files`
- `c94a66b` h4015 — orchestrator warn-capture + CLI fatal guard
- `9803c1a` ufy4c — installignore coverage + fixture dedup
- `f261f13` review hardening — pin nested-symlink branch, hoist staging guard (cli.py → 100%)

## Scope
- **In scope:** `packages/installer/` only (`core/overlay.py`, `core/orchestrator.py`, `core/installignore.py`, `cli.py` + unit tests).
- **Out of scope / intentionally NOT changed:** the pure merge strategies keep `warnings.warn` (capture is at the consumer by design); `stage_settings` is intentionally left multi-form (shared builder).

## Deliberate decisions a reviewer might otherwise flag
- **Warning capture lives in `orchestrator.stage_and_transform`, not threaded through `place_resolved`.** Keeps the merge core pure; existing `pytest.warns` overlay tests (which call `overlay_plugins` directly) stay valid.
- **`catch_warnings` is not thread-safe** — documented as safe only while staging is sequential (revisit if parallelised). Non-`UserWarning` categories raised in that scope are dropped (acceptable: staging emits only the merge `UserWarning`).
- **`_visible_names` counts symlinks by name while `_carry_files` skips them** — deliberate asymmetry (name-colliding symlink fails loud; disjoint one is dropped). Commented so it isn't "fixed" into a silent drop.
- **Dropped two stale bead items** (verified against the tree, NOT added to any AGENTS.md): the zsh-`scripts/lib` convention (`scripts/lib/` and `installignore_test.sh` no longer exist; `install.sh` is a uv stub) and the bandit S607 note (sole subprocess test already uses `sys.executable`).

## Test Plan
- [x] `make ci-installer` green: **607 passed, 99.77% coverage** (floor 90% branch), pip-audit clean, entry-verify ok
- [x] New behaviour is RED-first TDD; the nested-symlink and unreadable-manifest tests were mutation-verified to fail when their guard is removed
- [x] `cli.py` staging-error guard at **100%** coverage after the hoist

## Ground-truth files to check claims against
- `packages/installer/src/installer/core/overlay.py` (`_carry_files`, `overlay_plugins`)
- `packages/installer/src/installer/core/orchestrator.py` (`stage_and_transform`)
- `packages/installer/src/installer/cli.py` (single hoisted staging guard)
- `.installignore` (repo root — the real manifest the fixtures now source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)