### PR TITLE
feat(vizsuite): V1 attention ledger — ranked review list + view switcher (S3)

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -455,6 +455,7 @@
       button.type = "button";
       button.id = option.id;
       button.setAttribute("class", "viz-btn viz-view-switch");
+      button.setAttribute("aria-pressed", "false");
       button.textContent = option.label;
       button.addEventListener("click", function () {
         onSelect(option.name);

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -17,7 +17,8 @@
     legend: "viz-legend",
     root: "viz-root",
     drillPanel: "viz-drill-panel",
-    treemapView: "viz-view-treemap"
+    treemapView: "viz-view-treemap",
+    ledgerView: "viz-view-ledger"
   };
 
   // The three §6.2 input axes, in the same order/names as
@@ -431,6 +432,48 @@
     document.dispatchEvent(new CustomEvent("viz:theme-changed"));
   }
 
+  // ---- View switcher (spec §6.1: treemap ↔ ledger) — a control-row toggle
+  // between the registered top-level views. Mutually exclusive by design:
+  // only one view is ever mounted (spec §4.2's "fresh container per
+  // render" means switching destroys the outgoing view before mounting the
+  // next, never layering a second view's DOM on top). ----
+  var VIEW_SWITCH_OPTIONS = [
+    { name: "treemap", label: "Treemap", id: "viz-view-switch-treemap" },
+    { name: "ledger", label: "Ledger", id: "viz-view-switch-ledger" }
+  ];
+
+  function buildViewSwitcher(container, onSelect) {
+    var wrapper = document.createElement("div");
+    wrapper.id = "viz-view-switcher";
+    wrapper.setAttribute("class", "viz-view-switcher");
+    wrapper.setAttribute("role", "group");
+    wrapper.setAttribute("aria-label", "View");
+
+    var buttons = {};
+    VIEW_SWITCH_OPTIONS.forEach(function (option) {
+      var button = document.createElement("button");
+      button.type = "button";
+      button.id = option.id;
+      button.setAttribute("class", "viz-btn viz-view-switch");
+      button.textContent = option.label;
+      button.addEventListener("click", function () {
+        onSelect(option.name);
+      });
+      wrapper.appendChild(button);
+      buttons[option.name] = button;
+    });
+    container.appendChild(wrapper);
+
+    return {
+      setActive: function (name) {
+        VIEW_SWITCH_OPTIONS.forEach(function (option) {
+          var isActive = option.name === name;
+          buttons[option.name].setAttribute("aria-pressed", isActive ? "true" : "false");
+        });
+      }
+    };
+  }
+
   function main() {
     var scene = JSON.parse(document.getElementById("viz-scene").textContent);
     document.getElementById("viz-title").textContent = "viz — PR #" + scene.pr_number;
@@ -523,22 +566,49 @@
 
     document.addEventListener("viz:theme-changed", reencodeAll);
 
+    var activeView = null;
+
+    function unmountActiveView() {
+      if (!activeView) {
+        return;
+      }
+      if (activeView.handle && typeof activeView.handle.destroy === "function") {
+        activeView.handle.destroy();
+      }
+      if (activeView.container.parentNode) {
+        activeView.container.parentNode.removeChild(activeView.container);
+      }
+      mountedViews = [];
+      activeView = null;
+    }
+
     function mountView(name, mountId) {
       var registered = window.vizViews && window.vizViews[name];
       if (!registered || typeof registered.render !== "function") {
         return;
       }
-      // A fresh container per render (spec §4.2) — never a shared mount
-      // point, so a view never inherits another render's leftover DOM/state.
+      // Only one view mounted at a time (spec §6.1 view switcher): destroy
+      // the outgoing view before handing out a fresh container (spec §4.2 —
+      // never a shared mount point, so a view never inherits another
+      // render's leftover DOM/state).
+      unmountActiveView();
       var container = document.createElement("div");
       container.id = mountId;
       container.setAttribute("class", "viz-" + name);
       elements.root.appendChild(container);
       var handle = registered.render(container, scene, currentState());
       mountedViews.push(handle);
+      activeView = { name: name, container: container, handle: handle };
     }
 
+    var viewMountIds = { treemap: IDS.treemapView, ledger: IDS.ledgerView };
+    var viewSwitcher = buildViewSwitcher(elements.controls, function (name) {
+      mountView(name, viewMountIds[name]);
+      viewSwitcher.setActive(name);
+    });
+
     mountView("treemap", IDS.treemapView);
+    viewSwitcher.setActive("treemap");
   }
 
   main();

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -586,7 +586,7 @@
     function mountView(name, mountId) {
       var registered = window.vizViews && window.vizViews[name];
       if (!registered || typeof registered.render !== "function") {
-        return;
+        return false;
       }
       // Only one view mounted at a time (spec §6.1 view switcher): destroy
       // the outgoing view before handing out a fresh container (spec §4.2 —
@@ -600,12 +600,17 @@
       var handle = registered.render(container, scene, currentState());
       mountedViews.push(handle);
       activeView = { name: name, container: container, handle: handle };
+      return true;
     }
 
     var viewMountIds = { treemap: IDS.treemapView, ledger: IDS.ledgerView };
     var viewSwitcher = buildViewSwitcher(elements.controls, function (name) {
-      mountView(name, viewMountIds[name]);
-      viewSwitcher.setActive(name);
+      // Only reflect the switch in the toggle when the view actually
+      // mounted; a no-op mount (missing view module) would otherwise leave
+      // the switcher indicating a view that never replaced the current one.
+      if (mountView(name, viewMountIds[name])) {
+        viewSwitcher.setActive(name);
+      }
     });
 
     mountView("treemap", IDS.treemapView);

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -325,6 +325,111 @@ body {
   padding: 0.35rem;
 }
 
+/* ---- View switcher (spec §6.1: treemap ↔ ledger) — flow layout in the
+   shared control row, same button chrome as the theme/copy buttons. ---- */
+.viz-view-switcher {
+  display: flex;
+  gap: 0.25rem;
+}
+.viz-view-switch[aria-pressed="true"] {
+  background: var(--viz-border);
+  font-weight: 600;
+}
+
+/* ---- Attention ledger (spec §6.1): ranked what-to-review-first list. Flow
+   layout only (spec §4.2/§4.5), never absolute positioning — a list, not a
+   spatial layout. ---- */
+.viz-ledger-toggle-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+.viz-ledger-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.viz-ledger-section {
+  border: 1px solid var(--viz-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.viz-ledger-section-title {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--viz-secondary);
+  background: var(--viz-surface);
+  border-bottom: 1px solid var(--viz-border);
+}
+.viz-ledger-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--viz-border);
+  background: var(--viz-bg);
+  cursor: pointer;
+}
+.viz-ledger-row:last-child {
+  border-bottom: none;
+}
+.viz-ledger-row:hover {
+  background: var(--viz-surface);
+}
+/* Keyboard focus affordance (a11y), same treatment as the treemap's tiles
+   (spec §4.3 theme tokens: `--viz-fg` is the highest-contrast token in both
+   themes). */
+.viz-ledger-row:focus-visible {
+  outline: 2px solid var(--viz-fg);
+  outline-offset: -2px;
+  z-index: 1;
+}
+.viz-ledger-rank {
+  min-width: 2rem;
+  text-align: right;
+  color: var(--viz-muted);
+  font-variant-numeric: tabular-nums;
+}
+/* Reuses the legend's bordered-circle "file changed in this PR" badge
+   pattern (spec §4.5 legend completeness) — the same encoding, not a new
+   one. */
+.viz-ledger-badge {
+  flex: none;
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  border: 2px solid var(--viz-fg);
+  background: transparent;
+}
+.viz-ledger-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12.5px;
+}
+.viz-ledger-heat {
+  min-width: 3rem;
+  text-align: right;
+  color: var(--viz-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.viz-ledger-link {
+  flex: none;
+}
+.viz-ledger-diff-link {
+  font-size: 12px;
+  color: var(--viz-hue-blue);
+}
+.viz-ledger-diff-link:focus-visible {
+  outline: 2px solid var(--viz-fg);
+  outline-offset: 1px;
+}
+
 #viz-footer {
   margin-top: 1.5rem;
   padding-top: 0.75rem;

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -384,6 +384,11 @@ body {
 .viz-ledger-row:focus-visible {
   outline: 2px solid var(--viz-fg);
   outline-offset: -2px;
+  /* Rows are non-positioned flex children, so z-index alone is inert;
+     position: relative promotes the focused row into a stacking context
+     (matching the treemap tiles' positioned + z-index pattern) so the
+     inset focus ring draws above the adjacent rows' borders. */
+  position: relative;
   z-index: 1;
 }
 .viz-ledger-rank {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -248,6 +248,7 @@
       toggleButton.type = "button";
       toggleButton.id = IDS.modeToggle;
       toggleButton.setAttribute("class", "viz-btn");
+      toggleButton.setAttribute("aria-pressed", "false");
       toggleButton.setAttribute("aria-label", "Mix PR and context files into one ranking");
       toggleRow.appendChild(toggleButton);
       container.appendChild(toggleRow);

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -112,6 +112,9 @@
     if (digest) {
       digest.then(function (hex) {
         anchor.href = base + "#diff-" + hex;
+      }, function () {
+        // Fail soft: if hashing rejects, keep the unanchored /files link
+        // rather than surfacing an unhandled promise rejection.
       });
     }
     return holder;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -1,0 +1,303 @@
+// vizsuite/views/ledger.js — the attention-ledger view module (spec §6.1),
+// obeying the §4.2 view-module interface: render(container, scene, state) →
+// handle, with handle.destroy(). `handle.reencode(state)` re-sorts and
+// rebuilds the row list in place — ranking is weight-dependent, so a slider
+// change can reorder every row. That reorder is *not* the "never re-run
+// layout" case §4.2 protects: that guards a settled *spatial* layout (the
+// treemap's tile x/y/width/height), not a flat list's own paint order,
+// which the spec explicitly allows to reflow on re-rank.
+//
+// Diff-link decision (spec §6.1 "attention ledger" / G3): GitHub's per-file
+// anchor on a PR's "Files changed" tab is `pull/<n>/files#diff-<sha256hex
+// (path)>` (current, undocumented scheme). Computing that hash needs
+// SubtleCrypto, which only exists in a secure context (https, or
+// http://localhost) — never on a `file://` origin, which is exactly how
+// these artifacts are normally opened (spec §4.1: double-click, offline,
+// detached from any session). Rather than vendor a hand-rolled SHA-256
+// implementation for an anchor-only affordance, this module degrades: every
+// PR-file row gets the bare `.../pull/<n>/files` link synchronously (correct,
+// just not scrolled to the right file), then upgrades `href` in place to the
+// anchored form if-and-when a digest resolves. A `file://` artifact keeps the
+// still-useful bare-tab link forever; a served/https copy (this repo's
+// playwright checks, or a shared internal copy) gets the precise per-file
+// anchor a tick later. `repo_nwo` absent/empty (the PR verb couldn't resolve
+// the GitHub remote) never fabricates a URL — the file name renders unlinked
+// instead, same as any context (non-PR) file, which has no diff to link to.
+(function () {
+  "use strict";
+
+  window.vizViews = window.vizViews || {};
+
+  var IDS = {
+    listMount: "viz-ledger-list",
+    modeToggle: "viz-ledger-mode-toggle",
+    sectionPr: "viz-ledger-section-pr",
+    sectionContext: "viz-ledger-section-context",
+    sectionAll: "viz-ledger-section-all"
+  };
+
+  // Returns a Promise<string> (lowercase hex sha256) when SubtleCrypto is
+  // available in this context, or `null` synchronously when it is not, so
+  // the caller never blocks first paint on the digest.
+  function sha256HexOrNull(text) {
+    var subtle = window.crypto && window.crypto.subtle;
+    if (!subtle || typeof subtle.digest !== "function" || typeof TextEncoder === "undefined") {
+      return null;
+    }
+    var bytes = new TextEncoder().encode(text);
+    return subtle.digest("SHA-256", bytes).then(function (buffer) {
+      var view = new Uint8Array(buffer);
+      var hex = "";
+      for (var i = 0; i < view.length; i++) {
+        var byteHex = view[i].toString(16);
+        hex += byteHex.length === 1 ? "0" + byteHex : byteHex;
+      }
+      return hex;
+    });
+  }
+
+  // ---- scene.files → ranked rows (spec §6.1): one row per file, heat via
+  // the shared computeHeat (never re-derived here), in_pr read straight off
+  // the file's own attributes — the same flag the treemap reads for its
+  // badge/outline. ----
+  function computeRows(scene, computeHeat) {
+    return scene.files.map(function (file) {
+      var attributes = file.attributes || {};
+      return {
+        file: file,
+        heat: computeHeat(attributes),
+        inPr: Boolean(attributes.in_pr)
+      };
+    });
+  }
+
+  function byHeatDescThenPath(a, b) {
+    if (b.heat !== a.heat) {
+      return b.heat - a.heat;
+    }
+    if (a.file.path < b.file.path) {
+      return -1;
+    }
+    if (a.file.path > b.file.path) {
+      return 1;
+    }
+    return 0;
+  }
+
+  function buildDiffLinkHolder(scene, row) {
+    var holder = document.createElement("span");
+    holder.setAttribute("class", "viz-ledger-link");
+    if (!row.inPr || !scene.repo_nwo) {
+      return holder; // no PR diff for a context file; never fabricate a URL without repo_nwo
+    }
+    var base = "https://github.com/" + scene.repo_nwo + "/pull/" + scene.pr_number + "/files";
+    var anchor = document.createElement("a");
+    anchor.setAttribute("class", "viz-ledger-diff-link");
+    anchor.href = base;
+    anchor.target = "_blank";
+    anchor.rel = "noopener";
+    anchor.setAttribute("aria-label", "View diff for " + row.file.path + " on GitHub");
+    anchor.textContent = "Diff";
+    // The anchor is its own activation target — never let its click/keydown
+    // also trigger the row's drill-open handler (see wireRowActivation).
+    anchor.addEventListener("click", function (evt) {
+      evt.stopPropagation();
+    });
+    anchor.addEventListener("keydown", function (evt) {
+      evt.stopPropagation();
+    });
+    holder.appendChild(anchor);
+
+    var digest = sha256HexOrNull(row.file.path);
+    if (digest) {
+      digest.then(function (hex) {
+        anchor.href = base + "#diff-" + hex;
+      });
+    }
+    return holder;
+  }
+
+  // Click-vs-drag threshold (~4px, spec §4.2), mirroring the treemap tile
+  // pattern; reads the live bound row at pointerup/keydown rather than a
+  // captured snapshot, matching the same anti-staleness contract.
+  function wireRowActivation(el, onActivate) {
+    var startX = 0;
+    var startY = 0;
+    var moved = false;
+    function fromLink(evt) {
+      return Boolean(evt.target.closest && evt.target.closest("a"));
+    }
+    el.addEventListener("pointerdown", function (evt) {
+      startX = evt.clientX;
+      startY = evt.clientY;
+      moved = false;
+    });
+    el.addEventListener("pointermove", function (evt) {
+      if (Math.abs(evt.clientX - startX) > 4 || Math.abs(evt.clientY - startY) > 4) {
+        moved = true;
+      }
+    });
+    el.addEventListener("pointerup", function (evt) {
+      if (moved || fromLink(evt)) {
+        return;
+      }
+      onActivate();
+    });
+    // Enter/Space activate like a click (a11y); "Spacebar" is the legacy
+    // IE/Edge key value. A link inside the row handles its own activation.
+    el.addEventListener("keydown", function (evt) {
+      if (evt.key !== "Enter" && evt.key !== " " && evt.key !== "Spacebar") {
+        return;
+      }
+      if (fromLink(evt)) {
+        return;
+      }
+      evt.preventDefault();
+      onActivate();
+    });
+  }
+
+  function buildRow(scene, row, rank, openDrill) {
+    var el = document.createElement("div");
+    el.setAttribute("class", "viz-ledger-row");
+    el.setAttribute("data-path", row.file.path);
+    el.setAttribute("data-in-pr", row.inPr ? "true" : "false");
+    // Keyboard reachability + screen-reader semantics (a11y), same contract
+    // as the treemap's tiles.
+    el.setAttribute("role", "button");
+    el.setAttribute("tabindex", "0");
+    el.setAttribute(
+      "aria-label",
+      row.file.path + (row.inPr ? " (changed in this PR)" : "") + ", heat " + row.heat.toFixed(2)
+    );
+
+    var rankEl = document.createElement("span");
+    rankEl.setAttribute("class", "viz-ledger-rank");
+    rankEl.textContent = String(rank);
+    el.appendChild(rankEl);
+
+    if (row.inPr) {
+      // Reuses the legend's bordered-circle badge pattern (spec §4.5 legend
+      // completeness — this is the same encoding, not a new one).
+      var badge = document.createElement("span");
+      badge.setAttribute("class", "viz-ledger-badge");
+      badge.setAttribute("aria-hidden", "true");
+      el.appendChild(badge);
+    }
+
+    var pathEl = document.createElement("span");
+    pathEl.setAttribute("class", "viz-ledger-path");
+    pathEl.textContent = row.file.path;
+    el.appendChild(pathEl);
+
+    var heatEl = document.createElement("span");
+    heatEl.setAttribute("class", "viz-ledger-heat");
+    heatEl.textContent = row.heat.toFixed(2);
+    el.appendChild(heatEl);
+
+    el.appendChild(buildDiffLinkHolder(scene, row));
+
+    wireRowActivation(el, function () {
+      // The shape openDrill expects (spec: `fileNode.path` +
+      // `fileNode.orig.file.attributes`) — the same shape the treemap's
+      // pruned leaf nodes carry; built fresh here rather than duplicating
+      // any tree-building machinery the ledger doesn't need.
+      openDrill({ path: row.file.path, orig: { file: row.file } });
+    });
+
+    return el;
+  }
+
+  function buildSection(scene, id, title, rows, openDrill) {
+    var section = document.createElement("div");
+    section.id = id;
+    section.setAttribute("class", "viz-ledger-section");
+
+    var heading = document.createElement("h3");
+    heading.setAttribute("class", "viz-ledger-section-title");
+    heading.textContent = title + " (" + rows.length + ")";
+    section.appendChild(heading);
+
+    rows.forEach(function (row, index) {
+      section.appendChild(buildRow(scene, row, index + 1, openDrill));
+    });
+    return section;
+  }
+
+  window.vizViews.ledger = {
+    render: function (container, scene, state) {
+      var current = state;
+      // "separated" (PR files ranked above context files, each section
+      // ranked 1..N on its own) is the default view — a reviewer opening a
+      // PR wants the changed files first; "mixed" is one flat ranking across
+      // everything (spec §6.1).
+      var mode = "separated";
+
+      var toggleRow = document.createElement("div");
+      toggleRow.setAttribute("class", "viz-ledger-toggle-row");
+      var toggleButton = document.createElement("button");
+      toggleButton.type = "button";
+      toggleButton.id = IDS.modeToggle;
+      toggleButton.setAttribute("class", "viz-btn");
+      toggleRow.appendChild(toggleButton);
+      container.appendChild(toggleRow);
+
+      var listEl = document.createElement("div");
+      listEl.id = IDS.listMount;
+      listEl.setAttribute("class", "viz-ledger-list");
+      container.appendChild(listEl);
+
+      function updateToggleLabel() {
+        toggleButton.textContent =
+          mode === "separated" ? "Show mixed ranking" : "Show separated (PR / context)";
+        toggleButton.setAttribute("aria-pressed", mode === "mixed" ? "true" : "false");
+      }
+
+      function renderAll() {
+        while (listEl.firstChild) {
+          listEl.removeChild(listEl.firstChild);
+        }
+        var rows = computeRows(scene, current.computeHeat).sort(byHeatDescThenPath);
+        if (mode === "mixed") {
+          listEl.appendChild(
+            buildSection(scene, IDS.sectionAll, "All files", rows, current.openDrill)
+          );
+          return;
+        }
+        var prRows = rows.filter(function (row) {
+          return row.inPr;
+        });
+        var contextRows = rows.filter(function (row) {
+          return !row.inPr;
+        });
+        listEl.appendChild(
+          buildSection(scene, IDS.sectionPr, "Changed in this PR", prRows, current.openDrill)
+        );
+        listEl.appendChild(
+          buildSection(scene, IDS.sectionContext, "Context", contextRows, current.openDrill)
+        );
+      }
+
+      toggleButton.addEventListener("click", function () {
+        mode = mode === "separated" ? "mixed" : "separated";
+        updateToggleLabel();
+        renderAll();
+      });
+
+      updateToggleLabel();
+      renderAll();
+
+      return {
+        destroy: function () {
+          while (container.firstChild) {
+            container.removeChild(container.firstChild);
+          }
+        },
+        reencode: function (newState) {
+          current = newState;
+          renderAll();
+        }
+      };
+    }
+  };
+})();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -166,9 +166,10 @@
     // as the treemap's tiles.
     el.setAttribute("role", "button");
     el.setAttribute("tabindex", "0");
+    var heatText = row.heat.toFixed(2);
     el.setAttribute(
       "aria-label",
-      row.file.path + (row.inPr ? " (changed in this PR)" : "") + ", heat " + row.heat.toFixed(2)
+      row.file.path + (row.inPr ? " (changed in this PR)" : "") + ", heat " + heatText
     );
 
     var rankEl = document.createElement("span");
@@ -192,7 +193,7 @@
 
     var heatEl = document.createElement("span");
     heatEl.setAttribute("class", "viz-ledger-heat");
-    heatEl.textContent = row.heat.toFixed(2);
+    heatEl.textContent = heatText;
     el.appendChild(heatEl);
 
     el.appendChild(buildDiffLinkHolder(scene, row));

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -98,13 +98,18 @@
     anchor.rel = "noopener";
     anchor.setAttribute("aria-label", "View diff for " + row.file.path + " on GitHub");
     anchor.textContent = "Diff";
-    // The anchor is its own activation target — never let its click/keydown
-    // also trigger the row's drill-open handler (see wireRowActivation).
-    anchor.addEventListener("click", function (evt) {
+    // The anchor is its own activation target — never let its own events also
+    // trigger the row's drill-open handler (see wireRowActivation). The row
+    // activates on pointerup (with a `fromLink` .closest exemption), so
+    // stopping click/keydown alone leaves the pointer path guarded only by
+    // that exemption, which fails open when evt.target has no `.closest`
+    // (non-Element target). Stop the pointer events that drive row activation
+    // too, so the diff link can never double-fire "open drill" + "open diff".
+    function stopPropagation(evt) {
       evt.stopPropagation();
-    });
-    anchor.addEventListener("keydown", function (evt) {
-      evt.stopPropagation();
+    }
+    ["click", "keydown", "pointerdown", "pointerup"].forEach(function (type) {
+      anchor.addEventListener(type, stopPropagation);
     });
     holder.appendChild(anchor);
 

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -240,6 +240,7 @@
       toggleButton.type = "button";
       toggleButton.id = IDS.modeToggle;
       toggleButton.setAttribute("class", "viz-btn");
+      toggleButton.setAttribute("aria-label", "Mix PR and context files into one ranking");
       toggleRow.appendChild(toggleButton);
       container.appendChild(toggleRow);
 

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -126,6 +126,28 @@ def test_render_inlines_vendored_d3_scene_css_app_and_treemap_bundles():
     assert ".text(function (d) { return d.data.name; })" in html
 
 
+def test_render_inlines_ledger_view_bundle_and_playwright_hooks():
+    # Slice 3 (spec §6.1 attention ledger): the ledger view module is its own
+    # file under templates/static/views/, picked up by the same dynamic glob
+    # that already inlines treemap.js (item 6: bundle markers) — no change to
+    # `_read_views_bundle` needed, so this pins the *contract*, not the glob.
+    html = render_html(
+        _scene(
+            FileNode(path="src/app.py", checksum="aaa"),
+            FileNode(path="README.md", checksum="bbb"),
+        )
+    )
+
+    assert "vizsuite/views/ledger.js" in html
+    # Stable ids used as playwright verification hooks (spec §4.6): the
+    # ledger's list mount, the separated/mixed toggle, and the treemap↔ledger
+    # view switcher app.js now renders into the control row.
+    assert "viz-ledger-list" in html
+    assert "viz-ledger-mode-toggle" in html
+    assert "viz-view-switch-treemap" in html
+    assert "viz-view-switch-ledger" in html
+
+
 def test_hostile_strings_in_paths_and_fact_notes_render_inert():
     # Item 7 (complete): hostile strings in *paths* (a repeat of the slice-1
     # embedding case, now exercised alongside the new channel) and in a


### PR DESCRIPTION
## Summary

- Adds the §6.1 **attention ledger** — the ranked "what to review first" list — as the second view on the S2 shell:
- `templates/static/views/ledger.js` (new): §4.2 view module (`render(container, scene, state) → handle` with `destroy()`/`reencode(state)`). Per-file ranking by combined heat (descending); **separated/mixed toggle** — separated partitions on `in_pr` (PR net files section above context, each ranked 1..N), mixed is one global ranking; per-PR-file **GitHub diff link** built from `scene.repo_nwo` + `pr_number`. Rows are keyboard-operable (role/tabindex/Enter/Space, focus-visible ring) and drill into the shared panel. Weight changes re-rank in place via `reencode` (a list re-orders; no spatial layout to preserve).
- `app.js`: registers the ledger + adds a treemap ↔ ledger view switcher in the control row; `mountView` now destroys the outgoing view before mounting the next — exactly one live view.
- `scene.css`: ledger row/section/badge/link + switcher styles on existing theme tokens.
- `tests/unit/test_templates_html.py`: pins the ledger bundle inlining + stable playwright-hook ids; existing embedding/determinism/DOM-bind invariants unchanged.

Slice S3 (3/6) of the V1 views build (heat model → shell+treemap → **ledger** → edges → sonar → gated constellation). Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §6.1, §4.2, §4.5.

## Scope + design decisions

- **In scope:** ledger view + switcher + styles + artifact tests. No Python-side model changes.
- **Diff-link anchor decision (stated in code):** GitHub's per-file anchor is `pull/<n>/files#diff-<sha256hex(path)>`; `SubtleCrypto` exists only in secure contexts (never `file://`, the normal way these artifacts open). Rows render the bare `/pull/<n>/files` link synchronously and upgrade the `href` in place to the anchored form when the digest resolves; empty `repo_nwo` degrades to unlinked names. Links are `target="_blank" rel="noopener"`; hrefs only, no fetches — the offline invariant holds.
- **Worker design calls (documented in-line):** separated mode is the default (a reviewer wants changed files first); rank numbering restarts per section in separated mode.
- **Deliberately deferred (tracked):** `wireRowActivation` shares its click-vs-drag + Enter/Space scaffold shape with treemap's `wireTileInteractions` — consolidation into a shared helper is queued for the next slice, which adds the third consumer (rule of three).

## Review-gate disposition

HEAVY adversarial gate (4 lenses, 2-refuter panels, 12/12 agents clean): **ACCEPTANCE, clean-at-floor after 1 round — zero at-floor findings.** One sub-floor minor auto-applied (duplicate `toFixed` hoist); one sub-floor minor flagged and deferred as above.

## Test Plan

- [x] TDD red→green: ledger bundle + hook-id artifact test failed before `ledger.js`/`app.js` existed, green after
- [x] `make ci-vizsuite` fully green: ruff, format-check, mypy --strict, 125 tests, 100.00% line+branch coverage, pip-audit, entry-verify
- [x] Playwright on real artifacts (`viz pr 259`, `viz pr 260`): rank order cross-checked against recomputed heat for all 928/939 rows (zero mismatches); separated/mixed partitions exactly on `in_pr`; all 19/19 + 20/20 PR-file anchors match `https://github.com/<nwo>/pull/<n>/files#diff-[0-9a-f]{64}` with `rel="noopener"` (href-read only); drill via click and Enter, Escape closes; slider re-rank without reload; zero console errors; dark theme contrast verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
