### PR TITLE
feat(vizsuite): V1 view shell + estate treemap — first pixels (S2)

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/html.py
+++ b/packages/vizsuite/src/vizsuite/templates/html.py
@@ -37,6 +37,8 @@ _TEMPLATE = """<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>viz — PR artifact</title>
+<link rel="icon" href="data:,">
+
 <style>
 /*__VIZ_CSS__*/
 </style>

--- a/packages/vizsuite/src/vizsuite/templates/html.py
+++ b/packages/vizsuite/src/vizsuite/templates/html.py
@@ -7,13 +7,15 @@ Two invariants, both load-bearing from PR #1 (spec §4.6):
    never terminate the `<script>` element (stored XSS upstream of all DOM-level
    escaping). Achieved by escaping ``<``, ``>``, ``&`` to their ``\\uXXXX``
    forms, which `JSON.parse` reads back losslessly.
-2. **DOM binding** — every repo-derived string (file paths today, stories later)
-   is bound into the DOM via `textContent` (d3's ``.text``), never
-   `innerHTML` interpolation, so there is no stored-self-XSS window between this
-   slice and slice 5.
+2. **DOM binding** — every repo-derived string (file paths, directory names,
+   notes) is bound into the DOM via `textContent`/`.value` (or d3's ``.text``,
+   which sets `textContent`), never `innerHTML` interpolation, so there is no
+   stored-self-XSS window — held by the JS bootstrap (`app.js` and the
+   registered view modules under `views/`), not by this module.
 
-The template inlines the vendored d3 and the scene CSS from package data so the
-artifact is a single portable file.
+The template inlines the vendored d3, the scene CSS, and the JS bundle (the
+shared app shell plus every registered view module) from package data so the
+artifact is a single portable file — no runtime fetches, no build step.
 """
 
 from __future__ import annotations
@@ -40,29 +42,27 @@ _TEMPLATE = """<!DOCTYPE html>
 </style>
 </head>
 <body>
+<header id="viz-header">
 <h1 id="viz-title"></h1>
-<div id="viz-root"></div>
+<div id="viz-header-meta">Generated at <span id="viz-generated-at"></span></div>
+</header>
+<div id="viz-storage-warning" class="viz-warning-banner" hidden></div>
+<div id="viz-controls" class="viz-controls"></div>
+<div id="viz-legend" class="viz-legend"></div>
+<main id="viz-root"></main>
+<div id="viz-drill-panel" class="viz-drill-panel" hidden></div>
 <footer id="viz-footer">
 This artifact embeds data extracted from the repository.
-Generated at <span id="viz-generated-at"></span>.
 </footer>
 <script>
 /*__VIZ_D3__*/
 </script>
 <script id="viz-scene" type="application/json">__VIZ_SCENE_JSON__</script>
 <script>
-(function () {
-  "use strict";
-  var scene = JSON.parse(document.getElementById("viz-scene").textContent);
-  document.getElementById("viz-title").textContent = "viz — PR #" + scene.pr_number;
-  document.getElementById("viz-generated-at").textContent = scene.generated_at;
-  d3.select("#viz-root")
-    .selectAll("div.viz-file")
-    .data(scene.files)
-    .join("div")
-    .attr("class", "viz-file")
-    .text(function (d) { return d.path; });
-})();
+/*__VIZ_VIEWS__*/
+</script>
+<script>
+/*__VIZ_APP__*/
 </script>
 </body>
 </html>
@@ -92,10 +92,12 @@ def render_html(scene: Scene) -> str:
     scene_json = scene_to_script_json(scene_to_json(scene))
     css = _read_static("scene.css")
     d3 = _read_static("d3.min.js")
-    return _fill_template(css=css, d3=d3, scene_json=scene_json)
+    app = _read_static("app.js")
+    views = _read_views_bundle()
+    return _fill_template(css=css, d3=d3, app=app, views=views, scene_json=scene_json)
 
 
-def _fill_template(*, css: str, d3: str, scene_json: str) -> str:
+def _fill_template(*, css: str, d3: str, app: str, views: str, scene_json: str) -> str:
     """Fill the template placeholders in a single ``re.sub`` pass.
 
     One pass (never chained ``str.replace``) makes substitution
@@ -108,6 +110,8 @@ def _fill_template(*, css: str, d3: str, scene_json: str) -> str:
     replacements = {
         "/*__VIZ_CSS__*/": css,
         "/*__VIZ_D3__*/": d3,
+        "/*__VIZ_APP__*/": app,
+        "/*__VIZ_VIEWS__*/": views,
         "__VIZ_SCENE_JSON__": scene_json,
     }
     pattern = re.compile("|".join(re.escape(token) for token in replacements))
@@ -118,3 +122,20 @@ def _read_static(name: str) -> str:
     """Read a vendored asset from package data (works installed and from source)."""
     resource = importlib.resources.files("vizsuite").joinpath(f"templates/static/{name}")
     return resource.read_text(encoding="utf-8")
+
+
+def _read_views_bundle() -> str:
+    """Concatenate every registered view module under ``templates/static/views/``.
+
+    Sorted by filename for a deterministic, byte-stable bundle (spec test item
+    6) — each view file only calls ``registerView``-style self-registration
+    onto ``window.vizViews`` (see `app.js`), so concatenation order has no
+    behavioral effect; a stable order just keeps two builds of the same views
+    byte-identical.
+    """
+    views_dir = importlib.resources.files("vizsuite").joinpath("templates/static/views")
+    view_files = sorted(
+        (resource for resource in views_dir.iterdir() if resource.name.endswith(".js")),
+        key=lambda resource: resource.name,
+    )
+    return "\n".join(resource.read_text(encoding="utf-8") for resource in view_files)

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -80,12 +80,16 @@
     function set(path, value) {
       var key = keyFor(path);
       if (available) {
-        if (value) {
-          window.localStorage.setItem(key, value);
-        } else {
-          window.localStorage.removeItem(key);
+        try {
+          if (value) {
+            window.localStorage.setItem(key, value);
+          } else {
+            window.localStorage.removeItem(key);
+          }
+          return;
+        } catch (err) {
+          // Fall through to the in-memory map (e.g. quota exceeded).
         }
-        return;
       }
       if (value) {
         memory[key] = value;

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -159,7 +159,7 @@
       return sum + (weights[axis] || 0);
     }, 0);
     active.forEach(function (axis) {
-      var share = total > 0 ? weights[axis] / total : 0;
+      var share = total > 0 ? (weights[axis] || 0) / total : 0;
       var item = document.createElement("span");
       item.textContent = axis + " " + Math.round(share * 100) + "%";
       mixReadoutEl.appendChild(item);
@@ -333,13 +333,14 @@
         return unavailableAxes.indexOf(axis) === -1;
       });
       var weightTotal = activeAxes.reduce(function (sum, axis) {
-        return sum + weights[axis];
+        return sum + (weights[axis] || 0);
       }, 0);
 
       HEAT_AXES.forEach(function (axis) {
         var isUnavailable = unavailableAxes.indexOf(axis) !== -1;
         var raw = typeof attributes[axis] === "number" ? attributes[axis] : 0;
-        var share = isUnavailable || weightTotal <= 0 ? 0 : weights[axis] / weightTotal;
+        var share =
+          isUnavailable || weightTotal <= 0 ? 0 : (weights[axis] || 0) / weightTotal;
 
         var row = document.createElement("div");
         row.setAttribute("class", "viz-drill-row");

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -392,7 +392,13 @@
       var heatLabel = document.createElement("span");
       heatLabel.textContent = "combined heat";
       var heatValue = document.createElement("span");
-      heatValue.textContent = (typeof fileNode.heat === "number" ? fileNode.heat : 0).toFixed(2);
+      // Recompute from `attributes` + the current `weights` rather than the
+      // captured `fileNode.heat`: a full treemap re-render (collapse/resize)
+      // builds fresh nodes via pruneForLayout(), so the captured snapshot can
+      // go stale. Reusing computeHeatFactory keeps this readout consistent with
+      // the per-axis shares above and the tile colors (same math, live weights).
+      var combinedHeat = computeHeatFactory(weights, unavailableAxes)(attributes);
+      heatValue.textContent = combinedHeat.toFixed(2);
       heatRow.appendChild(heatLabel);
       heatRow.appendChild(heatValue);
       panelEl.appendChild(heatRow);

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -64,6 +64,25 @@
       available = false;
     }
     var memory = Object.create(null);
+    var fallbackHandler = null;
+    var fallbackNotified = false;
+
+    // Fires the registered handler the first time a runtime write falls back
+    // to the in-memory map (e.g. quota exceeded) so the UI can surface the
+    // non-persistence warning that boot-time feature detection would miss.
+    function notifyFallback() {
+      if (fallbackNotified) {
+        return;
+      }
+      fallbackNotified = true;
+      if (typeof fallbackHandler === "function") {
+        fallbackHandler();
+      }
+    }
+
+    function onFallback(handler) {
+      fallbackHandler = handler;
+    }
 
     function keyFor(path) {
       return prefix + path;
@@ -88,7 +107,10 @@
           }
           return;
         } catch (err) {
-          // Fall through to the in-memory map (e.g. quota exceeded).
+          // Fall through to the in-memory map (e.g. quota exceeded) and
+          // surface the non-persistence warning — notes stopped persisting
+          // mid-session even though storage was available at page-load.
+          notifyFallback();
         }
       }
       if (value) {
@@ -117,7 +139,13 @@
       return out;
     }
 
-    return { available: available, get: get, set: set, getAll: getAll };
+    return {
+      available: available,
+      get: get,
+      set: set,
+      getAll: getAll,
+      onFallback: onFallback
+    };
   }
 
   // ---- Theme (spec §4.3): an explicit `data-viz-theme` stamp beats the OS
@@ -419,6 +447,17 @@
         "Use “Copy notes as JSON” before closing this tab.";
       elements.storageWarning.hidden = false;
     }
+
+    // Storage was available at page-load but a later write failed (e.g. quota
+    // exceeded) — reveal the same banner so the reviewer sees that notes have
+    // stopped persisting mid-session.
+    annotationStore.onFallback(function () {
+      elements.storageWarning.textContent =
+        "Notes have stopped being saved (a localStorage write failed — the " +
+        "browser storage quota may be full). " +
+        "Use “Copy notes as JSON” before closing this tab.";
+      elements.storageWarning.hidden = false;
+    });
 
     var mountedViews = [];
 

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -380,14 +380,7 @@
   }
 
   function dispatchThemeChanged() {
-    var event;
-    if (typeof CustomEvent === "function") {
-      event = new CustomEvent("viz:theme-changed");
-    } else {
-      event = document.createEvent("Event");
-      event.initEvent("viz:theme-changed", true, true);
-    }
-    document.dispatchEvent(event);
+    document.dispatchEvent(new CustomEvent("viz:theme-changed"));
   }
 
   function main() {

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -1,0 +1,480 @@
+// vizsuite/app.js — shared view-shell harness (spec §4.2/§4.5): parses the
+// inlined scene, builds the weight-slider control row, legend, drill panel
+// and annotation baseline, wires the theme toggle, and mounts every
+// registered view (window.vizViews, populated by the views bundle that is
+// inlined immediately before this script) into a fresh container.
+//
+// Every repo-derived string (file/dir names, paths, notes) is bound via
+// `textContent`/`.value` (or d3's `.text()`, which sets `textContent`) —
+// never `innerHTML` — matching the DOM-bind invariant locked by the
+// templating layer (spec §4.6).
+(function () {
+  "use strict";
+
+  var IDS = {
+    storageWarning: "viz-storage-warning",
+    controls: "viz-controls",
+    legend: "viz-legend",
+    root: "viz-root",
+    drillPanel: "viz-drill-panel",
+    treemapView: "viz-view-treemap"
+  };
+
+  // The three §6.2 input axes, in the same order/names as
+  // `vizsuite.scene.heat._INPUT_AXES` — the JS recompute below mirrors that
+  // module's weighted-average formula exactly.
+  var HEAT_AXES = ["complexity", "load_bearing", "consequence"];
+
+  // ---- Heat math: Σ(wᵢ·vᵢ)/Σ(wᵢ) over the *active* axes only (an
+  // unavailable axis is excluded from both the sum and the normalizer, so
+  // the remaining axes renormalize — spec §6.2, mirrors `scene.heat.combine`
+  // exactly). ----
+  function computeHeatFactory(weights, unavailableAxes) {
+    var active = Object.keys(weights).filter(function (axis) {
+      return unavailableAxes.indexOf(axis) === -1;
+    });
+    var weightTotal = active.reduce(function (sum, axis) {
+      return sum + weights[axis];
+    }, 0);
+    return function (attributes) {
+      if (weightTotal <= 0) {
+        return 0;
+      }
+      var weightedSum = active.reduce(function (sum, axis) {
+        var value = typeof attributes[axis] === "number" ? attributes[axis] : 0;
+        return sum + weights[axis] * value;
+      }, 0);
+      return weightedSum / weightTotal;
+    };
+  }
+
+  // ---- Annotation store (spec §4.5/§5.8 baseline): localStorage, feature-
+  // detected, with an in-memory fallback so the copy-as-JSON button always
+  // works even when the origin (a bare `file://` artifact) disables storage.
+  // Notes key on `viz:<repo_nwo>:pr:<file-path>` — V1 has no Tier-2 fact ids,
+  // so the file is the annotatable unit. ----
+  function makeAnnotationStore(repoNwo) {
+    var prefix = "viz:" + repoNwo + ":pr:";
+    var available = false;
+    try {
+      window.localStorage.setItem(prefix + "__probe__", "1");
+      window.localStorage.removeItem(prefix + "__probe__");
+      available = true;
+    } catch (err) {
+      available = false;
+    }
+    var memory = Object.create(null);
+
+    function keyFor(path) {
+      return prefix + path;
+    }
+
+    function get(path) {
+      var key = keyFor(path);
+      if (available) {
+        return window.localStorage.getItem(key) || "";
+      }
+      return memory[key] || "";
+    }
+
+    function set(path, value) {
+      var key = keyFor(path);
+      if (available) {
+        if (value) {
+          window.localStorage.setItem(key, value);
+        } else {
+          window.localStorage.removeItem(key);
+        }
+        return;
+      }
+      if (value) {
+        memory[key] = value;
+      } else {
+        delete memory[key];
+      }
+    }
+
+    function getAll() {
+      var out = {};
+      if (available) {
+        for (var i = 0; i < window.localStorage.length; i++) {
+          var k = window.localStorage.key(i);
+          if (k && k.indexOf(prefix) === 0) {
+            out[k] = window.localStorage.getItem(k);
+          }
+        }
+      } else {
+        for (var mk in memory) {
+          if (Object.prototype.hasOwnProperty.call(memory, mk)) {
+            out[mk] = memory[mk];
+          }
+        }
+      }
+      return out;
+    }
+
+    return { available: available, get: get, set: set, getAll: getAll };
+  }
+
+  // ---- Theme (spec §4.3): an explicit `data-viz-theme` stamp beats the OS
+  // preference both ways; absent a stamp, OS `prefers-color-scheme` decides. ----
+  function currentThemeName() {
+    var stamped = document.documentElement.getAttribute("data-viz-theme");
+    if (stamped) {
+      return stamped;
+    }
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+
+  function wireThemeToggle(button, onChange) {
+    function applyLabel() {
+      button.textContent = currentThemeName() === "dark" ? "Light mode" : "Dark mode";
+    }
+    button.addEventListener("click", function () {
+      var next = currentThemeName() === "dark" ? "light" : "dark";
+      document.documentElement.setAttribute("data-viz-theme", next);
+      applyLabel();
+      onChange();
+    });
+    applyLabel();
+  }
+
+  // ---- Control row (spec §4.2/§4.5: flow layout only, never absolute
+  // positioning) — one slider per heat axis, disabled when unavailable,
+  // plus the live mix readout. ----
+  function updateMixReadout(mixReadoutEl, weights, unavailableAxes) {
+    while (mixReadoutEl.firstChild) {
+      mixReadoutEl.removeChild(mixReadoutEl.firstChild);
+    }
+    var active = HEAT_AXES.filter(function (axis) {
+      return unavailableAxes.indexOf(axis) === -1;
+    });
+    var total = active.reduce(function (sum, axis) {
+      return sum + (weights[axis] || 0);
+    }, 0);
+    active.forEach(function (axis) {
+      var share = total > 0 ? weights[axis] / total : 0;
+      var item = document.createElement("span");
+      item.textContent = axis + " " + Math.round(share * 100) + "%";
+      mixReadoutEl.appendChild(item);
+    });
+  }
+
+  function buildControls(container, weights, unavailableAxes, onWeightChange) {
+    var sliderRow = document.createElement("div");
+    sliderRow.setAttribute("class", "viz-slider-row");
+
+    HEAT_AXES.forEach(function (axis) {
+      var isUnavailable = unavailableAxes.indexOf(axis) !== -1;
+      var item = document.createElement("div");
+      item.setAttribute("class", "viz-slider-item");
+      item.setAttribute("data-axis", axis);
+      item.setAttribute("data-unavailable", isUnavailable ? "true" : "false");
+
+      var labelId = "viz-slider-label-" + axis;
+      var label = document.createElement("label");
+      label.id = labelId;
+      label.textContent = axis + (isUnavailable ? " (unavailable this run)" : "");
+
+      var input = document.createElement("input");
+      input.type = "range";
+      input.min = "0";
+      input.max = "1";
+      input.step = "0.01";
+      input.className = "viz-slider-input";
+      input.setAttribute("aria-labelledby", labelId);
+      input.setAttribute("data-axis", axis);
+      input.value = String(typeof weights[axis] === "number" ? weights[axis] : 0);
+      input.disabled = isUnavailable;
+
+      var valueEl = document.createElement("span");
+      valueEl.setAttribute("class", "viz-slider-value");
+      valueEl.textContent = Number(input.value).toFixed(2);
+
+      input.addEventListener("input", function () {
+        weights[axis] = Number(input.value);
+        valueEl.textContent = Number(input.value).toFixed(2);
+        onWeightChange();
+      });
+
+      item.appendChild(label);
+      item.appendChild(input);
+      item.appendChild(valueEl);
+      sliderRow.appendChild(item);
+    });
+
+    container.appendChild(sliderRow);
+
+    var mixReadout = document.createElement("div");
+    mixReadout.id = "viz-mix-readout";
+    mixReadout.setAttribute("class", "viz-mix-readout");
+    container.appendChild(mixReadout);
+    updateMixReadout(mixReadout, weights, unavailableAxes);
+
+    var themeButton = document.createElement("button");
+    themeButton.id = "viz-theme-toggle";
+    themeButton.type = "button";
+    themeButton.setAttribute("class", "viz-btn");
+    container.appendChild(themeButton);
+
+    var copyButton = document.createElement("button");
+    copyButton.id = "viz-copy-notes";
+    copyButton.type = "button";
+    copyButton.setAttribute("class", "viz-btn");
+    copyButton.textContent = "Copy notes as JSON";
+    container.appendChild(copyButton);
+
+    var copyStatus = document.createElement("span");
+    copyStatus.id = "viz-copy-status";
+    copyStatus.setAttribute("class", "viz-slider-value");
+    container.appendChild(copyStatus);
+
+    return {
+      mixReadout: mixReadout,
+      themeButton: themeButton,
+      copyButton: copyButton,
+      copyStatus: copyStatus
+    };
+  }
+
+  function wireCopyNotesButton(button, statusEl, annotationStore) {
+    button.addEventListener("click", function () {
+      var notes = annotationStore.getAll();
+      var payload = JSON.stringify(notes, null, 2);
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        statusEl.textContent = "Copy unsupported in this browser.";
+        return;
+      }
+      navigator.clipboard.writeText(payload).then(
+        function () {
+          statusEl.textContent = "Copied " + Object.keys(notes).length + " note(s).";
+        },
+        function () {
+          statusEl.textContent = "Copy failed — clipboard write was denied.";
+        }
+      );
+    });
+  }
+
+  // ---- Legend (spec §4.5: every encoding present in the scene appears
+  // here; no orphan entries) — the heat scale, the PR-touched marker, and
+  // the default-collapsed marker are the only encodings this view renders. ----
+  function buildLegend(container) {
+    var heatStops = [
+      { token: "heat-cold", label: "low attention" },
+      { token: "heat-mid", label: "medium attention" },
+      { token: "heat-hot", label: "high attention (collapsed groups show the worst offender)" }
+    ];
+    heatStops.forEach(function (stop) {
+      var item = document.createElement("span");
+      item.setAttribute("class", "viz-legend-item");
+      var swatch = document.createElement("span");
+      swatch.setAttribute("class", "viz-legend-swatch");
+      swatch.style.background = "var(--viz-" + stop.token + ")";
+      var label = document.createElement("span");
+      label.textContent = stop.label;
+      item.appendChild(swatch);
+      item.appendChild(label);
+      container.appendChild(item);
+    });
+
+    var prItem = document.createElement("span");
+    prItem.setAttribute("class", "viz-legend-item");
+    var prBadge = document.createElement("span");
+    prBadge.setAttribute("class", "viz-legend-badge");
+    var prLabel = document.createElement("span");
+    prLabel.textContent = "file changed in this PR";
+    prItem.appendChild(prBadge);
+    prItem.appendChild(prLabel);
+    container.appendChild(prItem);
+
+    var collapseItem = document.createElement("span");
+    collapseItem.setAttribute("class", "viz-legend-item");
+    var collapseGlyph = document.createElement("span");
+    collapseGlyph.textContent = "▸";
+    var collapseLabel = document.createElement("span");
+    collapseLabel.textContent = "collapsed group (no PR-touched files by default)";
+    collapseItem.appendChild(collapseGlyph);
+    collapseItem.appendChild(collapseLabel);
+    container.appendChild(collapseItem);
+  }
+
+  // ---- Drill panel (spec §4.2/§4.5): opaque overlay; Escape closes; the
+  // notes textarea binds via `.value`, never `innerHTML`. ----
+  function makeOpenDrill(panelEl, annotationStore, weights, unavailableAxes) {
+    return function (fileNode) {
+      while (panelEl.firstChild) {
+        panelEl.removeChild(panelEl.firstChild);
+      }
+
+      var closeBtn = document.createElement("button");
+      closeBtn.id = "viz-drill-panel-close";
+      closeBtn.type = "button";
+      closeBtn.setAttribute("class", "viz-btn");
+      closeBtn.textContent = "Close";
+      closeBtn.addEventListener("click", function () {
+        panelEl.hidden = true;
+      });
+      panelEl.appendChild(closeBtn);
+
+      var heading = document.createElement("h2");
+      heading.textContent = fileNode.path;
+      panelEl.appendChild(heading);
+
+      var attributes =
+        (fileNode.orig && fileNode.orig.file && fileNode.orig.file.attributes) || {};
+      var activeAxes = HEAT_AXES.filter(function (axis) {
+        return unavailableAxes.indexOf(axis) === -1;
+      });
+      var weightTotal = activeAxes.reduce(function (sum, axis) {
+        return sum + weights[axis];
+      }, 0);
+
+      HEAT_AXES.forEach(function (axis) {
+        var isUnavailable = unavailableAxes.indexOf(axis) !== -1;
+        var raw = typeof attributes[axis] === "number" ? attributes[axis] : 0;
+        var share = isUnavailable || weightTotal <= 0 ? 0 : weights[axis] / weightTotal;
+
+        var row = document.createElement("div");
+        row.setAttribute("class", "viz-drill-row");
+        var label = document.createElement("span");
+        label.textContent = axis + (isUnavailable ? " (unavailable)" : "");
+        var value = document.createElement("span");
+        value.textContent =
+          raw.toFixed(2) + " × " + Math.round(share * 100) + "% = " + (raw * share).toFixed(2);
+        row.appendChild(label);
+        row.appendChild(value);
+        panelEl.appendChild(row);
+      });
+
+      var heatRow = document.createElement("div");
+      heatRow.setAttribute("class", "viz-drill-row");
+      var heatLabel = document.createElement("span");
+      heatLabel.textContent = "combined heat";
+      var heatValue = document.createElement("span");
+      heatValue.textContent = (typeof fileNode.heat === "number" ? fileNode.heat : 0).toFixed(2);
+      heatRow.appendChild(heatLabel);
+      heatRow.appendChild(heatValue);
+      panelEl.appendChild(heatRow);
+
+      var notes = document.createElement("textarea");
+      notes.setAttribute("class", "viz-drill-notes");
+      notes.value = annotationStore.get(fileNode.path);
+      notes.addEventListener("input", function () {
+        annotationStore.set(fileNode.path, notes.value);
+      });
+      panelEl.appendChild(notes);
+
+      panelEl.hidden = false;
+    };
+  }
+
+  function wireDrillPanelClose(panelEl) {
+    document.addEventListener("keydown", function (evt) {
+      if (evt.key === "Escape" && !panelEl.hidden) {
+        panelEl.hidden = true;
+      }
+    });
+  }
+
+  function dispatchThemeChanged() {
+    var event;
+    if (typeof CustomEvent === "function") {
+      event = new CustomEvent("viz:theme-changed");
+    } else {
+      event = document.createEvent("Event");
+      event.initEvent("viz:theme-changed", true, true);
+    }
+    document.dispatchEvent(event);
+  }
+
+  function main() {
+    var scene = JSON.parse(document.getElementById("viz-scene").textContent);
+    document.getElementById("viz-title").textContent = "viz — PR #" + scene.pr_number;
+    document.getElementById("viz-generated-at").textContent = scene.generated_at;
+
+    var weights = {};
+    HEAT_AXES.forEach(function (axis) {
+      var defaults = scene.render_config && scene.render_config.default_weights;
+      if (defaults && typeof defaults[axis] === "number") {
+        weights[axis] = defaults[axis];
+      }
+    });
+    var unavailableAxes =
+      (scene.render_config && scene.render_config.unavailable_axes) || [];
+
+    var annotationStore = makeAnnotationStore(scene.repo_nwo);
+
+    var elements = {
+      storageWarning: document.getElementById(IDS.storageWarning),
+      controls: document.getElementById(IDS.controls),
+      legend: document.getElementById(IDS.legend),
+      root: document.getElementById(IDS.root),
+      drillPanel: document.getElementById(IDS.drillPanel)
+    };
+
+    if (!annotationStore.available) {
+      elements.storageWarning.textContent =
+        "Notes are not being saved (localStorage is unavailable on this origin). " +
+        "Use “Copy notes as JSON” before closing this tab.";
+      elements.storageWarning.hidden = false;
+    }
+
+    var mountedViews = [];
+
+    function onWeightChange() {
+      updateMixReadout(controls.mixReadout, weights, unavailableAxes);
+      reencodeAll();
+    }
+
+    function reencodeAll() {
+      var state = currentState();
+      mountedViews.forEach(function (handle) {
+        if (handle && typeof handle.reencode === "function") {
+          handle.reencode(state);
+        }
+      });
+    }
+
+    function currentState() {
+      return {
+        weights: weights,
+        unavailableAxes: unavailableAxes,
+        computeHeat: computeHeatFactory(weights, unavailableAxes),
+        theme: currentThemeName(),
+        openDrill: makeOpenDrill(elements.drillPanel, annotationStore, weights, unavailableAxes)
+      };
+    }
+
+    var controls = buildControls(elements.controls, weights, unavailableAxes, onWeightChange);
+    wireThemeToggle(controls.themeButton, function () {
+      document.dispatchEvent && dispatchThemeChanged();
+    });
+    wireCopyNotesButton(controls.copyButton, controls.copyStatus, annotationStore);
+    buildLegend(elements.legend);
+    wireDrillPanelClose(elements.drillPanel);
+
+    document.addEventListener("viz:theme-changed", reencodeAll);
+
+    function mountView(name, mountId) {
+      var registered = window.vizViews && window.vizViews[name];
+      if (!registered || typeof registered.render !== "function") {
+        return;
+      }
+      // A fresh container per render (spec §4.2) — never a shared mount
+      // point, so a view never inherits another render's leftover DOM/state.
+      var container = document.createElement("div");
+      container.id = mountId;
+      container.setAttribute("class", "viz-" + name);
+      elements.root.appendChild(container);
+      var handle = registered.render(container, scene, currentState());
+      mountedViews.push(handle);
+    }
+
+    mountView("treemap", IDS.treemapView);
+  }
+
+  main();
+})();

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -335,8 +335,12 @@
 
   // ---- Drill panel (spec §4.2/§4.5): opaque overlay; Escape closes; the
   // notes textarea binds via `.value`, never `innerHTML`. ----
-  function makeOpenDrill(panelEl, annotationStore, weights, unavailableAxes) {
+  function makeOpenDrill(panelEl, annotationStore, weights, unavailableAxes, drillState) {
     return function (fileNode) {
+      // Remember the open node so a weight change can recompute the
+      // weight-dependent breakdown in place (spec §4.5) — see onWeightChange.
+      drillState.node = fileNode;
+
       while (panelEl.firstChild) {
         panelEl.removeChild(panelEl.firstChild);
       }
@@ -347,6 +351,7 @@
       closeBtn.setAttribute("class", "viz-btn");
       closeBtn.textContent = "Close";
       closeBtn.addEventListener("click", function () {
+        drillState.node = null;
         panelEl.hidden = true;
       });
       panelEl.appendChild(closeBtn);
@@ -404,9 +409,10 @@
     };
   }
 
-  function wireDrillPanelClose(panelEl) {
+  function wireDrillPanelClose(panelEl, drillState) {
     document.addEventListener("keydown", function (evt) {
       if (evt.key === "Escape" && !panelEl.hidden) {
+        drillState.node = null;
         panelEl.hidden = true;
       }
     });
@@ -461,9 +467,22 @@
 
     var mountedViews = [];
 
+    // Shared drill-panel state: `node` holds the currently-open file node (or
+    // null when closed) so a weight change can refresh the open breakdown.
+    var drillState = { node: null };
+    var openDrill = makeOpenDrill(
+      elements.drillPanel, annotationStore, weights, unavailableAxes, drillState
+    );
+
     function onWeightChange() {
       updateMixReadout(controls.mixReadout, weights, unavailableAxes);
       reencodeAll();
+      // reencodeAll() repaints tiles and refreshes each node's heat in place;
+      // if the drill panel is open its shares + combined-heat math is now
+      // stale, so re-render it from the same node (no duplicated math).
+      if (drillState.node !== null && !elements.drillPanel.hidden) {
+        openDrill(drillState.node);
+      }
     }
 
     function reencodeAll() {
@@ -481,7 +500,7 @@
         unavailableAxes: unavailableAxes,
         computeHeat: computeHeatFactory(weights, unavailableAxes),
         theme: currentThemeName(),
-        openDrill: makeOpenDrill(elements.drillPanel, annotationStore, weights, unavailableAxes)
+        openDrill: openDrill
       };
     }
 
@@ -491,7 +510,7 @@
     });
     wireCopyNotesButton(controls.copyButton, controls.copyStatus, annotationStore);
     buildLegend(elements.legend);
-    wireDrillPanelClose(elements.drillPanel);
+    wireDrillPanelClose(elements.drillPanel, drillState);
 
     document.addEventListener("viz:theme-changed", reencodeAll);
 

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -56,9 +56,12 @@
   function makeAnnotationStore(repoNwo) {
     var prefix = "viz:" + repoNwo + ":pr:";
     var available = false;
+    // Probe key carries a NUL delimiter, which no valid repo path can
+    // contain, so it can never collide with a note key (`prefix + <path>`).
+    var probeKey = prefix + "\u0000probe";
     try {
-      window.localStorage.setItem(prefix + "__probe__", "1");
-      window.localStorage.removeItem(prefix + "__probe__");
+      window.localStorage.setItem(probeKey, "1");
+      window.localStorage.removeItem(probeKey);
       available = true;
     } catch (err) {
       available = false;

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -1,19 +1,87 @@
-/* vizsuite scene styles — minimal slice-1 skeleton; the V1 views land in .2.2. */
+/* vizsuite scene styles — shared F0 harness (view shell + controls + legend +
+   drill panel) plus the S2 estate-treemap view (spec §4.2/§4.3/§4.5/§4.6). */
+
+/* ---- Theme tokens (spec §4.3): every color/surface resolves via a `:root`
+   custom property so overlay elements mounted outside the view container
+   (the drill panel) still resolve them. Light is the default; the dark twin
+   applies both to OS dark (`prefers-color-scheme`) and to an explicit
+   `data-viz-theme="dark"` stamp from the in-page theme toggle. A `light`
+   stamp wins over OS dark (the `:not()` guard), matching the toggle's
+   "explicit choice beats ambient preference" rule. */
 :root {
   color-scheme: light dark;
-  --viz-bg: #ffffff;
-  --viz-fg: #1a1a1a;
-  --viz-muted: #6b7280;
-  --viz-border: #e5e7eb;
+  --viz-bg: #f9f9f7;
+  --viz-surface: #fcfcfb;
+  --viz-fg: #0b0b0b;
+  --viz-secondary: #52514e;
+  --viz-muted: #898781;
+  --viz-border: #e1e0d9;
+  --viz-border-strong: rgba(11, 11, 11, 0.18);
+  --viz-overlay-bg: #fcfcfb;
+
+  /* Semantic-heat sequential ramp (dataviz skill: multi-hue sequential is
+     permitted for "semantic heat", always with a scale legend). Anchored on
+     the validated status steps (good/warning/critical) — heat is a
+     continuous risk/attention magnitude, so it borrows the same read
+     without impersonating a discrete status chip. */
+  --viz-heat-cold: #0ca30c;
+  --viz-heat-mid: #fab219;
+  --viz-heat-hot: #d03b3b;
+  --viz-label-on-dark-fill: #ffffff;
+  --viz-label-on-light-fill: #0b0b0b;
+
+  /* Reserved F0 tokens: the five categorical plan-identity hues (spec §4.3).
+     Unused by the treemap view; declared now so later views (§7.1 plan
+     constellation) never have to touch theme tokens again. */
+  --viz-hue-blue: #2a78d6;
+  --viz-hue-aqua: #1baf7a;
+  --viz-hue-violet: #4a3aa7;
+  --viz-hue-magenta: #e87ba4;
+  --viz-hue-orange: #eb6834;
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --viz-bg: #0f1115;
-    --viz-fg: #e6e6e6;
-    --viz-muted: #9ca3af;
-    --viz-border: #2a2f3a;
+  :root:not([data-viz-theme="light"]) {
+    --viz-bg: #0d0d0d;
+    --viz-surface: #1a1a19;
+    --viz-fg: #ffffff;
+    --viz-secondary: #c3c2b7;
+    --viz-muted: #898781;
+    --viz-border: #2c2c2a;
+    --viz-border-strong: rgba(255, 255, 255, 0.22);
+    --viz-overlay-bg: #1a1a19;
+
+    --viz-heat-cold: #0ca30c;
+    --viz-heat-mid: #fab219;
+    --viz-heat-hot: #e66767;
+
+    --viz-hue-blue: #3987e5;
+    --viz-hue-aqua: #199e70;
+    --viz-hue-violet: #9085e9;
+    --viz-hue-magenta: #d55181;
+    --viz-hue-orange: #d95926;
   }
 }
+:root[data-viz-theme="dark"] {
+  --viz-bg: #0d0d0d;
+  --viz-surface: #1a1a19;
+  --viz-fg: #ffffff;
+  --viz-secondary: #c3c2b7;
+  --viz-muted: #898781;
+  --viz-border: #2c2c2a;
+  --viz-border-strong: rgba(255, 255, 255, 0.22);
+  --viz-overlay-bg: #1a1a19;
+
+  --viz-heat-cold: #0ca30c;
+  --viz-heat-mid: #fab219;
+  --viz-heat-hot: #e66767;
+
+  --viz-hue-blue: #3987e5;
+  --viz-hue-aqua: #199e70;
+  --viz-hue-violet: #9085e9;
+  --viz-hue-magenta: #d55181;
+  --viz-hue-orange: #d95926;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -28,16 +96,224 @@ body {
   margin: 0 0 0.25rem;
   font-size: 1.25rem;
 }
-#viz-root {
-  margin: 1rem 0;
+#viz-header-meta {
+  color: var(--viz-muted);
+  font-size: 12px;
 }
-.viz-file {
-  padding: 0.15rem 0.5rem;
-  border-bottom: 1px solid var(--viz-border);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  white-space: pre-wrap;
+
+/* ---- Annotation fallback banner (spec §4.5): visible, never silent. ---- */
+.viz-warning-banner {
+  margin: 0.75rem 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--viz-heat-mid);
+  border-radius: 4px;
+  color: var(--viz-fg);
+  background: color-mix(in srgb, var(--viz-heat-mid) 15%, var(--viz-surface));
+  font-size: 12px;
+}
+.viz-warning-banner[hidden] {
+  display: none;
+}
+
+/* ---- Control row (spec §4.2/§4.5): flow layout only, never absolute
+   positioning — structural non-overlap for controls at any viewport. ---- */
+.viz-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.5rem;
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--viz-border);
+  border-radius: 6px;
+  background: var(--viz-surface);
+}
+.viz-slider-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.viz-slider-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 9rem;
+}
+.viz-slider-item[data-unavailable="true"] {
+  opacity: 0.5;
+}
+.viz-slider-item label {
+  font-size: 12px;
+  color: var(--viz-secondary);
+}
+.viz-slider-item .viz-slider-value {
+  font-size: 11px;
+  color: var(--viz-muted);
+  font-variant-numeric: tabular-nums;
+}
+.viz-mix-readout {
+  font-size: 12px;
+  color: var(--viz-secondary);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.viz-btn {
+  border: 1px solid var(--viz-border-strong);
+  border-radius: 4px;
+  background: var(--viz-surface);
+  color: var(--viz-fg);
+  padding: 0.3rem 0.6rem;
+  font-size: 12px;
+  cursor: pointer;
+}
+.viz-btn:hover {
+  background: var(--viz-border);
+}
+
+/* ---- Legend (spec §4.5: every encoding present in the scene appears here). */
+.viz-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0 0 1rem;
+  font-size: 12px;
+  color: var(--viz-secondary);
+}
+.viz-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.viz-legend-swatch {
+  display: inline-block;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 2px;
+  border: 1px solid var(--viz-border-strong);
+}
+.viz-legend-badge {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  border: 2px solid var(--viz-fg);
+  background: transparent;
+}
+
+/* ---- Estate treemap (spec §6.1). ---- */
+#viz-root {
+  margin: 0 0 1rem;
+}
+.viz-treemap {
+  position: relative;
+  width: 100%;
+  height: 70vh;
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid var(--viz-border);
+  border-radius: 6px;
+  background: var(--viz-surface);
+}
+.viz-tile {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1px solid var(--viz-border-strong);
+  overflow: hidden;
+  cursor: pointer;
+}
+.viz-tile--dir {
+  background: var(--viz-surface);
+}
+.viz-tile--dir > .viz-tile-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0 4px;
+  background: var(--viz-border);
+  font-size: 10px;
+  white-space: nowrap;
+}
+.viz-tile--file {
+  display: flex;
+  align-items: flex-end;
+}
+.viz-tile-label {
+  display: block;
+  width: 100%;
+  padding: 1px 3px;
+  font-size: 10px;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.viz-tile-label--hidden {
+  display: none;
+}
+.viz-tile[data-in-pr="true"] {
+  outline: 2px solid var(--viz-fg);
+  outline-offset: -2px;
+}
+.viz-tile[data-collapsed="true"] .viz-collapse-glyph::before {
+  content: "▸";
+}
+.viz-tile:not([data-collapsed="true"]) .viz-collapse-glyph::before {
+  content: "▾";
+}
+.viz-tile--dir[data-collapsed="true"] {
+  background: var(--viz-surface);
+}
+
+/* ---- Drill panel (spec §4.2/§4.5): opaque overlay, bordered, Escape closes. */
+.viz-drill-panel {
+  position: fixed;
+  top: 10vh;
+  right: 1rem;
+  width: min(24rem, 90vw);
+  max-height: 70vh;
+  overflow: auto;
+  background: var(--viz-overlay-bg);
+  opacity: 1;
+  color: var(--viz-fg);
+  border: 1px solid var(--viz-border-strong);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  padding: 0.75rem 1rem;
+  z-index: 10;
+}
+.viz-drill-panel[hidden] {
+  display: none;
+}
+.viz-drill-panel h2 {
+  font-size: 0.95rem;
+  margin: 0 0 0.5rem;
   word-break: break-all;
 }
+.viz-drill-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: 0.15rem 0;
+  border-bottom: 1px solid var(--viz-border);
+}
+.viz-drill-notes {
+  width: 100%;
+  min-height: 4rem;
+  margin-top: 0.5rem;
+  font: inherit;
+  color: var(--viz-fg);
+  background: var(--viz-surface);
+  border: 1px solid var(--viz-border);
+  border-radius: 4px;
+  padding: 0.35rem;
+}
+
 #viz-footer {
   margin-top: 1.5rem;
   padding-top: 0.75rem;

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -260,6 +260,17 @@ body {
   outline: 2px solid var(--viz-fg);
   outline-offset: -2px;
 }
+/* Keyboard focus affordance (a11y): a visible, theme-aware ring on the
+   focused tile. `--viz-fg` is the highest-contrast token in both themes
+   (black on light, white on dark). Ordered after the in-pr rule and drawn
+   just outside the tile (outset offset + raised z-index) so it stays
+   distinct from the inset in-pr outline — a focused in-pr tile still shows
+   focus. */
+.viz-tile:focus-visible {
+  outline: 2px solid var(--viz-fg);
+  outline-offset: 1px;
+  z-index: 1;
+}
 .viz-tile[data-collapsed="true"] .viz-collapse-glyph::before {
   content: "▸";
 }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -1,0 +1,371 @@
+// vizsuite/views/treemap.js — the estate-treemap view module (spec §6.1),
+// obeying the §4.2 view-module interface: render(container, scene, state) →
+// handle, with handle.destroy(); a fresh container per render, deterministic
+// pre-settled layout (d3.treemap runs once, synchronously, before first
+// paint). `handle.reencode(state)` is this module's encoding-only refresh
+// hook — weight/theme changes repaint tile colors without ever touching a
+// tile's x/y/width/height (spec §4.2: "encoding-only changes … never re-run
+// layout").
+//
+// Registers itself on `window.vizViews`, the registry app.js reads to mount
+// every known view; this file assumes nothing about load order relative to
+// app.js beyond that both run before `main()` calls `render()`.
+(function () {
+  "use strict";
+
+  window.vizViews = window.vizViews || {};
+
+  // ---- Flat scene.files paths → a nested dir/file tree. ----
+  function buildTree(files) {
+    var root = { name: "", path: "", isFile: false, children: [], _index: Object.create(null) };
+    files.forEach(function (file) {
+      var parts = file.path.split("/");
+      var node = root;
+      for (var i = 0; i < parts.length; i++) {
+        var part = parts[i];
+        var isLeaf = i === parts.length - 1;
+        if (isLeaf) {
+          node.children.push({ name: part, path: file.path, isFile: true, file: file });
+          continue;
+        }
+        var existing = node._index[part];
+        if (!existing) {
+          existing = {
+            name: part,
+            path: node.path ? node.path + "/" + part : part,
+            isFile: false,
+            children: [],
+            _index: Object.create(null)
+          };
+          node._index[part] = existing;
+          node.children.push(existing);
+        }
+        node = existing;
+      }
+    });
+    return root;
+  }
+
+  // ---- Bottom-up aggregation: a directory's heat is the *worst-offender*
+  // (max) over its descendants — hiding detail behind a collapse never hides
+  // risk (spec §6.1) — and `inPr`/`count` drive the default-collapse rule
+  // and tile sizing respectively. ----
+  function annotate(node, computeHeat) {
+    if (node.isFile) {
+      node.heat = computeHeat(node.file.attributes || {});
+      node.inPr = Boolean(node.file.attributes && node.file.attributes.in_pr);
+      node.count = 1;
+      return;
+    }
+    var maxHeat = 0;
+    var hasPr = false;
+    var count = 0;
+    node.children.forEach(function (child) {
+      annotate(child, computeHeat);
+      maxHeat = Math.max(maxHeat, child.heat);
+      hasPr = hasPr || child.inPr;
+      count += child.count;
+    });
+    node.heat = maxHeat;
+    node.inPr = hasPr;
+    node.count = count || 1;
+  }
+
+  // ---- Default collapse (spec §6.1): a group with no PR-touched
+  // descendant starts collapsed, at every depth; root is never collapsible. ----
+  function collectDefaultCollapsed(node, collapsed) {
+    if (node.isFile) {
+      return;
+    }
+    node.children.forEach(function (child) {
+      collectDefaultCollapsed(child, collapsed);
+    });
+    if (node.path && !node.inPr) {
+      collapsed[node.path] = true;
+    }
+  }
+
+  // ---- Prune the tree for layout: a collapsed directory becomes a leaf
+  // (sized by its file count, colored by its rolled-up heat) so the treemap
+  // reflows — siblings absorb the freed space (spec §6.1). ----
+  function pruneForLayout(node, collapsed) {
+    if (node.isFile) {
+      return {
+        name: node.name,
+        path: node.path,
+        isFile: true,
+        collapsed: false,
+        heat: node.heat,
+        inPr: node.inPr,
+        value: 1,
+        orig: node
+      };
+    }
+    var isCollapsed = Boolean(node.path) && Boolean(collapsed[node.path]);
+    if (isCollapsed) {
+      return {
+        name: node.name,
+        path: node.path,
+        isFile: false,
+        collapsed: true,
+        heat: node.heat,
+        inPr: node.inPr,
+        value: node.count,
+        orig: node
+      };
+    }
+    return {
+      name: node.name,
+      path: node.path,
+      isFile: false,
+      collapsed: false,
+      heat: node.heat,
+      inPr: node.inPr,
+      children: node.children.map(function (child) {
+        return pruneForLayout(child, collapsed);
+      }),
+      orig: node
+    };
+  }
+
+  function layoutTreemap(root, width, height) {
+    var hierarchyRoot = d3
+      .hierarchy(root, function (d) {
+        return d.children;
+      })
+      .sum(function (d) {
+        return d.value || 0;
+      })
+      .sort(function (a, b) {
+        return b.value - a.value;
+      });
+    d3
+      .treemap()
+      .size([width, height])
+      .paddingOuter(2)
+      .paddingTop(function (d) {
+        return d.children ? 16 : 0;
+      })
+      .paddingInner(1)
+      .round(true)(hierarchyRoot);
+    return hierarchyRoot;
+  }
+
+  // ---- Heat color scale (spec §4.3): the ramp anchors are `:root` custom
+  // properties, resolved fresh so a theme change (media query or the
+  // `data-viz-theme` stamp) picks up its own twin on the next reencode. ----
+  function makeHeatColorScale() {
+    var style = getComputedStyle(document.documentElement);
+    var cold = style.getPropertyValue("--viz-heat-cold").trim();
+    var mid = style.getPropertyValue("--viz-heat-mid").trim();
+    var hot = style.getPropertyValue("--viz-heat-hot").trim();
+    return d3
+      .scaleLinear()
+      .domain([0, 0.5, 1])
+      .range([cold, mid, hot])
+      .interpolate(d3.interpolateRgb)
+      .clamp(true);
+  }
+
+  // Label color chosen by luminance of the underlying fill, per theme (spec §4.3).
+  function labelColorFor(colorString) {
+    var rgb = d3.rgb(colorString);
+    var luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+    return luminance > 0.6 ? "var(--viz-label-on-light-fill)" : "var(--viz-label-on-dark-fill)";
+  }
+
+  // ---- Encoding-only repaint: background + label color from the current
+  // heat scale, and label-declutter (hide labels tiles too small to hold
+  // them) — never touches x0/y0/x1/y1 (no layout re-run). ----
+  function applyEncoding(selection, heatScale) {
+    selection.each(function (d) {
+      var wrapper = d3.select(this);
+      var isLeafLike = d.data.isFile || d.data.collapsed;
+      var label = wrapper.select(".viz-tile-label");
+      if (isLeafLike) {
+        var color = heatScale(d.data.heat);
+        wrapper.style("background-color", color);
+        label.style("color", labelColorFor(color));
+      } else {
+        wrapper.style("background-color", null);
+        label.style("color", null);
+      }
+      var width = d.x1 - d.x0;
+      var height = d.y1 - d.y0;
+      var minHeight = d.data.isFile ? 12 : 18;
+      label.classed("viz-tile-label--hidden", width < 26 || height < minHeight);
+    });
+  }
+
+  // Click-vs-drag threshold (~4px, spec §4.2): reads the *live* bound datum
+  // at pointerup (never a captured snapshot), so a tile that has survived
+  // several re-layouts always acts on its current data.
+  function wireTileInteractions(el, handlers) {
+    var startX = 0;
+    var startY = 0;
+    var moved = false;
+    el.addEventListener("pointerdown", function (evt) {
+      startX = evt.clientX;
+      startY = evt.clientY;
+      moved = false;
+    });
+    el.addEventListener("pointermove", function (evt) {
+      if (Math.abs(evt.clientX - startX) > 4 || Math.abs(evt.clientY - startY) > 4) {
+        moved = true;
+      }
+    });
+    el.addEventListener("pointerup", function () {
+      if (moved) {
+        return;
+      }
+      var current = d3.select(el).datum();
+      if (current.data.isFile) {
+        handlers.onFileClick(current.data);
+      } else {
+        handlers.onDirClick(current.data);
+      }
+    });
+  }
+
+  function buildTileContent(wrapper, d) {
+    if (d.data.isFile) {
+      wrapper.append("span").attr("class", "viz-tile-label").text(function (d) { return d.data.name; });
+      return;
+    }
+    if (d.data.collapsed) {
+      var label = wrapper.append("span").attr("class", "viz-tile-label");
+      label.append("span").attr("class", "viz-collapse-glyph");
+      label.append("span").text(function (d) {
+        return " " + d.data.name + " (" + d.value + ")";
+      });
+      return;
+    }
+    var header = wrapper.append("div").attr("class", "viz-tile-header");
+    header.append("span").attr("class", "viz-collapse-glyph");
+    header
+      .append("span")
+      .attr("class", "viz-tile-label")
+      .text(function (d) {
+        return d.data.name;
+      });
+  }
+
+  function renderTiles(container, tree, collapsed, heatScale, handlers) {
+    var rect = container.getBoundingClientRect();
+    var width = rect.width || container.clientWidth || 960;
+    var height = rect.height || container.clientHeight || 600;
+    var pruned = pruneForLayout(tree, collapsed);
+    var hierarchyRoot = layoutTreemap(pruned, width, height);
+    var nodes = hierarchyRoot.descendants().filter(function (d) {
+      return d.depth > 0;
+    });
+
+    var sel = d3
+      .select(container)
+      .selectAll("div.viz-tile")
+      .data(nodes, function (d) {
+        return d.data.path;
+      });
+
+    sel.exit().remove();
+
+    var entered = sel.enter().append("div");
+    var merged = entered.merge(sel);
+
+    merged
+      .attr("class", function (d) {
+        return "viz-tile " + (d.data.isFile ? "viz-tile--file" : "viz-tile--dir");
+      })
+      .attr("data-path", function (d) {
+        return d.data.path;
+      })
+      .attr("data-collapsed", function (d) {
+        return d.data.collapsed ? "true" : "false";
+      })
+      .attr("data-in-pr", function (d) {
+        return d.data.inPr ? "true" : "false";
+      })
+      .style("left", function (d) {
+        return d.x0 + "px";
+      })
+      .style("top", function (d) {
+        return d.y0 + "px";
+      })
+      .style("width", function (d) {
+        return Math.max(0, d.x1 - d.x0) + "px";
+      })
+      .style("height", function (d) {
+        return Math.max(0, d.y1 - d.y0) + "px";
+      });
+
+    // Content is rebuilt on every full render (mount, collapse toggle,
+    // resize) — cheap at estate scale and the only way a persisting
+    // directory tile's chrome can flip between its expanded/collapsed shape.
+    merged.each(function (d) {
+      var wrapper = d3.select(this);
+      wrapper.selectAll("*").remove();
+      buildTileContent(wrapper, d);
+    });
+
+    entered.each(function () {
+      wireTileInteractions(this, handlers);
+    });
+
+    applyEncoding(merged, heatScale);
+  }
+
+  window.vizViews.treemap = {
+    render: function (container, scene, state) {
+      var tree = buildTree(scene.files);
+      var current = state;
+      annotate(tree, current.computeHeat);
+
+      var collapsed = Object.create(null);
+      collectDefaultCollapsed(tree, collapsed);
+
+      var heatScale = makeHeatColorScale();
+
+      var handlers = {
+        onDirClick: function (data) {
+          if (collapsed[data.path]) {
+            delete collapsed[data.path];
+          } else {
+            collapsed[data.path] = true;
+          }
+          fullRender();
+        },
+        onFileClick: function (data) {
+          current.openDrill(data);
+        }
+      };
+
+      function fullRender() {
+        renderTiles(container, tree, collapsed, heatScale, handlers);
+      }
+
+      fullRender();
+
+      var resizeHandler = function () {
+        fullRender();
+      };
+      window.addEventListener("resize", resizeHandler);
+
+      return {
+        destroy: function () {
+          window.removeEventListener("resize", resizeHandler);
+          d3.select(container).selectAll("*").remove();
+        },
+        reencode: function (newState) {
+          current = newState;
+          annotate(tree, current.computeHeat);
+          heatScale = makeHeatColorScale();
+          var selection = d3.select(container).selectAll("div.viz-tile");
+          selection.each(function (d) {
+            d.data.heat = d.data.orig.heat;
+          });
+          applyEncoding(selection, heatScale);
+        }
+      };
+    }
+  };
+})();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -210,6 +210,17 @@
     var startX = 0;
     var startY = 0;
     var moved = false;
+    // Single dispatch shared by pointer and keyboard activation — reads the
+    // *live* bound datum at event time so a tile that survived several
+    // re-layouts always acts on its current data.
+    function activate() {
+      var current = d3.select(el).datum();
+      if (current.data.isFile) {
+        handlers.onFileClick(current.data);
+      } else {
+        handlers.onDirClick(current.data);
+      }
+    }
     el.addEventListener("pointerdown", function (evt) {
       startX = evt.clientX;
       startY = evt.clientY;
@@ -224,13 +235,35 @@
       if (moved) {
         return;
       }
-      var current = d3.select(el).datum();
-      if (current.data.isFile) {
-        handlers.onFileClick(current.data);
-      } else {
-        handlers.onDirClick(current.data);
-      }
+      activate();
     });
+    // Keyboard operability (a11y): Enter and Space trigger the exact same
+    // drill/collapse action as a click. Space must preventDefault or the page
+    // scrolls; "Spacebar" is the legacy IE/Edge key value. Bound on tile enter
+    // alongside the pointer handlers, so it persists across d3 re-layouts.
+    el.addEventListener("keydown", function (evt) {
+      if (evt.key !== "Enter" && evt.key !== " " && evt.key !== "Spacebar") {
+        return;
+      }
+      evt.preventDefault();
+      activate();
+    });
+  }
+
+  // Accessible name for a tile (a11y), set via the `aria-label` attribute —
+  // repo-derived path strings flow through d3's `.attr()` (never innerHTML), so
+  // the textContent/attribute-only binding invariant holds. Recomputed in the
+  // merged attr chain on every render so a directory's collapsed/expanded flip
+  // updates its announced state.
+  function tileAriaLabel(d) {
+    var data = d.data;
+    if (data.isFile) {
+      return data.path;
+    }
+    if (data.collapsed) {
+      return data.path + " (collapsed directory, " + data.count + " files)";
+    }
+    return data.path + " (directory)";
   }
 
   function buildTileContent(wrapper, d) {
@@ -291,6 +324,12 @@
       .attr("data-in-pr", function (d) {
         return d.data.inPr ? "true" : "false";
       })
+      // Keyboard reachability + screen-reader semantics (a11y): tiles are
+      // focusable buttons with an accessible name. Re-applied every render so
+      // rebuilt/toggled tiles keep the contract.
+      .attr("role", "button")
+      .attr("tabindex", "0")
+      .attr("aria-label", tileAriaLabel)
       .style("left", function (d) {
         return d.x0 + "px";
       })

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -110,7 +110,13 @@
         collapsed: true,
         heat: node.heat,
         inPr: node.inPr,
-        value: node.count,
+        count: node.count,
+        // Nominal, sub-linear sizing — collapse is an attention-allocation
+        // act (spec §6.1): a collapsed group must actually shrink (never
+        // keep its expanded footprint) so siblings absorb the freed space.
+        // A mild log scale still hints "more hidden here" without ever
+        // approaching the group's expanded, file-count-proportional area.
+        value: Math.max(1, Math.log2(node.count + 1)),
         orig: node
       };
     }
@@ -236,7 +242,7 @@
       var label = wrapper.append("span").attr("class", "viz-tile-label");
       label.append("span").attr("class", "viz-collapse-glyph");
       label.append("span").text(function (d) {
-        return " " + d.data.name + " (" + d.value + ")";
+        return " " + d.data.name + " (" + d.data.count + ")";
       });
       return;
     }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -351,13 +351,23 @@
 
       fullRender();
 
+      var resizeDebounceTimer = null;
       var resizeHandler = function () {
-        fullRender();
+        if (resizeDebounceTimer) {
+          clearTimeout(resizeDebounceTimer);
+        }
+        resizeDebounceTimer = setTimeout(function () {
+          resizeDebounceTimer = null;
+          fullRender();
+        }, 150);
       };
       window.addEventListener("resize", resizeHandler);
 
       return {
         destroy: function () {
+          if (resizeDebounceTimer) {
+            clearTimeout(resizeDebounceTimer);
+          }
           window.removeEventListener("resize", resizeHandler);
           d3.select(container).selectAll("*").remove();
         },

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -82,7 +82,13 @@ def test_fill_template_substitution_is_order_independent():
     # the single-pass re.sub() cannot, because injected content is never
     # re-scanned.
     hostile_css = "body::after { content: '__VIZ_SCENE_JSON__'; }"
-    out = _fill_template(css=hostile_css, d3="/* d3 */", scene_json='{"pr_number":7}')
+    out = _fill_template(
+        css=hostile_css,
+        d3="/* d3 */",
+        app="/* app */",
+        views="/* views */",
+        scene_json='{"pr_number":7}',
+    )
 
     # the css's literal token survived (was not substituted as the scene slot)...
     assert "content: '__VIZ_SCENE_JSON__';" in out
@@ -90,7 +96,7 @@ def test_fill_template_substitution_is_order_independent():
     assert out.count('{"pr_number":7}') == 1
 
 
-def test_render_inlines_vendored_d3_and_scene_css_and_estate_paths():
+def test_render_inlines_vendored_d3_scene_css_app_and_treemap_bundles():
     html = render_html(
         _scene(
             FileNode(path="src/app.py", checksum="aaa"),
@@ -100,15 +106,24 @@ def test_render_inlines_vendored_d3_and_scene_css_and_estate_paths():
 
     assert html.startswith("<!DOCTYPE html>")
     assert "d3js.org v7.9.0" in html  # vendored d3 inlined
-    assert ".viz-file" in html  # scene css inlined
+    assert ".viz-treemap {" in html  # scene css inlined (treemap styles)
+    # the app + treemap JS bundles are inlined (item 6: bundle markers) —
+    # each source file's own identifying banner comment proves it landed.
+    assert "vizsuite/app.js" in html
+    assert "vizsuite/views/treemap.js" in html
+    # the treemap view's mount id is a stable string constant (spec §4.6
+    # verification hook), present in the inlined app.js source even though the
+    # element itself is created at runtime, not by the Python template.
+    assert "viz-view-treemap" in html
     # estate paths are present (inside the inlined JSON scene)
     assert "src/app.py" in html
     assert "README.md" in html
-    # the bootstrap binds each repo-derived path through d3's `.text` (which sets
-    # textContent), never `innerHTML` interpolation — the binding invariant.
-    # (`innerHTML` appears inside vendored d3 itself; the invariant is about our
-    # own code, so we assert the binding call, not a global substring absence.)
-    assert ".text(function (d) { return d.path; })" in html
+    # the treemap binds each repo-derived file/dir name through d3's `.text`
+    # (which sets textContent), never `innerHTML` interpolation — the binding
+    # invariant. (`innerHTML` appears inside vendored d3 itself; the invariant
+    # is about our own code, so we assert the binding call, not a global
+    # substring absence.)
+    assert ".text(function (d) { return d.data.name; })" in html
 
 
 def test_hostile_strings_in_paths_and_fact_notes_render_inert():


### PR DESCRIPTION
## Summary

- Stands up the client-side view layer end-to-end with the estate treemap as the first (primary) view — the shared harness every later view slice reuses.
- `templates/static/app.js` (new): bootstrap shell — parses the inlined scene; builds the §4.5 control row (one weight slider per heat axis, driven by `scene.render_config.default_weights`, disabled for axes in `unavailable_axes`) with a live mix readout; legend; drill panel with per-axis contribution breakdown; annotation baseline (localStorage keyed `viz:<repo_nwo>:pr:<file-path>`, feature-detected with an in-memory fallback + visible non-persistence warning, copy-notes-as-JSON); theme toggle; and a view registry that mounts each registered view into a fresh container (§4.2). Slider drags recompute combined heat in JS with the exact same weighted-average formula the Python heat model pins (Σ(wᵢ·vᵢ)/Σ(wᵢ) over active axes, renormalized) — encoding-only, never re-runs layout.
- `templates/static/views/treemap.js` (new): the §6.1 estate-treemap view module obeying the §4.2 interface (`render(container, scene, state) → handle`, `handle.destroy()`): nested dir/file tree from flat scene paths, worst-offender (max) heat rollup on collapsed containers, no-PR-impact groups default-collapsed at every depth, collapse reflows (siblings absorb space; collapsed tiles take a sub-linear `log2(count+1)` nominal size), label declutter, 150ms-debounced resize.
- `templates/static/scene.css`: §4.3 `:root` theme tokens (heat ramp + reserved categorical hues), light default + dark twin, flow-layout control row (no absolute positioning), opaque overlays.
- `templates/html.py`: `/*__VIZ_APP__*/` + `/*__VIZ_VIEWS__*/` placeholder bundle inlined via the existing single-pass `_fill_template`; new mount points (`viz-controls`, `viz-legend`, `viz-root`, `viz-drill-panel`); replaces the slice-1 file-list bootstrap. The script-safe `scene_to_script_json` embedding invariant and DOM-bind (`textContent`, never `innerHTML`) invariant are unchanged and still test-pinned.

Slice S2 (2/6) of the V1 views build (heat model → **view shell + treemap** → ledger → edges → sonar → gated constellation). Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §4.2, §4.3, §4.5, §4.6, §6.1.

## Scope

- **In scope:** the shared JS shell + the treemap view + template wiring. Artifact stays fully self-contained/offline (no build step, no external deps).
- **Out of scope (later slices):** ledger/edges/sonar/constellation views; treemap zoom-to-fill (§6.1 lists it, this slice's contract does not — deferred); repo-root injection for `graphify-out`/`.viz` resolution (tracked hardening follow-up, unchanged from S1).
- **JS testing note:** JS modules have no unit harness by design (no build step); they are pinned by rendered-artifact tests (bundle markers, stable §4.6 ids, embedding/DOM-bind invariants) plus the browser verification below. CI never runs a browser.

## Review-gate disposition

HEAVY adversarial gate (4 lenses, 2-refuter panels): **ACCEPTANCE, clean-at-floor after 1 round — zero at-floor findings.** Two sub-floor minors were auto-applied and re-verified (`annotationStore.set()` storage-failure fallback; treemap resize debounce). One gate agent died on a structured-output cap — single-lens coverage bound disclosed, compensated by the browser verification pass and this review.

## Test Plan

- [x] TDD red→green on the Python side: `_fill_template` app/views bundle kwargs, bundle-marker + mount-id artifact assertions; determinism and `</script>`-escaping invariants pass unchanged
- [x] `make ci-vizsuite` fully green: ruff, format-check, mypy --strict, 124 tests, 100.00% line+branch coverage, pip-audit, entry-verify
- [x] Playwright verification against real artifacts (`viz pr 259`, `viz pr 260`): zero console errors (both PRs, both themes, cache-busted reload); heat colors pixel-verified against independently-computed expected values; legend has no orphan entries; drill overlay opaque with correct per-axis contribution; collapse/expand reflows with exact worst-offender rollup; no-PR-impact groups default-collapsed; slider drag re-encodes all tiles with zero layout-position change; dark-mode tokens resolve with luminance-chosen label colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
