### PR TITLE
feat(vizsuite): full scene envelope — provenance, fingerprints, escaping, schema gate (slice 5/5)

### DIFF
--- a/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
@@ -26,10 +26,40 @@ class PrView:
     commit_count: int
 
 
-def _shape_error(pr_number: int, stdout: str, *, reason: str) -> VizError:
+@dataclass(frozen=True)
+class PrMeta:
+    """PR author/review-state/timestamps (spec §4.4, plan slice 5).
+
+    Garnish metadata, not part of the reconciler's drift-critical scalar join
+    (`PrView`) — a separate, widened `gh pr view --json` call. `review_state`
+    normalizes gh's nullable `reviewDecision` (no review activity yet) to the
+    `"NONE"` sentinel rather than `None`, since a null review state here is
+    valid data, not a malformed response.
+    """
+
+    author: str
+    review_state: str
+    created_at: str
+    updated_at: str
+    merged_at: str | None
+
+
+def _nonzero_exit_error(pr_number: int, result: GhResult, *, source: str) -> VizError:
     return VizError(
         ErrorCode.ADAPTER_FAILURE,
-        "gh api graphql returned an unparseable or unexpected PR shape",
+        f"{source} exited nonzero",
+        detail={
+            "pr_number": pr_number,
+            "returncode": result.returncode,
+            "stderr": result.stderr.strip(),
+        },
+    )
+
+
+def _shape_error(pr_number: int, stdout: str, *, source: str, reason: str) -> VizError:
+    return VizError(
+        ErrorCode.ADAPTER_FAILURE,
+        f"{source} returned an unparseable or unexpected PR shape",
         detail={"pr_number": pr_number, "reason": reason, "raw_excerpt": stdout[:200]},
     )
 
@@ -43,20 +73,13 @@ def parse_pr_view(result: GhResult, *, pr_number: int) -> PrView:
     null/absent pull request (a subscript of `None` → `TypeError`), or any missing
     scalar (`KeyError`) all funnel to the same alarm carrying the PR number.
     """
+    source = "gh api graphql"
     if result.returncode != 0:
-        raise VizError(
-            ErrorCode.ADAPTER_FAILURE,
-            "gh api graphql exited nonzero",
-            detail={
-                "pr_number": pr_number,
-                "returncode": result.returncode,
-                "stderr": result.stderr.strip(),
-            },
-        )
+        raise _nonzero_exit_error(pr_number, result, source=source)
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
-        raise _shape_error(pr_number, result.stdout, reason="invalid_json") from exc
+        raise _shape_error(pr_number, result.stdout, source=source, reason="invalid_json") from exc
     try:
         pull_request = payload["data"]["repository"]["pullRequest"]
         return PrView(
@@ -67,4 +90,36 @@ def parse_pr_view(result: GhResult, *, pr_number: int) -> PrView:
             commit_count=pull_request["commits"]["totalCount"],
         )
     except (KeyError, TypeError) as exc:
-        raise _shape_error(pr_number, result.stdout, reason=type(exc).__name__) from exc
+        raise _shape_error(
+            pr_number, result.stdout, source=source, reason=type(exc).__name__
+        ) from exc
+
+
+def parse_pr_meta(result: GhResult, *, pr_number: int) -> PrMeta:
+    """Parse one `gh pr view --json` response into a `PrMeta`.
+
+    Mirrors `parse_pr_view`'s discipline: a nonzero exit, non-JSON stdout, or a
+    missing scalar (`author.login`, `createdAt`, `updatedAt`) is a loud typed
+    `VizError(ADAPTER_FAILURE)`, never a silent default. A `null`/absent
+    `reviewDecision` is normalized to the `"NONE"` sentinel — valid data for a
+    PR with no review activity yet, not a malformed response.
+    """
+    source = "gh pr view --json"
+    if result.returncode != 0:
+        raise _nonzero_exit_error(pr_number, result, source=source)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise _shape_error(pr_number, result.stdout, source=source, reason="invalid_json") from exc
+    try:
+        return PrMeta(
+            author=payload["author"]["login"],
+            review_state=payload.get("reviewDecision") or "NONE",
+            created_at=payload["createdAt"],
+            updated_at=payload["updatedAt"],
+            merged_at=payload.get("mergedAt"),
+        )
+    except (KeyError, TypeError) as exc:
+        raise _shape_error(
+            pr_number, result.stdout, source=source, reason=type(exc).__name__
+        ) from exc

--- a/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
@@ -29,6 +29,11 @@ _PR_QUERY = (
     "}}}"
 )
 
+# `gh pr view --json` fields for the PR-metadata garnish (author/review-state/
+# timestamps, spec §4.4) — a separate, widened call from `_PR_QUERY`: this one
+# is metadata only, never part of the reconciler's drift-critical scalar join.
+_PR_META_FIELDS = "author,reviewDecision,createdAt,updatedAt,mergedAt"
+
 
 @dataclass(frozen=True)
 class GhResult:
@@ -39,6 +44,7 @@ class GhResult:
 
 class GhRunner(Protocol):
     def pr_graphql(self, pr_number: int) -> GhResult: ...  # pragma: no cover
+    def pr_meta(self, pr_number: int) -> GhResult: ...  # pragma: no cover
 
 
 class SubprocessGhRunner:
@@ -59,6 +65,18 @@ class SubprocessGhRunner:
                 "-f",
                 f"query={_PR_QUERY}",
             ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        return GhResult(
+            returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr
+        )
+
+    def pr_meta(self, pr_number: int) -> GhResult:  # pragma: no cover - needs gh auth+network
+        completed = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", _PR_META_FIELDS],
             capture_output=True,
             text=True,
             timeout=60,

--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -33,6 +33,9 @@ class ErrorCode(StrEnum):
     # slice 2: the PR base/head OID is still absent locally after fetch (a stale
     # clone or unreachable remote), so the snapshot cannot be built.
     SNAPSHOT_MISMATCH = "E_SNAPSHOT_MISMATCH"
+    # slice 5: a Tier-2/Tier-3-touched scene fact is missing its provenance or
+    # citations — the assembler's schema gate refuses to assemble it silently.
+    SCHEMA_INVALID = "E_SCHEMA_INVALID"
 
 
 @dataclass(frozen=True)

--- a/packages/vizsuite/src/vizsuite/extract/pr_metadata.py
+++ b/packages/vizsuite/src/vizsuite/extract/pr_metadata.py
@@ -1,0 +1,17 @@
+"""PR metadata extractor — author/review-state/timestamps (spec §4.4, slice 5).
+
+Tier-1 (deterministic): a widened `gh pr view --json` call, distinct from the
+OID-reconciliation graphql query (slice 2) — this one is metadata-only garnish,
+never part of the reconciler's drift-critical scalar join. Mirrors the
+adapter/parse split of `reconcile.pr_scope`/`adapters.gh.parse.parse_pr_view`.
+"""
+
+from __future__ import annotations
+
+from vizsuite.adapters.gh.parse import PrMeta, parse_pr_meta
+from vizsuite.adapters.gh.runner import GhRunner
+
+
+def pr_metadata(gh: GhRunner, pr_number: int) -> PrMeta:
+    """Fetch and parse the PR's author/review-state/timestamps."""
+    return parse_pr_meta(gh.pr_meta(pr_number), pr_number=pr_number)

--- a/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
+++ b/packages/vizsuite/src/vizsuite/reconcile/pr_scope.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from vizsuite.adapters.gh.parse import parse_pr_view
+from vizsuite.adapters.gh.parse import PrMeta, parse_pr_view
 from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
 from vizsuite.envelope import ErrorCode, JsonValue, VizError
 from vizsuite.extract.churn import FileChurn, churn
+from vizsuite.extract.pr_metadata import pr_metadata
 
 
 @dataclass(frozen=True)
@@ -25,18 +26,22 @@ class PrScope:
 
     `files` is the local *net* set (a file added-then-reverted within the PR is
     excluded), each carrying its summed churn; `head_oid` drives every downstream
-    immutable-object read (estate at head, scc snapshot in slice 3).
+    immutable-object read (estate at head, scc snapshot in slice 3). `meta` is
+    the author/review-state/timestamps garnish (slice 5) — deliberately absent
+    from slice 2, which returned no metadata.
     """
 
     pr_number: int
     head_oid: str
     base_oid: str
     files: dict[str, FileChurn]
+    meta: PrMeta
 
 
 def reconcile(pr_number: int, *, gh: GhRunner, git: GitRunner) -> PrScope:
     """Resolve OIDs and reconcile local net sets against GitHub's scalar counts."""
     pr = parse_pr_view(gh.pr_graphql(pr_number), pr_number=pr_number)
+    meta = pr_metadata(gh, pr_number)
 
     # Ensure both immutable OIDs are present locally so every downstream read is
     # against the object DB, not the operator's checkout. `pull/<n>/head` brings the
@@ -84,4 +89,6 @@ def reconcile(pr_number: int, *, gh: GhRunner, git: GitRunner) -> PrScope:
         )
 
     files = churn(git, commit_oids, net_files)
-    return PrScope(pr_number=pr_number, head_oid=pr.head_oid, base_oid=pr.base_oid, files=files)
+    return PrScope(
+        pr_number=pr_number, head_oid=pr.head_oid, base_oid=pr.base_oid, files=files, meta=meta
+    )

--- a/packages/vizsuite/src/vizsuite/scene/assemble.py
+++ b/packages/vizsuite/src/vizsuite/scene/assemble.py
@@ -1,14 +1,45 @@
-"""Minimal scene assembler (slice 1): estate nodes → `Scene`, no heat.
+"""Scene assembler: estate nodes + fingerprints + Tier-2/3 facts → `Scene`.
 
-Slice 3 merges the complexity/consequence axes and slice 5 folds in provenance,
-fingerprints, and the schema gate. Here the assembler is a pure function of its
-inputs — the clock is injected as `generated_at` rather than read from a module
-global, so assembly is deterministic and testable.
+Slice 3 merged the complexity/consequence heat axes at the `viz pr` verb level
+(threading them into scene node attributes is `.2.2`); slice 5 hardens the
+envelope itself: every assembly stamps a `Fingerprints` manifest (the PR's
+`base_oid`/`head_oid` plus the estate's own blob-SHA checksums — one pinned
+hash domain, §0.1) and runs the **schema gate**: any attached Tier-2/3 `Fact`
+missing provenance or citations is refused with a loud typed error before a
+`Scene` is ever constructed — no silent default, no dropped fact. The
+assembler stays a pure function of its inputs — the clock is injected as
+`generated_at` rather than read from a module global, so assembly is
+deterministic and testable.
 """
 
 from __future__ import annotations
 
-from vizsuite.scene.model import FileNode, Scene
+from collections.abc import Sequence
+
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.scene.model import (
+    AttributeDescriptor,
+    Fact,
+    FileNode,
+    Fingerprints,
+    Scene,
+)
+
+
+def _validate_facts(facts: Sequence[Fact]) -> None:
+    """Refuse any Tier-2/3 fact lacking provenance or citations (spec test item 8).
+
+    A missing `Provenance` and a present-but-citation-less one are the same
+    violation class: both mean the fact cannot be traced to its inputs, so
+    neither may reach an assembled `Scene`.
+    """
+    for fact in facts:
+        if fact.provenance is None or not fact.provenance.citations:
+            raise VizError(
+                ErrorCode.SCHEMA_INVALID,
+                "Tier-2/3 fact is missing provenance or citations",
+                detail={"fact_id": fact.id},
+            )
 
 
 def assemble(
@@ -17,16 +48,33 @@ def assemble(
     pr_number: int,
     generated_at: str,
     generator: str,
+    base_oid: str,
+    head_oid: str,
     schema_version: str = "1",
+    tool_versions: dict[str, str] | None = None,
+    facts: Sequence[Fact] = (),
+    descriptors: Sequence[AttributeDescriptor] = (),
 ) -> Scene:
-    """Assemble the estate `{path: blob_sha}` into a `Scene`.
+    """Assemble the estate `{path: blob_sha}` plus fingerprints/facts into a `Scene`.
 
     `generated_at` is the caller-supplied build stamp (the only non-deterministic
-    input); every other field is derived from the estate, so two assemblies of
-    the same estate differ only in that stamp (spec test item 6).
+    input); every other field is derived from the estate/OIDs/facts, so two
+    assemblies of the same inputs differ only in that stamp (spec test item 6)
+    and carry an identical `fingerprints.files` manifest (spec test item: the
+    per-file checksum is the estate blob SHA, deterministic across assemblies).
+    Raises `VizError(SCHEMA_INVALID)` before constructing anything if any `fact`
+    fails the schema gate.
     """
+    _validate_facts(facts)
+
     files = tuple(
         FileNode(path=path, checksum=blob_sha) for path, blob_sha in sorted(estate_map.items())
+    )
+    fingerprints = Fingerprints(
+        base_oid=base_oid,
+        head_oid=head_oid,
+        tool_versions=dict(tool_versions or {}),
+        files=dict(estate_map),
     )
     return Scene(
         schema_version=schema_version,
@@ -34,4 +82,7 @@ def assemble(
         generator=generator,
         pr_number=pr_number,
         files=files,
+        fingerprints=fingerprints,
+        descriptors=tuple(descriptors),
+        facts=tuple(facts),
     )

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -1,18 +1,22 @@
 """Typed scene dataclasses — the inlined-JSON contract every view will read.
 
-Slice-1 minimum (spec §4.4, plan §3.2): a shared envelope (`schema_version`,
+Slice 1 shipped the minimum: a shared envelope (`schema_version`,
 `generated_at`, `generator`) plus a per-suite payload of estate file nodes
 `{path, checksum, attributes:{}}`, where `checksum` is the git blob SHA. Slice 5
-hardens this into the full §4.4 envelope (fingerprints, descriptors, per-fact
-provenance, recommendations, reserved events). No `Any` at the boundary:
-`scene_to_json` parses the typed model down to a `dict[str, JsonValue]` once, and
-serialization is deterministic (files sorted by path) so the same estate always
-produces byte-identical scene JSON.
+hardens this into the full §4.4 envelope: `fingerprints` (the input-hash
+manifest the scene was built from), `descriptors` (self-describing attribute
+metadata), per-fact `Provenance` on two independent axes (source/verdict and
+freshness), `recommendations`/`events` reserved empty for V1/V3. No `Any` at
+the boundary: `scene_to_json` parses the typed model down to a
+`dict[str, JsonValue]` once, and serialization is deterministic (files and
+facts sorted by key) so the same inputs always produce byte-identical scene
+JSON.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 
 from vizsuite.envelope import JsonValue
 
@@ -24,6 +28,84 @@ class FileNode:
     attributes: dict[str, JsonValue] = field(default_factory=dict)  # heat axes land in .2.2/§6.2
 
 
+class ProvenanceKind(StrEnum):
+    """The source/verdict axis of per-fact provenance (spec §4.4)."""
+
+    ENCODED = "encoded"
+    INFERRED = "inferred"
+    ACCEPTED = "accepted"
+
+
+class Freshness(StrEnum):
+    """The staleness axis of per-fact provenance (spec §4.4).
+
+    Independent of `ProvenanceKind`: an accepted fact can be doubted without
+    losing its recorded acceptance (spec test item 8).
+    """
+
+    FRESH = "fresh"
+    DOUBTED = "doubted"
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """Per-fact provenance on two independent axes, plus mandatory citations.
+
+    `citations` are the inputs (bead ids, passages, graph regions) the fact
+    was derived from (spec §5.2: "input citations are mandatory at inference
+    time"). Empty citations fail the assembler's schema gate exactly like a
+    missing `Provenance` does — both are the same violation class.
+    """
+
+    kind: ProvenanceKind
+    freshness: Freshness = Freshness.FRESH
+    citations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Fact:
+    """A Tier-2/Tier-3-touched fact attached to the scene (spec §4.4).
+
+    `provenance` is `None` for an incoming fact `assemble()` has not yet
+    validated — a `Scene` never carries a `Fact` with `provenance=None` or
+    empty citations; the schema gate rejects it loudly instead of defaulting
+    or silently dropping it (spec test item 8). `note` is the fact's narrative
+    payload (e.g. a drill story) and is repo/agent-derived, hostile-input-safe
+    only via the templating/escaping boundary (spec test item 7) — never
+    sanitized here.
+    """
+
+    id: str
+    note: str
+    provenance: Provenance | None = None
+
+
+@dataclass(frozen=True)
+class AttributeDescriptor:
+    """Self-describing metadata for one scene attribute (spec §4.4)."""
+
+    name: str
+    unit: str
+    direction: str
+
+
+@dataclass(frozen=True)
+class Fingerprints:
+    """The input-hash manifest the scene was built from (spec §4.4/§5.4).
+
+    `files` mirrors each `FileNode.checksum` (the estate's git blob SHAs) as
+    the manifest's own record — one pinned hash domain (§0.1/§3.5.1), not a
+    second recomputation. `base_oid`/`head_oid` identify the reconciled PR
+    snapshot; `tool_versions` is reserved for extractor tool versions (none
+    are wired as of slice 5 — no scene consumer needs them yet).
+    """
+
+    base_oid: str
+    head_oid: str
+    tool_versions: dict[str, str] = field(default_factory=dict)
+    files: dict[str, str] = field(default_factory=dict)
+
+
 @dataclass(frozen=True)
 class Scene:
     schema_version: str
@@ -31,18 +113,58 @@ class Scene:
     generator: str
     pr_number: int
     files: tuple[FileNode, ...]
+    fingerprints: Fingerprints
+    descriptors: tuple[AttributeDescriptor, ...] = ()  # no scene attribute needs one until .2.2
+    facts: tuple[Fact, ...] = ()  # Tier-2/3 facts; empty until .2.2/.2.3 have a producer
+    recommendations: tuple[JsonValue, ...] = ()  # always empty for V1 (spec §4.4)
+    events: tuple[JsonValue, ...] = ()  # reserved for V3 (spec §4.4/§8); always empty here
+
+
+def _provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
+    return {
+        "kind": str(provenance.kind),
+        "freshness": str(provenance.freshness),
+        "citations": list(provenance.citations),
+    }
+
+
+def _fact_to_json(fact: Fact) -> dict[str, JsonValue]:
+    return {
+        "id": fact.id,
+        "note": fact.note,
+        "provenance": _provenance_to_json(fact.provenance) if fact.provenance is not None else None,
+    }
+
+
+def _descriptor_to_json(descriptor: AttributeDescriptor) -> dict[str, JsonValue]:
+    return {"name": descriptor.name, "unit": descriptor.unit, "direction": descriptor.direction}
+
+
+def _fingerprints_to_json(fingerprints: Fingerprints) -> dict[str, JsonValue]:
+    return {
+        "base_oid": fingerprints.base_oid,
+        "head_oid": fingerprints.head_oid,
+        "tool_versions": dict(fingerprints.tool_versions),
+        "files": dict(fingerprints.files),
+    }
 
 
 def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
-    """Serialize a `Scene` to a plain JSON-shaped mapping, files sorted by path.
+    """Serialize a `Scene` to a plain JSON-shaped mapping, files/facts sorted by key.
 
     Sorting here (not at the call site) makes the scene payload a deterministic
-    function of the estate, so `templates.html.render_html` is byte-stable modulo
+    function of its inputs, so `templates.html.render_html` is byte-stable modulo
     the `generated_at` stamp (spec test item 6).
     """
     files_json: list[JsonValue] = [
         {"path": node.path, "checksum": node.checksum, "attributes": node.attributes}
         for node in sorted(scene.files, key=lambda node: node.path)
+    ]
+    facts_json: list[JsonValue] = [
+        _fact_to_json(fact) for fact in sorted(scene.facts, key=lambda fact: fact.id)
+    ]
+    descriptors_json: list[JsonValue] = [
+        _descriptor_to_json(descriptor) for descriptor in scene.descriptors
     ]
     return {
         "schema_version": scene.schema_version,
@@ -50,4 +172,9 @@ def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
         "generator": scene.generator,
         "pr_number": scene.pr_number,
         "files": files_json,
+        "fingerprints": _fingerprints_to_json(scene.fingerprints),
+        "descriptors": descriptors_json,
+        "facts": facts_json,
+        "recommendations": list(scene.recommendations),
+        "events": list(scene.events),
     }

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -61,6 +61,8 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         pr_number=pr_number,
         generated_at=datetime.now(UTC).isoformat(),
         generator=f"vizsuite/{__version__}",
+        base_oid=scope.base_oid,
+        head_oid=scope.head_oid,
     )
     html = render_html(scene)
 
@@ -75,5 +77,7 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         "net_files": len(scope.files),
         "scored_files": len(complexity_scores),
         "consequential_files": sum(1 for value in consequence_scores.values() if value > 0),
+        "author": scope.meta.author,
+        "review_state": scope.meta.review_state,
     }
     return data

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -81,19 +81,27 @@ class ScriptedGitRunner:
 
 @dataclass
 class ScriptedGhRunner:
-    """Feeds one scripted `gh api graphql` raw result; records the PR asked for.
+    """Feeds one scripted `gh api graphql` result and one scripted `gh pr view
+    --json` metadata result; records the PR number every call asked for.
 
-    Reconcile parses this raw `GhResult` through the real `parse_pr_view`, so a
-    test exercises the actual parse path (not a hand-built `PrView`). Build the
-    `GhResult` with `gh_pr_result(...)`.
+    Reconcile parses these raw `GhResult`s through the real `parse_pr_view`/
+    `parse_pr_meta`, so a test exercises the actual parse path (not a
+    hand-built `PrView`/`PrMeta`). Build them with `gh_pr_result(...)` /
+    `gh_pr_meta_result(...)`; `meta_result` defaults to a valid fixture so
+    tests that only care about OID reconciliation need not script it.
     """
 
-    result: GhResult
+    result: GhResult = field(default_factory=lambda: gh_pr_result(changed_files=0, commit_count=0))
+    meta_result: GhResult = field(default_factory=lambda: gh_pr_meta_result())
     calls: list[tuple[str, int]] = field(default_factory=list)
 
     def pr_graphql(self, pr_number: int) -> GhResult:
         self.calls.append(("pr_graphql", pr_number))
         return self.result
+
+    def pr_meta(self, pr_number: int) -> GhResult:
+        self.calls.append(("pr_meta", pr_number))
+        return self.meta_result
 
 
 def gh_pr_result(
@@ -117,6 +125,25 @@ def gh_pr_result(
                 }
             }
         }
+    }
+    return GhResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def gh_pr_meta_result(
+    *,
+    author: str = "octocat",
+    review_state: str | None = "APPROVED",
+    created_at: str = "2026-07-01T00:00:00Z",
+    updated_at: str = "2026-07-02T00:00:00Z",
+    merged_at: str | None = None,
+) -> GhResult:
+    """Build a successful `gh pr view --json` `GhResult` (PR-metadata fixture)."""
+    payload = {
+        "author": {"login": author},
+        "reviewDecision": review_state,
+        "createdAt": created_at,
+        "updatedAt": updated_at,
+        "mergedAt": merged_at,
     }
     return GhResult(returncode=0, stdout=json.dumps(payload), stderr="")
 

--- a/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
+++ b/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
@@ -113,3 +113,81 @@ def test_missing_scalar_field_is_adapter_failure():
         parse_pr_view(result, pr_number=7)
 
     assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def _meta_stdout(
+    *,
+    author: str = "octocat",
+    review_decision: str | None = "APPROVED",
+    created_at: str = "2026-07-01T00:00:00Z",
+    updated_at: str = "2026-07-02T00:00:00Z",
+    merged_at: str | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "author": {"login": author},
+            "reviewDecision": review_decision,
+            "createdAt": created_at,
+            "updatedAt": updated_at,
+            "mergedAt": merged_at,
+        }
+    )
+
+
+def test_parses_author_review_state_and_timestamps():
+    from vizsuite.adapters.gh.parse import parse_pr_meta
+
+    result = GhResult(returncode=0, stdout=_meta_stdout(), stderr="")
+
+    meta = parse_pr_meta(result, pr_number=7)
+
+    assert meta.author == "octocat"
+    assert meta.review_state == "APPROVED"
+    assert meta.created_at == "2026-07-01T00:00:00Z"
+    assert meta.updated_at == "2026-07-02T00:00:00Z"
+    assert meta.merged_at is None
+
+
+def test_null_review_decision_normalizes_to_none_sentinel():
+    from vizsuite.adapters.gh.parse import parse_pr_meta
+
+    result = GhResult(returncode=0, stdout=_meta_stdout(review_decision=None), stderr="")
+
+    meta = parse_pr_meta(result, pr_number=7)
+
+    assert meta.review_state == "NONE"
+
+
+def test_meta_nonzero_gh_exit_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_meta
+
+    result = GhResult(returncode=1, stdout="", stderr="gh: not authenticated")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_meta(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+    assert exc_info.value.detail["pr_number"] == 7
+
+
+def test_meta_non_json_stdout_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_meta
+
+    result = GhResult(returncode=0, stdout="not json at all", stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_meta(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def test_meta_missing_author_field_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_meta
+
+    stdout = json.dumps({"reviewDecision": "APPROVED", "createdAt": "x", "updatedAt": "y"})
+    result = GhResult(returncode=0, stdout=stdout, stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_meta(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE

--- a/packages/vizsuite/tests/unit/test_assembly_determinism.py
+++ b/packages/vizsuite/tests/unit/test_assembly_determinism.py
@@ -16,7 +16,12 @@ _ESTATE = {"src/b.py": "sha_b", "src/a.py": "sha_a", "README.md": "sha_r"}
 
 def test_assemble_maps_estate_to_sorted_file_nodes():
     scene = assemble(
-        _ESTATE, pr_number=7, generated_at="2020-01-01T00:00:00+00:00", generator="vizsuite/0.1.0"
+        _ESTATE,
+        pr_number=7,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="vizsuite/0.1.0",
+        base_oid="base000",
+        head_oid="head111",
     )
 
     assert scene.pr_number == 7
@@ -28,7 +33,14 @@ def test_assemble_maps_estate_to_sorted_file_nodes():
 
 
 def test_render_is_deterministic_for_a_fixed_scene():
-    scene = assemble(_ESTATE, pr_number=1, generated_at="2020-01-01T00:00:00+00:00", generator="g")
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
 
     assert render_html(scene) == render_html(scene)
 
@@ -36,8 +48,26 @@ def test_render_is_deterministic_for_a_fixed_scene():
 def test_same_scene_same_html_modulo_stamp():
     stamp_a = "2020-01-01T00:00:00+00:00"
     stamp_b = "2099-12-31T23:59:59+00:00"
-    html_a = render_html(assemble(_ESTATE, pr_number=1, generated_at=stamp_a, generator="g"))
-    html_b = render_html(assemble(_ESTATE, pr_number=1, generated_at=stamp_b, generator="g"))
+    html_a = render_html(
+        assemble(
+            _ESTATE,
+            pr_number=1,
+            generated_at=stamp_a,
+            generator="g",
+            base_oid="base000",
+            head_oid="head111",
+        )
+    )
+    html_b = render_html(
+        assemble(
+            _ESTATE,
+            pr_number=1,
+            generated_at=stamp_b,
+            generator="g",
+            base_oid="base000",
+            head_oid="head111",
+        )
+    )
 
     # The stamp genuinely varies between runs...
     assert html_a != html_b

--- a/packages/vizsuite/tests/unit/test_extract_pr_metadata.py
+++ b/packages/vizsuite/tests/unit/test_extract_pr_metadata.py
@@ -1,0 +1,22 @@
+"""PR metadata extractor — author/review-state/timestamps (spec §4.4, slice 5).
+
+Mirrors the adapter/parse split used everywhere else: the extractor calls the
+`GhRunner` seam and parses the raw result through the real `parse_pr_meta`, so
+the test exercises the actual parse path, not a hand-built `PrMeta`.
+"""
+
+from __future__ import annotations
+
+from tests.fakes import ScriptedGhRunner, gh_pr_meta_result
+
+
+def test_pr_metadata_fetches_and_parses_via_the_gh_seam():
+    from vizsuite.extract.pr_metadata import pr_metadata
+
+    gh = ScriptedGhRunner(meta_result=gh_pr_meta_result(author="octocat", review_state="APPROVED"))
+
+    meta = pr_metadata(gh, 7)
+
+    assert meta.author == "octocat"
+    assert meta.review_state == "APPROVED"
+    assert ("pr_meta", 7) in gh.calls

--- a/packages/vizsuite/tests/unit/test_reconcile_pr_scope.py
+++ b/packages/vizsuite/tests/unit/test_reconcile_pr_scope.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.fakes import ScriptedGhRunner, ScriptedGitRunner, gh_pr_result
+from tests.fakes import ScriptedGhRunner, ScriptedGitRunner, gh_pr_meta_result, gh_pr_result
 from vizsuite.adapters.git.runner import ModifiedFileRow
 from vizsuite.envelope import ErrorCode, VizError
 from vizsuite.extract.churn import FileChurn
@@ -73,6 +73,22 @@ def test_happy_path_returns_scope_with_net_churn():
     }
     # churn walked the local (authoritative) commit set
     assert ("churn_for_commits", "c1") in git.calls
+
+
+def test_scope_carries_pr_metadata_author_review_state_and_timestamps():
+    from vizsuite.reconcile.pr_scope import reconcile
+
+    gh = ScriptedGhRunner(
+        result=gh_pr_result(changed_files=1, commit_count=1),
+        meta_result=gh_pr_meta_result(author="octocat", review_state="APPROVED"),
+    )
+    git = ScriptedGitRunner(present_oids=set(_PRESENT), diff_files=["a.py"], rev_list_oids=["c1"])
+
+    scope = reconcile(7, gh=gh, git=git)
+
+    assert scope.meta.author == "octocat"
+    assert scope.meta.review_state == "APPROVED"
+    assert ("pr_meta", 7) in gh.calls
 
 
 def test_reverted_only_file_excluded_from_scope():

--- a/packages/vizsuite/tests/unit/test_scene_assemble.py
+++ b/packages/vizsuite/tests/unit/test_scene_assemble.py
@@ -1,0 +1,102 @@
+"""Scene assembly: fingerprint manifest + full-envelope shape (plan slice 5).
+
+`assemble()` stamps a `Fingerprints` manifest whose `files` mirror the
+estate's own git-blob-SHA checksums (one pinned hash domain, §0.1 — not a
+second `git hash-object`/`hashlib` recomputation) plus the reconciled PR's
+`base_oid`/`head_oid`. The manifest — like every other field derived from the
+estate/OIDs — is a pure function of its inputs, so it is byte-identical across
+two assemblies of the same head. The envelope also carries `descriptors`,
+`recommendations`, and `events` — always empty for V1, but present in the
+serialized shape so a later slice (.2.2/.2.3) never breaks the contract.
+"""
+
+from __future__ import annotations
+
+from vizsuite.scene.assemble import assemble
+from vizsuite.scene.model import AttributeDescriptor, scene_to_json
+
+_ESTATE = {"src/a.py": "sha_a", "src/b.py": "sha_b"}
+
+
+def test_fingerprints_carry_oids_and_mirror_estate_blob_shas():
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+
+    assert scene.fingerprints.base_oid == "base000"
+    assert scene.fingerprints.head_oid == "head111"
+    # the per-file checksum IS the estate blob SHA — one pinned hash domain,
+    # not a second recomputation.
+    assert scene.fingerprints.files == _ESTATE
+
+
+def test_fingerprints_are_identical_across_two_assemblies_of_the_same_head():
+    scene_a = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+    scene_b = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2099-12-31T23:59:59+00:00",  # the stamp varies...
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+
+    # ...but the fingerprint manifest does not: it is a pure function of the
+    # estate and the reconciled OIDs, never the build clock.
+    assert scene_a.fingerprints == scene_b.fingerprints
+
+
+def test_scene_json_carries_the_full_envelope_shape():
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+
+    payload = scene_to_json(scene)
+
+    fingerprints = payload["fingerprints"]
+    assert isinstance(fingerprints, dict)
+    assert fingerprints["base_oid"] == "base000"
+    assert fingerprints["head_oid"] == "head111"
+    assert fingerprints["files"] == _ESTATE
+    # recommendations/events are always empty for V1 (spec §4.4); descriptors
+    # has no populated attribute to describe until .2.2 wires heat axes in.
+    assert payload["descriptors"] == []
+    assert payload["recommendations"] == []
+    assert payload["events"] == []
+    assert payload["facts"] == []
+
+
+def test_populated_descriptor_serializes_with_its_name_unit_and_direction():
+    descriptor = AttributeDescriptor(name="complexity", unit="0-1", direction="higher_is_hotter")
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        descriptors=[descriptor],
+    )
+
+    payload = scene_to_json(scene)
+
+    assert payload["descriptors"] == [
+        {"name": "complexity", "unit": "0-1", "direction": "higher_is_hotter"}
+    ]

--- a/packages/vizsuite/tests/unit/test_schema_gate.py
+++ b/packages/vizsuite/tests/unit/test_schema_gate.py
@@ -1,0 +1,74 @@
+"""Schema gate: `scene.assemble.assemble` rejects a Tier-2/3 fact lacking
+provenance or citations, loud and typed — never a silent default (spec test
+item 8, plan slice 5). An accepted fact that later becomes doubted must carry
+both independent axes (verdict + freshness) through assembly unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.scene.assemble import assemble
+from vizsuite.scene.model import Fact, Freshness, Provenance, ProvenanceKind
+
+_ESTATE = {"src/a.py": "sha_a"}
+
+
+def _assemble(facts: Sequence[Fact] = ()):
+    return assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="vizsuite/0.1.0",
+        base_oid="base000",
+        head_oid="head111",
+        facts=facts,
+    )
+
+
+def test_fact_missing_provenance_is_rejected():
+    fact = Fact(id="f1", note="a drill story")  # provenance=None: unvalidated
+
+    with pytest.raises(VizError) as exc_info:
+        _assemble(facts=[fact])
+
+    assert exc_info.value.code == ErrorCode.SCHEMA_INVALID
+    assert exc_info.value.detail["fact_id"] == "f1"
+
+
+def test_fact_with_provenance_but_no_citations_is_rejected():
+    fact = Fact(
+        id="f2",
+        note="an inferred edge",
+        provenance=Provenance(kind=ProvenanceKind.INFERRED, citations=()),
+    )
+
+    with pytest.raises(VizError) as exc_info:
+        _assemble(facts=[fact])
+
+    assert exc_info.value.code == ErrorCode.SCHEMA_INVALID
+    assert exc_info.value.detail["fact_id"] == "f2"
+
+
+def test_accepted_then_doubted_fact_carries_both_axes_through_assembly():
+    fact = Fact(
+        id="f3",
+        note="an accepted edge later doubted by a diff",
+        provenance=Provenance(
+            kind=ProvenanceKind.ACCEPTED,
+            freshness=Freshness.DOUBTED,
+            citations=("agents-config-yf2ov.2",),
+        ),
+    )
+
+    scene = _assemble(facts=[fact])
+
+    assert len(scene.facts) == 1
+    carried = scene.facts[0].provenance
+    assert carried is not None
+    # both axes are independent and both survive assembly unchanged.
+    assert carried.kind == ProvenanceKind.ACCEPTED
+    assert carried.freshness == Freshness.DOUBTED

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -1,26 +1,45 @@
 """HTML embedding boundary: the script-safe serializer and the inlined scene.
 
-Spec test item 7 (embedding half): a scene field containing ``</script>`` must
-survive inline embedding without terminating the `<script>` element.
+Spec test item 7 (complete): a scene field containing ``</script>`` must
+survive inline embedding without terminating the `<script>` element, and
+hostile strings in paths, Tier-2 fact notes ("stories"), and other
+repo/agent-derived content render inert — never interpolated into HTML, only
+ever escaped JSON text.
 """
 
 from __future__ import annotations
 
 import json
 
-from vizsuite.scene.model import FileNode, Scene
+from vizsuite.scene.model import Fact, FileNode, Fingerprints, Provenance, ProvenanceKind, Scene
 from vizsuite.templates.html import _fill_template, render_html, scene_to_script_json
 
 _SCENE_OPEN = '<script id="viz-scene" type="application/json">'
 
+_HOSTILE_STRINGS = (
+    "</textarea><script>alert(1)</script>",
+    "<script>alert(1)</script>",
+    '"><img src=x onerror=alert(1)>',
+)
 
-def _scene(*files: FileNode) -> Scene:
+
+def _scene(*files: FileNode, facts: tuple[Fact, ...] = ()) -> Scene:
     return Scene(
         schema_version="1",
         generated_at="2020-01-01T00:00:00+00:00",
         generator="vizsuite/0.1.0",
         pr_number=1,
         files=tuple(files),
+        fingerprints=Fingerprints(base_oid="base000", head_oid="head111"),
+        facts=facts,
+    )
+
+
+def _encoded_fact(fact_id: str, note: str) -> Fact:
+    return Fact(
+        id=fact_id,
+        note=note,
+        provenance=Provenance(kind=ProvenanceKind.ENCODED, citations=("evidence",)),
     )
 
 
@@ -90,3 +109,24 @@ def test_render_inlines_vendored_d3_and_scene_css_and_estate_paths():
     # (`innerHTML` appears inside vendored d3 itself; the invariant is about our
     # own code, so we assert the binding call, not a global substring absence.)
     assert ".text(function (d) { return d.path; })" in html
+
+
+def test_hostile_strings_in_paths_and_fact_notes_render_inert():
+    # Item 7 (complete): hostile strings in *paths* (a repeat of the slice-1
+    # embedding case, now exercised alongside the new channel) and in a
+    # Tier-2 fact's *note* (the "story"/annotation narrative payload) must
+    # both render inert — never interpolated as HTML, only ever escaped JSON
+    # text that round-trips losslessly through `JSON.parse`.
+    for hostile in _HOSTILE_STRINGS:
+        html = render_html(
+            _scene(
+                FileNode(path=f"src/{hostile}.py", checksum="deadbeef"),
+                facts=(_encoded_fact("f1", hostile),),
+            )
+        )
+
+        assert hostile not in html
+        block = _inlined_scene_block(html)
+        scene_data = json.loads(block)
+        assert scene_data["files"][0]["path"] == f"src/{hostile}.py"
+        assert scene_data["facts"][0]["note"] == hostile

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -62,6 +62,9 @@ def test_pr_reconciles_and_emits_html_from_head_estate(
     assert data["nodes"] == 2  # the estate (whole tree at head), not just the net set
     assert data["scored_files"] == 2  # complexity scored both estate files scc recognized
     assert data["consequential_files"] == 1  # src/app.py matched the .critical-paths marker
+    # slice 5: PR metadata garnish (author/review-state) is wired into the envelope.
+    assert data["author"] == "octocat"
+    assert data["review_state"] == "APPROVED"
 
     # The estate is resolved at the reconciled head OID — never the checkout's HEAD.
     assert ("ls_tree", "head111") in git.calls


### PR DESCRIPTION
## Summary

- Promotes the minimal scene envelope to the full spec contract (design spec §4.4): `schema_version`, `generated_at`, `generator`, `fingerprints` (base/head OIDs, tool versions, per-file `checksum`), `descriptors`, per-fact provenance (source kind + freshness axes), `recommendations[]` (empty for V1), reserved `events[]` (V3).
- **Schema gate** in `scene/assemble.py`: any Tier-2/3 fact lacking provenance is rejected with a loud typed error (`VizError`, new `ErrorCode.SCHEMA_INVALID`) — no silent defaults. An accepted-then-doubted fact carries both provenance axes through assembly.
- **Fingerprint checksums reuse the estate `blob_sha`** (plan §0.1: one pinned hash domain — deliberately no `git hash-object`/`hashlib` recomputation), deterministic across assemblies of the same head.
- New `extract/pr_metadata.py`: PR author/review-state/timestamps via a widened `gh pr view --json` call through the injected gh-runner seam; `PrScope` gains `meta`, wired through `viz pr` into the envelope.
- Hostile-fixture escaping tests (spec §9 / test item 7 complete): `</textarea>`, `<script>`, `"><img onerror=…` in paths and fact notes render inert; slice-1 `</script>` embedding case retained.

Slice 5/5 of the vizsuite data build (plan: `docs/plans/visualization-suite/2026-07-13-implementation-plan.md` §3 slice 5; spec: `docs/specs/2026-07-12-visualization-suite-design.md` §4.4, §9).

## Scope

- **In scope:** scene model + assembly hardening, schema gate, `pr_metadata` extractor, `PrScope.meta` wiring, hostile-fixture tests.
- **Deliberate no-op:** `templates/html.py` is unchanged — the plan listed it, but the §9 footer notice and the script-safe serializer's DOM-bind invariant already shipped in slice 1; the serializer generalizes to the new `facts`/`fingerprints` fields with zero code changes (proven by the hostile-fixture test routing fact notes through the same path). No view renders facts into the DOM yet (that's the views epic).
- **Deferred:** `Fingerprints.tool_versions` ships as an always-empty dict (no consumer yet; wiring real scc/gh/git version probes would be untested scope growth). `Scene.descriptors` structurally present, unpopulated until the views slice needs one.
- **Plan deviation, called out:** slice 1's plan text "pinned" the `ErrorCode` enum, but none of the six members fit "fact missing provenance" — `SCHEMA_INVALID` was added rather than force-fitting `ADAPTER_FAILURE` (subprocess-specific) or `RECONCILER_DRIFT` (OID/count-specific).

## Review-gate disposition

HEAVY adversarial gate exited **ACCEPTANCE (clean-at-floor)** after 1 round: no findings at or above the major floor. One sub-floor minor flagged, not applied (semantic change needing judgment): `reconcile()` now makes two sequential gh calls (`pr_graphql` then `pr_metadata`) instead of one widened GraphQL query — tracked in the adapter-hardening follow-up work item.

## Test Plan

- [x] TDD red→green per plan steps: schema gate (item 8), hostile strings (item 7 complete), fingerprint checksum determinism, `pr_metadata`/`PrScope.meta` wiring
- [x] 104 package tests passing (4 new test files + 5 extended)
- [x] `make ci-vizsuite` fully green: ruff, format-check, mypy --strict, 100.00% line+branch coverage (floor 90%), pip-audit clean, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
