### PR TITLE
fix(prgroom): posted-reply-ID ledger + legacy pr-inventory export (abn9.8.28, abn9.8.13.1)

### DIFF
--- a/packages/prgroom/src/prgroom/lifecycle/poll.py
+++ b/packages/prgroom/src/prgroom/lifecycle/poll.py
@@ -200,6 +200,11 @@ def _ingest_items(
     full reviews response (a verdict can repeat across polls without a new item).
     """
     seen = {(item.kind, item.identity.gh_id) for item in state.items}
+    # prgroom replies by POSTing a NEW comment whose fresh gh_id is unknown to `seen`;
+    # without this it would re-ingest its own reply every poll and re-triage forever
+    # (recursive self-reply spam). The reply's id was recorded on own_reply_id, so drop
+    # any ingested entry (any kind) whose gh_id matches one of our own posted replies.
+    own_replies = {str(item.own_reply_id) for item in state.items if item.own_reply_id}
     base = f"repos/{ref.owner}/{ref.repo}"
     # Paginate the three collection reads: prgroom's own reply reviews push any
     # nontrivial PR past GitHub's 30-per-page default, and an unpaginated read froze
@@ -219,6 +224,8 @@ def _ingest_items(
     ):
         for entry in raw:
             item = _to_item(kind, entry, ts_field, now=now, thread_id_map=thread_id_map)
+            if item.identity.gh_id in own_replies:
+                continue  # our own posted reply — never re-ingest (self-reply prevention)
             if (item.kind, item.identity.gh_id) not in seen:
                 seen.add((item.kind, item.identity.gh_id))
                 new.append(item)

--- a/packages/prgroom/src/prgroom/lifecycle/reply.py
+++ b/packages/prgroom/src/prgroom/lifecycle/reply.py
@@ -66,13 +66,25 @@ def _render_body(disp: Disposition) -> str:
     return _T_RATIONALE.render({"rationale": disp.rationale})
 
 
-def _post_reply(gh: GhClient, ref: PRRef, item: ReviewItem, body: str) -> None:
+def _post_reply(gh: GhClient, ref: PRRef, item: ReviewItem, body: str) -> int:
+    """POST the reply/comment and return the new comment's numeric id (0 if absent).
+
+    GitHub's reply/comment POST returns the created comment object carrying a numeric
+    ``id``; the caller records it on ``item.own_reply_id`` so a later poll can exclude
+    our own reply (recursive self-reply prevention). Defensive on shape: the id may be
+    int or str, and a malformed response with no usable id degrades to 0.
+    """
     if item.kind is ItemKind.REVIEW_THREAD:
         reply_id = item.identity.reply_to_comment_id or int(item.identity.gh_id)
         path = f"repos/{ref.owner}/{ref.repo}/pulls/{ref.number}/comments/{reply_id}/replies"
     else:
         path = f"repos/{ref.owner}/{ref.repo}/issues/{ref.number}/comments"
-    gh.rest("POST", path, fields={"body": body})
+    response = gh.rest("POST", path, fields={"body": body})
+    raw_id = response.get("id") if isinstance(response, dict) else None
+    try:
+        return int(raw_id)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
 
 
 _COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
@@ -188,7 +200,7 @@ def reply_pr(
                 # --rationale). Posting "" fails the GitHub API; skip it and leave `replied`
                 # False so a later rationale can still reply.
                 continue
-            _post_reply(gh, ref, item, body)
+            item.own_reply_id = _post_reply(gh, ref, item, body)
             item.replied = True
         _route_memory(state, gh=gh, ref=ref)
     except GhNotFoundError as exc:

--- a/packages/prgroom/src/prgroom/prsession/legacy_export.py
+++ b/packages/prgroom/src/prgroom/prsession/legacy_export.py
@@ -1,0 +1,246 @@
+"""Emit merge-guard's legacy pr-inventory format alongside prgroom state.
+
+``merge-guard``'s ``check-merge-eligibility.sh`` clears its ``untriaged_feedback``
+blocker ONLY from the legacy ``~/.claude/state/pr-inventory`` inventory (a
+per-head-SHA JSON file plus a ``.replyids`` sidecar). prgroom persists its own
+state under ``~/.local/state/prgroom`` in a different schema — invisible to
+merge-guard — so a PR prgroom has fully dispositioned could never reach merge
+eligibility. This module bridges the gap: at persist time prgroom ALSO emits the
+legacy files, byte-compatible with what the consumer reads. Neither merge-guard
+nor the prose skills change.
+
+Design:
+
+* The translation is a set of PURE functions (:func:`to_legacy_inventory`,
+  :func:`to_replyids_lines`, :func:`legacy_inventory_path`) — heavily tested.
+* :class:`LegacyExportStore` is a decorator Store that wraps the production
+  :class:`~prgroom.prsession.file.FileStore`. ``write`` persists inner state
+  FIRST (primary, atomic — never weakened), then best-effort emits the legacy
+  files inside a ``try/except`` that logs and never re-raises: state persistence
+  is primary, and merge-guard reads fail-closed, so a missing export merely keeps
+  the PR blocked (safe).
+
+The disposition→classification table is fail-closed and exhaustive: an unknown
+:class:`DispositionKind` raises (``KeyError``) rather than silently clearing a
+merge blocker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from pathlib import Path
+
+from prgroom.prsession.enums import DispositionKind, ItemKind
+from prgroom.prsession.file import write_atomic
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import JsonObj, PRGroomingState, ReviewItem
+from prgroom.prsession.store import Store
+
+_logger = logging.getLogger(__name__)
+
+LEGACY_SCHEMA_VERSION = 1
+LEGACY_DIR_ENV_VAR = "PRGROOM_LEGACY_INVENTORY_DIR"
+
+# Fail-closed disposition table. ``(classification, fix_outcome)`` per the
+# consumer's ``terminal_ok`` predicate: an item clears iff classification=="SKIP"
+# OR (classification=="FIX" AND fix_outcome in {"committed","already_addressed"}).
+# ESCALATE and FIX/failed are terminal but BLOCK (non-clearing) — safe defaults.
+# Keyed on every DispositionKind so a future member must be added deliberately;
+# a missing key raises KeyError (fail loud) rather than defaulting to CLEAR.
+_DISPOSITION_TO_LEGACY: dict[DispositionKind, tuple[str, str | None]] = {
+    DispositionKind.SKIPPED: ("SKIP", None),
+    DispositionKind.WONT_FIX: ("SKIP", None),
+    DispositionKind.FIXED: ("FIX", "committed"),
+    DispositionKind.ALREADY_ADDRESSED: ("FIX", "already_addressed"),
+    DispositionKind.DEFERRED: ("ESCALATE", None),
+    DispositionKind.ESCALATED: ("ESCALATE", None),
+    DispositionKind.FAILED: ("FIX", "failed"),
+}
+
+
+def resolve_legacy_dir(
+    override: Path | None = None, *, env: Mapping[str, str] | None = None
+) -> Path:
+    """Resolve the legacy pr-inventory export dir.
+
+    Precedence: explicit ``override`` arg > ``$PRGROOM_LEGACY_INVENTORY_DIR`` >
+    the merge-guard default ``~/.claude/state/pr-inventory``. ``Path.home()`` is
+    resolved lazily here (never at import time) so tests can inject a ``tmp_path``.
+    A blank env value is treated as unset (POSIX convention).
+    """
+    if override is not None:
+        return override
+    environ = env if env is not None else os.environ
+    raw = environ.get(LEGACY_DIR_ENV_VAR)
+    if raw:
+        return Path(raw)
+    return Path.home() / ".claude" / "state" / "pr-inventory"
+
+
+def _head_sha(state: PRGroomingState) -> str:
+    """The head SHA the legacy filename pins to: pushed head wins, else poll SHA."""
+    return state.last_pushed_head_sha or state.last_poll_sha
+
+
+def legacy_inventory_path(export_dir: Path, state: PRGroomingState) -> Path:
+    """``{export_dir}/{owner}-{repo}-{number}-{head_sha}.json`` (consumer filename)."""
+    pr = state.pr
+    stem = f"{pr.owner}-{pr.repo}-{pr.number}-{_head_sha(state)}"
+    return export_dir / f"{stem}.json"
+
+
+def _legacy_item(item: ReviewItem) -> JsonObj:
+    """Translate one dispositioned ReviewItem into a legacy inventory item.
+
+    Precondition: ``item.disposition is not None`` (untriaged items are filtered
+    by :func:`to_legacy_inventory` — they carry no terminal decision and the live
+    GitHub scan catches them fail-closed).
+    """
+    disposition = item.disposition
+    assert disposition is not None  # noqa: S101  # caller-guaranteed; see docstring
+    classification, fix_outcome = _DISPOSITION_TO_LEGACY[disposition.kind]
+    identity = item.identity
+    entry: JsonObj = {
+        "kind": item.kind.value,
+        "classification": classification,
+        "fix_outcome": fix_outcome,
+        "posted_reply_id": item.own_reply_id or None,
+    }
+    if item.kind is ItemKind.ISSUE_COMMENT:
+        entry["issue_comment_id"] = int(identity.gh_id)
+    elif item.kind is ItemKind.REVIEW_SUMMARY:
+        entry["review_id"] = int(identity.gh_id)
+    else:  # ItemKind.REVIEW_THREAD
+        entry["reply_to_comment_id"] = identity.reply_to_comment_id or int(identity.gh_id)
+        entry["thread_id"] = identity.thread_id or None
+    return entry
+
+
+def to_legacy_inventory(state: PRGroomingState) -> JsonObj:
+    """Translate grooming state into the legacy pr-inventory JSON object.
+
+    Only items WITH a disposition are emitted (an untriaged item has no terminal
+    decision). ``skill_a_completed`` is always ``True`` — the consumer counts NO
+    terminal dispositions from an inventory that lacks it. ``bot_review_cap_exhausted``
+    is always ``False`` (fail-closed: false keeps force-merge locked).
+    """
+    items = [_legacy_item(it) for it in state.items if it.disposition is not None]
+    copilot_status = "review_found" if state.reviewers else "not_requested"
+    head_sha = _head_sha(state)
+    return {
+        "schema_version": LEGACY_SCHEMA_VERSION,
+        "pr": {
+            "owner": state.pr.owner,
+            "repo": state.pr.repo,
+            "number": state.pr.number,
+            "head_sha_at_inventory": state.last_poll_sha,
+            "head_sha_after_push": head_sha,
+        },
+        "polling": {
+            "copilot_status": copilot_status,
+            "rereview_round_count": state.pr_review_retries_used,
+            "bot_review_cap_exhausted": False,
+        },
+        "items": items,
+        "crash_recovery": {
+            "skill_a_completed": True,
+            "last_completed_phase": str(state.phase),
+        },
+    }
+
+
+def to_replyids_lines(state: PRGroomingState) -> list[JsonObj]:
+    """The ``.replyids`` sidecar rows: one per item with a non-zero own_reply_id.
+
+    The consumer only collects ``.rid`` (to exclude prgroom's own reply comments
+    from the live issue-comment feed); ``k``/``v`` mirror the legacy key/value for
+    fidelity. Regenerated fully each write — never appended.
+    """
+    lines: list[JsonObj] = []
+    for item in state.items:
+        if item.own_reply_id == 0:
+            continue
+        identity = item.identity
+        if item.kind is ItemKind.ISSUE_COMMENT:
+            key, value = "issue_comment_id", str(identity.gh_id)
+        elif item.kind is ItemKind.REVIEW_SUMMARY:
+            key, value = "review_id", str(identity.gh_id)
+        else:  # ItemKind.REVIEW_THREAD
+            key, value = "reply_to_comment_id", str(identity.reply_to_comment_id or identity.gh_id)
+        lines.append({"k": key, "v": value, "rid": item.own_reply_id})
+    return lines
+
+
+def export_legacy_inventory(state: PRGroomingState, export_dir: Path) -> None:
+    """Atomically write the legacy inventory JSON + ``.replyids`` sidecar.
+
+    Skips entirely when there is no head SHA yet (bootstrap — nothing meaningful
+    to emit). Both files go through :func:`~prgroom.prsession.file.write_atomic`
+    (tempfile + fsync + ``os.replace``); the sidecar is regenerated in full, not
+    appended.
+    """
+    if not _head_sha(state):
+        return
+    export_dir.mkdir(parents=True, exist_ok=True)
+    inventory_path = legacy_inventory_path(export_dir, state)
+    inventory_bytes = json.dumps(to_legacy_inventory(state), indent=2, sort_keys=True).encode(
+        "utf-8"
+    )
+    write_atomic(inventory_path, inventory_bytes)
+
+    lines = to_replyids_lines(state)
+    sidecar_text = "\n".join(json.dumps(line) for line in lines) + "\n"
+    sidecar_path = inventory_path.with_name(inventory_path.name + ".replyids")
+    write_atomic(sidecar_path, sidecar_text.encode("utf-8"))
+
+
+class LegacyExportStore:
+    """Decorator Store: persist via ``inner``, then best-effort legacy export.
+
+    Structurally satisfies the :class:`~prgroom.prsession.store.Store` Protocol.
+    Every method but ``write`` delegates straight to ``inner``. ``write`` calls
+    ``inner.write`` first (primary, atomic — never weakened), then emits the
+    legacy pr-inventory inside a ``try/except`` that logs a warning and never
+    re-raises: a failed export must not break grooming, and merge-guard reads
+    fail-closed so a missing export simply keeps the PR blocked (safe).
+    """
+
+    def __init__(
+        self,
+        inner: Store,
+        *,
+        export_dir: Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._inner = inner
+        self._export_dir = resolve_legacy_dir(export_dir, env=env)
+
+    # -- Store protocol --
+
+    def read(self, ref: PRRef) -> PRGroomingState:
+        return self._inner.read(ref)
+
+    def write(self, ref: PRRef, state: PRGroomingState) -> None:
+        self._inner.write(ref, state)
+        try:
+            export_legacy_inventory(state, self._export_dir)
+        except Exception:
+            # Best-effort: state is already durably persisted above; a failed
+            # legacy export must never break grooming (the consumer fail-closes,
+            # so a missing export only keeps the merge blocked — safe).
+            _logger.warning(
+                "legacy pr-inventory export failed for %s", ref.display(), exc_info=True
+            )
+
+    def lock(self, ref: PRRef) -> AbstractContextManager[None]:
+        return self._inner.lock(ref)
+
+    def list_refs(self) -> list[PRRef]:
+        return self._inner.list_refs()
+
+    def delete(self, ref: PRRef) -> None:
+        self._inner.delete(ref)

--- a/packages/prgroom/src/prgroom/prsession/legacy_export.py
+++ b/packages/prgroom/src/prgroom/prsession/legacy_export.py
@@ -82,8 +82,18 @@ def resolve_legacy_dir(
 
 
 def _head_sha(state: PRGroomingState) -> str:
-    """The head SHA the legacy filename pins to: pushed head wins, else poll SHA."""
-    return state.last_pushed_head_sha or state.last_poll_sha
+    """The PR's current head SHA the legacy filename pins to.
+
+    ``last_review_invalidated_sha`` is set on *every* head change — prgroom's own
+    push (``push.py``) and an external push (``poll.py``'s sha attribution) — so it
+    tracks the current head, leading ``last_poll_sha`` only in the "pushed but not
+    yet re-polled" window. ``last_pushed_head_sha`` must NOT be used: it is set
+    solely by prgroom's own push and is never re-cleared, so after an external push
+    it goes stale and would pin the export to an old head (filename mismatch +
+    ``head_sha_after_push`` older than ``head_sha_at_inventory``). Falls back to
+    ``last_poll_sha`` for the bootstrap poll, which sets no invalidated sha.
+    """
+    return state.last_review_invalidated_sha or state.last_poll_sha
 
 
 def legacy_inventory_path(export_dir: Path, state: PRGroomingState) -> Path:

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -54,8 +54,11 @@ def resolve_store(
         # Wrap so the production file store ALSO emits merge-guard's legacy
         # pr-inventory at persist time (best-effort); the inner adapter is the
         # unchanged, pure FileStore. Only the file path is wrapped — bd/in-memory
-        # paths never reach here. Thread ``env`` through so the legacy-dir seam
-        # honours an injected environment (test isolation) rather than silently
-        # resolving against the real ``os.environ``.
-        return LegacyExportStore(FileStore(state_dir=state_dir), env=env)
+        # paths never reach here. Thread the SAME resolved ``environ`` (not the
+        # raw ``env``) into the legacy-dir seam so store selection and legacy-dir
+        # resolution agree on one environment source: an injected mapping drives
+        # both (test isolation), and an absent env resolves neither against the
+        # real ``os.environ`` — env is parsed once at the CLI boundary and passed
+        # inward, never reached as a hidden global here.
+        return LegacyExportStore(FileStore(state_dir=state_dir), env=environ)
     raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/src/prgroom/prsession/registry.py
+++ b/packages/prgroom/src/prgroom/prsession/registry.py
@@ -4,7 +4,9 @@ Resolves a ``--store`` flag value (or the ``PRGROOM_STORE`` env var, or the
 built-in default ``file``) to a concrete :class:`~prgroom.prsession.store.Store`.
 Precedence is **flag > env > default** — the flag is consulted first and only
 falls through to the env when unset. ``file`` yields the production
-:class:`~prgroom.prsession.file.FileStore`; ``bd`` is deferred (v2) and any
+:class:`~prgroom.prsession.file.FileStore` wrapped in
+:class:`~prgroom.prsession.legacy_export.LegacyExportStore` (so it also emits
+merge-guard's legacy pr-inventory at persist time); ``bd`` is deferred (v2) and any
 unknown name is a user error — both surface as a terminal
 ``PRECONDITION_STORE_UNAVAILABLE`` (exit 2, rendered 4-line block, no traceback).
 """
@@ -17,6 +19,7 @@ from pathlib import Path
 
 from prgroom.errors import ErrorCode, PreconditionError
 from prgroom.prsession.file import FileStore
+from prgroom.prsession.legacy_export import LegacyExportStore
 from prgroom.prsession.store import Store
 
 ENV_VAR = "PRGROOM_STORE"
@@ -48,5 +51,11 @@ def resolve_store(
     environ = env if env is not None else {}
     resolved = name if name is not None else (environ.get(ENV_VAR) or DEFAULT_STORE)
     if resolved == StoreName.FILE:
-        return FileStore(state_dir=state_dir)
+        # Wrap so the production file store ALSO emits merge-guard's legacy
+        # pr-inventory at persist time (best-effort); the inner adapter is the
+        # unchanged, pure FileStore. Only the file path is wrapped — bd/in-memory
+        # paths never reach here. Thread ``env`` through so the legacy-dir seam
+        # honours an injected environment (test isolation) rather than silently
+        # resolving against the real ``os.environ``.
+        return LegacyExportStore(FileStore(state_dir=state_dir), env=env)
     raise PreconditionError(ErrorCode.PRECONDITION_STORE_UNAVAILABLE, detail=resolved)

--- a/packages/prgroom/src/prgroom/prsession/state.py
+++ b/packages/prgroom/src/prgroom/prsession/state.py
@@ -175,6 +175,7 @@ class ReviewItem:
     cluster_id: str = ""
     disposition: Disposition | None = None
     replied: bool = False
+    own_reply_id: int = 0
     resolved: bool = False
     duplicate_of_gh_id: str = ""
 
@@ -192,6 +193,8 @@ class ReviewItem:
             d["disposition"] = self.disposition.to_dict()
         if self.replied:
             d["replied"] = self.replied
+        if self.own_reply_id:
+            d["own_reply_id"] = self.own_reply_id
         if self.resolved:
             d["resolved"] = self.resolved
         if self.duplicate_of_gh_id:
@@ -212,6 +215,7 @@ class ReviewItem:
             if raw_disposition is not None
             else None,
             replied=d.get("replied", False),
+            own_reply_id=d.get("own_reply_id", 0),
             resolved=d.get("resolved", False),
             duplicate_of_gh_id=d.get("duplicate_of_gh_id", ""),
         )

--- a/packages/prgroom/tests/integration/test_legacy_export_store.py
+++ b/packages/prgroom/tests/integration/test_legacy_export_store.py
@@ -1,0 +1,90 @@
+"""Integration tests for LegacyExportStore (bead abn9.8.13.1).
+
+The wrapping Store persists inner state (primary, must not be weakened) and THEN
+best-effort emits merge-guard's legacy pr-inventory files to an injected export
+dir. A failing export must never propagate from ``write`` nor lose inner state.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.legacy_export import LegacyExportStore
+from prgroom.prsession.memory import InMemoryStore
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+
+_T = datetime(2026, 7, 14, 12, 0, 0, tzinfo=UTC)
+_REF = PRRef("octo", "demo", 7)
+
+
+def _state() -> PRGroomingState:
+    return PRGroomingState(
+        pr=_REF,
+        phase=PRPhase.QUIESCED,
+        pr_review_retries_used=0,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+        last_poll_sha="headsha",
+        items=[
+            ReviewItem(
+                kind=ItemKind.REVIEW_SUMMARY,
+                identity=Identity(gh_id="555"),
+                author="copilot",
+                body_excerpt="...",
+                seen_at=_T,
+                disposition=Disposition(
+                    kind=DispositionKind.SKIPPED, decided_at=_T, decided_by="fix"
+                ),
+                own_reply_id=42,
+            )
+        ],
+    )
+
+
+def test_write_persists_inner_and_emits_legacy(tmp_path: Path) -> None:
+    inner = InMemoryStore()
+    store = LegacyExportStore(inner, export_dir=tmp_path)
+
+    store.write(_REF, _state())
+
+    # Inner state persisted and readable back through the wrapper.
+    assert store.read(_REF).phase == PRPhase.QUIESCED
+    # Legacy files emitted to the injected dir.
+    assert (tmp_path / "octo-demo-7-headsha.json").is_file()
+    assert (tmp_path / "octo-demo-7-headsha.json.replyids").is_file()
+
+
+def test_export_failure_does_not_propagate_and_inner_persists(tmp_path: Path) -> None:
+    inner = InMemoryStore()
+    # Point the export dir at a path whose parent is a FILE, so mkdir raises.
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x")
+    store = LegacyExportStore(inner, export_dir=blocker / "sub")
+
+    # Best-effort: the export blows up internally but write() returns normally.
+    store.write(_REF, _state())
+
+    # Primary persist survived the export failure.
+    assert store.read(_REF).phase == PRPhase.QUIESCED
+
+
+def test_delegates_lock_list_and_delete(tmp_path: Path) -> None:
+    inner = InMemoryStore()
+    store = LegacyExportStore(inner, export_dir=tmp_path)
+    store.write(_REF, _state())
+
+    assert store.list_refs() == [_REF]
+    with store.lock(_REF):
+        pass
+    store.delete(_REF)
+    assert store.list_refs() == []

--- a/packages/prgroom/tests/unit/test_legacy_export.py
+++ b/packages/prgroom/tests/unit/test_legacy_export.py
@@ -72,6 +72,7 @@ def _state(
     items: list[ReviewItem] | None = None,
     last_poll_sha: str = "pollsha",
     last_pushed_head_sha: str = "",
+    last_review_invalidated_sha: str = "",
     reviewers_present: bool = False,
     phase: PRPhase = PRPhase.QUIESCED,
 ) -> PRGroomingState:
@@ -96,6 +97,7 @@ def _state(
         quiescence=QuiescenceState(),
         last_poll_sha=last_poll_sha,
         last_pushed_head_sha=last_pushed_head_sha,
+        last_review_invalidated_sha=last_review_invalidated_sha,
         reviewers=reviewers,
         items=items or [],
     )
@@ -249,7 +251,16 @@ def test_copilot_status_review_found_when_reviewers_present() -> None:
 
 
 def test_pr_head_sha_fields() -> None:
-    inv = to_legacy_inventory(_state(last_poll_sha="poll", last_pushed_head_sha="pushed"))
+    # Production invariant: a prgroom push sets last_review_invalidated_sha
+    # alongside last_pushed_head_sha (push.py), and the head hasn't been re-polled
+    # yet — so head_sha_after_push tracks the freshly-pushed (invalidated) head.
+    inv = to_legacy_inventory(
+        _state(
+            last_poll_sha="poll",
+            last_pushed_head_sha="pushed",
+            last_review_invalidated_sha="pushed",
+        )
+    )
     assert inv["pr"] == {
         "owner": "octo-org",
         "repo": "demo-repo",
@@ -262,20 +273,48 @@ def test_pr_head_sha_fields() -> None:
 # ── Head-sha / filename precedence ──────────────────────────────────────────
 
 
-def test_filename_prefers_pushed_head_sha(tmp_path: Path) -> None:
+def test_filename_prefers_invalidated_head_sha(tmp_path: Path) -> None:
+    # The "just pushed, not yet re-polled" window: invalidated leads poll.
     path = legacy_inventory_path(
-        tmp_path, _state(last_poll_sha="poll", last_pushed_head_sha="pushed")
+        tmp_path,
+        _state(
+            last_poll_sha="poll",
+            last_pushed_head_sha="pushed",
+            last_review_invalidated_sha="pushed",
+        ),
     )
     assert path == tmp_path / "octo-org-demo-repo-42-pushed.json"
 
 
 def test_filename_falls_back_to_poll_sha(tmp_path: Path) -> None:
-    path = legacy_inventory_path(tmp_path, _state(last_poll_sha="poll", last_pushed_head_sha=""))
+    # Bootstrap poll sets last_poll_sha but no invalidated sha.
+    path = legacy_inventory_path(
+        tmp_path, _state(last_poll_sha="poll", last_review_invalidated_sha="")
+    )
     assert path == tmp_path / "octo-org-demo-repo-42-poll.json"
 
 
+def test_filename_ignores_stale_pushed_head_sha_after_external_push(tmp_path: Path) -> None:
+    # Regression (PR #274 review): after prgroom pushes head "oldpush", an EXTERNAL
+    # push moves the head to "newhead". poll.py advances last_poll_sha and
+    # last_review_invalidated_sha to "newhead" but leaves last_pushed_head_sha stale
+    # at "oldpush". The export MUST pin to the current head, never the stale push.
+    path = legacy_inventory_path(
+        tmp_path,
+        _state(
+            last_poll_sha="newhead",
+            last_review_invalidated_sha="newhead",
+            last_pushed_head_sha="oldpush",
+        ),
+    )
+    assert path == tmp_path / "octo-org-demo-repo-42-newhead.json"
+
+
 def test_export_skips_when_no_head_sha(tmp_path: Path) -> None:
-    export_legacy_inventory(_state(last_poll_sha="", last_pushed_head_sha=""), tmp_path)
+    export_legacy_inventory(
+        _state(last_poll_sha="", last_pushed_head_sha="", last_review_invalidated_sha=""),
+        tmp_path,
+    )
     assert list(tmp_path.iterdir()) == []
 
 

--- a/packages/prgroom/tests/unit/test_legacy_export.py
+++ b/packages/prgroom/tests/unit/test_legacy_export.py
@@ -1,0 +1,433 @@
+"""Unit tests for the pure legacy pr-inventory translation (bead abn9.8.13.1).
+
+merge-guard's ``check-merge-eligibility.sh`` clears its ``untriaged_feedback``
+blocker ONLY from the legacy ``~/.claude/state/pr-inventory`` inventory. These
+tests pin the pure translation prgroom emits into that format: the fail-closed
+disposition table, the per-kind id fields, filename/head-sha derivation, and the
+``.replyids`` sidecar — plus the consumer's own clearing predicate re-implemented
+as an oracle so a skipped item is proven to CLEAR and a failed item to BLOCK.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.legacy_export import (
+    _DISPOSITION_TO_LEGACY,
+    export_legacy_inventory,
+    legacy_inventory_path,
+    resolve_legacy_dir,
+    to_legacy_inventory,
+    to_replyids_lines,
+)
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+)
+
+_T = datetime(2026, 7, 14, 12, 0, 0, tzinfo=UTC)
+_REF = PRRef("octo-org", "demo-repo", 42)
+
+
+def _item(
+    kind: ItemKind,
+    *,
+    gh_id: str,
+    disposition: DispositionKind | None,
+    own_reply_id: int = 0,
+    reply_to_comment_id: int = 0,
+    thread_id: str = "",
+) -> ReviewItem:
+    disp = (
+        None
+        if disposition is None
+        else Disposition(kind=disposition, decided_at=_T, decided_by="fix-agent")
+    )
+    return ReviewItem(
+        kind=kind,
+        identity=Identity(
+            gh_id=gh_id,
+            thread_id=thread_id,
+            reply_to_comment_id=reply_to_comment_id,
+        ),
+        author="reviewer",
+        body_excerpt="...",
+        seen_at=_T,
+        disposition=disp,
+        own_reply_id=own_reply_id,
+    )
+
+
+def _state(
+    *,
+    items: list[ReviewItem] | None = None,
+    last_poll_sha: str = "pollsha",
+    last_pushed_head_sha: str = "",
+    reviewers_present: bool = False,
+    phase: PRPhase = PRPhase.QUIESCED,
+) -> PRGroomingState:
+    from prgroom.prsession.enums import ReviewerKind, ReviewerStatus
+    from prgroom.prsession.state import ReviewerState
+
+    reviewers = {}
+    if reviewers_present:
+        reviewers["copilot"] = ReviewerState(
+            identity="copilot",
+            kind=ReviewerKind.BOT,
+            status=ReviewerStatus.REVIEW_FOUND,
+            required=True,
+            last_request_at=_T,
+        )
+    return PRGroomingState(
+        pr=_REF,
+        phase=phase,
+        pr_review_retries_used=2,
+        last_polled_at=_T,
+        last_activity_at=_T,
+        quiescence=QuiescenceState(),
+        last_poll_sha=last_poll_sha,
+        last_pushed_head_sha=last_pushed_head_sha,
+        reviewers=reviewers,
+        items=items or [],
+    )
+
+
+# ── Disposition table: exhaustive + fail-closed ─────────────────────────────
+
+
+def test_disposition_table_covers_every_kind() -> None:
+    # Exhaustiveness proof: a future DispositionKind must be added deliberately,
+    # not silently default to CLEAR. The map is the merge-safety boundary.
+    assert set(_DISPOSITION_TO_LEGACY) == set(DispositionKind)
+
+
+@pytest.mark.parametrize(
+    ("disposition", "classification", "fix_outcome"),
+    [
+        (DispositionKind.SKIPPED, "SKIP", None),
+        (DispositionKind.WONT_FIX, "SKIP", None),
+        (DispositionKind.FIXED, "FIX", "committed"),
+        (DispositionKind.ALREADY_ADDRESSED, "FIX", "already_addressed"),
+        (DispositionKind.DEFERRED, "ESCALATE", None),
+        (DispositionKind.ESCALATED, "ESCALATE", None),
+        (DispositionKind.FAILED, "FIX", "failed"),
+    ],
+)
+def test_disposition_maps_to_expected_classification(
+    disposition: DispositionKind, classification: str, fix_outcome: str | None
+) -> None:
+    assert _DISPOSITION_TO_LEGACY[disposition] == (classification, fix_outcome)
+
+
+def test_unknown_disposition_raises_rather_than_clears() -> None:
+    # An enum value absent from the table must fail loudly (KeyError), never
+    # silently clear a blocker. Simulated with a bogus key since we cannot mint
+    # a new enum member.
+    with pytest.raises(KeyError):
+        _DISPOSITION_TO_LEGACY["not_a_real_disposition"]  # type: ignore[index]
+
+
+# ── Item translation ────────────────────────────────────────────────────────
+
+
+def test_untriaged_items_are_omitted() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[
+                _item(ItemKind.ISSUE_COMMENT, gh_id="1", disposition=None),
+                _item(ItemKind.ISSUE_COMMENT, gh_id="2", disposition=DispositionKind.SKIPPED),
+            ]
+        )
+    )
+    assert [i["issue_comment_id"] for i in inv["items"]] == [2]
+
+
+def test_issue_comment_id_field() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[_item(ItemKind.ISSUE_COMMENT, gh_id="777", disposition=DispositionKind.FIXED)]
+        )
+    )
+    item = inv["items"][0]
+    assert item["kind"] == "issue_comment"
+    assert item["issue_comment_id"] == 777
+    assert item["classification"] == "FIX"
+    assert item["fix_outcome"] == "committed"
+
+
+def test_review_summary_id_field() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[_item(ItemKind.REVIEW_SUMMARY, gh_id="555", disposition=DispositionKind.SKIPPED)]
+        )
+    )
+    item = inv["items"][0]
+    assert item["kind"] == "review_summary"
+    assert item["review_id"] == 555
+
+
+def test_review_thread_id_fields_prefer_reply_to_comment_id() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[
+                _item(
+                    ItemKind.REVIEW_THREAD,
+                    gh_id="999",
+                    disposition=DispositionKind.FIXED,
+                    reply_to_comment_id=321,
+                    thread_id="PRRT_abc",
+                )
+            ]
+        )
+    )
+    item = inv["items"][0]
+    assert item["kind"] == "review_thread"
+    assert item["reply_to_comment_id"] == 321
+    assert item["thread_id"] == "PRRT_abc"
+
+
+def test_review_thread_falls_back_to_gh_id_and_null_thread() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[
+                _item(
+                    ItemKind.REVIEW_THREAD,
+                    gh_id="888",
+                    disposition=DispositionKind.FIXED,
+                )
+            ]
+        )
+    )
+    item = inv["items"][0]
+    assert item["reply_to_comment_id"] == 888
+    assert item["thread_id"] is None
+
+
+def test_posted_reply_id_passthrough_and_null() -> None:
+    inv = to_legacy_inventory(
+        _state(
+            items=[
+                _item(
+                    ItemKind.ISSUE_COMMENT,
+                    gh_id="1",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=42,
+                ),
+                _item(ItemKind.ISSUE_COMMENT, gh_id="2", disposition=DispositionKind.SKIPPED),
+            ]
+        )
+    )
+    assert inv["items"][0]["posted_reply_id"] == 42
+    assert inv["items"][1]["posted_reply_id"] is None
+
+
+# ── Envelope fields ─────────────────────────────────────────────────────────
+
+
+def test_envelope_skill_a_completed_and_polling_defaults() -> None:
+    inv = to_legacy_inventory(_state(reviewers_present=False))
+    assert inv["schema_version"] == 1
+    assert inv["crash_recovery"]["skill_a_completed"] is True
+    assert inv["crash_recovery"]["last_completed_phase"] == "quiesced"
+    assert inv["polling"]["bot_review_cap_exhausted"] is False
+    assert inv["polling"]["copilot_status"] == "not_requested"
+    assert inv["polling"]["rereview_round_count"] == 2
+
+
+def test_copilot_status_review_found_when_reviewers_present() -> None:
+    inv = to_legacy_inventory(_state(reviewers_present=True))
+    assert inv["polling"]["copilot_status"] == "review_found"
+
+
+def test_pr_head_sha_fields() -> None:
+    inv = to_legacy_inventory(_state(last_poll_sha="poll", last_pushed_head_sha="pushed"))
+    assert inv["pr"] == {
+        "owner": "octo-org",
+        "repo": "demo-repo",
+        "number": 42,
+        "head_sha_at_inventory": "poll",
+        "head_sha_after_push": "pushed",
+    }
+
+
+# ── Head-sha / filename precedence ──────────────────────────────────────────
+
+
+def test_filename_prefers_pushed_head_sha(tmp_path: Path) -> None:
+    path = legacy_inventory_path(
+        tmp_path, _state(last_poll_sha="poll", last_pushed_head_sha="pushed")
+    )
+    assert path == tmp_path / "octo-org-demo-repo-42-pushed.json"
+
+
+def test_filename_falls_back_to_poll_sha(tmp_path: Path) -> None:
+    path = legacy_inventory_path(tmp_path, _state(last_poll_sha="poll", last_pushed_head_sha=""))
+    assert path == tmp_path / "octo-org-demo-repo-42-poll.json"
+
+
+def test_export_skips_when_no_head_sha(tmp_path: Path) -> None:
+    export_legacy_inventory(_state(last_poll_sha="", last_pushed_head_sha=""), tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+# ── Sidecar generation ──────────────────────────────────────────────────────
+
+
+def test_sidecar_only_items_with_reply_id() -> None:
+    lines = to_replyids_lines(
+        _state(
+            items=[
+                _item(
+                    ItemKind.ISSUE_COMMENT,
+                    gh_id="1",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=0,
+                ),
+                _item(
+                    ItemKind.ISSUE_COMMENT,
+                    gh_id="2",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=100,
+                ),
+            ]
+        )
+    )
+    assert lines == [{"k": "issue_comment_id", "v": "2", "rid": 100}]
+
+
+def test_sidecar_kv_per_kind() -> None:
+    lines = to_replyids_lines(
+        _state(
+            items=[
+                _item(
+                    ItemKind.ISSUE_COMMENT,
+                    gh_id="10",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=1,
+                ),
+                _item(
+                    ItemKind.REVIEW_SUMMARY,
+                    gh_id="20",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=2,
+                ),
+                _item(
+                    ItemKind.REVIEW_THREAD,
+                    gh_id="30",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=3,
+                    reply_to_comment_id=333,
+                ),
+            ]
+        )
+    )
+    assert lines == [
+        {"k": "issue_comment_id", "v": "10", "rid": 1},
+        {"k": "review_id", "v": "20", "rid": 2},
+        {"k": "reply_to_comment_id", "v": "333", "rid": 3},
+    ]
+
+
+def test_sidecar_thread_v_falls_back_to_gh_id() -> None:
+    lines = to_replyids_lines(
+        _state(
+            items=[
+                _item(
+                    ItemKind.REVIEW_THREAD,
+                    gh_id="30",
+                    disposition=DispositionKind.SKIPPED,
+                    own_reply_id=3,
+                ),
+            ]
+        )
+    )
+    assert lines == [{"k": "reply_to_comment_id", "v": "30", "rid": 3}]
+
+
+def test_sidecar_regenerates_fully_no_append(tmp_path: Path) -> None:
+    state = _state(
+        items=[
+            _item(
+                ItemKind.ISSUE_COMMENT,
+                gh_id="1",
+                disposition=DispositionKind.SKIPPED,
+                own_reply_id=5,
+            )
+        ]
+    )
+    export_legacy_inventory(state, tmp_path)
+    export_legacy_inventory(state, tmp_path)
+    sidecar = tmp_path / "octo-org-demo-repo-42-pollsha.json.replyids"
+    non_empty = [ln for ln in sidecar.read_text().splitlines() if ln.strip()]
+    assert len(non_empty) == 1
+
+
+# ── resolve_legacy_dir ──────────────────────────────────────────────────────
+
+
+def test_resolve_legacy_dir_override_wins(tmp_path: Path) -> None:
+    assert resolve_legacy_dir(tmp_path, env={}) == tmp_path
+
+
+def test_resolve_legacy_dir_env(tmp_path: Path) -> None:
+    assert resolve_legacy_dir(None, env={"PRGROOM_LEGACY_INVENTORY_DIR": str(tmp_path)}) == tmp_path
+
+
+def test_resolve_legacy_dir_default_home() -> None:
+    assert resolve_legacy_dir(None, env={}) == Path.home() / ".claude" / "state" / "pr-inventory"
+
+
+# ── End-to-end oracle: the consumer's clearing predicate ────────────────────
+
+
+def _clears(item: dict[str, object]) -> bool:
+    """Re-implements merge-guard ``terminal_ok`` (check-merge-eligibility.sh)."""
+    classification = item["classification"]
+    fix_outcome = item["fix_outcome"]
+    return classification == "SKIP" or (
+        classification == "FIX" and fix_outcome in {"committed", "already_addressed"}
+    )
+
+
+def test_e2e_skipped_item_clears_and_sidecar_has_rid(tmp_path: Path) -> None:
+    state = _state(
+        items=[
+            _item(
+                ItemKind.REVIEW_SUMMARY,
+                gh_id="555",
+                disposition=DispositionKind.SKIPPED,
+                own_reply_id=9001,
+            )
+        ]
+    )
+    export_legacy_inventory(state, tmp_path)
+    inv_path = tmp_path / "octo-org-demo-repo-42-pollsha.json"
+    inv = json.loads(inv_path.read_text())
+
+    assert inv["crash_recovery"]["skill_a_completed"] is True
+    (only,) = inv["items"]
+    assert _clears(only), "a skipped item MUST clear the untriaged_feedback blocker"
+
+    sidecar = json.loads(
+        (tmp_path / "octo-org-demo-repo-42-pollsha.json.replyids").read_text().strip()
+    )
+    assert sidecar["rid"] == 9001
+
+
+def test_e2e_failed_item_blocks(tmp_path: Path) -> None:
+    state = _state(
+        items=[_item(ItemKind.REVIEW_SUMMARY, gh_id="555", disposition=DispositionKind.FAILED)]
+    )
+    export_legacy_inventory(state, tmp_path)
+    inv = json.loads((tmp_path / "octo-org-demo-repo-42-pollsha.json").read_text())
+    (only,) = inv["items"]
+    assert not _clears(only), "a failed item MUST NOT clear (fail-closed)"

--- a/packages/prgroom/tests/unit/test_lifecycle_poll.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_poll.py
@@ -341,6 +341,33 @@ def test_duplicate_item_not_reappended_and_does_not_retrigger_phase() -> None:
     assert state.phase is PRPhase.AWAITING_REVIEW  # no new-item edge fired
 
 
+def test_own_posted_reply_is_not_ingested_as_new_item() -> None:
+    # Recursive-self-reply fix: prgroom replied by POSTing a new issue comment whose
+    # id was recorded on own_reply_id. A later poll sees that comment in the gh payload
+    # but must NOT re-ingest it as a fresh review item (else it re-triages forever).
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    start.items.append(
+        ReviewItem(
+            kind=ItemKind.REVIEW_SUMMARY,
+            identity=Identity(gh_id="21"),
+            author="copilot",
+            body_excerpt="please fix",
+            seen_at=_T0,
+            replied=True,
+            own_reply_id=99001,
+        )
+    )
+    # gh returns our own posted reply (id 99001) plus a genuinely new comment (id 12).
+    gh = _gh(
+        head_oid="same",
+        issue_comments=[_issue_comment(99001), _issue_comment(12)],
+    )
+    state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
+    ingested_ids = {i.identity.gh_id for i in state.items if i.kind is ItemKind.ISSUE_COMMENT}
+    assert "99001" not in ingested_ids  # our own reply dropped
+    assert "12" in ingested_ids  # a different comment still ingested (no over-filter)
+
+
 def test_top_level_review_comment_has_no_parent() -> None:
     # A top-level inline comment carries no in_reply_to_id → reply_to_comment_id 0.
     start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")

--- a/packages/prgroom/tests/unit/test_registry.py
+++ b/packages/prgroom/tests/unit/test_registry.py
@@ -14,28 +14,50 @@ import pytest
 
 from prgroom.errors import ErrorCode, PreconditionError, Tier
 from prgroom.prsession.file import FileStore
+from prgroom.prsession.legacy_export import LegacyExportStore
 from prgroom.prsession.registry import resolve_store
 
 
-def test_explicit_file_name_yields_filestore(tmp_path: Path) -> None:
+def test_explicit_file_name_yields_legacy_wrapped_filestore(tmp_path: Path) -> None:
+    # The "file" store is wrapped so it also emits merge-guard's legacy
+    # pr-inventory at persist time; the inner adapter is still the production
+    # FileStore.
     store = resolve_store("file", env={}, state_dir=tmp_path)
-    assert isinstance(store, FileStore)
+    assert isinstance(store, LegacyExportStore)
+    assert isinstance(store._inner, FileStore)
+
+
+def test_injected_env_threads_into_legacy_export_dir(tmp_path: Path) -> None:
+    # The injected env must drive the legacy-inventory dir, not the real
+    # os.environ — otherwise a test selecting the file store would write into
+    # the caller's real ~/.claude/state/pr-inventory (isolation seam leak).
+    legacy_dir = tmp_path / "pr-inventory"
+    store = resolve_store(
+        "file",
+        env={"PRGROOM_LEGACY_INVENTORY_DIR": str(legacy_dir)},
+        state_dir=tmp_path,
+    )
+    assert isinstance(store, LegacyExportStore)
+    assert store._export_dir == legacy_dir
 
 
 def test_default_when_no_flag_no_env_is_file(tmp_path: Path) -> None:
     store = resolve_store(None, env={}, state_dir=tmp_path)
-    assert isinstance(store, FileStore)
+    assert isinstance(store, LegacyExportStore)
+    assert isinstance(store._inner, FileStore)
 
 
 def test_env_selects_when_no_flag(tmp_path: Path) -> None:
     store = resolve_store(None, env={"PRGROOM_STORE": "file"}, state_dir=tmp_path)
-    assert isinstance(store, FileStore)
+    assert isinstance(store, LegacyExportStore)
+    assert isinstance(store._inner, FileStore)
 
 
 def test_flag_beats_env(tmp_path: Path) -> None:
     # Flag says file, env says bd: flag wins, so we get a FileStore (no error).
     store = resolve_store("file", env={"PRGROOM_STORE": "bd"}, state_dir=tmp_path)
-    assert isinstance(store, FileStore)
+    assert isinstance(store, LegacyExportStore)
+    assert isinstance(store._inner, FileStore)
 
 
 def test_bd_is_a_terminal_user_error(tmp_path: Path) -> None:
@@ -63,7 +85,8 @@ def test_blank_env_falls_back_to_default_file(tmp_path: Path) -> None:
     # resolve_state_dir's blank-XDG_STATE_HOME handling), not as an explicit
     # invalid selection — a stray `export PRGROOM_STORE=` must not break every run.
     store = resolve_store(None, env={"PRGROOM_STORE": ""}, state_dir=tmp_path)
-    assert isinstance(store, FileStore)
+    assert isinstance(store, LegacyExportStore)
+    assert isinstance(store._inner, FileStore)
 
 
 def test_blank_flag_is_an_explicit_error_not_a_fallback(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_reply_per_item.py
+++ b/packages/prgroom/tests/unit/test_reply_per_item.py
@@ -9,12 +9,17 @@ _NOW = datetime(2026, 6, 19, tzinfo=UTC)
 
 
 class _RecordingGh:
-    def __init__(self) -> None:
+    def __init__(self, post_reply_id: int | None = None) -> None:
         self.rest_calls: list[tuple[str, str, dict]] = []
         self.graphql_calls: list[tuple[str, dict]] = []
+        self._post_reply_id = post_reply_id
 
     def rest(self, method: str, path: str, *, fields=None):
         self.rest_calls.append((method, path, dict(fields or {})))
+        # A reply/comment POST returns the new comment object carrying its numeric id;
+        # the ledger captures it so a later poll can exclude our own reply.
+        if method == "POST" and self._post_reply_id is not None:
+            return {"id": self._post_reply_id}
         return {}
 
     def graphql(self, query: str, variables: dict):
@@ -213,6 +218,25 @@ def test_escalated_replied_regardless_of_escalation_filed() -> None:
     )
     reply_pr(_state([item]), gh=gh, ref=_ref())
     assert "Captured for follow-up" in gh.rest_calls[0][2]["body"]
+
+
+def test_reply_captures_own_reply_id_from_post_response() -> None:
+    # The POST response carries the new comment's numeric id; reply_pr records it on
+    # own_reply_id so a later poll can drop our own reply (recursive-self-reply fix).
+    gh = _RecordingGh(post_reply_id=424242)
+    state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)])
+    out = reply_pr(state, gh=gh, ref=_ref())
+    assert out.items[0].replied is True
+    assert out.items[0].own_reply_id == 424242
+
+
+def test_reply_own_reply_id_stays_zero_when_response_lacks_id() -> None:
+    # Defensive: a POST response with no usable "id" leaves own_reply_id at 0.
+    gh = _RecordingGh(post_reply_id=None)
+    state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)])
+    out = reply_pr(state, gh=gh, ref=_ref())
+    assert out.items[0].replied is True
+    assert out.items[0].own_reply_id == 0
 
 
 def test_idempotent_skips_already_replied() -> None:

--- a/packages/prgroom/tests/unit/test_state_serde.py
+++ b/packages/prgroom/tests/unit/test_state_serde.py
@@ -290,6 +290,47 @@ def test_disposition_falsy_false_gate_raises() -> None:
         Disposition.from_dict(raw)
 
 
+def test_own_reply_id_round_trips_when_set() -> None:
+    # The durable posted-reply-id ledger: our reply's own comment id survives the
+    # round-trip so a later poll can exclude it (recursive self-reply prevention).
+    item = ReviewItem(
+        kind=ItemKind.REVIEW_SUMMARY,
+        identity=Identity(gh_id="RS_1"),
+        author="copilot",
+        body_excerpt="overall LGTM",
+        seen_at=_T,
+        replied=True,
+        own_reply_id=987654,
+    )
+    d = item.to_dict()
+    assert d["own_reply_id"] == 987654
+    assert ReviewItem.from_dict(d) == item
+
+
+def test_own_reply_id_omitted_when_zero() -> None:
+    # §2 omit-if-falsy: an item we have not replied to carries no own_reply_id key.
+    item = ReviewItem(
+        kind=ItemKind.ISSUE_COMMENT,
+        identity=Identity(gh_id="IC_1"),
+        author="alice",
+        body_excerpt="nit",
+        seen_at=_T,
+    )
+    assert "own_reply_id" not in item.to_dict()
+
+
+def test_own_reply_id_defaults_to_zero_when_absent_on_read() -> None:
+    # A pre-ledger state file has no own_reply_id key; it must load as 0, not raise.
+    d = {
+        "kind": "issue_comment",
+        "identity": {"gh_id": "IC_1"},
+        "author": "alice",
+        "body_excerpt": "nit",
+        "seen_at": _T.isoformat(),
+    }
+    assert ReviewItem.from_dict(d).own_reply_id == 0
+
+
 def test_disposition_round_trips_through_item() -> None:
     item = ReviewItem(
         kind=ItemKind.REVIEW_THREAD,


### PR DESCRIPTION
## Summary
Two coupled prgroom fixes that make a fully-groomed PR actually reach merge-guard eligibility, and stop prgroom re-triaging its own replies.

- **abn9.8.28 — posted-reply-ID ledger.** prgroom replies to a `review_summary`/`issue_comment` by POSTing a *new* issue comment; its fresh `gh_id` was unknown to the `(kind, gh_id)` poll dedup, so every poll re-ingested and re-triaged prgroom's own reply (recursive self-reply spam — observed 4× on PR #211). Now the reply's numeric id is captured from the `_post_reply` REST response onto `ReviewItem.own_reply_id` and excluded from future poll ingestion.
- **abn9.8.13.1 — legacy pr-inventory export.** `merge-guard`'s `check-merge-eligibility.sh` clears its `untriaged_feedback` blocker only from the legacy `~/.claude/state/pr-inventory` store; prgroom wrote its own `~/.local/state/prgroom` schema, invisible to the gate. New `LegacyExportStore` decorator wraps the (unchanged, pure) `FileStore` and *also* emits the legacy inventory JSON + `.replyids` sidecar on write.

## Design notes for reviewers
- **Scope in:** `packages/prgroom/` only. `packages/vizsuite/` uncommitted work in the main tree is unrelated and not part of this branch.
- **Additive, non-desyncing by design.** merge-guard and the prose skills (`wait-for-pr-comments`, `reply-and-resolve-pr-threads`) are byte-for-byte untouched — prgroom emits *their* format, so nothing desyncs. The destructive swap-to-prgroom-only read is deliberately deferred to Phase-2 retirement (abn9.8.14).
- **Fail-closed merge-safety boundary.** `_DISPOSITION_TO_LEGACY` maps every `DispositionKind` explicitly; only `skipped`/`wont_fix` (→SKIP) and `fixed`/`already_addressed` (→FIX+committed/already_addressed) CLEAR. `deferred`/`escalated`/`failed` BLOCK. An unknown future kind raises `KeyError` (fail loud) rather than silently clearing. Only affects the issue_comment/review_summary untriaged block — review_thread items clear via the separate unresolved-thread GraphQL gate (not touched here; see abn9.8.29).
- **Best-effort export.** `LegacyExportStore.write` persists inner state first (primary, atomic — never weakened), then exports inside a `try/except` that logs and never re-raises. A failed export cannot break grooming, and merge-guard reads fail-closed so a missing export just keeps the PR blocked (safe).
- **Ground truth:** disposition mapping `packages/prgroom/src/prgroom/prsession/legacy_export.py`; reply capture `lifecycle/reply.py:_post_reply`; poll exclusion `lifecycle/poll.py:_ingest_items`.

## Test Plan
- [x] `make ci-prgroom` green: 978 tests, 99.65% coverage, mypy --strict, ruff, pip-audit, entry-verify
- [x] e2e oracle test re-implements merge-guard's `terminal_ok` predicate: a `skipped` review_summary CLEARS + its rid lands in the sidecar; a `failed` item BLOCKS
- [x] poll test: an ingested comment matching a prior item's `own_reply_id` is excluded; a different id is still ingested
- [x] HEAVY quality-gate workflow: acceptance / clean-at-floor (one applied fix, env-threading seam fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)