### PR TITLE
Implement brainstorm-pipeline streamlining (review routing, attention waiver, grill trigger, execution handoff)

### DIFF
--- a/src/user/.agents/skills/brainstorming/SKILL.md
+++ b/src/user/.agents/skills/brainstorming/SKILL.md
@@ -28,21 +28,22 @@ Every project goes through this process. A todo list, a single-function utility,
 
 You MUST create a task for each of these items and complete them in order:
 
-1. **Explore project context** — check files, docs, recent commits
+1. **Explore project context** — check files, docs, recent commits; check for `CONTEXT.md` / `CONTEXT-MAP.md` and, if present, activate the glossary discipline (see The Process below)
 2. **Offer visual companion** (if topic will involve visual questions) — this is its own message, not combined with a clarifying question. See the Visual Companion section below.
 3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 4. **Propose 2-3 approaches** — with trade-offs and your recommendation
 5. **Present design** — in sections scaled to their complexity, get user approval after each section
 6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` and commit
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
-8. **User reviews written spec** — ask user to review the spec file before proceeding
-9. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+8. **Review-depth routing** — assess the spec against the routing criteria; announce lean or deep; deep runs `ralf-review` once and fixes findings (see below)
+9. **Attention routing** — decide whether the user's review is needed: waive with a notice, or direct their attention to specific sections (see below)
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
 
 ## Process Flow
 
 ```dot
 digraph brainstorming {
-    "Explore project context" [shape=box];
+    "Explore project context\n(+ CONTEXT.md check)" [shape=box];
     "Visual questions ahead?" [shape=diamond];
     "Offer Visual Companion\n(own message, no other content)" [shape=box];
     "Ask clarifying questions" [shape=box];
@@ -51,10 +52,16 @@ digraph brainstorming {
     "User approves design?" [shape=diamond];
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
-    "User reviews spec?" [shape=diamond];
+    "Routing criteria hit?" [shape=diamond];
+    "ralf-review\n(single invocation)" [shape=box];
+    "Fix findings,\nrecord verdict" [shape=box];
+    "Waive human review?" [shape=diamond];
+    "Directed-attention review" [shape=box];
+    "User approves spec?" [shape=diamond];
+    "Revise spec" [shape=box];
     "Invoke writing-plans skill" [shape=doublecircle];
 
-    "Explore project context" -> "Visual questions ahead?";
+    "Explore project context\n(+ CONTEXT.md check)" -> "Visual questions ahead?";
     "Visual questions ahead?" -> "Offer Visual Companion\n(own message, no other content)" [label="yes"];
     "Visual questions ahead?" -> "Ask clarifying questions" [label="no"];
     "Offer Visual Companion\n(own message, no other content)" -> "Ask clarifying questions";
@@ -64,9 +71,17 @@ digraph brainstorming {
     "User approves design?" -> "Present design sections" [label="no, revise"];
     "User approves design?" -> "Write design doc" [label="yes"];
     "Write design doc" -> "Spec self-review\n(fix inline)";
-    "Spec self-review\n(fix inline)" -> "User reviews spec?";
-    "User reviews spec?" -> "Write design doc" [label="changes requested"];
-    "User reviews spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "Spec self-review\n(fix inline)" -> "Routing criteria hit?";
+    "Routing criteria hit?" -> "Waive human review?" [label="no — announce lean"];
+    "Routing criteria hit?" -> "ralf-review\n(single invocation)" [label="yes — announce deep"];
+    "ralf-review\n(single invocation)" -> "Fix findings,\nrecord verdict";
+    "Fix findings,\nrecord verdict" -> "Waive human review?";
+    "Waive human review?" -> "Invoke writing-plans skill" [label="yes — notice, no pause"];
+    "Waive human review?" -> "Directed-attention review" [label="no"];
+    "Directed-attention review" -> "User approves spec?";
+    "User approves spec?" -> "Invoke writing-plans skill" [label="approved"];
+    "User approves spec?" -> "Revise spec" [label="changes requested"];
+    "Revise spec" -> "Directed-attention review" [label="never re-routes"];
 }
 ```
 
@@ -77,6 +92,20 @@ digraph brainstorming {
 **Understanding the idea:**
 
 - Check out the current project state first (files, docs, recent commits)
+- Check for `CONTEXT.md` (or `CONTEXT-MAP.md` in multi-context repos). When present,
+  announce the file actually found ("`CONTEXT.md` found — glossary discipline active",
+  or "`CONTEXT-MAP.md` found — glossary discipline active" for a multi-context repo)
+  and adopt the grill-with-docs skill's glossary discipline inline for the rest of the
+  brainstorm: challenge the user's terms against the glossary, propose precise canonical
+  terms for fuzzy language, and update the glossary as terms resolve — in a single-context
+  repo that is the root `CONTEXT.md`; in a multi-context repo, resolve via `CONTEXT-MAP.md`
+  to the context(s) the design touches and update that context's `CONTEXT.md`. Glossary
+  entries only, no implementation details, per the glossary format that travels with the
+  grill-with-docs skill. Do not adopt grill-with-docs' ADR-offering step.
+- When no `CONTEXT.md` exists but the design coins load-bearing domain terms, offer
+  once — at spec-write time, folded into the attention-routing message, never as its
+  own blocking question — to start a `CONTEXT.md` per grill-with-docs. The offer
+  lapses if not taken up and does not repeat.
 - Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., "build a platform with chat, file storage, billing, and analytics"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.
 - If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.
 - For appropriately-scoped projects, ask questions one at a time to refine the idea
@@ -130,12 +159,65 @@ After writing the spec document, look at it with fresh eyes:
 
 Fix any issues inline. No need to re-review — just fix and move on.
 
-**User Review Gate:**
-After the spec review loop passes, ask the user to review the written spec before proceeding:
+**Review-Depth Routing:**
+After the spec self-review, assess the written spec against these routing criteria:
 
-> "Spec written and committed to `<path>`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan."
+- multiple interacting components or subsystems;
+- new or materially changed public contracts (APIs, schemas, file formats, skill
+  or workflow contracts other agents rely on);
+- security- or auth-adjacent surface;
+- data migration or other hard-to-reverse operations;
+- novel domain concepts introduced by this design;
+- a genuinely balanced trade-off resolved by judgment during the brainstorm.
 
-Wait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.
+No criterion hit → announce `Review routing: lean (no criteria hit)` and continue
+to Attention Routing.
+
+Any criterion hit → announce `Review routing: deep (criteria: <names>)` and invoke
+the `ralf-review` skill **exactly once**: target = the spec file; review criteria =
+the design's stated goals plus its acceptance criteria (goals-only when the spec
+carries none); cycle cap = that skill's default. Fix what the findings allow
+inline, but the recorded verdict is final: inline fixes improve the artifact the
+user receives — they never upgrade the verdict, and ralf-review is never re-invoked
+to earn a better score. Attention Routing reads the recorded verdict (its Score
+only; the report's recommended-action field stays advisory).
+
+Where the harness cannot dispatch an independent reviewer (no subagent or
+agent-dispatch primitive), the deep route is unavailable: criteria-hit specs go
+straight to directed-attention review — the gate below fails closed.
+
+**Attention Routing:**
+Decide whether the user's review of the written spec is needed. The conversational
+design-approval gate above (the HARD-GATE enforcement point) is untouched — only
+this post-write review stop is waivable. Waive it only when ALL of:
+
+- **(a) Review outcome clean** — deep review was either not warranted (lean route)
+  or ended in a recorded `PASS`. Any other verdict parks for the user, with the
+  verdict and residual concerns attached.
+- **(b) No divergence** — nothing in the written spec goes beyond what the user
+  approved conversationally: no post-approval design changes, and no material
+  assumptions or trade-offs the user has not seen (however the project marks them).
+- **(c) Frontier-tier session** — the session model is frontier-tier: currently
+  Claude Opus or above (Opus 4.x, Fable/Mythos 5) or an equivalent top-tier foreign
+  model. Read the tier from the runtime's declared model identity (the harness
+  states the powering model in the session context); if no identity is declared,
+  this condition fails. This is a qualification check on whatever model the user
+  already chose — never an instruction to select or escalate to a premium model.
+
+When unsure about any condition, do not waive. Announce the decision both ways:
+
+- **Waived:** post a compact notice — a one-paragraph summary of what the spec
+  commits to, plus "if you look anywhere, look at <section>" pointing at the least
+  conventional decision — then proceed directly to the writing-plans transition.
+  No question, no pause.
+- **Not waived:** post a directed-attention request — 2–5 bullets, each naming a
+  specific section, why it may surprise the user or carry risk, and what judgment
+  is being asked of them. Never a bare "please review."
+
+User-directed revisions do not re-enter deep review: when the user requests changes
+at a directed-attention stop, revise and return to the same attention stop — the
+user is engaged, and approving their own requested changes is the review. The user
+can always direct another deep review explicitly.
 
 **Implementation:**
 

--- a/src/user/.agents/skills/brainstorming/SKILL.md
+++ b/src/user/.agents/skills/brainstorming/SKILL.md
@@ -53,6 +53,7 @@ digraph brainstorming {
     "Write design doc" [shape=box];
     "Spec self-review\n(fix inline)" [shape=box];
     "Routing criteria hit?" [shape=diamond];
+    "Independent reviewer available?" [shape=diamond];
     "ralf-review\n(single invocation)" [shape=box];
     "Fix findings,\nrecord verdict" [shape=box];
     "Waive human review?" [shape=diamond];
@@ -73,7 +74,9 @@ digraph brainstorming {
     "Write design doc" -> "Spec self-review\n(fix inline)";
     "Spec self-review\n(fix inline)" -> "Routing criteria hit?";
     "Routing criteria hit?" -> "Waive human review?" [label="no — announce lean"];
-    "Routing criteria hit?" -> "ralf-review\n(single invocation)" [label="yes — announce deep"];
+    "Routing criteria hit?" -> "Independent reviewer available?" [label="yes — announce deep"];
+    "Independent reviewer available?" -> "ralf-review\n(single invocation)" [label="yes"];
+    "Independent reviewer available?" -> "Directed-attention review" [label="no — fails closed"];
     "ralf-review\n(single invocation)" -> "Fix findings,\nrecord verdict";
     "Fix findings,\nrecord verdict" -> "Waive human review?";
     "Waive human review?" -> "Invoke writing-plans skill" [label="yes — notice, no pause"];

--- a/src/user/.agents/skills/brainstorming/SKILL.md
+++ b/src/user/.agents/skills/brainstorming/SKILL.md
@@ -37,7 +37,7 @@ You MUST create a task for each of these items and complete them in order:
 7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)
 8. **Review-depth routing** — assess the spec against the routing criteria; announce lean or deep; deep runs `ralf-review` once and fixes findings (see below)
 9. **Attention routing** — decide whether the user's review is needed: waive with a notice, or direct their attention to specific sections (see below)
-10. **Transition to implementation** — invoke writing-plans skill to create implementation plan
+10. **Transition to implementation** — invoke writing-plans skill to create implementation plan; this is the only post-brainstorm implementation handoff (`ralf-review`, invoked in step 8, does not recur here)
 
 ## Process Flow
 

--- a/src/user/.agents/skills/grill-with-docs/SKILL.md
+++ b/src/user/.agents/skills/grill-with-docs/SKILL.md
@@ -25,8 +25,8 @@ If a question can be answered by exploring the codebase, explore the codebase in
 
 Note: the brainstorming skill adopts this skill's glossary discipline inline
 (challenge terms, sharpen language, update `CONTEXT.md`) whenever a `CONTEXT.md`
-exists at brainstorm time. grill-with-docs remains the standalone deep session for
-stress-testing an existing plan.
+or `CONTEXT-MAP.md` exists at brainstorm time. grill-with-docs remains the
+standalone deep session for stress-testing an existing plan.
 
 ## Domain awareness
 

--- a/src/user/.agents/skills/grill-with-docs/SKILL.md
+++ b/src/user/.agents/skills/grill-with-docs/SKILL.md
@@ -23,6 +23,11 @@ If a question can be answered by exploring the codebase, explore the codebase in
 
 <supporting-info>
 
+Note: the brainstorming skill adopts this skill's glossary discipline inline
+(challenge terms, sharpen language, update `CONTEXT.md`) whenever a `CONTEXT.md`
+exists at brainstorm time. grill-with-docs remains the standalone deep session for
+stress-testing an existing plan.
+
 ## Domain awareness
 
 During codebase exploration, also look for existing documentation:

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -151,7 +151,8 @@ hit → announce `Review routing: lean (no criteria hit)`. Any hit → announce
 Review-Depth Routing mechanics to the plan (a deliberate cross-skill
 read; both skills deploy together) — single `ralf-review` invocation, findings
 fixed inline but the recorded verdict is final and never re-earned, fail-closed
-where the harness cannot dispatch an independent reviewer — with target = the
+straight to the attention stop below when the harness cannot dispatch an
+independent reviewer — with target = the
 plan file and review criteria = coverage of the spec plus this skill's quality
 bar (see Remember and No Placeholders above).
 

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -147,12 +147,13 @@ defines for specs, flavored for plans.
 planning that the spec does not cover; the plan contains irreversible or migration
 steps; the task graph is large or has subtle ordering constraints. No criterion
 hit → announce `Review routing: lean (no criteria hit)`. Any hit → announce
-`Review routing: deep (criteria: <names>)` and invoke the `ralf-review` skill
-**exactly once** — target = the plan file; review criteria = coverage of the spec
-plus this skill's quality bar (no placeholders, type consistency, exact paths);
-cycle cap = that skill's default. Fix findings inline; the recorded verdict is
-final and is never re-earned by re-invocation. Where the harness cannot dispatch
-an independent reviewer, the deep route is unavailable and the gate fails closed.
+`Review routing: deep (criteria: <names>)` and apply the brainstorming skill's
+Review-Depth Routing mechanics verbatim to the plan (a deliberate cross-skill
+read; both skills deploy together) — single `ralf-review` invocation, findings
+fixed inline but the recorded verdict final and never re-earned, fail-closed
+where the harness cannot dispatch an independent reviewer — with target = the
+plan file and review criteria = coverage of the spec plus this skill's quality
+bar (no placeholders, type consistency, exact paths).
 
 **Attention routing:** apply the brainstorming skill's Attention Routing verbatim
 to the plan — waiver conditions (a) recorded outcome clean, (b) no divergence from

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -150,7 +150,7 @@ hit → announce `Review routing: lean (no criteria hit)`. Any hit → announce
 `Review routing: deep (criteria: <names>)` and apply the brainstorming skill's
 Review-Depth Routing mechanics to the plan (a deliberate cross-skill
 read; both skills deploy together) — single `ralf-review` invocation, findings
-fixed inline but the recorded verdict final and never re-earned, fail-closed
+fixed inline but the recorded verdict is final and never re-earned, fail-closed
 where the harness cannot dispatch an independent reviewer — with target = the
 plan file and review criteria = coverage of the spec plus this skill's quality
 bar (no placeholders, type consistency, exact paths).

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -155,7 +155,7 @@ where the harness cannot dispatch an independent reviewer — with target = the
 plan file and review criteria = coverage of the spec plus this skill's quality
 bar (no placeholders, type consistency, exact paths).
 
-**Attention routing:** apply the brainstorming skill's Attention Routing verbatim
+**Attention routing:** apply the brainstorming skill's Attention Routing
 to the plan — waiver conditions (a) recorded outcome clean, (b) no divergence from
 the spec and the approved design, (c) frontier-tier session per the declaration in
 the brainstorming skill's Attention Routing section (a deliberate cross-skill

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -153,7 +153,7 @@ read; both skills deploy together) — single `ralf-review` invocation, findings
 fixed inline but the recorded verdict is final and never re-earned, fail-closed
 where the harness cannot dispatch an independent reviewer — with target = the
 plan file and review criteria = coverage of the spec plus this skill's quality
-bar (no placeholders, type consistency, exact paths).
+bar (see Remember and No Placeholders above).
 
 **Attention routing:** apply the brainstorming skill's Attention Routing
 to the plan — waiver conditions (a) recorded outcome clean (lean route or recorded `PASS` — not `PASS_WITH_RESERVATIONS` or `FAIL`), (b) no divergence from

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -148,7 +148,7 @@ planning that the spec does not cover; the plan contains irreversible or migrati
 steps; the task graph is large or has subtle ordering constraints. No criterion
 hit → announce `Review routing: lean (no criteria hit)`. Any hit → announce
 `Review routing: deep (criteria: <names>)` and apply the brainstorming skill's
-Review-Depth Routing mechanics verbatim to the plan (a deliberate cross-skill
+Review-Depth Routing mechanics to the plan (a deliberate cross-skill
 read; both skills deploy together) — single `ralf-review` invocation, findings
 fixed inline but the recorded verdict final and never re-earned, fail-closed
 where the harness cannot dispatch an independent reviewer — with target = the

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -188,7 +188,7 @@ template:
 
 > Execute the implementation plan at `<plan-file path>` (spec: `<spec-file path>`).
 > Work on a feature branch in an isolated worktree. Dispatch one fresh subagent
-> per task; each task follows the test-driven-development skill. Start at Task 1.
+> per task; each task follows the `test-driven-development` skill. Start at Task 1.
 
 This is the pipeline's single terminal pause: everything is pre-decided, and the
 prompt exists to be handed to the user, who chooses when and where to clear

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -138,23 +138,57 @@ After writing the complete plan, look at the spec with fresh eyes and check the 
 
 If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
 
+## Plan Review Gate
+
+After the plan self-review, run the same two-step gate the brainstorming skill
+defines for specs, flavored for plans.
+
+**Routing criteria:** the plan deviates from the spec; scope was discovered during
+planning that the spec does not cover; the plan contains irreversible or migration
+steps; the task graph is large or has subtle ordering constraints. No criterion
+hit → announce `Review routing: lean (no criteria hit)`. Any hit → announce
+`Review routing: deep (criteria: <names>)` and invoke the `ralf-review` skill
+**exactly once** — target = the plan file; review criteria = coverage of the spec
+plus this skill's quality bar (no placeholders, type consistency, exact paths);
+cycle cap = that skill's default. Fix findings inline; the recorded verdict is
+final and is never re-earned by re-invocation. Where the harness cannot dispatch
+an independent reviewer, the deep route is unavailable and the gate fails closed.
+
+**Attention routing:** apply the brainstorming skill's Attention Routing verbatim
+to the plan — waiver conditions (a) recorded outcome clean, (b) no divergence from
+the spec and the approved design, (c) frontier-tier session per the declaration in
+the brainstorming skill's Attention Routing section (a deliberate cross-skill
+read; both skills deploy together). A plan that silently absorbed a surprising
+change never auto-proceeds. Waived or approved → Execution Handoff. Changes
+requested → revise the plan and return to the attention stop, never back through
+routing.
+
 ## Execution Handoff
 
-After saving the plan, offer execution choice:
+Do not ask which execution approach to use. State a recommendation with one line
+of reasoning:
 
-**"Plan complete and saved to `docs/plans/<filename>.md`. Two execution options:**
+- **Subagent-driven per-task dispatch** — the default where the harness supports
+  independent dispatch: one fresh subagent per task, each receiving the task,
+  required context, and instructions to use the `test-driven-development` skill;
+  review output between tasks.
+- **Workflow-orchestrated execution** — where the harness additionally supports
+  workflow orchestration and the task graph is large or parallelizable.
+- **Inline execution** — sequential in-session with per-task checkpoints
+  (`test-driven-development` red → green → refactor → commit per task); for
+  trivially small plans, and the degraded default on runtimes without independent
+  dispatch.
 
-**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+Then recommend a clean-context start — compact the session or begin a fresh one,
+so execution starts free of planning residue — and emit a copyable kickoff prompt
+filled with the session's actual artifact locations (project conventions override
+shipped defaults), varying the body with the recommended mode. Subagent-mode
+template:
 
-**2. Inline Execution** - Execute tasks in this session following the `test-driven-development` red-green-refactor cycle, with checkpoints for review
+> Execute the implementation plan at `<plan-file path>` (spec: `<spec-file path>`).
+> Work on a feature branch in an isolated worktree. Dispatch one fresh subagent
+> per task; each task follows the test-driven-development skill. Start at Task 1.
 
-**Which approach?"**
-
-**If Subagent-Driven chosen:**
-- Dispatch one fresh subagent per task
-- Each subagent receives: task spec, required context, and instructions to use `test-driven-development` skill
-- Review subagent output before dispatching the next task
-
-**If Inline Execution chosen:**
-- Execute tasks sequentially using `test-driven-development` (red → green → refactor → commit per task)
-- Checkpoint after each task: verify tests pass, commit, update plan checkboxes
+This is the pipeline's single terminal pause: everything is pre-decided, and the
+prompt exists to be handed to the user, who chooses when and where to clear
+context and start execution.

--- a/src/user/.agents/skills/writing-plans/SKILL.md
+++ b/src/user/.agents/skills/writing-plans/SKILL.md
@@ -156,7 +156,7 @@ plan file and review criteria = coverage of the spec plus this skill's quality
 bar (no placeholders, type consistency, exact paths).
 
 **Attention routing:** apply the brainstorming skill's Attention Routing
-to the plan — waiver conditions (a) recorded outcome clean, (b) no divergence from
+to the plan — waiver conditions (a) recorded outcome clean (lean route or recorded `PASS` — not `PASS_WITH_RESERVATIONS` or `FAIL`), (b) no divergence from
 the spec and the approved design, (c) frontier-tier session per the declaration in
 the brainstorming skill's Attention Routing section (a deliberate cross-skill
 read; both skills deploy together). A plan that silently absorbed a surprising


### PR DESCRIPTION
## Summary

Implements docs/plans/2026-07-11-brainstorm-pipeline-streamlining.md against docs/specs/2026-07-11-brainstorm-pipeline-streamlining.md (bead agents-config-r14bn). Prose-only edits to three shared skill bodies:

- **brainstorming/SKILL.md** — checklist + process-flow digraph updated; new glossary-discipline trigger (activates grill-with-docs' glossary discipline inline when `CONTEXT.md`/`CONTEXT-MAP.md` exists); the old unconditional "please review the spec" gate replaced with two-step **Review-Depth Routing** (auto-runs `ralf-review` when named complexity criteria hit) + **Attention Routing** (waives human review only when review-outcome-clean AND no-divergence AND frontier-tier-session all hold; otherwise directs the user to specific sections).
- **writing-plans/SKILL.md** — new `## Plan Review Gate` section applying the same two-step policy to the plan document (which previously had no review gate at all), cross-referencing brainstorming's mechanics rather than duplicating them; `## Execution Handoff` replaced from an open "which approach?" question to a stated recommendation + clean-context suggestion + copyable kickoff prompt.
- **grill-with-docs/SKILL.md** — one cross-reference line noting brainstorming now adopts its glossary discipline inline; grill-with-docs itself is otherwise unchanged.

## Scope

**In scope:** the three skill bodies listed above, prose only.
**Out of scope (see spec §8 Non-goals):** no new skill asset, no changes to ralf-review's internals/scoring, no owqa/capture-spec/M2 machinery, no decision-record/ADR requirements, no completion-gate or merge-policy changes, no model-routing config integration.

This is deliberately an **interim** behavior — prose in the calling skills now; the spec's locked decision is that the scheduled M2/M3 machinery (owqa gate, capture-spec verdict, adversarial-qa UC1 binding) absorbs or replaces it behind the same seams when it ships, with no prose changes required on this end (the review engine is `ralf-review`, invoked by skill name only).

## Ground truth

- Spec: `docs/specs/2026-07-11-brainstorm-pipeline-streamlining.md` (§9 has the 8 numbered acceptance criteria; §3.4 enumerates the exact edit surface)
- Plan: `docs/plans/2026-07-11-brainstorm-pipeline-streamlining.md` (task-by-task instructions with exact replacement text and grep-based verification commands)
- Bead: `agents-config-r14bn`

## Portability constraint

Per spec §5, shipped skill prose carries **no tracker/bead IDs and no repo-internal file paths** — sibling skills (`ralf-review`, `grill-with-docs`, `test-driven-development`) are referenced by name only, and harness-dependent features (independent-reviewer dispatch, workflow orchestration, declared model identity) are phrased capability-conditionally with an explicit fail-closed fallback. This was mechanically verified (see Test Plan).

## Test Plan

- [x] All plan-specified grep verification commands pass on all three files (structural checks, portability/tracker-ID absence, cross-file consistency per spec §9 AC7) — re-run fresh after a rebase onto `main`'s current tip, all green.
- [x] Repo smoke-test gate (`*_test.sh` across `src/user/.agents/skills/` and `src/user/.claude/hooks/`) run fresh: 33 suites, 32 pass. One pre-existing, unrelated failure in `reply-and-resolve-pr-threads/e2e-sidecar-persistence_test.sh` (missing `GH_TOKEN`/PR-base-SHA in this sandbox) — confirmed to reproduce identically on unmodified `main`, in a skill directory this PR never touches. Not a regression from this change.
- [x] HEAVY completion gate (`quality-gate` workflow, triggered by `.critical-paths: src/**` on all three files) ran a full adversarial pass: exited **acceptance / clean-at-floor** at the major-severity floor. One minor finding (writing-plans duplicating brainstorming's review-depth-routing mechanics instead of cross-referencing them, matching guidance already recorded on the bead from the spec's own HEAVY-gate pass) was fixed in a follow-up commit rather than deferred.

## Commits

Four content commits (one per plan task) plus one gate-remediation commit, in order: `feat(brainstorming)` → `feat(writing-plans)` → `docs(grill-with-docs)` → `refactor(writing-plans)` (cross-reference fix from the quality-gate finding).