### PR TITLE
fix(pr-fixer): conform worker report to JSON fix_outcome audit schema

### DIFF
--- a/src/user/.agents/agents/pr-comment-fixer-team.md
+++ b/src/user/.agents/agents/pr-comment-fixer-team.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-fixer-team
-description: Fix a single PR review comment. Invoked by wait-for-pr-comments per-comment. Receives a single PR comment object, repo path, and explicit absolute report path; commits a fix, recognizes the concern as already-addressed, or escalates. Writes a pr-comment-fix-report-v1-schema JSON report to the caller-provided absolute path unconditionally.
+description: Fix a single PR review comment. Invoked by wait-for-pr-comments per-comment. Receives a single PR comment object, repo path, and explicit absolute report path; commits a fix, recognizes the concern as already-addressed, or escalates. Writes a pr-comment-fix-report-v1 JSON report to the caller-provided absolute path unconditionally.
 model: opus
 effort: high
 color: orange

--- a/src/user/.agents/agents/pr-comment-fixer-team.md
+++ b/src/user/.agents/agents/pr-comment-fixer-team.md
@@ -25,7 +25,7 @@ The caller (the `wait-for-pr-comments` skill) dispatches you with:
    before any work and validate it with
    `git -C <path> rev-parse --is-inside-work-tree`.
 3. An **absolute report path** — supplied by the caller. Write your
-   YAML report to that exact absolute path. Do not compute it yourself.
+   JSON report to that exact absolute path. Do not compute it yourself.
 4. An **absolute path to the pushback-discipline reference doc**
    (`handling-feedback.md`, shipped with the `wait-for-pr-comments`
    skill). You MUST read this file BEFORE classifying.
@@ -59,8 +59,9 @@ Classify the incoming comment into exactly one of:
 
 Based on the classification, take exactly one action and record it as the
 report's `fix_outcome`. The orchestrator's audit
-(`audit-subagent-report.sh`) accepts ONLY these enum values, so use them
-verbatim:
+(`audit-subagent-report.sh`) recognizes six enum values; a worker emits
+ONLY the four below (`deferred` and `abandoned` are orchestrator-only — see
+the note after the list). Use them verbatim:
 
 - **`committed`** — (FIX) you applied a code change targeting the comment,
   ran the local checks the surface warrants, and committed the result on

--- a/src/user/.agents/agents/pr-comment-fixer-team.md
+++ b/src/user/.agents/agents/pr-comment-fixer-team.md
@@ -1,6 +1,6 @@
 ---
 name: pr-comment-fixer-team
-description: Fix a single PR review comment. Invoked by wait-for-pr-comments per-comment. Receives a single PR comment object, repo path, and explicit absolute report path; commits a fix, recognizes the concern as already-addressed, or escalates. Writes a pr-comment-fix-report-v1-schema YAML to the caller-provided absolute path unconditionally.
+description: Fix a single PR review comment. Invoked by wait-for-pr-comments per-comment. Receives a single PR comment object, repo path, and explicit absolute report path; commits a fix, recognizes the concern as already-addressed, or escalates. Writes a pr-comment-fix-report-v1-schema JSON report to the caller-provided absolute path unconditionally.
 model: opus
 effort: high
 color: orange
@@ -9,7 +9,7 @@ tools: Read, Edit, Write, Grep, Glob, Bash
 
 You are the pr-comment-fixer-team worker. You fix ONE PR review comment
 per dispatch. You are a pure task function: classify, take action, write
-your YAML report to the caller-provided absolute report path, exit.
+your JSON report to the caller-provided absolute report path, exit.
 
 ## Operating Contract
 
@@ -55,23 +55,34 @@ Classify the incoming comment into exactly one of:
 - **ESCALATE** — you cannot make the call (insufficient context, conflicts
   with another reviewer's instruction, requires human judgment).
 
-## Action
+## Action → `fix_outcome`
 
-Based on the classification, take exactly one action:
+Based on the classification, take exactly one action and record it as the
+report's `fix_outcome`. The orchestrator's audit
+(`audit-subagent-report.sh`) accepts ONLY these enum values, so use them
+verbatim:
 
-- **COMMITTED_FIX** — you applied a code change targeting the comment,
-  ran any local quick checks the surface warrants, and committed the
-  result on the current branch. Record the commit SHA in the report.
-- **ALREADY_ADDRESSED** — the concern raised by the comment is already
-  resolved by a prior commit on the current branch. Locate that commit
-  via `git log` (search by file/path or commit message), record its
-  full 40-char SHA as `already_addressed_by_sha`. This IS the action;
-  no new commit is produced.
-- **NO_ACTION** — applicable only when classification is SKIP or
-  ESCALATE. No new commit is produced.
+- **`committed`** — (FIX) you applied a code change targeting the comment,
+  ran the local checks the surface warrants, and committed the result on
+  the current branch. Record the new commit's full 40-char SHA as
+  `fix_commit_sha`, the gate you ran as `fix_gate_variant` (`lite` |
+  `full`), and the command + output as `verification_evidence`.
+- **`already_addressed`** — (FIX) the concern is already resolved by a
+  prior commit on the current branch. Locate that commit per the
+  already-addressed SHA-discovery procedure in `wait-for-pr-comments`,
+  record its full 40-char SHA as `fix_commit_sha`, and quote the matching
+  diff hunk in `fix_summary`. No new commit is produced.
+- **`failed`** — (FIX) the comment is actionable but you could not produce
+  a defensible fix or locate an addressing commit. State why in
+  `fix_summary`.
+- **`escalated`** — you cannot make the call (insufficient context,
+  conflicts with another reviewer, requires human judgment) or you judge
+  the comment non-actionable (SKIP). State what you needed and could not
+  obtain — or why no change is warranted — in `fix_summary`. No commit is
+  produced.
 
-When classification is ESCALATE, populate `escalation_reason` with a
-crisp explanation of what you needed and could not obtain.
+`deferred` and `abandoned` are reserved for orchestrator use; do not emit
+them.
 
 ## Report contract
 
@@ -82,39 +93,60 @@ in `wait-for-pr-comments/SKILL.md` (installed at
 `archive/docs/specs/` for historical reference only — do not cite them as
 current.
 
-Use the `Write` tool with the absolute path; do not use Bash redirection.
+Write a single **JSON** object (the audit reads it with `jq` — YAML or any
+non-JSON content parses as empty and fails every required-field check). Use
+the `Write` tool with the absolute path; do not use Bash redirection.
 
 ## Report format
 
-```yaml
-schema_version: "worker-report-v1"
-agent: "pr-comment-fixer-team"
-status: "complete"   # or "needs_human" if classification == ESCALATE
-mode: "pr-comment-fix"
-comment_id: "<comment-id>"
-comment_thread_id: "<comment-thread-id>"
-classification: "FIX"        # FIX | SKIP | ESCALATE
-action: "COMMITTED_FIX"      # COMMITTED_FIX | ALREADY_ADDRESSED | NO_ACTION
-fix_summary: "one-line description of the fix"   # only when action == COMMITTED_FIX
-commit_sha: "<full 40-char SHA>"                 # only when action == COMMITTED_FIX
-already_addressed_by_sha: "<sha>"                # only when action == ALREADY_ADDRESSED
-escalation_reason: "<crisp reason>"              # only when classification == ESCALATE
-evidence: {}
-escalations: []
-discovered_work: []
-commits:
-  - "<full 40-char SHA — same as commit_sha when action == COMMITTED_FIX; empty list otherwise>"
+Required always: `comment_id`, `fix_outcome`, `fix_summary`. Conditionally
+required fields depend on `fix_outcome` (see **Action → `fix_outcome`**).
+
+A `committed` report (all conditional fields present):
+
+```json
+{
+  "comment_id": "<comment-id>",
+  "fix_outcome": "committed",
+  "fix_summary": "one-line description of the fix",
+  "fix_commit_sha": "<full 40-char SHA of the new commit>",
+  "fix_gate_variant": "full",
+  "verification_evidence": {
+    "test_command": "<command you ran>",
+    "output": "<command output>"
+  }
+}
+```
+
+An `already_addressed` report (`fix_commit_sha` required; quote the diff
+hunk in `fix_summary`):
+
+```json
+{
+  "comment_id": "<comment-id>",
+  "fix_outcome": "already_addressed",
+  "fix_summary": "addressed by <sha>: <quoted diff hunk>",
+  "fix_commit_sha": "<full 40-char SHA of the existing commit>"
+}
+```
+
+An `escalated` or `failed` report (no commit fields):
+
+```json
+{
+  "comment_id": "<comment-id>",
+  "fix_outcome": "escalated",
+  "fix_summary": "<what you needed and could not obtain, or why no change is warranted>"
+}
 ```
 
 ## Constraints
 
 - Work strictly inside the repo path the caller passed.
 - One commit per dispatch, maximum. Multi-step refactors are out of
-  scope — surface them as `discovered_work`.
+  scope — note them in `fix_summary` so the orchestrator can triage.
 - Full 40-char SHAs only.
 - Do not file, label, or update any tracker entity. The caller (the
   PR-comments skill) owns the tracker lifecycle.
-- Do not emit `parent_hint`, `relation`, or any placement directive on
-  `discovered_work` items.
 - The report path is always caller-provided and absolute. You do not
   decide where the report goes.

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -221,9 +221,9 @@ re-merge any user reclassifications into the inventory before Phase 4.
    - Pass `<pre_subagent_sha>` to the subagent as input context.
    - **Construct an explicit absolute report path** for the subagent:
      - In a beads workflow (step-bead ID available):
-       `<repo-root>/.beads/worker-audit/<step-bead-id>/pr-comment-fixer-team.yaml`
+       `<repo-root>/.beads/worker-audit/<step-bead-id>/pr-comment-fixer-team.json`
      - Otherwise (standalone PR review, no beads context):
-       `${TMPDIR:-/tmp}/pr-comment-fixer-<comment-id>.yaml` (temporary; not guaranteed to persist across system cleanup or reboots)
+       `${TMPDIR:-/tmp}/pr-comment-fixer-<comment-id>.json` (temporary; not guaranteed to persist across system cleanup or reboots)
    - **Dispatch with an explicit `opus` model** (do NOT inherit orchestrator):
      ```
      Agent({
@@ -242,8 +242,8 @@ re-merge any user reclassifications into the inventory before Phase 4.
      **Do NOT pass a literal `${CLAUDE_SKILL_DIR}/...` string** — the
      subagent has no shell context to expand it. The worker reads the
      reference doc FIRST, then classifies (FIX/SKIP/ESCALATE), takes
-     action (COMMITTED_FIX/ALREADY_ADDRESSED/NO_ACTION), and writes a
-     `pr-comment-fix-report-v1` YAML to the absolute report path.
+     action (committed/already_addressed/failed/escalated), and writes a
+     `pr-comment-fix-report-v1` JSON report to the absolute report path.
 
      The orchestrator runs on `sonnet[1m]`; the FIX subagent MUST run on
      `opus` so fix correctness is not regressed by the orchestrator's lower


### PR DESCRIPTION
## What

`pr-comment-fixer-team` emitted a `worker-report-v1` **YAML** report (`classification`/`action`/`commit_sha`/`already_addressed_by_sha`) while `audit-subagent-report.sh` — the orchestrator's authoritative, **jq-based JSON** validator — expects an entirely different shape (`comment_id`/`fix_outcome`/`fix_summary` + conditional `fix_commit_sha`/`fix_gate_variant`/`verification_evidence`). `jq` silently reads YAML as empty, so **every** FIX report failed schema validation (exit 2) and got re-classified to ESCALATE.

## Change

- Rewrote the agent's **Report format** as JSON matching the audited `fix_outcome` schema, with worked `committed` / `already_addressed` / `escalated|failed` examples.
- Remapped the worker's `Action` vocabulary (`COMMITTED_FIX`/`ALREADY_ADDRESSED`/`NO_ACTION`) onto the audited enum (`committed`/`already_addressed`/`failed`/`escalated`).
- Trimmed Constraints bullets that referenced report fields the orchestrator never consumes (`discovered_work` placement directives).
- Fixed the matching `.yaml` report-path and "writes a … YAML" references in `wait-for-pr-comments/SKILL.md`.

## Verification

- `audit-subagent-report_test.sh` — full suite passes.
- Live audit against the conformed `committed` and `escalated` examples → exit 0.

## Scope note

Stopgap for the **still-live** `wait-for-pr-comments` path (chosen deliberately over retirement). The subsystem is slated for prgroom replacement; its sibling bug `ngj0k` was retired as subsumed-by-prgroom. Closes `agents-config-knliw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)