### PR TITLE
feat(vizsuite): funnel rungs 1–2 + viz queue/sweep CLI legs (S3)

### DIFF
--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -48,6 +48,14 @@ def _add_pr_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) ->
     pr_parser.add_argument("number", type=int, metavar="N", help="the pull-request number")
 
 
+def _add_queue_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    subparsers.add_parser("queue", help="list the unresolved reassessment queue")
+
+
+def _add_sweep_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    subparsers.add_parser("sweep", help="run funnel rungs 1-2 over the sidecar's fact files")
+
+
 def _build_parser() -> _EnvelopeArgumentParser:
     parser = _EnvelopeArgumentParser(prog="viz", description="viz — repo/PR visualization suite")
     parser.add_argument(
@@ -66,6 +74,8 @@ def _build_parser() -> _EnvelopeArgumentParser:
     # VizError handling exactly like a bad top-level flag does.
     subparsers = parser.add_subparsers(dest="verb", parser_class=_EnvelopeArgumentParser)
     _add_pr_subparser(subparsers)
+    _add_queue_subparser(subparsers)
+    _add_sweep_subparser(subparsers)
     return parser
 
 

--- a/packages/vizsuite/src/vizsuite/funnel/rungs.py
+++ b/packages/vizsuite/src/vizsuite/funnel/rungs.py
@@ -1,0 +1,140 @@
+"""Staleness funnel rungs 1-2 — pure fact-reassessment classification (spec §5.4).
+
+The spec's funnel has four rungs, each strictly cheaper than the next; a fact
+exits at the first rung that clears it. This module implements only the two
+rungs the spec pins as "pure CLI code" — rung 3 (the agentic doubt check)
+belongs to the future `viz` skill/cron and is never invoked from here; rung 4
+(human reassessment) is just the `viz queue` read path over `flags.json`, not a
+rung this module evaluates.
+
+**Rung 1 (hash check)** is a single equality check over the *entire* tracked
+input-fingerprint set, not a per-fact check — every fact trivially clears it
+whenever nothing tracked changed at all, which is exactly why the spec calls
+it "free" and strictly cheaper than rung 2's per-fact citation-intersection
+test. `evaluate_fact` still takes one fact at a time (the sweep verb calls it
+once per Tier-2 record), but the *changed-key computation* is the same set
+for every call in one sweep.
+
+**Rung 2 (provenance-intersection)** compares that changed-key set against
+`fact.provenance.citations` (spec §5.2: a fact's citations are exactly the
+inputs it was derived from). The matching rule is deliberately simple: a
+tracked input key is "changed" if it is present in exactly one of
+`recorded_input_hashes`/`current_input_hashes`, or present in both with a
+different value; rung 2 clears when the changed-key set does not intersect
+the fact's citations, using plain string-equality set membership — no path
+normalization, no fuzzy matching. Both mappings are opaque `{input-key: hash}`
+snapshots the caller supplies (the sweep verb sources them from the sidecar
+manifest and a fresh Tier-1 fingerprint read respectively); this module never
+touches git, a file, or the sidecar itself.
+
+**Restamping** sets the fact's `basis_hash` to a deterministic hash of the
+entire `current_input_hashes` mapping — the spec's "new fingerprint" is the
+whole tracked input set, not just the fact's own cited subset (which, by rung
+2's own passing condition, did not change). This keeps `basis_hash`
+synchronized with the sidecar's global fingerprint state for future
+rejection-memory comparisons (§5.3), even though the fact's own citations
+were untouched by the change that tripped rung 1. The accompanying audit note
+is carried on the returned `Restamped` outcome only — this module never
+writes it anywhere; persisting or reporting it is the caller's job.
+
+**Contract-version invalidation is out of scope here.** Spec §5.2 warns that
+"rung 2 must never silently restamp facts produced under an obsolete
+inference contract" (a `prompt_version`/`model_id`/`schema_version` change).
+`evaluate_fact` never inspects those fields — a caller that must honor that
+invariant folds a contract-version key into both hash mappings (a version
+bump then changes that key, and any fact effectively "citing" it is caught by
+the same intersection test) or enforces it upstream. Documented here rather
+than silently assumed away.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vizsuite.sidecar.models import FactRecord
+
+
+@dataclass(frozen=True)
+class Reused:
+    """Rung 1 cleared: no tracked input changed since the fact's manifest baseline."""
+
+    fact: FactRecord
+
+
+@dataclass(frozen=True)
+class Restamped:
+    """Rung 2 cleared: inputs changed, but none the fact cites — auto-restamped.
+
+    `fact` carries the new `basis_hash`; every other field is unchanged from
+    the input record. `note` is the audit note the spec requires alongside the
+    restamp — the caller decides how (or whether) to persist/report it.
+    """
+
+    fact: FactRecord
+    note: str
+
+
+@dataclass(frozen=True)
+class FlaggedForReassessment:
+    """Neither rung cleared: a doubt candidate for rung 3/4 (the future skill + queue).
+
+    `fact` is the original, unmodified record — this outcome never writes
+    anything; the caller (the sweep verb) is responsible for raising a doubt
+    flag referencing `fact.fact_id`.
+    """
+
+    fact: FactRecord
+    changed_citations: frozenset[str]
+    reason: str
+
+
+RungOutcome = Reused | Restamped | FlaggedForReassessment
+
+
+def _changed_keys(recorded: Mapping[str, str], current: Mapping[str, str]) -> frozenset[str]:
+    """Every input key whose value differs (or is present in only one mapping)."""
+    keys = set(recorded) | set(current)
+    return frozenset(key for key in keys if recorded.get(key) != current.get(key))
+
+
+def _restamped_basis_hash(current_input_hashes: Mapping[str, str]) -> str:
+    """Deterministic hash of the entire current fingerprint set — "the new fingerprint"."""
+    content = json.dumps(dict(current_input_hashes), sort_keys=True)
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return f"basis-{digest[:16]}"
+
+
+def evaluate_fact(
+    fact: FactRecord,
+    *,
+    recorded_input_hashes: Mapping[str, str],
+    current_input_hashes: Mapping[str, str],
+) -> RungOutcome:
+    """Run `fact` through funnel rungs 1-2 and return its typed exit outcome."""
+    changed = _changed_keys(recorded_input_hashes, current_input_hashes)
+    if not changed:
+        return Reused(fact=fact)
+
+    intersecting = changed & frozenset(fact.provenance.citations)
+    if not intersecting:
+        restamped_fact = FactRecord(
+            fact_id=fact.fact_id,
+            matching_descriptor=fact.matching_descriptor,
+            basis_hash=_restamped_basis_hash(current_input_hashes),
+            provenance=fact.provenance,
+            payload=fact.payload,
+        )
+        note = (
+            f"auto-restamped: {len(changed)} tracked input(s) changed but none "
+            "intersect this fact's citations"
+        )
+        return Restamped(fact=restamped_fact, note=note)
+
+    return FlaggedForReassessment(
+        fact=fact,
+        changed_citations=intersecting,
+        reason=f"cited input(s) changed: {', '.join(sorted(intersecting))}",
+    )

--- a/packages/vizsuite/src/vizsuite/sidecar/store.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/store.py
@@ -233,7 +233,14 @@ class SidecarStore:
                 if time.monotonic() >= deadline:
                     raise _LockTimeoutError(lock_path, self.lock_timeout) from None
                 time.sleep(self.lock_poll_interval)
-        ensure_viz_gitignore(self.viz_dir)
+        # The depth counter is still 0 here, so `_locked()`'s finally-unlink
+        # would never run — a raise out of the gitignore write must not leak
+        # the just-created lock file (that would permanently block all writers).
+        try:
+            ensure_viz_gitignore(self.viz_dir)
+        except BaseException:
+            lock_path.unlink(missing_ok=True)
+            raise
 
     # ---- manifest (Tier-2, wholesale-rewrite) ------------------------------
 

--- a/packages/vizsuite/src/vizsuite/sidecar/store.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/store.py
@@ -9,6 +9,15 @@ overnight sweep and an on-demand command can never interleave a torn write
 deterministic (sorted keys, records sorted by id) so rewriting unchanged
 content is byte-stable.
 
+A caller needing a multi-file read→classify→write cycle to commit atomically
+wraps it in `transaction()`, which holds the lock across the whole cycle so
+no other writer can interleave between the reads and the writes (or between
+one file's rewrite and the next). The lock is re-entrant PER STORE INSTANCE:
+`write_*` calls nested inside a `transaction()` reuse the already-held lock
+instead of self-deadlocking on the non-reentrant `.viz/lock` file. Re-entrancy
+is per-instance, not per-path — a SECOND `SidecarStore` on the same root still
+contends for the lock and still gets `SIDECAR_LOCKED`.
+
 Tier-2 files (`manifest.json`/`edges.json`/`steps.json`/
 `recommendations.json`/`flags.json`) expose wholesale-rewrite APIs.
 `verdicts.json` is Tier 3 and exposes only `upsert_verdict` — there is
@@ -28,7 +37,7 @@ import os
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypeVar
 
@@ -141,6 +150,20 @@ def _load_records(path: Path, parse_one: Callable[[JsonValue], _T]) -> tuple[_T,
         raise _MalformedSidecarFileError(path, str(exc)) from exc
 
 
+@dataclass
+class _LockDepth:
+    """Mutable per-instance re-entrancy counter for `SidecarStore`.
+
+    The store is a frozen dataclass, but re-entrant locking needs mutable
+    per-instance state. A mutable holder (rather than a rebindable int field)
+    supplies it without unfreezing the store: the frozen field binds once to
+    this holder, and only the holder's `value` mutates. Excluded from the
+    store's `__eq__`/`__repr__` — it is transient runtime state, not identity.
+    """
+
+    value: int = 0
+
+
 @dataclass(frozen=True)
 class SidecarStore:
     """The `.viz/` sidecar's single entry point. `root` is injected, never `Path.cwd()`.
@@ -153,6 +176,7 @@ class SidecarStore:
     root: Path
     lock_timeout: float = _DEFAULT_LOCK_TIMEOUT_S
     lock_poll_interval: float = _DEFAULT_LOCK_POLL_INTERVAL_S
+    _lock_depth: _LockDepth = field(default_factory=_LockDepth, repr=False, compare=False)
 
     @property
     def viz_dir(self) -> Path:
@@ -162,12 +186,42 @@ class SidecarStore:
         return self.viz_dir / filename
 
     @contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Hold the single-writer lock across an entire read→classify→write cycle.
+
+        Reads issued inside see a stable snapshot; every `write_*` nested inside
+        commits under the same lock hold — no other writer can interleave between
+        the reads and the writes (or between one file's rewrite and the next),
+        which is exactly the cross-file atomicity a whole-sidecar sweep needs.
+        The nested `write_*` calls reuse this hold (re-entrant per instance)
+        rather than deadlocking on the non-reentrant `.viz/lock` file.
+        """
+        with self._locked():
+            yield
+
+    @contextmanager
     def _locked(self) -> Iterator[None]:
+        # Re-entrant PER INSTANCE: only the outermost entry (depth 0→1) creates
+        # the `.viz/lock` file, and only the outermost exit (1→0) unlinks it, so
+        # a `write_*` nested inside `transaction()` reuses the held lock instead
+        # of self-deadlocking on the non-reentrant exclusive-create.
+        if self._lock_depth.value == 0:
+            self._acquire_lock_file()
+        self._lock_depth.value += 1
+        try:
+            yield
+        finally:
+            self._lock_depth.value -= 1
+            if self._lock_depth.value == 0:
+                self._path(_LOCK_FILENAME).unlink(missing_ok=True)
+
+    def _acquire_lock_file(self) -> None:
         # Acquire the lock BEFORE any other working-tree write: `.viz/` must
         # exist for the exclusive-create below, but the `.gitignore` rewrite is
         # deferred until the lock is held. A failed acquisition then leaves only
-        # an (idempotent) empty `.viz/` directory — no torn `.gitignore` — and
-        # the non-atomic read-then-write is serialized under the lock.
+        # an (idempotent) empty `.viz/` directory — no torn `.gitignore`, and the
+        # depth counter is never incremented — and the non-atomic read-then-write
+        # is serialized under the lock.
         lock_path = self._path(_LOCK_FILENAME)
         self.viz_dir.mkdir(parents=True, exist_ok=True)
         deadline = time.monotonic() + self.lock_timeout
@@ -179,11 +233,7 @@ class SidecarStore:
                 if time.monotonic() >= deadline:
                     raise _LockTimeoutError(lock_path, self.lock_timeout) from None
                 time.sleep(self.lock_poll_interval)
-        try:
-            ensure_viz_gitignore(self.viz_dir)
-            yield
-        finally:
-            lock_path.unlink(missing_ok=True)
+        ensure_viz_gitignore(self.viz_dir)
 
     # ---- manifest (Tier-2, wholesale-rewrite) ------------------------------
 

--- a/packages/vizsuite/src/vizsuite/verbs/__init__.py
+++ b/packages/vizsuite/src/vizsuite/verbs/__init__.py
@@ -2,7 +2,7 @@
 
 `cli.main` looks the handler up here after argparse has already rejected any
 unknown subcommand, so a name reaching dispatch is always registered. Slice 1
-ships one verb, `pr`; later slices register more here.
+shipped `pr`; the .2.3 sidecar slices register more here (`queue`, `sweep`).
 """
 
 from __future__ import annotations
@@ -13,7 +13,11 @@ from collections.abc import Callable
 from vizsuite.envelope import JsonValue
 from vizsuite.runners import Runners
 from vizsuite.verbs.pr import pr
+from vizsuite.verbs.queue import queue
+from vizsuite.verbs.sweep import sweep
 
 VERBS: dict[str, Callable[[Runners, Namespace], JsonValue]] = {
     "pr": pr,
+    "queue": queue,
+    "sweep": sweep,
 }

--- a/packages/vizsuite/src/vizsuite/verbs/queue.py
+++ b/packages/vizsuite/src/vizsuite/verbs/queue.py
@@ -1,0 +1,65 @@
+"""`viz queue` — the reassessment queue read path (spec §5.3/§5.4 rung 4).
+
+Rung 4 is "a queue, not a process": every flag currently in `flags.json` *is*
+the unresolved set — `viz verdict` (a later slice) resolves a flag by
+removing it from the file atomically, so there is no separate "resolved"
+marker to filter on here. `viz queue` is therefore a pure read-and-join: every
+flag, joined to its fact (searched across `edges.json`/`steps.json`/
+`recommendations.json` — the same `fact_id` namespace `reconcile.py` mints
+into) and, for an `orphaned_verdict` flag, its verdict. Never writes anything,
+never touches an adapter.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from vizsuite.envelope import JsonValue
+from vizsuite.runners import Runners
+from vizsuite.sidecar.models import FactRecord, VerdictRecord, fact_record_to_json
+from vizsuite.sidecar.models import flag_record_to_json as _flag_to_json
+from vizsuite.sidecar.models import verdict_record_to_json as _verdict_to_json
+from vizsuite.sidecar.store import SidecarStore
+
+
+def _facts_by_id(store: SidecarStore) -> dict[str, FactRecord]:
+    """Merge the three Tier-2 fact files into one `fact_id -> FactRecord` map.
+
+    `fact_id` is minted from a namespace shared across edges/steps/
+    recommendations (`reconcile.content_fact_id`), so a collision across the
+    three files would itself be a sidecar defect; the last file read wins in
+    that case rather than raising, since this is a best-effort read path.
+    """
+    merged: dict[str, FactRecord] = {}
+    for record in (*store.read_edges(), *store.read_steps(), *store.read_recommendations()):
+        merged[record.fact_id] = record
+    return merged
+
+
+def queue(_runners: Runners, _args: Namespace) -> JsonValue:
+    """Handle `viz queue`: read `flags.json`, join to facts and verdicts.
+
+    Returns the envelope `data`: `count` and `entries`, each entry carrying
+    the raw flag plus its joined `fact`/`verdict` (`None` when the referenced
+    record is missing — a flag can outlive the record it points to across a
+    rebuild). Entries are sorted by `flag_id` for deterministic output.
+    """
+    store = SidecarStore(Path.cwd())
+    facts_by_id = _facts_by_id(store)
+    verdicts_by_id: dict[str, VerdictRecord] = {
+        verdict.verdict_id: verdict for verdict in store.read_verdicts()
+    }
+
+    entries: list[JsonValue] = []
+    for flag in sorted(store.read_flags(), key=lambda flag: flag.flag_id):
+        fact = facts_by_id.get(flag.fact_id)
+        verdict = verdicts_by_id.get(flag.verdict_id) if flag.verdict_id is not None else None
+        entry: dict[str, JsonValue] = {
+            "flag": _flag_to_json(flag),
+            "fact": fact_record_to_json(fact) if fact is not None else None,
+            "verdict": _verdict_to_json(verdict) if verdict is not None else None,
+        }
+        entries.append(entry)
+
+    return {"count": len(entries), "entries": entries}

--- a/packages/vizsuite/src/vizsuite/verbs/sweep.py
+++ b/packages/vizsuite/src/vizsuite/verbs/sweep.py
@@ -37,10 +37,12 @@ from pathlib import Path
 
 from vizsuite.envelope import JsonValue
 from vizsuite.extract.estate import estate
-from vizsuite.funnel.rungs import Restamped, Reused, evaluate_fact
+from vizsuite.funnel.rungs import FlaggedForReassessment, Restamped, Reused, evaluate_fact
 from vizsuite.runners import Runners
 from vizsuite.sidecar.models import FactRecord, FlagKind, FlagRecord, Manifest
 from vizsuite.sidecar.store import SidecarStore
+
+_FactFileEntry = tuple[tuple[FactRecord, ...], Callable[[Sequence[FactRecord]], None]]
 
 
 def _mint_flag_id(fact_id: str) -> str:
@@ -82,9 +84,7 @@ def sweep(runners: Runners, _args: Namespace) -> JsonValue:
     reused_count = restamped_count = flagged_count = 0
     new_flags_by_id: dict[str, FlagRecord] = {}
 
-    fact_files: tuple[
-        tuple[tuple[FactRecord, ...], Callable[[Sequence[FactRecord]], None]], ...
-    ] = (
+    fact_files: tuple[_FactFileEntry, ...] = (
         (store.read_edges(), store.write_edges),
         (store.read_steps(), store.write_steps),
         (store.read_recommendations(), store.write_recommendations),
@@ -108,9 +108,7 @@ def sweep(runners: Runners, _args: Namespace) -> JsonValue:
             elif isinstance(outcome, Restamped):
                 restamped_count += 1
                 rewritten.append(outcome.fact)
-            else:
-                # `RungOutcome`'s only remaining member: mypy narrows `outcome` to
-                # `FlaggedForReassessment` here by elimination (strict mode verifies it).
+            elif isinstance(outcome, FlaggedForReassessment):
                 flagged_count += 1
                 rewritten.append(outcome.fact)
                 flag_id = _mint_flag_id(outcome.fact.fact_id)
@@ -120,6 +118,8 @@ def sweep(runners: Runners, _args: Namespace) -> JsonValue:
                     kind=FlagKind.DOUBT,
                     reason=outcome.reason,
                 )
+            else:
+                raise TypeError(outcome)
         write(rewritten)
 
     if new_flags_by_id:

--- a/packages/vizsuite/src/vizsuite/verbs/sweep.py
+++ b/packages/vizsuite/src/vizsuite/verbs/sweep.py
@@ -1,0 +1,139 @@
+"""`viz sweep` — funnel rungs 1-2 over the sidecar's fact files (spec §5.4/§5.5).
+
+Sweep is the "Tier-1 extraction, funnel rungs 1-2" CLI leg of the spec's
+overnight-sweep accelerant (rung 3's agentic doubt check and rung 4's human
+queue are out of scope — a future `viz` skill layers rung 3 on top of this
+same verb). It computes a fresh current fingerprint via the already-existing
+`estate` extractor over `runners.git` (no new git call — `git ls-tree -r
+HEAD` is exactly the Tier-1 file-fingerprint source the codebase already
+has), compares it against the sidecar manifest's recorded `input_hashes`
+baseline, classifies every Tier-2 fact (`edges.json`/`steps.json`/
+`recommendations.json`) through `funnel.rungs.evaluate_fact`, rewrites the
+fact files and `flags.json` accordingly, and advances the manifest to the new
+fingerprint (closing rung 1's own loop: the next sweep's baseline is this
+sweep's current, so only genuinely new changes register as "changed"). Every
+write goes through `SidecarStore`, so it is lock-guarded and atomic exactly
+like every other sidecar writer; `verdicts.json` is never opened.
+
+**A fact with an already-pending flag is never re-evaluated.** Absent this
+guard, a fact sitting in the reassessment queue (rung 4) awaiting a human
+verdict could be silently restamped or reused by a later sweep the moment an
+unrelated input drifts back into alignment — contradicting the standing doubt
+flag out from under the human review it is waiting on. Such a fact is instead
+carried through unmodified and counted in the `flagged` bucket alongside any
+newly-flagged fact from this run; a fact is removed from that bucket only by
+an explicit `viz verdict` resolving its flag (a later slice), never by sweep.
+
+Flag ids are minted deterministically from `fact_id` alone (`_mint_flag_id`),
+so re-running sweep never mints a second flag for the same fact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from argparse import Namespace
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from vizsuite.envelope import JsonValue
+from vizsuite.extract.estate import estate
+from vizsuite.funnel.rungs import Restamped, Reused, evaluate_fact
+from vizsuite.runners import Runners
+from vizsuite.sidecar.models import FactRecord, FlagKind, FlagRecord, Manifest
+from vizsuite.sidecar.store import SidecarStore
+
+
+def _mint_flag_id(fact_id: str) -> str:
+    """Deterministic doubt-flag id: purely a function of `fact_id`.
+
+    Guarantees a fact maps to the same flag id across sweeps, so upserting by
+    `flag_id` (below) is a true idempotent merge rather than an accumulating
+    duplicate.
+    """
+    digest = hashlib.sha256(fact_id.encode("utf-8")).hexdigest()
+    return f"flag-{digest[:16]}"
+
+
+def sweep(runners: Runners, _args: Namespace) -> JsonValue:
+    """Handle `viz sweep`: classify every Tier-2 fact through funnel rungs 1-2.
+
+    Returns the envelope `data`: `reused`/`restamped`/`flagged` counts across
+    all three fact files combined.
+    """
+    store = SidecarStore(Path.cwd())
+
+    manifest = store.read_manifest()
+    if manifest is not None:
+        recorded_input_hashes = manifest.input_hashes
+        schema_version, prompt_version, model_id = (
+            manifest.schema_version,
+            manifest.prompt_version,
+            manifest.model_id,
+        )
+    else:
+        recorded_input_hashes = {}
+        schema_version, prompt_version, model_id = "", "", ""
+
+    current_input_hashes = estate(runners.git, "HEAD")
+
+    existing_flags = store.read_flags()
+    already_flagged_fact_ids = {flag.fact_id for flag in existing_flags}
+
+    reused_count = restamped_count = flagged_count = 0
+    new_flags_by_id: dict[str, FlagRecord] = {}
+
+    fact_files: tuple[
+        tuple[tuple[FactRecord, ...], Callable[[Sequence[FactRecord]], None]], ...
+    ] = (
+        (store.read_edges(), store.write_edges),
+        (store.read_steps(), store.write_steps),
+        (store.read_recommendations(), store.write_recommendations),
+    )
+    for records, write in fact_files:
+        rewritten: list[FactRecord] = []
+        for record in records:
+            if record.fact_id in already_flagged_fact_ids:
+                flagged_count += 1
+                rewritten.append(record)
+                continue
+
+            outcome = evaluate_fact(
+                record,
+                recorded_input_hashes=recorded_input_hashes,
+                current_input_hashes=current_input_hashes,
+            )
+            if isinstance(outcome, Reused):
+                reused_count += 1
+                rewritten.append(outcome.fact)
+            elif isinstance(outcome, Restamped):
+                restamped_count += 1
+                rewritten.append(outcome.fact)
+            else:
+                # `RungOutcome`'s only remaining member: mypy narrows `outcome` to
+                # `FlaggedForReassessment` here by elimination (strict mode verifies it).
+                flagged_count += 1
+                rewritten.append(outcome.fact)
+                flag_id = _mint_flag_id(outcome.fact.fact_id)
+                new_flags_by_id[flag_id] = FlagRecord(
+                    flag_id=flag_id,
+                    fact_id=outcome.fact.fact_id,
+                    kind=FlagKind.DOUBT,
+                    reason=outcome.reason,
+                )
+        write(rewritten)
+
+    if new_flags_by_id:
+        merged = {flag.flag_id: flag for flag in existing_flags}
+        merged.update(new_flags_by_id)
+        store.write_flags(tuple(merged.values()))
+
+    store.write_manifest(
+        Manifest(
+            schema_version=schema_version,
+            prompt_version=prompt_version,
+            model_id=model_id,
+            input_hashes=current_input_hashes,
+        )
+    )
+
+    return {"reused": reused_count, "restamped": restamped_count, "flagged": flagged_count}

--- a/packages/vizsuite/src/vizsuite/verbs/sweep.py
+++ b/packages/vizsuite/src/vizsuite/verbs/sweep.py
@@ -11,9 +11,11 @@ baseline, classifies every Tier-2 fact (`edges.json`/`steps.json`/
 `recommendations.json`) through `funnel.rungs.evaluate_fact`, rewrites the
 fact files and `flags.json` accordingly, and advances the manifest to the new
 fingerprint (closing rung 1's own loop: the next sweep's baseline is this
-sweep's current, so only genuinely new changes register as "changed"). Every
-write goes through `SidecarStore`, so it is lock-guarded and atomic exactly
-like every other sidecar writer; `verdicts.json` is never opened.
+sweep's current, so only genuinely new changes register as "changed"). The
+entire read→classify→write cycle runs inside a single `SidecarStore.transaction()`,
+so it holds the single-writer lock across all the reads and every fact/flag/
+manifest write — no concurrent writer can interleave and leave a cross-file
+state that never existed atomically; `verdicts.json` is never opened.
 
 **A fact with an already-pending flag is never re-evaluated.** Absent this
 guard, a fact sitting in the reassessment queue (rung 4) awaiting a human
@@ -64,76 +66,82 @@ def sweep(runners: Runners, _args: Namespace) -> JsonValue:
     """
     store = SidecarStore(Path.cwd())
 
-    manifest = store.read_manifest()
-    if manifest is not None:
-        recorded_input_hashes = manifest.input_hashes
-        schema_version, prompt_version, model_id = (
-            manifest.schema_version,
-            manifest.prompt_version,
-            manifest.model_id,
-        )
-    else:
-        recorded_input_hashes = {}
-        schema_version, prompt_version, model_id = "", "", ""
-
-    current_input_hashes = estate(runners.git, "HEAD")
-
-    existing_flags = store.read_flags()
-    already_flagged_fact_ids = {flag.fact_id for flag in existing_flags}
-
-    reused_count = restamped_count = flagged_count = 0
-    new_flags_by_id: dict[str, FlagRecord] = {}
-
-    fact_files: tuple[_FactFileEntry, ...] = (
-        (store.read_edges(), store.write_edges),
-        (store.read_steps(), store.write_steps),
-        (store.read_recommendations(), store.write_recommendations),
-    )
-    for records, write in fact_files:
-        rewritten: list[FactRecord] = []
-        for record in records:
-            if record.fact_id in already_flagged_fact_ids:
-                flagged_count += 1
-                rewritten.append(record)
-                continue
-
-            outcome = evaluate_fact(
-                record,
-                recorded_input_hashes=recorded_input_hashes,
-                current_input_hashes=current_input_hashes,
+    # The entire read→classify→write cycle runs under ONE lock hold: the reads
+    # below see a stable snapshot and every write commits under the same hold,
+    # so no concurrent writer can interleave between a read and its write (or
+    # between two fact-file rewrites) and leave a cross-file state that never
+    # existed atomically.
+    with store.transaction():
+        manifest = store.read_manifest()
+        if manifest is not None:
+            recorded_input_hashes = manifest.input_hashes
+            schema_version, prompt_version, model_id = (
+                manifest.schema_version,
+                manifest.prompt_version,
+                manifest.model_id,
             )
-            if isinstance(outcome, Reused):
-                reused_count += 1
-                rewritten.append(outcome.fact)
-            elif isinstance(outcome, Restamped):
-                restamped_count += 1
-                rewritten.append(outcome.fact)
-            elif isinstance(outcome, FlaggedForReassessment):
-                flagged_count += 1
-                rewritten.append(outcome.fact)
-                flag_id = _mint_flag_id(outcome.fact.fact_id)
-                new_flags_by_id[flag_id] = FlagRecord(
-                    flag_id=flag_id,
-                    fact_id=outcome.fact.fact_id,
-                    kind=FlagKind.DOUBT,
-                    reason=outcome.reason,
-                )
-            else:
-                raise TypeError(outcome)
-        write(rewritten)
+        else:
+            recorded_input_hashes = {}
+            schema_version, prompt_version, model_id = "", "", ""
 
-    if new_flags_by_id:
-        merged = {flag.flag_id: flag for flag in existing_flags}
-        merged.update(new_flags_by_id)
-        store.write_flags(tuple(merged.values()))
+        current_input_hashes = estate(runners.git, "HEAD")
 
-    store.write_manifest(
-        Manifest(
-            schema_version=schema_version,
-            prompt_version=prompt_version,
-            model_id=model_id,
-            input_hashes=current_input_hashes,
+        existing_flags = store.read_flags()
+        already_flagged_fact_ids = {flag.fact_id for flag in existing_flags}
+
+        reused_count = restamped_count = flagged_count = 0
+        new_flags_by_id: dict[str, FlagRecord] = {}
+
+        fact_files: tuple[_FactFileEntry, ...] = (
+            (store.read_edges(), store.write_edges),
+            (store.read_steps(), store.write_steps),
+            (store.read_recommendations(), store.write_recommendations),
         )
-    )
+        for records, write in fact_files:
+            rewritten: list[FactRecord] = []
+            for record in records:
+                if record.fact_id in already_flagged_fact_ids:
+                    flagged_count += 1
+                    rewritten.append(record)
+                    continue
+
+                outcome = evaluate_fact(
+                    record,
+                    recorded_input_hashes=recorded_input_hashes,
+                    current_input_hashes=current_input_hashes,
+                )
+                if isinstance(outcome, Reused):
+                    reused_count += 1
+                    rewritten.append(outcome.fact)
+                elif isinstance(outcome, Restamped):
+                    restamped_count += 1
+                    rewritten.append(outcome.fact)
+                elif isinstance(outcome, FlaggedForReassessment):
+                    flagged_count += 1
+                    rewritten.append(outcome.fact)
+                    flag_id = _mint_flag_id(outcome.fact.fact_id)
+                    new_flags_by_id[flag_id] = FlagRecord(
+                        flag_id=flag_id,
+                        fact_id=outcome.fact.fact_id,
+                        kind=FlagKind.DOUBT,
+                        reason=outcome.reason,
+                    )
+                else:
+                    raise TypeError(outcome)
+            write(rewritten)
+
+        if new_flags_by_id:
+            merged = {flag.flag_id: flag for flag in existing_flags}
+            merged.update(new_flags_by_id)
+            store.write_flags(tuple(merged.values()))
+
+        store.write_manifest(
+            Manifest(
+                schema_version=schema_version,
+                prompt_version=prompt_version,
+                model_id=model_id,
+                input_hashes=current_input_hashes,
+            )
+        )
 
     return {"reused": reused_count, "restamped": restamped_count, "flagged": flagged_count}

--- a/packages/vizsuite/tests/unit/test_funnel_rungs.py
+++ b/packages/vizsuite/tests/unit/test_funnel_rungs.py
@@ -1,0 +1,130 @@
+"""Staleness funnel rungs 1-2 — pure classification over sidecar facts (spec §5.4).
+
+Rung 1 (hash check) and rung 2 (provenance-intersection) are the two "pure CLI
+code" rungs `evaluate_fact` implements; rung 3 (agentic doubt check) and rung 4
+(the human reassessment queue) are out of scope here (spec §5.4: "Rungs 1-2 are
+pure CLI code; rung 3 belongs to the skill/cron; rung 4 is a queue, not a
+process").
+"""
+
+from __future__ import annotations
+
+from vizsuite.funnel.rungs import FlaggedForReassessment, Restamped, Reused, evaluate_fact
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import FactRecord, MatchingDescriptor
+
+
+def _fact(
+    fact_id: str = "fact-1",
+    *,
+    citations: tuple[str, ...] = (),
+    basis_hash: str = "basis-orig",
+) -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind="dependency"),
+        basis_hash=basis_hash,
+        provenance=Provenance(
+            kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=citations
+        ),
+    )
+
+
+def test_rung1_reuses_fact_verbatim_when_no_tracked_input_changed():
+    fact = _fact(citations=("src/app.py",))
+    hashes = {"src/app.py": "sha-a", "README.md": "sha-b"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=hashes, current_input_hashes=dict(hashes))
+
+    assert outcome == Reused(fact=fact)
+
+
+def test_rung1_clears_even_when_fact_has_no_citations():
+    fact = _fact(citations=())
+    hashes = {"src/app.py": "sha-a"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=hashes, current_input_hashes=dict(hashes))
+
+    assert outcome == Reused(fact=fact)
+
+
+def test_rung2_restamps_when_changed_inputs_do_not_intersect_citations():
+    fact = _fact(citations=("src/app.py",), basis_hash="basis-orig")
+    recorded = {"src/app.py": "sha-a", "README.md": "sha-b"}
+    current = {"src/app.py": "sha-a", "README.md": "sha-b-changed"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=recorded, current_input_hashes=current)
+
+    assert isinstance(outcome, Restamped)
+    assert outcome.fact.fact_id == fact.fact_id
+    assert outcome.fact.basis_hash != fact.basis_hash  # restamped, not the original value
+    assert outcome.fact.provenance == fact.provenance  # citations/freshness carried through
+    assert outcome.fact.matching_descriptor == fact.matching_descriptor
+    assert outcome.fact.payload == fact.payload
+    assert outcome.note  # non-empty audit note
+
+
+def test_restamp_basis_hash_is_a_deterministic_function_of_current_fingerprints_only():
+    recorded = {"src/app.py": "sha-a", "README.md": "sha-b"}
+    current = {"src/app.py": "sha-a", "README.md": "sha-b-changed"}
+    fact_one = _fact(fact_id="fact-1", citations=("src/app.py",), basis_hash="basis-one")
+    fact_two = _fact(fact_id="fact-2", citations=("src/app.py",), basis_hash="basis-two")
+
+    outcome_one = evaluate_fact(
+        fact_one, recorded_input_hashes=recorded, current_input_hashes=current
+    )
+    outcome_two = evaluate_fact(
+        fact_two, recorded_input_hashes=recorded, current_input_hashes=current
+    )
+
+    assert isinstance(outcome_one, Restamped)
+    assert isinstance(outcome_two, Restamped)
+    # Same current fingerprint set -> same restamped basis_hash, regardless of
+    # the two facts' distinct original fact_id/basis_hash.
+    assert outcome_one.fact.basis_hash == outcome_two.fact.basis_hash
+
+
+def test_neither_rung_clears_flags_for_reassessment_when_a_cited_input_changed():
+    fact = _fact(citations=("src/app.py",))
+    recorded = {"src/app.py": "sha-a"}
+    current = {"src/app.py": "sha-a-changed"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=recorded, current_input_hashes=current)
+
+    assert isinstance(outcome, FlaggedForReassessment)
+    assert outcome.fact == fact  # the fact is carried through unmodified — no write happens
+    assert outcome.changed_citations == frozenset({"src/app.py"})
+    assert "src/app.py" in outcome.reason
+
+
+def test_flag_reports_only_the_intersecting_citations_not_every_changed_key():
+    fact = _fact(citations=("src/app.py", "README.md"))
+    recorded = {"src/app.py": "sha-a", "README.md": "sha-b", "other.py": "sha-c"}
+    current = {"src/app.py": "sha-a-changed", "README.md": "sha-b", "other.py": "sha-c-changed"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=recorded, current_input_hashes=current)
+
+    assert isinstance(outcome, FlaggedForReassessment)
+    # other.py changed too but is not cited — only the cited+changed key surfaces.
+    assert outcome.changed_citations == frozenset({"src/app.py"})
+
+
+def test_an_added_key_the_fact_cites_flags_for_reassessment():
+    fact = _fact(citations=("new/file.py",))
+    recorded: dict[str, str] = {}
+    current = {"new/file.py": "sha-a"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=recorded, current_input_hashes=current)
+
+    assert isinstance(outcome, FlaggedForReassessment)
+    assert outcome.changed_citations == frozenset({"new/file.py"})
+
+
+def test_a_removed_key_the_fact_does_not_cite_restamps():
+    fact = _fact(citations=("src/app.py",))
+    recorded = {"src/app.py": "sha-a", "removed.py": "sha-old"}
+    current = {"src/app.py": "sha-a"}
+
+    outcome = evaluate_fact(fact, recorded_input_hashes=recorded, current_input_hashes=current)
+
+    assert isinstance(outcome, Restamped)

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -526,3 +526,24 @@ def test_store_reads_and_writes_are_scoped_to_the_injected_root(tmp_path: Path):
 
     assert store_a.read_manifest() == Manifest(schema_version="a")
     assert store_b.read_manifest() is None
+
+
+def test_lock_file_is_not_leaked_when_the_gitignore_write_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The gitignore write runs after the lock file is created but before the
+    # depth counter is incremented — a raise there must unlink the lock, or
+    # every future writer is permanently locked out.
+    store = SidecarStore(tmp_path)
+
+    def _boom(_viz_dir: Path) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("vizsuite.sidecar.store.ensure_viz_gitignore", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        store.write_manifest(Manifest(schema_version="1"))
+
+    monkeypatch.undo()
+    assert not (store.viz_dir / "lock").exists()
+    store.write_manifest(Manifest(schema_version="1"))  # no lockout — acquires cleanly
+    assert store.read_manifest() == Manifest(schema_version="1")

--- a/packages/vizsuite/tests/unit/test_sidecar_store.py
+++ b/packages/vizsuite/tests/unit/test_sidecar_store.py
@@ -430,6 +430,87 @@ def test_concurrent_writers_do_not_interleave(tmp_path: Path, monkeypatch: pytes
     assert events == ["start", "end", "start", "end"]
 
 
+# ---- transaction(): re-entrant single-writer hold across a whole cycle -----
+
+
+def test_transaction_allows_nested_writes_without_self_deadlock(tmp_path: Path):
+    # The lock file is non-reentrant, so a write nested inside the transaction
+    # would deadlock (until SIDECAR_LOCKED) if the lock were re-acquired rather
+    # than reused. A short timeout would surface that regression as a failure.
+    store = SidecarStore(tmp_path, lock_timeout=0.2, lock_poll_interval=0.01)
+
+    with store.transaction():
+        store.write_manifest(Manifest(schema_version="1"))
+        store.write_edges((_fact("edge-1"),))
+        assert (store.viz_dir / "lock").exists()  # held for the whole cycle
+
+    assert not (store.viz_dir / "lock").exists()  # released at the outermost exit
+    assert store.read_manifest() == Manifest(schema_version="1")
+    assert store.read_edges() == (_fact("edge-1"),)
+
+
+def test_nested_transactions_release_only_at_the_outermost_exit(tmp_path: Path):
+    store = SidecarStore(tmp_path)
+
+    with store.transaction():
+        with store.transaction():
+            store.write_manifest(Manifest(schema_version="1"))
+            assert (store.viz_dir / "lock").exists()
+        # the inner exit must NOT release the lock — the outer hold is still live.
+        assert (store.viz_dir / "lock").exists()
+
+    assert not (store.viz_dir / "lock").exists()
+
+
+def test_transaction_releases_lock_when_a_nested_write_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = SidecarStore(tmp_path)
+
+    def _boom(_self: Path, _target: Path) -> Path:
+        raise OSError("simulated crash before rename")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError, match="simulated crash"), store.transaction():
+        store.write_manifest(Manifest(schema_version="1"))
+
+    monkeypatch.undo()
+    # a raise inside the nested region still unwinds to depth 0 and unlinks.
+    assert not (store.viz_dir / "lock").exists()
+    store.write_manifest(Manifest(schema_version="2"))  # lock is usable again
+    assert store.read_manifest() == Manifest(schema_version="2")
+
+
+def test_second_store_write_during_a_transaction_gets_sidecar_locked(tmp_path: Path):
+    # Re-entrancy is PER INSTANCE, not per-path-global: a second store on the
+    # same root still contends for the `.viz/lock` file and is locked out while
+    # the first store holds a transaction.
+    holder = SidecarStore(tmp_path)
+    contender = SidecarStore(tmp_path, lock_timeout=0.05, lock_poll_interval=0.01)
+
+    with holder.transaction(), pytest.raises(VizError) as exc_info:
+        contender.write_manifest(Manifest(schema_version="contend"))
+
+    assert exc_info.value.code == ErrorCode.SIDECAR_LOCKED
+    # once the holder's transaction exits, the contender can write.
+    contender.write_manifest(Manifest(schema_version="after"))
+    assert contender.read_manifest() == Manifest(schema_version="after")
+
+
+def test_stores_on_the_same_root_are_equal_regardless_of_lock_depth(tmp_path: Path):
+    # The transient re-entrancy counter is excluded from equality: a store
+    # mid-transaction (depth 1) still equals a fresh store (depth 0) on the
+    # same root.
+    held = SidecarStore(tmp_path)
+    fresh = SidecarStore(tmp_path)
+
+    with held.transaction():
+        assert held._lock_depth.value == 1
+        assert held == fresh
+
+    assert held == fresh
+
+
 # ---- root injection: no module-global cwd assumption -----------------------
 
 

--- a/packages/vizsuite/tests/unit/test_verbs_queue.py
+++ b/packages/vizsuite/tests/unit/test_verbs_queue.py
@@ -1,0 +1,179 @@
+"""`viz queue` — the reassessment queue read path (spec §5.3/§5.4 rung 4).
+
+`viz queue` is exactly the unresolved flags in `flags.json`, joined to their
+facts (across `edges.json`/`steps.json`/`recommendations.json`) and, for
+`orphaned_verdict` flags, their verdict — a pure read path with no writes.
+Every flag currently on disk *is* the unresolved set: `viz verdict` (a later
+slice) resolves a flag by removing it from `flags.json`, so there is no
+separate "resolved" marker to filter on here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_cli
+from vizsuite.adapters.git.runner import LsTreeRow
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    MatchingDescriptor,
+    Verdict,
+    VerdictRecord,
+)
+from vizsuite.sidecar.store import SidecarStore
+
+
+class _ExplodingGitRunner:
+    """Proves `viz queue` never touches git — a pure sidecar read path."""
+
+    def ls_tree(self, rev: str) -> list[LsTreeRow]:
+        raise AssertionError(f"queue must never call git, got rev={rev!r}")
+
+
+def _fact(fact_id: str, *, kind: str = "dependency") -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind=kind),
+        basis_hash=f"hash-{fact_id}",
+        provenance=Provenance(kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH),
+    )
+
+
+def test_queue_is_empty_when_no_flags_exist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+
+    exit_code, envelope, stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert envelope["data"] == {"count": 0, "entries": []}
+
+
+def test_queue_joins_a_doubt_flag_to_its_fact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    store.write_flags(
+        (FlagRecord(flag_id="flag-1", fact_id="edge-1", kind=FlagKind.DOUBT, reason="churned"),)
+    )
+
+    exit_code, envelope, _stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert data["count"] == 1
+    entry = data["entries"][0]
+    assert entry["flag"]["flag_id"] == "flag-1"
+    assert entry["fact"]["fact_id"] == "edge-1"
+    assert entry["verdict"] is None
+
+
+def test_queue_joins_an_orphaned_verdict_flag_to_its_fact_and_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id="verdict-1", fact_id="edge-1", verdict=Verdict.ACCEPT, basis_hash="hash-old"
+        )
+    )
+    store.write_flags(
+        (
+            FlagRecord(
+                flag_id="flag-1",
+                fact_id="edge-1",
+                kind=FlagKind.ORPHANED_VERDICT,
+                reason="fact vanished on rebuild",
+                verdict_id="verdict-1",
+            ),
+        )
+    )
+
+    exit_code, envelope, _stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    entry = data["entries"][0]
+    assert entry["fact"]["fact_id"] == "edge-1"
+    assert entry["verdict"]["verdict_id"] == "verdict-1"
+
+
+def test_queue_entry_fact_and_verdict_are_none_when_referenced_records_are_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    # A flag surviving a rebuild that dropped its fact/verdict entirely — the
+    # join degrades gracefully instead of crashing.
+    store.write_flags(
+        (
+            FlagRecord(
+                flag_id="flag-1",
+                fact_id="missing-fact",
+                kind=FlagKind.ORPHANED_VERDICT,
+                reason="fact and verdict both gone",
+                verdict_id="missing-verdict",
+            ),
+        )
+    )
+
+    exit_code, envelope, _stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    entry = data["entries"][0]
+    assert entry["fact"] is None
+    assert entry["verdict"] is None
+
+
+def test_queue_resolves_facts_stored_in_steps_and_recommendations_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_steps((_fact("step-1", kind="waypoint"),))
+    store.write_recommendations((_fact("rec-1", kind="dependency"),))
+    store.write_flags(
+        (
+            FlagRecord(flag_id="flag-1", fact_id="step-1", kind=FlagKind.DOUBT, reason="a"),
+            FlagRecord(flag_id="flag-2", fact_id="rec-1", kind=FlagKind.DOUBT, reason="b"),
+        )
+    )
+
+    exit_code, envelope, _stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert data["count"] == 2
+    fact_ids = {entry["fact"]["fact_id"] for entry in data["entries"]}
+    assert fact_ids == {"step-1", "rec-1"}
+
+
+def test_queue_entries_are_sorted_by_flag_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"), _fact("edge-2")))
+    store.write_flags(
+        (
+            FlagRecord(flag_id="flag-b", fact_id="edge-2", kind=FlagKind.DOUBT, reason="b"),
+            FlagRecord(flag_id="flag-a", fact_id="edge-1", kind=FlagKind.DOUBT, reason="a"),
+        )
+    )
+
+    exit_code, envelope, _stderr = run_cli(["queue"], git_runner=_ExplodingGitRunner())
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert [entry["flag"]["flag_id"] for entry in data["entries"]] == ["flag-a", "flag-b"]

--- a/packages/vizsuite/tests/unit/test_verbs_sweep.py
+++ b/packages/vizsuite/tests/unit/test_verbs_sweep.py
@@ -22,6 +22,7 @@ import pytest
 
 from tests.conftest import run_cli
 from tests.fakes import ScriptedGitRunner, blob
+from vizsuite.envelope import ErrorCode, VizError
 from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
 from vizsuite.sidecar.models import (
     FactRecord,
@@ -212,6 +213,39 @@ def test_sweep_is_lock_guarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     assert exit_code == 1
     assert envelope["error"]["code"] == "E_SIDECAR_LOCKED"
+
+
+def test_sweep_holds_the_lock_across_the_whole_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Prove the read→classify→write cycle is one atomic hold: a second store
+    # attempting a write MID-SWEEP (between the reads and the writes, hooked via
+    # the per-fact classify call) is locked out with SIDECAR_LOCKED.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    store.write_edges((_fact("edge-1", citations=("src/app.py",)),))
+
+    contention: list[object] = []
+    sweep_module = importlib.import_module("vizsuite.verbs.sweep")
+    real_evaluate = sweep_module.evaluate_fact
+
+    def _spy_evaluate(record: FactRecord, **kwargs: object) -> object:
+        contender = SidecarStore(tmp_path, lock_timeout=0.02, lock_poll_interval=0.005)
+        try:
+            contender.write_manifest(Manifest(schema_version="intruder"))
+        except VizError as exc:
+            contention.append(exc.code)
+        else:
+            contention.append(None)  # acquired — the transaction failed to hold the lock
+        return real_evaluate(record, **kwargs)
+
+    monkeypatch.setattr(sweep_module, "evaluate_fact", _spy_evaluate)
+
+    exit_code, _envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert contention == [ErrorCode.SIDECAR_LOCKED]  # the one fact classified, contender locked out
 
 
 def test_sweep_never_touches_verdicts_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/packages/vizsuite/tests/unit/test_verbs_sweep.py
+++ b/packages/vizsuite/tests/unit/test_verbs_sweep.py
@@ -14,6 +14,7 @@ silently restamped out from under the flag).
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 
@@ -290,3 +291,27 @@ def test_sweep_output_is_valid_json_and_manifest_bytes_are_deterministic(
     manifest_path = SidecarStore(tmp_path).viz_dir / "manifest.json"
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert payload["input_hashes"] == _CURRENT_FINGERPRINT
+
+
+def test_sweep_raises_on_an_unknown_rung_outcome_variant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The classification chain ends in a defensive raise: if `RungOutcome` ever
+    # grows a fourth variant that sweep doesn't handle, the sweep must fail
+    # loud rather than silently miscounting the fact as flagged.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    store.write_edges((_fact("edge-1", citations=("src/app.py",)),))
+    # String-target setattr would resolve `vizsuite.verbs.sweep` to the *function*
+    # re-exported by `verbs/__init__`, not the submodule — patch the module object.
+    sweep_module = importlib.import_module("vizsuite.verbs.sweep")
+    monkeypatch.setattr(sweep_module, "evaluate_fact", lambda *_args, **_kwargs: object())
+
+    exit_code, envelope, stderr = run_cli(["sweep"], git_runner=_git())
+
+    # cli.main's guarded region converts the TypeError into the single
+    # E_INTERNAL envelope (envelope invariant) with the traceback on stderr.
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr

--- a/packages/vizsuite/tests/unit/test_verbs_sweep.py
+++ b/packages/vizsuite/tests/unit/test_verbs_sweep.py
@@ -1,0 +1,292 @@
+"""`viz sweep` — funnel rungs 1-2 over the sidecar's fact files (spec §5.4/§5.5).
+
+Sweep is the "Tier-1 extraction, funnel rungs 1-2" CLI leg of the spec's
+overnight-sweep accelerant: it reads a fresh current fingerprint (via the
+already-existing `estate` extractor over `runners.git`, never a new git call),
+compares it against the sidecar manifest's recorded baseline, classifies every
+Tier-2 fact (edges/steps/recommendations) through `funnel.rungs.evaluate_fact`,
+rewrites the fact files and `flags.json` accordingly, and advances the
+manifest to the new fingerprint — all under the sidecar's single-writer lock.
+It never touches `verdicts.json`, and never re-evaluates a fact that already
+has a pending flag (a doubt candidate mid-queue for human review is never
+silently restamped out from under the flag).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedGitRunner, blob
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    Manifest,
+    MatchingDescriptor,
+    Verdict,
+    VerdictRecord,
+)
+from vizsuite.sidecar.store import SidecarStore
+
+_CURRENT_FINGERPRINT = {"src/app.py": "sha-app-1", "docs/readme.md": "sha-readme-1"}
+
+
+def _git(fingerprint: dict[str, str] = _CURRENT_FINGERPRINT) -> ScriptedGitRunner:
+    return ScriptedGitRunner(ls_tree_rows=[blob(path, sha) for path, sha in fingerprint.items()])
+
+
+def _fact(
+    fact_id: str, *, citations: tuple[str, ...] = (), basis_hash: str = "basis-orig"
+) -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind="dependency"),
+        basis_hash=basis_hash,
+        provenance=Provenance(
+            kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=citations
+        ),
+    )
+
+
+def test_sweep_writes_a_fresh_manifest_and_reports_zero_counts_on_an_empty_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    exit_code, envelope, stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert envelope["data"] == {"reused": 0, "restamped": 0, "flagged": 0}
+    store = SidecarStore(tmp_path)
+    assert store.read_manifest() == Manifest(schema_version="", input_hashes=_CURRENT_FINGERPRINT)
+
+
+def test_sweep_reuses_a_fact_verbatim_when_the_manifest_matches_the_current_fingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    fact = _fact("edge-1", citations=("src/app.py",))
+    store.write_edges((fact,))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"] == {"reused": 1, "restamped": 0, "flagged": 0}
+    assert store.read_edges() == (fact,)  # byte-for-byte the same record
+
+
+def test_sweep_restamps_a_fact_when_a_changed_input_is_not_among_its_citations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    recorded = dict(_CURRENT_FINGERPRINT)
+    recorded["docs/readme.md"] = "sha-readme-OLD"  # readme changed; the fact doesn't cite it
+    store.write_manifest(Manifest(schema_version="1", input_hashes=recorded))
+    fact = _fact("edge-1", citations=("src/app.py",), basis_hash="basis-orig")
+    store.write_edges((fact,))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"] == {"reused": 0, "restamped": 1, "flagged": 0}
+    (restamped,) = store.read_edges()
+    assert restamped.fact_id == "edge-1"
+    assert restamped.basis_hash != "basis-orig"
+    assert store.read_flags() == ()  # no flag raised
+
+
+def test_sweep_flags_a_fact_when_a_cited_input_changed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    recorded = dict(_CURRENT_FINGERPRINT)
+    recorded["src/app.py"] = "sha-app-OLD"  # app.py changed; the fact cites exactly this
+    store.write_manifest(Manifest(schema_version="1", input_hashes=recorded))
+    fact = _fact("edge-1", citations=("src/app.py",), basis_hash="basis-orig")
+    store.write_edges((fact,))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"] == {"reused": 0, "restamped": 0, "flagged": 1}
+    assert store.read_edges() == (fact,)  # flagged facts are carried through unmodified
+    (flag,) = store.read_flags()
+    assert flag.fact_id == "edge-1"
+    assert flag.kind == FlagKind.DOUBT
+    assert "src/app.py" in flag.reason
+
+
+def test_sweep_never_reevaluates_a_fact_that_already_has_a_pending_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The manifest matches the current fingerprint exactly, so absent the
+    # pending flag this fact would trivially clear rung 1 (reused) — but it
+    # must never be silently restamped/reused out from under a standing
+    # doubt flag still awaiting human disposition.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    fact = _fact("edge-1", citations=("src/app.py",), basis_hash="basis-orig")
+    store.write_edges((fact,))
+    pre_existing_flag = FlagRecord(
+        flag_id="flag-preexisting", fact_id="edge-1", kind=FlagKind.DOUBT, reason="prior doubt"
+    )
+    store.write_flags((pre_existing_flag,))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"] == {"reused": 0, "restamped": 0, "flagged": 1}
+    assert store.read_edges() == (fact,)  # untouched — basis_hash never changed
+    assert store.read_flags() == (pre_existing_flag,)  # untouched, not duplicated
+
+
+def test_sweep_preserves_unrelated_existing_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id="verdict-1",
+            fact_id="vanished-fact",
+            verdict=Verdict.ACCEPT,
+            basis_hash="hash-x",
+        )
+    )
+    unrelated_flag = FlagRecord(
+        flag_id="flag-orphan",
+        fact_id="vanished-fact",
+        kind=FlagKind.ORPHANED_VERDICT,
+        reason="fact vanished on rebuild",
+        verdict_id="verdict-1",
+    )
+    store.write_flags((unrelated_flag,))
+    recorded = dict(_CURRENT_FINGERPRINT)
+    recorded["src/app.py"] = "sha-app-OLD"
+    store.write_manifest(Manifest(schema_version="1", input_hashes=recorded))
+    store.write_edges((_fact("edge-1", citations=("src/app.py",)),))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"]["flagged"] == 1
+    flags = {flag.flag_id: flag for flag in store.read_flags()}
+    assert flags["flag-orphan"] == unrelated_flag  # carried through unchanged
+    assert len(flags) == 2  # plus the newly-raised doubt flag for edge-1
+
+
+def test_sweep_processes_steps_and_recommendations_alongside_edges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(Manifest(schema_version="1", input_hashes=_CURRENT_FINGERPRINT))
+    store.write_edges((_fact("edge-1"),))
+    store.write_steps((_fact("step-1"),))
+    store.write_recommendations((_fact("rec-1"),))
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert envelope["data"] == {"reused": 3, "restamped": 0, "flagged": 0}
+
+
+def test_sweep_is_lock_guarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.viz_dir.mkdir(parents=True)
+    (store.viz_dir / "lock").touch()  # simulate another writer already holding the lock
+
+    exit_code, envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_LOCKED"
+
+
+def test_sweep_never_touches_verdicts_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    recorded = dict(_CURRENT_FINGERPRINT)
+    recorded["src/app.py"] = "sha-app-OLD"
+    store.write_manifest(Manifest(schema_version="1", input_hashes=recorded))
+    store.write_edges((_fact("edge-1", citations=("src/app.py",)),))  # will be flagged
+    store.write_steps((_fact("step-1", citations=("docs/readme.md",)),))  # will be restamped
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id="verdict-1", fact_id="edge-1", verdict=Verdict.ACCEPT, basis_hash="h"
+        )
+    )
+    verdicts_path = store.viz_dir / "verdicts.json"
+    before = verdicts_path.read_bytes()
+
+    exit_code, _envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    after = verdicts_path.read_bytes()
+    assert after == before
+
+
+def test_sweeping_twice_on_unchanged_state_does_not_duplicate_the_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    recorded = dict(_CURRENT_FINGERPRINT)
+    recorded["src/app.py"] = "sha-app-OLD"
+    store.write_manifest(Manifest(schema_version="1", input_hashes=recorded))
+    store.write_edges((_fact("edge-1", citations=("src/app.py",)),))
+
+    first_exit, first_envelope, _ = run_cli(["sweep"], git_runner=_git())
+    second_exit, second_envelope, _ = run_cli(["sweep"], git_runner=_git())
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert first_envelope["data"] == {"reused": 0, "restamped": 0, "flagged": 1}
+    assert second_envelope["data"] == {"reused": 0, "restamped": 0, "flagged": 1}
+    assert len(store.read_flags()) == 1  # not duplicated
+
+
+def test_sweep_carries_forward_existing_manifest_contract_versions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_manifest(
+        Manifest(
+            schema_version="3",
+            prompt_version="p9",
+            model_id="m9",
+            input_hashes=_CURRENT_FINGERPRINT,
+        )
+    )
+
+    exit_code, _envelope, _stderr = run_cli(["sweep"], git_runner=_git())
+
+    assert exit_code == 0
+    assert store.read_manifest() == Manifest(
+        schema_version="3", prompt_version="p9", model_id="m9", input_hashes=_CURRENT_FINGERPRINT
+    )
+
+
+def test_sweep_output_is_valid_json_and_manifest_bytes_are_deterministic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Sanity check that the manifest write goes through the store's normal
+    # deterministic serialization (sorted keys) rather than some ad-hoc dump.
+    monkeypatch.chdir(tmp_path)
+
+    run_cli(["sweep"], git_runner=_git())
+
+    manifest_path = SidecarStore(tmp_path).viz_dir / "manifest.json"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["input_hashes"] == _CURRENT_FINGERPRINT


### PR DESCRIPTION
## Summary

- Adds the §5.4 **staleness funnel rungs 1–2** plus the reassessment queue's CLI legs (slice S3 of the sidecar/funnel/review-queue build, after S1 store #275 and S2 reconciliation #277):
- `funnel/rungs.py` (new): pure rung evaluation, no I/O —
  - **Rung 1 (fingerprint short-circuit):** tracked input set unchanged → `Reused` verbatim.
  - **Rung 2 (provenance-intersection):** inputs changed but the change set doesn't intersect the fact's cited inputs → `Restamped` against the new fingerprint, carrying an audit note.
  - **Neither** → `FlaggedForReassessment` (the doubt-candidate output; rung 3 — agentic doubt — deliberately belongs to the future `viz` skill, not this slice).
  - Typed outcome union of frozen dataclasses, mirroring `reconcile.py`'s style.
- `verbs/sweep.py` (new): `viz sweep` — reads the current fingerprint via the existing `estate` extractor (zero new git surface), classifies every Tier-2 fact under the store's single-writer lock, rewrites fact files + `flags.json`, advances the manifest baseline, and reports `{reused, restamped, flagged}` counts in the JSON envelope. **Never touches `verdicts.json`** — pinned by a byte-identical before/after test. Facts already carrying a pending flag are never re-evaluated (a doubt candidate mid-queue can't be silently restamped out from under human review).
- `verbs/queue.py` (new): `viz queue` — read-only join of unresolved flags to their facts and verdicts; the reassessment queue read path.
- `cli.py` / `verbs/__init__.py`: both verbs registered per the existing envelope/dispatch pattern.
- 31 new tests (235 total): rung exits per class, lock guard (contention → `SIDECAR_LOCKED`), verdicts-untouched byte assertion, flag idempotency across repeat sweeps, pending-flag skip, queue joins, manifest advancement, deterministic serialization, and a defensive-guard test for unknown rung-outcome variants.

Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.4, §5.5, §5.6.

## Scope + design decisions

- **Fingerprint source = existing `estate(runners.git, "HEAD")` extractor** (`{path: blob_sha}`) — the spec names no mechanism yet; this reuses the already-injected git runner with zero new adapter code.
- **Rung 1 is a single global equality check** over the tracked input set (strictly cheaper than rung 2's per-fact citation intersection, matching the spec's cost ordering); both rungs share one changed-key computation.
- **Sweep advances the manifest to the current fingerprint** after each run — otherwise rung 1's baseline would stay permanently stale after the first change and could never short-circuit again.
- **Contract-version invalidation (§5.2) is a documented open gap** — `prompt_version`/`model_id` don't factor into rung evaluation yet; recorded on the epic to land with the sweep-integration layer (cron/skill slices), where a contract-version key folds into both hash mappings for free.
- **Audit note lives on the `Restamped` outcome**, not injected into `FactRecord.payload` — avoids inventing sidecar schema outside this slice.

## Review-gate disposition

HEAVY adversarial gate (6 lenses, 3-refuter panels, 30 agents, ACCEPTANCE clean-at-floor after 1 round): 2 quality fixes applied and re-verified first-hand (type-alias extraction for the dense `fact_files` annotation; the elimination-by-comment `else` replaced with an explicit `isinstance` chain ending in a defensive raise — now proven by a test that patches `evaluate_fact` to return a rogue variant and asserts the `E_INTERNAL` envelope). 4 minors deferred with rationale to the existing cleanup bead: `Path.cwd()` injection hardening across all three verbs as one pass, deterministic-id idiom consolidation, and the loop-invariant changed-key hoist.

## Test Plan

- [x] TDD red→green: rung/queue/sweep tests written first, failed before the modules existed, green after
- [x] `make ci-vizsuite` fully green (exit 0, verified post-gate-fixes): ruff, format-check, mypy --strict, 235 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
