### PR TITLE
feat(pr-review): generalize poll bot filter (jdzcd) + align guard numbering (hvy47)

### DIFF
--- a/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
+++ b/src/user/.agents/skills/reply-and-resolve-pr-threads/SKILL.md
@@ -76,7 +76,7 @@ Apply the six Phase 0 precedence rules above. After mode is resolved, run schema
   || { echo "schema validation failed"; exit 1; }
 ```
 
-`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The validator enforces ten guards (all documented in §"Schema validation guards" below). `--phase 0` runs guards 1–9; `--phase 2` (the default) runs all ten. Guard 10 (replyable items have `reply_body`) is deferred to Phase 2 because `render-reply-bodies.sh` is what populates the field — Phase 0 invocations would always fail it on a raw inventory.
+`validate-inventory.sh` exits 0 if valid, non-zero with the violating item logged to stderr otherwise. On non-zero: abort with no replies posted. The validator enforces ten guards (all documented in §"Schema validation guards" below). `--phase 0` runs guards 0–8; `--phase 2` (the default) runs all ten. Guard 10 (replyable items have `reply_body`) is deferred to Phase 2 because `render-reply-bodies.sh` is what populates the field — Phase 0 invocations would always fail it on a raw inventory.
 
 ### Phase 1 — Read inventory + verify head SHA
 
@@ -317,18 +317,18 @@ PR-public text. **No internal jargon** (`bd`, bead IDs, `ESCALATE`, `inventory`,
 
 ## Schema validation guards
 
-`validate-inventory.sh` (shipped with `wait-for-pr-comments`) enforces ten guards. Skill B Phase 0 invokes the validator before Phase 1 (pre-render); Phase 2 invokes it again after `render-reply-bodies.sh` (post-render, to catch guard 10). Skill B aborts on any failure. The guards exist so Phase 2/3 can trust the inventory shape:
+`validate-inventory.sh` (shipped with `wait-for-pr-comments`) enforces ten guards, numbered to match the `# Guard N:` comments in the script. Skill B Phase 0 invokes the validator before Phase 1 (pre-render); Phase 2 invokes it again after `render-reply-bodies.sh` (post-render, to catch guard 10). The numbering skips 9 — an earlier schema-sanity guard now absorbed into guard 0. Skill B aborts on any failure. The guards exist so Phase 2/3 can trust the inventory shape:
 
-1. **Non-empty rationale** — reject if any item has `rationale == "" or null`. Rationale is user-facing for SKIP replies; an empty rationale would post an empty PR comment.
-2. **`escalation_filed` only on ESCALATE** — reject if any item has `classification != "ESCALATE"` and `escalation_filed == true`.
-3. **`review_summary` has no thread/comment IDs** — reject if any item has `kind == "review_summary"` and any of `thread_id`/`reply_to_comment_id`/`issue_comment_id` is non-null.
-4. **Non-FIX items have null `fix_outcome`** — reject if any item has `classification != "FIX"` and `fix_outcome != null`.
-5. **FIX items have a valid `fix_outcome`** — reject if any item has `classification == "FIX"` and `fix_outcome` is not one of `committed | already_addressed | failed`. (Skill A only writes the inventory after Phase 4 completes; every FIX item must have a non-null outcome.)
-6. **`committed` outcome carries SHA + summary + gate variant** — reject if any item has `fix_outcome == "committed"` and any of `fix_commit_sha`/`fix_summary`/`fix_gate_variant` is null.
-7. **`already_addressed` outcome carries SHA** — reject if any item has `fix_outcome == "already_addressed"` and `fix_commit_sha` is null.
-8. **ESCALATE must be filed** — reject if any item has `classification == "ESCALATE"` and `escalation_filed != true`. Skill A's interactive Phase 3.5 reclassifies ESCALATEs to FIX/SKIP/DEFER before write; autonomous Phase 3.5 sets `escalation_filed=true`. An unfiled ESCALATE at write time means a Skill A bug — without this guard, Skill B would silently skip the item without a reply.
-9. **Schema sanity** — reject if JSON parse fails or `schema_version != 1`.
-10. **Replyable items have `reply_body`** — reject if any replyable item (FIX, SKIP, or ESCALATE-with-`escalation_filed=true`) has a null or empty `reply_body`. This guard runs on the rendered inventory (after `render-reply-bodies.sh`) to confirm rendering succeeded. Guard 10 is NOT checked on the raw inventory at Phase 0 — `render-reply-bodies.sh` is what populates the field.
+- **Guard 0 — schema sanity** — reject if JSON parse fails or `schema_version != 1`.
+- **Guard 1 — non-empty rationale** — reject if any item has `rationale == "" or null`. Rationale is user-facing for SKIP replies; an empty rationale would post an empty PR comment.
+- **Guard 2 — `escalation_filed` only on ESCALATE** — reject if any item has `classification != "ESCALATE"` and `escalation_filed == true`.
+- **Guard 3 — `review_summary` has no thread/comment IDs** — reject if any item has `kind == "review_summary"` and any of `thread_id`/`reply_to_comment_id`/`issue_comment_id` is non-null.
+- **Guard 4 — non-FIX items have null `fix_outcome`** — reject if any item has `classification != "FIX"` and `fix_outcome != null`.
+- **Guard 5 — FIX items have a valid `fix_outcome`** — reject if any item has `classification == "FIX"` and `fix_outcome` is not one of `committed | already_addressed | failed`. (Skill A only writes the inventory after Phase 4 completes; every FIX item must have a non-null outcome.)
+- **Guard 6 — `committed` outcome carries SHA + summary + gate variant** — reject if any item has `fix_outcome == "committed"` and any of `fix_commit_sha`/`fix_summary`/`fix_gate_variant` is null.
+- **Guard 7 — `already_addressed` outcome carries SHA** — reject if any item has `fix_outcome == "already_addressed"` and `fix_commit_sha` is null.
+- **Guard 8 — ESCALATE must be filed** — reject if any item has `classification == "ESCALATE"` and `escalation_filed != true`. Skill A's interactive Phase 3.5 reclassifies ESCALATEs to FIX/SKIP/DEFER before write; autonomous Phase 3.5 sets `escalation_filed=true`. An unfiled ESCALATE at write time means a Skill A bug — without this guard, Skill B would silently skip the item without a reply.
+- **Guard 10 — replyable items have `reply_body`** — reject if any replyable item (FIX, SKIP, or ESCALATE-with-`escalation_filed=true`) has a null or empty `reply_body`. This guard runs on the rendered inventory (after `render-reply-bodies.sh`) to confirm rendering succeeded. Guard 10 is NOT checked on the raw inventory at Phase 0 — `render-reply-bodies.sh` is what populates the field.
 
 On reject: validator logs the violating item to stderr; Skill B aborts with no replies posted.
 

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -138,7 +138,10 @@ failure).
 
 Background bash — zero Anthropic tokens during the wait.
 
-1. **Quick check** whether Copilot is already a requested reviewer:
+1. **Quick check** whether Copilot is already a requested reviewer (a
+    Copilot-specific convenience glance to decide `--skip-request-check`; the
+    launched script in step 3 does the authoritative policy-allowlist matching,
+    so this substring probe need not generalize to non-Copilot bots):
     ```
     gh api repos/<owner>/<repo>/issues/<n>/events \
       --jq '[.[] | select(
@@ -150,10 +153,15 @@ Background bash — zero Anthropic tokens during the wait.
 2. **Capture** `<polling_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
     This timestamp anchors the stale-cache guard for re-review rounds.
 3. **Launch** `poll-copilot-review.sh --owner "$OWNER" --repo "$REPO" --pr "$PR"
-    --timeout-seconds <resolved_policy.bot_inactivity_timeout_seconds>` in the
-    background (the value resolved in Phase 1 step 5; default 1200 when the
-    resolver's built-in default applies). Omitting this flag silently falls
-    back to the script's own 600s default, so always pass it explicitly.
+    --timeout-seconds <resolved_policy.bot_inactivity_timeout_seconds>
+    --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"` in the
+    background (both values come from the policy resolved in Phase 1 step 5;
+    timeout defaults to 1200 when the resolver's built-in default applies).
+    Omitting `--timeout-seconds` silently falls back to the script's own 600s
+    default, so always pass it explicitly. `--bot-reviewers` aligns polling to
+    the exact bot identities the merge gate trusts, generalizing detection
+    beyond Copilot; omit it only when running the script standalone, where it
+    falls back to a Copilot-substring match.
     Pass `--skip-request-check` if step 1 returned > 0.
     In re-review context (round ≥ 2), also pass
     `--since-timestamp <polling_since_timestamp>` so the script rejects
@@ -382,10 +390,12 @@ Abort.
 
 4. **If** `copilot_work_started` detected, launch `poll-copilot-review.sh
    --owner "$OWNER" --repo "$REPO" --pr "$PR"
-   --skip-request-check --since-timestamp <rereview_since_timestamp>`
+   --skip-request-check --since-timestamp <rereview_since_timestamp>
+   --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"`
    to await the actual review. The `--since-timestamp` guard prevents the
    stale-cache bug where the script returns the prior round's review instead
-   of the new one.
+   of the new one; `--bot-reviewers` keeps re-review detection aligned to the
+   same policy allowlist used in Phase 2.
 
 5. **If** a new review arrives, return to **Phase 3 (round +1)**.
 
@@ -866,46 +876,48 @@ Returns 0 if valid, non-zero with the violating item logged to stderr.
 
 ## Schema validation guards
 
-`validate-inventory.sh` runs these ten guards. Skill B invokes it twice —
-`--phase 0` before `render-reply-bodies.sh` runs (guards 1–9), then the default
-`--phase 2` after render (all ten, adding guard 10). Corrupt inventory → hard
-abort with no replies posted:
+`validate-inventory.sh` runs these ten guards, numbered to match the
+`# Guard N:` comments in the script. Skill B invokes it twice — `--phase 0`
+before `render-reply-bodies.sh` runs (guards 0–8), then the default `--phase 2`
+after render (all ten, adding guard 10). The numbering skips 9 — an earlier
+schema-sanity guard now absorbed into guard 0. Corrupt inventory → hard abort
+with no replies posted:
 
-1. **Schema parse + version** — JSON parses and `schema_version == 1`.
-2. **Rationale non-empty** — every item has a non-empty `rationale`
-   (regardless of classification — SKIP rationale becomes the public reply,
-   so empty rationale = empty PR comment).
-3. **`escalation_filed` only on ESCALATE** — reject if any item has
-   `classification != "ESCALATE"` and `escalation_filed == true`.
-4. **`review_summary` IDs** — reject if any item has
-   `kind == "review_summary"` and either any of `thread_id` /
-   `reply_to_comment_id` / `issue_comment_id` is non-null, or `review_id`
-   is null.
-5. **Non-FIX → null `fix_outcome`** — reject if any item has
-   `classification != "FIX"` and `fix_outcome != null`.
-6. **FIX → valid `fix_outcome`** — reject if any item has
-   `classification == "FIX"` and `fix_outcome` is not one of
-   `committed | already_addressed | failed` (Phase 7 writes only after
-   Phase 4 completes — every FIX item must have a non-null outcome).
-7. **`committed` requires all fields** — reject if any item has
-   `fix_outcome == "committed"` and any of `fix_commit_sha` / `fix_summary`
-   / `fix_gate_variant` is null.
-8. **`already_addressed` requires SHA** — reject if any item has
-   `fix_outcome == "already_addressed"` and `fix_commit_sha` is null.
-9. **ESCALATE must be filed** — reject if any item has
-   `classification == "ESCALATE"` and `escalation_filed != true`.
-   Interactive Phase 3.5 reclassifies ESCALATEs to FIX/SKIP/DEFER before
-   write; autonomous Phase 3.5 sets `escalation_filed=true`. An unfiled
-   ESCALATE at write time means a Skill A bug — Skill B would otherwise
-   silently skip it without a reply.
-10. **Replyable has `reply_body`** (`--phase 2` only) — reject if any FIX,
-   SKIP, or filed-ESCALATE item has a null/empty `reply_body`. This guard runs
-   only after `render-reply-bodies.sh` (Skill B's helper, in
-   `reply-and-resolve-pr-threads/`) populates the field, so `--phase 0`
-   (pre-render, on the raw inventory) skips it. **Skill A never populates
-   `reply_body` — rendering is Skill B's job.** If the render helper looks
-   "missing" from `wait-for-pr-comments/`, it isn't broken; it lives in Skill
-   B's directory. Stop and check the boundary before working around it.
+- **Guard 0 — schema parse + version** — JSON parses and `schema_version == 1`.
+- **Guard 1 — rationale non-empty** — every item has a non-empty `rationale`
+  (regardless of classification — SKIP rationale becomes the public reply,
+  so empty rationale = empty PR comment).
+- **Guard 2 — `escalation_filed` only on ESCALATE** — reject if any item has
+  `classification != "ESCALATE"` and `escalation_filed == true`.
+- **Guard 3 — `review_summary` IDs** — reject if any item has
+  `kind == "review_summary"` and either any of `thread_id` /
+  `reply_to_comment_id` / `issue_comment_id` is non-null, or `review_id`
+  is null.
+- **Guard 4 — non-FIX → null `fix_outcome`** — reject if any item has
+  `classification != "FIX"` and `fix_outcome != null`.
+- **Guard 5 — FIX → valid `fix_outcome`** — reject if any item has
+  `classification == "FIX"` and `fix_outcome` is not one of
+  `committed | already_addressed | failed` (Phase 7 writes only after
+  Phase 4 completes — every FIX item must have a non-null outcome).
+- **Guard 6 — `committed` requires all fields** — reject if any item has
+  `fix_outcome == "committed"` and any of `fix_commit_sha` / `fix_summary`
+  / `fix_gate_variant` is null.
+- **Guard 7 — `already_addressed` requires SHA** — reject if any item has
+  `fix_outcome == "already_addressed"` and `fix_commit_sha` is null.
+- **Guard 8 — ESCALATE must be filed** — reject if any item has
+  `classification == "ESCALATE"` and `escalation_filed != true`.
+  Interactive Phase 3.5 reclassifies ESCALATEs to FIX/SKIP/DEFER before
+  write; autonomous Phase 3.5 sets `escalation_filed=true`. An unfiled
+  ESCALATE at write time means a Skill A bug — Skill B would otherwise
+  silently skip it without a reply.
+- **Guard 10 — replyable has `reply_body`** (`--phase 2` only) — reject if any
+  FIX, SKIP, or filed-ESCALATE item has a null/empty `reply_body`. This guard
+  runs only after `render-reply-bodies.sh` (Skill B's helper, in
+  `reply-and-resolve-pr-threads/`) populates the field, so `--phase 0`
+  (pre-render, on the raw inventory) skips it. **Skill A never populates
+  `reply_body` — rendering is Skill B's job.** If the render helper looks
+  "missing" from `wait-for-pr-comments/`, it isn't broken; it lives in Skill
+  B's directory. Stop and check the boundary before working around it.
 
 On reject: log violating item to stderr; abort with no replies posted.
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -3,12 +3,21 @@
 # Replaces the background agent polling in wait-for-pr-comments skill.
 # Zero Anthropic API tokens consumed — pure bash + gh CLI.
 #
-# Usage: poll-copilot-review.sh --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>] [--timeout-seconds <n>]
+# Usage: poll-copilot-review.sh --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>] [--timeout-seconds <n>] [--bot-reviewers <json-array>]
 #
 # --timeout-seconds sets the give-up window for sub-phase C (the main
 # review-wait poll). Default 600 (~10 minutes, this script's historical
 # behavior). Callers should pass the resolved review policy's
 # bot_inactivity_timeout_seconds (see merge-guard/resolve_policy.py).
+#
+# --bot-reviewers is a JSON array of the exact reviewer identities to poll for
+# (e.g. '["Copilot", "copilot-pull-request-reviewer[bot]"]'). When supplied,
+# review/comment matching is an EXACT (case-insensitive) login match against
+# that list instead of the default Copilot substring — generalizing the poll to
+# any bot the merge policy trusts. Callers should pass the resolved review
+# policy's bot_reviewers list (see merge-guard/resolve_policy.py); the same
+# exact-identity allowlist the merge gate enforces. Omit it to keep the
+# standalone Copilot-substring default.
 #
 # Exit codes:
 #   0 — Review found (JSON on stdout)
@@ -32,7 +41,7 @@ source "$(dirname "$0")/lib.sh"
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
 usage() {
-    echo "Usage: $0 --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>] [--timeout-seconds <n>]" >&2
+    echo "Usage: $0 --owner <o> --repo <r> --pr <n> [--skip-request-check] [--since-timestamp <ISO-8601>] [--timeout-seconds <n>] [--bot-reviewers <json-array>]" >&2
     exit 3
 }
 
@@ -42,6 +51,7 @@ PR=""
 SKIP_REQUEST=false
 SINCE=""
 TIMEOUT_SECONDS=""
+BOT_REVIEWERS=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -60,6 +70,11 @@ while [[ $# -gt 0 ]]; do
         --timeout-seconds)
             [[ -n "${2:-}" ]] || { echo "Error: --timeout-seconds requires a value" >&2; exit 3; }
             TIMEOUT_SECONDS="$2"
+            shift 2
+            ;;
+        --bot-reviewers)
+            [[ -n "${2:-}" ]] || { echo "Error: --bot-reviewers requires a value" >&2; exit 3; }
+            BOT_REVIEWERS="$2"
             shift 2
             ;;
         *)
@@ -84,12 +99,34 @@ TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
     exit 3
 }
 
+# Validate --bot-reviewers (when provided) as a non-empty JSON array of strings,
+# then canonicalize via jq so only clean, re-serialized JSON is interpolated
+# into the jq filters below (no raw user string reaches a jq program).
+if [[ -n "$BOT_REVIEWERS" ]]; then
+    BOT_REVIEWERS=$(jq -ce 'if (type == "array" and length > 0 and all(.[]; type == "string")) then . else error("bad") end' <<<"$BOT_REVIEWERS" 2>/dev/null) || {
+        echo "Error: --bot-reviewers must be a non-empty JSON array of strings" >&2
+        exit 3
+    }
+fi
+
 # ── Constants ─────────────────────────────────────────────────────────────────
 
-# Copilot identity varies by endpoint — case-insensitive match covers both
-# Events API: login "Copilot" (type "Bot")
-# Reviews/Comments API: login "copilot-pull-request-reviewer[bot]" (type "Bot")
-COPILOT_LOGIN_FILTER='test("copilot"; "i")'
+# Login-matching filter, applied via `<login> | ${COPILOT_LOGIN_FILTER}`.
+#
+# Default (no --bot-reviewers): Copilot identity varies by endpoint, so a
+# case-insensitive substring match covers both —
+#   Events API:           login "Copilot"                            (type "Bot")
+#   Reviews/Comments API: login "copilot-pull-request-reviewer[bot]" (type "Bot")
+#
+# With --bot-reviewers: match logins EXACTLY (case-insensitively) against the
+# policy's allowlist instead, generalizing the poll to any trusted bot. The
+# array is pre-validated + jq-canonicalized above, so embedding it in the jq
+# program is safe.
+if [[ -n "$BOT_REVIEWERS" ]]; then
+    COPILOT_LOGIN_FILTER="ascii_downcase as \$l | (${BOT_REVIEWERS} | map(ascii_downcase) | index(\$l)) != null"
+else
+    COPILOT_LOGIN_FILTER='test("copilot"; "i")'
+fi
 COPILOT_REVIEW_FILTER="(.user.type == \"Bot\") and (.user.login | ${COPILOT_LOGIN_FILTER})"
 
 # ── Helper functions ──────────────────────────────────────────────────────────

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -101,9 +101,11 @@ TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
 
 # Validate --bot-reviewers (when provided) as a non-empty JSON array of strings,
 # then canonicalize via jq so only clean, re-serialized JSON is interpolated
-# into the jq filters below (no raw user string reaches a jq program).
+# into the jq filters below (no raw user string reaches a jq program). The
+# non-string check is select-based (not all/2) to match the guard idiom in
+# validate-inventory.sh and stay unambiguously jq-1.5-safe.
 if [[ -n "$BOT_REVIEWERS" ]]; then
-    BOT_REVIEWERS=$(jq -ce 'if (type == "array" and length > 0 and all(.[]; type == "string")) then . else error("bad") end' <<<"$BOT_REVIEWERS" 2>/dev/null) || {
+    BOT_REVIEWERS=$(jq -ce 'if (type == "array" and length > 0 and ([.[] | select(type != "string")] | length) == 0) then . else error("bad") end' <<<"$BOT_REVIEWERS" 2>/dev/null) || {
         echo "Error: --bot-reviewers must be a non-empty JSON array of strings" >&2
         exit 3
     }

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -122,4 +122,37 @@ assert "tiny --timeout-seconds exits 1 (timeout)" "[ \$rc_tiny_timeout -eq 1 ]"
 assert "tiny --timeout-seconds reports copilot_review_timeout" "printf '%s' '$out' | grep -q copilot_review_timeout"
 assert "tiny --timeout-seconds does not wait for the default ~10-minute window" "[ \$elapsed -lt 15 ]"
 
+# ── --bot-reviewers (generalizes the poll to non-Copilot policy bots) ────────
+
+assert "accepts --bot-reviewers flag" "grep -q -- '--bot-reviewers' '$SCRIPT'"
+
+# Malformed values must be rejected up front (exit 3), not silently ignored.
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers 'not-json' 2>/dev/null
+rc_bad_bots=$?
+assert "exits 3 for non-array --bot-reviewers" "[ \$rc_bad_bots -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '[]' 2>/dev/null
+rc_empty_bots=$?
+assert "exits 3 for empty --bot-reviewers array" "[ \$rc_empty_bots -eq 3 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["ok", 3]' 2>/dev/null
+rc_mixed_bots=$?
+assert "exits 3 for --bot-reviewers array with a non-string" "[ \$rc_mixed_bots -eq 3 ]"
+
+# A non-Copilot bot review is found ONLY when its identity is in --bot-reviewers,
+# proving the poll matches by policy allowlist, not the hardcoded Copilot substring.
+FIXTURE_REVIEWS_OTHERBOT='[{"user":{"login":"My-Bot[bot]","type":"Bot"},"state":"COMMENTED","submitted_at":"2026-01-01T00:00:00Z"}]'
+
+out_bot=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 5 --bot-reviewers '["my-bot[bot]"]' 2>/dev/null)
+rc_bot=$?
+assert "non-Copilot bot in --bot-reviewers yields a found review (exit 0)" "[ \$rc_bot -eq 0 ]"
+assert "matched review reports copilot_review_found" "printf '%s' \"\$out_bot\" | grep -q copilot_review_found"
+
+# Control: the same bot is invisible to the default Copilot filter → timeout.
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 >/dev/null 2>&1
+rc_default=$?
+assert "default Copilot filter does NOT match the non-Copilot bot (timeout, exit 1)" "[ \$rc_default -eq 1 ]"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory.sh
@@ -11,7 +11,7 @@
 #
 # --phase controls which guards run:
 #   --phase 2 (default) — runs all ten guards (the full post-render contract)
-#   --phase 0           — runs guards 1–9 only, skipping guard 10
+#   --phase 0           — runs guards 0–8 only, skipping guard 10
 #                         (replyable-has-reply_body). Phase 0 is invoked on
 #                         the RAW inventory before `render-reply-bodies.sh`
 #                         populates `reply_body`, so guard 10 cannot yet

--- a/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/validate-inventory_test.sh
@@ -2,7 +2,7 @@
 # Smoke test for validate-inventory.sh
 #
 # Verifies the --phase flag honors the pipeline contract:
-#   --phase 0 runs guards 1-9 only (raw inventory; reply_body not yet populated)
+#   --phase 0 runs guards 0-8 only (raw inventory; reply_body not yet populated)
 #   --phase 2 (default) runs all ten guards
 
 set -u
@@ -50,7 +50,7 @@ rc_missing=$?
 assert "missing file exits 66" "[ \$rc_missing -eq 66 ]"
 
 # --- Raw inventory: a FIX-committed item lacks reply_body (typical Phase 0 input) ---
-# Guard 10 would reject this; guards 1-9 should pass.
+# Guard 10 would reject this; guards 0-8 should pass.
 RAW="$TMP/raw.json"
 cat >"$RAW" <<'JSON'
 {


### PR DESCRIPTION
## Summary

Two P3 cleanups to the PR-review skill set, bundled on one branch (beads `hvy47` + `jdzcd`).

- **jdzcd — `poll-copilot-review.sh` gains an optional `--bot-reviewers <json-array>` flag.** When passed, review/comment matching becomes an **exact, case-insensitive** login match against the policy's `bot_reviewers` identities; when omitted, the prior Copilot-substring default is preserved byte-for-byte (backward compatible, standalone-runnable). This generalizes polling to any bot the merge policy trusts, aligning detection with the exact-identity allowlist the merge gate already enforces. Both `wait-for-pr-comments` launch sites now pass the resolved list.
- **hvy47 — guard-numbering alignment.** The narrative "Schema validation guards" lists in both skill docs were off-by-one vs the authoritative `validate-inventory.sh`. Realigned to the script's 0-indexed `# Guard N` comments (schema = Guard 0; the absorbed guard 9 is explicitly noted as skipped), and converted to explicit `**Guard N**` bullets so markdown ordinals can't silently drift again. "guards 1–9" → "guards 0–8" fixed in the script header and test comments too.

## Scope

**In scope (6 files):**
- `poll-copilot-review.sh` — new flag + input validation + jq-canonicalization; `poll-copilot-review_test.sh` — +7 tests.
- `wait-for-pr-comments/SKILL.md` — guard list renumber (hvy47) + two launch-site edits & a quick-check parenthetical (jdzcd).
- `reply-and-resolve-pr-threads/SKILL.md` — guard list renumber + phase-range wording (hvy47).
- `validate-inventory.sh` / `validate-inventory_test.sh` — header/comment phase-range wording (hvy47, comments only — no behavior change).

**Deliberately out of scope:**
- `docs/plans/*` and `docs/specs/*` guard references — dated, point-in-time artifacts left as historical record (one plan line literally documents the hvy47 deferral). Rewriting them would violate the "state the decision, not its history" convention.
- Guard 3 *summary wording* imprecision vs the script's `review_id` numeric-type check — **pre-existing** (not introduced here), filed as follow-up bead `agents-config-zi9c7`.

## Ground truth to check claims against

- `validate-inventory.sh` per-guard comments (`# Guard 0` … `# Guard 8`, `# Guard 9 (renumbered)`, `# Guard 10`) are the authoritative numbering the docs now mirror.
- The exact-match jq filter is `.user.login | ascii_downcase as $l | (ARRAY | map(ascii_downcase) | index($l)) != null`. It intentionally uses `index()` (not `IN()`) to honor the repo's documented jq-1.5 constraint.
- `--bot-reviewers` input is validated as a non-empty JSON string-array and re-serialized via `jq -ce` before interpolation into the jq program — no raw caller string reaches jq (injection guard).

## Test Plan

- [x] `poll-copilot-review_test.sh` — 29/29 (incl. 7 new: arg validation + a discriminating positive/control pair proving a non-Copilot bot matches *only* via the flag).
- [x] `validate-inventory_test.sh` — 20/20.
- [x] Full suites in both skill dirs — 21/21 green.
- [x] `bash -n` clean on all changed scripts; guard-number sweep shows zero stray "1–9" ranges in `src/`.
- [x] Quality review (adversarial): no BLOCKING/CRITICAL/MAJOR findings; jq behavior, injection safety, jq-1.5 compat, and exact backward compatibility empirically confirmed.

## Merge

Do **not** auto-merge — repo policy is `explicit` (needs a human "merge it").
