### PR TITLE
feat(lifecycle): M0 mitigations - interim protocol, in-flight claim audit, claim-lease rules (wgclw.17-21)

### DIFF
--- a/docs/specs/2026-07-04-spec-capture-glue.md
+++ b/docs/specs/2026-07-04-spec-capture-glue.md
@@ -79,13 +79,39 @@ brainstorm ends (in-session design approved)      external artifact dropped in
 Judgment lives in the skill (distillation, checklist); every mechanical,
 repeatable step lives in the script (code over prose).
 
+A fourth event closes the loop outside this diagram, at spec-PR merge —
+`capture_spec.py` runs the interim delivery protocol
+(docs/specs/2026-07-05-work-lifecycle-and-facade.md §9) directly until the
+`work` facade ships its lifecycle verbs: it decomposes the merged spec's
+`## Continuations` manifest under the still-open bead, then releases the
+claim — mint-before-anything-closes. See §7 for the script's full
+delivery-time contract.
+
 ## 4. Origins and placement
+
+Capture is one bead, pre-facade: the captured bead is the objective, and the
+work lifecycle design's lazy path
+(docs/specs/2026-07-05-work-lifecycle-and-facade.md §6) governs how
+implementation work materializes. The commitment lives in the spec's
+`## Continuations` manifest — made binding by the manifest lens (§5) — and
+at spec-PR merge delivery decomposes it under the still-open bead: a single
+unit mints one typed child, multiple units mint N, and `- none` means the
+spec is the deliverable and the bead closes at merge. The dependency-blocked
+`[Impl]` placeholder belongs to the facade's `spec` shape: once
+`packages/workcli` ships noun-templated creation, idea-origin captures that
+expect implementation instantiate that full shape (`work create spec`:
+container + design child + blocked placeholder) instead of a bare leaf, and
+the script's delivery step becomes placeholder reconciliation per the
+lifecycle design's §6. Interruption is self-reporting either way: a merged
+spec with no children yet leaves the bead open + `spec-ready` + childless —
+planning-queue membership, not silence. This is a distinct mechanism from
+the readiness gaps in §6 below, which stay notes-only.
 
 - **Bead-origin** (brainstorm started from an existing bead): the script
   stamps `brainstormed` on the bead, appends the spec path + a one-line
   decision summary to the bead's notes, and leaves the dependency hierarchy
-  untouched. The spec header carries the bead id (dated specs are exempt from
-  the no-tracker-IDs rule).
+  untouched. The spec header carries the bead id (dated specs are exempt
+  from the no-tracker-IDs rule).
 - **Idea-origin**: the skill asks exactly one placement question at capture —
   a parent (milestone or epic id) or explicit orphan. The script then creates
   the bead (`--parent` when given; orphan otherwise), stamps `brainstormed`,
@@ -105,9 +131,14 @@ Explicitly **not** a review loop.
 - **Single pass, draining lenses only** (per D5): placeholder scan (TBD/TODO/
   empty sections), internal contradictions, ambiguity (a requirement readable
   two ways), scope (single implementation plan vs needs decomposition),
-  testable acceptance criteria. The alternatives/optimality lens is
-  **excluded by design** — that work happened during the brainstorm, and it is
-  the lens that never drains (the codex-treadmill generator).
+  testable acceptance criteria, and — per the work lifecycle design's
+  manifest requirement
+  (docs/specs/2026-07-05-work-lifecycle-and-facade.md §6) — manifest present
+  and parseable: a `## Continuations` section with one
+  `- <noun>: <title> — AC: …` bullet per item, or the literal `- none`. The
+  alternatives/optimality lens is **excluded by design** — that work happened
+  during the brainstorm, and it is the lens that never drains (the
+  codex-treadmill generator).
 - **Evidence-shaped gaps** (per D8): every gap must quote the offending line
   or name the missing section. A gap that cannot cite its evidence does not
   ship.
@@ -136,7 +167,10 @@ Explicitly **not** a review loop.
   `ASSUMPTION:` gaps live in the bead's notes, not as child beads — child
   beads would pollute the hierarchy the placement question just got right,
   and close-walk semantics make disposable question-children hazardous. If
-  gap volume proves notes-unwieldy, a follow-up can revisit.
+  gap volume proves notes-unwieldy, a follow-up can revisit. This is
+  unrelated to the implementation children delivery mints per §4 — those are
+  real planned work under the still-open bead, not disposable
+  question-children.
 - Re-entry bookkeeping: the script stamps `spec-reassessed` alongside the
   swap on the single allowed re-entry, making "second not-ready → park" a
   mechanical check, not a memory. `ASSUMPTION:` label name.
@@ -156,16 +190,24 @@ Explicitly **not** a review loop.
   as a skill asset, the gate-triage/resolve-policy pattern): deterministic
   operations only — dated-filename computation and collision handling
   (`-2` suffix on same-day same-topic), spec file write, bead create/link,
-  label stamping in a fixed order (link notes → labels → gaps), gaps
-  append (bd `--append-notes`, never the clobbering replace flags), verdict
-  recording, and a `--json` result envelope (paths, bead id, verdict, gap
-  count) so callers — including a future PDLC orchestrator binding — can
-  consume it mechanically. Exit non-zero with a specific error on any bd
-  failure; no silent fallbacks.
+  label stamping in a fixed order (link notes → labels → gaps), gaps append
+  (bd `--append-notes`, never the clobbering replace flags), verdict
+  recording, delivery decomposition (§4), and a `--json` result envelope
+  (paths, bead id, verdict, gap count, minted child ids at delivery) so
+  callers — including a future PDLC orchestrator binding — can consume it
+  mechanically. Exit non-zero with a specific error on any bd failure; no
+  silent fallbacks.
 - The skill never shells raw `bd` for these operations; the script is the
-  single place bd quirks live (aligned with the work-facade CLI direction —
-  when the `work` facade ships, the script swaps its bd calls for facade
-  calls behind its own boundary).
+  single place bd quirks live. `capture_spec.py` is a client of the `work`
+  facade, not a competing implementation of it: until `packages/workcli`
+  ships its lifecycle verbs, the script implements the interim protocol
+  (docs/specs/2026-07-05-work-lifecycle-and-facade.md §9) directly at
+  spec-PR merge — it decomposes the merged spec's manifest under the
+  still-open bead (§4), minting the typed children there, releases the
+  claim, and stamps labels, mint-before-anything-closes ordering, always.
+  Once the facade ships, the
+  script delegates these same mutations to `work` verbs instead of raw `bd`
+  calls, behind its own boundary.
 
 ## 8. External-artifact intake
 
@@ -224,6 +266,12 @@ arbitrary markdown, not by per-surface adapters.
 9. bd failure mid-sequence (fake fails on label step): non-zero exit, error
    names the failed step, prior steps' effects reported (no silent partial
    success).
+10. Delivery decomposition: a merged spec whose manifest names two units
+    mints exactly two typed children under the still-open bead and releases
+    the claim; a re-run is a no-op (idempotent); a `- none` manifest closes
+    the bead at merge; an interrupted run (fake fails after child 1 of 2)
+    leaves the bead open and claimed-released with one child — the re-run
+    mints only the missing child.
 
 ## 12. Assumption ledger (scan here, Scott)
 
@@ -232,7 +280,7 @@ arbitrary markdown, not by per-surface adapters.
 - `ASSUMPTION:` label names `spec-ready` / `spec-gaps` / `spec-reassessed`.
 - `ASSUMPTION:` gaps auto-file into bead **notes** (numbered answer-me block),
   not child beads.
-- `ASSUMPTION:` checklist wording of the five draining lenses (§5) — the lens
+- `ASSUMPTION:` checklist wording of the six draining lenses (§5) — the lens
   *set* is locked; the prompt text is the skill author's.
 - `ASSUMPTION:` duplicate-title guard is exact-match only (fuzzy dedup is
   human judgment, out of scope).

--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -219,3 +219,12 @@ scripted-bd fake, no live Dolt in unit tests).
 - `ASSUMPTION:` §2/§7 GH Issues implementation deferred until contract-test
   review still doubts the seam; v1 is bd-only.
 - `ASSUMPTION:` §4 envelope field names and initial error-code set.
+
+## Continuations
+
+- feat: transport layer in `packages/workcli` — the twelve contract verbs,
+  JSON envelope + protocol handshake, `Backend` adapter seam, bd adapter
+  behind a subprocess boundary port — AC: test plan items 1–10 pass under a
+  CI gate matching the installer/prgroom discipline. (The lifecycle layer's
+  continuation is tracked in the work lifecycle and facade design's own
+  manifest, docs/specs/2026-07-05-work-lifecycle-and-facade.md.)

--- a/src/plugins/beads/.agents/rules/beads.md
+++ b/src/plugins/beads/.agents/rules/beads.md
@@ -5,3 +5,5 @@
 - `bd dolt pull` fails with "cannot merge with uncommitted changes." Sync via `bd dolt commit` then `bd dolt push` — a successful push proves you were not behind.
 - `bd label remove` signature: `[issue-ids...] [label]` — label is the last arg, one label per call.
 - After `bd close <last-child>`, always `bd show <parent-epic>` to confirm; close-walk auto-close is unreliable. Close the epic manually if all children are closed and it is still open.
+- A bead's `in_progress` status is a claim lease — the work belongs to a live session for the current phase. Release it (`bd update <id> --status open`) or deliver it before the session ends, never abandon a claimed bead behind a merged spec or PR. `bd ready` surfaces only `open` beads, so a stale claim hides the work from every dispatch queue.
+- Containers exit the planning queue only via the explicit `planned` label, which is revocable — re-planning removes it. Child count never implies `planned`.

--- a/src/user/.agents/skills/brainstorming/SKILL.md
+++ b/src/user/.agents/skills/brainstorming/SKILL.md
@@ -142,6 +142,18 @@ Wait for the user's response. If they request changes, make them and re-run the 
 - Invoke the writing-plans skill to create a detailed implementation plan
 - Do NOT invoke any other skill. writing-plans is the next step.
 
+**Tracked work handoff (if the project uses a work tracker):**
+
+- End the design doc with a `## Continuations` section naming each follow-on
+  work item to create (noun/title/acceptance criteria), or the literal
+  `- none — this spec is the deliverable`.
+- When the design doc's PR merges: mint those continuation items in the
+  tracker as children under the still-open tracked objective per that
+  section, then release the claim on the objective (status back to
+  open/unclaimed). Mint-before-anything-closes — successors exist before
+  anything closes or releases. Never leave the tracked objective claimed
+  behind a merged design doc.
+
 ## Key Principles
 
 - **One question at a time** - Don't overwhelm with multiple questions

--- a/src/user/.agents/skills/whats-next/SKILL.md
+++ b/src/user/.agents/skills/whats-next/SKILL.md
@@ -80,12 +80,14 @@ Top-level shape:
     "human":          0,
     "planning_ready": 3,
     "brainstorm":     42,
-    "implementation": 6
+    "implementation": 6,
+    "in_flight":      19
   },
   "human":          [ ...beads ],
   "planning_ready": [ ...beads ],
   "brainstorm":     [ ...beads ],
-  "implementation": [ ...beads ]
+  "implementation": [ ...beads ],
+  "in_flight":      [ ...in-flight beads ]
 }
 ```
 
@@ -114,9 +116,36 @@ Each bead entry (already prefix-stripped and typed-ancestor split):
 
 All sections are pre-sorted: **priority ascending (P0 first), then `created_at` ascending**.
 
+`in_flight` is a different kind of section: a cross-cutting audit of every
+`in_progress` bead, not one of the four work-queue lists above. It is
+**mode-independent** — present in every `--mode` value's output, never gated
+or truncated by `--mode` or `--limit` (unlike the four queues, its whole
+point is showing every stale claim, not a top-N sample) — matching the
+always-present `totals` field. Each entry:
+
+```json
+{
+  "id":              "agents-config-wgclw.15",
+  "short_id":        "wgclw.15",
+  "title":           "...",
+  "assignee":        "Scott Hamilton",
+  "claim_age_days":  1,
+  "pr_flagged":      true
+}
+```
+
+- `assignee` — `""` if unassigned
+- `claim_age_days` — whole days since the bead's status transitioned to
+  `in_progress`; `null` if bd returned no usable timestamp
+- `pr_flagged` — `true` when the bead's notes contain a GitHub PR URL,
+  meaning the work may already be merged and the claim just wasn't closed
+  out
+
+Sorted **oldest claim first** (largest `claim_age_days` first).
+
 ## Step 2: Render sections
 
-Skip any section whose list is empty.
+Skip any empty queue section (`in_flight` is exempt — it always renders its summary line; see Step 3).
 
 | Section key | Heading |
 |---|---|
@@ -124,8 +153,9 @@ Skip any section whose list is empty.
 | `planning_ready` | **Planning-ready** |
 | `brainstorm` | **Ready to brainstorm** |
 | `implementation` | **Ready to implement** |
+| `in_flight` | **In flight (claimed)** |
 
-`all` mode renders attention + planning-ready + brainstorm + implementation queue in that order.
+`all` mode renders attention + planning-ready + brainstorm + implementation queue in that order. `in_flight` renders **last, in every mode** — it's a cross-cutting audit, not one of the mode-selected queues, so it always appears after whatever queue(s) the requested mode surfaced.
 
 ## Step 3: Present
 
@@ -152,6 +182,30 @@ Example:
 | 1 |           |         |             | abn9    | milestone | Milestone M1 — Stabilize and ship          |
 | 2 | abn9      |         |             | bf6     | task    | Externalize long bead specs to docs/beads/   |
 ```
+
+`in_flight` uses its own 5-column table (it carries different fields — no
+priority/milestone/type). The `Flag` column holds `⚠ PR` when `pr_flagged`
+is `true`, empty otherwise; never interleave annotation lines between table
+rows (a bare line inside a markdown table breaks its rendering):
+
+| Bead ID | Title | Assignee | Claim Age (days) | Flag |
+|---|---|---|---|---|
+
+When any row is flagged, add one legend line after the table:
+`⚠ PR = a PR URL is recorded on the bead — verify the claim is live; candidate for retroactive delivery.`
+
+Example:
+
+```
+| Bead ID   | Title                                          | Assignee        | Claim Age (days) | Flag |
+|-----------|------------------------------------------------|------------------|-------------------|------|
+| 7bk       | Specialized agent fleet (M3 worker fleet)       |                  | 69                |      |
+| wgclw.15  | Installer settings.json merge reorders keys     | Scott Hamilton   | 1                 | ⚠ PR |
+
+⚠ PR = a PR URL is recorded on the bead — verify the claim is live; candidate for retroactive delivery.
+```
+
+`in_flight` is never subject to `--label` — see the argparse help for why. It is also never subject to `--limit`; every in_progress bead renders, always. This section is an audit, not a work-selection queue, so it renders its own summary line, not the truncation/empty-state lines below: if `totals.in_flight` is `0`, say `No in-progress claims.`; otherwise `N bead(s) currently claimed (in_progress).`
 
 Close with a summary line driven by `totals` (which always carries the full, unfiltered-by-limit count per section). If the displayed count equals the total: `Ready: N beads`. If any section is truncated: name the gap and offer the affordance in plain words, e.g. `Showing top 10 of 42 brainstorm, 3 of 3 planning — say "show all" to see the rest.` When a `--label` filter is active, state it: `Scoped to label "install".` If every section is empty, the empty-state message is mode-specific so it does not falsely point a single-section caller at the human-attention queue:
 

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -19,6 +19,7 @@ import json
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +286,94 @@ def extract_typed_ancestors(bead_id, ancestry_map, known, shorten):
 
 
 # ---------------------------------------------------------------------------
+# In-flight (claimed) beads
+# ---------------------------------------------------------------------------
+#
+# `bd ready` (the source for every section above) only ever returns
+# `status: open` beads, so a bead left `in_progress` by a dead or abandoned
+# session is invisible to every list above it. This section surfaces every
+# in_progress bead directly, oldest claim first, so a stale claim gets
+# caught instead of silently blocking whoever would otherwise pick up the
+# work it's still holding.
+#
+# Authoritative rationale for the section's independence: in_flight is a
+# cross-cutting audit list, not a mode-selected work queue — it is never
+# gated by --mode, never truncated by --limit, and never filtered by
+# --label. The whole point is to surface EVERY stale claim, not a top-N
+# or per-queue sample of them.
+
+PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/\d+")
+
+
+def parse_bd_timestamp(ts):
+    """Parse a bd ISO-8601 UTC timestamp (e.g. '2026-07-04T17:58:57Z') to an
+    aware datetime. Returns None on missing/unparseable input so callers
+    degrade gracefully instead of raising.
+    """
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def claim_age_days(started_at):
+    """Whole days elapsed since a bead's `started_at` timestamp.
+
+    `started_at` is the field used here, not `updated_at`: bd stamps
+    `started_at` once, at the moment a bead's status transitions to
+    in_progress, and it does not move on later edits. `updated_at` does
+    move on any field edit (e.g. a notes update), so a bead claimed weeks
+    ago with a recent notes edit would understate its claim age under
+    `updated_at`.
+
+    Returns None when unparseable, so the caller can render a dash rather
+    than a bogus age.
+    """
+    ts = parse_bd_timestamp(started_at)
+    if ts is None:
+        return None
+    return max(0, (datetime.now(timezone.utc) - ts).days)
+
+
+def build_in_flight(all_active, shorten):
+    """Build the 'In flight (claimed)' section: every bead with status
+    in_progress, sorted oldest claim first.
+
+    Flags beads whose notes carry a GitHub PR URL (recorded per interim
+    protocol 9.3) as candidates for retroactive delivery — the work may
+    already be done and merged, with the claim simply never closed out.
+
+    `all_active` (bd list --status open,in_progress) already carries
+    `notes` — bd list --json includes it by default, no --long needed —
+    so no extra `bd show` calls are required here.
+    """
+    in_flight = [b for b in all_active if b.get("status") == "in_progress"]
+
+    def sort_key(bead):
+        # Unparseable/missing timestamps can't be placed by age — push
+        # them to the end rather than guessing they're the oldest.
+        return parse_bd_timestamp(bead.get("started_at")) or datetime.max.replace(
+            tzinfo=timezone.utc
+        )
+
+    in_flight.sort(key=sort_key)
+
+    result = []
+    for b in in_flight:
+        result.append({
+            "id": b["id"],
+            "short_id": shorten(b["id"]),
+            "title": b.get("title", ""),
+            "assignee": b.get("assignee") or "",
+            "claim_age_days": claim_age_days(b.get("started_at")),
+            "pr_flagged": bool(PR_URL_RE.search(b.get("notes") or "")),
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -323,10 +412,13 @@ def main():
     )
     parser.add_argument(
         "--label", default=None, metavar="LABEL",
-        help="Restrict every section to beads whose own labels include LABEL "
-             "(case-insensitive exact match). The caller is responsible for "
-             "reducing a natural-language qualifier to its canonical label "
-             "(e.g. installer/installation -> install).",
+        help="Restrict every mode-selected queue (human/planning/brainstorm/"
+             "implementation) to beads whose own labels include LABEL "
+             "(case-insensitive exact match). Does NOT filter `in_flight` — "
+             "that section is an unscoped stale-claim audit and always shows "
+             "every in_progress bead regardless of --label. The caller is "
+             "responsible for reducing a natural-language qualifier to its "
+             "canonical label (e.g. installer/installation -> install).",
     )
     args = parser.parse_args()
     limit = args.limit
@@ -503,6 +595,11 @@ def main():
     if not human_raw and not ready_raw and not all_active and not planning_raw:
         sys.exit(1)
 
+    # Never gated by --mode/--limit/--label — see the "In-flight (claimed)
+    # beads" section comment above build_in_flight for the rationale.
+    in_flight_beads = build_in_flight(all_active, shorten)
+    totals["in_flight"] = len(in_flight_beads)
+
     output = {
         "mode": mode,
         "project_prefix": prefix,
@@ -525,6 +622,9 @@ def main():
         output["planning_ready"] = enrich(planning_beads)
     elif mode == "human":
         output["human"] = enrich(human_beads)
+
+    # Mode-independent, like `totals` (see the in-flight section comment).
+    output["in_flight"] = in_flight_beads
 
     print(json.dumps(output, indent=2))
 

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -306,16 +306,25 @@ PR_URL_RE = re.compile(r"https://github\.com/\S+/pull/\d+")
 
 
 def parse_bd_timestamp(ts):
-    """Parse a bd ISO-8601 UTC timestamp (e.g. '2026-07-04T17:58:57Z') to an
-    aware datetime. Returns None on missing/unparseable input so callers
-    degrade gracefully instead of raising.
+    """Parse a bd ISO-8601 UTC timestamp (e.g. '2026-07-04T17:58:57Z') to a
+    timezone-aware datetime. Returns None on missing/non-string/unparseable
+    input so callers degrade gracefully instead of raising.
+
+    An offsetless ISO string (no trailing 'Z' or explicit offset) parses to a
+    naive datetime; it is coerced to UTC so every non-None return is aware.
+    This keeps downstream arithmetic against `datetime.now(timezone.utc)`
+    (claim_age_days) and comparison against an aware `datetime.max`
+    (build_in_flight's sort key) from raising TypeError on naive/aware mixes.
     """
-    if not ts:
+    if not isinstance(ts, str) or not ts:
         return None
     try:
-        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
-    except ValueError:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
         return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def claim_age_days(started_at):

--- a/src/user/.agents/skills/whats-next/collect.py
+++ b/src/user/.agents/skills/whats-next/collect.py
@@ -608,7 +608,8 @@ def main():
     }
 
     # Per spec §"--mode contract": absent sections are ABSENT from JSON,
-    # not empty arrays.
+    # not empty arrays. Exception: `in_flight` (and `totals.in_flight`) is
+    # mode-independent and ALWAYS present — see the in-flight section comment.
     if mode == "all":
         output["human"] = enrich(human_beads)
         output["planning_ready"] = enrich(planning_beads)

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -238,6 +238,8 @@ pass "T5: typed-ancestor extraction emits exact milestone/feature/parent_epic/ty
 # T6. Mode key matrix: exact top-level section-key sets per mode.
 # Per spec §"--mode contract": absent sections are ABSENT from JSON,
 # not empty arrays. Top-level 'mode' field carries the mode value.
+# `in_flight` is mode-independent (like `totals`/`mode`/`project_prefix`/
+# `limit`) and is ALWAYS present regardless of mode — asserted below.
 # -----------------------------------------------------------------------------
 TMP_T6=$(mktemp -d)
 trap 'rm -rf "$TMP_T3" "$TMP_T5" "$TMP_T6"' EXIT
@@ -310,6 +312,14 @@ if present != expect:
 mode_val = os.environ["MODE_VALUE"]
 if out.get("mode") != mode_val:
     raise SystemExit(f"top-level 'mode' field expected {mode_val!r}, got {out.get('mode')!r}")
+# `in_flight` is mode-independent: it must appear in EVERY mode's output
+# (the new always-present contract). This shim has no in_progress beads,
+# so the value is an empty list.
+if "in_flight" not in out:
+    raise SystemExit(f"'in_flight' must be present in every mode; keys: {sorted(out.keys())}")
+if out.get("totals", {}).get("in_flight") != len(out["in_flight"]):
+    raise SystemExit(f"totals.in_flight must match len(in_flight); "
+                     f"totals={out.get('totals')}, in_flight={out['in_flight']}")
 PY
 }
 
@@ -319,7 +329,7 @@ assert_mode_keys brainstorm      "$expect_brainstorm" brainstorm
 assert_mode_keys implementation  "$expect_impl"       implementation
 assert_mode_keys planning        "$expect_planning"   planning
 assert_mode_keys human           "$expect_human"      human
-pass "T6: --mode emits exact section-key set per spec §--mode contract (all | brainstorm | implementation | planning | human)"
+pass "T6: --mode emits exact section-key set per spec §--mode contract (all | brainstorm | implementation | planning | human); in_flight always present"
 
 # -----------------------------------------------------------------------------
 # T8. is_impl_candidate handles `feature` leaf-impl beads (regression for
@@ -832,8 +842,10 @@ assert ids("human") == ["proj-h-inst"], f"human: {ids('human')}"
 assert ids("brainstorm") == ["proj-b-inst"], f"brainstorm: {ids('brainstorm')}"
 assert ids("implementation") == ["proj-i-inst"], f"implementation: {ids('implementation')}"
 assert ids("planning_ready") == ["proj-p-inst"], f"planning_ready: {ids('planning_ready')}"
+# `in_flight` is mode-independent and always present in totals (no in_progress
+# beads in this fixture → count 0), exempt from --label filtering.
 t = out["totals"]
-assert t == {"human":1,"planning_ready":1,"brainstorm":1,"implementation":1}, f"totals: {t}"
+assert t == {"human":1,"planning_ready":1,"brainstorm":1,"implementation":1,"in_flight":0}, f"totals: {t}"
 PY
 pass "T13a: --label install filters all sections to install-labeled beads; totals reflect filter"
 

--- a/src/user/.agents/skills/whats-next/collect_test.sh
+++ b/src/user/.agents/skills/whats-next/collect_test.sh
@@ -898,4 +898,36 @@ grep -qE '^ready --limit 0 --json$' "$CALL_LOG" \
     || fail "T14: bd ready must be called with '--limit 0' to avoid the 100-row cap (calls: $(cat "$CALL_LOG"))"
 pass "T14: bd ready is invoked with --limit 0 (no silent 100-row cap)"
 
+# -----------------------------------------------------------------------------
+# T15. parse_bd_timestamp always returns a timezone-aware datetime (or None).
+# Regression for PR #231 comment 3525472321: an offsetless ISO string parsed
+# to a NAIVE datetime, which raised TypeError in claim_age_days() (subtracting
+# from an aware datetime.now) and in build_in_flight's sort key (comparing
+# against an aware datetime.max). Non-string input must return None, not raise.
+# -----------------------------------------------------------------------------
+python3 - "$COLLECT_PY" <<'PY' || fail "T15: parse_bd_timestamp naive/non-string handling incorrect"
+import importlib.util, sys
+from datetime import datetime, timezone
+spec = importlib.util.spec_from_file_location("collect_mod", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+# Offsetless (naive) ISO string → aware datetime coerced to UTC.
+aware = mod.parse_bd_timestamp("2026-07-04T17:58:57")
+assert aware is not None, "offsetless timestamp must parse, not return None"
+assert aware.tzinfo is not None, "offsetless parse must be coerced to an aware datetime"
+assert aware.utcoffset() == timezone.utc.utcoffset(None), "naive parse must be coerced to UTC"
+# Aware arithmetic against now(utc) must not raise (the reported TypeError).
+_ = datetime.now(timezone.utc) - aware
+
+# Z-suffixed timestamp stays aware.
+zaware = mod.parse_bd_timestamp("2026-07-04T17:58:57Z")
+assert zaware is not None and zaware.tzinfo is not None, "Z-suffixed parse must be aware"
+
+# Non-string / missing input → None, never raising.
+for bad in (None, 12345, [], {}, ""):
+    assert mod.parse_bd_timestamp(bad) is None, f"non-string/empty input {bad!r} must return None"
+PY
+pass "T15: parse_bd_timestamp returns aware datetimes and None for non-string/missing input"
+
 echo "All collect.py red-phase tests reached — script exits 0 only when every assertion above passes."

--- a/src/user/.claude/skills/fablize/SKILL.md
+++ b/src/user/.claude/skills/fablize/SKILL.md
@@ -87,7 +87,7 @@ model's.
    |---|---|
    | Q1 | Batch composition — confirm the set, or adjust it |
    | Q2 | Spec grouping — one dated spec per item, or grouped specs covering related items |
-   | Q3 | End-state per item — spec merged + description/AC updated + a readiness label stamped, or leave labeling to a separate readiness gate |
+   | Q3 | Readiness labeling per item — stamp a readiness label at spec merge, or leave labeling to a separate readiness gate (either way, continuation items get minted and the claim gets released at merge — that end-state is not optional; see step 9) |
    | Q4 | Involvement split — which items need interactive brainstorming with the human, and which can be spec'd autonomously |
 
 6. **STOP.** Wait for the human's answers. Do not dispatch anything —
@@ -106,12 +106,19 @@ model's.
    further, that's nested dispatch — follow the orchestrating-subagents
    skill rather than letting the worker spawn a child it can't await.
 9. **Deliver.** Per item (or per approved group): a dated design spec in the
-   project's specs directory, following the local pattern; the item's
-   description/acceptance criteria updated to point at the spec; a readiness
-   label applied per the Q3 answer. Ship specs the same way the environment
-   already ships everything else — through its normal completion-gate,
-   worktree, and PR discipline; fablize doesn't restate that machinery, only
-   feeds it.
+   project's specs directory, following the local pattern, ending with a
+   `## Continuations` section that names each follow-on work item to create
+   (`- <noun>: <title> — AC: …`) or the literal `- none — this spec is the
+   deliverable`. Ship it the same way the environment already ships
+   everything else — through its normal completion-gate, worktree, and PR
+   discipline; fablize doesn't restate that machinery, only feeds it. At
+   spec-PR merge, the delivering session: mints the continuation items in the
+   work tracker as children under the still-open objective per the manifest,
+   releases the claim on the item (status back to open/unclaimed), and stamps
+   phase labels (a readiness label per the Q3 answer).
+   Mint-before-anything-closes, always — successors are created before
+   anything closes or releases. A work item left claimed behind a merged spec is a defect; a
+   readiness label stamped on a still-claimed item is not a deliverable.
 
 ## Red Flags
 
@@ -123,6 +130,7 @@ model's.
 | "One strong model can just implement this directly, why spec it" | That defeats the window argument: spec now while frontier capacity is available, implement later on whatever's cheap then. |
 | "Mixed-domain batch is fine, they're all just backlog items" | Domain-mixing is the context-switch tax fablize exists to avoid; keep one domain per batch. |
 | "The survey phase is mechanical — any model can start it and we can switch later" | Fail fast at entry — batch selection and spec judgment are the point of the window; a mid-flow model switch re-derives context on the expensive model, wasting the budget. |
+| "I'll leave the item claimed — implementation comes next anyway" | No. The claim releases at spec merge regardless of what happens next; mint the continuations, release the claim, stamp the labels, in that order. A still-claimed item behind a merged spec is a defect, not a shortcut. |
 
 ## NOT For
 


### PR DESCRIPTION
## Summary

Executes the M0 mitigations from the work-lifecycle design (docs/specs/2026-07-05-work-lifecycle-and-facade.md, merged in #229) — the cheap fixes for the stale-claim problem that left six specfest beads invisible to dispatch.

- **fablize + brainstorming adopt the interim protocol (§9)** (`agents-config-wgclw.18`): specs end with a `## Continuations` manifest; at spec-PR merge, continuations are minted under the still-open objective, the claim is released, labels stamped — mint-before-anything-closes. New fablize red-flag row for the "leave it claimed" rationalization. Both skills state the protocol inline (deployed assets cite no repo paths).
- **whats-next "In flight (claimed)" audit section** (`agents-config-wgclw.19`): `collect.py` renders every `in_progress` bead with claim age (from `started_at`, clamped ≥ 0), oldest first, flagging beads whose notes carry a PR URL as retroactive-delivery candidates. Cross-cutting audit: exempt from `--mode`/`--limit`/`--label`. First live run surfaced 19 claims, including one at 69 days.
- **beads rules: claim-lease + `planned` convention** (`agents-config-wgclw.20`): status is a claim lease — release or deliver before session close; containers exit planning only via the explicit, revocable `planned` label.
- **Spec amendments** (`agents-config-wgclw.21`): spec-capture-glue repositioned as a facade client implementing the interim protocol at delivery (lazy-path decomposition under the still-open bead; placeholder mechanics arrive with the facade's `spec` noun), manifest lens added as the sixth draining lens, delivery-decomposition test contract added; CLI contract spec retrofitted with its `## Continuations` manifest.

Bead-state repair (`agents-config-wgclw.17`, executed outside this diff, synced to Dolt): six stuck beads released → `open` + `brainstormed`; wave-2 five audited (no stale claims); `t142.2` caught via PR enumeration; `wgclw.9` reconciled into an objective container (`planned`, children `wgclw.9.1` transport → `wgclw.9.2` lifecycle).

## Verification

- HEAVY completion gate (22-agent workflow): **acceptance, clean-at-floor** — 4 minor findings fixed in-round (incl. clock-skew negative claim age), 2 flagged: the GFM-breaking table annotation (fixed: flag column + legend), and the protocol restated across three artifacts (accepted: deployed skills must be self-contained; each copy is scaled to its home, canonical rationale lives in the lifecycle spec).
- `py_compile` clean; live run: 19 in-flight beads, all ages ≥ 0; AC greps pass per bead (mint-before-close in both skills, claim-lease + planned in beads.md, six lenses + manifest in specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hYEFr76fMSTyRunVxSsdv
