### PR TITLE
feat(vizsuite): PR OID resolution + git<->GitHub scalar reconciler (slice 2/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ htmlcov/
 
 # optimize-my-skill --deep workspaces (persistent but not committed)
 .eval-runs/
+
+# vizsuite artifact output (`viz pr` writes .viz/out/*.html at cwd)
+.viz/

--- a/packages/vizsuite/pyproject.toml
+++ b/packages/vizsuite/pyproject.toml
@@ -3,10 +3,10 @@ name = "vizsuite"
 version = "0.1.0"
 description = "vizsuite — repo/PR visualization suite (Tier-1 extractors, PR-scoped reconciliation, scene assembly, HTML rendering)."
 requires-python = ">=3.11.4"
-dependencies = []
+dependencies = ["pydriller>=2.5"]
 # Extractor deps are staged in the slice that first needs them (avoids landing
-# unexercised deps in the skeleton PR): slice 2 adds "pydriller"; slice 4 adds
-# "networkx>=3.4,<4". doit + diskcache are the .2.3 funnel substrate (not here).
+# unexercised deps in the skeleton PR): slice 2 adds "pydriller" (churn); slice 4
+# adds "networkx>=3.4,<4". doit + diskcache are the .2.3 funnel substrate (not here).
 # scc + gh + git are external binaries invoked as subprocesses (not pip deps).
 # d3 is vendored JS.
 
@@ -46,8 +46,12 @@ strict = true
 warn_unreachable = true
 disallow_any_decorated = true
 enable_error_code = ["redundant-expr", "truthy-bool", "possibly-undefined"]
-# If pydriller/networkx lack complete stubs under --strict, add a surgical
-# [[tool.mypy.overrides]] with ignore_missing_imports for that module only.
+
+# pydriller ships no type stubs; scope the missing-imports allowance to it alone
+# (slice 4 adds the same for networkx) so --strict stays on everywhere else.
+[[tool.mypy.overrides]]
+module = ["pydriller.*"]
+ignore_missing_imports = true
 
 [tool.coverage.run]
 branch = true

--- a/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
@@ -1,0 +1,70 @@
+"""gh api graphql shape parsing → typed `PrView`.
+
+`gh api graphql` stdout is the reconciler's only contract with the real `gh`
+binary; this module turns that raw shape into vizsuite's `PrView` and is the
+single place a malformed/failed `gh` response becomes a loud typed
+`VizError(ADAPTER_FAILURE)` rather than a silent default (mirrors ``workcli``'s
+bd/parse drift discipline). `SubprocessGhRunner.pr_graphql` returns the raw
+`GhResult`; the reconciler calls this parser on it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from vizsuite.adapters.gh.runner import GhResult
+from vizsuite.envelope import ErrorCode, VizError
+
+
+@dataclass(frozen=True)
+class PrView:
+    base_oid: str
+    head_oid: str
+    base_ref: str
+    changed_files: int
+    commit_count: int
+
+
+def _shape_error(pr_number: int, stdout: str, *, reason: str) -> VizError:
+    return VizError(
+        ErrorCode.ADAPTER_FAILURE,
+        "gh api graphql returned an unparseable or unexpected PR shape",
+        detail={"pr_number": pr_number, "reason": reason, "raw_excerpt": stdout[:200]},
+    )
+
+
+def parse_pr_view(result: GhResult, *, pr_number: int) -> PrView:
+    """Parse one `gh api graphql` PR response into a `PrView`.
+
+    Every failure mode is a loud typed `VizError(ADAPTER_FAILURE)`, never a silent
+    default (spec §6.3's two-source join depends on this response, so a failed or
+    drifted second witness must alarm): a nonzero `gh` exit, non-JSON stdout, a
+    null/absent pull request (a subscript of `None` → `TypeError`), or any missing
+    scalar (`KeyError`) all funnel to the same alarm carrying the PR number.
+    """
+    if result.returncode != 0:
+        raise VizError(
+            ErrorCode.ADAPTER_FAILURE,
+            "gh api graphql exited nonzero",
+            detail={
+                "pr_number": pr_number,
+                "returncode": result.returncode,
+                "stderr": result.stderr.strip(),
+            },
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise _shape_error(pr_number, result.stdout, reason="invalid_json") from exc
+    try:
+        pull_request = payload["data"]["repository"]["pullRequest"]
+        return PrView(
+            base_oid=pull_request["baseRefOid"],
+            head_oid=pull_request["headRefOid"],
+            base_ref=pull_request["baseRefName"],
+            changed_files=pull_request["changedFiles"],
+            commit_count=pull_request["commits"]["totalCount"],
+        )
+    except (KeyError, TypeError) as exc:
+        raise _shape_error(pr_number, result.stdout, reason=type(exc).__name__) from exc

--- a/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
@@ -1,0 +1,69 @@
+"""The gh subprocess port — the fake's seam.
+
+`GhRunner` is the interface every reconcile test replaces with
+`tests/fakes.ScriptedGhRunner`; `SubprocessGhRunner` is the sole implementation
+that actually shells out to real `gh`. The port returns a *raw* `GhResult`
+(returncode + stdout + stderr) exactly like ``workcli``'s `BdRunner.run` — every
+shape decision lives in `gh/parse.py` (`parse_pr_view`), so the failure/drift
+logic is unit-tested against scripted `GhResult`s and the only uncovered code is
+the thin `subprocess.run` line (a `gh api graphql` call needs auth + network, so
+CI never runs it — the gate uses fakes, plan §3.4.1).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Protocol
+
+# One `gh api graphql` query for the PR's immutable OIDs, base ref name, and the
+# two *un-truncated* scalar counts (changedFiles / commits.totalCount) — the
+# scalar path sidesteps the `first:100` cap that `gh pr view --json files,commits`
+# imposes (plan §3.5, F4). `{owner}`/`{repo}` are gh's current-repo placeholders,
+# substituted by gh in `-F` field values.
+_PR_QUERY = (
+    "query($owner:String!,$repo:String!,$number:Int!){"
+    "repository(owner:$owner,name:$repo){"
+    "pullRequest(number:$number){"
+    "baseRefOid headRefOid baseRefName changedFiles commits{totalCount}"
+    "}}}"
+)
+
+
+@dataclass(frozen=True)
+class GhResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class GhRunner(Protocol):
+    def pr_graphql(self, pr_number: int) -> GhResult: ...  # pragma: no cover
+
+
+class SubprocessGhRunner:
+    """Drives the real `gh` binary. One graphql query per PR; raw result out."""
+
+    def pr_graphql(self, pr_number: int) -> GhResult:  # pragma: no cover - needs gh auth+network
+        completed = subprocess.run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-F",
+                "owner={owner}",
+                "-F",
+                "repo={repo}",
+                "-F",
+                f"number={pr_number}",
+                "-f",
+                f"query={_PR_QUERY}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return GhResult(
+            returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr
+        )

--- a/packages/vizsuite/src/vizsuite/adapters/git/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/git/runner.py
@@ -3,9 +3,9 @@
 `GitRunner` is the interface every contract test replaces with
 `tests/fakes.ScriptedGitRunner`; `SubprocessGitRunner` is the sole
 implementation that actually shells out to real `git`. Slice 1 needs only
-`ls_tree`; slice 2 extends this same file with `rev_parse`/`cat_object_exists`/
-`rev_list`/`diff_name_only`/`fetch_pr`/`fetch_base`/`churn_for_commits`, and
-slice 3 adds `archive_tar`.
+`ls_tree`; slice 2 extends this same file with `cat_object_exists`/`rev_list`/
+`diff_name_only`/`fetch_pr`/`fetch_base`/`churn_for_commits`, and slice 3 adds
+`archive_tar`.
 
 `ls_tree` reads the immutable commit *tree object* (`git ls-tree -r <rev>`),
 never the mutable index (`git ls-files`), so every consumer sees a property of
@@ -49,7 +49,6 @@ class ModifiedFileRow(NamedTuple):
 
 class GitRunner(Protocol):
     def ls_tree(self, rev: str) -> list[LsTreeRow]: ...  # pragma: no cover
-    def rev_parse(self, rev: str) -> str: ...  # pragma: no cover
     def cat_object_exists(self, oid: str) -> bool: ...  # pragma: no cover
     def rev_list(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
     def diff_name_only(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
@@ -74,16 +73,6 @@ class SubprocessGitRunner:
             check=True,
         )
         return [_parse_ls_tree_line(line) for line in completed.stdout.splitlines() if line]
-
-    def rev_parse(self, rev: str) -> str:
-        completed = subprocess.run(
-            ["git", "rev-parse", rev],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            check=True,
-        )
-        return completed.stdout.strip()
 
     def cat_object_exists(self, oid: str) -> bool:
         # `git cat-file -e <oid>` exits 0 iff the object is present locally.

--- a/packages/vizsuite/src/vizsuite/adapters/git/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/git/runner.py
@@ -15,6 +15,7 @@ the snapshot rather than the operator's checkout state.
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Sequence
 from typing import NamedTuple, Protocol
 
 
@@ -32,12 +33,37 @@ class LsTreeRow(NamedTuple):
     path: str
 
 
+class ModifiedFileRow(NamedTuple):
+    """One PyDriller `ModifiedFile` reduced to the fields churn needs.
+
+    `new_path` is ``None`` for a pure delete, `old_path` is ``None`` for a pure
+    add; the churn extractor keys by ``new_path or old_path``. Line counts are the
+    per-commit deltas that get summed across the PR's commit set.
+    """
+
+    new_path: str | None
+    old_path: str | None
+    added: int
+    deleted: int
+
+
 class GitRunner(Protocol):
     def ls_tree(self, rev: str) -> list[LsTreeRow]: ...  # pragma: no cover
+    def rev_parse(self, rev: str) -> str: ...  # pragma: no cover
+    def cat_object_exists(self, oid: str) -> bool: ...  # pragma: no cover
+    def rev_list(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
+    def diff_name_only(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
+    def fetch_pr(self, pr_number: int) -> None: ...  # pragma: no cover
+    def fetch_base(self, base_ref: str) -> None: ...  # pragma: no cover
+    def churn_for_commits(
+        self, commit_oids: Sequence[str]
+    ) -> list[ModifiedFileRow]: ...  # pragma: no cover
 
 
 class SubprocessGitRunner:
-    """Drives real `git`. `ls_tree` reads the immutable tree object at `rev`."""
+    """Drives real `git`. Every read is against the immutable object DB — the tree
+    object (`ls_tree`), commit objects (`rev_list`, `churn_for_commits`), or the
+    merge-base diff (`diff_name_only`) — never the operator's working tree."""
 
     def ls_tree(self, rev: str) -> list[LsTreeRow]:
         completed = subprocess.run(
@@ -48,6 +74,89 @@ class SubprocessGitRunner:
             check=True,
         )
         return [_parse_ls_tree_line(line) for line in completed.stdout.splitlines() if line]
+
+    def rev_parse(self, rev: str) -> str:
+        completed = subprocess.run(
+            ["git", "rev-parse", rev],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        return completed.stdout.strip()
+
+    def cat_object_exists(self, oid: str) -> bool:
+        # `git cat-file -e <oid>` exits 0 iff the object is present locally.
+        completed = subprocess.run(
+            ["git", "cat-file", "-e", oid],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return completed.returncode == 0
+
+    def rev_list(self, base: str, head: str) -> list[str]:
+        completed = subprocess.run(
+            ["git", "rev-list", f"{base}..{head}"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        return [line for line in completed.stdout.splitlines() if line]
+
+    def diff_name_only(self, base: str, head: str) -> list[str]:
+        # 3-dot: the merge-base..head net diff, matching GitHub's "Files changed".
+        completed = subprocess.run(
+            ["git", "diff", f"{base}...{head}", "--name-only"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        return [line for line in completed.stdout.splitlines() if line]
+
+    def fetch_pr(self, pr_number: int) -> None:  # pragma: no cover - needs a remote PR ref
+        subprocess.run(
+            ["git", "fetch", "origin", f"pull/{pr_number}/head"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+    def fetch_base(self, base_ref: str) -> None:  # pragma: no cover - needs a remote
+        subprocess.run(
+            ["git", "fetch", "origin", base_ref],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+    def churn_for_commits(self, commit_oids: Sequence[str]) -> list[ModifiedFileRow]:
+        # Read each commit *object* by SHA via `Git.get_commit` — not
+        # `Repository(only_commits=...)`, whose branch-traversal filter silently
+        # yields nothing for a commit unreachable from the checked-out HEAD (the
+        # normal PR-head case: the head is not merged into the current branch). This
+        # reads the object DB directly, so churn is a property of the snapshot, not
+        # the checkout. Imported lazily so the estate-only path never pays the cost.
+        from pydriller import Git as PyDrillerGit
+
+        git_repo = PyDrillerGit(".")
+        rows: list[ModifiedFileRow] = []
+        for oid in commit_oids:
+            for modified in git_repo.get_commit(oid).modified_files:
+                rows.append(
+                    ModifiedFileRow(
+                        new_path=modified.new_path,
+                        old_path=modified.old_path,
+                        added=modified.added_lines,
+                        deleted=modified.deleted_lines,
+                    )
+                )
+        return rows
 
 
 def _parse_ls_tree_line(line: str) -> LsTreeRow:

--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -20,6 +20,7 @@ from collections.abc import Sequence
 from typing import NoReturn, TextIO
 
 from vizsuite import PROTOCOL_VERSION
+from vizsuite.adapters.gh.runner import GhRunner, SubprocessGhRunner
 from vizsuite.adapters.git.runner import GitRunner, SubprocessGitRunner
 from vizsuite.envelope import ErrorCode, JsonValue, VizError, emit_failure, emit_success
 from vizsuite.render import render_human
@@ -118,7 +119,7 @@ def main(
     *,
     git_runner: GitRunner | None = None,
     scc_runner: object | None = None,
-    gh_runner: object | None = None,
+    gh_runner: GhRunner | None = None,
     out: TextIO | None = None,
     err: TextIO | None = None,
 ) -> int:
@@ -158,8 +159,8 @@ def main(
         # handshake never touches any adapter.
         runners = Runners(
             git=git_runner if git_runner is not None else SubprocessGitRunner(),
+            gh=gh_runner if gh_runner is not None else SubprocessGhRunner(),
             scc=scc_runner,
-            gh=gh_runner,
         )
         data = handler(runners, args)
     except VizError as verb_error:

--- a/packages/vizsuite/src/vizsuite/extract/churn.py
+++ b/packages/vizsuite/src/vizsuite/extract/churn.py
@@ -1,0 +1,38 @@
+"""Churn extractor — per-file added/deleted sums over the PR's net set.
+
+Symmetric with `extract/estate.py`: takes the `GitRunner` seam and reduces the
+PyDriller per-commit modified-file rows (`git.churn_for_commits`) to one
+`FileChurn` per path, restricted to the PR's *net* file set so a reverted-only
+file (present in the churn union, absent from the net diff) contributes no heat
+(plan §3.5). Churn only heats — it is never used to lower a score.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from vizsuite.adapters.git.runner import GitRunner
+
+
+@dataclass(frozen=True)
+class FileChurn:
+    added: int
+    deleted: int
+
+
+def churn(git: GitRunner, commit_oids: Sequence[str], net_files: set[str]) -> dict[str, FileChurn]:
+    """Sum per-file line churn across the commit set, restricted to `net_files`.
+
+    Keys by ``new_path`` (falling back to ``old_path`` so a pure delete stays in
+    scope); a row whose resolved path is outside `net_files` is dropped — the
+    reverted-only exclusion that keeps churn heat honest.
+    """
+    totals: dict[str, FileChurn] = {}
+    for row in git.churn_for_commits(commit_oids):
+        path = row.new_path or row.old_path
+        if path is None or path not in net_files:
+            continue
+        prev = totals.get(path, FileChurn(added=0, deleted=0))
+        totals[path] = FileChurn(added=prev.added + row.added, deleted=prev.deleted + row.deleted)
+    return totals

--- a/packages/vizsuite/src/vizsuite/extract/churn.py
+++ b/packages/vizsuite/src/vizsuite/extract/churn.py
@@ -27,12 +27,18 @@ def churn(git: GitRunner, commit_oids: Sequence[str], net_files: set[str]) -> di
     Keys by ``new_path`` (falling back to ``old_path`` so a pure delete stays in
     scope); a row whose resolved path is outside `net_files` is dropped — the
     reverted-only exclusion that keeps churn heat honest.
+
+    Every net file is seeded at zero churn *first*, so a net-set path with no
+    matching churn row (a pure rename, a binary or mode-only change PyDriller
+    keyed under a different path) still appears with `FileChurn(0, 0)`. The result
+    therefore always covers the whole net set — the contract `PrScope.files`
+    documents — rather than silently dropping to a subset.
     """
-    totals: dict[str, FileChurn] = {}
+    totals: dict[str, FileChurn] = {path: FileChurn(added=0, deleted=0) for path in net_files}
     for row in git.churn_for_commits(commit_oids):
         path = row.new_path or row.old_path
         if path is None or path not in net_files:
             continue
-        prev = totals.get(path, FileChurn(added=0, deleted=0))
+        prev = totals[path]
         totals[path] = FileChurn(added=prev.added + row.added, deleted=prev.deleted + row.deleted)
     return totals

--- a/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
+++ b/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
@@ -1,0 +1,79 @@
+"""PR snapshot resolution + git↔GitHub scalar reconciliation (plan §3.5, slice 2).
+
+`reconcile` resolves the PR's immutable base/head OIDs and reconciles local git's
+authoritative net file/commit *sets* against GitHub's *un-truncated scalar counts*.
+Every read is against the immutable object DB (never the operator's checkout), so a
+concurrent session mutating the main tree cannot corrupt the artifact. Disagreement
+is a loud `RECONCILER_DRIFT`; OIDs still absent after a fetch are `SNAPSHOT_MISMATCH`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from vizsuite.adapters.gh.parse import parse_pr_view
+from vizsuite.adapters.gh.runner import GhRunner
+from vizsuite.adapters.git.runner import GitRunner
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+from vizsuite.extract.churn import FileChurn, churn
+
+
+@dataclass(frozen=True)
+class PrScope:
+    """The reconciled PR scope handed to the extractors and the scene assembler.
+
+    `files` is the local *net* set (a file added-then-reverted within the PR is
+    excluded), each carrying its summed churn; `head_oid` drives every downstream
+    immutable-object read (estate at head, scc snapshot in slice 3).
+    """
+
+    pr_number: int
+    head_oid: str
+    base_oid: str
+    files: dict[str, FileChurn]
+
+
+def reconcile(pr_number: int, *, gh: GhRunner, git: GitRunner) -> PrScope:
+    """Resolve OIDs and reconcile local net sets against GitHub's scalar counts."""
+    pr = parse_pr_view(gh.pr_graphql(pr_number), pr_number=pr_number)
+
+    # Ensure both immutable OIDs are present locally so every downstream read is
+    # against the object DB, not the operator's checkout. `pull/<n>/head` brings the
+    # head (forks too); the base tip is never an ancestor of it, so the base ref is
+    # fetched separately. Still absent after both fetches ⇒ stale clone / unreachable
+    # remote — refuse loudly rather than die on a cryptic later git error.
+    if not git.cat_object_exists(pr.head_oid):
+        git.fetch_pr(pr_number)
+    if not git.cat_object_exists(pr.base_oid):
+        git.fetch_base(pr.base_ref)
+    missing = [oid for oid in (pr.base_oid, pr.head_oid) if not git.cat_object_exists(oid)]
+    if missing:
+        raise VizError(
+            ErrorCode.SNAPSHOT_MISMATCH,
+            "PR base/head not present locally after fetch; check network/remote",
+            detail={"missing_oids": cast("list[JsonValue]", missing)},
+        )
+
+    net_files = set(git.diff_name_only(pr.base_oid, pr.head_oid))
+    if len(net_files) != pr.changed_files:
+        raise VizError(
+            ErrorCode.RECONCILER_DRIFT,
+            "local net file count disagrees with GitHub",
+            detail={
+                "local": len(net_files),
+                "github_changed_files": pr.changed_files,
+                "note": "criss-cross histories may pick different merge bases",
+            },
+        )
+
+    commit_oids = git.rev_list(pr.base_oid, pr.head_oid)
+    if len(commit_oids) != pr.commit_count:
+        raise VizError(
+            ErrorCode.RECONCILER_DRIFT,
+            "local commit count disagrees with GitHub",
+            detail={"local": len(commit_oids), "github_commits": pr.commit_count},
+        )
+
+    files = churn(git, sorted(commit_oids), net_files)
+    return PrScope(pr_number=pr_number, head_oid=pr.head_oid, base_oid=pr.base_oid, files=files)

--- a/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
+++ b/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
@@ -43,11 +43,19 @@ def reconcile(pr_number: int, *, gh: GhRunner, git: GitRunner) -> PrScope:
     # head (forks too); the base tip is never an ancestor of it, so the base ref is
     # fetched separately. Still absent after both fetches ⇒ stale clone / unreachable
     # remote — refuse loudly rather than die on a cryptic later git error.
-    if not git.cat_object_exists(pr.head_oid):
+    head_present = git.cat_object_exists(pr.head_oid)
+    if not head_present:
         git.fetch_pr(pr_number)
-    if not git.cat_object_exists(pr.base_oid):
+        head_present = git.cat_object_exists(pr.head_oid)
+    base_present = git.cat_object_exists(pr.base_oid)
+    if not base_present:
         git.fetch_base(pr.base_ref)
-    missing = [oid for oid in (pr.base_oid, pr.head_oid) if not git.cat_object_exists(oid)]
+        base_present = git.cat_object_exists(pr.base_oid)
+    missing = [
+        oid
+        for oid, present in ((pr.base_oid, base_present), (pr.head_oid, head_present))
+        if not present
+    ]
     if missing:
         raise VizError(
             ErrorCode.SNAPSHOT_MISMATCH,
@@ -75,5 +83,5 @@ def reconcile(pr_number: int, *, gh: GhRunner, git: GitRunner) -> PrScope:
             detail={"local": len(commit_oids), "github_commits": pr.commit_count},
         )
 
-    files = churn(git, sorted(commit_oids), net_files)
+    files = churn(git, commit_oids, net_files)
     return PrScope(pr_number=pr_number, head_oid=pr.head_oid, base_oid=pr.base_oid, files=files)

--- a/packages/vizsuite/src/vizsuite/runners.py
+++ b/packages/vizsuite/src/vizsuite/runners.py
@@ -5,20 +5,22 @@ every adapter (git today; scc + gh in later slices) arrives as an argument
 rather than a module global. Pinning the bundle now keeps the verb→handler
 contract stable as slices 2/3 add the scc and gh adapters.
 
-`scc`/`gh` are typed `object | None` because their runner *protocols* do not
-exist yet (they are created in slices 3 and 2 respectively); those slices narrow
-these fields to the real `SccRunner`/`GhRunner` protocol types.
+`scc` is still typed `object | None` because its runner *protocol* does not exist
+yet (it is created in slice 3, which narrows the field to the real `SccRunner`
+type). `gh` is now the real `GhRunner` — slice 2's reconciler needs it on every
+`viz pr`, so `cli.main` always constructs one.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
+from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
 
 
 @dataclass(frozen=True)
 class Runners:
     git: GitRunner
+    gh: GhRunner
     scc: object | None = None  # reserved: SubprocessSccRunner lands in slice 3
-    gh: object | None = None  # reserved: SubprocessGhRunner lands in slice 2

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -1,9 +1,10 @@
 """`viz pr <n>` — build the PR-shape artifact.
 
-Slice 1 walking skeleton: extract the estate at ``HEAD`` → assemble a heat-free
-scene → render one self-contained HTML file into `.viz/out/pr-<n>.html`. Slice 2
-replaces the ``HEAD`` estate with the reconciled PR head-OID estate (fetch →
-resolve OIDs → scalar reconcile) and slice 3+ thickens the heat axes.
+Slice 2: reconcile the PR to its immutable head OID (fetch → resolve OIDs →
+scalar reconcile against GitHub), then build the estate at that head OID — never
+the operator's ``HEAD`` checkout — and assemble a heat-free scene into one
+self-contained HTML file at `.viz/out/pr-<n>.html`. Slice 3+ thickens the heat
+axes (consuming the reconciled net set + churn); slice 5 hardens the envelope.
 """
 
 from __future__ import annotations
@@ -16,19 +17,21 @@ from vizsuite import __version__
 from vizsuite.envelope import JsonValue
 from vizsuite.extract.estate import estate
 from vizsuite.output import ensure_viz_dir
+from vizsuite.reconcile.pr_scope import reconcile
 from vizsuite.runners import Runners
 from vizsuite.scene.assemble import assemble
 from vizsuite.templates.html import render_html
 
 
 def pr(runners: Runners, args: Namespace) -> JsonValue:
-    """Handle `viz pr <n>`: estate → scene → HTML artifact on disk.
+    """Handle `viz pr <n>`: reconcile → head-OID estate → scene → HTML on disk.
 
-    Returns the envelope `data`: the written artifact path, the PR number, and
-    the estate node count.
+    Returns the envelope `data`: the written artifact path, the PR number, the
+    estate node count, and the reconciled net-file count.
     """
     pr_number: int = args.number
-    estate_map = estate(runners.git, "HEAD")
+    scope = reconcile(pr_number, gh=runners.gh, git=runners.git)
+    estate_map = estate(runners.git, scope.head_oid)
     scene = assemble(
         estate_map,
         pr_number=pr_number,
@@ -45,5 +48,6 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         "pr": pr_number,
         "artifact": str(artifact),
         "nodes": len(estate_map),
+        "net_files": len(scope.files),
     }
     return data

--- a/packages/vizsuite/tests/conftest.py
+++ b/packages/vizsuite/tests/conftest.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Sequence
 from io import StringIO
 
+from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
 from vizsuite.cli import main
 from vizsuite.envelope import JsonValue
@@ -15,6 +16,7 @@ def run_cli(
     argv: Sequence[str],
     *,
     git_runner: GitRunner | None = None,
+    gh_runner: GhRunner | None = None,
 ) -> tuple[int, dict[str, JsonValue], str]:
     """Invoke `main()` capturing stdout/stderr; return `(exit_code, envelope, stderr)`.
 
@@ -24,6 +26,6 @@ def run_cli(
     """
     out = StringIO()
     err = StringIO()
-    exit_code = main(argv, git_runner=git_runner, out=out, err=err)
+    exit_code = main(argv, git_runner=git_runner, gh_runner=gh_runner, out=out, err=err)
     envelope: dict[str, JsonValue] = json.loads(out.getvalue())
     return exit_code, envelope, err.getvalue()

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -9,27 +9,106 @@ returned data and what the code under test actually asked the adapter for.
 
 from __future__ import annotations
 
+import json
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 
-from vizsuite.adapters.git.runner import LsTreeRow
+from vizsuite.adapters.gh.runner import GhResult
+from vizsuite.adapters.git.runner import LsTreeRow, ModifiedFileRow
 
 
 @dataclass
 class ScriptedGitRunner:
-    """Feeds a scripted `git ls-tree` result; records every call's revision.
+    """Feeds scripted git results; records every call flat as ``(method, *args)``.
 
     - `.ls_tree_rows`: the rows every `ls_tree(rev)` call returns.
-    - `.calls`: each invocation as ``(method, rev)`` — the assertion surface for
-      what the code under test asked git for (e.g. that estate reads ``HEAD`` in
-      slice 1, the resolved head OID in slice 2).
+    - `.churn_rows`: the rows every `churn_for_commits(oids)` call returns.
+    - `.calls`: each invocation as ``(method, *string_args)`` — the assertion
+      surface for what the code under test asked git for (e.g. that estate reads
+      ``HEAD`` in slice 1, the resolved head OID in slice 2). Recorded flat and
+      all-`str` so the tuple stays homogeneous.
     """
 
     ls_tree_rows: list[LsTreeRow] = field(default_factory=list)
-    calls: list[tuple[str, str]] = field(default_factory=list)
+    churn_rows: list[ModifiedFileRow] = field(default_factory=list)
+    # Reconcile seam: OIDs cat_object_exists reports present, the OIDs a fetch
+    # makes present (empty ⇒ a fetch resolves nothing → SNAPSHOT_MISMATCH), the
+    # local net diff, and the local commit set.
+    present_oids: set[str] = field(default_factory=set)
+    fetch_brings: set[str] = field(default_factory=set)
+    diff_files: list[str] = field(default_factory=list)
+    rev_list_oids: list[str] = field(default_factory=list)
+    calls: list[tuple[str, ...]] = field(default_factory=list)
 
     def ls_tree(self, rev: str) -> list[LsTreeRow]:
         self.calls.append(("ls_tree", rev))
         return list(self.ls_tree_rows)
+
+    def churn_for_commits(self, commit_oids: Sequence[str]) -> list[ModifiedFileRow]:
+        self.calls.append(("churn_for_commits", *commit_oids))
+        return list(self.churn_rows)
+
+    def cat_object_exists(self, oid: str) -> bool:
+        self.calls.append(("cat_object_exists", oid))
+        return oid in self.present_oids
+
+    def diff_name_only(self, base: str, head: str) -> list[str]:
+        self.calls.append(("diff_name_only", base, head))
+        return list(self.diff_files)
+
+    def rev_list(self, base: str, head: str) -> list[str]:
+        self.calls.append(("rev_list", base, head))
+        return list(self.rev_list_oids)
+
+    def fetch_pr(self, pr_number: int) -> None:
+        self.calls.append(("fetch_pr", str(pr_number)))
+        self.present_oids |= self.fetch_brings
+
+    def fetch_base(self, base_ref: str) -> None:
+        self.calls.append(("fetch_base", base_ref))
+        self.present_oids |= self.fetch_brings
+
+
+@dataclass
+class ScriptedGhRunner:
+    """Feeds one scripted `gh api graphql` raw result; records the PR asked for.
+
+    Reconcile parses this raw `GhResult` through the real `parse_pr_view`, so a
+    test exercises the actual parse path (not a hand-built `PrView`). Build the
+    `GhResult` with `gh_pr_result(...)`.
+    """
+
+    result: GhResult
+    calls: list[tuple[str, int]] = field(default_factory=list)
+
+    def pr_graphql(self, pr_number: int) -> GhResult:
+        self.calls.append(("pr_graphql", pr_number))
+        return self.result
+
+
+def gh_pr_result(
+    *,
+    base_oid: str = "base000",
+    head_oid: str = "head111",
+    base_ref: str = "main",
+    changed_files: int,
+    commit_count: int,
+) -> GhResult:
+    """Build a successful `gh api graphql` `GhResult` for a PR (the common fixture)."""
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "baseRefOid": base_oid,
+                    "headRefOid": head_oid,
+                    "baseRefName": base_ref,
+                    "changedFiles": changed_files,
+                    "commits": {"totalCount": commit_count},
+                }
+            }
+        }
+    }
+    return GhResult(returncode=0, stdout=json.dumps(payload), stderr="")
 
 
 def blob(path: str, blob_sha: str = "0" * 40) -> LsTreeRow:

--- a/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
+++ b/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
@@ -1,0 +1,115 @@
+"""gh api graphql JSON → typed `PrView` (plan slice 2; test item 11 support).
+
+`parse_pr_view` is the single place that turns the raw `gh api graphql` stdout
+into vizsuite's `PrView`. The runner (`SubprocessGhRunner`) only shells out; every
+shape decision — nonzero exit, non-JSON, a null/absent pull request, a missing
+scalar — lands here as a loud typed `VizError(ADAPTER_FAILURE)`, never a silent
+default (mirrors workcli's bd/parse drift discipline). These tests drive the parser
+directly on scripted `GhResult`s, so no `gh` binary is ever touched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vizsuite.adapters.gh.runner import GhResult
+from vizsuite.envelope import ErrorCode, VizError
+
+
+def _graphql_stdout(
+    *,
+    base_oid: str = "base000",
+    head_oid: str = "head111",
+    base_ref: str = "main",
+    changed_files: int = 2,
+    commit_count: int = 3,
+) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "baseRefOid": base_oid,
+                        "headRefOid": head_oid,
+                        "baseRefName": base_ref,
+                        "changedFiles": changed_files,
+                        "commits": {"totalCount": commit_count},
+                    }
+                }
+            }
+        }
+    )
+
+
+def test_parses_oids_ref_and_scalar_counts():
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    result = GhResult(returncode=0, stdout=_graphql_stdout(), stderr="")
+
+    pr = parse_pr_view(result, pr_number=7)
+
+    assert pr.base_oid == "base000"
+    assert pr.head_oid == "head111"
+    assert pr.base_ref == "main"
+    assert pr.changed_files == 2
+    assert pr.commit_count == 3
+
+
+def test_nonzero_gh_exit_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    result = GhResult(returncode=1, stdout="", stderr="gh: not authenticated")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_view(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+    # the PR number and gh's own stderr survive into the error detail for triage
+    assert exc_info.value.detail["pr_number"] == 7
+    assert "not authenticated" in str(exc_info.value.detail["stderr"])
+
+
+def test_non_json_stdout_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    result = GhResult(returncode=0, stdout="not json at all", stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_view(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def test_null_pull_request_is_adapter_failure():
+    # graphql returns pullRequest: null for a number that resolves to no PR.
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    stdout = json.dumps({"data": {"repository": {"pullRequest": None}}})
+    result = GhResult(returncode=0, stdout=stdout, stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_view(result, pr_number=999)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+    assert exc_info.value.detail["pr_number"] == 999
+
+
+def test_missing_scalar_field_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    pull_request = {
+        "baseRefOid": "b",
+        "headRefOid": "h",
+        "baseRefName": "main",
+        # changedFiles omitted — a drifted gh shape must alarm, not default to 0
+        "commits": {"totalCount": 1},
+    }
+    stdout = json.dumps({"data": {"repository": {"pullRequest": pull_request}}})
+    result = GhResult(returncode=0, stdout=stdout, stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_view(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_extract_churn.py
+++ b/packages/vizsuite/tests/unit/test_extract_churn.py
@@ -1,0 +1,51 @@
+"""Churn extractor — per-file added/deleted sums restricted to the net set.
+
+Symmetric with `extract/estate.py`: takes the `GitRunner` seam, calls
+`churn_for_commits` (the PyDriller walk), and reduces the raw per-commit
+modified-file rows to one `FileChurn` per path — but only for files in the PR's
+*net* set, so a file added-then-reverted within the PR (present in the churn
+union, absent from the net diff) contributes no heat. Driven through
+`ScriptedGitRunner`; no real git/PyDriller here.
+"""
+
+from __future__ import annotations
+
+from tests.fakes import ScriptedGitRunner
+from vizsuite.adapters.git.runner import ModifiedFileRow
+
+
+def test_churn_sums_per_file_and_restricts_to_net():
+    from vizsuite.extract.churn import FileChurn, churn
+
+    git = ScriptedGitRunner(
+        churn_rows=[
+            ModifiedFileRow(new_path="a.py", old_path="a.py", added=5, deleted=1),
+            ModifiedFileRow(new_path="a.py", old_path="a.py", added=3, deleted=0),
+            ModifiedFileRow(new_path="b.py", old_path=None, added=10, deleted=0),
+            ModifiedFileRow(new_path="c.py", old_path="c.py", added=9, deleted=9),
+        ]
+    )
+
+    result = churn(git, ["oid1", "oid2"], net_files={"a.py", "b.py"})
+
+    # a.py summed across both commits; b.py once; c.py excluded (not in net set).
+    assert result == {
+        "a.py": FileChurn(added=8, deleted=1),
+        "b.py": FileChurn(added=10, deleted=0),
+    }
+    assert ("churn_for_commits", "oid1", "oid2") in git.calls
+
+
+def test_deleted_file_keys_by_old_path():
+    from vizsuite.extract.churn import FileChurn, churn
+
+    git = ScriptedGitRunner(
+        churn_rows=[
+            ModifiedFileRow(new_path=None, old_path="gone.py", added=0, deleted=7),
+        ]
+    )
+
+    result = churn(git, ["oid1"], net_files={"gone.py"})
+
+    # a pure delete has new_path=None; it keys by old_path so it stays in scope.
+    assert result == {"gone.py": FileChurn(added=0, deleted=7)}

--- a/packages/vizsuite/tests/unit/test_extract_churn.py
+++ b/packages/vizsuite/tests/unit/test_extract_churn.py
@@ -49,3 +49,25 @@ def test_deleted_file_keys_by_old_path():
 
     # a pure delete has new_path=None; it keys by old_path so it stays in scope.
     assert result == {"gone.py": FileChurn(added=0, deleted=7)}
+
+
+def test_net_file_with_no_churn_row_appears_with_zero_churn():
+    from vizsuite.extract.churn import FileChurn, churn
+
+    git = ScriptedGitRunner(
+        churn_rows=[
+            ModifiedFileRow(new_path="a.py", old_path="a.py", added=4, deleted=2),
+        ]
+    )
+
+    # `b.py` is in the reconciled net set but no per-commit row resolves to it
+    # (a rename whose PyDriller row keyed to a different path, or a mode-only /
+    # binary change). It must still appear: `PrScope.files` IS the net set, and
+    # `reconcile` already pinned len(net_files) == GitHub's changed_files, so a
+    # dropped key would silently undercount the PR shape with no error.
+    result = churn(git, ["oid1"], net_files={"a.py", "b.py"})
+
+    assert result == {
+        "a.py": FileChurn(added=4, deleted=2),
+        "b.py": FileChurn(added=0, deleted=0),
+    }

--- a/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
+++ b/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
@@ -23,6 +23,17 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)  # noqa: S603, S607
 
 
+def _git_out(cwd: Path, *args: str) -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def _init_repo(root: Path, files: Sequence[tuple[str, str]]) -> None:
     _git(root, "init", "-q")
     _git(root, "config", "user.email", "t@example.com")
@@ -47,3 +58,70 @@ def test_ls_tree_reads_committed_blob_rows(tmp_path: Path, monkeypatch: pytest.M
         assert row.obj_type == "blob"
         assert row.mode.startswith("100")
         assert len(row.blob_sha) == 40  # full git object SHA-1
+
+
+def _two_commit_repo(root: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    """A base commit (a.py) then a head commit (modifies a.py, adds b.py). Returns (base, head)."""
+    _init_repo(root, [("a.py", "x = 1\n")])
+    base = _git_out(root, "rev-parse", "HEAD")
+    (root / "a.py").write_text("x = 2\n", encoding="utf-8")
+    (root / "b.py").write_text("y = 1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "head")
+    head = _git_out(root, "rev-parse", "HEAD")
+    monkeypatch.chdir(root)
+    return base, head
+
+
+def test_rev_parse_cat_exists_rev_list_diff_on_real_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    base, head = _two_commit_repo(tmp_path, monkeypatch)
+    runner = SubprocessGitRunner()
+
+    assert runner.rev_parse("HEAD") == head
+    assert runner.cat_object_exists(head) is True
+    assert runner.cat_object_exists("0" * 40) is False  # a well-formed but absent OID
+    assert runner.rev_list(base, head) == [head]  # exactly one commit in base..head
+    assert set(runner.diff_name_only(base, head)) == {"a.py", "b.py"}  # 3-dot net diff
+
+
+def test_churn_for_commits_sums_real_pydriller_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    base, head = _two_commit_repo(tmp_path, monkeypatch)
+    head_only = SubprocessGitRunner().rev_list(base, head)
+
+    rows = SubprocessGitRunner().churn_for_commits(head_only)
+
+    by_path = {(row.new_path or row.old_path): row for row in rows}
+    # the head commit modified a.py (1 added, 1 deleted) and added b.py (1 added).
+    assert by_path["a.py"].added == 1
+    assert by_path["a.py"].deleted == 1
+    assert by_path["b.py"].added == 1
+    assert by_path["b.py"].deleted == 0
+
+
+def test_churn_for_commits_reads_commit_unreachable_from_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The real case: a PR head not merged into the checked-out branch. PyDriller's
+    # branch-traversal filter (Repository(only_commits=...)) would silently yield
+    # nothing for it; churn must read the commit object directly by SHA.
+    _init_repo(tmp_path, [("a.py", "x = 1\n")])
+    base_branch = _git_out(tmp_path, "rev-parse", "--abbrev-ref", "HEAD")
+    _git(tmp_path, "checkout", "-q", "-b", "feature")
+    (tmp_path / "a.py").write_text("x = 2\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("y = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "feature")
+    feature = _git_out(tmp_path, "rev-parse", "HEAD")
+    _git(tmp_path, "checkout", "-q", base_branch)  # HEAD no longer reaches `feature`
+    monkeypatch.chdir(tmp_path)
+
+    rows = SubprocessGitRunner().churn_for_commits([feature])
+
+    by_path = {(row.new_path or row.old_path): row for row in rows}
+    assert by_path["a.py"].added == 1
+    assert by_path["a.py"].deleted == 1
+    assert by_path["b.py"].added == 1

--- a/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
+++ b/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
@@ -3,7 +3,7 @@
 Every other test drives a `ScriptedGitRunner` fake; this file is the sole place
 that proves the `git ls-tree -r` wiring (argv, tab-delimited parse, blob rows)
 actually works, against a real throwaway repo (git is always available in CI).
-Slice 2 extends this seam with rev_parse/rev_list/diff/etc.
+Slice 2 extends this seam with cat_object_exists/rev_list/diff/churn/etc.
 """
 
 from __future__ import annotations
@@ -73,13 +73,10 @@ def _two_commit_repo(root: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[str, 
     return base, head
 
 
-def test_rev_parse_cat_exists_rev_list_diff_on_real_repo(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+def test_cat_exists_rev_list_diff_on_real_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     base, head = _two_commit_repo(tmp_path, monkeypatch)
     runner = SubprocessGitRunner()
 
-    assert runner.rev_parse("HEAD") == head
     assert runner.cat_object_exists(head) is True
     assert runner.cat_object_exists("0" * 40) is False  # a well-formed but absent OID
     assert runner.rev_list(base, head) == [head]  # exactly one commit in base..head

--- a/packages/vizsuite/tests/unit/test_reconcile_pr_scope.py
+++ b/packages/vizsuite/tests/unit/test_reconcile_pr_scope.py
@@ -1,0 +1,172 @@
+"""PR reconciler — the two-source scalar drift alarm (spec test item 11).
+
+Local git is authoritative for the file/commit *sets*; GitHub is a second witness
+via un-truncated *scalar counts* (`changedFiles`, `commits.totalCount`), so the
+join survives PRs of any size (no `first:100` list cap). Disagreement is a loud
+`RECONCILER_DRIFT`; base/head OIDs still absent after a fetch is `SNAPSHOT_MISMATCH`.
+Driven entirely through scripted gh/git fakes — the real parse runs, no subprocess.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.fakes import ScriptedGhRunner, ScriptedGitRunner, gh_pr_result
+from vizsuite.adapters.git.runner import ModifiedFileRow
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.extract.churn import FileChurn
+
+_PRESENT = {"base000", "head111"}  # gh_pr_result defaults; both OIDs local by default
+
+
+def test_file_count_drift_raises_reconciler_drift():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=2, commit_count=1))
+    git = ScriptedGitRunner(present_oids=set(_PRESENT), diff_files=["only_one.py"])
+
+    with pytest.raises(VizError) as exc_info:
+        reconcile(7, gh=gh, git=git)
+
+    assert exc_info.value.code == ErrorCode.RECONCILER_DRIFT
+    assert exc_info.value.detail["local"] == 1
+    assert exc_info.value.detail["github_changed_files"] == 2
+
+
+def test_commit_count_drift_raises_reconciler_drift():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # file counts agree (1 == 1) but the commit counts disagree (1 local vs 2).
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=1, commit_count=2))
+    git = ScriptedGitRunner(present_oids=set(_PRESENT), diff_files=["a.py"], rev_list_oids=["c1"])
+
+    with pytest.raises(VizError) as exc_info:
+        reconcile(7, gh=gh, git=git)
+
+    assert exc_info.value.code == ErrorCode.RECONCILER_DRIFT
+    assert exc_info.value.detail["local"] == 1
+    assert exc_info.value.detail["github_commits"] == 2
+
+
+def test_happy_path_returns_scope_with_net_churn():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=2, commit_count=1))
+    git = ScriptedGitRunner(
+        present_oids=set(_PRESENT),
+        diff_files=["a.py", "b.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="a.py", old_path="a.py", added=4, deleted=1),
+            ModifiedFileRow(new_path="b.py", old_path=None, added=2, deleted=0),
+        ],
+    )
+
+    scope = reconcile(7, gh=gh, git=git)
+
+    assert scope.pr_number == 7
+    assert scope.head_oid == "head111"
+    assert scope.base_oid == "base000"
+    assert scope.files == {
+        "a.py": FileChurn(added=4, deleted=1),
+        "b.py": FileChurn(added=2, deleted=0),
+    }
+    # churn walked the local (authoritative) commit set
+    assert ("churn_for_commits", "c1") in git.calls
+
+
+def test_reverted_only_file_excluded_from_scope():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # b.py was added then reverted inside the PR: present in the churn union, absent
+    # from the net diff. It must not reach the scene or it would misdirect review heat.
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=1, commit_count=1))
+    git = ScriptedGitRunner(
+        present_oids=set(_PRESENT),
+        diff_files=["a.py"],  # net set = {a.py}
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="a.py", old_path="a.py", added=3, deleted=0),
+            ModifiedFileRow(new_path="b.py", old_path="b.py", added=5, deleted=5),
+        ],
+    )
+
+    scope = reconcile(7, gh=gh, git=git)
+
+    assert set(scope.files) == {"a.py"}
+    assert "b.py" not in scope.files
+
+
+def test_big_pr_over_100_files_does_not_false_drift():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # 150 net files with changedFiles=150 — a value a `first:100` list read would have
+    # truncated to 100 and mis-flagged as drift. The scalar path is cap-immune.
+    net = [f"src/f{i}.py" for i in range(150)]
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=150, commit_count=1))
+    git = ScriptedGitRunner(present_oids=set(_PRESENT), diff_files=net, rev_list_oids=["c1"])
+
+    scope = reconcile(7, gh=gh, git=git)
+
+    assert scope.head_oid == "head111"  # built, no RECONCILER_DRIFT raised
+
+
+def test_unfetchable_head_raises_snapshot_mismatch():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # head absent locally and the PR fetch resolves nothing → refuse loudly, no scene.
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=1, commit_count=1))
+    git = ScriptedGitRunner(
+        present_oids={"base000"},  # base present, head absent
+        fetch_brings=set(),  # fetch resolves nothing
+        diff_files=["a.py"],
+        rev_list_oids=["c1"],
+    )
+
+    with pytest.raises(VizError) as exc_info:
+        reconcile(7, gh=gh, git=git)
+
+    assert exc_info.value.code == ErrorCode.SNAPSHOT_MISMATCH
+    assert "head111" in exc_info.value.detail["missing_oids"]
+    # the PR-head fetch was attempted before giving up
+    assert ("fetch_pr", "7") in git.calls
+
+
+def test_unfetchable_base_raises_snapshot_mismatch():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # `pull/<n>/head` never brings the base tip; the base ref must be fetched
+    # separately, and if that resolves nothing the snapshot cannot be built.
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=1, commit_count=1))
+    git = ScriptedGitRunner(
+        present_oids={"head111"},  # head present, base absent
+        fetch_brings=set(),
+        diff_files=["a.py"],
+        rev_list_oids=["c1"],
+    )
+
+    with pytest.raises(VizError) as exc_info:
+        reconcile(7, gh=gh, git=git)
+
+    assert exc_info.value.code == ErrorCode.SNAPSHOT_MISMATCH
+    assert "base000" in exc_info.value.detail["missing_oids"]
+    assert ("fetch_base", "main") in git.calls
+
+
+def test_head_absent_then_fetched_reconciles():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    # head absent, but the PR fetch brings it → reconcile proceeds to success.
+    gh = ScriptedGhRunner(gh_pr_result(changed_files=1, commit_count=1))
+    git = ScriptedGitRunner(
+        present_oids={"base000"},
+        fetch_brings={"head111"},  # the fetch resolves the head OID
+        diff_files=["a.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[ModifiedFileRow(new_path="a.py", old_path="a.py", added=1, deleted=0)],
+    )
+
+    scope = reconcile(7, gh=gh, git=git)
+
+    assert scope.head_oid == "head111"
+    assert ("fetch_pr", "7") in git.calls

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -1,4 +1,12 @@
-"""`viz pr <n>` end-to-end (spec test item 6 setup): estate → scene → HTML file."""
+"""`viz pr <n>` end-to-end (plan slice 2): reconcile → head-OID estate → HTML.
+
+Slice 2 replaces slice 1's ``HEAD`` estate with the reconciled PR head OID: the
+verb resolves/fetches the immutable base/head OIDs, reconciles local git's net
+sets against GitHub's scalar counts, then builds the estate at the *head OID* (not
+the operator's checkout). The first test fakes every adapter; the second runs the
+real `SubprocessGitRunner` over a throwaway repo with only `gh` (the external
+service) faked, proving the git wiring end-to-end.
+"""
 
 from __future__ import annotations
 
@@ -8,66 +16,93 @@ from pathlib import Path
 import pytest
 
 from tests.conftest import run_cli
-from tests.fakes import ScriptedGitRunner, blob
+from tests.fakes import ScriptedGhRunner, ScriptedGitRunner, blob, gh_pr_result
+from vizsuite.adapters.git.runner import ModifiedFileRow
 
 
-def test_pr_emits_html_artifact_from_estate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_pr_reconciles_and_emits_html_from_head_estate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
     git = ScriptedGitRunner(
-        ls_tree_rows=[blob("src/app.py", "aaa111"), blob("README.md", "bbb222")]
+        present_oids={"base000", "head111"},
+        diff_files=["src/app.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=3, deleted=0)
+        ],
+        ls_tree_rows=[blob("src/app.py", "aaa111"), blob("README.md", "bbb222")],
     )
 
-    exit_code, envelope, stderr = run_cli(["pr", "1"], git_runner=git)
+    exit_code, envelope, stderr = run_cli(["pr", "7"], git_runner=git, gh_runner=gh)
 
     assert exit_code == 0
     assert stderr == ""
     assert envelope["ok"] is True
     data = envelope["data"]
     assert isinstance(data, dict)
-    assert data["pr"] == 1
-    assert data["nodes"] == 2
+    assert data["pr"] == 7
+    assert data["nodes"] == 2  # the estate (whole tree at head), not just the net set
 
-    # Slice 1 resolves the estate at HEAD (pre-gh; slice 2 uses the head OID).
-    assert git.calls == [("ls_tree", "HEAD")]
+    # The estate is resolved at the reconciled head OID — never the checkout's HEAD.
+    assert ("ls_tree", "head111") in git.calls
+    assert ("ls_tree", "HEAD") not in git.calls
 
-    # data.artifact is a real self-contained HTML file carrying the estate nodes.
     artifact = Path(str(data["artifact"]))
-    assert artifact == tmp_path / ".viz" / "out" / "pr-1.html"
-    assert artifact.is_file()
+    assert artifact == tmp_path / ".viz" / "out" / "pr-7.html"
     html = artifact.read_text(encoding="utf-8")
     assert html.startswith("<!DOCTYPE html>")
     assert "src/app.py" in html
-    assert "README.md" in html
-
-    # The portable versioned sidecar ignores only out/.
-    gitignore = tmp_path / ".viz" / ".gitignore"
-    assert "out/" in gitignore.read_text().splitlines()
 
 
 def _git(cwd: Path, *args: str) -> None:
-    # A known binary (git) on test-literal args — the intentional-subprocess case.
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)  # noqa: S603, S607
 
 
-def test_pr_builds_against_real_git_with_default_runner(
+def _rev_parse(cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_pr_reconciles_against_real_git_with_fake_gh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    # No injected runner → main constructs the real SubprocessGitRunner and reads
-    # the estate from an actual committed tree.
+    # Real SubprocessGitRunner over a two-commit repo; only gh (the external
+    # service) is faked, with the real base/head OIDs the reconciler must agree with.
     _git(tmp_path, "init", "-q")
     _git(tmp_path, "config", "user.email", "t@example.com")
     _git(tmp_path, "config", "user.name", "t")
-    (tmp_path / "hello.py").write_text("print('hi')\n", encoding="utf-8")
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
     _git(tmp_path, "add", "-A")
-    _git(tmp_path, "commit", "-qm", "init")
+    _git(tmp_path, "commit", "-qm", "base")
+    base = _rev_parse(tmp_path)
+    (tmp_path / "a.py").write_text("x = 2\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("y = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "head")
+    head = _rev_parse(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    exit_code, envelope, stderr = run_cli(["pr", "3"])
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid=base, head_oid=head, changed_files=2, commit_count=1)
+    )
+
+    exit_code, envelope, stderr = run_cli(["pr", "5"], gh_runner=gh)
 
     assert exit_code == 0
     assert stderr == ""
     data = envelope["data"]
     assert isinstance(data, dict)
     artifact = Path(str(data["artifact"]))
-    assert artifact == tmp_path / ".viz" / "out" / "pr-3.html"
-    assert "hello.py" in artifact.read_text(encoding="utf-8")
+    html = artifact.read_text(encoding="utf-8")
+    assert "a.py" in html
+    assert "b.py" in html

--- a/packages/vizsuite/uv.lock
+++ b/packages/vizsuite/uv.lock
@@ -294,6 +294,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +420,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
+name = "lizard"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/94/4967d0868e7db39a72fa2dbef9a798c4d661178f3836bfec58091606f0f3/lizard-1.23.0.tar.gz", hash = "sha256:ed75cd45f086a2f51d6be64b0149b71bda820f92f95e30898254528bb949f795", size = 92659, upload-time = "2026-06-02T06:17:27.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/d9/25e62cbb9c4077a2dabc73e5f34dc947887f4fe1526f53d2c0489abfc186/lizard-1.23.0-py2.py3-none-any.whl", hash = "sha256:e9111e35c8a5f2e00d55cab318fca3504622991417411ea16cf46874fb752f42", size = 100830, upload-time = "2026-06-02T06:17:26.076Z" },
 ]
 
 [[package]]
@@ -656,6 +693,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydriller"
+version = "2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "lizard" },
+    { name = "pytz" },
+    { name = "types-pytz" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/e2/15ad5b65069112abb25835532439efb7460fdf78cd8a7f861df0e6f7dd60/pydriller-2.10-py3-none-any.whl", hash = "sha256:1e9df1c3af131ab4eb1cfa829b81eecfed70fd6f05ae8bbc6b04a678a88f9f0f", size = 37208, upload-time = "2026-07-01T07:40:21.189Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -717,6 +768,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +827,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
     { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
     { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]
@@ -842,6 +911,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pytz"
+version = "2026.2.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/d9/9fa4019d2235bd374293e1fd4153879b28b6ae1d2bae98addd352c9713f2/types_pytz-2026.2.0.20260518.tar.gz", hash = "sha256:e5d254329e9c4e91f0781b22c43a4bb2d10bb044d97b24c4b05d45567b0eae16", size = 10871, upload-time = "2026-05-18T06:02:45.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/89/41e80670779a223d8bc8bc83019a619988cfa5c432cedac5cec23884fbc4/types_pytz-2026.2.0.20260518-py3-none-any.whl", hash = "sha256:3a12eaa38f476bd650902a9c9bb442f03f3c7dee2be5c5848bce61bd708d205a", size = 10125, upload-time = "2026-05-18T06:02:44.968Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -863,6 +941,9 @@ wheels = [
 name = "vizsuite"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pydriller" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -875,6 +956,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pydriller", specifier = ">=2.5" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What & why

Slice 2 of 5 for the vizsuite V1 data build (`bd yf2ov.2.1`). Resolves a PR's
immutable base/head OIDs and reconciles local git's authoritative net file/commit
**sets** against GitHub's **un-truncated scalar counts**, then builds the estate
at the reconciled head OID — never the operator's `HEAD` checkout.

- **`adapters/gh/{runner,parse}`** — one un-truncated `gh api graphql` query →
  typed `PrView` (base/head OID, base ref, `changedFiles`, `commits.totalCount`).
  Every failure mode (nonzero exit, non-JSON, null PR, missing scalar) is a loud
  `ADAPTER_FAILURE`. Scalar counts sidestep the `first: 100` pagination cap.
- **`adapters/git/runner`** — `cat_object_exists` / `rev_list` / `diff_name_only`
  / `fetch_pr` / `fetch_base` / `churn_for_commits`, all immutable-object reads.
- **`reconcile/pr_scope`** — resolve OIDs (fetch `pull/<n>/head` + base ref if
  absent; `SNAPSHOT_MISMATCH` if still missing), reconcile local net sets vs
  GitHub scalars (`RECONCILER_DRIFT` on disagreement), build net-restricted churn.
- **`extract/churn`** + **`verbs/pr`** wired to build the estate at the reconciled
  head OID.

### The bug the fakes couldn't catch

Real `viz pr 258` first returned `net_files: 0`. Root cause: PyDriller's
`Repository(only_commits=…)` only traverses commits **reachable from the checked-out
HEAD**, so a PR head not merged into the current branch (the normal case) yields
empty churn. Fixed to read each commit by SHA via `pydriller.Git.get_commit`;
regression-tested against an unreachable commit.

## Completion gate (HEAVY)

19 files / ~1096 LOC / new dependency → **HEAVY** tier. The multi-lens adversarial
gate (6 finder lenses × 3 refuters × 3 rounds) exited via **round-cap termination**
with a `human-review-required` verdict — an honest "not a clean ledger", not a
clean bill of health. Findings triaged:

| Finding | Severity | Disposition |
|---|---|---|
| `churn()` silently dropped net files with zero churn rows → `scope.files` a subset of the net set | MAJOR/correctness | **Fixed** (RED→GREEN; net_files now == GitHub changedFiles exactly) |
| `rev_parse` added with zero production callers | MINOR/quality | **Removed** (YAGNI) |
| needless `sorted()` before churn; doubled `cat-file` calls | MINOR | **Fixed** (gate auto-applied, re-verified) |
| git/gh adapters cwd-coupled (no `repo_root` injection) | MAJOR/arch | **Deferred → `.2.1.3`** |
| 7 `subprocess.run` sites duplicate boilerplate | MINOR/reuse | **Deferred → `.2.1.3`** |

**Deferred** (`bd yf2ov.2.1.3`, sibling under the epic, open): adapter `repo_root`
injection + shared subprocess helper. Blast-radius — a proper fix reaches into
merged slice-1 code and roughly doubles the diff. Not triggered today (CLI runs
from repo root; tests pin via `chdir`).

## Evidence

- `make ci-vizsuite` green: **56 tests, 100% coverage** (377 stmts / 60 branch, 0 miss),
  mypy `--strict` clean (24 files), pip-audit clean (incl. pydriller), entry-verify pass.
- Live end-to-end: **#258 → net_files 38 = gh 38**, **#255 → net_files 7 = gh 7**.

## Reviewer note

Opening this **for your review before merge** per the "slice 2, stop at PR" call —
not auto-merging. The standout item to sanity-check is the deferred adapter
cwd-coupling (`.2.1.3`): confirm you're comfortable shipping it as tracked debt
rather than pulling it into this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2zcQep4jXpEFFRE5SnQc2
