### PR TITLE
feat(vizsuite): scene dependency edges from EXTRACTED centrality (S4)

### DIFF
--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -39,10 +39,14 @@ class CentralityAxis:
     `scores` is `None` exactly when the axis is unavailable (optional
     dependency absent, stale, or unparseable) — distinct from an *available*
     axis whose graph happens to carry zero qualifying edges (an empty dict).
+    `edges` is the same file-level `DiGraph`'s EXTRACTED, intra-file-excluded
+    edge list the scores were derived from (one graph build, kept together);
+    it is empty whenever the axis is unavailable — never a stale edge set.
     """
 
     scores: dict[str, float] | None
     unavailable_reason: str | None = None
+    edges: tuple[tuple[str, str], ...] = ()
 
     @property
     def is_available(self) -> bool:
@@ -53,14 +57,16 @@ class CentralityAxis:
         return CentralityAxis(scores=None, unavailable_reason=reason)
 
     @staticmethod
-    def from_indegree(indegree: dict[str, int]) -> CentralityAxis:
+    def from_indegree(
+        indegree: dict[str, int], edges: tuple[tuple[str, str], ...] = ()
+    ) -> CentralityAxis:
         """Normalize raw file-level in-degree counts to a 0-1 axis."""
         max_degree = max(indegree.values(), default=0)
         scores = {
             path: (degree / max_degree if max_degree > 0 else 0.0)
             for path, degree in indegree.items()
         }
-        return CentralityAxis(scores=scores)
+        return CentralityAxis(scores=scores, edges=edges)
 
 
 def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
@@ -105,4 +111,7 @@ def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
         return CentralityAxis.unavailable(
             "graph.json malformed (missing or wrong-shape nodes/links)"
         )
-    return CentralityAxis.from_indegree(dict(graph.in_degree()))  # normalized 0-1 per file
+    # Same graph, same pass: the edge list backing `scores` is just this
+    # DiGraph's own (already EXTRACTED-only, intra-file-excluded) edges.
+    edges = tuple(sorted(graph.edges()))
+    return CentralityAxis.from_indegree(dict(graph.in_degree()), edges=edges)

--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -113,5 +113,7 @@ def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
         )
     # Same graph, same pass: the edge list backing `scores` is just this
     # DiGraph's own (already EXTRACTED-only, intra-file-excluded) edges.
-    edges = tuple(sorted(graph.edges()))
+    # Ordering is left to the downstream `scene_to_json` sort — no need to
+    # sort twice.
+    edges = tuple(graph.edges())
     return CentralityAxis.from_indegree(dict(graph.in_degree()), edges=edges)

--- a/packages/vizsuite/src/vizsuite/scene/assemble.py
+++ b/packages/vizsuite/src/vizsuite/scene/assemble.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 from vizsuite.envelope import ErrorCode, JsonValue, VizError
 from vizsuite.scene.model import (
     AttributeDescriptor,
+    Edge,
     Fact,
     FileNode,
     Fingerprints,
@@ -58,6 +59,7 @@ def assemble(
     attributes: dict[str, dict[str, JsonValue]] | None = None,
     render_config: RenderConfig | None = None,
     repo_nwo: str = "",
+    edges: Sequence[Edge] = (),
 ) -> Scene:
     """Assemble the estate `{path: blob_sha}` plus fingerprints/facts into a `Scene`.
 
@@ -70,6 +72,9 @@ def assemble(
     fails the schema gate. `attributes` (keyed by path, as produced by
     `scene.heat.combine`) attaches each file's heat-axis values to its matching
     `FileNode`; a path with no entry keeps the pre-.2.2 empty attribute map.
+    `edges` (typically the EXTRACTED centrality axis's file-dependency pairs,
+    tagged `kind="dependency"` by the caller) threads onto the scene as-is —
+    `scene_to_json` is the sort point, not this function.
     """
     _validate_facts(facts)
 
@@ -93,6 +98,7 @@ def assemble(
         fingerprints=fingerprints,
         descriptors=tuple(descriptors),
         facts=tuple(facts),
+        edges=tuple(edges),
         render_config=render_config
         if render_config is not None
         else RenderConfig(default_weights={}),

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -81,6 +81,20 @@ class Fact:
 
 
 @dataclass(frozen=True)
+class Edge:
+    """A directed top-level file-dependency edge (spec §4.4 typed-edge shape).
+
+    `kind` is the edge-kind vocabulary tag (spec §4.4 encoding-spine); V1's
+    only source is the EXTRACTED centrality axis, so `kind` is always
+    `"dependency"` here.
+    """
+
+    source: str
+    target: str
+    kind: str
+
+
+@dataclass(frozen=True)
 class AttributeDescriptor:
     """Self-describing metadata for one scene attribute (spec §4.4)."""
 
@@ -130,6 +144,7 @@ class Scene:
     fingerprints: Fingerprints
     descriptors: tuple[AttributeDescriptor, ...] = ()  # heat axes' metadata, via .2.2 (§4.4)
     facts: tuple[Fact, ...] = ()  # Tier-2/3 facts; empty until .2.3 has a producer
+    edges: tuple[Edge, ...] = ()  # EXTRACTED file-dependency edges (§4.4), via .2.2 centrality
     recommendations: tuple[JsonValue, ...] = ()  # always empty for V1 (spec §4.4)
     events: tuple[JsonValue, ...] = ()  # reserved for V3 (spec §4.4/§8); always empty here
     render_config: RenderConfig = field(default_factory=lambda: RenderConfig(default_weights={}))
@@ -154,6 +169,10 @@ def _fact_to_json(fact: Fact) -> dict[str, JsonValue]:
 
 def _descriptor_to_json(descriptor: AttributeDescriptor) -> dict[str, JsonValue]:
     return {"name": descriptor.name, "unit": descriptor.unit, "direction": descriptor.direction}
+
+
+def _edge_to_json(edge: Edge) -> dict[str, JsonValue]:
+    return {"source": edge.source, "target": edge.target, "kind": edge.kind}
 
 
 def _fingerprints_to_json(fingerprints: Fingerprints) -> dict[str, JsonValue]:
@@ -189,6 +208,10 @@ def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
     descriptors_json: list[JsonValue] = [
         _descriptor_to_json(descriptor) for descriptor in scene.descriptors
     ]
+    edges_json: list[JsonValue] = [
+        _edge_to_json(edge)
+        for edge in sorted(scene.edges, key=lambda edge: (edge.source, edge.target, edge.kind))
+    ]
     return {
         "schema_version": scene.schema_version,
         "generated_at": scene.generated_at,
@@ -198,6 +221,7 @@ def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
         "fingerprints": _fingerprints_to_json(scene.fingerprints),
         "descriptors": descriptors_json,
         "facts": facts_json,
+        "edges": edges_json,
         "recommendations": list(scene.recommendations),
         "events": list(scene.events),
         "render_config": _render_config_to_json(scene.render_config),

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -36,7 +36,7 @@ from vizsuite.reconcile.snapshot import materialize
 from vizsuite.runners import Runners
 from vizsuite.scene import heat
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import RenderConfig
+from vizsuite.scene.model import Edge, RenderConfig
 from vizsuite.templates.html import render_html
 
 
@@ -74,6 +74,12 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         estate_map, complexity_scores, consequence_scores, centrality, set(scope.files)
     )
 
+    # The centrality axis's own EXTRACTED, intra-file-excluded edges (empty
+    # when the axis is unavailable — same fail-soft guarantee as load_bearing).
+    edges = tuple(
+        Edge(source=source, target=target, kind="dependency") for source, target in centrality.edges
+    )
+
     scene = assemble(
         estate_map,
         pr_number=pr_number,
@@ -88,6 +94,7 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
             unavailable_axes=heat_model.unavailable_axes,
         ),
         repo_nwo=scope.meta.repo_nwo,
+        edges=edges,
     )
     html = render_html(scene)
 

--- a/packages/vizsuite/tests/unit/test_extract_centrality.py
+++ b/packages/vizsuite/tests/unit/test_extract_centrality.py
@@ -126,6 +126,34 @@ def test_naive_node_link_graph_construction_lacks_in_degree_locking_the_trap() -
         naive_graph.in_degree()  # type: ignore[operator]
 
 
+def test_edges_are_extracted_only_and_intra_file_excluded(tmp_path: Path) -> None:
+    # a.py -> b.py is a genuine cross-file EXTRACTED edge (must appear in edges).
+    # c.py -> d.py is INFERRED only (Tier-2, out of scope — must be excluded).
+    # e1/e2 are two symbols in the SAME file (intra-file EXTRACTED edge, excluded).
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[
+            _node("a1", "a.py"),
+            _node("b1", "b.py"),
+            _node("c1", "c.py"),
+            _node("d1", "d.py"),
+            _node("e1", "e.py"),
+            _node("e2", "e.py"),
+        ],
+        links=[
+            _link("a1", "b1", relation="calls", confidence="EXTRACTED"),
+            _link("c1", "d1", relation="calls", confidence="INFERRED"),
+            _link("e1", "e2", relation="uses", confidence="EXTRACTED"),
+        ],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID)
+
+    assert axis.is_available
+    assert axis.edges == (("a.py", "b.py"),)
+
+
 def test_head_built_graph_scores_a_newly_added_files_incoming_edges(tmp_path: Path) -> None:
     # A head-built graph (built_at_commit == head_oid) already contains the new
     # file's edges — no overlay step needed, just the preflight passing.
@@ -256,11 +284,16 @@ def test_centrality_axis_unavailable_and_from_indegree_helpers() -> None:
     assert unavailable.scores is None
     assert unavailable.unavailable_reason == "no graphify-out"
     assert not unavailable.is_available
+    assert unavailable.edges == ()  # fail-soft means empty edges too, never stale ones
 
     available = CentralityAxis.from_indegree({"a.py": 2, "b.py": 1, "c.py": 0})
     assert available.is_available
     assert available.scores == {"a.py": 1.0, "b.py": 0.5, "c.py": 0.0}
+    assert available.edges == ()  # edges is opt-in via the `edges=` kwarg
 
     empty = CentralityAxis.from_indegree({})
     assert empty.is_available
     assert empty.scores == {}
+
+    edged = CentralityAxis.from_indegree({"a.py": 1}, edges=(("x.py", "a.py"),))
+    assert edged.edges == (("x.py", "a.py"),)

--- a/packages/vizsuite/tests/unit/test_scene_assemble.py
+++ b/packages/vizsuite/tests/unit/test_scene_assemble.py
@@ -13,7 +13,7 @@ serialized shape so a later slice (.2.2/.2.3) never breaks the contract.
 from __future__ import annotations
 
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import AttributeDescriptor, RenderConfig, scene_to_json
+from vizsuite.scene.model import AttributeDescriptor, Edge, RenderConfig, scene_to_json
 
 _ESTATE = {"src/a.py": "sha_a", "src/b.py": "sha_b"}
 
@@ -158,6 +158,59 @@ def test_render_config_and_repo_nwo_thread_into_the_serialized_envelope():
         "unavailable_axes": ["load_bearing"],
     }
     assert payload["repo_nwo"] == "octocat/hello-world"
+
+
+def test_edges_default_to_empty_when_graphify_is_unavailable():
+    # Fail-soft: an unavailable centrality axis carries empty edges (see
+    # test_extract_centrality.py), and a Scene assembled without any edges
+    # input defaults to the same empty tuple — never crash, never stale edges.
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+    )
+
+    assert scene.edges == ()
+    assert scene_to_json(scene)["edges"] == []
+
+
+def test_edges_thread_through_assemble_and_serialize_sorted_and_deterministically():
+    # Deliberately reverse-ordered input to prove scene_to_json sorts, not the caller.
+    edges = [
+        Edge(source="b.py", target="a.py", kind="dependency"),
+        Edge(source="a.py", target="b.py", kind="dependency"),
+    ]
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        edges=edges,
+    )
+
+    assert scene.edges == tuple(edges)
+    payload = scene_to_json(scene)
+    assert payload["edges"] == [
+        {"source": "a.py", "target": "b.py", "kind": "dependency"},
+        {"source": "b.py", "target": "a.py", "kind": "dependency"},
+    ]
+
+    # Byte-stable across two assemblies of the same edges — only the stamp varies.
+    scene_b = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2099-12-31T23:59:59+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        edges=edges,
+    )
+    assert scene_to_json(scene_b)["edges"] == payload["edges"]
 
 
 def test_render_config_and_repo_nwo_default_when_omitted():

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -267,6 +267,11 @@ def test_pr_threads_heat_axes_repo_nwo_and_in_pr_into_the_scene(
     assert by_path["src/app.py"]["in_pr"] is True  # net-set file
     assert by_path["lib/util.py"]["in_pr"] is False  # context-only file
     assert by_path["src/app.py"]["load_bearing"] == 1.0  # sole EXTRACTED in-edge
+    # .2.2 slice 4: the same EXTRACTED, intra-file-excluded edge backing
+    # load_bearing threads onto the scene as a top-level dependency edge.
+    assert scene["edges"] == [
+        {"source": "lib/util.py", "target": "src/app.py", "kind": "dependency"}
+    ]
 
 
 def test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent(
@@ -304,3 +309,5 @@ def test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent(
     by_path = {node["path"]: node["attributes"] for node in scene["files"]}
     # a real zero, never a stale/omitted value (spec §6.2).
     assert by_path["src/app.py"]["load_bearing"] == 0.0
+    # fail-soft: an unavailable centrality axis threads an empty edge set too.
+    assert scene["edges"] == []


### PR DESCRIPTION
## Summary

- Adds the top-level file→file **dependency edge set** to the scene envelope (G1) — the prerequisite for the S5 sonar and S6 constellation views. Pure Python; no view/JS/template changes.
- `extract/centrality.py`: `CentralityAxis` gains `edges: tuple[tuple[str, str], ...] = ()`, derived from the **same** `DiGraph` pass that produces the in-degree scores (already EXTRACTED-only, intra-file-excluded) — no second graph build. Every existing fail-soft branch (graphify absent/stale/torn/wrong-shape → `unavailable`) preserved, now also yielding empty edges.
- `scene/model.py`: new frozen `Edge(source, target, kind)` dataclass (`kind="dependency"` for V1's EXTRACTED graph, per the §4.4 typed-edge shape); `Scene.edges: tuple[Edge, ...] = ()`; `scene_to_json` serializes edges deterministically, sorted by `(source, target, kind)`.
- `scene/assemble.py` / `verbs/pr.py`: `assemble(...)` gains an `edges` parameter; `viz pr` threads the centrality axis's edges through as `Edge` tuples.
- Tests: 125 → 128 (`test_extract_centrality.py`, `test_scene_assemble.py`, `test_verbs_pr.py` extended) — EXTRACTED-only + intra-file exclusion, fail-soft empty edges, deterministic byte-stable serialization.

Slice S4 (4/6) of the V1 views build (heat model → shell+treemap → ledger → **edges** → sonar → gated constellation). Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §4.4, §6.1, §6.2.

## Scope + design decisions

- **In scope:** scene-level edge data only. The consuming views (sonar, constellation) land in S5/S6 and degrade to a visible "dependency graph unavailable" state on an empty edge set.
- **Ordering owned at the serialization boundary:** `centrality_axis` returns edges in graph insertion order; `scene_to_json` sorts before emission. One source of truth for determinism — the byte-stability tests pin it.
- **No playwright leg this slice:** nothing renders differently; artifact verification resumes with S5.

## Review-gate disposition

HEAVY adversarial gate (3 lenses, 2-refuter panels, 7/7 agents clean): **ACCEPTANCE, clean-at-floor after 1 round — zero at-floor findings.** One sub-floor minor auto-applied (redundant double-sort removed, second commit); zero deferred.

## Test Plan

- [x] TDD red→green ×4: `CentralityAxis.edges` (AttributeError first), `Scene.edges`/`Edge` (AttributeError first), `assemble(edges=...)` (TypeError first), `viz pr` wiring (empty-list assertion first)
- [x] `make ci-vizsuite` fully green: ruff, format-check, mypy --strict, 128 tests, 100.00% line+branch coverage, pip-audit, entry-verify
- [x] Fail-soft: graphify absent/stale/torn → `unavailable` axis + `edges=()`; scene assembles and serializes cleanly
- [x] Determinism: scene JSON byte-stable across two assemblies with differing stamps; existing `test_assembly_determinism.py` unchanged and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
