### PR TITLE
feat(vizsuite): tracker port + full-graph cycle guard (S4)

### DIFF
--- a/packages/vizsuite/pyproject.toml
+++ b/packages/vizsuite/pyproject.toml
@@ -38,11 +38,13 @@ select = ["E","W","F","I","B","UP","SIM","S","RET","ARG","PTH","TRY","RUF","N"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "TRY003"]
-# The subprocess adapters run known binaries (git/scc/gh) on controlled argv —
-# the intentional-subprocess case S603/S607 exist to let a boundary opt out of.
+# The subprocess adapters run known binaries (git/scc/gh/work) on controlled
+# argv — the intentional-subprocess case S603/S607 exist to let a boundary opt
+# out of.
 "src/vizsuite/adapters/git/runner.py" = ["S603", "S607"]
 "src/vizsuite/adapters/scc/runner.py" = ["S603", "S607"]
 "src/vizsuite/adapters/gh/runner.py" = ["S603", "S607"]
+"src/vizsuite/tracker/port.py" = ["S603", "S607"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -44,6 +44,19 @@ class ErrorCode(StrEnum):
     # by another writer after the bounded retry window — never an unbounded
     # block.
     SIDECAR_LOCKED = "E_SIDECAR_LOCKED"
+    # tracker slice: the `work` CLI's protocol-version handshake returned a
+    # major version this port was not built against (work-facade contract
+    # spec §5: additive fields bump MINOR, a breaking change bumps MAJOR).
+    TRACKER_PROTOCOL_MISMATCH = "E_TRACKER_PROTOCOL_MISMATCH"
+    # tracker slice: `work`'s stdout did not parse as JSON, or parsed JSON did
+    # not match the envelope/data shape this port expects.
+    TRACKER_MALFORMED_ENVELOPE = "E_TRACKER_MALFORMED_ENVELOPE"
+    # tracker slice: `work` emitted `ok: false` -- the facade's own error code
+    # and message are carried in this error's `detail`.
+    TRACKER_BACKEND_ERROR = "E_TRACKER_BACKEND_ERROR"
+    # tracker slice: the port verb has no mapped `work` verb today (e.g.
+    # resequence, spec §5.7) -- never a `bd` shell-out fallback (spec §5.6).
+    TRACKER_NOT_SUPPORTED = "E_TRACKER_NOT_SUPPORTED"
 
 
 @dataclass(frozen=True)

--- a/packages/vizsuite/src/vizsuite/tracker/cycle_guard.py
+++ b/packages/vizsuite/src/vizsuite/tracker/cycle_guard.py
@@ -84,16 +84,28 @@ def _find_path(
 ) -> tuple[str, ...] | None:
     """DFS from `node` toward `target` following depends-on edges; `None` if
     unreachable. Children are visited in sorted order (`_combined_children`),
-    so the first path found is the same path on every run."""
-    if node == target:
-        return (node,)
-    if node in visited:
-        return None
+    so the first path found is the same path on every run. The stack is
+    explicit — a dependency chain deeper than Python's recursion limit must
+    still yield a typed result, never a `RecursionError` escaping the
+    `Safe`/`CycleRefusal` contract. The caller (`find_cycle`) guarantees
+    `node != target` (self-loops are refused upstream) and a fresh `visited`
+    set, so there are no entry-time checks here."""
     visited.add(node)
-    for child in _combined_children(port, sidecar_children, node):
-        found = _find_path(port, sidecar_children, node=child, target=target, visited=visited)
-        if found is not None:
-            return (node, *found)
+    path = [node]
+    stack = [iter(_combined_children(port, sidecar_children, node))]
+    while stack:
+        child = next(stack[-1], None)
+        if child is None:
+            stack.pop()
+            path.pop()
+            continue
+        if child == target:
+            return (*path, child)
+        if child in visited:
+            continue
+        visited.add(child)
+        path.append(child)
+        stack.append(iter(_combined_children(port, sidecar_children, child)))
     return None
 
 

--- a/packages/vizsuite/src/vizsuite/tracker/cycle_guard.py
+++ b/packages/vizsuite/src/vizsuite/tracker/cycle_guard.py
@@ -1,0 +1,126 @@
+"""cycle_guard.py — pure cycle-safety check over the FULL accepted logical
+dependency graph (spec §5.3/§5.7, test item 17): beads `blocks` edges (read
+on demand via the injected `TrackerPort`) plus sidecar-held accepted
+dependency edges, passed in directly as plain data, including type-wall
+`related-to` fallbacks the sidecar alone knows are true dependencies (beads
+carries no metadata distinguishing a fallback `related-to` edge from an
+incidental one written for a conflict/overlap/synergy fact -- spec §5.3).
+
+The FLAG WRITE on refusal belongs to the caller (a future slice) — this
+module only computes and returns the typed result; it never touches
+`flags.json` or any other sidecar file.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from vizsuite.tracker.port import TrackerPort
+
+_BLOCKS_KIND = "blocks"
+
+
+@dataclass(frozen=True)
+class SidecarDependencyEdge:
+    """One sidecar-held accepted dependency edge (spec §5.3), in the same
+    "`from_bead` depends on `to_bead`" direction `ProposedEdge` and
+    `TrackerPort.add_edge` use. Covers both a promoted-dependency edge and a
+    type-wall `related-to` fallback the sidecar knows is a true dependency."""
+
+    from_bead: str
+    to_bead: str
+
+
+@dataclass(frozen=True)
+class ProposedEdge:
+    """The `blocks` write under consideration: `from_bead` would depend on
+    `to_bead`, matching `TrackerPort.add_edge`'s own argument order."""
+
+    from_bead: str
+    to_bead: str
+
+
+@dataclass(frozen=True)
+class Safe:
+    """The proposed edge closes no cycle in the combined graph."""
+
+
+@dataclass(frozen=True)
+class CycleRefusal:
+    """The proposed edge would close a cycle.
+
+    `cycle` is the full closed loop, starting and ending at `from_bead`:
+    ``(from_bead, to_bead, ..., from_bead)``.
+    """
+
+    cycle: tuple[str, ...]
+
+
+CycleCheckResult = Safe | CycleRefusal
+
+
+def _combined_children(
+    port: TrackerPort, sidecar_children: Mapping[str, frozenset[str]], node: str
+) -> list[str]:
+    """Every bead `node` depends on: beads `blocks` deps (read via `port`)
+    union the sidecar's accepted dependency edges from `node` -- sorted for
+    deterministic traversal (spec: "deterministic traversal ... so the
+    reported cycle path is reproducible")."""
+    bead = port.read_bead(node)
+    beads_children = {edge.id for edge in bead.deps if edge.type == _BLOCKS_KIND}
+    combined = beads_children | sidecar_children.get(node, frozenset())
+    return sorted(combined)
+
+
+def _find_path(
+    port: TrackerPort,
+    sidecar_children: Mapping[str, frozenset[str]],
+    *,
+    node: str,
+    target: str,
+    visited: set[str],
+) -> tuple[str, ...] | None:
+    """DFS from `node` toward `target` following depends-on edges; `None` if
+    unreachable. Children are visited in sorted order (`_combined_children`),
+    so the first path found is the same path on every run."""
+    if node == target:
+        return (node,)
+    if node in visited:
+        return None
+    visited.add(node)
+    for child in _combined_children(port, sidecar_children, node):
+        found = _find_path(port, sidecar_children, node=child, target=target, visited=visited)
+        if found is not None:
+            return (node, *found)
+    return None
+
+
+def find_cycle(
+    port: TrackerPort,
+    sidecar_edges: Sequence[SidecarDependencyEdge],
+    proposed: ProposedEdge,
+) -> CycleCheckResult:
+    """Refuse `proposed` iff it would close a cycle in beads `blocks` edges
+    (via `port`) plus `sidecar_edges` (spec test item 17).
+
+    `proposed` reads as "`from_bead` depends on `to_bead`"; a cycle exists
+    iff `to_bead` already transitively depends on `from_bead` in the existing
+    combined graph -- adding the edge would then close
+    ``from_bead -> to_bead -> ... -> from_bead``.
+    """
+    if proposed.from_bead == proposed.to_bead:
+        return CycleRefusal(cycle=(proposed.from_bead, proposed.to_bead))
+
+    sidecar_children: dict[str, set[str]] = defaultdict(set)
+    for edge in sidecar_edges:
+        sidecar_children[edge.from_bead].add(edge.to_bead)
+    frozen_children = {node: frozenset(children) for node, children in sidecar_children.items()}
+
+    existing_path = _find_path(
+        port, frozen_children, node=proposed.to_bead, target=proposed.from_bead, visited=set()
+    )
+    if existing_path is None:
+        return Safe()
+    return CycleRefusal(cycle=(proposed.from_bead, *existing_path))

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -122,8 +122,7 @@ def _inconsistent_exit_error(argv: Sequence[str], result: TrackerResult) -> VizE
     )
 
 
-def _backend_error(argv: Sequence[str], envelope: Any) -> VizError:
-    error = envelope.get("error") or {}
+def _backend_error(argv: Sequence[str], error: dict[str, Any]) -> VizError:
     return VizError(
         ErrorCode.TRACKER_BACKEND_ERROR,
         f"work CLI returned an error envelope: {error.get('message', '<no message>')}",
@@ -152,8 +151,18 @@ def _run_and_parse(runner: TrackerRunner, argv: Sequence[str]) -> Any:
         ok = envelope["ok"]
     except (KeyError, TypeError) as exc:
         raise _malformed_shape_error(argv, result) from exc
-    if ok is not True:
-        raise _backend_error(argv, envelope)
+    if not isinstance(ok, bool):
+        # `ok` must be a JSON boolean — a null/string here is contract drift,
+        # not a backend error; misclassifying it would mask the drift.
+        raise _malformed_shape_error(argv, result)
+    if ok is False:
+        error = envelope.get("error")
+        if not isinstance(error, dict):
+            # An `ok: false` envelope whose `error` is not an object violates
+            # the contract — refuse it as malformed rather than crash on a
+            # `.get` of a string/list (or invent a backend message).
+            raise _malformed_shape_error(argv, result)
+        raise _backend_error(argv, error)
     if result.returncode != 0:
         # An `ok: true` envelope from a nonzero exit is an inconsistent state
         # (partial output, crash after print) — refuse it rather than treat
@@ -170,6 +179,19 @@ def _malformed_bead_error(bead_id: str, exc: Exception) -> VizError:
     )
 
 
+class _NotAListError(TypeError):
+    """Raised when a bead field that must be a JSON array is some other type.
+
+    Iterating a string/dict would silently yield characters/keys instead of
+    failing loud on shape drift (the message is fixed on the class per ruff
+    TRY003); `_parse_bead_record`'s except clause converts it to the typed
+    malformed error.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("expected a JSON array")
+
+
 def _parse_dep_edge(raw: Any) -> DepEdgeRecord:
     return DepEdgeRecord(id=str(raw["id"]), type=str(raw["type"]), status=str(raw["status"]))
 
@@ -177,11 +199,15 @@ def _parse_dep_edge(raw: Any) -> DepEdgeRecord:
 def _parse_bead_record(data: Any, *, bead_id: str) -> BeadRecord:
     """Parse `work show <id>`'s single-object `data` into a `BeadRecord`."""
     try:
+        labels = data["labels"]
+        deps = data["deps"]
+        if not isinstance(labels, list) or not isinstance(deps, list):
+            raise _NotAListError
         return BeadRecord(
             id=str(data["id"]),
             status=str(data["status"]),
-            labels=tuple(str(label) for label in data["labels"]),
-            deps=tuple(_parse_dep_edge(entry) for entry in data["deps"]),
+            labels=tuple(str(label) for label in labels),
+            deps=tuple(_parse_dep_edge(entry) for entry in deps),
         )
     except (KeyError, TypeError) as exc:
         raise _malformed_bead_error(bead_id, exc) from exc

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -201,8 +201,26 @@ class _NotAListError(TypeError):
         super().__init__("expected a JSON array")
 
 
+class _NotAStringError(TypeError):
+    """Raised when an envelope field that must be a JSON string is some other
+    type. `str(...)` coercion would turn contract drift (null/number/object)
+    into a plausible value like "None" instead of failing loud (fixed message
+    per ruff TRY003)."""
+
+    def __init__(self) -> None:
+        super().__init__("expected a JSON string")
+
+
+def _as_str(value: Any) -> str:
+    if not isinstance(value, str):
+        raise _NotAStringError
+    return value
+
+
 def _parse_dep_edge(raw: Any) -> DepEdgeRecord:
-    return DepEdgeRecord(id=str(raw["id"]), type=str(raw["type"]), status=str(raw["status"]))
+    return DepEdgeRecord(
+        id=_as_str(raw["id"]), type=_as_str(raw["type"]), status=_as_str(raw["status"])
+    )
 
 
 def _parse_bead_record(data: Any, *, bead_id: str) -> BeadRecord:
@@ -213,9 +231,9 @@ def _parse_bead_record(data: Any, *, bead_id: str) -> BeadRecord:
         if not isinstance(labels, list) or not isinstance(deps, list):
             raise _NotAListError
         return BeadRecord(
-            id=str(data["id"]),
-            status=str(data["status"]),
-            labels=tuple(str(label) for label in labels),
+            id=_as_str(data["id"]),
+            status=_as_str(data["status"]),
+            labels=tuple(_as_str(label) for label in labels),
             deps=tuple(_parse_dep_edge(entry) for entry in deps),
         )
     except (KeyError, TypeError) as exc:
@@ -311,7 +329,7 @@ class TrackerPort:
             argv.extend(["--acceptance", acceptance])
         data = _run_and_parse(self._runner, argv)
         try:
-            return str(data["id"])
+            return _as_str(data["id"])
         except (KeyError, TypeError) as exc:
             raise VizError(
                 ErrorCode.TRACKER_MALFORMED_ENVELOPE,

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -176,11 +176,15 @@ def _run_and_parse(runner: TrackerRunner, argv: Sequence[str]) -> Any:
         raise _malformed_shape_error(argv, result) from exc
 
 
-def _malformed_bead_error(bead_id: str, exc: Exception) -> VizError:
+def _malformed_bead_error(bead_id: str, exc: Exception, data: Any) -> VizError:
     return VizError(
         ErrorCode.TRACKER_MALFORMED_ENVELOPE,
         f"work show {bead_id} returned an unexpected bead shape",
-        detail={"bead_id": bead_id, "reason": type(exc).__name__},
+        detail={
+            "bead_id": bead_id,
+            "reason": type(exc).__name__,
+            "raw_data_excerpt": repr(data)[:200],
+        },
     )
 
 
@@ -215,7 +219,7 @@ def _parse_bead_record(data: Any, *, bead_id: str) -> BeadRecord:
             deps=tuple(_parse_dep_edge(entry) for entry in deps),
         )
     except (KeyError, TypeError) as exc:
-        raise _malformed_bead_error(bead_id, exc) from exc
+        raise _malformed_bead_error(bead_id, exc, data) from exc
 
 
 class TrackerPort:

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -168,7 +168,12 @@ def _run_and_parse(runner: TrackerRunner, argv: Sequence[str]) -> Any:
         # (partial output, crash after print) — refuse it rather than treat
         # it as success and hide a real subprocess failure.
         raise _inconsistent_exit_error(argv, result)
-    return envelope.get("data")
+    try:
+        # The envelope contract always carries `data` — a missing key is
+        # drift, distinct from a contract-valid `data: null`.
+        return envelope["data"]
+    except KeyError as exc:
+        raise _malformed_shape_error(argv, result) from exc
 
 
 def _malformed_bead_error(bead_id: str, exc: Exception) -> VizError:
@@ -235,7 +240,7 @@ class TrackerPort:
             raise VizError(
                 ErrorCode.TRACKER_MALFORMED_ENVELOPE,
                 "work --protocol-version returned no protocol field",
-                detail={},
+                detail={"raw_data_excerpt": repr(data)[:200]},
             ) from exc
         if not isinstance(protocol, str):
             raise VizError(

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -85,11 +85,24 @@ class BeadRecord:
     deps: tuple[DepEdgeRecord, ...]
 
 
+def _result_detail(argv: Sequence[str], result: TrackerResult) -> dict[str, Any]:
+    """Diagnostic fields every malformed-envelope error carries (house
+    convention — the scc/gh adapters include the same trio): a raw subprocess
+    failure (missing binary, crash, permission) is diagnosable from the error
+    alone, without rerunning under a debugger."""
+    return {
+        "argv": list(argv),
+        "returncode": result.returncode,
+        "stderr_excerpt": result.stderr[:200],
+        "raw_excerpt": result.stdout[:200],
+    }
+
+
 def _malformed_json_error(argv: Sequence[str], result: TrackerResult) -> VizError:
     return VizError(
         ErrorCode.TRACKER_MALFORMED_ENVELOPE,
         "work CLI stdout did not parse as JSON",
-        detail={"argv": list(argv), "raw_excerpt": result.stdout[:200]},
+        detail=_result_detail(argv, result),
     )
 
 
@@ -97,7 +110,15 @@ def _malformed_shape_error(argv: Sequence[str], result: TrackerResult) -> VizErr
     return VizError(
         ErrorCode.TRACKER_MALFORMED_ENVELOPE,
         "work CLI stdout did not match the envelope shape",
-        detail={"argv": list(argv), "raw_excerpt": result.stdout[:200]},
+        detail=_result_detail(argv, result),
+    )
+
+
+def _inconsistent_exit_error(argv: Sequence[str], result: TrackerResult) -> VizError:
+    return VizError(
+        ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+        "work CLI exited nonzero while emitting an ok envelope",
+        detail=_result_detail(argv, result),
     )
 
 
@@ -133,6 +154,11 @@ def _run_and_parse(runner: TrackerRunner, argv: Sequence[str]) -> Any:
         raise _malformed_shape_error(argv, result) from exc
     if ok is not True:
         raise _backend_error(argv, envelope)
+    if result.returncode != 0:
+        # An `ok: true` envelope from a nonzero exit is an inconsistent state
+        # (partial output, crash after print) — refuse it rather than treat
+        # it as success and hide a real subprocess failure.
+        raise _inconsistent_exit_error(argv, result)
     return envelope.get("data")
 
 

--- a/packages/vizsuite/src/vizsuite/tracker/port.py
+++ b/packages/vizsuite/src/vizsuite/tracker/port.py
@@ -1,0 +1,278 @@
+"""tracker/port.py — the sole beads boundary (spec §5.6 tracker quarantine).
+
+`TrackerPort` speaks the `work` CLI's JSON-envelope contract
+(docs/specs/2026-07-04-work-facade-cli-contract.md) via an injected
+`TrackerRunner`, mirroring the gh/git adapter seam (a `Protocol` port plus a
+`SubprocessTrackerRunner` implementation and `tests/fakes.ScriptedTrackerRunner`
+fake). vizsuite never shells `bd` directly: a verb this port cannot map onto a
+`work` verb today (e.g. `resequence` -- the facade has no resequence verb,
+spec §5.7) raises a typed `VizError(TRACKER_NOT_SUPPORTED)` rather than
+falling back to a direct `bd` invocation.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from vizsuite.adapters.subprocess_util import run
+from vizsuite.envelope import ErrorCode, VizError
+
+# workcli's PROTOCOL_VERSION is semver MAJOR.MINOR (work-facade contract spec
+# §5): additive fields bump MINOR, any breaking envelope/data change bumps
+# MAJOR. This port is built against MAJOR "1" -- a mismatch here means a
+# breaking contract change the port has not been updated for; a MINOR bump is
+# always compatible and never trips this check.
+_EXPECTED_PROTOCOL_MAJOR = "1"
+
+DepKind = Literal["blocks", "related-to"]
+
+
+@dataclass(frozen=True)
+class TrackerResult:
+    """One `work` subprocess invocation's raw result -- mirrors `gh.runner.GhResult`."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class TrackerRunner(Protocol):
+    def run(self, argv: Sequence[str]) -> TrackerResult: ...  # pragma: no cover
+
+
+class SubprocessTrackerRunner:
+    """Drives the real `work` binary against an injected `repo_root` (default
+    ``"."``) -- never the process's actual working directory. One `work`
+    invocation per call; the raw result comes back unparsed (every shape
+    decision lives in this module's `_run_and_parse`, mirroring how
+    `SubprocessGhRunner` defers all parsing to `gh/parse.py`)."""
+
+    def __init__(self, repo_root: str = ".") -> None:
+        self._root = repo_root
+
+    def run(self, argv: Sequence[str]) -> TrackerResult:
+        completed = run(["work", *argv], cwd=self._root, timeout=60, check=False)
+        return TrackerResult(
+            returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr
+        )
+
+
+@dataclass(frozen=True)
+class DepEdgeRecord:
+    """One dependency edge exactly as `work show`'s `deps` field carries it."""
+
+    id: str
+    type: str
+    status: str
+
+
+@dataclass(frozen=True)
+class BeadRecord:
+    """The subset of `work show`'s item shape the cycle guard needs.
+
+    Only id/status/labels/deps are modeled here -- every other field
+    workcli's `Item` carries (title, type, priority, description, ...) is
+    intentionally ignored, so an additive envelope change (a MINOR bump)
+    never breaks this port.
+    """
+
+    id: str
+    status: str
+    labels: tuple[str, ...]
+    deps: tuple[DepEdgeRecord, ...]
+
+
+def _malformed_json_error(argv: Sequence[str], result: TrackerResult) -> VizError:
+    return VizError(
+        ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+        "work CLI stdout did not parse as JSON",
+        detail={"argv": list(argv), "raw_excerpt": result.stdout[:200]},
+    )
+
+
+def _malformed_shape_error(argv: Sequence[str], result: TrackerResult) -> VizError:
+    return VizError(
+        ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+        "work CLI stdout did not match the envelope shape",
+        detail={"argv": list(argv), "raw_excerpt": result.stdout[:200]},
+    )
+
+
+def _backend_error(argv: Sequence[str], envelope: Any) -> VizError:
+    error = envelope.get("error") or {}
+    return VizError(
+        ErrorCode.TRACKER_BACKEND_ERROR,
+        f"work CLI returned an error envelope: {error.get('message', '<no message>')}",
+        detail={
+            "argv": list(argv),
+            "code": error.get("code"),
+            "backend_detail": error.get("detail"),
+        },
+    )
+
+
+def _run_and_parse(runner: TrackerRunner, argv: Sequence[str]) -> Any:
+    """Run `argv` through `runner`, parse the JSON envelope, and return `data`.
+
+    Mirrors `adapters/gh/parse.py`'s discipline: every failure mode -- non-JSON
+    stdout, a shape that isn't the envelope contract, or the facade's own
+    `ok: false` error envelope -- raises a typed `VizError`, never a silent
+    default or a raw `KeyError`/`TypeError` escaping this boundary.
+    """
+    result = runner.run(argv)
+    try:
+        envelope = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise _malformed_json_error(argv, result) from exc
+    try:
+        ok = envelope["ok"]
+    except (KeyError, TypeError) as exc:
+        raise _malformed_shape_error(argv, result) from exc
+    if ok is not True:
+        raise _backend_error(argv, envelope)
+    return envelope.get("data")
+
+
+def _malformed_bead_error(bead_id: str, exc: Exception) -> VizError:
+    return VizError(
+        ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+        f"work show {bead_id} returned an unexpected bead shape",
+        detail={"bead_id": bead_id, "reason": type(exc).__name__},
+    )
+
+
+def _parse_dep_edge(raw: Any) -> DepEdgeRecord:
+    return DepEdgeRecord(id=str(raw["id"]), type=str(raw["type"]), status=str(raw["status"]))
+
+
+def _parse_bead_record(data: Any, *, bead_id: str) -> BeadRecord:
+    """Parse `work show <id>`'s single-object `data` into a `BeadRecord`."""
+    try:
+        return BeadRecord(
+            id=str(data["id"]),
+            status=str(data["status"]),
+            labels=tuple(str(label) for label in data["labels"]),
+            deps=tuple(_parse_dep_edge(entry) for entry in data["deps"]),
+        )
+    except (KeyError, TypeError) as exc:
+        raise _malformed_bead_error(bead_id, exc) from exc
+
+
+class TrackerPort:
+    """The sole beads boundary vizsuite is permitted to use (spec §5.6).
+
+    Verifies the `work` CLI's protocol-version handshake before the first
+    real verb dispatch (once per instance, then cached); every verb call
+    after that goes through the same JSON-envelope parsing.
+    """
+
+    def __init__(self, runner: TrackerRunner) -> None:
+        self._runner = runner
+        self._handshake_ok = False
+
+    def _ensure_handshake(self) -> None:
+        if self._handshake_ok:
+            return
+        data = _run_and_parse(self._runner, ["--protocol-version"])
+        try:
+            protocol = data["protocol"]
+        except (KeyError, TypeError) as exc:
+            raise VizError(
+                ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+                "work --protocol-version returned no protocol field",
+                detail={},
+            ) from exc
+        if not isinstance(protocol, str):
+            raise VizError(
+                ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+                "work --protocol-version's protocol field is not a string",
+                detail={"protocol": protocol},
+            )
+        major = protocol.split(".", 1)[0]
+        if major != _EXPECTED_PROTOCOL_MAJOR:
+            raise VizError(
+                ErrorCode.TRACKER_PROTOCOL_MISMATCH,
+                f"work CLI protocol {protocol!r} is incompatible with this tracker "
+                f"port (expects major version {_EXPECTED_PROTOCOL_MAJOR}.x)",
+                detail={"actual_protocol": protocol, "expected_major": _EXPECTED_PROTOCOL_MAJOR},
+            )
+        self._handshake_ok = True
+
+    def read_bead(self, bead_id: str) -> BeadRecord:
+        """`work show <id>` -- the read primitive the cycle guard traverses on."""
+        self._ensure_handshake()
+        data = _run_and_parse(self._runner, ["show", bead_id])
+        return _parse_bead_record(data, bead_id=bead_id)
+
+    def add_edge(self, from_id: str, to_id: str, kind: DepKind) -> None:
+        """`work dep add <from_id> <to_id> --type <kind>` (`from_id` depends on `to_id`,
+        spec §3: "dep add A B = A depends on B")."""
+        self._ensure_handshake()
+        _run_and_parse(self._runner, ["dep", "add", from_id, to_id, "--type", kind])
+
+    def append_note(self, bead_id: str, text: str) -> None:
+        """`work note <id> <text>` -- append-only, never a clobbering update."""
+        self._ensure_handshake()
+        _run_and_parse(self._runner, ["note", bead_id, text])
+
+    def mint_bead(
+        self,
+        noun: str,
+        title: str,
+        *,
+        parent: str | None = None,
+        orphan: bool = False,
+        description: str | None = None,
+        priority: str | None = None,
+        acceptance: str | None = None,
+    ) -> str:
+        """`work create <noun> --title T (--parent ID | --orphan) [...]`.
+
+        Exactly one of `parent`/`orphan` is required by the facade itself
+        (`E_USAGE` otherwise) -- this port does not re-validate that rule; the
+        facade is the single source of truth for tracker business logic
+        (spec §5.6 tracker quarantine).
+        """
+        self._ensure_handshake()
+        argv = ["create", noun, "--title", title]
+        if orphan:
+            argv.append("--orphan")
+        elif parent is not None:
+            argv.extend(["--parent", parent])
+        if description is not None:
+            argv.extend(["--description", description])
+        if priority is not None:
+            argv.extend(["--priority", priority])
+        if acceptance is not None:
+            argv.extend(["--acceptance", acceptance])
+        data = _run_and_parse(self._runner, argv)
+        try:
+            return str(data["id"])
+        except (KeyError, TypeError) as exc:
+            raise VizError(
+                ErrorCode.TRACKER_MALFORMED_ENVELOPE,
+                "work create did not return a bead id",
+                detail={"argv": list(argv)},
+            ) from exc
+
+    def relabel(self, bead_id: str, labels: Sequence[str], *, remove: bool = False) -> None:
+        """`work label {add,remove} <id> <label>...`."""
+        self._ensure_handshake()
+        action = "remove" if remove else "add"
+        _run_and_parse(self._runner, ["label", action, bead_id, *labels])
+
+    def resequence(self) -> None:
+        """No facade verb exists for resequencing (spec §5.7: `ruling-needed`,
+        never `one-click`, "the `work` facade has no resequence verb"). Raises
+        `TRACKER_NOT_SUPPORTED` without ever touching the runner -- not even
+        the protocol handshake -- and never falls back to a direct `bd`
+        shell-out (spec §5.6 tracker quarantine).
+        """
+        raise VizError(
+            ErrorCode.TRACKER_NOT_SUPPORTED,
+            "resequence: the work facade exposes no resequence verb; vizsuite "
+            "never shells `bd` directly to fill the gap (spec §5.6/§5.7)",
+        )

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from vizsuite.adapters.gh.runner import GhResult
 from vizsuite.adapters.git.runner import LsTreeRow, ModifiedFileRow
 from vizsuite.adapters.scc.runner import SccResult
+from vizsuite.tracker.port import TrackerResult
 
 
 @dataclass
@@ -198,3 +199,80 @@ def tar_of(files: dict[str, str]) -> bytes:
             info.size = len(data)
             tar.addfile(info, io.BytesIO(data))
     return buffer.getvalue()
+
+
+@dataclass
+class ScriptedTrackerRunner:
+    """Feeds scripted `work` envelope responses; records every argv invocation.
+
+    - `.protocol`: the protocol string the `--protocol-version` handshake
+      returns (default `"1.0"`, matching `TrackerPort`'s expected major;
+      mismatch tests override this).
+    - `.show_results`: `{bead_id: TrackerResult}` — the envelope `work show
+      <id>` returns for that id.
+    - `.responses`: an explicit `{argv-tuple: TrackerResult}` override for any
+      argv a test needs to script precisely -- including `("--protocol-version",)`
+      or `("show", id)`, both of which it takes precedence over.
+    - `.calls`: every argv this fake was asked to run, in order — the
+      assertion surface for what `TrackerPort` actually sent (and, for
+      `resequence`, that nothing was sent at all).
+    """
+
+    protocol: str = "1.0"
+    show_results: dict[str, TrackerResult] = field(default_factory=dict)
+    responses: dict[tuple[str, ...], TrackerResult] = field(default_factory=dict)
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def run(self, argv: Sequence[str]) -> TrackerResult:
+        key = tuple(argv)
+        self.calls.append(key)
+        if key in self.responses:
+            return self.responses[key]
+        if key == ("--protocol-version",):
+            return tracker_ok({"protocol": self.protocol})
+        if len(key) == 2 and key[0] == "show" and key[1] in self.show_results:
+            return self.show_results[key[1]]
+        raise AssertionError(f"ScriptedTrackerRunner: no scripted response for {argv!r}")
+
+
+def tracker_ok(data: object) -> TrackerResult:
+    """Build a successful `work` envelope `TrackerResult` carrying `data`."""
+    payload = {"protocol": "1.0", "ok": True, "data": data, "error": None}
+    return TrackerResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def tracker_error(code: str, message: str, detail: object = None) -> TrackerResult:
+    """Build a failing `work` envelope `TrackerResult` (`ok: false`)."""
+    payload = {
+        "protocol": "1.0",
+        "ok": False,
+        "data": None,
+        "error": {"code": code, "message": message, "detail": detail},
+    }
+    return TrackerResult(returncode=1, stdout=json.dumps(payload), stderr="")
+
+
+def tracker_show_ok(
+    bead_id: str,
+    *,
+    status: str = "open",
+    labels: Sequence[str] = (),
+    deps: Sequence[tuple[str, str, str]] = (),
+) -> TrackerResult:
+    """Build a successful `work show <id>` `TrackerResult`.
+
+    Only the four fields `TrackerPort.read_bead` parses (id/status/labels/deps)
+    are populated — every other field a real `work show` response carries
+    (title, type, priority, ...) is irrelevant to the port and omitted for
+    fixture brevity. `deps` entries are `(id, type, status)` tuples.
+    """
+    data = {
+        "id": bead_id,
+        "status": status,
+        "labels": list(labels),
+        "deps": [
+            {"id": dep_id, "type": dep_type, "status": dep_status}
+            for dep_id, dep_type, dep_status in deps
+        ],
+    }
+    return tracker_ok(data)

--- a/packages/vizsuite/tests/unit/test_tracker_cycle_guard.py
+++ b/packages/vizsuite/tests/unit/test_tracker_cycle_guard.py
@@ -1,0 +1,132 @@
+"""cycle_guard.find_cycle: cycle-safety over the FULL accepted logical
+dependency graph (spec §5.3/§5.7, test item 17).
+
+The combined graph is beads `blocks` edges (read on demand through
+`TrackerPort`, backed by `tests.fakes.ScriptedTrackerRunner` — no real
+subprocess) plus sidecar-held accepted dependency edges passed in directly as
+plain data (the sidecar itself is a separate concern this slice does not
+read/write). These tests cover beads-only cycles, sidecar-only cycles, mixed
+paths, safe cases, and pin the deterministic (sorted-child) traversal order.
+"""
+
+from __future__ import annotations
+
+from tests.fakes import ScriptedTrackerRunner, tracker_show_ok
+from vizsuite.tracker.cycle_guard import (
+    CycleRefusal,
+    ProposedEdge,
+    Safe,
+    SidecarDependencyEdge,
+    find_cycle,
+)
+from vizsuite.tracker.port import TrackerPort, TrackerResult
+
+
+def _port(show_results: dict[str, TrackerResult]) -> tuple[TrackerPort, ScriptedTrackerRunner]:
+    runner = ScriptedTrackerRunner(show_results=show_results)
+    return TrackerPort(runner), runner
+
+
+def test_safe_when_target_unreachable():
+    port, _runner = _port({"b": tracker_show_ok("b", deps=[])})
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("a", "b"))
+
+    assert result == Safe()
+
+
+def test_cycle_through_beads_edges_alone():
+    # "b" already (directly) depends on "a" via a real beads `blocks` edge;
+    # proposing "a depends on b" would close the loop.
+    port, _runner = _port({"b": tracker_show_ok("b", deps=[("a", "blocks", "open")])})
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("a", "b"))
+
+    assert result == CycleRefusal(cycle=("a", "b", "a"))
+
+
+def test_cycle_through_sidecar_edges_alone():
+    # "y" depends on "x" only via a sidecar-held accepted edge (e.g. a
+    # type-wall `related-to` fallback) -- beads itself carries no `blocks`
+    # edge for this pair.
+    port, _runner = _port({"y": tracker_show_ok("y", deps=[])})
+    sidecar_edges = (SidecarDependencyEdge(from_bead="y", to_bead="x"),)
+
+    result = find_cycle(port, sidecar_edges=sidecar_edges, proposed=ProposedEdge("x", "y"))
+
+    assert result == CycleRefusal(cycle=("x", "y", "x"))
+
+
+def test_cycle_through_mixed_beads_and_sidecar_edges():
+    # q -[sidecar]-> r -[beads blocks]-> p; proposing "p depends on q" closes
+    # a cycle that crosses both edge sources.
+    port, _runner = _port(
+        {
+            "q": tracker_show_ok("q", deps=[]),
+            "r": tracker_show_ok("r", deps=[("p", "blocks", "open")]),
+        }
+    )
+    sidecar_edges = (SidecarDependencyEdge(from_bead="q", to_bead="r"),)
+
+    result = find_cycle(port, sidecar_edges=sidecar_edges, proposed=ProposedEdge("p", "q"))
+
+    assert result == CycleRefusal(cycle=("p", "q", "r", "p"))
+
+
+def test_related_to_beads_edges_do_not_count_toward_cycles():
+    # A beads `related-to` edge that is NOT a sidecar-declared dependency
+    # fallback (e.g. discoverability for an overlap/conflict/synergy fact)
+    # must never be treated as a logical dependency.
+    port, _runner = _port({"b": tracker_show_ok("b", deps=[("a", "related-to", "open")])})
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("a", "b"))
+
+    assert result == Safe()
+
+
+def test_self_loop_is_refused_without_touching_the_port():
+    runner = ScriptedTrackerRunner()
+    port = TrackerPort(runner)
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("x.1", "x.1"))
+
+    assert result == CycleRefusal(cycle=("x.1", "x.1"))
+    assert runner.calls == []
+
+
+def test_safe_diamond_does_not_revisit_a_shared_node():
+    port, runner = _port(
+        {
+            "start": tracker_show_ok(
+                "start", deps=[("n1", "blocks", "open"), ("n2", "blocks", "open")]
+            ),
+            "n1": tracker_show_ok("n1", deps=[("shared", "blocks", "open")]),
+            "n2": tracker_show_ok("n2", deps=[("shared", "blocks", "open")]),
+            "shared": tracker_show_ok("shared", deps=[]),
+        }
+    )
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("target", "start"))
+
+    assert result == Safe()
+    # "shared" is reachable via both n1 and n2 -- the visited-set
+    # short-circuit means it is read exactly once, not twice.
+    assert runner.calls.count(("show", "shared")) == 1
+
+
+def test_deterministic_cycle_path_explores_the_lexicographically_first_child():
+    # "start" depends on both path_b and path_a; sorted order visits path_a
+    # first. path_b has NO scripted `show` response on purpose -- if the
+    # traversal ever visited it, the fake would raise, proving determinism.
+    port, _runner = _port(
+        {
+            "start": tracker_show_ok(
+                "start", deps=[("path_b", "blocks", "open"), ("path_a", "blocks", "open")]
+            ),
+            "path_a": tracker_show_ok("path_a", deps=[("end", "blocks", "open")]),
+        }
+    )
+
+    result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("end", "start"))
+
+    assert result == CycleRefusal(cycle=("end", "start", "path_a", "end"))

--- a/packages/vizsuite/tests/unit/test_tracker_cycle_guard.py
+++ b/packages/vizsuite/tests/unit/test_tracker_cycle_guard.py
@@ -130,3 +130,25 @@ def test_deterministic_cycle_path_explores_the_lexicographically_first_child():
     result = find_cycle(port, sidecar_edges=(), proposed=ProposedEdge("end", "start"))
 
     assert result == CycleRefusal(cycle=("end", "start", "path_a", "end"))
+
+
+def test_a_chain_deeper_than_the_recursion_limit_still_returns_a_typed_result():
+    # 5000-link sidecar chain: n0000 -> n0001 -> ... -> n5000. Proposing
+    # "n5000 depends on n0000" closes the loop; the traversal must walk the
+    # full depth and return CycleRefusal, never a RecursionError escaping the
+    # Safe/CycleRefusal contract (each node also answers an empty beads read).
+    depth = 5000
+    names = [f"n{i:04d}" for i in range(depth + 1)]
+    show_results = {name: tracker_show_ok(name, deps=[]) for name in names}
+    port, _runner = _port(show_results)
+    sidecar_edges = tuple(
+        SidecarDependencyEdge(from_bead=names[i], to_bead=names[i + 1]) for i in range(depth)
+    )
+
+    result = find_cycle(
+        port, sidecar_edges=sidecar_edges, proposed=ProposedEdge(names[-1], names[0])
+    )
+
+    assert isinstance(result, CycleRefusal)
+    assert len(result.cycle) == depth + 2  # n5000, n0000..n5000
+    assert result.cycle[0] == names[-1] and result.cycle[-1] == names[-1]

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -572,3 +572,57 @@ def test_malformed_bead_error_carries_raw_data_excerpt():
 
     assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
     assert "surprise" in exc_info.value.detail["raw_data_excerpt"]
+
+
+def test_non_string_bead_fields_are_malformed_not_coerced():
+    # str() coercion would turn a null id into the literal string "None" —
+    # contract drift must refuse as malformed instead.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout=(
+            '{"protocol": "1.0", "ok": true, "error": null, "data":'
+            ' {"id": null, "status": "open", "labels": [], "deps": []}}'
+        ),
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_non_string_dep_edge_fields_are_malformed_not_coerced():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout=(
+            '{"protocol": "1.0", "ok": true, "error": null, "data":'
+            ' {"id": "x.1", "status": "open", "labels": [],'
+            ' "deps": [{"id": "y.1", "type": "blocks", "status": 7}]}}'
+        ),
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_mint_bead_with_non_string_id_is_malformed_not_none_string():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("create", "task", "--title", "T", "--orphan")] = TrackerResult(
+        returncode=0,
+        stdout='{"protocol": "1.0", "ok": true, "error": null, "data": {"id": null}}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.mint_bead("task", "T", orphan=True)
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -451,3 +451,75 @@ def test_ok_envelope_with_nonzero_exit_is_refused_as_inconsistent():
     assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
     assert exc_info.value.detail["returncode"] == 1
     assert exc_info.value.detail["stderr_excerpt"] == "late crash"
+
+
+def test_non_bool_ok_is_malformed_not_backend_error():
+    # `ok: null` / `ok: "true"` is contract drift, not a backend error —
+    # misclassifying it as TRACKER_BACKEND_ERROR would mask the drift.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout='{"protocol": "1.0", "ok": null, "data": null, "error": null}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_ok_false_with_non_object_error_is_malformed():
+    # An `ok: false` envelope whose `error` is a bare string violates the
+    # contract; refusing it as malformed beats crashing on `.get` of a str.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=1,
+        stdout='{"protocol": "1.0", "ok": false, "data": null, "error": "boom"}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_bead_labels_as_string_is_malformed_not_character_tuple():
+    # Iterating a string would silently yield a tuple of characters —
+    # shape drift must fail loud instead.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout=(
+            '{"protocol": "1.0", "ok": true, "error": null, "data":'
+            ' {"id": "x.1", "status": "open", "labels": "oops", "deps": []}}'
+        ),
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_bead_deps_as_object_is_malformed():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout=(
+            '{"protocol": "1.0", "ok": true, "error": null, "data":'
+            ' {"id": "x.1", "status": "open", "labels": [], "deps": {"id": "y"}}}'
+        ),
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -416,3 +416,38 @@ def test_subprocess_runner_default_repo_root_is_dot(monkeypatch: pytest.MonkeyPa
     SubprocessTrackerRunner().run(["--protocol-version"])
 
     assert calls[0]["cwd"] == "."
+
+
+def test_malformed_envelope_error_carries_returncode_and_stderr():
+    # House convention (scc/gh adapters): a raw subprocess failure is
+    # diagnosable from the typed error alone — returncode + stderr included.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=127, stdout="not json", stderr="work: command crashed"
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    detail = exc_info.value.detail
+    assert detail["returncode"] == 127
+    assert detail["stderr_excerpt"] == "work: command crashed"
+
+
+def test_ok_envelope_with_nonzero_exit_is_refused_as_inconsistent():
+    # exit != 0 alongside an `ok: true` envelope is an inconsistent state
+    # (partial output, crash after print) — never treated as success.
+    ok_result = tracker_show_ok("x.1")
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=1, stdout=ok_result.stdout, stderr="late crash"
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+    assert exc_info.value.detail["returncode"] == 1
+    assert exc_info.value.detail["stderr_excerpt"] == "late crash"

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -556,3 +556,19 @@ def test_handshake_missing_protocol_error_carries_raw_data_excerpt():
 
     assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
     assert "wrong" in exc_info.value.detail["raw_data_excerpt"]
+
+
+def test_malformed_bead_error_carries_raw_data_excerpt():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout='{"protocol": "1.0", "ok": true, "error": null, "data": {"surprise": true}}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+    assert "surprise" in exc_info.value.detail["raw_data_excerpt"]

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -523,3 +523,36 @@ def test_bead_deps_as_object_is_malformed():
         port.read_bead("x.1")
 
     assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_envelope_missing_data_key_is_malformed():
+    # The contract always carries `data`; a missing key is drift, distinct
+    # from a contract-valid `data: null`.
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(
+        returncode=0,
+        stdout='{"protocol": "1.0", "ok": true, "error": null}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_handshake_missing_protocol_error_carries_raw_data_excerpt():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("--protocol-version",)] = TrackerResult(
+        returncode=0,
+        stdout='{"protocol": "1.0", "ok": true, "data": {"wrong": "shape"}, "error": null}',
+        stderr="",
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+    assert "wrong" in exc_info.value.detail["raw_data_excerpt"]

--- a/packages/vizsuite/tests/unit/test_tracker_port.py
+++ b/packages/vizsuite/tests/unit/test_tracker_port.py
@@ -1,0 +1,418 @@
+"""TrackerPort: the sole beads boundary (spec §5.6 tracker quarantine, §5's
+protocol-version handshake).
+
+`TrackerPort` speaks the `work` CLI's JSON-envelope contract
+(docs/specs/2026-07-04-work-facade-cli-contract.md) via an injected
+`TrackerRunner`, mirroring the gh/git adapter seam. These tests drive it
+entirely against `tests.fakes.ScriptedTrackerRunner` — no real subprocess, no
+`bd`, ever. `SubprocessTrackerRunner`'s argv/cwd wiring is proven separately by
+monkeypatching `subprocess.run` (mirrors `test_adapters_gh_runner.py`).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.fakes import ScriptedTrackerRunner, tracker_error, tracker_ok, tracker_show_ok
+from vizsuite.envelope import ErrorCode, VizError
+from vizsuite.tracker.port import (
+    BeadRecord,
+    DepEdgeRecord,
+    SubprocessTrackerRunner,
+    TrackerPort,
+    TrackerResult,
+)
+
+# ── handshake ──────────────────────────────────────────────────────────────
+
+
+def test_handshake_runs_once_before_first_verb_dispatch():
+    runner = ScriptedTrackerRunner(show_results={"x.1": tracker_show_ok("x.1")})
+    port = TrackerPort(runner)
+
+    port.read_bead("x.1")
+
+    assert runner.calls[0] == ("--protocol-version",)
+    assert runner.calls[1] == ("show", "x.1")
+
+
+def test_handshake_is_cached_across_multiple_verb_calls():
+    runner = ScriptedTrackerRunner(
+        show_results={"x.1": tracker_show_ok("x.1"), "x.2": tracker_show_ok("x.2")}
+    )
+    port = TrackerPort(runner)
+
+    port.read_bead("x.1")
+    port.read_bead("x.2")
+
+    assert runner.calls.count(("--protocol-version",)) == 1
+
+
+def test_handshake_accepts_same_major_different_minor():
+    runner = ScriptedTrackerRunner(protocol="1.7", show_results={"x.1": tracker_show_ok("x.1")})
+    port = TrackerPort(runner)
+
+    bead = port.read_bead("x.1")
+
+    assert bead.id == "x.1"
+
+
+def test_handshake_rejects_a_different_major_protocol_version():
+    runner = ScriptedTrackerRunner(protocol="2.0", show_results={"x.1": tracker_show_ok("x.1")})
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_PROTOCOL_MISMATCH
+    assert exc_info.value.detail["actual_protocol"] == "2.0"
+    assert exc_info.value.detail["expected_major"] == "1"
+    # the mismatch is caught at the handshake -- `show` is never dispatched
+    assert ("show", "x.1") not in runner.calls
+
+
+def test_handshake_with_missing_protocol_field_is_malformed():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("--protocol-version",)] = tracker_ok({"nope": "field"})
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_handshake_with_non_string_protocol_field_is_malformed():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("--protocol-version",)] = tracker_ok({"protocol": 1.0})
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+# ── envelope parsing (shared _run_and_parse path, exercised via read_bead) ──
+
+
+def test_non_json_stdout_is_malformed_envelope():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(returncode=1, stdout="not json", stderr="")
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_envelope_not_an_object_is_malformed():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = TrackerResult(returncode=0, stdout="42", stderr="")
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_envelope_missing_ok_key_is_malformed():
+    runner = ScriptedTrackerRunner()
+    stdout = json.dumps({"protocol": "1.0", "data": {}})
+    runner.responses[("show", "x.1")] = TrackerResult(returncode=0, stdout=stdout, stderr="")
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_error_envelope_is_backend_error_carrying_facades_own_code():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("show", "x.1")] = tracker_error(
+        "E_NOT_FOUND", "no such item", detail={"id": "x.1"}
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_BACKEND_ERROR
+    assert exc_info.value.detail["code"] == "E_NOT_FOUND"
+    assert exc_info.value.detail["backend_detail"] == {"id": "x.1"}
+    assert "no such item" in exc_info.value.message
+
+
+# ── read_bead ────────────────────────────────────────────────────────────
+
+
+def test_read_bead_parses_id_status_labels_deps():
+    runner = ScriptedTrackerRunner(
+        show_results={
+            "x.1": tracker_show_ok(
+                "x.1",
+                status="in_progress",
+                labels=["shape-feat", "planned"],
+                deps=[("x.0", "blocks", "closed")],
+            )
+        }
+    )
+    port = TrackerPort(runner)
+
+    bead = port.read_bead("x.1")
+
+    assert bead == BeadRecord(
+        id="x.1",
+        status="in_progress",
+        labels=("shape-feat", "planned"),
+        deps=(DepEdgeRecord(id="x.0", type="blocks", status="closed"),),
+    )
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        "not-an-object",
+        {"status": "open", "labels": [], "deps": []},  # missing id
+        {"id": "x.1", "labels": [], "deps": []},  # missing status
+        {"id": "x.1", "status": "open", "deps": []},  # missing labels
+        {"id": "x.1", "status": "open", "labels": []},  # missing deps
+        {"id": "x.1", "status": "open", "labels": [], "deps": "nope"},  # deps not a list
+        {"id": "x.1", "status": "open", "labels": [], "deps": [123]},  # dep entry not an object
+        {
+            "id": "x.1",
+            "status": "open",
+            "labels": [],
+            "deps": [{"id": "x.0", "type": "blocks"}],  # dep entry missing status
+        },
+    ],
+)
+def test_read_bead_malformed_shapes_raise(data: object):
+    runner = ScriptedTrackerRunner()
+    runner.show_results["x.1"] = tracker_ok(data)
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.read_bead("x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+# ── add_edge ────────────────────────────────────────────────────────────
+
+
+def test_add_edge_sends_dep_add_with_type():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("dep", "add", "x.1", "x.2", "--type", "blocks")] = tracker_ok(None)
+    port = TrackerPort(runner)
+
+    port.add_edge("x.1", "x.2", "blocks")
+
+    assert ("dep", "add", "x.1", "x.2", "--type", "blocks") in runner.calls
+
+
+def test_add_edge_supports_related_to_kind():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("dep", "add", "x.1", "x.2", "--type", "related-to")] = tracker_ok(None)
+    port = TrackerPort(runner)
+
+    port.add_edge("x.1", "x.2", "related-to")
+
+    assert ("dep", "add", "x.1", "x.2", "--type", "related-to") in runner.calls
+
+
+def test_add_edge_propagates_backend_error_envelope():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("dep", "add", "x.1", "x.2", "--type", "blocks")] = tracker_error(
+        "E_TYPE_WALL", "blocks: epic may not block task"
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.add_edge("x.1", "x.2", "blocks")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_BACKEND_ERROR
+    assert exc_info.value.detail["code"] == "E_TYPE_WALL"
+
+
+# ── append_note ─────────────────────────────────────────────────────────
+
+
+def test_append_note_sends_note_verb():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("note", "x.1", "hello")] = tracker_ok(None)
+    port = TrackerPort(runner)
+
+    port.append_note("x.1", "hello")
+
+    assert ("note", "x.1", "hello") in runner.calls
+
+
+# ── mint_bead ───────────────────────────────────────────────────────────
+
+
+def test_mint_bead_with_parent_returns_new_id():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("create", "feat", "--title", "New thing", "--parent", "x.1")] = tracker_ok(
+        {"id": "x.2"}
+    )
+    port = TrackerPort(runner)
+
+    new_id = port.mint_bead("feat", "New thing", parent="x.1")
+
+    assert new_id == "x.2"
+
+
+def test_mint_bead_with_orphan_omits_parent_flag():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("create", "chore", "--title", "Orphan chore", "--orphan")] = tracker_ok(
+        {"id": "x.9"}
+    )
+    port = TrackerPort(runner)
+
+    new_id = port.mint_bead("chore", "Orphan chore", orphan=True)
+
+    assert new_id == "x.9"
+
+
+def test_mint_bead_appends_optional_fields_in_order():
+    runner = ScriptedTrackerRunner()
+    argv = (
+        "create",
+        "bugfix",
+        "--title",
+        "Fix it",
+        "--parent",
+        "x.1",
+        "--description",
+        "desc",
+        "--priority",
+        "P1",
+        "--acceptance",
+        "criteria",
+    )
+    runner.responses[argv] = tracker_ok({"id": "x.3"})
+    port = TrackerPort(runner)
+
+    new_id = port.mint_bead(
+        "bugfix",
+        "Fix it",
+        parent="x.1",
+        description="desc",
+        priority="P1",
+        acceptance="criteria",
+    )
+
+    assert new_id == "x.3"
+    assert argv in runner.calls
+
+
+def test_mint_bead_malformed_response_without_id_raises():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("create", "feat", "--title", "T", "--parent", "x.1")] = tracker_ok({})
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.mint_bead("feat", "T", parent="x.1")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_MALFORMED_ENVELOPE
+
+
+def test_mint_bead_without_parent_or_orphan_propagates_facades_usage_error():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("create", "feat", "--title", "T")] = tracker_error(
+        "E_USAGE", "create feat: exactly one of --parent or --orphan is required"
+    )
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.mint_bead("feat", "T")
+
+    assert exc_info.value.code == ErrorCode.TRACKER_BACKEND_ERROR
+    assert exc_info.value.detail["code"] == "E_USAGE"
+
+
+# ── relabel ─────────────────────────────────────────────────────────────
+
+
+def test_relabel_add_sends_label_add():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("label", "add", "x.1", "planned", "spec-ready")] = tracker_ok(None)
+    port = TrackerPort(runner)
+
+    port.relabel("x.1", ["planned", "spec-ready"])
+
+    assert ("label", "add", "x.1", "planned", "spec-ready") in runner.calls
+
+
+def test_relabel_remove_sends_label_remove():
+    runner = ScriptedTrackerRunner()
+    runner.responses[("label", "remove", "x.1", "planned")] = tracker_ok(None)
+    port = TrackerPort(runner)
+
+    port.relabel("x.1", ["planned"], remove=True)
+
+    assert ("label", "remove", "x.1", "planned") in runner.calls
+
+
+# ── resequence: not supported today (spec §5.7) ─────────────────────────
+
+
+def test_resequence_raises_not_supported_without_touching_the_runner():
+    runner = ScriptedTrackerRunner()
+    port = TrackerPort(runner)
+
+    with pytest.raises(VizError) as exc_info:
+        port.resequence()
+
+    assert exc_info.value.code == ErrorCode.TRACKER_NOT_SUPPORTED
+    # never attempts the handshake either -- a verb with no facade mapping
+    # never touches the subprocess boundary at all (spec §5.6).
+    assert runner.calls == []
+
+
+# ── SubprocessTrackerRunner: real `work` subprocess wiring ──────────────
+
+
+class _RecordingCompletedProcess:
+    returncode = 0
+    stdout = '{"protocol": "1.0", "ok": true, "data": null, "error": null}'
+    stderr = ""
+
+
+def _record_run(calls: list[dict[str, Any]]) -> Any:
+    def _fake_run(argv: list[str], **kwargs: Any) -> _RecordingCompletedProcess:
+        calls.append({"argv": argv, **kwargs})
+        return _RecordingCompletedProcess()
+
+    return _fake_run
+
+
+def test_subprocess_runner_runs_work_against_the_injected_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(subprocess, "run", _record_run(calls))
+
+    SubprocessTrackerRunner(repo_root=str(tmp_path)).run(["show", "x.1"])
+
+    assert len(calls) == 1
+    assert calls[0]["cwd"] == str(tmp_path)
+    assert calls[0]["argv"] == ["work", "show", "x.1"]
+
+
+def test_subprocess_runner_default_repo_root_is_dot(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(subprocess, "run", _record_run(calls))
+
+    SubprocessTrackerRunner().run(["--protocol-version"])
+
+    assert calls[0]["cwd"] == "."


### PR DESCRIPTION
## Summary

- Adds the **tracker port + full-graph cycle guard** — the suite's sole beads boundary and the safety property every future mutation shares (slice S4 of the sidecar/funnel/review-queue build, after S1 #275, S2 #277, S3 #278):
- `tracker/port.py` (new): `TrackerPort` speaking the `work` facade's JSON-envelope contract through an injected `TrackerRunner` (Protocol + `SubprocessTrackerRunner`, mirroring the existing gh/git runner seam — no module-global client, and **zero `bd` invocations anywhere**, per the §5.6 tracker quarantine):
  - **Protocol-version handshake** before first use; mismatch → typed `TRACKER_PROTOCOL_MISMATCH`.
  - Verb mapping onto today's facade surface: read bead → `show`; add edge → `dep add --type {blocks|related-to}`; append note → `note`; mint bead → `create <noun>` (noun-templated public creation, never the `--raw` transport primitive); relabel → `label {add|remove}`.
  - **`resequence()` is a permanent typed `TRACKER_NOT_SUPPORTED`** — no facade verb exists; the port raises without touching the runner, never falling back to a `bd` shell-out.
  - Typed errors for every failure class (error envelope, malformed JSON, protocol mismatch, unsupported verb); frozen result dataclasses parsing only the fields the suite needs (a MINOR envelope bump never breaks the port).
- `tracker/cycle_guard.py` (new): pure `find_cycle` over the FULL accepted logical dependency graph — beads `blocks` edges (read via the port) PLUS sidecar-held accepted dependency edges including type-wall `related-to` fallbacks (which beads alone cannot distinguish from incidental `related-to` edges). Typed `Safe`/`CycleRefusal` result carrying the reproducible cycle path; flag-writing on refusal deliberately belongs to the S5 caller. **Iterative explicit-stack DFS** — a dependency chain deeper than Python's recursion limit still yields the typed result (5000-link chain test), with deterministic sorted-child traversal pinned by test.
- `envelope.py`: four tracker error codes, existing style. `pyproject.toml`: `tracker/port.py` added to the existing S603/S607 subprocess-boundary ignore list (fourth runner, same convention). `tests/fakes.py`: `ScriptedTrackerRunner` + envelope builders.
- 42 new tests (284 total): handshake + every typed-error path against the scripted fake; cycles through beads edges alone, sidecar edges alone, and mixed paths; `related-to` beads edges excluded unless sidecar-declared; deterministic path reporting; deep-chain typed result.

Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.3, §5.6, §5.7; `docs/specs/2026-07-04-work-facade-cli-contract.md` (the envelope contract the port speaks).

## Scope + design decisions

- **Edge direction pinned end-to-end:** workcli's `dep add A B` = "A depends on B"; `TrackerPort.add_edge`, `ProposedEdge`, and `SidecarDependencyEdge` all use the identical direction, so graph traversal needs no inverse-edge verb.
- **Only beads edges typed exactly `blocks` count toward cycles** — a beads `related-to` edge participates only when the sidecar separately declares it a true type-wall fallback dependency (tested explicitly).
- **`mint_bead` does not re-validate facade business rules** (e.g. parent/orphan exclusivity) — the facade owns tracker rules per the quarantine; its `E_USAGE` surfaces as `TRACKER_BACKEND_ERROR`.
- No verb registration in `cli.py` — the port is a library seam consumed by S5 (`viz verdict` promotion) and S6 (`viz apply`).

## Review-gate disposition

HEAVY adversarial gate (6 lenses, 3-refuter panels, 10 agents, ACCEPTANCE clean-at-floor after 1 round, zero fixes auto-applied): one sub-floor minor flagged — unbounded recursion in the cycle DFS (RecursionError past ~1000-deep chains would escape the typed-result contract). **Fixed** (second commit): explicit-stack rewrite, deep-chain test, dead entry checks removed; re-verified first-hand at 100.00%.

## Test Plan

- [x] TDD red→green: port + cycle-guard tests written first, failed before the modules existed, green after
- [x] `make ci-vizsuite` fully green (exit 0, verified post-gate-fix): ruff, format-check, mypy --strict, 284 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
