### PR TITLE
refactor(installer): stream file hashing via hashlib.file_digest

### DIFF
--- a/packages/installer/src/installer/core/hashing.py
+++ b/packages/installer/src/installer/core/hashing.py
@@ -1,0 +1,27 @@
+"""Bounded-memory file hashing.
+
+A single streaming sha-256 helper shared by every site that fingerprints a file
+on disk (``sync`` dest comparison, ``prune_hash`` file-orphan guard,
+``receipt.dir_content_digest``). Streaming via :func:`hashlib.file_digest`
+(stdlib 3.11+) keeps memory bounded regardless of file size; the digest is
+byte-identical to hashing ``path.read_bytes()`` in one shot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def sha256_file(path: Path) -> bytes:
+    """Return the raw sha-256 digest of ``path``'s contents, read in bounded memory.
+
+    Hex callers use ``.hex()`` on the result — identical to ``hexdigest()``.
+    Symlinks are dereferenced (the file is opened for reading), matching the
+    prior ``read_bytes()`` behaviour at every call site.
+    """
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "sha256").digest()

--- a/packages/installer/src/installer/core/prune_hash.py
+++ b/packages/installer/src/installer/core/prune_hash.py
@@ -13,9 +13,9 @@ two (the TOCTOU window of the interactive confirm prompt) is never deleted."""
 
 from __future__ import annotations
 
-import hashlib
 from typing import TYPE_CHECKING
 
+from installer.core.hashing import sha256_file
 from installer.core.receipt import dir_content_digest
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ def is_safe_to_prune(
         except OSError:
             return False  # unreadable inner file: cannot confirm ownership — relinquish
     try:
-        actual = hashlib.sha256(orphan.path.read_bytes()).hexdigest()
+        actual = sha256_file(orphan.path).hex()
     except FileNotFoundError:
         return True
     except OSError:

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from installer.core.hashing import sha256_file
+
 SCHEMA_VERSION = 1
 
 
@@ -73,8 +75,8 @@ def dir_content_digest(path: Path) -> str:
     sorted ``(relpath, sha256(bytes))`` of every file under ``path``.
 
     Mirrors ``sync._dir_is_unchanged``'s notion of owned content — files only
-    (empty dirs ignored), symlinks dereferenced (``rglob``/``read_bytes`` follow
-    them) — so a digest match means the same thing as "directory is unchanged" at
+    (empty dirs ignored), symlinks dereferenced (``rglob`` and the per-file read
+    follow them) — so a digest match means the same thing as "directory is unchanged" at
     install time. Order-independent via the sort; stable across runs on the same
     POSIX platform (relpaths are encoded with the OS separator, so the value is not
     portable across separator families — fine for this POSIX-targeted installer)."""
@@ -85,7 +87,7 @@ def dir_content_digest(path: Path) -> str:
         # instead of raising UnicodeEncodeError at the prune boundary.
         h.update(str(f.relative_to(path)).encode("utf-8", "surrogateescape"))
         h.update(b"\0")
-        h.update(hashlib.sha256(f.read_bytes()).digest())
+        h.update(sha256_file(f))
         h.update(b"\0")
     return "sha256:" + h.hexdigest()
 

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -75,8 +75,8 @@ def dir_content_digest(path: Path) -> str:
     sorted ``(relpath, sha256(bytes))`` of every file under ``path``.
 
     Mirrors ``sync._dir_is_unchanged``'s notion of owned content — files only
-    (empty dirs ignored), symlinks dereferenced (``rglob`` and the per-file read
-    follow them) — so a digest match means the same thing as "directory is unchanged" at
+    (empty dirs ignored), symlinks dereferenced (both ``rglob`` and the per-file
+    read follow them) — so a digest match means the same thing as "directory is unchanged" at
     install time. Order-independent via the sort; stable across runs on the same
     POSIX platform (relpaths are encoded with the OS separator, so the value is not
     portable across separator families — fine for this POSIX-targeted installer)."""

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from installer.core.backup import back_up, new_timestamp, valid_timestamp
 from installer.core.consent import require_consent
+from installer.core.hashing import sha256_file
 from installer.core.merge.strategies.json_union import merge_settings_bytes
 from installer.core.model import Counters, FileKind, InstallOutcome, Outcome
 from installer.core.paths import is_safe_relpath
@@ -128,7 +129,7 @@ def sync(
     content = source.read_bytes()
     dest_exists = dest.is_file()
 
-    if dest_exists and _sha256(dest.read_bytes()) == _sha256(content):
+    if dest_exists and sha256_file(dest) == _sha256(content):
         counters.skipped += 1
         return counters
 

--- a/packages/installer/tests/unit/test_hashing.py
+++ b/packages/installer/tests/unit/test_hashing.py
@@ -1,0 +1,29 @@
+"""Unit tests for the streaming file-digest helper."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from installer.core.hashing import sha256_file
+
+
+def test_matches_in_memory_digest_for_multichunk_file(tmp_path: Path) -> None:
+    """sha256_file streams the same canonical digest the in-memory path produced.
+
+    Sized well past file_digest's internal read buffer so a single-read bug
+    (truncated digest) would diverge from hashing the whole byte string.
+    """
+    data = b"".join(bytes([i % 256]) for i in range(300_000))
+    target = tmp_path / "blob.bin"
+    target.write_bytes(data)
+
+    assert sha256_file(target).hex() == hashlib.sha256(data).hexdigest()
+
+
+def test_empty_file(tmp_path: Path) -> None:
+    """An empty file hashes to the canonical sha-256 of no bytes."""
+    target = tmp_path / "empty.bin"
+    target.write_bytes(b"")
+
+    assert sha256_file(target) == hashlib.sha256(b"").digest()

--- a/packages/installer/tests/unit/test_hashing.py
+++ b/packages/installer/tests/unit/test_hashing.py
@@ -14,7 +14,7 @@ def test_matches_in_memory_digest_for_multichunk_file(tmp_path: Path) -> None:
     Sized well past file_digest's internal read buffer so a single-read bug
     (truncated digest) would diverge from hashing the whole byte string.
     """
-    data = b"".join(bytes([i % 256]) for i in range(300_000))
+    data = bytes(i % 256 for i in range(300_000))
     target = tmp_path / "blob.bin"
     target.write_bytes(data)
 


### PR DESCRIPTION
## Summary
- Adds a single streaming digest helper `installer.core.hashing.sha256_file` (`hashlib.file_digest`, stdlib 3.11+) that hashes a file in bounded memory.
- Converts the three installer sites that previously read whole files into memory before sha256: `sync` dest comparison, `prune_hash.is_safe_to_prune` file-orphan branch, and `receipt.dir_content_digest`.
- Digest-identical to the prior `read_bytes()` path — pure non-behavioral refactor. Origin: Copilot flag on PR #204.

## Scope
- **In scope:** the three file-read-then-hash sites named above + the new helper + its unit test.
- **Out of scope (intentionally left in memory):** `sync`'s source `content` hash and the receipt-`effective` hashes — those bytes are needed for the write/record path, not a read-purely-to-hash. The receipt-integrity hash operates on an in-memory serialized blob, not a file. These are correctly *not* converted.

## Ground truth for claims
- `bytes.hex() == hexdigest()` and `file_digest(...).digest()` equals `sha256(read_bytes()).digest()` — pinned by `tests/unit/test_hashing.py` (multichunk 300 KB file + empty file).
- Symlink dereference and `FileNotFoundError`/`OSError` handling in `prune_hash` are preserved (`path.open("rb")` raises the same types as `read_bytes()`).

## Test Plan
- [x] `make ci-installer` green: ruff lint + format, mypy --strict, 704 passed / 1 skipped, 99.43% coverage, pip-audit clean, entry-verify.
- [x] New `test_hashing.py` proves digest equivalence across read-buffer boundaries.

Closes agents-config-3v4fo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)