### PR TITLE
feat(workcli): creating-spec create/promote recovery (PR-3/3, 9.5)

### DIFF
--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -16,6 +16,7 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import ORPHAN_MARKER
 from workcli.lifecycle.nouns import (
+    CREATING_SPEC_LABEL,
     DESIGN_CHILD_LABEL,
     IMPL_PLACEHOLDER_LABEL,
     NOUN_TEMPLATES,
@@ -28,29 +29,43 @@ from workcli.model import CreateFields
 
 
 def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> tuple[str, str]:
-    """Create the design child + blocked placeholder under an existing container.
+    """Find-or-create the design child + blocked placeholder under a container.
 
-    Returns (design_child_id, placeholder_id). Does NOT stamp `planned` --
-    the caller stamps it LAST (L16). Records the `impl-placeholder` label on
-    the placeholder; the design child gets `shape-design`.
+    Returns (design_child_id, placeholder_id). **Idempotent** (spec §6, L16):
+    a child already carrying `shape-design` / `impl-placeholder` under the
+    container is reused, never duplicated -- so the `reconcile` sweep (or a
+    re-run) that replays an interrupted instantiation mints only what a partial
+    crash left missing. Does NOT stamp `planned` or touch `creating-spec` -- the
+    caller owns that ordering (planned last, `creating-spec` removed after).
     """
-    design_child_id = backend.create(
-        CreateFields(
-            title=f"Design: {title}",
-            type="task",
-            parent=container_id,
-            labels=(DESIGN_CHILD_LABEL,),
+    design_child_id: str | None = None
+    placeholder_id: str | None = None
+    for child_id in backend.get(container_id).children:
+        child = backend.get(child_id)
+        if DESIGN_CHILD_LABEL in child.labels:
+            design_child_id = child_id
+        elif IMPL_PLACEHOLDER_LABEL in child.labels:
+            placeholder_id = child_id
+
+    if design_child_id is None:
+        design_child_id = backend.create(
+            CreateFields(
+                title=f"Design: {title}",
+                type="task",
+                parent=container_id,
+                labels=(DESIGN_CHILD_LABEL,),
+            )
         )
-    )
-    placeholder_id = backend.create(
-        CreateFields(
-            title=f"[Impl] {title} (scope: per spec)",
-            type="task",
-            parent=container_id,
-            labels=(IMPL_PLACEHOLDER_LABEL,),
-            blocked_by=design_child_id,
+    if placeholder_id is None:
+        placeholder_id = backend.create(
+            CreateFields(
+                title=f"[Impl] {title} (scope: per spec)",
+                type="task",
+                parent=container_id,
+                labels=(IMPL_PLACEHOLDER_LABEL,),
+                blocked_by=design_child_id,
+            )
         )
-    )
     return design_child_id, placeholder_id
 
 
@@ -99,17 +114,20 @@ def _create_spec_container(
             type=template.bd_type,
             priority=args.priority,
             parent=parent,
-            labels=(template.shape_label,),
+            labels=(template.shape_label, CREATING_SPEC_LABEL),
             acceptance=args.acceptance,
         )
     )
     if args.orphan:
         backend.append_note(container_id, ORPHAN_MARKER)
     design_child_id, placeholder_id = instantiate_spec_shape(backend, container_id, args.title)
-    # Stamped strictly last (L16): an interrupted create leaves an
-    # unplanned, self-reporting container in the Planning queue rather than
-    # a queue-invisible one.
+    # `planned` is stamped, then `creating-spec` is removed, STRICTLY LAST (L16).
+    # A crash anywhere before this removal leaves a `shape-spec` container that
+    # is NOT `planned` and still carries `creating-spec`: it self-reports into
+    # the Planning queue (visible) AND is finished by the `reconcile` sweep
+    # through the handle (auto-recoverable). Both nets fire.
     backend.label_mutate("add", container_id, [PLANNED_LABEL])
+    backend.label_mutate("remove", container_id, [CREATING_SPEC_LABEL])
     return {"id": container_id, "design_child": design_child_id, "placeholder": placeholder_id}
 
 

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -69,6 +69,33 @@ def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> t
     return design_child_id, placeholder_id
 
 
+def finalize_spec_instantiation(backend: Backend, container_id: str, title: str) -> tuple[str, str]:
+    """Idempotently complete a spec container born under `creating-spec`.
+
+    The single source of the L16 completion tail shared by `create spec`,
+    `promote`, and the `reconcile` sweep -- triplicating it is what let the
+    `promote` crash window drift open. Every step is idempotent, so replaying it
+    over any crash point (or a fully healed container) converges:
+
+    1. Ensure the container *shape* (`shape-spec` on, `shape-feat` off). `create
+       spec` births the container already `shape-spec`, so this is a no-op there;
+       `promote` adds `creating-spec` before its own swap, so a crash in that
+       window leaves a `shape-feat` item -- this is the *only* path that
+       reconstructs the swap, without which the sweep would heal a children-
+       bearing item that `is_container` rejects (a claimable leaf with children).
+    2. Mint only the template children a partial crash left missing.
+    3. Stamp `planned`, then remove the `creating-spec` handle STRICTLY LAST.
+
+    Returns (design_child_id, placeholder_id).
+    """
+    backend.label_mutate("add", container_id, ["shape-spec"])
+    backend.label_mutate("remove", container_id, ["shape-feat"])
+    design_child_id, placeholder_id = instantiate_spec_shape(backend, container_id, title)
+    backend.label_mutate("add", container_id, [PLANNED_LABEL])
+    backend.label_mutate("remove", container_id, [CREATING_SPEC_LABEL])
+    return design_child_id, placeholder_id
+
+
 def _validate_usage(args: Namespace, noun: Noun) -> None:
     if args.type is not None:
         raise WorkError(
@@ -120,14 +147,13 @@ def _create_spec_container(
     )
     if args.orphan:
         backend.append_note(container_id, ORPHAN_MARKER)
-    design_child_id, placeholder_id = instantiate_spec_shape(backend, container_id, args.title)
-    # `planned` is stamped, then `creating-spec` is removed, STRICTLY LAST (L16).
-    # A crash anywhere before this removal leaves a `shape-spec` container that
-    # is NOT `planned` and still carries `creating-spec`: it self-reports into
-    # the Planning queue (visible) AND is finished by the `reconcile` sweep
+    # The completion tail (mint children, stamp `planned`, drop `creating-spec`
+    # strictly last -- L16) is shared with `promote` and the `reconcile` sweep.
+    # A crash anywhere before the handle comes off leaves a `shape-spec`
+    # container that is NOT `planned` and still carries `creating-spec`: it
+    # self-reports into the Planning queue (visible) AND is finished by the sweep
     # through the handle (auto-recoverable). Both nets fire.
-    backend.label_mutate("add", container_id, [PLANNED_LABEL])
-    backend.label_mutate("remove", container_id, [CREATING_SPEC_LABEL])
+    design_child_id, placeholder_id = finalize_spec_instantiation(backend, container_id, args.title)
     return {"id": container_id, "design_child": design_child_id, "placeholder": placeholder_id}
 
 

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -57,5 +57,12 @@ IMPL_PLACEHOLDER_LABEL = "impl-placeholder"
 # manifest children are minted. A declared container-shape handle (joins
 # `_CONTAINER_SHAPE_LABELS`), so `claim` refuses it by label, never child count.
 IMPL_CONTAINER_LABEL = "shape-impl-container"
+# A spec container mid-instantiation: born with this handle (create spec /
+# promote) and removed STRICTLY LAST, after design child + placeholder exist and
+# `planned` is stamped. Its presence is the queryable signal `reconcile`
+# enumerates interrupted spec instantiations through (L10/L16); its absence means
+# the template is wholly minted. Not a container-shape label -- the container
+# already carries `shape-spec` for the claim guard.
+CREATING_SPEC_LABEL = "creating-spec"
 PLANNED_LABEL = "planned"
 SPEC_READY_LABEL = "spec-ready"

--- a/packages/workcli/src/workcli/lifecycle/reconcile.py
+++ b/packages/workcli/src/workcli/lifecycle/reconcile.py
@@ -24,8 +24,13 @@ from workcli.lifecycle import (
     has_marker,
     manifest_snapshot,
 )
+from workcli.lifecycle.create import finalize_spec_instantiation
 from workcli.lifecycle.deliver import reconcile_placeholder
-from workcli.lifecycle.nouns import DESIGN_CHILD_LABEL, IMPL_PLACEHOLDER_LABEL
+from workcli.lifecycle.nouns import (
+    CREATING_SPEC_LABEL,
+    DESIGN_CHILD_LABEL,
+    IMPL_PLACEHOLDER_LABEL,
+)
 from workcli.model import Item, QueryFilters
 
 
@@ -119,6 +124,23 @@ def _sweep_orphaned_designs(backend: Backend, *, dry_run: bool) -> list[JsonValu
     return findings
 
 
+def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> list[JsonValue]:
+    """Enumerate `creating-spec` handles; finish each interrupted spec
+    instantiation (`create spec` / `promote` crashed before the handle came off,
+    L16) via the shared `finalize_spec_instantiation` -- the same idempotent tail
+    the write paths run, so a crashed `promote` gets its `shape-feat`->`shape-spec`
+    swap reconstructed, not just create-spec's tail replayed. `query()` returns a
+    fully-populated Item whose `id`/`title` (both required bd fields) are all
+    `finalize` needs; it re-`get()`s the container's children itself. A second
+    sweep over a healed container finds no handle -- idempotent."""
+    findings: list[JsonValue] = []
+    for container in backend.query(QueryFilters(label=CREATING_SPEC_LABEL)):
+        if not dry_run:
+            finalize_spec_instantiation(backend, container.id, container.title)
+        findings.append(_finding(container.id, "interrupted_instantiation", repaired=not dry_run))
+    return findings
+
+
 def reconcile(backend: Backend, args: Namespace) -> JsonValue:
     """`work reconcile [--dry-run]` (plan L10). Reads no external state (no spec
     file); every candidate is found through a completion handle."""
@@ -126,4 +148,5 @@ def reconcile(backend: Backend, args: Namespace) -> JsonValue:
     findings = _sweep_interrupted_delivers(backend, dry_run=dry_run)
     findings += _sweep_pending_placeholders(backend, dry_run=dry_run)
     findings += _sweep_orphaned_designs(backend, dry_run=dry_run)
+    findings += _sweep_interrupted_instantiations(backend, dry_run=dry_run)
     return {"findings": findings}

--- a/packages/workcli/src/workcli/lifecycle/reconcile.py
+++ b/packages/workcli/src/workcli/lifecycle/reconcile.py
@@ -129,9 +129,10 @@ def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> lis
     instantiation (`create spec` / `promote` crashed before the handle came off,
     L16) via the shared `finalize_spec_instantiation` -- the same idempotent tail
     the write paths run, so a crashed `promote` gets its `shape-feat`->`shape-spec`
-    swap reconstructed, not just create-spec's tail replayed. `query()` returns a
-    fully-populated Item whose `id`/`title` (both required bd fields) are all
-    `finalize` needs; it re-`get()`s the container's children itself. A second
+    swap reconstructed, not just create-spec's tail replayed. `query()` yields a
+    lean Item (no children/deps -- see the module docstring), but its scalar
+    `id`/`title` (both required bd fields) are all `finalize` needs; `finalize`'s
+    `instantiate_spec_shape` re-`get()`s the container's children itself. A second
     sweep over a healed container finds no handle -- idempotent."""
     findings: list[JsonValue] = []
     for container in backend.query(QueryFilters(label=CREATING_SPEC_LABEL)):

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -17,7 +17,7 @@ from argparse import Namespace
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
-from workcli.lifecycle.create import instantiate_spec_shape
+from workcli.lifecycle.create import finalize_spec_instantiation
 from workcli.lifecycle.nouns import CREATING_SPEC_LABEL, PLANNED_LABEL
 
 
@@ -77,14 +77,12 @@ def promote(backend: Backend, args: Namespace) -> JsonValue:
     if "shape-spec" in item.labels:
         return {"id": args.id, "promoted": "spec"}
 
-    # `creating-spec` first, removed strictly LAST (L16). A crash mid-promote
-    # leaves the handle on, so the `reconcile` sweep finishes the template
-    # (idempotent `instantiate_spec_shape`), stamps `planned`, and drops the
-    # handle -- rather than stranding a half-promoted, queue-invisible container.
+    # `creating-spec` is added FIRST -- before the shape swap -- so any crash
+    # from here on leaves the handle set and the `reconcile` sweep replays the
+    # shared completion tail (`finalize_spec_instantiation`: swap shape-feat->
+    # shape-spec, mint the template children, stamp `planned`, drop the handle
+    # strictly last, L16). A crash before the handle is added leaves an untouched
+    # `shape-feat` leaf -- promote simply never started.
     backend.label_mutate("add", args.id, [CREATING_SPEC_LABEL])
-    backend.label_mutate("add", args.id, ["shape-spec"])
-    backend.label_mutate("remove", args.id, ["shape-feat"])
-    instantiate_spec_shape(backend, args.id, item.title)
-    backend.label_mutate("add", args.id, [PLANNED_LABEL])
-    backend.label_mutate("remove", args.id, [CREATING_SPEC_LABEL])
+    finalize_spec_instantiation(backend, args.id, item.title)
     return {"id": args.id, "promoted": "spec"}

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -18,7 +18,7 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
 from workcli.lifecycle.create import instantiate_spec_shape
-from workcli.lifecycle.nouns import PLANNED_LABEL
+from workcli.lifecycle.nouns import CREATING_SPEC_LABEL, PLANNED_LABEL
 
 
 def claim(backend: Backend, args: Namespace) -> JsonValue:
@@ -77,10 +77,14 @@ def promote(backend: Backend, args: Namespace) -> JsonValue:
     if "shape-spec" in item.labels:
         return {"id": args.id, "promoted": "spec"}
 
+    # `creating-spec` first, removed strictly LAST (L16). A crash mid-promote
+    # leaves the handle on, so the `reconcile` sweep finishes the template
+    # (idempotent `instantiate_spec_shape`), stamps `planned`, and drops the
+    # handle -- rather than stranding a half-promoted, queue-invisible container.
+    backend.label_mutate("add", args.id, [CREATING_SPEC_LABEL])
     backend.label_mutate("add", args.id, ["shape-spec"])
     backend.label_mutate("remove", args.id, ["shape-feat"])
     instantiate_spec_shape(backend, args.id, item.title)
-    # Stamped strictly last (L16) -- mirrors `create spec`'s mint-before-
-    # planned discipline.
     backend.label_mutate("add", args.id, [PLANNED_LABEL])
+    backend.label_mutate("remove", args.id, [CREATING_SPEC_LABEL])
     return {"id": args.id, "promoted": "spec"}

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -72,10 +72,15 @@ def plan(backend: Backend, args: Namespace) -> JsonValue:
 def promote(backend: Backend, args: Namespace) -> JsonValue:
     """`work promote ID` -- a `shape-feat` leaf becomes a `shape-spec` container (L16)."""
     item = backend.get(args.id)
-    if "shape-feat" not in item.labels:
-        raise WorkError(ErrorCode.USAGE, f"{args.id}: only a feat can be promoted")
+    # `shape-spec` short-circuit FIRST, so a promote rerun is replay-safe: an
+    # interrupted promote leaves `[shape-spec, creating-spec]` (shape-feat already
+    # swapped off), and re-running must return a graceful no-op -- not trip the
+    # "only a feat" guard below on the now-absent shape-feat. The reconcile sweep
+    # finishes the still-present handle.
     if "shape-spec" in item.labels:
         return {"id": args.id, "promoted": "spec"}
+    if "shape-feat" not in item.labels:
+        raise WorkError(ErrorCode.USAGE, f"{args.id}: only a feat can be promoted")
 
     # `creating-spec` is added FIRST -- before the shape swap -- so any crash
     # from here on leaves the handle set and the `reconcile` sweep replays the

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -318,11 +318,19 @@ def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
         steps=[
             ScriptedStep(("search",), _search_result()),
             ScriptedStep(("create",), _create_result("x.1")),  # container
+            ScriptedStep(
+                ("label", "add"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # shape-spec
+            ScriptedStep(
+                ("label", "remove"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # shape-feat
             ScriptedStep(("show",), _search_result(_item_raw("x.1", "T"))),  # instantiate get
             ScriptedStep(("create",), _create_result("x.2")),  # design child
             ScriptedStep(("create",), _create_result("x.3")),  # placeholder
-            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
-            ScriptedStep(("label", "remove"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),  # planned
+            ScriptedStep(
+                ("label", "remove"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # creating-spec
         ]
     )
 
@@ -346,6 +354,8 @@ def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
             "--labels",
             "shape-spec,creating-spec",
         ),
+        ("label", "add", "x.1", "shape-spec"),
+        ("label", "remove", "x.1", "shape-feat"),
         ("show", "x.1", "--json"),
         (
             "create",
@@ -386,11 +396,19 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
             ScriptedStep(("search",), _search_result()),
             ScriptedStep(("create",), _create_result("x.1")),  # container
             ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr="")),  # orphan note
+            ScriptedStep(
+                ("label", "add"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # shape-spec
+            ScriptedStep(
+                ("label", "remove"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # shape-feat
             ScriptedStep(("show",), _search_result(_item_raw("x.1", "T"))),  # instantiate get
             ScriptedStep(("create",), _create_result("x.2")),  # design child
             ScriptedStep(("create",), _create_result("x.3")),  # placeholder
-            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
-            ScriptedStep(("label", "remove"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),  # planned
+            ScriptedStep(
+                ("label", "remove"), BdResult(returncode=0, stdout="", stderr="")
+            ),  # creating-spec
         ]
     )
 
@@ -417,5 +435,5 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
     # The container itself is orphaned, but its own children (design child +
     # placeholder) are still parented under it -- orphan-by-choice is a
     # placement decision about the top-level item, never its own children.
-    assert all("--parent" in call and "x.1" in call for call in runner.calls[4:6])
+    assert all("--parent" in call and "x.1" in call for call in runner.calls[6:8])
     assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -313,14 +313,16 @@ def test_create_epic_sends_one_create_with_epic_type_and_shape_label():
     ]
 
 
-def test_create_spec_mints_container_then_design_child_then_placeholder_then_stamps_planned_last():
+def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
     runner = ScriptedBdRunner(
         steps=[
             ScriptedStep(("search",), _search_result()),
             ScriptedStep(("create",), _create_result("x.1")),  # container
+            ScriptedStep(("show",), _search_result(_item_raw("x.1", "T"))),  # instantiate get
             ScriptedStep(("create",), _create_result("x.2")),  # design child
             ScriptedStep(("create",), _create_result("x.3")),  # placeholder
             ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "remove"), BdResult(returncode=0, stdout="", stderr="")),
         ]
     )
 
@@ -342,8 +344,9 @@ def test_create_spec_mints_container_then_design_child_then_placeholder_then_sta
             "--parent",
             "P",
             "--labels",
-            "shape-spec",
+            "shape-spec,creating-spec",
         ),
+        ("show", "x.1", "--json"),
         (
             "create",
             "--json",
@@ -371,7 +374,10 @@ def test_create_spec_mints_container_then_design_child_then_placeholder_then_sta
             "x.2",
         ),
         ("label", "add", "x.1", "planned"),
+        ("label", "remove", "x.1", "creating-spec"),
     ]
+    # `creating-spec` comes off strictly last, after `planned` (L16).
+    assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")
 
 
 def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_orphan_note():
@@ -380,9 +386,11 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
             ScriptedStep(("search",), _search_result()),
             ScriptedStep(("create",), _create_result("x.1")),  # container
             ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr="")),  # orphan note
+            ScriptedStep(("show",), _search_result(_item_raw("x.1", "T"))),  # instantiate get
             ScriptedStep(("create",), _create_result("x.2")),  # design child
             ScriptedStep(("create",), _create_result("x.3")),  # placeholder
             ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "remove"), BdResult(returncode=0, stdout="", stderr="")),
         ]
     )
 
@@ -394,10 +402,20 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
     assert envelope["data"] == {"id": "x.1", "design_child": "x.2", "placeholder": "x.3"}
     assert runner.calls[:3] == [
         ("search", "T", "--json"),
-        ("create", "--json", "--title", "T", "--type", "feature", "--labels", "shape-spec"),
+        (
+            "create",
+            "--json",
+            "--title",
+            "T",
+            "--type",
+            "feature",
+            "--labels",
+            "shape-spec,creating-spec",
+        ),
         ("update", "x.1", "--append-notes", ORPHAN_MARKER),
     ]
     # The container itself is orphaned, but its own children (design child +
     # placeholder) are still parented under it -- orphan-by-choice is a
     # placement decision about the top-level item, never its own children.
-    assert all("--parent" in call and "x.1" in call for call in runner.calls[3:5])
+    assert all("--parent" in call and "x.1" in call for call in runner.calls[4:6])
+    assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -207,9 +207,13 @@ VERB_CASES: list[VerbCase] = [
         [
             ScriptedStep(("search",), _search_result()),  # no title collision
             ScriptedStep(("create",), _lifecycle_create_result("s.1")),  # container
+            ScriptedStep(
+                ("show",), _show_result(_item_raw("s.1", "New Objective"))
+            ),  # instantiate get
             ScriptedStep(("create",), _lifecycle_create_result("s.2")),  # design child
             ScriptedStep(("create",), _lifecycle_create_result("s.3")),  # placeholder
-            ScriptedStep(("label", "add"), _OK),  # planned, stamped last
+            ScriptedStep(("label", "add"), _OK),  # planned
+            ScriptedStep(("label", "remove"), _OK),  # creating-spec, removed last
         ],
         ["create", "feat", "--title", "Existing Feature", "--parent", "P"],
         [ScriptedStep(("search",), _search_result(_item_raw("f.9", "Existing Feature")))],
@@ -271,11 +275,16 @@ VERB_CASES: list[VerbCase] = [
             ScriptedStep(
                 ("show",), _show_result(_item_raw("m.1", "T", status="open", labels=["shape-feat"]))
             ),
+            ScriptedStep(("label", "add"), _OK),  # creating-spec
             ScriptedStep(("label", "add"), _OK),  # shape-spec
             ScriptedStep(("label", "remove"), _OK),  # shape-feat
+            ScriptedStep(
+                ("show",), _show_result(_item_raw("m.1", "T", status="open", labels=["shape-spec"]))
+            ),  # instantiate get
             ScriptedStep(("create",), _lifecycle_create_result("m.2")),  # design child
             ScriptedStep(("create",), _lifecycle_create_result("m.3")),  # placeholder
-            ScriptedStep(("label", "add"), _OK),  # planned, stamped last
+            ScriptedStep(("label", "add"), _OK),  # planned
+            ScriptedStep(("label", "remove"), _OK),  # creating-spec, removed last
         ],
         ["promote", "m.2"],  # not shape-feat -> E_USAGE
         [ScriptedStep(("show",), _show_result(_item_raw("m.2", "T", status="open")))],

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -207,6 +207,8 @@ VERB_CASES: list[VerbCase] = [
         [
             ScriptedStep(("search",), _search_result()),  # no title collision
             ScriptedStep(("create",), _lifecycle_create_result("s.1")),  # container
+            ScriptedStep(("label", "add"), _OK),  # shape-spec (finalize shape guard)
+            ScriptedStep(("label", "remove"), _OK),  # shape-feat (finalize shape guard)
             ScriptedStep(
                 ("show",), _show_result(_item_raw("s.1", "New Objective"))
             ),  # instantiate get
@@ -296,6 +298,7 @@ VERB_CASES: list[VerbCase] = [
             ScriptedStep(("list",), _list_result()),  # interrupted-deliver sweep: empty
             ScriptedStep(("list",), _list_result()),  # pending-placeholder sweep: empty
             ScriptedStep(("list",), _list_result()),  # orphaned-design sweep: empty
+            ScriptedStep(("list",), _list_result()),  # interrupted-instantiation sweep: empty
         ],
         ["reconcile"],
         [ScriptedStep(("list",), _GARBAGE)],  # unparseable bd list output -> E_BACKEND_DRIFT

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -20,9 +20,11 @@ import pytest
 from tests.fake_backend import FakeBackend
 from workcli.envelope import ErrorCode, WorkError
 from workcli.lifecycle import DELIVERED_MARKER, MANIFEST_MARKER, SPEC_MARKER, manifest_snapshot
+from workcli.lifecycle.create import instantiate_spec_shape
 from workcli.lifecycle.deliver import deliver, reconcile_placeholder
 from workcli.lifecycle.manifest import Manifest, ManifestItem, serialize_manifest
 from workcli.lifecycle.nouns import (
+    CREATING_SPEC_LABEL,
     DESIGN_CHILD_LABEL,
     IMPL_CONTAINER_LABEL,
     IMPL_PLACEHOLDER_LABEL,
@@ -552,3 +554,51 @@ def test_reconcile_repairs_pending_placeholder_with_no_design_sibling():
     assert "shape-feat" in placeholder.labels
     assert IMPL_PLACEHOLDER_LABEL not in placeholder.labels
     assert {"id": "p", "kind": "unreconciled_placeholder", "repaired": True} in findings
+
+
+# --- creating-spec recovery (spec §6, plan L16: interrupted spec instantiation) ---
+
+
+def _creating_spec_container(backend: FakeBackend, *, with_design=False, with_placeholder=False):
+    """A spec container mid-instantiation: carries `creating-spec`, not yet
+    `planned`. `with_design`/`with_placeholder` seed the children a partial crash
+    would have already minted before dying."""
+    backend.add("c", title="T", type="feature", labels=["shape-spec", CREATING_SPEC_LABEL])
+    if with_design:
+        backend.add("d", title="Design: T", type="task", parent="c", labels=[DESIGN_CHILD_LABEL])
+    if with_placeholder:
+        backend.add(
+            "p",
+            title="[Impl] T (scope: per spec)",
+            type="task",
+            parent="c",
+            labels=[IMPL_PLACEHOLDER_LABEL],
+            deps=[DepEdge(id="d", type="blocks", status="open")],
+        )
+
+
+def test_instantiate_spec_shape_is_idempotent_when_both_children_exist():
+    # A replay (reconcile sweep, or a re-run) over a container whose design child
+    # and placeholder already exist must find-or-create: return the existing ids,
+    # mint nothing new -- no duplicate template children (spec §6, L16).
+    backend = FakeBackend()
+    _creating_spec_container(backend, with_design=True, with_placeholder=True)
+
+    design_id, placeholder_id = instantiate_spec_shape(backend, "c", "T")
+
+    assert (design_id, placeholder_id) == ("d", "p")
+    assert sorted(backend.get("c").children) == ["d", "p"]
+
+
+def test_instantiate_spec_shape_ignores_children_that_are_neither_design_nor_placeholder():
+    # Defensive: a stray child under the container (neither `shape-design` nor
+    # `impl-placeholder`) is skipped by the find-or-create scan -- the real
+    # design child + placeholder are still located, nothing duplicated.
+    backend = FakeBackend()
+    _creating_spec_container(backend, with_design=True, with_placeholder=True)
+    backend.add("stray", title="unrelated", type="task", parent="c", labels=["shape-chore"])
+
+    design_id, placeholder_id = instantiate_spec_shape(backend, "c", "T")
+
+    assert (design_id, placeholder_id) == ("d", "p")
+    assert sorted(backend.get("c").children) == ["d", "p", "stray"]

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -19,7 +19,13 @@ import pytest
 
 from tests.fake_backend import FakeBackend
 from workcli.envelope import ErrorCode, WorkError
-from workcli.lifecycle import DELIVERED_MARKER, MANIFEST_MARKER, SPEC_MARKER, manifest_snapshot
+from workcli.lifecycle import (
+    DELIVERED_MARKER,
+    MANIFEST_MARKER,
+    SPEC_MARKER,
+    is_container,
+    manifest_snapshot,
+)
 from workcli.lifecycle.create import instantiate_spec_shape
 from workcli.lifecycle.deliver import deliver, reconcile_placeholder
 from workcli.lifecycle.manifest import Manifest, ManifestItem, serialize_manifest
@@ -602,3 +608,103 @@ def test_instantiate_spec_shape_ignores_children_that_are_neither_design_nor_pla
 
     assert (design_id, placeholder_id) == ("d", "p")
     assert sorted(backend.get("c").children) == ["d", "p", "stray"]
+
+
+def _assert_instantiation_healed(backend: FakeBackend) -> None:
+    """The healed end-state of an interrupted spec instantiation: `planned` on,
+    `creating-spec` off, exactly one design child + one placeholder minted."""
+    container = backend.get("c")
+    assert "planned" in container.labels
+    assert CREATING_SPEC_LABEL not in container.labels
+    child_labels = [backend.get(cid).labels for cid in container.children]
+    design = [ls for ls in child_labels if DESIGN_CHILD_LABEL in ls]
+    placeholder = [ls for ls in child_labels if IMPL_PLACEHOLDER_LABEL in ls]
+    assert len(design) == 1
+    assert len(placeholder) == 1
+
+
+def test_reconcile_heals_interrupted_instantiation_with_no_children():
+    # A crash right after the container was born (`creating-spec` on, no children
+    # yet): the sweep mints the whole template, stamps `planned`, drops the
+    # handle last -- reaching the same state a clean `create spec` would.
+    backend = FakeBackend()
+    _creating_spec_container(backend)  # no children
+
+    findings = _reconcile(backend)
+
+    _assert_instantiation_healed(backend)
+    assert {"id": "c", "kind": "interrupted_instantiation", "repaired": True} in findings
+
+
+def test_reconcile_heals_interrupted_instantiation_with_only_design_child():
+    # A crash after the design child was minted but before the placeholder: the
+    # idempotent replay mints only the missing placeholder, never a second design.
+    backend = FakeBackend()
+    _creating_spec_container(backend, with_design=True)  # design only, no placeholder
+
+    findings = _reconcile(backend)
+
+    _assert_instantiation_healed(backend)
+    # the pre-existing design child is reused, not duplicated
+    designs = [
+        cid for cid in backend.get("c").children if DESIGN_CHILD_LABEL in backend.get(cid).labels
+    ]
+    assert designs == ["d"]
+    assert {"id": "c", "kind": "interrupted_instantiation", "repaired": True} in findings
+
+
+def test_reconcile_heals_interrupted_instantiation_with_both_children_not_yet_planned():
+    # A crash after both template children exist but before `planned` was stamped
+    # (`creating-spec` still on): the sweep mints nothing, only stamps `planned`
+    # and drops the handle -- no duplicate children.
+    backend = FakeBackend()
+    _creating_spec_container(backend, with_design=True, with_placeholder=True)
+
+    findings = _reconcile(backend)
+
+    _assert_instantiation_healed(backend)
+    assert sorted(backend.get("c").children) == ["d", "p"]  # no duplicates minted
+    assert {"id": "c", "kind": "interrupted_instantiation", "repaired": True} in findings
+
+
+def test_reconcile_interrupted_instantiation_dry_run_reports_without_mutating():
+    backend = FakeBackend()
+    _creating_spec_container(backend)  # no children
+
+    findings = _reconcile(backend, dry_run=True)
+
+    container = backend.get("c")
+    assert CREATING_SPEC_LABEL in container.labels  # untouched
+    assert "planned" not in container.labels
+    assert container.children == []  # nothing minted
+    assert {"id": "c", "kind": "interrupted_instantiation", "repaired": False} in findings
+
+
+def test_reconcile_over_a_healed_instantiation_finds_no_creating_spec():
+    backend = FakeBackend()
+    _creating_spec_container(backend)
+
+    _reconcile(backend)  # heal
+    second = _reconcile(backend)  # idempotent second pass
+
+    assert not any(f["kind"] == "interrupted_instantiation" for f in second)
+
+
+def test_reconcile_heals_promote_crash_before_the_shape_feat_to_spec_swap():
+    # `promote` adds `creating-spec` FIRST, then swaps shape-feat->shape-spec in
+    # later calls. A crash in that window leaves a still-`shape-feat` item under
+    # the handle. The sweep must reconstruct the container shape (not just replay
+    # create-spec's tail), else it heals a children-bearing item that is_container
+    # rejects -- a claimable leaf with children, unrepairable once the handle is
+    # gone. Healed state must be a real container: shape-spec on, shape-feat off.
+    backend = FakeBackend()
+    backend.add("c", title="T", type="feature", labels=["shape-feat", CREATING_SPEC_LABEL])
+
+    findings = _reconcile(backend)
+
+    container = backend.get("c")
+    assert "shape-spec" in container.labels
+    assert "shape-feat" not in container.labels
+    assert is_container(container)  # claim() now correctly refuses it as a container
+    _assert_instantiation_healed(backend)
+    assert {"id": "c", "kind": "interrupted_instantiation", "repaired": True} in findings

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -428,3 +428,28 @@ def test_promote_already_shape_spec_is_a_noop():
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1", "promoted": "spec"}
     assert runner.calls == [("show", "x.1", "--json")]
+
+
+def test_promote_rerun_after_shape_swap_is_replay_safe():
+    # The crash window `finalize` opens: a crash after the shape-feat->shape-spec
+    # swap but before `creating-spec` comes off leaves `[shape-spec, creating-spec]`
+    # (no shape-feat). A promote rerun -- the obvious manual recovery -- must NOT
+    # raise E_USAGE on the "only a feat can be promoted" guard; the shape-spec
+    # short-circuit is checked first, so it returns a graceful no-op (the handle
+    # stays for the reconcile sweep to finish).
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("show",),
+                _show_result(
+                    _item_raw("x.1", status="open", labels=["shape-spec", "creating-spec"])
+                ),
+            ),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["promote", "x.1"], runner)
+
+    assert exit_code == 0
+    assert envelope["data"] == {"id": "x.1", "promoted": "spec"}
+    assert runner.calls == [("show", "x.1", "--json")]  # no mutation on the replay

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -329,18 +329,25 @@ def test_plan_with_both_done_and_undo_is_usage_error():
 # --- promote --------------------------------------------------------------
 
 
-def test_promote_shape_feat_leaf_mints_spec_shape_in_order_planned_stamped_last():
+def test_promote_shape_feat_leaf_mints_spec_shape_in_order_creating_spec_removed_last():
     runner = ScriptedBdRunner(
         steps=[
             ScriptedStep(
                 ("show",),
                 _show_result(_item_raw("x.1", status="open", labels=["shape-feat"], title="T")),
             ),
+            ScriptedStep(("label", "add"), _OK),  # creating-spec
             ScriptedStep(("label", "add"), _OK),  # shape-spec
             ScriptedStep(("label", "remove"), _OK),  # shape-feat
+            # instantiate_spec_shape's find-or-create get: x.1 has no children yet
+            ScriptedStep(
+                ("show",),
+                _show_result(_item_raw("x.1", status="open", labels=["shape-spec"], title="T")),
+            ),
             ScriptedStep(("create",), _create_result("x.2")),  # design child
             ScriptedStep(("create",), _create_result("x.3")),  # placeholder
             ScriptedStep(("label", "add"), _OK),  # planned
+            ScriptedStep(("label", "remove"), _OK),  # creating-spec (LAST)
         ]
     )
 
@@ -350,8 +357,10 @@ def test_promote_shape_feat_leaf_mints_spec_shape_in_order_planned_stamped_last(
     assert envelope["data"] == {"id": "x.1", "promoted": "spec"}
     assert runner.calls == [
         ("show", "x.1", "--json"),
+        ("label", "add", "x.1", "creating-spec"),
         ("label", "add", "x.1", "shape-spec"),
         ("label", "remove", "x.1", "shape-feat"),
+        ("show", "x.1", "--json"),
         (
             "create",
             "--json",
@@ -379,7 +388,10 @@ def test_promote_shape_feat_leaf_mints_spec_shape_in_order_planned_stamped_last(
             "x.2",
         ),
         ("label", "add", "x.1", "planned"),
+        ("label", "remove", "x.1", "creating-spec"),
     ]
+    # `creating-spec` comes off strictly last -- after `planned` (L16).
+    assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")
     # No reparent/new-parent call on x.1 itself -- id, parent, and edges
     # untouched (L16/plan item 10).
     assert not any(call[:2] == ("update", "x.1") for call in runner.calls)


### PR DESCRIPTION
## What

PR-3 (final) of the workcli deliver↔reconcile recovery-contract redesign (`agents-config-wgclw.9.5`). Makes an interrupted **spec instantiation** (`create spec` / `promote`) recoverable through the single `creating-spec` completion handle.

Sequence: PR-1 recovery core (#267) → PR-2 container semantics (#271) → **PR-3 create/promote recovery (this)**.

## Changes

- **`creating-spec` handle** — a spec container carries it from birth (create) or from the first mutation (promote) and it is removed **strictly last**, after `planned`. Its presence is the queryable signal that instantiation is unfinished.
- **`finalize_spec_instantiation`** (`create.py`) — the single source of the L16 completion tail (ensure container shape → mint missing template children → stamp `planned` → drop the handle last). Shared by `create spec`, `promote`, and the reconcile sweep. Every step idempotent, so replay over any crash point converges.
- **`_sweep_interrupted_instantiations`** — reconcile enumerates `creating-spec` handles and finishes each via `finalize`; wired 4th in `reconcile()`.

## Crash window this closes (found by the HEAVY gate)

`promote` adds `creating-spec` **before** its `shape-feat`→`shape-spec` swap. A crash in that window left a still-`shape-feat` item under the handle. The first-cut sweep replayed only create-spec's tail, so it healed that item into a children-bearing **non-container** — a claimable leaf with children, unrepairable once the handle came off. `finalize` now reconstructs the shape swap idempotently, so the healed state is always a valid `planned` container. Regression test: `test_reconcile_heals_promote_crash_before_the_shape_feat_to_spec_swap`.

The same extraction resolves the gate's DRY/architecture major — the completion tail was triplicated across create/promote/reconcile and had already drifted; it is now single-sourced.

## Tests

`test_recovery.py`: promote-crash recovery; interrupted-instantiation heal (no / design-only / both children); dry-run; idempotency; `instantiate_spec_shape` find-or-create. Call-order sequences (`test_create_noun`, `test_envelope_invariants`) updated for the finalize shape guard. **374 passed, 100% coverage**, audit + entry-verify clean (`make ci-workcli`).

## Knowingly accepted

`instantiate_spec_shape`'s find-loop does a per-child `backend.get()` (N+1) — N is exactly 2 (design + placeholder), and a `break` would change first-vs-last match semantics with duplicate labels. Not worth the risk at N=2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)