### PR TITLE
fix(prgroom): paginate poll list reads + derive CI from check-runs (jkha6)

### DIFF
--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -70,7 +70,12 @@ class GhClient(Protocol):
     def head_ref_name(self, ref: PRRef) -> str: ...  # pragma: no cover
 
     def rest(
-        self, method: str, path: str, *, fields: dict[str, str] | None = None
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict[str, str] | None = None,
+        paginate: bool = False,
     ) -> Any: ...  # pragma: no cover  # gh api returns object|array|primitive; caller narrows
 
     def graphql(self, query: str, variables: JsonObj) -> JsonObj: ...  # pragma: no cover
@@ -146,8 +151,21 @@ class GhCli:
         parsed: JsonObj = json.loads(out)
         return str(parsed["headRefName"])
 
-    def rest(self, method: str, path: str, *, fields: dict[str, str] | None = None) -> Any:
+    def rest(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict[str, str] | None = None,
+        paginate: bool = False,
+    ) -> Any:
         argv = ["gh", "api", "--method", method, path]
+        if paginate:
+            # gh walks every page and concatenates the JSON arrays into one, so a list
+            # read returns ALL items — not just GitHub's first 30. Only valid on GET
+            # collection endpoints (the callers that opt in); object endpoints must not
+            # set it (gh would emit one object per page, breaking json.loads).
+            argv.append("--paginate")
         for key, value in (fields or {}).items():
             argv += ["-f", f"{key}={value}"]
         out = self._run(argv)

--- a/packages/prgroom/src/prgroom/lifecycle/poll.py
+++ b/packages/prgroom/src/prgroom/lifecycle/poll.py
@@ -6,7 +6,8 @@ copy (the caller owns ``store.write``). It is **read-only over GitHub** — ever
 call is a REST ``GET`` via the injected :class:`~prgroom.gh.client.GhClient`; no
 push, no review re-request, no resolve.
 
-One poll issues six REST reads in this fixed order (plus one conditional GraphQL read):
+One poll issues these REST reads in a fixed order (plus one conditional GraphQL read,
+and a conditional combined-status fallback read):
 
 1. ``head_ref_oid`` — the remote HEAD SHA. Drives the §3.4 bootstrap / attribution
    / push-detection math. An empty HEAD short-circuits the rest (a PR with no
@@ -15,7 +16,8 @@ One poll issues six REST reads in this fixed order (plus one conditional GraphQL
    → ``merged`` transition. A 404 here is a vanished PR/repo mid-run, mapped to
    ``RUNTIME_GH_TERMINAL`` (the startup precondition that owns
    ``PRECONDITION_REPO_UNREACHABLE`` is out of this verb's scope).
-3. issue comments, 4. reviews, 5. review (inline) comments — ingested into
+3. issue comments, 4. reviews, 5. review (inline) comments — each a ``--paginate``d
+   collection read (all pages, not just GitHub's first 30), ingested into
    :class:`ReviewItem`s (natural key ``(kind, gh_id)``; never re-appended) and used
    to flip reviewer engagement (§4.1).
 5a. **GraphQL ``reviewThreads`` thread-id map** — issued only when step 5 returned
@@ -23,9 +25,12 @@ One poll issues six REST reads in this fixed order (plus one conditional GraphQL
    to its ``PRRT_*`` node id (the id ``resolveReviewThread`` consumes and §8.2
    recurrence keys on); REST exposes only comment databaseIds, so this one GraphQL
    read bridges the key-space. A comment absent from the map degrades to ``""``.
-6. CI combined-status for the head SHA — mapped to ``success | pending | failure |
-   absent`` for ``quiescence.ci_state``. A 404 there means no CI configured →
-   ``absent`` (not an error).
+6. CI for the head SHA — read from **check runs** (``commits/{sha}/check-runs``) and
+   rolled up to ``success | pending | failure`` for ``quiescence.ci_state``. A commit
+   with no check runs falls back to the legacy combined-status endpoint (classic commit
+   statuses); a 404 there means no CI configured → ``absent`` (not an error). Reading
+   check runs first is what lets an Actions-only repo ever reach ``success`` — the
+   combined-status endpoint is blind to Actions and reports pending/0 forever (jkha6).
 
 After the reads it runs ``evaluate_reviewer_timeouts`` (§4.1 auto-decline), stamps
 ``last_polled_at``, advances ``last_activity_at`` on any observed mutation, and
@@ -63,8 +68,26 @@ _BODY_EXCERPT_LEN = 200
 # error, e.g. a check that errored out) is a non-green terminal verdict and maps to
 # `failure`. A 404 (no CI configured) maps to `absent` at the call site; any other
 # empty/unknown value is treated as `pending` (CI exists but has no verdict yet).
+# This endpoint is the FALLBACK path only: it is blind to GitHub Actions check runs,
+# so an Actions-only repo reports pending/total_count=0 here forever (the jkha6
+# defect) — _ci_state reads check runs first and only falls back here for a commit
+# with no check runs (a classic-commit-status CI).
 _CI_STATES_PASSTHROUGH: frozenset[str] = frozenset({"success", "pending", "failure"})
 _CI_STATES_FAILURE: frozenset[str] = frozenset({"error"})
+
+# GitHub check-run conclusions that are a non-green terminal verdict. A failure among
+# them outranks a still-running run — CI cannot go green once one has failed. The rest
+# ({success, neutral, skipped}) are non-failing; a run still queued/in_progress (no
+# conclusion yet) holds the rollup at `pending`.
+_CHECK_RUN_FAILURE_CONCLUSIONS: frozenset[str] = frozenset(
+    {"failure", "timed_out", "action_required", "cancelled", "stale"}
+)
+_CHECK_RUN_SUCCESS_CONCLUSIONS: frozenset[str] = frozenset({"success", "neutral", "skipped"})
+# GitHub caps per_page at 100; one page covers realistic check-run matrices. A commit
+# with >100 check runs would miss the overflow — an accepted bound, revisited only if a
+# real repo hits it. (Object endpoints can't use --paginate: gh would emit one object
+# per page and break json.loads.)
+_CHECK_RUNS_PER_PAGE = "100"
 
 
 def poll_pr(
@@ -140,10 +163,15 @@ def _head_ref_oid(gh: GhClient, ref: PRRef) -> str:
         raise vanished_pr_terminal(ref) from exc
 
 
-def _gh_get(gh: GhClient, ref: PRRef, path: str) -> Any:
-    """``gh.rest("GET", path)`` with a 404 mapped to terminal (vanished PR/repo)."""
+def _gh_get(gh: GhClient, ref: PRRef, path: str, *, paginate: bool = False) -> Any:
+    """``gh.rest("GET", path)`` with a 404 mapped to terminal (vanished PR/repo).
+
+    ``paginate`` opts a collection read into gh's ``--paginate`` page-walk so items
+    past the first 30 are returned (the jkha6 defect: an unpaginated list read froze
+    grooming once a PR accrued >30 reviews/comments).
+    """
     try:
-        return gh.rest("GET", path)
+        return gh.rest("GET", path, paginate=paginate)
     except GhNotFoundError as exc:
         raise vanished_pr_terminal(ref) from exc
 
@@ -173,9 +201,12 @@ def _ingest_items(
     """
     seen = {(item.kind, item.identity.gh_id) for item in state.items}
     base = f"repos/{ref.owner}/{ref.repo}"
-    raw_issue = _gh_get(gh, ref, f"{base}/issues/{ref.number}/comments")
-    raw_reviews = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/reviews")
-    raw_review_comments = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/comments")
+    # Paginate the three collection reads: prgroom's own reply reviews push any
+    # nontrivial PR past GitHub's 30-per-page default, and an unpaginated read froze
+    # grooming on the invisible page-2+ items (jkha6).
+    raw_issue = _gh_get(gh, ref, f"{base}/issues/{ref.number}/comments", paginate=True)
+    raw_reviews = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/reviews", paginate=True)
+    raw_review_comments = _gh_get(gh, ref, f"{base}/pulls/{ref.number}/comments", paginate=True)
     # Only review-thread items carry a thread_id, so the bridging GraphQL read is
     # skipped entirely when this PR surfaced no inline comments (most polls).
     thread_id_map = fetch_thread_id_map(gh, ref) if raw_review_comments else {}
@@ -329,7 +360,51 @@ def _observe_engagement(
 
 
 def _ci_state(gh: GhClient, ref: PRRef, head_sha: str) -> str:
-    """Map the gh combined-status for ``head_sha`` to the §4.1 ci_state vocabulary."""
+    """Resolve §4.1 ci_state for ``head_sha``, preferring check runs over combined-status.
+
+    GitHub Actions reports via check runs; the legacy combined-status endpoint returns
+    pending/total_count=0 on an Actions-only repo, so it can never reach `success` there
+    (the jkha6 defect). Read check runs first and roll them up; only a commit with no
+    check runs (a classic-commit-status CI, or none configured) falls back to
+    combined-status.
+    """
+    rollup = _check_runs_state(gh, ref, head_sha)
+    return rollup if rollup is not None else _combined_status_state(gh, ref, head_sha)
+
+
+def _check_runs_state(gh: GhClient, ref: PRRef, head_sha: str) -> str | None:
+    """Roll the head SHA's check runs up to success|pending|failure; ``None`` if none exist.
+
+    ``None`` signals "no check runs on this commit" so ``_ci_state`` falls back to the
+    combined-status endpoint. A 404 (unexpected on a valid head SHA) is treated the same
+    as no check runs — fall back rather than error.
+    """
+    try:
+        payload = gh.rest(
+            "GET",
+            f"repos/{ref.owner}/{ref.repo}/commits/{head_sha}/check-runs",
+            fields={"per_page": _CHECK_RUNS_PER_PAGE},
+        )
+    except GhNotFoundError:
+        return None
+    runs = payload.get("check_runs") or []
+    if not runs:
+        return None
+    all_passed = True
+    for run in runs:
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion in _CHECK_RUN_FAILURE_CONCLUSIONS:
+            return "failure"  # a definitive failure outranks any still-running run
+        if not (
+            str(run.get("status") or "") == "completed"
+            and conclusion in _CHECK_RUN_SUCCESS_CONCLUSIONS
+        ):
+            all_passed = False
+    return "success" if all_passed else "pending"
+
+
+def _combined_status_state(gh: GhClient, ref: PRRef, head_sha: str) -> str:
+    """Map the legacy combined-status for ``head_sha`` to ci_state (the fallback path)."""
     try:
         status = gh.rest("GET", f"repos/{ref.owner}/{ref.repo}/commits/{head_sha}/status")
     except GhNotFoundError:

--- a/packages/prgroom/tests/unit/test_cli_poll.py
+++ b/packages/prgroom/tests/unit/test_cli_poll.py
@@ -34,6 +34,8 @@ def _ok(payload: object) -> CommandResult:
 
 
 def _gh_with_head(head: str, *, ci: str = "success") -> GhCli:
+    # The CI read is check-runs first (jkha6); map ci= to a single completed check run.
+    conclusion = ci
     return GhCli(
         RecordedRunner(
             [
@@ -42,7 +44,12 @@ def _gh_with_head(head: str, *, ci: str = "success") -> GhCli:
                 _ok([]),
                 _ok([]),
                 _ok([]),
-                _ok({"state": ci}),
+                _ok(
+                    {
+                        "total_count": 1,
+                        "check_runs": [{"status": "completed", "conclusion": conclusion}],
+                    }
+                ),
             ]
         )
     )

--- a/packages/prgroom/tests/unit/test_cli_run.py
+++ b/packages/prgroom/tests/unit/test_cli_run.py
@@ -91,10 +91,19 @@ class _MergedGh:
         del ref
         return "abc123"
 
-    def rest(self, method: str, path: str, *, fields: dict[str, str] | None = None) -> Any:
-        del method, fields
+    def rest(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict[str, str] | None = None,
+        paginate: bool = False,
+    ) -> Any:
+        del method, fields, paginate
         if path == "repos/octo/demo/pulls/7":
             return {"merged_at": "2026-06-09T12:00:00Z"}  # merged close
+        if path.endswith("/check-runs"):
+            return {"total_count": 0, "check_runs": []}  # no check runs → status fallback
         if path.endswith("/status"):
             return {"state": "success"}
         return []  # issue comments / reviews / review comments — none

--- a/packages/prgroom/tests/unit/test_lifecycle_poll.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_poll.py
@@ -54,6 +54,20 @@ def _gh_http_error(status: int, message: str) -> CommandResult:
     return CommandResult(returncode=1, stdout=body, stderr=f"gh: {message} (HTTP {status})")
 
 
+# The poll CI read is check-runs first, so `_gh`'s ci= knob maps to a single check run.
+# success/failure/pending cover every `_gh` caller; the combined-status FALLBACK path
+# (empty check runs) is exercised by the dedicated fallback tests, never by `_gh`.
+_CI_TO_CHECK_RUN: dict[str, dict[str, object]] = {
+    "success": {"status": "completed", "conclusion": "success"},
+    "failure": {"status": "completed", "conclusion": "failure"},
+    "pending": {"status": "in_progress", "conclusion": None},
+}
+
+
+def _ci_check_runs_read(ci: str) -> CommandResult:
+    return _ok({"total_count": 1, "check_runs": [_CI_TO_CHECK_RUN[ci]]})
+
+
 def _gh(
     *,
     head_oid: str = "headsha1",
@@ -85,7 +99,7 @@ def _gh(
     ]
     if review_comments:
         results.append(_thread_map_ok(thread_nodes or []))
-    results.append(_ok({"state": ci}))
+    results.append(_ci_check_runs_read(ci))
     return GhCli(RecordedRunner(results))
 
 
@@ -366,7 +380,7 @@ def test_review_thread_item_gets_graphql_node_id_as_thread_id() -> None:
                 _ok([]),  # reviews
                 _ok([_review_comment(31)]),  # review comments (REST databaseId 31)
                 _thread_map_ok([{"id": "PRRT_x", "comments": {"nodes": [{"databaseId": 31}]}}]),
-                _ok({"state": "success"}),  # CI status
+                _check_runs_ok([_check_run()]),  # CI (check runs)
             ]
         )
     )
@@ -389,7 +403,7 @@ def test_review_thread_thread_id_empty_when_unmapped() -> None:
                 _ok([]),
                 _ok([_review_comment(31)]),
                 _thread_map_ok([]),  # empty map → no node id for comment 31
-                _ok({"state": "success"}),
+                _check_runs_ok([_check_run()]),  # CI (check runs)
             ]
         )
     )
@@ -628,16 +642,17 @@ def test_ci_failure_passed_through() -> None:
     assert state.quiescence.ci_state == "failure"
 
 
-def test_ci_unknown_rollup_maps_to_pending() -> None:
-    # An empty/unknown combined-status state (not in {success, pending, failure})
-    # is treated as pending — CI exists but is not yet a gate-satisfying verdict.
+def test_ci_combined_status_unknown_rollup_maps_to_pending() -> None:
+    # Fallback path: a commit with no check runs falls back to combined-status; an
+    # empty/unknown state there (not success/pending/failure) is treated as pending.
     results = [
         _ok({"headRefOid": "same"}),
         _ok({"state": "open", "merged_at": None}),
         _ok([]),
         _ok([]),
         _ok([]),
-        _ok({"state": ""}),  # gh returns empty when no rollup verdict yet
+        _ok({"total_count": 0, "check_runs": []}),  # no check runs → fall back
+        _ok({"state": ""}),  # combined-status has no rollup verdict yet
     ]
     gh = GhCli(RecordedRunner(results))
     start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
@@ -645,27 +660,38 @@ def test_ci_unknown_rollup_maps_to_pending() -> None:
     assert state.quiescence.ci_state == "pending"
 
 
-def test_ci_404_maps_to_absent() -> None:
-    # The status endpoint 404s when no CI is configured for the commit → "absent".
+def test_ci_check_runs_404_falls_back_to_combined_status() -> None:
+    # An unexpected 404 on the check-runs endpoint is not terminal: treat it as "no
+    # check runs" and fall back to combined-status rather than erroring.
     results = [
         _ok({"headRefOid": "same"}),
         _ok({"state": "open", "merged_at": None}),
         _ok([]),
         _ok([]),
         _ok([]),
-        _gh_http_error(404, "Not Found"),
+        _gh_http_error(404, "Not Found"),  # check-runs 404 → fall back
+        _ok({"state": "success"}),  # combined-status carries the verdict
     ]
     gh = GhCli(RecordedRunner(results))
     start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
     state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
-    assert state.quiescence.ci_state == "absent"
+    assert state.quiescence.ci_state == "success"
 
 
-def test_ci_error_maps_to_failure() -> None:
-    # GitHub's combined-status returns state in {success, pending, failure, error};
+def test_ci_combined_status_error_maps_to_failure() -> None:
+    # Fallback path: combined-status returns state in {success, pending, failure, error};
     # an `error` rollup is a CI error, not "not yet" — map it to failure, not pending.
+    results = [
+        _ok({"headRefOid": "same"}),
+        _ok({"state": "open", "merged_at": None}),
+        _ok([]),
+        _ok([]),
+        _ok([]),
+        _ok({"total_count": 0, "check_runs": []}),  # no check runs → fall back
+        _ok({"state": "error"}),
+    ]
+    gh = GhCli(RecordedRunner(results))
     start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
-    gh = _gh(head_oid="same", ci="error")
     state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
     assert state.quiescence.ci_state == "failure"
 
@@ -933,3 +959,151 @@ def test_graphql_failed_error_propagates_unchanged() -> None:
     with pytest.raises(PrgroomError) as exc:
         poll_pr(start, ref=_REF, gh=_RaisingGh(), deps=_deps(), config=_config())
     assert exc.value.code is ErrorCode.RUNTIME_GRAPHQL_FAILED
+
+
+# ── CI via check-runs (Actions-only repos) + list pagination (jkha6) ──
+
+
+def _check_run(status: str = "completed", conclusion: str | None = "success") -> dict[str, object]:
+    return {"status": status, "conclusion": conclusion}
+
+
+def _check_runs_ok(runs: list[dict[str, object]]) -> CommandResult:
+    return _ok({"total_count": len(runs), "check_runs": runs})
+
+
+def _poll_reads(
+    *,
+    head: str = "same",
+    issue_comments: list[dict[str, object]] | None = None,
+    reviews: list[dict[str, object]] | None = None,
+    review_comments: list[dict[str, object]] | None = None,
+    thread_nodes: list[dict[str, object]] | None = None,
+    trailing: list[CommandResult],
+) -> list[CommandResult]:
+    """The fixed head/PR/issue/reviews/review-comments prefix + caller-supplied CI reads.
+
+    Mirrors ``_gh`` but returns the raw result list so a test can hold the
+    ``RecordedRunner`` and assert on the argv (e.g. ``--paginate``). ``trailing``
+    carries the CI reads: one check-runs read, plus a combined-status read only when
+    the test exercises the empty-check-runs fallback.
+    """
+    reads = [
+        _ok({"headRefOid": head}),
+        _ok({"state": "open", "merged_at": None}),
+        _ok(issue_comments or []),
+        _ok(reviews or []),
+        _ok(review_comments or []),
+    ]
+    if review_comments:
+        reads.append(_thread_map_ok(thread_nodes or []))
+    reads.extend(trailing)
+    return reads
+
+
+def test_ci_derives_success_from_check_runs_not_blind_combined_status() -> None:
+    # The core jkha6 defect-2 fix: on an Actions-only repo the legacy combined-status
+    # endpoint returns pending/total_count=0 forever. poll must read check-runs and
+    # roll a completed/success run up to ci_state="success" — never blinded by (nor
+    # even reading) combined-status when check runs exist.
+    runner = RecordedRunner(_poll_reads(trailing=[_check_runs_ok([_check_run()])]))
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "success"
+
+
+def test_ci_check_runs_in_progress_maps_to_pending() -> None:
+    runner = RecordedRunner(
+        _poll_reads(trailing=[_check_runs_ok([_check_run(status="in_progress", conclusion=None)])])
+    )
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "pending"
+
+
+def test_ci_check_runs_failure_conclusion_maps_to_failure() -> None:
+    runner = RecordedRunner(
+        _poll_reads(trailing=[_check_runs_ok([_check_run(conclusion="failure")])])
+    )
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "failure"
+
+
+def test_ci_failed_run_wins_over_still_running_run() -> None:
+    # Precedence: a definitive failure beats an in-progress run — CI won't go green.
+    runner = RecordedRunner(
+        _poll_reads(
+            trailing=[
+                _check_runs_ok(
+                    [
+                        _check_run(conclusion="failure"),
+                        _check_run(status="in_progress", conclusion=None),
+                    ]
+                )
+            ]
+        )
+    )
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "failure"
+
+
+def test_ci_neutral_and_skipped_conclusions_count_as_success() -> None:
+    runner = RecordedRunner(
+        _poll_reads(
+            trailing=[
+                _check_runs_ok([_check_run(conclusion="neutral"), _check_run(conclusion="skipped")])
+            ]
+        )
+    )
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "success"
+
+
+def test_ci_falls_back_to_combined_status_when_no_check_runs() -> None:
+    # A repo whose CI posts classic commit statuses (no check runs) must still work:
+    # empty check-runs → fall back to the combined-status endpoint.
+    runner = RecordedRunner(_poll_reads(trailing=[_check_runs_ok([]), _ok({"state": "success"})]))
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "success"
+
+
+def test_ci_absent_when_no_check_runs_and_no_combined_status() -> None:
+    # Empty check-runs + a 404 on combined-status (no CI configured at all) → absent.
+    runner = RecordedRunner(
+        _poll_reads(trailing=[_check_runs_ok([]), _gh_http_error(404, "Not Found")])
+    )
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert state.quiescence.ci_state == "absent"
+
+
+def test_list_reads_request_pagination() -> None:
+    # Defect-1 fix: the three REST list reads (issue comments, reviews, review
+    # comments) must pass --paginate so items beyond GitHub's 30-per-page default are
+    # ingested. The single-object reads (PR resource, check-runs) must NOT paginate.
+    runner = RecordedRunner(_poll_reads(trailing=[_check_runs_ok([_check_run()])]))
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    for path in (
+        "repos/octo/demo/issues/7/comments",
+        "repos/octo/demo/pulls/7/reviews",
+        "repos/octo/demo/pulls/7/comments",
+    ):
+        assert any(path in call and "--paginate" in call for call in runner.calls), path
+    # exactly the three list reads paginate — the PR resource and check-runs do not
+    assert sum("--paginate" in call for call in runner.calls) == 3
+
+
+def test_ingests_reviews_beyond_the_first_thirty() -> None:
+    # Regression guard (acceptance-mandated): gh --paginate concatenates pages into
+    # one array, so poll must ingest every item, not cap at 30. (PR #234 froze because
+    # a re-review landed on page 4 and was never seen.)
+    many = [_review(1000 + i) for i in range(35)]
+    runner = RecordedRunner(_poll_reads(reviews=many, trailing=[_check_runs_ok([_check_run()])]))
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    state = poll_pr(start, ref=_REF, gh=GhCli(runner), deps=_deps(), config=_config())
+    assert sum(i.kind is ItemKind.REVIEW_SUMMARY for i in state.items) == 35


### PR DESCRIPTION
## Summary

Fixes two `poll_pr` defects (bead `agents-config-jkha6`) that silently froze prgroom grooming — confirmed live on PR #234 and PR #241.

1. **Blind past REST page 1.** `GhClient.rest` shelled out to `gh api` with no `--paginate`, so every collection read returned only the first 30 items. Once a PR accrued >30 reviews/comments (which prgroom's own reply reviews guarantee), new items landed on later pages and `_ingest_items` never saw them. The three poll collection reads (issue comments, reviews, review comments) now pass `--paginate`.
2. **CI never green on Actions-only repos.** `_ci_state` read the legacy combined-status endpoint (`commits/{sha}/status`), which returns `pending`/`total_count=0` forever on repos whose CI is GitHub Actions check runs — so `ci_state` could never reach `success` and the quiescence gate could never pass. It now derives CI from `commits/{sha}/check-runs` (rolled up **failure > pending > success**), falling back to combined-status only for commits with no check runs.

## Changes

- `gh/client.py` — `rest()` gains `paginate: bool = False` (appends `--paginate`; gh concatenates array pages).
- `lifecycle/poll.py` — list reads paginated; `_ci_state` split into `_check_runs_state` (rollup) + `_combined_status_state` (fallback).
- Tests — new coverage for check-runs rollup (success/pending/failure, failure-wins precedence, neutral/skipped), combined-status fallback (success/error/pending/absent + check-runs 404 fallback), and `--paginate` argv assertion; poll-driving fixtures swept to the new read sequence.

## Scope / reviewer notes

- **In scope:** Actions-only CI derivation + list pagination, per the bead's acceptance criteria.
- **Out of scope (known follow-up `agents-config-abn9.8.33`):** mixed-CI repos running *both* Actions check runs and a classic Status-API check on the same SHA. This PR reads check-runs-first and does not merge the two signal sources, so a red classic status can be missed when check runs exist. This is the mirror of the pre-existing blind spot and matches the bead's "fallback" design; merging both signals (with correct `total_count==0` handling) is filed separately.
- **Accepted bound:** the check-runs read uses `per_page=100` (a single page); a commit with >100 check runs would miss the overflow. Documented in-code; object endpoints can't use `--paginate` safely.

## Test Plan

- [x] `make ci-prgroom` green from the worktree: **938 passed**, 99.64% coverage (floor 90%), `mypy --strict src`, ruff lint + format, pip-audit, entry-verify all clean.
- [x] RED→GREEN verified for every new behavior (argv assertion fails without the fix; check-runs rollup fails against the old combined-status read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
