### PR TITLE
feat(installer): directory-level content-drift protection via recursive digest

### DIFF
--- a/packages/installer/src/installer/core/prune_hash.py
+++ b/packages/installer/src/installer/core/prune_hash.py
@@ -3,9 +3,11 @@
 A FILE orphan is pruned only while its on-disk bytes still match the receipt's
 recorded sha256 (or the file is genuinely gone); a user-modified, type-drifted, or
 unreadable path is relinquished — kept on disk, dropped from the receipt. A DIR
-orphan is pruned only while the path is still a real directory (recursive
-content-drift protection is deferred); a dir path that drifted to a file or symlink
-is relinquished. The same per-orphan decision (``is_safe_to_prune``) is evaluated at scan
+orphan is pruned only while the path is still a real directory AND (when a digest
+was recorded) its recursive content digest still matches the owned state; a dir
+that drifted to a file or symlink, or whose contents the user edited, is
+relinquished. A legacy dir entry recorded before digests existed degrades to the
+type-check-only guard. The same per-orphan decision (``is_safe_to_prune``) is evaluated at scan
 time AND re-evaluated at the deletion boundary, so a path that changes between the
 two (the TOCTOU window of the interactive confirm prompt) is never deleted."""
 
@@ -13,6 +15,8 @@ from __future__ import annotations
 
 import hashlib
 from typing import TYPE_CHECKING
+
+from installer.core.receipt import dir_content_digest
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -22,7 +26,11 @@ if TYPE_CHECKING:
 
 
 def is_safe_to_prune(
-    orphan: Orphan, *, home: Path, recorded_sha_by_path: dict[Path, str | None]
+    orphan: Orphan,
+    *,
+    home: Path,
+    recorded_sha_by_path: dict[Path, str | None],
+    recorded_digest_by_path: dict[Path, str | None] | None = None,
 ) -> bool:
     """Whether ``orphan`` is currently safe to prune (vs relinquish / keep).
 
@@ -34,17 +42,31 @@ def is_safe_to_prune(
     deletion boundary (``run_prune`` re-checks just before backup/delete), closing
     the TOCTOU window between the scan and the actual delete.
 
-    - dir: prunable only while still a real directory (or already gone); a path that
-      type-drifted to a file or symlink is the user's now (recursive CONTENT-drift
-      for still-real dirs stays deferred). ``is_symlink`` is tested first so a
-      dir-symlink never counts as a real directory.
+    - dir: prunable while still a real directory (or already gone) AND, when a
+      digest was recorded for it, its live recursive content digest still matches
+      the owned state; a path that type-drifted to a file or symlink, or whose
+      contents the user edited, is relinquished. A legacy entry with no recorded
+      digest degrades to the type-check-only guard. ``is_symlink`` is tested first
+      so a dir-symlink never counts as a real directory.
     - file: prunable when the bytes still match the recorded sha256, or the file
       genuinely vanished (``FileNotFoundError`` — the delete is a no-op). A digest
       mismatch (user-modified) or an unreadable path (a directory now occupies it,
       or a permission/FS error) is NOT prunable — we cannot confirm the bytes are
       ours and the delete would not be a no-op."""
     if orphan.kind == "dir":
-        return not orphan.path.is_symlink() and (not orphan.path.exists() or orphan.path.is_dir())
+        if orphan.path.is_symlink():
+            return False
+        if not orphan.path.exists():
+            return True  # already gone; the delete is a no-op
+        if not orphan.path.is_dir():
+            return False  # type-drifted to a file — the user's now
+        recorded = (recorded_digest_by_path or {}).get(orphan.path.relative_to(home))
+        if recorded is None:
+            return True  # legacy entry with no recorded digest: type-check only
+        try:
+            return dir_content_digest(orphan.path) == recorded
+        except OSError:
+            return False  # unreadable inner file: cannot confirm ownership — relinquish
     try:
         actual = hashlib.sha256(orphan.path.read_bytes()).hexdigest()
     except FileNotFoundError:
@@ -60,6 +82,7 @@ def partition_file_orphans(
     *,
     home: Path,
     recorded_sha_by_path: dict[Path, str | None],
+    recorded_digest_by_path: dict[Path, str | None] | None = None,
 ) -> tuple[list[Orphan], set[Path]]:
     """Split orphans into (to_prune, relinquished_home_relative_paths).
 
@@ -68,7 +91,12 @@ def partition_file_orphans(
     to_prune: list[Orphan] = []
     relinquished: set[Path] = set()
     for orphan in orphans:
-        if is_safe_to_prune(orphan, home=home, recorded_sha_by_path=recorded_sha_by_path):
+        if is_safe_to_prune(
+            orphan,
+            home=home,
+            recorded_sha_by_path=recorded_sha_by_path,
+            recorded_digest_by_path=recorded_digest_by_path,
+        ):
             to_prune.append(orphan)
         else:
             relinquished.add(orphan.path.relative_to(home))

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -25,6 +25,11 @@ class ReceiptEntry:
     root: Path
     kind: Literal["file", "dir"]
     sha256: str | None
+    dir_digest: str | None = None
+    """Recursive content fingerprint for a ``dir`` entry (``None`` for files and for
+    legacy dir entries recorded before this field existed). Lets the prune boundary
+    relinquish a directory whose contents drifted from the owned state — the
+    directory analogue of ``sha256`` for files."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,9 +52,39 @@ def canonical_bytes(receipt: Receipt) -> bytes:
     payload: dict[str, object] = {
         "schema_version": receipt.schema_version,
         "roots": sorted(str(r) for r in receipt.roots),
-        "entries": [[str(e.path), e.owner, str(e.root), e.kind, e.sha256] for e in entries],
+        "entries": [_entry_canonical(e) for e in entries],
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _entry_canonical(e: ReceiptEntry) -> list[object]:
+    """Canonical list form of an entry. ``dir_digest`` is appended ONLY when present,
+    so a receipt written before this field existed (no digest on any entry) hashes
+    byte-identically — its persisted integrity still validates, with no
+    ``SCHEMA_VERSION`` bump."""
+    base: list[object] = [str(e.path), e.owner, str(e.root), e.kind, e.sha256]
+    if e.dir_digest is not None:
+        base.append(e.dir_digest)
+    return base
+
+
+def dir_content_digest(path: Path) -> str:
+    """A recursive content fingerprint of a directory tree: ``sha256:<hex>`` over the
+    sorted ``(relpath, sha256(bytes))`` of every file under ``path``.
+
+    Mirrors ``sync._dir_is_unchanged``'s notion of owned content — files only
+    (empty dirs ignored), symlinks dereferenced (``rglob``/``read_bytes`` follow
+    them) — so a digest match means the same thing as "directory is unchanged" at
+    install time. Order-independent via the sort; stable across runs on the same
+    POSIX platform (relpaths are encoded with the OS separator, so the value is not
+    portable across separator families — fine for this POSIX-targeted installer)."""
+    h = hashlib.sha256()
+    for f in sorted(p for p in path.rglob("*") if p.is_file()):
+        h.update(str(f.relative_to(path)).encode("utf-8"))
+        h.update(b"\0")
+        h.update(hashlib.sha256(f.read_bytes()).digest())
+        h.update(b"\0")
+    return "sha256:" + h.hexdigest()
 
 
 def compute_integrity(receipt: Receipt) -> str:

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -80,7 +80,10 @@ def dir_content_digest(path: Path) -> str:
     portable across separator families — fine for this POSIX-targeted installer)."""
     h = hashlib.sha256()
     for f in sorted(p for p in path.rglob("*") if p.is_file()):
-        h.update(str(f.relative_to(path)).encode("utf-8"))
+        # surrogateescape so a filename with undecodable bytes (POSIX allows them;
+        # the os layer fsdecodes them to lone surrogates) re-encodes losslessly
+        # instead of raising UnicodeEncodeError at the prune boundary.
+        h.update(str(f.relative_to(path)).encode("utf-8", "surrogateescape"))
         h.update(b"\0")
         h.update(hashlib.sha256(f.read_bytes()).digest())
         h.update(b"\0")

--- a/packages/installer/src/installer/core/receipt_build.py
+++ b/packages/installer/src/installer/core/receipt_build.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from installer.core.model import FileKind, InstallOutcome, Outcome, StagingPlan
 from installer.core.ownership import PRUNE_NAMESPACES, entry_for, route_entry_for
-from installer.core.receipt import Receipt, ReceiptEntry
+from installer.core.receipt import Receipt, ReceiptEntry, dir_content_digest
 
 if TYPE_CHECKING:
     from installer.plugins.base import PluginAdapter
@@ -29,8 +29,10 @@ def entries_from_outcomes(
     namespaces. A ``settings.json`` write is excluded even under a prune namespace:
     it is a merge-target holding the user's bytes (mirroring ``is_prunable``'s
     ``FileKind.SETTINGS_JSON`` guard), so recording it would make the user's merged
-    file eligible for orphan pruning. Directory writes carry ``sha256=None``; the
-    kind is inferred from sha256 presence."""
+    file eligible for orphan pruning. Directory writes carry ``sha256=None`` and a
+    recursive ``dir_digest`` of the just-installed tree (the owned state), so a
+    later prune can relinquish a directory whose contents drifted; the kind is
+    inferred from sha256 presence."""
     out: list[ReceiptEntry] = []
     for o in outcomes:
         if o.outcome is Outcome.DECLINED:
@@ -40,13 +42,21 @@ def entries_from_outcomes(
             continue
         if rel.name == FileKind.SETTINGS_JSON.value:
             continue
+        is_file = o.sha256 is not None
+        # dir_content_digest re-walks the just-installed tree. A transient unreadable
+        # inner file raises OSError and aborts receipt finalization (fail loud): a
+        # half-readable tree would record a digest that mis-classifies the directory
+        # at the next prune boundary, so refusing to stamp a wrong receipt is safer
+        # than recording one. (The prune path, by contrast, catches OSError and
+        # relinquishes — it must never delete on uncertainty.)
         out.append(
             ReceiptEntry(
                 path=o.dest.relative_to(home),
                 owner=tool,
                 root=dest_root.relative_to(home),
-                kind="file" if o.sha256 is not None else "dir",
+                kind="file" if is_file else "dir",
                 sha256=o.sha256,
+                dir_digest=None if is_file else dir_content_digest(o.dest),
             )
         )
     return out

--- a/packages/installer/src/installer/core/receipt_store.py
+++ b/packages/installer/src/installer/core/receipt_store.py
@@ -29,13 +29,18 @@ class ReceiptRead:
 
 
 def _entry_to_json(e: ReceiptEntry) -> dict[str, object]:
-    return {
+    out: dict[str, object] = {
         "path": str(e.path),
         "owner": e.owner,
         "root": str(e.root),
         "kind": e.kind,
         "sha256": e.sha256,
     }
+    # Emitted only when present, so a legacy receipt (no digests) round-trips
+    # byte-for-byte and existing integrity digests keep validating.
+    if e.dir_digest is not None:
+        out["dir_digest"] = e.dir_digest
+    return out
 
 
 def _entry_from_json(d: object) -> ReceiptEntry:
@@ -55,6 +60,15 @@ def _entry_from_json(d: object) -> ReceiptEntry:
         raise ValueError("file entry requires string sha256")  # noqa: TRY003  # caught -> CORRUPT; single call-site
     if kind == "dir" and sha is not None:
         raise ValueError("dir entry must have null sha256")  # noqa: TRY003  # caught -> CORRUPT; single call-site
+    # dir_digest is the directory analogue of sha256: optional (absent only on
+    # legacy dir entries recorded before the field existed), str when present, and
+    # never on a file entry. A file carrying one, or a non-string digest, is
+    # schema-invalid on a file-deleting boundary -> CORRUPT (fail closed).
+    dir_digest = d.get("dir_digest")
+    if dir_digest is not None and not isinstance(dir_digest, str):
+        raise ValueError("dir_digest must be string or null")  # noqa: TRY003  # caught -> CORRUPT; single call-site
+    if kind == "file" and dir_digest is not None:
+        raise ValueError("file entry must not have dir_digest")  # noqa: TRY003  # caught -> CORRUPT; single call-site
     # Validate the string fields rather than ``str()``-coercing them: a JSON
     # number/list would otherwise coerce to a path/owner whose digest still
     # matches (the integrity is computed over the coerced form), silently
@@ -72,6 +86,7 @@ def _entry_from_json(d: object) -> ReceiptEntry:
         root=Path(root),
         kind=kind,
         sha256=sha,
+        dir_digest=dir_digest,
     )
 
 

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -127,8 +127,12 @@ def prune_pipeline(
         allowlist=allowlist,
     )
     recorded_sha_by_path = {e.path: e.sha256 for e in prior.entries}
+    recorded_digest_by_path = {e.path: e.dir_digest for e in prior.entries}
     to_prune, relinquished = partition_file_orphans(
-        orphans, home=home, recorded_sha_by_path=recorded_sha_by_path
+        orphans,
+        home=home,
+        recorded_sha_by_path=recorded_sha_by_path,
+        recorded_digest_by_path=recorded_digest_by_path,
     )
 
     removed: set[Path] = set()
@@ -143,7 +147,10 @@ def prune_pipeline(
         # Re-check ownership at the destructive boundary (closes the TOCTOU window
         # between this partition and the actual delete — see prune_hash.is_safe_to_prune).
         revalidate=lambda o: is_safe_to_prune(
-            o, home=home, recorded_sha_by_path=recorded_sha_by_path
+            o,
+            home=home,
+            recorded_sha_by_path=recorded_sha_by_path,
+            recorded_digest_by_path=recorded_digest_by_path,
         ),
     )
     pruned_paths = {p.relative_to(home) for p in removed}

--- a/packages/installer/tests/unit/test_prune_hash.py
+++ b/packages/installer/tests/unit/test_prune_hash.py
@@ -131,3 +131,105 @@ def test_dir_orphan_now_a_symlink_is_relinquished(tmp_path: Path) -> None:
     to_prune, relinquished = partition_file_orphans([o], home=tmp_path, recorded_sha_by_path={})
     assert to_prune == []
     assert relinquished == {Path(".claude/skills/foo")}
+
+
+def test_dir_orphan_matching_digest_is_pruned(tmp_path: Path) -> None:
+    """A recorded DIR orphan whose live recursive digest still matches the owned
+    state is prunable — it is genuinely our pristine directory."""
+    from installer.core.prune_hash import is_safe_to_prune
+    from installer.core.receipt import dir_content_digest
+
+    d = tmp_path / ".claude" / "skills" / "foo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("owned")
+    digest = dir_content_digest(d)
+    o = Orphan(tool="claude", namespace="skills", path=d, kind="dir")
+    assert is_safe_to_prune(
+        o,
+        home=tmp_path,
+        recorded_sha_by_path={},
+        recorded_digest_by_path={Path(".claude/skills/foo"): digest},
+    )
+
+
+def test_dir_orphan_content_drift_is_relinquished(tmp_path: Path) -> None:
+    """A still-real DIR orphan whose inner contents drifted from the recorded digest
+    (the user edited a file inside) is relinquished, not pruned — recursive
+    content-drift protection beyond the cheap type-check."""
+    from installer.core.receipt import dir_content_digest
+
+    d = tmp_path / ".claude" / "skills" / "foo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("owned")
+    digest = dir_content_digest(d)
+    (d / "SKILL.md").write_text("user edited this")
+    o = Orphan(tool="claude", namespace="skills", path=d, kind="dir")
+    to_prune, relinquished = partition_file_orphans(
+        [o],
+        home=tmp_path,
+        recorded_sha_by_path={},
+        recorded_digest_by_path={Path(".claude/skills/foo"): digest},
+    )
+    assert to_prune == []
+    assert relinquished == {Path(".claude/skills/foo")}
+
+
+def test_dir_orphan_legacy_no_digest_falls_back_to_type_check(tmp_path: Path) -> None:
+    """A legacy DIR entry recorded before digests existed (digest is None) keeps the
+    pre-feature behavior: prunable while still a real directory, regardless of
+    contents."""
+    d = tmp_path / ".claude" / "skills" / "foo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("anything")
+    o = Orphan(tool="claude", namespace="skills", path=d, kind="dir")
+    to_prune, relinquished = partition_file_orphans(
+        [o],
+        home=tmp_path,
+        recorded_sha_by_path={},
+        recorded_digest_by_path={Path(".claude/skills/foo"): None},
+    )
+    assert to_prune == [o]
+    assert relinquished == set()
+
+
+def test_dir_orphan_unreadable_inner_file_is_relinquished(tmp_path: Path) -> None:
+    """An OSError while recomputing the digest (an inner file became unreadable)
+    relinquishes — ownership cannot be confirmed, so the directory is left intact."""
+    import installer.core.prune_hash as prune_hash
+
+    d = tmp_path / ".claude" / "skills" / "foo"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("owned")
+    o = Orphan(tool="claude", namespace="skills", path=d, kind="dir")
+
+    def boom(_path: Path) -> str:
+        raise OSError
+
+    original = prune_hash.dir_content_digest
+    prune_hash.dir_content_digest = boom  # type: ignore[assignment]
+    try:
+        to_prune, relinquished = partition_file_orphans(
+            [o],
+            home=tmp_path,
+            recorded_sha_by_path={},
+            recorded_digest_by_path={Path(".claude/skills/foo"): "sha256:recorded"},
+        )
+    finally:
+        prune_hash.dir_content_digest = original  # type: ignore[assignment]
+    assert to_prune == []
+    assert relinquished == {Path(".claude/skills/foo")}
+
+
+def test_dir_orphan_absent_on_disk_falls_through_to_prune(tmp_path: Path) -> None:
+    """A recorded DIR orphan whose path has already vanished is prunable: the delete
+    is a no-op, and there are no contents to drift from the recorded digest."""
+    missing = tmp_path / ".claude" / "skills" / "gone"
+    o = Orphan(tool="claude", namespace="skills", path=missing, kind="dir")
+    to_prune, relinquished = partition_file_orphans(
+        [o],
+        home=tmp_path,
+        recorded_sha_by_path={},
+        recorded_digest_by_path={Path(".claude/skills/gone"): "sha256:recorded"},
+    )
+    assert to_prune == [o]
+    assert relinquished == set()

--- a/packages/installer/tests/unit/test_receipt_build.py
+++ b/packages/installer/tests/unit/test_receipt_build.py
@@ -142,3 +142,20 @@ def test_desired_route_keys_includes_shipped_route_files(tmp_path: Path) -> None
     beads = BeadsPlugin(name="beads", source_path=src, which=lambda _c: None)
     keys = desired_route_keys([beads], home=home)
     assert ("beads", Path(".beads/formulas/a.toml")) in keys
+
+
+def test_entries_from_outcomes_records_dir_digest_for_real_dir(tmp_path: Path) -> None:
+    # A dir outcome is recorded with a recursive digest of the installed tree, so a
+    # later prune can detect content drift. The digest equals dir_content_digest.
+    from installer.core.receipt import dir_content_digest
+
+    home = tmp_path
+    skill = home / ".claude" / "skills" / "foo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("owned content")
+    outcomes = [InstallOutcome(skill, Outcome.WRITTEN, None)]
+    entries = entries_from_outcomes(outcomes, tool="claude", dest_root=home / ".claude", home=home)
+    entry = entries[0]
+    assert entry.kind == "dir"
+    assert entry.sha256 is None
+    assert entry.dir_digest == dir_content_digest(skill)

--- a/packages/installer/tests/unit/test_receipt_model.py
+++ b/packages/installer/tests/unit/test_receipt_model.py
@@ -45,3 +45,24 @@ def test_dir_content_digest_changes_when_file_added_or_removed(tmp_path: Path) -
     assert with_added != base
     (d / "b.txt").unlink()
     assert dir_content_digest(d) == base
+
+
+def test_dir_content_digest_survives_undecodable_filename(tmp_path: Path) -> None:
+    """A file whose name carries undecodable bytes (POSIX-legal; fsdecoded to lone
+    surrogates) must not crash the digest — it is re-encoded with surrogateescape.
+    Skipped on filesystems that reject such names (e.g. APFS on macOS)."""
+    import os
+
+    from installer.core.receipt import dir_content_digest
+
+    d = tmp_path / "d"
+    d.mkdir()
+    bad_name = os.fsdecode(b"bad\xff.txt")  # lone surrogate after fsdecode
+    try:
+        (d / bad_name).write_text("payload")
+    except (OSError, UnicodeError):
+        import pytest
+
+        pytest.skip("filesystem rejects undecodable filenames")
+    # Must return a digest, not raise UnicodeEncodeError.
+    assert dir_content_digest(d).startswith("sha256:")

--- a/packages/installer/tests/unit/test_receipt_model.py
+++ b/packages/installer/tests/unit/test_receipt_model.py
@@ -31,3 +31,17 @@ def test_integrity_is_independent_of_roots_order() -> None:
     a = Receipt(roots=(Path(".claude"), Path(".beads")), entries=())
     b = Receipt(roots=(Path(".beads"), Path(".claude")), entries=())
     assert compute_integrity(a) == compute_integrity(b)
+
+
+def test_dir_content_digest_changes_when_file_added_or_removed(tmp_path: Path) -> None:
+    from installer.core.receipt import dir_content_digest
+
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "a.txt").write_text("alpha")
+    base = dir_content_digest(d)
+    (d / "b.txt").write_text("beta")
+    with_added = dir_content_digest(d)
+    assert with_added != base
+    (d / "b.txt").unlink()
+    assert dir_content_digest(d) == base

--- a/packages/installer/tests/unit/test_receipt_store.py
+++ b/packages/installer/tests/unit/test_receipt_store.py
@@ -317,3 +317,96 @@ def test_non_string_roots_element_is_corrupt(tmp_path: Path) -> None:
     }
     path.write_text(json.dumps(doc), encoding="utf-8")
     assert read_receipt(path).status is ReadStatus.CORRUPT
+
+
+def test_dir_entry_with_digest_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "install-receipt.json"
+    receipt = Receipt(
+        entries=(
+            ReceiptEntry(
+                Path(".claude/skills/foo"),
+                "claude",
+                Path(".claude"),
+                "dir",
+                None,
+                dir_digest="sha256:deadbeef",
+            ),
+        )
+    )
+    write_receipt(path, receipt)
+    result = read_receipt(path)
+    assert result.status is ReadStatus.OK
+    assert result.receipt is not None
+    assert result.receipt.entries[0].dir_digest == "sha256:deadbeef"
+
+
+def test_legacy_dir_entry_without_digest_still_validates(tmp_path: Path) -> None:
+    # A dir entry carrying no digest (what pre-feature installs wrote) must read OK:
+    # dir_digest is omitted from both the JSON and the canonical integrity bytes, so
+    # the persisted digest still matches — no SCHEMA_VERSION bump, no forced reinstall.
+    path = tmp_path / "install-receipt.json"
+    write_receipt(
+        path,
+        Receipt(
+            entries=(
+                ReceiptEntry(Path(".claude/skills/foo"), "claude", Path(".claude"), "dir", None),
+            )
+        ),
+    )
+    assert "dir_digest" not in path.read_text(encoding="utf-8")
+    result = read_receipt(path)
+    assert result.status is ReadStatus.OK
+    assert result.receipt is not None
+    assert result.receipt.entries[0].dir_digest is None
+
+
+def test_file_entry_carrying_dir_digest_is_corrupt(tmp_path: Path) -> None:
+    # dir_digest on a file entry is schema-invalid -> CORRUPT (fail closed). The
+    # entry validator rejects it before integrity is even checked.
+    path = tmp_path / "install-receipt.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "integrity": "sha256:whatever",
+                "roots": [],
+                "entries": [
+                    {
+                        "path": ".claude/rules/x.md",
+                        "owner": "claude",
+                        "root": ".claude",
+                        "kind": "file",
+                        "sha256": "ab",
+                        "dir_digest": "sha256:nope",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert read_receipt(path).status is ReadStatus.CORRUPT
+
+
+def test_non_string_dir_digest_is_corrupt(tmp_path: Path) -> None:
+    path = tmp_path / "install-receipt.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "integrity": "sha256:whatever",
+                "roots": [],
+                "entries": [
+                    {
+                        "path": ".claude/skills/foo",
+                        "owner": "claude",
+                        "root": ".claude",
+                        "kind": "dir",
+                        "sha256": None,
+                        "dir_digest": 123,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert read_receipt(path).status is ReadStatus.CORRUPT


### PR DESCRIPTION
## Summary

Extends the install receipt's file-level content-drift protection to **directories**. Closes `agents-config-fkewj`.

- The receipt records a recursive `dir_digest` per directory entry, computed by re-walking the just-installed tree in `receipt_build.entries_from_outcomes`.
- `dir_content_digest` mirrors `sync._dir_is_unchanged` by construction (same `rglob("*") if is_file` + `read_bytes` mechanism — files only, symlinks dereferenced), so "digest matches" means exactly "directory unchanged since install."
- At the prune boundary, a still-real directory whose live digest drifted from the recorded value is **relinquished** (kept on disk, dropped from the receipt) instead of deleted — the directory analogue of the existing `sha256` guard for files. Threaded into both scan-time partitioning and the revalidate-at-delete closure; OSError on recompute fails closed (relinquish).

## Scope

- **In:** `receipt.py` (`dir_digest` field + `dir_content_digest` + canonical-form helper), `receipt_build.py`, `receipt_store.py`, `prune_hash.py`, `run.py`. Tests across `test_prune_hash`, `test_receipt_store`, `test_receipt_build`, `test_receipt_model`.
- **Out:** `model.py` / `sync.py` deliberately untouched — the digest is computed in the receipt-build layer, not threaded through `InstallOutcome`. This is the design choice that kept the change to 5 source files.

## Back-compat (no SCHEMA_VERSION bump)

`dir_digest` is additive and optional. It is omitted from both `canonical_bytes` (the integrity hash) and the JSON when `None`, so a pre-feature receipt on disk (dir entries, no digest) hashes byte-identically and still validates. Asserted by `test_legacy_dir_entry_without_digest_still_validates`.

## Known one-cycle window (intentional, mitigated)

A legacy dir entry carried from a pre-feature receipt has no recorded digest, so it degrades to the prior **type-check-only** guard. On the *first* `--prune` after upgrading, an orphaned directory from such a receipt is deletable even if the user edited files inside it — until a post-upgrade install rewrites the receipt with digests. This is graceful degradation, and it is mitigated by **backup-before-delete** (recoverable from the backup dir). Surfaced here per reviewer feedback; deemed acceptable given the backup safety net.

## Test Plan

- [x] `make ci-installer` — lint, format, mypy --strict, pytest --cov, pip-audit, entry-verify
- [x] 702 passed, 99.43% coverage (90% branch floor)
- [x] New branches covered: dir digest match/drift/legacy-fallback/OSError/absent (prune); round-trip/legacy/file-carrying-digest/non-string (store); build digest; model add/remove

## Ground truth for reviewers

- Back-compat claim: `receipt.py` `_entry_canonical` + `receipt_store.py` `_entry_to_json`/`_entry_from_json`
- Fail-closed delete boundary: `prune_flow.py` revalidate digest re-walk + lstat-identity snapshot + backup-before-delete (unchanged but load-bearing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)