### PR TITLE
fix(reply-and-resolve): durable canonical-keyed sidecars for posted reply ids

### DIFF
--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -416,11 +416,13 @@ done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
 # Durable, canonical-path-keyed sidecar written by post-replies.sh — one JSONL
 # line per successful reply POST, shape {"k","v","rid"}. An ADDITIONAL, more
 # crash-robust source of posted-reply exclusions than inventory
-# posted_reply_id fields: it is written at POST time, before any inventory
-# bookkeeping, so it still reflects a reply even if the run crashed before an
-# inventory could record it. Tolerant of a truncated final line (a hard-killed
-# process mid-append) — a strict slurp would abort the whole script on one bad
-# line, so parse per-line and drop anything unparseable instead.
+# posted_reply_id fields: record_reply_id() appends to this sidecar right
+# after attempting the inventory-side write, independent of whether that
+# inventory write succeeds or targets a discarded scratch copy — so it still
+# reflects a reply even if the inventory-side record is lost or never reaches
+# a durable path. Tolerant of a truncated final line (a hard-killed process
+# mid-append) — a strict slurp would abort the whole script on one bad line,
+# so parse per-line and drop anything unparseable instead.
 sidecar_reply_ids='[]'
 while IFS= read -r -d '' sc_file; do
     file_rids=$(jq -R 'fromjson? // empty' "$sc_file" 2>/dev/null | jq -s '[.[].rid] | map(select(. != null))') || file_rids='[]'

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -413,16 +413,32 @@ while IFS= read -r -d '' inv_file; do
 done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
          -name "${OWNER}-${REPO}-${PR}-*.json" -print0 2>/dev/null)
 
+# Durable, canonical-path-keyed sidecar written by post-replies.sh — one JSONL
+# line per successful reply POST, shape {"k","v","rid"}. An ADDITIONAL, more
+# crash-robust source of posted-reply exclusions than inventory
+# posted_reply_id fields: it is written at POST time, before any inventory
+# bookkeeping, so it still reflects a reply even if the run crashed before an
+# inventory could record it. Tolerant of a truncated final line (a hard-killed
+# process mid-append) — a strict slurp would abort the whole script on one bad
+# line, so parse per-line and drop anything unparseable instead.
+sidecar_reply_ids='[]'
+while IFS= read -r -d '' sc_file; do
+    file_rids=$(jq -R 'fromjson? // empty' "$sc_file" 2>/dev/null | jq -s '[.[].rid] | map(select(. != null))') || file_rids='[]'
+    sidecar_reply_ids=$(jq -n --argjson a "$sidecar_reply_ids" --argjson b "${file_rids:-[]}" '$a + $b')
+done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
+         -name "${OWNER}-${REPO}-${PR}-*.json.replyids" -print0 2>/dev/null)
+
 untriaged=$(jq -n \
     --argjson live_issue "$(jq '[.[] | {id, author: .user.login}]' <<<"$ISSUE_COMMENTS")" \
     --argjson live_summaries "$(jq '[.[] | select((.body // "") != "") | {review_id: .id, author: .user.login}]' <<<"$ALL_REVIEWS")" \
     --argjson recorded "$inventory_items" \
-    --argjson recorded_complete "$completed_inventory_items" '
+    --argjson recorded_complete "$completed_inventory_items" \
+    --argjson sidecar_replies "$sidecar_reply_ids" '
     def terminal_ok:
         (.classification == "SKIP")
         or (.classification == "FIX"
             and (.fix_outcome == "committed" or .fix_outcome == "already_addressed"));
-    ([ $recorded[] | .posted_reply_id // empty ] | unique) as $agent_replies
+    (([ $recorded[] | .posted_reply_id // empty ] + $sidecar_replies) | unique) as $agent_replies
     | ([ $recorded_complete[] | select(.kind == "issue_comment" and terminal_ok) | .issue_comment_id ] | unique) as $done_issue
     | ([ $recorded_complete[] | select(.kind == "review_summary" and terminal_ok) | .review_id // empty ] | unique) as $done_review
     | ([ $live_issue[]

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -426,6 +426,59 @@ out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs"); rc=$?
 assert "review_summary triaged by review_id clears" "[ \$rc -eq 0 ]"
 clean_invs
 
+# ── Durable reply-id sidecar (<owner>-<repo>-<pr>-<sha>.json.replyids) is
+#    unioned into the posted-reply exclusion set as an ADDITIONAL, more
+#    crash-robust source than inventory posted_reply_id fields ─────────────
+write_replyids() {  # write_replyids <filename> <jsonl-line>...
+  local file="$1"; shift
+  printf '%s\n' "$@" > "$INV_DIR/$file"
+}
+clean_sidecars() { rm -f "$INV_DIR"/*.replyids; }
+
+# A. sidecar-only exclusion: rid appears ONLY in a .replyids sidecar (no
+#    inventory posted_reply_id anywhere) → still excluded, eligible
+clean_invs; clean_sidecars
+IC_SC='[{"id": 900, "user": {"login": "reviewer"}, "body": "please fix the naming"}]'
+write_replyids "o-r-1-sidecarsha1.json.replyids" '{"k":"issue_comment_id","v":"900","rid":900}'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_SC"); rc=$?
+assert "sidecar-only rid excludes matching live comment (no inventory posted_reply_id)" "[ \$rc -eq 0 ]"
+clean_sidecars
+
+# B. truncated final line tolerated: one valid line + one malformed
+#    (hard-killed mid-append) final line → no crash, valid line still excludes
+write_replyids "o-r-1-truncsha1.json.replyids" \
+  '{"k":"issue_comment_id","v":"900","rid":900}' \
+  '{"k":"issue_comment_id","v":"901","rid":901'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_SC"); rc=$?
+assert "truncated final sidecar line does not crash the script" "[ -n \"\$out\" ] && [ \$rc -ne 3 ]"
+assert "valid line ahead of a truncated one still excludes its rid" "[ \$rc -eq 0 ]"
+clean_sidecars
+
+# C. cross-sha union: two sidecar files for the same PR at different head
+#    shas → rids from BOTH are excluded
+IC_CROSS='[{"id": 970, "user": {"login": "reviewer"}, "body": "fix X"}, {"id": 971, "user": {"login": "reviewer"}, "body": "fix Y"}]'
+write_replyids "o-r-1-crossshaA.json.replyids" '{"k":"issue_comment_id","v":"970","rid":970}'
+write_replyids "o-r-1-crossshaB.json.replyids" '{"k":"issue_comment_id","v":"971","rid":971}'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_CROSS"); rc=$?
+assert "rids from two different-sha sidecars both excluded (union)" "[ \$rc -eq 0 ]"
+clean_sidecars
+
+# D. duplicate rid across (and within) sidecars doesn't break the union+unique
+IC_DUP='[{"id": 980, "user": {"login": "reviewer"}, "body": "dup across files"}]'
+write_replyids "o-r-1-dupshaA.json.replyids" '{"k":"issue_comment_id","v":"980","rid":980}'
+write_replyids "o-r-1-dupshaB.json.replyids" '{"k":"issue_comment_id","v":"980","rid":980}'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_DUP"); rc=$?
+assert "duplicate rid across two sidecars still excludes without jq error" "[ \$rc -eq 0 ]"
+clean_sidecars
+
+IC_DUP2='[{"id": 981, "user": {"login": "reviewer"}, "body": "dup within one file"}]'
+write_replyids "o-r-1-dupsame.json.replyids" \
+  '{"k":"issue_comment_id","v":"981","rid":981}' \
+  '{"k":"issue_comment_id","v":"981","rid":981}'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_DUP2"); rc=$?
+assert "duplicate rid twice within one sidecar still excludes without jq error" "[ \$rc -eq 0 ]"
+clean_sidecars
+
 # ── Task 18: prgroom internal atoms ──────────────────────────────────────────
 PG_BLOCKED='{"merge_gates":{"phase_is_quiesced":true,"last_error_clear":true,"no_blocker_items":false,"human_review_satisfied":true},"auto_merge_eligible":false}'
 PG_ERROR='{"merge_gates":{"phase_is_quiesced":true,"last_error_clear":false,"no_blocker_items":true,"human_review_satisfied":true},"auto_merge_eligible":false}'

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -239,6 +239,8 @@ inventory so every replyable item already has `.reply_body`):
 ${CLAUDE_SKILL_DIR}/post-replies.sh \
   --inventory "$RENDERED" \
   --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+  --reply-id-sidecar "${INVENTORY_FILE}.replyids" \
+  --posted-sidecar "${INVENTORY_FILE}.posted" \
   [--skip-comment-ids "<csv>"]
 # per item, one of:
 #   POSTED <comment_id>
@@ -260,10 +262,15 @@ reason label (e.g., `FAILED 12345 gh-rest-reply-failed — HTTP 422:
 Validation Failed`).
 
 **Self-recording idempotency** — each successful POST appends its
-`<comment_id>` to a sidecar `<inventory>.posted`. On startup the
-sidecar is unioned with `--skip-comment-ids` to form the effective
-skip-set, so crash-recovery re-runs against the same inventory SKIP
-previously-posted items automatically.
+`<comment_id>` to a sidecar `${INVENTORY_FILE}.posted`, keyed to the
+canonical inventory path so it durably survives past the run (not to the
+discarded `$RENDERED` temp copy). On startup the sidecar is unioned with
+`--skip-comment-ids` to form the effective skip-set, so crash-recovery
+re-runs against the same inventory SKIP previously-posted items
+automatically. A companion `${INVENTORY_FILE}.replyids` sidecar durably
+records each posted reply's own GitHub comment id; `merge-guard/check-merge-eligibility.sh`
+reads it to exclude the agent's own replies from the untriaged-feedback
+blocker.
 
 Sidecar cleanup:
 - **100%-success run, no `--skip-comment-ids` supplied** → sidecar is deleted.

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/e2e-sidecar-persistence_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/e2e-sidecar-persistence_test.sh
@@ -89,7 +89,7 @@ assert "(a) canonical inventory has one FIX/SKIP issue_comment item" \
 # ── (b) simulate the real Phase 2 sequence ───────────────────────────────────
 # RENDERED = a mktemp scratch copy with .reply_body hand-populated (faithful
 # stand-in for render-reply-bodies.sh's output, per the task's own allowance).
-RENDERED="$(mktemp)"
+RENDERED="$(mktemp "$TMP/rendered.XXXXXX")"
 jq '.items[0].reply_body = "Acknowledged — skipping as cosmetic."' "$INVENTORY_FILE" > "$RENDERED"
 
 # Fake gh: POST returns a synthetic reply id, mirroring the shim pattern

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/e2e-sidecar-persistence_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/e2e-sidecar-persistence_test.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# e2e-sidecar-persistence_test.sh — cross-component regression test:
+# post-replies.sh's durable reply-id/posted sidecars must survive SKILL.md's
+# `$RENDERED="$(mktemp)"` indirection and be discoverable by
+# merge-guard/check-merge-eligibility.sh at the CANONICAL inventory path.
+#
+# Why this test exists: the original post-replies_test.sh always passed a
+# stable path directly as --inventory, never exercising the real Phase 2
+# sequence where --inventory is a scratch mktemp copy ($RENDERED) distinct
+# from the canonical $INVENTORY_FILE. That blind spot let a sidecar get
+# silently keyed to the discarded scratch file and orphaned on every
+# resume/read, while unit tests stayed green.
+#
+# This test drives the REAL post-replies.sh using the LITERAL invocation text
+# extracted from SKILL.md's "Post replies for every inventory item" code
+# block (not a hand-typed re-statement of it), so a flag-name or path-
+# derivation drift in SKILL.md's prose fails this test even though SKILL.md
+# has no bash test file of its own. It then drives the REAL
+# check-merge-eligibility.sh and asserts the agent's own posted reply is
+# excluded from the untriaged-feedback blocker.
+#
+# This test MUST fail if any of the following is reverted:
+#   - post-replies.sh: --reply-id-sidecar / --posted-sidecar flag support
+#   - SKILL.md: Phase 2 passing those flags keyed to $INVENTORY_FILE (not $RENDERED)
+#   - check-merge-eligibility.sh: the *.json.replyids sidecar glob + union
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+POST_REPLIES="$HERE/post-replies.sh"
+SKILL_MD="$HERE/SKILL.md"
+MERGE_GUARD_DIR="$(cd "$HERE/../merge-guard" && pwd)"
+CHECK_ELIGIBILITY="$MERGE_GUARD_DIR/check-merge-eligibility.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+assert() {
+  if eval "$2"; then
+    echo "  ok: $1"
+  else
+    echo "  FAIL: $1"
+    FAIL=1
+  fi
+}
+
+echo "[e2e-sidecar-persistence_test]"
+
+assert "post-replies.sh exists" "[ -f '$POST_REPLIES' ]"
+assert "SKILL.md exists" "[ -f '$SKILL_MD' ]"
+assert "check-merge-eligibility.sh exists" "[ -f '$CHECK_ELIGIBILITY' ]"
+
+# ── (a) canonical inventory, shaped like the real convention ────────────────
+# <owner>-<repo>-<pr>-<sha>.json, one SKIP issue_comment item, pre-render
+# (no .reply_body yet — that only lands on the separate $RENDERED copy,
+# mirroring the real Phase 2 split).
+OWNER=o
+REPO=r
+PR=42
+FAKE_HOME="$TMP/home"
+INV_DIR="$FAKE_HOME/.claude/state/pr-inventory"
+mkdir -p "$INV_DIR"
+INVENTORY_FILE="$INV_DIR/${OWNER}-${REPO}-${PR}-deadbeefsha1.json"
+
+# The ORIGINAL reviewer's comment this item replies to.
+ORIGINAL_COMMENT_ID=900
+
+jq -n --argjson cid "$ORIGINAL_COMMENT_ID" '{
+  schema_version: 1,
+  pr: {number: 42, owner: "o", repo: "r"},
+  items: [
+    {
+      kind: "issue_comment",
+      thread_id: null,
+      reply_to_comment_id: null,
+      issue_comment_id: $cid,
+      classification: "SKIP",
+      fix_outcome: null,
+      rationale: "cosmetic nit, not worth a code change",
+      reply_body: null
+    }
+  ],
+  crash_recovery: {skill_a_completed: true, last_completed_phase: "7-write-inventory"}
+}' > "$INVENTORY_FILE"
+
+assert "(a) canonical inventory file created" "[ -f '$INVENTORY_FILE' ]"
+assert "(a) canonical inventory has one FIX/SKIP issue_comment item" \
+  "[ \"\$(jq -r '.items | length' \"$INVENTORY_FILE\")\" = 1 ]"
+
+# ── (b) simulate the real Phase 2 sequence ───────────────────────────────────
+# RENDERED = a mktemp scratch copy with .reply_body hand-populated (faithful
+# stand-in for render-reply-bodies.sh's output, per the task's own allowance).
+RENDERED="$(mktemp)"
+jq '.items[0].reply_body = "Acknowledged — skipping as cosmetic."' "$INVENTORY_FILE" > "$RENDERED"
+
+# Fake gh: POST returns a synthetic reply id, mirroring the shim pattern
+# already used in post-replies_test.sh.
+SYNTHETIC_REPLY_ID=700099
+FAKEBIN="$TMP/bin"
+mkdir -p "$FAKEBIN"
+cat > "$FAKEBIN/gh" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "api" ]; then
+  printf '{"id": ${SYNTHETIC_REPLY_ID}}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$FAKEBIN/gh"
+
+# Extract the LITERAL Phase 2 post-replies.sh invocation out of SKILL.md's
+# own code block (not a hand-typed re-statement) so a drift in SKILL.md's
+# flag names/paths fails this test even though SKILL.md has no bash test of
+# its own. Blank out the bracketed-optional --skip-comment-ids line (it is
+# documentation syntax, not literal shell) rather than deleting it outright,
+# so the preceding line's trailing `\` still joins onto a real (blank) line.
+# Stop BEFORE the closing ``` fence (exclude it) — awk's pattern-action model
+# evaluates actions top-to-bottom per line, so a single rule can't both
+# "print this line" and "then exit without having printed it"; splitting the
+# fence check into its own leading rule lets it fire (and exit) before the
+# print rule ever sees that line.
+PHASE2_CMD="$(awk 'p && /^```$/{exit} /post-replies\.sh \\$/{p=1} p{print}' "$SKILL_MD" \
+  | sed 's/\[--skip-comment-ids "<csv>"\]//')"
+
+assert "SKILL.md Phase 2 block extracted (non-empty)" "[ -n \"\$PHASE2_CMD\" ]"
+assert "SKILL.md Phase 2 block has no stray code-fence backticks" \
+  "! printf '%s' \"\$PHASE2_CMD\" | grep -q '\`\`\`'"
+assert "SKILL.md Phase 2 block passes --reply-id-sidecar" \
+  "printf '%s' \"\$PHASE2_CMD\" | grep -q -- '--reply-id-sidecar'"
+assert "SKILL.md Phase 2 block passes --posted-sidecar" \
+  "printf '%s' \"\$PHASE2_CMD\" | grep -q -- '--posted-sidecar'"
+assert "SKILL.md Phase 2 sidecars are keyed to \$INVENTORY_FILE, not \$RENDERED" \
+  "printf '%s' \"\$PHASE2_CMD\" | grep -qE '\\{INVENTORY_FILE\\}\\.(replyids|posted)'"
+
+CLAUDE_SKILL_DIR="$HERE"
+PATH="$FAKEBIN:$PATH" eval "$PHASE2_CMD" > "$TMP/phase2-out.txt" 2>&1
+rc_phase2=$?
+
+assert "Phase 2 post-replies.sh invocation succeeds" "[ \$rc_phase2 -eq 0 ]"
+
+# ── (c) sidecar lands at the CANONICAL path, not next to \$RENDERED ─────────
+# .replyids has no "100%-success" cleanup (its whole point is to durably
+# outlive the run), so it must persist. .posted DOES get deleted on a
+# 100%-success run with no --skip-comment-ids (same cleanup contract as the
+# legacy <inventory>.posted derivation — see post-replies.sh's IDEMPOTENCY
+# header); this single-item run is 100%-success, so its absence here is
+# correct, not a regression (resume/no-duplicate-post is exercised by
+# post-replies_test.sh's own Test C on a partial-failure run instead).
+assert "canonical .replyids sidecar exists (not orphaned on the discarded \$RENDERED copy)" \
+  "[ -f '${INVENTORY_FILE}.replyids' ]"
+assert "canonical .posted sidecar is cleaned up after a 100%-success run (same contract as the legacy derivation)" \
+  "[ ! -f '${INVENTORY_FILE}.posted' ]"
+assert "no .replyids sidecar materializes next to the discarded \$RENDERED mktemp copy" \
+  "[ ! -f '${RENDERED}.replyids' ]"
+
+assert "every .replyids sidecar line parses as JSON" \
+  "jq -c . '${INVENTORY_FILE}.replyids' >/dev/null 2>&1"
+assert ".replyids sidecar records the synthetic reply id against the original comment id" \
+  "[ \"\$(jq -r --argjson cid \"$ORIGINAL_COMMENT_ID\" 'select(.k==\"issue_comment_id\" and (.v|tostring)==(\$cid|tostring)) | .rid' \"${INVENTORY_FILE}.replyids\")\" = \"$SYNTHETIC_REPLY_ID\" ]"
+
+# ── (d) check-merge-eligibility.sh must now report ELIGIBLE ─────────────────
+# Live GitHub state after the reply: the ORIGINAL reviewer comment (900) is
+# still there (issue comments never "resolve"), PLUS a brand-new live comment
+# that IS the agent's own reply (id = the synthetic reply id). Without the
+# sidecar exclusion, that second comment reads as fresh untriaged reviewer
+# feedback and blocks the PR forever.
+STUB_DIR="$TMP/eligibility-bin"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "auth" ] && exit 0
+if [ "$1" = "api" ]; then
+  shift
+  if [ "$1" = "graphql" ]; then
+    printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+    exit 0
+  fi
+  path="$1"; shift
+  filter=""
+  while [ $# -gt 0 ]; do
+    case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
+  done
+  case "$path" in
+    */requested_reviewers)  body='{"users":[],"teams":[]}' ;;
+    */issues/*/events*)     body='[]' ;;
+    */issues/*/comments*)   body="${FIXTURE_ISSUE_COMMENTS}" ;;
+    */pulls/*/reviews*)     body='[]' ;;
+    */protection/required_status_checks*) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+    */rules/branches/*)     echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;
+    */pulls/*)              body="${FIXTURE_PR}" ;;
+    *)                      body='{}' ;;
+  esac
+  if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+cat > "$STUB_DIR/prgroom" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$STUB_DIR/prgroom"
+
+HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+export FIXTURE_PR
+FIXTURE_PR=$(jq -nc --arg sha "$HEAD_SHA" \
+  '{state:"open", head:{sha:$sha}, base:{ref:"main"}, created_at:"2026-01-01T00:00:00Z"}')
+export FIXTURE_ISSUE_COMMENTS
+FIXTURE_ISSUE_COMMENTS=$(jq -nc \
+  --argjson orig "$ORIGINAL_COMMENT_ID" --argjson rid "$SYNTHETIC_REPLY_ID" \
+  '[{id: $orig, user: {login: "reviewer", type: "User"}},
+    {id: $rid,  user: {login: "the-agent", type: "User"}}]')
+
+BASE_POLICY='{"bot_review_expected":false,"bot_reviewers":[],"bot_inactivity_timeout_seconds":1200,"human_approvers_required":0,"human_review_timeout_seconds":null,"merge_authorization":"explicit","merge_rule":null}'
+
+out_elig=$(env HOME="$FAKE_HOME" PATH="$STUB_DIR:$PATH" \
+  FIXTURE_PR="$FIXTURE_PR" FIXTURE_ISSUE_COMMENTS="$FIXTURE_ISSUE_COMMENTS" \
+  "$CHECK_ELIGIBILITY" --owner "$OWNER" --repo "$REPO" --pr "$PR" --policy-json "$BASE_POLICY" 2>"$TMP/eligibility-err.txt")
+rc_elig=$?
+
+assert "check-merge-eligibility.sh exits 0 (eligible)" "[ \$rc_elig -eq 0 ]"
+assert "status is eligible" "[ \"\$(jq -r '.status' <<<\"\$out_elig\" 2>/dev/null)\" = eligible ]"
+assert "blockers array is empty (agent's own reply excluded via .replyids sidecar)" \
+  "[ \"\$(jq -r '.blockers | length' <<<\"\$out_elig\" 2>/dev/null)\" = 0 ]"
+assert "no untriaged_feedback blocker naming the agent's own reply id" \
+  "! jq -e '.blockers[]? | select(.code==\"untriaged_feedback\")' <<<\"\$out_elig\" >/dev/null 2>&1"
+
+if [ "$rc_elig" != "0" ]; then
+  echo "  (debug) check-merge-eligibility stderr: $(cat "$TMP/eligibility-err.txt")" >&2
+  echo "  (debug) check-merge-eligibility stdout: $out_elig" >&2
+fi
+
+exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -12,14 +12,17 @@
 #                     posted_reply_id must be excluded from the hash.)
 #
 # IDEMPOTENCY: this helper is self-recording. Each successful POST is
-# appended to a sidecar file <inventory>.posted (one cid per line), or to
-# --posted-sidecar when supplied. On startup the sidecar is read and unioned
-# with --skip-comment-ids to form the effective skip-set, so crash-recovery
-# re-runs against the same inventory will SKIP previously-posted items
-# automatically. --posted-sidecar decouples this file from --inventory: pass
-# a durable, fixed path when --inventory is itself a mktemp scratch copy that
-# changes on every resume, so the skip-set survives across resumes instead of
-# being orphaned by a fresh mktemp path each run.
+# appended to the --posted-sidecar file (one cid per line). On startup the
+# sidecar is read and unioned with --skip-comment-ids to form the effective
+# skip-set, so crash-recovery re-runs against the same inventory will SKIP
+# previously-posted items automatically. --posted-sidecar and
+# --reply-id-sidecar are both REQUIRED (not defaulted off --inventory):
+# --inventory is routinely a mktemp scratch copy (Skill B renders reply
+# bodies into a temp file before posting), and a caller that forgot to pass
+# an explicit durable path would silently lose the sidecar/reply-id record
+# the moment that temp file is discarded — exactly the bug this pair of
+# flags exists to prevent. A missing flag is a caller bug; fail the run
+# loudly (exit 2) rather than degrade to a silently-incomplete record.
 # - On a 100%-success run (any_failed=0) AND when --skip-comment-ids was
 #   NOT supplied, the sidecar is deleted: the script can prove the sidecar
 #   is a complete record of what this inventory needed.
@@ -57,15 +60,14 @@
 #   --owner            <o>     repository owner
 #   --repo             <r>     repository name
 #   --pr               <n>     PR number
-#   --skip-comment-ids <csv>   (optional) csv of comment_ids to skip
-#   --posted-sidecar   <file>  (optional) durable path for the posted-cid
-#                              sidecar; replaces the default <inventory>.posted
-#                              derivation so it survives a fresh --inventory
-#                              mktemp path on resume
-#   --reply-id-sidecar <file>  (optional) JSONL file to append one
+#   --posted-sidecar   <file>  REQUIRED. Durable path for the posted-cid
+#                              sidecar — must survive a fresh --inventory
+#                              mktemp path on resume.
+#   --reply-id-sidecar <file>  REQUIRED. JSONL file to append one
 #                              {"k":...,"v":...,"rid":...} record per
 #                              successful POST, so the created reply id
-#                              survives outside the (possibly scratch) --inventory
+#                              survives outside the (possibly scratch) --inventory.
+#   --skip-comment-ids <csv>   (optional) csv of comment_ids to skip
 #
 # Outputs:
 #   stdout: per item, one of:
@@ -91,19 +93,21 @@ set -euo pipefail
 usage() {
   cat <<EOF
 Usage: $(basename "$0") --inventory <file> --owner <o> --repo <r> --pr <n>
+                        --posted-sidecar <file> --reply-id-sidecar <file>
                         [--skip-comment-ids <csv>]
-                        [--posted-sidecar <file>] [--reply-id-sidecar <file>]
 
 Posts replies to each inventory item. Self-recording: each POSTED cid is
-appended to <inventory>.posted (or --posted-sidecar, when supplied);
-subsequent runs against the same sidecar automatically SKIP previously-
-posted items. A 100%-success run deletes the sidecar UNLESS
---skip-comment-ids was supplied (in which case the operator has externally
-asserted some items are already done and the script can't prove the
-sidecar is complete, so it is preserved); partial-failure runs preserve
-the sidecar for retry. --reply-id-sidecar, when supplied, additionally
-appends one JSONL {k,v,rid} record per successful POST so the created
-reply id survives outside --inventory.
+appended to --posted-sidecar; subsequent runs against the same sidecar
+automatically SKIP previously-posted items. A 100%-success run deletes the
+sidecar UNLESS --skip-comment-ids was supplied (in which case the operator
+has externally asserted some items are already done and the script can't
+prove the sidecar is complete, so it is preserved); partial-failure runs
+preserve the sidecar for retry. --reply-id-sidecar additionally appends one
+JSONL {k,v,rid} record per successful POST so the created reply id survives
+outside --inventory. Both sidecar flags are REQUIRED: --inventory is
+routinely a mktemp scratch copy, and defaulting either sidecar path off of
+it would silently drop the durable record the moment that copy is
+discarded.
 EOF
   exit 2
 }
@@ -137,9 +141,17 @@ done
 [ -n "$REPO" ]  || { echo "error: --repo is required" >&2; exit 2; }
 [ -n "$PR" ]    || { echo "error: --pr is required" >&2; exit 2; }
 [ -f "$INV" ]   || { echo "error: inventory file not found: $INV" >&2; exit 2; }
+[ -n "$POSTED_SIDECAR_FLAG" ] || {
+  echo "error: --posted-sidecar is required — pass a durable path (never let it default off --inventory, which may be a scratch mktemp copy)" >&2
+  exit 2
+}
+[ -n "$REPLY_ID_SIDECAR_FLAG" ] || {
+  echo "error: --reply-id-sidecar is required — without it, posted replies get no durable record and merge-eligibility will treat them as untriaged forever" >&2
+  exit 2
+}
 
-POSTED_SIDECAR="${POSTED_SIDECAR_FLAG:-${INV}.posted}"
-REPLY_ID_SIDECAR="${REPLY_ID_SIDECAR_FLAG:-}"
+POSTED_SIDECAR="$POSTED_SIDECAR_FLAG"
+REPLY_ID_SIDECAR="$REPLY_ID_SIDECAR_FLAG"
 
 # Normalize --skip-comment-ids: strip ALL whitespace so operators or tooling
 # passing "11111, 22222" (with spaces/newlines) still match the *,<cid>,*
@@ -151,7 +163,7 @@ skipset=","
 if [ -n "$SKIP_CSV" ]; then
   skipset="${skipset}${SKIP_CSV},"
 fi
-# Union any prior <inventory>.posted entries into the skipset.
+# Union any prior --posted-sidecar entries into the skipset.
 # Defensively strip whitespace per line — we control the writer, but the
 # normalization is cheap and symmetric with the CSV handling above.
 if [ -f "$POSTED_SIDECAR" ]; then
@@ -193,20 +205,20 @@ record_reply_id() {  # record_reply_id <item-key> <match-value> <reply-id>
   fi
 
   # Durable sidecar copy of the reply id, decoupled from $INV (which may be a
-  # scratch mktemp copy the caller discards). Fatal on failure — mirrors the
-  # .posted append's fatal pattern below: under `set -e`, a failing RHS of
-  # `&&` is silently swallowed, so this must be its own `if ! cmd` guard, not
-  # `cmdA && cmdB`. The record is built into a variable FIRST, with its own
-  # `|| record_json=""` guard, so a jq construction failure is caught
-  # explicitly too — a bare `printf '%s\n' "$(jq ...)"` would swallow a
-  # failing inner command substitution (its exit status doesn't propagate
-  # through printf) and silently append a blank line while still returning 0.
-  if [ -n "$REPLY_ID_SIDECAR" ]; then
-    record_json="$(jq -nc --arg k "$key" --arg v "$val" --argjson rid "$rid" '{k:$k,v:$v,rid:$rid}')" || record_json=""
-    if [ -z "$record_json" ] || ! printf '%s\n' "$record_json" >> "$REPLY_ID_SIDECAR"; then
-      echo "WARNING $val reply-id-sidecar-append-failed: reply $rid posted to GitHub and recorded on $INV but the durable sidecar write to $REPLY_ID_SIDECAR failed; the merge-eligibility check may not exclude this reply until the sidecar is manually repaired" >&2
-      any_failed=1
-    fi
+  # scratch mktemp copy the caller discards). REPLY_ID_SIDECAR is guaranteed
+  # non-empty here — the flag is required at startup. Fatal on failure —
+  # mirrors the .posted append's fatal pattern below: under `set -e`, a
+  # failing RHS of `&&` is silently swallowed, so this must be its own
+  # `if ! cmd` guard, not `cmdA && cmdB`. The record is built into a variable
+  # FIRST, with its own `|| record_json=""` guard, so a jq construction
+  # failure is caught explicitly too — a bare `printf '%s\n' "$(jq ...)"`
+  # would swallow a failing inner command substitution (its exit status
+  # doesn't propagate through printf) and silently append a blank line while
+  # still returning 0.
+  record_json="$(jq -nc --arg k "$key" --arg v "$val" --argjson rid "$rid" '{k:$k,v:$v,rid:$rid}')" || record_json=""
+  if [ -z "$record_json" ] || ! printf '%s\n' "$record_json" >> "$REPLY_ID_SIDECAR"; then
+    echo "WARNING $val reply-id-sidecar-append-failed: reply $rid posted to GitHub and recorded on $INV but the durable sidecar write to $REPLY_ID_SIDECAR failed; the merge-eligibility check may not exclude this reply until the sidecar is manually repaired" >&2
+    any_failed=1
   fi
 }
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies.sh
@@ -12,10 +12,14 @@
 #                     posted_reply_id must be excluded from the hash.)
 #
 # IDEMPOTENCY: this helper is self-recording. Each successful POST is
-# appended to a sidecar file <inventory>.posted (one cid per line). On
-# startup the sidecar is read and unioned with --skip-comment-ids to form
-# the effective skip-set, so crash-recovery re-runs against the same
-# inventory will SKIP previously-posted items automatically.
+# appended to a sidecar file <inventory>.posted (one cid per line), or to
+# --posted-sidecar when supplied. On startup the sidecar is read and unioned
+# with --skip-comment-ids to form the effective skip-set, so crash-recovery
+# re-runs against the same inventory will SKIP previously-posted items
+# automatically. --posted-sidecar decouples this file from --inventory: pass
+# a durable, fixed path when --inventory is itself a mktemp scratch copy that
+# changes on every resume, so the skip-set survives across resumes instead of
+# being orphaned by a fresh mktemp path each run.
 # - On a 100%-success run (any_failed=0) AND when --skip-comment-ids was
 #   NOT supplied, the sidecar is deleted: the script can prove the sidecar
 #   is a complete record of what this inventory needed.
@@ -54,6 +58,14 @@
 #   --repo             <r>     repository name
 #   --pr               <n>     PR number
 #   --skip-comment-ids <csv>   (optional) csv of comment_ids to skip
+#   --posted-sidecar   <file>  (optional) durable path for the posted-cid
+#                              sidecar; replaces the default <inventory>.posted
+#                              derivation so it survives a fresh --inventory
+#                              mktemp path on resume
+#   --reply-id-sidecar <file>  (optional) JSONL file to append one
+#                              {"k":...,"v":...,"rid":...} record per
+#                              successful POST, so the created reply id
+#                              survives outside the (possibly scratch) --inventory
 #
 # Outputs:
 #   stdout: per item, one of:
@@ -80,14 +92,18 @@ usage() {
   cat <<EOF
 Usage: $(basename "$0") --inventory <file> --owner <o> --repo <r> --pr <n>
                         [--skip-comment-ids <csv>]
+                        [--posted-sidecar <file>] [--reply-id-sidecar <file>]
 
 Posts replies to each inventory item. Self-recording: each POSTED cid is
-appended to <inventory>.posted; subsequent runs against the same
-inventory automatically SKIP previously-posted items. A 100%-success run
-deletes the sidecar UNLESS --skip-comment-ids was supplied (in which
-case the operator has externally asserted some items are already done
-and the script can't prove the sidecar is complete, so it is preserved);
-partial-failure runs preserve the sidecar for retry.
+appended to <inventory>.posted (or --posted-sidecar, when supplied);
+subsequent runs against the same sidecar automatically SKIP previously-
+posted items. A 100%-success run deletes the sidecar UNLESS
+--skip-comment-ids was supplied (in which case the operator has externally
+asserted some items are already done and the script can't prove the
+sidecar is complete, so it is preserved); partial-failure runs preserve
+the sidecar for retry. --reply-id-sidecar, when supplied, additionally
+appends one JSONL {k,v,rid} record per successful POST so the created
+reply id survives outside --inventory.
 EOF
   exit 2
 }
@@ -97,17 +113,21 @@ OWNER=""
 REPO=""
 PR=""
 SKIP_CSV=""
+REPLY_ID_SIDECAR_FLAG=""
+POSTED_SIDECAR_FLAG=""
 
 [ $# -gt 0 ] || usage
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --inventory)        INV="${2:-}";      shift 2 ;;
-    --owner)            OWNER="${2:-}";    shift 2 ;;
-    --repo)             REPO="${2:-}";     shift 2 ;;
-    --pr)               PR="${2:-}";       shift 2 ;;
-    --skip-comment-ids) SKIP_CSV="${2:-}"; shift 2 ;;
-    -h|--help)          usage ;;
+    --inventory)         INV="${2:-}";                  shift 2 ;;
+    --owner)             OWNER="${2:-}";                shift 2 ;;
+    --repo)              REPO="${2:-}";                 shift 2 ;;
+    --pr)                PR="${2:-}";                   shift 2 ;;
+    --skip-comment-ids)  SKIP_CSV="${2:-}";              shift 2 ;;
+    --reply-id-sidecar)  REPLY_ID_SIDECAR_FLAG="${2:-}"; shift 2 ;;
+    --posted-sidecar)    POSTED_SIDECAR_FLAG="${2:-}";   shift 2 ;;
+    -h|--help)           usage ;;
     *) echo "error: unknown flag: $1" >&2; usage ;;
   esac
 done
@@ -118,7 +138,8 @@ done
 [ -n "$PR" ]    || { echo "error: --pr is required" >&2; exit 2; }
 [ -f "$INV" ]   || { echo "error: inventory file not found: $INV" >&2; exit 2; }
 
-POSTED_SIDECAR="${INV}.posted"
+POSTED_SIDECAR="${POSTED_SIDECAR_FLAG:-${INV}.posted}"
+REPLY_ID_SIDECAR="${REPLY_ID_SIDECAR_FLAG:-}"
 
 # Normalize --skip-comment-ids: strip ALL whitespace so operators or tooling
 # passing "11111, 22222" (with spaces/newlines) still match the *,<cid>,*
@@ -154,7 +175,7 @@ jq -c '.items[]?' "$INV" > "$TMP"
 # author login (the agent commonly posts through its human operator's own
 # GitHub account, so a login filter would hide that human's real comments).
 record_reply_id() {  # record_reply_id <item-key> <match-value> <reply-id>
-  local key="$1" val="$2" rid="$3" tmp_inv match_count
+  local key="$1" val="$2" rid="$3" tmp_inv match_count record_json
   match_count="$(jq --arg k "$key" --arg v "$val" \
       '[.items[] | select(((.[$k] // "") | tostring) == $v)] | length' "$INV" 2>/dev/null)" || match_count=0
   if [ "${match_count:-0}" -eq 0 ]; then
@@ -169,6 +190,23 @@ record_reply_id() {  # record_reply_id <item-key> <match-value> <reply-id>
   else
     rm -f "$tmp_inv"
     echo "WARNING $val reply-id-record-failed: reply $rid posted to GitHub but not recorded in $INV; the eligibility check will treat it as incoming feedback until triaged" >&2
+  fi
+
+  # Durable sidecar copy of the reply id, decoupled from $INV (which may be a
+  # scratch mktemp copy the caller discards). Fatal on failure — mirrors the
+  # .posted append's fatal pattern below: under `set -e`, a failing RHS of
+  # `&&` is silently swallowed, so this must be its own `if ! cmd` guard, not
+  # `cmdA && cmdB`. The record is built into a variable FIRST, with its own
+  # `|| record_json=""` guard, so a jq construction failure is caught
+  # explicitly too — a bare `printf '%s\n' "$(jq ...)"` would swallow a
+  # failing inner command substitution (its exit status doesn't propagate
+  # through printf) and silently append a blank line while still returning 0.
+  if [ -n "$REPLY_ID_SIDECAR" ]; then
+    record_json="$(jq -nc --arg k "$key" --arg v "$val" --argjson rid "$rid" '{k:$k,v:$v,rid:$rid}')" || record_json=""
+    if [ -z "$record_json" ] || ! printf '%s\n' "$record_json" >> "$REPLY_ID_SIDECAR"; then
+      echo "WARNING $val reply-id-sidecar-append-failed: reply $rid posted to GitHub and recorded on $INV but the durable sidecar write to $REPLY_ID_SIDECAR failed; the merge-eligibility check may not exclude this reply until the sidecar is manually repaired" >&2
+      any_failed=1
+    fi
   fi
 }
 

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -119,8 +119,26 @@ cat >"$INV_MIXED" <<'JSON'
 }
 JSON
 
+# --posted-sidecar / --reply-id-sidecar are REQUIRED flags. Tests that don't
+# specifically exercise sidecar behavior pass a fresh, unique scratch path
+# per invocation (SIDECAR_N / RIDCAR_N) so no unrelated test's state leaks
+# in. Tests that DO exercise sidecar durability/idempotency pass the same
+# explicit path across multiple invocations of the same inventory — noted
+# inline at each such case.
+sc_n=0
+next_pair() {  # sets SC and RC to a fresh, index-matched pair. Must run in
+  # the parent shell (never via command substitution) — sc_n's increment
+  # would otherwise be lost in a subshell and every "don't care" test would
+  # collide on the same sidecar paths.
+  sc_n=$((sc_n + 1))
+  SC="$TMP/sc-$sc_n.posted"
+  RC="$TMP/sc-$sc_n.replyids"
+}
+
 # Behavior test: --skip-comment-ids must be accepted as a flag.
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   --skip-comment-ids "11111,22222" > "$TMP/skip-out.txt" 2>&1
 rc_skip=$?
 assert "--skip-comment-ids is not rejected as unknown flag (rc != 2)" \
@@ -130,7 +148,9 @@ assert "--skip-comment-ids is not rejected as unknown flag (rc != 2)" \
 # comment_id token. Regression guard against a prior bug where the script
 # read a non-existent .comment_id field and emitted 'POSTED ' (empty token
 # after the space) for every successful post.
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/posted-out.txt" 2>&1
 rc_posted=$?
 if [ "$rc_posted" = "0" ]; then
@@ -160,7 +180,9 @@ fi
 
 # Behavior test (SKIP contract with real id shape): passing the real numeric
 # ids in --skip-comment-ids must SKIP both items.
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   --skip-comment-ids "11111,22222" > "$TMP/skipped-out.txt" 2>&1
 if grep -qE '^SKIPPED 11111$' "$TMP/skipped-out.txt" && grep -qE '^SKIPPED 22222$' "$TMP/skipped-out.txt"; then
   echo "  ok: --skip-comment-ids matches real id fields per kind"
@@ -182,7 +204,9 @@ exit 1
 FAKE
 chmod +x "$FAKEBIN_FAIL/gh"
 
+next_pair
 PATH="$FAKEBIN_FAIL:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/failed-out.txt" 2>&1
 rc_failed=$?
 if [ "$rc_failed" = "1" ]; then
@@ -235,7 +259,9 @@ cat >"$INV_NO_BODY" <<'JSON'
   ]
 }
 JSON
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_NO_BODY" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/nobody-out.txt" 2>&1
 rc_nobody=$?
 if [ "$rc_nobody" = "1" ]; then
@@ -271,7 +297,9 @@ cat >"$INV_ESCALATE" <<'JSON'
   ]
 }
 JSON
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_ESCALATE" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/escalate-out.txt" 2>&1
 rc_escalate=$?
 if [ "$rc_escalate" = "0" ] && grep -qE '^POSTED 44444$' "$TMP/escalate-out.txt"; then
@@ -301,7 +329,9 @@ cat >"$INV_RSUM" <<'JSON'
   ]
 }
 JSON
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/rsum-out.txt" 2>&1
 rc_rsum=$?
 if [ "$rc_rsum" = "0" ] && grep -qE '^POSTED summary-[0-9a-f]+$' "$TMP/rsum-out.txt"; then
@@ -311,7 +341,9 @@ else
   FAIL=1
 fi
 # Same-content re-run must produce the SAME synthetic cid (idempotency anchor).
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/rsum-out2.txt" 2>&1
 cid1="$(grep -oE 'summary-[0-9a-f]+' "$TMP/rsum-out.txt"  | head -1)"
 cid2="$(grep -oE 'summary-[0-9a-f]+' "$TMP/rsum-out2.txt" | head -1)"
@@ -346,7 +378,9 @@ fi
 
 # review_summary → /issues/N/comments (NOT /pulls/...).
 : > "$FAKE_GH_LOG"
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RSUM" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/rsum-endpoint-out.txt" 2>&1
 if grep -qE 'repos/o/r/issues/1/comments' "$FAKE_GH_LOG" \
    && ! grep -qE 'repos/o/r/pulls/' "$FAKE_GH_LOG"; then
@@ -368,7 +402,9 @@ cat >"$INV_RT" <<'JSON'
   ]
 }
 JSON
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_RT" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/rt-endpoint-out.txt" 2>&1
 if grep -qE 'repos/o/r/pulls/1/comments/99999/replies' "$FAKE_GH_LOG"; then
   echo "  ok: review_thread hits /pulls/N/comments/<reply_to>/replies"
@@ -389,7 +425,9 @@ cat >"$INV_IC" <<'JSON'
   ]
 }
 JSON
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_IC" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   > "$TMP/ic-endpoint-out.txt" 2>&1
 if grep -qE 'repos/o/r/issues/1/comments' "$FAKE_GH_LOG" \
    && ! grep -qE 'repos/o/r/pulls/' "$FAKE_GH_LOG"; then
@@ -414,6 +452,7 @@ cat >"$INV_UNION" <<'JSON'
 JSON
 printf '81111\n' > "${INV_UNION}.posted"
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_UNION" --owner o --repo r --pr 1 \
+  --posted-sidecar "${INV_UNION}.posted" --reply-id-sidecar "${INV_UNION}.replyids" \
   --skip-comment-ids "82222" > "$TMP/union-out.txt" 2>&1
 if grep -qE '^SKIPPED 81111$' "$TMP/union-out.txt" \
    && grep -qE '^SKIPPED 82222$' "$TMP/union-out.txt" \
@@ -425,7 +464,7 @@ else
 fi
 
 # Behavior test (sidecar idempotency): a successful 100% run MUST delete
-# any prior <inventory>.posted sidecar so re-runs don't keep stale state.
+# the --posted-sidecar file so re-runs don't keep stale state.
 INV_SIDECAR_CLEAN="$TMP/inv-sidecar-clean.json"
 cat >"$INV_SIDECAR_CLEAN" <<'JSON'
 {
@@ -445,31 +484,34 @@ cat >"$INV_SIDECAR_CLEAN" <<'JSON'
 }
 JSON
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_CLEAN" --owner o --repo r --pr 1 \
+  --posted-sidecar "${INV_SIDECAR_CLEAN}.posted" --reply-id-sidecar "${INV_SIDECAR_CLEAN}.replyids" \
   > "$TMP/sidecar-clean-out.txt" 2>&1
 if [ -f "${INV_SIDECAR_CLEAN}.posted" ]; then
-  echo "  FAIL: 100% success should delete <inventory>.posted sidecar; still present"
+  echo "  FAIL: 100% success should delete the --posted-sidecar file; still present"
   FAIL=1
 else
-  echo "  ok: 100% success deletes <inventory>.posted sidecar"
+  echo "  ok: 100% success deletes the --posted-sidecar file"
 fi
 
-# Behavior test (sidecar idempotency): a prior <inventory>.posted sidecar
-# MUST be honored as an implicit skip-set on the next invocation. Simulate
-# a crashed prior run that already POSTED 55555 before dying.
+# Behavior test (sidecar idempotency): a prior --posted-sidecar file MUST be
+# honored as an implicit skip-set on the next invocation. Simulate a crashed
+# prior run that already POSTED 55555 before dying. Reuses the same durable
+# path as the previous test so the "prior run" fixture is realistic.
 PRE_POSTED="${INV_SIDECAR_CLEAN}.posted"
 printf '55555\n' > "$PRE_POSTED"
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_CLEAN" --owner o --repo r --pr 1 \
+  --posted-sidecar "$PRE_POSTED" --reply-id-sidecar "${INV_SIDECAR_CLEAN}.replyids" \
   > "$TMP/sidecar-skip-out.txt" 2>&1
 if grep -qE '^SKIPPED 55555$' "$TMP/sidecar-skip-out.txt" \
    && ! grep -qE '^POSTED 55555$' "$TMP/sidecar-skip-out.txt"; then
-  echo "  ok: prior <inventory>.posted entries are honored as implicit skip-set"
+  echo "  ok: prior --posted-sidecar entries are honored as implicit skip-set"
 else
   echo "  FAIL: prior sidecar entry 55555 should SKIP (and not POST); got: $(cat "$TMP/sidecar-skip-out.txt")"
   FAIL=1
 fi
 
 # Behavior test (sidecar idempotency): a partial-failure run MUST preserve
-# the sidecar so the next invocation can pick up where it left off.
+# the --posted-sidecar file so the next invocation can pick up where it left off.
 INV_SIDECAR_PARTIAL="$TMP/inv-sidecar-partial.json"
 cat >"$INV_SIDECAR_PARTIAL" <<'JSON'
 {
@@ -511,6 +553,7 @@ exit 0
 FAKE
 chmod +x "$FAKEBIN_PART/gh"
 PATH="$FAKEBIN_PART:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_PARTIAL" --owner o --repo r --pr 1 \
+  --posted-sidecar "${INV_SIDECAR_PARTIAL}.posted" --reply-id-sidecar "${INV_SIDECAR_PARTIAL}.replyids" \
   > "$TMP/sidecar-partial-out.txt" 2>&1
 rc_partial=$?
 if [ "$rc_partial" = "1" ]; then
@@ -563,6 +606,7 @@ JSON
 # Pre-populate sidecar with X (91111); operator asserts Y (92222) is done.
 printf '91111\n' > "${INV_SIDECAR_SKIP_CSV}.posted"
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_SIDECAR_SKIP_CSV" --owner o --repo r --pr 1 \
+  --posted-sidecar "${INV_SIDECAR_SKIP_CSV}.posted" --reply-id-sidecar "${INV_SIDECAR_SKIP_CSV}.replyids" \
   --skip-comment-ids "92222" > "$TMP/sidecar-skipcsv-out.txt" 2>&1
 rc_skipcsv=$?
 if [ "$rc_skipcsv" = "0" ]; then
@@ -582,7 +626,9 @@ fi
 # must still match the skipset cids. Regression guard against operators or tooling
 # that pass "11111, 22222" instead of "11111,22222".
 : > "$FAKE_GH_LOG"
+next_pair
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_MIXED" --owner o --repo r --pr 1 \
+  --posted-sidecar "$SC" --reply-id-sidecar "$RC" \
   --skip-comment-ids "11111, 22222" > "$TMP/csv-ws-out.txt" 2>&1
 if grep -qE '^SKIPPED 11111$' "$TMP/csv-ws-out.txt" \
    && grep -qE '^SKIPPED 22222$' "$TMP/csv-ws-out.txt"; then
@@ -592,10 +638,10 @@ else
   FAIL=1
 fi
 
-# Behavior test (sidecar append failure is surfaced): if the sidecar path is
-# un-writable (simulated by making it a directory), the script must emit a
-# WARNING on stderr and exit 1 — NOT silently print POSTED while the state
-# write is lost.
+# Behavior test (sidecar append failure is surfaced): if the --posted-sidecar
+# path is un-writable (simulated by making it a directory), the script must
+# emit a WARNING on stderr and exit 1 — NOT silently print POSTED while the
+# state write is lost.
 INV_WRITE_FAIL="$TMP/inv-write-fail.json"
 cat >"$INV_WRITE_FAIL" <<'JSON'
 {
@@ -609,6 +655,7 @@ JSON
 # Make the sidecar path a directory so >> fails.
 mkdir -p "${INV_WRITE_FAIL}.posted"
 PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_WRITE_FAIL" --owner o --repo r --pr 1 \
+  --posted-sidecar "${INV_WRITE_FAIL}.posted" --reply-id-sidecar "${INV_WRITE_FAIL}.replyids" \
   > "$TMP/write-fail-out.txt" 2> "$TMP/write-fail-err.txt"
 rc_wf=$?
 if [ "$rc_wf" = "1" ]; then
@@ -642,6 +689,65 @@ else
   echo "  ok: rejects nonexistent inventory file"
 fi
 
+# Failure path: --posted-sidecar is required. Omitting it (even with
+# --reply-id-sidecar supplied) must fail loudly with a usage error (exit 2)
+# BEFORE anything is posted — never silently derive a scratch/default path.
+INV_REQFLAG="$TMP/inv-reqflag.json"
+cat >"$INV_REQFLAG" <<'JSON'
+{
+  "schema_version": 1,
+  "pr": {"number": 1, "owner": "o", "repo": "r"},
+  "items": [
+    {"kind":"review_thread","thread_id":"T_req","reply_to_comment_id":66001,"issue_comment_id":null,"classification":"FIX","fix_outcome":"committed","reply_body":"ok"}
+  ]
+}
+JSON
+out_noposted=$(PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_REQFLAG" --owner o --repo r --pr 1 \
+  --reply-id-sidecar "$TMP/reqflag-a.replyids" 2>&1)
+rc_noposted=$?
+if [ "$rc_noposted" = "2" ]; then
+  echo "  ok: missing --posted-sidecar exits 2 (usage error)"
+else
+  echo "  FAIL: missing --posted-sidecar should exit 2; got $rc_noposted; out=$out_noposted"
+  FAIL=1
+fi
+if grep -qi -- '--posted-sidecar is required' <<<"$out_noposted"; then
+  echo "  ok: missing --posted-sidecar names the flag in the error"
+else
+  echo "  FAIL: expected an error naming --posted-sidecar as required; got: $out_noposted"
+  FAIL=1
+fi
+if grep -qE '^POSTED' <<<"$out_noposted"; then
+  echo "  FAIL: missing --posted-sidecar must not post anything before failing"
+  FAIL=1
+else
+  echo "  ok: missing --posted-sidecar posts nothing"
+fi
+
+# Failure path: --reply-id-sidecar is required. Omitting it (even with
+# --posted-sidecar supplied) must fail loudly with a usage error (exit 2).
+out_noridcar=$(PATH="$FAKEBIN:$PATH" "$SCRIPT" --inventory "$INV_REQFLAG" --owner o --repo r --pr 1 \
+  --posted-sidecar "$TMP/reqflag-b.posted" 2>&1)
+rc_noridcar=$?
+if [ "$rc_noridcar" = "2" ]; then
+  echo "  ok: missing --reply-id-sidecar exits 2 (usage error)"
+else
+  echo "  FAIL: missing --reply-id-sidecar should exit 2; got $rc_noridcar; out=$out_noridcar"
+  FAIL=1
+fi
+if grep -qi -- '--reply-id-sidecar is required' <<<"$out_noridcar"; then
+  echo "  ok: missing --reply-id-sidecar names the flag in the error"
+else
+  echo "  FAIL: expected an error naming --reply-id-sidecar as required; got: $out_noridcar"
+  FAIL=1
+fi
+if grep -qE '^POSTED' <<<"$out_noridcar"; then
+  echo "  FAIL: missing --reply-id-sidecar must not post anything before failing"
+  FAIL=1
+else
+  echo "  ok: missing --reply-id-sidecar posts nothing"
+fi
+
 # ── posted_reply_id recording ────────────────────────────────────────────────
 T16="$(mktemp -d)"
 cat > "$T16/gh" <<'STUB'
@@ -660,7 +766,8 @@ jq -n '{schema_version: 1, pr: {}, polling: {}, items: [
    fix_outcome: null, reply_body: "Acknowledged — skipping as cosmetic."}
 ], crash_recovery: {skill_a_completed: true, last_completed_phase: "7-write-inventory"}}' > "$T16/inv.json"
 
-out16=$(PATH="$T16:$PATH" "$HERE/post-replies.sh" --inventory "$T16/inv.json" --owner o --repo r --pr 1 2>&1)
+out16=$(PATH="$T16:$PATH" "$HERE/post-replies.sh" --inventory "$T16/inv.json" --owner o --repo r --pr 1 \
+  --posted-sidecar "$T16/sc.posted" --reply-id-sidecar "$T16/sc.replyids" 2>&1)
 rc16=$?
 assert "post succeeds against stub" "[ \$rc16 -eq 0 ]"
 assert "POSTED line emitted" "grep -q 'POSTED 4242' <<<\"\$out16\""
@@ -695,18 +802,25 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
    classification: "FIX", fix_outcome: "committed", reply_body: "will fail first attempt"}
 ]}' > "$INV17"
 
-out17a=$(PATH="$T17:$PATH" "$HERE/post-replies.sh" --inventory "$INV17" --owner o --repo r --pr 1 2>&1)
+# --posted-sidecar is reused across BOTH invocations (run 1 and run 2) —
+# that's the point of this test: idempotency across separate runs against
+# the same durable sidecar path.
+POSTED17="$T17/durable.posted"
+RID17="$T17/durable.replyids"
+out17a=$(PATH="$T17:$PATH" "$HERE/post-replies.sh" --inventory "$INV17" --owner o --repo r --pr 1 \
+  --posted-sidecar "$POSTED17" --reply-id-sidecar "$RID17" 2>&1)
 rc17a=$?
 cid17="$(printf '%s' "$out17a" | grep -oE 'POSTED summary-[0-9a-f]+' | awk '{print $2}')"
 
 assert "run 1: partial failure (thread post fails) exits 1" "[ \$rc17a -eq 1 ]"
 assert "run 1: review_summary POSTED with a synthetic cid" "[ -n \"\$cid17\" ]"
 assert "run 1: sidecar records the summary cid" \
-  "[ -f \"${INV17}.posted\" ] && grep -qF \"\$cid17\" \"${INV17}.posted\""
+  "[ -f \"$POSTED17\" ] && grep -qF \"\$cid17\" \"$POSTED17\""
 assert "run 1: posted_reply_id recorded on the review_summary item" \
   "[ \"\$(jq -r '.items[0].posted_reply_id' \"$INV17\")\" = \"900001\" ]"
 
-out17b=$(PATH="$T17:$PATH" "$HERE/post-replies.sh" --inventory "$INV17" --owner o --repo r --pr 1 2>&1)
+out17b=$(PATH="$T17:$PATH" "$HERE/post-replies.sh" --inventory "$INV17" --owner o --repo r --pr 1 \
+  --posted-sidecar "$POSTED17" --reply-id-sidecar "$RID17" 2>&1)
 rc17b=$?
 assert "run 2: still partial failure (thread post keeps failing)" "[ \$rc17b -eq 1 ]"
 assert "run 2: review_summary is SKIPPED (same cid as run 1), not re-posted" \
@@ -734,7 +848,8 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
   {kind: "review_summary", review_id: 18001, thread_id: null, reply_to_comment_id: null, issue_comment_id: null,
    classification: "SKIP", reply_body: "Acknowledged."}
 ]}' > "$INV18"
-out18=$(PATH="$T18:$PATH" "$HERE/post-replies.sh" --inventory "$INV18" --owner o --repo r --pr 1 2>&1)
+out18=$(PATH="$T18:$PATH" "$HERE/post-replies.sh" --inventory "$INV18" --owner o --repo r --pr 1 \
+  --posted-sidecar "$T18/sc.posted" --reply-id-sidecar "$T18/sc.replyids" 2>&1)
 rc18=$?
 assert "(a) review_summary+review_id: run succeeds" "[ \$rc18 -eq 0 ]"
 assert "(a) review_summary+review_id: posted_reply_id recorded by review_id match" \
@@ -754,7 +869,8 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
   {kind: "review_thread", thread_id: "T_19", reply_to_comment_id: 612345, issue_comment_id: null,
    classification: "FIX", fix_outcome: "committed", reply_body: "fixed"}
 ]}' > "$INV19"
-out19=$(PATH="$T19:$PATH" "$HERE/post-replies.sh" --inventory "$INV19" --owner o --repo r --pr 1 2>&1)
+out19=$(PATH="$T19:$PATH" "$HERE/post-replies.sh" --inventory "$INV19" --owner o --repo r --pr 1 \
+  --posted-sidecar "$T19/sc.posted" --reply-id-sidecar "$T19/sc.replyids" 2>&1)
 rc19=$?
 assert "(b) review_thread: run succeeds" "[ \$rc19 -eq 0 ]"
 assert "(b) review_thread: posted_reply_id recorded by reply_to_comment_id match" \
@@ -775,7 +891,8 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
   {kind: "review_summary", thread_id: null, reply_to_comment_id: null, issue_comment_id: null,
    classification: "SKIP", reply_body: "Legacy item, no review_id."}
 ]}' > "$INV20A"
-out20a=$(PATH="$T20A:$PATH" "$HERE/post-replies.sh" --inventory "$INV20A" --owner o --repo r --pr 1 2>&1)
+out20a=$(PATH="$T20A:$PATH" "$HERE/post-replies.sh" --inventory "$INV20A" --owner o --repo r --pr 1 \
+  --posted-sidecar "$T20A/sc.posted" --reply-id-sidecar "$T20A/sc.replyids" 2>&1)
 rc20a=$?
 assert "(c) legacy review_summary w/o review_id: run still succeeds (no crash)" "[ \$rc20a -eq 0 ]"
 assert "(c) legacy review_summary w/o review_id: WARNING names the missing review_id" \
@@ -803,7 +920,8 @@ printf '{"id": 900099}'
 exit 0
 STUB
 chmod +x "$T20B/gh"
-out20b=$(PATH="$T20B:$PATH" "$HERE/post-replies.sh" --inventory "$INV20B" --owner o --repo r --pr 1 2>&1)
+out20b=$(PATH="$T20B:$PATH" "$HERE/post-replies.sh" --inventory "$INV20B" --owner o --repo r --pr 1 \
+  --posted-sidecar "$T20B/sc.posted" --reply-id-sidecar "$T20B/sc.replyids" 2>&1)
 rc20b=$?
 unset NOMATCH_INV
 assert "(d) no-match record: run still succeeds (no crash)" "[ \$rc20b -eq 0 ]"
@@ -813,7 +931,9 @@ assert "(d) no-match record: posted_reply_id NOT recorded anywhere" \
   "[ \"\$(jq -r '.items[0].posted_reply_id // \"null\"' \"$INV20B\")\" = \"null\" ]"
 rm -rf "$T20B"
 
-# ── --reply-id-sidecar / --posted-sidecar flags (durable reply-id + posted state) ──
+# ── --reply-id-sidecar / --posted-sidecar flags (durable reply-id + posted
+# state; both REQUIRED — see the standalone required-flag failure-path tests
+# above) ──────────────────────────────────────────────────────────────────
 
 # Behavior test (A): --reply-id-sidecar appends one JSONL record per POST,
 # {"k":<match_key>,"v":<match_val>,"rid":<reply_id>}, for both issue_comment
@@ -837,7 +957,7 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
 ]}' > "$INV_A"
 RID_SIDECAR_A="$TA/reply-ids.jsonl"
 out_a=$(PATH="$TA:$PATH" "$HERE/post-replies.sh" --inventory "$INV_A" --owner o --repo r --pr 1 \
-  --reply-id-sidecar "$RID_SIDECAR_A" 2>&1)
+  --posted-sidecar "$TA/posted.txt" --reply-id-sidecar "$RID_SIDECAR_A" 2>&1)
 rc_a=$?
 if [ "$rc_a" = "0" ] && [ -f "$RID_SIDECAR_A" ]; then
   echo "  ok: --reply-id-sidecar run succeeds and creates the sidecar file"
@@ -870,7 +990,8 @@ rm -rf "$TA"
 # Behavior test (B1): --reply-id-sidecar append failure is fatal (mirrors the
 # existing .posted append-failure test at "sidecar append failure causes exit
 # 1" above): point --reply-id-sidecar at a directory so `>>` fails; must
-# WARNING to stderr and exit 1.
+# WARNING to stderr and exit 1. --posted-sidecar points at a normal writable
+# path so only the reply-id-sidecar failure is under test.
 TB1="$(mktemp -d)"
 cat > "$TB1/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -889,7 +1010,7 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
 RID_SIDECAR_B1="$TB1/reply-ids-dir"
 mkdir -p "$RID_SIDECAR_B1"
 out_b1=$(PATH="$TB1:$PATH" "$HERE/post-replies.sh" --inventory "$INV_B1" --owner o --repo r --pr 1 \
-  --reply-id-sidecar "$RID_SIDECAR_B1" 2>&1)
+  --posted-sidecar "$TB1/posted.txt" --reply-id-sidecar "$RID_SIDECAR_B1" 2>&1)
 rc_b1=$?
 if [ "$rc_b1" = "1" ]; then
   echo "  ok: --reply-id-sidecar append failure (directory path) causes exit 1"
@@ -906,9 +1027,8 @@ fi
 rmdir "$RID_SIDECAR_B1" 2>/dev/null || rm -rf "$RID_SIDECAR_B1"
 rm -rf "$TB1"
 
-# Behavior test (B2): --posted-sidecar append failure is fatal, and the flag
-# REPLACES the default <inventory>.posted derivation (the default path must
-# stay untouched — proving the flag, not the legacy path, is what's live).
+# Behavior test (B2): --posted-sidecar append failure is fatal. --reply-id-sidecar
+# points at a normal writable path so only the posted-sidecar failure is under test.
 TB2="$(mktemp -d)"
 cat > "$TB2/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -927,7 +1047,7 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
 POSTED_SIDECAR_B2="$TB2/posted-dir"
 mkdir -p "$POSTED_SIDECAR_B2"
 out_b2=$(PATH="$TB2:$PATH" "$HERE/post-replies.sh" --inventory "$INV_B2" --owner o --repo r --pr 1 \
-  --posted-sidecar "$POSTED_SIDECAR_B2" 2>&1)
+  --posted-sidecar "$POSTED_SIDECAR_B2" --reply-id-sidecar "$TB2/replyids.txt" 2>&1)
 rc_b2=$?
 if [ "$rc_b2" = "1" ]; then
   echo "  ok: --posted-sidecar append failure (directory path) causes exit 1"
@@ -941,12 +1061,6 @@ else
   echo "  FAIL: expected WARNING with 'sidecar-append-failed'; got: $out_b2"
   FAIL=1
 fi
-if [ -f "${INV_B2}.posted" ]; then
-  echo "  FAIL: --posted-sidecar should replace the default <inventory>.posted derivation, but the default path was written"
-  FAIL=1
-else
-  echo "  ok: --posted-sidecar replaces the default <inventory>.posted derivation (default path untouched)"
-fi
 rmdir "$POSTED_SIDECAR_B2" 2>/dev/null || rm -rf "$POSTED_SIDECAR_B2"
 rm -rf "$TB2"
 
@@ -954,7 +1068,7 @@ rm -rf "$TB2"
 # --posted-sidecar path reused across two SEPARATE invocations of the script
 # must dedup across the runs. Regression guard for the bug where the
 # production caller passes a fresh mktemp --inventory on every resume,
-# orphaning the prior run's <inventory>.posted and re-posting every item.
+# orphaning any inventory-derived sidecar path and re-posting every item.
 TC="$(mktemp -d)"
 cat > "$TC/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -975,8 +1089,9 @@ jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
    classification: "FIX", fix_outcome: "committed", reply_body: "will keep failing"}
 ]}' > "$INV_C"
 POSTED_SIDECAR_C="$TC/durable.posted"
+RID_SIDECAR_C="$TC/durable.replyids"
 out_c1=$(PATH="$TC:$PATH" "$HERE/post-replies.sh" --inventory "$INV_C" --owner o --repo r --pr 1 \
-  --posted-sidecar "$POSTED_SIDECAR_C" 2>&1)
+  --posted-sidecar "$POSTED_SIDECAR_C" --reply-id-sidecar "$RID_SIDECAR_C" 2>&1)
 rc_c1=$?
 if [ "$rc_c1" = "1" ] && grep -qE '^POSTED 97777$' <<<"$out_c1"; then
   echo "  ok: run 1 (partial failure) POSTs 97777 and exits 1"
@@ -991,10 +1106,10 @@ else
   FAIL=1
 fi
 # Simulate resume: SAME durable --posted-sidecar path reused across a second,
-# separate invocation (this is what the production caller's fresh --inventory
-# mktemp broke: the old derivation ${INV}.posted would differ on resume).
+# separate invocation (this is what a fresh --inventory mktemp on resume would
+# break if the sidecar path were derived from --inventory instead of durable).
 out_c2=$(PATH="$TC:$PATH" "$HERE/post-replies.sh" --inventory "$INV_C" --owner o --repo r --pr 1 \
-  --posted-sidecar "$POSTED_SIDECAR_C" 2>&1)
+  --posted-sidecar "$POSTED_SIDECAR_C" --reply-id-sidecar "$RID_SIDECAR_C" 2>&1)
 if grep -qE '^SKIPPED 97777$' <<<"$out_c2" && ! grep -qE '^POSTED 97777$' <<<"$out_c2"; then
   echo "  ok: run 2 (same durable --posted-sidecar) SKIPs 97777 — no duplicate GitHub post"
 else
@@ -1002,46 +1117,5 @@ else
   FAIL=1
 fi
 rm -rf "$TC"
-
-# Behavior test (D): backward compat — no --reply-id-sidecar / --posted-sidecar
-# supplied must behave exactly as before: no new sidecar file materializes,
-# and the legacy <inventory>.posted derivation still governs idempotency.
-TD="$(mktemp -d)"
-cat > "$TD/gh" <<'STUB'
-#!/usr/bin/env bash
-if [ "$1" = "api" ]; then
-  printf '{"id": 700005}'
-  exit 0
-fi
-exit 0
-STUB
-chmod +x "$TD/gh"
-INV_D="$TD/inv.json"
-jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
-  {kind: "review_thread", thread_id: "T_D", reply_to_comment_id: 98888, issue_comment_id: null,
-   classification: "FIX", fix_outcome: "committed", reply_body: "ok"}
-]}' > "$INV_D"
-out_d=$(PATH="$TD:$PATH" "$HERE/post-replies.sh" --inventory "$INV_D" --owner o --repo r --pr 1 2>&1)
-rc_d=$?
-if [ "$rc_d" = "0" ] && grep -qE '^POSTED 98888$' <<<"$out_d"; then
-  echo "  ok: (D) no new flags: run succeeds and POSTs as before"
-else
-  echo "  FAIL: (D) expected POSTED 98888 exit 0; rc=$rc_d out=$out_d"
-  FAIL=1
-fi
-if [ -f "${INV_D}.posted" ]; then
-  echo "  FAIL: (D) 100%-success run without new flags should still delete <inventory>.posted (legacy behavior); it is still present"
-  FAIL=1
-else
-  echo "  ok: (D) legacy <inventory>.posted behavior unchanged (deleted on 100% success)"
-fi
-no_extra_files="$(find "$TD" -maxdepth 1 -type f ! -name 'gh' ! -name 'inv.json' | wc -l | tr -d ' ')"
-if [ "$no_extra_files" = "0" ]; then
-  echo "  ok: (D) no new sidecar file materializes when flags are omitted"
-else
-  echo "  FAIL: (D) unexpected extra file(s) created without new flags: $(find "$TD" -maxdepth 1 -type f)"
-  FAIL=1
-fi
-rm -rf "$TD"
 
 exit $FAIL

--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/post-replies_test.sh
@@ -813,4 +813,235 @@ assert "(d) no-match record: posted_reply_id NOT recorded anywhere" \
   "[ \"\$(jq -r '.items[0].posted_reply_id // \"null\"' \"$INV20B\")\" = \"null\" ]"
 rm -rf "$T20B"
 
+# ── --reply-id-sidecar / --posted-sidecar flags (durable reply-id + posted state) ──
+
+# Behavior test (A): --reply-id-sidecar appends one JSONL record per POST,
+# {"k":<match_key>,"v":<match_val>,"rid":<reply_id>}, for both issue_comment
+# and review_thread kinds.
+TA="$(mktemp -d)"
+cat > "$TA/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  printf '{"id": 700001}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TA/gh"
+INV_A="$TA/inv.json"
+jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
+  {kind: "issue_comment", issue_comment_id: 93333, thread_id: null, reply_to_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"},
+  {kind: "review_thread", thread_id: "T_A", reply_to_comment_id: 94444, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"}
+]}' > "$INV_A"
+RID_SIDECAR_A="$TA/reply-ids.jsonl"
+out_a=$(PATH="$TA:$PATH" "$HERE/post-replies.sh" --inventory "$INV_A" --owner o --repo r --pr 1 \
+  --reply-id-sidecar "$RID_SIDECAR_A" 2>&1)
+rc_a=$?
+if [ "$rc_a" = "0" ] && [ -f "$RID_SIDECAR_A" ]; then
+  echo "  ok: --reply-id-sidecar run succeeds and creates the sidecar file"
+else
+  echo "  FAIL: --reply-id-sidecar run should exit 0 and create the file; rc=$rc_a out=$out_a"
+  FAIL=1
+fi
+if jq -c . "$RID_SIDECAR_A" >/dev/null 2>&1; then
+  echo "  ok: every reply-id-sidecar line parses as JSON"
+else
+  echo "  FAIL: reply-id-sidecar contains a line that doesn't parse as JSON: $(cat "$RID_SIDECAR_A" 2>&1)"
+  FAIL=1
+fi
+ic_line="$(jq -c 'select(.k=="issue_comment_id")' "$RID_SIDECAR_A" 2>/dev/null)"
+if [ "$(jq -r '.v' <<<"$ic_line" 2>/dev/null)" = "93333" ] && [ "$(jq -r '.rid' <<<"$ic_line" 2>/dev/null)" = "700001" ]; then
+  echo "  ok: reply-id-sidecar record for issue_comment has k=issue_comment_id v=93333 rid=700001"
+else
+  echo "  FAIL: issue_comment reply-id-sidecar record wrong; got: $ic_line"
+  FAIL=1
+fi
+rt_line="$(jq -c 'select(.k=="reply_to_comment_id")' "$RID_SIDECAR_A" 2>/dev/null)"
+if [ "$(jq -r '.v' <<<"$rt_line" 2>/dev/null)" = "94444" ] && [ "$(jq -r '.rid' <<<"$rt_line" 2>/dev/null)" = "700001" ]; then
+  echo "  ok: reply-id-sidecar record for review_thread has k=reply_to_comment_id v=94444 rid=700001"
+else
+  echo "  FAIL: review_thread reply-id-sidecar record wrong; got: $rt_line"
+  FAIL=1
+fi
+rm -rf "$TA"
+
+# Behavior test (B1): --reply-id-sidecar append failure is fatal (mirrors the
+# existing .posted append-failure test at "sidecar append failure causes exit
+# 1" above): point --reply-id-sidecar at a directory so `>>` fails; must
+# WARNING to stderr and exit 1.
+TB1="$(mktemp -d)"
+cat > "$TB1/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  printf '{"id": 700002}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TB1/gh"
+INV_B1="$TB1/inv.json"
+jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
+  {kind: "review_thread", thread_id: "T_B1", reply_to_comment_id: 95555, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"}
+]}' > "$INV_B1"
+RID_SIDECAR_B1="$TB1/reply-ids-dir"
+mkdir -p "$RID_SIDECAR_B1"
+out_b1=$(PATH="$TB1:$PATH" "$HERE/post-replies.sh" --inventory "$INV_B1" --owner o --repo r --pr 1 \
+  --reply-id-sidecar "$RID_SIDECAR_B1" 2>&1)
+rc_b1=$?
+if [ "$rc_b1" = "1" ]; then
+  echo "  ok: --reply-id-sidecar append failure (directory path) causes exit 1"
+else
+  echo "  FAIL: --reply-id-sidecar append failure should exit 1; got $rc_b1"
+  FAIL=1
+fi
+if grep -qi 'reply-id-sidecar-append-failed' <<<"$out_b1"; then
+  echo "  ok: --reply-id-sidecar append failure emits WARNING naming the reply id and sidecar path"
+else
+  echo "  FAIL: expected WARNING with 'reply-id-sidecar-append-failed'; got: $out_b1"
+  FAIL=1
+fi
+rmdir "$RID_SIDECAR_B1" 2>/dev/null || rm -rf "$RID_SIDECAR_B1"
+rm -rf "$TB1"
+
+# Behavior test (B2): --posted-sidecar append failure is fatal, and the flag
+# REPLACES the default <inventory>.posted derivation (the default path must
+# stay untouched — proving the flag, not the legacy path, is what's live).
+TB2="$(mktemp -d)"
+cat > "$TB2/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  printf '{"id": 700003}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TB2/gh"
+INV_B2="$TB2/inv.json"
+jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
+  {kind: "review_thread", thread_id: "T_B2", reply_to_comment_id: 96666, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"}
+]}' > "$INV_B2"
+POSTED_SIDECAR_B2="$TB2/posted-dir"
+mkdir -p "$POSTED_SIDECAR_B2"
+out_b2=$(PATH="$TB2:$PATH" "$HERE/post-replies.sh" --inventory "$INV_B2" --owner o --repo r --pr 1 \
+  --posted-sidecar "$POSTED_SIDECAR_B2" 2>&1)
+rc_b2=$?
+if [ "$rc_b2" = "1" ]; then
+  echo "  ok: --posted-sidecar append failure (directory path) causes exit 1"
+else
+  echo "  FAIL: --posted-sidecar append failure should exit 1; got $rc_b2"
+  FAIL=1
+fi
+if grep -qi 'sidecar-append-failed' <<<"$out_b2"; then
+  echo "  ok: --posted-sidecar append failure emits WARNING"
+else
+  echo "  FAIL: expected WARNING with 'sidecar-append-failed'; got: $out_b2"
+  FAIL=1
+fi
+if [ -f "${INV_B2}.posted" ]; then
+  echo "  FAIL: --posted-sidecar should replace the default <inventory>.posted derivation, but the default path was written"
+  FAIL=1
+else
+  echo "  ok: --posted-sidecar replaces the default <inventory>.posted derivation (default path untouched)"
+fi
+rmdir "$POSTED_SIDECAR_B2" 2>/dev/null || rm -rf "$POSTED_SIDECAR_B2"
+rm -rf "$TB2"
+
+# Behavior test (C): --resume does not double-post. A durable, non-temp
+# --posted-sidecar path reused across two SEPARATE invocations of the script
+# must dedup across the runs. Regression guard for the bug where the
+# production caller passes a fresh mktemp --inventory on every resume,
+# orphaning the prior run's <inventory>.posted and re-posting every item.
+TC="$(mktemp -d)"
+cat > "$TC/gh" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    *"/comments/97778/replies"*) echo "fail-on-97778" >&2; exit 1 ;;
+  esac
+done
+printf '{"id": 700004}'
+exit 0
+STUB
+chmod +x "$TC/gh"
+INV_C="$TC/inv.json"
+jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
+  {kind: "review_thread", thread_id: "T_Cx", reply_to_comment_id: 97777, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"},
+  {kind: "review_thread", thread_id: "T_Cy", reply_to_comment_id: 97778, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "will keep failing"}
+]}' > "$INV_C"
+POSTED_SIDECAR_C="$TC/durable.posted"
+out_c1=$(PATH="$TC:$PATH" "$HERE/post-replies.sh" --inventory "$INV_C" --owner o --repo r --pr 1 \
+  --posted-sidecar "$POSTED_SIDECAR_C" 2>&1)
+rc_c1=$?
+if [ "$rc_c1" = "1" ] && grep -qE '^POSTED 97777$' <<<"$out_c1"; then
+  echo "  ok: run 1 (partial failure) POSTs 97777 and exits 1"
+else
+  echo "  FAIL: run 1 should POST 97777 and exit 1 (97778 fails); rc=$rc_c1 out=$out_c1"
+  FAIL=1
+fi
+if [ -f "$POSTED_SIDECAR_C" ] && grep -qE '^97777$' "$POSTED_SIDECAR_C"; then
+  echo "  ok: run 1 preserves durable --posted-sidecar with 97777 recorded"
+else
+  echo "  FAIL: durable --posted-sidecar should contain 97777 after partial run; got: $(cat "$POSTED_SIDECAR_C" 2>&1 || echo missing)"
+  FAIL=1
+fi
+# Simulate resume: SAME durable --posted-sidecar path reused across a second,
+# separate invocation (this is what the production caller's fresh --inventory
+# mktemp broke: the old derivation ${INV}.posted would differ on resume).
+out_c2=$(PATH="$TC:$PATH" "$HERE/post-replies.sh" --inventory "$INV_C" --owner o --repo r --pr 1 \
+  --posted-sidecar "$POSTED_SIDECAR_C" 2>&1)
+if grep -qE '^SKIPPED 97777$' <<<"$out_c2" && ! grep -qE '^POSTED 97777$' <<<"$out_c2"; then
+  echo "  ok: run 2 (same durable --posted-sidecar) SKIPs 97777 — no duplicate GitHub post"
+else
+  echo "  FAIL: run 2 should SKIP 97777 without re-posting; out=$out_c2"
+  FAIL=1
+fi
+rm -rf "$TC"
+
+# Behavior test (D): backward compat — no --reply-id-sidecar / --posted-sidecar
+# supplied must behave exactly as before: no new sidecar file materializes,
+# and the legacy <inventory>.posted derivation still governs idempotency.
+TD="$(mktemp -d)"
+cat > "$TD/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "api" ]; then
+  printf '{"id": 700005}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TD/gh"
+INV_D="$TD/inv.json"
+jq -n '{schema_version: 1, pr: {number: 1, owner: "o", repo: "r"}, items: [
+  {kind: "review_thread", thread_id: "T_D", reply_to_comment_id: 98888, issue_comment_id: null,
+   classification: "FIX", fix_outcome: "committed", reply_body: "ok"}
+]}' > "$INV_D"
+out_d=$(PATH="$TD:$PATH" "$HERE/post-replies.sh" --inventory "$INV_D" --owner o --repo r --pr 1 2>&1)
+rc_d=$?
+if [ "$rc_d" = "0" ] && grep -qE '^POSTED 98888$' <<<"$out_d"; then
+  echo "  ok: (D) no new flags: run succeeds and POSTs as before"
+else
+  echo "  FAIL: (D) expected POSTED 98888 exit 0; rc=$rc_d out=$out_d"
+  FAIL=1
+fi
+if [ -f "${INV_D}.posted" ]; then
+  echo "  FAIL: (D) 100%-success run without new flags should still delete <inventory>.posted (legacy behavior); it is still present"
+  FAIL=1
+else
+  echo "  ok: (D) legacy <inventory>.posted behavior unchanged (deleted on 100% success)"
+fi
+no_extra_files="$(find "$TD" -maxdepth 1 -type f ! -name 'gh' ! -name 'inv.json' | wc -l | tr -d ' ')"
+if [ "$no_extra_files" = "0" ]; then
+  echo "  ok: (D) no new sidecar file materializes when flags are omitted"
+else
+  echo "  FAIL: (D) unexpected extra file(s) created without new flags: $(find "$TD" -maxdepth 1 -type f)"
+  FAIL=1
+fi
+rm -rf "$TD"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory.sh
@@ -18,7 +18,8 @@
 #   4. Writes to <path>.tmp.<pid>, then `mv` to final path (POSIX-atomic on
 #      the same filesystem).
 #   5. Runs retention housekeeping: delete files older than 30 days in the
-#      inventory directory. Never touches files newer than 30 days.
+#      inventory directory (covers the canonical *.json inventories and their
+#      *.replyids / *.posted sidecars). Never touches files newer than 30 days.
 #
 # Exit codes:
 #   0  — write succeeded
@@ -80,5 +81,5 @@ mv "$TMP" "$PATH_OUT"
 # deletion of unrelated JSON files.
 EXPECTED_DIR="${HOME}/.claude/state/pr-inventory"
 if [ "$DIR_OUT" = "$EXPECTED_DIR" ]; then
-    find "$EXPECTED_DIR" -type f -name '*.json' -mtime +30 -delete 2>/dev/null || true
+    find "$EXPECTED_DIR" -type f \( -name '*.json' -o -name '*.replyids' -o -name '*.posted' \) -mtime +30 -delete 2>/dev/null || true
 fi

--- a/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/write-inventory_test.sh
@@ -90,4 +90,52 @@ printf 'not-json' | "$SCRIPT" --state complete --phase p1 --output "$OUT_BAD" 2>
 rc_bad_json=$?
 assert "exits 65 on invalid JSON input" "[ \$rc_bad_json -eq 65 ]"
 
+# --- Retention pruning: new .replyids/.posted sidecar suffixes ---
+# The prune sweep only fires when --output's directory exactly equals
+# ${HOME}/.claude/state/pr-inventory, so HOME is redirected to an isolated
+# fixture dir before invoking the script (mirrors the FAKE_HOME pattern in
+# merge-guard/check-merge-eligibility_test.sh) — never touches the real
+# ~/.claude/state/pr-inventory.
+PRUNE_HOME="$TMP/prune-home"
+PRUNE_DIR="$PRUNE_HOME/.claude/state/pr-inventory"
+mkdir -p "$PRUNE_DIR"
+
+old_ts() {
+  date -v-31d +%Y%m%d0000 2>/dev/null || date -d '31 days ago' +%Y%m%d0000
+}
+OLD_TS="$(old_ts)"
+
+OLD_REPLYIDS="$PRUNE_DIR/o-r-1-abc.json.replyids"
+OLD_POSTED="$PRUNE_DIR/o-r-1-abc.json.posted"
+NEW_REPLYIDS="$PRUNE_DIR/o-r-2-def.json.replyids"
+NEW_POSTED="$PRUNE_DIR/o-r-2-def.json.posted"
+OLD_OTHER_PREFIX_REPLYIDS="$PRUNE_DIR/o-r-9-zzz.json.replyids"
+
+: > "$OLD_REPLYIDS"; : > "$OLD_POSTED"
+: > "$NEW_REPLYIDS"; : > "$NEW_POSTED"
+: > "$OLD_OTHER_PREFIX_REPLYIDS"
+touch -t "$OLD_TS" "$OLD_REPLYIDS" "$OLD_POSTED" "$OLD_OTHER_PREFIX_REPLYIDS"
+
+PRUNE_OUT="$PRUNE_DIR/o-r-1-abc.json"
+printf '{"schema_version":1,"pr":{"number":1},"items":[]}' | \
+  env HOME="$PRUNE_HOME" "$SCRIPT" --state complete --phase 7-write-inventory --output "$PRUNE_OUT" 2>/dev/null
+rc_prune=$?
+assert "prune run exits 0" "[ \$rc_prune -eq 0 ]"
+
+# A. New-suffix pruning fires for backdated sidecars
+assert "backdated .replyids sidecar pruned" "[ ! -e '$OLD_REPLYIDS' ]"
+assert "backdated .posted sidecar pruned" "[ ! -e '$OLD_POSTED' ]"
+
+# B. Recent sidecars survive
+assert "recent .replyids sidecar survives" "[ -e '$NEW_REPLYIDS' ]"
+assert "recent .posted sidecar survives" "[ -e '$NEW_POSTED' ]"
+
+# C. Other-PR-prefix sidecar: the pre-existing .json prune sweeps the whole
+# directory by mtime alone with no filename-prefix scoping (verified against
+# the live find predicate), so the new suffixes inherit that same
+# directory-wide breadth rather than narrowing it — a backdated sidecar for a
+# different PR prefix is pruned too, same as same-prefix backdated files.
+assert "backdated other-prefix .replyids sidecar shares existing directory-wide prune scope" \
+  "[ ! -e '$OLD_OTHER_PREFIX_REPLYIDS' ]"
+
 exit $FAIL


### PR DESCRIPTION
## Summary

- `post-replies.sh` derived both its idempotency sidecar (`.posted`) and (as of PR #209) its reply-id record from `--inventory`, which the `reply-and-resolve-pr-threads` skill wires to a discarded `mktemp` scratch copy every run. Neither ever persisted anywhere durable.
- Consequence 1 (agents-config-tn5gc): `merge-guard/check-merge-eligibility.sh`'s untriaged-feedback exclusion reads `posted_reply_id` from the canonical inventory, which was always `null` — so the agent's own just-posted SKIP/review_summary reply re-blocked merge eligibility on every check, forever.
- Consequence 2 (agents-config-zcbol): on `--resume`, Phase 2 re-`mktemp`s, orphaning the prior run's `.posted` sidecar — the skip-set comes back empty and every item gets re-POSTed, spamming duplicate reply comments.
- Fix: two new flags on `post-replies.sh` (`--reply-id-sidecar`, `--posted-sidecar`), derived by the skill from the **canonical** inventory path instead of the temp. Both flags are **required** — the script exits 2 before posting anything if either is omitted, since the only production caller (`reply-and-resolve-pr-threads/SKILL.md` Phase 2) always passes both; a silent-degrade default is exactly the failure mode this PR closes. `check-merge-eligibility.sh` tolerantly unions the sidecar's recorded ids into its exclusion set (survives a crash-truncated append). `write-inventory.sh`'s existing 30-day retention sweep now also covers both sidecar suffixes — it stays the sole pruning authority; `check-merge-eligibility.sh` remains a pure reader with no filesystem mutation.

## Scope

In scope: `post-replies.sh`, `reply-and-resolve-pr-threads/SKILL.md` (Phase 2 invocation only), `check-merge-eligibility.sh`, `write-inventory.sh`, plus their test files and one new end-to-end test.

Out of scope (deliberately, not overlooked): the pre-existing `*.json` retention sweep has no filename-prefix scoping (sweeps the whole directory by mtime) — the new sidecar suffixes inherit that same breadth by design; narrowing it is a separate, unrelated concern. A broader architectural revisit (a shared PR-state contract library so `merge-guard` can reconstruct eligibility from GitHub independent of `prgroom`) is tracked separately as `agents-config-abn9.8.31` — not part of this PR.

## Ground truth for reviewers

- The bug and fix design are recorded in full (with file:line evidence) on `agents-config-tn5gc`'s `.design` field — `bd show agents-config-tn5gc --json`.
- The new `e2e-sidecar-persistence_test.sh` is the load-bearing regression test: it extracts and evals the *literal* Phase 2 code block out of `SKILL.md` itself (not a hand-typed restatement) against the real `post-replies.sh`, then drives the real `check-merge-eligibility.sh`. It was proven load-bearing by individually reverting each of the three core files to pre-fix HEAD and confirming the exact original `untriaged_feedback` blocker symptom reappears each time.

## Test Plan

- [x] `post-replies_test.sh` — 79 assertions, 0 FAIL (sidecar emit, fatal-append-on-failure for both sidecars, `--resume` no-duplicate-post, required-flag failure paths)
- [x] `check-merge-eligibility_test.sh` — 116 assertions, 0 FAIL (sidecar-only exclusion, truncated-line tolerance, cross-sha union, duplicate-rid handling)
- [x] `write-inventory_test.sh` — 29 assertions, 0 FAIL (first-ever prune coverage for `.replyids`/`.posted`, backdated-vs-recent, other-PR files)
- [x] `skill_b_frontmatter_test.sh`, `validate-inventory_test.sh` — unaffected, still green
- [x] `e2e-sidecar-persistence_test.sh` — 20 assertions, 0 FAIL
- [x] Full quality-review + simplify completion gate run on each increment; all findings fixed and re-verified (a `jq`-inside-`printf` swallow hole, test fixtures using the wrong `k` field name, a test-helper subshell isolation bug, a stale code comment overstating a crash-ordering guarantee, and a leaked mktemp file outside test cleanup)

🤖 Generated with a Claude Code multi-agent workflow (parallel TDD implementation + completion gate)

https://claude.ai/code/session_01JRy25uqUdcVe2qFNWVgjdk
