### PR TITLE
feat(skills): fablize — frontier-window specfest workflow skill (abn9.41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ It's simple: this project hosts "agent configuration" (and tools, helpers, etc.)
 - **Always edit source, never deployed artifacts** — when the user asks to change a skill, agent, command, rule, or any other configuration artifact, edit the source file under `src/` (e.g., `src/user/.agents/skills/`, `src/user/.claude/rules/`). Files under `~/.claude/`, `~/.codex/`, `~/.gemini/`, etc. are deploy outputs and will be overwritten on the next installer run. If you catch yourself editing a path outside `src/`, stop and find the source equivalent.
 - **No file-path citations in specs or prose** — Remember that the files that get written into the user space get used in OTHER projects.  Thus our assets CANNOT reference project-internal resources.  `INSTRUCTIONS.md.template` and all shared templates are flattened into per-tool assembled files at install time via `DYNAMIC-INCLUDE`. File-path citations (`INSTRUCTIONS.md > <section>`) are dead-ends after assembly. Always reference shared content by concept or block name (e.g., "the canonical decision matrix", "the `<decision-matrix>` block") so cross-references survive flattening.
 - **NEVER run `scripts/install.sh` or `scripts/install.py` automatically** — only the user runs the installer, and only when they explicitly say so
+- **Placement by capability-dependency, not asset type** — a new skill/agent/rule goes in the shared tree `src/user/.agents/` only if it works on every supported tool; anything that depends on tool-specific capabilities (e.g. Claude subagent orchestration, the Skill tool, AskUserQuestion, hooks) goes in that tool's tree (e.g. `src/user/.claude/skills/`)
 
 ## Repository Structure (current, not target state)
 
@@ -60,6 +61,7 @@ It's simple: this project hosts "agent configuration" (and tools, helpers, etc.)
   - `USER-PERSONA.md.template` - User persona template
 - `src/user/.claude/` - **Claude-specific** content (copies to `~/.claude/`)
   - `commands/` - Slash command definitions (`.md`)
+  - `skills/` - Claude-only skills (skills that depend on Claude-specific capabilities); cross-tool skills are sourced from `src/user/.agents/skills/`
   - `rules/` - Claude-specific rules (rules that only apply to Claude contexts); general rules are sourced from `src/user/.agents/rules/`
   - `AGENTS.md.template` - Claude instruction file (refs shared + Claude extensions)
   - `CLAUDE.md.template` - Points to AGENTS.md

--- a/src/user/.claude/skills/fablize/SKILL.md
+++ b/src/user/.claude/skills/fablize/SKILL.md
@@ -12,18 +12,19 @@ a limited window — before it becomes unavailable or cost-prohibitive — spend
 that window closing spec gaps on backlog work, not implementing it. The
 output is design specs and implementation-ready backlog items that a cheaper
 or lesser model can execute correctly later. The name is a legacy of one such
-window; the mechanic is model-agnostic — run this whenever the strongest
-available frontier model is at the helm, regardless of what it's called.
+window; the mechanic is model-agnostic.
 
 Fablize does not implement anything. It turns "I have frontier capacity for
 N days" into a prioritized, batched, human-approved spec-writing pipeline.
+
+Mind the token budget throughout — the whole premise is a scarce, expensive
+resource; a phase that burns it on process rather than spec quality has
+defeated the point.
 
 ## When to Use
 
 - A temporary capability or budget window is closing and thin-spec backlog
   sits behind it.
-- The user asks to "fablize," run a "specfest," "spec out beads," "close spec
-  gaps," or "get X ready for a cheaper model."
 - The user wants a batch of backlog items made implementation-ready without
   doing the implementation now.
 
@@ -89,9 +90,6 @@ N days" into a prioritized, batched, human-approved spec-writing pipeline.
    already ships everything else — through its normal completion-gate,
    worktree, and PR discipline; fablize doesn't restate that machinery, only
    feeds it.
-10. **Mind the token budget throughout** — the whole premise is a scarce,
-    expensive resource; a phase that burns it on process rather than spec
-    quality has defeated the point.
 
 ## Red Flags
 

--- a/src/user/.claude/skills/fablize/SKILL.md
+++ b/src/user/.claude/skills/fablize/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: fablize
+description: Use when a frontier-tier model is available for a limited window and the goal is to close spec gaps on backlog work before that window closes or the model becomes cost-prohibitive. Triggers on "fablize", "specfest", "spec out the backlog", "spec out beads", "close spec gaps before the model window closes", "get the backlog ready for a cheaper model", "make these tickets implementable by a lesser model", or any request to batch-produce design specs from thin backlog items while premium model capacity is available. Does not implement anything.
+---
+
+# fablize
+
+## Overview
+
+A "specfest": when the strongest available frontier model is at the helm for
+a limited window — before it becomes unavailable or cost-prohibitive — spend
+that window closing spec gaps on backlog work, not implementing it. The
+output is design specs and implementation-ready backlog items that a cheaper
+or lesser model can execute correctly later. The name is a legacy of one such
+window; the mechanic is model-agnostic — run this whenever the strongest
+available frontier model is at the helm, regardless of what it's called.
+
+Fablize does not implement anything. It turns "I have frontier capacity for
+N days" into a prioritized, batched, human-approved spec-writing pipeline.
+
+## When to Use
+
+- A temporary capability or budget window is closing and thin-spec backlog
+  sits behind it.
+- The user asks to "fablize," run a "specfest," "spec out beads," "close spec
+  gaps," or "get X ready for a cheaper model."
+- The user wants a batch of backlog items made implementation-ready without
+  doing the implementation now.
+
+## Phase 1 — Survey (autonomous, no approval needed)
+
+1. **Learn what's already spec'd.** Check recent merged history for spec
+   work, and read the project's dated-specs directory (`docs/specs/` by
+   convention — detect the actual location, or ask, if this project differs)
+   to learn the local spec-output pattern. Skip anything already carrying a
+   merged spec — those items are usually already in progress.
+2. **Collect the backlog.** Invoke the whats-next skill in `all` mode with no
+   truncation, and pull the full open/deferred backlog from the work tracker.
+3. **Measure spec coverage.** For each plausible candidate, pull its full
+   record and gauge how much description, design rationale, and acceptance
+   criteria it already carries. Classify each as **already-spec'd**
+   (externalized spec doc, implementation-ready label, rich acceptance
+   criteria) or **thin** (one-line description, no design, no AC). Check
+   upstream dependency edges too — don't propose spec'ing something a blocked
+   dependency makes structurally moot.
+
+## Phase 2 — Select and present (ends in a hard STOP)
+
+4. **Select a small batch.** Default 4–6 items; never propose more without
+   the human explicitly asking for a bigger batch. Rank candidates by, in
+   order:
+   - (a) benefits most from a frontier pass — thin spec × high
+     judgment-density (ambiguous scope, architectural trade-offs,
+     cross-cutting design);
+   - (b) container/priority standing in the roadmap;
+   - (c) conceptual cohesion — one domain per batch, so the human reviewing
+     spec output isn't context-switching between unrelated subsystems.
+5. **Present the batch for approval.** Show: a table of the selected items
+   (priority, roadmap position, evidence of the spec gap, title); the
+   rejected alternative clusters with a one-line reason each; and these four
+   questions:
+
+   | # | Question |
+   |---|---|
+   | Q1 | Batch composition — confirm the set, or adjust it |
+   | Q2 | Spec grouping — one dated spec per item, or grouped specs covering related items |
+   | Q3 | End-state per item — spec merged + description/AC updated + a readiness label stamped, or leave labeling to a separate readiness gate |
+   | Q4 | Involvement split — which items need interactive brainstorming with the human, and which can be spec'd autonomously |
+
+6. **STOP.** Wait for the human's answers. Do not dispatch anything —
+   interactive or autonomous — before this approval lands.
+
+## Phase 3 — Execute (after approval)
+
+7. **Interactive items** — brainstorm with the human one question at a time,
+   each preceded by enough context that they can answer confidently without
+   re-deriving it themselves.
+8. **Autonomous items** — dispatch right-sized workers. Every dispatch names
+   a model and an effort level explicitly: mechanical survey/extraction work
+   goes to a cheap model at low effort, spec synthesis to a mid-tier model,
+   judgment-dense synthesis (architecture, trade-off resolution) stays with
+   the frontier model. If a frontier-tier worker itself needs to fan out
+   further, that's nested dispatch — follow the orchestrating-subagents
+   skill rather than letting the worker spawn a child it can't await.
+9. **Deliver.** Per item (or per approved group): a dated design spec in the
+   project's specs directory, following the local pattern; the item's
+   description/acceptance criteria updated to point at the spec; a readiness
+   label applied per the Q3 answer. Ship specs the same way the environment
+   already ships everything else — through its normal completion-gate,
+   worktree, and PR discipline; fablize doesn't restate that machinery, only
+   feeds it.
+10. **Mind the token budget throughout** — the whole premise is a scarce,
+    expensive resource; a phase that burns it on process rather than spec
+    quality has defeated the point.
+
+## Red Flags
+
+| Rationalization | Reality |
+|---|---|
+| "The batch could be a bit bigger" | No — human review time is the bottleneck, not model capacity. Default stays 4–6. |
+| "This item's spec looks good enough" | Measure description/design/AC content per item; don't eyeball it. |
+| "I'll skip the STOP and start spec'ing — the batch is obviously right" | Never. Phase 2 always ends in a stop; approval is not optional. |
+| "One strong model can just implement this directly, why spec it" | That defeats the window argument: spec now while frontier capacity is available, implement later on whatever's cheap then. |
+| "Mixed-domain batch is fine, they're all just backlog items" | Domain-mixing is the context-switch tax fablize exists to avoid; keep one domain per batch. |
+
+## NOT For
+
+- Implementing the work itself — fablize only produces specs and
+  implementation-ready backlog items.
+- Backlog items that already carry an adequate spec — those don't need a
+  frontier pass.
+- Substituting for the project's own readiness or verification gates —
+  fablize feeds those gates, it doesn't replace them.
+- Merging pull requests — spec output ships as a PR like anything else;
+  fablize doesn't touch merge authority.

--- a/src/user/.claude/skills/fablize/SKILL.md
+++ b/src/user/.claude/skills/fablize/SKILL.md
@@ -35,8 +35,10 @@ defeated the point.
    convention — detect the actual location, or ask, if this project differs)
    to learn the local spec-output pattern. Skip anything already carrying a
    merged spec — those items are usually already in progress.
-2. **Collect the backlog.** Invoke the whats-next skill in `all` mode with no
-   truncation, and pull the full open/deferred backlog from the work tracker.
+2. **Collect the backlog.** Invoke the whats-next skill in `all` mode with its
+   "show everything" signal — the affordance it documents as `--limit 0` for the
+   complete, untruncated list — so candidates aren't selected from a truncated
+   backlog, and pull the full open/deferred backlog from the work tracker.
 3. **Measure spec coverage.** For each plausible candidate, pull its full
    record and gauge how much description, design rationale, and acceptance
    criteria it already carries. Classify each as **already-spec'd**

--- a/src/user/.claude/skills/fablize/evals/trigger-eval.json
+++ b/src/user/.claude/skills/fablize/evals/trigger-eval.json
@@ -1,0 +1,20 @@
+[
+  {"query": "fablize the backlog before our frontier session runs out today", "should_trigger": true},
+  {"query": "we've got frontier model access for like 3 more days, let's use it to spec out the thin backlog items so a cheaper model can pick them up later", "should_trigger": true},
+  {"query": "can you run a specfest on the worker-fleet epic, I want specs ready before we lose the premium budget", "should_trigger": true},
+  {"query": "close the spec gaps on these tickets while we still have premium model time this week", "should_trigger": true},
+  {"query": "get the issues in the auth area ready for a lesser model to implement -- need proper design specs first, not code", "should_trigger": true},
+  {"query": "spec out a batch of beads, we have frontier capacity right now and I don't want to waste it implementing when a cheap model could do that later", "should_trigger": true},
+  {"query": "prep the backlog for whoever's running sonnet next week -- pick some good candidates and write specs for them", "should_trigger": true},
+  {"query": "do a specfest pass, pick like 5 items that need the most design thinking and spec those out", "should_trigger": true},
+  {"query": "our frontier window closes tonight, spec out whatever's thin so it's shovel-ready for a cheaper model tomorrow", "should_trigger": true},
+  {"query": "implement bead 42, it already has a full design spec attached", "should_trigger": false},
+  {"query": "can you write a design spec for this one feature I'm describing to you right now", "should_trigger": false},
+  {"query": "what's next on the backlog, what's ready to work on", "should_trigger": false},
+  {"query": "review this PR for code quality and correctness issues before I merge it", "should_trigger": false},
+  {"query": "can you merge this PR now that the specs on it are approved", "should_trigger": false},
+  {"query": "the model seems really slow today, is there an outage or something", "should_trigger": false},
+  {"query": "brainstorm this one idea with me from scratch, I don't have a ticket for it yet", "should_trigger": false},
+  {"query": "run a security review on the auth changes before we ship", "should_trigger": false},
+  {"query": "we need to update the AGENTS.md conventions doc for the new install labels", "should_trigger": false}
+]


### PR DESCRIPTION
## Summary

- Adds the **fablize** skill (`src/user/.claude/skills/fablize/SKILL.md`) — a "specfest" workflow: when a frontier-tier model is available for a limited window, spend that window closing spec gaps on thin backlog beads so cheaper models can implement them later. Three phases: autonomous survey → batch selection with a hard human-approval STOP (four standard questions) → execution via interactive brainstorming + right-sized subagent dispatch.
- Adds a **placement-by-capability rule** to the root `AGENTS.md`: shared `src/user/.agents/` only for cross-tool assets; capability-dependent assets (Claude subagent orchestration, Skill tool, etc.) go in the owning tool's tree. Also documents the existing `src/user/.claude/skills/` directory in the Repository Structure listing (it existed on disk and in the installer routing table but not in the doc).
- Bundles `evals/trigger-eval.json` — an 18-query trigger-eval fixture (9 should-trigger / 9 should-not) authored per the writing-skills methodology, **not yet executed** (deliberate; see gaps).

## Scope

- **In scope**: `src/user/.claude/skills/fablize/SKILL.md` (new, 114 lines), `src/user/.claude/skills/fablize/evals/trigger-eval.json` (new fixture), `AGENTS.md` (+2 lines).
- **Out of scope**: no installer changes needed (`claude.py` already routes the `skills` namespace); no changes to sibling skills; no execution of the eval fixture.

## Artifact nature (for reviewers)

This is a **process/discipline skill** — prose instructions, no executable code. It is Claude-only by design (it orchestrates Claude subagents and skill invocation), hence its placement in `src/user/.claude/skills/` rather than the shared tree — precedent: `orchestrating-subagents` in the same tree.

Ground truth to check claims against:
- `src/user/.claude/AGENTS.md` — install model for the Claude-only tree (name-uniqueness across merged tree).
- `src/user/.agents/skills/whats-next/SKILL.md` — structural sibling whose conventions (Red Flags table, NOT For section) this skill follows; fablize references whats-next by name, which is valid because skills co-deploy.
- `packages/installer/src/installer/tools/claude.py` line ~30 — `skills` is a routed namespace.

## Intentional gaps (do not flag as missing)

- The trigger-eval fixture is authored but **not run** — executing it requires ~54 subagent dispatches and the known headless skill-trigger eval blind spot makes its recall signal suspect; deferred and recorded on the tracking bead.
- No worked example or flowchart in the skill — deliberate for a linear, table-driven process skill, consistent with the sibling.
- The skill body deliberately contains **no work-tracker IDs and no repo-internal paths** (it deploys to other projects); `docs/specs/` appears only as a named convention with detect-or-ask fallback. Verified clean by grep.

## Test plan

- [x] HEAVY quality-gate (13-agent multi-lens fleet): acceptance, clean at major-severity floor; 3 minor prose findings applied and committed
- [x] Portability grep (tracker IDs, milestone codenames, repo-internal paths): zero matches
- [x] Frontmatter: name matches folder; description 547/1024 chars
- [x] `evals/trigger-eval.json` parses as valid JSON
- [x] Name-collision scan across `src/user/.agents/skills`, `src/user/.claude/skills`, `src/plugins/*`: exactly one `fablize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hYEFr76fMSTyRunVxSsdv
