### PR TITLE
feat(vizsuite): V1 heat model — cross-axis weighted average + scene view-readiness (S1)

### DIFF
--- a/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/parse.py
@@ -34,6 +34,7 @@ class PrMeta:
     created_at: str
     updated_at: str
     merged_at: str | None
+    repo_nwo: str  # `repository.nameWithOwner` (spec §6.2/G3), same round trip
 
 
 @dataclass(frozen=True)
@@ -84,13 +85,15 @@ def parse_pr_view(result: GhResult, *, pr_number: int) -> PrView:
     except json.JSONDecodeError as exc:
         raise _shape_error(pr_number, result.stdout, source=source, reason="invalid_json") from exc
     try:
-        pull_request = payload["data"]["repository"]["pullRequest"]
+        repository = payload["data"]["repository"]
+        pull_request = repository["pullRequest"]
         meta = PrMeta(
             author=pull_request["author"]["login"],
             review_state=pull_request.get("reviewDecision") or "NONE",
             created_at=pull_request["createdAt"],
             updated_at=pull_request["updatedAt"],
             merged_at=pull_request.get("mergedAt"),
+            repo_nwo=repository["nameWithOwner"],
         )
         return PrView(
             base_oid=pull_request["baseRefOid"],

--- a/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
+++ b/packages/vizsuite/src/vizsuite/adapters/gh/runner.py
@@ -29,6 +29,7 @@ from vizsuite.adapters.subprocess_util import run
 _PR_QUERY = (
     "query($owner:String!,$repo:String!,$number:Int!){"
     "repository(owner:$owner,name:$repo){"
+    "nameWithOwner "
     "pullRequest(number:$number){"
     "baseRefOid headRefOid baseRefName changedFiles commits{totalCount}"
     "author{login} reviewDecision createdAt updatedAt mergedAt"

--- a/packages/vizsuite/src/vizsuite/scene/assemble.py
+++ b/packages/vizsuite/src/vizsuite/scene/assemble.py
@@ -1,12 +1,12 @@
 """Scene assembler: estate nodes + fingerprints + Tier-2/3 facts → `Scene`.
 
-Slice 3 merged the complexity/consequence heat axes at the `viz pr` verb level
-(threading them into scene node attributes is `.2.2`); slice 5 hardens the
-envelope itself: every assembly stamps a `Fingerprints` manifest (the PR's
-`base_oid`/`head_oid` plus the estate's own blob-SHA checksums — one pinned
-hash domain, §0.1) and runs the **schema gate**: any attached Tier-2/3 `Fact`
-missing provenance or citations is refused with a loud typed error before a
-`Scene` is ever constructed — no silent default, no dropped fact. The
+Slice 5 hardens the envelope: every assembly stamps a `Fingerprints` manifest
+(the PR's `base_oid`/`head_oid` plus the estate's own blob-SHA checksums — one
+pinned hash domain, §0.1) and runs the **schema gate**: any attached Tier-2/3
+`Fact` missing provenance or citations is refused with a loud typed error
+before a `Scene` is ever constructed — no silent default, no dropped fact.
+`.2.2` threads the cross-axis heat fusion (`scene.heat.combine`) into each
+file's `attributes`, plus `render_config`/`repo_nwo` into the envelope. The
 assembler stays a pure function of its inputs — the clock is injected as
 `generated_at` rather than read from a module global, so assembly is
 deterministic and testable.
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
 from vizsuite.scene.model import (
     AttributeDescriptor,
     Fact,
     FileNode,
     Fingerprints,
+    RenderConfig,
     Scene,
 )
 
@@ -54,6 +55,9 @@ def assemble(
     tool_versions: dict[str, str] | None = None,
     facts: Sequence[Fact] = (),
     descriptors: Sequence[AttributeDescriptor] = (),
+    attributes: dict[str, dict[str, JsonValue]] | None = None,
+    render_config: RenderConfig | None = None,
+    repo_nwo: str = "",
 ) -> Scene:
     """Assemble the estate `{path: blob_sha}` plus fingerprints/facts into a `Scene`.
 
@@ -63,12 +67,16 @@ def assemble(
     and carry an identical `fingerprints.files` manifest (spec test item: the
     per-file checksum is the estate blob SHA, deterministic across assemblies).
     Raises `VizError(SCHEMA_INVALID)` before constructing anything if any `fact`
-    fails the schema gate.
+    fails the schema gate. `attributes` (keyed by path, as produced by
+    `scene.heat.combine`) attaches each file's heat-axis values to its matching
+    `FileNode`; a path with no entry keeps the pre-.2.2 empty attribute map.
     """
     _validate_facts(facts)
 
+    file_attributes = attributes or {}
     files = tuple(
-        FileNode(path=path, checksum=blob_sha) for path, blob_sha in sorted(estate_map.items())
+        FileNode(path=path, checksum=blob_sha, attributes=dict(file_attributes.get(path, {})))
+        for path, blob_sha in sorted(estate_map.items())
     )
     fingerprints = Fingerprints(
         base_oid=base_oid,
@@ -85,4 +93,8 @@ def assemble(
         fingerprints=fingerprints,
         descriptors=tuple(descriptors),
         facts=tuple(facts),
+        render_config=render_config
+        if render_config is not None
+        else RenderConfig(default_weights={}),
+        repo_nwo=repo_nwo,
     )

--- a/packages/vizsuite/src/vizsuite/scene/heat.py
+++ b/packages/vizsuite/src/vizsuite/scene/heat.py
@@ -25,7 +25,8 @@ DEFAULT_WEIGHTS: Mapping[str, float] = {
     "consequence": 0.25,
 }
 
-_HEAT_AXES = ("complexity", "load_bearing", "consequence", "heat")
+_INPUT_AXES = ("complexity", "load_bearing", "consequence")
+_HEAT_AXES = (*_INPUT_AXES, "heat")
 _AXIS_UNIT = "0-1"
 _AXIS_DIRECTION = "higher_is_hotter"
 
@@ -60,9 +61,16 @@ def combine(
     """Fuse the three §6.2 axes into one per-file heat, weighted-average style.
 
     ``heat = Σ(wᵢ·vᵢ) / Σ(wᵢ)``. A file absent from a per-file score map
-    (complexity/consequence/load-bearing alike) contributes a real zero.
+    (complexity/consequence/load-bearing alike) contributes a real zero. An
+    axis omitted from ``weights`` simply drops out of the mix; an *unknown*
+    weight key is a caller error and raises ``ValueError`` (valid axes are
+    complexity/load_bearing/consequence).
     """
     effective_weights = dict(weights) if weights is not None else dict(DEFAULT_WEIGHTS)
+    unknown_axes = set(effective_weights) - set(_INPUT_AXES)
+    if unknown_axes:
+        msg = f"unknown weight axes {sorted(unknown_axes)}; valid axes are {list(_INPUT_AXES)}"
+        raise ValueError(msg)
     # Load-bearing drops out of the mix entirely — weight excluded, not just
     # zeroed — exactly when the axis itself is unavailable; the remaining two
     # axes renormalize over their own weight sum (spec §6.2: "weight controls

--- a/packages/vizsuite/src/vizsuite/scene/heat.py
+++ b/packages/vizsuite/src/vizsuite/scene/heat.py
@@ -1,0 +1,97 @@
+"""Cross-axis heat fusion — the §6.2 weighted average over complexity,
+load-bearing, and consequence (distinct from the per-axis extractors, which
+stay untouched here).
+
+`combine()` fuses the three finished axes into one per-file heat via a
+user-tunable weighted average (slider semantics per §4.5: share-of-importance,
+not a volume knob — a file weak on an axis cools as that axis gains weight).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+
+from vizsuite.envelope import JsonValue
+from vizsuite.extract.centrality import CentralityAxis
+from vizsuite.scene.model import AttributeDescriptor
+
+# Tunable cross-axis mix (spec §6.2). The tested invariants are share-of-
+# importance cooling and renormalization-on-unavailable — never these specific
+# numbers.
+DEFAULT_WEIGHTS: Mapping[str, float] = {
+    "complexity": 0.4,
+    "load_bearing": 0.35,
+    "consequence": 0.25,
+}
+
+_HEAT_AXES = ("complexity", "load_bearing", "consequence", "heat")
+_AXIS_UNIT = "0-1"
+_AXIS_DIRECTION = "higher_is_hotter"
+
+
+@dataclass(frozen=True)
+class HeatModel:
+    """The combined cross-axis fusion result for one estate (spec §6.2/§4.4).
+
+    `attributes` maps each estate path to its per-axis values, combined heat,
+    and PR membership (`in_pr`). `descriptors` self-describes the four
+    heat-bearing attributes only — `in_pr` is a membership flag, not a 0-1
+    heat axis. `default_weights` is the effective weight mix this `combine()`
+    call used (the UI's slider starting positions); `unavailable_axes` lists
+    axes to render disabled.
+    """
+
+    attributes: dict[str, dict[str, JsonValue]]
+    descriptors: tuple[AttributeDescriptor, ...]
+    default_weights: dict[str, float]
+    unavailable_axes: tuple[str, ...]
+
+
+def combine(
+    estate: Mapping[str, str],
+    complexity_scores: Mapping[str, float],
+    consequence_scores: Mapping[str, float],
+    centrality: CentralityAxis,
+    pr_files: Collection[str],
+    *,
+    weights: Mapping[str, float] | None = None,
+) -> HeatModel:
+    """Fuse the three §6.2 axes into one per-file heat, weighted-average style.
+
+    ``heat = Σ(wᵢ·vᵢ) / Σ(wᵢ)``. A file absent from a per-file score map
+    (complexity/consequence/load-bearing alike) contributes a real zero.
+    """
+    effective_weights = dict(weights) if weights is not None else dict(DEFAULT_WEIGHTS)
+    # Load-bearing drops out of the mix entirely — weight excluded, not just
+    # zeroed — exactly when the axis itself is unavailable; the remaining two
+    # axes renormalize over their own weight sum (spec §6.2: "weight controls
+    # exclude it; never report a stale graph as post-PR centrality").
+    unavailable_axes = () if centrality.is_available else ("load_bearing",)
+    active_weights = {
+        axis: weight for axis, weight in effective_weights.items() if axis not in unavailable_axes
+    }
+    weight_total = sum(active_weights.values())
+    centrality_scores = centrality.scores or {}
+
+    attributes: dict[str, dict[str, JsonValue]] = {}
+    for path in estate:
+        values = {
+            "complexity": complexity_scores.get(path, 0.0),
+            "load_bearing": centrality_scores.get(path, 0.0),
+            "consequence": consequence_scores.get(path, 0.0),
+        }
+        weighted_sum = sum(active_weights[axis] * values[axis] for axis in active_weights)
+        heat_value = weighted_sum / weight_total if weight_total > 0 else 0.0
+        attributes[path] = {**values, "heat": heat_value, "in_pr": path in pr_files}
+
+    descriptors = tuple(
+        AttributeDescriptor(name=name, unit=_AXIS_UNIT, direction=_AXIS_DIRECTION)
+        for name in _HEAT_AXES
+    )
+    return HeatModel(
+        attributes=attributes,
+        descriptors=descriptors,
+        default_weights=effective_weights,
+        unavailable_axes=unavailable_axes,
+    )

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -25,7 +25,7 @@ from vizsuite.envelope import JsonValue
 class FileNode:
     path: str
     checksum: str  # git blob SHA at the snapshot (spec §0.1 / §3.5.1)
-    attributes: dict[str, JsonValue] = field(default_factory=dict)  # heat axes land in .2.2/§6.2
+    attributes: dict[str, JsonValue] = field(default_factory=dict)  # heat axes (§6.2), via .2.2
 
 
 class ProvenanceKind(StrEnum):
@@ -107,6 +107,20 @@ class Fingerprints:
 
 
 @dataclass(frozen=True)
+class RenderConfig:
+    """Slider/legend render hints for the cross-axis heat mix (spec §4.5/§6.2).
+
+    `default_weights` seeds each weight slider's starting position;
+    `unavailable_axes` disables the slider(s) whose axis could not be computed
+    (e.g. a stale/absent graphify build) — never silently reporting a stale
+    value as current (spec §6.2).
+    """
+
+    default_weights: dict[str, float]
+    unavailable_axes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class Scene:
     schema_version: str
     generated_at: str  # the one non-deterministic field; isolated for the determinism gate
@@ -114,10 +128,12 @@ class Scene:
     pr_number: int
     files: tuple[FileNode, ...]
     fingerprints: Fingerprints
-    descriptors: tuple[AttributeDescriptor, ...] = ()  # no scene attribute needs one until .2.2
-    facts: tuple[Fact, ...] = ()  # Tier-2/3 facts; empty until .2.2/.2.3 have a producer
+    descriptors: tuple[AttributeDescriptor, ...] = ()  # heat axes' metadata, via .2.2 (§4.4)
+    facts: tuple[Fact, ...] = ()  # Tier-2/3 facts; empty until .2.3 has a producer
     recommendations: tuple[JsonValue, ...] = ()  # always empty for V1 (spec §4.4)
     events: tuple[JsonValue, ...] = ()  # reserved for V3 (spec §4.4/§8); always empty here
+    render_config: RenderConfig = field(default_factory=lambda: RenderConfig(default_weights={}))
+    repo_nwo: str = ""  # spec §6.2/G3; populated once the PR verb threads it through
 
 
 def _provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
@@ -149,6 +165,13 @@ def _fingerprints_to_json(fingerprints: Fingerprints) -> dict[str, JsonValue]:
     }
 
 
+def _render_config_to_json(render_config: RenderConfig) -> dict[str, JsonValue]:
+    return {
+        "default_weights": dict(render_config.default_weights),
+        "unavailable_axes": list(render_config.unavailable_axes),
+    }
+
+
 def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
     """Serialize a `Scene` to a plain JSON-shaped mapping, files/facts sorted by key.
 
@@ -177,4 +200,6 @@ def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
         "facts": facts_json,
         "recommendations": list(scene.recommendations),
         "events": list(scene.events),
+        "render_config": _render_config_to_json(scene.render_config),
+        "repo_nwo": scene.repo_nwo,
     }

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -4,10 +4,14 @@ Reconcile the PR to its immutable head OID (fetch → resolve OIDs → scalar
 reconcile against GitHub), build the estate at that head OID — never the
 operator's ``HEAD`` checkout — then materialize the head snapshot from
 `git archive` so scc scores per-file complexity against the committed tree (a
-dirty working copy can never leak in). The heat-free scene is assembled into one
-self-contained HTML file at `.viz/out/pr-<n>.html`. Threading the per-file heat
-values into scene node attributes + the cross-axis fusion is `.2.2` (§6.2); this
-verb delivers the extraction layer and proves the snapshot→scc plumbing.
+dirty working copy can never leak in). The load-bearing axis reads
+`graphify-out/graph.json` from the **live working tree** (it is gitignored,
+so it is never in the materialized snapshot), head-guarded by
+`centrality_axis` itself; an absent/stale graph fails soft to an unavailable
+axis, never a crash and never stale-as-fresh (§6.2). The three axes fuse into
+one per-file heat (`scene.heat.combine`), thread into scene node attributes,
+and the scene assembles into one self-contained HTML file at
+`.viz/out/pr-<n>.html`.
 """
 
 from __future__ import annotations
@@ -16,11 +20,13 @@ import shutil
 from argparse import Namespace
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from vizsuite import __version__
 from vizsuite.adapters.critical_paths import read_critical_paths
 from vizsuite.adapters.scc.parse import parse_scc
 from vizsuite.envelope import JsonValue
+from vizsuite.extract.centrality import centrality_axis
 from vizsuite.extract.complexity import complexity
 from vizsuite.extract.consequence import consequence
 from vizsuite.extract.estate import estate
@@ -28,7 +34,9 @@ from vizsuite.output import ensure_viz_dir
 from vizsuite.reconcile.pr_scope import reconcile
 from vizsuite.reconcile.snapshot import materialize
 from vizsuite.runners import Runners
+from vizsuite.scene import heat
 from vizsuite.scene.assemble import assemble
+from vizsuite.scene.model import RenderConfig
 from vizsuite.templates.html import render_html
 
 
@@ -36,8 +44,8 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
     """Handle `viz pr <n>`: reconcile → head-OID estate → snapshot → scc → scene → HTML.
 
     Returns the envelope `data`: the written artifact path, the PR number, the
-    estate node count, the reconciled net-file count, and the number of files the
-    complexity axis scored.
+    estate node count, the reconciled net-file count, the number of files the
+    complexity axis scored, and the heat axes that were available to combine.
     """
     pr_number: int = args.number
     scope = reconcile(pr_number, gh=runners.gh, git=runners.git)
@@ -46,9 +54,7 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
     # scc scans a *materialized* snapshot of the head tree, never the live
     # checkout, so a dirty working copy can't leak into the artifact; the snapshot
     # also carries `.critical-paths` for the consequence axis. Both heat axes are
-    # scored before the tempdir is torn down. The per-file heat values thread into
-    # scene node attributes in `.2.2` (§6.2); scoring them here proves the
-    # snapshot→scc→complexity and snapshot→consequence chains end-to-end on real data.
+    # scored before the tempdir is torn down.
     snapshot = materialize(runners.git, scope.head_oid, set(estate_map))
     try:
         scc_records = parse_scc(runners.scc.scan(snapshot))
@@ -58,6 +64,15 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
     finally:
         shutil.rmtree(snapshot, ignore_errors=True)
 
+    # The load-bearing axis reads the LIVE working tree's `graphify-out/graph.json`
+    # (gitignored — never in the materialized snapshot); `centrality_axis` itself
+    # guards staleness against `scope.head_oid` and fails soft to unavailable.
+    graph_path = Path.cwd() / "graphify-out" / "graph.json"
+    centrality = centrality_axis(graph_path, scope.head_oid)
+    heat_model = heat.combine(
+        estate_map, complexity_scores, consequence_scores, centrality, set(scope.files)
+    )
+
     scene = assemble(
         estate_map,
         pr_number=pr_number,
@@ -65,6 +80,13 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         generator=f"vizsuite/{__version__}",
         base_oid=scope.base_oid,
         head_oid=scope.head_oid,
+        attributes=heat_model.attributes,
+        descriptors=heat_model.descriptors,
+        render_config=RenderConfig(
+            default_weights=heat_model.default_weights,
+            unavailable_axes=heat_model.unavailable_axes,
+        ),
+        repo_nwo=scope.meta.repo_nwo,
     )
     html = render_html(scene)
 
@@ -81,5 +103,13 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         "consequential_files": sum(1 for value in consequence_scores.values() if value > 0),
         "author": scope.meta.author,
         "review_state": scope.meta.review_state,
+        "heat_axes_available": cast(
+            "list[JsonValue]",
+            sorted(
+                axis
+                for axis in heat_model.default_weights
+                if axis not in heat_model.unavailable_axes
+            ),
+        ),
     }
     return data

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -53,8 +53,9 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
 
     # scc scans a *materialized* snapshot of the head tree, never the live
     # checkout, so a dirty working copy can't leak into the artifact; the snapshot
-    # also carries `.critical-paths` for the consequence axis. Both heat axes are
-    # scored before the tempdir is torn down.
+    # also carries `.critical-paths` for the consequence axis. Both snapshot-scored
+    # axes (complexity, consequence) are scored before the tempdir is torn down; the
+    # load-bearing axis is computed later from the live working tree (see below).
     snapshot = materialize(runners.git, scope.head_oid, set(estate_map))
     try:
         scc_records = parse_scc(runners.scc.scan(snapshot))

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -104,12 +104,15 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         "consequential_files": sum(1 for value in consequence_scores.values() if value > 0),
         "author": scope.meta.author,
         "review_state": scope.meta.review_state,
+        # Availability is a data property of the axes, not a property of the
+        # caller's weight mix: derive from the canonical input axes
+        # (`heat.DEFAULT_WEIGHTS` keys) minus the axes the model reports
+        # unavailable. Deriving from `heat_model.default_weights` would wrongly
+        # drop an available axis a caller merely omitted from `weights`.
         "heat_axes_available": cast(
             "list[JsonValue]",
             sorted(
-                axis
-                for axis in heat_model.default_weights
-                if axis not in heat_model.unavailable_axes
+                axis for axis in heat.DEFAULT_WEIGHTS if axis not in heat_model.unavailable_axes
             ),
         ),
     }

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -111,6 +111,7 @@ def gh_pr_result(
     created_at: str = "2026-07-01T00:00:00Z",
     updated_at: str = "2026-07-02T00:00:00Z",
     merged_at: str | None = None,
+    repo_nwo: str = "octocat/hello-world",
 ) -> GhResult:
     """Build a successful `gh api graphql` `GhResult` for a PR (the common fixture).
 
@@ -120,6 +121,7 @@ def gh_pr_result(
     payload = {
         "data": {
             "repository": {
+                "nameWithOwner": repo_nwo,
                 "pullRequest": {
                     "baseRefOid": base_oid,
                     "headRefOid": head_oid,
@@ -131,7 +133,7 @@ def gh_pr_result(
                     "createdAt": created_at,
                     "updatedAt": updated_at,
                     "mergedAt": merged_at,
-                }
+                },
             }
         }
     }

--- a/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
+++ b/packages/vizsuite/tests/unit/test_adapters_gh_parse.py
@@ -33,11 +33,13 @@ def _graphql_stdout(
     created_at: str = "2026-07-01T00:00:00Z",
     updated_at: str = "2026-07-02T00:00:00Z",
     merged_at: str | None = None,
+    name_with_owner: str = "octocat/hello-world",
 ) -> str:
     return json.dumps(
         {
             "data": {
                 "repository": {
+                    "nameWithOwner": name_with_owner,
                     "pullRequest": {
                         "baseRefOid": base_oid,
                         "headRefOid": head_oid,
@@ -49,7 +51,7 @@ def _graphql_stdout(
                         "createdAt": created_at,
                         "updatedAt": updated_at,
                         "mergedAt": merged_at,
-                    }
+                    },
                 }
             }
         }
@@ -73,6 +75,7 @@ def test_parses_oids_ref_scalar_counts_and_meta_in_one_round_trip():
     assert pr.meta.created_at == "2026-07-01T00:00:00Z"
     assert pr.meta.updated_at == "2026-07-02T00:00:00Z"
     assert pr.meta.merged_at is None
+    assert pr.meta.repo_nwo == "octocat/hello-world"
 
 
 def test_null_review_decision_normalizes_to_none_sentinel():
@@ -139,6 +142,31 @@ def test_missing_scalar_field_is_adapter_failure():
         "updatedAt": "y",
         "mergedAt": None,
     }
+    stdout = json.dumps({"data": {"repository": {"pullRequest": pull_request}}})
+    result = GhResult(returncode=0, stdout=stdout, stderr="")
+
+    with pytest.raises(VizError) as exc_info:
+        parse_pr_view(result, pr_number=7)
+
+    assert exc_info.value.code == ErrorCode.ADAPTER_FAILURE
+
+
+def test_missing_name_with_owner_is_adapter_failure():
+    from vizsuite.adapters.gh.parse import parse_pr_view
+
+    pull_request = {
+        "baseRefOid": "b",
+        "headRefOid": "h",
+        "baseRefName": "main",
+        "changedFiles": 1,
+        "commits": {"totalCount": 1},
+        "author": {"login": "octocat"},
+        "reviewDecision": "APPROVED",
+        "createdAt": "x",
+        "updatedAt": "y",
+        "mergedAt": None,
+    }
+    # nameWithOwner omitted from repository — a drifted gh shape must alarm.
     stdout = json.dumps({"data": {"repository": {"pullRequest": pull_request}}})
     result = GhResult(returncode=0, stdout=stdout, stderr="")
 

--- a/packages/vizsuite/tests/unit/test_assembly_determinism.py
+++ b/packages/vizsuite/tests/unit/test_assembly_determinism.py
@@ -7,7 +7,10 @@ the whole pipeline is a pure function of estate + stamp.
 
 from __future__ import annotations
 
+from vizsuite.extract.centrality import CentralityAxis
+from vizsuite.scene import heat
 from vizsuite.scene.assemble import assemble
+from vizsuite.scene.model import RenderConfig
 from vizsuite.templates.html import render_html
 
 # Deliberately out of sorted order to prove assemble sorts.
@@ -72,4 +75,42 @@ def test_same_scene_same_html_modulo_stamp():
     # The stamp genuinely varies between runs...
     assert html_a != html_b
     # ...and it is the ONLY thing that varies: replacing it makes them identical.
+    assert html_a.replace(stamp_a, "<STAMP>") == html_b.replace(stamp_b, "<STAMP>")
+
+
+def test_heat_populated_scene_is_still_deterministic_modulo_stamp():
+    # .2.2: attributes/render_config/repo_nwo are new inputs to assemble() — the
+    # determinism guarantee must hold with them populated, not just the bare
+    # pre-.2.2 shape the tests above cover.
+    complexity_scores = {"src/a.py": 0.2, "src/b.py": 0.8, "README.md": 0.0}
+    consequence_scores = {"src/a.py": 0.0, "src/b.py": 1.0, "README.md": 0.0}
+    centrality = CentralityAxis.unavailable("graphify-out absent")
+    heat_model = heat.combine(
+        _ESTATE, complexity_scores, consequence_scores, centrality, pr_files={"src/a.py"}
+    )
+    render_config = RenderConfig(
+        default_weights=heat_model.default_weights, unavailable_axes=heat_model.unavailable_axes
+    )
+
+    def _build(stamp: str) -> str:
+        scene = assemble(
+            _ESTATE,
+            pr_number=1,
+            generated_at=stamp,
+            generator="g",
+            base_oid="base000",
+            head_oid="head111",
+            attributes=heat_model.attributes,
+            descriptors=heat_model.descriptors,
+            render_config=render_config,
+            repo_nwo="octocat/hello-world",
+        )
+        return render_html(scene)
+
+    stamp_a = "2020-01-01T00:00:00+00:00"
+    stamp_b = "2099-12-31T23:59:59+00:00"
+    html_a = _build(stamp_a)
+    html_b = _build(stamp_b)
+
+    assert html_a != html_b
     assert html_a.replace(stamp_a, "<STAMP>") == html_b.replace(stamp_b, "<STAMP>")

--- a/packages/vizsuite/tests/unit/test_scene_assemble.py
+++ b/packages/vizsuite/tests/unit/test_scene_assemble.py
@@ -13,7 +13,7 @@ serialized shape so a later slice (.2.2/.2.3) never breaks the contract.
 from __future__ import annotations
 
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import AttributeDescriptor, scene_to_json
+from vizsuite.scene.model import AttributeDescriptor, RenderConfig, scene_to_json
 
 _ESTATE = {"src/a.py": "sha_a", "src/b.py": "sha_b"}
 
@@ -100,3 +100,76 @@ def test_populated_descriptor_serializes_with_its_name_unit_and_direction():
     assert payload["descriptors"] == [
         {"name": "complexity", "unit": "0-1", "direction": "higher_is_hotter"}
     ]
+
+
+def test_attributes_thread_into_matching_file_nodes_by_path():
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        attributes={
+            "src/a.py": {
+                "complexity": 0.2,
+                "load_bearing": 0.5,
+                "consequence": 0.0,
+                "heat": 0.3,
+                "in_pr": True,
+            }
+        },
+    )
+
+    by_path = {node.path: node.attributes for node in scene.files}
+    assert by_path["src/a.py"] == {
+        "complexity": 0.2,
+        "load_bearing": 0.5,
+        "consequence": 0.0,
+        "heat": 0.3,
+        "in_pr": True,
+    }
+    # a file with no entry in the attribute map keeps the pre-.2.2 empty shape.
+    assert by_path["src/b.py"] == {}
+
+
+def test_render_config_and_repo_nwo_thread_into_the_serialized_envelope():
+    render_config = RenderConfig(
+        default_weights={"complexity": 0.4, "load_bearing": 0.35, "consequence": 0.25},
+        unavailable_axes=("load_bearing",),
+    )
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        render_config=render_config,
+        repo_nwo="octocat/hello-world",
+    )
+
+    assert scene.render_config == render_config
+    assert scene.repo_nwo == "octocat/hello-world"
+
+    payload = scene_to_json(scene)
+    assert payload["render_config"] == {
+        "default_weights": {"complexity": 0.4, "load_bearing": 0.35, "consequence": 0.25},
+        "unavailable_axes": ["load_bearing"],
+    }
+    assert payload["repo_nwo"] == "octocat/hello-world"
+
+
+def test_render_config_and_repo_nwo_default_when_omitted():
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+
+    payload = scene_to_json(scene)
+    assert payload["render_config"] == {"default_weights": {}, "unavailable_axes": []}
+    assert payload["repo_nwo"] == ""

--- a/packages/vizsuite/tests/unit/test_scene_heat.py
+++ b/packages/vizsuite/tests/unit/test_scene_heat.py
@@ -131,6 +131,20 @@ def test_descriptors_name_all_four_heat_axes_not_in_pr() -> None:
     assert names == {"complexity", "load_bearing", "consequence", "heat"}
 
 
+def test_combine_rejects_unknown_weight_axis() -> None:
+    # An unknown weight key can't index into the per-file value map — validate
+    # loudly at the boundary rather than raising a bare KeyError mid-fusion.
+    with pytest.raises(ValueError, match="bogus"):
+        combine(
+            {"a.py": "sha_a"},
+            {"a.py": 0.5},
+            {"a.py": 0.5},
+            _available_centrality(),
+            pr_files=set(),
+            weights={"bogus": 1.0},
+        )
+
+
 def test_default_weights_reflects_the_effective_weights_used() -> None:
     estate = {"a.py": "sha_a"}
     custom_weights = {"complexity": 0.5, "load_bearing": 0.3, "consequence": 0.2}

--- a/packages/vizsuite/tests/unit/test_scene_heat.py
+++ b/packages/vizsuite/tests/unit/test_scene_heat.py
@@ -1,0 +1,147 @@
+"""Cross-axis heat fusion (spec §6.2/§4.5): the weighted average over
+complexity, load-bearing, and consequence, plus PR-membership and
+self-describing metadata.
+
+Tests pin the *invariants* the spec cares about — the weighted-average
+formula, share-of-importance cooling, renormalization when the load-bearing
+axis is unavailable, and the real-zero-vs-unavailable distinction — never the
+tunable `DEFAULT_WEIGHTS` values themselves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vizsuite.extract.centrality import CentralityAxis
+from vizsuite.scene.heat import DEFAULT_WEIGHTS, combine
+
+_ESTATE = {"a.py": "sha_a", "b.py": "sha_b", "c.py": "sha_c"}
+_COMPLEXITY = {"a.py": 0.2, "b.py": 0.8, "c.py": 0.5}
+_CONSEQUENCE = {"a.py": 0.0, "b.py": 1.0, "c.py": 0.5}
+
+
+def _available_centrality() -> CentralityAxis:
+    return CentralityAxis(scores={"a.py": 0.5, "b.py": 1.0, "c.py": 0.0})
+
+
+def test_combine_computes_the_weighted_average_at_default_weights() -> None:
+    model = combine(_ESTATE, _COMPLEXITY, _CONSEQUENCE, _available_centrality(), pr_files=set())
+
+    weight_total = sum(DEFAULT_WEIGHTS.values())
+    load_bearing = {"a.py": 0.5, "b.py": 1.0, "c.py": 0.0}
+    for path in _ESTATE:
+        expected = (
+            DEFAULT_WEIGHTS["complexity"] * _COMPLEXITY[path]
+            + DEFAULT_WEIGHTS["load_bearing"] * load_bearing[path]
+            + DEFAULT_WEIGHTS["consequence"] * _CONSEQUENCE[path]
+        ) / weight_total
+        assert model.attributes[path]["heat"] == pytest.approx(expected)
+
+
+def test_raising_weight_on_a_weak_axis_cools_the_file_weak_on_it() -> None:
+    # a.py is weak on complexity (0.2) but strong on load-bearing/consequence.
+    # Weighting heavily toward complexity must pull its heat DOWN toward 0.2 —
+    # share-of-importance, not a volume knob (spec §4.5).
+    weights_favoring_strong_axes = {"complexity": 0.1, "load_bearing": 0.45, "consequence": 0.45}
+    weights_favoring_weak_axis = {"complexity": 0.8, "load_bearing": 0.1, "consequence": 0.1}
+
+    model_low = combine(
+        _ESTATE,
+        _COMPLEXITY,
+        _CONSEQUENCE,
+        _available_centrality(),
+        pr_files=set(),
+        weights=weights_favoring_strong_axes,
+    )
+    model_high = combine(
+        _ESTATE,
+        _COMPLEXITY,
+        _CONSEQUENCE,
+        _available_centrality(),
+        pr_files=set(),
+        weights=weights_favoring_weak_axis,
+    )
+
+    heat_low = model_low.attributes["a.py"]["heat"]
+    heat_high = model_high.attributes["a.py"]["heat"]
+    assert isinstance(heat_low, float)
+    assert isinstance(heat_high, float)
+    assert heat_high < heat_low
+
+
+def test_unavailable_centrality_drops_load_bearing_and_renormalizes() -> None:
+    centrality = CentralityAxis.unavailable("graphify-out absent")
+    estate = {"a.py": "sha_a"}
+    complexity = {"a.py": 0.4}
+    consequence = {"a.py": 0.6}
+
+    model = combine(estate, complexity, consequence, centrality, pr_files=set())
+
+    assert model.unavailable_axes == ("load_bearing",)
+    weight_total = DEFAULT_WEIGHTS["complexity"] + DEFAULT_WEIGHTS["consequence"]
+    expected = (
+        DEFAULT_WEIGHTS["complexity"] * 0.4 + DEFAULT_WEIGHTS["consequence"] * 0.6
+    ) / weight_total
+    assert model.attributes["a.py"]["heat"] == pytest.approx(expected)
+    # the attribute value is still a real zero — only the WEIGHT is excluded,
+    # never silently reported as stale-as-fresh centrality.
+    assert model.attributes["a.py"]["load_bearing"] == 0.0
+
+
+def test_file_absent_from_available_centrality_scores_gets_a_real_zero() -> None:
+    # Axis IS available; this file simply has no qualifying in-edges. Distinct
+    # from axis-unavailable: the weight still counts, the value is a real 0.0.
+    centrality = CentralityAxis(scores={"a.py": 0.9})  # b.py absent from scores
+    estate = {"a.py": "sha_a", "b.py": "sha_b"}
+    complexity = {"a.py": 0.5, "b.py": 0.5}
+    consequence = {"a.py": 0.5, "b.py": 0.5}
+
+    model = combine(estate, complexity, consequence, centrality, pr_files=set())
+
+    assert model.unavailable_axes == ()
+    assert model.attributes["b.py"]["load_bearing"] == 0.0
+    weight_total = sum(DEFAULT_WEIGHTS.values())
+    expected_b_heat = (
+        DEFAULT_WEIGHTS["complexity"] * 0.5
+        + DEFAULT_WEIGHTS["load_bearing"] * 0.0
+        + DEFAULT_WEIGHTS["consequence"] * 0.5
+    ) / weight_total
+    assert model.attributes["b.py"]["heat"] == pytest.approx(expected_b_heat)
+
+
+def test_in_pr_membership_reflects_the_net_file_set() -> None:
+    estate = {"a.py": "sha_a", "b.py": "sha_b"}
+    complexity = {"a.py": 0.5, "b.py": 0.5}
+    consequence = {"a.py": 0.5, "b.py": 0.5}
+    centrality = CentralityAxis.unavailable("no graph")
+
+    model = combine(estate, complexity, consequence, centrality, pr_files={"a.py"})
+
+    assert model.attributes["a.py"]["in_pr"] is True
+    assert model.attributes["b.py"]["in_pr"] is False
+
+
+def test_descriptors_name_all_four_heat_axes_not_in_pr() -> None:
+    estate = {"a.py": "sha_a"}
+    model = combine(
+        estate, {"a.py": 0.5}, {"a.py": 0.5}, CentralityAxis.unavailable("x"), pr_files=set()
+    )
+
+    names = {descriptor.name for descriptor in model.descriptors}
+    assert names == {"complexity", "load_bearing", "consequence", "heat"}
+
+
+def test_default_weights_reflects_the_effective_weights_used() -> None:
+    estate = {"a.py": "sha_a"}
+    custom_weights = {"complexity": 0.5, "load_bearing": 0.3, "consequence": 0.2}
+
+    model = combine(
+        estate,
+        {"a.py": 0.5},
+        {"a.py": 0.5},
+        CentralityAxis.unavailable("x"),
+        pr_files=set(),
+        weights=custom_weights,
+    )
+
+    assert model.default_weights == custom_weights

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -251,6 +251,8 @@ def test_pr_threads_heat_axes_repo_nwo_and_in_pr_into_the_scene(
 
     assert scene["repo_nwo"] == "octocat/demo"
     assert scene["render_config"]["unavailable_axes"] == []  # graph present + fresh
+    # envelope mirror of the available heat axes (all present when nothing is unavailable)
+    assert data["heat_axes_available"] == ["complexity", "consequence", "load_bearing"]
     names = {descriptor["name"] for descriptor in scene["descriptors"]}
     assert names == {"complexity", "load_bearing", "consequence", "heat"}
 
@@ -297,6 +299,8 @@ def test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent(
     scene = _extract_scene(artifact.read_text(encoding="utf-8"))
 
     assert scene["render_config"]["unavailable_axes"] == ["load_bearing"]
+    # envelope mirror: load_bearing drops out of the available axes when graphify-out/ is absent
+    assert data["heat_axes_available"] == ["complexity", "consequence"]
     by_path = {node["path"]: node["attributes"] for node in scene["files"]}
     # a real zero, never a stale/omitted value (spec §6.2).
     assert by_path["src/app.py"]["load_bearing"] == 0.0

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -12,8 +12,11 @@ end-to-end.
 
 from __future__ import annotations
 
+import json
+import re
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -28,6 +31,43 @@ from tests.fakes import (
     tar_of,
 )
 from vizsuite.adapters.git.runner import ModifiedFileRow
+
+_SCENE_SCRIPT_RE = re.compile(
+    r'<script id="viz-scene" type="application/json">(.*?)</script>', re.DOTALL
+)
+
+
+def _extract_scene(html: str) -> dict[str, Any]:
+    """Pull the inlined scene JSON back out of a rendered artifact.
+
+    The embedding boundary escapes `<`/`>`/`&` to `\\uXXXX` (spec §4.6); those
+    are valid JSON string escapes, so `json.loads` reads the extracted text
+    back losslessly.
+    """
+    match = _SCENE_SCRIPT_RE.search(html)
+    assert match is not None
+    scene: dict[str, Any] = json.loads(match.group(1))
+    return scene
+
+
+def _write_graph(
+    tmp_path: Path,
+    *,
+    built_at_commit: str,
+    nodes: list[dict[str, str]],
+    links: list[dict[str, str]],
+) -> None:
+    graph_dir = tmp_path / "graphify-out"
+    graph_dir.mkdir()
+    payload = {
+        "directed": False,
+        "multigraph": False,
+        "graph": {},
+        "built_at_commit": built_at_commit,
+        "nodes": nodes,
+        "links": links,
+    }
+    (graph_dir / "graph.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 def test_pr_reconciles_and_emits_html_from_head_estate(
@@ -160,3 +200,103 @@ def test_pr_reconciles_against_real_git_with_fake_gh(
     html = artifact.read_text(encoding="utf-8")
     assert "a.py" in html
     assert "b.py" in html
+
+
+def test_pr_threads_heat_axes_repo_nwo_and_in_pr_into_the_scene(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # .2.2: centrality is wired via the live-tree graphify-out/graph.json,
+    # fused with complexity/consequence into per-file heat, and the repo slug
+    # threads through from the widened gh graphql response.
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(
+            base_oid="base000",
+            head_oid="head111",
+            changed_files=1,
+            commit_count=1,
+            repo_nwo="octocat/demo",
+        )
+    )
+    git = ScriptedGitRunner(
+        present_oids={"base000", "head111"},
+        diff_files=["src/app.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=3, deleted=0)
+        ],
+        ls_tree_rows=[blob("src/app.py", "aaa111"), blob("lib/util.py", "bbb222")],
+        archive_tar_bytes=tar_of({"src/app.py": "x = 1\n", "lib/util.py": "y = 1\n"}),
+    )
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5, "lib/util.py": 2}))
+    _write_graph(
+        tmp_path,
+        built_at_commit="head111",
+        nodes=[
+            {"id": "s1", "source_file": "lib/util.py"},
+            {"id": "s2", "source_file": "src/app.py"},
+        ],
+        links=[{"source": "s1", "target": "s2", "relation": "calls", "confidence": "EXTRACTED"}],
+    )
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "11"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["repo_nwo"] == "octocat/demo"
+    assert scene["render_config"]["unavailable_axes"] == []  # graph present + fresh
+    names = {descriptor["name"] for descriptor in scene["descriptors"]}
+    assert names == {"complexity", "load_bearing", "consequence", "heat"}
+
+    by_path = {node["path"]: node["attributes"] for node in scene["files"]}
+    assert set(by_path["src/app.py"]) == {
+        "complexity",
+        "load_bearing",
+        "consequence",
+        "heat",
+        "in_pr",
+    }
+    assert by_path["src/app.py"]["in_pr"] is True  # net-set file
+    assert by_path["lib/util.py"]["in_pr"] is False  # context-only file
+    assert by_path["src/app.py"]["load_bearing"] == 1.0  # sole EXTRACTED in-edge
+
+
+def test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)  # no graphify-out/ written — the optional-dep absent case
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = ScriptedGitRunner(
+        present_oids={"base000", "head111"},
+        diff_files=["src/app.py"],
+        rev_list_oids=["c1"],
+        churn_rows=[
+            ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=3, deleted=0)
+        ],
+        ls_tree_rows=[blob("src/app.py", "aaa111")],
+        archive_tar_bytes=tar_of({"src/app.py": "x = 1\n"}),
+    )
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "12"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["render_config"]["unavailable_axes"] == ["load_bearing"]
+    by_path = {node["path"]: node["attributes"] for node in scene["files"]}
+    # a real zero, never a stale/omitted value (spec §6.2).
+    assert by_path["src/app.py"]["load_bearing"] == 0.0


### PR DESCRIPTION
## Summary

- Adds the V1 cross-axis heat model (`scene/heat.py`): per-file combined heat as a weighted average over the **available** §6.2 axes (complexity, load-bearing/centrality, consequence). An unavailable centrality axis drops its term and renormalizes over the remaining two; a file merely absent from an available axis's scores gets a real `0.0`. `DEFAULT_WEIGHTS` are tunable constants — tests pin the invariants (renormalization, share-of-importance cooling), not the weight values.
- Wires the `.2.1` centrality extractor into `viz pr`: reads `graphify-out/graph.json` from the live working tree (head-guarded by `centrality_axis`; the file is gitignored so it is deliberately not part of the snapshot), fail-soft to a two-axis average when absent/stale.
- Scene view-readiness for the upcoming view slices: per-file attributes (per-axis values + combined `heat` + `in_pr` membership from the PR's net file set), `render_config` (default weights + unavailable-axis list for the §4.5 slider row), and `repo_nwo` (widened GraphQL `nameWithOwner`; needed for §6.1 diff links and the annotation key namespace).
- Envelope data gains `heat_axes_available` so callers can see axis degradation without parsing the HTML.

Slice S1 (1/6) of the V1 views build (bead-level plan: heat model → view shell + treemap → ledger → edges → sonar → gated constellation). Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §4.4, §4.5, §6.1, §6.2.

## Scope

- **In scope:** Python-side heat fusion + scene enrichment only. No view/JS code — the first pixels land in S2.
- **Design decisions (spec allowed either):** `repo_nwo` lives on `PrMeta`; per-file `load_bearing` stays `0.0` when the whole axis is unavailable (uniform attribute shape for the JS layer — `render_config.unavailable_axes` is the UI's disable signal); `heat.combine` takes a plain `Collection[str]` of net paths, keeping it decoupled from `reconcile`.

## Review-gate disposition

HEAVY adversarial gate (6 lenses, 3-refuter panels): **ACCEPTANCE, clean-at-floor after 1 round — zero at-floor findings.** One sub-floor minor flagged, not applied (semantic): `verbs/pr.py` reads `Path.cwd()` directly for the graph path/out dir instead of an injected root — testability nit, tracked in the epic's hardening notes.

## Test Plan

- [x] TDD red→green per slice spec: weighted average + cooling, unavailable-axis renormalization, attribute/`render_config`/`repo_nwo` threading, `in_pr` membership, `nameWithOwner` parse + malformed→`ADAPTER_FAILURE`, `viz pr` end-to-end wiring (scene JSON asserted from rendered HTML), fail-soft with `graphify-out` absent
- [x] Determinism (test item 6) preserved with all new fields populated
- [x] 123 package tests passing; `make ci-vizsuite` fully green: ruff, format-check, mypy --strict (34 files), 100.00% line+branch coverage, pip-audit clean, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
