### PR TITLE
fix(installer): harden profiles.py user-manifest loader + selector matcher (eeyx9)

### DIFF
--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -267,10 +267,11 @@ def _match_segments(pattern: list[str], key: list[str]) -> bool:
         if pi == len(pattern):
             result = ki == len(key)
         elif pattern[pi] == "**":
-            if pi + 1 == len(pattern):
-                result = True
-            else:
-                result = any(match(pi + 1, kj) for kj in range(ki, len(key) + 1))
+            # `**` matches zero segments (advance past it) OR one-or-more
+            # (consume one key segment, `**` stays active). Two O(1) probes per
+            # state — not an O(K) scan — so the memoized bound is a true
+            # O(len(pattern) * len(key)), matching the docstring.
+            result = match(pi + 1, ki) or (ki < len(key) and match(pi, ki + 1))
         elif ki == len(key) or (pattern[pi] != "*" and pattern[pi] != key[ki]):
             result = False
         else:

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -160,14 +160,27 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
     collision (no silent shadowing) — compose or rename instead. The merged
     `Manifest.scopes` comes only from the shipped file.
 
-    A `user` path that is not provided or genuinely absent is ignored. One
-    that exists but is not a regular file (a directory or broken symlink), or
-    a regular file that cannot be read, fails loud with a `ProfilesError`
-    naming the path — the same fail-loud posture the rest of this module holds.
+    A `user` path that is not provided or genuinely absent (nothing at the
+    path) is ignored. Anything else fails loud with a `ProfilesError` naming
+    the path: a path that cannot be accessed (e.g. a non-searchable parent
+    directory), one that exists but is not a regular file (a directory or
+    broken symlink), or a regular file that cannot be read — the same
+    fail-loud posture the rest of this module holds.
     """
     manifest = _parse_manifest_file(shipped, allow_scopes=True)
-    if user is None or not (user.exists() or user.is_symlink()):
-        return manifest  # not provided, or genuinely absent — ignore
+    if user is None:
+        return manifest
+    try:
+        # `lstat` (not `exists()`/`is_symlink()`, which swallow every OSError
+        # and return False): only a genuinely-missing path (FileNotFoundError)
+        # is ignored; an inaccessible one (e.g. a non-searchable parent) fails
+        # loud instead of being silently treated as absent.
+        user.lstat()
+    except FileNotFoundError:
+        return manifest  # genuinely absent — ignore
+    except OSError as exc:
+        msg = f"user manifest {user} could not be accessed: {exc}"
+        raise ProfilesError(msg) from exc
     if not user.is_file():
         # `is_file()` is True for an unreadable regular file (it stats the type,
         # not the content), so this branch is only non-regular-file objects; an

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -160,19 +160,19 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
     collision (no silent shadowing) — compose or rename instead. The merged
     `Manifest.scopes` comes only from the shipped file.
 
-    A `user` path that is not provided or genuinely absent is ignored; one
-    that exists but is not a readable regular file (a directory, a broken
-    symlink, or an unreadable file) fails loud with a `ProfilesError` naming
-    the path — the same fail-loud posture the rest of this module holds.
+    A `user` path that is not provided or genuinely absent is ignored. One
+    that exists but is not a regular file (a directory or broken symlink), or
+    a regular file that cannot be read, fails loud with a `ProfilesError`
+    naming the path — the same fail-loud posture the rest of this module holds.
     """
     manifest = _parse_manifest_file(shipped, allow_scopes=True)
     if user is None or not (user.exists() or user.is_symlink()):
         return manifest  # not provided, or genuinely absent — ignore
     if not user.is_file():
-        msg = (
-            f"user manifest {user} is not a readable regular file "
-            "(directory, broken symlink, or unreadable)"
-        )
+        # `is_file()` is True for an unreadable regular file (it stats the type,
+        # not the content), so this branch is only non-regular-file objects; an
+        # unreadable regular file is caught by the read below.
+        msg = f"user manifest {user} is not a regular file (a directory or broken symlink)"
         raise ProfilesError(msg)
     try:
         user_manifest = _parse_manifest_file(user, allow_scopes=False)

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -159,12 +159,26 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
     not declare `[scopes]`; a profile name present in both files is a
     collision (no silent shadowing) — compose or rename instead. The merged
     `Manifest.scopes` comes only from the shipped file.
+
+    A `user` path that is not provided or genuinely absent is ignored; one
+    that exists but is not a readable regular file (a directory, a broken
+    symlink, or an unreadable file) fails loud with a `ProfilesError` naming
+    the path — the same fail-loud posture the rest of this module holds.
     """
     manifest = _parse_manifest_file(shipped, allow_scopes=True)
-    if user is None or not user.is_file():
-        return manifest
-
-    user_manifest = _parse_manifest_file(user, allow_scopes=False)
+    if user is None or not (user.exists() or user.is_symlink()):
+        return manifest  # not provided, or genuinely absent — ignore
+    if not user.is_file():
+        msg = (
+            f"user manifest {user} is not a readable regular file "
+            "(directory, broken symlink, or unreadable)"
+        )
+        raise ProfilesError(msg)
+    try:
+        user_manifest = _parse_manifest_file(user, allow_scopes=False)
+    except OSError as exc:
+        msg = f"user manifest {user} could not be read: {exc}"
+        raise ProfilesError(msg) from exc
     collisions = set(manifest.profiles) & set(user_manifest.profiles)
     if collisions:
         names = ", ".join(sorted(collisions))
@@ -238,18 +252,33 @@ def _selector_matches(selector: str, candidate_key: str) -> bool:
 
 
 def _match_segments(pattern: list[str], key: list[str]) -> bool:
-    if not pattern:
-        return not key
-    head, *rest = pattern
-    if head == "**":
-        if not rest:
-            return True
-        return any(_match_segments(rest, key[i:]) for i in range(len(key) + 1))
-    if not key:
-        return False
-    if head != "*" and head != key[0]:
-        return False
-    return _match_segments(rest, key[1:])
+    """Memoized on `(pattern_index, key_index)`. Every subproblem is a suffix
+    pair of `pattern`/`key`, uniquely identified by its two start offsets, so
+    caching bounds the work to O(len(pattern) * len(key)) — a hand-authored
+    selector with many `**` globs cannot exponentially backtrack (self-
+    inflicted DoS). The match semantics are unchanged: `**` = zero-or-more
+    segments, `*` = exactly one, a literal matches an equal segment."""
+    memo: dict[tuple[int, int], bool] = {}
+
+    def match(pi: int, ki: int) -> bool:
+        cached = memo.get((pi, ki))
+        if cached is not None:
+            return cached
+        if pi == len(pattern):
+            result = ki == len(key)
+        elif pattern[pi] == "**":
+            if pi + 1 == len(pattern):
+                result = True
+            else:
+                result = any(match(pi + 1, kj) for kj in range(ki, len(key) + 1))
+        elif ki == len(key) or (pattern[pi] != "*" and pattern[pi] != key[ki]):
+            result = False
+        else:
+            result = match(pi + 1, ki + 1)
+        memo[(pi, ki)] = result
+        return result
+
+    return match(0, 0)
 
 
 def _specificity(selector: str) -> tuple[bool, int]:
@@ -319,6 +348,19 @@ def _assign_scope(
     return _break_specificity_tie(key, defaults, source="[scopes]")
 
 
+def _match_selector_or_error(
+    selector: str, universe: Mapping[str, Sequence[UniverseRef]], *, label: str
+) -> set[str]:
+    """Every universe key `selector` matches; a selector matching nothing is a
+    `ProfilesError` (dead selectors fail loud, never silently no-op). `label`
+    prefixes the message so include and exclude call sites stay distinct."""
+    keys = {key for key in universe if _selector_matches(selector, key)}
+    if not keys:
+        msg = f"{label} matches nothing in the staged universe"
+        raise ProfilesError(msg)
+    return keys
+
+
 def resolve(
     manifest: Manifest,
     selection: Sequence[str],
@@ -347,22 +389,13 @@ def resolve(
 
     matched_includes: set[str] = set()
     for profile_name, entry in contributing_includes:
-        keys = {key for key in universe if _selector_matches(entry.selector, key)}
-        if not keys:
-            msg = (
-                f"include selector {entry.selector!r} (profile {profile_name!r}) "
-                "matches nothing in the staged universe"
-            )
-            raise ProfilesError(msg)
-        matched_includes.update(keys)
+        label = f"include selector {entry.selector!r} (profile {profile_name!r})"
+        matched_includes.update(_match_selector_or_error(entry.selector, universe, label=label))
 
     matched_excludes: set[str] = set()
     for selector in excludes:
-        keys = {key for key in universe if _selector_matches(selector, key)}
-        if not keys:
-            msg = f"exclude selector {selector!r} matches nothing in the staged universe"
-            raise ProfilesError(msg)
-        matched_excludes.update(keys)
+        label = f"exclude selector {selector!r}"
+        matched_excludes.update(_match_selector_or_error(selector, universe, label=label))
 
     result_keys = matched_includes - matched_excludes
     if not result_keys:

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -14,6 +14,7 @@ design contract this module implements.
 
 from __future__ import annotations
 
+import stat
 import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
@@ -181,12 +182,24 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
     except OSError as exc:
         msg = f"user manifest {user} could not be accessed: {exc}"
         raise ProfilesError(msg) from exc
-    if not user.is_file():
-        # `is_file()` is True for an unreadable regular file (it stats the type,
-        # not the content), so this branch is only non-regular-file objects; an
-        # unreadable regular file is caught by the read below.
-        msg = f"user manifest {user} is not a regular file (e.g. a directory or broken symlink)"
-        raise ProfilesError(msg)
+    not_regular_msg = (
+        f"user manifest {user} is not a regular file (e.g. a directory or broken symlink)"
+    )
+    try:
+        # An explicit resolving stat (not `is_file()`, which swallows every
+        # OSError into False): a target under a non-searchable directory must
+        # surface as an access error, not be misreported as "not a regular
+        # file". Reading the content (below) is what catches an unreadable
+        # *regular* file — stat only inspects metadata, so it succeeds there.
+        stat_result = user.stat()
+    except FileNotFoundError:
+        raise ProfilesError(not_regular_msg) from None  # broken symlink — target is gone
+    except OSError as exc:
+        msg = f"user manifest {user} could not be accessed: {exc}"
+        raise ProfilesError(msg) from exc
+    if not stat.S_ISREG(stat_result.st_mode):
+        # a directory, FIFO, socket, device — resolves but is not a regular file.
+        raise ProfilesError(not_regular_msg)
     try:
         user_manifest = _parse_manifest_file(user, allow_scopes=False)
     except OSError as exc:

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -163,7 +163,7 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
     A `user` path that is not provided or genuinely absent (nothing at the
     path) is ignored. Anything else fails loud with a `ProfilesError` naming
     the path: a path that cannot be accessed (e.g. a non-searchable parent
-    directory), one that exists but is not a regular file (a directory or
+    directory), one that exists but is not a regular file (e.g. a directory or
     broken symlink), or a regular file that cannot be read — the same
     fail-loud posture the rest of this module holds.
     """
@@ -185,7 +185,7 @@ def load_manifest(shipped: Path, user: Path | None = None) -> Manifest:
         # `is_file()` is True for an unreadable regular file (it stats the type,
         # not the content), so this branch is only non-regular-file objects; an
         # unreadable regular file is caught by the read below.
-        msg = f"user manifest {user} is not a regular file (a directory or broken symlink)"
+        msg = f"user manifest {user} is not a regular file (e.g. a directory or broken symlink)"
         raise ProfilesError(msg)
     try:
         user_manifest = _parse_manifest_file(user, allow_scopes=False)

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -9,6 +9,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import signal
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -123,6 +127,57 @@ def test_selector_matches_pattern_longer_than_key_no_match() -> None:
 def test_selector_matches_double_star_mid_pattern_matches_any_gap() -> None:
     assert _selector_matches("a/**/b", "a/x/y/b") is True
     assert _selector_matches("a/**/b", "a/c") is False
+
+
+def test_selector_matches_consecutive_double_stars_behave_as_one() -> None:
+    """Consecutive `**` segments collapse to the same zero-or-more-segments
+    meaning as a single `**` — the semantics the bound must preserve."""
+    assert _selector_matches("**/**/skills", "skills") is True
+    assert _selector_matches("**/**/skills", "a/b/skills") is True
+    assert _selector_matches("**/**/skills", "a/b/rules") is False
+    assert _selector_matches("a/**/**/b", "a/b") is True
+    assert _selector_matches("a/**/**/b", "a/x/y/b") is True
+
+
+@contextlib.contextmanager
+def _hard_time_budget(seconds: int) -> Iterator[None]:
+    """Fail loud if the wrapped block runs past `seconds` wall-clock — a hard
+    termination guard (SIGALRM, Unix main thread) for the DoS-bound tests. A
+    regression to unbounded matching hangs and trips the alarm; the bounded
+    matcher returns in microseconds, far under any sane budget."""
+
+    def _fire(_signum: int, _frame: object) -> None:
+        msg = f"selector match exceeded {seconds}s budget (unbounded-recursion regression)"
+        raise TimeoutError(msg)
+
+    previous = signal.signal(signal.SIGALRM, _fire)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="SIGALRM is Unix-only")
+def test_selector_matches_pathological_consecutive_stars_terminates() -> None:
+    """A hand-authored selector with many consecutive `**` against a long
+    non-matching key must not exponentially backtrack (self-inflicted DoS)."""
+    pattern = "/".join(["**"] * 25 + ["z"])
+    key = "/".join(["abc"] * 40)  # no "z" — forces full exploration
+    with _hard_time_budget(3):
+        assert _selector_matches(pattern, key) is False
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="SIGALRM is Unix-only")
+def test_selector_matches_pathological_separated_stars_terminates() -> None:
+    """`**` globs separated by ambiguous literals are the harder backtracking
+    case that collapsing consecutive `**` alone would not bound — memoization
+    on (pattern, key) position must keep it polynomial."""
+    pattern = "/".join(["**", "a"] * 20 + ["z"])
+    key = "/".join(["a"] * 40)  # no "z" — no match, full backtracking
+    with _hard_time_budget(3):
+        assert _selector_matches(pattern, key) is False
 
 
 def test_specificity_literal_beats_glob() -> None:
@@ -280,6 +335,50 @@ def test_load_manifest_missing_user_file_is_ignored(tmp_path: Path) -> None:
     manifest = load_manifest(shipped, absent)
 
     assert set(manifest.profiles) == {"full", "project-lean", "no-brainstorming"}
+
+
+def test_load_manifest_user_path_is_directory_errors(tmp_path: Path) -> None:
+    """A `user` path that exists but is a directory must fail loud (naming the
+    path), not be silently ignored like an absent file — the fail-loud posture
+    distinguishes not-provided/absent from exists-but-not-a-regular-file."""
+    shipped = tmp_path / "profiles.toml"
+    shipped.write_text(_SHIPPED_TOML)
+    user_dir = tmp_path / "user-profiles.toml"
+    user_dir.mkdir()
+
+    with pytest.raises(ProfilesError, match=r"not a readable regular file"):
+        load_manifest(shipped, user_dir)
+
+
+def test_load_manifest_user_path_is_broken_symlink_errors(tmp_path: Path) -> None:
+    """A `user` path that is a dangling symlink exists (the link is present)
+    but resolves to no regular file — fail loud rather than silently ignore."""
+    shipped = tmp_path / "profiles.toml"
+    shipped.write_text(_SHIPPED_TOML)
+    link = tmp_path / "user-profiles.toml"
+    link.symlink_to(tmp_path / "nowhere.toml")
+
+    with pytest.raises(ProfilesError, match=r"not a readable regular file"):
+        load_manifest(shipped, link)
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid") or os.geteuid() == 0,
+    reason="root bypasses file permission bits, so an unreadable file stays readable",
+)
+def test_load_manifest_unreadable_user_file_errors(tmp_path: Path) -> None:
+    """A `user` path that is a regular file the process cannot read must fail
+    loud as a ProfilesError naming the path, not surface a raw OSError."""
+    shipped = tmp_path / "profiles.toml"
+    shipped.write_text(_SHIPPED_TOML)
+    user = tmp_path / "user-profiles.toml"
+    user.write_text('schema = 1\n[profiles.my-lean]\ninclude = ["instructions"]\n')
+    user.chmod(0o000)
+    try:
+        with pytest.raises(ProfilesError, match=r"could not be read"):
+            load_manifest(shipped, user)
+    finally:
+        user.chmod(0o644)  # restore so tmp_path teardown can remove it
 
 
 def test_load_manifest_scalar_scopes_table_errors(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -145,6 +146,10 @@ def _hard_time_budget(seconds: int) -> Iterator[None]:
     termination guard (SIGALRM, Unix main thread) for the DoS-bound tests. A
     regression to unbounded matching hangs and trips the alarm; the bounded
     matcher returns in microseconds, far under any sane budget."""
+    if threading.current_thread() is not threading.main_thread():
+        # `signal.signal` raises ValueError off the main thread; skip rather
+        # than fail if a runner/plugin executes this test in a worker thread.
+        pytest.skip("signal-based time budget requires the main thread")
 
     def _fire(_signum: int, _frame: object) -> None:
         msg = f"selector match exceeded {seconds}s budget (unbounded-recursion regression)"

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -346,7 +346,7 @@ def test_load_manifest_user_path_is_directory_errors(tmp_path: Path) -> None:
     user_dir = tmp_path / "user-profiles.toml"
     user_dir.mkdir()
 
-    with pytest.raises(ProfilesError, match=r"not a readable regular file"):
+    with pytest.raises(ProfilesError, match=r"not a regular file"):
         load_manifest(shipped, user_dir)
 
 
@@ -358,7 +358,7 @@ def test_load_manifest_user_path_is_broken_symlink_errors(tmp_path: Path) -> Non
     link = tmp_path / "user-profiles.toml"
     link.symlink_to(tmp_path / "nowhere.toml")
 
-    with pytest.raises(ProfilesError, match=r"not a readable regular file"):
+    with pytest.raises(ProfilesError, match=r"not a regular file"):
         load_manifest(shipped, link)
 
 

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -381,6 +381,29 @@ def test_load_manifest_unreadable_user_file_errors(tmp_path: Path) -> None:
         user.chmod(0o644)  # restore so tmp_path teardown can remove it
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid") or os.geteuid() == 0,
+    reason="root traverses non-searchable directories, so the path stays accessible",
+)
+def test_load_manifest_inaccessible_user_path_errors(tmp_path: Path) -> None:
+    """A `user` path that exists but cannot be stat'd (a non-searchable parent
+    directory) must fail loud, not be swallowed as 'absent'. `Path.exists()`
+    returns False on that OSError, so a naive presence pre-check would silently
+    ignore a real-but-inaccessible user manifest."""
+    shipped = tmp_path / "profiles.toml"
+    shipped.write_text(_SHIPPED_TOML)
+    restricted = tmp_path / "restricted"
+    restricted.mkdir()
+    user = restricted / "user-profiles.toml"
+    user.write_text('schema = 1\n[profiles.my-lean]\ninclude = ["instructions"]\n')
+    restricted.chmod(0o000)
+    try:
+        with pytest.raises(ProfilesError, match=r"could not be accessed"):
+            load_manifest(shipped, user)
+    finally:
+        restricted.chmod(0o755)  # restore so tmp_path teardown can remove it
+
+
 def test_load_manifest_scalar_scopes_table_errors(tmp_path: Path) -> None:
     """A `scopes` value that is a scalar (`scopes = 1`) must fail loud with a
     ProfilesError, not an AttributeError from calling `.items()` on an int."""

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -150,13 +150,15 @@ def _hard_time_budget(seconds: int) -> Iterator[None]:
         msg = f"selector match exceeded {seconds}s budget (unbounded-recursion regression)"
         raise TimeoutError(msg)
 
-    previous = signal.signal(signal.SIGALRM, _fire)
-    signal.alarm(seconds)
+    previous_handler = signal.signal(signal.SIGALRM, _fire)
+    previous_remaining = signal.alarm(seconds)  # returns any prior timer's remaining seconds
     try:
         yield
     finally:
         signal.alarm(0)
-        signal.signal(signal.SIGALRM, previous)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_remaining:
+            signal.alarm(previous_remaining)  # restore a pre-existing alarm we displaced
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="SIGALRM is Unix-only")
@@ -400,6 +402,31 @@ def test_load_manifest_inaccessible_user_path_errors(tmp_path: Path) -> None:
     try:
         with pytest.raises(ProfilesError, match=r"could not be accessed"):
             load_manifest(shipped, user)
+    finally:
+        restricted.chmod(0o755)  # restore so tmp_path teardown can remove it
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid") or os.geteuid() == 0,
+    reason="root traverses non-searchable directories, so the target stays accessible",
+)
+def test_load_manifest_symlink_to_inaccessible_target_errors(tmp_path: Path) -> None:
+    """A `user` symlink whose target is a real regular file inside a
+    non-searchable directory must fail loud as an *access* error, not be
+    misreported as 'not a regular file' — the resolving stat() must surface
+    the OSError rather than let `is_file()` swallow it into False."""
+    shipped = tmp_path / "profiles.toml"
+    shipped.write_text(_SHIPPED_TOML)
+    restricted = tmp_path / "restricted"
+    restricted.mkdir()
+    target = restricted / "real-profiles.toml"
+    target.write_text('schema = 1\n[profiles.my-lean]\ninclude = ["instructions"]\n')
+    link = tmp_path / "user-profiles.toml"
+    link.symlink_to(target)
+    restricted.chmod(0o000)
+    try:
+        with pytest.raises(ProfilesError, match=r"could not be accessed"):
+            load_manifest(shipped, link)
     finally:
         restricted.chmod(0o755)  # restore so tmp_path teardown can remove it
 


### PR DESCRIPTION
## Summary
Pre-hardens `packages/installer/src/installer/core/profiles.py` before S2 wires the user-manifest caller. Three sub-floor robustness findings from S1's HEAVY gate (bead `agents-config-eeyx9`):

1. **Fail-loud loader** — `load_manifest` now raises `ProfilesError` naming the path when the optional user path exists but is not a readable regular file (directory, broken symlink, unreadable). A not-provided or genuinely absent path is still ignored, as before. Closes a silent-omission gap contradicting the module's fail-loud posture.
2. **Bounded selector matcher** — `_match_segments` rewritten as an index-memoized closure on `(pattern_idx, key_idx)`, bounding glob matching to O(P·K). Kills exponential backtracking on hand-authored selectors with many `**` globs (self-inflicted DoS from a malformed `~/.agents/profiles.toml`). **Match semantics unchanged.**
3. **DRY extract** — include/exclude "match selector against universe or error" pulled into `_match_selector_or_error`; error messages byte-identical.

## Scope
- **In:** `core/profiles.py` (the 3 findings) + `tests/unit/test_profiles.py` (6 new tests).
- **Out:** No caller wiring — the resolver remains a pure library with no live caller (that's S2, `agents-config-viiud`). The shipped `profiles.toml` is clean; findings 1–2 are only reachable via a hand-authored user manifest.

## Ground truth
- Design spec: `docs/specs/2026-07-06-profiles-scope-routing.md` (§5 manifest, §6 resolver).
- The user-manifest path (`load_manifest`'s `user=` param) has **no live caller yet** — this PR hardens it ahead of S2. Not a dead-code smell; deliberate pre-hardening.

## Test Plan
- [x] 3 fail-loud user-path cases (directory / broken symlink / unreadable — the last skipif-guarded under root).
- [x] 2 SIGALRM-guarded DoS-termination cases (consecutive + separated `**`), proving the memo bound.
- [x] 1 consecutive-`**` semantics case (refactor safety net).
- [x] `make ci-installer` green: 788 passed / 1 skipped, 99.46% cov, mypy --strict clean, pip-audit clean.
- [x] HEAVY completion gate (quality-gate workflow): ACCEPTANCE, clean-at-floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)