### PR TITLE
feat(prgroom): GateStrength enum + Disposition.gate validation/audit

### DIFF
--- a/docs/plans/2026-07-11-prgroom-gate-strength.md
+++ b/docs/plans/2026-07-11-prgroom-gate-strength.md
@@ -62,8 +62,18 @@ class GateStrength(StrEnum):
     LITE = "lite"
 
     @classmethod
-    def parse(cls, raw: str) -> GateStrength | None:
-        """None for anything that is not a canonical gate value (lenient boundary parse)."""
+    def parse(cls, raw: object) -> GateStrength | None:
+        """None for anything that is not a canonical gate value (lenient boundary parse).
+
+        ``raw`` is typed ``object`` because the value flows from a contract
+        boundary (``FixItemResult.recommended_gate``) that may carry whatever a
+        provider emitted for that JSON field — a canonical string, but also
+        ``null`` (Python ``None``), a number, a bool, a list, or a dict. The
+        non-str guard makes that leniency explicit: any non-str value returns
+        ``None`` rather than raising.
+        """
+        if not isinstance(raw, str):
+            return None
         try:
             return cls(raw)
         except ValueError:
@@ -148,10 +158,15 @@ Import: add `GateStrength` to the `prgroom.prsession.enums` import block. Field 
             d["gate"] = self.gate.value
 ```
 
-`from_dict` (line 117) — falsy-raw guard keeps legacy `""` loading as None while an unknown non-empty value raises like `kind` does:
+`from_dict` (line 117) — absent-form guard keeps legacy `""` loading as None while any other value (including falsy `0`/`False`) parses or raises like `kind` does:
 
 ```python
-            gate=GateStrength(raw_gate) if (raw_gate := d.get("gate")) else None,
+            # Absent-form guard: missing/legacy "" load as None; anything else must
+            # parse or raise like `kind` does (corrupt state file, not silent data
+            # loss). Only None and "" are absent — falsy 0/False still parse-or-raise.
+            gate=GateStrength(raw_gate)
+            if (raw_gate := d.get("gate")) is not None and raw_gate != ""
+            else None,
 ```
 
 - [ ] **Step 4: Run to verify all serde tests pass**

--- a/docs/plans/2026-07-11-prgroom-gate-strength.md
+++ b/docs/plans/2026-07-11-prgroom-gate-strength.md
@@ -1,0 +1,348 @@
+# GateStrength Enum + Disposition.gate Validation Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `recommended_gate` load-bearing: type `Disposition.gate` as a `GateStrength` enum and flip a `FIXED` item with an absent/invalid gate to `FAILED` via the fix audit (spec: `docs/specs/2026-06-20-prgroom-fix-verify-subsystem.md` §6.1; bead `agents-config-abn9.8.23.1`).
+
+**Architecture:** `GateStrength(StrEnum)` joins the serialization-contract enums in `prsession/enums.py` with a lenient `parse()` classmethod. `Disposition.gate` retypes `str → GateStrength | None` (omit-when-None JSON, additive — schema_version stays 1). The fix audit gains one per-item rule in `_audit_fixed` (gate check runs AFTER the sha checks so richer sha violations keep winning). `FixItemResult.recommended_gate` stays a raw `str` at the contract boundary — lenient parse, audit owns validation (the `MemoryEntry.classification` precedent).
+
+**Tech Stack:** Python 3.12, dataclasses, StrEnum, pytest. Package gate: `make ci-prgroom` (lint, format, typecheck, coverage, audit).
+
+**Out of scope:** the `verify` VerbStep, tier selection, `VerifyVerdict`, config (all `abn9.8.23.2`); `resolve_escalated --as fixed` keeps building gate-less dispositions (None-handling at tier selection is 8.23.2's concern).
+
+---
+
+### Task 1: `GateStrength` enum + lenient `parse()`
+
+**Files:**
+- Modify: `packages/prgroom/src/prgroom/prsession/enums.py`
+- Test: `packages/prgroom/tests/unit/test_gate_strength.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""GateStrength enum + lenient parse (fix-verify spec §6.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from prgroom.prsession.enums import GateStrength
+
+
+def test_values_are_the_serialization_contract() -> None:
+    assert GateStrength.FULL.value == "full"
+    assert GateStrength.LITE.value == "lite"
+
+
+@pytest.mark.parametrize(("raw", "want"), [("full", GateStrength.FULL), ("lite", GateStrength.LITE)])
+def test_parse_accepts_valid_values(raw: str, want: GateStrength) -> None:
+    assert GateStrength.parse(raw) is want
+
+
+@pytest.mark.parametrize("raw", ["", "banana", "FULL", " full"])
+def test_parse_returns_none_for_invalid(raw: str) -> None:
+    assert GateStrength.parse(raw) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_gate_strength.py -v`
+Expected: FAIL with `ImportError: cannot import name 'GateStrength'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `packages/prgroom/src/prgroom/prsession/enums.py`:
+
+```python
+class GateStrength(StrEnum):
+    """The verify tier a fix recommends for its item (fix-verify spec §6.1)."""
+
+    FULL = "full"
+    LITE = "lite"
+
+    @classmethod
+    def parse(cls, raw: str) -> GateStrength | None:
+        """None for anything that is not a canonical gate value (lenient boundary parse)."""
+        try:
+            return cls(raw)
+        except ValueError:
+            return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_gate_strength.py -v`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/prgroom/src/prgroom/prsession/enums.py packages/prgroom/tests/unit/test_gate_strength.py
+git commit -m "feat(prgroom): add GateStrength enum with lenient parse"
+```
+
+### Task 2: Retype `Disposition.gate` as `GateStrength | None`
+
+**Files:**
+- Modify: `packages/prgroom/src/prgroom/prsession/state.py:87,102-103,117`
+- Test: `packages/prgroom/tests/unit/test_state_serde.py:95,183` + new tests
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test_state_serde.py`, update the two existing `Disposition` constructions: `gate="full"` → `gate=GateStrength.FULL` (line 95) and `gate="lite"` → `gate=GateStrength.LITE` (line 183); add `GateStrength` to the `prgroom.prsession.enums` import. Then append:
+
+```python
+def test_disposition_gate_roundtrips_as_enum() -> None:
+    d = Disposition(
+        kind=DispositionKind.FIXED,
+        decided_at=_T,
+        decided_by="agent",
+        gate=GateStrength.FULL,
+    )
+    encoded = d.to_dict()
+    assert encoded["gate"] == "full"
+    decoded = Disposition.from_dict(encoded)
+    assert decoded.gate is GateStrength.FULL
+
+
+def test_disposition_gate_none_is_omitted_and_loads_none() -> None:
+    d = Disposition(kind=DispositionKind.SKIPPED, decided_at=_T, decided_by="agent")
+    encoded = d.to_dict()
+    assert "gate" not in encoded
+    assert Disposition.from_dict(encoded).gate is None
+
+
+def test_disposition_legacy_empty_gate_loads_none() -> None:
+    # Pre-enum writers omitted falsy gates, but a hand-edited "" must not raise.
+    raw = {"kind": "skipped", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": ""}
+    assert Disposition.from_dict(raw).gate is None
+
+
+def test_disposition_invalid_gate_raises() -> None:
+    # Same strictness as kind: an unknown non-empty enum value is a corrupt state file.
+    raw = {"kind": "fixed", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": "banana"}
+    with pytest.raises(ValueError, match="banana"):
+        Disposition.from_dict(raw)
+```
+
+(Reuse the module's existing `_T` timestamp constant and `pytest` import; add either if absent.)
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_state_serde.py -v`
+Expected: the four new tests FAIL (`encoded["gate"]` is a bare enum repr / no ValueError); pre-existing tests still pass.
+
+- [ ] **Step 3: Implement in `state.py`**
+
+Import: add `GateStrength` to the `prgroom.prsession.enums` import block. Field (line 87):
+
+```python
+    gate: GateStrength | None = None
+```
+
+`to_dict` (lines 102-103):
+
+```python
+        if self.gate is not None:
+            d["gate"] = self.gate.value
+```
+
+`from_dict` (line 117) — falsy-raw guard keeps legacy `""` loading as None while an unknown non-empty value raises like `kind` does:
+
+```python
+            gate=GateStrength(raw_gate) if (raw_gate := d.get("gate")) else None,
+```
+
+- [ ] **Step 4: Run to verify all serde tests pass**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_state_serde.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/prgroom/src/prgroom/prsession/state.py packages/prgroom/tests/unit/test_state_serde.py
+git commit -m "feat(prgroom): type Disposition.gate as GateStrength | None"
+```
+
+### Task 3: Fix-audit rule — FIXED requires a valid gate
+
+**Files:**
+- Modify: `packages/prgroom/src/prgroom/agent/fix_audit.py` (`_audit_fixed` + module docstring §5 list)
+- Test: `packages/prgroom/tests/unit/test_agent_fix_audit.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test_agent_fix_audit.py`, update the one clean-FIXED fixture (line 62) to carry a gate:
+
+```python
+    out = FixOutput(
+        items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"], recommended_gate="full")]
+    )
+```
+
+Append after `test_fixed_claiming_pre_baseline_sha_is_audit_failed`:
+
+```python
+def test_fixed_with_empty_gate_is_audit_failed() -> None:
+    # §6.1: recommended_gate is load-bearing — a FIXED item must carry a valid tier.
+    req = _req("C_1")
+    out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"])])
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+    assert "recommended_gate" in v["C_1"].detail
+
+
+def test_fixed_with_invalid_gate_is_audit_failed() -> None:
+    req = _req("C_1")
+    out = FixOutput(
+        items=[
+            _row("C_1", DispositionKind.FIXED, commit_shas=["new1"], recommended_gate="banana")
+        ]
+    )
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+
+
+def test_fixed_gate_check_runs_after_sha_checks() -> None:
+    # An unreachable sha must keep its richer UNREACHABLE_SHA code even when the
+    # gate is also missing — first offending rule wins, shas first.
+    req = _req("C_1")
+    out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["ghost"])])
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_UNREACHABLE_SHA
+
+
+def test_non_fixed_dispositions_need_no_gate() -> None:
+    req = _req("C_1")
+    out = FixOutput(
+        items=[_row("C_1", DispositionKind.ALREADY_ADDRESSED, commit_shas=["base"])]
+    )
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster=set())
+    assert "C_1" not in v
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_agent_fix_audit.py -v`
+Expected: `test_fixed_with_empty_gate_is_audit_failed` and `test_fixed_with_invalid_gate_is_audit_failed` FAIL (no violation produced); the rest PASS.
+
+- [ ] **Step 3: Implement the audit rule**
+
+In `fix_audit.py`: add `GateStrength` to the `prgroom.prsession.enums` import. In `_audit_fixed`, after the sha loop (before the final `return None`):
+
+```python
+    if GateStrength.parse(row.recommended_gate) is None:
+        return _fail(
+            row,
+            f"item {row.gh_id!r} 'fixed' has missing/invalid recommended_gate "
+            f"{row.recommended_gate!r} (must be one of {[g.value for g in GateStrength]})",
+        )
+```
+
+Module docstring, extend the `fixed` bullet in the §5 list:
+
+```
+* ``fixed`` → ≥1 claimed sha, every claimed sha is a NEW commit
+  (``∈ new_in_cluster``), and ``recommended_gate`` parses as a
+  :class:`~prgroom.prsession.enums.GateStrength` — an absent/invalid gate is a
+  ``CONTRACT_FIX_AUDIT_FAILED`` (§6.1 makes the gate load-bearing). ...
+```
+
+- [ ] **Step 4: Run to verify all audit tests pass**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_agent_fix_audit.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/prgroom/src/prgroom/agent/fix_audit.py packages/prgroom/tests/unit/test_agent_fix_audit.py
+git commit -m "feat(prgroom): fix audit fails FIXED items with missing/invalid recommended_gate"
+```
+
+### Task 4: `run_fix` builds enum-typed gates end-to-end
+
+**Files:**
+- Modify: `packages/prgroom/src/prgroom/agent/fix.py:336-345` (`_clean_disposition`)
+- Test: `packages/prgroom/tests/unit/test_agent_fix.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `test_agent_fix.py`: add `GateStrength` to the `prgroom.prsession.enums` import; strengthen line 163 to the enum identity:
+
+```python
+    assert c1.gate is GateStrength.FULL
+```
+
+Append (reusing the module's existing fake-git/dispatcher helpers — follow the pattern of the surrounding `run_fix` tests for constructing `req`/dispatcher/git fakes):
+
+```python
+def test_fixed_row_with_missing_gate_flips_to_failed_end_to_end() -> None:
+    # The audit rule rides through run_fix: a FIXED row without a gate lands FAILED
+    # with the gate cause in the rationale, and the built disposition carries no gate.
+    req = _fix_input("C_1")
+    out = FixOutput(
+        items=[
+            FixItemResult(
+                gh_id="C_1",
+                disposition=DispositionKind.FIXED,
+                commit_shas=["n1"],
+            )
+        ]
+    )
+    git = _GitStub(pre="pre", post="post", new=["n1"])
+    result = run_fix(
+        req, _StubDispatcher(out), git, now=_T, decided_by="agent", known_thread_ids=set()
+    )
+    d = result.dispositions["C_1"]
+    assert d.kind is DispositionKind.FAILED
+    assert "recommended_gate" in d.rationale
+    assert d.gate is None
+```
+
+(`_fix_input` / `_GitStub` / `_StubDispatcher` stand for the file's actual helper names — reuse whatever the existing `run_fix` tests in that file use; do not invent parallel fakes.)
+
+- [ ] **Step 2: Run to verify the new test fails**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_agent_fix.py -v`
+Expected: the new test FAILS (item lands FIXED, not FAILED) — it needs Task 3's audit rule plus this task's typing to fully pass; with Task 3 landed the flip already works, so the failure to look for here is `c1.gate is GateStrength.FULL` (a raw `"full"` str fails the `is` check).
+
+- [ ] **Step 3: Implement the conversion**
+
+In `fix.py`: add `GateStrength` to the imports from `prgroom.prsession.state`'s sibling (`from prgroom.prsession.enums import GateStrength`). In `_clean_disposition`:
+
+```python
+        gate=GateStrength.parse(row.recommended_gate),
+```
+
+(For a clean FIXED row the audit guarantees a valid value; for other kinds an absent/garbage gate parses to None instead of raising — `_clean_disposition` stays total.)
+
+- [ ] **Step 4: Run to verify all fix tests pass**
+
+Run: `cd packages/prgroom && uv run pytest tests/unit/test_agent_fix.py tests/unit/test_contracts_fit.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/prgroom/src/prgroom/agent/fix.py packages/prgroom/tests/unit/test_agent_fix.py
+git commit -m "feat(prgroom): build Disposition.gate as GateStrength in run_fix"
+```
+
+### Task 5: Whole-package gate
+
+- [ ] **Step 1: Run the package CI gate**
+
+Run: `make ci-prgroom` (repo root)
+Expected: lint, format-check, typecheck, coverage, audit, entry-verify all green. Typecheck is the real audit here — it sweeps every other `Disposition(...)` construction site (`resolve_escalated.py`, `agent/errors.py`, integration tests) for str/enum mismatches the unit runs missed.
+
+- [ ] **Step 2: Fix any stragglers typecheck finds, re-run, commit**
+
+```bash
+git add -A packages/prgroom
+git commit -m "test(prgroom): sweep remaining gate call sites to GateStrength"
+```
+
+(Skip the commit if Step 1 was already green with nothing to sweep.)

--- a/packages/prgroom/src/prgroom/agent/fix.py
+++ b/packages/prgroom/src/prgroom/agent/fix.py
@@ -39,6 +39,7 @@ from prgroom.agent.fix_audit import audit_fix_items, audit_orphans
 from prgroom.agent.memory_audit import audit_memory
 from prgroom.errors import ErrorCode
 from prgroom.escalation import Escalation, Severity
+from prgroom.prsession.enums import GateStrength
 from prgroom.prsession.state import Disposition
 
 if TYPE_CHECKING:
@@ -341,7 +342,9 @@ def _clean_disposition(row: FixItemResult, *, now: datetime, decided_by: str) ->
         rationale=row.rationale,
         commits=list(row.commit_shas),
         response_path=row.response_path,
-        gate=row.recommended_gate,
+        # Lenient parse keeps this total: a clean FIXED row's gate is audit-guaranteed
+        # valid; any other kind's absent/garbage gate becomes None instead of raising.
+        gate=GateStrength.parse(row.recommended_gate),
     )
 
 

--- a/packages/prgroom/src/prgroom/agent/fix_audit.py
+++ b/packages/prgroom/src/prgroom/agent/fix_audit.py
@@ -14,10 +14,14 @@ The two sets:
 
 §5 fix audit guards:
 
-* ``fixed`` → ≥1 claimed sha, and every claimed sha is a NEW commit
-  (``∈ new_in_cluster``). No commits → ``CONTRACT_FIX_AUDIT_FAILED``; a sha in
-  neither set → ``CONTRACT_FIX_UNREACHABLE_SHA``; a sha that is a pre-baseline
-  ancestor → ``CONTRACT_FIX_AUDIT_FAILED`` (a ``fixed`` must be new work).
+* ``fixed`` → ≥1 claimed sha, every claimed sha is a NEW commit
+  (``∈ new_in_cluster``), and ``recommended_gate`` parses as a
+  :class:`~prgroom.prsession.enums.GateStrength`. No commits →
+  ``CONTRACT_FIX_AUDIT_FAILED``; a sha in neither set →
+  ``CONTRACT_FIX_UNREACHABLE_SHA``; a sha that is a pre-baseline ancestor →
+  ``CONTRACT_FIX_AUDIT_FAILED`` (a ``fixed`` must be new work); an absent/invalid
+  gate → ``CONTRACT_FIX_AUDIT_FAILED`` (the fix-verify spec §6.1 makes the gate
+  load-bearing; the sha checks run first so their richer codes win).
 * ``already_addressed`` → every claimed sha predates the baseline
   (``∈ ancestors_of_pre``). A sha in neither set → ``CONTRACT_FIX_UNREACHABLE_SHA``;
   a brand-new sha → ``CONTRACT_FIX_AUDIT_FAILED`` (claims pre-existing but isn't).
@@ -34,7 +38,7 @@ from typing import TYPE_CHECKING
 from prgroom.agent.errors import AuditViolation
 from prgroom.errors import ErrorCode
 from prgroom.escalation import Severity
-from prgroom.prsession.enums import DispositionKind
+from prgroom.prsession.enums import DispositionKind, GateStrength
 
 if TYPE_CHECKING:
     from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput
@@ -109,6 +113,12 @@ def _audit_fixed(
         if sha in ancestors_of_pre:
             return _fail(row, f"item {row.gh_id!r} 'fixed' claims pre-baseline commit {sha!r}")
         return _unreachable(row, sha)
+    if GateStrength.parse(row.recommended_gate) is None:
+        return _fail(
+            row,
+            f"item {row.gh_id!r} 'fixed' has missing/invalid recommended_gate "
+            f"{row.recommended_gate!r} (must be one of {[g.value for g in GateStrength]})",
+        )
     return None
 
 

--- a/packages/prgroom/src/prgroom/prsession/enums.py
+++ b/packages/prgroom/src/prgroom/prsession/enums.py
@@ -49,8 +49,19 @@ class GateStrength(StrEnum):
     LITE = "lite"
 
     @classmethod
-    def parse(cls, raw: str) -> GateStrength | None:
-        """None for anything that is not a canonical gate value (lenient boundary parse)."""
+    def parse(cls, raw: object) -> GateStrength | None:
+        """None for anything that is not a canonical gate value (lenient boundary parse).
+
+        ``raw`` is typed ``object`` because this is a contract-boundary parse: the
+        value flows from ``FixOutput.from_dict`` (``recommended_gate``), which passes
+        through whatever a provider emitted for that JSON field — a canonical string,
+        but also ``null`` (Python ``None``), a number, a bool, a list, or a dict. The
+        non-str guard makes that leniency explicit: any non-str value returns ``None``,
+        so a malformed gate becomes a ``CONTRACT_FIX_AUDIT_FAILED`` violation downstream
+        rather than an exception.
+        """
+        if not isinstance(raw, str):
+            return None
         try:
             return cls(raw)
         except ValueError:

--- a/packages/prgroom/src/prgroom/prsession/enums.py
+++ b/packages/prgroom/src/prgroom/prsession/enums.py
@@ -42,6 +42,21 @@ class DispositionKind(StrEnum):
     FAILED = "failed"
 
 
+class GateStrength(StrEnum):
+    """The verify tier a fix recommends for its item (fix-verify spec §6.1)."""
+
+    FULL = "full"
+    LITE = "lite"
+
+    @classmethod
+    def parse(cls, raw: str) -> GateStrength | None:
+        """None for anything that is not a canonical gate value (lenient boundary parse)."""
+        try:
+            return cls(raw)
+        except ValueError:
+            return None
+
+
 class ReviewerKind(StrEnum):
     """Whether a reviewer is a human or a bot (§2)."""
 

--- a/packages/prgroom/src/prgroom/prsession/state.py
+++ b/packages/prgroom/src/prgroom/prsession/state.py
@@ -115,9 +115,12 @@ class Disposition:
             rationale=d.get("rationale", ""),
             commits=list(d.get("commits", [])),
             response_path=d.get("response_path"),
-            # Falsy-raw guard: legacy "" loads as None; an unknown non-empty value
-            # raises like `kind` does (corrupt state file, not silent data loss).
-            gate=GateStrength(raw_gate) if (raw_gate := d.get("gate")) else None,
+            # Absent-form guard: missing/legacy "" load as None; anything else must
+            # parse or raise like `kind` does (corrupt state file, not silent data
+            # loss). Only None and "" are absent — falsy 0/False still parse-or-raise.
+            gate=GateStrength(raw_gate)
+            if (raw_gate := d.get("gate")) is not None and raw_gate != ""
+            else None,
             escalation_filed=d.get("escalation_filed", False),
         )
 

--- a/packages/prgroom/src/prgroom/prsession/state.py
+++ b/packages/prgroom/src/prgroom/prsession/state.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from prgroom.prsession.enums import (
     DispositionKind,
+    GateStrength,
     ItemKind,
     PRPhase,
     ReviewerKind,
@@ -84,7 +85,7 @@ class Disposition:
     rationale: str = ""
     commits: list[str] = field(default_factory=list)
     response_path: str | None = None
-    gate: str = ""
+    gate: GateStrength | None = None
     escalation_filed: bool = False
 
     def to_dict(self) -> JsonObj:
@@ -99,8 +100,8 @@ class Disposition:
             d["commits"] = list(self.commits)
         if self.response_path is not None:
             d["response_path"] = self.response_path
-        if self.gate:
-            d["gate"] = self.gate
+        if self.gate is not None:
+            d["gate"] = self.gate.value
         if self.escalation_filed:
             d["escalation_filed"] = self.escalation_filed
         return d
@@ -114,7 +115,9 @@ class Disposition:
             rationale=d.get("rationale", ""),
             commits=list(d.get("commits", [])),
             response_path=d.get("response_path"),
-            gate=d.get("gate", ""),
+            # Falsy-raw guard: legacy "" loads as None; an unknown non-empty value
+            # raises like `kind` does (corrupt state file, not silent data loss).
+            gate=GateStrength(raw_gate) if (raw_gate := d.get("gate")) else None,
             escalation_filed=d.get("escalation_filed", False),
         )
 

--- a/packages/prgroom/tests/unit/test_agent_fix.py
+++ b/packages/prgroom/tests/unit/test_agent_fix.py
@@ -17,7 +17,7 @@ from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEn
 from prgroom.agent.dispatcher import AllProvidersFailedError
 from prgroom.agent.fix import run_fix
 from prgroom.escalation import Severity
-from prgroom.prsession.enums import DispositionKind, ItemKind
+from prgroom.prsession.enums import DispositionKind, GateStrength, ItemKind
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import Disposition, Identity, ReviewItem
 
@@ -160,13 +160,49 @@ def test_clean_output_maps_dispositions_straight_through() -> None:
     assert c1.kind is DispositionKind.FIXED
     assert c1.commits == ["n1"]
     assert c1.rationale == "fixed it"
-    assert c1.gate == "full"
+    assert c1.gate is GateStrength.FULL
     assert c1.response_path == "/o/C_1.md"
     assert c1.decided_at == _NOW
     assert c1.decided_by == "prgroom"
     assert res.dispositions["C_2"].kind is DispositionKind.WONT_FIX
     assert res.escalations == []
     assert res.stashed is False
+
+
+def test_fixed_row_with_missing_gate_flips_to_failed_end_to_end() -> None:
+    # The §6.1 audit rule rides through run_fix: a FIXED row without a gate lands
+    # FAILED with the gate cause in the rationale, and the built disposition
+    # carries no gate (failed_disposition drops it).
+    req = _req("C_1")
+    out = FixOutput(
+        items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["n1"])]
+    )
+    git = _git(ancestors=["pre"], new=["n1"])
+    res = run_fix(req, FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
+    d = res.dispositions["C_1"]
+    assert d.kind is DispositionKind.FAILED
+    assert "recommended_gate" in d.rationale
+    assert d.gate is None
+
+
+def test_clean_non_fixed_row_with_garbage_gate_parses_to_none() -> None:
+    # _clean_disposition must stay total: a non-FIXED row (no gate audit) carrying
+    # a garbage recommended_gate builds a gate-less disposition instead of raising.
+    req = _req("C_1")
+    out = FixOutput(
+        items=[
+            FixItemResult(
+                gh_id="C_1",
+                disposition=DispositionKind.SKIPPED,
+                rationale="ack",
+                recommended_gate="banana",
+            )
+        ]
+    )
+    res = run_fix(req, FixDispatcherStub(out), _git(), now=_NOW, decided_by="prgroom")
+    d = res.dispositions["C_1"]
+    assert d.kind is DispositionKind.SKIPPED
+    assert d.gate is None
 
 
 # ───────────────────────── per-item audit failure ─────────────────────────

--- a/packages/prgroom/tests/unit/test_agent_fix.py
+++ b/packages/prgroom/tests/unit/test_agent_fix.py
@@ -205,7 +205,14 @@ def test_cluster_flip_rationale_carries_the_hard_violation_detail() -> None:
     # its disposition.rationale (the lifecycle reads rationale, not last_error), not
     # a generic marker. Here C_1 is a valid 'fixed' but n2 is an unclaimed orphan.
     out = FixOutput(
-        items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["n1"])]
+        items=[
+            FixItemResult(
+                gh_id="C_1",
+                disposition=DispositionKind.FIXED,
+                commit_shas=["n1"],
+                recommended_gate="full",
+            )
+        ]
     )
     git = _git(ancestors=["pre"], new=["n1", "n2"])
     res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
@@ -221,7 +228,14 @@ def test_swept_item_rationale_is_the_spec_string_with_no_added_prefix() -> None:
     # "cluster failed: " — that diverges from the documented contract string the
     # lifecycle/resolver read as the source of truth for the cause.
     out = FixOutput(
-        items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["n1"])],
+        items=[
+            FixItemResult(
+                gh_id="C_1",
+                disposition=DispositionKind.FIXED,
+                commit_shas=["n1"],
+                recommended_gate="full",
+            )
+        ],
         memory_writes=["/etc/passwd"],  # escapes memory_dir → hard containment BLOCK
     )
     git = _git(ancestors=["pre"], new=["n1"])  # n1 claimed → no orphan, only containment

--- a/packages/prgroom/tests/unit/test_agent_fix_audit.py
+++ b/packages/prgroom/tests/unit/test_agent_fix_audit.py
@@ -66,6 +66,29 @@ def test_fixed_with_new_commit_is_clean() -> None:
     assert "C_1" not in v
 
 
+def test_fixed_with_null_recommended_gate_from_dict_is_audit_failed() -> None:
+    # Reviewer's exact scenario end-to-end: a provider emits `"recommended_gate": null`.
+    # After json load that is Python None, which from_dict assigns verbatim. The sha
+    # checks pass (new1 is a new commit), so GateStrength.parse(None) -> None drives a
+    # CONTRACT_FIX_AUDIT_FAILED violation — NOT a TypeError crashing the audit.
+    req = _req("C_1")
+    out = FixOutput.from_dict(
+        {
+            "items": [
+                {
+                    "gh_id": "C_1",
+                    "disposition": "fixed",
+                    "commit_shas": ["new1"],
+                    "recommended_gate": None,
+                }
+            ]
+        }
+    )
+    assert out.items[0].recommended_gate is None
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+
+
 def test_fixed_with_no_commits_is_audit_failed() -> None:
     req = _req("C_1")
     out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=[])])

--- a/packages/prgroom/tests/unit/test_agent_fix_audit.py
+++ b/packages/prgroom/tests/unit/test_agent_fix_audit.py
@@ -59,7 +59,9 @@ def _row(gh_id: str, kind: DispositionKind, **kw: object) -> FixItemResult:
 
 def test_fixed_with_new_commit_is_clean() -> None:
     req = _req("C_1")
-    out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"])])
+    out = FixOutput(
+        items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"], recommended_gate="full")]
+    )
     v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
     assert "C_1" not in v
 
@@ -84,6 +86,40 @@ def test_fixed_claiming_pre_baseline_sha_is_audit_failed() -> None:
     out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["base"])])
     v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
     assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+
+
+def test_fixed_with_empty_gate_is_audit_failed() -> None:
+    # §6.1: recommended_gate is load-bearing — a FIXED item must carry a valid tier.
+    req = _req("C_1")
+    out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"])])
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+    assert "recommended_gate" in v["C_1"].detail
+
+
+def test_fixed_with_invalid_gate_is_audit_failed() -> None:
+    req = _req("C_1")
+    out = FixOutput(
+        items=[_row("C_1", DispositionKind.FIXED, commit_shas=["new1"], recommended_gate="banana")]
+    )
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_AUDIT_FAILED
+
+
+def test_fixed_gate_check_runs_after_sha_checks() -> None:
+    # An unreachable sha must keep its richer UNREACHABLE_SHA code even when the
+    # gate is also missing — first offending rule wins, shas first.
+    req = _req("C_1")
+    out = FixOutput(items=[_row("C_1", DispositionKind.FIXED, commit_shas=["ghost"])])
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster={"new1"})
+    assert v["C_1"].code is ErrorCode.CONTRACT_FIX_UNREACHABLE_SHA
+
+
+def test_non_fixed_dispositions_need_no_gate() -> None:
+    req = _req("C_1")
+    out = FixOutput(items=[_row("C_1", DispositionKind.ALREADY_ADDRESSED, commit_shas=["base"])])
+    v = audit_fix_items(req, out, ancestors_of_pre={"base"}, new_in_cluster=set())
+    assert "C_1" not in v
 
 
 # ───────────────────────── already_addressed ─────────────────────────

--- a/packages/prgroom/tests/unit/test_gate_strength.py
+++ b/packages/prgroom/tests/unit/test_gate_strength.py
@@ -1,0 +1,24 @@
+"""GateStrength enum + lenient parse (fix-verify spec §6.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from prgroom.prsession.enums import GateStrength
+
+
+def test_values_are_the_serialization_contract() -> None:
+    assert GateStrength.FULL.value == "full"
+    assert GateStrength.LITE.value == "lite"
+
+
+@pytest.mark.parametrize(
+    ("raw", "want"), [("full", GateStrength.FULL), ("lite", GateStrength.LITE)]
+)
+def test_parse_accepts_valid_values(raw: str, want: GateStrength) -> None:
+    assert GateStrength.parse(raw) is want
+
+
+@pytest.mark.parametrize("raw", ["", "banana", "FULL", " full"])
+def test_parse_returns_none_for_invalid(raw: str) -> None:
+    assert GateStrength.parse(raw) is None

--- a/packages/prgroom/tests/unit/test_gate_strength.py
+++ b/packages/prgroom/tests/unit/test_gate_strength.py
@@ -22,3 +22,11 @@ def test_parse_accepts_valid_values(raw: str, want: GateStrength) -> None:
 @pytest.mark.parametrize("raw", ["", "banana", "FULL", " full"])
 def test_parse_returns_none_for_invalid(raw: str) -> None:
     assert GateStrength.parse(raw) is None
+
+
+@pytest.mark.parametrize("raw", [None, 5, 5.0, True, ["full"], {"x": 1}])
+def test_parse_returns_none_for_non_str(raw: object) -> None:
+    # The leniency is EXPLICIT, not incidental: a provider emitting JSON null (Python
+    # None) or any other non-str for recommended_gate must yield None, not raise —
+    # so a malformed gate lands as a CONTRACT_FIX_AUDIT_FAILED violation downstream.
+    assert GateStrength.parse(raw) is None

--- a/packages/prgroom/tests/unit/test_lifecycle_fix.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix.py
@@ -195,7 +195,12 @@ def test_fix_applies_dispositions_from_result(tmp_path: Path) -> None:
     dispatcher = FixDispatcherStub(
         [
             _out(
-                FixItemResult(gh_id="a", disposition=DispositionKind.FIXED, commit_shas=["sha1"]),
+                FixItemResult(
+                    gh_id="a",
+                    disposition=DispositionKind.FIXED,
+                    commit_shas=["sha1"],
+                    recommended_gate="full",
+                ),
                 FixItemResult(gh_id="b", disposition=DispositionKind.SKIPPED, rationale="ack only"),
             )
         ]
@@ -229,7 +234,16 @@ def test_fix_applies_per_cluster_not_state_wide_gh_id(tmp_path: Path) -> None:
         disposition=prior,
     )
     dispatcher = FixDispatcherStub(
-        [_out(FixItemResult(gh_id="dup", disposition=DispositionKind.FIXED, commit_shas=["sha1"]))]
+        [
+            _out(
+                FixItemResult(
+                    gh_id="dup",
+                    disposition=DispositionKind.FIXED,
+                    commit_shas=["sha1"],
+                    recommended_gate="full",
+                )
+            )
+        ]
     )
     out, _sink, _git = _run(
         _state(target, sibling), dispatcher, tmp_path, git=FakeGit(new_commits=["sha1"])

--- a/packages/prgroom/tests/unit/test_lifecycle_fix_memory_routing.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix_memory_routing.py
@@ -154,7 +154,12 @@ def test_clean_routable_extends_pending_memory(tmp_path: Path) -> None:
     dispatcher = FixDispatcherStub(
         [
             _out(
-                FixItemResult(gh_id="a", disposition=DispositionKind.FIXED, commit_shas=["s1"]),
+                FixItemResult(
+                    gh_id="a",
+                    disposition=DispositionKind.FIXED,
+                    commit_shas=["s1"],
+                    recommended_gate="full",
+                ),
                 memory=[MemoryEntry(classification="CONTEXTUAL", content="why")],
             )
         ]
@@ -189,7 +194,10 @@ class _SymlinkPlantingDispatcher:
         return FixOutput(
             items=[
                 FixItemResult(
-                    gh_id=self.gh_id, disposition=DispositionKind.FIXED, commit_shas=["s1"]
+                    gh_id=self.gh_id,
+                    disposition=DispositionKind.FIXED,
+                    commit_shas=["s1"],
+                    recommended_gate="full",
                 )
             ],
             memory=[MemoryEntry(classification="CONTEXTUAL", path=str(link))],

--- a/packages/prgroom/tests/unit/test_state_serde.py
+++ b/packages/prgroom/tests/unit/test_state_serde.py
@@ -20,6 +20,7 @@ import pytest
 
 from prgroom.prsession.enums import (
     DispositionKind,
+    GateStrength,
     ItemKind,
     PRPhase,
     ReviewerKind,
@@ -92,7 +93,7 @@ def test_round_trip_preserves_fully_populated_state() -> None:
         rationale="addressed the off-by-one",
         commits=["abc123", "def456"],
         response_path="/tmp/resp.md",  # noqa: S108  # test fixture path, not a real temp write
-        gate="full",
+        gate=GateStrength.FULL,
     )
     item = ReviewItem(
         kind=ItemKind.REVIEW_THREAD,
@@ -180,7 +181,7 @@ def test_every_optional_field_round_trips_when_populated() -> None:
         rationale="needs a human",
         commits=["sha"],
         response_path="/r.md",
-        gate="lite",
+        gate=GateStrength.LITE,
         escalation_filed=True,
     )
     item = ReviewItem(
@@ -240,6 +241,39 @@ def test_parsing_a_tz_naive_datetime_string_raises() -> None:
     d["last_polled_at"] = "2026-06-09T12:00:00"  # no offset
     with pytest.raises(ValueError, match="timezone-aware"):
         PRGroomingState.from_dict(d)
+
+
+def test_disposition_gate_roundtrips_as_enum() -> None:
+    d = Disposition(
+        kind=DispositionKind.FIXED,
+        decided_at=_T,
+        decided_by="agent",
+        gate=GateStrength.FULL,
+    )
+    encoded = d.to_dict()
+    assert encoded["gate"] == "full"
+    decoded = Disposition.from_dict(encoded)
+    assert decoded.gate is GateStrength.FULL
+
+
+def test_disposition_gate_none_is_omitted_and_loads_none() -> None:
+    d = Disposition(kind=DispositionKind.SKIPPED, decided_at=_T, decided_by="agent")
+    encoded = d.to_dict()
+    assert "gate" not in encoded
+    assert Disposition.from_dict(encoded).gate is None
+
+
+def test_disposition_legacy_empty_gate_loads_none() -> None:
+    # Pre-enum writers omitted falsy gates, but a hand-edited "" must not raise.
+    raw = {"kind": "skipped", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": ""}
+    assert Disposition.from_dict(raw).gate is None
+
+
+def test_disposition_invalid_gate_raises() -> None:
+    # Same strictness as kind: an unknown non-empty enum value is a corrupt state file.
+    raw = {"kind": "fixed", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": "banana"}
+    with pytest.raises(ValueError, match="banana"):
+        Disposition.from_dict(raw)
 
 
 def test_disposition_round_trips_through_item() -> None:

--- a/packages/prgroom/tests/unit/test_state_serde.py
+++ b/packages/prgroom/tests/unit/test_state_serde.py
@@ -276,6 +276,20 @@ def test_disposition_invalid_gate_raises() -> None:
         Disposition.from_dict(raw)
 
 
+def test_disposition_falsy_zero_gate_raises() -> None:
+    # 0 is falsy but not an absent-form (None/""); a truthiness guard would hide it.
+    raw = {"kind": "fixed", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": 0}
+    with pytest.raises(ValueError):
+        Disposition.from_dict(raw)
+
+
+def test_disposition_falsy_false_gate_raises() -> None:
+    # False is falsy but not an absent-form (None/""); it must parse-or-raise, not vanish.
+    raw = {"kind": "fixed", "decided_at": _T.isoformat(), "decided_by": "agent", "gate": False}
+    with pytest.raises(ValueError):
+        Disposition.from_dict(raw)
+
+
 def test_disposition_round_trips_through_item() -> None:
     item = ReviewItem(
         kind=ItemKind.REVIEW_THREAD,


### PR DESCRIPTION
## Summary
- Adds `GateStrength(StrEnum)` (`full`/`lite`) to `prsession/enums.py` with a lenient `parse()` classmethod, per the fix-verify subsystem spec (`docs/specs/2026-06-20-prgroom-fix-verify-subsystem.md` §6.1).
- Retypes `Disposition.gate` from free `str` to `GateStrength | None` — additive, omit-when-None JSON, `schema_version` stays 1; legacy `""` loads as `None`, an unknown non-empty value raises like `kind` does.
- New fix-audit rule: a `FIXED` item whose `recommended_gate` is absent/invalid flips to `FAILED` via `CONTRACT_FIX_AUDIT_FAILED`. Sha checks run first so their richer codes (`CONTRACT_FIX_UNREACHABLE_SHA`) keep precedence.
- `run_fix`'s `_clean_disposition` builds the enum via lenient parse (stays total for non-FIXED rows carrying garbage gates).

This makes `recommended_gate` load-bearing — the prerequisite for the verify VerbStep (tier selection reads "strongest `Disposition.gate` across clean FIXED items").

## Scope
- **In:** `packages/prgroom/src/prgroom/prsession/enums.py`, `prsession/state.py`, `agent/fix_audit.py`, `agent/fix.py` + unit tests; the implementation plan doc `docs/plans/2026-07-11-prgroom-gate-strength.md`.
- **Out (deliberate):** the verify VerbStep, tier selection, `VerifyVerdict`, `[verify]` config, `PRECONDITION_NO_VERIFY_CONFIG` (all next bead in the wave); `resolve_escalated --as fixed` still builds gate-less dispositions — None-handling at tier selection belongs to the verify-step bead. `FixItemResult.recommended_gate` stays a raw `str` at the contract boundary by design (lenient parse, audit owns validation — the `MemoryEntry.classification` precedent).

## Ground truth
- Spec: `docs/specs/2026-06-20-prgroom-fix-verify-subsystem.md` §6.1 (GateStrength), §5 (audit contract).
- Bead: agents-config-abn9.8.23.1.

## Test Plan
- [x] `make ci-prgroom` green: 911 tests pass, coverage 99.63% (floor 90%), `mypy --strict` clean, ruff lint+format clean, pip-audit no known vulnerabilities.
- [x] New tests: enum values + lenient parse; serde round-trip/omission/legacy-empty/invalid-raise; audit rules (empty gate, invalid gate, sha-precedence, non-FIXED exemption); end-to-end `run_fix` flip + enum-typed clean disposition.
- [x] HEAVY quality-gate workflow (6 finder lenses, 3-refuter panels): ACCEPTANCE, zero major+ findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QX2rb8m9Qb67Xf9hSnB39k