### PR TITLE
feat(workcli): shape-impl-container label + claim/deliver container guards (9.5)

### DIFF
--- a/packages/workcli/src/workcli/lifecycle/__init__.py
+++ b/packages/workcli/src/workcli/lifecycle/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from workcli.lifecycle.manifest import Manifest, deserialize_manifest
+from workcli.lifecycle.nouns import IMPL_CONTAINER_LABEL
 from workcli.model import Item
 
 DELIVERED_MARKER = "[work] delivered:"  # leaf note prefix; full: "[work] delivered: <evidence>"
@@ -10,7 +11,7 @@ MANIFEST_MARKER = (
 )
 ORPHAN_MARKER = "[work] orphan-by-choice"  # item note (exact)
 
-_CONTAINER_SHAPE_LABELS = frozenset({"shape-spec", "shape-epic"})
+_CONTAINER_SHAPE_LABELS = frozenset({"shape-spec", "shape-epic", IMPL_CONTAINER_LABEL})
 _CONTAINER_TYPES = frozenset({"epic", "milestone"})  # legacy/unstamped fallback
 
 

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -5,9 +5,10 @@ Dispatches on the `shape-design` label (CLI surface table): a design
 child's `deliver` parses the merged spec's `## Continuations` manifest and
 reconciles the sibling placeholder (L7/L8); a leaf's `deliver` verifies
 bd-observable evidence before recording the `[work] delivered:` marker and
-closing. `reconcile_placeholder` is exported for reuse by `reconcile`
-(Task 6) -- it is short-circuit idempotent on the `impl-placeholder`
-label's absence.
+closing. A container is refused outright -- it completes via close-walk when
+its children close, never through `deliver`. `reconcile_placeholder` is
+exported for reuse by `reconcile` (Task 6) -- it is short-circuit idempotent
+on the `impl-placeholder` label's absence.
 """
 
 from __future__ import annotations
@@ -21,12 +22,14 @@ from workcli.lifecycle import (
     MANIFEST_MARKER,
     SPEC_MARKER,
     has_marker,
+    is_container,
     manifest_snapshot,
     spec_path,
 )
 from workcli.lifecycle.manifest import Manifest, parse_continuations, serialize_manifest
 from workcli.lifecycle.nouns import (
     DESIGN_CHILD_LABEL,
+    IMPL_CONTAINER_LABEL,
     IMPL_PLACEHOLDER_LABEL,
     NOUN_TEMPLATES,
     SPEC_READY_LABEL,
@@ -201,6 +204,18 @@ def deliver(backend: Backend, args: Namespace) -> JsonValue:
     item = backend.get(args.id)
     if DESIGN_CHILD_LABEL in item.labels:
         return _deliver_design(backend, args, item)
+    # A container is never delivered directly: it closes via close-walk when its
+    # children close (spec §6/§8). Refuse at dispatch -- before any evidence
+    # check or leaf mutation -- so `deliver` on a spec/epic/`shape-impl-container`
+    # fails loud instead of silently recording a leaf delivery on a container.
+    if is_container(item):
+        raise WorkError(
+            ErrorCode.USAGE,
+            (
+                f"deliver {args.id}: {args.id} is a container; a container closes via "
+                f"close-walk when its children close, not through `deliver`"
+            ),
+        )
     return _deliver_leaf(backend, args, item)
 
 
@@ -234,10 +249,15 @@ def _reconcile_multi(backend: Backend, placeholder: Item, manifest: Manifest) ->
                 acceptance=item.acceptance,
             )
         )
-    # `impl-placeholder` is removed by the shared completion tail, strictly
-    # last -- only once every manifest child exists AND the design child has
-    # closed (L10: this label is the queryable handle `reconcile` enumerates
-    # interrupted expansions through).
+    # Stamp the placeholder as the impl sub-container so `claim` and the router
+    # treat it as a declared-state container (spec §6 -- keyed on the label, not
+    # child count). Idempotent (label add is set-union), so an interrupted
+    # expansion replays through the still-present handle and re-stamps
+    # harmlessly. Applied BEFORE the shared tail removes `impl-placeholder`
+    # last: that handle is the queryable signal `reconcile` enumerates
+    # interrupted expansions through, dropped only once every child exists AND
+    # the design child has closed (L10).
+    backend.label_mutate("add", placeholder.id, [IMPL_CONTAINER_LABEL])
 
 
 def _design_sibling(backend: Backend, placeholder: Item) -> Item | None:
@@ -269,7 +289,8 @@ def reconcile_placeholder(backend: Backend, placeholder_id: str, manifest: Manif
     Body, by manifest shape:
     none -> close the placeholder + reason note (only when non-empty);
     single -> set_type + retitle + set_acceptance + add shape label (+ spec-ready);
-    multi -> mint the MISSING children (compared to existing by title).
+    multi -> mint the MISSING children (compared to existing by title) + stamp
+    `shape-impl-container` on the placeholder.
 
     Then the shared tail, unconditionally: close the design child, then remove
     `impl-placeholder` STRICTLY LAST. That ordering (C1/C2, L10) makes the

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -53,5 +53,9 @@ NOUN_TEMPLATES: dict[Noun, NounTemplate] = {
 
 DESIGN_CHILD_LABEL = "shape-design"
 IMPL_PLACEHOLDER_LABEL = "impl-placeholder"
+# The multi-unit reconciled sub-container: the placeholder becomes this once its
+# manifest children are minted. A declared container-shape handle (joins
+# `_CONTAINER_SHAPE_LABELS`), so `claim` refuses it by label, never child count.
+IMPL_CONTAINER_LABEL = "shape-impl-container"
 PLANNED_LABEL = "planned"
 SPEC_READY_LABEL = "spec-ready"

--- a/packages/workcli/tests/unit/test_deliver.py
+++ b/packages/workcli/tests/unit/test_deliver.py
@@ -93,6 +93,50 @@ def test_deliver_design_without_spec_is_usage_error_with_no_bd_call():
     assert runner.calls == [("show", "d.1", "--json")]
 
 
+def test_deliver_on_impl_container_is_usage_error_pointing_to_close_walk():
+    # A multi-unit reconciled sub-container (`shape-impl-container`, no
+    # `shape-design`) completes by close-walk when its children close, never by
+    # `deliver`. The guard trips at dispatch, before any evidence check or leaf
+    # mutation -- only `show` is called.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("show",),
+                _show_result(_item_raw("x.1", status="open", labels=["shape-impl-container"])),
+            ),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["deliver", "x.1"], runner)
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.USAGE)
+    assert runner.calls == [("show", "x.1", "--json")]
+
+
+def test_deliver_on_spec_container_is_usage_error():
+    # The guard is the declared-state container test (`is_container`), not the
+    # new label alone: a `shape-spec` container is refused identically.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("show",),
+                _show_result(_item_raw("x.1", status="open", labels=["shape-spec"])),
+            ),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["deliver", "x.1"], runner)
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.USAGE)
+    assert runner.calls == [("show", "x.1", "--json")]
+
+
 def test_deliver_design_with_leaf_flags_is_usage_error_naming_them():
     # --pr/--items/--trivial belong to leaf delivery; a design child rejects
     # them rather than silently ignoring them (fail fast at the boundary).

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -24,6 +24,7 @@ from workcli.lifecycle.deliver import deliver, reconcile_placeholder
 from workcli.lifecycle.manifest import Manifest, ManifestItem, serialize_manifest
 from workcli.lifecycle.nouns import (
     DESIGN_CHILD_LABEL,
+    IMPL_CONTAINER_LABEL,
     IMPL_PLACEHOLDER_LABEL,
     SPEC_READY_LABEL,
 )
@@ -317,6 +318,10 @@ def test_deliver_design_multi_mints_children_under_placeholder_and_closes_design
     placeholder = backend.get("p")
     child_titles = {backend.get(cid).title for cid in placeholder.children}
     assert child_titles == {"Alpha", "Beta"}
+    # The placeholder is now the impl sub-container: stamped so `claim`/the
+    # router treat it as a declared-state container (spec §6), with the
+    # completion handle removed strictly last.
+    assert IMPL_CONTAINER_LABEL in placeholder.labels
     assert IMPL_PLACEHOLDER_LABEL not in placeholder.labels
     assert backend.get("d").status == "closed"
 
@@ -333,6 +338,8 @@ def test_reconcile_multi_mints_only_the_missing_children():
     titles = [backend.get(cid).title for cid in backend.get("p").children]
     assert sorted(titles) == ["Alpha", "Beta"]
     assert titles.count("Alpha") == 1
+    # Re-stamped idempotently across the interrupted expansion's replay.
+    assert IMPL_CONTAINER_LABEL in backend.get("p").labels
     assert IMPL_PLACEHOLDER_LABEL not in backend.get("p").labels
     assert backend.get("d").status == "closed"
 

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -107,9 +107,7 @@ def test_claim_on_impl_container_is_not_claimable_by_label():
         steps=[
             ScriptedStep(
                 ("show",),
-                _show_result(
-                    _item_raw("x.1", status="open", labels=["shape-impl-container"])
-                ),
+                _show_result(_item_raw("x.1", status="open", labels=["shape-impl-container"])),
             ),
         ]
     )

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -98,6 +98,31 @@ def test_claim_on_childless_epic_is_not_claimable_with_no_ready_or_claim_call():
     assert runner.calls == [("show", "x.1", "--json")]
 
 
+def test_claim_on_impl_container_is_not_claimable_by_label():
+    # A multi-unit reconciled sub-container carries `shape-impl-container`;
+    # `claim` refuses it exactly like any other container, keyed on the label
+    # (never child count) -- the new handle joins the declared container set, so
+    # the guard trips before the `ready` set is even consulted.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("show",),
+                _show_result(
+                    _item_raw("x.1", status="open", labels=["shape-impl-container"])
+                ),
+            ),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["claim", "x.1"], runner)
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.NOT_CLAIMABLE)
+    assert runner.calls == [("show", "x.1", "--json")]
+
+
 def test_claim_on_leaf_absent_from_ready_set_is_not_claimable_blocked():
     runner = ScriptedBdRunner(
         steps=[


### PR DESCRIPTION
## What & why

PR-2 of 3 for the `workcli` lifecycle **recovery-contract redesign** (bead `agents-config-wgclw.9.5`). Adds the container semantics the redesign needs: a dedicated `shape-impl-container` handle, and guards that stop `claim`/`deliver` from acting on a container.

Authoritative contract: `docs/specs/2026-07-05-work-lifecycle-and-facade.md` §6/§8 and `docs/plans/2026-07-12-workcli-lifecycle-layer.md` L16 (both landed in PR-1).

## The changes

- **Mint `shape-impl-container`** (`lifecycle/nouns.py`) — the declared container-shape handle a multi-unit placeholder becomes once its manifest children exist. Added to `_CONTAINER_SHAPE_LABELS` so `is_container` recognizes it.
- **`claim` refuses it** — `claim` already guards on `is_container`; the new label joins the container set, so a reconciled sub-container is refused (`E_NOT_CLAIMABLE`) keyed on the label, never child count (spec §5/invariant 5).
- **`deliver` refuses any container** (`lifecycle/deliver.py`) — a new dispatch guard: a `spec`/`epic`/`shape-impl-container` is refused before any evidence check or leaf mutation. A container closes via close-walk when its children close, never through `deliver`.
- **Multi-unit reconcile stamps it** (`_reconcile_multi`) — when the placeholder becomes the impl sub-container, it is stamped `shape-impl-container` (idempotent; applied before the `impl-placeholder` handle is removed last), completing the spec §6 promise "so `claim` refuses it."

## Contract decision

`deliver`-refuses-container raises **`E_USAGE`** (deliver's existing guard vocabulary); `claim`-refuses-container raises `E_NOT_CLAIMABLE`. The asymmetry is deliberate — there is no `E_NOT_DELIVERABLE` code, and `USAGE` is the honest "wrong invocation" signal.

## Testing (TDD, red→green per slice)

- `claim` refuses `shape-impl-container` (call-order, `test_transitions.py`)
- `deliver` on a container → `E_USAGE`, no mutation (call-order, `test_deliver.py`; covers the new label *and* a `shape-spec` container to prove the guard is `is_container`, not label-specific)
- multi-unit reconcile stamps the label (state-based, `test_recovery.py`; plus the interrupted-replay idempotency case)

`make ci-workcli`: **363 passed, 100% line+branch coverage**, mypy `--strict` clean, pip-audit clean, entry-verify OK.

## HEAVY completion gate

`packages/**` floors to HEAVY. The adversarial quality-gate workflow (finder lenses correctness/security/simplify + refuter panels) ran **clean at the major floor: 0 findings, 0 applied fixes**.

## Scope deferred to PR-3

- `creating-spec` handle + idempotent `instantiate_spec_shape` + create/promote recovery + reconcile incomplete-create population + dead `SPEC_MARKER`/`spec_path` cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
