### PR TITLE
feat(merge-guard): admin-bypass fact for GitHub ruleset review-count rejections

### DIFF
--- a/docs/architecture/review-merge-policy/design.md
+++ b/docs/architecture/review-merge-policy/design.md
@@ -229,6 +229,50 @@ cannot pick unsafe defaults.
 - This predicate relies on the eligibility floor's triage-completeness facts;
   it does not add a parallel comment-classification mechanism.
 
+**admin-bypass availability** (never a blocker — informs *how* Step 5 issues
+an already-authorized merge, not *whether* one is eligible):
+
+- A repo's own GitHub branch protection is enforced through a **ruleset**
+  (`GET /repos/{owner}/{repo}/rules/branches/{branch}`), independent of this
+  policy's Axis 1 `human-approvers-required`. When that endpoint returns a
+  `pull_request` rule with `required_approving_review_count > 0` for the
+  target branch, GitHub itself will refuse a plain merge unless a qualifying
+  approval exists — and neither a bot review (Copilot's state is never
+  `APPROVED`) nor the PR author's own approval (self-approval is not
+  possible) can satisfy it. This rule is **left in place** — it is exactly
+  what protects the branch from every contributor who is not the repo owner
+  (or an equivalently trusted identity) acting through this agent.
+- Each matching rule carries a `ruleset_id`. `GET
+  /repos/{owner}/{repo}/rulesets/{ruleset_id}` returns
+  `current_user_can_bypass` (`always` | `pull_requests_only` | `none`) —
+  GitHub's own, pre-computed answer to "can the identity that authenticated
+  this `gh` call bypass this specific ruleset," never re-derived from
+  `bypass_actors` locally (role-to-actor-id mapping is GitHub's to resolve,
+  not this script's).
+- *Bypassable* iff **every** `pull_request` rule covering the branch resolves
+  `current_user_can_bypass` to `always` or `pull_requests_only` — one
+  non-bypassable ruleset among several fails the whole predicate closed.
+  Either value is sufficient for a PR merge (a "pull request only" bypass
+  grant already covers merging a PR); `always` additionally covers direct
+  pushes, irrelevant here.
+- *Not applicable* (`review_rule_active = false`) when no `pull_request` rule
+  with a positive required-approving-review count targets the branch — the
+  fact carries no opinion, since there is nothing for `--admin` to bypass.
+- A fetch failure other than "no rules for this branch" (a genuine 404) fails
+  closed: exit 3, never a silent "assume bypassable" or "assume blocked."
+- This predicate certifies only that the `pull_request` rule(s) are
+  bypassable — `current_user_can_bypass` is reported **per ruleset**, and a
+  ruleset commonly bundles unrelated rule types (this repo's own ruleset also
+  carries `deletion`, `non_fast_forward`, `required_linear_history`,
+  `copilot_code_review` alongside `pull_request`, all sharing one bypass
+  grant). `gh pr merge --admin` is a **blanket** bypass of every rule in that
+  ruleset the identity is entitled to bypass, not a scalpel on the review
+  rule alone — see Consumers for why that scope must be named explicitly
+  before it is exercised.
+- This predicate never authorizes anything by itself. It only tells
+  merge-guard whether a GitHub-side rejection *of an already-authorized
+  merge* may be resolved with `--admin` — see Consumers.
+
 ## Resolver contract
 
 ```
@@ -349,6 +393,35 @@ holds. The one eligibility-bypass path is an explicit, separately-named human
 in-session instruction naming the ineligibility being overridden — logged,
 and never available to `never`, `rule-based`, or any autonomous path. Every
 merge is issued with `--match-head-commit`.
+
+A GitHub repository ruleset requiring an approving review (the mechanism that
+protects a public repo's `main` from every contributor) is a **separate**
+gate this policy does not own and does not weaken — it stays configured
+exactly as the repo owner set it. Neither a bot review nor the PR author's
+own approval can satisfy it, so an already-authorized merge (eligible **and**
+Axis 2 satisfied) can still be refused by GitHub itself. When that happens,
+merge-guard consults `facts.admin_bypass`: if the authenticated identity
+already holds a standing GitHub bypass grant on that rule
+(`current_user_can_bypass` of `always` or `pull_requests_only`), it may
+retry once with `--admin`, announcing that it did so and why; otherwise it
+fails closed and hands off. This is **not** a third eligibility-bypass path
+alongside force-merge — it never overrides anything this policy's own
+eligibility floor asserts, and it only ever fires after Axis 2 has already
+authorized the merge on its own terms. It exists because GitHub's merge
+endpoint requires a bypass to be exercised explicitly per merge even for an
+identity permanently entitled to it; `--admin` is that explicit exercise, not
+a new privilege the agent invents.
+
+`--admin` is **not** a scalpel on the review rule alone — it is GitHub's
+blanket bypass of every rule in the covering ruleset the identity is entitled
+to bypass, since `current_user_can_bypass` is computed per ruleset, not per
+rule. `facts.admin_bypass` only certifies the `pull_request` rule(s) are
+bypassable; it says nothing about any other rule type sharing that ruleset
+(or a different one) that GitHub's rejection message did not name. This is
+why merge-guard must read and quote GitHub's actual rejection text and
+confirm it names the approving-review requirement specifically before
+retrying — an inferred reason is not enough grounds to invoke a blanket
+bypass.
 
 **wait-for-pr-comments** — calls the resolver at entry and runs the
 poll/resolve cycle per Axis 1; skips polling when nothing is expected; on

--- a/docs/architecture/review-merge-policy/design.md
+++ b/docs/architecture/review-merge-policy/design.md
@@ -258,8 +258,14 @@ an already-authorized merge, not *whether* one is eligible):
 - *Not applicable* (`review_rule_active = false`) when no `pull_request` rule
   with a positive required-approving-review count targets the branch — the
   fact carries no opinion, since there is nothing for `--admin` to bypass.
-- A fetch failure other than "no rules for this branch" (a genuine 404) fails
-  closed: exit 3, never a silent "assume bypassable" or "assume blocked."
+- A fetch failure on this fact never aborts eligibility. Because
+  `admin_bypass` gates no entry in `blockers[]`, denying a merge that may not
+  even need `--admin` over a transient GitHub/API error would be wrong. The
+  branch-rules list fetch (a non-404 failure) degrades to the inert "no
+  rulesets" state (`review_rule_active = false`); an individual ruleset detail
+  fetch failure degrades to non-bypassable (`current_actor_can_bypass = false`,
+  the fail-closed default for the `--admin` decision) and continues. Both warn
+  on stderr; neither silently assumes "bypassable."
 - This predicate certifies only that the `pull_request` rule(s) are
   bypassable — `current_user_can_bypass` is reported **per ruleset**, and a
   ruleset commonly bundles unrelated rule types (this repo's own ruleset also

--- a/src/user/.agents/skills/merge-guard/SKILL.md
+++ b/src/user/.agents/skills/merge-guard/SKILL.md
@@ -70,8 +70,13 @@ ${CLAUDE_SKILL_DIR}/check-merge-eligibility.sh \
 
 The JSON carries: `head_ref_oid` (the SHA every fact was computed against),
 `blockers[]` (`{code, details}`), `facts` (`bot_clean_review_at_head`,
-`distinct_current_approvers`, `ci_state`, `review_wait`, ...), and
-`merge_command_hint`.
+`distinct_current_approvers`, `ci_state`, `review_wait`, `admin_bypass`, ...),
+and `merge_command_hint`.
+
+`facts.admin_bypass` (`{review_rule_active, required_approving_review_count,
+current_actor_can_bypass}`) is never a blocker — it never affects eligibility.
+It exists solely for Step 5, to decide whether a GitHub-side review-count
+rejection may be retried with `--admin`.
 
 ### Step 4: Apply Axis 2 (`merge_authorization` from the policy JSON)
 
@@ -133,6 +138,40 @@ gh pr merge <n> --squash --match-head-commit "<head_ref_oid from the JSON>"
 - `gh pr merge` can exit 0 while printing a rejection. Confirm:
   `gh pr view <n> --json state` (expect `MERGED`).
 
+**If GitHub itself rejects the merge**, capture and read its actual rejection
+text first — never infer the reason from context. Only proceed down this
+path if that text specifically names the approving-review requirement (a
+"review required" / base-branch-policy refusal naming reviews — not a
+stale-head rejection, not a CI failure, not some other rule). If the text
+names anything else, or you're not sure, treat it as an unknown rejection:
+re-run Step 3, do not consult `admin_bypass`, do not use `--admin`.
+
+Once the rejection is confirmed to be the approving-review requirement,
+consult `facts.admin_bypass`:
+
+| `facts.admin_bypass` | Action |
+|---|---|
+| `review_rule_active == false` | This wasn't a review-count rejection — something else is wrong. Re-run Step 3 from scratch; never retry blind. |
+| `current_actor_can_bypass == true` | GitHub already grants the authenticated identity a standing bypass on this rule (the ruleset's `current_user_can_bypass` is `always` or `pull_requests_only`). Retry once: `gh pr merge <n> --squash --admin --match-head-commit "<head_ref_oid>"`. Announce plainly that `--admin` was used, quote the rejection text that justified it, and note why — the identity holds a pre-existing GitHub bypass grant, and eligibility + authorization were already confirmed independently of it. This is a deliberate, logged exercise of a grant a human configured, never a new override. |
+| `current_actor_can_bypass == false` | The identity has no bypass grant. **Fail closed** — do not retry with `--admin`. Report the rejection and hand off to a human who either holds the bypass grant or can adjust the ruleset. |
+
+This `--admin` retry is **not** the force-merge override above — force-merge
+bypasses *this policy's own* eligibility floor on explicit human instruction;
+this retry bypasses nothing this guard controls, and every blocker this
+guard's own eligibility floor asserts still fully applies. But `--admin`
+itself is **not scoped to the review rule** — GitHub computes
+`current_user_can_bypass` per *ruleset*, not per rule, so `--admin` blanket-
+bypasses every rule in that ruleset the identity is entitled to bypass (this
+repo's own ruleset, for example, bundles `deletion`, `non_fast_forward`,
+`required_linear_history`, and `copilot_code_review` alongside
+`pull_request` under one bypass grant). `facts.admin_bypass` certifies only
+that the `pull_request` rule(s) are bypassable — it says nothing about any
+other rule sharing that ruleset. That is exactly why the rejection text must
+be read and confirmed first: `--admin` should only ever be reached to answer
+a rejection it was actually confirmed to address. It is unreachable in
+`never` mode (Step 5 never runs there) and available, once normal
+authorization already succeeded, in both `explicit` and `rule-based` modes.
+
 ## Decision Matrix
 
 | Axis 2 | Eligible | Rule holds | Human instructed | Action |
@@ -156,3 +195,5 @@ gh pr merge <n> --squash --match-head-commit "<head_ref_oid from the JSON>"
 | "It's blocked but rule-based says merge" | Rule-based NEVER bypasses the floor. Eligible AND rule — both. |
 | "The script errored, probably fine" | Exit 3 = unknown state. Do not merge. Report. |
 | "`gh pr merge` exited 0, so it merged" | It can exit 0 on rejection. Confirm state == MERGED. |
+| "GitHub's review rule blocked it, just add `--admin`" | Only if `facts.admin_bypass.current_actor_can_bypass == true` **and** you've read the rejection text and confirmed it names the review requirement. If false, or you didn't check the text, hand off — don't force it. |
+| "`--admin` only bypasses the review rule" | It's a blanket ruleset bypass. `facts.admin_bypass` only certifies the `pull_request` rule(s) are bypassable, not every rule in the ruleset. |

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -289,8 +289,11 @@ else
     if grep -qiE 'HTTP 404|Not Found' "$rules_stderr"; then
         rules_json='[]'   # no rulesets target this branch
     else
-        echo "Error: failed to fetch branch rules: $(cat "$rules_stderr")" >&2
-        rm -f "$rules_stderr"; exit 3
+        # admin_bypass never gates a blocker, so a transient fetch failure on
+        # it must not deny a merge that may not even need --admin. Degrade to
+        # the inert "no rulesets" state and warn rather than abort eligibility.
+        echo "Warning: failed to fetch branch rules (admin_bypass degraded to inert): $(cat "$rules_stderr")" >&2
+        rules_json='[]'
     fi
 fi
 rm -f "$rules_stderr"
@@ -306,7 +309,12 @@ if [[ "$required_approving_review_count" -gt 0 ]]; then
     while IFS= read -r rid; do
         [[ -n "$rid" ]] || continue
         bypass=$(gh_api "repos/${OWNER}/${REPO}/rulesets/${rid}" --jq '.current_user_can_bypass') || {
-            echo "Error: failed to fetch ruleset ${rid} bypass status" >&2; exit 3; }
+            # An unreadable ruleset fails closed for the narrow --admin decision
+            # (treat as non-bypassable) and continues — never aborts eligibility
+            # over an informational fact.
+            echo "Warning: failed to fetch ruleset ${rid} bypass status (treating as non-bypassable)" >&2
+            current_actor_can_bypass=false
+            continue; }
         [[ "$bypass" == "always" || "$bypass" == "pull_requests_only" ]] || current_actor_can_bypass=false
     done <<<"$ruleset_ids"
 fi

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -7,6 +7,11 @@
 #   - positive facts (bot clean review at head, distinct current approvers) are
 #     emitted for merge-rule evaluation in merge-guard SKILL.md — they are
 #     facts here, never blockers.
+#   - facts.admin_bypass reports whether the authenticated identity already
+#     holds a standing GitHub ruleset bypass grant on a required-approving-
+#     review rule for this branch — never a blocker; merge-guard SKILL.md
+#     consults it only to decide whether a review-count merge rejection may
+#     be retried with `--admin`.
 #
 # Usage:
 #   check-merge-eligibility.sh --owner <o> --repo <r> --pr <n> --policy-json '<json>'
@@ -267,6 +272,49 @@ if [[ "$ci_state" != "green" && "$ci_state" != "none" ]]; then
     add_blocker ci_not_green \
         "required checks not green: $(jq -r '.not_green | join(", ")' <<<"$ci_eval") (pending/absent fails closed)"
 fi
+# ── Fact: admin-bypass availability for a required-approving-review rule ────
+# GitHub's own required-approving-review rule (enforced via a repository
+# ruleset) is a SEPARATE gate from this policy's own Axis 1
+# human-approvers-required — it stays in place for every contributor without
+# a bypass grant. This fact only reports whether the CURRENTLY AUTHENTICATED
+# identity already holds a standing bypass GitHub itself issued
+# (current_user_can_bypass), so merge-guard can retry a review-count
+# rejection with --admin for a merge this policy has already authorized —
+# never to invent a new override. Never a blocker: it does not gate
+# eligibility, only how Step 5 in merge-guard SKILL.md issues the merge.
+rules_stderr=$(mktemp)
+if rules_json=$(gh api "repos/${OWNER}/${REPO}/rules/branches/${BASE_REF_ENC}" 2>"$rules_stderr"); then
+    :
+else
+    if grep -qiE 'HTTP 404|Not Found' "$rules_stderr"; then
+        rules_json='[]'   # no rulesets target this branch
+    else
+        echo "Error: failed to fetch branch rules: $(cat "$rules_stderr")" >&2
+        rm -f "$rules_stderr"; exit 3
+    fi
+fi
+rm -f "$rules_stderr"
+
+review_rulesets=$(jq -c '[ .[]? | select(.type == "pull_request") ]' <<<"$rules_json")
+required_approving_review_count=$(jq '[ .[].parameters.required_approving_review_count? // 0 ] | (max // 0)' <<<"$review_rulesets")
+review_rule_active=false
+current_actor_can_bypass=null
+if [[ "$required_approving_review_count" -gt 0 ]]; then
+    review_rule_active=true
+    current_actor_can_bypass=true
+    ruleset_ids=$(jq -r '[ .[].ruleset_id ] | unique | .[]' <<<"$review_rulesets")
+    while IFS= read -r rid; do
+        [[ -n "$rid" ]] || continue
+        bypass=$(gh_api "repos/${OWNER}/${REPO}/rulesets/${rid}" --jq '.current_user_can_bypass') || {
+            echo "Error: failed to fetch ruleset ${rid} bypass status" >&2; exit 3; }
+        [[ "$bypass" == "always" || "$bypass" == "pull_requests_only" ]] || current_actor_can_bypass=false
+    done <<<"$ruleset_ids"
+fi
+set_fact admin_bypass "$(jq -n \
+    --argjson active "$review_rule_active" \
+    --argjson count "$required_approving_review_count" \
+    --argjson canpass "$current_actor_can_bypass" \
+    '{review_rule_active: $active, required_approving_review_count: $count, current_actor_can_bypass: $canpass}')"
 # ── Blocker: expected review still in flight ─────────────────────────────────
 # A review that hasn't happened YET is otherwise indistinguishable from one
 # that concluded clean — both read "no blocker" on every other row. Block

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -64,6 +64,27 @@ if [ "$1" = "api" ]; then
         body="${FIXTURE_REQUIRED_CHECKS}" ;;
     */check-runs*)          body="${FIXTURE_CHECK_RUNS:-'{\"check_runs\":[]}'}" ;;
     */commits/*/status*)    body="${FIXTURE_COMMIT_STATUS:-'{\"statuses\":[]}'}" ;;
+    */rules/branches/*)
+        if [ "${FIXTURE_RULES_FAIL:-0}" = 1 ]; then
+          echo "gh: 500 Internal Server Error" >&2; exit 1
+        fi
+        if [ "${FIXTURE_RULES_404:-1}" = 1 ]; then
+          echo "gh: Not Found (HTTP 404)" >&2; exit 1
+        fi
+        body="${FIXTURE_BRANCH_RULES:-[]}" ;;
+    */rulesets/*)
+        if [ "${FIXTURE_RULESET_FAIL:-0}" = 1 ]; then
+          echo "gh: 500 Internal Server Error" >&2; exit 1
+        fi
+        case "$path" in
+          # a null ruleset_id renders as the literal path segment "null" —
+          # real GitHub 404s that; the stub mirrors it unconditionally so a
+          # null id can't silently resolve to a fake bypass grant
+          */rulesets/null) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+          */rulesets/111)  body="${FIXTURE_RULESET_111:-'{\"current_user_can_bypass\":\"none\"}'}" ;;
+          */rulesets/222)  body="${FIXTURE_RULESET_222:-'{\"current_user_can_bypass\":\"none\"}'}" ;;
+          *)               body="${FIXTURE_RULESET_BYPASS:-'{\"current_user_can_bypass\":\"none\"}'}" ;;
+        esac ;;
     */pulls/*)              body="${FIXTURE_PR:-'{\"state\":\"open\",\"head\":{\"sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"},\"base\":{\"ref\":\"main\"},\"created_at\":\"2026-01-01T00:00:00Z\"}'}" ;;
     *)                      body='{}' ;;
   esac
@@ -244,6 +265,64 @@ REQ_UNPINNED='{"strict":false,"contexts":["legacy/lint"],"checks":[{"context":"l
 out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=0 FIXTURE_REQUIRED_CHECKS="$REQ_UNPINNED" \
       FIXTURE_COMMIT_STATUS='{"statuses":[{"context":"legacy/lint","state":"success"}]}'); rc=$?
 assert "unpinned req satisfied by legacy status → eligible" "[ \$rc -eq 0 ]"
+
+# ── admin-bypass fact: authenticated identity's standing bypass grant on a
+#    GitHub ruleset's required-approving-review rule (separate from Axis 1) ──
+# no rules apply to this branch (default 404) → inert, not required
+out=$(run_script "$BASE_POLICY"); rc=$?
+assert "no branch rules → admin_bypass inert, still eligible" "[ \$rc -eq 0 ]"
+assert "review_rule_active false" "[ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = false ]"
+assert "required_approving_review_count 0" "[ \"\$(jq '.facts.admin_bypass.required_approving_review_count' <<<\"\$out\")\" = 0 ]"
+assert "current_actor_can_bypass null when inactive" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = null ]"
+
+RULES_ONE='[{"type":"pull_request","ruleset_id":111,"parameters":{"required_approving_review_count":1}}]'
+
+# ruleset active, current identity holds an "always" bypass grant
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_111='{"current_user_can_bypass":"always"}'); rc=$?
+assert "always-bypass identity → current_actor_can_bypass true" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = true ]"
+assert "review_rule_active true when count > 0" "[ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = true ]"
+assert "required_approving_review_count echoed" "[ \"\$(jq '.facts.admin_bypass.required_approving_review_count' <<<\"\$out\")\" = 1 ]"
+
+# pull_requests_only bypass mode also counts as bypassable
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_111='{"current_user_can_bypass":"pull_requests_only"}'); rc=$?
+assert "pull_requests_only bypass → true" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = true ]"
+
+# identity NOT on the bypass list (GitHub's real negative enum is "none") →
+# fail closed, false
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_111='{"current_user_can_bypass":"none"}'); rc=$?
+assert "none-bypass identity → current_actor_can_bypass false" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
+
+# an unrecognized value is never treated as bypassable — the allow-list
+# rejects anything that isn't exactly "always" or "pull_requests_only"
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_111='{"current_user_can_bypass":"garbage"}'); rc=$?
+assert "unrecognized bypass value → current_actor_can_bypass false" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
+
+# two rulesets covering the branch: one bypassable, one not → AND is false
+RULES_TWO='[{"type":"pull_request","ruleset_id":111,"parameters":{"required_approving_review_count":1}},{"type":"pull_request","ruleset_id":222,"parameters":{"required_approving_review_count":2}}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_TWO" \
+      FIXTURE_RULESET_111='{"current_user_can_bypass":"always"}' FIXTURE_RULESET_222='{"current_user_can_bypass":"none"}'); rc=$?
+assert "mixed bypass across rulesets → false (fail closed)" "[ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
+assert "required_approving_review_count is the max across rulesets" "[ \"\$(jq '.facts.admin_bypass.required_approving_review_count' <<<\"\$out\")\" = 2 ]"
+
+# a pull_request rule with count 0 (e.g. code-owner-review only) doesn't activate this fact
+RULES_ZERO='[{"type":"pull_request","ruleset_id":111,"parameters":{"required_approving_review_count":0,"require_code_owner_review":true}}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ZERO"); rc=$?
+assert "zero-count pull_request rule → review_rule_active false" "[ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = false ]"
+
+# a rule with count > 0 but a null ruleset_id → jq renders it as the literal
+# path segment "null", GitHub 404s that, so this fails closed to exit 3
+# rather than silently skipping the per-ruleset bypass check
+RULES_NULL_ID='[{"type":"pull_request","ruleset_id":null,"parameters":{"required_approving_review_count":1}}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_NULL_ID"); rc=$?
+assert "null ruleset_id with active count exits 3 (fail closed)" "[ \$rc -eq 3 ]"
+
+# rules/branches fetch fails for a reason other than 404 → fail closed (exit 3)
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_FAIL=1); rc=$?
+assert "branch-rules fetch hard failure exits 3" "[ \$rc -eq 3 ]"
+
+# a ruleset's own detail fetch fails after being listed → fail closed (exit 3)
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_FAIL=1); rc=$?
+assert "ruleset detail fetch hard failure exits 3" "[ \$rc -eq 3 ]"
 
 # ── Task 13: review still in flight ──────────────────────────────────────────
 BOT_POLICY=$(jq -c '.bot_review_expected = true' <<<"$BASE_POLICY")

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -310,19 +310,26 @@ out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES
 assert "zero-count pull_request rule → review_rule_active false" "[ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = false ]"
 
 # a rule with count > 0 but a null ruleset_id → jq renders it as the literal
-# path segment "null", GitHub 404s that, so this fails closed to exit 3
-# rather than silently skipping the per-ruleset bypass check
+# path segment "null", GitHub 404s that detail fetch. admin_bypass never gates
+# a blocker, so the unreadable ruleset degrades to non-bypassable (fail closed
+# for --admin) and eligibility continues rather than aborting.
 RULES_NULL_ID='[{"type":"pull_request","ruleset_id":null,"parameters":{"required_approving_review_count":1}}]'
 out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_NULL_ID"); rc=$?
-assert "null ruleset_id with active count exits 3 (fail closed)" "[ \$rc -eq 3 ]"
+assert "null ruleset_id with active count → eligible, current_actor_can_bypass false (fail closed for --admin)" \
+    "[ \$rc -eq 0 ] && [ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
 
-# rules/branches fetch fails for a reason other than 404 → fail closed (exit 3)
+# rules/branches fetch fails for a reason other than 404 → admin_bypass degrades
+# to the inert "no rulesets" state (never aborts eligibility over an
+# informational fact)
 out=$(run_script "$BASE_POLICY" FIXTURE_RULES_FAIL=1); rc=$?
-assert "branch-rules fetch hard failure exits 3" "[ \$rc -eq 3 ]"
+assert "branch-rules fetch hard failure → eligible, admin_bypass inert (review_rule_active false, current_actor_can_bypass null)" \
+    "[ \$rc -eq 0 ] && [ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = false ] && [ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = null ]"
 
-# a ruleset's own detail fetch fails after being listed → fail closed (exit 3)
+# a ruleset's own detail fetch fails after being listed → degrade to
+# non-bypassable (fail closed for --admin) and continue rather than abort
 out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_ONE" FIXTURE_RULESET_FAIL=1); rc=$?
-assert "ruleset detail fetch hard failure exits 3" "[ \$rc -eq 3 ]"
+assert "ruleset detail fetch hard failure → eligible, current_actor_can_bypass false (fail closed for --admin)" \
+    "[ \$rc -eq 0 ] && [ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
 
 # ── Task 13: review still in flight ──────────────────────────────────────────
 BOT_POLICY=$(jq -c '.bot_review_expected = true' <<<"$BASE_POLICY")


### PR DESCRIPTION
## Summary
- Adds `facts.admin_bypass` to `check-merge-eligibility.sh` — reports whether the currently-authenticated `gh` identity already holds a standing GitHub bypass grant on this branch's required-approving-review ruleset rule. Never a blocker; eligibility is untouched.
- Documents the `--admin` retry procedure in `merge-guard/SKILL.md` Step 5 and in `docs/architecture/review-merge-policy/design.md`: usable only after this policy's own eligibility + Axis 2 authorization already held, and only once GitHub's rejection text is read and confirmed to name the approving-review requirement — `--admin` is a blanket bypass of the whole covering ruleset, not scoped to the review rule alone, so the docs are explicit about that scope and about never inferring the rejection reason.
- Fixes the GitHub bypass enum used in docs/tests (`never` → the real `none`) and adds two edge-case tests (unrecognized bypass value, null `ruleset_id`).

## Context for reviewers
This closes the gap discovered while merging PR #209: `main`'s ruleset requires 1 approving review, but Copilot's review state is never `APPROVED` and the PR author can't self-approve — so `gh pr merge` gets refused even when this repo's own two-axis review/merge policy has already authorized the merge. Investigation confirmed via `gh api` that the ruleset already grants `current_user_can_bypass: always` to the repo-admin role; GitHub just requires that grant to be exercised explicitly per merge via `--admin` rather than applying it implicitly. The fix detects that grant as a fact rather than hard-coding `--admin` everywhere, and the docs are deliberately conservative about when it's safe to use.

**Scope note:** two related-but-out-of-scope items surfaced during review and are filed separately, not fixed here: the CI-eligibility floor's blindness to ruleset-defined (as opposed to classic-protection) required status checks (`agents-config-7d5h8`), and a DRY opportunity between the new fact's 404-tolerant fetch and the existing CI-green block's fetch (`agents-config-oh7a7`). Both are `discovered-from` this PR's parent bead, `agents-config-t7esw`.

## Test plan
- [x] `bash -n` clean on both changed scripts
- [x] `check-merge-eligibility_test.sh`: 110/110 assertions passing (98 pre-existing + 12 new)
- [x] `quality-reviewer` agent pass, verified live against this repo's actual ruleset API — findings addressed
- [x] `simplify` pass (3 parallel reviewers: reuse/quality/efficiency) — no auto-apply items; one flagged duplication deferred with rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)