### PR TITLE
feat(vizsuite): scc complexity + consequence axis extractors (slice 3/5)

### DIFF
--- a/packages/vizsuite/pyproject.toml
+++ b/packages/vizsuite/pyproject.toml
@@ -3,10 +3,15 @@ name = "vizsuite"
 version = "0.1.0"
 description = "vizsuite — repo/PR visualization suite (Tier-1 extractors, PR-scoped reconciliation, scene assembly, HTML rendering)."
 requires-python = ">=3.11.4"
-dependencies = ["pydriller>=2.5"]
+dependencies = [
+    "pathspec>=0.12",
+    "pydriller>=2.5",
+]
 # Extractor deps are staged in the slice that first needs them (avoids landing
-# unexercised deps in the skeleton PR): slice 2 adds "pydriller" (churn); slice 4
-# adds "networkx>=3.4,<4". doit + diskcache are the .2.3 funnel substrate (not here).
+# unexercised deps in the skeleton PR): slice 2 adds "pydriller" (churn); slice 3
+# adds "pathspec" (consequence reads .critical-paths with the gate's own gitwildmatch
+# semantics — one source of truth); slice 4 adds "networkx>=3.4,<4". doit + diskcache
+# are the .2.3 funnel substrate (not here).
 # scc + gh + git are external binaries invoked as subprocesses (not pip deps).
 # d3 is vendored JS.
 

--- a/packages/vizsuite/src/vizsuite/adapters/git/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/git/runner.py
@@ -18,6 +18,8 @@ import subprocess
 from collections.abc import Sequence
 from typing import NamedTuple, Protocol
 
+from vizsuite.envelope import ErrorCode, VizError
+
 
 class LsTreeRow(NamedTuple):
     """One `git ls-tree -r` row: ``<mode> <obj_type> <blob_sha>\\t<path>``.
@@ -111,13 +113,26 @@ class SubprocessGitRunner:
         # `git archive` serializes the commit *tree object* to a tar on stdout —
         # binary bytes, so no `text=True`. The snapshot scc scans (slice 3) is
         # extracted from this tar, never the operator's working tree, so a dirty
-        # checkout cannot leak into the artifact (the Path-C invariant).
+        # checkout cannot leak into the artifact (the Path-C invariant). A failure
+        # surfaces as a typed ADAPTER_FAILURE (not a raw CalledProcessError → an
+        # opaque E_INTERNAL), matching the loud-boundary contract of the other
+        # slice-3 adapters.
         completed = subprocess.run(
             ["git", "archive", "--format=tar", oid],
             capture_output=True,
             timeout=120,
-            check=True,
+            check=False,
         )
+        if completed.returncode != 0:
+            raise VizError(
+                ErrorCode.ADAPTER_FAILURE,
+                "git archive failed",
+                detail={
+                    "oid": oid,
+                    "returncode": completed.returncode,
+                    "stderr": completed.stderr.decode("utf-8", "replace").strip()[:500],
+                },
+            )
         return completed.stdout
 
     def fetch_pr(self, pr_number: int) -> None:  # pragma: no cover - needs a remote PR ref

--- a/packages/vizsuite/src/vizsuite/adapters/git/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/git/runner.py
@@ -52,6 +52,7 @@ class GitRunner(Protocol):
     def cat_object_exists(self, oid: str) -> bool: ...  # pragma: no cover
     def rev_list(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
     def diff_name_only(self, base: str, head: str) -> list[str]: ...  # pragma: no cover
+    def archive_tar(self, oid: str) -> bytes: ...  # pragma: no cover
     def fetch_pr(self, pr_number: int) -> None: ...  # pragma: no cover
     def fetch_base(self, base_ref: str) -> None: ...  # pragma: no cover
     def churn_for_commits(
@@ -105,6 +106,19 @@ class SubprocessGitRunner:
             check=True,
         )
         return [line for line in completed.stdout.splitlines() if line]
+
+    def archive_tar(self, oid: str) -> bytes:
+        # `git archive` serializes the commit *tree object* to a tar on stdout —
+        # binary bytes, so no `text=True`. The snapshot scc scans (slice 3) is
+        # extracted from this tar, never the operator's working tree, so a dirty
+        # checkout cannot leak into the artifact (the Path-C invariant).
+        completed = subprocess.run(
+            ["git", "archive", "--format=tar", oid],
+            capture_output=True,
+            timeout=120,
+            check=True,
+        )
+        return completed.stdout
 
     def fetch_pr(self, pr_number: int) -> None:  # pragma: no cover - needs a remote PR ref
         subprocess.run(

--- a/packages/vizsuite/src/vizsuite/adapters/scc/parse.py
+++ b/packages/vizsuite/src/vizsuite/adapters/scc/parse.py
@@ -1,0 +1,68 @@
+"""scc JSON shape parsing → typed `SccRecord`s keyed by normalized `Location`.
+
+`SubprocessSccRunner.scan` returns the raw `SccResult`; this module turns scc's
+`--by-file --format json` shape (per-language elements, each embedding a `Files`
+array of FileJobs) into a flat `{location: SccRecord}` map. It is the single place
+a failed or malformed scc run becomes a loud `VizError(ADAPTER_FAILURE)` (mirrors
+gh/parse). Each `Location` is normalized — a leading ``./`` stripped — so keys are
+repo-relative and join the estate (scc prefixes every `Location` with the `.` path
+argument it was invoked on).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from vizsuite.adapters.scc.runner import SccResult
+from vizsuite.envelope import ErrorCode, VizError
+
+
+@dataclass(frozen=True)
+class SccRecord:
+    complexity: int
+    code: int
+    lines: int
+    language: str
+
+
+def _shape_error(stdout: str, *, reason: str) -> VizError:
+    return VizError(
+        ErrorCode.ADAPTER_FAILURE,
+        "scc returned an unparseable or unexpected shape",
+        detail={"reason": reason, "raw_excerpt": stdout[:200]},
+    )
+
+
+def parse_scc(result: SccResult) -> dict[str, SccRecord]:
+    """Parse one scc `--by-file --format json` response into `{location: SccRecord}`.
+
+    A nonzero scc exit, non-JSON stdout, or a missing FileJob scalar all funnel to
+    the same `VizError(ADAPTER_FAILURE)` — never a silent default (a silently-empty
+    complexity axis is the failure class §6.2's join sanity exists to prevent).
+    """
+    if result.returncode != 0:
+        raise VizError(
+            ErrorCode.ADAPTER_FAILURE,
+            "scc exited nonzero",
+            detail={"returncode": result.returncode, "stderr": result.stderr.strip()},
+        )
+    try:
+        languages = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise _shape_error(result.stdout, reason="invalid_json") from exc
+
+    records: dict[str, SccRecord] = {}
+    try:
+        for language in languages:
+            for file_job in language["Files"]:
+                location = file_job["Location"].removeprefix("./")
+                records[location] = SccRecord(
+                    complexity=file_job["Complexity"],
+                    code=file_job["Code"],
+                    lines=file_job["Lines"],
+                    language=file_job["Language"],
+                )
+    except (KeyError, TypeError) as exc:
+        raise _shape_error(result.stdout, reason=type(exc).__name__) from exc
+    return records

--- a/packages/vizsuite/src/vizsuite/adapters/scc/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/scc/runner.py
@@ -1,0 +1,66 @@
+"""The scc subprocess port — the fake's seam.
+
+`SccRunner` is the interface every complexity test replaces with
+`tests/fakes.ScriptedSccRunner`; `SubprocessSccRunner` (added with its preflight
+test) is the sole implementation that shells out to the real `scc` binary. The
+port returns a *raw* `SccResult` (returncode + stdout + stderr) exactly like the
+gh port — every shape decision lives in `scc/parse.py` (`parse_scc`), so the
+parse/drift logic is unit-tested against scripted `SccResult`s and the only
+uncovered code is the thin `subprocess.run` exec (scc may be absent in CI). scc
+scans a *materialized snapshot* dir, never the live checkout, invoked with
+`cwd=<snapshot>` on `.` so each `Location` stays repo-relative (plan §3.5).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from vizsuite.envelope import ErrorCode, VizError
+
+_SCC_INSTALL_HINT = (
+    "scc binary not found on PATH; install scc (https://github.com/boyter/scc) "
+    "so `viz pr` can score per-file complexity"
+)
+
+
+@dataclass(frozen=True)
+class SccResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class SccRunner(Protocol):
+    def scan(self, snapshot_dir: Path) -> SccResult: ...  # pragma: no cover
+
+
+class SubprocessSccRunner:
+    """Drives the real `scc` binary, scanning the materialized snapshot dir.
+
+    Preflights `shutil.which("scc")` so a missing binary is a typed
+    `VizError(ADAPTER_FAILURE)` with an install hint, not a cryptic subprocess
+    error surfacing deep in the verb. scc runs with `cwd=<snapshot>` on `.`, so
+    every `Location` it emits is repo-relative and joins the estate.
+    """
+
+    def scan(self, snapshot_dir: Path) -> SccResult:
+        if shutil.which("scc") is None:
+            raise VizError(ErrorCode.ADAPTER_FAILURE, _SCC_INSTALL_HINT)
+        return self._run_scc(snapshot_dir)  # pragma: no cover - needs the scc binary on PATH
+
+    def _run_scc(self, snapshot_dir: Path) -> SccResult:  # pragma: no cover - needs scc on PATH
+        completed = subprocess.run(
+            ["scc", "--by-file", "--format", "json", "."],
+            cwd=snapshot_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        return SccResult(
+            returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr
+        )

--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -22,6 +22,7 @@ from typing import NoReturn, TextIO
 from vizsuite import PROTOCOL_VERSION
 from vizsuite.adapters.gh.runner import GhRunner, SubprocessGhRunner
 from vizsuite.adapters.git.runner import GitRunner, SubprocessGitRunner
+from vizsuite.adapters.scc.runner import SccRunner, SubprocessSccRunner
 from vizsuite.envelope import ErrorCode, JsonValue, VizError, emit_failure, emit_success
 from vizsuite.render import render_human
 from vizsuite.runners import Runners
@@ -118,7 +119,7 @@ def main(
     argv: Sequence[str] | None = None,
     *,
     git_runner: GitRunner | None = None,
-    scc_runner: object | None = None,
+    scc_runner: SccRunner | None = None,
     gh_runner: GhRunner | None = None,
     out: TextIO | None = None,
     err: TextIO | None = None,
@@ -160,7 +161,7 @@ def main(
         runners = Runners(
             git=git_runner if git_runner is not None else SubprocessGitRunner(),
             gh=gh_runner if gh_runner is not None else SubprocessGhRunner(),
-            scc=scc_runner,
+            scc=scc_runner if scc_runner is not None else SubprocessSccRunner(),
         )
         data = handler(runners, args)
     except VizError as verb_error:

--- a/packages/vizsuite/src/vizsuite/extract/complexity.py
+++ b/packages/vizsuite/src/vizsuite/extract/complexity.py
@@ -1,0 +1,56 @@
+"""Complexity heat axis — scc baseline + never-cool churn boost (spec §6.2, slice 3).
+
+The full §6.2 Complexity axis, not the scc baseline alone: each estate file's scc
+complexity is normalized to a 0-1 estate-wide baseline, then the PR-touched (net)
+files get a churn-scaled boost on top — clamped to 1.0 and never below the
+baseline (churn only heats, never cools). Files outside the estate are ignored; an
+empty estate∩scc overlap is a loud `VizError(ADAPTER_FAILURE)` — a silently-empty
+complexity axis is exactly the join failure this guard prevents. The cross-axis
+weighted average of the three finished axes lives in `.2.2`, not here.
+"""
+
+from __future__ import annotations
+
+from vizsuite.adapters.scc.parse import SccRecord
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.extract.churn import FileChurn
+
+# Tunable heat-model constant: the fraction of the 0-1 range the most-churned net
+# file may add on top of its baseline. The spec-mandated invariants (never-cool
+# clamp, touched-files-only application) are what the tests pin — not this weight.
+CHURN_BOOST_WEIGHT = 0.5
+
+
+def complexity(
+    estate: dict[str, str],
+    scc_records: dict[str, SccRecord],
+    pr_files: dict[str, FileChurn],
+) -> dict[str, float]:
+    """Per-file 0-1 complexity heat over the estate scope.
+
+    `estate` is the canonical `{path: blob_sha}` file set; only its keys are
+    scored. `scc_records` supplies each file's complexity; `pr_files` (the
+    reconciled net set with churn) selects which files get the churn boost.
+    """
+    scored = {path: record for path, record in scc_records.items() if path in estate}
+    if not scored:
+        raise VizError(
+            ErrorCode.ADAPTER_FAILURE,
+            "no scc record joins the estate scope; the complexity axis would be empty",
+            detail={"estate_size": len(estate), "scc_records": len(scc_records)},
+        )
+
+    max_complexity = max(record.complexity for record in scored.values())
+    net_churn = {
+        path: pr_files[path].added + pr_files[path].deleted for path in scored if path in pr_files
+    }
+    max_churn = max(net_churn.values(), default=0)
+
+    heat: dict[str, float] = {}
+    for path, record in scored.items():
+        baseline = record.complexity / max_complexity if max_complexity > 0 else 0.0
+        boost = 0.0
+        if max_churn > 0 and net_churn.get(path, 0) > 0:
+            boost = CHURN_BOOST_WEIGHT * (net_churn[path] / max_churn)
+        heat[path] = min(1.0, baseline + boost)  # boost only heats; never below baseline
+    return heat

--- a/packages/vizsuite/src/vizsuite/extract/consequence.py
+++ b/packages/vizsuite/src/vizsuite/extract/consequence.py
@@ -21,7 +21,7 @@ _CRITICAL_PATHS_FILE = ".critical-paths"
 # gate-policy / security / public-contract path scores above baseline, below an
 # explicit marker.
 _SECURITY_MARKERS = ("auth", "security", "credential", "secret", "token", "crypto", "login")
-_GATE_POLICY_NAMES = (".critical-paths", "project-config.toml")
+_GATE_POLICY_NAMES = (_CRITICAL_PATHS_FILE, "project-config.toml")
 _PUBLIC_CONTRACT_NAMES = ("__init__.py",)
 
 CONSEQUENCE_MARKED = 1.0  # matches an explicit `.critical-paths` policy marker
@@ -41,13 +41,22 @@ def _load_critical_paths(snapshot_dir: Path) -> GitIgnoreSpec:
 
 
 def _heuristic_hit(path: str) -> bool:
-    """A path-class heuristic match: gate-policy, security-adjacent, or public-contract."""
-    name = path.rsplit("/", 1)[-1]
+    """A path-class heuristic match: gate-policy, security-adjacent, or public-contract.
+
+    Security markers match a whole path *segment* — a directory name or the
+    filename stem — never an arbitrary substring, so `auth/`, `token.py`, and
+    `security/` score while incidental substrings (`tokenizer.py`, `author.py`) do
+    not spuriously inflate the consequence axis.
+    """
     lowered = path.lower()
+    name = lowered.rsplit("/", 1)[-1]
+    directories = lowered.split("/")[:-1]
+    stem = name.split(".", 1)[0]
     return (
         name in _GATE_POLICY_NAMES
         or name in _PUBLIC_CONTRACT_NAMES
-        or any(marker in lowered for marker in _SECURITY_MARKERS)
+        or stem in _SECURITY_MARKERS
+        or any(directory in _SECURITY_MARKERS for directory in directories)
     )
 
 

--- a/packages/vizsuite/src/vizsuite/extract/consequence.py
+++ b/packages/vizsuite/src/vizsuite/extract/consequence.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from pathspec import GitIgnoreSpec
 
+from vizsuite.envelope import ErrorCode, VizError
+
 _CRITICAL_PATHS_FILE = ".critical-paths"
 
 # Path-class heuristics (§6.2): a file is load-bearing by class even without an
@@ -36,7 +38,16 @@ def _load_critical_paths(snapshot_dir: Path) -> GitIgnoreSpec:
     very file, so consequence and the gate agree on what is load-bearing by policy.
     """
     marker_file = snapshot_dir / _CRITICAL_PATHS_FILE
-    lines = marker_file.read_text(encoding="utf-8").splitlines() if marker_file.is_file() else []
+    if not marker_file.is_file():
+        return GitIgnoreSpec.from_lines([])
+    try:
+        lines = marker_file.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise VizError(
+            ErrorCode.ADAPTER_FAILURE,
+            "could not read .critical-paths from the materialized snapshot",
+            detail={"path": str(marker_file), "error": str(exc)},
+        ) from exc
     return GitIgnoreSpec.from_lines(lines)
 
 

--- a/packages/vizsuite/src/vizsuite/extract/consequence.py
+++ b/packages/vizsuite/src/vizsuite/extract/consequence.py
@@ -1,0 +1,71 @@
+"""Consequence heat axis — `.critical-paths` markers + path-class heuristics (spec §6.2).
+
+Consequence is "load-bearing by policy", 0-1 per estate file. It is seeded from the
+repo's `.critical-paths` markers — read from the *materialized snapshot* with the
+same gitignore semantics the completion gate's triage uses, so the two share one
+source of truth — plus path-class heuristics (gate-policy files, security-adjacent
+paths, public contracts) that score a file high by class even absent an explicit
+marker. The cross-axis weighted average of the three axes lives in `.2.2`, not here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pathspec import GitIgnoreSpec
+
+_CRITICAL_PATHS_FILE = ".critical-paths"
+
+# Path-class heuristics (§6.2): a file is load-bearing by class even without an
+# explicit `.critical-paths` marker. Tunable; the tested invariant is that a
+# gate-policy / security / public-contract path scores above baseline, below an
+# explicit marker.
+_SECURITY_MARKERS = ("auth", "security", "credential", "secret", "token", "crypto", "login")
+_GATE_POLICY_NAMES = (".critical-paths", "project-config.toml")
+_PUBLIC_CONTRACT_NAMES = ("__init__.py",)
+
+CONSEQUENCE_MARKED = 1.0  # matches an explicit `.critical-paths` policy marker
+CONSEQUENCE_HEURISTIC = 0.75  # matches a path-class heuristic (no explicit marker)
+CONSEQUENCE_BASELINE = 0.0  # neither policy nor class → not load-bearing by policy
+
+
+def _load_critical_paths(snapshot_dir: Path) -> GitIgnoreSpec:
+    """Compile the snapshot's `.critical-paths` into a gitignore spec (empty if absent).
+
+    Uses the same gitignore semantics the completion gate's triage applies to this
+    very file, so consequence and the gate agree on what is load-bearing by policy.
+    """
+    marker_file = snapshot_dir / _CRITICAL_PATHS_FILE
+    lines = marker_file.read_text(encoding="utf-8").splitlines() if marker_file.is_file() else []
+    return GitIgnoreSpec.from_lines(lines)
+
+
+def _heuristic_hit(path: str) -> bool:
+    """A path-class heuristic match: gate-policy, security-adjacent, or public-contract."""
+    name = path.rsplit("/", 1)[-1]
+    lowered = path.lower()
+    return (
+        name in _GATE_POLICY_NAMES
+        or name in _PUBLIC_CONTRACT_NAMES
+        or any(marker in lowered for marker in _SECURITY_MARKERS)
+    )
+
+
+def consequence(estate: dict[str, str], snapshot_dir: Path) -> dict[str, float]:
+    """Per-file 0-1 consequence over the estate: `.critical-paths` markers + heuristics.
+
+    An estate file matching a marker scores `CONSEQUENCE_MARKED` (policy is
+    authoritative); a path-class heuristic match scores `CONSEQUENCE_HEURISTIC`; all
+    others `CONSEQUENCE_BASELINE`. The whole estate is scored, so every scene node
+    has a consequence value in `.2.2`.
+    """
+    spec = _load_critical_paths(snapshot_dir)
+    heat: dict[str, float] = {}
+    for path in estate:
+        if spec.match_file(path):
+            heat[path] = CONSEQUENCE_MARKED
+        elif _heuristic_hit(path):
+            heat[path] = CONSEQUENCE_HEURISTIC
+        else:
+            heat[path] = CONSEQUENCE_BASELINE
+    return heat

--- a/packages/vizsuite/src/vizsuite/reconcile/snapshot.py
+++ b/packages/vizsuite/src/vizsuite/reconcile/snapshot.py
@@ -1,0 +1,59 @@
+"""Materialize a PR-head snapshot from `git archive` (plan §3.5, slice 3).
+
+`materialize` extracts the immutable `git archive` tar at the resolved head OID
+into a fresh tempdir, so scc scans a snapshot of the *committed* tree — never the
+operator's working checkout. A dirty working tree can therefore never leak into
+the artifact (the Path-C invariant). A post-extract sanity check requires every
+estate path present on disk, else `VizError(ADAPTER_FAILURE)` — guarding
+`export-ignore` gitattribute drops in arbitrary target repos (a silently-thin
+snapshot is the failure class this guard exists to prevent). The tempdir
+self-cleans on any failure; on success the caller tears the returned dir down in
+a `finally`.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import tarfile
+from pathlib import Path
+from tempfile import mkdtemp
+from typing import cast
+
+from vizsuite.adapters.git.runner import GitRunner
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+
+
+def _assert_estate_materialized(snapshot: Path, estate_paths: set[str]) -> None:
+    """Alarm loudly if any estate path is absent from the extracted snapshot."""
+    missing = sorted(path for path in estate_paths if not (snapshot / path).exists())
+    if missing:
+        raise VizError(
+            ErrorCode.ADAPTER_FAILURE,
+            "estate paths absent from the materialized snapshot (export-ignore?)",
+            detail={
+                "missing": cast("list[JsonValue]", missing[:20]),
+                "missing_count": len(missing),
+            },
+        )
+
+
+def materialize(git: GitRunner, head_oid: str, estate_paths: set[str]) -> Path:
+    """Extract the `git archive` tar at `head_oid` to a tempdir; sanity-check the estate.
+
+    Returns the snapshot directory (the caller `shutil.rmtree`s it on the way out).
+    Raises `VizError(ADAPTER_FAILURE)` — after removing the tempdir so nothing
+    leaks — when any estate path is absent from the extracted snapshot.
+    """
+    tar_bytes = git.archive_tar(head_oid)
+    snapshot = Path(mkdtemp(prefix="vizsuite-snapshot-"))
+    try:
+        with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:") as tar:
+            tar.extractall(snapshot, filter="data")
+        _assert_estate_materialized(snapshot, estate_paths)
+    except BaseException:
+        # Any failure — the sanity alarm, a corrupt tar, an interrupt mid-extract —
+        # must not strand the tempdir; clean up, then re-raise unchanged.
+        shutil.rmtree(snapshot, ignore_errors=True)
+        raise
+    return snapshot

--- a/packages/vizsuite/src/vizsuite/runners.py
+++ b/packages/vizsuite/src/vizsuite/runners.py
@@ -1,14 +1,12 @@
 """`Runners` — the injected outside-world dependency bundle handed to verbs.
 
 `cli.main` builds one `Runners` and passes it to the dispatched verb handler, so
-every adapter (git today; scc + gh in later slices) arrives as an argument
-rather than a module global. Pinning the bundle now keeps the verb→handler
-contract stable as slices 2/3 add the scc and gh adapters.
+every adapter (git, gh, scc) arrives as an argument rather than a module global.
+Pinning the bundle keeps the verb→handler contract stable across slices.
 
-`scc` is still typed `object | None` because its runner *protocol* does not exist
-yet (it is created in slice 3, which narrows the field to the real `SccRunner`
-type). `gh` is now the real `GhRunner` — slice 2's reconciler needs it on every
-`viz pr`, so `cli.main` always constructs one.
+All three adapters are required: `viz pr` reconciles (gh), reads the head-OID
+estate + snapshot (git), and scores complexity from a materialized snapshot (scc)
+on every run, so `cli.main` always constructs each one.
 """
 
 from __future__ import annotations
@@ -17,10 +15,11 @@ from dataclasses import dataclass
 
 from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
+from vizsuite.adapters.scc.runner import SccRunner
 
 
 @dataclass(frozen=True)
 class Runners:
     git: GitRunner
     gh: GhRunner
-    scc: object | None = None  # reserved: SubprocessSccRunner lands in slice 3
+    scc: SccRunner

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -1,37 +1,61 @@
 """`viz pr <n>` — build the PR-shape artifact.
 
-Slice 2: reconcile the PR to its immutable head OID (fetch → resolve OIDs →
-scalar reconcile against GitHub), then build the estate at that head OID — never
-the operator's ``HEAD`` checkout — and assemble a heat-free scene into one
-self-contained HTML file at `.viz/out/pr-<n>.html`. Slice 3+ thickens the heat
-axes (consuming the reconciled net set + churn); slice 5 hardens the envelope.
+Reconcile the PR to its immutable head OID (fetch → resolve OIDs → scalar
+reconcile against GitHub), build the estate at that head OID — never the
+operator's ``HEAD`` checkout — then materialize the head snapshot from
+`git archive` so scc scores per-file complexity against the committed tree (a
+dirty working copy can never leak in). The heat-free scene is assembled into one
+self-contained HTML file at `.viz/out/pr-<n>.html`. Threading the per-file heat
+values into scene node attributes + the cross-axis fusion is `.2.2` (§6.2); this
+verb delivers the extraction layer and proves the snapshot→scc plumbing.
 """
 
 from __future__ import annotations
 
+import shutil
 from argparse import Namespace
 from datetime import UTC, datetime
 from pathlib import Path
 
 from vizsuite import __version__
+from vizsuite.adapters.scc.parse import parse_scc
 from vizsuite.envelope import JsonValue
+from vizsuite.extract.complexity import complexity
+from vizsuite.extract.consequence import consequence
 from vizsuite.extract.estate import estate
 from vizsuite.output import ensure_viz_dir
 from vizsuite.reconcile.pr_scope import reconcile
+from vizsuite.reconcile.snapshot import materialize
 from vizsuite.runners import Runners
 from vizsuite.scene.assemble import assemble
 from vizsuite.templates.html import render_html
 
 
 def pr(runners: Runners, args: Namespace) -> JsonValue:
-    """Handle `viz pr <n>`: reconcile → head-OID estate → scene → HTML on disk.
+    """Handle `viz pr <n>`: reconcile → head-OID estate → snapshot → scc → scene → HTML.
 
     Returns the envelope `data`: the written artifact path, the PR number, the
-    estate node count, and the reconciled net-file count.
+    estate node count, the reconciled net-file count, and the number of files the
+    complexity axis scored.
     """
     pr_number: int = args.number
     scope = reconcile(pr_number, gh=runners.gh, git=runners.git)
     estate_map = estate(runners.git, scope.head_oid)
+
+    # scc scans a *materialized* snapshot of the head tree, never the live
+    # checkout, so a dirty working copy can't leak into the artifact; the snapshot
+    # also carries `.critical-paths` for the consequence axis. Both heat axes are
+    # scored before the tempdir is torn down. The per-file heat values thread into
+    # scene node attributes in `.2.2` (§6.2); scoring them here proves the
+    # snapshot→scc→complexity and snapshot→consequence chains end-to-end on real data.
+    snapshot = materialize(runners.git, scope.head_oid, set(estate_map))
+    try:
+        scc_records = parse_scc(runners.scc.scan(snapshot))
+        complexity_scores = complexity(estate_map, scc_records, scope.files)
+        consequence_scores = consequence(estate_map, snapshot)
+    finally:
+        shutil.rmtree(snapshot, ignore_errors=True)
+
     scene = assemble(
         estate_map,
         pr_number=pr_number,
@@ -49,5 +73,7 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         "artifact": str(artifact),
         "nodes": len(estate_map),
         "net_files": len(scope.files),
+        "scored_files": len(complexity_scores),
+        "consequential_files": sum(1 for value in consequence_scores.values() if value > 0),
     }
     return data

--- a/packages/vizsuite/tests/conftest.py
+++ b/packages/vizsuite/tests/conftest.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
+from vizsuite.adapters.scc.runner import SccRunner
 from vizsuite.cli import main
 from vizsuite.envelope import JsonValue
 
@@ -17,6 +18,7 @@ def run_cli(
     *,
     git_runner: GitRunner | None = None,
     gh_runner: GhRunner | None = None,
+    scc_runner: SccRunner | None = None,
 ) -> tuple[int, dict[str, JsonValue], str]:
     """Invoke `main()` capturing stdout/stderr; return `(exit_code, envelope, stderr)`.
 
@@ -26,6 +28,8 @@ def run_cli(
     """
     out = StringIO()
     err = StringIO()
-    exit_code = main(argv, git_runner=git_runner, gh_runner=gh_runner, out=out, err=err)
+    exit_code = main(
+        argv, git_runner=git_runner, gh_runner=gh_runner, scc_runner=scc_runner, out=out, err=err
+    )
     envelope: dict[str, JsonValue] = json.loads(out.getvalue())
     return exit_code, envelope, err.getvalue()

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -9,12 +9,16 @@ returned data and what the code under test actually asked the adapter for.
 
 from __future__ import annotations
 
+import io
 import json
+import tarfile
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from vizsuite.adapters.gh.runner import GhResult
 from vizsuite.adapters.git.runner import LsTreeRow, ModifiedFileRow
+from vizsuite.adapters.scc.runner import SccResult
 
 
 @dataclass
@@ -38,6 +42,8 @@ class ScriptedGitRunner:
     fetch_brings: set[str] = field(default_factory=set)
     diff_files: list[str] = field(default_factory=list)
     rev_list_oids: list[str] = field(default_factory=list)
+    # Snapshot seam (slice 3): the tar bytes every `archive_tar(oid)` call returns.
+    archive_tar_bytes: bytes = b""
     calls: list[tuple[str, ...]] = field(default_factory=list)
 
     def ls_tree(self, rev: str) -> list[LsTreeRow]:
@@ -59,6 +65,10 @@ class ScriptedGitRunner:
     def rev_list(self, base: str, head: str) -> list[str]:
         self.calls.append(("rev_list", base, head))
         return list(self.rev_list_oids)
+
+    def archive_tar(self, oid: str) -> bytes:
+        self.calls.append(("archive_tar", oid))
+        return self.archive_tar_bytes
 
     def fetch_pr(self, pr_number: int) -> None:
         self.calls.append(("fetch_pr", str(pr_number)))
@@ -111,6 +121,61 @@ def gh_pr_result(
     return GhResult(returncode=0, stdout=json.dumps(payload), stderr="")
 
 
+@dataclass
+class ScriptedSccRunner:
+    """Feeds one scripted scc `SccResult`; records the snapshot dir it was told to scan.
+
+    The complexity path parses this raw result through the real `parse_scc`, so a
+    test exercises the actual parse path (not a hand-built record map). Build the
+    result with `scc_result(...)`; assert on `.calls` for the snapshot dir the verb
+    handed scc (and, after the verb's `finally`, that the dir was torn down).
+    """
+
+    result: SccResult
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def scan(self, snapshot_dir: Path) -> SccResult:
+        self.calls.append(("scan", str(snapshot_dir)))
+        return self.result
+
+
+def scc_result(files: dict[str, int]) -> SccResult:
+    """Build a successful scc `SccResult` scoring `{location: complexity}` (one Python block)."""
+    payload = [
+        {
+            "Name": "Python",
+            "Files": [
+                {
+                    "Location": f"./{location}",
+                    "Language": "Python",
+                    "Lines": complexity_value * 10,
+                    "Code": complexity_value * 8,
+                    "Complexity": complexity_value,
+                }
+                for location, complexity_value in files.items()
+            ],
+        }
+    ]
+    return SccResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
 def blob(path: str, blob_sha: str = "0" * 40) -> LsTreeRow:
     """Build a `blob` `LsTreeRow` (the common case) for fixtures."""
     return LsTreeRow(mode="100644", obj_type="blob", blob_sha=blob_sha, path=path)
+
+
+def tar_of(files: dict[str, str]) -> bytes:
+    """Build an in-memory tar of `{path: text}` — a stand-in for `git archive` bytes.
+
+    Lets a materialize test drive `ScriptedGitRunner.archive_tar_bytes` without a
+    real repo, so the extract + estate-sanity logic is exercised in isolation from
+    the git subprocess (which its own real-subprocess test covers).
+    """
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        for path, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=path)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buffer.getvalue()

--- a/packages/vizsuite/tests/unit/test_adapters_scc_parse.py
+++ b/packages/vizsuite/tests/unit/test_adapters_scc_parse.py
@@ -1,0 +1,91 @@
+"""`scc --by-file --format json` shape parsing → typed per-file `SccRecord`s.
+
+Mirrors `gh/parse`'s drift discipline: a nonzero scc exit or unparseable stdout
+is a loud `VizError(ADAPTER_FAILURE)`, and each `FileJob` `Location` is normalized
+(a leading ``./`` stripped) so the keys join the repo-relative estate.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vizsuite.adapters.scc.parse import parse_scc
+from vizsuite.adapters.scc.runner import SccResult
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+
+
+def _scc_result(payload: JsonValue, *, returncode: int = 0, stderr: str = "") -> SccResult:
+    return SccResult(returncode=returncode, stdout=json.dumps(payload), stderr=stderr)
+
+
+def test_parse_flattens_language_files_and_normalizes_locations() -> None:
+    # scc groups files under per-language elements; each FileJob's Location is
+    # prefixed with the path scc was invoked on (`.`), so keys arrive as `./x`.
+    payload: JsonValue = [
+        {
+            "Name": "Python",
+            "Files": [
+                {
+                    "Location": "./src/app.py",
+                    "Language": "Python",
+                    "Lines": 120,
+                    "Code": 100,
+                    "Complexity": 7,
+                },
+                {
+                    "Location": "./util.py",
+                    "Language": "Python",
+                    "Lines": 40,
+                    "Code": 30,
+                    "Complexity": 2,
+                },
+            ],
+        },
+        {
+            "Name": "Go",
+            "Files": [
+                {
+                    "Location": "main.go",
+                    "Language": "Go",
+                    "Lines": 50,
+                    "Code": 45,
+                    "Complexity": 3,
+                }
+            ],
+        },
+    ]
+
+    records = parse_scc(_scc_result(payload))
+
+    assert set(records) == {"src/app.py", "util.py", "main.go"}  # ./ stripped, flattened
+    app = records["src/app.py"]
+    assert app.complexity == 7
+    assert app.code == 100
+    assert app.lines == 120
+    assert app.language == "Python"
+    assert records["main.go"].complexity == 3  # a location with no ./ prefix is untouched
+
+
+def test_parse_nonzero_exit_alarms() -> None:
+    with pytest.raises(VizError) as excinfo:
+        parse_scc(SccResult(returncode=1, stdout="", stderr="scc: boom"))
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def test_parse_invalid_json_alarms() -> None:
+    with pytest.raises(VizError) as excinfo:
+        parse_scc(SccResult(returncode=0, stdout="not json{", stderr=""))
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def test_parse_missing_filejob_scalar_alarms() -> None:
+    # A FileJob missing a required scalar (Complexity) is scc drift — a loud
+    # VizError, never a silent skip that would thin the complexity axis.
+    payload: JsonValue = [
+        {"Name": "Python", "Files": [{"Location": "./a.py", "Language": "Python", "Lines": 10}]}
+    ]
+    with pytest.raises(VizError) as excinfo:
+        parse_scc(_scc_result(payload))
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_adapters_scc_runner.py
+++ b/packages/vizsuite/tests/unit/test_adapters_scc_runner.py
@@ -1,0 +1,30 @@
+"""`SubprocessSccRunner` preflight: a missing scc binary alarms before any scan.
+
+The unit suite drives `ScriptedSccRunner`; the only real-`scc` code is the exec
+itself (pragma no-cover — scc may be absent in CI). This test covers the
+`shutil.which` preflight branch: with scc off PATH, `scan` raises a typed
+`VizError(ADAPTER_FAILURE)` carrying an install hint rather than dying on a
+cryptic subprocess error deep in the verb.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from vizsuite.adapters.scc.runner import SubprocessSccRunner
+from vizsuite.envelope import ErrorCode, VizError
+
+
+def test_scan_without_scc_on_path_alarms_with_install_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+    with pytest.raises(VizError) as excinfo:
+        SubprocessSccRunner().scan(tmp_path)
+
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE
+    assert "scc" in excinfo.value.message.lower()

--- a/packages/vizsuite/tests/unit/test_extract_complexity.py
+++ b/packages/vizsuite/tests/unit/test_extract_complexity.py
@@ -1,0 +1,70 @@
+"""Complexity heat axis (spec §6.2): scc baseline + never-cool churn boost.
+
+The axis normalizes scc per-file complexity to a 0-1 estate-wide baseline, then
+heats the PR-touched (net) files by a churn-scaled boost that never cools a file
+below its baseline. The tests pin the *invariants* — baseline normalization,
+context files unaffected, touched-with-churn strictly hotter, zero-churn net files
+unchanged, non-estate files ignored, empty overlap alarms — not the tunable boost
+weight.
+"""
+
+from __future__ import annotations
+
+import pytest
+from vizsuite.extract.complexity import complexity
+
+from vizsuite.adapters.scc.parse import SccRecord
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.extract.churn import FileChurn
+
+
+def _record(complexity_value: int) -> SccRecord:
+    # Only Complexity drives the axis; the other scc fields ride along for later axes.
+    return SccRecord(complexity=complexity_value, code=1, lines=1, language="Python")
+
+
+def test_complexity_baseline_with_never_cool_churn_boost() -> None:
+    estate = {"ctx.py": "s1", "touched.py": "s2", "quiet.py": "s3", "peak.py": "s4"}
+    scc_records = {
+        "ctx.py": _record(5),  # context file, in estate, not in the net set
+        "touched.py": _record(4),  # net file with churn → must heat above baseline
+        "quiet.py": _record(7),  # net file, zero churn → must stay at baseline
+        "peak.py": _record(10),  # estate-wide max complexity → baseline 1.0
+        "vendored.py": _record(9),  # NOT in the estate → must be ignored
+    }
+    pr_files = {
+        "touched.py": FileChurn(added=30, deleted=0),  # the only churn → max_churn
+        "quiet.py": FileChurn(added=0, deleted=0),  # a pure-rename net file: zero churn
+    }
+
+    heat = complexity(estate, scc_records, pr_files)
+
+    assert "vendored.py" not in heat  # outside the estate scope → dropped
+    assert heat["peak.py"] == 1.0  # normalized to the estate-wide max
+    assert heat["ctx.py"] == 0.5  # 5/10 baseline, untouched by any boost
+    assert heat["quiet.py"] == 0.7  # 7/10 baseline; zero churn → no boost (never-cool)
+    assert heat["touched.py"] > 0.4  # 4/10 baseline heated by churn (strictly above)
+    assert heat["touched.py"] <= 1.0  # clamped to the 0-1 range
+
+
+def test_complexity_high_baseline_zero_churn_never_cools() -> None:
+    # A net file that is complex (high scc baseline) but had zero churn must never
+    # score below its baseline — churn only heats, it never cools (§6.2).
+    estate = {"complex.py": "s1", "simple.py": "s2"}
+    scc_records = {"complex.py": _record(10), "simple.py": _record(2)}
+    pr_files = {"complex.py": FileChurn(added=0, deleted=0)}  # touched, but no churn
+
+    heat = complexity(estate, scc_records, pr_files)
+
+    assert heat["complex.py"] == 1.0  # baseline preserved, not cooled by the zero churn
+
+
+def test_complexity_empty_estate_scc_overlap_alarms() -> None:
+    # scc scored only files outside the estate → the axis would be silently empty.
+    estate = {"src/app.py": "s1"}
+    scc_records = {"vendored/lib.py": _record(3)}
+
+    with pytest.raises(VizError) as excinfo:
+        complexity(estate, scc_records, pr_files={})
+
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_extract_consequence.py
+++ b/packages/vizsuite/tests/unit/test_extract_consequence.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from vizsuite.envelope import ErrorCode, VizError
 from vizsuite.extract.consequence import consequence
 
 
@@ -65,3 +68,14 @@ def test_consequence_security_heuristic_matches_segments_not_substrings(tmp_path
     assert scores["src/author.py"] == 0.0
     assert scores["src/auth/handler.py"] > 0.0
     assert scores["src/token.py"] > 0.0
+
+
+def test_consequence_unreadable_critical_paths_alarms(tmp_path: Path) -> None:
+    # A `.critical-paths` that exists but can't be decoded (or read) must surface
+    # as a typed ADAPTER_FAILURE, not a raw OSError/UnicodeDecodeError → E_INTERNAL.
+    (tmp_path / ".critical-paths").write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+
+    with pytest.raises(VizError) as excinfo:
+        consequence({"a.py": "s1"}, tmp_path)
+
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_extract_consequence.py
+++ b/packages/vizsuite/tests/unit/test_extract_consequence.py
@@ -47,3 +47,21 @@ def test_consequence_without_a_critical_paths_file_uses_heuristics_only(tmp_path
 
     assert scores["src/security/vault.py"] > 0.0  # security heuristic still fires
     assert scores["lib/util.py"] == 0.0  # nothing matches → baseline
+
+
+def test_consequence_security_heuristic_matches_segments_not_substrings(tmp_path: Path) -> None:
+    # A security marker matches a path *segment* (dir or filename stem), never an
+    # incidental substring — else `tokenizer.py`/`author.py` would wrongly score.
+    estate = {
+        "src/tokenizer.py": "s1",  # 'token' substring, not a segment → baseline
+        "src/author.py": "s2",  # 'auth' substring, not a segment → baseline
+        "src/auth/handler.py": "s3",  # 'auth' directory segment → heuristic hit
+        "src/token.py": "s4",  # 'token' filename stem → heuristic hit
+    }
+
+    scores = consequence(estate, tmp_path)
+
+    assert scores["src/tokenizer.py"] == 0.0
+    assert scores["src/author.py"] == 0.0
+    assert scores["src/auth/handler.py"] > 0.0
+    assert scores["src/token.py"] > 0.0

--- a/packages/vizsuite/tests/unit/test_extract_consequence.py
+++ b/packages/vizsuite/tests/unit/test_extract_consequence.py
@@ -1,0 +1,49 @@
+"""Consequence heat axis (spec §6.2): `.critical-paths` markers + path-class heuristics.
+
+An estate file matching a `.critical-paths` marker scores maximum consequence
+(policy is authoritative); a file matching a path-class heuristic — gate-policy,
+security-adjacent, or public-contract — scores high even without a marker; all
+others baseline. `.critical-paths` is read from the materialized snapshot dir (the
+same file the completion gate reads), never the live checkout. The tests pin the
+*invariants* — marker beats heuristic beats baseline, everything in 0-1 — not the
+tunable heuristic score.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vizsuite.extract.consequence import consequence
+
+
+def test_consequence_scores_markers_max_and_heuristics_high(tmp_path: Path) -> None:
+    # `.critical-paths` lives in the snapshot dir (a tracked file in the archive).
+    (tmp_path / ".critical-paths").write_text("packages/**\nMakefile\n", encoding="utf-8")
+    estate = {
+        "packages/vizsuite/cli.py": "s1",  # matches the packages/** marker → max
+        "Makefile": "s2",  # matches the Makefile marker → max
+        "src/auth/token.py": "s3",  # security-adjacent heuristic, no marker → high
+        ".critical-paths": "s4",  # gate-policy file heuristic → high
+        "docs/notes.md": "s5",  # neither marker nor heuristic → baseline
+    }
+
+    scores = consequence(estate, tmp_path)
+
+    assert scores["packages/vizsuite/cli.py"] == 1.0  # explicit policy marker
+    assert scores["Makefile"] == 1.0
+    assert scores["docs/notes.md"] == 0.0  # plain file → baseline
+    # heuristics score high (above baseline) without any marker, but below the
+    # authoritative explicit marker.
+    assert scores["docs/notes.md"] < scores["src/auth/token.py"] < 1.0
+    assert scores[".critical-paths"] > 0.0
+    assert all(0.0 <= value <= 1.0 for value in scores.values())  # 0-1 range
+
+
+def test_consequence_without_a_critical_paths_file_uses_heuristics_only(tmp_path: Path) -> None:
+    # No `.critical-paths` in the snapshot → only the path-class heuristics contribute.
+    estate = {"src/security/vault.py": "s1", "lib/util.py": "s2"}
+
+    scores = consequence(estate, tmp_path)
+
+    assert scores["src/security/vault.py"] > 0.0  # security heuristic still fires
+    assert scores["lib/util.py"] == 0.0  # nothing matches → baseline

--- a/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
+++ b/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
@@ -8,7 +8,9 @@ Slice 2 extends this seam with cat_object_exists/rev_list/diff/churn/etc.
 
 from __future__ import annotations
 
+import io
 import subprocess
+import tarfile
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -122,3 +124,19 @@ def test_churn_for_commits_reads_commit_unreachable_from_head(
     assert by_path["a.py"].added == 1
     assert by_path["a.py"].deleted == 1
     assert by_path["b.py"].added == 1
+
+
+def test_archive_tar_streams_the_committed_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # `git archive` reads the commit *tree object*, so the tar carries exactly the
+    # committed blobs — the immutable-snapshot seam scc will scan in slice 3.
+    _init_repo(tmp_path, [("a.py", "x = 1\n"), ("src/b.py", "y = 2\n")])
+    monkeypatch.chdir(tmp_path)
+
+    tar_bytes = SubprocessGitRunner().archive_tar("HEAD")
+
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:") as tar:
+        members = {m.name: m for m in tar.getmembers() if m.isfile()}
+        assert {"a.py", "src/b.py"} <= set(members)
+        extracted = tar.extractfile("a.py")
+        assert extracted is not None
+        assert extracted.read() == b"x = 1\n"

--- a/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
+++ b/packages/vizsuite/tests/unit/test_git_subprocess_runner.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from vizsuite.adapters.git.runner import SubprocessGitRunner
+from vizsuite.envelope import ErrorCode, VizError
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -140,3 +141,18 @@ def test_archive_tar_streams_the_committed_tree(tmp_path: Path, monkeypatch: pyt
         extracted = tar.extractfile("a.py")
         assert extracted is not None
         assert extracted.read() == b"x = 1\n"
+
+
+def test_archive_tar_types_git_failure_as_adapter_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A failing `git archive` (here: an absent OID) must surface as a typed
+    # ADAPTER_FAILURE, not a raw CalledProcessError that the CLI reports as
+    # E_INTERNAL — the loud-boundary contract the other slice-3 adapters honor.
+    _init_repo(tmp_path, [("a.py", "x = 1\n")])
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(VizError) as excinfo:
+        SubprocessGitRunner().archive_tar("0" * 40)  # well-formed but absent OID
+
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_reconcile_snapshot.py
+++ b/packages/vizsuite/tests/unit/test_reconcile_snapshot.py
@@ -1,0 +1,84 @@
+"""`materialize()` — extract the git-archive tar to a tempdir, sanity-check the estate.
+
+The snapshot scc scans (slice 3) is extracted from `git archive`, never the live
+checkout, so a dirty working tree can never leak into the artifact (the Path-C
+invariant, proven by the real-subprocess test). `materialize` self-cleans its
+tempdir on any failure; on success the caller tears the returned dir down in a
+`finally`. The fake-driven tests exercise the extract + estate-sanity logic in
+isolation; the real-`git` test proves the archive seam end-to-end.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.fakes import ScriptedGitRunner, tar_of
+from vizsuite.adapters.git.runner import SubprocessGitRunner
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.reconcile.snapshot import materialize
+
+
+def test_materialize_extracts_the_archive_at_the_head_oid() -> None:
+    git = ScriptedGitRunner(archive_tar_bytes=tar_of({"a.py": "x = 1\n", "src/b.py": "y = 2\n"}))
+
+    snapshot = materialize(git, "head111", {"a.py", "src/b.py"})
+
+    try:
+        assert snapshot.is_dir()
+        assert (snapshot / "a.py").read_text(encoding="utf-8") == "x = 1\n"
+        assert (snapshot / "src" / "b.py").read_text(encoding="utf-8") == "y = 2\n"
+        # The archive is taken at the resolved head OID, never the checkout's HEAD.
+        assert ("archive_tar", "head111") in git.calls
+    finally:
+        shutil.rmtree(snapshot, ignore_errors=True)
+
+
+def test_materialize_missing_estate_path_alarms_and_self_cleans(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An estate path the archive dropped (an `export-ignore` gitattribute in a
+    # target repo) must alarm loudly, not yield a silently-thin snapshot — and the
+    # tempdir must not leak when it does.
+    git = ScriptedGitRunner(archive_tar_bytes=tar_of({"a.py": "x = 1\n"}))
+    made = tmp_path / "snap"
+    monkeypatch.setattr("vizsuite.reconcile.snapshot.mkdtemp", lambda *_a, **_k: str(made))
+
+    with pytest.raises(VizError) as excinfo:
+        materialize(git, "head111", {"a.py", "gone.py"})
+
+    assert excinfo.value.code == ErrorCode.ADAPTER_FAILURE
+    assert "gone.py" in str(excinfo.value.detail)
+    assert not made.exists()  # self-cleaned — no leaked tempdir
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)  # noqa: S603, S607
+
+
+def test_materialize_snapshot_cannot_leak_a_dirty_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Commit content A, then dirty the worktree (edit tracked -> B, add untracked).
+    # The snapshot at the commit must be exactly A with the untracked file absent —
+    # the test a guard-based "is the tree clean?" design could never pass.
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "tracked.py").write_text("A\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "A")
+    (tmp_path / "tracked.py").write_text("B\n", encoding="utf-8")  # modify tracked
+    (tmp_path / "untracked.py").write_text("leak\n", encoding="utf-8")  # add untracked
+    monkeypatch.chdir(tmp_path)
+
+    snapshot = materialize(SubprocessGitRunner(), "HEAD", {"tracked.py"})
+
+    try:
+        assert (snapshot / "tracked.py").read_text(encoding="utf-8") == "A\n"  # committed, not B
+        assert not (snapshot / "untracked.py").exists()  # untracked never leaks
+    finally:
+        shutil.rmtree(snapshot, ignore_errors=True)

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -1,11 +1,13 @@
-"""`viz pr <n>` end-to-end (plan slice 2): reconcile → head-OID estate → HTML.
+"""`viz pr <n>` end-to-end (plan slices 2-3): reconcile → head-OID estate →
+materialized snapshot → scc complexity → HTML.
 
-Slice 2 replaces slice 1's ``HEAD`` estate with the reconciled PR head OID: the
-verb resolves/fetches the immutable base/head OIDs, reconciles local git's net
-sets against GitHub's scalar counts, then builds the estate at the *head OID* (not
-the operator's checkout). The first test fakes every adapter; the second runs the
-real `SubprocessGitRunner` over a throwaway repo with only `gh` (the external
-service) faked, proving the git wiring end-to-end.
+Slice 2 replaced slice 1's ``HEAD`` estate with the reconciled PR head OID. Slice
+3 adds the per-file heat plumbing: the verb materializes the head snapshot from
+`git archive`, scc scans *that tempdir* (never the live checkout), the complexity
+axis is scored, and the tempdir is torn down in a `finally`. The first two tests
+fake every adapter; the last runs the real `SubprocessGitRunner` over a throwaway
+repo with only `gh` and `scc` (external binaries) faked, proving the git wiring
+end-to-end.
 """
 
 from __future__ import annotations
@@ -16,7 +18,15 @@ from pathlib import Path
 import pytest
 
 from tests.conftest import run_cli
-from tests.fakes import ScriptedGhRunner, ScriptedGitRunner, blob, gh_pr_result
+from tests.fakes import (
+    ScriptedGhRunner,
+    ScriptedGitRunner,
+    ScriptedSccRunner,
+    blob,
+    gh_pr_result,
+    scc_result,
+    tar_of,
+)
 from vizsuite.adapters.git.runner import ModifiedFileRow
 
 
@@ -35,9 +45,13 @@ def test_pr_reconciles_and_emits_html_from_head_estate(
             ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=3, deleted=0)
         ],
         ls_tree_rows=[blob("src/app.py", "aaa111"), blob("README.md", "bbb222")],
+        archive_tar_bytes=tar_of(
+            {"src/app.py": "x = 1\n", "README.md": "# hi\n", ".critical-paths": "src/**\n"}
+        ),
     )
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5, "README.md": 2}))
 
-    exit_code, envelope, stderr = run_cli(["pr", "7"], git_runner=git, gh_runner=gh)
+    exit_code, envelope, stderr = run_cli(["pr", "7"], git_runner=git, gh_runner=gh, scc_runner=scc)
 
     assert exit_code == 0
     assert stderr == ""
@@ -46,6 +60,8 @@ def test_pr_reconciles_and_emits_html_from_head_estate(
     assert isinstance(data, dict)
     assert data["pr"] == 7
     assert data["nodes"] == 2  # the estate (whole tree at head), not just the net set
+    assert data["scored_files"] == 2  # complexity scored both estate files scc recognized
+    assert data["consequential_files"] == 1  # src/app.py matched the .critical-paths marker
 
     # The estate is resolved at the reconciled head OID — never the checkout's HEAD.
     assert ("ls_tree", "head111") in git.calls
@@ -56,6 +72,39 @@ def test_pr_reconciles_and_emits_html_from_head_estate(
     html = artifact.read_text(encoding="utf-8")
     assert html.startswith("<!DOCTYPE html>")
     assert "src/app.py" in html
+
+
+def test_pr_materializes_snapshot_scans_scc_then_cleans_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Slice-3 plumbing: the verb materializes the head snapshot from `git archive`,
+    # scc scans *that tempdir* (never the live checkout), and the tempdir is torn
+    # down afterwards — a leaked snapshot dir is the failure this asserts against.
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = ScriptedGitRunner(
+        present_oids={"base000", "head111"},
+        diff_files=["src/app.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=8, deleted=0)
+        ],
+        ls_tree_rows=[blob("src/app.py", "aaa111")],
+        archive_tar_bytes=tar_of({"src/app.py": "x = 1\n"}),
+    )
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 6}))
+
+    exit_code, _envelope, _stderr = run_cli(
+        ["pr", "9"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    assert ("archive_tar", "head111") in git.calls  # snapshot at the resolved head OID
+    assert len(scc.calls) == 1  # scc scanned exactly one dir
+    scanned_dir = Path(scc.calls[0][1])
+    assert not scanned_dir.exists()  # the snapshot tempdir was rmtree'd in the finally
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -76,8 +125,9 @@ def _rev_parse(cwd: Path) -> str:
 def test_pr_reconciles_against_real_git_with_fake_gh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    # Real SubprocessGitRunner over a two-commit repo; only gh (the external
-    # service) is faked, with the real base/head OIDs the reconciler must agree with.
+    # Real SubprocessGitRunner over a two-commit repo — real archive+materialize —
+    # with only gh and scc (external binaries) faked, using the real base/head OIDs
+    # the reconciler must agree with.
     _git(tmp_path, "init", "-q")
     _git(tmp_path, "config", "user.email", "t@example.com")
     _git(tmp_path, "config", "user.name", "t")
@@ -95,8 +145,9 @@ def test_pr_reconciles_against_real_git_with_fake_gh(
     gh = ScriptedGhRunner(
         gh_pr_result(base_oid=base, head_oid=head, changed_files=2, commit_count=1)
     )
+    scc = ScriptedSccRunner(scc_result({"a.py": 3, "b.py": 1}))
 
-    exit_code, envelope, stderr = run_cli(["pr", "5"], gh_runner=gh)
+    exit_code, envelope, stderr = run_cli(["pr", "5"], gh_runner=gh, scc_runner=scc)
 
     assert exit_code == 0
     assert stderr == ""

--- a/packages/vizsuite/uv.lock
+++ b/packages/vizsuite/uv.lock
@@ -942,6 +942,7 @@ name = "vizsuite"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pathspec" },
     { name = "pydriller" },
 ]
 
@@ -956,7 +957,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydriller", specifier = ">=2.5" }]
+requires-dist = [
+    { name = "pathspec", specifier = ">=0.12" },
+    { name = "pydriller", specifier = ">=2.5" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Slice 3/5 of the vizsuite `.2.1` epic (bead `agents-config-yf2ov.2.1.4`) — the per-file **heat extraction layer**. Adds the materialized-snapshot machinery and both Tier-1 heat axes that need file contents on disk.

## What landed

- **`git archive_tar(oid)`** — streams the committed-tree tarball (binary out).
- **`reconcile/snapshot.py::materialize`** — extracts the archive to a tempdir (`tarfile`, `filter="data"`), estate-sanity guarded (a missing path → `ADAPTER_FAILURE`), **self-cleaning on any failure**; caller `rmtree`s on success. The **Path-C invariant** (a dirty checkout can never leak in) is proven with a real-`git` test.
- **`adapters/scc/{runner,parse}.py`** — `SubprocessSccRunner` (`shutil.which` preflight + install hint) + `parse_scc` (flatten `Files[]`, normalize `./`-prefixed `Location`s, drift → `ADAPTER_FAILURE`), mirroring the `gh` adapter.
- **`extract/complexity.py`** — the full §6.2 Complexity axis: estate-scoped scc baseline (÷ estate max) + a never-cool churn boost on the reconciled net files.
- **`extract/consequence.py`** — `.critical-paths` markers (read from the snapshot with the **gate's own gitignore semantics** — one source of truth) + path-class heuristics → per-file 0-1.
- **`viz pr` wiring** — materialize → scc → complexity + consequence, `rmtree` in a `finally`; the envelope surfaces `scored_files` / `consequential_files`.
- **New dep `pathspec`** (consequence `.critical-paths` matching).

## Scope boundary

Slice 3 delivers the **extraction layer** and proves the snapshot→scc→axes plumbing end-to-end. Threading per-file heat into scene node attributes + the cross-axis weighted average stay in `.2.2` (§6.2, per the `FileNode` comment).

## Testing / evidence

- `make ci-vizsuite` green: **72 tests, 100% coverage**, mypy `--strict` clean, ruff + format clean, `pip-audit` no vulnerabilities, entry-verify passes.
- TDD throughout (red→green per cycle), fakes over mocks; real-subprocess tests for `archive_tar` + the Path-C invariant (git is always in CI); the scc exec line is `# pragma: no cover` (scc may be absent in CI), the preflight branch fake-covered.

## Completion gate

HEAVY `quality-gate` workflow (6 finder dimensions × 3 refuters, xhigh synthesis) → **ACCEPTANCE, clean-at-floor** (0 major+). One auto-DRY fix applied; one minor correctness finding (security heuristic over-matched substrings → now matches whole path segments, fixed here with a test); two minor architectural items (parse-scaffold DRY, consequence IO port) deferred to bead `agents-config-yf2ov.2.1.3`.

## Two in-flight decisions (flagging, not burying)

1. **`pathspec` dep** — the plan's dep-staging comment didn't anticipate it, but consequence must read `.critical-paths` with the same gitignore semantics the gate uses. Hand-rolling would drift from that single source of truth.
2. **Scope** — extraction layer only; scene-attribute threading + cross-axis fusion stay in `.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
