### PR TITLE
feat(vizsuite): graphify EXTRACTED-dependency centrality extractor (slice 4/5)

### DIFF
--- a/packages/vizsuite/pyproject.toml
+++ b/packages/vizsuite/pyproject.toml
@@ -6,12 +6,13 @@ requires-python = ">=3.11.4"
 dependencies = [
     "pathspec>=0.12",
     "pydriller>=2.5",
+    "networkx>=3.4,<4",
 ]
 # Extractor deps are staged in the slice that first needs them (avoids landing
 # unexercised deps in the skeleton PR): slice 2 adds "pydriller" (churn); slice 3
 # adds "pathspec" (consequence reads .critical-paths with the gate's own gitwildmatch
-# semantics — one source of truth); slice 4 adds "networkx>=3.4,<4". doit + diskcache
-# are the .2.3 funnel substrate (not here).
+# semantics — one source of truth); slice 4 adds "networkx" (centrality). doit +
+# diskcache are the .2.3 funnel substrate (not here).
 # scc + gh + git are external binaries invoked as subprocesses (not pip deps).
 # d3 is vendored JS.
 
@@ -52,10 +53,10 @@ warn_unreachable = true
 disallow_any_decorated = true
 enable_error_code = ["redundant-expr", "truthy-bool", "possibly-undefined"]
 
-# pydriller ships no type stubs; scope the missing-imports allowance to it alone
-# (slice 4 adds the same for networkx) so --strict stays on everywhere else.
+# pydriller/networkx ship no complete type stubs; scope the missing-imports
+# allowance to them alone so --strict stays on everywhere else.
 [[tool.mypy.overrides]]
-module = ["pydriller.*"]
+module = ["pydriller.*", "networkx.*"]
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -1,0 +1,98 @@
+"""Graphify EXTRACTED-dependency centrality axis (spec §6.2, plan §3.6).
+
+Load-bearing axis sourced from graphify's `graph.json`, restricted to
+deterministic (Tier-1 `EXTRACTED`) dependency-relation edges — `INFERRED`
+edges (60% of the real graph's dependency-relation edges) are Tier-2 inference
+and out of scope here (R3-1); counting them would launder agent-produced
+inference into a "deterministic" axis. The graph is undirected, symbol-level
+node-link JSON with no stored centrality, so this module rolls symbols up to a
+file-level `DiGraph` (dropping intra-file edges) and scores normalized
+in-degree. `nx.node_link_graph` is deliberately never used to build that graph:
+for this `directed: false` payload it returns an undirected `Graph`, which has
+no `in_degree`.
+
+graphify is an optional dependency: an absent `graphify-out/`, a stale build
+(`built_at_commit != head_oid`), or unparseable/torn JSON all fail soft to
+`CentralityAxis.unavailable(...)` — never a crash, never stale-as-fresh.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+# Dependency-relation edge types the centrality axis considers; non-dependency
+# relations (`contains`, `rationale_for`, ...) never contribute (item 9).
+DEP_RELATIONS = frozenset({"calls", "uses", "imports_from", "inherits", "implements"})
+_EXTRACTED = "EXTRACTED"  # Tier-1 determinism boundary (R3-1)
+
+
+@dataclass(frozen=True)
+class CentralityAxis:
+    """Per-file 0-1 in-degree centrality, or unavailable with a reason.
+
+    `scores` is `None` exactly when the axis is unavailable (optional
+    dependency absent, stale, or unparseable) — distinct from an *available*
+    axis whose graph happens to carry zero qualifying edges (an empty dict).
+    """
+
+    scores: dict[str, float] | None
+    unavailable_reason: str | None = None
+
+    @property
+    def is_available(self) -> bool:
+        return self.scores is not None
+
+    @staticmethod
+    def unavailable(reason: str) -> CentralityAxis:
+        return CentralityAxis(scores=None, unavailable_reason=reason)
+
+    @staticmethod
+    def from_indegree(indegree: dict[str, int]) -> CentralityAxis:
+        """Normalize raw file-level in-degree counts to a 0-1 axis."""
+        max_degree = max(indegree.values(), default=0)
+        scores = {
+            path: (degree / max_degree if max_degree > 0 else 0.0)
+            for path, degree in indegree.items()
+        }
+        return CentralityAxis(scores=scores)
+
+
+def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
+    """Load-bearing axis from graphify. Tier-1 determinism: `EXTRACTED` edges
+    only (`INFERRED` graph edges are Tier-2, out of scope for `.2.1`). Intra-file
+    edges are dropped; projected post-PR centrality via the head-graph preflight
+    (no overlay — a head-built graph already contains new code's edges).
+    """
+    if not graph_path.exists():
+        return CentralityAxis.unavailable("graphify-out absent")  # optional dep, fail soft
+    try:
+        raw: dict[str, Any] = json.loads(graph_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return CentralityAxis.unavailable("graph.json unreadable (torn mid-write?)")  # fail soft
+    if raw.get("built_at_commit") != head_oid:
+        return CentralityAxis.unavailable("graph build-commit != PR head")  # never stale-as-fresh
+
+    try:
+        nodes = raw["nodes"]
+        links = raw["links"]
+    except (KeyError, TypeError):
+        return CentralityAxis.unavailable("graph.json missing nodes/links")
+
+    id_to_file = {n["id"]: n["source_file"] for n in nodes if n.get("source_file")}
+    graph: nx.DiGraph[str] = nx.DiGraph()
+    for link in links:
+        if link.get("relation") not in DEP_RELATIONS:
+            continue
+        if link.get("confidence") != _EXTRACTED:  # Tier-1 determinism (R3-1)
+            continue
+        src = id_to_file.get(link.get("source"))
+        dst = id_to_file.get(link.get("target"))
+        if src is None or dst is None or src == dst:  # drop intra-file edges
+            continue
+        graph.add_edge(src, dst)  # file-level dependency edge
+    return CentralityAxis.from_indegree(dict(graph.in_degree()))  # normalized 0-1 per file

--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -12,7 +12,8 @@ for this `directed: false` payload it returns an undirected `Graph`, which has
 no `in_degree`.
 
 graphify is an optional dependency: an absent `graphify-out/`, a stale build
-(`built_at_commit != head_oid`), or unparseable/torn JSON all fail soft to
+(`built_at_commit != head_oid`), unparseable/torn JSON, or valid JSON of the
+wrong shape (non-object payload, malformed nodes/links) all fail soft to
 `CentralityAxis.unavailable(...)` — never a crash, never stale-as-fresh.
 """
 
@@ -71,28 +72,37 @@ def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
     if not graph_path.exists():
         return CentralityAxis.unavailable("graphify-out absent")  # optional dep, fail soft
     try:
-        raw: dict[str, Any] = json.loads(graph_path.read_text(encoding="utf-8"))
+        raw: Any = json.loads(graph_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return CentralityAxis.unavailable("graph.json unreadable (torn mid-write?)")  # fail soft
+    if not isinstance(raw, dict):
+        return CentralityAxis.unavailable("graph.json malformed (not a JSON object)")
     if raw.get("built_at_commit") != head_oid:
         return CentralityAxis.unavailable("graph build-commit != PR head")  # never stale-as-fresh
 
+    # The whole rollup + graph build is one fail-soft boundary: graphify's JSON
+    # is outside-world input, so any wrong-shape payload that survived parsing
+    # (non-object nodes/links entries, non-iterable containers, missing keys)
+    # funnels to unavailable() rather than escaping as a raw exception.
     try:
         nodes = raw["nodes"]
         links = raw["links"]
-    except (KeyError, TypeError):
-        return CentralityAxis.unavailable("graph.json missing nodes/links")
-
-    id_to_file = {n["id"]: n["source_file"] for n in nodes if n.get("source_file")}
-    graph: nx.DiGraph[str] = nx.DiGraph()
-    for link in links:
-        if link.get("relation") not in DEP_RELATIONS:
-            continue
-        if link.get("confidence") != _EXTRACTED:  # Tier-1 determinism (R3-1)
-            continue
-        src = id_to_file.get(link.get("source"))
-        dst = id_to_file.get(link.get("target"))
-        if src is None or dst is None or src == dst:  # drop intra-file edges
-            continue
-        graph.add_edge(src, dst)  # file-level dependency edge
+        id_to_file = {
+            n["id"]: n["source_file"] for n in nodes if n.get("id") and n.get("source_file")
+        }
+        graph: nx.DiGraph[str] = nx.DiGraph()
+        for link in links:
+            if link.get("relation") not in DEP_RELATIONS:
+                continue
+            if link.get("confidence") != _EXTRACTED:  # Tier-1 determinism (R3-1)
+                continue
+            src = id_to_file.get(link.get("source"))
+            dst = id_to_file.get(link.get("target"))
+            if src is None or dst is None or src == dst:  # drop intra-file edges
+                continue
+            graph.add_edge(src, dst)  # file-level dependency edge
+    except (KeyError, TypeError, AttributeError):
+        return CentralityAxis.unavailable(
+            "graph.json malformed (missing or wrong-shape nodes/links)"
+        )
     return CentralityAxis.from_indegree(dict(graph.in_degree()))  # normalized 0-1 per file

--- a/packages/vizsuite/tests/unit/test_extract_centrality.py
+++ b/packages/vizsuite/tests/unit/test_extract_centrality.py
@@ -209,6 +209,48 @@ def test_graph_json_missing_nodes_or_links_is_unavailable_not_a_crash(tmp_path: 
     assert axis.scores is None
 
 
+@pytest.mark.parametrize(
+    "payload_text",
+    [
+        pytest.param('["not", "an", "object"]', id="top-level-array"),
+        pytest.param('"just a string"', id="top-level-string"),
+        pytest.param(
+            json.dumps({"built_at_commit": HEAD_OID, "nodes": ["a", "b"], "links": []}),
+            id="non-object-nodes",
+        ),
+        pytest.param(
+            json.dumps(
+                {
+                    "built_at_commit": HEAD_OID,
+                    "nodes": [{"id": "a", "source_file": "a.py"}],
+                    "links": ["not-an-object"],
+                }
+            ),
+            id="non-object-links",
+        ),
+        pytest.param(
+            json.dumps({"built_at_commit": HEAD_OID, "nodes": 42, "links": 7}),
+            id="non-iterable-nodes-links",
+        ),
+    ],
+)
+def test_valid_json_with_wrong_shape_is_unavailable_not_a_crash(
+    tmp_path: Path, payload_text: str
+) -> None:
+    # Valid JSON that is not the expected node-link object shape (top-level
+    # array/scalar, non-object node or link entries, non-iterable containers)
+    # must fail soft like any other malformed graph.json — never raise.
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(payload_text, encoding="utf-8")
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.unavailable_reason
+
+
 def test_centrality_axis_unavailable_and_from_indegree_helpers() -> None:
     unavailable = CentralityAxis.unavailable("no graphify-out")
     assert unavailable.scores is None

--- a/packages/vizsuite/tests/unit/test_extract_centrality.py
+++ b/packages/vizsuite/tests/unit/test_extract_centrality.py
@@ -1,0 +1,224 @@
+"""Graphify EXTRACTED-dependency centrality axis (spec §6.2, plan §3.6).
+
+Fixtures use the real `directed: false` node-link shape graphify emits, with
+mixed `confidence` values, so both the confidence filter and the
+`Graph`-vs-`DiGraph` trap are exercised against ground truth, not a
+convenience shape. The tests pin the *invariants* the spec cares about
+(Tier-1 determinism, intra-file exclusion, head-graph projection, fail-soft
+optional-dependency behavior, relation filtering) — not a specific score.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+import pytest
+
+from vizsuite.extract.centrality import DEP_RELATIONS, CentralityAxis, centrality_axis
+
+HEAD_OID = "head1234"
+
+
+def _node(node_id: str, source_file: str) -> dict[str, Any]:
+    return {"id": node_id, "source_file": source_file}
+
+
+def _link(source: str, target: str, *, relation: str, confidence: str) -> dict[str, Any]:
+    return {"source": source, "target": target, "relation": relation, "confidence": confidence}
+
+
+def _graph_json(
+    *, built_at_commit: str, nodes: list[dict[str, Any]], links: list[dict[str, Any]]
+) -> dict[str, Any]:
+    # The real graphify node-link shape: undirected, symbol-level.
+    return {
+        "directed": False,
+        "multigraph": False,
+        "graph": {},
+        "built_at_commit": built_at_commit,
+        "nodes": nodes,
+        "links": links,
+    }
+
+
+def _write_graph(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(json.dumps(payload), encoding="utf-8")
+    return graph_path
+
+
+def test_only_extracted_dependency_edges_contribute_an_inferred_only_hub_scores_zero(
+    tmp_path: Path,
+) -> None:
+    # hub.py has one incoming EXTRACTED edge and one incoming INFERRED edge from
+    # a different file; only the EXTRACTED edge may count toward its in-degree.
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[
+            _node("s1", "caller_a.py"),
+            _node("s2", "hub.py"),
+            _node("s3", "caller_b.py"),
+            _node("s4", "inferred_only_hub.py"),
+        ],
+        links=[
+            _link("s1", "s2", relation="calls", confidence="EXTRACTED"),
+            _link("s3", "s4", relation="calls", confidence="INFERRED"),
+        ],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert axis.is_available
+    assert axis.scores is not None
+    assert axis.scores["hub.py"] == 1.0  # its only qualifying in-edge is EXTRACTED
+    # An INFERRED-only hub never accumulates in-degree from that edge — it is
+    # either absent from the scored map or explicitly zero.
+    assert axis.scores.get("inferred_only_hub.py", 0.0) == 0.0
+
+
+def test_intra_file_edges_are_excluded_and_would_flip_the_ranking(tmp_path: Path) -> None:
+    # Two symbols inside the SAME file reference each other (an intra-file
+    # EXTRACTED edge) — if counted, quiet.py would falsely outrank real_hub.py.
+    # real_hub.py's two incoming edges originate in a genuinely different file.
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[
+            _node("q1", "quiet.py"),
+            _node("q2", "quiet.py"),  # same file as q1
+            _node("h1", "real_hub.py"),
+            _node("c1", "caller.py"),
+            _node("c2", "caller.py"),
+        ],
+        links=[
+            _link("q1", "q2", relation="calls", confidence="EXTRACTED"),  # intra-file, must drop
+            _link("c1", "h1", relation="calls", confidence="EXTRACTED"),
+            _link("c2", "h1", relation="uses", confidence="EXTRACTED"),
+        ],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert axis.scores is not None
+    assert "quiet.py" not in axis.scores  # the only edge touching it was intra-file
+    assert axis.scores["real_hub.py"] == 1.0  # the genuine cross-file hub
+
+
+def test_naive_node_link_graph_construction_lacks_in_degree_locking_the_trap() -> None:
+    # Documents the exact defect this module avoids: nx.node_link_graph() on a
+    # directed:false payload returns an undirected Graph, which has no
+    # in_degree — the naive path this module must never take.
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    naive_graph = nx.node_link_graph(payload, edges="links")
+
+    assert isinstance(naive_graph, nx.Graph)
+    assert not isinstance(naive_graph, nx.DiGraph)
+    with pytest.raises(AttributeError):
+        naive_graph.in_degree()  # type: ignore[operator]
+
+
+def test_head_built_graph_scores_a_newly_added_files_incoming_edges(tmp_path: Path) -> None:
+    # A head-built graph (built_at_commit == head_oid) already contains the new
+    # file's edges — no overlay step needed, just the preflight passing.
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[_node("n1", "existing_caller.py"), _node("n2", "new_hub.py")],
+        links=[_link("n1", "n2", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert axis.scores is not None
+    assert axis.scores["new_hub.py"] > 0.0
+
+
+def test_absent_graphify_out_is_unavailable_not_a_crash(tmp_path: Path) -> None:
+    missing_path = tmp_path / "graphify-out" / "graph.json"
+
+    axis = centrality_axis(missing_path, HEAD_OID)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.unavailable_reason
+
+
+def test_stale_build_commit_is_unavailable_never_stale_as_fresh(tmp_path: Path) -> None:
+    payload = _graph_json(
+        built_at_commit="some-other-commit",
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert not axis.is_available
+    assert axis.scores is None
+
+
+def test_truncated_invalid_json_is_unavailable_not_a_crash(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text('{"built_at_commit": "head1234", "nodes": [', encoding="utf-8")
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert not axis.is_available
+    assert axis.scores is None
+
+
+def test_non_dependency_relations_do_not_contribute(tmp_path: Path) -> None:
+    # `contains`/`rationale_for` are not dependency relations; even at
+    # EXTRACTED confidence they must never contribute to in-degree.
+    assert "contains" not in DEP_RELATIONS
+    assert "rationale_for" not in DEP_RELATIONS
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[_node("p1", "parent.py"), _node("p2", "child.py")],
+        links=[
+            _link("p1", "p2", relation="contains", confidence="EXTRACTED"),
+            _link("p1", "p2", relation="rationale_for", confidence="EXTRACTED"),
+        ],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert axis.scores is not None
+    assert axis.scores.get("child.py", 0.0) == 0.0
+
+
+def test_graph_json_missing_nodes_or_links_is_unavailable_not_a_crash(tmp_path: Path) -> None:
+    # Well-formed JSON, correct built_at_commit, but missing the nodes/links keys
+    # entirely (a malformed graphify emission) — must fail soft, not KeyError.
+    graph_path = _write_graph(tmp_path, {"built_at_commit": HEAD_OID})
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert not axis.is_available
+    assert axis.scores is None
+
+
+def test_centrality_axis_unavailable_and_from_indegree_helpers() -> None:
+    unavailable = CentralityAxis.unavailable("no graphify-out")
+    assert unavailable.scores is None
+    assert unavailable.unavailable_reason == "no graphify-out"
+    assert not unavailable.is_available
+
+    available = CentralityAxis.from_indegree({"a.py": 2, "b.py": 1, "c.py": 0})
+    assert available.is_available
+    assert available.scores == {"a.py": 1.0, "b.py": 0.5, "c.py": 0.0}
+
+    empty = CentralityAxis.from_indegree({})
+    assert empty.is_available
+    assert empty.scores == {}

--- a/packages/vizsuite/tests/unit/test_extract_complexity.py
+++ b/packages/vizsuite/tests/unit/test_extract_complexity.py
@@ -11,11 +11,11 @@ weight.
 from __future__ import annotations
 
 import pytest
-from vizsuite.extract.complexity import complexity
 
 from vizsuite.adapters.scc.parse import SccRecord
 from vizsuite.envelope import ErrorCode, VizError
 from vizsuite.extract.churn import FileChurn
+from vizsuite.extract.complexity import complexity
 
 
 def _record(complexity_value: int) -> SccRecord:

--- a/packages/vizsuite/uv.lock
+++ b/packages/vizsuite/uv.lock
@@ -581,6 +581,15 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -942,6 +951,7 @@ name = "vizsuite"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "networkx" },
     { name = "pathspec" },
     { name = "pydriller" },
 ]
@@ -958,6 +968,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "networkx", specifier = ">=3.4,<4" },
     { name = "pathspec", specifier = ">=0.12" },
     { name = "pydriller", specifier = ">=2.5" },
 ]


### PR DESCRIPTION
## Summary

- Adds the graphify centrality extractor (`extract/centrality.py`): a per-file 0–1 in-degree axis built from **EXTRACTED-confidence dependency edges only** (`calls`, `uses`, `imports_from`, `inherits`, `implements`), per the implementation plan's Tier-1 determinism boundary — INFERRED edges (60% of the real graph) are deliberately excluded.
- Builds a file-level `nx.DiGraph` via symbol→file rollup; drops intra-file edges; `nx.node_link_graph` is deliberately not used (the `directed:false` payload would yield an undirected `Graph` with no `in_degree` — a trap locked by a dedicated test).
- Fail-soft optional dependency: absent `graphify-out/`, stale `built_at_commit`, torn/unparseable JSON, **and valid JSON of the wrong shape** all return `CentralityAxis.unavailable(...)`, never a crash.
- Adds `networkx>=3.4,<4` (+ `uv.lock`, surgical mypy override for missing stubs).

Slice 4/5 of the vizsuite data build (plan: `docs/plans/visualization-suite/2026-07-13-implementation-plan.md` §3 slice 4, §3.6; spec: `docs/specs/2026-07-12-visualization-suite-design.md` §6.2).

## Scope

- **In scope:** the extractor, its tests, the dependency. One pre-existing 2-line import-sort lint violation in `test_extract_complexity.py` (from slice 3, verified present on main) is fixed here because it blocked `make ci-vizsuite` entirely.
- **Out of scope (slice 5):** wiring the axis into scene assembly / CLI / envelope.

## Review-gate disposition

The HEAVY adversarial gate exited at its round cap (not clean); dispositions:
- MAJOR (wrong-shape `graph.json` crashes past the documented fail-soft contract) — **fixed in `b4cb864`** with 5 parametrized shape tests (top-level array/scalar, non-object nodes/links entries, non-iterable containers).
- Mechanical `n.get("id")` guard — applied and folded into `b4cb864`.
- Minor (reuse): min-max normalization duplicated between `centrality.py` and `complexity.py` — deferred to the adapter-hardening follow-up under the rule of three (two uses today); tracked in the epic's hardening work item.

## Test Plan

- [x] TDD red→green per plan steps: confidence filter, intra-file exclusion, `Graph`-vs-`DiGraph` trap, head-graph preflight, fail-soft set, relation filtering (test item 10)
- [x] 15 centrality tests (10 planned + 5 shape-hardening); 89 package tests total
- [x] `make ci-vizsuite` fully green: ruff, format-check, mypy --strict, 100% line+branch coverage, pip-audit clean, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
