### PR TITLE
fix(merge-guard): exclude reply comments from unseen-comment count

### DIFF
--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -160,7 +160,11 @@ fi
 
 echo "Checking comment counts..." >&2
 
-total_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" --jq 'length') || {
+# Count only top-level review comments. Reply comments (in_reply_to_id set) —
+# including the agent's own thread replies — are not new reviewer feedback, so
+# counting them inflates the total and false-positive-blocks the merge.
+total_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
+    --jq '[.[] | select(.in_reply_to_id == null)] | length') || {
     echo "Error: failed to fetch comments" >&2; exit 3;
 }
 

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -163,8 +163,10 @@ echo "Checking comment counts..." >&2
 # Count only top-level review comments. Reply comments (in_reply_to_id set) —
 # including the agent's own thread replies — are not new reviewer feedback, so
 # counting them inflates the total and false-positive-blocks the merge.
-total_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments" \
-    --jq '[.[] | select(.in_reply_to_id == null)] | length') || {
+# Paginate (default page size ~30) so PRs with many comments aren't undercounted
+# and wrongly marked eligible: --paginate emits the per-page count, summed below.
+total_comments=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}/comments?per_page=100" --paginate \
+    --jq '[.[] | select(.in_reply_to_id == null)] | length' | jq -s 'add // 0') || {
     echo "Error: failed to fetch comments" >&2; exit 3;
 }
 

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -90,7 +90,7 @@ if [ "$1" = "api" ]; then
     */requested_reviewers) body='{"users":[],"teams":[]}' ;;
     */issues/*/events)     body='[]' ;;
     */pulls/*/reviews)     body='[]' ;;
-    */pulls/*/comments)    body="$FIXTURE_COMMENTS" ;;
+    */pulls/*/comments|*/pulls/*/comments\?*) body="$FIXTURE_COMMENTS" ;;
     */pulls/*)             body='{"state":"open"}' ;;
     *)                     body='{}' ;;
   esac

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -70,4 +70,47 @@ assert "exits 3 for unknown flag" "[ \$rc_bogus -eq 3 ]"
 rc_dangling=$?
 assert "exits 3 for flag with no value (not silent exit 1)" "[ \$rc_dangling -eq 3 ]"
 
+# ── Regression (nnqwg): reply comments must NOT count toward unseen ───────────
+# A gh stub returns canned JSON per endpoint so the comment-counting jq filter
+# runs end-to-end. Fixture: 2 top-level reviewer comments + 2 agent replies.
+# With both top-level comments triaged (--comments-seen 2), the buggy `length`
+# count yields 4 → unseen=2 → exit 2. The fix counts only top-level (2) → eligible.
+STUB_DIR="$TMP/bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "auth" ] && exit 0
+if [ "$1" = "api" ]; then
+  path="$2"; shift 2
+  filter=""
+  while [ $# -gt 0 ]; do
+    case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
+  done
+  case "$path" in
+    */requested_reviewers) body='{"users":[],"teams":[]}' ;;
+    */issues/*/events)     body='[]' ;;
+    */pulls/*/reviews)     body='[]' ;;
+    */pulls/*/comments)    body="$FIXTURE_COMMENTS" ;;
+    */pulls/*)             body='{"state":"open"}' ;;
+    *)                     body='{}' ;;
+  esac
+  if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+
+export FIXTURE_COMMENTS='[
+  {"id":1,"in_reply_to_id":null,"user":{"login":"reviewer"}},
+  {"id":2,"in_reply_to_id":null,"user":{"login":"reviewer"}},
+  {"id":3,"in_reply_to_id":1,"user":{"login":"agent"}},
+  {"id":4,"in_reply_to_id":2,"user":{"login":"agent"}}
+]'
+
+reply_out=$(PATH="$STUB_DIR:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --comments-seen 2 2>/dev/null)
+rc_replies=$?
+assert "reply comments excluded → eligible (exit 0)" "[ \$rc_replies -eq 0 ]"
+assert "total_comments counts only top-level (==2)" "[ \"\$(printf '%s' \"\$reply_out\" | jq -r '.total_comments')\" = '2' ]"
+
 exit $FAIL


### PR DESCRIPTION
## Summary

`check-merge-eligibility.sh` counted total PR review comments with a raw `--jq 'length'`, which includes **reply comments** (`in_reply_to_id` set) — including the agent's own thread replies posted during triage. After replying to N review threads, the total inflated by N, so the script reported phantom unseen comments and **false-positive-blocked the merge** (exit 2, `unseen_comments`).

Observed on PR #125: 11 triaged top-level comments + 11 agent thread replies = 22 total → reported 11 unseen, blocked. Ground-truth unseen was 0.

## Fix

Filter the count to top-level comments only: `[.[] | select(.in_reply_to_id == null)] | length`.

## Test

Adds a `gh`-stub regression test (`check-merge-eligibility_test.sh`) that feeds a fixture of 2 top-level reviewer comments + 2 agent replies. With both top-level triaged (`--comments-seen 2`), the old `length` count yielded 4 → exit 2; the fix counts 2 → eligible (exit 0). Full suite: 20/20 green.

Closes nnqwg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)