### PR TITLE
feat(docs): specfest wave 2 — post-Fable economics specs (abn9.40.1, 25rmt, abn9.40.3, qptb4, g42cj)

### DIFF
--- a/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
+++ b/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
@@ -59,13 +59,26 @@ They are facts, not assumptions.
 Change `_invocation_for_claude` (`subprocess_runner.py:227-239`) to append
 `--output-format json`, and post-process in the runner (claude-only):
 
-1. Parse stdout as the envelope. On success: expose `envelope["result"]` as the
+1. Parse stdout as the envelope. On parse success: expose `envelope["result"]` as the
    effective stdout the dispatcher sees, and populate a new
-   `AgentRunResult.usage: UsageFigures | None` from `usage.input_tokens`,
-   `usage.output_tokens`, and `total_cost_usd` (authoritative-estimate from the CLI —
-   preferred over rate math whenever present).
-2. On parse failure (older CLI, plain text): fall back to current behavior — raw stdout
-   through, `usage=None`. Never fail a dispatch over telemetry.
+   `AgentRunResult.usage: UsageFigures | None` with
+   `tokens_in = usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens`
+   (**all input-side tokens** — the envelope's bare `input_tokens` is only the uncached
+   slice; the §3.1 sample shows 10 uncached vs ~36k cached, so summing is the difference
+   between volume truth and a 3-orders-of-magnitude undercount), `tokens_out =
+   usage.output_tokens`, and `reported_cost_usd = total_cost_usd` (authoritative-estimate
+   from the CLI — preferred over rate math whenever present; cache pricing tiers are
+   already folded into it, which is why cost never re-derives from the summed tokens).
+2. Unwrap and usage capture happen **regardless of `is_error`/`subtype`**. The dispatch
+   outcome stays owned by the existing classification rules: a non-zero exit is a link
+   `error` before the envelope is ever consulted; exit 0 with `is_error: true` and no
+   parseable contract inside `result` classifies `malformed` and falls through the chain.
+   The envelope's error flag never short-circuits classification on its own.
+3. On envelope parse failure (plain-text stdout): fall back to current behavior — raw
+   stdout through, `usage=None`. Never fail a dispatch over telemetry. Note the bound on
+   this fallback: a CLI old enough to *reject* the flag exits non-zero before stdout
+   matters, which surfaces as an ordinary link failure and the chain moves on — the
+   fallback covers envelope anomalies, not flag rejection.
 
 **Interaction trap (do not skip):** today `_loads_lenient` (`dispatcher.py:392-422`)
 takes the **last top-level JSON object** in stdout. With the envelope flag, that object
@@ -83,8 +96,9 @@ tokens used
 21,631
 ```
 
-Parse the last non-empty stderr lines for `tokens used` followed by a
-comma-grouped integer → `tokens_total`. codex provides **no in/out split** in this mode;
+Parse the last non-empty stderr lines for `tokens used` followed by an
+integer with optional comma grouping (`\d{1,3}(,\d{3})*|\d+` — counts under
+1,000 carry no comma) → `tokens_total`. codex provides **no in/out split** in this mode;
 `input_tokens`/`output_tokens` stay `None`. (A `--json` mode may carry richer usage; the
 one verified codex JSON envelope in-repo — the merge-judge's `task --json` — has **no**
 usage field, so this spec builds only on the verified stderr trailer.)
@@ -99,8 +113,12 @@ ceiling regardless).
 
 ## 4. Ledger bridge — prgroom → `spend.jsonl` (bead agents-config-abn9.40.1)
 
-One spend record per **completed dispatch** (success or terminal failure), appended at
-the `cli.py` layer where the dispatcher returns — not inside `_run_chain`. Mapping to the
+One spend record per **completed dispatch** (success or terminal failure), emitted via a
+new dispatcher-level `spend_hook` — a completion callback invoked exactly once per
+dispatch after the chain resolves (never per attempt, never inside `_run_chain`'s link
+loop), passed at dispatcher construction in `_build_cluster_dispatcher` /
+`_build_fix_dispatcher` (`cli.py:134-167`) — the same construction seam
+agents-config-abn9.8.26 uses for the per-attempt `usage_hook`. Mapping to the
 routing-spec §7 record:
 
 | spend field | source |
@@ -111,7 +129,7 @@ routing-spec §7 record:
 | `provider`, `billing` | routing-spec §4.1 default `cli→provider` map (explicit `provider` key when the chain entry carries one); billing from `model-routing.toml [providers.*]` when present |
 | `rung` | index of the winning link in the chain |
 | `tokens_in`/`tokens_out` | `AgentRunResult.usage` (§3); null when uncaptured |
-| `cost_usd` | claude: `reported_cost_usd` verbatim. codex: `tokens_total × cost_per_mtok_out` from configured rates, ceiling-conservative. others: `null` |
+| `cost_usd` | claude: `reported_cost_usd` verbatim. codex: `tokens_total / 1_000_000 × cost_per_mtok_out` from configured rates, ceiling-conservative. others: `null` |
 | `estimated` | **new boolean field** (heavy-gate-run precedent): `false` for claude's reported cost, `true` for codex rate-math, absent/`null` when `cost_usd` is null |
 | `outcome`, `retries`, `escalated_to` | from the dispatch result (`gate-pass`/`provider-fail`/`timeout`/`parse-fail` vocabulary per routing spec §7) |
 
@@ -159,11 +177,13 @@ an unread scheduled report is noise. Revisit after two manual cycles.
 
 Fixtures are the captured probe outputs, embedded as literal strings — no live CLI calls:
 
-1. claude envelope → unwrapped `result` reaches the dispatcher; `usage` populated;
+1. claude envelope → unwrapped `result` reaches the dispatcher; `usage` populated with
+   the summed `tokens_in` (uncached + cache-creation + cache-read, per §3.1 rule 1);
    contract JSON inside `result` parses via the existing lenient path.
 2. claude plain-text stdout (no envelope) → passthrough, `usage=None`, dispatch succeeds.
-3. Envelope with `is_error: true` → dispatch outcome follows the error; usage still
-   captured when present.
+3. Envelope with `is_error: true`, exit 0, no contract in `result` → unwrap and usage
+   capture still happen; dispatch classifies `malformed` and falls through the chain
+   (§3.1 rule 2 — the flag never short-circuits classification).
 4. codex stderr with trailer → `tokens_total` parsed (comma-grouped); stderr without
    trailer → `None`, no error.
 5. Bridge: completed fix dispatch (fake result, temp ledger dir) → exactly one
@@ -200,6 +220,9 @@ model is answerable from the rollup output, and per session via its ccusage sect
   rows in `spend.jsonl` for unified queries, that's a v2 record kind.
 - `ASSUMPTION:` `--output-format json` is safe for all prgroom claude dispatches (the
   envelope's `result` field faithfully carries the final text; verified on one probe).
-  The plain-text fallback bounds the blast radius if an environment ships an older CLI.
+  A CLI that emits plain text despite the flag is covered by the fallback; a CLI old
+  enough to *reject* the flag fails the link outright and the chain falls back laterally
+  — accepted, since pinning a CLI-version probe for a hypothetical museum piece is
+  machinery without a consumer.
 - `ASSUMPTION:` manual weekly ritual beats cron in v1 (§5). Flip to `schedule`/cron only
   after the manual loop proves the report gets read.

--- a/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
+++ b/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
@@ -123,6 +123,9 @@ routing-spec §7 record:
 
 | spend field | source |
 |---|---|
+| `ts` | ISO-8601 UTC captured at spend-record append time from the injected clock (`prgroom.deps.Clock`) |
+| `session` | `null` — prgroom runs headless; there is no interactive session id to record |
+| `repo` | the PR's `owner/repo` from the dispatch `PRRef` |
 | `archetype` | contract: `cluster` → `classifier`, `fix` → `implementer` |
 | `context` | `"background"` (prgroom is never interactive) |
 | `cli`, `model` | the winning chain link's `AgentSpec` |
@@ -130,8 +133,11 @@ routing-spec §7 record:
 | `rung` | index of the winning link in the chain |
 | `tokens_in`/`tokens_out` | `AgentRunResult.usage` (§3); null when uncaptured |
 | `cost_usd` | claude: `reported_cost_usd` verbatim. codex: `tokens_total / 1_000_000 × cost_per_mtok_out` from configured rates, ceiling-conservative. others: `null` |
-| `estimated` | **new boolean field** (heavy-gate-run precedent): `false` for claude's reported cost, `true` for codex rate-math, absent/`null` when `cost_usd` is null |
+| `estimated` | **additive field beyond the §7 record** (heavy-gate-run precedent), tolerated-absent by readers per the §3.3 JSONL-evolution rule — the routing spec's §7 schema stays canonical: `false` for claude's reported cost, `true` for codex rate-math, absent/`null` when `cost_usd` is null |
 | `outcome`, `retries`, `escalated_to` | from the dispatch result (`gate-pass`/`provider-fail`/`timeout`/`parse-fail` vocabulary per routing spec §7) |
+
+This table covers every field of the routing-spec §7 record; `estimated` is the single
+additive extension this spec introduces beyond that canonical shape.
 
 Config read (`model-routing.toml` rates) is parse-only and optional: absent file or
 missing rate → `cost_usd: null`, never a crash, never a blocked dispatch.

--- a/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
+++ b/docs/specs/2026-07-04-cost-telemetry-and-token-capture.md
@@ -1,0 +1,205 @@
+# Cost Telemetry: Token Capture, Ledger Bridge, Weekly Rollup — Design
+
+**Date:** 2026-07-04
+**Status:** Draft (pending review)
+**Beads:** agents-config-abn9.40.1 (cost telemetry + rollup), agents-config-25rmt (usage-line token parser). One spec, two beads — edits here affect both; each bead's AC section is separate (§9).
+**Related:** `2026-07-04-model-routing-policy-and-escalation-ladder.md` §7 defines the ledger this spec feeds; `2026-07-04-cross-model-heavy-gate-panel.md` §5 appends `heavy-gate-run` records this spec's rollup must aggregate; bead agents-config-abn9.8.26 owns the per-attempt `usage_hook` plumbing this spec deliberately does not duplicate (§4 interface contract).
+**Decision:** Capture real token/cost figures from the claude and codex CLIs using their **verified** output formats (§3 — captured live 2026-07-04, no longer stipulated); bridge prgroom dispatches into the canonical `~/.agents/spend.jsonl` ledger at dispatch completion; make cost visible through a `spend_rollup.py` script run as a weekly manual ritual. Interactive-session cost comes from `ccusage` at rollup time, not from a new capture hook.
+
+## 1. Problem
+
+The model-routing spec locked a spend ceiling enforced from `~/.agents/spend.jsonl` — but
+the ledger has **zero writers**. prgroom's own `usage.jsonl` also receives zero production
+rows (`usage_hook` is never passed at either dispatcher build site, `cli.py:134-167`), and
+even when wired its `input_tokens`/`output_tokens` are hardcoded `None`
+(`dispatcher.py:353-354`) because no parser exists for what the CLIs emit. Four design
+docs assert "Claude and Codex CLIs both emit a usage line" without one captured example.
+Interactive-session cost (the main loop the human drives) has no capture mechanism at all.
+
+Post-Fable operations cannot tune model routing without seeing cost per dispatch, per
+model, per session. That visibility is this spec.
+
+## 2. Architecture: three sources, one canonical ledger
+
+| Source | Granularity | Writer | Record kind |
+|---|---|---|---|
+| prgroom dispatches | per completed dispatch | the bridge (§4, this spec) | routing-spec §7 dispatch record |
+| HEAVY gate runs | per gate run | quality-gate workflow (already spec'd, PR #220) | `heavy-gate-run` |
+| Interactive sessions | per session/day/week | **none** — `ccusage` reads Claude Code's local session data at rollup time | not ledgered in v1 |
+
+`spend.jsonl` stays the single canonical cost store (locked decision 3 of the routing
+spec). prgroom's `usage.jsonl` remains prgroom's *internal per-attempt* observability
+record (every chain-link attempt, including failures — agents-config-abn9.8.26's
+domain); `spend.jsonl` records *per-dispatch outcomes* (the winning rung). Two files, two
+jobs, one direction of flow.
+
+Interactive sessions are deliberately not ledgered: they bill against the subscription
+(ceiling-exempt, `cost_usd` would be 0) and Claude Code already persists the session data
+`ccusage` aggregates. A capture hook would add machinery for a number we can already read.
+
+## 3. Token capture — verified CLI formats (bead agents-config-25rmt)
+
+Both formats below were captured live on 2026-07-04 (probe transcripts in the PR).
+They are facts, not assumptions.
+
+### 3.1 claude CLI — JSON envelope
+
+`claude -p <prompt> --output-format json` emits a single JSON envelope on stdout:
+
+```json
+{"type":"result","subtype":"success","is_error":false,"duration_ms":2436,
+ "result":"<the agent's final text — the contract payload lives here>",
+ "session_id":"...","total_cost_usd":0.02487,
+ "usage":{"input_tokens":10,"cache_creation_input_tokens":18301,
+          "cache_read_input_tokens":17757,"output_tokens":43, "...":"..."},
+ "modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":10,"outputTokens":43,
+               "costUSD":0.02487,"...":"..."}}}
+```
+
+Change `_invocation_for_claude` (`subprocess_runner.py:227-239`) to append
+`--output-format json`, and post-process in the runner (claude-only):
+
+1. Parse stdout as the envelope. On success: expose `envelope["result"]` as the
+   effective stdout the dispatcher sees, and populate a new
+   `AgentRunResult.usage: UsageFigures | None` from `usage.input_tokens`,
+   `usage.output_tokens`, and `total_cost_usd` (authoritative-estimate from the CLI —
+   preferred over rate math whenever present).
+2. On parse failure (older CLI, plain text): fall back to current behavior — raw stdout
+   through, `usage=None`. Never fail a dispatch over telemetry.
+
+**Interaction trap (do not skip):** today `_loads_lenient` (`dispatcher.py:392-422`)
+takes the **last top-level JSON object** in stdout. With the envelope flag, that object
+is the *envelope*, not the contract payload — the unwrap in step 1 MUST happen in the
+runner before the dispatcher parses, or every claude dispatch becomes `malformed`.
+The unwrap is keyed on the envelope shape (`"type":"result"` + `"result"` key present),
+not on the CLI name alone.
+
+### 3.2 codex CLI — stderr trailer
+
+`codex exec --model <m> <prompt>` emits the reply on stdout and a **stderr** trailer:
+
+```
+tokens used
+21,631
+```
+
+Parse the last non-empty stderr lines for `tokens used` followed by a
+comma-grouped integer → `tokens_total`. codex provides **no in/out split** in this mode;
+`input_tokens`/`output_tokens` stay `None`. (A `--json` mode may carry richer usage; the
+one verified codex JSON envelope in-repo — the merge-judge's `task --json` — has **no**
+usage field, so this spec builds only on the verified stderr trailer.)
+
+### 3.3 Schema additions
+
+`UsageRecord` (`usage.py`) gains two nullable fields (additive JSONL evolution — readers
+must tolerate absent keys): `tokens_total: int | None` (codex path) and
+`reported_cost_usd: float | None` (claude path). opencode and ollama emit no counts —
+all token fields stay `None` (ollama is `billing = "free"`; its rungs never hit the
+ceiling regardless).
+
+## 4. Ledger bridge — prgroom → `spend.jsonl` (bead agents-config-abn9.40.1)
+
+One spend record per **completed dispatch** (success or terminal failure), appended at
+the `cli.py` layer where the dispatcher returns — not inside `_run_chain`. Mapping to the
+routing-spec §7 record:
+
+| spend field | source |
+|---|---|
+| `archetype` | contract: `cluster` → `classifier`, `fix` → `implementer` |
+| `context` | `"background"` (prgroom is never interactive) |
+| `cli`, `model` | the winning chain link's `AgentSpec` |
+| `provider`, `billing` | routing-spec §4.1 default `cli→provider` map (explicit `provider` key when the chain entry carries one); billing from `model-routing.toml [providers.*]` when present |
+| `rung` | index of the winning link in the chain |
+| `tokens_in`/`tokens_out` | `AgentRunResult.usage` (§3); null when uncaptured |
+| `cost_usd` | claude: `reported_cost_usd` verbatim. codex: `tokens_total × cost_per_mtok_out` from configured rates, ceiling-conservative. others: `null` |
+| `estimated` | **new boolean field** (heavy-gate-run precedent): `false` for claude's reported cost, `true` for codex rate-math, absent/`null` when `cost_usd` is null |
+| `outcome`, `retries`, `escalated_to` | from the dispatch result (`gate-pass`/`provider-fail`/`timeout`/`parse-fail` vocabulary per routing spec §7) |
+
+Config read (`model-routing.toml` rates) is parse-only and optional: absent file or
+missing rate → `cost_usd: null`, never a crash, never a blocked dispatch.
+
+**Interface contract with agents-config-abn9.8.26 (no scope overlap):** abn9.8.26 wires
+the per-attempt `usage_hook` into both dispatcher build sites and fixes `decided_by`;
+this spec's bridge appends per-dispatch spend records at dispatch completion. They touch
+the same call sites but different records; either can land first. When both are in:
+`usage.jsonl` = every attempt (with real tokens from §3), `spend.jsonl` = every dispatch.
+
+## 5. Weekly rollup (bead agents-config-abn9.40.1)
+
+`spend_rollup.py` — PEP 723 script, shipped on the same skill-asset route as the routing
+spec's `resolve_route.py` (code over prose; no new installer namespace). Reads
+`~/.agents/spend.jsonl`, emits markdown to stdout:
+
+- Month-to-date metered spend vs. `[budget].monthly_ceiling_usd`, with days remaining.
+- Per-archetype × model table: dispatches, gate-pass rate, tokens, `cost_usd`
+  (estimated share flagged) — the A/B substrate the routing spec's outcome fields exist
+  for, plus `heavy-gate-run` records aggregated as their own row.
+- Week-over-week delta (this ISO week vs. last).
+- Corrupt lines counted and reported (`ledger_errors` discipline), never fatal.
+- **Session section:** if `ccusage` is on PATH, shell out (`ccusage --json`, last 7 days)
+  and render per-day session cost; if absent, print the one-line install hint. `ccusage`
+  is a rollup-time *reader*, never a ledger writer — no double counting.
+
+**Ritual:** manual, weekly — `uv run spend_rollup.py` (documented in `docs/guide/`, one
+paragraph). No cron in v1: the ritual's consumer is a human deciding routing changes, and
+an unread scheduled report is noise. Revisit after two manual cycles.
+
+## 6. Out of scope
+
+- OTel/Claude Code telemetry export — no consumer exists; ccusage covers session
+  visibility. Revisit only if a dashboard consumer materializes.
+- Provider billing-API reconciliation (unchanged from routing spec §10).
+- Hook-based automatic ledger capture for interactive sessions (§2 rationale).
+- opencode/ollama token parsing (no counts exposed by those CLIs' plain modes today).
+- prgroom reading `model-routing.toml` for *routing* (unchanged deferral) — the bridge's
+  read here is rates-only.
+- The `usage_hook` wiring and `decided_by`/partial-fallback fixes (agents-config-abn9.8.26).
+
+## 7. Test plan
+
+Fixtures are the captured probe outputs, embedded as literal strings — no live CLI calls:
+
+1. claude envelope → unwrapped `result` reaches the dispatcher; `usage` populated;
+   contract JSON inside `result` parses via the existing lenient path.
+2. claude plain-text stdout (no envelope) → passthrough, `usage=None`, dispatch succeeds.
+3. Envelope with `is_error: true` → dispatch outcome follows the error; usage still
+   captured when present.
+4. codex stderr with trailer → `tokens_total` parsed (comma-grouped); stderr without
+   trailer → `None`, no error.
+5. Bridge: completed fix dispatch (fake result, temp ledger dir) → exactly one
+   spend line, correct archetype/rung/provider mapping; cost paths: reported (claude),
+   estimated (codex + rates), null (no rates).
+6. Rollup: temp `spend.jsonl` with dispatch + heavy-gate-run + one corrupt line →
+   table renders, corrupt count = 1, ceiling math correct across a month boundary.
+
+## 8. Sequencing
+
+25rmt (§3) has no dependencies and unblocks real numbers everywhere. The bridge (§4)
+consumes §3 but can land with null tokens. The rollup (§5) consumes whatever exists.
+Strictly independent of abn9.8.26, by the §4 interface contract.
+
+## 9. Acceptance criteria
+
+**agents-config-25rmt:** claude invoker uses `--output-format json` with envelope unwrap
++ plain-text fallback (tests 1–3); codex stderr trailer parsed (test 4);
+`AgentRunResult.usage` populated; `UsageRecord` carries the new nullable fields;
+`make ci-prgroom` green.
+
+**agents-config-abn9.40.1:** every completed prgroom dispatch appends one spend record
+(test 5); `spend_rollup.py` ships and renders the §5 sections from a real ledger
+(test 6); the weekly ritual is documented in `docs/guide/`; cost per dispatch and per
+model is answerable from the rollup output, and per session via its ccusage section.
+
+## 10. Assumption ledger (scan here, Scott)
+
+- `ASSUMPTION:` pricing codex's undifferentiated `tokens_total` at the **output** rate is
+  the right ceiling-conservative call (overestimates spend, never under). Alternative: a
+  configurable in/out split ratio — rejected as tuning theater without evidence.
+- `ASSUMPTION:` interactive sessions stay un-ledgered in v1 (ccusage at read time
+  suffices; subscription billing makes their ceiling contribution 0). If you want session
+  rows in `spend.jsonl` for unified queries, that's a v2 record kind.
+- `ASSUMPTION:` `--output-format json` is safe for all prgroom claude dispatches (the
+  envelope's `result` field faithfully carries the final text; verified on one probe).
+  The plain-text fallback bounds the blast radius if an environment ships an older CLI.
+- `ASSUMPTION:` manual weekly ritual beats cron in v1 (§5). Flip to `schedule`/cron only
+  after the manual loop proves the report gets read.

--- a/docs/specs/2026-07-04-foreign-cli-consolidation.md
+++ b/docs/specs/2026-07-04-foreign-cli-consolidation.md
@@ -102,8 +102,11 @@ archetype override row (same shape as the user table), not a bespoke key.
 
 1. `project-config.toml [foreign-cli]` contains only binary-path keys and the rewritten
    comment; the four model keys and two concurrency keys are gone.
-2. `grep -rn "codex_red_tests_model\|codex_green_loop_iter1_model\|codex_adversarial_review_model\|gemini_green_loop_iter2_model\|codex_max_concurrent\|gemini_max_concurrent" --include="*" .`
-   over the live tree (excluding `archive/` and `docs/specs/`) returns zero hits.
+2. `grep -rn "codex_red_tests_model\|codex_green_loop_iter1_model\|codex_adversarial_review_model\|gemini_green_loop_iter2_model\|codex_max_concurrent\|gemini_max_concurrent" --exclude-dir=.git --exclude-dir=.beads --exclude-dir=graphify-out --exclude=issues.backup.jsonl . | grep -v -E '^(\./)?(archive|docs/specs)/'`
+   over the live tree returns zero hits (excluded: `archive/`, `docs/specs/` — including
+   this spec — git objects, beads tracker data, and the generated graph). The `archive/`
+   and `docs/specs/` exclusions are path-scoped by the trailing filter, so a same-named
+   directory elsewhere in the tree (e.g. a future `packages/*/specs/`) is still scanned.
 3. `docs/guide/reference.md` and `docs/guide/configuration.md` describe `[foreign-cli]`
    as binaries-only and point model selection at the routing table.
 4. The forward-mapping table (§4) is present in this spec and cited from the

--- a/docs/specs/2026-07-04-foreign-cli-consolidation.md
+++ b/docs/specs/2026-07-04-foreign-cli-consolidation.md
@@ -1,0 +1,119 @@
+# Consolidate `[foreign-cli]` into the Model-Routing Surface — Design
+
+**Date:** 2026-07-04
+**Status:** Draft (pending review)
+**Beads:** agents-config-g42cj (sole bead)
+**Related specs:** `2026-07-04-model-routing-policy-and-escalation-ladder.md` (the archetype table this spec consolidates into). Changes to that spec's §3/§4 config shape ripple here.
+**Decision:** Delete the four dead per-stage model keys and two dead concurrency keys from `project-config.toml [foreign-cli]`; the section retains binary paths only. Future per-stage foreign-model choice routes through the archetype table (`[model-routing]` per-repo override), per the forward-mapping table in §4. No code changes — every deleted key is dead config.
+
+## 1. Problem
+
+`project-config.toml [foreign-cli]` (lines 101–115) pins per-stage foreign models
+(`codex_red_tests_model`, `codex_green_loop_iter1_model`, `codex_adversarial_review_model`,
+`gemini_green_loop_iter2_model`) plus concurrency hints (`codex_max_concurrent`,
+`gemini_max_concurrent`) with no fallback semantics. The model-routing spec introduced an
+archetype-keyed table with ordered fallback chains and a per-repo `[model-routing]`
+override, making stage-named single-model pins a competing, weaker mechanism.
+
+**Ground truth (2026-07-04 consumer audit):** every model and concurrency key in
+`[foreign-cli]` is dead config. The only readers that ever existed are the archived
+bead-formula TOMLs (`archive/src/plugins/beads/.beads/formulas/implement-feature.formula.toml:311`,
+`fix-bug.formula.toml:358`), superseded by the M0 rearchitecture. The stages named in the
+section's own doc-comment (`red-tests`, `green-loop`) survive only as a display-label
+string in `packages/pdlc` and in design prose. The two live mechanisms that *do* pick
+foreign models — the ralf-implement skill's hardcoded cycle models and merge-guard's
+`[merge-policy].judge-model` — never read `[foreign-cli]`.
+
+Consolidation is therefore a deletion plus a forward-mapping convention, not a migration.
+
+## 2. Changes to `project-config.toml`
+
+Delete:
+
+- `codex_red_tests_model`, `codex_green_loop_iter1_model`, `codex_adversarial_review_model`,
+  `gemini_green_loop_iter2_model` — stage pins with zero live readers.
+- `codex_max_concurrent`, `gemini_max_concurrent` — zero live readers; the chain-entry
+  shape (`cli`, `model`, `effort`, `write`, `timeout`, `provider`) has no concurrency
+  field, and inventing one without a consumer would be dead config with a new name. If a
+  real concurrency limiter lands, its natural home is per-provider
+  (`[providers.*].max_concurrent` in `model-routing.toml`), where the limit is a property
+  of the account/endpoint, not of a stage.
+
+Retain (binaries only, with a rewritten section comment):
+
+```toml
+# ---------------------------------------------------------------------------
+# [foreign-cli] — foreign-CLI binary locations only.
+# Model selection lives in the archetype routing table
+# (~/.agents/model-routing.toml, overridable per-repo via [model-routing]).
+# ---------------------------------------------------------------------------
+[foreign-cli]
+# codex_binary_path  = ""        # default: ${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs
+gemini_binary_path   = "gemini"
+```
+
+No `[model-routing]` rows are added now — the shipped archetype defaults already cover
+every live dispatch site, and a per-repo override without a divergent need is noise.
+
+## 3. Code changes
+
+None. The consumer audit found zero live code paths reading any deleted key. Acceptance
+is proven by grep, not by tests.
+
+## 4. Forward mapping (the convention this spec establishes)
+
+When a future orchestrator revives stage-shaped dispatches, the old stage pins map to
+archetype rows — resolve through the routing table, never through new stage-named keys:
+
+| Historical `[foreign-cli]` key | Intent | Archetype row |
+|---|---|---|
+| `codex_red_tests_model` | adversarial test review | `reviewer` |
+| `codex_green_loop_iter1_model` | foreign-eyes implementation review, cycle 1 | `reviewer` |
+| `codex_adversarial_review_model` | deep pre-merge adversarial pass | `judge` |
+| `gemini_green_loop_iter2_model` | foreign-eyes review, cycle 2 | `reviewer` (panel diversity comes from the cross-model round-robin, not a per-stage pin) |
+
+A repo wanting a different model for one of these purposes writes a `[model-routing]`
+archetype override row (same shape as the user table), not a bespoke key.
+
+## 5. Documentation sweep
+
+- `docs/guide/reference.md:80` — `[foreign-cli]` row becomes "foreign-CLI binary paths";
+  add a `[model-routing]` row pointing at the archetype table.
+- `docs/guide/configuration.md:103-106` — same reframing; note model selection moved to
+  the routing table.
+- `project-config.toml` §2 comment block — rewritten as shown above.
+
+## 6. Explicitly out of scope (deliberate, not missed)
+
+- **`[merge-policy].judge-model` / `judge-effort`** — structurally the same
+  pinned-model pattern, but a *sanctioned, pinned contract*: merge-guard's
+  `judge_merge.py` is an autonomous `codex task` caller whose flags and model are pinned
+  by the codex-routing rule ("do not change or remove them without updating that judge").
+  A merge-authorization judge must not silently re-route through a fallback ladder — a
+  cheaper rung substituting mid-judgment would weaken the cross-model guard. Consolidating
+  it is a separate decision with its own risk profile; recorded here so the asymmetry is
+  conscious.
+- **ralf-implement's hardcoded cycle models** (`SKILL.md:110,206-212`,
+  `subagent-foreign-cycle.md:48`) — wiring RALF onto the resolver is the deferred
+  model-sequencing-hints work (bead agents-config-evi), not a config sweep.
+- Building a concurrency limiter or `[providers.*].max_concurrent` — no consumer exists.
+
+## 7. Acceptance criteria
+
+1. `project-config.toml [foreign-cli]` contains only binary-path keys and the rewritten
+   comment; the four model keys and two concurrency keys are gone.
+2. `grep -rn "codex_red_tests_model\|codex_green_loop_iter1_model\|codex_adversarial_review_model\|gemini_green_loop_iter2_model\|codex_max_concurrent\|gemini_max_concurrent" --include="*" .`
+   over the live tree (excluding `archive/` and `docs/specs/`) returns zero hits.
+3. `docs/guide/reference.md` and `docs/guide/configuration.md` describe `[foreign-cli]`
+   as binaries-only and point model selection at the routing table.
+4. The forward-mapping table (§4) is present in this spec and cited from the
+   `[foreign-cli]` comment block, so the next stage-dispatch author finds the convention.
+
+## 8. Assumption ledger (scan here, Scott)
+
+- `ASSUMPTION:` the archived formula pipeline never returns in a form that reads these
+  keys (M0 supersession is final). If it does, its successor consumes the resolver.
+- `ASSUMPTION:` the §4 archetype assignments for the historical stage intents
+  (reviewer/reviewer/judge/reviewer) match your mental model; re-map on review if not.
+- `ASSUMPTION:` leaving `[merge-policy].judge-model` pinned (not consolidating) is the
+  right risk call for the merge-judge contract (§6).

--- a/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
+++ b/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
@@ -45,9 +45,10 @@ as-is. Do not treat it as a full-file replacement:
 }
 ```
 
-- Auth: `{env:OPENROUTER_API_KEY}` — config stays secret-free; the env var is documented
-  in `docs/guide/configuration.md`. No key → provider unusable → dispatcher availability
-  fallback moves to the next rung (fail-lateral, never fail-open).
+- Auth: `{env:OPENROUTER_API_KEY}` — config stays secret-free; the env var gets documented
+  in `docs/guide/configuration.md` as part of this bead's implementation (see §8). No key →
+  provider unusable → dispatcher availability fallback moves to the next rung (fail-lateral,
+  never fail-open).
 - "Profiles" (the bead's word) = **named models under one provider block**, selected
   per-dispatch via `--model openrouter/<id>` — not multiple jsonc files. opencode's
   invoker already passes `spec.model` verbatim (`subprocess_runner.py:256-257`), so no

--- a/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
+++ b/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
@@ -125,7 +125,10 @@ test skips without `OPENROUTER_API_KEY`):
 Common shape: a trivial contract prompt ("Return exactly this JSON object: {...}")
 dispatched through `SubprocessAgentRunner` (the real spawn path, not fakes), generous
 per-test timeout (120s), cheapest model per family. The suite exists to falsify argv and
-stdout-discipline assumptions at the OS boundary — not to test model quality.
+stdout-discipline assumptions at the OS boundary. The parseability assertion deliberately
+includes one sliver of model behavior: a rung whose model cannot round-trip a trivial
+JSON contract is unusable to prgroom regardless of argv correctness, and the smoke should
+go red on it — that is rung fitness, not model-quality benchmarking.
 
 ### 3.3 Cost posture
 

--- a/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
+++ b/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
@@ -22,13 +22,17 @@ cannot exercise an OpenRouter rung.
 
 ### 2.1 opencode provider block
 
-Extend `src/user/.opencode/opencode.jsonc.template` with a custom provider (OpenRouter is
-OpenAI-compatible; opencode addresses models as `providerID/modelID`):
+Add a custom provider block to the existing `src/user/.opencode/opencode.jsonc.template`
+(OpenRouter is OpenAI-compatible; opencode addresses models as `providerID/modelID`). The
+template already carries `$schema`, `model`, `skills`, and a `permission` block; the snippet
+below is **additive** — the only new key is `"provider"`, and every other existing key stays
+as-is. Do not treat it as a full-file replacement:
 
 ```jsonc
 {
-  "model": "moonshotai/kimi-k2.6",          // unchanged default
-  "provider": {
+  // ...existing keys unchanged: "$schema", "skills", and the "permission" block...
+  "model": "moonshotai/kimi-k2.6",          // existing key, unchanged default
+  "provider": {                             // NEW — the only added key
     "openrouter": {
       "name": "OpenRouter",
       "options": { "apiKey": "{env:OPENROUTER_API_KEY}" },

--- a/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
+++ b/docs/specs/2026-07-04-openrouter-wiring-and-invoker-smoke.md
@@ -1,0 +1,191 @@
+# OpenRouter Provider Wiring + Real-Binary Invoker Smoke — Design
+
+**Date:** 2026-07-04
+**Status:** Draft (pending review)
+**Beads:** agents-config-abn9.40.3 (OpenRouter wiring), agents-config-qptb4 (real-binary smoke). One spec, two beads — edits here affect both; each bead's AC section is separate (§8). abn9.40.3's own AC ("passes qptb4 smoke") makes qptb4 a blocker; the beads edge is created alongside this spec.
+**Related:** `2026-07-04-model-routing-policy-and-escalation-ladder.md` (locked decision 5 makes OpenRouter a candidate rung family; §4.1 defines `provider = "openrouter"` resolution); `2026-07-04-cross-model-heavy-gate-panel.md` (consumes OpenCode profiles when present).
+**Decision:** Wire OpenRouter as an opencode custom-provider block (env-keyed auth, named cheap-tier models) so any dispatcher can reach OpenRouter rungs via `opencode run --model openrouter/<id>` with zero prgroom code changes; prove the whole four-invoker OS boundary with an explicit opt-in real-binary smoke suite (new `real_binary` pytest marker, excluded from CI by default).
+
+## 1. Problem
+
+The routing spec's cheap tier (GLM 5.2, Fugu Ultra) is reachable only through OpenRouter,
+and nothing in the repo wires it: `opencode.jsonc.template` has a single flat
+`"model"` key, no provider table, no OpenRouter/GLM/Fugu references anywhere in shipped
+config. Meanwhile prgroom's four invokers (claude/codex/opencode/ollama) are tested
+entirely through fakes — argv shapes, `--effort` acceptance, codex stdout discipline,
+opencode's model-token format, and stdout JSON parseability are all unverified
+OS-boundary assumptions (PR #142 deep review, MINOR-8). The two problems gate each other:
+wiring without the smoke is another stack of stipulations; the smoke without wiring
+cannot exercise an OpenRouter rung.
+
+## 2. OpenRouter wiring (bead agents-config-abn9.40.3)
+
+### 2.1 opencode provider block
+
+Extend `src/user/.opencode/opencode.jsonc.template` with a custom provider (OpenRouter is
+OpenAI-compatible; opencode addresses models as `providerID/modelID`):
+
+```jsonc
+{
+  "model": "moonshotai/kimi-k2.6",          // unchanged default
+  "provider": {
+    "openrouter": {
+      "name": "OpenRouter",
+      "options": { "apiKey": "{env:OPENROUTER_API_KEY}" },
+      "models": {
+        "z-ai/glm-5.2": {},
+        "fugu/fugu-ultra": {}
+      }
+    }
+  }
+}
+```
+
+- Auth: `{env:OPENROUTER_API_KEY}` — config stays secret-free; the env var is documented
+  in `docs/guide/configuration.md`. No key → provider unusable → dispatcher availability
+  fallback moves to the next rung (fail-lateral, never fail-open).
+- "Profiles" (the bead's word) = **named models under one provider block**, selected
+  per-dispatch via `--model openrouter/<id>` — not multiple jsonc files. opencode's
+  invoker already passes `spec.model` verbatim (`subprocess_runner.py:256-257`), so no
+  prgroom change is needed.
+- `ASSUMPTION:` exact option-key names (`options.apiKey`) and nested model IDs
+  (`openrouter/z-ai/glm-5.2` — a two-slash token) follow opencode's documented
+  custom-provider shape; the archived precedent in this repo is stale. **The smoke (§3)
+  is the verification step** — implementation must adjust the block to whatever the real
+  binary accepts and record the verified shape back into this spec's PR.
+
+### 2.2 Reaching OpenRouter from prgroom chains
+
+No `AgentSpec` change. An OpenRouter rung in `.prgroom.toml` is simply:
+
+```toml
+[agents.cluster]
+primary   = { cli = "ollama",   model = "gemma4" }
+fallback  = { cli = "opencode", model = "openrouter/z-ai/glm-5.2", timeout = 120 }
+fallback2 = { cli = "claude",   model = "haiku", effort = "high" }
+```
+
+This worked example ships as `docs/guide/` content (the repo currently has **no**
+runnable `.prgroom.toml` sample anywhere — this closes that gap). The routing-layer
+`provider = "openrouter"` key exists only in `model-routing.toml` chain entries for
+billing attribution (routing spec §4.1); prgroom's dialect does not carry it, and
+prgroom's unknown-key handling is warn-and-ignore (`subprocess_runner.py:289-295`) — do
+not put `provider` keys in `.prgroom.toml`.
+
+### 2.3 Documented fallback ladder (the bead's second AC clause)
+
+The ladder for cheap-tier dispatches is the routing table's, not a new mechanism:
+OpenRouter rungs appear in archetype chains (`mechanical` preferred rung, `classifier`
+alternates) with `provider = "openrouter"`; unavailability (no key, endpoint down,
+binary missing) is a **lateral** availability fallback to the next rung; gate failure
+**climbs**. This spec adds the OpenRouter-specific operational notes to the guide: env
+var, expected failure shape when the key is absent (opencode exits non-zero → prgroom
+classifies `unavailable` → next rung), and the two shipped model names.
+
+## 3. Real-binary invoker smoke (bead agents-config-qptb4)
+
+### 3.1 Gating — explicit opt-in, first-class
+
+New in `packages/prgroom/pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+markers = ["real_binary: dispatches a real agent CLI; opt-in via `make smoke-agents`"]
+addopts = "-m 'not real_binary'"
+```
+
+and a Make target:
+
+```make
+smoke-agents:  ## real-binary invoker smoke (requires local CLIs; never in CI)
+	cd packages/prgroom && uv run pytest -m real_binary -v
+```
+
+Rationale: the repo's one real-binary precedent (`test_git_real.py`'s bare `skipif`)
+passes in CI only because git happens to exist on runners. Agent CLIs *could* appear on a
+future runner image; an implicit-absence skip would then silently start spending money in
+CI. The marker + default exclusion makes "non-CI-gating" (the bead's requirement) an
+explicit property, not an accident of PATH. `make ci-prgroom` is unaffected (`addopts`
+excludes the marker from every default pytest invocation, including `cov-prgroom`).
+
+### 3.2 The smoke tests
+
+`packages/prgroom/tests/smoke/test_real_invokers.py`, one test per invoker plus one
+OpenRouter variant, each additionally `skipif` its binary is absent (and the OpenRouter
+test skips without `OPENROUTER_API_KEY`):
+
+| Test | Dispatch | Asserts |
+|---|---|---|
+| claude | `AgentSpec(cli="claude", model="haiku", extra={"effort": "low"})` | exit 0; `--effort` accepted; stdout yields a parseable object via `_loads_lenient` (envelope-unwrapped once the token-capture spec lands) |
+| codex | `AgentSpec(cli="codex", model="gpt-5.4-mini")` | exit 0; stdout parseable; (observed) stderr trailer present |
+| opencode | `AgentSpec(cli="opencode", model="<template default>")` | exit 0; `--model` token accepted; stdout parseable |
+| opencode × OpenRouter | `AgentSpec(cli="opencode", model="openrouter/z-ai/glm-5.2")` | exit 0 with the §2.1 provider block active — **this row is abn9.40.3's AC** |
+| ollama | `AgentSpec(cli="ollama", model="gemma4")` | stdin prompt path works; stdout parseable |
+
+Common shape: a trivial contract prompt ("Return exactly this JSON object: {...}")
+dispatched through `SubprocessAgentRunner` (the real spawn path, not fakes), generous
+per-test timeout (120s), cheapest model per family. The suite exists to falsify argv and
+stdout-discipline assumptions at the OS boundary — not to test model quality.
+
+### 3.3 Cost posture
+
+One run ≈ four trivial dispatches on cheapest rungs (haiku, gpt-5.4-mini, GLM,
+local ollama) — negligible but not zero; it is manual and documented as such. Spend
+attribution to the ledger arrives with the cost-telemetry spec; until then smoke runs
+are unledgered by design.
+
+## 4. Sequencing
+
+qptb4's harness (§3.1–3.2, minus the OpenRouter row) has no dependencies and should land
+first — it also verifies assumptions the token-capture spec builds on (envelope flag
+acceptance, codex trailer presence). abn9.40.3 (§2) then lands and turns on the
+OpenRouter row. The beads edge (abn9.40.3 blocked-by qptb4) encodes this.
+
+## 5. Out of scope
+
+- prgroom reading `model-routing.toml` (routing spec §10 deferral unchanged).
+- Making prgroom's unknown-extra-key handling strict (warn-and-ignore noted; a
+  fail-loud config validator is its own decision).
+- Gemini CLI wiring (no gemini invoker exists in prgroom's `_KNOWN_CLIS`).
+- CI execution of the smoke, ever, without a deliberate opt-in change to this design.
+- Rate-limit/retry tuning for OpenRouter (availability fallback covers v1).
+
+## 6. Test plan
+
+The smoke suite *is* the test plan for the OS boundary. Unit-level: marker exclusion
+(default `pytest` collects zero `real_binary` tests), env-gate skip (no
+`OPENROUTER_API_KEY` → OpenRouter test skips with a named reason), and the guide example
+`.prgroom.toml` parses through `load_chain` (fixture test — catches dialect drift).
+
+## 7. Rollback / degradation
+
+Everything is additive: the provider block is inert without the env key; the marker
+excludes by default; the worked example is docs. Removal = revert.
+
+## 8. Acceptance criteria
+
+**agents-config-qptb4:** marker + addopts + `make smoke-agents` exist; the four invoker
+tests run against real binaries locally and each asserts exit/argv/stdout-parseability;
+default CI invocations collect none of them (`make ci-prgroom` output proves it);
+`load_chain` fixture test for the worked `.prgroom.toml` example passes.
+
+**agents-config-abn9.40.3:** `opencode.jsonc.template` ships the OpenRouter provider
+block (verified shape per §2.1); `OPENROUTER_API_KEY` + fallback behavior documented in
+the guide; the opencode × OpenRouter smoke row passes locally with a real key; the
+worked chain example (§2.2) is in the guide. Verified model-ID token shape recorded in
+the implementing PR.
+
+## 9. Assumption ledger (scan here, Scott)
+
+- `ASSUMPTION:` opencode custom-provider block shape (§2.1) — pinned to be *verified by
+  the smoke*, adjusted at implementation, and the verified shape recorded. If opencode
+  cannot address OpenRouter models cleanly, fallback design is an OpenAI-compat base-URL
+  provider entry; same seam, different keys.
+- `ASSUMPTION:` `z-ai/glm-5.2` and `fugu/fugu-ultra` are the intended cheap-tier model
+  ids (names taken from the routing spec's locked decision 5; exact OpenRouter catalog
+  ids confirmed at implementation).
+- `ASSUMPTION:` marker + `addopts` exclusion is acceptable as the repo's first registered
+  pytest marker (a new convention, justified in §3.1 — implicit-absence skips are how CI
+  starts spending money).
+- `ASSUMPTION:` ollama smoke uses `gemma4` (the classifier row's local rung); any locally
+  pulled model works — the test should accept an env override `PRGROOM_SMOKE_OLLAMA_MODEL`.


### PR DESCRIPTION
## Summary

Specfest wave 2 — three dated design specs closing the spec gaps on the post-Fable economics cluster, so the covered beads are implementable by non-frontier models:

- **`2026-07-04-cost-telemetry-and-token-capture.md`** (beads `abn9.40.1` + `25rmt`) — token capture from the claude/codex CLIs using **live-verified** output formats (claude `--output-format json` envelope with `usage` + `total_cost_usd`; codex stderr `tokens used` trailer — probe transcripts below), a `spend_hook` bridge appending one record per prgroom dispatch to the canonical `~/.agents/spend.jsonl`, and a `spend_rollup.py` weekly ritual with a ccusage session section.
- **`2026-07-04-openrouter-wiring-and-invoker-smoke.md`** (beads `abn9.40.3` + `qptb4`) — opencode custom-provider block for OpenRouter (env-keyed auth, named cheap-tier models), a worked `.prgroom.toml` chain example, and an opt-in `real_binary` pytest marker + `make smoke-agents` suite that verifies all four invoker OS boundaries; explicitly excluded from CI by `addopts`.
- **`2026-07-04-foreign-cli-consolidation.md`** (bead `g42cj`) — consumer audit proved every `[foreign-cli]` model/concurrency key is dead config (only archived formula TOMLs ever read them); the spec is a deletion + forward-mapping convention, with `[merge-policy].judge-model` deliberately left pinned (rationale in its §6).

## Review disclosure (read this first)

The HEAVY quality-gate (45 agents, 4 lenses, 2 refuters) ran 3 rounds and **terminated at its round cap rather than converging** — recommendation was human-review-required, not clean. Disposition:

- 5 mechanical fixes auto-applied and verified (codex cost formula was off by 10⁶ — now `tokens_total / 1_000_000 × cost_per_mtok_out`; comma-optional trailer regex; path-scoped AC2 grep).
- 5 flagged semantic items resolved by the spec author in `af85bdb`: `tokens_in` now sums cache tokens (the probe itself showed 10 uncached vs ~36k cached — the undercount would have been 3 orders of magnitude); `is_error:true` envelope path pinned to the existing exit-code/malformed classification; flag-rejection fallback bound documented; bridge seam respecified as a dispatcher-construction `spend_hook` (the previously named seam did not exist); smoke parseability scope owned as rung-fitness.

Residual: round-cap termination means coverage is not exhaustive. These are Draft (pending review) specs — reviewer skepticism is welcome, especially on the telemetry spec's §3.1/§4.

## Scope

- **In**: three new files under `docs/specs/`. Nothing else.
- **Out**: all implementation (the beads carry it); `AGENTS.md`/config/code untouched.

## Artifact nature (for reviewers)

Desired-state design specs — they describe *intended* implementations against the current code. File:line anchors reference code as it exists today (`subprocess_runner.py`, `dispatcher.py`, `cli.py` in `packages/prgroom`). Components they name (`spend_hook`, `UsageFigures`, `spend_rollup.py`, the `real_binary` marker, the OpenRouter provider block) **do not exist yet — by design**; flagging them as missing is the artifact working correctly.

Ground truth to check claims against:
- `packages/prgroom/src/prgroom/agent/{subprocess_runner,dispatcher,usage}.py`, `cli.py` — all invoker/dispatcher/schema claims.
- `docs/specs/2026-07-04-model-routing-policy-and-escalation-ladder.md` §4/§7 — ledger dialect and provider resolution these specs must agree with.
- `project-config.toml` lines 101–115 — the `[foreign-cli]` section under consolidation.

## Probe transcripts (verified formats)

claude (`claude -p "Reply with exactly: ok" --model claude-haiku-4-5-20251001 --output-format json`, 2026-07-04):
envelope with `"total_cost_usd":0.0249`, `"usage":{"input_tokens":10,"cache_creation_input_tokens":18301,"cache_read_input_tokens":17757,"output_tokens":43,...}`, per-model `modelUsage` with `costUSD`.

codex (`codex exec --model gpt-5.4-mini "Reply with exactly: ok"`, 2026-07-04): stdout `ok`; stderr banner ending in `tokens used\n21,631`.

## Test plan

- [x] HEAVY quality-gate: 3 rounds, all mechanical fixes applied + verified; semantic flags resolved and committed (disclosure above)
- [x] foreign-cli AC2 grep executed verbatim: hits only `project-config.toml` (the six keys the implementation deletes)
- [x] Spec headers carry Status/Beads/co-coverage blast-radius notes; covered beads updated in bd (descriptions point here; `implementation-ready` stamped; qptb4→abn9.40.3 blocks edge added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hYEFr76fMSTyRunVxSsdv
