### PR TITLE
feat(vizsuite): fact identity + reconciliation + rejection memory (S2)

### DIFF
--- a/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
@@ -58,7 +58,7 @@ from vizsuite.sidecar.models import FactRecord, MatchingDescriptor, Verdict, Ver
 
 _MAJORITY_THRESHOLD = 0.5
 
-BeadOverlapRule = Callable[["tuple[str, ...]", "tuple[str, ...]"], bool]
+BeadOverlapRule = Callable[[tuple[str, ...], tuple[str, ...]], bool]
 
 
 @dataclass(frozen=True)

--- a/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
@@ -61,6 +61,21 @@ _MAJORITY_THRESHOLD = 0.5
 BeadOverlapRule = Callable[[tuple[str, ...], tuple[str, ...]], bool]
 
 
+class _EndpointArityMismatchError(ValueError):
+    """Raised when two same-kind descriptors carry different endpoint counts.
+
+    Endpoint arity is structural per kind (an edge has two endpoints, a step
+    one), so a mismatch means a corrupt or hand-edited sidecar record — fail
+    loud with a named error rather than guessing a non-match and silently
+    minting a duplicate fact. Subclassing `ValueError` keeps it in the same
+    malformed-input family the store wraps as `SIDECAR_MALFORMED` (the message
+    is fixed on the class per ruff TRY003).
+    """
+
+    def __init__(self) -> None:
+        super().__init__("same-kind descriptors have mismatched endpoint arity")
+
+
 @dataclass(frozen=True)
 class Candidate:
     """A freshly re-derived Tier-2 fact, not yet reconciled to a durable fact id."""
@@ -176,6 +191,8 @@ def _bead_anchor_match(
         return False
     if not candidate.endpoint_bead_ids or not existing.endpoint_bead_ids:
         return False
+    if len(candidate.endpoint_bead_ids) != len(existing.endpoint_bead_ids):
+        raise _EndpointArityMismatchError
     return all(
         overlap(c_ids, e_ids)
         for c_ids, e_ids in zip(

--- a/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/reconcile.py
@@ -1,0 +1,284 @@
+"""Fact identity, reconciliation, and rejection memory — pure functions over
+the sidecar's existing records (spec §5.3).
+
+`reconcile_facts`/`reconcile_steps` take a batch of freshly re-derived
+`Candidate`s plus the existing `FactRecord`s/`VerdictRecord`s a caller already
+read from the `SidecarStore`, and return one `ReconcileOutcome` per candidate,
+in input order. There is no I/O here — the store stays the sole file-I/O
+boundary; a caller reads the existing population once, calls this module, then
+writes back whatever the returned outcomes imply (mint a record for a
+`Minted`, carry the inherited id forward for a `Matched`/`Suppressed`/
+`Resurfaced`, raise a flag for an `Ambiguous`).
+
+**Matching tiers** (descriptor -> existing record): bead-anchor overlap first,
+then plan-pair + kind. A prose-only candidate (empty `endpoint_bead_ids`) never
+clears the bead-anchor tier, so it always resolves on plan-pair + kind alone —
+this "tier 3" is mechanically the same code path as the tier-2 fallback, not a
+separate branch. Two overlap rules exist because the spec states two different
+thresholds for two different fact kinds: edges/recommendations match on *any*
+shared bead id (`any_bead_overlap` — bead ids are the most stable substrate, so
+one shared anchor is enough to prove "the same endpoint" even across a plan
+rename); steps match on a *strict majority* (`majority_bead_overlap`, `> 0.5`
+Jaccard, ASSUMPTION: exactly 50% is a tie, not a majority, and does not
+inherit) so renumbering/reordering never silently reuses an unrelated step's
+verdict history. `reconcile_facts` defaults to the any-overlap rule (edges,
+recommendations); `reconcile_steps` is the majority-overlap entry point for
+steps.json.
+
+**Ambiguity** — more than one existing record matches the same tier — is
+always a typed `Ambiguous` result carrying every match (the history); this
+module never guesses.
+
+**Rejection memory** compares a matched fact's live verdict (if any) against
+the candidate's `basis_hash`: `REJECT` + same `basis_hash` -> `Suppressed`;
+`REJECT` + a changed `basis_hash` -> `Resurfaced`, carrying the prior verdict
+so a caller never presents it as fresh. `existing_verdicts` is folded to one
+verdict per `fact_id` (last one in iteration order wins) — the store's actual
+usage keeps exactly one live verdict per fact (`viz verdict <fact-id>` upserts
+by the same id it is given), so this fold is a formality, not a real
+tie-break.
+
+**Fact id minting** is deterministic: `content_fact_id` (the default
+`mint_fact_id` strategy) hashes the candidate's matching descriptor plus its
+`basis_hash` — no randomness, no wall-clock, so re-running reconciliation on
+unchanged inputs always mints the same id. Callers may inject their own
+`mint_fact_id` (e.g. a caller-side sequence allocator) instead.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from vizsuite.envelope import JsonValue
+from vizsuite.scene.model import Provenance
+from vizsuite.sidecar.models import FactRecord, MatchingDescriptor, Verdict, VerdictRecord
+
+_MAJORITY_THRESHOLD = 0.5
+
+BeadOverlapRule = Callable[["tuple[str, ...]", "tuple[str, ...]"], bool]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A freshly re-derived Tier-2 fact, not yet reconciled to a durable fact id."""
+
+    matching_descriptor: MatchingDescriptor
+    basis_hash: str
+    provenance: Provenance
+    payload: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Minted:
+    """No existing record matched: `fact_id` is a brand-new durable identity."""
+
+    fact_id: str
+    candidate: Candidate
+
+
+@dataclass(frozen=True)
+class Matched:
+    """Candidate matched exactly one existing record and inherits its fact id.
+
+    No rejection-memory branch applies: the matched fact carries no verdict,
+    or its live verdict is `ACCEPT`/`DISMISS` rather than `REJECT`.
+    """
+
+    fact_id: str
+    candidate: Candidate
+
+
+@dataclass(frozen=True)
+class Suppressed:
+    """Candidate matched a fact whose live verdict is `REJECT` with the SAME `basis_hash`."""
+
+    fact_id: str
+    candidate: Candidate
+    prior_verdict: VerdictRecord
+
+
+@dataclass(frozen=True)
+class Resurfaced:
+    """Candidate matched a fact whose live verdict is `REJECT` with a CHANGED `basis_hash`.
+
+    `prior_verdict` is carried so a caller can annotate the resurfaced fact
+    with its prior rejection instead of presenting it as fresh (spec §5.3).
+    """
+
+    fact_id: str
+    candidate: Candidate
+    prior_verdict: VerdictRecord
+
+
+@dataclass(frozen=True)
+class Ambiguous:
+    """Candidate matched MORE THAN ONE existing record — never guessed, surfaced with history."""
+
+    candidate: Candidate
+    matches: tuple[FactRecord, ...]
+
+
+ReconcileOutcome = Minted | Matched | Suppressed | Resurfaced | Ambiguous
+
+
+def any_bead_overlap(candidate_ids: tuple[str, ...], existing_ids: tuple[str, ...]) -> bool:
+    """Tier-1 overlap rule for edges/recommendations: any shared bead id counts.
+
+    Bead ids are the most stable identity substrate (spec §5.3) — a single
+    shared anchor across a plan rename is enough to prove "the same endpoint."
+    """
+    return bool(set(candidate_ids) & set(existing_ids))
+
+
+def majority_bead_overlap(candidate_ids: tuple[str, ...], existing_ids: tuple[str, ...]) -> bool:
+    """Tier-1 overlap rule for steps.json: strictly-greater-than-50% Jaccard overlap.
+
+    Spec §5.3: "a step inherits its predecessor's id when their bead-id sets
+    majority-overlap." Jaccard (`|intersection| / |union|`) is the pinned
+    similarity metric; the boundary is STRICT (`> 0.5`) — two bead-id sets that
+    overlap on exactly half their union do not carry the id over (falls
+    through to the plan-pair + kind tier instead).
+    """
+    candidate_set, existing_set = set(candidate_ids), set(existing_ids)
+    union = candidate_set | existing_set
+    if not union:
+        return False
+    return (len(candidate_set & existing_set) / len(union)) > _MAJORITY_THRESHOLD
+
+
+def content_fact_id(candidate: Candidate) -> str:
+    """Deterministic default fact-id minting: a stable hash over descriptor + basis hash.
+
+    No randomness, no wall-clock — the same candidate content always mints the
+    same id (spec §5.3: "reconciliation is deterministic CLI code").
+    """
+    descriptor = candidate.matching_descriptor
+    content = json.dumps(
+        {
+            "plan_pair": list(descriptor.plan_pair),
+            "kind": descriptor.kind,
+            "endpoint_bead_ids": [list(ids) for ids in descriptor.endpoint_bead_ids],
+            "basis_hash": candidate.basis_hash,
+        },
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return f"fact-{digest[:16]}"
+
+
+def _bead_anchor_match(
+    candidate: MatchingDescriptor, existing: MatchingDescriptor, overlap: BeadOverlapRule
+) -> bool:
+    if candidate.kind != existing.kind:
+        return False
+    if not candidate.endpoint_bead_ids or not existing.endpoint_bead_ids:
+        return False
+    return all(
+        overlap(c_ids, e_ids)
+        for c_ids, e_ids in zip(
+            candidate.endpoint_bead_ids, existing.endpoint_bead_ids, strict=True
+        )
+    )
+
+
+def _plan_pair_match(candidate: MatchingDescriptor, existing: MatchingDescriptor) -> bool:
+    return candidate.kind == existing.kind and candidate.plan_pair == existing.plan_pair
+
+
+def _find_matches(
+    candidate_descriptor: MatchingDescriptor,
+    existing_records: Sequence[FactRecord],
+    overlap: BeadOverlapRule,
+) -> tuple[FactRecord, ...]:
+    bead_matches = tuple(
+        record
+        for record in existing_records
+        if _bead_anchor_match(candidate_descriptor, record.matching_descriptor, overlap)
+    )
+    if bead_matches:
+        return bead_matches
+    return tuple(
+        record
+        for record in existing_records
+        if _plan_pair_match(candidate_descriptor, record.matching_descriptor)
+    )
+
+
+def _reconcile(
+    candidates: Sequence[Candidate],
+    existing_records: Sequence[FactRecord],
+    existing_verdicts: Sequence[VerdictRecord],
+    *,
+    bead_overlap: BeadOverlapRule,
+    mint_fact_id: Callable[[Candidate], str],
+) -> tuple[ReconcileOutcome, ...]:
+    verdict_by_fact_id = {verdict.fact_id: verdict for verdict in existing_verdicts}
+    outcomes: list[ReconcileOutcome] = []
+    for candidate in candidates:
+        matches = _find_matches(candidate.matching_descriptor, existing_records, bead_overlap)
+        if len(matches) > 1:
+            outcomes.append(Ambiguous(candidate=candidate, matches=matches))
+            continue
+        if not matches:
+            outcomes.append(Minted(fact_id=mint_fact_id(candidate), candidate=candidate))
+            continue
+        fact_id = matches[0].fact_id
+        verdict = verdict_by_fact_id.get(fact_id)
+        if verdict is not None and verdict.verdict == Verdict.REJECT:
+            if verdict.basis_hash == candidate.basis_hash:
+                outcome: ReconcileOutcome = Suppressed(
+                    fact_id=fact_id, candidate=candidate, prior_verdict=verdict
+                )
+            else:
+                outcome = Resurfaced(fact_id=fact_id, candidate=candidate, prior_verdict=verdict)
+            outcomes.append(outcome)
+            continue
+        outcomes.append(Matched(fact_id=fact_id, candidate=candidate))
+    return tuple(outcomes)
+
+
+def reconcile_facts(
+    candidates: Sequence[Candidate],
+    existing_records: Sequence[FactRecord],
+    existing_verdicts: Sequence[VerdictRecord],
+    *,
+    mint_fact_id: Callable[[Candidate], str] = content_fact_id,
+) -> tuple[ReconcileOutcome, ...]:
+    """Reconcile edges.json/recommendations.json candidates (spec §5.3).
+
+    Bead-anchor tier uses `any_bead_overlap` — a single shared bead id proves
+    "the same endpoint" regardless of plan rename.
+    """
+    return _reconcile(
+        candidates,
+        existing_records,
+        existing_verdicts,
+        bead_overlap=any_bead_overlap,
+        mint_fact_id=mint_fact_id,
+    )
+
+
+def reconcile_steps(
+    candidates: Sequence[Candidate],
+    existing_records: Sequence[FactRecord],
+    existing_verdicts: Sequence[VerdictRecord],
+    *,
+    mint_fact_id: Callable[[Candidate], str] = content_fact_id,
+) -> tuple[ReconcileOutcome, ...]:
+    """Reconcile steps.json candidates (spec §5.3): step id inheritance.
+
+    Bead-anchor tier uses `majority_bead_overlap` (`> 0.5` Jaccard, strict) so
+    a re-synthesized step inherits its predecessor's id only when their
+    bead-id sets majority-overlap; renumbering/reordering never orphans a
+    verdict, and an unrelated step never inherits an unrelated history.
+    """
+    return _reconcile(
+        candidates,
+        existing_records,
+        existing_verdicts,
+        bead_overlap=majority_bead_overlap,
+        mint_fact_id=mint_fact_id,
+    )

--- a/packages/vizsuite/tests/unit/test_sidecar_reconcile.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_reconcile.py
@@ -1,0 +1,330 @@
+"""Fact identity, reconciliation, and rejection-memory pure functions (spec §5.3).
+
+Every case here builds `existing_records`/`existing_verdicts` by hand and feeds
+them plus fresh `Candidate`s to `reconcile_facts`/`reconcile_steps` — there is
+no I/O, no `SidecarStore`, no clock, no randomness. `content_fact_id` (the
+default id-minting strategy) is content-derived, so equality assertions on
+`Minted` outcomes can simply re-derive the expected id from the same candidate.
+"""
+
+from __future__ import annotations
+
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import FactRecord, MatchingDescriptor, Verdict, VerdictRecord
+from vizsuite.sidecar.reconcile import (
+    Ambiguous,
+    Candidate,
+    Matched,
+    Minted,
+    Resurfaced,
+    Suppressed,
+    any_bead_overlap,
+    content_fact_id,
+    majority_bead_overlap,
+    reconcile_facts,
+    reconcile_steps,
+)
+
+_PROVENANCE = Provenance(
+    kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=("spec:5.2",)
+)
+
+
+def _descriptor(
+    *,
+    plan_pair: tuple[str, str] = ("plan-a", "plan-b"),
+    kind: str = "dependency",
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = (),
+) -> MatchingDescriptor:
+    return MatchingDescriptor(plan_pair=plan_pair, kind=kind, endpoint_bead_ids=endpoint_bead_ids)
+
+
+def _candidate(
+    *,
+    plan_pair: tuple[str, str] = ("plan-a", "plan-b"),
+    kind: str = "dependency",
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = (),
+    basis_hash: str = "hash-1",
+) -> Candidate:
+    return Candidate(
+        matching_descriptor=_descriptor(
+            plan_pair=plan_pair, kind=kind, endpoint_bead_ids=endpoint_bead_ids
+        ),
+        basis_hash=basis_hash,
+        provenance=_PROVENANCE,
+    )
+
+
+def _fact(
+    fact_id: str,
+    *,
+    plan_pair: tuple[str, str] = ("plan-a", "plan-b"),
+    kind: str = "dependency",
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = (),
+    basis_hash: str = "hash-1",
+) -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=_descriptor(
+            plan_pair=plan_pair, kind=kind, endpoint_bead_ids=endpoint_bead_ids
+        ),
+        basis_hash=basis_hash,
+        provenance=_PROVENANCE,
+    )
+
+
+def _verdict(
+    fact_id: str, verdict: Verdict, *, basis_hash: str = "hash-1", annotation: str = ""
+) -> VerdictRecord:
+    return VerdictRecord(
+        verdict_id=f"verdict-{fact_id}",
+        fact_id=fact_id,
+        verdict=verdict,
+        basis_hash=basis_hash,
+        annotation=annotation,
+    )
+
+
+# ---- tier 1: bead-anchor overlap (any-overlap rule, edges/recommendations) --
+
+
+def test_bead_anchor_overlap_inherits_the_existing_fact_id_despite_plan_rename():
+    existing = _fact("edge-1", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    candidate = _candidate(
+        plan_pair=("renamed-a", "renamed-b"),
+        endpoint_bead_ids=(("bead-1", "bead-9"), ("bead-2",)),
+    )
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="edge-1", candidate=candidate),)
+
+
+def test_bead_overlap_with_different_kind_never_matches():
+    existing = _fact("edge-1", kind="dependency", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    candidate = _candidate(kind="conflict", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Minted(fact_id=content_fact_id(candidate), candidate=candidate),)
+
+
+# ---- tier 2: plan-pair + kind fallback --------------------------------------
+
+
+def test_falls_back_to_plan_pair_and_kind_when_bead_anchors_dont_overlap():
+    existing = _fact("edge-1", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    candidate = _candidate(endpoint_bead_ids=(("bead-9",), ("bead-8",)))
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="edge-1", candidate=candidate),)
+
+
+def test_kind_mismatch_mints_a_new_id_even_with_the_same_plan_pair():
+    existing = _fact("edge-1", kind="dependency")
+    candidate = _candidate(kind="conflict")
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Minted(fact_id=content_fact_id(candidate), candidate=candidate),)
+
+
+# ---- tier 3: prose-only (zero anchors) matches on plan-pair + kind alone ----
+
+
+def test_prose_only_candidate_matches_on_plan_pair_and_kind_alone():
+    existing = _fact("edge-1")
+    candidate = _candidate()
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="edge-1", candidate=candidate),)
+
+
+def test_no_existing_records_mints_a_new_fact_id():
+    candidate = _candidate()
+
+    outcomes = reconcile_facts((candidate,), (), ())
+
+    assert outcomes == (Minted(fact_id=content_fact_id(candidate), candidate=candidate),)
+
+
+# ---- ambiguity: never guessed, surfaced with the full match history --------
+
+
+def test_ambiguous_when_multiple_existing_records_bead_anchor_match():
+    existing_a = _fact("edge-1", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    existing_b = _fact("edge-2", endpoint_bead_ids=(("bead-1",), ("bead-3",)))
+    candidate = _candidate(endpoint_bead_ids=(("bead-1",), ("bead-2", "bead-3")))
+
+    outcomes = reconcile_facts((candidate,), (existing_a, existing_b), ())
+
+    assert outcomes == (Ambiguous(candidate=candidate, matches=(existing_a, existing_b)),)
+
+
+def test_ambiguous_when_multiple_prose_only_records_share_plan_pair_and_kind():
+    existing_a = _fact("edge-1")
+    existing_b = _fact("edge-2")
+    candidate = _candidate()
+
+    outcomes = reconcile_facts((candidate,), (existing_a, existing_b), ())
+
+    assert outcomes == (Ambiguous(candidate=candidate, matches=(existing_a, existing_b)),)
+
+
+# ---- rejection memory: basis_hash tracked separately from identity ---------
+
+
+def test_matched_fact_rejected_with_same_basis_hash_is_suppressed():
+    existing = _fact("edge-1", basis_hash="hash-1")
+    candidate = _candidate(basis_hash="hash-1")
+    verdict = _verdict("edge-1", Verdict.REJECT, basis_hash="hash-1")
+
+    outcomes = reconcile_facts((candidate,), (existing,), (verdict,))
+
+    assert outcomes == (Suppressed(fact_id="edge-1", candidate=candidate, prior_verdict=verdict),)
+
+
+def test_matched_fact_rejected_with_changed_basis_hash_resurfaces_annotated():
+    existing = _fact("edge-1", basis_hash="hash-1")
+    candidate = _candidate(basis_hash="hash-2")
+    verdict = _verdict("edge-1", Verdict.REJECT, basis_hash="hash-1", annotation="too speculative")
+
+    outcomes = reconcile_facts((candidate,), (existing,), (verdict,))
+
+    assert outcomes == (Resurfaced(fact_id="edge-1", candidate=candidate, prior_verdict=verdict),)
+    # never presented as fresh: the caller can always recover the prior rejection.
+    assert outcomes[0].prior_verdict.annotation == "too speculative"  # type: ignore[union-attr]
+
+
+def test_matched_fact_with_accepted_verdict_reconciles_normally():
+    existing = _fact("edge-1")
+    candidate = _candidate()
+    verdict = _verdict("edge-1", Verdict.ACCEPT)
+
+    outcomes = reconcile_facts((candidate,), (existing,), (verdict,))
+
+    assert outcomes == (Matched(fact_id="edge-1", candidate=candidate),)
+
+
+def test_matched_fact_with_no_verdict_at_all_reconciles_normally():
+    existing = _fact("edge-1")
+    candidate = _candidate()
+
+    outcomes = reconcile_facts((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="edge-1", candidate=candidate),)
+
+
+# ---- step id inheritance: majority (>50%, strict) bead-set overlap ---------
+
+
+def test_reconcile_steps_inherits_predecessor_id_on_majority_bead_overlap():
+    existing = _fact("step-1", kind="step", endpoint_bead_ids=(("bead-1", "bead-2"),))
+    candidate = _candidate(kind="step", endpoint_bead_ids=(("bead-1", "bead-2", "bead-3"),))
+    # intersection {bead-1,bead-2}=2, union {bead-1,bead-2,bead-3}=3 -> 2/3 > 0.5.
+
+    outcomes = reconcile_steps((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="step-1", candidate=candidate),)
+
+
+def test_reconcile_steps_exact_half_overlap_does_not_inherit_the_id():
+    existing = _fact(
+        "step-1", kind="step", endpoint_bead_ids=(("bead-1",),), plan_pair=("plan-a", "plan-b")
+    )
+    candidate = _candidate(
+        kind="step", endpoint_bead_ids=(("bead-1", "bead-2"),), plan_pair=("plan-x", "plan-y")
+    )
+    # intersection {bead-1}=1, union {bead-1,bead-2}=2 -> exactly 0.5: NOT a majority.
+    # plan_pair also differs, so tier 2 doesn't rescue it either.
+
+    outcomes = reconcile_steps((candidate,), (existing,), ())
+
+    assert outcomes == (Minted(fact_id=content_fact_id(candidate), candidate=candidate),)
+
+
+def test_reconcile_steps_exact_half_overlap_still_falls_back_to_plan_pair_tier():
+    existing = _fact(
+        "step-1", kind="step", endpoint_bead_ids=(("bead-1",),), plan_pair=("plan-a", "plan-b")
+    )
+    candidate = _candidate(
+        kind="step", endpoint_bead_ids=(("bead-1", "bead-2"),), plan_pair=("plan-a", "plan-b")
+    )
+    # Same exact-half overlap as above, but the plan_pair is unchanged this time,
+    # so tier 2 (plan-pair + kind) still recovers the match.
+
+    outcomes = reconcile_steps((candidate,), (existing,), ())
+
+    assert outcomes == (Matched(fact_id="step-1", candidate=candidate),)
+
+
+def test_reconcile_steps_ambiguous_when_multiple_predecessors_majority_overlap():
+    existing_a = _fact("step-1", kind="step", endpoint_bead_ids=(("bead-1", "bead-2"),))
+    existing_b = _fact("step-2", kind="step", endpoint_bead_ids=(("bead-1", "bead-3"),))
+    candidate = _candidate(kind="step", endpoint_bead_ids=(("bead-1", "bead-2", "bead-3"),))
+    # Each existing set overlaps the candidate's 3-id set 2/3 -> both > 0.5.
+
+    outcomes = reconcile_steps((candidate,), (existing_a, existing_b), ())
+
+    assert outcomes == (Ambiguous(candidate=candidate, matches=(existing_a, existing_b)),)
+
+
+# ---- determinism: same inputs -> same ids, across repeated runs ------------
+
+
+def test_reconciliation_is_deterministic_across_repeated_runs():
+    existing = _fact("edge-1", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    candidates = (
+        _candidate(endpoint_bead_ids=(("bead-1",), ("bead-2",))),
+        _candidate(plan_pair=("plan-x", "plan-y"), kind="synergy"),
+    )
+
+    first = reconcile_facts(candidates, (existing,), ())
+    second = reconcile_facts(candidates, (existing,), ())
+
+    assert first == second
+    assert isinstance(first[1], Minted)
+    assert isinstance(second[1], Minted)
+    assert first[1].fact_id == second[1].fact_id
+
+
+def test_content_fact_id_is_deterministic_and_content_derived():
+    candidate = _candidate()
+    same_candidate = _candidate()
+    different_basis = _candidate(basis_hash="hash-2")
+
+    assert content_fact_id(candidate) == content_fact_id(same_candidate)
+    assert content_fact_id(candidate) != content_fact_id(different_basis)
+
+
+def test_reconcile_accepts_an_injected_mint_fact_id_factory():
+    candidate = _candidate()
+
+    outcomes = reconcile_facts((candidate,), (), (), mint_fact_id=lambda _candidate: "custom-id")
+
+    assert outcomes == (Minted(fact_id="custom-id", candidate=candidate),)
+
+
+# ---- overlap-rule helpers: direct unit coverage ----------------------------
+
+
+def test_any_bead_overlap_true_on_a_shared_id():
+    assert any_bead_overlap(("bead-1", "bead-2"), ("bead-2", "bead-3")) is True
+
+
+def test_any_bead_overlap_false_on_disjoint_sets():
+    assert any_bead_overlap(("bead-1",), ("bead-2",)) is False
+
+
+def test_majority_bead_overlap_true_above_half():
+    assert majority_bead_overlap(("bead-1", "bead-2"), ("bead-1", "bead-2", "bead-3")) is True
+
+
+def test_majority_bead_overlap_false_at_exact_half():
+    assert majority_bead_overlap(("bead-1",), ("bead-1", "bead-2")) is False
+
+
+def test_majority_bead_overlap_false_on_empty_sets():
+    assert majority_bead_overlap((), ()) is False

--- a/packages/vizsuite/tests/unit/test_sidecar_reconcile.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_reconcile.py
@@ -9,6 +9,8 @@ default id-minting strategy) is content-derived, so equality assertions on
 
 from __future__ import annotations
 
+import pytest
+
 from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
 from vizsuite.sidecar.models import FactRecord, MatchingDescriptor, Verdict, VerdictRecord
 from vizsuite.sidecar.reconcile import (
@@ -86,6 +88,15 @@ def _verdict(
 
 
 # ---- tier 1: bead-anchor overlap (any-overlap rule, edges/recommendations) --
+
+
+def test_mismatched_endpoint_arity_fails_loud_never_mints_a_duplicate():
+
+    existing = _fact("edge-1", endpoint_bead_ids=(("bead-1",), ("bead-2",)))
+    candidate = _candidate(endpoint_bead_ids=(("bead-1",),))
+
+    with pytest.raises(ValueError, match="mismatched endpoint arity"):
+        reconcile_facts((candidate,), (existing,), ())
 
 
 def test_bead_anchor_overlap_inherits_the_existing_fact_id_despite_plan_rename():


### PR DESCRIPTION
## Summary

- Adds the §5.3 **fact identity + reconciliation + rejection memory** contract as pure functions over the sidecar store (slice S2 of the sidecar/funnel/review-queue CLI build, following the S1 store foundation, #275):
- `sidecar/reconcile.py` (new): `reconcile_facts` (edges/recommendations) and `reconcile_steps` (steps) — two thin entry points over one private engine, parameterized by an injected `BeadOverlapRule` strategy rather than kind-sniffing:
  - **Durable fact ids minted at first inference** — `content_fact_id` is a SHA-256 over descriptor + basis_hash: deterministic, no randomness, no wall-clock; the minting strategy is injectable.
  - **Matching tiers:** bead-id anchor sets first (edges/recommendations: any shared bead id; steps: strict >50% Jaccard), then plan-pair + kind; prose-only candidates (zero anchors) match plan-pair + kind alone.
  - **Ambiguity is surfaced, never guessed** — multiple same-kind matches return a typed `Ambiguous` result carrying the full match history.
  - **Rejection memory** (`basis_hash` tracked separately from identity): rejected + same hash ⇒ `Suppressed`; rejected + changed hash ⇒ `Resurfaced` carrying the prior verdict so callers annotate instead of presenting as fresh.
  - Outcome type is a 5-member discriminated union of frozen dataclasses (`Minted` / `Matched` / `Suppressed` / `Resurfaced` / `Ambiguous`), each carrying the full candidate — callers persist outcomes without re-deriving anything.
- 25 new tests: all tiers, ambiguity, both rejection-memory branches, determinism (same inputs → identical outputs re-run), step-inheritance boundary cases including exact-half Jaccard falling through to the plan-pair tier, and fail-loud arity-mismatch behavior.

Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.3.

## Scope + design decisions (spec ambiguities pinned here)

- **Edge/recommendation anchor overlap = any shared bead id** — bead ids are the spec's "most stable substrate"; one shared anchor proves endpoint identity across a plan rename.
- **Step "majority overlap" = Jaccard, strict `> 0.5`** — exactly half does NOT inherit (tested; the exact-half candidate still falls through to plan-pair + kind).
- **Mismatched endpoint arity between same-kind records fails loud** with a named `ValueError` subclass (the store's malformed-input family) rather than guessing a non-match and silently minting a duplicate fact — arity is structural per kind, so a mismatch means a corrupt or hand-edited sidecar record.
- Pure functions only — no I/O, no store reads; the store remains the sole I/O boundary (S1 contract).

## Review-gate disposition

HEAVY adversarial gate (4 lenses, 2-refuter panels, 9 agents, ACCEPTANCE clean-at-floor after 1 round): zero at-floor findings; two sub-floor minors flagged for judgment. (1) bare-`zip` arity crash — **fixed** (typed fail-loud guard, commit 3). (2) per-record `set(candidate_ids)` rebuild in the overlap rules — **deferred with rationale**: hoisting requires signature churn on the public injectable-strategy seam for negligible gain at realistic sidecar sizes (dozens to low hundreds of facts); revisit if `viz sweep` profiling ever shows heat.

## Test Plan

- [x] TDD red→green: reconcile tests written first, failed before `reconcile.py` existed, green after
- [x] `make ci-vizsuite` fully green (exit 0, verified post-gate-fix): ruff, format-check, mypy --strict, 208 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
