### PR TITLE
docs(readme): include templates in the collection summary line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agents-config
 
-Versioned collection of agents, skills, and commands for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
+Versioned collection of agents, skills, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
 
 ## Vision
 


### PR DESCRIPTION
## Summary
- README's opening line lists "agents, skills, and commands" but omits "templates," which AGENTS.md's parallel description includes (src/ has a templates surface: `INSTRUCTIONS.md.template`, `AGENTS.md.template`, etc.)

## Test plan
- Doc-only change; no build/test impact

---
Created as a live test fixture to exercise the merge-guard admin_bypass fact end-to-end (bead agents-config-t7esw / PR #210). Safe to merge normally or close once the test is complete.