### PR TITLE
fix(docs): correct stale 'auto-installs Python 3.11' to ≥3.11

### DIFF
--- a/docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-plan.md
+++ b/docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-plan.md
@@ -498,7 +498,7 @@ make ci-installer    # full quality gate (tests, lint, format-check, typecheck, 
 make test-installer  # just pytest
 ```
 
-First-time setup: `uv` auto-installs Python 3.11 if missing (one-time slow run; subsequent runs are fast).
+First-time setup: `uv` auto-installs Python ≥3.11 if missing (one-time slow run; subsequent runs are fast).
 
 ## Status
 


### PR DESCRIPTION
## What

`docs/specs/2026-05-17-w1qls.1.1-installer-scaffold-plan.md` line 501 claimed `uv` auto-installs a pinned **Python 3.11**. The installer's `pyproject.toml` declares `requires-python = ">=3.11"`, so `uv` installs the latest satisfying version, not a pin.

## Change

One word: `Python 3.11` → `Python ≥3.11` in the first-time-setup prose. Pinned CI literals (`uv python install 3.11`) are intentional and left untouched.

Closes agents-config-fvtyt (discovered during H.5 PR review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)