### PR TITLE
fix(installer): close residual prune-boundary TOCTOU via lstat-identity recheck

### DIFF
--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -263,9 +263,9 @@ def _back_up_and_delete(
     desired end state (the path is gone) is already achieved.
     """
     # Snapshot the path's filesystem identity BEFORE revalidate inspects it, so the
-    # recheck below spans the whole revalidate->delete window (the residual TOCTOU
-    # codex flagged: a path swapped between a passing revalidate and the unlink/rmtree
-    # would otherwise be backed up then removed).
+    # recheck below spans the whole revalidate window (the residual TOCTOU codex
+    # flagged: a path swapped between a passing revalidate and the unlink/rmtree would
+    # otherwise be backed up then removed).
     identity_before = _lstat_identity(orphan.path)
     if revalidate is not None and not revalidate(orphan):
         # Drifted since the orphan scan (the TOCTOU window of the confirm prompt):
@@ -276,29 +276,28 @@ def _back_up_and_delete(
             verbose=True,
         )
         return
-    counters = per_tool.setdefault(orphan.tool, Counters())
-    if orphan.path.exists():
-        dest = back_up(orphan.path, timestamp)
-        counters.backed_up += 1
-        io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
-    # Re-check identity immediately before the destructive op: a path whose identity
-    # moved since the snapshot was swapped during the revalidate/backup window and is
-    # now the user's — leave it in place (not deleted, not counted, not in ``removed``,
+    # Re-check identity before any backup or delete: a path whose identity moved since
+    # the snapshot was swapped during the revalidate window and is now the user's —
+    # leave it in place (not backed up, not deleted, not counted, not in ``removed``,
     # so the receipt keeps the entry and re-evaluates it next run). An already-gone
     # path is a stable ``None`` identity and falls through to the no-op delete below.
     #
-    # This recheck sits AFTER the backup, not before it, so the remaining exposed
-    # window is the irreducible lstat->unlink gap rather than the backup itself —
-    # which for a directory orphan is a potentially-slow ``copytree``. The cost is
-    # that a swap landing before the backup leaves the user's replacement copied
-    # into the backup dir (harmless and additive: the original stays in place, the
-    # copy is recoverable), with a ``backed_up`` tally that has no matching prune.
+    # The recheck precedes the backup deliberately: it keeps ``backed_up`` from ever
+    # incrementing without a following prune (preserving ``summary._is_changed``'s
+    # invariant that a backup only rides along a real change) and avoids leaving a
+    # phantom all-zero ``per_tool`` bucket. The residual backup->unlink window is the
+    # irreducible cost of not having handle-relative (openat/unlinkat) ops.
     if _lstat_identity(orphan.path) != identity_before:
         io.info(
             f"Skipped {orphan.path.name} — replaced since the orphan scan; left in place",
             verbose=True,
         )
         return
+    counters = per_tool.setdefault(orphan.tool, Counters())
+    if orphan.path.exists():
+        dest = back_up(orphan.path, timestamp)
+        counters.backed_up += 1
+        io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
     # A symlink (to a dir OR a file) is removed with ``unlink``, which deletes
     # the link itself, never its target. ``rmtree`` is reserved for real
     # directories: ``Path.is_dir()`` follows symlinks, so a dir-symlink would

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -35,6 +35,30 @@ _ONE_BY_ONE = "o"
 _CANCEL = "c"
 
 
+def _lstat_identity(path: Path) -> tuple[int, int, int, int, int] | None:
+    """Filesystem identity of ``path`` for the prune-boundary TOCTOU recheck.
+
+    Returns ``(st_dev, st_ino, st_mtime_ns, st_ctime_ns, st_size)`` — enough to
+    detect an unlink-then-recreate even when the OS recycles the freed inode
+    number (the times and size still move). ``st_ctime_ns`` (inode-change time)
+    is included specifically because it is NOT settable via ``os.utime``, so an
+    adversary who restores a forged ``st_mtime_ns`` on the swapped-in file still
+    cannot match the recreation's ctime. ``lstat`` does NOT follow symlinks,
+    matching how ``unlink``/``rmtree`` below act on the link itself, never its
+    target.
+
+    A genuinely-absent path (or one whose parent component is no longer a
+    directory) is ``None`` — the "expected gone" sentinel, distinct from any
+    real entry. Any other ``OSError`` (e.g. permission) propagates, consistent
+    with the destructive ops below not swallowing real errors.
+    """
+    try:
+        st = path.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    return (st.st_dev, st.st_ino, st.st_mtime_ns, st.st_ctime_ns, st.st_size)
+
+
 class PruneAbortedError(RuntimeError):
     """Raised when a non-interactive ``--prune-only`` run lacks authorization.
 
@@ -238,6 +262,11 @@ def _back_up_and_delete(
     ``pruned`` and recorded in ``removed`` so the receipt drops the entry — the
     desired end state (the path is gone) is already achieved.
     """
+    # Snapshot the path's filesystem identity BEFORE revalidate inspects it, so the
+    # recheck below spans the whole revalidate->delete window (the residual TOCTOU
+    # codex flagged: a path swapped between a passing revalidate and the unlink/rmtree
+    # would otherwise be backed up then removed).
+    identity_before = _lstat_identity(orphan.path)
     if revalidate is not None and not revalidate(orphan):
         # Drifted since the orphan scan (the TOCTOU window of the confirm prompt):
         # leave it in place, do not back up / delete / count, and do not record it
@@ -252,6 +281,24 @@ def _back_up_and_delete(
         dest = back_up(orphan.path, timestamp)
         counters.backed_up += 1
         io.info(f"Backed up {orphan.path.name} -> {dest.parent.name}/{dest.name}", verbose=True)
+    # Re-check identity immediately before the destructive op: a path whose identity
+    # moved since the snapshot was swapped during the revalidate/backup window and is
+    # now the user's — leave it in place (not deleted, not counted, not in ``removed``,
+    # so the receipt keeps the entry and re-evaluates it next run). An already-gone
+    # path is a stable ``None`` identity and falls through to the no-op delete below.
+    #
+    # This recheck sits AFTER the backup, not before it, so the remaining exposed
+    # window is the irreducible lstat->unlink gap rather than the backup itself —
+    # which for a directory orphan is a potentially-slow ``copytree``. The cost is
+    # that a swap landing before the backup leaves the user's replacement copied
+    # into the backup dir (harmless and additive: the original stays in place, the
+    # copy is recoverable), with a ``backed_up`` tally that has no matching prune.
+    if _lstat_identity(orphan.path) != identity_before:
+        io.info(
+            f"Skipped {orphan.path.name} — replaced since the orphan scan; left in place",
+            verbose=True,
+        )
+        return
     # A symlink (to a dir OR a file) is removed with ``unlink``, which deletes
     # the link itself, never its target. ``rmtree`` is reserved for real
     # directories: ``Path.is_dir()`` follows symlinks, so a dir-symlink would

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -276,18 +276,25 @@ def _back_up_and_delete(
             verbose=True,
         )
         return
-    # Re-check identity before any backup or delete: a path whose identity moved since
-    # the snapshot was swapped during the revalidate window and is now the user's —
-    # leave it in place (not backed up, not deleted, not counted, not in ``removed``,
-    # so the receipt keeps the entry and re-evaluates it next run). An already-gone
-    # path is a stable ``None`` identity and falls through to the no-op delete below.
+    # Re-check identity before any backup or delete. Block ONLY when a *different,
+    # still-present* object now sits at the path (``identity_after`` is non-None and
+    # differs): that is a real replacement swapped in during the revalidate window, and
+    # is now the user's — leave it in place (not backed up, not deleted, not counted,
+    # not in ``removed``, so the receipt keeps the entry and re-evaluates it next run).
+    #
+    # A ``None`` ``identity_after`` means the path simply VANISHED (whether absent from
+    # the start, or removed mid-window) — there is no object to protect, so fall through
+    # to the no-op delete below and count it pruned. That keeps a vanished orphan
+    # consistent with an absent-from-start one (the desired end state — path gone — is
+    # achieved) instead of leaving the receipt to re-evaluate a path that is already gone.
     #
     # The recheck precedes the backup deliberately: it keeps ``backed_up`` from ever
     # incrementing without a following prune (preserving ``summary._is_changed``'s
     # invariant that a backup only rides along a real change) and avoids leaving a
     # phantom all-zero ``per_tool`` bucket. The residual backup->unlink window is the
     # irreducible cost of not having handle-relative (openat/unlinkat) ops.
-    if _lstat_identity(orphan.path) != identity_before:
+    identity_after = _lstat_identity(orphan.path)
+    if identity_after is not None and identity_after != identity_before:
         io.info(
             f"Skipped {orphan.path.name} — replaced since the orphan scan; left in place",
             verbose=True,

--- a/packages/installer/src/installer/core/prune_flow.py
+++ b/packages/installer/src/installer/core/prune_flow.py
@@ -276,11 +276,13 @@ def _back_up_and_delete(
             verbose=True,
         )
         return
-    # Re-check identity before any backup or delete. Block ONLY when a *different,
-    # still-present* object now sits at the path (``identity_after`` is non-None and
-    # differs): that is a real replacement swapped in during the revalidate window, and
-    # is now the user's — leave it in place (not backed up, not deleted, not counted,
-    # not in ``removed``, so the receipt keeps the entry and re-evaluates it next run).
+    # Re-check identity before any backup or delete. Block whenever a still-present
+    # object's identity differs from the snapshot (``identity_after`` is non-None and
+    # differs) — the tuple carries mtime/ctime/size, so this catches both a wholesale
+    # replacement and an in-place modification/touch during the revalidate window. Either
+    # way the path is the user's now, so leave it in place (not backed up, not deleted,
+    # not counted, not in ``removed``, so the receipt keeps the entry and re-evaluates it
+    # next run).
     #
     # A ``None`` ``identity_after`` means the path simply VANISHED (whether absent from
     # the start, or removed mid-window) — there is no object to protect, so fall through
@@ -296,7 +298,7 @@ def _back_up_and_delete(
     identity_after = _lstat_identity(orphan.path)
     if identity_after is not None and identity_after != identity_before:
         io.info(
-            f"Skipped {orphan.path.name} — replaced since the orphan scan; left in place",
+            f"Skipped {orphan.path.name} — changed at the prune boundary; left in place",
             verbose=True,
         )
         return

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -114,6 +114,44 @@ def test_revalidate_with_is_safe_to_prune_keeps_file_modified_after_scan(tmp_pat
     assert removed == set()  # not recorded as pruned -> self-heals (relinquished) next run
 
 
+def test_path_swapped_between_revalidate_and_delete_is_left_intact(tmp_path: Path) -> None:
+    """Residual prune-boundary TOCTOU: a path swapped AFTER ``revalidate`` blesses it
+    but BEFORE the delete is left in place — not deleted, not counted, not recorded in
+    ``removed``. The swap is injected from inside the ``revalidate`` callback (the only
+    code that runs between the ownership snapshot and the destructive op), so the guard
+    must compare filesystem identity captured before revalidate against identity at the
+    delete boundary — re-running ownership alone cannot catch a same-path replacement
+    that itself passes ownership.
+    """
+    o = _file_orphan(tmp_path, "claude", "skills", "victim", body="ours")
+
+    def swap_then_pass(_o: Orphan) -> bool:
+        # Adversary replaces our orphan with a user-owned file at the same path
+        # after the installer has committed to pruning it.
+        o.path.unlink()
+        o.path.write_text("user replacement")
+        return True
+
+    removed: set[Path] = set()
+    per_tool = run_prune(
+        [o],
+        io=ScriptedIO(),
+        timestamp=_TS,
+        auto_yes=True,
+        removed=removed,
+        revalidate=swap_then_pass,
+    )
+
+    assert o.path.read_text() == "user replacement"  # the swapped-in file survives
+    assert sum(c.pruned for c in per_tool.values()) == 0  # nothing counted as pruned
+    assert removed == set()  # receipt keeps the entry -> re-evaluated next run
+    # The swap landed before the backup, so the recheck (which sits after the
+    # backup, to keep the exposed window at the irreducible lstat->unlink gap)
+    # leaves the user's replacement harmlessly copied into the backup dir. Pin
+    # that deliberate consequence rather than leave it silently tolerated.
+    assert sum(c.backed_up for c in per_tool.values()) == 1
+
+
 def test_three_way_all_deletes_every_orphan(tmp_path: Path) -> None:
     """
     Given two orphans and an interactive answer of "all"

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -116,11 +116,11 @@ def test_revalidate_with_is_safe_to_prune_keeps_file_modified_after_scan(tmp_pat
 
 def test_path_swapped_between_revalidate_and_delete_is_left_intact(tmp_path: Path) -> None:
     """Residual prune-boundary TOCTOU: a path swapped AFTER ``revalidate`` blesses it
-    but BEFORE the delete is left in place — not deleted, not counted, not recorded in
-    ``removed``. The swap is injected from inside the ``revalidate`` callback (the only
-    code that runs between the ownership snapshot and the destructive op), so the guard
-    must compare filesystem identity captured before revalidate against identity at the
-    delete boundary — re-running ownership alone cannot catch a same-path replacement
+    but BEFORE the destructive section is left in place — not deleted, not counted, not
+    recorded in ``removed``. The swap is injected from inside the ``revalidate``
+    callback (the only code that runs between the ownership snapshot and the recheck),
+    so the guard must compare filesystem identity captured before revalidate against
+    identity after it — re-running ownership alone cannot catch a same-path replacement
     that itself passes ownership.
     """
     o = _file_orphan(tmp_path, "claude", "skills", "victim", body="ours")
@@ -143,13 +143,12 @@ def test_path_swapped_between_revalidate_and_delete_is_left_intact(tmp_path: Pat
     )
 
     assert o.path.read_text() == "user replacement"  # the swapped-in file survives
-    assert sum(c.pruned for c in per_tool.values()) == 0  # nothing counted as pruned
     assert removed == set()  # receipt keeps the entry -> re-evaluated next run
-    # The swap landed before the backup, so the recheck (which sits after the
-    # backup, to keep the exposed window at the irreducible lstat->unlink gap)
-    # leaves the user's replacement harmlessly copied into the backup dir. Pin
-    # that deliberate consequence rather than leave it silently tolerated.
-    assert sum(c.backed_up for c in per_tool.values()) == 1
+    # The recheck precedes the backup, so a detected swap touches nothing: no delete,
+    # no backup, and crucially no per_tool bucket at all. An empty mapping pins that
+    # the skip never increments ``backed_up`` without a prune (which would break
+    # summary._is_changed) and never leaks a phantom all-zero bucket.
+    assert per_tool == {}
 
 
 def test_three_way_all_deletes_every_orphan(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -151,6 +151,37 @@ def test_path_swapped_between_revalidate_and_delete_is_left_intact(tmp_path: Pat
     assert per_tool == {}
 
 
+def test_path_vanishing_in_window_is_counted_pruned_not_skipped(tmp_path: Path) -> None:
+    """A path PRESENT at the identity snapshot but GONE by the recheck (removed during
+    the revalidate window, not replaced) is treated as a completed prune — counted and
+    recorded in ``removed`` so the receipt drops it — NOT skipped as a replacement. The
+    identity guard blocks only a different still-present object; a ``None`` recheck means
+    the path simply vanished, so it falls through to the no-op delete. This keeps a
+    vanished orphan consistent with an absent-from-start one (which existing tests pin as
+    counted-pruned), rather than leaving the receipt to re-chase a path that is gone.
+    """
+    o = _file_orphan(tmp_path, "claude", "skills", "vanisher", body="ours")
+
+    def remove_then_pass(_o: Orphan) -> bool:
+        o.path.unlink()  # path vanishes mid-window (no replacement object left behind)
+        return True
+
+    removed: set[Path] = set()
+    per_tool = run_prune(
+        [o],
+        io=ScriptedIO(),
+        timestamp=_TS,
+        auto_yes=True,
+        removed=removed,
+        revalidate=remove_then_pass,
+    )
+
+    assert not o.path.exists()  # end state achieved: the orphan is gone
+    assert per_tool["claude"].pruned == 1  # counted, so the receipt drops the entry
+    assert per_tool["claude"].backed_up == 0  # nothing on disk to back up
+    assert removed == {o.path}
+
+
 def test_three_way_all_deletes_every_orphan(tmp_path: Path) -> None:
     """
     Given two orphans and an interactive answer of "all"


### PR DESCRIPTION
## Summary
- Closes the residual TOCTOU window in the install-receipt prune flow that codex flagged in PR #200 round-10 review (rated *medium*, already mitigated by backup-first + a single-writer advisory flock).
- The flow already re-validates orphan ownership at the destructive boundary (`revalidate` callback), closing the scan→confirm window. The residual gap was between `revalidate()` returning `True` and the actual `unlink`/`rmtree`: a path swapped in that gap would be backed up then deleted.
- Fix: snapshot the path's `lstat` identity `(st_dev, st_ino, st_mtime_ns, st_ctime_ns, st_size)` before `revalidate`, re-check it before the destructive section, and **skip-and-keep** on a still-present mismatch — not deleted, not counted, not added to `removed`, so the receipt keeps the entry and re-evaluates it next run.

## Scope
- **In scope:** `packages/installer/src/installer/core/prune_flow.py` (new `_lstat_identity` helper + snapshot/recheck in `_back_up_and_delete`) and its test `packages/installer/tests/unit/test_prune_flow.py` (two regression tests).
- **Out of scope:** the sibling bead `fkewj` (directory-level *content*-drift protection via a recorded recursive digest) is a separate ~7-file receipt-schema change, deferred to its own PR.

## Design notes for the reviewer
- This is the originating issue's **"option 2 (minimal)"**. Option 1 (atomic move-to-quarantine restructure) was deliberately rejected as disproportionate to a low-real-world-impact residual race. The change **narrows, not closes**, the window: true closure needs handle-relative (`openat`/`unlinkat`) ops. The code comments say so explicitly.
- `st_ctime_ns` is in the identity tuple specifically because it is **not settable via `os.utime`**, defeating a forged-`mtime` swap. The tuple also catches an in-place modification/touch, not only a wholesale replacement.
- **The identity recheck precedes the backup, by design.** Placing it before the backup (and before the `per_tool` bucket is created) keeps `backed_up` from ever incrementing without a following prune — preserving `summary._is_changed`'s documented invariant that a backup only rides along a real change — and avoids leaking a phantom all-zero counter bucket. The residual backup→`unlink` window is the irreducible cost of path-based (non-handle-relative) ops.
- The guard blocks only a **still-present** mismatch: a path that simply vanished mid-window (`lstat` → `None`) falls through to the counted no-op delete, keeping it consistent with an absent-from-start orphan (both count as pruned so the receipt drops them).

## Test Plan
- [x] `make ci-installer` green: 691 passed, 99.42% coverage (90% branch floor), `mypy --strict` clean, `ruff` clean, `pip-audit` no vulns, entry-verify OK.
- [x] `test_path_swapped_between_revalidate_and_delete_is_left_intact` — a same-path replacement that passes ownership re-validation is left intact (no delete, no backup, no bucket).
- [x] `test_path_vanishing_in_window_is_counted_pruned_not_skipped` — a path removed mid-window is counted pruned, consistent with absent-from-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)