### PR TITLE
fix(wait-for-pr-comments): Phase 9 excludes SKIP/ESCALATE from re-loop trigger (aexb)

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -416,13 +416,32 @@ manually (add `--mode autonomous --bead-id <id>` if applicable)."
 After Skill B completes, verify no review threads were missed before
 considering the await-review step done.
 
+**Why filter against the inventory.** SKIP and ESCALATE threads are
+intentionally never resolved (SKIP replies argue the reviewer's point;
+ESCALATE awaits human judgment). Without filtering, any SKIP/ESCALATE
+thread keeps the unresolved count > 0 forever and Phase 9 re-loops
+infinitely (3→4→5→6→7→8→9→3→…). The round cap does not save this path
+because the cap fires only when Phase 6 detects a new review, which it
+won't on a pure re-classification loop.
+
 1. **Query** for all unresolved, non-outdated review threads (pagination handled internally):
    ```bash
    ${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR"
    # stdout: {count: N, thread_ids: ["<graphql-thread-id>", ...]}
    ```
-2. **Count** threads where `isResolved == false` and `isOutdated == false`.
+2. **Filter** the result against the inventory to exclude threads the
+   current round classified SKIP or ESCALATE (intentionally unresolved).
+   Only genuinely actionable threads remain — unresolved FIX items whose
+   resolution didn't take, or threads not in the inventory at all (new
+   comments posted after Skill A's Phase 3 fetch):
+   ```bash
+   ${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
+     --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+   | ${CLAUDE_SKILL_DIR}/filter-actionable-threads.sh \
+     --inventory "$INVENTORY_PATH"
+   # stdout: {count: N, thread_ids: [...]} — SKIP/ESCALATE excluded
+   ```
 3. **If count > 0**: treat as a new review round. Return to **Phase 3
    (round +1)**. Phase 3 must **re-fetch full thread details** (the Phase 9
    query's `comments` preview is for triage only; the canonical source for
@@ -763,6 +782,17 @@ ${CLAUDE_SKILL_DIR}/request-rereview.sh \
 ${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
   --owner "$OWNER" --repo "$REPO" --pr "$PR"
 # stdout: {count: <n>, thread_ids: [...]}
+```
+
+**Filter actionable threads** (Phase 9 — excludes SKIP/ESCALATE from the
+re-loop trigger):
+
+```bash
+${CLAUDE_SKILL_DIR}/count-unresolved-threads.sh \
+  --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+| ${CLAUDE_SKILL_DIR}/filter-actionable-threads.sh \
+  --inventory "$INVENTORY_PATH"
+# stdout: {count: <n>, thread_ids: [...]} — SKIP/ESCALATE excluded
 ```
 
 **Validate inventory** — Skill B invokes this twice (Phase 0 with `--phase 0`

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
@@ -61,7 +61,7 @@ if ! RESULT="$(printf '%s' "$THREAD_IDS" | jq -c --slurpfile inv "$INVENTORY" '
   as $inv_threads
   | $unresolved
   | map(. as $tid
-      | ($inv_threads | map(select(.thread_id == $tid)) | first) as $match
+      | ($inv_threads | map(select(.thread_id == $tid)) | .[0] // null) as $match
       | if $match == null
         then .
         elif $match.classification == "SKIP" or $match.classification == "ESCALATE"

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Purpose: filter count-unresolved-threads.sh output against the PR inventory,
+# excluding threads that are intentionally unresolved (SKIP / ESCALATE
+# classifications). Phase 9 uses this to decide whether to re-loop: only
+# genuinely actionable threads (unresolved FIX, or threads not in the
+# inventory at all) should trigger a new review round.
+#
+# Inputs:
+#   stdin:        JSON from count-unresolved-threads.sh
+#                 {count: <n>, thread_ids: ["<id>", ...]}
+#   --inventory <path>  PR inventory JSON (schema_version 1)
+#
+# Outputs:
+#   stdout: JSON {count: <n>, thread_ids: [<id>, ...]} — only actionable threads
+#   exit codes:
+#     0 = success
+#     1 = inventory file missing / unreadable
+#     2 = bad flag usage or stdin parse failure
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") --inventory <path> < <count-unresolved-threads JSON>
+
+Reads count-unresolved-threads.sh output from stdin and filters out thread IDs
+that the inventory marks SKIP or ESCALATE (intentionally unresolved). Emits
+JSON {count, thread_ids} of remaining actionable threads.
+EOF
+  exit 2
+}
+
+INVENTORY=""
+
+[ $# -gt 0 ] || usage
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --inventory) INVENTORY="${2:-}"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "error: unknown flag: $1" >&2; usage ;;
+  esac
+done
+
+[ -n "$INVENTORY" ] || { echo "error: --inventory is required" >&2; exit 2; }
+[ -r "$INVENTORY" ] || { echo "error: cannot read inventory: $INVENTORY" >&2; exit 1; }
+
+STDIN_JSON="$(cat)"
+
+ERR_TMP="$(mktemp)"
+trap 'rm -f "$ERR_TMP"' EXIT
+
+if ! THREAD_IDS="$(printf '%s' "$STDIN_JSON" | jq -c '.thread_ids // []' 2>"$ERR_TMP")"; then
+  echo "error: failed to parse stdin JSON: $(cat "$ERR_TMP")" >&2
+  exit 2
+fi
+
+printf '%s' "$THREAD_IDS" | jq -c --slurpfile inv "$INVENTORY" '
+  . as $unresolved
+  | ($inv[0].items // [])
+  | map(select(.thread_id != null) | {thread_id, classification})
+  as $inv_threads
+  | $unresolved
+  | map(. as $tid
+      | ($inv_threads | map(select(.thread_id == $tid)) | first) as $match
+      | if $match == null
+        then .
+        elif $match.classification == "SKIP" or $match.classification == "ESCALATE"
+        then empty
+        else .
+        end)
+  | {count: length, thread_ids: .}
+'

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
@@ -15,7 +15,7 @@
 #   exit codes:
 #     0 = success
 #     1 = inventory file missing / unreadable
-#     2 = bad flag usage or stdin parse failure
+#     2 = bad flag usage or JSON parse/processing failure (stdin or inventory)
 set -euo pipefail
 
 usage() {

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads.sh
@@ -54,7 +54,7 @@ if ! THREAD_IDS="$(printf '%s' "$STDIN_JSON" | jq -c '.thread_ids // []' 2>"$ERR
   exit 2
 fi
 
-printf '%s' "$THREAD_IDS" | jq -c --slurpfile inv "$INVENTORY" '
+if ! RESULT="$(printf '%s' "$THREAD_IDS" | jq -c --slurpfile inv "$INVENTORY" '
   . as $unresolved
   | ($inv[0].items // [])
   | map(select(.thread_id != null) | {thread_id, classification})
@@ -69,4 +69,9 @@ printf '%s' "$THREAD_IDS" | jq -c --slurpfile inv "$INVENTORY" '
         else .
         end)
   | {count: length, thread_ids: .}
-'
+' 2>"$ERR_TMP")"; then
+  echo "error: failed to process inventory or thread IDs: $(cat "$ERR_TMP")" >&2
+  exit 2
+fi
+
+printf '%s\n' "$RESULT"

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
@@ -16,6 +16,7 @@
 #   6. review_summary / issue_comment items (no thread_id) → ignored
 #   7. Missing --inventory flag → exit 2
 #   8. Inventory file missing → exit 1
+#   9. Malformed inventory JSON → exit 2 with script-level error message
 
 set -u
 

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
@@ -129,4 +129,12 @@ printf '%s' "$EMPTY_THREADS" | "$SCRIPT" --inventory "$TMP/nonexistent.json" > "
 rc8=$?
 assert "test 8: exits 1 on missing inventory file" "[ \$rc8 -eq 1 ]"
 
+# --- Test 9: malformed inventory JSON → exit 2 with helpful message ---
+MALFORMED_THREADS='{"count":1,"thread_ids":["t1"]}'
+echo '{not valid json' > "$TMP/inv9.json"
+printf '%s' "$MALFORMED_THREADS" | "$SCRIPT" --inventory "$TMP/inv9.json" > "$TMP/out9.json" 2>&1
+rc9=$?
+assert "test 9: exits 2 on malformed inventory JSON" "[ \$rc9 -eq 2 ]"
+assert "test 9: stderr has script-level error message" "grep -qE '^error:' '$TMP/out9.json'"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
@@ -41,14 +41,6 @@ assert "script file exists" "[ -f '$SCRIPT' ]"
 assert "script is executable" "[ -x '$SCRIPT' ]"
 assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
 
-# --- Helper to build a count-unresolved-threads-style JSON payload ---
-make_threads_json() {
-  # $1 = space-separated thread IDs
-  local ids="$1"
-  jq -nc --argjson ids "$(printf '%s' "$ids" | jq -R 'split(" ") | map(select(length>0))')" \
-    '{count: ($ids | length), thread_ids: $ids}'
-}
-
 # --- Helper to build an inventory items array ---
 make_inventory() {
   # Each arg: "<thread_id>:<classification>"

--- a/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/filter-actionable-threads_test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Test for filter-actionable-threads.sh
+#
+# Phase 9's loop trigger must exclude threads that are intentionally
+# unresolved (SKIP / ESCALATE classifications in the inventory). This helper
+# post-processes count-unresolved-threads.sh output against the inventory so
+# Phase 9 only re-loops on genuinely actionable threads (unresolved FIX or
+# threads not present in the inventory at all).
+#
+# Behaviors covered:
+#   1. Empty unresolved list → count 0, empty thread_ids
+#   2. All threads are SKIP in inventory → count 0 (the bug aexb fixes)
+#   3. All threads are ESCALATE in inventory → count 0
+#   4. Mix of SKIP + FIX → only FIX thread remains
+#   5. Thread not in inventory (genuinely new) → preserved (count > 0)
+#   6. review_summary / issue_comment items (no thread_id) → ignored
+#   7. Missing --inventory flag → exit 2
+#   8. Inventory file missing → exit 1
+
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/filter-actionable-threads.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[filter-actionable-threads_test]"
+
+assert "script file exists" "[ -f '$SCRIPT' ]"
+assert "script is executable" "[ -x '$SCRIPT' ]"
+assert "uses set -euo pipefail" "grep -qE 'set -euo pipefail' '$SCRIPT'"
+
+# --- Helper to build a count-unresolved-threads-style JSON payload ---
+make_threads_json() {
+  # $1 = space-separated thread IDs
+  local ids="$1"
+  jq -nc --argjson ids "$(printf '%s' "$ids" | jq -R 'split(" ") | map(select(length>0))')" \
+    '{count: ($ids | length), thread_ids: $ids}'
+}
+
+# --- Helper to build an inventory items array ---
+make_inventory() {
+  # Each arg: "<thread_id>:<classification>"
+  local items="[]"
+  for spec in "$@"; do
+    local tid="${spec%%:*}"
+    local cls="${spec##*:}"
+    items="$(jq -nc --argjson a "$items" --arg tid "$tid" --arg cls "$cls" \
+      '$a + [{thread_id: $tid, classification: $cls}]')"
+  done
+  printf '%s' "$items"
+}
+
+# --- Test 1: empty unresolved list ---
+EMPTY_THREADS='{"count":0,"thread_ids":[]}'
+echo '{"items":[]}' > "$TMP/inv1.json"
+printf '%s' "$EMPTY_THREADS" | "$SCRIPT" --inventory "$TMP/inv1.json" > "$TMP/out1.json" 2>&1
+rc1=$?
+assert "test 1: exits 0 on empty threads" "[ \$rc1 -eq 0 ]"
+assert "test 1: count is 0" "jq -e '.count == 0' '$TMP/out1.json' >/dev/null 2>&1"
+assert "test 1: thread_ids empty" "jq -e '(.thread_ids | length) == 0' '$TMP/out1.json' >/dev/null 2>&1"
+
+# --- Test 2: all SKIP → count 0 (the aexb bug) ---
+SKIP_THREADS='{"count":2,"thread_ids":["t1","t2"]}'
+INV2="$(make_inventory t1:SKIP t2:SKIP)"
+echo "{\"items\":$INV2}" > "$TMP/inv2.json"
+printf '%s' "$SKIP_THREADS" | "$SCRIPT" --inventory "$TMP/inv2.json" > "$TMP/out2.json" 2>&1
+rc2=$?
+assert "test 2: exits 0 when all SKIP" "[ \$rc2 -eq 0 ]"
+assert "test 2: count is 0 (SKIP excluded)" "jq -e '.count == 0' '$TMP/out2.json' >/dev/null 2>&1"
+assert "test 2: thread_ids empty" "jq -e '(.thread_ids | length) == 0' '$TMP/out2.json' >/dev/null 2>&1"
+
+# --- Test 3: all ESCALATE → count 0 ---
+ESC_THREADS='{"count":1,"thread_ids":["t3"]}'
+INV3="$(make_inventory t3:ESCALATE)"
+echo "{\"items\":$INV3}" > "$TMP/inv3.json"
+printf '%s' "$ESC_THREADS" | "$SCRIPT" --inventory "$TMP/inv3.json" > "$TMP/out3.json" 2>&1
+rc3=$?
+assert "test 3: exits 0 when all ESCALATE" "[ \$rc3 -eq 0 ]"
+assert "test 3: count is 0 (ESCALATE excluded)" "jq -e '.count == 0' '$TMP/out3.json' >/dev/null 2>&1"
+
+# --- Test 4: mix of SKIP + FIX → only FIX remains ---
+MIX_THREADS='{"count":2,"thread_ids":["t1","t4"]}'
+INV4="$(make_inventory t1:SKIP t4:FIX)"
+echo "{\"items\":$INV4}" > "$TMP/inv4.json"
+printf '%s' "$MIX_THREADS" | "$SCRIPT" --inventory "$TMP/inv4.json" > "$TMP/out4.json" 2>&1
+rc4=$?
+assert "test 4: exits 0 on mix" "[ \$rc4 -eq 0 ]"
+assert "test 4: count is 1 (FIX preserved)" "jq -e '.count == 1' '$TMP/out4.json' >/dev/null 2>&1"
+assert "test 4: thread_ids contains t4 only" "jq -e '.thread_ids == [\"t4\"]' '$TMP/out4.json' >/dev/null 2>&1"
+
+# --- Test 5: thread not in inventory → preserved (genuinely new) ---
+NEW_THREADS='{"count":1,"thread_ids":["tUnknown"]}'
+echo '{"items":[]}' > "$TMP/inv5.json"
+printf '%s' "$NEW_THREADS" | "$SCRIPT" --inventory "$TMP/inv5.json" > "$TMP/out5.json" 2>&1
+rc5=$?
+assert "test 5: exits 0 on unknown thread" "[ \$rc5 -eq 0 ]"
+assert "test 5: count is 1 (unknown preserved)" "jq -e '.count == 1' '$TMP/out5.json' >/dev/null 2>&1"
+assert "test 5: thread_ids contains tUnknown" "jq -e '.thread_ids == [\"tUnknown\"]' '$TMP/out5.json' >/dev/null 2>&1"
+
+# --- Test 6: review_summary / issue_comment items (no thread_id) ignored ---
+# Inventory has a SKIP review_summary (no thread_id) and a SKIP review_thread.
+# Unresolved list has the thread. Only the thread's classification matters.
+SUMMARY_THREADS='{"count":1,"thread_ids":["t1"]}'
+INV6="$(jq -nc '[{classification: "SKIP"}, {thread_id: "t1", classification: "SKIP"}]')"
+echo "{\"items\":$INV6}" > "$TMP/inv6.json"
+printf '%s' "$SUMMARY_THREADS" | "$SCRIPT" --inventory "$TMP/inv6.json" > "$TMP/out6.json" 2>&1
+rc6=$?
+assert "test 6: exits 0 with summary items present" "[ \$rc6 -eq 0 ]"
+assert "test 6: count is 0 (thread t1 is SKIP)" "jq -e '.count == 0' '$TMP/out6.json' >/dev/null 2>&1"
+
+# --- Test 7: missing --inventory flag → exit 2 ---
+printf '%s' "$EMPTY_THREADS" | "$SCRIPT" > "$TMP/out7.json" 2>&1
+rc7=$?
+assert "test 7: exits 2 on missing --inventory" "[ \$rc7 -eq 2 ]"
+
+# --- Test 8: inventory file missing → exit 1 ---
+printf '%s' "$EMPTY_THREADS" | "$SCRIPT" --inventory "$TMP/nonexistent.json" > "$TMP/out8.json" 2>&1
+rc8=$?
+assert "test 8: exits 1 on missing inventory file" "[ \$rc8 -eq 1 ]"
+
+exit $FAIL


### PR DESCRIPTION
## Problem (bead `aexb`)

Phase 9 of `wait-for-pr-comments` called `count-unresolved-threads.sh` and looped back to Phase 3 if count > 0. But **SKIP threads are by design never resolved** (replied with rationale, left open), and **ESCALATE threads await human judgment**. Any SKIP/ESCALATE thread kept count > 0 forever, causing an infinite loop:

```
3 → 4 → 5 → 6 → 7 → 8 → 9 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 3 → ...
```

The round cap (≥6) did not save this path because it fires **only when Phase 6 detects a new review**, which it won't on a pure re-classification loop — Copilot has nothing new to review.

## Fix

New `filter-actionable-threads.sh` helper post-processes `count-unresolved-threads.sh` output against the inventory, excluding thread IDs classified SKIP or ESCALATE in the current round. Phase 9 now pipes the count script through the filter and re-loops only on genuinely actionable threads:

- Unresolved FIX items whose resolution didn't take
- Threads not in the inventory at all (new comments posted after Phase 3's fetch)

### Design decision

`count-unresolved-threads.sh` stays a pure GitHub-state query (no inventory awareness). Filtering is a separate concern — the inventory is Skill A's state, and the count script is a stateless GraphQL wrapper. Mixing them would break separation of concerns and make the count script untestable in isolation.

## Changes

| File | Change |
|------|--------|
| `filter-actionable-threads.sh` | **New.** Reads count JSON from stdin, filters against inventory, emits `{count, thread_ids}` of actionable threads only. |
| `filter-actionable-threads_test.sh` | **New.** 8-test suite: empty / all-SKIP / all-ESCALATE / mix / unknown-thread / summary-items / missing-flag / missing-file. |
| `count-unresolved-threads.sh` | Unchanged. |
| `SKILL.md` | Phase 9 rewritten to pipe through the filter; helper invocation pattern added to the templates section. |

## Test evidence

```
=== filter-actionable-threads_test.sh ===
[filter-actionable-threads_test]
  ok: script file exists
  ok: script is executable
  ok: uses set -euo pipefail
  ok: test 1: exits 0 on empty threads
  ok: test 1: count is 0
  ok: test 1: thread_ids empty
  ok: test 2: exits 0 when all SKIP
  ok: test 2: count is 0 (SKIP excluded)
  ok: test 2: thread_ids empty
  ok: test 3: exits 0 when all ESCALATE
  ok: test 3: count is 0 (ESCALATE excluded)
  ok: test 4: exits 0 on mix
  ok: test 4: count is 1 (FIX preserved)
  ok: test 4: thread_ids contains t4 only
  ok: test 5: exits 0 on unknown thread
  ok: test 5: count is 1 (unknown preserved)
  ok: test 5: thread_ids contains tUnknown
  ok: test 6: exits 0 with summary items present
  ok: test 6: count is 0 (thread t1 is SKIP)
  ok: test 7: exits 2 on missing --inventory
  ok: test 8: exits 1 on missing inventory file
```

Full skill test suite (13 scripts) — all PASS, no regressions.

Closes bead `aexb`.