### PR TITLE
docs(merge-approver): document [merge-policy.approver] setup + correct contents:write requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The core architecture is in place, and several keystone enablers have shipped si
 - The "no, not ready" brainstorm-readiness gate is implicit, not enforced (milestone M2)
 - The 85/5/10 ratio is not yet instrumented — aspirational, not measured
 - No spec post-mortem feedback loop yet — failures don't automatically improve future brainstorming
-- Rule-based auto-merge exists but is opt-in per repo; most repos still default to `explicit` (a human "ship it")
+- Rule-based auto-merge exists but is opt-in per repo; most repos still default to `explicit` (a human "ship it") — though on a protected branch it can satisfy the required review via an App-attested approver (`[merge-policy.approver]`)
 - The PDLC Orchestrator (the FSM that would run overnight autonomy) is an early tracer bullet — CLI, durable state, and the strike/recovery machine are designed, not built (milestone M4)
 
 Treat the vision as direction and the rules-as-written as the current contract. Contributions are welcome.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -100,6 +100,42 @@ Absent a `[merge-policy]` section, `explicit` applies — creating a PR is never
 authorization to merge. This is enforced by the `merge-guard` skill; see
 [The SDLC Workflow](./sdlc-workflow.md#7-merge) for how it plays out.
 
+#### Autonomous merge on a protected branch — `[merge-policy.approver]`
+
+If your default branch has protection requiring an approving review, a `rule-based`
+merge would otherwise stall: there is no human to approve, and an agent cannot
+approve its own PR. The optional approver closes that gap — a **GitHub App** submits
+an attested approving review at merge time, pinned to the exact commit the
+eligibility floor checked, *satisfying* the required-review rule rather than
+bypassing it.
+
+```toml
+[merge-policy.approver]           # opt-in; omit the block and behavior is unchanged
+type         = "github-app"
+app-id       = 123456
+key-path-env = "MERGE_GUARD_APPROVER_KEY_PATH"   # env var that names the PEM path
+```
+
+One-time setup (the repo owner does this; the agent cannot):
+
+1. Create a GitHub App (Settings → Developer settings → GitHub Apps) with **no
+   webhook**, installable only on your account. Grant it **Pull requests: Read &
+   write** *and* **Contents: Read & write** — both are required. Without
+   `Contents: write`, GitHub records the App's approval but does **not** count it
+   toward the required review.
+2. Generate a private key; store the PEM locally (e.g.
+   `~/.config/merge-guard/approver.pem`, `chmod 600`) — never in any repo. Install
+   the App on the repo.
+3. Export the env var named above to the PEM path, e.g. in your shell profile:
+   `export MERGE_GUARD_APPROVER_KEY_PATH="$HOME/.config/merge-guard/approver.pem"`.
+
+The approver is **mechanism, not authorization**: `merge-guard` runs it only after a
+`rule-based` merge is already authorized and the eligibility floor re-clears, and any
+failure is a fail-loud hand-off to you — never an `--admin` bypass. **Security:**
+because the App holds `Contents: write`, the PEM key can push code to the repo, so
+guard it like any write credential. (At run time the approver mints a token scoped
+down to `pull_requests: write` only, but a holder of the key can mint more.)
+
 ### Adversarial review — `[foreign-cli]`
 
 If you use cross-model review (Codex/Gemini), point at their binaries and pick

--- a/docs/guide/sdlc-workflow.md
+++ b/docs/guide/sdlc-workflow.md
@@ -118,7 +118,9 @@ enforced by the **`merge-guard`** skill:
 - **`never`** — hands off to you.
 - **`explicit`** (default) — waits for your direct "merge it" / "ship it".
 - **`rule-based`** — auto-merges only when the named rule *and* the live
-  eligibility check both pass.
+  eligibility check both pass. On a protected branch that requires a review, an
+  optional App-attested approver (configured via `[merge-policy.approver]`) supplies
+  that review at merge time so the merge can proceed without a human.
 
 When in doubt, `merge-guard` treats the PR as *not* authorized. This is a
 deliberate risk-asymmetric default: the cost of a wrong merge outweighs the cost

--- a/docs/specs/2026-07-11-merge-approver-app-design.md
+++ b/docs/specs/2026-07-11-merge-approver-app-design.md
@@ -77,14 +77,18 @@ One-time manual setup per install target (owner does this; the agent cannot):
 1. GitHub → Settings → Developer settings → GitHub Apps → New GitHub App.
    - Name: `merge-guard-approver` (display identity: `merge-guard-approver[bot]`).
    - Webhook: **unchecked** (no hosted receiver).
-   - Permissions: **Pull requests: Read & write**. Nothing else.
+   - Permissions: **Pull requests: Read & write** and **Contents: Read & write** —
+     both required. Without `Contents: write`, GitHub records the App's approving
+     review but does **not** count it toward `required_approving_review_count`
+     (`reviewDecision` stays `REVIEW_REQUIRED`). This widens the key's blast radius
+     — see §5.
    - Installable: only on the owning account.
 2. Generate a private key (GitHub issues RSA/PKCS#1); store it locally, e.g.
    `~/.config/merge-guard/approver.pem`, `chmod 600`. Never in any repo.
 3. Install the App on the target repository.
 
 The installation ID is resolved at runtime from the App JWT
-(`GET /app/installations`) — it is not configuration.
+(`GET /repos/{repo}/installation`) — it is not configuration.
 
 ### 3.2 Configuration contract (opt-in switch)
 
@@ -141,8 +145,9 @@ Behavior:
    `iat` backdated 60s, `exp` +9 min, `iss` = app-id).
 2. Exchange JWT for a short-lived installation token, scoped down at mint time to
    this single repo and `pull_requests: write` — the least privilege a review
-   POST needs — so a leaked token cannot exercise the installation's other grants
-   (`GET /app/installations` → `POST /app/installations/{id}/access_tokens`).
+   POST needs — so a leaked *token* cannot exercise the installation's other grants,
+   including `contents: write` (see §5). Mint flow: `GET /app` →
+   `GET /repos/{repo}/installation` → `POST /app/installations/{id}/access_tokens`.
 3. Fetch the PR. If this App already has an APPROVED review at `--head-sha`
    (REST reviews list filtered to the App's `[bot]` login — `reviewDecision` is
    GraphQL-only) → exit 0 (idempotent).
@@ -215,8 +220,12 @@ reproducibility on the work-machine fork:
 
 ## 5. Security considerations
 
-- **Blast radius of the key**: approvals (and PR-write actions) on the installed
-  repos only. Narrower than any PAT. Local file, 0600, outside all repos.
+- **Blast radius of the key**: the App installation holds **`Contents: write`**
+  (required for its approval to count — see §3.1), so a holder of the PEM key can
+  push code to the installed repos, not just approve PRs. Guard it as a write
+  credential: local file, 0600, outside all repos. Mitigation: `approve_pr.py` mints
+  a token scoped down to `pull_requests: write` at run time, so the token it actually
+  uses cannot push — but a holder of the key itself can mint the fuller grant.
 - **No new bypass**: the ruleset's bypass list is untouched; the App *satisfies*
   the review rule. Emergency manual bypass remains the owner's, manually.
 - **External PRs**: unaffected. The approver runs only inside merge-guard's
@@ -235,12 +244,17 @@ Two load-bearing assumptions are verified on a real PR before this design is
 declared working; both have designed fallbacks:
 
 - **(a) An App approval counts toward `required_approving_review_count`.**
-  Expected yes (standard bot-approval mechanics; the App is not the PR author).
-  Falsified → the post-approve re-read halts (see §4) and the design is revisited.
-- **(b) The auto-mode classifier permits approve-then-merge.** Unlike `--admin`,
-  this exercises a purpose-built, human-provisioned credential to satisfy (not
-  bypass) the rule. Falsified → owner runs the recorded command once; precedent
-  documented in the skill.
+  Verified on PR #250 — **conditional on the App holding `Contents: write`**. With
+  `Pull requests: write` alone the approval is recorded but does not count
+  (`reviewDecision` stays `REVIEW_REQUIRED`); granting `Contents: write` flips it to
+  `APPROVED` and a plain merge succeeds. `author_association` reads `NONE` either
+  way — GitHub's review-counting honors the App's real repo write permission, not
+  that field. Had it failed outright, the post-approve re-read would halt (see §4).
+- **(b) The auto-mode classifier permits approve-then-merge.** Verified on PR #250 —
+  the plain (non-`--admin`) squash merge completed. Unlike `--admin`, this exercises
+  a purpose-built, human-provisioned credential to satisfy (not bypass) the rule.
+  Had it been blocked, the fallback is the owner running the recorded command once;
+  precedent documented in the skill.
 
 ## 7. Test plan
 


### PR DESCRIPTION
## Summary

Documentation-only change (no code) covering the now-shipped **merge-approver GitHub App**:

- **Job A — user-facing setup docs.** New `[merge-policy.approver]` section in the configuration guide (config block, one-time App setup, security note), plus one-line mentions in `README.md` and the SDLC-workflow merge step.
- **Job B — correction.** The App's approving review only counts toward branch protection's required review when the App holds **`Contents: Read & write`** — not `Pull requests: write` alone. This was proven live by the PR #250 tracer bullet. Corrects the design spec (§3.1 permissions, §5 blast radius, §6 tracer-bullet outcomes) and fixes a pre-existing stale endpoint reference.

## Scope

- **In scope:** `docs/guide/configuration.md`, `docs/guide/sdlc-workflow.md`, `README.md`, `docs/specs/2026-07-11-merge-approver-app-design.md`.
- **Out of scope (intentionally untouched):** the HLD (`docs/architecture/review-merge-policy/design.md`) and the implementation plan — investigated and confirmed they never carried the stale `pull_requests:write`-only claim, so editing them would add noise. The App's code shipped in #250 and is not re-touched here.

## Artifact nature & ground truth

- The spec is a **dated design doc**; §6 ("Assumptions to verify") records the tracer-bullet *outcomes* — that is the section's purpose (the repo's carve-out for dated-spec review ledgers), not forbidden in-body change-log narration.
- **Load-bearing facts, verifiable against shipped code:**
  - The runtime token stays least-privilege — `approve_pr.py`'s `mint()` requests `{"permissions": {"pull_requests": "write"}}` only. The docs deliberately distinguish this from the App-install grant (the PEM key can mint the fuller `contents:write` grant → wider key blast radius). Do not "simplify" that distinction away.
  - Config field names (`type`, `app-id`, `key-path-env`) match `project-config.toml`'s real `[merge-policy.approver]` block.
  - Corrected endpoint: `approve_pr.py` calls `GET /app` → `GET /repos/{repo}/installation` → `POST /app/installations/{id}/access_tokens` (the old `GET /app/installations` list-all reference was wrong).

## Test Plan

Docs-only; no unit tests or build apply (no `src/**` or `packages/**` touched, so the package CI gates are unaffected). Verified: exactly 4 files changed, code fences balanced, no stale `GET /app/installations` remaining, all cross-references (§3.1/§5/§6) resolve. The repo's `ci` check will run as the newly-required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
