### PR TITLE
fix(settings): migrate Write() deny rules to Edit() for enforced file guards

### DIFF
--- a/src/user/.claude/settings.json.template
+++ b/src/user/.claude/settings.json.template
@@ -23,11 +23,11 @@
       "Read(~/.ssh/*)",
       "Read(/etc/shadow)",
       "Read(/etc/passwd)",
-      "Write(/etc/*)",
-      "Write(/bin/*)",
-      "Write(/usr/bin/*)",
-      "Write(/sbin/*)",
-      "Write(/usr/sbin/*)"
+      "Edit(/etc/*)",
+      "Edit(/bin/*)",
+      "Edit(/usr/bin/*)",
+      "Edit(/sbin/*)",
+      "Edit(/usr/sbin/*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary
- Migrates the five `Write(/…/*)` permission **deny** rules in `src/user/.claude/settings.json.template` to `Edit(/…/*)` for the same paths (`/etc`, `/bin`, `/usr/bin`, `/sbin`, `/usr/sbin`).
- Claude Code's permission engine only enforces `Edit(path)` guards for file-writing tools; an `Edit` rule covers **Write, Edit, and NotebookEdit**. The prior `Write(path)` deny rules were silently unenforced, left those system dirs unguarded, and emitted a startup warning on every launch.
- Net effect **strengthens** protection: one rule now guards three tools instead of a dead rule guarding none.

## Scope
- **In scope:** the 5-line deny-list swap in the settings template (source of truth). Nothing else changed.
- **Out of scope:** the installer's inability to remove stale/renamed keys from an already-deployed `~/.claude/settings.json` (union-merge only adds). Filed as discovered work `agents-config-abn9.37.1.3`.

## Artifact nature
Source template — installed to `~/.claude/settings.json` at install time via jq union-merge. This is current-state config, not a design doc.

## Ground truth to check against
- Diff: `src/user/.claude/settings.json.template` deny array.
- The warning text this fixes: *"Write(/bin/*) is not matched by file permission checks — only Edit(path) rules are. Use Edit(/bin/*) instead."* (emitted by Claude Code at session start).

## Test Plan
- [x] `python3 -m json.tool src/user/.claude/settings.json.template` — valid JSON.
- [x] HEAVY completion gate (correctness / security / simplify lenses) — accepted clean-at-floor, 0 findings ≥ major.
- [ ] Post-install: launch Claude Code, confirm the five `Write(...)` warnings no longer appear.
