### PR TITLE
fix(merge-guard): fail open on GitHub-Pro-paywall 403 for branch protection

### DIFF
--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -221,6 +221,14 @@ if prot=$(gh api "repos/${OWNER}/${REPO}/branches/${BASE_REF_ENC}/protection/req
 else
     if grep -qiE 'HTTP 404|Not Found|Branch not protected' "$prot_stderr"; then
         prot=""   # no protection → empty required set
+    elif grep -qi 'upgrade to github pro or make this repository public' "$prot_stderr" \
+         && grep -qi '(HTTP 403)' "$prot_stderr"; then
+        # Private repo without GitHub Pro/Team: GitHub blocks reading branch-
+        # protection config with this exact 403 instead of 404ing. Narrow
+        # text+status match only — a differently-worded 403 (missing token
+        # scope, app permission, etc.) is a real authNZ failure and must
+        # still fail closed below, not be swallowed by this branch.
+        prot=""
     else
         echo "Error: failed to fetch branch protection: $(cat "$prot_stderr")" >&2
         rm -f "$prot_stderr"; exit 3

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -71,6 +71,12 @@ if [ "$1" = "api" ]; then
         if [ -n "${FIXTURE_BASE_REF_ENCODED:-}" ] && [[ "$path" != *"branches/${FIXTURE_BASE_REF_ENCODED}/protection"* ]]; then
           echo "gh: Not Found (HTTP 404)" >&2; exit 1
         fi
+        if [ "${FIXTURE_PROTECTION_PRO_PAYWALL:-0}" = 1 ]; then
+          echo "gh: Upgrade to GitHub Pro or make this repository public to enable this feature. (HTTP 403)" >&2; exit 1
+        fi
+        if [ "${FIXTURE_PROTECTION_FAIL:-0}" = 1 ]; then
+          echo "gh: Resource not accessible by integration (HTTP 403)" >&2; exit 1
+        fi
         if [ "${FIXTURE_PROTECTION_404:-1}" = 1 ]; then
           echo "gh: Not Found (HTTP 404)" >&2; exit 1
         fi
@@ -335,6 +341,21 @@ run_failed()    { jq -n '{check_runs:[{name:"ci/build",status:"completed",conclu
 # no branch protection (stub default 404) → vacuously green
 out=$(run_script "$BASE_POLICY"); rc=$?
 assert "no protection → ci_state none, eligible" "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.ci_state' <<<\"\$out\")\" = none ]"
+
+# GitHub's plan-paywall 403 for private repos without GitHub Pro/Team blocks
+# reading branch-protection config outright (never 404s). Narrow text+status
+# match only — vacuously green here reflects a verified ground truth (this
+# script's real target repo has no branch protection configured), not a guess.
+out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_PRO_PAYWALL=1); rc=$?
+assert "GitHub-Pro-paywall 403 on branch protection → vacuously green, eligible" \
+  "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.ci_state' <<<\"\$out\")\" = none ]"
+
+# a differently-worded 403 (missing token scope, app permission, etc.) must
+# NOT be swallowed by the narrow paywall match — a real authNZ failure still
+# fails closed exactly as before.
+out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_FAIL=1); rc=$?
+assert "non-paywall 403 on branch protection still fails closed (exit 3)" "[ \$rc -eq 3 ]"
+assert "non-paywall 403 prints no verdict" "[ -z \"\$out\" ]"
 
 # required + success from the pinned app → green
 out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=0 FIXTURE_REQUIRED_CHECKS="$REQ_ONE" FIXTURE_CHECK_RUNS="$(run_ok)"); rc=$?


### PR DESCRIPTION
## Summary

Since this repo went private, `check-merge-eligibility.sh` has been hard-failing (exit 3) on every single PR, because GitHub's branch-protection `required_status_checks` endpoint returns `HTTP 403 "Upgrade to GitHub Pro or make this repository public to enable this feature."` on a private repo without GitHub Pro/Team, instead of the 404 the script's error handling already tolerated.

Reproduced live against `scotthamilton77/agents-config` PR #217 and confirmed via the GitHub UI (Settings → Branches) that this repo genuinely has no classic branch protection configured — so treating this specific 403 as "no required checks" (vacuously green) reflects real ground truth, not a guessed fallback. It's also structurally guaranteed: GitHub's Pro/Team paywall blocks *configuring* branch protection on a private repo just as it blocks *reading* it, so a private repo hitting this exact message can never have branch-protection-based required checks in the first place.

## What changed

- Added a narrow `elif` branch in the branch-protection error handling: only fails open (empty required-checks set) when stderr matches **both** the exact paywall phrase *and* `(HTTP 403)`. Any other 403/error shape (missing token scope, app permission denial, a real outage) still falls through to the original hard-fail branch (`exit 3`) — a genuine authNZ failure is never masked.
- Two new pinned tests: one for the paywall-message case (must now return eligible/vacuously-green instead of crashing), one for a differently-worded 403 (`"Resource not accessible by integration"`) that must still fail closed — the regression guard against widening the fail-open net.

Reviewed by `quality-reviewer`: no CRITICAL/HIGH findings. One cheap suggestion (case-consistency on the second `grep`) applied; two others (a theoretical multi-line stderr edge case, and an optional audit-log breadcrumb) were left out as non-issues / out of scope for this fix.

## Test plan

- [x] `check-merge-eligibility_test.sh`: 134/134 assertions pass, including the 2 new cases
- [x] Live repro against `scotthamilton77/agents-config` PR #217 (real private repo): script now returns a proper eligibility verdict (`status: blocked`, `ci_state: none`, real unrelated blockers) instead of crashing with exit 3
- [x] Confirmed via GitHub UI that this repo has no branch-protection config to lose visibility into

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcPY1gdMxdc9MH1F4MF92P