### PR TITLE
feat(vizsuite): .viz/ sidecar store foundation — models, lock, atomic writes (S1)

### DIFF
--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -36,6 +36,14 @@ class ErrorCode(StrEnum):
     # slice 5: a Tier-2/Tier-3-touched scene fact is missing its provenance or
     # citations — the assembler's schema gate refuses to assemble it silently.
     SCHEMA_INVALID = "E_SCHEMA_INVALID"
+    # sidecar slice: a `.viz/*.json` record file's content doesn't parse into its
+    # typed record shape (bad JSON, missing/mistyped field) — never a raw
+    # KeyError/JSONDecodeError escaping the sidecar read boundary.
+    SIDECAR_MALFORMED = "E_SIDECAR_MALFORMED"
+    # sidecar slice: the single-writer advisory lock (`.viz/lock`) is still held
+    # by another writer after the bounded retry window — never an unbounded
+    # block.
+    SIDECAR_LOCKED = "E_SIDECAR_LOCKED"
 
 
 @dataclass(frozen=True)

--- a/packages/vizsuite/src/vizsuite/output.py
+++ b/packages/vizsuite/src/vizsuite/output.py
@@ -1,33 +1,62 @@
 """`.viz/` sidecar bootstrap — the portable, versioned output location.
 
-`ensure_viz_dir` creates `<root>/.viz/out/` and writes a versioned
-`<root>/.viz/.gitignore` containing `out/`. Committing that sidecar (not editing
-the target repo's root `.gitignore`) makes `viz pr` portable: generated HTML is
-ignored in *any* target repo. It ignores **only** `out/` — Tier-3 verdict
-sidecars under `.viz/` are versioned and must stay tracked (none exist in .2.1).
+`ensure_viz_dir` creates `<root>/.viz/out/` and, via the shared
+`ensure_viz_gitignore` helper, writes a versioned `<root>/.viz/.gitignore`
+ignoring the machine-managed sidecar entries (`lock`, `out/`). Committing that
+sidecar (not editing the target repo's root `.gitignore`) makes `viz pr`
+portable: generated HTML and the advisory lock are ignored in *any* target
+repo. Only the managed entries are ignored — Tier-3 verdict sidecars under
+`.viz/` are versioned and must stay tracked (none exist in .2.1).
+
+`ensure_viz_gitignore` is the single owner of `.viz/.gitignore` maintenance,
+shared by both sidecar writers (this module and `vizsuite.sidecar.store`), so
+the file is byte-identical regardless of which command runs first.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-_GITIGNORE_LINE = "out/"
+# The machine-managed `.viz/.gitignore` entries, in canonical (alphabetical)
+# order. Both sidecar writers install the *complete* set through
+# `ensure_viz_gitignore`, so whichever runs first produces an identical file.
+_MANAGED_GITIGNORE_LINES = ("lock", "out/")
+
+
+def ensure_viz_gitignore(viz_dir: Path) -> None:
+    """Idempotently ensure `<viz_dir>/.gitignore` ignores every managed entry.
+
+    The single owner of `.viz/.gitignore` maintenance, shared by both sidecar
+    writers. Creates `viz_dir` if needed, reads the existing `.gitignore`
+    (empty if absent), and appends every managed entry (`lock`, `out/`) that is
+    absent — in one write, in canonical order — while preserving any existing
+    lines and never reordering them.
+
+    Convergence: whichever writer runs first installs the complete managed set,
+    so the resulting file is byte-identical regardless of call order.
+    Idempotent: a second call with all entries already present is a no-op
+    (byte-stable).
+    """
+    viz_dir.mkdir(parents=True, exist_ok=True)
+    gitignore = viz_dir / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    lines = existing.splitlines()
+    missing = [entry for entry in _MANAGED_GITIGNORE_LINES if entry not in lines]
+    if not missing:
+        return
+    prefix = existing if existing == "" or existing.endswith("\n") else existing + "\n"
+    gitignore.write_text(prefix + "".join(f"{entry}\n" for entry in missing), encoding="utf-8")
 
 
 def ensure_viz_dir(root: Path) -> Path:
-    """Idempotently ensure `<root>/.viz/out/` exists and `.viz/.gitignore` ignores `out/`.
+    """Idempotently ensure `<root>/.viz/out/` exists and `.viz/.gitignore` is managed.
 
     Returns the `out/` directory. Safe to call repeatedly: the directory is
-    created with `exist_ok`, and the `out/` ignore line is appended only when
-    absent (existing `.viz/.gitignore` content is preserved).
+    created with `exist_ok`, and the managed ignore entries are appended only
+    when absent (existing `.viz/.gitignore` content is preserved).
     """
     viz_dir = root / ".viz"
     out_dir = viz_dir / "out"
     out_dir.mkdir(parents=True, exist_ok=True)
-
-    gitignore = viz_dir / ".gitignore"
-    existing = gitignore.read_text() if gitignore.exists() else ""
-    if _GITIGNORE_LINE not in existing.splitlines():
-        prefix = existing if existing == "" or existing.endswith("\n") else existing + "\n"
-        gitignore.write_text(f"{prefix}{_GITIGNORE_LINE}\n")
+    ensure_viz_gitignore(viz_dir)
     return out_dir

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -151,7 +151,7 @@ class Scene:
     repo_nwo: str = ""  # spec §6.2/G3; populated once the PR verb threads it through
 
 
-def _provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
+def provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
     return {
         "kind": str(provenance.kind),
         "freshness": str(provenance.freshness),
@@ -163,7 +163,7 @@ def _fact_to_json(fact: Fact) -> dict[str, JsonValue]:
     return {
         "id": fact.id,
         "note": fact.note,
-        "provenance": _provenance_to_json(fact.provenance) if fact.provenance is not None else None,
+        "provenance": provenance_to_json(fact.provenance) if fact.provenance is not None else None,
     }
 
 

--- a/packages/vizsuite/src/vizsuite/sidecar/models.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/models.py
@@ -9,8 +9,8 @@ separately from identity), and per-fact `Provenance` (reused from
 scene envelope carries, not a second one). `payload` holds the record-kind-
 specific fields; this foundation slice does not yet model V2's per-kind
 domain shapes (§7.2) — later slices read typed views over `payload` without
-changing this envelope. `FlagRecord` models a `flags.json` entry (doubt or
-orphaned-verdict); `VerdictRecord` models a `verdicts.json` entry; `Manifest`
+changing this envelope. `FlagRecord` models a `flags.json` entry (`doubt` or
+`orphaned_verdict`); `VerdictRecord` models a `verdicts.json` entry; `Manifest`
 models `manifest.json`.
 
 Every `*_to_json`/`*_from_json` pair is a pure mapping function, mirroring
@@ -31,7 +31,7 @@ from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind, provenan
 
 
 class FlagKind(StrEnum):
-    """The two `flags.json` record kinds (spec §5.3): doubt vs orphaned-verdict."""
+    """The two `flags.json` record kinds (spec §5.3): `doubt` vs `orphaned_verdict`."""
 
     DOUBT = "doubt"
     ORPHANED_VERDICT = "orphaned_verdict"
@@ -75,7 +75,7 @@ class FactRecord:
 class _FlagVerdictInvariantError(ValueError):
     """Raised when a `FlagRecord`'s `verdict_id` presence disagrees with its `kind`.
 
-    An orphaned-verdict flag must carry a `verdict_id`; a doubt flag must not.
+    An `orphaned_verdict` flag must carry a `verdict_id`; a `doubt` flag must not.
     Subclassing `ValueError` lets the sidecar store wrap a violation from a
     deserialized record into a `VizError(SIDECAR_MALFORMED)` at the read
     boundary (the message is fixed on the class per ruff TRY003).
@@ -87,9 +87,9 @@ class _FlagVerdictInvariantError(ValueError):
 
 @dataclass(frozen=True)
 class FlagRecord:
-    """A `flags.json` entry: a doubt flag or an orphaned-verdict flag (spec §5.3).
+    """A `flags.json` entry: a `doubt` flag or an `orphaned_verdict` flag (spec §5.3).
 
-    `verdict_id` is set only for an orphaned-verdict flag (the verdict whose
+    `verdict_id` is set only for an `orphaned_verdict` flag (the verdict whose
     subject fact changed or vanished on rebuild); a doubt flag references only
     its fact. `__post_init__` enforces this invariant in both directions so both
     directly-constructed and deserialized records are guaranteed consistent.

--- a/packages/vizsuite/src/vizsuite/sidecar/models.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/models.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 
 from vizsuite.envelope import JsonValue
-from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind, provenance_to_json
 
 
 class FlagKind(StrEnum):
@@ -178,14 +178,6 @@ def _as_list(value: JsonValue) -> list[JsonValue]:
 # ---- Provenance (reused shape from vizsuite.scene.model) -------------------
 
 
-def _provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
-    return {
-        "kind": str(provenance.kind),
-        "freshness": str(provenance.freshness),
-        "citations": list(provenance.citations),
-    }
-
-
 def _provenance_from_json(data: JsonValue) -> Provenance:
     mapping = _as_dict(data)
     citations = [_as_str(item) for item in _as_list(mapping["citations"])]
@@ -231,7 +223,7 @@ def fact_record_to_json(record: FactRecord) -> dict[str, JsonValue]:
         "fact_id": record.fact_id,
         "matching_descriptor": _matching_descriptor_to_json(record.matching_descriptor),
         "basis_hash": record.basis_hash,
-        "provenance": _provenance_to_json(record.provenance),
+        "provenance": provenance_to_json(record.provenance),
         "payload": dict(record.payload),
     }
 

--- a/packages/vizsuite/src/vizsuite/sidecar/models.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/models.py
@@ -72,13 +72,27 @@ class FactRecord:
     payload: dict[str, JsonValue] = field(default_factory=dict)
 
 
+class _FlagVerdictInvariantError(ValueError):
+    """Raised when a `FlagRecord`'s `verdict_id` presence disagrees with its `kind`.
+
+    An orphaned-verdict flag must carry a `verdict_id`; a doubt flag must not.
+    Subclassing `ValueError` lets the sidecar store wrap a violation from a
+    deserialized record into a `VizError(SIDECAR_MALFORMED)` at the read
+    boundary (the message is fixed on the class per ruff TRY003).
+    """
+
+    def __init__(self) -> None:
+        super().__init__("verdict_id must be set iff kind is ORPHANED_VERDICT")
+
+
 @dataclass(frozen=True)
 class FlagRecord:
     """A `flags.json` entry: a doubt flag or an orphaned-verdict flag (spec §5.3).
 
     `verdict_id` is set only for an orphaned-verdict flag (the verdict whose
     subject fact changed or vanished on rebuild); a doubt flag references only
-    its fact.
+    its fact. `__post_init__` enforces this invariant in both directions so both
+    directly-constructed and deserialized records are guaranteed consistent.
     """
 
     flag_id: str
@@ -86,6 +100,10 @@ class FlagRecord:
     kind: FlagKind
     reason: str
     verdict_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.kind == FlagKind.ORPHANED_VERDICT) != (self.verdict_id is not None):
+            raise _FlagVerdictInvariantError
 
 
 @dataclass(frozen=True)

--- a/packages/vizsuite/src/vizsuite/sidecar/models.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/models.py
@@ -1,0 +1,319 @@
+"""Sidecar record dataclasses — the five `.viz/*.json` record files' typed
+shapes (spec §5.3).
+
+`FactRecord` is the shared Tier-2 envelope for `edges.json`/`steps.json`/
+`recommendations.json`: a durable `fact_id`, the identity-reconciliation
+`MatchingDescriptor` snapshot, `basis_hash` (the cited-inputs stamp, tracked
+separately from identity), and per-fact `Provenance` (reused from
+`vizsuite.scene.model` — the sidecar's provenance axis is the same concept the
+scene envelope carries, not a second one). `payload` holds the record-kind-
+specific fields; this foundation slice does not yet model V2's per-kind
+domain shapes (§7.2) — later slices read typed views over `payload` without
+changing this envelope. `FlagRecord` models a `flags.json` entry (doubt or
+orphaned-verdict); `VerdictRecord` models a `verdicts.json` entry; `Manifest`
+models `manifest.json`.
+
+Every `*_to_json`/`*_from_json` pair is a pure mapping function, mirroring
+`vizsuite.scene.model.scene_to_json`'s style. `*_from_json` raises a plain
+`TypeError`/`ValueError`/`KeyError` on a malformed shape — the sidecar store
+(the actual file-I/O boundary) is what converts that into a typed
+`VizError(SIDECAR_MALFORMED)` so a raw parse exception never reaches a CLI
+caller (spec §5.3: "parse/validate at the boundary").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from vizsuite.envelope import JsonValue
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+
+
+class FlagKind(StrEnum):
+    """The two `flags.json` record kinds (spec §5.3): doubt vs orphaned-verdict."""
+
+    DOUBT = "doubt"
+    ORPHANED_VERDICT = "orphaned_verdict"
+
+
+class Verdict(StrEnum):
+    """The three Tier-3 verdict values a human can record (spec §5.7/§10 item 3)."""
+
+    ACCEPT = "accept"
+    REJECT = "reject"
+    DISMISS = "dismiss"
+
+
+@dataclass(frozen=True)
+class MatchingDescriptor:
+    """The identity-reconciliation snapshot taken at inference time (spec §5.3).
+
+    `endpoint_bead_ids` snapshots each endpoint's bead-id anchor set as it
+    resolved *at that moment* — reconciliation on rebuild matches against this
+    snapshot and never depends on re-reading Tier-2 files. Prose-only plans
+    (zero-bead anchors) fall back to `plan_pair` + `kind` alone, so
+    `endpoint_bead_ids` defaults to empty.
+    """
+
+    plan_pair: tuple[str, str]
+    kind: str
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = ()
+
+
+@dataclass(frozen=True)
+class FactRecord:
+    """One Tier-2 fact shared by `edges.json`/`steps.json`/`recommendations.json`."""
+
+    fact_id: str
+    matching_descriptor: MatchingDescriptor
+    basis_hash: str
+    provenance: Provenance
+    payload: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FlagRecord:
+    """A `flags.json` entry: a doubt flag or an orphaned-verdict flag (spec §5.3).
+
+    `verdict_id` is set only for an orphaned-verdict flag (the verdict whose
+    subject fact changed or vanished on rebuild); a doubt flag references only
+    its fact.
+    """
+
+    flag_id: str
+    fact_id: str
+    kind: FlagKind
+    reason: str
+    verdict_id: str | None = None
+
+
+@dataclass(frozen=True)
+class VerdictRecord:
+    """A `verdicts.json` entry: the durable human judgment on one fact (spec §5.3).
+
+    `basis_hash` snapshots the fact's `basis_hash` *at verdict time* — the
+    rejection-memory comparison (same basis ⇒ suppressed, changed basis ⇒
+    resurfaces annotated with the prior rejection) reads this stamp, never a
+    re-derivation from the current fact.
+    """
+
+    verdict_id: str
+    fact_id: str
+    verdict: Verdict
+    basis_hash: str
+    annotation: str = ""
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """`manifest.json`: the fingerprint manifest (spec §5.3/§5.4).
+
+    `input_hashes` covers the Tier-1 inputs the sidecar build hash-checked
+    (funnel rung 1); `prompt_version`/`model_id` pin the inference-contract
+    version that a fact's `basis_hash` also covers (§5.2), so a contract
+    change is visible as a manifest change too.
+    """
+
+    schema_version: str
+    prompt_version: str = ""
+    model_id: str = ""
+    input_hashes: dict[str, str] = field(default_factory=dict)
+
+
+# ---- parse-boundary helpers (raise on a shape mismatch) --------------------
+
+
+class _ExpectedStringError(TypeError):
+    """Raised by `_as_str` when a sidecar JSON value is not a string.
+
+    The message is fixed on the class (ruff TRY003: no message argument at the
+    `raise` site) while `isinstance(exc, TypeError)` still holds for callers
+    matching on the vanilla type.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("expected a string")
+
+
+class _ExpectedObjectError(TypeError):
+    """Raised by `_as_dict` when a sidecar JSON value is not an object."""
+
+    def __init__(self) -> None:
+        super().__init__("expected an object")
+
+
+class _ExpectedArrayError(TypeError):
+    """Raised by `_as_list` when a sidecar JSON value is not an array."""
+
+    def __init__(self) -> None:
+        super().__init__("expected an array")
+
+
+class _InvalidPlanPairLengthError(ValueError):
+    """Raised when a matching descriptor's `plan_pair` isn't exactly 2 entries."""
+
+    def __init__(self) -> None:
+        super().__init__("plan_pair must have exactly 2 entries")
+
+
+def _as_str(value: JsonValue) -> str:
+    if not isinstance(value, str):
+        raise _ExpectedStringError
+    return value
+
+
+def _as_dict(value: JsonValue) -> dict[str, JsonValue]:
+    if not isinstance(value, dict):
+        raise _ExpectedObjectError
+    return value
+
+
+def _as_list(value: JsonValue) -> list[JsonValue]:
+    if not isinstance(value, list):
+        raise _ExpectedArrayError
+    return value
+
+
+# ---- Provenance (reused shape from vizsuite.scene.model) -------------------
+
+
+def _provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
+    return {
+        "kind": str(provenance.kind),
+        "freshness": str(provenance.freshness),
+        "citations": list(provenance.citations),
+    }
+
+
+def _provenance_from_json(data: JsonValue) -> Provenance:
+    mapping = _as_dict(data)
+    citations = [_as_str(item) for item in _as_list(mapping["citations"])]
+    return Provenance(
+        kind=ProvenanceKind(_as_str(mapping["kind"])),
+        freshness=Freshness(_as_str(mapping["freshness"])),
+        citations=tuple(citations),
+    )
+
+
+# ---- MatchingDescriptor -----------------------------------------------------
+
+
+def _matching_descriptor_to_json(descriptor: MatchingDescriptor) -> dict[str, JsonValue]:
+    return {
+        "plan_pair": list(descriptor.plan_pair),
+        "kind": descriptor.kind,
+        "endpoint_bead_ids": [list(ids) for ids in descriptor.endpoint_bead_ids],
+    }
+
+
+def _matching_descriptor_from_json(data: JsonValue) -> MatchingDescriptor:
+    mapping = _as_dict(data)
+    plan_pair = [_as_str(item) for item in _as_list(mapping["plan_pair"])]
+    if len(plan_pair) != 2:
+        raise _InvalidPlanPairLengthError
+    endpoint_bead_ids = tuple(
+        tuple(_as_str(bead_id) for bead_id in _as_list(ids))
+        for ids in _as_list(mapping["endpoint_bead_ids"])
+    )
+    return MatchingDescriptor(
+        plan_pair=(plan_pair[0], plan_pair[1]),
+        kind=_as_str(mapping["kind"]),
+        endpoint_bead_ids=endpoint_bead_ids,
+    )
+
+
+# ---- FactRecord (public: read by the sidecar store) ------------------------
+
+
+def fact_record_to_json(record: FactRecord) -> dict[str, JsonValue]:
+    return {
+        "fact_id": record.fact_id,
+        "matching_descriptor": _matching_descriptor_to_json(record.matching_descriptor),
+        "basis_hash": record.basis_hash,
+        "provenance": _provenance_to_json(record.provenance),
+        "payload": dict(record.payload),
+    }
+
+
+def fact_record_from_json(data: JsonValue) -> FactRecord:
+    mapping = _as_dict(data)
+    return FactRecord(
+        fact_id=_as_str(mapping["fact_id"]),
+        matching_descriptor=_matching_descriptor_from_json(mapping["matching_descriptor"]),
+        basis_hash=_as_str(mapping["basis_hash"]),
+        provenance=_provenance_from_json(mapping["provenance"]),
+        payload=_as_dict(mapping["payload"]),
+    )
+
+
+# ---- FlagRecord (public: read by the sidecar store) ------------------------
+
+
+def flag_record_to_json(record: FlagRecord) -> dict[str, JsonValue]:
+    return {
+        "flag_id": record.flag_id,
+        "fact_id": record.fact_id,
+        "kind": str(record.kind),
+        "reason": record.reason,
+        "verdict_id": record.verdict_id,
+    }
+
+
+def flag_record_from_json(data: JsonValue) -> FlagRecord:
+    mapping = _as_dict(data)
+    verdict_id = mapping.get("verdict_id")
+    return FlagRecord(
+        flag_id=_as_str(mapping["flag_id"]),
+        fact_id=_as_str(mapping["fact_id"]),
+        kind=FlagKind(_as_str(mapping["kind"])),
+        reason=_as_str(mapping["reason"]),
+        verdict_id=_as_str(verdict_id) if verdict_id is not None else None,
+    )
+
+
+# ---- VerdictRecord (public: read by the sidecar store) ---------------------
+
+
+def verdict_record_to_json(record: VerdictRecord) -> dict[str, JsonValue]:
+    return {
+        "verdict_id": record.verdict_id,
+        "fact_id": record.fact_id,
+        "verdict": str(record.verdict),
+        "basis_hash": record.basis_hash,
+        "annotation": record.annotation,
+    }
+
+
+def verdict_record_from_json(data: JsonValue) -> VerdictRecord:
+    mapping = _as_dict(data)
+    return VerdictRecord(
+        verdict_id=_as_str(mapping["verdict_id"]),
+        fact_id=_as_str(mapping["fact_id"]),
+        verdict=Verdict(_as_str(mapping["verdict"])),
+        basis_hash=_as_str(mapping["basis_hash"]),
+        annotation=_as_str(mapping.get("annotation", "")),
+    )
+
+
+# ---- Manifest (public: read by the sidecar store) --------------------------
+
+
+def manifest_to_json(manifest: Manifest) -> dict[str, JsonValue]:
+    return {
+        "schema_version": manifest.schema_version,
+        "prompt_version": manifest.prompt_version,
+        "model_id": manifest.model_id,
+        "input_hashes": dict(manifest.input_hashes),
+    }
+
+
+def manifest_from_json(data: JsonValue) -> Manifest:
+    mapping = _as_dict(data)
+    input_hashes = _as_dict(mapping.get("input_hashes", {}))
+    return Manifest(
+        schema_version=_as_str(mapping["schema_version"]),
+        prompt_version=_as_str(mapping.get("prompt_version", "")),
+        model_id=_as_str(mapping.get("model_id", "")),
+        input_hashes={key: _as_str(value) for key, value in input_hashes.items()},
+    )

--- a/packages/vizsuite/src/vizsuite/sidecar/store.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/store.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import TypeVar
 
 from vizsuite.envelope import ErrorCode, JsonValue, VizError
+from vizsuite.output import ensure_viz_gitignore
 from vizsuite.sidecar.models import (
     FactRecord,
     FlagRecord,
@@ -57,11 +58,6 @@ _STEPS_FILENAME = "steps.json"
 _RECOMMENDATIONS_FILENAME = "recommendations.json"
 _FLAGS_FILENAME = "flags.json"
 _VERDICTS_FILENAME = "verdicts.json"
-
-# `out/` is `vizsuite.output.ensure_viz_dir`'s concern; the store owns `lock`'s
-# entry directly so a sidecar-only workflow (no `viz pr` run yet) still ends up
-# with a correct `.gitignore` regardless of which bootstrap ran first.
-_GITIGNORE_LINE = "lock"
 
 _DEFAULT_LOCK_TIMEOUT_S = 5.0
 _DEFAULT_LOCK_POLL_INTERVAL_S = 0.05
@@ -145,16 +141,6 @@ def _load_records(path: Path, parse_one: Callable[[JsonValue], _T]) -> tuple[_T,
         raise _MalformedSidecarFileError(path, str(exc)) from exc
 
 
-def _ensure_lock_ignored(viz_dir: Path) -> None:
-    """Idempotently ensure `.viz/.gitignore` ignores `lock` (append-if-absent)."""
-    viz_dir.mkdir(parents=True, exist_ok=True)
-    gitignore = viz_dir / ".gitignore"
-    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
-    if _GITIGNORE_LINE not in existing.splitlines():
-        prefix = existing if existing == "" or existing.endswith("\n") else existing + "\n"
-        gitignore.write_text(f"{prefix}{_GITIGNORE_LINE}\n", encoding="utf-8")
-
-
 @dataclass(frozen=True)
 class SidecarStore:
     """The `.viz/` sidecar's single entry point. `root` is injected, never `Path.cwd()`.
@@ -194,7 +180,7 @@ class SidecarStore:
                     raise _LockTimeoutError(lock_path, self.lock_timeout) from None
                 time.sleep(self.lock_poll_interval)
         try:
-            _ensure_lock_ignored(self.viz_dir)
+            ensure_viz_gitignore(self.viz_dir)
             yield
         finally:
             lock_path.unlink(missing_ok=True)

--- a/packages/vizsuite/src/vizsuite/sidecar/store.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/store.py
@@ -177,8 +177,13 @@ class SidecarStore:
 
     @contextmanager
     def _locked(self) -> Iterator[None]:
+        # Acquire the lock BEFORE any other working-tree write: `.viz/` must
+        # exist for the exclusive-create below, but the `.gitignore` rewrite is
+        # deferred until the lock is held. A failed acquisition then leaves only
+        # an (idempotent) empty `.viz/` directory — no torn `.gitignore` — and
+        # the non-atomic read-then-write is serialized under the lock.
         lock_path = self._path(_LOCK_FILENAME)
-        _ensure_lock_ignored(self.viz_dir)
+        self.viz_dir.mkdir(parents=True, exist_ok=True)
         deadline = time.monotonic() + self.lock_timeout
         while True:
             try:
@@ -189,6 +194,7 @@ class SidecarStore:
                     raise _LockTimeoutError(lock_path, self.lock_timeout) from None
                 time.sleep(self.lock_poll_interval)
         try:
+            _ensure_lock_ignored(self.viz_dir)
             yield
         finally:
             lock_path.unlink(missing_ok=True)

--- a/packages/vizsuite/src/vizsuite/sidecar/store.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/store.py
@@ -1,0 +1,269 @@
+"""`.viz/` sidecar store — read/write for the fingerprint manifest plus the
+five Tier-2/Tier-3 record files (spec §5.3).
+
+Every writing operation takes the single-writer advisory lock (`.viz/lock`)
+and writes temp-file-then-atomic-rename in the same directory, so the
+overnight sweep and an on-demand command can never interleave a torn write
+(spec test item 16). Lock contention past a bounded retry raises a typed
+`VizError(SIDECAR_LOCKED)` — never an unbounded block. Serialization is
+deterministic (sorted keys, records sorted by id) so rewriting unchanged
+content is byte-stable.
+
+Tier-2 files (`manifest.json`/`edges.json`/`steps.json`/
+`recommendations.json`/`flags.json`) expose wholesale-rewrite APIs.
+`verdicts.json` is Tier 3 and exposes only `upsert_verdict` — there is
+deliberately no `write_verdicts`: nothing but an explicit human verdict may
+touch it (spec §5.3: "Tier 3 is only ever invalidated, never silently
+deleted").
+
+The sidecar root is injected at construction — never read from `Path.cwd()`
+or another module global — mirroring how `Runners` bundles the adapters
+`cli.main` injects into every verb handler.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagRecord,
+    Manifest,
+    VerdictRecord,
+    fact_record_from_json,
+    fact_record_to_json,
+    flag_record_from_json,
+    flag_record_to_json,
+    manifest_from_json,
+    manifest_to_json,
+    verdict_record_from_json,
+    verdict_record_to_json,
+)
+
+_T = TypeVar("_T")
+
+_LOCK_FILENAME = "lock"
+_MANIFEST_FILENAME = "manifest.json"
+_EDGES_FILENAME = "edges.json"
+_STEPS_FILENAME = "steps.json"
+_RECOMMENDATIONS_FILENAME = "recommendations.json"
+_FLAGS_FILENAME = "flags.json"
+_VERDICTS_FILENAME = "verdicts.json"
+
+# `out/` is `vizsuite.output.ensure_viz_dir`'s concern; the store owns `lock`'s
+# entry directly so a sidecar-only workflow (no `viz pr` run yet) still ends up
+# with a correct `.gitignore` regardless of which bootstrap ran first.
+_GITIGNORE_LINE = "lock"
+
+_DEFAULT_LOCK_TIMEOUT_S = 5.0
+_DEFAULT_LOCK_POLL_INTERVAL_S = 0.05
+
+_MALFORMED_EXCEPTIONS = (KeyError, TypeError, ValueError)
+
+
+class _LockTimeoutError(VizError):
+    """Raised when the sidecar lock is still held past the bounded retry window."""
+
+    def __init__(self, lock_path: Path, timeout: float) -> None:
+        super().__init__(
+            ErrorCode.SIDECAR_LOCKED,
+            "could not acquire the sidecar lock before the retry deadline",
+            detail={"lock_path": str(lock_path), "timeout_s": timeout},
+        )
+
+
+class _MalformedSidecarFileError(VizError):
+    """Raised when a `.viz/*.json` file's content is invalid JSON or the wrong shape."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(
+            ErrorCode.SIDECAR_MALFORMED,
+            "sidecar file is not valid JSON or does not match its record shape",
+            detail={"path": str(path), "reason": reason},
+        )
+
+
+class _NotAnArrayError(TypeError):
+    """Raised when a Tier-2 record file's parsed JSON content isn't an array."""
+
+    def __init__(self) -> None:
+        super().__init__("expected a JSON array")
+
+
+def _atomic_write_json(path: Path, payload: JsonValue) -> None:
+    """Write `payload` as deterministic JSON via temp-file-then-atomic-rename.
+
+    The temp file is unique per call (pid + monotonic nanoseconds) and lives in
+    `path`'s own directory so the final `Path.replace` is an atomic same-
+    filesystem rename. A crash between the temp write and the rename leaves an
+    inert stray temp file — the canonical `path` is only ever touched by the
+    rename itself, so it is never partially written (spec test item 16).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.{time.monotonic_ns()}.tmp")
+    tmp_path.write_text(json.dumps(payload, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _load_json(path: Path) -> JsonValue | None:
+    if not path.exists():
+        return None
+    try:
+        raw: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise _MalformedSidecarFileError(path, str(exc)) from exc
+    return raw
+
+
+def _load_manifest(path: Path) -> Manifest | None:
+    raw = _load_json(path)
+    if raw is None:
+        return None
+    try:
+        return manifest_from_json(raw)
+    except _MALFORMED_EXCEPTIONS as exc:
+        raise _MalformedSidecarFileError(path, str(exc)) from exc
+
+
+def _load_records(path: Path, parse_one: Callable[[JsonValue], _T]) -> tuple[_T, ...]:
+    raw = _load_json(path)
+    if raw is None:
+        return ()
+    try:
+        if not isinstance(raw, list):
+            raise _NotAnArrayError
+        return tuple(parse_one(item) for item in raw)
+    except _MALFORMED_EXCEPTIONS as exc:
+        raise _MalformedSidecarFileError(path, str(exc)) from exc
+
+
+def _ensure_lock_ignored(viz_dir: Path) -> None:
+    """Idempotently ensure `.viz/.gitignore` ignores `lock` (append-if-absent)."""
+    viz_dir.mkdir(parents=True, exist_ok=True)
+    gitignore = viz_dir / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+    if _GITIGNORE_LINE not in existing.splitlines():
+        prefix = existing if existing == "" or existing.endswith("\n") else existing + "\n"
+        gitignore.write_text(f"{prefix}{_GITIGNORE_LINE}\n", encoding="utf-8")
+
+
+@dataclass(frozen=True)
+class SidecarStore:
+    """The `.viz/` sidecar's single entry point. `root` is injected, never `Path.cwd()`.
+
+    `lock_timeout`/`lock_poll_interval` are constructor-level (not per-call
+    kwargs) so a caller or test can size the bounded retry once, without
+    threading extra parameters through every write method.
+    """
+
+    root: Path
+    lock_timeout: float = _DEFAULT_LOCK_TIMEOUT_S
+    lock_poll_interval: float = _DEFAULT_LOCK_POLL_INTERVAL_S
+
+    @property
+    def viz_dir(self) -> Path:
+        return self.root / ".viz"
+
+    def _path(self, filename: str) -> Path:
+        return self.viz_dir / filename
+
+    @contextmanager
+    def _locked(self) -> Iterator[None]:
+        lock_path = self._path(_LOCK_FILENAME)
+        _ensure_lock_ignored(self.viz_dir)
+        deadline = time.monotonic() + self.lock_timeout
+        while True:
+            try:
+                lock_path.open("x", encoding="utf-8").close()
+                break
+            except FileExistsError:
+                if time.monotonic() >= deadline:
+                    raise _LockTimeoutError(lock_path, self.lock_timeout) from None
+                time.sleep(self.lock_poll_interval)
+        try:
+            yield
+        finally:
+            lock_path.unlink(missing_ok=True)
+
+    # ---- manifest (Tier-2, wholesale-rewrite) ------------------------------
+
+    def read_manifest(self) -> Manifest | None:
+        return _load_manifest(self._path(_MANIFEST_FILENAME))
+
+    def write_manifest(self, manifest: Manifest) -> None:
+        with self._locked():
+            _atomic_write_json(self._path(_MANIFEST_FILENAME), manifest_to_json(manifest))
+
+    # ---- edges (Tier-2, wholesale-rewrite) ---------------------------------
+
+    def read_edges(self) -> tuple[FactRecord, ...]:
+        return _load_records(self._path(_EDGES_FILENAME), fact_record_from_json)
+
+    def write_edges(self, records: Sequence[FactRecord]) -> None:
+        with self._locked():
+            _write_fact_records(self._path(_EDGES_FILENAME), records)
+
+    # ---- steps (Tier-2, wholesale-rewrite) ---------------------------------
+
+    def read_steps(self) -> tuple[FactRecord, ...]:
+        return _load_records(self._path(_STEPS_FILENAME), fact_record_from_json)
+
+    def write_steps(self, records: Sequence[FactRecord]) -> None:
+        with self._locked():
+            _write_fact_records(self._path(_STEPS_FILENAME), records)
+
+    # ---- recommendations (Tier-2, wholesale-rewrite) -----------------------
+
+    def read_recommendations(self) -> tuple[FactRecord, ...]:
+        return _load_records(self._path(_RECOMMENDATIONS_FILENAME), fact_record_from_json)
+
+    def write_recommendations(self, records: Sequence[FactRecord]) -> None:
+        with self._locked():
+            _write_fact_records(self._path(_RECOMMENDATIONS_FILENAME), records)
+
+    # ---- flags (Tier-2, machine-owned, wholesale-rewrite) ------------------
+
+    def read_flags(self) -> tuple[FlagRecord, ...]:
+        return _load_records(self._path(_FLAGS_FILENAME), flag_record_from_json)
+
+    def write_flags(self, records: Sequence[FlagRecord]) -> None:
+        with self._locked():
+            sorted_records = sorted(records, key=lambda record: record.flag_id)
+            _atomic_write_json(
+                self._path(_FLAGS_FILENAME),
+                [flag_record_to_json(record) for record in sorted_records],
+            )
+
+    # ---- verdicts (Tier 3 — append-or-update-single-verdict ONLY) ----------
+
+    def read_verdicts(self) -> tuple[VerdictRecord, ...]:
+        return _load_records(self._path(_VERDICTS_FILENAME), verdict_record_from_json)
+
+    def upsert_verdict(self, record: VerdictRecord) -> None:
+        """Append a new verdict or update an existing one by `verdict_id`.
+
+        The only public `verdicts.json` mutation — there is deliberately no
+        `write_verdicts`: Tier 3 is only ever invalidated, never silently
+        rewritten wholesale (spec §5.3). Unrelated verdicts are carried
+        through unchanged.
+        """
+        path = self._path(_VERDICTS_FILENAME)
+        with self._locked():
+            existing = _load_records(path, verdict_record_from_json)
+            by_id = {item.verdict_id: item for item in existing}
+            by_id[record.verdict_id] = record
+            sorted_records = sorted(by_id.values(), key=lambda item: item.verdict_id)
+            _atomic_write_json(path, [verdict_record_to_json(item) for item in sorted_records])
+
+
+def _write_fact_records(path: Path, records: Sequence[FactRecord]) -> None:
+    sorted_records = sorted(records, key=lambda record: record.fact_id)
+    _atomic_write_json(path, [fact_record_to_json(record) for record in sorted_records])

--- a/packages/vizsuite/tests/unit/test_output.py
+++ b/packages/vizsuite/tests/unit/test_output.py
@@ -13,15 +13,15 @@ def test_creates_out_dir_and_ignores_the_managed_set(tmp_path: Path):
     assert out == tmp_path / ".viz" / "out"
     assert out.is_dir()
     # Both managed entries, in canonical (alphabetical) order.
-    assert (tmp_path / ".viz" / ".gitignore").read_text().splitlines() == ["lock", "out/"]
+    assert (tmp_path / ".viz" / ".gitignore").read_text(encoding="utf-8").splitlines() == ["lock", "out/"]
 
 
 def test_idempotent_no_duplicate_ignore_lines(tmp_path: Path):
     ensure_viz_dir(tmp_path)
-    first = (tmp_path / ".viz" / ".gitignore").read_text()
+    first = (tmp_path / ".viz" / ".gitignore").read_text(encoding="utf-8")
 
     ensure_viz_dir(tmp_path)
-    second = (tmp_path / ".viz" / ".gitignore").read_text()
+    second = (tmp_path / ".viz" / ".gitignore").read_text(encoding="utf-8")
 
     assert first == second == "lock\nout/\n"
 
@@ -29,11 +29,11 @@ def test_idempotent_no_duplicate_ignore_lines(tmp_path: Path):
 def test_preserves_existing_gitignore_content(tmp_path: Path):
     viz = tmp_path / ".viz"
     viz.mkdir()
-    (viz / ".gitignore").write_text("# custom\nscratch/\n")
+    (viz / ".gitignore").write_text("# custom\nscratch/\n", encoding="utf-8")
 
     ensure_viz_dir(tmp_path)
 
-    lines = (viz / ".gitignore").read_text().splitlines()
+    lines = (viz / ".gitignore").read_text(encoding="utf-8").splitlines()
     # Existing lines preserved and never reordered; managed entries appended.
     assert lines == ["# custom", "scratch/", "lock", "out/"]
 
@@ -41,11 +41,11 @@ def test_preserves_existing_gitignore_content(tmp_path: Path):
 def test_no_op_when_managed_set_already_present(tmp_path: Path):
     viz = tmp_path / ".viz"
     viz.mkdir()
-    (viz / ".gitignore").write_text("lock\nout/\n")
+    (viz / ".gitignore").write_text("lock\nout/\n", encoding="utf-8")
 
     ensure_viz_dir(tmp_path)
 
-    assert (viz / ".gitignore").read_text() == "lock\nout/\n"
+    assert (viz / ".gitignore").read_text(encoding="utf-8") == "lock\nout/\n"
 
 
 def test_appends_only_the_missing_managed_entry(tmp_path: Path):
@@ -53,8 +53,8 @@ def test_appends_only_the_missing_managed_entry(tmp_path: Path):
     viz.mkdir()
     # A pre-existing partial file (only `out/`): the absent `lock` is appended,
     # existing content is preserved and never reordered.
-    (viz / ".gitignore").write_text("out/\n")
+    (viz / ".gitignore").write_text("out/\n", encoding="utf-8")
 
     ensure_viz_gitignore(viz)
 
-    assert (viz / ".gitignore").read_text() == "out/\nlock\n"
+    assert (viz / ".gitignore").read_text(encoding="utf-8") == "out/\nlock\n"

--- a/packages/vizsuite/tests/unit/test_output.py
+++ b/packages/vizsuite/tests/unit/test_output.py
@@ -13,7 +13,8 @@ def test_creates_out_dir_and_ignores_the_managed_set(tmp_path: Path):
     assert out == tmp_path / ".viz" / "out"
     assert out.is_dir()
     # Both managed entries, in canonical (alphabetical) order.
-    assert (tmp_path / ".viz" / ".gitignore").read_text(encoding="utf-8").splitlines() == ["lock", "out/"]
+    gitignore = tmp_path / ".viz" / ".gitignore"
+    assert gitignore.read_text(encoding="utf-8").splitlines() == ["lock", "out/"]
 
 
 def test_idempotent_no_duplicate_ignore_lines(tmp_path: Path):

--- a/packages/vizsuite/tests/unit/test_output.py
+++ b/packages/vizsuite/tests/unit/test_output.py
@@ -1,25 +1,29 @@
-"""`.viz/` sidecar bootstrap: idempotent dir creation + portable `out/` ignore."""
+"""`.viz/` sidecar bootstrap: idempotent dir creation + canonical managed ignore."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from vizsuite.output import ensure_viz_dir
+from vizsuite.output import ensure_viz_dir, ensure_viz_gitignore
 
 
-def test_creates_out_dir_and_ignores_it(tmp_path: Path):
+def test_creates_out_dir_and_ignores_the_managed_set(tmp_path: Path):
     out = ensure_viz_dir(tmp_path)
 
     assert out == tmp_path / ".viz" / "out"
     assert out.is_dir()
-    assert (tmp_path / ".viz" / ".gitignore").read_text().splitlines() == ["out/"]
+    # Both managed entries, in canonical (alphabetical) order.
+    assert (tmp_path / ".viz" / ".gitignore").read_text().splitlines() == ["lock", "out/"]
 
 
-def test_idempotent_no_duplicate_ignore_line(tmp_path: Path):
+def test_idempotent_no_duplicate_ignore_lines(tmp_path: Path):
     ensure_viz_dir(tmp_path)
-    ensure_viz_dir(tmp_path)
+    first = (tmp_path / ".viz" / ".gitignore").read_text()
 
-    assert (tmp_path / ".viz" / ".gitignore").read_text().count("out/") == 1
+    ensure_viz_dir(tmp_path)
+    second = (tmp_path / ".viz" / ".gitignore").read_text()
+
+    assert first == second == "lock\nout/\n"
 
 
 def test_preserves_existing_gitignore_content(tmp_path: Path):
@@ -30,14 +34,27 @@ def test_preserves_existing_gitignore_content(tmp_path: Path):
     ensure_viz_dir(tmp_path)
 
     lines = (viz / ".gitignore").read_text().splitlines()
-    assert lines == ["# custom", "scratch/", "out/"]
+    # Existing lines preserved and never reordered; managed entries appended.
+    assert lines == ["# custom", "scratch/", "lock", "out/"]
 
 
-def test_no_op_when_out_already_ignored(tmp_path: Path):
+def test_no_op_when_managed_set_already_present(tmp_path: Path):
     viz = tmp_path / ".viz"
     viz.mkdir()
-    (viz / ".gitignore").write_text("out/\n")
+    (viz / ".gitignore").write_text("lock\nout/\n")
 
     ensure_viz_dir(tmp_path)
 
-    assert (viz / ".gitignore").read_text() == "out/\n"
+    assert (viz / ".gitignore").read_text() == "lock\nout/\n"
+
+
+def test_appends_only_the_missing_managed_entry(tmp_path: Path):
+    viz = tmp_path / ".viz"
+    viz.mkdir()
+    # A pre-existing partial file (only `out/`): the absent `lock` is appended,
+    # existing content is preserved and never reordered.
+    (viz / ".gitignore").write_text("out/\n")
+
+    ensure_viz_gitignore(viz)
+
+    assert (viz / ".gitignore").read_text() == "out/\nlock\n"

--- a/packages/vizsuite/tests/unit/test_sidecar_models.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_models.py
@@ -241,6 +241,40 @@ def test_flag_record_from_json_rejects_unknown_kind():
         )
 
 
+def test_flag_record_rejects_doubt_flag_carrying_a_verdict_id():
+    with pytest.raises(ValueError, match="verdict_id must be set iff"):
+        FlagRecord(
+            flag_id="flag-1",
+            fact_id="fact-1",
+            kind=FlagKind.DOUBT,
+            reason="input changed",
+            verdict_id="verdict-1",
+        )
+
+
+def test_flag_record_rejects_orphaned_verdict_flag_without_a_verdict_id():
+    with pytest.raises(ValueError, match="verdict_id must be set iff"):
+        FlagRecord(
+            flag_id="flag-2",
+            fact_id="fact-1",
+            kind=FlagKind.ORPHANED_VERDICT,
+            reason="fact vanished on rebuild",
+        )
+
+
+def test_flag_record_from_json_rejects_doubt_flag_with_verdict_id():
+    with pytest.raises(ValueError, match="verdict_id must be set iff"):
+        flag_record_from_json(
+            {
+                "flag_id": "flag-1",
+                "fact_id": "fact-1",
+                "kind": "doubt",
+                "reason": "input changed",
+                "verdict_id": "verdict-1",
+            }
+        )
+
+
 def test_verdict_record_round_trips_through_json():
     record = VerdictRecord(
         verdict_id="verdict-1",

--- a/packages/vizsuite/tests/unit/test_sidecar_models.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_models.py
@@ -1,0 +1,322 @@
+"""Sidecar record dataclasses: round-trip (de)serialization + malformed-shape
+rejection (spec §5.3).
+
+Each record's `_to_json`/`_from_json` pair is a pure mapping — the store owns
+the file I/O and wraps any raised error into a typed `VizError` at the read
+boundary (see `test_sidecar_store.py`); here we drive the mapping functions
+directly to prove round-trip fidelity and that a malformed shape raises
+(never silently coerces or drops a field).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    Manifest,
+    MatchingDescriptor,
+    Verdict,
+    VerdictRecord,
+    fact_record_from_json,
+    fact_record_to_json,
+    flag_record_from_json,
+    flag_record_to_json,
+    manifest_from_json,
+    manifest_to_json,
+    verdict_record_from_json,
+    verdict_record_to_json,
+)
+
+_PROVENANCE = Provenance(
+    kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=("spec:5.2",)
+)
+_DESCRIPTOR = MatchingDescriptor(
+    plan_pair=("plan-a", "plan-b"),
+    kind="dependency",
+    endpoint_bead_ids=(("bead-1", "bead-2"), ("bead-3",)),
+)
+
+
+def test_fact_record_round_trips_through_json():
+    record = FactRecord(
+        fact_id="fact-1",
+        matching_descriptor=_DESCRIPTOR,
+        basis_hash="hash-1",
+        provenance=_PROVENANCE,
+        payload={"story": "a depends on b"},
+    )
+
+    payload = fact_record_to_json(record)
+    restored = fact_record_from_json(payload)
+
+    assert restored == record
+    assert payload == {
+        "fact_id": "fact-1",
+        "matching_descriptor": {
+            "plan_pair": ["plan-a", "plan-b"],
+            "kind": "dependency",
+            "endpoint_bead_ids": [["bead-1", "bead-2"], ["bead-3"]],
+        },
+        "basis_hash": "hash-1",
+        "provenance": {
+            "kind": "inferred",
+            "freshness": "fresh",
+            "citations": ["spec:5.2"],
+        },
+        "payload": {"story": "a depends on b"},
+    }
+
+
+def test_fact_record_round_trips_with_empty_endpoint_bead_ids():
+    # Prose-only plans anchor on plan_pair + kind alone (spec §5.3).
+    descriptor = MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind="overlap")
+    record = FactRecord(
+        fact_id="fact-2",
+        matching_descriptor=descriptor,
+        basis_hash="hash-2",
+        provenance=_PROVENANCE,
+    )
+
+    restored = fact_record_from_json(fact_record_to_json(record))
+
+    assert restored == record
+    assert restored.matching_descriptor.endpoint_bead_ids == ()
+    assert restored.payload == {}
+
+
+def test_fact_record_from_json_rejects_non_dict_input():
+    with pytest.raises(TypeError):
+        fact_record_from_json("not-a-dict")
+
+
+def test_fact_record_from_json_rejects_non_dict_matching_descriptor():
+    with pytest.raises(TypeError):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": "nope",
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_fact_record_from_json_rejects_missing_required_key():
+    with pytest.raises(KeyError):
+        fact_record_from_json(
+            {
+                "matching_descriptor": {
+                    "plan_pair": ["a", "b"],
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_matching_descriptor_from_json_rejects_wrong_length_plan_pair():
+    with pytest.raises(ValueError, match="plan_pair"):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": {
+                    "plan_pair": ["only-one"],
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_matching_descriptor_from_json_rejects_non_str_endpoint_bead_id():
+    with pytest.raises(TypeError):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": {
+                    "plan_pair": ["a", "b"],
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [[1, 2]],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_matching_descriptor_from_json_rejects_non_list_plan_pair():
+    with pytest.raises(TypeError):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": {
+                    "plan_pair": "a,b",
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_provenance_from_json_rejects_non_list_citations():
+    with pytest.raises(TypeError):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": {
+                    "plan_pair": ["a", "b"],
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": "inferred", "freshness": "fresh", "citations": "not-a-list"},
+                "payload": {},
+            }
+        )
+
+
+def test_provenance_from_json_rejects_non_str_kind():
+    with pytest.raises(TypeError):
+        fact_record_from_json(
+            {
+                "fact_id": "fact-1",
+                "matching_descriptor": {
+                    "plan_pair": ["a", "b"],
+                    "kind": "dependency",
+                    "endpoint_bead_ids": [],
+                },
+                "basis_hash": "hash-1",
+                "provenance": {"kind": 1, "freshness": "fresh", "citations": []},
+                "payload": {},
+            }
+        )
+
+
+def test_flag_record_round_trips_as_a_doubt_flag_with_no_verdict_id():
+    record = FlagRecord(
+        flag_id="flag-1", fact_id="fact-1", kind=FlagKind.DOUBT, reason="input changed"
+    )
+
+    payload = flag_record_to_json(record)
+    restored = flag_record_from_json(payload)
+
+    assert restored == record
+    assert payload["verdict_id"] is None
+
+
+def test_flag_record_round_trips_as_an_orphaned_verdict_flag_with_verdict_id():
+    record = FlagRecord(
+        flag_id="flag-2",
+        fact_id="fact-1",
+        kind=FlagKind.ORPHANED_VERDICT,
+        reason="fact vanished on rebuild",
+        verdict_id="verdict-1",
+    )
+
+    restored = flag_record_from_json(flag_record_to_json(record))
+
+    assert restored == record
+    assert restored.verdict_id == "verdict-1"
+
+
+def test_flag_record_from_json_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="not a valid FlagKind"):
+        flag_record_from_json(
+            {"flag_id": "flag-1", "fact_id": "fact-1", "kind": "bogus", "reason": "x"}
+        )
+
+
+def test_verdict_record_round_trips_through_json():
+    record = VerdictRecord(
+        verdict_id="verdict-1",
+        fact_id="fact-1",
+        verdict=Verdict.ACCEPT,
+        basis_hash="hash-1",
+        annotation="looks right",
+    )
+
+    payload = verdict_record_to_json(record)
+    restored = verdict_record_from_json(payload)
+
+    assert restored == record
+    assert payload == {
+        "verdict_id": "verdict-1",
+        "fact_id": "fact-1",
+        "verdict": "accept",
+        "basis_hash": "hash-1",
+        "annotation": "looks right",
+    }
+
+
+def test_verdict_record_defaults_annotation_to_empty_string():
+    record = VerdictRecord(
+        verdict_id="verdict-2", fact_id="fact-2", verdict=Verdict.REJECT, basis_hash="hash-2"
+    )
+
+    restored = verdict_record_from_json(verdict_record_to_json(record))
+
+    assert restored.annotation == ""
+
+
+def test_verdict_record_from_json_rejects_unknown_verdict():
+    with pytest.raises(ValueError, match="not a valid Verdict"):
+        verdict_record_from_json(
+            {
+                "verdict_id": "verdict-1",
+                "fact_id": "fact-1",
+                "verdict": "bogus",
+                "basis_hash": "hash-1",
+                "annotation": "",
+            }
+        )
+
+
+def test_manifest_round_trips_through_json():
+    manifest = Manifest(
+        schema_version="1",
+        prompt_version="p1",
+        model_id="m1",
+        input_hashes={"docs/specs/x.md": "sha-1"},
+    )
+
+    payload = manifest_to_json(manifest)
+    restored = manifest_from_json(payload)
+
+    assert restored == manifest
+    assert payload == {
+        "schema_version": "1",
+        "prompt_version": "p1",
+        "model_id": "m1",
+        "input_hashes": {"docs/specs/x.md": "sha-1"},
+    }
+
+
+def test_manifest_round_trips_with_only_schema_version_given():
+    manifest = Manifest(schema_version="1")
+
+    restored = manifest_from_json(manifest_to_json(manifest))
+
+    assert restored == manifest
+    assert restored.prompt_version == ""
+    assert restored.model_id == ""
+    assert restored.input_hashes == {}
+
+
+def test_manifest_from_json_rejects_non_dict_input_hashes():
+    with pytest.raises(TypeError):
+        manifest_from_json({"schema_version": "1", "input_hashes": "nope"})

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -282,6 +282,20 @@ def test_lock_contention_raises_typed_error_after_bounded_retry(tmp_path: Path):
     assert exc_info.value.code == ErrorCode.SIDECAR_LOCKED
 
 
+def test_failed_lock_acquisition_writes_no_gitignore(tmp_path: Path):
+    store = SidecarStore(tmp_path, lock_timeout=0.05, lock_poll_interval=0.01)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "lock").touch()  # another writer already holds the lock
+
+    with pytest.raises(VizError) as exc_info:
+        store.write_manifest(Manifest(schema_version="1"))
+
+    assert exc_info.value.code == ErrorCode.SIDECAR_LOCKED
+    # The `.gitignore` rewrite is deferred until the lock is held, so a failed
+    # acquisition leaves the working tree untouched.
+    assert not (store.viz_dir / ".gitignore").exists()
+
+
 def test_lock_is_released_after_a_successful_write(tmp_path: Path):
     store = SidecarStore(tmp_path)
 

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -184,6 +184,30 @@ def test_read_edges_on_record_missing_field_raises_typed_error(tmp_path: Path):
     assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
 
 
+def test_read_flags_on_invalid_verdict_id_invariant_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    # A doubt flag must not carry a verdict_id — the FlagRecord invariant.
+    (store.viz_dir / "flags.json").write_text(
+        json.dumps(
+            [
+                {
+                    "flag_id": "flag-1",
+                    "fact_id": "edge-1",
+                    "kind": "doubt",
+                    "reason": "churned",
+                    "verdict_id": "verdict-1",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_flags()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
 def test_read_manifest_on_invalid_json_raises_typed_error(tmp_path: Path):
     store = SidecarStore(tmp_path)
     store.viz_dir.mkdir(parents=True)

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.output import ensure_viz_dir
 from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
 from vizsuite.sidecar.models import (
     FactRecord,
@@ -262,6 +263,24 @@ def test_write_preserves_existing_gitignore_content(tmp_path: Path):
 
     lines = (store.viz_dir / ".gitignore").read_text(encoding="utf-8").splitlines()
     assert lines == ["out/", "lock"]
+
+
+def test_gitignore_is_call_order_independent_across_both_writers(tmp_path: Path):
+    # Both sidecar writers share `ensure_viz_gitignore`, which installs the
+    # complete managed set — so whichever runs first, the committed
+    # `.viz/.gitignore` is byte-identical regardless of call order.
+    store_first = tmp_path / "store-first"
+    output_first = tmp_path / "output-first"
+
+    SidecarStore(store_first).write_manifest(Manifest(schema_version="1"))
+    ensure_viz_dir(store_first)
+
+    ensure_viz_dir(output_first)
+    SidecarStore(output_first).write_manifest(Manifest(schema_version="1"))
+
+    store_first_bytes = (store_first / ".viz" / ".gitignore").read_bytes()
+    output_first_bytes = (output_first / ".viz" / ".gitignore").read_bytes()
+    assert store_first_bytes == output_first_bytes == b"lock\nout/\n"
 
 
 # ---- Tier discipline in the API shape: no wholesale verdicts.json rewrite --

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -1,0 +1,390 @@
+"""`.viz/` sidecar store: read/write, locking, atomic writes, and the Tier
+discipline in the API shape itself (spec §5.3, test items 16).
+
+No live process/thread races beyond what's needed to prove the lock actually
+serializes writers; every test drives `SidecarStore` directly against a
+`tmp_path` root — the store never assumes a module-global cwd (root is always
+injected).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    Manifest,
+    MatchingDescriptor,
+    Verdict,
+    VerdictRecord,
+)
+from vizsuite.sidecar.store import SidecarStore
+
+_PROVENANCE = Provenance(
+    kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=("spec:5.2",)
+)
+
+
+def _fact(fact_id: str, *, kind: str = "dependency") -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind=kind),
+        basis_hash=f"hash-{fact_id}",
+        provenance=_PROVENANCE,
+    )
+
+
+def _verdict(verdict_id: str, fact_id: str, *, annotation: str = "") -> VerdictRecord:
+    return VerdictRecord(
+        verdict_id=verdict_id,
+        fact_id=fact_id,
+        verdict=Verdict.ACCEPT,
+        basis_hash=f"hash-{fact_id}",
+        annotation=annotation,
+    )
+
+
+# ---- manifest + the five record files: round-trip with validation ---------
+
+
+def test_read_manifest_returns_none_when_absent(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+
+    assert store.read_manifest() is None
+
+
+def test_manifest_round_trips_through_the_store(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    manifest = Manifest(schema_version="1", prompt_version="p1", model_id="m1")
+
+    store.write_manifest(manifest)
+
+    assert store.read_manifest() == manifest
+
+
+@pytest.mark.parametrize(
+    ("write_method", "read_method", "records"),
+    [
+        ("write_edges", "read_edges", (_fact("edge-1"), _fact("edge-2", kind="conflict"))),
+        ("write_steps", "read_steps", (_fact("step-1"),)),
+        ("write_recommendations", "read_recommendations", (_fact("rec-1"),)),
+    ],
+)
+def test_fact_record_files_round_trip_and_default_empty(
+    tmp_path: Path, write_method: str, read_method: str, records: tuple[FactRecord, ...]
+):
+    store = SidecarStore(tmp_path)
+
+    assert getattr(store, read_method)() == ()
+
+    getattr(store, write_method)(records)
+
+    assert getattr(store, read_method)() == records
+
+
+def test_flags_round_trip_and_default_empty(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    flags = (
+        FlagRecord(flag_id="flag-1", fact_id="edge-1", kind=FlagKind.DOUBT, reason="churned"),
+        FlagRecord(
+            flag_id="flag-2",
+            fact_id="edge-2",
+            kind=FlagKind.ORPHANED_VERDICT,
+            reason="vanished",
+            verdict_id="verdict-1",
+        ),
+    )
+
+    assert store.read_flags() == ()
+
+    store.write_flags(flags)
+
+    assert store.read_flags() == flags
+
+
+def test_fact_record_files_rewrite_wholesale_and_drop_omitted_records(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"), _fact("edge-2")))
+
+    store.write_edges((_fact("edge-3"),))
+
+    assert store.read_edges() == (_fact("edge-3"),)
+
+
+# ---- deterministic serialization: byte-stable rewrites ---------------------
+
+
+def test_rewriting_unchanged_content_is_byte_stable(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    records = (_fact("edge-2"), _fact("edge-1"))  # deliberately unsorted input
+
+    store.write_edges(records)
+    first_bytes = (store.viz_dir / "edges.json").read_bytes()
+
+    store.write_edges(records)
+    second_bytes = (store.viz_dir / "edges.json").read_bytes()
+
+    assert first_bytes == second_bytes
+    # sorted by fact_id, not insertion order — proves the store sorts, not the caller.
+    assert [entry["fact_id"] for entry in json.loads(first_bytes)] == ["edge-1", "edge-2"]
+
+
+def test_manifest_write_is_byte_stable_across_rewrites(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    manifest = Manifest(schema_version="1", input_hashes={"b": "2", "a": "1"})
+
+    store.write_manifest(manifest)
+    first_bytes = (store.viz_dir / "manifest.json").read_bytes()
+    store.write_manifest(manifest)
+    second_bytes = (store.viz_dir / "manifest.json").read_bytes()
+
+    assert first_bytes == second_bytes
+
+
+# ---- malformed sidecar content: typed error, never a raw parse exception ---
+
+
+def test_read_edges_on_invalid_json_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "edges.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_edges()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+def test_read_edges_on_wrong_shape_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    # a JSON object where an array of records is expected.
+    (store.viz_dir / "edges.json").write_text(json.dumps({"oops": True}), encoding="utf-8")
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_edges()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+def test_read_edges_on_record_missing_field_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "edges.json").write_text(json.dumps([{"fact_id": "x"}]), encoding="utf-8")
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_edges()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+def test_read_manifest_on_invalid_json_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "manifest.json").write_text("not json at all", encoding="utf-8")
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_manifest()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+def test_read_manifest_on_valid_json_wrong_shape_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    # valid JSON, but missing the required `schema_version` key.
+    (store.viz_dir / "manifest.json").write_text(
+        json.dumps({"prompt_version": "p1"}), encoding="utf-8"
+    )
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_manifest()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+def test_read_verdicts_on_malformed_content_raises_typed_error(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "verdicts.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(VizError) as exc_info:
+        store.read_verdicts()
+    assert exc_info.value.code == ErrorCode.SIDECAR_MALFORMED
+
+
+# ---- gitignore bootstrap: lock (and by extension out/) never committed ----
+
+
+def test_write_ensures_lock_is_gitignored(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+
+    store.write_manifest(Manifest(schema_version="1"))
+
+    lines = (store.viz_dir / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert "lock" in lines
+
+
+def test_write_preserves_existing_gitignore_content(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / ".gitignore").write_text("out/\n", encoding="utf-8")
+
+    store.write_manifest(Manifest(schema_version="1"))
+
+    lines = (store.viz_dir / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines == ["out/", "lock"]
+
+
+# ---- Tier discipline in the API shape: no wholesale verdicts.json rewrite --
+
+
+def test_store_exposes_no_wholesale_verdict_rewrite_api():
+    assert not hasattr(SidecarStore, "write_verdicts")
+    assert hasattr(SidecarStore, "upsert_verdict")
+
+
+def test_upsert_verdict_appends_a_new_verdict(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+
+    store.upsert_verdict(_verdict("verdict-1", "edge-1"))
+
+    assert store.read_verdicts() == (_verdict("verdict-1", "edge-1"),)
+
+
+def test_upsert_verdict_updates_in_place_and_preserves_unrelated_verdicts(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.upsert_verdict(_verdict("verdict-1", "edge-1", annotation="first"))
+    store.upsert_verdict(_verdict("verdict-2", "edge-2", annotation="unrelated"))
+
+    store.upsert_verdict(_verdict("verdict-1", "edge-1", annotation="revised"))
+
+    verdicts = {record.verdict_id: record for record in store.read_verdicts()}
+    assert len(verdicts) == 2
+    assert verdicts["verdict-1"].annotation == "revised"
+    assert verdicts["verdict-2"].annotation == "unrelated"  # untouched by the update
+
+
+# ---- locking + atomic writes -----------------------------------------------
+
+
+def test_lock_contention_raises_typed_error_after_bounded_retry(tmp_path: Path):
+    store = SidecarStore(tmp_path, lock_timeout=0.05, lock_poll_interval=0.01)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "lock").touch()  # simulate another writer already holding the lock
+
+    with pytest.raises(VizError) as exc_info:
+        store.write_manifest(Manifest(schema_version="1"))
+    assert exc_info.value.code == ErrorCode.SIDECAR_LOCKED
+
+
+def test_lock_is_released_after_a_successful_write(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+
+    store.write_manifest(Manifest(schema_version="1"))
+
+    assert not (store.viz_dir / "lock").exists()
+
+
+def test_lock_is_released_after_a_failed_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    store = SidecarStore(tmp_path)
+
+    def _boom(_self: Path, _target: Path) -> Path:
+        raise OSError("simulated crash before rename")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError, match="simulated crash"):
+        store.write_manifest(Manifest(schema_version="1"))
+
+    monkeypatch.undo()
+    assert not (store.viz_dir / "lock").exists()
+    # the lock is usable again for the next write.
+    store.write_manifest(Manifest(schema_version="2"))
+    assert store.read_manifest() == Manifest(schema_version="2")
+
+
+def test_crash_before_rename_leaves_canonical_file_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1"))
+    canonical = store.viz_dir / "manifest.json"
+    original_bytes = canonical.read_bytes()
+
+    def _boom(_self: Path, _target: Path) -> Path:
+        raise OSError("simulated crash before rename")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError):
+        store.write_manifest(Manifest(schema_version="2"))
+    monkeypatch.undo()
+
+    assert canonical.read_bytes() == original_bytes
+    # a stray temp file is left behind by the crashed write...
+    leftovers = [p for p in store.viz_dir.iterdir() if ".manifest.json." in p.name]
+    assert len(leftovers) == 1
+    # ...but it is inert: a fresh read still sees only the canonical content...
+    assert store.read_manifest() == Manifest(schema_version="1")
+    # ...and a later successful write is unaffected by the stray leftover.
+    store.write_manifest(Manifest(schema_version="3"))
+    assert store.read_manifest() == Manifest(schema_version="3")
+
+
+def test_stray_leftover_temp_file_is_ignored_on_read(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1"))
+    # plant a stray temp file as a crashed writer would leave behind.
+    (store.viz_dir / ".manifest.json.99999.stray.tmp").write_text("garbage", encoding="utf-8")
+
+    assert store.read_manifest() == Manifest(schema_version="1")
+
+
+def test_concurrent_writers_do_not_interleave(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    store_a = SidecarStore(tmp_path, lock_timeout=2.0, lock_poll_interval=0.01)
+    store_b = SidecarStore(tmp_path, lock_timeout=2.0, lock_poll_interval=0.01)
+    events: list[str] = []
+    original_dumps = json.dumps
+
+    def _slow_dumps(*args: object, **kwargs: object) -> str:
+        events.append("start")
+        time.sleep(0.05)
+        result = original_dumps(*args, **kwargs)
+        events.append("end")
+        return result
+
+    monkeypatch.setattr("vizsuite.sidecar.store.json.dumps", _slow_dumps)
+
+    def _write(store: SidecarStore, tag: str) -> None:
+        store.write_manifest(Manifest(schema_version=tag))
+
+    t1 = threading.Thread(target=_write, args=(store_a, "a"))
+    t2 = threading.Thread(target=_write, args=(store_b, "b"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    # The lock serializes the two writers: a second "start" never appears
+    # before the first "end" — no interleaved writes.
+    assert events == ["start", "end", "start", "end"]
+
+
+# ---- root injection: no module-global cwd assumption -----------------------
+
+
+def test_store_reads_and_writes_are_scoped_to_the_injected_root(tmp_path: Path):
+    root_a = tmp_path / "repo-a"
+    root_b = tmp_path / "repo-b"
+    root_a.mkdir()
+    root_b.mkdir()
+    store_a = SidecarStore(root_a)
+    store_b = SidecarStore(root_b)
+
+    store_a.write_manifest(Manifest(schema_version="a"))
+
+    assert store_a.read_manifest() == Manifest(schema_version="a")
+    assert store_b.read_manifest() is None


### PR DESCRIPTION
## Summary

- Adds the §5.3 **`.viz/` sidecar store foundation** — the persistence layer every later `.2.3` slice (reconciliation, funnel, verdicts, apply) builds on:
- `sidecar/models.py` (new): frozen dataclasses for the sidecar record files — `FactRecord` (shared Tier-2 envelope for edges/steps/recommendations: `fact_id`, `matching_descriptor` snapshot, `basis_hash`, provenance), `FlagRecord`/`FlagKind`, `VerdictRecord`/`Verdict`, `Manifest` — plus pure `*_to_json`/`*_from_json` boundary mappings that raise typed shape errors on malformed input (no raw `KeyError`/`JSONDecodeError` escapes). Provenance reuses `vizsuite.scene.model`'s type and serializer — one shape, one home.
- `sidecar/store.py` (new): `SidecarStore` with an injected root path (no `Path.cwd()`). Every write is temp-file-then-`Path.replace` atomic rename; every writing operation takes a single-writer advisory lock (`.viz/lock`, exclusive-create) with bounded retry → typed `SIDECAR_LOCKED` error, never an unbounded block. Deterministic serialization (sorted keys, records sorted by id) — rewriting unchanged content is byte-stable. `.viz/.gitignore` maintained idempotently (`lock`; `out/` remains the artifact writer's concern).
- **Tier discipline in the API shape** (§5.3): manifest/edges/steps/recommendations/flags get wholesale-rewrite APIs; `verdicts.json` is exposed ONLY through `upsert_verdict` — no `write_verdicts` exists, asserted by test. Tier-3 human verdicts are structurally never machine-rewritten wholesale.
- `envelope.py`: two new error codes (`SIDECAR_MALFORMED`, `SIDECAR_LOCKED`), existing style.
- 46 new tests: round-trips all files, malformed-shape rejection per field class, lock contention + release on success/failure, crash-before-rename leaves canonical file untouched, stray temp file inert, concurrent-writer non-interleaving, byte-stable rewrite, and the no-wholesale-verdicts-API assertion.

Slice S1 (1/6) of the sidecar + staleness-funnel + review-queue CLI build. Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.3.

## Scope + design decisions

- **In scope:** persistence layer only — models, store, lock, atomicity, determinism, tier shape. Fact identity/reconciliation (S2), funnel rungs (S3), tracker port (S4), verdict/promotion verbs (S5), apply (S6) are deliberate follow-up slices; nothing here wires into `cli.py` yet.
- **Fact `payload` is an opaque `dict[str, JsonValue]`** by design: V2's typed domain payloads (§7.2) aren't built yet; later slices add typed payload readers without changing the envelope.
- **Lock is advisory, exclusive-create based** — portable, no `fcntl` dependency; contention surfaces as a typed error the CLI envelope can carry.

## Review-gate disposition

HEAVY adversarial gate (4 lenses, 2-refuter panels, 12 agents, ACCEPTANCE clean-at-floor after 2 rounds): 1 major reuse finding applied — sidecar/models.py duplicated scene/model.py's provenance serializer verbatim; fix renames the scene helper public (`provenance_to_json`) and imports it (second commit). Fix audited first-hand: zero stale references, `make ci-vizsuite` re-run green. Nothing deferred, nothing open.

## Test Plan

- [x] TDD red→green: sidecar tests written first, failed before `models.py`/`store.py` existed, green after
- [x] `make ci-vizsuite` fully green (run twice: post-implementation and post-gate-fix): ruff, format-check, mypy --strict, 176 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
