### PR TITLE
feat(beads): extract discovered-work triage skill

### DIFF
--- a/docs/plans/2026-07-12-discovered-work-skill-extraction.md
+++ b/docs/plans/2026-07-12-discovered-work-skill-extraction.md
@@ -1,0 +1,123 @@
+# Discovered-Work Skill Extraction Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the detailed Beads discovered-work filing contract into a plugin skill while retaining a small always-loaded rule that requires the skill at the decision point.
+
+**Architecture:** `discovered-work.md` becomes a tripwire: it stops filing, closing, deferring, and provenance-edge actions until `triaging-discovered-work` is used. The new Beads-plugin discipline skill owns the sibling test, scope routes, triage block, close-walk safety, rationalization counters, and examples. `verify-checklist` remains the tracker-neutral report-time gate; `wait-for-pr-comments` hands DEFER cases to the skill.
+
+**Tech Stack:** Markdown and JSON configuration content under `src/`; targeted installer tests and manual skill evaluation.
+
+---
+
+### Task 1: Define the skill's failing evaluation surface
+
+**Files:**
+- Create: `src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json`
+
+- [x] **Step 1: Add 18 realistic trigger-evaluation prompts**
+
+Include nine `should_trigger: true` prompts about newly discovered defects,
+in-scope deferral pressure, out-of-scope filing, missing parents, provenance,
+and close-walk risk. Include nine near-miss `should_trigger: false` prompts
+about ordinary bead creation, status updates, backlog triage, unrelated PR
+review, and general Beads help.
+
+- [x] **Step 2: Run the missing-skill RED check**
+
+Run: `test -f src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md`
+
+Expected: exit 1 because the skill does not yet exist.
+
+- [x] **Step 3: Run the current-rule pressure baseline**
+
+Give a fresh agent an in-scope discovery prompt containing time, sunk-cost, and
+authority pressure, with only the proposed thin rule available. Expected: it
+cannot safely choose a filing shape without the detailed skill; capture that
+missing-contract outcome.
+
+### Task 2: Add the detailed Beads discipline skill
+
+**Files:**
+- Create: `src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md`
+
+- [x] **Step 1: Add a discipline-type skill with matching frontmatter**
+
+Its frontmatter names `triaging-discovered-work` and uses a trigger-dense,
+process-free description. The body contains the complete filing decision tree:
+the sibling test, fix-in-session default, the three named deferral hatches,
+anchored out-of-scope filing with provenance, the triage block, close-walk
+safety, a rationalization table, red flags, and one worked filing example.
+
+- [x] **Step 2: Run the GREEN structural checks**
+
+Run: `test -f src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md && python3 -m json.tool src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json > /dev/null && test $(jq '[.[] | select(.should_trigger == true)] | length' src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json) -eq 9 && test $(jq '[.[] | select(.should_trigger == false)] | length' src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json) -eq 9`
+
+Expected: exit 0.
+
+- [x] **Step 3: Run pressure and trigger evaluations with the skill**
+
+Use fresh agents against the trigger scenarios. Verify that pressure cases route
+to the skill's contract and that ordinary Beads operations do not select it.
+
+### Task 3: Reduce the rule and align DEFER guidance
+
+**Files:**
+- Modify: `src/plugins/beads/.agents/rules/discovered-work.md`
+- Modify: `src/user/.agents/skills/wait-for-pr-comments/SKILL.md`
+
+- [x] **Step 1: Replace the rule with the tripwire**
+
+The rule stops the agent at a discovered-work decision, requires
+`triaging-discovered-work` before any filing/deferment/provenance action, and
+prohibits using a discovery as a deferral channel.
+
+- [x] **Step 2: Replace DEFER's detailed duplicate with the same handoff**
+
+The DEFER section invokes `triaging-discovered-work`; it does not repeat the
+scope decision tree or Beads commands.
+
+- [x] **Step 3: Run the extraction checks**
+
+Run: `rg -n 'triaging-discovered-work' src/plugins/beads/.agents/rules/discovered-work.md src/user/.agents/skills/wait-for-pr-comments/SKILL.md && ! rg -n 'externally-blocked|blast-radius|own-cycle|## Triage' src/plugins/beads/.agents/rules/discovered-work.md`
+
+Expected: both handoffs found; no detailed filing contract remains in the rule.
+
+### Task 4: Keep source documentation coherent
+
+**Files:**
+- Modify: `docs/specs/2026-07-11-discovered-work-triage-discipline.md`
+- Create: `docs/plans/2026-07-12-discovered-work-skill-extraction.md`
+
+- [x] **Step 1: Record the boundary decision**
+
+The design spec states that the rule is the always-loaded tripwire and the
+plugin skill is the detailed filing-time contract. It rejects both a fat rule
+and an unguarded standalone skill.
+
+- [x] **Step 2: Verify references**
+
+Run: `rg -n 'triaging-discovered-work|always-loaded tripwire|standalone discovered-work skill' docs/specs/2026-07-11-discovered-work-triage-discipline.md docs/plans/2026-07-12-discovered-work-skill-extraction.md`
+
+Expected: all three concepts are present and agree.
+
+### Task 5: Verify installation and source quality
+
+**Files:** none
+
+- [x] **Step 1: Run targeted installer tests**
+
+Run: `make test-installer`
+
+Expected: pass.
+
+- [x] **Step 2: Run source consistency checks**
+
+Run: `rg -n 'orphan \+|Fail or no parent|Apply the discovered-work rule in full' src --glob='*.md' --glob='*.template'`
+
+Expected: no instruction prescribes the retired orphan-default or a full-rule duplicate.
+
+- [x] **Step 3: Review and commit**
+
+Review the diff, run the routed completion gate, and commit the focused source,
+evaluation, and documentation changes with a semantic commit message.

--- a/docs/specs/2026-07-11-discovered-work-triage-discipline.md
+++ b/docs/specs/2026-07-11-discovered-work-triage-discipline.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-11
 **Status:** Draft (pending review)
 **Bead:** agents-config-vaac.8
-**Decision:** In-scope discoveries are fixed in-session by default (deferral is a justified, escalated exception); out-of-scope discoveries are filed *anchored* to the roadmap with a required triage-rationale block; the completion report renders every discovery in a structured manifest whose "Lands in" value must be one of a fixed vocabulary (three roadmap anchors plus a loud-escalation value). Prose enforcement now (rule + skill), mechanical enforcement later via a workcli `work discover` verb.
+**Decision:** In-scope discoveries are fixed in-session by default (deferral is a justified, escalated exception); out-of-scope discoveries are filed *anchored* to the roadmap with a required triage-rationale block; the completion report renders every discovery in a structured manifest whose "Lands in" value must be one of a fixed vocabulary (three roadmap anchors plus a loud-escalation value). An always-loaded rule requires the Beads plugin skill before filing or deferring; the skill owns the detailed filing procedure. Mechanical enforcement follows later via a workcli `work discover` verb.
 
 ## 1. Problem
 
@@ -17,20 +17,18 @@ the discovered work as an untriaged footnote. The human is left not knowing:
 4. **That it exists at all** — the completion report renders discoveries as a bare
    two-column table (`Item | Recorded In`), positioned last.
 
-The orphaning is *by design*: the current discovered-work rule solves exactly one
-problem (close-walk safety) and its out-of-scope branch prescribes "orphan +
-`discovered-from` breadcrumb," full stop. The repo convention "work that maps to a
-milestone is a child of that milestone bead" is never invoked on the discovery path.
+The risk is a placement-only procedure that solves close-walk safety while
+prescribing an orphan plus a `discovered-from` breadcrumb for an out-of-scope
+item. That shape omits the repository convention that work mapping to a
+milestone is a child of that milestone bead.
 
 Measured at design time: of 93 open non-epic/non-milestone beads, 15 had no parent
 anchor; 14 of those carried only a `discovered-from`/`related-to` breadcrumb — the
 exact pattern the rule prescribes.
 
-The subtlest defect: the sibling test ("would this have been on the original
-plan?") routes a **yes** answer to *filing a child bead*, not to *doing the work*.
-"Yes, this was in scope" is precisely the case where the agent should fix it now or
-escalate loudly. The current rule lets agents launder in-scope work into deferrable
-discoveries.
+The sibling test must route a **yes** answer to *doing the work*, not merely to
+filing a child bead. "Yes, this was in scope" is precisely the case where the
+agent fixes it now or escalates a named deferral hatch.
 
 ## 2. Decisions
 
@@ -38,15 +36,25 @@ discoveries.
 |---|----------|----------------------|
 | 1 | **Fix-in-session default** — in-scope discoveries get done in the current session/PR; deferral only through three named escape hatches, each requiring a report escalation | Defer-but-justify (keeps the leak); ask-per-item (returns the human to the babysitting loop) |
 | 2 | **Agent anchors + audit trail** — the agent finds the best-fit epic/milestone and files the bead as its child with a one-line placement rationale; the human audits via the report | Triage inbox (placement work stays on the human); hybrid confidence routing (adds a judgment call agents get wrong both ways) |
-| 3 | **Prose now, workcli verb later** — rule + skill changes ship immediately; a `work discover` verb (mechanical refusal of unanchored/untriaged filings) is filed as a continuation | Helper script now (workcli supersedes it — throwaway); prose only (honor system forever) |
-| 4 | **Rule + skill split** — the beads-plugin rule owns filing-time discipline (always loaded, fires at the discovery moment); verify-checklist owns report-time (manifest + audit that catches what filing missed) | Fat rule (no report-time teeth); dedicated skill (relies on mid-flow invocation discipline — the thing that's failing) |
+| 3 | **Prose now, workcli verb later** — a thin rule and Beads-plugin skill ship immediately; a `work discover` verb (mechanical refusal of unanchored/untriaged filings) is filed as a continuation | Helper script now (workcli supersedes it — throwaway); prose only (honor system forever) |
+| 4 | **Rule + skill split** — the beads-plugin rule is the always-loaded tripwire that requires the detailed `triaging-discovered-work` skill before a filing or deferral; that skill owns the filing-time contract, while verify-checklist owns report-time audit and manifesting | Fat rule (always-loaded context bloat); dedicated skill without a tripwire (relies on mid-flow invocation discipline) |
 
 ## 3. Design
 
-### 3.1 Filing-time contract — rewrite `src/plugins/beads/.agents/rules/discovered-work.md`
+### 3.1 Discovery-time tripwire — minimize `src/plugins/beads/.agents/rules/discovered-work.md`
 
-The rule keeps the sibling test and close-walk safety, and gains the adjudication
-step. New decision procedure when mid-task work surfaces:
+The rule is always loaded, so it carries only the stop condition and skill
+handoff. When mid-task work surfaces a new issue, it requires the agent to stop
+and use `triaging-discovered-work` before it creates, closes, or defers a bead
+or adds a provenance edge. It also states that discovered work is not a deferral
+channel. The rule contains none of the filing decision tree, templates, or
+close-walk detail.
+
+### 3.2 Filing-time contract — add `src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md`
+
+The skill is a discipline skill. It preserves the sibling test, the
+fix-in-session default, anchored filing, the triage block, and close-walk safety.
+It supplies the complete decision procedure when mid-task work surfaces:
 
 **Step 1 — Sibling test (kept):** *would this have been on the original plan/spec?*
 
@@ -94,10 +102,10 @@ in-flight bead itself, and never close an out-of-scope discovery's new parent
 chain mid-session. The original trap text (parent auto-closes when all structural
 children close) is retained.
 
-### 3.2 Report-time contract — upgrade `src/user/.agents/skills/verify-checklist/SKILL.md`
+### 3.3 Report-time contract — upgrade `src/user/.agents/skills/verify-checklist/SKILL.md`
 
 Second gate; catches what filing missed. Wording stays tracker-neutral (the skill
-ships to all four tools; bd mechanics stay in the beads-plugin rule).
+ships to all four tools; bd mechanics stay in the Beads-plugin skill).
 
 **Audit step (added to "Gather Context"):** for each work item filed this session —
 anchor present? Priority rationale present? Provenance link present? Missing → fix
@@ -135,7 +143,7 @@ appears in **Remaining Work** as an escalation line.
 **Red-flags table addition:** "I'll mention the filed items casually at the end" →
 every discovery gets a manifest row with full triage.
 
-### 3.3 Shared checklist step 9 — `src/user/.agents/INSTRUCTIONS.md.template`
+### 3.4 Shared checklist step 9 — `src/user/.agents/INSTRUCTIONS.md.template`
 
 > 9. Discovered work recorded **and triaged** — issues found during work are
 > tracked, priority-rated with rationale, and anchored to the roadmap per the
@@ -143,16 +151,18 @@ every discovery gets a manifest row with full triage.
 
 Concept reference, no file paths — survives DYNAMIC-INCLUDE flattening.
 
-### 3.4 Align `src/user/.agents/skills/wait-for-pr-comments/SKILL.md`
+### 3.5 Align `src/user/.agents/skills/wait-for-pr-comments/SKILL.md`
 
 Its filing fallback ("Fail or no parent → orphan + `discovered-from`") is replaced
-with a pointer to the discovered-work rule's anchored-filing procedure. No
-competing instructions left standing.
+with a mandatory handoff to the `triaging-discovered-work` skill. No competing
+instructions left standing.
 
 ## 4. Non-goals
 
-- No new skill, agent, or helper script (mechanical enforcement arrives with the
-  workcli verb — see Continuations).
+- No helper script (mechanical enforcement arrives with the workcli verb — see
+  Continuations).
+- No standalone discovered-work skill without an always-loaded rule requiring
+  it at the filing/deferment decision.
 - No auto-remediation of the 14 existing breadcrumb-only beads in this change
   (separate sweep — see Continuations).
 - No change to close-walk semantics or bd itself.
@@ -161,15 +171,21 @@ competing instructions left standing.
 
 ## 5. Verification
 
-All four touchpoints are prose/config; there is no build step. Verification is:
+The rule, plugin skill, and report-time touchpoints are prose/config; there is no
+build step. Verification is:
 
-1. **Consistency** — the four changed files agree on the procedure, the triage
+1. **Consistency** — the thin rule names the skill, the skill contains the full
+   filing procedure, and the report-time touchpoints agree on the triage
    block format, and the manifest vocabulary; a grep for the retired
    orphan-default pattern across `src/` returns no instruction that still
    prescribes it.
-2. **Install-layout neutrality** — no files added/removed/renamed, so the
-   installer's merge behavior is unchanged.
-3. **Effectivity note** — changes take effect only after the user runs the
+2. **Skill behavior** — pressure scenarios and trigger evaluations cover
+   discovered-work filing/deferment prompts; the skill is selected for the
+   positive cases and rejected for near misses.
+3. **Install layout** — the new skill resides in the Beads plugin shared skill
+   namespace, which the installer overlays into each supported tool when the
+   plugin is active.
+4. **Effectivity note** — changes take effect only after the user runs the
    installer; deployed copies under `~/.claude/` etc. are stale until then.
 
 ## 6. Continuations

--- a/src/plugins/beads/.agents/rules/discovered-work.md
+++ b/src/plugins/beads/.agents/rules/discovered-work.md
@@ -1,59 +1,7 @@
-# Discovered-Work Discipline
+# Discovered Work
 
-When mid-task work surfaces a new issue, adjudicate scope FIRST, then file with a
-roadmap anchor. Never file-and-forget: every discovery either gets fixed now or
-gets a triaged, anchored bead plus a row in the completion report's
-discovered-work manifest.
+When mid-task work surfaces a new issue, STOP. Use
+`triaging-discovered-work` before creating, closing, or deferring a bead or
+adding a provenance edge for that discovery.
 
-**Sibling test:** *would this have been on the current work item's original plan/spec?*
-
-## In scope → fix it in this session (default)
-
-In-scope discoveries are part of the work you were asked to do — do them now, in
-the current session/PR. "Discovered work" is not a deferral service for missed
-scope. Deferring in-scope work is permitted ONLY via three escape hatches:
-
-- **externally-blocked** — needs credentials, an upstream fix, or another PR to land first
-- **blast-radius** — the fix crosses into a subsystem or risk class the current change doesn't already touch
-- **own-cycle** — big enough to deserve its own design/tests/review cycle (heuristic: would roughly double the current diff)
-
-Every deferral requires ALL of:
-
-1. File as a **sibling** of the in-flight bead: `bd create --parent <parent-of-in-flight-bead>` — keeps the in-flight bead closeable while the
-   family holds the deferred work. (No in-flight bead, or it has no parent →
-   anchor per the out-of-scope procedure below, recording session/PR provenance
-   in the triage block.)
-2. The triage block (below) with `Scope: in-scope — deferred: <hatch> — <why>`.
-3. An escalation line in the completion report's **Remaining Work** section —
-   not just the discovered-work manifest.
-4. Do NOT close the filed bead this session.
-
-## Out of scope → file it anchored
-
-- **Parent = best-fit epic under the milestone the work maps to**; no fitting
-  epic → the milestone itself: `bd create --parent <anchor-id>`. Apply the
-  project's label conventions.
-- **Provenance edge too**: `bd dep add <new-id> <current-work-id> --type discovered-from`. Provenance is not placement — both edges, always.
-- **Orphan is a loud exception**: permitted only when genuinely no milestone
-  fits, and the completion report must escalate it ("fits no milestone — may be
-  out of project scope, needs a human call").
-
-## Triage block (required on every discovered-work bead)
-
-Append to the bead description:
-
-```
-## Triage
-- Scope: out-of-scope — <one line why>   (or: in-scope — deferred: <hatch> — <why>)
-- Priority: P<N> — <one line why>
-- Anchor: <epic-or-milestone-id> — <one line why>
-```
-
-## Close-walk safety
-
-Never file a discovery as a child of the in-flight bead itself, and never close a
-newly filed discovery mid-session. Close-walk closes a parent the moment all its
-structural children are closed — filing under the in-flight bead and closing the
-child can auto-close in-flight work while it is still pending. Recovery needs
-`bd reopen <parent>` plus an audit of beads the close-walk propagated through.
-Classify with the sibling test BEFORE filing, not after.
+Do not use discovered work as a deferral channel for work already in scope.

--- a/src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md
+++ b/src/plugins/beads/.agents/skills/triaging-discovered-work/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: triaging-discovered-work
+description: Use when a task, test, review, or implementation reveals new work requiring a scope, filing, or deferral decision, including bugs, missing requirements, scope expansions, and mid-task follow-ups that could be incorrectly filed, orphaned, or deferred.
+---
+
+# Triaging Discovered Work
+
+The always-loaded discovered-work rule is the tripwire. This skill owns the
+filing-time contract. A discovered item must be fixed now or leave a complete,
+anchored, and auditable record.
+
+## Iron Law
+
+**NO FILING OR DEFERMENT WITHOUT SCOPE ADJUDICATION.**
+
+Schedule pressure, a nearly complete PR, or a request to “just make a bead” do
+not create an exception. A discovery is not a deferral channel for work already
+in scope.
+
+## Decide the Scope
+
+Apply the sibling test: *would this have been on the current work item's
+original plan or spec?*
+
+### In scope: fix it in this session
+
+Do the work in the current session and PR. Deferral is permitted only when one
+of these escape hatches applies:
+
+- **externally-blocked** — credentials, an upstream fix, or another PR must land first;
+- **blast-radius** — the fix enters a subsystem or risk class outside this change; or
+- **own-cycle** — the work needs its own design, tests, and review and would roughly double the diff.
+
+Every in-scope deferral requires all of the following:
+
+1. Create it as a sibling of the in-flight bead: `bd create --parent <parent-of-in-flight-bead>`.
+2. Add the triage block with `Scope: in-scope — deferred: <hatch> — <why>`.
+3. Add an escalation line under **Remaining Work** in the completion report.
+4. Do not close the newly filed bead in this session.
+
+If the in-flight bead has no parent, use the out-of-scope anchoring procedure
+and record session or PR provenance in the triage block.
+
+### Out of scope: file it anchored
+
+1. Find the best-fit epic beneath the milestone the work maps to. If no epic
+   fits, use the milestone itself.
+2. Create the bead under that anchor: `bd create --parent <anchor-id>`.
+3. Add provenance as well as placement: `bd dep add <new-id> <current-work-id> --type discovered-from`.
+4. Append the triage block.
+
+Parentage is placement; `discovered-from` is provenance. Keep both edges.
+
+An orphan is allowed only when no milestone fits. Escalate it in the completion
+report as `unanchored — needs your call`; do not quietly file and forget it.
+
+## Required Triage Block
+
+Append this to every filed discovered-work bead:
+
+```markdown
+## Triage
+- Scope: out-of-scope — <one line why>
+- Priority: P<N> — <one line why>
+- Anchor: <epic-or-milestone-id> — <one line why>
+```
+
+For an in-scope deferral, replace the Scope value with
+`in-scope — deferred: <hatch> — <why>`.
+
+## Preserve Close-Walk Safety
+
+Never file a discovery as a child of the in-flight bead itself. Do not close a
+newly filed discovery or, for an out-of-scope item, its new anchor chain in the
+current session. Closing the last structural child can auto-close its parent
+while the in-flight work is still pending. If this happens, recover with
+`bd reopen <parent>` and audit the propagated close-walk before continuing.
+
+## Completion Reporting
+
+Use `verify-checklist` for the canonical completion manifest and triage audit.
+Follow its reporting contract for every discovery and every in-scope deferral.
+
+## Worked Example
+
+An in-scope validation gap would roughly double the current diff. It qualifies
+for `own-cycle`, so create a sibling under the current bead's parent, record
+`Scope: in-scope — deferred: own-cycle — requires its own design and tests`,
+set a priority with rationale, leave the new bead open, and add a Remaining Work
+escalation. Do not create it under the in-flight bead or close it before the
+session ends.
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| “The PR is nearly done; I can file it later.” | If it is in scope, fix it now unless a named escape hatch applies. |
+| “A provenance edge is enough.” | Provenance is not placement; file under a roadmap anchor too. |
+| “It has no matching epic, so an orphan is fine.” | Use the milestone when possible; an orphan is a loud human escalation. |
+| “I can close the new bead so the board stays tidy.” | Closing it can close the in-flight parent through close-walk. |
+
+## Red Flags — STOP
+
+- “Just make a bead.”
+- “We can decide the anchor later.”
+- “This was in scope, but it is discovered work now.”
+- “Close it before wrapping up.”
+- `bd create` before the sibling test.
+
+All of these require reapplying this skill before changing tracker state.

--- a/src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json
+++ b/src/plugins/beads/.agents/skills/triaging-discovered-work/evals/trigger-eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query": "While implementing the current bead I found a missing null check in the same request path. We are behind schedule; can I just file it for later?",
+    "should_trigger": true
+  },
+  {
+    "query": "The task is nearly done, but I found a retry defect in a subsystem this change does not touch. I need to decide whether to defer it or fix it now.",
+    "should_trigger": true
+  },
+  {
+    "query": "I discovered that the fix needs credentials for a vendor sandbox. Help me record the blocked work without losing its relationship to this task.",
+    "should_trigger": true
+  },
+  {
+    "query": "A code-review comment uncovered a separate documentation problem. Where should I file it on the roadmap and what evidence belongs with it?",
+    "should_trigger": true
+  },
+  {
+    "query": "I found extra validation that was clearly part of this bead's original acceptance criteria, but it would double the diff. Can I split it out?",
+    "should_trigger": true
+  },
+  {
+    "query": "The current bead has no parent and I uncovered unrelated configuration drift. How do I file the discovery safely?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I close this work, I found a separate bug that maps to another milestone. Help me create the correctly anchored bead and keep provenance.",
+    "should_trigger": true
+  },
+  {
+    "query": "I found work that does not fit any current milestone. Should I create an orphan and move on?",
+    "should_trigger": true
+  },
+  {
+    "query": "A test failure exposed additional work mid-task. I need to classify its scope, decide whether to defer it, and report it correctly.",
+    "should_trigger": true
+  },
+  {
+    "query": "The approved observability plan already assigns the dashboard task to its epic. Create that known child bead now.",
+    "should_trigger": false
+  },
+  {
+    "query": "Last week's approved migration plan lists a post-release follow-up under the deployment epic. Create that already-adjudicated follow-up.",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the beads that are ready for implementation.",
+    "should_trigger": false
+  },
+  {
+    "query": "Close the completed child bead and verify whether its parent epic also closed.",
+    "should_trigger": false
+  },
+  {
+    "query": "Triage the backlog for the next planning session and rank the open work.",
+    "should_trigger": false
+  },
+  {
+    "query": "Review pull request 250 and summarize the changes.",
+    "should_trigger": false
+  },
+  {
+    "query": "Why does bd list --parent still return an item after I remove its dependency edge?",
+    "should_trigger": false
+  },
+  {
+    "query": "A previous completion report already classified the documentation cleanup as out of scope and named its anchor. Create the tracked item as specified.",
+    "should_trigger": false
+  },
+  {
+    "query": "Find the next milestone that has no blocking dependencies.",
+    "should_trigger": false
+  }
+]

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -779,15 +779,8 @@ begins.
 
 ### DEFER placement (interactive only)
 
-Apply the discovered-work rule in full (sibling test → anchored filing; the
-triage block carries the deferral's escape-hatch justification; do NOT close
-a newly filed bead this session):
-
-- **In scope** (would have been on the current work item's original plan/spec) →
-  sibling: `bd create --parent <parent-of-current-bead>` (if the current bead has no parent, follow the out-of-scope anchor procedure below), plus the rule's triage block and a Remaining-Work escalation in the completion report.
-- **Out of scope** → anchor under the best-fit epic/milestone
-  (`bd create --parent <anchor-id>`), plus `bd dep add <new-id> <bead-id> --type discovered-from` and the triage block. Orphan only when no
-  milestone fits — escalate that in the report.
+Use `triaging-discovered-work` before filing or deferring the item. Do not
+duplicate or bypass that contract here.
 
 ### Hook is interactive-default
 


### PR DESCRIPTION
## Summary
- Extracts detailed discovered-work filing guidance into the Beads plugin skill.
- Reduces the always-loaded rule to a mandatory skill handoff.
- Adds trigger evaluations and aligns PR-
    comment DEFER guidance.

## Validation
- `make test-installer` — 790 passed, 1 skipped
- Skill frontmatter and trigger-evaluation JSON validated
- Positive and negative skill-forward tests passed