### PR TITLE
feat(installer): S2 project-scoped install (--project, src/kits/, per-project receipt)

### DIFF
--- a/docs/plans/2026-07-12-s2-project-scoped-install.md
+++ b/docs/plans/2026-07-12-s2-project-scoped-install.md
@@ -1,0 +1,825 @@
+# S2 — Project-Scoped Install Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking. All paths are relative to the repo root `packages/installer/` unless absolute. Run the gate with `make ci-installer` from the repo root.
+
+**Goal:** Add project-scoped install to the installer: `--project <path>` binds the project scope for a run, staging tool-scoped content under `<project>/.claude/` and a tool-agnostic `src/kits/` tree (v1: the beads `PRIME.md` kit) under the project root, tracked by a project-local receipt.
+
+**Architecture:** Approach A — kits ride the S1 resolver for *selection* (via a nullable `UniverseRef.tool`) but materialize, record, and prune through the *existing plugin-route machinery* (a kit is the project-scope mirror of a plugin route, owner `kit:<name>`). The resolver is wired into `cli._run` after `stage_and_transform`; a `--project` run forks to a project tail (filtered `sync_plan` for tool refs + kit routes for kit refs) under a project-local receipt lock, and never runs the user tool sync or user plugin routes. The user run keeps byte-identical output, guarded by a parity golden.
+
+**Tech Stack:** Python 3.12, uv, pytest (`--cov` branch ≥90%), mypy `--strict`, ruff. Source: `packages/installer/src/installer/`. Tests: `packages/installer/tests/unit/`.
+
+**Spec:** `docs/specs/2026-07-12-s2-project-scoped-install-design.md` (committed `9814a9a`, RALF-converged PASS).
+
+---
+
+## Mechanism note (read before Task 8)
+
+The spec's §6.2 sketched "`record_receipt` gains a kit-outcomes input." This plan uses the **cleaner realization**: because a kit is plugin-route-shaped, kit writes flow through the **existing** `plugin_outcomes` channel keyed by owner `kit:<name>`, and kit installs run through the **existing** `install_plugin_routes` / `prune_pipeline` `plugins` slot via a tiny `PluginAdapter`-conforming wrapper (`_KitRouteAdapter`). This needs **no signature change** to `record_receipt`, `install_plugin_routes`, or `prune_pipeline` — the same observable behavior (a `kit:<name>`-owned, `.beads`-rooted project receipt entry that prunes correctly). This is a deviation from the spec's *stated mechanism* (not its behavior) and is flagged for the plan-review gate.
+
+`PluginAdapter` is a `@runtime_checkable Protocol` (`plugins/base.py:30-63`): `name` (property) · `source_path` (property) · `is_detected(home) -> bool` · `routes(home) -> tuple[PluginRoute, ...]`. A kit wrapper conforms structurally.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/installer/core/kits.py` — kit staging: `stage_kits`, `kit_universe`, `kit_routes`, `kit_name_of`, and the `_KitRouteAdapter` plugin-wrapper. One responsibility: turn `src/kits/<kit>/**` into resolver refs + plugin-route adapters.
+- `src/kits/beads/.beads/PRIME.md` — the beads kit content (v1's only kit file).
+- `tests/unit/test_kits.py` — unit tests for `core/kits.py`.
+- `tests/unit/test_cli_project.py` — integration tests for `--project` runs.
+
+**Modified files:**
+- `src/installer/core/profiles.py` — nullable `UniverseRef.tool`; sort-key fix (`:447`).
+- `profiles.toml` (repo root) — add `kits/** = project` scope + `[profiles.beads-kit]`.
+- `src/installer/tools/base.py` — add `project_namespaces()` to the `ToolAdapter` Protocol.
+- `src/installer/tools/{claude,codex,gemini,opencode}.py` — implement `project_namespaces()`.
+- `src/installer/cli.py` — `--project`/`--profiles` flags; the project-run fork; resolver-on for user runs; detection suggestion; dump-stage kit rendering.
+- `src/installer/core/config.py` — project profile-set persistence read/write (`project-config.toml [install]`).
+- `tests/unit/test_profiles.py` — coverage-guard test; nullable-ref sort test.
+
+---
+
+## Phase 0 — Foundations (no user-visible behavior change)
+
+### Task 1: Nullable `UniverseRef.tool` + sort-key fix
+
+**Files:**
+- Modify: `src/installer/core/profiles.py` (`UniverseRef` ~:221; `resolve` sort key `:447`)
+- Test: `tests/unit/test_profiles.py`
+
+- [ ] **Step 1: Write the failing test**
+
+The test must drive the real `resolve()` sort key (`profiles.py:447`) with a `tool=None` ref — not reimplement the sort inline — so it genuinely goes red on the unfixed line. Use a self-contained synthetic manifest (Task 1 runs before the `profiles.toml` edits in Task 2, so do not depend on the shipped manifest):
+
+```python
+# tests/unit/test_profiles.py
+from pathlib import Path
+from installer.core.profiles import Manifest, Profile, IncludeEntry, UniverseRef, resolve, Scope
+from installer.core.model import Tool
+
+def test_resolve_sorts_tool_none_kit_ref_without_crash() -> None:
+    kit_ref = UniverseRef(tool=None, dest_relpath=Path(".beads/PRIME.md"))
+    tool_ref = UniverseRef(tool=Tool.CLAUDE, dest_relpath=Path("skills/x"))
+    universe = {"kits/beads/PRIME": [kit_ref], "skills/x": [tool_ref]}
+    manifest = Manifest(
+        schema=1,
+        scopes={"kits/**": Scope.PROJECT, "skills/**": Scope.PROJECT},
+        profiles={"p": Profile(name="p", includes=(IncludeEntry(selector="**", scope=None),), excludes=())},
+    )
+    resolved = resolve(manifest, ("p",), universe, bound_scopes=frozenset({Scope.PROJECT}))
+    proj = resolved.included[Scope.PROJECT]
+    assert proj[0].tool is None          # tool=None sorts first (key "" < "claude")
+    assert kit_ref in proj and tool_ref in proj
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_profiles.py::test_resolve_sorts_tool_none_kit_ref_without_crash -v`
+Expected: FAIL — `resolve()`'s final sort at `profiles.py:447` reads `r.tool.value`, raising `AttributeError: 'NoneType' object has no attribute 'value'` on the kit ref.
+
+- [ ] **Step 3: Make the change**
+
+In `src/installer/core/profiles.py`, change the `UniverseRef` dataclass field:
+
+```python
+@dataclass(frozen=True, slots=True)
+class UniverseRef:
+    tool: Tool | None   # None ⇒ tool-agnostic kit ref; materializes at the project root
+    dest_relpath: Path
+```
+
+And change the `resolve()` final sort key (currently at ~:447):
+
+```python
+    final_included = {
+        scope: tuple(
+            sorted(
+                refs,
+                key=lambda r: (r.tool.value if r.tool is not None else "", r.dest_relpath.as_posix()),
+            )
+        )
+        for scope, refs in included.items()
+    }
+```
+
+- [ ] **Step 4: Run test + full profiles suite to verify pass + no regression**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_profiles.py -v`
+Expected: PASS (including the existing golden/anti-drift tests — the sort change is a no-op for tool refs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/core/profiles.py tests/unit/test_profiles.py
+git commit -m "feat(installer): allow tool-agnostic UniverseRef (nullable tool) for kits"
+```
+
+---
+
+### Task 2: Manifest — `kits/** = project` scope + `beads-kit` profile + coverage guard
+
+**Files:**
+- Modify: `profiles.toml` (repo root)
+- Test: `tests/unit/test_profiles.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_profiles.py
+from installer.core import namespaces
+
+def test_beads_kit_profile_exists_and_scopes_kits_to_project() -> None:
+    manifest = load_manifest(Path(__file__).resolve().parents[4] / "profiles.toml")
+    assert "beads-kit" in manifest.profiles
+    # The kits/** scope default routes to project.
+    assert any(sel == "kits/**" and scope is Scope.PROJECT for sel, scope in manifest.scopes.items())
+
+def test_scopes_cover_universe_eligible_namespaces() -> None:
+    # Guard: every STAGED namespace (TOOL_SCOPED ∪ SHARED) plus the synthetic
+    # instructions/settings must have a [scopes] match, or a forced-full user run
+    # crashes. formulas is plugin-routed (never a universe key) and must NOT be required.
+    manifest = load_manifest(Path(__file__).resolve().parents[4] / "profiles.toml")
+    eligible = set(namespaces.TOOL_SCOPED) | set(namespaces.SHARED) | {"instructions", "settings"}
+    scope_selectors = list(manifest.scopes.keys())
+    for ns in eligible:
+        probe = ns if ns in ("instructions", "settings") else f"{ns}/probe"
+        matched = any(_selector_matches_public(sel, probe) for sel in scope_selectors)
+        assert matched, f"namespace {ns!r} has no [scopes] entry"
+    assert "formulas" not in {s.split("/")[0] for s in scope_selectors}
+```
+
+Note: `_selector_matches_public` — if `_selector_matches` is private, import it as `from installer.core.profiles import _selector_matches as _selector_matches_public`. (Reusing the resolver's own matcher keeps the guard faithful.)
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_profiles.py::test_beads_kit_profile_exists_and_scopes_kits_to_project -v`
+Expected: FAIL — `beads-kit` not in profiles; no `kits/**` scope.
+
+- [ ] **Step 3: Edit `profiles.toml`**
+
+Add to the `[scopes]` table:
+
+```toml
+"kits/**"      = "project"
+```
+
+Add a new profile:
+
+```toml
+# The beads project kit (PRIME.md → <project>/.beads/PRIME.md). Project-scoped.
+[profiles.beads-kit]
+include = ["kits/beads/**"]
+```
+
+- [ ] **Step 4: Run to verify pass + re-pin the parity golden**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_profiles.py -v`
+Expected: PASS, including `test_golden_full_profile_is_byte_identical_to_todays_install` and `test_shipped_profiles_resolve_against_real_universe` — both build a **tool-only** universe (`project_universe(build_plan(...))`, no kit staging) and never select `beads-kit`, and `_assign_scope` is called only for matched result keys, so no `kits/...` key ever enters those resolves. The manifest additions are therefore inert for those tests; they stay green unchanged (no golden re-pin needed). If either *does* fail, stop — it means the additions leaked into the tool universe, which is a real regression, not an expected re-pin.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add profiles.toml tests/unit/test_profiles.py
+git commit -m "feat(installer): add kits/** project scope and beads-kit profile"
+```
+
+---
+
+### Task 3: `project_namespaces()` capability on `ToolAdapter` + all adapters
+
+**Files:**
+- Modify: `src/installer/tools/base.py`, `tools/claude.py`, `tools/codex.py`, `tools/gemini.py`, `tools/opencode.py`
+- Test: `tests/unit/test_tools.py` (or the existing per-adapter test file; create `tests/unit/test_project_namespaces.py` if none fits)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_project_namespaces.py
+from installer.tools.registry import get_adapter
+from installer.core.model import Tool
+
+def test_project_namespaces_matrix() -> None:
+    assert get_adapter(Tool.CLAUDE).project_namespaces() == ("skills", "agents", "commands")
+    assert get_adapter(Tool.CODEX).project_namespaces() == ()
+    assert get_adapter(Tool.GEMINI).project_namespaces() == ()
+    assert get_adapter(Tool.OPENCODE).project_namespaces() == ()
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_project_namespaces.py -v`
+Expected: FAIL — `AttributeError: 'ClaudeAdapter' object has no attribute 'project_namespaces'`.
+
+- [ ] **Step 3: Add the Protocol method + implementations**
+
+In `tools/base.py`, add to the `ToolAdapter` Protocol (keep the load-bearing pragma):
+
+```python
+    def project_namespaces(self) -> tuple[str, ...]: ...  # pragma: no cover
+```
+
+In `tools/claude.py` `ClaudeAdapter`:
+
+```python
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ("skills", "agents", "commands")
+```
+
+In `tools/codex.py`, `tools/gemini.py`, `tools/opencode.py`, add to each adapter:
+
+```python
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_project_namespaces.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/tools/ tests/unit/test_project_namespaces.py
+git commit -m "feat(installer): declare per-tool project_namespaces() capability matrix"
+```
+
+---
+
+## Phase 1 — Tracer bullet (kit end-to-end via the project fork)
+
+### Task 4: Author the beads kit content
+
+**Files:**
+- Create: `src/kits/beads/.beads/PRIME.md`
+
+- [ ] **Step 1: Create the kit file**
+
+Copy this repo's curated `.beads/PRIME.md` as the seed, generalizing repo-specific lines (it is currently "verified 1:1 for this repo"). The v1 kit is exactly this one file. Content is prose (no frontmatter — `bd prime` consumes it verbatim). Keep it ruthlessly minimal per the beads `PRIME.md` editing conventions.
+
+- [ ] **Step 2: Verify tree shape**
+
+Run: `ls -la src/kits/beads/.beads/PRIME.md`
+Expected: file exists at exactly `src/kits/beads/.beads/PRIME.md` (tree-mirror: this maps to `<project>/.beads/PRIME.md`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/kits/beads/.beads/PRIME.md
+git commit -m "feat(installer): add beads project kit (PRIME.md)"
+```
+
+---
+
+### Task 5: `stage_kits` + `kit_universe` + `kit_name_of`
+
+**Files:**
+- Create: `src/installer/core/kits.py`
+- Test: `tests/unit/test_kits.py`
+
+- [ ] **Step 1: Write the failing test** (against the final `StagedKitRef` contract — one red-green pass, no mid-task contract change)
+
+```python
+# tests/unit/test_kits.py
+from pathlib import Path
+from installer.core.kits import stage_kits, kit_universe, kit_name_of, StagedKitRef
+
+def _seed(root: Path) -> Path:
+    kits = root / "kits"
+    (kits / "beads" / ".beads").mkdir(parents=True)
+    (kits / "beads" / ".beads" / "PRIME.md").write_bytes(b"beads prime\n")
+    return kits
+
+def test_stage_kits_tree_mirror_and_selector_key(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)
+    staged = stage_kits(kits)
+    assert len(staged) == 1
+    sk = staged[0]
+    assert sk.selector_key == "kits/beads/.beads/PRIME.md"   # source-relative selector key
+    assert sk.ref.tool is None
+    assert sk.ref.dest_relpath == Path(".beads/PRIME.md")    # verbatim tree-mirror, no .md strip
+    universe = kit_universe(staged)
+    assert universe["kits/beads/.beads/PRIME.md"] == [sk.ref]
+
+def test_stage_kits_missing_root_is_empty(tmp_path: Path) -> None:
+    assert stage_kits(tmp_path / "nope") == []
+
+def test_kit_name_of_is_first_segment_under_kits() -> None:
+    assert kit_name_of("kits/beads/.beads/PRIME.md") == "beads"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_kits.py -v`
+Expected: FAIL — `ModuleNotFoundError: installer.core.kits`.
+
+- [ ] **Step 3: Implement `core/kits.py`** (final contract; `StagedKitRef` carries the selector key the resolver universe needs)
+
+```python
+# src/installer/core/kits.py
+from __future__ import annotations
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from installer.core.profiles import UniverseRef
+
+def kit_name_of(selector_key: str) -> str:
+    """The kit name is the segment directly under ``kits/`` — the single source of
+    identity shared by the selector side and the receipt/prune owner (``kit:<name>``)."""
+    parts = selector_key.split("/")
+    if len(parts) < 2 or parts[0] != "kits":
+        raise ValueError(f"not a kit selector key: {selector_key!r}")
+    return parts[1]
+
+@dataclass(frozen=True, slots=True)
+class StagedKitRef:
+    selector_key: str          # kits/<kit>/<subpath> — for the resolver universe
+    ref: UniverseRef           # tool=None, dest_relpath=<subpath> (verbatim tree-mirror)
+
+def stage_kits(kits_root: Path) -> list[StagedKitRef]:
+    """Walk ``src/kits/<kit>/**``; one StagedKitRef per file. dest_relpath is verbatim
+    (no suffix strip); selector_key is source-relative (``kits/<kit>/<subpath>``)."""
+    if not kits_root.is_dir():
+        return []
+    out: list[StagedKitRef] = []
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+        name = kit_dir.name
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+            dest_relpath = f.relative_to(kit_dir)
+            selector = f"kits/{name}/{dest_relpath.as_posix()}"
+            out.append(StagedKitRef(selector_key=selector, ref=UniverseRef(tool=None, dest_relpath=dest_relpath)))
+    return out
+
+def kit_universe(staged: Iterable[StagedKitRef]) -> dict[str, list[UniverseRef]]:
+    universe: dict[str, list[UniverseRef]] = {}
+    for sk in staged:
+        universe.setdefault(sk.selector_key, []).append(sk.ref)
+    return universe
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_kits.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/core/kits.py tests/unit/test_kits.py
+git commit -m "feat(installer): stage_kits + kit_universe + kit_name_of"
+```
+
+---
+
+### Task 6: `kit_routes` + `_KitRouteAdapter` (plugin-route wrapper)
+
+**Files:**
+- Modify: `src/installer/core/kits.py`
+- Test: `tests/unit/test_kits.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_kits.py
+from installer.plugins.base import PluginRoute, PluginAdapter
+from installer.core.kits import kit_routes, kit_adapters
+
+def test_kit_routes_grouped_by_dir_and_execbit(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)                      # kits/beads/.beads/PRIME.md (0o644)
+    project = tmp_path / "proj"
+    routes_by_kit = kit_routes(kits, project)
+    assert set(routes_by_kit) == {"beads"}
+    routes = routes_by_kit["beads"]
+    assert len(routes) == 1
+    r = routes[0]
+    assert r.dest_dir == project / ".beads"
+    assert r.source_dir == kits / "beads" / ".beads"
+    assert r.executable is False
+
+def test_kit_adapters_conform_to_plugin_adapter(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)
+    project = tmp_path / "proj"
+    adapters = kit_adapters(kits, project, selected={"beads"})
+    assert len(adapters) == 1
+    a = adapters[0]
+    assert isinstance(a, PluginAdapter)          # runtime_checkable Protocol
+    assert a.name == "kit:beads"
+    assert a.routes(project) == tuple(kit_routes(kits, project)["beads"])
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_kits.py -k kit_routes or kit_adapters -v`
+Expected: FAIL — `kit_routes` / `kit_adapters` undefined.
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/installer/core/kits.py (append)
+import os
+from installer.plugins.base import PluginRoute
+
+def kit_routes(kits_root: Path, project_root: Path) -> dict[str, list[PluginRoute]]:
+    """Per kit, one PluginRoute per (destination directory × exec-bit). Mirrors
+    PluginAdapter.routes(home) but grouped by kit name for per-kit owners."""
+    result: dict[str, list[PluginRoute]] = {}
+    if not kits_root.is_dir():
+        return result
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+        groups: dict[tuple[Path, bool], list[str]] = {}
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+            rel = f.relative_to(kit_dir)
+            execbit = bool(f.stat().st_mode & 0o111)
+            groups.setdefault((rel.parent, execbit), []).append(rel.suffix)
+        routes: list[PluginRoute] = []
+        for (destdir, execbit), _suffixes in groups.items():
+            routes.append(
+                PluginRoute(
+                    source_dir=kit_dir / destdir,
+                    dest_dir=project_root / destdir,
+                    glob="*",
+                    executable=execbit,
+                )
+            )
+        result[kit_dir.name] = routes
+    return result
+
+@dataclass(frozen=True, slots=True)
+class _KitRouteAdapter:
+    """A selected kit presented as a PluginAdapter so it rides the existing
+    install_plugin_routes / prune_pipeline / receipt machinery unchanged."""
+    _name: str                       # "kit:<name>"
+    _source_path: Path               # the kit source dir
+    _routes: tuple[PluginRoute, ...]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def source_path(self) -> Path:
+        return self._source_path
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002 — always active (explicitly selected)
+        return True
+
+    def routes(self, home: Path) -> tuple[PluginRoute, ...]:  # noqa: ARG002 — dest baked in
+        return self._routes
+
+def kit_adapters(kits_root: Path, project_root: Path, *, selected: set[str]) -> list[_KitRouteAdapter]:
+    routes_by_kit = kit_routes(kits_root, project_root)
+    return [
+        _KitRouteAdapter(_name=f"kit:{name}", _source_path=kits_root / name, _routes=tuple(routes))
+        for name, routes in routes_by_kit.items()
+        if name in selected
+    ]
+```
+
+Note: the `glob="*"` groups match every file in the dest dir; because a kit dir is grouped per (dir × exec-bit), all files in one route share the exec bit. If two kits ever produce the same dest file, that is a fatal collision — add the guard in Task 8's integration (or here if trivial).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_kits.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/core/kits.py tests/unit/test_kits.py
+git commit -m "feat(installer): kit_routes + PluginAdapter-conforming kit wrapper"
+```
+
+---
+
+### Task 7: `--project` / `--profiles` flags + project-path validation
+
+**Files:**
+- Modify: `src/installer/cli.py` (`_build_parser` after `--plugins`, ~:73; a path guard after `resolved_repo_root`, ~:148)
+- Test: `tests/unit/test_cli_project.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_cli_project.py
+from pathlib import Path
+from installer.cli import main
+from installer.core.io_port import ScriptedIO  # adjust import to the real ScriptedIO location
+
+def test_profiles_without_project_errors(tmp_path: Path, capsys) -> None:
+    rc = main(["--profiles=beads-kit", "--yes"], home=tmp_path, io=ScriptedIO(interactive=False), repo_root=_hermetic(tmp_path))
+    assert rc == 2
+    assert "--profiles requires --project" in capsys.readouterr().err
+
+def test_project_path_missing_errors(tmp_path: Path, capsys) -> None:
+    rc = main(["--project", str(tmp_path / "nope"), "--profiles=beads-kit", "--yes"],
+              home=tmp_path, io=ScriptedIO(interactive=False), repo_root=_hermetic(tmp_path))
+    assert rc == 2
+    assert "nope" in capsys.readouterr().err
+```
+
+`_hermetic(tmp_path)` mirrors `test_cli_smoke._hermetic_repo` (creates `src/user/.agents` + tool dirs + copies the real `.installignore`). Factor a shared helper or copy it into this test file.
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_project.py -v`
+Expected: FAIL — flags unknown / no guard.
+
+- [ ] **Step 3: Add flags + guards**
+
+In `_build_parser()`, after the `--plugins` block (cli.py:~73), before `--yes`:
+
+```python
+    parser.add_argument("--project", metavar="PATH", default=None, type=Path,
+                        help="Install project-scoped content into PATH instead of user space.")
+    parser.add_argument("--profiles", metavar="CSV", default=None,
+                        help="Comma-separated profile names (requires --project in this version).")
+```
+
+In `_run()`, immediately after `resolved_repo_root` is set (cli.py:~148), add:
+
+```python
+    if args.profiles is not None and args.project is None:
+        sys.stderr.write("installer: --profiles requires --project in this version\n")
+        return 2
+    if args.project is not None and not args.project.is_dir():
+        sys.stderr.write(f"installer: --project path is not a directory: {args.project}\n")
+        return 2
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_project.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/cli.py tests/unit/test_cli_project.py
+git commit -m "feat(installer): --project/--profiles flags + project-path guard"
+```
+
+---
+
+### Task 8: TRACER — project-run fork writes the kit end-to-end
+
+**Files:**
+- Modify: `src/installer/cli.py` (the fork; a `_run_project(...)` helper)
+- Modify: `src/installer/core/kits.py` (fatal same-dest guard, if not already)
+- Test: `tests/unit/test_cli_project.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# tests/unit/test_cli_project.py
+def test_project_beads_kit_writes_prime_and_receipt(tmp_path: Path) -> None:
+    repo = _hermetic(tmp_path)
+    # seed the beads kit into the hermetic repo
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    rc = main(["--project", str(project), "--profiles=beads-kit", "--yes"],
+              home=tmp_path, io=ScriptedIO(interactive=False), repo_root=repo)
+    assert rc == 0
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
+    receipt = project / ".agents-config" / "install-receipt.json"
+    assert receipt.is_file()
+    assert "kit:beads" in receipt.read_text()          # owner recorded
+    # user space untouched
+    assert not (tmp_path / ".beads").exists()
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_project.py::test_project_beads_kit_writes_prime_and_receipt -v`
+Expected: FAIL — no project fork; nothing written.
+
+- [ ] **Step 3: Implement the fork**
+
+In `_run()`, place the fork **immediately after the `if args.dump_stage is not None:` terminal block** (cli.py:227-236) and right before `config = Config(...)` (cli.py:238). This ordering matters: putting it after the dump block means a plain `--project` run forks here, while `--project --dump-stage` falls through to the existing user dump branch (a harmless tool-plan dump) until Task 16 replaces it with kit-aware rendering — it never routes a dump flag into `_run_project`'s real install:
+
+```python
+    # ... existing `if args.dump_stage is not None:` block (returns) ...
+
+    if args.project is not None:
+        return _run_project(
+            args, plans=plans, project_root=args.project, repo_root=resolved_repo_root, io=io,
+        )
+    # ... existing `config = Config(...)` + user mutation section, unchanged ...
+```
+
+Add `_run_project(...)` (new function in cli.py). Tracer scope — kit tail only (tool tail + persistence + prune + validation come in Phase 2):
+
+```python
+def _run_project(args, *, plans, project_root: Path, repo_root: Path, io: IOPort) -> int:
+    from installer.core.kits import stage_kits, kit_universe, kit_name_of, kit_adapters
+    from installer.core.profiles import load_manifest, project_universe, resolve, Scope
+    from installer.core.receipt import Receipt
+    from installer.core.receipt_store import read_receipt, ReadStatus
+    from installer.core.receipt_lock import receipt_lock
+
+    kits_root = repo_root / "src" / "kits"
+    staged_kits = stage_kits(kits_root)
+    universe = project_universe(plans.values())
+    for key, refs in kit_universe(staged_kits).items():
+        universe.setdefault(key, []).extend(refs)
+
+    manifest = load_manifest(repo_root / "profiles.toml")
+    selection = tuple(p.strip() for p in args.profiles.split(",")) if args.profiles else ()
+    if not selection:
+        sys.stderr.write("installer: project install needs an explicit profile (no implicit full)\n")
+        return 2
+    resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
+
+    # which kits are selected: a kit is selected iff ≥1 of its refs' dest_relpaths landed in included[PROJECT]
+    project_dests = {r.dest_relpath for r in resolved.included.get(Scope.PROJECT, ())}
+    selected_kits = {
+        kit_name_of(sk.selector_key) for sk in staged_kits if sk.ref.dest_relpath in project_dests
+    }
+    adapters = kit_adapters(kits_root, project_root, selected=selected_kits)
+
+    receipt_path = project_root / ".agents-config" / "install-receipt.json"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_cm = nullcontext() if args.dry_run else receipt_lock(receipt_path.with_suffix(".lock"))
+    plugin_outcomes: dict[str, list[InstallOutcome]] = {}
+    counters: dict[str, Counters] = {}
+    try:
+        with lock_cm:
+            prior_read = read_receipt(receipt_path)
+            prior = prior_read.receipt if prior_read.status is ReadStatus.OK and prior_read.receipt else Receipt()
+            _merge_into(counters, install_plugin_routes(
+                adapters, home=project_root, io=io, dry_run=args.dry_run, auto_yes=args.yes,
+                outcomes_by_plugin=plugin_outcomes,
+            ))
+            if not args.dry_run:
+                record_receipt(
+                    receipt_path, prior=prior, dest_roots={}, home=project_root,
+                    tool_outcomes={}, plugin_outcomes=plugin_outcomes,
+                    pruned_paths=set(), relinquished_paths=set(),
+                )
+    except ReceiptLockBusy:
+        io.err(f"another install holds the project receipt lock at {receipt_path}")
+        return 1
+    except ConsentRequiredError:
+        return 1
+    render_summary(counters, tools=[], plugins=sorted(plugin_outcomes), all_tools=[], all_plugins=[], verbose=args.verbose, io=io)
+    return 0
+```
+
+Import `install_plugin_routes`, `record_receipt`, `InstallOutcome`, `Counters`, `ConsentRequiredError`, `ReceiptLockBusy`, `nullcontext`, `render_summary`, `_merge_into` at the top of cli.py (most are already imported for the user path).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_project.py -v`
+Expected: PASS — `<project>/.beads/PRIME.md` written, `kit:beads` receipt recorded, user space untouched.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/installer/cli.py src/installer/core/kits.py tests/unit/test_cli_project.py
+git commit -m "feat(installer): project-run fork installs kit end-to-end (tracer)"
+```
+
+**TRACER COMPLETE** — the architecture spine is proven end-to-end. Phase 2 expands.
+
+---
+
+## Phase 2 — Expand
+
+### Task 9: Resolver-on for user runs (parity-preserving)
+
+**Files:**
+- Modify: `src/installer/cli.py` (insert resolve+filter into the user mutation section, after `stage_and_transform`, before `install_pipeline`)
+- Test: `tests/unit/test_cli_smoke.py` (parity), `tests/unit/test_profiles.py` (golden)
+
+- [ ] **Step 1: Write the failing test** — an end-to-end parity assertion that a no-flag user install is byte-identical after resolver insertion:
+
+```python
+# tests/unit/test_cli_project.py (or test_cli_smoke.py)
+def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
+    repo = _hermetic(tmp_path)
+    rc = main(["--tools=claude", "--yes"], home=tmp_path, io=ScriptedIO(interactive=False), repo_root=repo)
+    assert rc == 0
+    assert (tmp_path / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"
+    # every file the pre-resolver install produced is still present and identical
+```
+
+- [ ] **Step 2: Run to verify current pass (baseline), then insert resolver and confirm still-pass.** The behavior must not change; this task guards it while wiring the resolver in.
+
+- [ ] **Step 3: Insert resolver-on for the user path.** In the user mutation section, before `install_pipeline`, build `universe = project_universe(plans.values())`, `resolved = resolve(manifest, (), universe, bound_scopes=frozenset({Scope.USER}))` (empty selection ⇒ `full`), then narrow each tool plan with `filter_plan_to_scope(plans[tool], kept_dest_relpaths)` where `kept` = the USER-bound refs' dest_relpaths. Pass the filtered plans to `install_pipeline`. For `full`, `kept` is the whole plan, so output is byte-identical.
+
+- [ ] **Step 4: Run parity + golden**
+
+Run: `cd packages/installer && uv run pytest tests/unit/test_cli_smoke.py tests/unit/test_profiles.py -v`
+Expected: PASS (byte-identical).
+
+- [ ] **Step 5: Commit** `feat(installer): wire resolver into user install path (parity-preserving)`
+
+---
+
+### Task 10: Project selection — persisted set read + no-implicit-full errors
+
+**Files:** Modify `cli.py` `_run_project` selection block; `core/config.py` (add `read_project_profiles(project_root) -> tuple[str, ...] | None`). Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — `--project p` with no `--profiles` and no persisted set errors "no implicit full"; with a persisted `[install] profiles=["beads-kit"]` it resolves that set.
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** Add `read_project_profiles` (parse `<project>/project-config.toml` `[install].profiles` with `tomllib`; return `None` if absent). In `_run_project`, selection = `--profiles` CSV → else persisted → else the existing exit-2 error.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): project profile selection (persisted-set read, explicit-profile error)`
+
+---
+
+### Task 11: Tool tail for project runs + `project_namespaces()` validation pass
+
+**Files:** Modify `cli.py` `_run_project` (add the tool tail); Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — a profile with an explicit `{select="skills/<x>", scope="project"}` override, `--project p` → writes `<p>/.claude/skills/<x>`; a `{select="commands/<y>", scope="project"}` for a tool without `commands` in `project_namespaces()` errors naming tool+namespace. (Add a fixture profile to the hermetic manifest, or use a temp manifest.)
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** In `_run_project`, for the tool refs in `included[PROJECT]`: run the validation pass (each tool ref's `dest_relpath.parts[0]` must be in `get_adapter(tool).project_namespaces()`, else exit-1 error naming tool+namespace); then `filter_plan_to_scope(plans[tool], kept)` and `sync_plan(get_adapter(tool), filtered, home=project_root, ...)`, feeding `tool_outcomes`; record via the existing `record_receipt` `tool_outcomes` + `dest_roots={adapter.name: adapter.dest_dir(project_root)}`.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): project tool tail + project_namespaces validation`
+
+---
+
+### Task 12: Kit-scope pre-resolve guard
+
+**Files:** Modify `cli.py` `_run_project` (guard before `resolve`); Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — a selected profile carrying `{select="kits/beads/**", scope="user"}` (and a broad `{select="**", scope="user"}`) errors pre-resolve naming the selector.
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** Before `resolve`, iterate the selected profiles' `IncludeEntry`s; for any with an explicit non-`PROJECT` `scope`, if its `selector` matches any key in the kit universe (via `_selector_matches`), exit-2 (or exit-1 per taxonomy) error naming the selector.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): pre-resolve kit-scope guard (kits are project-only)`
+
+---
+
+### Task 13: Project persistence (`project-config.toml [install]`)
+
+**Files:** Modify `core/config.py` (`write_project_profiles`), `cli.py` `_run_project`; Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — round-trip: `--project p --profiles beads-kit` writes `[install] profiles=["beads-kit"]` to `<p>/project-config.toml`; a bare `--project p` re-run reads it; `--dry-run` writes no `project-config.toml`.
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** Add `write_project_profiles(project_root, profiles)` (merge into an existing `project-config.toml`, preserving other tables; write the `[install] profiles` array). Call it in `_run_project` only on a successful, non-dry-run install, inside the lock, at the same point as the receipt write.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): persist chosen profiles to project-config.toml [install]`
+
+---
+
+### Task 14: Kit prune (deselected kit → orphan)
+
+**Files:** Modify `cli.py` `_run_project` (wire prune via the kit adapters); Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — install `beads-kit`; re-install still-selected `beads-kit` with `--prune` does **not** delete `<p>/.beads/PRIME.md`; then a run selecting a different (empty-of-beads) project profile with `--prune` **removes** the orphaned `PRIME.md`. User receipt untouched.
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** In `_run_project`, when `args.prune`/`args.prune_only`, call `prune_pipeline(adapters=<project tool adapters>, plugins=<kit adapters>, plans=<filtered project plans>, prior=prior, home=project_root, discovered_plugin_names={a.name for a in kit_adapters(kits_root, project_root, selected=all_kit_names)}, io=io, ...)`. The kit adapters feed `desired_route_keys`/`live_roots_by_owner` via the existing plugin path (they conform to `PluginAdapter`); `discovered_plugin_names` must include *all* kit owners (selected or not) so a deselected kit's prior entry is in `scope_owners` and thus prunable. Capture `pruned_paths`/`relinquished_paths` into `record_receipt`.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): prune orphaned kit files via the plugin-route prune path`
+
+---
+
+### Task 15: Detection-suggests-only (user runs)
+
+**Files:** Modify `cli.py` (after the user-run summary print); Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — a user run whose cwd shows `.beads/` (or a `project-config.toml` with `[install]`) prints exactly one `io.info` suggestion line; a `--project` run prints none. (Inject cwd via a `cwd: Path` param on `_run`/`main` for testability, defaulting to `Path.cwd()`.)
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** After the user summary, if `(cwd / ".beads").is_dir()` or a `[install]` table exists in `cwd / "project-config.toml"`, `io.info("This looks like a project. To install project-scoped content here: install.sh --project .")`. No scan beyond cwd. Skip entirely on a `--project` run.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): detection-suggests-only notice on user runs`
+
+---
+
+### Task 16: `--dump-stage` under `--project`
+
+**Files:** Modify `cli.py` (dump branch); Test: `test_cli_project.py`.
+
+- [ ] **Step 1: Failing test** — `--project p --profiles beads-kit --dump-stage <dir>` lists the kit refs (dest + owner) alongside tool refs; kit content is not written to the dump.
+- [ ] **Step 2: Run — fail.**
+- [ ] **Step 3:** When `args.project` and `args.dump_stage`, after resolve, render the resolved project plan: tool refs via the existing `dump_plan` tree; kit refs as a listing (`kit:<name>  <dest_relpath>`). Terminal branch (return 0), like the user dump.
+- [ ] **Step 4: Run — pass.**
+- [ ] **Step 5: Commit** `feat(installer): --dump-stage lists kit refs on project runs`
+
+---
+
+### Task 17: Gate green + continuations
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `cd packages/installer && make ci-installer`
+Expected: lint, format-check, mypy --strict, coverage (branch ≥90%), pip-audit, entry-verify all green. Fix any coverage gaps on changed code (add tests, do not lower the floor).
+
+- [ ] **Step 2: Update `docs/architecture/installer/` if an HLD artifact references the adapter contract or the receipt/prune flow** (the `project_namespaces()` addition and the project-receipt path). Keep it evergreen; amend in place.
+
+- [ ] **Step 3: Commit** `chore(installer): S2 gate green + HLD touch-up`
+
+- [ ] **Step 4: Continuations (on PR merge, per spec §8):** mint **S2.5 — user-scope profile selection wiring** as a child of `agents-config-uxns2.1`, `depends-on agents-config-viiud`; then release the S2 claim. Do not close `viiud` until the continuation exists.
+
+---
+
+## Self-review checklist (run before handing off)
+
+- **Spec coverage:** §2 decisions 1-6 → Tasks 1,2,4,5-6,8-9 (resolver-on), 12 (kit-scope), 6 (whole-route); §5.1 fork → 8,11; §5.2 matrix → 3,11; §5.6 guard → 12; §6.1 selection/coverage/persistence/dump/flags → 7,9,10,13,16; §6.2 receipt+prune → 8,14; §6.4 detection → 15; §6.6 tests 1-13 → mapped across tasks. No orphan requirement.
+- **Deviation flagged:** the plugin-channel reuse for kit receipt/prune (mechanism note) — plan-review gate must confirm it satisfies §6.2's behavior.
+- **Type consistency:** `StagedKitRef.selector_key`/`.ref`, `kit_name_of`, `kit_routes -> dict[str, list[PluginRoute]]`, `_KitRouteAdapter` (name `kit:<name>`) used consistently Tasks 5,6,8,14.
+- **No placeholders:** every task shows real test + impl code or an exact signature/edit.

--- a/docs/specs/2026-07-12-s2-project-scoped-install-design.md
+++ b/docs/specs/2026-07-12-s2-project-scoped-install-design.md
@@ -1,0 +1,437 @@
+# S2 — Project-Scoped Install: Design
+
+**Status:** draft
+**Slice:** S2 of the profiles-only scope-routing rollout
+**Bead:** agents-config-viiud
+**Elaborates:** `docs/specs/2026-07-06-profiles-scope-routing.md` §8 (Project materialization)
+**Depends on:** S1 (`agents-config-uxns2.1.3`, the pure resolver + manifest loader) — landed
+
+## 1. Scope
+
+S2 turns the pure scope-routing resolver landed in S1 into a working install
+path and adds project materialization on top of it. Concretely it delivers:
+
+- a `--project <path>` CLI flag that binds the **project** scope for a run;
+- a per-tool `project_namespaces()` capability declaration and a validation
+  pass that enforces it;
+- a `src/kits/<kit>/` source tree for tool-agnostic, project-relative content,
+  with a first inhabitant: the **beads kit** (`.beads/PRIME.md`);
+- a project-local install receipt at `<project>/.agents-config/install-receipt.json`
+  with its own lock, prune, and uninstall mechanics;
+- the detection-suggests-only notice on user-scope runs.
+
+### 1.1 Starting reality
+
+The S1 resolver (`packages/installer/src/installer/core/profiles.py`) is pure and
+fully unit-tested but has **zero production callers** — `cli.py` has no
+`--profiles` flag and the resolver is not wired into the install pipeline. S2
+therefore also performs the **first wiring** of the resolver into the live
+install flow. That wiring is deliberately scoped: see §7 (Deferred work).
+
+## 2. Decisions
+
+Settled inputs, not open questions.
+
+1. **Resolver-on for every run; project-only selection UX in S2.** The resolver
+   is wired into *every* install (user and project). User runs resolve the
+   default `full` profile, which is provably a no-op filter (§6.1). The
+   `--profiles` selection surface and profile persistence are honored only for
+   `--project` runs in S2. User-scope `--profiles`, user persistence, and the
+   `DYNAMIC-INCLUDE-ALL-RULES` exclude-flattening are deferred (§7).
+2. **Kit destinations use the tree-mirror convention.** A kit's source layout
+   *is* its project-relative destination layout:
+   `src/kits/beads/.beads/PRIME.md` → `<project>/.beads/PRIME.md`. No per-kit
+   manifest, no per-file frontmatter.
+3. **The beads kit v1 ships `PRIME.md` only.** Content adapted from this repo's
+   curated `.beads/PRIME.md`, generalized where repo-specific. This repo does
+   not dogfood the kit in S2 (a follow-up).
+4. **Kits are structurally project-only.** Kit content never installs to user
+   space. Beyond the `kits/** → project` default in `[scopes]`, an explicit
+   per-selector override that would route a kit to a non-project scope is a
+   fail-loud validation error (§5.6).
+5. **Kits materialize as project-scoped routes; selection is whole-kit.** Kit
+   content is installed, recorded, and pruned through the *existing* plugin-route
+   machinery (§5.1, §6.2) rather than a bespoke channel — a kit is the
+   project-scope mirror of a plugin route. A kit is selected as a unit (a profile
+   includes `kits/<kit>/**`); sub-file kit selection is not a v1 use case.
+
+## 3. Architecture
+
+Project-scoped content is two populations that share one resolver for
+*selection* and split into two thin materialization tails.
+
+### 3.1 Where the resolver sits
+
+The resolver is wired into `cli._run` **after** `stage_and_transform` completes —
+on the fully transformed per-tool plans, never on raw `build_plan` output. This
+placement is load-bearing for the byte-identical-parity invariant (§6.1): the
+live staging pipeline is
+
+```
+build_plan → overlay_plugins → apply_extensions → flatten_plan_templates → post_staging_transforms
+```
+
+Plugin overlay *adds* items to `plan.items` (beads/graphify/codex rules) and
+flattening *rewrites/drops* items. Building the universe from `build_plan` output
+(pre-overlay) would leave plugin-contributed dest paths out of the universe, and
+`filter_plan_to_scope` would then silently drop them from the plan that reaches
+`sync_plan`. The universe **must** be projected from the transformed plans so its
+key set equals the transformed plans' item set.
+
+### 3.2 Data flow
+
+```
+  src/user/.claude/  ─ build_plan ─┐
+  + src/plugins/*    (overlay)     │  stage_and_transform (full pipeline)
+  + extensions/flatten/transforms  ▼
+                    transformed per-tool StagingPlans
+                                   │ project_universe(transformed_plans)
+                                   │   keys: skills/x, agents/y … (tool refs)
+                                   ▼
+  src/kits/<kit>/   ┌──────────────────────────────┐
+  (NEW tree)        │ stage_kits() ──► KitStaging   │
+                    │  refs:  kits/beads/… (tool=None)│ kit_universe(kits)
+                    │  routes: src→<project>/.beads/ │   keys: kits/beads/… (refs)
+                    └──────────────┬────────────────┘
+                                   ▼
+                merged universe: dict[selector → [ref…]]   (tool refs ∪ kit refs)
+                                   │
+              resolve(manifest, selection, universe, bound_scopes)
+                (pure; one-line sort-key fix for tool=None — §4.1)
+                                   │
+                       ResolvedPlan.included[scope] = [refs…]
+                                   │
+                   ┌───────────────┴────────────────┐
+          tool refs (tool≠None)            kit refs (tool=None)
+                   │                                │
+   filter_plan_to_scope + sync_plan(        selected kit → Route(s);
+     adapter, home=<project_root>)          sync_routes(routes, dest=<project>)
+     → <project>/.claude/<ns>/              → <project>/.beads/PRIME.md
+                   │                                │
+   entries_from_outcomes            entries_from_route_outcomes(owner=kit)
+                   └───────────────┬────────────────┘
+              one project receipt @ <project>/.agents-config/ (one lock)
+```
+
+### 3.3 Why kits are not just another namespace
+
+For a *tool* item, the selector key **is** the normalized destination path — a
+skill stages as `dest_relpath = skills/brainstorming` and the selector
+`skills/brainstorming` matches it directly. Source layout, destination layout,
+and selector vocabulary coincide.
+
+Kits break that coincidence in two places, which is why they are a separate
+channel:
+
+1. **Selector ≠ destination.** The beads kit's selector is `kits/beads/**`
+   (source-tree-relative, under `src/kits/`), but its destination is
+   `.beads/PRIME.md` (project-root-relative). The existing selector-key
+   derivation (`_selector_key`) reads the selector *from* the destination; kits
+   cannot, so they carry both paths explicitly.
+2. **Verbatim destination.** `_selector_key` strips `.md`/`.template` for
+   namespaced items. `PRIME.md` is consumed verbatim by `bd prime`; its name and
+   bytes must be preserved. The route path (§5.1) installs verbatim names,
+   matching this requirement exactly.
+
+## 4. Ref shape and staging
+
+### 4.1 `UniverseRef.tool` becomes nullable
+
+```python
+@dataclass(frozen=True, slots=True)
+class UniverseRef:
+    tool: Tool | None   # None ⇒ tool-agnostic kit ref; materialize at the project root
+    dest_relpath: Path
+```
+
+`tool=None` means the ref materializes at the project root, not under a tool
+subtree. A single nullable is preferred over a distinct `KitRef` union: the pure
+resolver treats refs opaquely — it groups by selector key and partitions by
+scope — so a nullable flows through `resolve()` **transparently except for one
+line**: the `final_included` sort key currently reads `r.tool.value`
+(`profiles.py:447`) and must become tolerant of `None`
+(`(r.tool.value if r.tool is not None else "", r.dest_relpath.as_posix())`).
+That is the *only* resolver change S2 makes; a `KitRef` union would instead force
+every `ResolvedPlan.included` consumer to pattern-match two types.
+
+Note: `tool=None` is free for the resolver and for materialization dispatch, but
+receipt attribution needs a concrete owner string that `None` cannot supply.
+That owner is defined in §6.2 (`kit:<name>`), independent of the ref's `tool`
+field.
+
+### 4.2 `stage_kits`
+
+`stage_kits(kits_root)` walks `src/kits/<kit>/**` recursively and produces, per
+kit:
+
+- **universe refs** — one `UniverseRef(tool=None, dest_relpath=<subpath>)` per
+  file, keyed by its **selector key** `kits/<kit>/<subpath>` (source-relative)
+  for the resolver;
+- **routes** — one `PluginRoute`-shaped route per distinct destination
+  directory (routes install a flat file set per directory), with
+  `source_dir = <kit>/<destdir>`, `dest_dir = <project>/<destdir>`, a glob
+  selecting the kit's files there, and `executable` from the source mode bit.
+  The beads kit is a single route (`src/kits/beads/.beads/*` → `<project>/.beads/`).
+
+A missing `src/kits/` yields nothing. Two kit sources resolving to the same
+destination is a fatal error naming both source paths.
+
+### 4.3 `kit_universe` and merge
+
+`kit_universe(stage_kits output)` groups the kit refs by selector key into
+`dict[str, list[UniverseRef]]`. The caller merges it with
+`project_universe(transformed_plans)` and hands the union to `resolve()`. Kits
+ride the resolver for **selection** only.
+
+## 5. Materialization, capability matrix, and enforcement
+
+### 5.1 Two tails
+
+`resolve()` returns `ResolvedPlan.included[scope]`, a mix of tool refs and kit
+refs. Materialization dispatches on `ref.tool`:
+
+- **Tool refs** (`tool != None`): `filter_plan_to_scope(plan, kept_dest_relpaths)`
+  narrows the tool's transformed `StagingPlan` to the project-bound refs, then
+  `sync_plan(adapter, filtered_plan, home=<project_root>)` writes them. Because
+  `dest_dir(base) → base/".claude"` is parameterized on its base, passing the
+  project root yields `<project>/.claude/<ns>/` with no new sync code. Receipt
+  entries come from `entries_from_outcomes` (their dest paths are
+  namespace-rooted, e.g. `skills/…`, so they pass the `PRUNE_NAMESPACES` filter).
+- **Kit refs** (`tool == None`): the selected kit's routes are installed via the
+  existing `sync_routes(routes, dest_dir=<project_root>/…)`, and recorded via
+  `entries_from_route_outcomes(outs, plugin="kit:<name>", home=<project_root>)`.
+  This reuses the plugin-route path wholesale: verbatim names, `.beads`-rooted
+  entries (`route_entry_for` computes `root = dest_dir.relative_to(base).parts[0]`
+  → `.beads`), consent-gated overwrite, and prune tracking — the same machinery
+  that already installs the beads plugin's `~/.beads/formulas` on the user side.
+
+### 5.2 `project_namespaces()` capability matrix
+
+Added to the `ToolAdapter` Protocol (it does not exist today) and all four
+adapters:
+
+| Tool | `project_namespaces()` |
+|---|---|
+| Claude | `("skills", "agents", "commands")` — land under `<project>/.claude/<ns>/` |
+| Codex | `()` |
+| Gemini | `()` |
+| OpenCode | `()` |
+
+Capability facts live in code as data; routing *preferences* live in the
+manifest. Because `[scopes]` defaults skills/agents/commands to `user`, a
+tool-scoped namespace reaches project scope only via an explicit per-selector
+scope override in a profile.
+
+### 5.3 Instructions and settings are never project-routable
+
+Enforced by the matrix: no adapter lists `instructions` or `settings`. A
+project's `CLAUDE.md`/`AGENTS.md` and settings are project-authored artifacts the
+installer must not collide with.
+
+### 5.4 Validation pass (post-resolve, not in the resolver)
+
+The pure resolver stays selector-agnostic. A post-resolve validation pass in the
+orchestrator/cli layer enforces the capability rules over `ResolvedPlan`:
+
+- For each **tool** ref bound to project scope, assert its namespace is in that
+  adapter's `project_namespaces()`, else error naming tool + namespace.
+- For each **kit** ref (`tool=None`), assert its assigned scope is `PROJECT`,
+  else error naming the selector (§5.6).
+
+### 5.5 One binding per run
+
+Per §7 of the parent spec, a run has exactly one primary scope binding. A
+`--project` run binds `PROJECT` and does **not** bind `USER`; it structurally
+cannot write user space. There is thus no dual-scope run, no receipt-lock
+nesting, and no lock-ordering hazard — a run holds exactly one receipt lock. The
+project run's tool tail and kit tail both write under that one lock and both feed
+one receipt (§6.2).
+
+### 5.6 Kit scope enforcement
+
+Kits are structurally project-only. Any kit ref (`tool=None`) that resolves to a
+non-`PROJECT` scope — reachable only via a hand-authored explicit override such
+as `{ select = "kits/beads/**", scope = "user" }` — is a fail-loud validation
+error naming the selector. This mirrors the "instructions/settings are never
+project-routable" guardrail and keeps a clean boundary: plugin routes carry
+user-space out-of-tree content; kits carry project-space out-of-tree content.
+
+## 6. CLI, binding, receipt, collisions, errors
+
+### 6.1 Scope binding
+
+`--project <path>` sets the run's scope binding. `<path>` must already exist and
+be a directory — a missing path or a non-directory is a fail-loud error naming
+the path (§6.5). Write permission is not pre-checked; a non-writable destination
+surfaces through the existing OS-error/consent path like any other write. The
+installer does not require `<path>` to look like a project (no `.git`/
+`project-config.toml` precondition); detection (§6.4) only *suggests*.
+
+One resolver, a scope-parameterized tail:
+
+| Facet | User run (no `--project`) | Project run (`--project <p>`) |
+|---|---|---|
+| `bound_scopes` | `{USER}` | `{PROJECT}` |
+| Selection | forced `full`; `--profiles` rejected (§6.5) | `--profiles` CSV → else persisted `[install]` in `<p>/project-config.toml` → else error |
+| Universe | `project_universe(transformed_plans)` | same **+** `kit_universe(stage_kits())` |
+| Dest base | `home` → `~/.claude` | `<p>` → `<p>/.claude` (same `dest_dir` fn) |
+| Out-of-tree content | plugin routes (`~/.beads/formulas`) | kit routes (`<p>/.beads/…`) |
+| Receipt + lock | `~/.config/agents-config/install-receipt.json` | `<p>/.agents-config/install-receipt.json` (own `.lock`) |
+| Persistence | none in S2 (deferred) | chosen profiles → `<p>/project-config.toml [install]` |
+
+The user run's forced-`full` resolution matches `**`, routes everything to its
+`user` default, drops nothing, and is byte-identical to today's install. This is
+the safety invariant behind the resolver-on decision, guarded end-to-end by the
+parity test (§6.6 test 1).
+
+**New coupling from wiring the resolver into every run:** the forced-`full` run
+requires that `[scopes]` (plus the synthetic `instructions`/`settings` keys)
+matches *every* staged namespace — `resolve()` raises `ProfilesError` if any
+universe key has no `[scopes]` match. Today `[scopes]` covers `namespaces.ALL`
+plus the synthetics, so parity holds; but a future namespace added to
+`namespaces.ALL` without a corresponding `[scopes]` entry would crash *every*
+user install. §6.6 test adds a CI guard asserting `[scopes]` coverage of
+`namespaces.ALL`. The namespace-addition checklist gains one edit: a `[scopes]`
+entry in `profiles.toml`.
+
+**Flag interactions.** `--tools` continues to gate which tool plans are staged
+and therefore which tool refs feed `project_universe`; kit staging is unaffected
+(kits are tool-agnostic). A project profile whose selector targets a tool
+excluded via `--tools` resolves to nothing and fails loud as a dead selector —
+S2 does not add a distinct message for the `--tools`/`--profiles` mismatch.
+`--dump-stage` under `--project` includes kit refs alongside tool refs (dest
+path and owner; content is not dumped), so the dump reflects the resolved project
+plan. `--prune`/`--prune-only` operate against the project receipt when
+`--project` is set (§6.2).
+
+### 6.2 Project receipt
+
+The project receipt reuses the `Receipt` schema, `read_receipt`/`write_receipt`/
+`merge_receipt`, and `receipt_lock` unchanged, at
+`<p>/.agents-config/install-receipt.json` with its own sibling `.lock` and
+entries anchored project-root-relative. It records both populations in one
+receipt under one lock:
+
+- **Tool entries** via `entries_from_outcomes` (namespace-rooted paths pass the
+  `PRUNE_NAMESPACES` filter).
+- **Kit entries** via `entries_from_route_outcomes` with owner `kit:<name>` — a
+  non-tool owner, exactly like a plugin owner. `scope_owners` already unions any
+  non-tool owner found in the prior receipt (`retired_plugin_owners`), and
+  `validate_entry` already has the non-tool-owner branch, so kit entries are in
+  scope for prune with **no change** to `scope_owners`/`validate_entry`/root
+  validation (`.beads` is already an accepted route root today).
+
+`record_receipt` gains a kit-outcomes input (route-shaped) whose entries are
+appended to the flat `installed` list before `merge_receipt`; the desired-set for
+orphan detection includes the selected kits' route keys (a
+`desired_route_keys`-shaped set), so a deselected kit's files are detected as
+orphans and pruned. The user receipt is never read or written by a project run,
+and vice versa.
+
+### 6.3 Collision handling
+
+Kit content installs through `sync_routes`, inheriting its skip-if-identical /
+back-up-before-overwrite / consent behavior — so an existing project file (e.g. a
+repo's hand-authored `.beads/PRIME.md`) is backed up and the overwrite is gated
+exactly like any other write. Kits never touch the staging **merge registry**
+(consulted only by `_add_item` in base staging and `overlay.py::_place` in plugin
+overlay — phases kits never enter). Tool-scoped project content reuses
+`sync_plan`, inheriting its merge and consent behavior unchanged.
+
+### 6.4 Detection-suggests-only
+
+On a **user** run, if the working directory shows a `.beads/` directory *or* a
+`project-config.toml` carrying an `[install]` table, the installer prints exactly
+one advisory line via `io.info`, after the install summary:
+
+> This looks like a project. To install project-scoped content here: `install.sh --project .`
+
+No prompt, no write, no scanning beyond the working directory. A `--project` run
+prints no suggestion.
+
+### 6.5 Error taxonomy
+
+All fail-loud; every message names the offender.
+
+| Case | Where | Message shape |
+|---|---|---|
+| `--profiles` without `--project` | cli, pre-resolve | "`--profiles` requires `--project` in this version" |
+| `--project <path>` missing or not a directory | cli, pre-stage | names the path |
+| Project run, no `--profiles` and no persisted set | pre-resolve CLI guard (see note) | "project install needs an explicit profile (no implicit full)" |
+| Selected profiles → empty project partition | resolve (step 8 today) | "the run would do nothing; no content bound to project" |
+| Tool ref → project, namespace ∉ `project_namespaces()` | post-resolve validation | names tool + namespace |
+| Kit ref → non-`PROJECT` scope | post-resolve validation | names the selector |
+| Two kit sources → same destination | `stage_kits` | names both source paths |
+| Concurrent project install | project `receipt_lock` | `ReceiptLockBusy` |
+
+Note: the "no implicit full for a project run" rule is enforced as a **pre-resolve
+CLI/orchestrator guard**, not inside `resolve()` — `resolve()` today defaults an
+empty selection to `["full"]` with no `bound_scopes`-aware branch, and S2 does not
+add scope-aware defaulting to the pure resolver. The CLI decides the selection
+(explicit `--profiles` → persisted set → error for a project run) *before*
+calling `resolve()`.
+
+### 6.6 Testing strategy
+
+Behavioral contracts per the parent spec §10 conventions — ScriptedIO fakes,
+temp trees, no live installs.
+
+1. **End-to-end parity (non-negotiable):** a no-flag user install through the
+   newly-wired resolver (inserted after `stage_and_transform`) is byte-identical
+   to today's install, including plugin-overlaid content.
+2. **`[scopes]` coverage guard:** `[scopes]` plus the synthetic
+   `instructions`/`settings` keys cover `namespaces.ALL`, so a future namespace
+   addition fails in CI, not in users' installs.
+3. `stage_kits`: tree-mirror destination; verbatim name (PRIME.md stays
+   PRIME.md); source-relative selector key; recursive walk; route grouping by
+   destination directory; executable-bit carry; empty on missing `src/kits/`.
+4. Integration: `--project p --profiles beads-kit` writes `<p>/.beads/PRIME.md`;
+   `--project p --profiles sdlc` errors (empty project partition).
+5. Kit-scope guard: an override routing `kits/**` → user errors.
+6. `project_namespaces()` matrix: a Claude skill → project works; a namespace →
+   project for an unsupporting tool errors naming both.
+7. Project receipt round-trip: install → prune → uninstall against a temp project
+   tree; a beads kit dropped from a later selection is pruned as an orphan; the
+   user receipt is untouched throughout.
+8. Detection-suggestion: a user run in a cwd with `.beads/` prints exactly one
+   line; a `--project` run prints none.
+9. Overwrite: a kit install over an existing `.beads/PRIME.md` backs it up and
+   respects `--yes` / prompt.
+10. `--project p --profiles beads-kit --dry-run` previews would-be writes via
+    `io`, creates no files, and leaves no `.agents-config/install-receipt.json`
+    or `.lock` under `<p>`.
+11. `--project` path missing / not a directory errors naming the path.
+
+## 7. Deferred work (non-goals for S2)
+
+The resolver-on decision intentionally leaves user-scope *selection* unwired.
+These move to a dedicated successor slice (§8):
+
+- `--profiles` honored on **user** runs (user-scope filtering end-to-end);
+- user-scope profile persistence at `~/.agents/agents-config.toml`;
+- the `DYNAMIC-INCLUDE-ALL-RULES` vs `DYNAMIC-INCLUDE-RULES` exclude-flattening
+  boundary in `templates.py` (flagged by S1's test docstring as belonging to the
+  orchestrator-wiring slice) — required so a user-scope exclude actually removes
+  a rule from the rebuilt instruction file, not only its standalone copy.
+
+Also out of scope: dogfooding the beads kit into this repo (decision 3); any kit
+beyond beads; multi-file/nested kits beyond the single-route beads case (the
+route-grouping generalizes, but only beads is exercised in S2); `installer.toml`
+`tool_dest_overrides` retirement (S3, `agents-config-uxns2.1.2`, independent).
+
+## 8. Continuations
+
+Work items to mint when this design's PR merges (children under the still-open
+`agents-config-uxns2.1` profiles container; release the S2 claim only after
+minting):
+
+- **S2.5 — user-scope profile selection wiring.**
+  *Acceptance:* `--profiles` filters content on user runs; excluded rules are
+  removed from rebuilt `DYNAMIC-INCLUDE-ALL-RULES` instruction files (not only
+  their standalone copies); the chosen set persists to
+  `~/.agents/agents-config.toml` and is re-read on a subsequent user run;
+  `make ci-installer` green.
+  *Graph:* child of `agents-config-uxns2.1`; **depends-on** `agents-config-viiud`
+  (S2). No child→parent `blocks` edge.
+
+- none further — S3 (`agents-config-uxns2.1.2`) already exists and is independent.

--- a/docs/specs/2026-07-12-s2-project-scoped-install-design.md
+++ b/docs/specs/2026-07-12-s2-project-scoped-install-design.md
@@ -11,6 +11,9 @@
 S2 turns the pure scope-routing resolver landed in S1 into a working install
 path and adds project materialization on top of it. Concretely it delivers:
 
+- **manifest additions** to the shipped `profiles.toml`: a `kits/** → project`
+  `[scopes]` default and a `beads-kit` profile — neither exists today, and kits
+  cannot resolve without them (§2 decision 6);
 - a `--project <path>` CLI flag that binds the **project** scope for a run;
 - a per-tool `project_namespaces()` capability declaration and a validation
   pass that enforces it;
@@ -18,6 +21,7 @@ path and adds project materialization on top of it. Concretely it delivers:
   with a first inhabitant: the **beads kit** (`.beads/PRIME.md`);
 - a project-local install receipt at `<project>/.agents-config/install-receipt.json`
   with its own lock, prune, and uninstall mechanics;
+- project profile persistence to `<project>/project-config.toml` `[install]`;
 - the detection-suggests-only notice on user-scope runs.
 
 ### 1.1 Starting reality
@@ -46,14 +50,23 @@ Settled inputs, not open questions.
    curated `.beads/PRIME.md`, generalized where repo-specific. This repo does
    not dogfood the kit in S2 (a follow-up).
 4. **Kits are structurally project-only.** Kit content never installs to user
-   space. Beyond the `kits/** → project` default in `[scopes]`, an explicit
-   per-selector override that would route a kit to a non-project scope is a
-   fail-loud validation error (§5.6).
-5. **Kits materialize as project-scoped routes; selection is whole-kit.** Kit
-   content is installed, recorded, and pruned through the *existing* plugin-route
-   machinery (§5.1, §6.2) rather than a bespoke channel — a kit is the
-   project-scope mirror of a plugin route. A kit is selected as a unit (a profile
-   includes `kits/<kit>/**`); sub-file kit selection is not a v1 use case.
+   space. Beyond the `kits/** → project` default S2 *adds* to `[scopes]`, an
+   explicit per-selector override that would route a kit to a non-project scope
+   is a fail-loud validation error (§5.6).
+5. **Kits materialize whole-route through the plugin-route machinery.** Kit
+   content is installed, recorded, and pruned through the *existing*
+   plugin-route path (§5.1, §6.2) rather than a bespoke channel — a kit is the
+   project-scope mirror of a plugin route. Materialization is **whole-route**: a
+   kit route installs its entire source directory; a route runs iff at least one
+   of its files appears in the resolved `PROJECT` partition. Per-file kit
+   selectors cannot subset a route in v1 (a matching selector promotes to the
+   whole route); the `beads-kit` profile selects the whole kit via
+   `kits/beads/**`.
+6. **S2 edits the shipped `profiles.toml`.** Add `"kits/**" = "project"` to
+   `[scopes]` and add `[profiles.beads-kit]` with `include = ["kits/beads/**"]`.
+   This is a required S2 change, not a pre-existing state — the parity golden
+   (§6.6 test 1) must be re-pinned to account for it (it adds a project-default
+   selector and a profile but changes nothing a `full` user run stages).
 
 ## 3. Architecture
 
@@ -88,11 +101,10 @@ key set equals the transformed plans' item set.
                                    │ project_universe(transformed_plans)
                                    │   keys: skills/x, agents/y … (tool refs)
                                    ▼
-  src/kits/<kit>/   ┌──────────────────────────────┐
-  (NEW tree)        │ stage_kits() ──► KitStaging   │
-                    │  refs:  kits/beads/… (tool=None)│ kit_universe(kits)
-                    │  routes: src→<project>/.beads/ │   keys: kits/beads/… (refs)
-                    └──────────────┬────────────────┘
+  src/kits/<kit>/   ┌──────────────────────────────────────┐
+  (NEW tree)        │ stage_kits(kits_root) ──► kit refs     │ kit_universe(refs)
+                    │   UniverseRef(tool=None, dest_relpath) │   keys: kits/beads/… (refs)
+                    └──────────────┬─────────────────────────┘
                                    ▼
                 merged universe: dict[selector → [ref…]]   (tool refs ∪ kit refs)
                                    │
@@ -101,16 +113,21 @@ key set equals the transformed plans' item set.
                                    │
                        ResolvedPlan.included[scope] = [refs…]
                                    │
-                   ┌───────────────┴────────────────┐
-          tool refs (tool≠None)            kit refs (tool=None)
-                   │                                │
-   filter_plan_to_scope + sync_plan(        selected kit → Route(s);
-     adapter, home=<project_root>)          sync_routes(routes, dest=<project>)
-     → <project>/.claude/<ns>/              → <project>/.beads/PRIME.md
-                   │                                │
-   entries_from_outcomes            entries_from_route_outcomes(owner=kit)
-                   └───────────────┬────────────────┘
-              one project receipt @ <project>/.agents-config/ (one lock)
+       ┌───────────────────────────┴───────────────────────────┐
+  USER run (bound {USER})                        PROJECT run (bound {PROJECT})
+  install_pipeline(home=~)                       ── the user tool sync and
+   + install_plugin_routes(home=~)                  install_plugin_routes are
+                                                     NOT run (§5.1, §6.1) ──
+                                                 tool tail:  filter_plan_to_scope
+                                                   + sync_plan(adapter, home=<p>)
+                                                   → <p>/.claude/<ns>/
+                                                 kit tail:   for name in selected_kits:
+                                                   sync_routes(kit_routes[name])
+                                                     (dest_dir baked into each route)
+                                                   → <p>/.beads/PRIME.md
+                                                   entries_from_route_outcomes(
+                                                     plugin=f"kit:{name}")  # per kit
+                                                 one receipt @ <p>/.agents-config/
 ```
 
 ### 3.3 Why kits are not just another namespace
@@ -149,61 +166,98 @@ subtree. A single nullable is preferred over a distinct `KitRef` union: the pure
 resolver treats refs opaquely — it groups by selector key and partitions by
 scope — so a nullable flows through `resolve()` **transparently except for one
 line**: the `final_included` sort key currently reads `r.tool.value`
-(`profiles.py:447`) and must become tolerant of `None`
+(`profiles.py:447`, the only read of `r.tool` in `resolve()`) and must become
+tolerant of `None`
 (`(r.tool.value if r.tool is not None else "", r.dest_relpath.as_posix())`).
 That is the *only* resolver change S2 makes; a `KitRef` union would instead force
 every `ResolvedPlan.included` consumer to pattern-match two types.
 
 Note: `tool=None` is free for the resolver and for materialization dispatch, but
 receipt attribution needs a concrete owner string that `None` cannot supply.
-That owner is defined in §6.2 (`kit:<name>`), independent of the ref's `tool`
-field.
+That owner is `kit:<name>`, assigned at receipt-build time (§6.2), independent of
+the ref's `tool` field.
 
-### 4.2 `stage_kits`
+### 4.2 Staging: `stage_kits` (refs) and `kit_routes` (routes)
 
-`stage_kits(kits_root)` walks `src/kits/<kit>/**` recursively and produces, per
-kit:
+Two functions, split by what each needs — mirroring the plugin precedent, where
+`PluginAdapter.routes(home)` injects the destination root at call time while the
+source layout is fixed:
 
-- **universe refs** — one `UniverseRef(tool=None, dest_relpath=<subpath>)` per
-  file, keyed by its **selector key** `kits/<kit>/<subpath>` (source-relative)
-  for the resolver;
-- **routes** — one `PluginRoute`-shaped route per distinct destination
-  directory (routes install a flat file set per directory), with
-  `source_dir = <kit>/<destdir>`, `dest_dir = <project>/<destdir>`, a glob
-  selecting the kit's files there, and `executable` from the source mode bit.
-  The beads kit is a single route (`src/kits/beads/.beads/*` → `<project>/.beads/`).
+```python
+def stage_kits(kits_root: Path) -> list[UniverseRef]:
+    # walks src/kits/<kit>/** ; one UniverseRef(tool=None, dest_relpath=<subpath>)
+    # per file, keyed by selector key "kits/<kit>/<subpath>" for the resolver.
+    # project-root-independent (refs carry no absolute path).
 
-A missing `src/kits/` yields nothing. Two kit sources resolving to the same
-destination is a fatal error naming both source paths.
+def kit_routes(kits_root: Path, project_root: Path) -> dict[str, list[PluginRoute]]:
+    # keyed by kit name; per kit, one PluginRoute per (destination directory ×
+    # exec-bit): source_dir under the kit, dest_dir = project_root/<destdir>,
+    # glob selecting that group's files, executable set for the group.
+    # Mirrors PluginAdapter.routes(home) but grouped by kit for per-kit owners.
+```
+
+`stage_kits` feeds the resolver universe (§4.3). `kit_routes` is called during
+materialization for the selected kits (§5.1). Routes are grouped by
+`(destination directory × exec-bit)` because a `PluginRoute` applies one
+`executable` bit to every file its glob matches (the beads plugin splits
+`formulas`/`scripts` for exactly this reason); a single kit directory mixing
+executable and non-executable files needs multiple routes. The beads kit is a
+single non-executable route (`src/kits/beads/.beads/*` → `<project>/.beads/`).
+
+**Kit identity.** A kit's name is the directory name directly under `src/kits/`,
+which is also the second segment of its selector key `kits/<name>/<subpath>`.
+Both the selector side (`stage_kits`, which builds the universe keys) and the
+materialization/receipt side (`kit_routes`' dict key, the `kit:<name>` receipt
+owner, and the prune desired-keys) derive the name from that one source via a
+single shared helper, so the `kit:<name>` owner string is provably byte-stable
+across an install run and a later prune run.
+
+A missing `src/kits/` yields nothing from both. Two kit sources resolving to the
+same destination is a fatal error naming both source paths.
 
 ### 4.3 `kit_universe` and merge
 
-`kit_universe(stage_kits output)` groups the kit refs by selector key into
+`kit_universe(stage_kits(kits_root))` groups the kit refs by selector key into
 `dict[str, list[UniverseRef]]`. The caller merges it with
 `project_universe(transformed_plans)` and hands the union to `resolve()`. Kits
 ride the resolver for **selection** only.
 
 ## 5. Materialization, capability matrix, and enforcement
 
-### 5.1 Two tails
+### 5.1 The two tails and the run fork
 
-`resolve()` returns `ResolvedPlan.included[scope]`, a mix of tool refs and kit
-refs. Materialization dispatches on `ref.tool`:
+`cli._run` forks on the scope binding. This fork is the largest implementation
+surface and is stated explicitly so two implementers build it identically:
 
-- **Tool refs** (`tool != None`): `filter_plan_to_scope(plan, kept_dest_relpaths)`
-  narrows the tool's transformed `StagingPlan` to the project-bound refs, then
-  `sync_plan(adapter, filtered_plan, home=<project_root>)` writes them. Because
-  `dest_dir(base) → base/".claude"` is parameterized on its base, passing the
-  project root yields `<project>/.claude/<ns>/` with no new sync code. Receipt
-  entries come from `entries_from_outcomes` (their dest paths are
-  namespace-rooted, e.g. `skills/…`, so they pass the `PRUNE_NAMESPACES` filter).
-- **Kit refs** (`tool == None`): the selected kit's routes are installed via the
-  existing `sync_routes(routes, dest_dir=<project_root>/…)`, and recorded via
-  `entries_from_route_outcomes(outs, plugin="kit:<name>", home=<project_root>)`.
-  This reuses the plugin-route path wholesale: verbatim names, `.beads`-rooted
-  entries (`route_entry_for` computes `root = dest_dir.relative_to(base).parts[0]`
-  → `.beads`), consent-gated overwrite, and prune tracking — the same machinery
-  that already installs the beads plugin's `~/.beads/formulas` on the user side.
+- A **user run** performs the existing `install_pipeline(home=~)` (tool sync) and
+  `install_plugin_routes(home=~)` (plugin routes), unchanged — except each tool
+  plan is first narrowed by `filter_plan_to_scope` to the `USER`-bound refs
+  (which, for the forced-`full` profile, is the whole plan — §6.1 parity).
+- A **project run** does **not** run the user tool sync or `install_plugin_routes`
+  at all (running either against `home=~` would write user space, violating §5.5;
+  against `home=<project>` would leak user-scope plugin content into the project).
+  It runs only two project tails, both under the project receipt lock:
+  - **Tool tail** (`tool != None` refs): `filter_plan_to_scope(plan, kept)`
+    narrows the transformed `StagingPlan` to the project-bound refs, then
+    `sync_plan(adapter, filtered_plan, home=<project_root>)` writes them. Because
+    `dest_dir(base) → base/".claude"` is parameterized on its base, the project
+    root yields `<project>/.claude/<ns>/`. Recorded via `entries_from_outcomes`,
+    called with `dest_root=<project>/.claude` (drives the `PRUNE_NAMESPACES` filter
+    on `o.dest.relative_to(dest_root)`) and `home=<project_root>` (drives the
+    project-relative recorded entry path).
+  - **Kit tail** (`tool == None` refs): the caller determines which kits are
+    selected by cross-referencing the retained kit-universe map (selector key
+    `kits/<name>/…` → refs) against `included[PROJECT]` — a kit is selected iff at
+    least one of its refs' `dest_relpath`s is in `included[PROJECT]`. For each
+    selected kit, `kit_routes(kits_root, project_root)[<name>]` gives its routes
+    (destination already baked into each route's `dest_dir`), `sync_routes`
+    installs them, and the writes are recorded with **that kit's** owner via
+    `entries_from_route_outcomes(outs, plugin=f"kit:{name}", home=<project_root>)`
+    — one call per kit, since the API takes one owner per call. This reuses the
+    plugin-route path wholesale: verbatim names, `.beads`-rooted entries
+    (`route_entry_for` derives the root from the file's parent under the base →
+    `.beads`), consent-gated overwrite, and prune tracking — the same machinery
+    that installs the beads plugin's `~/.beads/formulas` on the user side.
 
 ### 5.2 `project_namespaces()` capability matrix
 
@@ -228,33 +282,50 @@ Enforced by the matrix: no adapter lists `instructions` or `settings`. A
 project's `CLAUDE.md`/`AGENTS.md` and settings are project-authored artifacts the
 installer must not collide with.
 
-### 5.4 Validation pass (post-resolve, not in the resolver)
+### 5.4 Validation passes
 
-The pure resolver stays selector-agnostic. A post-resolve validation pass in the
-orchestrator/cli layer enforces the capability rules over `ResolvedPlan`:
+Two capability checks sit outside the pure resolver (which stays
+selector-agnostic):
 
-- For each **tool** ref bound to project scope, assert its namespace is in that
-  adapter's `project_namespaces()`, else error naming tool + namespace.
-- For each **kit** ref (`tool=None`), assert its assigned scope is `PROJECT`,
-  else error naming the selector (§5.6).
+- **Tool-namespace (post-resolve).** For each **tool** ref in
+  `ResolvedPlan.included[PROJECT]`, assert its namespace (`dest_relpath.parts[0]`)
+  is in that adapter's `project_namespaces()`, else error naming tool + namespace.
+  Tool refs routed to project are present in `included[PROJECT]` carrying tool and
+  destination, so this check has the identity it needs.
+- **Kit-scope (pre-resolve — §5.6).** The mirror check for kits *cannot* run over
+  `ResolvedPlan`: a kit wrongly routed to a non-project scope is dropped by
+  `resolve()` into an anonymous `dropped_counts` tally, losing its selector
+  identity, so a post-resolve pass could neither see nor name it. The kit-scope
+  guard therefore runs before `resolve()` — see §5.6.
 
 ### 5.5 One binding per run
 
 Per §7 of the parent spec, a run has exactly one primary scope binding. A
 `--project` run binds `PROJECT` and does **not** bind `USER`; it structurally
-cannot write user space. There is thus no dual-scope run, no receipt-lock
-nesting, and no lock-ordering hazard — a run holds exactly one receipt lock. The
-project run's tool tail and kit tail both write under that one lock and both feed
-one receipt (§6.2).
+cannot write user space (§5.1 fork). There is thus no dual-scope run, no
+receipt-lock nesting, and no lock-ordering hazard — a run holds exactly one
+receipt lock, and the project run's tool tail and kit tail both write under it
+and feed one receipt (§6.2).
 
-### 5.6 Kit scope enforcement
+### 5.6 Kit scope enforcement (pre-resolve guard)
 
-Kits are structurally project-only. Any kit ref (`tool=None`) that resolves to a
-non-`PROJECT` scope — reachable only via a hand-authored explicit override such
-as `{ select = "kits/beads/**", scope = "user" }` — is a fail-loud validation
-error naming the selector. This mirrors the "instructions/settings are never
-project-routable" guardrail and keeps a clean boundary: plugin routes carry
-user-space out-of-tree content; kits carry project-space out-of-tree content.
+Kits are structurally project-only. The only way a kit reaches a non-project
+scope is an explicit per-selector override in a selected profile (including a
+user-authored `~/.agents/profiles.toml`), e.g.
+`{ select = "kits/beads/**", scope = "user" }` — the shipped `kits/** → project`
+default cannot be overridden by `[scopes]` (user manifests may not declare
+`[scopes]`).
+
+The guard runs in the orchestrator layer **before `resolve()`**, where selector
+identity still exists: for each `IncludeEntry` of the selected profiles that
+carries an explicit non-`PROJECT` `scope`, if its `selector` matches any key in
+the kit universe (via `_selector_matches`), raise a fail-loud error naming the
+selector. Running pre-resolve is required because `resolve()` discards the
+identity of dropped refs (§5.4), and it makes the error fire regardless of
+whether other project content coexists in the run. This mirrors the
+"instructions/settings are never project-routable" guardrail and keeps a clean
+boundary: plugin routes carry user-space out-of-tree content; kits carry
+project-space out-of-tree content.
 
 ## 6. CLI, binding, receipt, collisions, errors
 
@@ -267,44 +338,57 @@ surfaces through the existing OS-error/consent path like any other write. The
 installer does not require `<path>` to look like a project (no `.git`/
 `project-config.toml` precondition); detection (§6.4) only *suggests*.
 
-One resolver, a scope-parameterized tail:
+One resolver, a scope-parameterized fork (§5.1):
 
 | Facet | User run (no `--project`) | Project run (`--project <p>`) |
 |---|---|---|
 | `bound_scopes` | `{USER}` | `{PROJECT}` |
 | Selection | forced `full`; `--profiles` rejected (§6.5) | `--profiles` CSV → else persisted `[install]` in `<p>/project-config.toml` → else error |
 | Universe | `project_universe(transformed_plans)` | same **+** `kit_universe(stage_kits())` |
-| Dest base | `home` → `~/.claude` | `<p>` → `<p>/.claude` (same `dest_dir` fn) |
-| Out-of-tree content | plugin routes (`~/.beads/formulas`) | kit routes (`<p>/.beads/…`) |
+| Tool sync | `install_pipeline(home=~)` | filtered `sync_plan(home=<p>)`; user `install_pipeline` **not** run |
+| Out-of-tree content | `install_plugin_routes(home=~)` | kit routes only; `install_plugin_routes` **not** run |
 | Receipt + lock | `~/.config/agents-config/install-receipt.json` | `<p>/.agents-config/install-receipt.json` (own `.lock`) |
-| Persistence | none in S2 (deferred) | chosen profiles → `<p>/project-config.toml [install]` |
+| Persistence | none in S2 (deferred) | chosen profiles → `<p>/project-config.toml [install]` (see below) |
 
 The user run's forced-`full` resolution matches `**`, routes everything to its
 `user` default, drops nothing, and is byte-identical to today's install. This is
 the safety invariant behind the resolver-on decision, guarded end-to-end by the
 parity test (§6.6 test 1).
 
-**New coupling from wiring the resolver into every run:** the forced-`full` run
-requires that `[scopes]` (plus the synthetic `instructions`/`settings` keys)
-matches *every* staged namespace — `resolve()` raises `ProfilesError` if any
-universe key has no `[scopes]` match. Today `[scopes]` covers `namespaces.ALL`
-plus the synthetics, so parity holds; but a future namespace added to
-`namespaces.ALL` without a corresponding `[scopes]` entry would crash *every*
-user install. §6.6 test adds a CI guard asserting `[scopes]` coverage of
-`namespaces.ALL`. The namespace-addition checklist gains one edit: a `[scopes]`
-entry in `profiles.toml`.
+**Universe-coverage coupling.** Wiring the resolver into every run makes it a hard
+requirement that every *universe key* has a `[scopes]` (or explicit) match —
+`resolve()` raises `ProfilesError` otherwise. Universe keys are exactly the
+namespaces that appear in a transformed tool `StagingPlan` (`TOOL_SCOPED ∪
+SHARED`) plus the synthetic `instructions`/`settings`. This is **not**
+`namespaces.ALL`: `formulas` is in `ALL` but is plugin-routed (installed via a
+`PluginRoute`, never staged into a `StagingPlan`), so it never becomes a universe
+key and correctly has no `[scopes]` entry. §6.6 test 2 guards coverage of the
+*universe-eligible* set (`TOOL_SCOPED ∪ SHARED ∪ {instructions, settings}`), not
+`ALL`, so a future *staged* namespace added without a `[scopes]` entry fails in
+CI rather than in users' installs. The namespace-addition checklist gains one
+edit — a `[scopes]` entry — only when the new namespace is staged (not
+plugin-routed).
+
+**Persistence.** On a successful, non-`--dry-run` project run, the resolved
+profile set is written to `<p>/project-config.toml` under `[install]` as
+`profiles = ["<name>", …]`, at the same point and under the same gating as the
+project receipt write (after materialization succeeds, inside the project lock).
+`--dry-run` never writes `project-config.toml`. A bare `--project <p>` re-run
+with no `--profiles` reads this persisted set (§6.1 Selection); `--profiles`
+overrides it and re-persists.
 
 **Flag interactions.** `--tools` continues to gate which tool plans are staged
 and therefore which tool refs feed `project_universe`; kit staging is unaffected
 (kits are tool-agnostic). A project profile whose selector targets a tool
-excluded via `--tools` resolves to nothing and fails loud as a dead selector —
-S2 does not add a distinct message for the `--tools`/`--profiles` mismatch.
-`--dump-stage` under `--project` includes kit refs alongside tool refs (dest
-path and owner; content is not dumped), so the dump reflects the resolved project
-plan. `--prune`/`--prune-only` operate against the project receipt when
-`--project` is set (§6.2).
+excluded via `--tools` resolves to nothing and fails loud as a dead selector — S2
+adds no distinct message for that mismatch. `--dump-stage` under `--project`
+requires a **new** kit-ref rendering (dest path + owner, no content) added
+alongside `dump_plan`'s tool-plan tree output, since kit refs never enter a tool
+`StagingPlan`; the resolver and kit staging run before the dump branch so the
+listing reflects the resolved project plan. `--prune`/`--prune-only` operate
+against the project receipt when `--project` is set (§6.2).
 
-### 6.2 Project receipt
+### 6.2 Project receipt and prune
 
 The project receipt reuses the `Receipt` schema, `read_receipt`/`write_receipt`/
 `merge_receipt`, and `receipt_lock` unchanged, at
@@ -315,18 +399,27 @@ receipt under one lock:
 - **Tool entries** via `entries_from_outcomes` (namespace-rooted paths pass the
   `PRUNE_NAMESPACES` filter).
 - **Kit entries** via `entries_from_route_outcomes` with owner `kit:<name>` — a
-  non-tool owner, exactly like a plugin owner. `scope_owners` already unions any
-  non-tool owner found in the prior receipt (`retired_plugin_owners`), and
-  `validate_entry` already has the non-tool-owner branch, so kit entries are in
-  scope for prune with **no change** to `scope_owners`/`validate_entry`/root
-  validation (`.beads` is already an accepted route root today).
+  non-tool owner, exactly like a plugin owner.
 
-`record_receipt` gains a kit-outcomes input (route-shaped) whose entries are
-appended to the flat `installed` list before `merge_receipt`; the desired-set for
-orphan detection includes the selected kits' route keys (a
-`desired_route_keys`-shaped set), so a deselected kit's files are detected as
-orphans and pruned. The user receipt is never read or written by a project run,
-and vice versa.
+**No change is needed** to `scope_owners` (its `retired_plugin_owners` union
+already re-includes any non-tool owner found in the prior receipt) or to
+`validate_entry` (its non-tool-owner allowlist branch already accepts a `.beads`
+root). The two seams that **do** need wiring:
+
+- `record_receipt` (`core/run.py`) gains a kit-outcomes input; the kit route
+  entries are appended to the flat `installed` list before `merge_receipt`.
+- `prune_pipeline` (`core/run.py`) — **not** `record_receipt` — is where orphan
+  detection lives. Today it computes the desired route set via
+  `desired_route_keys(plugins, home)`, which iterates `PluginAdapter.routes()`;
+  kits are not plugins, so with no change the kit desired-set is empty and a
+  still-selected kit's just-installed file is flagged an orphan and pruned. S2
+  gives `prune_pipeline` the selected kits' routes (per §5.1) feeding a
+  `desired_route_keys`-shaped set, keyed by the same `kit:<name>` owner helper the
+  record side uses (§4.2) so install-side and prune-side owners provably match,
+  and seeds `live_roots_by_owner["kit:<name>"]`. Selected-kit files are thus
+  desired (not orphaned) and a *deselected* kit's files are detected as orphans
+  and pruned. The user receipt is never read or written by a project run, and
+  vice versa.
 
 ### 6.3 Collision handling
 
@@ -360,8 +453,8 @@ All fail-loud; every message names the offender.
 | Project run, no `--profiles` and no persisted set | pre-resolve CLI guard (see note) | "project install needs an explicit profile (no implicit full)" |
 | Selected profiles → empty project partition | resolve (step 8 today) | "the run would do nothing; no content bound to project" |
 | Tool ref → project, namespace ∉ `project_namespaces()` | post-resolve validation | names tool + namespace |
-| Kit ref → non-`PROJECT` scope | post-resolve validation | names the selector |
-| Two kit sources → same destination | `stage_kits` | names both source paths |
+| Kit selector overridden to non-`PROJECT` scope | pre-resolve guard (§5.6) | names the selector |
+| Two kit sources → same destination | `stage_kits`/`kit_routes` | names both source paths |
 | Concurrent project install | project `receipt_lock` | `ReceiptLockBusy` |
 
 Note: the "no implicit full for a project run" rule is enforced as a **pre-resolve
@@ -378,29 +471,41 @@ temp trees, no live installs.
 
 1. **End-to-end parity (non-negotiable):** a no-flag user install through the
    newly-wired resolver (inserted after `stage_and_transform`) is byte-identical
-   to today's install, including plugin-overlaid content.
-2. **`[scopes]` coverage guard:** `[scopes]` plus the synthetic
-   `instructions`/`settings` keys cover `namespaces.ALL`, so a future namespace
-   addition fails in CI, not in users' installs.
-3. `stage_kits`: tree-mirror destination; verbatim name (PRIME.md stays
-   PRIME.md); source-relative selector key; recursive walk; route grouping by
-   destination directory; executable-bit carry; empty on missing `src/kits/`.
+   to today's install, including plugin-overlaid content, and unaffected by the
+   added `kits/**` scope and `beads-kit` profile.
+2. **Universe-coverage guard:** the `[scopes]` selectors cover the
+   universe-eligible namespace set `TOOL_SCOPED ∪ SHARED ∪ {instructions,
+   settings}`, so a future *staged* namespace without a `[scopes]` entry fails in
+   CI. The guard must not require a `formulas` entry (plugin-routed, never a
+   universe key).
+3. `stage_kits`/`kit_routes`: tree-mirror destination; verbatim name (PRIME.md
+   stays PRIME.md); source-relative selector key; recursive walk; route grouping
+   per (destination directory × exec-bit); executable-bit carry; empty on missing
+   `src/kits/`.
 4. Integration: `--project p --profiles beads-kit` writes `<p>/.beads/PRIME.md`;
    `--project p --profiles sdlc` errors (empty project partition).
-5. Kit-scope guard: an override routing `kits/**` → user errors.
+5. Kit-scope guard: a selected profile with `{ select = "kits/**", scope = "user" }`
+   errors pre-resolve, naming the selector.
 6. `project_namespaces()` matrix: a Claude skill → project works; a namespace →
    project for an unsupporting tool errors naming both.
 7. Project receipt round-trip: install → prune → uninstall against a temp project
-   tree; a beads kit dropped from a later selection is pruned as an orphan; the
-   user receipt is untouched throughout.
-8. Detection-suggestion: a user run in a cwd with `.beads/` prints exactly one
+   tree; a re-install of a still-selected kit does **not** prune its file; a beads
+   kit dropped from a later selection **is** pruned as an orphan; the user receipt
+   is untouched throughout.
+8. Persistence round-trip: `--project p --profiles beads-kit` writes
+   `[install] profiles = ["beads-kit"]` to `<p>/project-config.toml`; a bare
+   `--project p` re-run reads it; `--project p --profiles beads-kit --dry-run`
+   writes no `project-config.toml`.
+9. Detection-suggestion: a user run in a cwd with `.beads/` prints exactly one
    line; a `--project` run prints none.
-9. Overwrite: a kit install over an existing `.beads/PRIME.md` backs it up and
-   respects `--yes` / prompt.
-10. `--project p --profiles beads-kit --dry-run` previews would-be writes via
+10. Overwrite: a kit install over an existing `.beads/PRIME.md` backs it up and
+    respects `--yes` / prompt.
+11. `--project p --profiles beads-kit --dry-run` previews would-be writes via
     `io`, creates no files, and leaves no `.agents-config/install-receipt.json`
     or `.lock` under `<p>`.
-11. `--project` path missing / not a directory errors naming the path.
+12. `--project` path missing / not a directory errors naming the path.
+13. `--dump-stage` under `--project` lists kit refs (dest + owner) alongside tool
+    refs.
 
 ## 7. Deferred work (non-goals for S2)
 
@@ -415,9 +520,10 @@ These move to a dedicated successor slice (§8):
   a rule from the rebuilt instruction file, not only its standalone copy.
 
 Also out of scope: dogfooding the beads kit into this repo (decision 3); any kit
-beyond beads; multi-file/nested kits beyond the single-route beads case (the
-route-grouping generalizes, but only beads is exercised in S2); `installer.toml`
-`tool_dest_overrides` retirement (S3, `agents-config-uxns2.1.2`, independent).
+beyond beads; a kit directory with **mixed** exec bits (v1 groups routes per
+(dir × exec-bit), which handles it, but only the single-route beads case is
+exercised); `installer.toml` `tool_dest_overrides` retirement (S3,
+`agents-config-uxns2.1.2`, independent).
 
 ## 8. Continuations
 

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -72,6 +72,19 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--project",
+        metavar="PATH",
+        default=None,
+        type=Path,
+        help="Install project-scoped content into PATH instead of user space.",
+    )
+    parser.add_argument(
+        "--profiles",
+        metavar="CSV",
+        default=None,
+        help="Comma-separated profile names (requires --project in this version).",
+    )
+    parser.add_argument(
         "--yes",
         "-y",
         action="store_true",
@@ -146,6 +159,13 @@ def _run(
     args = _build_parser().parse_args(argv)
     resolved_home = home if home is not None else Path.home()
     resolved_repo_root = repo_root if repo_root is not None else _REPO_ROOT
+
+    if args.profiles is not None and args.project is None:
+        sys.stderr.write("installer: --profiles requires --project in this version\n")
+        return 2
+    if args.project is not None and not args.project.is_dir():
+        sys.stderr.write(f"installer: --project path is not a directory: {args.project}\n")
+        return 2
 
     if io is None:
         from installer.core.io_port import TerminalIO

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -13,6 +13,7 @@ from installer.config import (
     resolve_plugins,
     resolve_plugins_root,
     resolve_tools,
+    write_project_profiles,
 )
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
@@ -597,6 +598,7 @@ def _run_project(
                     pruned_paths=set(),
                     relinquished_paths=set(),
                 )
+                write_project_profiles(project_root, selection)
     except ReceiptLockBusy:
         io.err(f"another install holds the project receipt lock at {receipt_path}")
         return 1

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -24,6 +24,7 @@ from installer.core.model import Counters, InstallOutcome
 from installer.core.orchestrator import stage_and_transform
 from installer.core.profiles import (
     Scope,
+    _selector_matches,
     filter_plan_to_scope,
     load_manifest,
     project_universe,
@@ -481,6 +482,28 @@ def _run_project(
                 "installer: project install needs an explicit profile (no implicit full)\n"
             )
             return 2
+    # Pre-resolve kit-scope guard: kits are project-only. resolve() discards a
+    # dropped ref's identity into anonymous per-scope counts, so a check after
+    # resolve() would be a tautology — it can never name the offending
+    # selector. Walk the selected profiles' IncludeEntries directly instead.
+    kit_keys = set(kit_universe(staged_kits))
+    for name in selection:
+        profile = manifest.profiles.get(name)
+        if profile is None:
+            continue  # let resolve() raise the real unknown-profile error
+        for entry in profile.includes:
+            scope = entry.scope
+            if (
+                scope is not None
+                and scope is not Scope.PROJECT
+                and any(_selector_matches(entry.selector, key) for key in kit_keys)
+            ):
+                sys.stderr.write(
+                    f"installer: kit selector {entry.selector!r} cannot be scoped to "
+                    f"{scope.value!r}; kits are project-only\n"
+                )
+                return 2
+
     resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
 
     # A kit is selected iff at least one of its refs' dest_relpaths landed in

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -18,7 +18,7 @@ from installer.config import (
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installignore import load_installignore
-from installer.core.kits import kit_adapters, kit_name_of, kit_universe, stage_kits
+from installer.core.kits import kit_adapters, kit_name_of, kit_routes, kit_universe, stage_kits
 from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.model import Counters, InstallOutcome
@@ -553,6 +553,13 @@ def _run_project(
     counters: dict[str, Counters] = {}
     tool_outcomes: dict[str, list[InstallOutcome]] = {}
     plugin_outcomes: dict[str, list[InstallOutcome]] = {}
+    pruned_paths: set[Path] = set()
+    relinquished_paths: set[Path] = set()
+    # ALL kit names present under src/kits/ — selected or not — so a
+    # deselected kit's prior receipt entry lands in scope_owners and is
+    # prunable (mirrors the user path's discovered_plugin_names, which is
+    # also the full discovered set, not just the resolved selection).
+    all_kit_owner_names = {f"kit:{name}" for name in kit_routes(kits_root, project_root)}
     try:
         with lock_cm:
             prior_read = read_receipt(receipt_path)
@@ -561,32 +568,54 @@ def _run_project(
                 if prior_read.status is ReadStatus.OK and prior_read.receipt is not None
                 else Receipt()
             )
-            try:
-                _merge_into(
-                    counters,
-                    install_pipeline(
+            if not args.prune_only:
+                try:
+                    _merge_into(
+                        counters,
+                        install_pipeline(
+                            tool_adapters,
+                            plans=tool_plans,
+                            home=project_root,
+                            io=io,
+                            dry_run=args.dry_run,
+                            auto_yes=args.yes,
+                            outcomes_by_tool=tool_outcomes,
+                        ),
+                    )
+                    _merge_into(
+                        counters,
+                        install_plugin_routes(
+                            kit_route_adapters,
+                            home=project_root,
+                            io=io,
+                            dry_run=args.dry_run,
+                            auto_yes=args.yes,
+                            outcomes_by_plugin=plugin_outcomes,
+                        ),
+                    )
+                except ConsentRequiredError:
+                    return 1
+
+            if args.prune or args.prune_only:
+                try:
+                    outcome = prune_pipeline(
                         tool_adapters,
+                        plugins=kit_route_adapters,
                         plans=tool_plans,
+                        prior=prior,
                         home=project_root,
+                        discovered_plugin_names=all_kit_owner_names,
                         io=io,
                         dry_run=args.dry_run,
                         auto_yes=args.yes,
-                        outcomes_by_tool=tool_outcomes,
-                    ),
-                )
-                _merge_into(
-                    counters,
-                    install_plugin_routes(
-                        kit_route_adapters,
-                        home=project_root,
-                        io=io,
-                        dry_run=args.dry_run,
-                        auto_yes=args.yes,
-                        outcomes_by_plugin=plugin_outcomes,
-                    ),
-                )
-            except ConsentRequiredError:
-                return 1
+                        prune_only=args.prune_only,
+                    )
+                except PruneAbortedError:
+                    return 1
+                _merge_into(counters, outcome.counters)
+                pruned_paths = outcome.pruned_paths
+                relinquished_paths = outcome.relinquished_paths
+
             if not args.dry_run:
                 record_receipt(
                     receipt_path,
@@ -595,8 +624,8 @@ def _run_project(
                     home=project_root,
                     tool_outcomes=tool_outcomes,
                     plugin_outcomes=plugin_outcomes,
-                    pruned_paths=set(),
-                    relinquished_paths=set(),
+                    pruned_paths=pruned_paths,
+                    relinquished_paths=relinquished_paths,
                 )
                 write_project_profiles(project_root, selection)
     except ReceiptLockBusy:

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from installer.config import (
     Config,
+    parse_profiles_csv,
     read_project_profiles,
     resolve_plugins,
     resolve_plugins_root,
@@ -508,7 +509,11 @@ def _run_project(
 
     manifest = load_manifest(repo_root / "profiles.toml")
     if args.profiles:
-        selection: tuple[str, ...] = tuple(p.strip() for p in args.profiles.split(","))
+        try:
+            selection: tuple[str, ...] = parse_profiles_csv(args.profiles)
+        except ValueError as exc:
+            sys.stderr.write(f"installer: {exc}\n")
+            return 2
     else:
         try:
             persisted = read_project_profiles(project_root)
@@ -634,6 +639,16 @@ def _run_project(
     try:
         with lock_cm:
             prior_read = read_receipt(receipt_path)
+            # A CORRUPT prior is fail-closed (mirrors the user path): skip prune
+            # and leave the receipt untouched rather than overwriting it with a
+            # fresh record, which would permanently erase the tracking of
+            # previously-installed project paths and defeat future --prune.
+            receipt_corrupt = prior_read.status is ReadStatus.CORRUPT
+            if receipt_corrupt:
+                io.err(
+                    f"project install receipt at {receipt_path} is unreadable; skipping "
+                    "prune and leaving it untouched — reset or migrate it to re-enable pruning"
+                )
             prior = (
                 prior_read.receipt
                 if prior_read.status is ReadStatus.OK and prior_read.receipt is not None
@@ -667,7 +682,7 @@ def _run_project(
                 except ConsentRequiredError:
                     return 1
 
-            if args.prune or args.prune_only:
+            if (args.prune or args.prune_only) and not receipt_corrupt:
                 try:
                     outcome = prune_pipeline(
                         tool_adapters,
@@ -687,7 +702,7 @@ def _run_project(
                 pruned_paths = outcome.pruned_paths
                 relinquished_paths = outcome.relinquished_paths
 
-            if not args.dry_run:
+            if not args.dry_run and not receipt_corrupt:
                 record_receipt(
                     receipt_path,
                     prior=prior,
@@ -698,6 +713,10 @@ def _run_project(
                     pruned_paths=pruned_paths,
                     relinquished_paths=relinquished_paths,
                 )
+            # Persisting the chosen selection targets project-config.toml, not the
+            # install receipt, so a corrupt receipt does not block it — the user's
+            # explicit intent is recorded regardless, keeping bare re-runs working.
+            if not args.dry_run:
                 write_project_profiles(project_root, selection)
     except ReceiptLockBusy:
         io.err(f"another install holds the project receipt lock at {receipt_path}")

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -489,13 +489,45 @@ def _run_project(
     selected_kits = {
         kit_name_of(sk.selector_key) for sk in staged_kits if sk.ref.dest_relpath in project_dests
     }
-    adapters = kit_adapters(kits_root, project_root, selected=selected_kits)
+    kit_route_adapters = kit_adapters(kits_root, project_root, selected=selected_kits)
+
+    # Tool tail: refs in the resolved PROJECT scope with a tool (as opposed to
+    # tool-agnostic kit refs, whose `ref.tool is None`) get synced under
+    # `project_root`'s tool tree instead of the plugin-route path above.
+    # Validation-first: every such ref's top-level namespace segment must be
+    # one of the destination tool's declared `project_namespaces()` — a tool
+    # with an empty `project_namespaces()` (Codex/Gemini/OpenCode today)
+    # accepts no project-scoped tool refs at all. Fails loud, naming the tool
+    # and namespace, before any file is written.
+    tool_dest_relpaths: dict[Tool, set[Path]] = {}
+    for ref in resolved.included.get(Scope.PROJECT, ()):
+        if ref.tool is not None:
+            tool_dest_relpaths.setdefault(ref.tool, set()).add(ref.dest_relpath)
+    for tool, dest_relpaths in tool_dest_relpaths.items():
+        allowed_namespaces = set(get_adapter(tool).project_namespaces())
+        for dest_relpath in sorted(dest_relpaths):
+            namespace = dest_relpath.parts[0]
+            if namespace not in allowed_namespaces:
+                sys.stderr.write(
+                    f"installer: tool {tool.value!r} cannot install {namespace!r} to "
+                    f"project scope (not in its project_namespaces()); selected "
+                    f"path: {dest_relpath}\n"
+                )
+                return 1
+
+    tool_adapters = [get_adapter(tool) for tool in tool_dest_relpaths]
+    tool_dest_roots = {adapter.name: adapter.dest_dir(project_root) for adapter in tool_adapters}
+    tool_plans = {
+        tool: filter_plan_to_scope(plans[tool], dest_relpaths)
+        for tool, dest_relpaths in tool_dest_relpaths.items()
+    }
 
     receipt_path = project_root / ".agents-config" / "install-receipt.json"
     lock_cm: AbstractContextManager[None] = (
         nullcontext() if args.dry_run else receipt_lock(receipt_path.with_suffix(".lock"))
     )
     counters: dict[str, Counters] = {}
+    tool_outcomes: dict[str, list[InstallOutcome]] = {}
     plugin_outcomes: dict[str, list[InstallOutcome]] = {}
     try:
         with lock_cm:
@@ -508,8 +540,20 @@ def _run_project(
             try:
                 _merge_into(
                     counters,
+                    install_pipeline(
+                        tool_adapters,
+                        plans=tool_plans,
+                        home=project_root,
+                        io=io,
+                        dry_run=args.dry_run,
+                        auto_yes=args.yes,
+                        outcomes_by_tool=tool_outcomes,
+                    ),
+                )
+                _merge_into(
+                    counters,
                     install_plugin_routes(
-                        adapters,
+                        kit_route_adapters,
                         home=project_root,
                         io=io,
                         dry_run=args.dry_run,
@@ -523,9 +567,9 @@ def _run_project(
                 record_receipt(
                     receipt_path,
                     prior=prior,
-                    dest_roots={},
+                    dest_roots=tool_dest_roots,
                     home=project_root,
-                    tool_outcomes={},
+                    tool_outcomes=tool_outcomes,
                     plugin_outcomes=plugin_outcomes,
                     pruned_paths=set(),
                     relinquished_paths=set(),
@@ -536,7 +580,7 @@ def _run_project(
 
     render_summary(
         counters,
-        tools=[],
+        tools=[t.value for t in tool_dest_relpaths],
         plugins=sorted(plugin_outcomes),
         all_tools=[],
         all_plugins=[],

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -280,6 +280,17 @@ def _run(
         sys.stderr.write(f"installer: {exc}\n")
         return 1
 
+    # A `--project` run forks here to the project-scoped tail: it installs kit
+    # content (tool-agnostic project refs) under a project-local receipt and
+    # never touches user space or runs the user tool/plugin install below. This
+    # fork sits BEFORE the user `--dump-stage` branch below so `--project
+    # --dump-stage` renders the resolved PROJECT plan (tool refs + kit refs)
+    # from inside `_run_project` instead of falling through to the user dump.
+    if args.project is not None:
+        return _run_project(
+            args, plans=plans, project_root=args.project, repo_root=resolved_repo_root, io=io
+        )
+
     if args.dump_stage is not None:
         try:
             dump_plan(plans, args.dump_stage, io=io)
@@ -290,17 +301,6 @@ def _run(
             sys.stderr.write(f"installer: {exc}\n")
             return 2
         return 0
-
-    # A `--project` run forks here to the project-scoped tail: it installs kit
-    # content (tool-agnostic project refs) under a project-local receipt and
-    # never touches user space or runs the user tool/plugin install below.
-    # `--project --dump-stage` falls through to the dump branch above (unchanged
-    # until a future task teaches the dump renderer about kits), so this fork
-    # only ever sees a plain `--project` run.
-    if args.project is not None:
-        return _run_project(
-            args, plans=plans, project_root=args.project, repo_root=resolved_repo_root, io=io
-        )
 
     # Resolver-on for the user path (S2 Task 9): narrow every tool plan to the
     # USER-bound refs the active profile selection resolves to. The user CLI
@@ -578,6 +578,26 @@ def _run_project(
         tool: filter_plan_to_scope(plans[tool], dest_relpaths)
         for tool, dest_relpaths in tool_dest_relpaths.items()
     }
+
+    # `--project --dump-stage` renders the resolved PROJECT plan and returns —
+    # read-only, like the user dump branch it replaces for this path. Tool
+    # refs materialise via the same `dump_plan` tree the user path uses (empty
+    # when the resolved plan carries none); kit refs have no tool tree to land
+    # in, so they render as a `kit:<name>  <dest_relpath>` listing instead.
+    # Nothing under `project_root` is written — no kit content, no receipt.
+    if args.dump_stage is not None:
+        try:
+            dump_plan(tool_plans, args.dump_stage, io=io)
+        except ValueError as exc:
+            sys.stderr.write(f"installer: {exc}\n")
+            return 2
+        for name, dest_relpath in sorted(
+            (kit_name_of(sk.selector_key), sk.ref.dest_relpath)
+            for sk in staged_kits
+            if sk.ref.dest_relpath in project_dests
+        ):
+            io.info(f"kit:{name}  {dest_relpath}")
+        return 0
 
     receipt_path = project_root / ".agents-config" / "install-receipt.json"
     lock_cm: AbstractContextManager[None] = (

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -16,7 +16,13 @@ from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.model import Counters, InstallOutcome
 from installer.core.orchestrator import stage_and_transform
-from installer.core.profiles import Scope, load_manifest, project_universe, resolve
+from installer.core.profiles import (
+    Scope,
+    filter_plan_to_scope,
+    load_manifest,
+    project_universe,
+    resolve,
+)
 from installer.core.prune_flow import PruneAbortedError
 from installer.core.receipt import Receipt
 from installer.core.receipt_lock import ReceiptLockBusy, receipt_lock
@@ -268,6 +274,30 @@ def _run(
         return _run_project(
             args, plans=plans, project_root=args.project, repo_root=resolved_repo_root, io=io
         )
+
+    # Resolver-on for the user path (S2 Task 9): narrow every tool plan to the
+    # USER-bound refs the active profile selection resolves to. The user CLI
+    # exposes no --profiles flag yet, so the selection is always empty, which
+    # resolve() treats as the "full" profile (`include = ["**"]`) — every
+    # staged item matches, so filtering changes nothing and the install stays
+    # byte-identical to the pre-resolver output. Guarded on a non-empty
+    # universe: an empty universe (every active tool plan staged zero items)
+    # has nothing to resolve or filter, and skipping avoids both a spurious
+    # profiles.toml requirement and resolve()'s "matches nothing"/"resolves to
+    # zero items" errors on synthetic all-empty fixtures — real installs always
+    # stage at least one item, so this guard never changes real behavior.
+    universe = project_universe(plans.values())
+    if universe:
+        manifest = load_manifest(resolved_repo_root / "profiles.toml")
+        resolved = resolve(manifest, (), universe, bound_scopes=frozenset({Scope.USER}))
+        kept_by_tool: dict[Tool, set[Path]] = {}
+        for ref in resolved.included.get(Scope.USER, ()):
+            if ref.tool is not None:
+                kept_by_tool.setdefault(ref.tool, set()).add(ref.dest_relpath)
+        plans = {
+            tool: filter_plan_to_scope(plan, kept_by_tool.get(tool, set()))
+            for tool, plan in plans.items()
+        }
 
     config = Config(home=resolved_home, tools=tools, auto_yes=args.yes)
     adapters = [get_adapter(tool) for tool in tools]

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -19,12 +19,13 @@ from installer.config import (
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installignore import load_installignore
-from installer.core.kits import kit_adapters, kit_name_of, kit_routes, kit_universe, stage_kits
+from installer.core.kits import kit_adapters, kit_name_of, kit_universe, stage_kits
 from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.model import Counters, InstallOutcome
 from installer.core.orchestrator import stage_and_transform
 from installer.core.profiles import (
+    ProfilesError,
     Scope,
     _selector_matches,
     filter_plan_to_scope,
@@ -302,7 +303,7 @@ def _run(
             return 2
         return 0
 
-    # Resolver-on for the user path (S2 Task 9): narrow every tool plan to the
+    # Resolver-on for the user path: narrow every tool plan to the
     # USER-bound refs the active profile selection resolves to. The user CLI
     # exposes no --profiles flag yet, so the selection is always empty, which
     # resolve() treats as the "full" profile (`include = ["**"]`) — every
@@ -491,7 +492,7 @@ def _run_project(
 ) -> int:
     """The project-scoped tail: install kit content under ``project_root``.
 
-    Tracer scope only (S2 plan Task 8) — kit refs alone. A kit rides the
+    Tracer scope only — kit refs alone. A kit rides the
     existing plugin-route machinery under owner ``kit:<name>`` via
     ``_KitRouteAdapter``, so it needs no new receipt/prune plumbing: this
     mirrors the user path's plugin-route install + receipt-record, scoped to a
@@ -500,16 +501,25 @@ def _run_project(
     """
     kits_root = repo_root / "src" / "kits"
     staged_kits = stage_kits(kits_root)
+    kit_refs = kit_universe(staged_kits)
     universe = project_universe(plans.values())
-    for key, refs in kit_universe(staged_kits).items():
+    for key, refs in kit_refs.items():
         universe.setdefault(key, []).extend(refs)
 
     manifest = load_manifest(repo_root / "profiles.toml")
     if args.profiles:
         selection: tuple[str, ...] = tuple(p.strip() for p in args.profiles.split(","))
     else:
-        persisted = read_project_profiles(project_root)
-        if persisted is not None:
+        try:
+            persisted = read_project_profiles(project_root)
+        except ValueError as exc:
+            sys.stderr.write(f"installer: malformed project-config.toml [install]: {exc}\n")
+            return 2
+        # An empty persisted list is treated the same as no persisted list: it is
+        # NOT an implicit "full" selection. resolve() reads an empty selection as
+        # the full profile, so falling through here would silently bypass the
+        # no-implicit-full guarantee project installs are supposed to enforce.
+        if persisted:
             selection = persisted
         else:
             sys.stderr.write(
@@ -520,7 +530,7 @@ def _run_project(
     # dropped ref's identity into anonymous per-scope counts, so a check after
     # resolve() would be a tautology — it can never name the offending
     # selector. Walk the selected profiles' IncludeEntries directly instead.
-    kit_keys = set(kit_universe(staged_kits))
+    kit_keys = set(kit_refs)
     for name in selection:
         profile = manifest.profiles.get(name)
         if profile is None:
@@ -538,7 +548,11 @@ def _run_project(
                 )
                 return 2
 
-    resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
+    try:
+        resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
+    except ProfilesError as exc:
+        sys.stderr.write(f"installer: {exc}\n")
+        return 2
 
     # A kit is selected iff at least one of its refs' dest_relpaths landed in
     # the resolved PROJECT scope.
@@ -612,7 +626,11 @@ def _run_project(
     # deselected kit's prior receipt entry lands in scope_owners and is
     # prunable (mirrors the user path's discovered_plugin_names, which is
     # also the full discovered set, not just the resolved selection).
-    all_kit_owner_names = {f"kit:{name}" for name in kit_routes(kits_root, project_root)}
+    all_kit_owner_names = (
+        {f"kit:{p.name}" for p in kits_root.iterdir() if p.is_dir()}
+        if kits_root.is_dir()
+        else set()
+    )
     try:
         with lock_cm:
             prior_read = read_receipt(receipt_path)

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -632,7 +632,7 @@ def _run_project(
     # prunable (mirrors the user path's discovered_plugin_names, which is
     # also the full discovered set, not just the resolved selection).
     all_kit_owner_names = (
-        {f"kit:{p.name}" for p in kits_root.iterdir() if p.is_dir()}
+        {f"kit:{p.name}" for p in kits_root.iterdir() if p.is_dir() and not p.is_symlink()}
         if kits_root.is_dir()
         else set()
     )
@@ -716,8 +716,18 @@ def _run_project(
             # Persisting the chosen selection targets project-config.toml, not the
             # install receipt, so a corrupt receipt does not block it — the user's
             # explicit intent is recorded regardless, keeping bare re-runs working.
+            # A malformed/unreadable existing project-config.toml (or a write
+            # failure) must not crash after a successful install: surface it as a
+            # clean exit-1 diagnostic. The install + receipt are already committed.
             if not args.dry_run:
-                write_project_profiles(project_root, selection)
+                try:
+                    write_project_profiles(project_root, selection)
+                except (ValueError, OSError) as exc:
+                    io.err(
+                        "install completed but persisting the profile selection to "
+                        f"project-config.toml failed: {exc}"
+                    )
+                    return 1
     except ReceiptLockBusy:
         io.err(f"another install holds the project receipt lock at {receipt_path}")
         return 1

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -491,14 +491,17 @@ def _run_project(
     repo_root: Path,
     io: IOPort,
 ) -> int:
-    """The project-scoped tail: install kit content under ``project_root``.
+    """The project-scoped tail: resolve, validate, and install project content.
 
-    Tracer scope only — kit refs alone. A kit rides the
-    existing plugin-route machinery under owner ``kit:<name>`` via
-    ``_KitRouteAdapter``, so it needs no new receipt/prune plumbing: this
-    mirrors the user path's plugin-route install + receipt-record, scoped to a
-    project-local receipt and lock instead of the user one. The user tool
-    sync, user plugin routes, prune, and validation passes never run here.
+    Handles the full project install: staging kits, resolving the selection to
+    the PROJECT scope, the kit-scope + project-namespace validation guards, tool
+    syncing under ``project_root``'s tool tree, kit route installs (a kit rides
+    the existing plugin-route machinery under owner ``kit:<name>`` via
+    ``_KitRouteAdapter``), prune, project-local receipt recording, and profile
+    persistence. The load-bearing invariant: this path writes only under
+    ``project_root`` (never user space) and tracks state in a project-local
+    receipt guarded by a project-local lock. The user-space install pipeline and
+    user plugin routes never run here.
     """
     kits_root = repo_root / "src" / "kits"
     staged_kits = stage_kits(kits_root)
@@ -508,7 +511,10 @@ def _run_project(
         universe.setdefault(key, []).extend(refs)
 
     manifest = load_manifest(repo_root / "profiles.toml")
-    if args.profiles:
+    # `is not None` (not truthiness): an explicit `--profiles=` (empty string) is
+    # routed through parse_profiles_csv and rejected cleanly, rather than silently
+    # falling back to the persisted set as if the flag were omitted.
+    if args.profiles is not None:
         try:
             selection: tuple[str, ...] = parse_profiles_csv(args.profiles)
         except ValueError as exc:

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -11,10 +11,12 @@ from installer.config import Config, resolve_plugins, resolve_plugins_root, reso
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installignore import load_installignore
+from installer.core.kits import kit_adapters, kit_name_of, kit_universe, stage_kits
 from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.model import Counters, InstallOutcome
 from installer.core.orchestrator import stage_and_transform
+from installer.core.profiles import Scope, load_manifest, project_universe, resolve
 from installer.core.prune_flow import PruneAbortedError
 from installer.core.receipt import Receipt
 from installer.core.receipt_lock import ReceiptLockBusy, receipt_lock
@@ -33,6 +35,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     from installer.core.io_port import IOPort
+    from installer.core.model import StagingPlan, Tool
     from installer.plugins.base import PluginAdapter
 
 # The repo root is the agents-config checkout containing ``src/user/.agents`` and
@@ -255,6 +258,17 @@ def _run(
             return 2
         return 0
 
+    # A `--project` run forks here to the project-scoped tail: it installs kit
+    # content (tool-agnostic project refs) under a project-local receipt and
+    # never touches user space or runs the user tool/plugin install below.
+    # `--project --dump-stage` falls through to the dump branch above (unchanged
+    # until a future task teaches the dump renderer about kits), so this fork
+    # only ever sees a plain `--project` run.
+    if args.project is not None:
+        return _run_project(
+            args, plans=plans, project_root=args.project, repo_root=resolved_repo_root, io=io
+        )
+
     config = Config(home=resolved_home, tools=tools, auto_yes=args.yes)
     adapters = [get_adapter(tool) for tool in tools]
 
@@ -390,6 +404,101 @@ def _run(
         plugins=[p.name for p in plugins],
         all_tools=[t.value for t in known_tools()],
         all_plugins=list(discover(resolve_plugins_root(resolved_repo_root, os.environ))),
+        verbose=args.verbose,
+        io=io,
+    )
+    return 0
+
+
+def _run_project(
+    args: argparse.Namespace,
+    *,
+    plans: dict[Tool, StagingPlan],
+    project_root: Path,
+    repo_root: Path,
+    io: IOPort,
+) -> int:
+    """The project-scoped tail: install kit content under ``project_root``.
+
+    Tracer scope only (S2 plan Task 8) — kit refs alone. A kit rides the
+    existing plugin-route machinery under owner ``kit:<name>`` via
+    ``_KitRouteAdapter``, so it needs no new receipt/prune plumbing: this
+    mirrors the user path's plugin-route install + receipt-record, scoped to a
+    project-local receipt and lock instead of the user one. The user tool
+    sync, user plugin routes, prune, and validation passes never run here.
+    """
+    kits_root = repo_root / "src" / "kits"
+    staged_kits = stage_kits(kits_root)
+    universe = project_universe(plans.values())
+    for key, refs in kit_universe(staged_kits).items():
+        universe.setdefault(key, []).extend(refs)
+
+    manifest = load_manifest(repo_root / "profiles.toml")
+    selection = tuple(p.strip() for p in args.profiles.split(",")) if args.profiles else ()
+    if not selection:
+        sys.stderr.write(
+            "installer: project install needs an explicit profile (no implicit full)\n"
+        )
+        return 2
+    resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
+
+    # A kit is selected iff at least one of its refs' dest_relpaths landed in
+    # the resolved PROJECT scope.
+    project_dests = {r.dest_relpath for r in resolved.included.get(Scope.PROJECT, ())}
+    selected_kits = {
+        kit_name_of(sk.selector_key) for sk in staged_kits if sk.ref.dest_relpath in project_dests
+    }
+    adapters = kit_adapters(kits_root, project_root, selected=selected_kits)
+
+    receipt_path = project_root / ".agents-config" / "install-receipt.json"
+    lock_cm: AbstractContextManager[None] = (
+        nullcontext() if args.dry_run else receipt_lock(receipt_path.with_suffix(".lock"))
+    )
+    counters: dict[str, Counters] = {}
+    plugin_outcomes: dict[str, list[InstallOutcome]] = {}
+    try:
+        with lock_cm:
+            prior_read = read_receipt(receipt_path)
+            prior = (
+                prior_read.receipt
+                if prior_read.status is ReadStatus.OK and prior_read.receipt is not None
+                else Receipt()
+            )
+            try:
+                _merge_into(
+                    counters,
+                    install_plugin_routes(
+                        adapters,
+                        home=project_root,
+                        io=io,
+                        dry_run=args.dry_run,
+                        auto_yes=args.yes,
+                        outcomes_by_plugin=plugin_outcomes,
+                    ),
+                )
+            except ConsentRequiredError:
+                return 1
+            if not args.dry_run:
+                record_receipt(
+                    receipt_path,
+                    prior=prior,
+                    dest_roots={},
+                    home=project_root,
+                    tool_outcomes={},
+                    plugin_outcomes=plugin_outcomes,
+                    pruned_paths=set(),
+                    relinquished_paths=set(),
+                )
+    except ReceiptLockBusy:
+        io.err(f"another install holds the project receipt lock at {receipt_path}")
+        return 1
+
+    render_summary(
+        counters,
+        tools=[],
+        plugins=sorted(plugin_outcomes),
+        all_tools=[],
+        all_plugins=[],
         verbose=args.verbose,
         io=io,
     )

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import tomllib
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -153,6 +154,7 @@ def main(
     home: Path | None = None,
     io: IOPort | None = None,
     repo_root: Path | None = None,
+    cwd: Path | None = None,
 ) -> int:
     """CLI entry point. Runs the installer, catching Ctrl-C at the boundary so an
     interactive abort (e.g. at an overwrite prompt) exits cleanly with code 130 and
@@ -160,10 +162,25 @@ def main(
     Every other exit — argparse's ``SystemExit``, the guarded config-error returns —
     passes through unchanged."""
     try:
-        return _run(argv, home=home, io=io, repo_root=repo_root)
+        return _run(argv, home=home, io=io, repo_root=repo_root, cwd=cwd)
     except KeyboardInterrupt:
         sys.stderr.write("\nAborted.\n")
         return 130
+
+
+def _has_install_table(project_config_path: Path) -> bool:
+    """True iff ``project_config_path`` exists, parses as TOML, and has an
+    ``[install]`` table. Best-effort: any read/parse failure counts as "no
+    table" rather than raising — this feeds a passive, suggest-only notice
+    on the USER path, which must never fail a real install over a malformed
+    or unreadable file it does not own."""
+    if not project_config_path.is_file():
+        return False
+    try:
+        data = tomllib.loads(project_config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return False
+    return isinstance(data.get("install"), dict)
 
 
 def _run(
@@ -172,10 +189,12 @@ def _run(
     home: Path | None = None,
     io: IOPort | None = None,
     repo_root: Path | None = None,
+    cwd: Path | None = None,
 ) -> int:
     args = _build_parser().parse_args(argv)
     resolved_home = home if home is not None else Path.home()
     resolved_repo_root = repo_root if repo_root is not None else _REPO_ROOT
+    resolved_cwd = cwd if cwd is not None else Path.cwd()
 
     if args.profiles is not None and args.project is None:
         sys.stderr.write("installer: --profiles requires --project in this version\n")
@@ -445,6 +464,20 @@ def _run(
         verbose=args.verbose,
         io=io,
     )
+
+    # Passive, suggest-only notice for the USER path only (a --project run
+    # returns earlier via _run_project and never reaches here): if cwd looks
+    # like a project (a .beads/ dir, or a project-config.toml carrying an
+    # [install] table), point at the project-scoped install without acting
+    # on it. No scan beyond cwd itself.
+    if (resolved_cwd / ".beads").is_dir() or _has_install_table(
+        resolved_cwd / "project-config.toml"
+    ):
+        io.info(
+            "This looks like a project. To install project-scoped content "
+            "here: install.sh --project ."
+        )
+
     return 0
 
 

--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -7,7 +7,13 @@ from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from installer.config import Config, resolve_plugins, resolve_plugins_root, resolve_tools
+from installer.config import (
+    Config,
+    read_project_profiles,
+    resolve_plugins,
+    resolve_plugins_root,
+    resolve_tools,
+)
 from installer.core.consent import ConsentRequiredError
 from installer.core.dump import dump_plan
 from installer.core.installignore import load_installignore
@@ -464,12 +470,17 @@ def _run_project(
         universe.setdefault(key, []).extend(refs)
 
     manifest = load_manifest(repo_root / "profiles.toml")
-    selection = tuple(p.strip() for p in args.profiles.split(",")) if args.profiles else ()
-    if not selection:
-        sys.stderr.write(
-            "installer: project install needs an explicit profile (no implicit full)\n"
-        )
-        return 2
+    if args.profiles:
+        selection: tuple[str, ...] = tuple(p.strip() for p in args.profiles.split(","))
+    else:
+        persisted = read_project_profiles(project_root)
+        if persisted is not None:
+            selection = persisted
+        else:
+            sys.stderr.write(
+                "installer: project install needs an explicit profile (no implicit full)\n"
+            )
+            return 2
     resolved = resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.PROJECT}))
 
     # A kit is selected iff at least one of its refs' dest_relpaths landed in

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -99,8 +99,6 @@ def read_project_profiles(project_root: Path) -> tuple[str, ...] | None:
     missing-file convention. Raises ``ValueError`` only on a genuine contract
     violation: a present ``[install]`` table whose ``profiles`` is not a list
     of strings.
-
-    Read-only: this task does not add a writer (that is S2 Task 13).
     """
     path = project_root / "project-config.toml"
     if not path.is_file():

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import tomllib
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+
+import tomli_w
 
 from installer.core.model import Tool
 from installer.plugins.base import PluginAdapter
@@ -121,6 +123,31 @@ def read_project_profiles(project_root: Path) -> tuple[str, ...] | None:
         raise ValueError(msg)  # single call-site; subclass not justified
 
     return tuple(profiles)
+
+
+def write_project_profiles(project_root: Path, profiles: Sequence[str]) -> None:
+    """Persist ``profiles`` to ``<project_root>/project-config.toml``'s
+    ``[install].profiles``, the write-side counterpart to
+    ``read_project_profiles``.
+
+    Merges into any existing file rather than clobbering it: every other
+    top-level table (e.g. ``[merge-policy]``) survives untouched, and only
+    the ``install.profiles`` key is set. A missing file is created fresh with
+    just the ``[install]`` table.
+    """
+    path = project_root / "project-config.toml"
+    data: dict[str, object] = {}
+    if path.is_file():
+        data = dict(tomllib.loads(path.read_text(encoding="utf-8")))
+
+    existing_install = data.get("install")
+    install: dict[str, object] = (
+        dict(existing_install) if isinstance(existing_install, dict) else {}
+    )
+    install["profiles"] = list(profiles)
+    data["install"] = install
+
+    path.write_text(tomli_w.dumps(data), encoding="utf-8")
 
 
 def resolve_plugins_root(repo_root: Path, env: Mapping[str, str]) -> Path:

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -90,6 +90,24 @@ def resolve_plugins(
     return tuple(discovered[name] for name in seen)
 
 
+def parse_profiles_csv(csv: str) -> tuple[str, ...]:
+    """Translate the ``--profiles=`` CLI value into a resolved profile-name tuple.
+
+    Split on commas, strip whitespace, reject empty names (a stray comma such as
+    ``beads-kit,`` would otherwise resolve as an unknown empty profile), and
+    dedupe preserving first occurrence and user order. Mirrors ``resolve_tools``.
+    Raises ``ValueError`` on an empty name. The caller only invokes this for a
+    truthy ``--profiles`` value, so an all-empty value cannot reach here.
+    """
+    seen: dict[str, None] = {}
+    for raw in csv.split(","):
+        name = raw.strip()
+        if not name:
+            raise ValueError("--profiles contains an empty profile name (check for stray commas)")  # noqa: TRY003  # single call-site; subclass not justified
+        seen.setdefault(name, None)
+    return tuple(seen.keys())
+
+
 def read_project_profiles(project_root: Path) -> tuple[str, ...] | None:
     """Read the persisted profile selection from ``<project_root>/project-config.toml``.
 

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tomllib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -85,6 +86,41 @@ def resolve_plugins(
             raise UnknownPluginError(name, valid)
         seen.setdefault(name, None)
     return tuple(discovered[name] for name in seen)
+
+
+def read_project_profiles(project_root: Path) -> tuple[str, ...] | None:
+    """Read the persisted profile selection from ``<project_root>/project-config.toml``.
+
+    Returns ``tuple(data["install"]["profiles"])`` when present, else ``None``
+    — absence of the file or of the ``[install]`` table is a valid state (no
+    persisted selection yet), not an error, mirroring ``load_installer_toml``'s
+    missing-file convention. Raises ``ValueError`` only on a genuine contract
+    violation: a present ``[install]`` table whose ``profiles`` is not a list
+    of strings.
+
+    Read-only: this task does not add a writer (that is S2 Task 13).
+    """
+    path = project_root / "project-config.toml"
+    if not path.is_file():
+        return None
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    install = data.get("install")
+    if install is None:
+        return None
+    if not isinstance(install, dict):
+        got = type(install).__name__
+        msg = f"project-config.toml: [install] must be a table, got {got}"
+        raise ValueError(msg)  # noqa: TRY004  # ValueError is the documented config-error contract
+
+    profiles = install.get("profiles")
+    if profiles is None:
+        return None
+    if not isinstance(profiles, list) or not all(isinstance(p, str) for p in profiles):
+        msg = "project-config.toml: [install] profiles must be a list of strings"
+        raise ValueError(msg)  # single call-site; subclass not justified
+
+    return tuple(profiles)
 
 
 def resolve_plugins_root(repo_root: Path, env: Mapping[str, str]) -> Path:

--- a/packages/installer/src/installer/config.py
+++ b/packages/installer/src/installer/config.py
@@ -114,15 +114,21 @@ def read_project_profiles(project_root: Path) -> tuple[str, ...] | None:
     Returns ``tuple(data["install"]["profiles"])`` when present, else ``None``
     — absence of the file or of the ``[install]`` table is a valid state (no
     persisted selection yet), not an error, mirroring ``load_installer_toml``'s
-    missing-file convention. Raises ``ValueError`` only on a genuine contract
-    violation: a present ``[install]`` table whose ``profiles`` is not a list
-    of strings.
+    missing-file convention. Raises ``ValueError`` on any config error: a present
+    ``[install]`` table whose ``profiles`` is not a list of strings, or a file
+    that exists but is unreadable/undecodable/malformed (``OSError`` and TOML/
+    Unicode decode errors are normalized to ``ValueError`` so the single caller
+    guard surfaces one clean diagnostic instead of a traceback).
     """
     path = project_root / "project-config.toml"
     if not path.is_file():
         return None
 
-    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:  # ValueError covers TOMLDecodeError + UnicodeDecodeError
+        msg = f"project-config.toml could not be read: {exc}"
+        raise ValueError(msg) from exc  # documented config-error contract
     install = data.get("install")
     if install is None:
         return None

--- a/packages/installer/src/installer/core/kits.py
+++ b/packages/installer/src/installer/core/kits.py
@@ -29,9 +29,9 @@ def stage_kits(kits_root: Path) -> list[StagedKitRef]:
     if not kits_root.is_dir():
         return []
     out: list[StagedKitRef] = []
-    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir() and not p.is_symlink()):
         name = kit_dir.name
-        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file() and not p.is_symlink()):
             dest_relpath = f.relative_to(kit_dir)
             selector = f"kits/{name}/{dest_relpath.as_posix()}"
             out.append(
@@ -62,9 +62,9 @@ def kit_routes(kits_root: Path, project_root: Path) -> dict[str, list[PluginRout
     result: dict[str, list[PluginRoute]] = {}
     if not kits_root.is_dir():
         return result
-    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir() and not p.is_symlink()):
         routes: list[PluginRoute] = []
-        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file() and not p.is_symlink()):
             rel = f.relative_to(kit_dir)
             routes.append(
                 PluginRoute(

--- a/packages/installer/src/installer/core/kits.py
+++ b/packages/installer/src/installer/core/kits.py
@@ -51,25 +51,27 @@ def kit_universe(staged: Iterable[StagedKitRef]) -> dict[str, list[UniverseRef]]
 
 
 def kit_routes(kits_root: Path, project_root: Path) -> dict[str, list[PluginRoute]]:
-    """Per kit, one PluginRoute per (destination directory x exec-bit). Mirrors
-    PluginAdapter.routes(home) but grouped by kit name for per-kit owners."""
+    """Per kit, one PluginRoute per file: ``glob`` is the file's exact name and
+    the route carries that file's own exec bit. A single ``glob='*'`` route per
+    (dir x exec-bit) group would re-glob the whole directory (``sync_routes``
+    globs ``source_dir`` for each route), so a directory mixing executable and
+    non-executable files would install every file once per group — twice, each
+    with the wrong mode. Per-file routes install each file exactly once with its
+    correct permission bit. Mirrors ``PluginAdapter.routes(home)`` but grouped by
+    kit name for per-kit owners."""
     result: dict[str, list[PluginRoute]] = {}
     if not kits_root.is_dir():
         return result
     for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
-        groups: dict[tuple[Path, bool], list[str]] = {}
+        routes: list[PluginRoute] = []
         for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
             rel = f.relative_to(kit_dir)
-            execbit = bool(f.stat().st_mode & 0o111)
-            groups.setdefault((rel.parent, execbit), []).append(rel.suffix)
-        routes: list[PluginRoute] = []
-        for (destdir, execbit), _suffixes in groups.items():
             routes.append(
                 PluginRoute(
-                    source_dir=kit_dir / destdir,
-                    dest_dir=project_root / destdir,
-                    glob="*",
-                    executable=execbit,
+                    source_dir=kit_dir / rel.parent,
+                    dest_dir=project_root / rel.parent,
+                    glob=f.name,
+                    executable=bool(f.stat().st_mode & 0o111),
                 )
             )
         result[kit_dir.name] = routes

--- a/packages/installer/src/installer/core/kits.py
+++ b/packages/installer/src/installer/core/kits.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from installer.core.profiles import UniverseRef
+
+
+def kit_name_of(selector_key: str) -> str:
+    """The kit name is the segment directly under ``kits/`` — the single source of
+    identity shared by the selector side and the receipt/prune owner (``kit:<name>``)."""
+    parts = selector_key.split("/")
+    if len(parts) < 2 or parts[0] != "kits":
+        raise ValueError(f"not a kit selector key: {selector_key!r}")  # noqa: TRY003  # single call-site
+    return parts[1]
+
+
+@dataclass(frozen=True, slots=True)
+class StagedKitRef:
+    selector_key: str  # kits/<kit>/<subpath> — for the resolver universe
+    ref: UniverseRef  # tool=None, dest_relpath=<subpath> (verbatim tree-mirror)
+
+
+def stage_kits(kits_root: Path) -> list[StagedKitRef]:
+    """Walk ``src/kits/<kit>/**``; one StagedKitRef per file. dest_relpath is verbatim
+    (no suffix strip); selector_key is source-relative (``kits/<kit>/<subpath>``)."""
+    if not kits_root.is_dir():
+        return []
+    out: list[StagedKitRef] = []
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+        name = kit_dir.name
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+            dest_relpath = f.relative_to(kit_dir)
+            selector = f"kits/{name}/{dest_relpath.as_posix()}"
+            out.append(
+                StagedKitRef(
+                    selector_key=selector,
+                    ref=UniverseRef(tool=None, dest_relpath=dest_relpath),
+                )
+            )
+    return out
+
+
+def kit_universe(staged: Iterable[StagedKitRef]) -> dict[str, list[UniverseRef]]:
+    universe: dict[str, list[UniverseRef]] = {}
+    for sk in staged:
+        universe.setdefault(sk.selector_key, []).append(sk.ref)
+    return universe

--- a/packages/installer/src/installer/core/kits.py
+++ b/packages/installer/src/installer/core/kits.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from installer.core.profiles import UniverseRef
+from installer.plugins.base import PluginRoute
 
 
 def kit_name_of(selector_key: str) -> str:
@@ -47,3 +48,64 @@ def kit_universe(staged: Iterable[StagedKitRef]) -> dict[str, list[UniverseRef]]
     for sk in staged:
         universe.setdefault(sk.selector_key, []).append(sk.ref)
     return universe
+
+
+def kit_routes(kits_root: Path, project_root: Path) -> dict[str, list[PluginRoute]]:
+    """Per kit, one PluginRoute per (destination directory x exec-bit). Mirrors
+    PluginAdapter.routes(home) but grouped by kit name for per-kit owners."""
+    result: dict[str, list[PluginRoute]] = {}
+    if not kits_root.is_dir():
+        return result
+    for kit_dir in sorted(p for p in kits_root.iterdir() if p.is_dir()):
+        groups: dict[tuple[Path, bool], list[str]] = {}
+        for f in sorted(p for p in kit_dir.rglob("*") if p.is_file()):
+            rel = f.relative_to(kit_dir)
+            execbit = bool(f.stat().st_mode & 0o111)
+            groups.setdefault((rel.parent, execbit), []).append(rel.suffix)
+        routes: list[PluginRoute] = []
+        for (destdir, execbit), _suffixes in groups.items():
+            routes.append(
+                PluginRoute(
+                    source_dir=kit_dir / destdir,
+                    dest_dir=project_root / destdir,
+                    glob="*",
+                    executable=execbit,
+                )
+            )
+        result[kit_dir.name] = routes
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class _KitRouteAdapter:
+    """A selected kit presented as a PluginAdapter so it rides the existing
+    install_plugin_routes / prune_pipeline / receipt machinery unchanged."""
+
+    _name: str  # "kit:<name>"
+    _source_path: Path  # the kit source dir
+    _routes: tuple[PluginRoute, ...]
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def source_path(self) -> Path:
+        return self._source_path
+
+    def is_detected(self, home: Path) -> bool:  # noqa: ARG002 — always active (explicitly selected)
+        return True
+
+    def routes(self, home: Path) -> tuple[PluginRoute, ...]:  # noqa: ARG002 — dest baked in
+        return self._routes
+
+
+def kit_adapters(
+    kits_root: Path, project_root: Path, *, selected: set[str]
+) -> list[_KitRouteAdapter]:
+    routes_by_kit = kit_routes(kits_root, project_root)
+    return [
+        _KitRouteAdapter(_name=f"kit:{name}", _source_path=kits_root / name, _routes=tuple(routes))
+        for name, routes in routes_by_kit.items()
+        if name in selected
+    ]

--- a/packages/installer/src/installer/core/profiles.py
+++ b/packages/installer/src/installer/core/profiles.py
@@ -223,7 +223,7 @@ class UniverseRef:
     """One staged item's tool + destination path, indexed under its
     normalized selector key by `project_universe`."""
 
-    tool: Tool
+    tool: Tool | None  # None => tool-agnostic kit ref; materializes at the project root
     dest_relpath: Path
 
 
@@ -444,7 +444,15 @@ def resolve(
         raise ProfilesError(msg)
 
     final_included = {
-        scope: tuple(sorted(refs, key=lambda r: (r.tool.value, r.dest_relpath.as_posix())))
+        scope: tuple(
+            sorted(
+                refs,
+                key=lambda r: (
+                    r.tool.value if r.tool is not None else "",
+                    r.dest_relpath.as_posix(),
+                ),
+            )
+        )
         for scope, refs in included.items()
     }
     return ResolvedPlan(included=final_included, dropped_counts=dropped_counts)

--- a/packages/installer/src/installer/tools/base.py
+++ b/packages/installer/src/installer/tools/base.py
@@ -23,6 +23,8 @@ class ToolAdapter(Protocol):
 
     def scoped_namespaces(self) -> tuple[str, ...]: ...  # pragma: no cover
 
+    def project_namespaces(self) -> tuple[str, ...]: ...  # pragma: no cover
+
     def should_install_namespace(self, namespace: str, source: str) -> bool: ...  # pragma: no cover
 
     def post_staging_transforms(

--- a/packages/installer/src/installer/tools/claude.py
+++ b/packages/installer/src/installer/tools/claude.py
@@ -31,6 +31,9 @@ class ClaudeAdapter:
     def scoped_namespaces(self) -> tuple[str, ...]:
         return namespaces.TOOL_SCOPED
 
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ("skills", "agents", "commands")
+
     def should_install_namespace(
         self,
         namespace: str,  # noqa: ARG002  # protocol parameter; ClaudeAdapter accepts uniformly

--- a/packages/installer/src/installer/tools/codex.py
+++ b/packages/installer/src/installer/tools/codex.py
@@ -25,6 +25,9 @@ class CodexAdapter:
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ()
 
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ()
+
     def should_install_namespace(
         self,
         namespace: str,  # noqa: ARG002  # protocol parameter; CodexAdapter accepts uniformly

--- a/packages/installer/src/installer/tools/gemini.py
+++ b/packages/installer/src/installer/tools/gemini.py
@@ -89,6 +89,9 @@ class GeminiAdapter:
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ()
 
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ()
+
     def should_install_namespace(
         self,
         namespace: str,  # noqa: ARG002  # protocol parameter; GeminiAdapter accepts uniformly

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -35,6 +35,9 @@ class OpenCodeAdapter:
     def scoped_namespaces(self) -> tuple[str, ...]:
         return ()
 
+    def project_namespaces(self) -> tuple[str, ...]:
+        return ()
+
     def should_install_namespace(self, namespace: str, source: str) -> bool:
         # Skip the shared agents/ namespace: OpenCode's agent frontmatter format
         # differs from the shared format (see OPENCODE-EXTENSIONS.md).

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -141,6 +141,84 @@ def test_project_persisted_profiles_resolved_without_explicit_flag(tmp_path: Pat
     assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
 
 
+def _hermetic_repo_with_project_tool_profile(tmp_path: Path) -> Path:
+    """``_hermetic_repo`` plus a hermetic ``profiles.toml`` (independent of the
+    real repo-root one — no beads kit needed) carrying one profile,
+    ``proj-skill``, that routes the shared ``skills/foo`` namespace item to
+    project scope via an explicit include-entry override. Also seeds a real
+    ``skills/foo`` shared skill dir so it stages as a ``DIR`` item for every
+    tool (shared namespaces stage for all tools regardless of
+    ``scoped_namespaces()`` — see ``core/staging.py`` Phase 2)."""
+    repo = _hermetic_repo(tmp_path)
+    skill_dir = repo / "src" / "user" / ".agents" / "skills" / "foo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(b"foo skill\n")
+    (repo / "profiles.toml").write_text(
+        "schema = 1\n"
+        "\n"
+        "[scopes]\n"
+        '"instructions" = "user"\n'
+        '"settings" = "user"\n'
+        '"skills/**" = "user"\n'
+        '"agents/**" = "user"\n'
+        '"rules/**" = "user"\n'
+        "\n"
+        "[profiles.proj-skill]\n"
+        'include = [{select="skills/foo", scope="project"}]\n',
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_project_tool_ref_writes_under_project_dest(tmp_path: Path) -> None:
+    """A project-scoped tool ref (skills/foo, scope="project") for the sole
+    active tool (claude, whose project_namespaces() includes "skills") writes
+    under <project>/.claude/skills/foo and is recorded in the receipt under
+    the claude dest root — the tool tail, not the kit path."""
+    repo = _hermetic_repo_with_project_tool_profile(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=proj-skill", "--tools=claude", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (project / ".claude" / "skills" / "foo" / "SKILL.md").read_bytes() == b"foo skill\n"
+    receipt = project / ".agents-config" / "install-receipt.json"
+    assert receipt.is_file()
+    assert "claude" in receipt.read_text()
+    # Never wrote to user space.
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_project_tool_ref_outside_project_namespaces_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The same profile selected for codex — whose project_namespaces() is ()
+    — must fail validation naming the tool and namespace, never silently
+    install or silently drop the ref."""
+    repo = _hermetic_repo_with_project_tool_profile(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=proj-skill", "--tools=codex", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "codex" in err
+    assert "skills" in err
+    assert not (project / ".codex").exists()
+
+
 def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
     """A plain user install (no --project) must stay byte-identical once
     main()'s resolver pass (S2 Task 9) is wired in ahead of install_pipeline.

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -232,6 +232,26 @@ def test_project_profiles_trailing_comma_rejected_cleanly(
     assert not (project / ".beads").exists()
 
 
+def test_project_empty_profiles_flag_rejected_not_treated_as_omitted(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An explicit --profiles= (empty string) is routed through parse_profiles_csv
+    and rejected cleanly, not silently treated as if the flag were omitted."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    assert "empty profile name" in capsys.readouterr().err
+
+
 def test_project_corrupt_receipt_left_untouched_install_proceeds(tmp_path: Path) -> None:
     """A CORRUPT project receipt fails closed (mirrors the user path): the install
     still proceeds, but the receipt is NOT overwritten — overwriting would erase

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -142,6 +142,71 @@ def test_project_persisted_profiles_resolved_without_explicit_flag(tmp_path: Pat
     assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
 
 
+def test_project_persisted_empty_profiles_list_is_not_implicit_full(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A persisted but EMPTY ``[install] profiles = []`` must NOT be read as an
+    implicit "full" selection — it hits the no-implicit-full guard, same as no
+    persisted config at all. (resolve() treats an empty selection as the full
+    profile, so this guards against a silent full project install.)"""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "project-config.toml").write_text("[install]\nprofiles = []\n", encoding="utf-8")
+
+    rc = main(
+        ["--project", str(project), "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    assert "no implicit full" in capsys.readouterr().err
+    assert not (project / ".beads").exists()
+
+
+def test_project_unknown_profile_exits_cleanly_without_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An unknown --profiles name surfaces resolve()'s ProfilesError as a clean
+    exit-2 diagnostic, not an uncaught traceback."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=does-not-exist", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    assert capsys.readouterr().err.startswith("installer:")
+
+
+def test_project_malformed_persisted_config_exits_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A persisted ``[install] profiles`` that is not a list of strings exits 2
+    with a diagnostic instead of raising ValueError out of read_project_profiles."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "project-config.toml").write_text("[install]\nprofiles = 42\n", encoding="utf-8")
+
+    rc = main(
+        ["--project", str(project), "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    assert "malformed project-config.toml" in capsys.readouterr().err
+
+
 def _hermetic_repo_with_project_tool_profile(tmp_path: Path) -> Path:
     """``_hermetic_repo`` plus a hermetic ``profiles.toml`` (independent of the
     real repo-root one — no beads kit needed) carrying one profile,

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -1,0 +1,64 @@
+"""Tests for the --project/--profiles guard rails (Task 7 of the S2 plan).
+
+This version adds only the argparse flags and two early validation guards in
+_run(); no project-scoped install behavior exists yet. Each test pins one
+guard's coded decision (exit code + message), not argparse machinery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from installer.cli import main
+from installer.core.io_port import ScriptedIO
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _write_installignore(repo: Path) -> None:
+    """Mirror the real repo-root .installignore so cli.main's up-front fail-fast
+    load finds it. Copied from the REAL manifest (not retyped) so it cannot
+    drift from it. See test_cli_smoke._write_installignore."""
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".installignore").write_text(
+        (_REPO_ROOT / ".installignore").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def _hermetic_repo(tmp_path: Path) -> Path:
+    """A minimal source repo: one shared template so a Claude plan is
+    non-empty, plus empty tool-root dirs the adapters expect. Mirrors
+    test_cli_smoke._hermetic_repo."""
+    repo = tmp_path / "repo"
+    shared = repo / "src" / "user" / ".agents"
+    shared.mkdir(parents=True)
+    (shared / "INSTRUCTIONS.md.template").write_bytes(b"shared laws\n")
+    for tool in ("claude", "codex", "gemini", "opencode"):
+        (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
+    _write_installignore(repo)
+    return repo
+
+
+def test_profiles_without_project_errors(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        ["--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=_hermetic_repo(tmp_path),
+    )
+    assert rc == 2
+    assert "--profiles requires --project" in capsys.readouterr().err
+
+
+def test_project_path_missing_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(
+        ["--project", str(tmp_path / "nope"), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=_hermetic_repo(tmp_path),
+    )
+    assert rc == 2
+    assert "nope" in capsys.readouterr().err

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -6,6 +6,7 @@ guard's coded decision (exit code + message), not argparse machinery."""
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -278,3 +279,88 @@ def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
 
     assert rc == 0
     assert (tmp_path / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"
+
+
+def test_project_install_persists_profiles_then_bare_rerun_reinstalls(tmp_path: Path) -> None:
+    """A successful ``--project p --profiles=beads-kit`` install writes
+    <p>/project-config.toml's [install].profiles; a subsequent BARE
+    ``--project p`` (no --profiles) then reads that persisted selection
+    (Task 10's read_project_profiles path) and reinstalls beads-kit."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc == 0
+
+    config_path = project / "project-config.toml"
+    assert config_path.is_file()
+    data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert data["install"]["profiles"] == ["beads-kit"]
+
+    (project / ".beads" / "PRIME.md").unlink()
+
+    rc2 = main(
+        ["--project", str(project), "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc2 == 0
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
+
+
+def test_project_dry_run_writes_no_project_config_or_receipt(tmp_path: Path) -> None:
+    """``--project p --profiles=beads-kit --dry-run`` must not write
+    project-config.toml or the receipt — dry-run is a no-op on disk."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes", "--dry-run"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert not (project / "project-config.toml").exists()
+    assert not (project / ".agents-config" / "install-receipt.json").exists()
+
+
+def test_project_install_preserves_other_tables_in_project_config(tmp_path: Path) -> None:
+    """A pre-existing project-config.toml with an unrelated [merge-policy]
+    table must keep that table intact after ``--project p --profiles=beads-kit``
+    sets [install].profiles."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    config_path = project / "project-config.toml"
+    config_path.write_text('[merge-policy]\nmerge-authorization = "explicit"\n', encoding="utf-8")
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert data["merge-policy"] == {"merge-authorization": "explicit"}
+    assert data["install"]["profiles"] == ["beads-kit"]

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -62,3 +62,36 @@ def test_project_path_missing_errors(tmp_path: Path, capsys: pytest.CaptureFixtu
     )
     assert rc == 2
     assert "nope" in capsys.readouterr().err
+
+
+def _hermetic_repo_with_profiles(tmp_path: Path) -> Path:
+    """``_hermetic_repo`` plus the real ``profiles.toml`` (needed to resolve
+    ``beads-kit``) and the beads kit content the tracer installs."""
+    repo = _hermetic_repo(tmp_path)
+    (repo / "profiles.toml").write_text(
+        (_REPO_ROOT / "profiles.toml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    return repo
+
+
+def test_project_beads_kit_writes_prime_and_receipt(tmp_path: Path) -> None:
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
+    receipt = project / ".agents-config" / "install-receipt.json"
+    assert receipt.is_file()
+    assert "kit:beads" in receipt.read_text()
+    assert not (tmp_path / ".beads").exists()

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -340,6 +340,81 @@ def test_project_dry_run_writes_no_project_config_or_receipt(tmp_path: Path) -> 
     assert not (project / ".agents-config" / "install-receipt.json").exists()
 
 
+def _hermetic_repo_with_two_kits(tmp_path: Path) -> Path:
+    """``_hermetic_repo`` plus a hermetic ``profiles.toml`` carrying two
+    project-scoped kits — ``beads`` and ``other`` — each behind its own
+    profile, so a run can select one while the other's prior receipt entry
+    becomes prunable."""
+    repo = _hermetic_repo(tmp_path)
+    beads_kit = repo / "src" / "kits" / "beads" / ".beads"
+    beads_kit.mkdir(parents=True)
+    (beads_kit / "PRIME.md").write_bytes(b"beads prime\n")
+    other_kit = repo / "src" / "kits" / "other" / ".other"
+    other_kit.mkdir(parents=True)
+    (other_kit / "OTHER.md").write_bytes(b"other kit\n")
+    (repo / "profiles.toml").write_text(
+        "schema = 1\n"
+        "\n"
+        "[scopes]\n"
+        '"instructions" = "user"\n'
+        '"settings" = "user"\n'
+        '"kits/**" = "project"\n'
+        "\n"
+        "[profiles.beads-kit]\n"
+        'include = ["kits/beads/**"]\n'
+        "\n"
+        "[profiles.other-kit]\n"
+        'include = ["kits/other/**"]\n',
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_project_prune_keeps_selected_kit_removes_deselected_kit_orphan(
+    tmp_path: Path,
+) -> None:
+    """A still-selected kit's files survive --prune; a deselected kit's prior
+    receipt entry becomes an orphan and is removed. User space untouched."""
+    repo = _hermetic_repo_with_two_kits(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc == 0
+    prime = project / ".beads" / "PRIME.md"
+    assert prime.read_bytes() == b"beads prime\n"
+
+    # Still selected, --prune: PRIME.md must NOT be deleted.
+    rc2 = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes", "--prune"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc2 == 0
+    assert prime.is_file()
+
+    # Deselect beads-kit in favor of other-kit, --prune: PRIME.md orphaned and removed.
+    rc3 = main(
+        ["--project", str(project), "--profiles=other-kit", "--yes", "--prune"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+    assert rc3 == 0
+    assert not prime.exists()
+    assert (project / ".other" / "OTHER.md").read_bytes() == b"other kit\n"
+
+    # User space (home) never touched.
+    assert not (tmp_path / ".beads").exists()
+    assert not (tmp_path / ".agents-config").exists()
+
+
 def test_project_install_preserves_other_tables_in_project_config(tmp_path: Path) -> None:
     """A pre-existing project-config.toml with an unrelated [merge-policy]
     table must keep that table intact after ``--project p --profiles=beads-kit``

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -439,3 +439,76 @@ def test_project_install_preserves_other_tables_in_project_config(tmp_path: Path
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert data["merge-policy"] == {"merge-authorization": "explicit"}
     assert data["install"]["profiles"] == ["beads-kit"]
+
+
+def _suggestion_lines(io: ScriptedIO) -> list[str]:
+    return [
+        e.message
+        for e in io.transcript
+        if e.channel == "info" and "looks like a project" in e.message
+    ]
+
+
+def test_user_run_with_beads_dir_in_cwd_suggests_project_install(tmp_path: Path) -> None:
+    """A USER run (no --project) whose cwd contains a .beads/ dir prints
+    exactly one suggestion line pointing at --project ."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    cwd = tmp_path / "proj"
+    (cwd / ".beads").mkdir(parents=True)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--tools=claude", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+        cwd=cwd,
+    )
+
+    assert rc == 0
+    assert len(_suggestion_lines(io)) == 1
+
+
+def test_user_run_with_plain_cwd_suggests_nothing(tmp_path: Path) -> None:
+    """A USER run whose cwd has neither .beads/ nor a project-config.toml
+    [install] table prints no suggestion line."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    cwd = tmp_path / "plain"
+    cwd.mkdir()
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--tools=claude", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+        cwd=cwd,
+    )
+
+    assert rc == 0
+    assert _suggestion_lines(io) == []
+
+
+def test_project_run_never_suggests_even_with_beads_dir_in_cwd(tmp_path: Path) -> None:
+    """A --project run prints no suggestion line, even when cwd (a DIFFERENT
+    directory than the project target) looks like a project."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    cwd = tmp_path / "cwd_looks_like_project"
+    (cwd / ".beads").mkdir(parents=True)
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+        cwd=cwd,
+    )
+
+    assert rc == 0
+    assert _suggestion_lines(io) == []

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -219,6 +219,45 @@ def test_project_tool_ref_outside_project_namespaces_errors(
     assert not (project / ".codex").exists()
 
 
+def test_project_kit_selector_scoped_to_user_errors_pre_resolve(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Kits are project-only. A profile that routes a kit selector to a
+    non-project scope must fail BEFORE resolve() runs — resolve() would
+    silently drop the kit ref into the USER scope's counts, discarding its
+    identity, so only a pre-resolve check can name the offending selector."""
+    repo = _hermetic_repo(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    (repo / "profiles.toml").write_text(
+        "schema = 1\n"
+        "\n"
+        "[scopes]\n"
+        '"instructions" = "user"\n'
+        '"settings" = "user"\n'
+        "\n"
+        "[profiles.bad-kit-scope]\n"
+        'include = [{select="kits/beads/**", scope="user"}, {select="**", scope="user"}]\n',
+        encoding="utf-8",
+    )
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=bad-kit-scope", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "kits/beads/**" in err
+    assert not (project / ".beads").exists()
+    assert not (tmp_path / ".beads").exists()
+
+
 def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
     """A plain user install (no --project) must stay byte-identical once
     main()'s resolver pass (S2 Task 9) is wired in ahead of install_pipeline.

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -97,6 +97,50 @@ def test_project_beads_kit_writes_prime_and_receipt(tmp_path: Path) -> None:
     assert not (tmp_path / ".beads").exists()
 
 
+def test_project_no_profiles_no_persisted_config_errors_no_implicit_full(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No --profiles and no project-config.toml: still the exit-2 guard."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no implicit full" in err
+
+
+def test_project_persisted_profiles_resolved_without_explicit_flag(tmp_path: Path) -> None:
+    """No --profiles, but <project>/project-config.toml persists a selection:
+    that selection resolves and installs, exactly as if passed via --profiles."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "project-config.toml").write_text(
+        '[install]\nprofiles = ["beads-kit"]\n', encoding="utf-8"
+    )
+
+    rc = main(
+        ["--project", str(project), "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"
+
+
 def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
     """A plain user install (no --project) must stay byte-identical once
     main()'s resolver pass (S2 Task 9) is wired in ahead of install_pipeline.

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -95,3 +95,25 @@ def test_project_beads_kit_writes_prime_and_receipt(tmp_path: Path) -> None:
     assert receipt.is_file()
     assert "kit:beads" in receipt.read_text()
     assert not (tmp_path / ".beads").exists()
+
+
+def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
+    """A plain user install (no --project) must stay byte-identical once
+    main()'s resolver pass (S2 Task 9) is wired in ahead of install_pipeline.
+
+    An empty CLI profile selection resolves to the "full" profile
+    (`include = ["**"]` in profiles.toml), so every staged item matches and
+    filter_plan_to_scope narrows each tool plan to itself — a no-op. This
+    pins that no-op end to end against the real repo-root profiles.toml
+    (needed for the resolver to run at all)."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+
+    rc = main(
+        ["--tools=claude", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (tmp_path / ".claude" / "INSTRUCTIONS.md").read_bytes() == b"shared laws\n"

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -1,8 +1,11 @@
-"""Tests for the --project/--profiles guard rails (Task 7 of the S2 plan).
+"""Tests for project-scoped install (the ``--project``/``--profiles`` flow).
 
-This version adds only the argparse flags and two early validation guards in
-_run(); no project-scoped install behavior exists yet. Each test pins one
-guard's coded decision (exit code + message), not argparse machinery."""
+Covers the CLI guard rails (flag validation, project-path + kit-scope guards,
+clean error exits) and end-to-end project installs: kit materialization,
+project-local receipt, corrupt-receipt fail-close, profile persistence, prune,
+``--dump-stage``, and the user-run suggestion notice. Each test pins a coded
+decision (exit code + message, or a materialized-file/receipt assertion), not
+argparse or stdlib machinery."""
 
 from __future__ import annotations
 
@@ -274,6 +277,32 @@ def test_project_corrupt_receipt_left_untouched_install_proceeds(tmp_path: Path)
     assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"  # install proceeded
     assert receipt_path.read_bytes() == before  # corrupt receipt left byte-for-byte untouched
     assert any("unreadable" in e.message for e in io.transcript)
+
+
+def test_project_persist_over_malformed_existing_config_exits_cleanly(tmp_path: Path) -> None:
+    """With an explicit --profiles (which skips the persisted-config read at
+    selection time), a malformed EXISTING project-config.toml is only hit at the
+    persistence step. The install still completes, but the persistence failure
+    surfaces as a clean exit-1 diagnostic instead of an uncaught traceback."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "project-config.toml").write_text("not = valid = toml", encoding="utf-8")
+
+    io = ScriptedIO(interactive=False)
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 1
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"  # install proceeded
+    assert any("persisting the profile selection" in e.message for e in io.transcript)
 
 
 def _hermetic_repo_with_project_tool_profile(tmp_path: Path) -> Path:

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -6,6 +6,7 @@ guard's coded decision (exit code + message), not argparse machinery."""
 
 from __future__ import annotations
 
+import json
 import tomllib
 from pathlib import Path
 
@@ -205,6 +206,74 @@ def test_project_malformed_persisted_config_exits_cleanly(
 
     assert rc == 2
     assert "malformed project-config.toml" in capsys.readouterr().err
+
+
+def test_project_profiles_trailing_comma_rejected_cleanly(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A stray trailing comma in --profiles is rejected with a clean exit-2
+    diagnostic, not a confusing downstream 'unknown empty profile' error."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit,", "--yes"],
+        home=tmp_path,
+        io=ScriptedIO(interactive=False),
+        repo_root=repo,
+    )
+
+    assert rc == 2
+    assert "empty profile name" in capsys.readouterr().err
+    assert not (project / ".beads").exists()
+
+
+def test_project_corrupt_receipt_left_untouched_install_proceeds(tmp_path: Path) -> None:
+    """A CORRUPT project receipt fails closed (mirrors the user path): the install
+    still proceeds, but the receipt is NOT overwritten — overwriting would erase
+    the record of previously-installed paths and defeat future --prune."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    receipt_path = project / ".agents-config" / "install-receipt.json"
+    receipt_path.parent.mkdir(parents=True)
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "integrity": "sha256:deadbeef",  # forged digest -> read_receipt CORRUPT
+                "roots": [".beads"],
+                "entries": [
+                    {
+                        "path": ".beads/STALE.md",
+                        "owner": "kit:beads",
+                        "root": ".beads",
+                        "kind": "file",
+                        "sha256": None,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    before = receipt_path.read_bytes()
+
+    io = ScriptedIO(interactive=False)
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--yes"],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    assert (project / ".beads" / "PRIME.md").read_bytes() == b"beads prime\n"  # install proceeded
+    assert receipt_path.read_bytes() == before  # corrupt receipt left byte-for-byte untouched
+    assert any("unreadable" in e.message for e in io.transcript)
 
 
 def _hermetic_repo_with_project_tool_profile(tmp_path: Path) -> Path:

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -512,3 +512,31 @@ def test_project_run_never_suggests_even_with_beads_dir_in_cwd(tmp_path: Path) -
 
     assert rc == 0
     assert _suggestion_lines(io) == []
+
+
+def test_project_dump_stage_lists_kit_refs_and_writes_nothing(tmp_path: Path) -> None:
+    """``--project p --profiles=beads-kit --dump-stage <dir>`` renders the
+    resolved PROJECT plan (kit refs listed as ``kit:<name>  <dest_relpath>``)
+    and returns 0 WITHOUT installing kit content or writing a receipt — a dump
+    is read-only, even under --project."""
+    repo = _hermetic_repo_with_profiles(tmp_path)
+    kit = repo / "src" / "kits" / "beads" / ".beads"
+    kit.mkdir(parents=True)
+    (kit / "PRIME.md").write_bytes(b"beads prime\n")
+    project = tmp_path / "proj"
+    project.mkdir()
+    out = tmp_path / "dump"
+    io = ScriptedIO(interactive=False)
+
+    rc = main(
+        ["--project", str(project), "--profiles=beads-kit", "--dump-stage", str(out)],
+        home=tmp_path,
+        io=io,
+        repo_root=repo,
+    )
+
+    assert rc == 0
+    kit_lines = [e.message for e in io.transcript if e.channel == "info" and "kit:" in e.message]
+    assert kit_lines == ["kit:beads  .beads/PRIME.md"]
+    assert not (project / ".beads" / "PRIME.md").exists()
+    assert not (project / ".agents-config" / "install-receipt.json").exists()

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -60,6 +60,17 @@ def _write_installignore(repo: Path) -> None:
     )
 
 
+def _write_profiles_toml(repo: Path) -> None:
+    """Mirror the real profiles.toml so main()'s resolver pass (S2 Task 9) can
+    load it. Only needed by fixtures that stage non-empty tool plans — main()
+    skips the resolver entirely on an empty universe, so an all-empty fixture
+    (e.g. ``_repo_with_installer_toml``) needs no profiles.toml. Copied from
+    the REAL manifest (not retyped) so it cannot drift from it."""
+    (repo / "profiles.toml").write_text(
+        (_REPO_ROOT / "profiles.toml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
 def _repo_with_installer_toml(tmp_path: Path) -> Path:
     """Create a minimal repo_root carrying the required .installignore manifest.
 
@@ -82,6 +93,7 @@ def _hermetic_repo(tmp_path: Path) -> Path:
     for tool in ("claude", "codex", "gemini", "opencode"):
         (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
     _write_installignore(repo)
+    _write_profiles_toml(repo)
     return repo
 
 
@@ -614,6 +626,10 @@ def test_prune_only_honors_plugins_override(tmp_path: Path) -> None:
     widget is excluded.
     """
     repo = _repo_with_installer_toml(tmp_path)
+    # The widget-active run below stages a non-empty universe (rules/widget-rule),
+    # so main()'s resolver pass needs profiles.toml — the widget-excluded run
+    # re-uses the same repo_root and stays empty-universe either way.
+    _write_profiles_toml(repo)
     rule = repo / "src" / "plugins" / "widget" / ".claude" / "rules" / "widget-rule.md"
     rule.parent.mkdir(parents=True)
     rule.write_bytes(b"widget rule\n")
@@ -838,6 +854,7 @@ def _hermetic_repo_with_skill(tmp_path: Path) -> Path:
     for tool in ("claude", "codex", "gemini", "opencode"):
         (repo / "src" / "user" / f".{tool}").mkdir(parents=True)
     _write_installignore(repo)
+    _write_profiles_toml(repo)
     return repo
 
 

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from installer.config import resolve_tools
+from installer.config import read_project_profiles, resolve_tools
 from installer.core.model import Tool
 from installer.tools import registry
 from installer.tools.registry import UnknownToolError
@@ -168,3 +168,36 @@ def test_garbage_csv_token_is_rejected(tmp_path: Path) -> None:
     """
     with pytest.raises(UnknownToolError):
         resolve_tools(home=tmp_path, override_csv="foo")
+
+
+def test_read_project_profiles_returns_tuple_when_install_profiles_present(
+    tmp_path: Path,
+) -> None:
+    """
+    Given <project>/project-config.toml with [install] profiles = ["beads-kit"]
+    When read_project_profiles(project_root) is called
+    Then the result is ("beads-kit",).
+    """
+    (tmp_path / "project-config.toml").write_text(
+        '[install]\nprofiles = ["beads-kit"]\n', encoding="utf-8"
+    )
+    assert read_project_profiles(tmp_path) == ("beads-kit",)
+
+
+def test_read_project_profiles_returns_none_when_file_absent(tmp_path: Path) -> None:
+    """
+    Given a project root with no project-config.toml
+    When read_project_profiles(project_root) is called
+    Then the result is None (absence is a valid state, not an error).
+    """
+    assert read_project_profiles(tmp_path) is None
+
+
+def test_read_project_profiles_returns_none_when_install_table_absent(tmp_path: Path) -> None:
+    """
+    Given project-config.toml present but with no [install] table
+    When read_project_profiles(project_root) is called
+    Then the result is None.
+    """
+    (tmp_path / "project-config.toml").write_text('[other]\nfoo = "bar"\n', encoding="utf-8")
+    assert read_project_profiles(tmp_path) is None

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -13,7 +13,12 @@ from pathlib import Path
 
 import pytest
 
-from installer.config import read_project_profiles, resolve_tools, write_project_profiles
+from installer.config import (
+    parse_profiles_csv,
+    read_project_profiles,
+    resolve_tools,
+    write_project_profiles,
+)
 from installer.core.model import Tool
 from installer.tools import registry
 from installer.tools.registry import UnknownToolError
@@ -212,6 +217,17 @@ def test_write_project_profiles_round_trips_through_read(tmp_path: Path) -> None
     """
     write_project_profiles(tmp_path, ("beads-kit",))
     assert read_project_profiles(tmp_path) == ("beads-kit",)
+
+
+def test_parse_profiles_csv_strips_dedupes_preserving_order() -> None:
+    assert parse_profiles_csv("beads-kit") == ("beads-kit",)
+    assert parse_profiles_csv(" a , b , a ") == ("a", "b")  # strip + dedupe first-occurrence
+
+
+def test_parse_profiles_csv_rejects_empty_name() -> None:
+    # A stray trailing comma would otherwise resolve as an unknown empty profile.
+    with pytest.raises(ValueError, match="empty profile name"):
+        parse_profiles_csv("beads-kit,")
 
 
 def test_write_project_profiles_preserves_other_tables(tmp_path: Path) -> None:

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -8,11 +8,12 @@ coded decisions. See the writing-unit-tests skill's Tautology Filter."""
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 import pytest
 
-from installer.config import read_project_profiles, resolve_tools
+from installer.config import read_project_profiles, resolve_tools, write_project_profiles
 from installer.core.model import Tool
 from installer.tools import registry
 from installer.tools.registry import UnknownToolError
@@ -201,3 +202,29 @@ def test_read_project_profiles_returns_none_when_install_table_absent(tmp_path: 
     """
     (tmp_path / "project-config.toml").write_text('[other]\nfoo = "bar"\n', encoding="utf-8")
     assert read_project_profiles(tmp_path) is None
+
+
+def test_write_project_profiles_round_trips_through_read(tmp_path: Path) -> None:
+    """
+    Given a project root with no project-config.toml
+    When write_project_profiles(project_root, ("beads-kit",)) is called
+    Then read_project_profiles(project_root) returns ("beads-kit",).
+    """
+    write_project_profiles(tmp_path, ("beads-kit",))
+    assert read_project_profiles(tmp_path) == ("beads-kit",)
+
+
+def test_write_project_profiles_preserves_other_tables(tmp_path: Path) -> None:
+    """
+    Given project-config.toml with an unrelated [merge-policy] table
+    When write_project_profiles(project_root, ("beads-kit",)) is called
+    Then [merge-policy] survives and [install].profiles is set.
+    """
+    path = tmp_path / "project-config.toml"
+    path.write_text('[merge-policy]\nmerge-authorization = "explicit"\n', encoding="utf-8")
+
+    write_project_profiles(tmp_path, ("beads-kit",))
+
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    assert data["merge-policy"] == {"merge-authorization": "explicit"}
+    assert data["install"]["profiles"] == ["beads-kit"]

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -230,6 +230,15 @@ def test_parse_profiles_csv_rejects_empty_name() -> None:
         parse_profiles_csv("beads-kit,")
 
 
+def test_read_project_profiles_malformed_toml_normalized_to_valueerror(tmp_path: Path) -> None:
+    # A present-but-unparseable project-config.toml is normalized to ValueError
+    # (not a bare TOMLDecodeError) so the single caller guard surfaces one clean
+    # diagnostic instead of a traceback.
+    (tmp_path / "project-config.toml").write_text("this is not = valid = toml", encoding="utf-8")
+    with pytest.raises(ValueError, match="could not be read"):
+        read_project_profiles(tmp_path)
+
+
 def test_write_project_profiles_preserves_other_tables(tmp_path: Path) -> None:
     """
     Given project-config.toml with an unrelated [merge-policy] table

--- a/packages/installer/tests/unit/test_kits.py
+++ b/packages/installer/tests/unit/test_kits.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from installer.core.kits import StagedKitRef, kit_name_of, kit_universe, stage_kits
+
+
+def _seed(root: Path) -> Path:
+    kits = root / "kits"
+    (kits / "beads" / ".beads").mkdir(parents=True)
+    (kits / "beads" / ".beads" / "PRIME.md").write_bytes(b"beads prime\n")
+    return kits
+
+
+def test_stage_kits_tree_mirror_and_selector_key(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)
+    staged = stage_kits(kits)
+    assert len(staged) == 1
+    sk = staged[0]
+    assert sk.selector_key == "kits/beads/.beads/PRIME.md"
+    assert sk.ref.tool is None
+    assert sk.ref.dest_relpath == Path(".beads/PRIME.md")
+    universe = kit_universe(staged)
+    assert universe["kits/beads/.beads/PRIME.md"] == [sk.ref]
+
+
+def test_stage_kits_missing_root_is_empty(tmp_path: Path) -> None:
+    assert stage_kits(tmp_path / "nope") == []
+
+
+def test_kit_name_of_is_first_segment_under_kits() -> None:
+    assert kit_name_of("kits/beads/.beads/PRIME.md") == "beads"

--- a/packages/installer/tests/unit/test_kits.py
+++ b/packages/installer/tests/unit/test_kits.py
@@ -50,6 +50,34 @@ def test_kit_routes_grouped_by_dir_and_execbit(tmp_path: Path) -> None:
     assert r.executable is False
 
 
+def test_kit_routes_mixed_exec_bits_one_route_per_file_correct_mode(tmp_path: Path) -> None:
+    # A kit dir holding both a non-exec and an exec file in the SAME directory
+    # must yield one route per file (glob = exact filename), each carrying its
+    # own exec bit. A single glob="*" route per exec group would re-glob the
+    # whole dir and install every file once per group — twice, with the wrong
+    # mode. This pins the per-file contract that prevents that.
+    kits = tmp_path / "kits"
+    tooldir = kits / "toolkit" / "bin"
+    tooldir.mkdir(parents=True)
+    plain = tooldir / "notes.md"
+    plain.write_bytes(b"notes\n")
+    script = tooldir / "run.sh"
+    script.write_bytes(b"#!/bin/sh\n")
+    script.chmod(0o755)
+
+    routes = kit_routes(kits, tmp_path / "proj")["toolkit"]
+    assert len(routes) == 2  # one per file, NOT one per (dir x exec-bit) group
+    by_glob = {r.glob: r for r in routes}
+    assert set(by_glob) == {"notes.md", "run.sh"}
+    assert by_glob["notes.md"].executable is False
+    assert by_glob["run.sh"].executable is True
+    # Every route globs exactly its own file, so no route re-matches a sibling
+    # of a different exec class.
+    for r in routes:
+        matched = sorted(p.name for p in r.source_dir.glob(r.glob) if p.is_file())
+        assert matched == [r.glob]
+
+
 def test_kit_adapters_conform_to_plugin_adapter(tmp_path: Path) -> None:
     kits = _seed(tmp_path)
     project = tmp_path / "proj"

--- a/packages/installer/tests/unit/test_kits.py
+++ b/packages/installer/tests/unit/test_kits.py
@@ -78,6 +78,29 @@ def test_kit_routes_mixed_exec_bits_one_route_per_file_correct_mode(tmp_path: Pa
         assert matched == [r.glob]
 
 
+def test_stage_kits_and_kit_routes_skip_symlinks(tmp_path: Path) -> None:
+    # Symlinks are excluded from both the kit-dir enumeration and the file walk,
+    # so a kit can never dereference a link to copy bytes from outside src/kits
+    # (matches the repo's overlay.py symlink-skip policy).
+    kits = tmp_path / "kits"
+    (kits / "beads" / ".beads").mkdir(parents=True)
+    (kits / "beads" / ".beads" / "PRIME.md").write_bytes(b"real\n")
+    outside = tmp_path / "secret.txt"
+    outside.write_bytes(b"secret\n")
+    (kits / "beads" / ".beads" / "link.md").symlink_to(outside)  # symlinked FILE
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "X.md").write_bytes(b"x\n")
+    (kits / "linkkit").symlink_to(elsewhere, target_is_directory=True)  # symlinked DIR
+
+    selectors = {sk.selector_key for sk in stage_kits(kits)}
+    assert selectors == {"kits/beads/.beads/PRIME.md"}  # link.md + linkkit excluded
+
+    routes_by_kit = kit_routes(kits, tmp_path / "proj")
+    assert set(routes_by_kit) == {"beads"}  # symlinked kit dir excluded
+    assert [r.glob for r in routes_by_kit["beads"]] == ["PRIME.md"]  # symlinked file excluded
+
+
 def test_kit_adapters_conform_to_plugin_adapter(tmp_path: Path) -> None:
     kits = _seed(tmp_path)
     project = tmp_path / "proj"

--- a/packages/installer/tests/unit/test_kits.py
+++ b/packages/installer/tests/unit/test_kits.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
-from installer.core.kits import StagedKitRef, kit_name_of, kit_universe, stage_kits
+from installer.core.kits import (
+    kit_adapters,
+    kit_name_of,
+    kit_routes,
+    kit_universe,
+    stage_kits,
+)
+from installer.plugins.base import PluginAdapter
 
 
 def _seed(root: Path) -> Path:
@@ -28,3 +35,27 @@ def test_stage_kits_missing_root_is_empty(tmp_path: Path) -> None:
 
 def test_kit_name_of_is_first_segment_under_kits() -> None:
     assert kit_name_of("kits/beads/.beads/PRIME.md") == "beads"
+
+
+def test_kit_routes_grouped_by_dir_and_execbit(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)
+    project = tmp_path / "proj"
+    routes_by_kit = kit_routes(kits, project)
+    assert set(routes_by_kit) == {"beads"}
+    routes = routes_by_kit["beads"]
+    assert len(routes) == 1
+    r = routes[0]
+    assert r.dest_dir == project / ".beads"
+    assert r.source_dir == kits / "beads" / ".beads"
+    assert r.executable is False
+
+
+def test_kit_adapters_conform_to_plugin_adapter(tmp_path: Path) -> None:
+    kits = _seed(tmp_path)
+    project = tmp_path / "proj"
+    adapters = kit_adapters(kits, project, selected={"beads"})
+    assert len(adapters) == 1
+    a = adapters[0]
+    assert isinstance(a, PluginAdapter)  # runtime_checkable Protocol
+    assert a.name == "kit:beads"
+    assert a.routes(project) == tuple(kit_routes(kits, project)["beads"])

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from installer.core import namespaces
 from installer.core.installignore import InstallIgnore
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 from installer.core.profiles import (
@@ -936,6 +937,30 @@ def test_shipped_profiles_resolve_against_real_universe(
     resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.USER}))
 
 
+def test_beads_kit_profile_exists_and_scopes_kits_to_project() -> None:
+    manifest = load_manifest(_REPO_ROOT / "profiles.toml")
+    assert "beads-kit" in manifest.profiles
+    # The kits/** scope default routes to project.
+    assert any(
+        sel == "kits/**" and scope is Scope.PROJECT for sel, scope in manifest.scopes.items()
+    )
+
+
+def test_scopes_cover_universe_eligible_namespaces() -> None:
+    """Guard: every STAGED namespace (TOOL_SCOPED union SHARED) plus the synthetic
+    instructions/settings must have a [scopes] match, or a forced-full user run
+    crashes. formulas is plugin-routed (never a universe key) and must NOT be
+    required."""
+    manifest = load_manifest(_REPO_ROOT / "profiles.toml")
+    eligible = set(namespaces.TOOL_SCOPED) | set(namespaces.SHARED) | {"instructions", "settings"}
+    scope_selectors = list(manifest.scopes.keys())
+    for ns in eligible:
+        probe = ns if ns in ("instructions", "settings") else f"{ns}/probe"
+        matched = any(_selector_matches(sel, probe) for sel in scope_selectors)
+        assert matched, f"namespace {ns!r} has no [scopes] entry"
+    assert "formulas" not in {s.split("/")[0] for s in scope_selectors}
+
+
 def test_resolve_sorts_tool_none_kit_ref_without_crash() -> None:
     """A tool-agnostic `UniverseRef` (`tool=None`, e.g. a kit file destined for
     the project root) must not crash the final sort in `resolve()`, and must
@@ -946,7 +971,9 @@ def test_resolve_sorts_tool_none_kit_ref_without_crash() -> None:
     manifest = Manifest(
         schema=1,
         scopes={"kits/**": Scope.PROJECT, "skills/**": Scope.PROJECT},
-        profiles={"p": Profile(name="p", includes=(IncludeEntry(selector="**", scope=None),), excludes=())},
+        profiles={
+            "p": Profile(name="p", includes=(IncludeEntry(selector="**", scope=None),), excludes=())
+        },
     )
     resolved = resolve(manifest, ("p",), universe, bound_scopes=frozenset({Scope.PROJECT}))
     proj = resolved.included[Scope.PROJECT]

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -934,3 +934,21 @@ def test_shipped_profiles_resolve_against_real_universe(
     manifest = load_manifest(_REPO_ROOT / "profiles.toml")
 
     resolve(manifest, selection, universe, bound_scopes=frozenset({Scope.USER}))
+
+
+def test_resolve_sorts_tool_none_kit_ref_without_crash() -> None:
+    """A tool-agnostic `UniverseRef` (`tool=None`, e.g. a kit file destined for
+    the project root) must not crash the final sort in `resolve()`, and must
+    sort before any tool-bound ref (empty-string sort key < "claude")."""
+    kit_ref = UniverseRef(tool=None, dest_relpath=Path(".beads/PRIME.md"))
+    tool_ref = UniverseRef(tool=Tool.CLAUDE, dest_relpath=Path("skills/x"))
+    universe = {"kits/beads/PRIME": [kit_ref], "skills/x": [tool_ref]}
+    manifest = Manifest(
+        schema=1,
+        scopes={"kits/**": Scope.PROJECT, "skills/**": Scope.PROJECT},
+        profiles={"p": Profile(name="p", includes=(IncludeEntry(selector="**", scope=None),), excludes=())},
+    )
+    resolved = resolve(manifest, ("p",), universe, bound_scopes=frozenset({Scope.PROJECT}))
+    proj = resolved.included[Scope.PROJECT]
+    assert proj[0].tool is None
+    assert kit_ref in proj and tool_ref in proj

--- a/packages/installer/tests/unit/test_project_namespaces.py
+++ b/packages/installer/tests/unit/test_project_namespaces.py
@@ -1,0 +1,9 @@
+from installer.core.model import Tool
+from installer.tools.registry import get_adapter
+
+
+def test_project_namespaces_matrix() -> None:
+    assert get_adapter(Tool.CLAUDE).project_namespaces() == ("skills", "agents", "commands")
+    assert get_adapter(Tool.CODEX).project_namespaces() == ()
+    assert get_adapter(Tool.GEMINI).project_namespaces() == ()
+    assert get_adapter(Tool.OPENCODE).project_namespaces() == ()

--- a/profiles.toml
+++ b/profiles.toml
@@ -13,6 +13,7 @@ schema = 1
 "commands/**"  = "user"
 "workflows/**" = "user"
 "hooks/**"     = "user"
+"kits/**"      = "project"
 
 # Today's behavior: install everything, user-scoped. The zero-breakage default.
 [profiles.full]
@@ -31,3 +32,7 @@ include = ["rules/**", "skills/**", "agents/**", "commands/**", "workflows/**"]
 # Exclude-only profile — composes with any include set.
 [profiles.no-brainstorming]
 exclude = ["skills/brainstorming"]
+
+# The beads project kit (PRIME.md -> <project>/.beads/PRIME.md). Project-scoped.
+[profiles.beads-kit]
+include = ["kits/beads/**"]

--- a/src/kits/beads/.beads/PRIME.md
+++ b/src/kits/beads/.beads/PRIME.md
@@ -1,0 +1,66 @@
+# Beads — Project Issue Tracker
+
+This project tracks durable work with **bd (beads)**.
+
+## Task tracking
+
+- **bd is for durable work** — issues, discovered follow-ups, anything that must
+  outlive the session. File the bead *before* writing code for it; mark it
+  in-progress when you start.
+- **In-session planning is yours** — use your native Task / ToDo tools freely to
+  plan and track the steps of the work you're doing right now. bd tracks *what*
+  needs doing across sessions; your task list tracks *how* you execute it this one.
+- Don't run `bd edit` — it opens `$EDITOR` and hangs a non-interactive agent.
+  Edit fields inline: `bd update <id> --title/--description/--notes/--design`.
+
+## Essential commands
+
+```bash
+bd --help  /  bd <command> --help   # authoritative flag reference — read before guessing
+bd ready                            # claimable work (no open blockers) — default 100 rows
+bd list                             # open issues — default 50 rows; --all includes closed
+bd show <id>                        # full detail + dependencies
+bd update <id> --claim              # claim work
+bd create --title="…" --description="…" --type=task|bug|feature|epic --priority=P2
+bd dep add <id> <depends-on>        # <id> depends on <depends-on>
+bd close <id> [<id> …]              # complete (space-separate to batch)
+bd search <query>                   # find by keyword
+```
+
+- Add **`--json`** to read commands for machine-readable output.
+- `bd ready` / `bd list` truncate (100 / 50 rows) — pass **`--limit 0`** for an unbounded list.
+- Priority is `0`–`4` / `P0`–`P4` (0 = critical, 2 = medium, 4 = backlog) — never "high/medium/low".
+
+## Gotchas worth knowing
+
+- **`--notes` / `--description` / `--acceptance` overwrite the entire field.** To add
+  without clobbering, use **`--append-notes`**. Replace-variants are for initial write
+  or deliberate overwrite only.
+- **`bd … --json` shapes that trip `jq`:**
+    - `bd show <id> --json` is a single-element **array** — index `.[0]`.
+    - Multi-line fields (`notes` / `description` / `acceptance`) carry literal newlines
+      `jq` rejects — read them with Python, not `jq`.
+    - `.dependencies[]` (in `bd show --json`) is the **full target bead** plus a
+      `.dependency_type` field, not a lean edge:
+      `.[0].dependencies | map({id, type: .dependency_type})`.
+    - `bd label list <id> --json` is a **flat array of strings** — `jq 'index("foo")'`,
+      not `.labels | index(...)`.
+    - `bd dep list <id> --direction up|down --json` → `{id, dependency_type, status}`
+      where `.id` is the bead at the *other* end of the edge.
+- **`blocks` has a type wall:** epics block only epics, non-epics block only non-epics —
+  cross-type is a hard error. For a soft task→epic link use `--type related-to`.
+- **`bd create --parent <id>` auto-creates the dependency edge** — don't also
+  `bd dep add <child> <parent>`; bd rejects it as a deadlock.
+- **`bd create` is pure capture** — filing a bead is not starting it. Reserve
+  "Starting work on <id>…" for when the user explicitly directs work on a specific bead.
+
+## Session close — work isn't done until it's pushed
+
+```bash
+git pull --rebase
+bd dolt push          # sync beads to the Dolt remote
+git push
+git status            # must read "up to date with origin"
+```
+
+If a push fails, resolve and retry — never leave work stranded locally.

--- a/src/kits/beads/.beads/PRIME.md
+++ b/src/kits/beads/.beads/PRIME.md
@@ -9,7 +9,7 @@ This project tracks durable work with **bd (beads)**.
   in-progress when you start.
 - **In-session planning is yours** — use your native Task / ToDo tools freely to
   plan and track the steps of the work you're doing right now. bd tracks *what*
-  needs doing across sessions; your task list tracks *how* you execute it this one.
+  needs doing across sessions; your task list tracks *how* you execute it in this session.
 - Don't run `bd edit` — it opens `$EDITOR` and hangs a non-interactive agent.
   Edit fields inline: `bd update <id> --title/--description/--notes/--design`.
 


### PR DESCRIPTION
## Summary

Adds **project-scoped install** to the installer: `install.sh --project <path> --profiles <csv>` materializes tool-scoped content under `<project>/.claude/` and a tool-agnostic `src/kits/` tree (v1: the beads `PRIME.md` kit) at the project root, tracked by a project-local receipt at `<project>/.agents-config/install-receipt.json`.

**Architecture (Approach A):** kits ride the S1 resolver for *selection* (via a nullable `UniverseRef.tool`) but materialize, record, and prune through the *existing plugin-route machinery* — a kit is the project-scope mirror of a plugin route, owner `kit:<name>`, via a `PluginAdapter`-conforming `_KitRouteAdapter`. No signature change to `record_receipt`/`install_plugin_routes`/`prune_pipeline`. The resolver is also wired into the user path (parity-preserving: empty selection ⇒ full ⇒ byte-identical output, guarded by the existing golden test).

Implemented via the committed TDD plan `docs/plans/2026-07-12-s2-project-scoped-install.md` (spec `docs/specs/2026-07-12-s2-project-scoped-install-design.md`), 16 tasks, tracer at Task 8.

## Scope

**In scope (this PR):**
- `--project`/`--profiles` flags + project-path guard; project-run fork (`_run_project`)
- `core/kits.py` (stage_kits, kit_universe, kit_routes, `_KitRouteAdapter`, kit_adapters)
- `kits/** = project` scope + `beads-kit` profile in `profiles.toml`
- per-tool `project_namespaces()` capability + validation pass
- project profile persistence (`project-config.toml [install]`), kit prune, detection-suggests-only notice, `--dump-stage` under `--project`
- `src/kits/beads/.beads/PRIME.md` — the v1 kit (single file)

**Out of scope (deferred, tracked):**
- Multi-kit correctness (`agents-config-uxns2.3`, P2) — kit selection currently back-maps by dest path and would cross-select two kits sharing a subpath. **Latent: v1 ships one kit, never triggers.** Clean fix needs an S1 resolver-contract change; deferred by design (blast-radius). Blocks any 2nd-kit addition.
- User-scope profile-selection wiring (planned continuation) — this PR is project-only UX by design.
- `_run_project`/`_run` orchestration de-dup (`agents-config-uxns2.4`, P3) — deliberate plan-reviewed fork; maintainability follow-up.

## Artifact nature

`docs/specs/*` and `docs/plans/*` are **point-in-time design artifacts** (desired-state); the code is the current reality and is the superset. Don't flag the spec/plan for describing intent broader than a single PR — that's expected.

## Ground-truth files for claims
- Behavior: `packages/installer/src/installer/cli.py` (`_run_project`), `core/kits.py`, `core/profiles.py`
- Tests: `packages/installer/tests/unit/test_cli_project.py`, `test_kits.py`, `test_profiles.py`
- Parity guard: `test_profiles.py::test_golden_full_profile_is_byte_identical_to_todays_install`

## Test Plan
- [x] `make ci-installer` green — 825 passed, 1 skipped, 98.67% branch cov, pip-audit clean, entry-verify clean
- [x] Rebased clean onto current `origin/main` (zero file overlap with the 28 intervening commits)
- [x] HEAVY completion gate run; actionable findings fixed (per-file kit routes, empty-profile guard, clean error exits), latent findings deferred as tracked beads above
- [ ] Reviewer: confirm user-install parity (golden test) and that kit content never installs to user space

🤖 Generated with [Claude Code](https://claude.com/claude-code)