### PR TITLE
feat(vizsuite): viz verdict + accept-time edge promotion (S5)

### DIFF
--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -27,6 +27,7 @@ from vizsuite.adapters.scc.runner import SccRunner, SubprocessSccRunner
 from vizsuite.envelope import ErrorCode, JsonValue, VizError, emit_failure, emit_success
 from vizsuite.render import render_human
 from vizsuite.runners import Runners
+from vizsuite.tracker.port import SubprocessTrackerRunner, TrackerRunner
 from vizsuite.verbs import VERBS
 
 
@@ -56,6 +57,23 @@ def _add_sweep_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser])
     subparsers.add_parser("sweep", help="run funnel rungs 1-2 over the sidecar's fact files")
 
 
+def _add_verdict_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    verdict_parser = subparsers.add_parser(
+        "verdict", help="record a Tier-3 verdict on a fact, edge-promoting an accepted edge"
+    )
+    verdict_parser.add_argument(
+        "fact_id", metavar="FACT_ID", help="the fact id to record a verdict on"
+    )
+    verdict_parser.add_argument(
+        "verdict", choices=["accept", "reject", "dismiss"], help="the verdict to record"
+    )
+    verdict_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="preview the bead mutations that would happen without writing anything",
+    )
+
+
 def _build_parser() -> _EnvelopeArgumentParser:
     parser = _EnvelopeArgumentParser(prog="viz", description="viz — repo/PR visualization suite")
     parser.add_argument(
@@ -76,6 +94,7 @@ def _build_parser() -> _EnvelopeArgumentParser:
     _add_pr_subparser(subparsers)
     _add_queue_subparser(subparsers)
     _add_sweep_subparser(subparsers)
+    _add_verdict_subparser(subparsers)
     return parser
 
 
@@ -132,6 +151,7 @@ def main(
     git_runner: GitRunner | None = None,
     scc_runner: SccRunner | None = None,
     gh_runner: GhRunner | None = None,
+    tracker_runner: TrackerRunner | None = None,
     out: TextIO | None = None,
     err: TextIO | None = None,
 ) -> int:
@@ -177,6 +197,9 @@ def main(
             git=git_runner if git_runner is not None else SubprocessGitRunner(repo_root=repo_root),
             gh=gh_runner if gh_runner is not None else SubprocessGhRunner(repo_root=repo_root),
             scc=scc_runner if scc_runner is not None else SubprocessSccRunner(),
+            tracker=tracker_runner
+            if tracker_runner is not None
+            else SubprocessTrackerRunner(repo_root=repo_root),
         )
         data = handler(runners, args)
     except VizError as verb_error:

--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -57,10 +57,35 @@ class ErrorCode(StrEnum):
     # tracker slice: the port verb has no mapped `work` verb today (e.g.
     # resequence, spec §5.7) -- never a `bd` shell-out fallback (spec §5.6).
     TRACKER_NOT_SUPPORTED = "E_TRACKER_NOT_SUPPORTED"
+    # verdict slice: `dismiss` recorded against a fact that isn't in
+    # `recommendations.json` (spec §5.3/§10 item 3: "dismiss is valid only for
+    # recommendation-class facts").
+    VERDICT_DISMISS_NOT_RECOMMENDATION = "E_VERDICT_DISMISS_NOT_RECOMMENDATION"
+    # verdict slice: an edge-class fact's matching descriptor has no bead-id
+    # anchor on one (or both) endpoints -- a prose-only plan's edge can be
+    # reconciled and verdicted, but never edge-promoted until it gains a real
+    # bead anchor.
+    VERDICT_NO_BEAD_ANCHOR = "E_VERDICT_NO_BEAD_ANCHOR"
+    # verdict slice: an accept-time `blocks` promotion would close a cycle in
+    # the full accepted logical dependency graph (spec §5.3/§5.7, test item
+    # 17) -- refused with the cycle path in `detail`; no tracker edge written.
+    VERDICT_CYCLE_REFUSAL = "E_VERDICT_CYCLE_REFUSAL"
 
 
-@dataclass(frozen=True)
+@dataclass
 class VizError(Exception):
+    """`frozen=True` was previously used here but is unsafe for an `Exception`
+    subclass: CPython's exception machinery mutates `__traceback__`/
+    `__context__`/`__cause__` on the instance during propagation, and on
+    Python 3.14 a nested `@contextmanager` teardown (e.g. `SidecarStore.
+    transaction()` wrapping `_locked()`) explicitly assigns `exc.__traceback__`
+    while re-throwing into the generator — a frozen dataclass's `__setattr__`
+    override turns that assignment into a `FrozenInstanceError`, masking the
+    real error with an unrelated crash. Field values still behave as
+    immutable by convention (nothing in this codebase mutates a `VizError`
+    after construction); only the enforcement is gone.
+    """
+
     code: ErrorCode
     message: str
     detail: dict[str, JsonValue] = field(default_factory=dict)

--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -90,6 +90,12 @@ class VizError(Exception):
     message: str
     detail: dict[str, JsonValue] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        # The dataclass-generated __init__ never calls Exception.__init__, so
+        # args would stay () and str(error) would render empty in an uncaught
+        # traceback.
+        super().__init__(self.message)
+
 
 def emit_success(data: JsonValue, out: TextIO = sys.stdout) -> int:
     json.dump({"protocol": PROTOCOL_VERSION, "ok": True, "data": data, "error": None}, out)

--- a/packages/vizsuite/src/vizsuite/runners.py
+++ b/packages/vizsuite/src/vizsuite/runners.py
@@ -1,12 +1,14 @@
 """`Runners` — the injected outside-world dependency bundle handed to verbs.
 
 `cli.main` builds one `Runners` and passes it to the dispatched verb handler, so
-every adapter (git, gh, scc) arrives as an argument rather than a module global.
-Pinning the bundle keeps the verb→handler contract stable across slices.
+every adapter (git, gh, scc, tracker) arrives as an argument rather than a module
+global. Pinning the bundle keeps the verb→handler contract stable across slices.
 
-All three adapters are required: `viz pr` reconciles (gh), reads the head-OID
+All four adapters are required: `viz pr` reconciles (gh), reads the head-OID
 estate + snapshot (git), and scores complexity from a materialized snapshot (scc)
-on every run, so `cli.main` always constructs each one.
+on every run; `viz verdict` drives edge promotion through `tracker` (wrapped in a
+`TrackerPort` by the verb itself, mirroring how `viz pr` wraps `scc`/`gh`). `cli.main`
+always constructs each adapter regardless of which verb dispatches.
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ from dataclasses import dataclass
 from vizsuite.adapters.gh.runner import GhRunner
 from vizsuite.adapters.git.runner import GitRunner
 from vizsuite.adapters.scc.runner import SccRunner
+from vizsuite.tracker.port import TrackerRunner
 
 
 @dataclass(frozen=True)
@@ -23,3 +26,4 @@ class Runners:
     git: GitRunner
     gh: GhRunner
     scc: SccRunner
+    tracker: TrackerRunner

--- a/packages/vizsuite/src/vizsuite/sidecar/models.py
+++ b/packages/vizsuite/src/vizsuite/sidecar/models.py
@@ -9,9 +9,11 @@ separately from identity), and per-fact `Provenance` (reused from
 scene envelope carries, not a second one). `payload` holds the record-kind-
 specific fields; this foundation slice does not yet model V2's per-kind
 domain shapes (§7.2) — later slices read typed views over `payload` without
-changing this envelope. `FlagRecord` models a `flags.json` entry (`doubt` or
-`orphaned_verdict`); `VerdictRecord` models a `verdicts.json` entry; `Manifest`
-models `manifest.json`.
+changing this envelope (the verdict slice's `payload["promotion"]`
+edge-promotion ledger is one such typed view, see `vizsuite.verbs.verdict`).
+`FlagRecord` models a `flags.json` entry (`doubt`, `orphaned_verdict`, or
+`orphaned_edge_promotion`); `VerdictRecord` models a `verdicts.json` entry;
+`Manifest` models `manifest.json`.
 
 Every `*_to_json`/`*_from_json` pair is a pure mapping function, mirroring
 `vizsuite.scene.model.scene_to_json`'s style. `*_from_json` raises a plain
@@ -31,10 +33,16 @@ from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind, provenan
 
 
 class FlagKind(StrEnum):
-    """The two `flags.json` record kinds (spec §5.3): `doubt` vs `orphaned_verdict`."""
+    """The three `flags.json` record kinds (spec §5.3): `doubt`,
+    `orphaned_verdict`, or `orphaned_edge_promotion`."""
 
     DOUBT = "doubt"
     ORPHANED_VERDICT = "orphaned_verdict"
+    # verdict slice: a previously-promoted edge's recorded bead pair fell
+    # outside the fact's current bead-id anchors after re-synthesis. A
+    # promoted tracker edge is never auto-removed (spec §5.3), so this flags
+    # the mismatch for human disposition instead of silently dropping it.
+    ORPHANED_EDGE_PROMOTION = "orphaned_edge_promotion"
 
 
 class Verdict(StrEnum):

--- a/packages/vizsuite/src/vizsuite/verbs/__init__.py
+++ b/packages/vizsuite/src/vizsuite/verbs/__init__.py
@@ -2,7 +2,8 @@
 
 `cli.main` looks the handler up here after argparse has already rejected any
 unknown subcommand, so a name reaching dispatch is always registered. Slice 1
-shipped `pr`; the .2.3 sidecar slices register more here (`queue`, `sweep`).
+shipped `pr`; the .2.3 sidecar slices register more here (`queue`, `sweep`,
+`verdict`).
 """
 
 from __future__ import annotations
@@ -15,9 +16,11 @@ from vizsuite.runners import Runners
 from vizsuite.verbs.pr import pr
 from vizsuite.verbs.queue import queue
 from vizsuite.verbs.sweep import sweep
+from vizsuite.verbs.verdict import verdict
 
 VERBS: dict[str, Callable[[Runners, Namespace], JsonValue]] = {
     "pr": pr,
     "queue": queue,
     "sweep": sweep,
+    "verdict": verdict,
 }

--- a/packages/vizsuite/src/vizsuite/verbs/verdict.py
+++ b/packages/vizsuite/src/vizsuite/verbs/verdict.py
@@ -1,0 +1,507 @@
+"""`viz verdict <fact-id> <accept|reject|dismiss>` — Tier-3 verdict recording
+plus accept-time edge promotion (spec §5.3/§5.7, test items 5/14/17).
+
+Verdicts are written exclusively through `SidecarStore.upsert_verdict` (the
+only public `verdicts.json` mutation); the verdict write and the resolution of
+the fact's pending `flags.json` entry commit atomically inside one
+`store.transaction()`. `dismiss` is valid only for a recommendation-class fact
+(one found in `recommendations.json`) — recorded against any other class it is
+a typed refusal, no write at all.
+
+Accepting an edge-class fact (found in `edges.json`) edge-promotes it into
+beads through `TrackerPort`: a `dependency` fact runs `cycle_guard.find_cycle`
+over the full accepted logical dependency graph (beads `blocks` edges plus
+every other already-promoted `dependency`-kind sidecar edge, including
+type-wall `related-to` fallbacks) before attempting a real `blocks` edge,
+falling back to `related-to` on a type-wall backend error (`work dep add`
+itself enforces the epic/non-epic wall — this module never duplicates that
+rule, it only reacts to the typed failure); `conflict`/`overlap`/`synergy`
+facts always write `related-to` directly, sidecar-authoritative on kind, with
+no cycle check (they carry no logical dependency). The chosen bead pair and
+the tracker edge kind actually written are recorded on the fact's own
+`payload["promotion"]` ledger entry — idempotency checks THIS ledger, never
+re-derivation, so re-accepting an already-promoted fact never touches the
+tracker again. If re-synthesis has since moved the fact's bead-id anchors so
+the recorded pair no longer resolves within them, the (idempotent) re-accept
+raises an `orphaned_edge_promotion` flag for human disposition; the promoted
+tracker edge itself is never auto-removed.
+
+`--dry-run` runs the identical decision logic (the cycle check's `read_bead`
+calls are pure reads, so they still run) but performs zero sidecar or tracker
+mutation: no `store.transaction()` is ever entered, and no `add_edge`/
+`append_note` call is ever issued.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from argparse import Namespace
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+from vizsuite.runners import Runners
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    MatchingDescriptor,
+    Verdict,
+    VerdictRecord,
+)
+from vizsuite.sidecar.store import SidecarStore
+from vizsuite.tracker.cycle_guard import (
+    CycleRefusal,
+    ProposedEdge,
+    Safe,
+    SidecarDependencyEdge,
+    find_cycle,
+)
+from vizsuite.tracker.port import DepKind, TrackerPort
+
+_DEPENDENCY_KIND = "dependency"
+_DISCOVERABILITY_KINDS = frozenset({"conflict", "overlap", "synergy"})
+_TYPE_WALL_BACKEND_CODE = "E_TYPE_WALL"
+_PROMOTION_PAYLOAD_KEY = "promotion"
+
+
+# ---- the promotion ledger (spec §5.3: "the chosen bead pair is recorded on
+# the fact's ledger entry") ---------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromotionLedgerEntry:
+    """The accept-time edge-promotion record on an edge fact's
+    `payload["promotion"]`: the chosen bead pair plus the tracker edge kind
+    actually written. Idempotency checks THIS ledger, never re-derivation."""
+
+    from_bead: str
+    to_bead: str
+    tracker_edge_kind: DepKind
+
+
+def _ledger_to_json(entry: PromotionLedgerEntry) -> dict[str, JsonValue]:
+    return {
+        "from_bead": entry.from_bead,
+        "to_bead": entry.to_bead,
+        "tracker_edge_kind": entry.tracker_edge_kind,
+    }
+
+
+class _MalformedLedgerShapeError(TypeError):
+    """Raised when a `payload["promotion"]` value isn't the ledger's shape."""
+
+    def __init__(self) -> None:
+        super().__init__("promotion ledger entry has an invalid shape")
+
+
+def _parse_ledger_payload(raw: JsonValue) -> PromotionLedgerEntry:
+    if not isinstance(raw, dict):
+        raise _MalformedLedgerShapeError
+    from_bead, to_bead, tracker_edge_kind = (
+        raw["from_bead"],
+        raw["to_bead"],
+        raw["tracker_edge_kind"],
+    )
+    if not (
+        isinstance(from_bead, str)
+        and isinstance(to_bead, str)
+        and isinstance(tracker_edge_kind, str)
+    ):
+        raise _MalformedLedgerShapeError
+    return PromotionLedgerEntry(
+        from_bead=from_bead,
+        to_bead=to_bead,
+        tracker_edge_kind=cast("DepKind", tracker_edge_kind),
+    )
+
+
+def _read_ledger(fact: FactRecord) -> PromotionLedgerEntry | None:
+    """Read `fact.payload["promotion"]`, or `None` if never promoted.
+
+    `payload` is an opaque `dict[str, JsonValue]` as far as `SidecarStore` is
+    concerned (spec: "later slices read typed views over `payload` without
+    changing this envelope") -- this module owns validating its own typed view
+    over it, so a corrupt ledger (hand-edited or written by a future
+    incompatible version) is refused the same way the store refuses a corrupt
+    record shape at its own read boundary: `VizError(SIDECAR_MALFORMED)`.
+    """
+    raw = fact.payload.get(_PROMOTION_PAYLOAD_KEY)
+    if raw is None:
+        return None
+    try:
+        return _parse_ledger_payload(raw)
+    except (KeyError, TypeError) as exc:
+        raise VizError(
+            ErrorCode.SIDECAR_MALFORMED,
+            "a fact's promotion ledger entry is not valid",
+            detail={"fact_id": fact.fact_id, "reason": str(exc)},
+        ) from exc
+
+
+def _is_orphaned(entry: PromotionLedgerEntry, descriptor: MatchingDescriptor) -> bool:
+    """True iff the ledger's recorded pair no longer resolves within the
+    fact's CURRENT bead-id anchor sets (spec: "if re-synthesis moves the
+    recorded pair's beads out of the endpoints' anchor sets, an orphaned
+    edge-promotion flag is raised")."""
+    if len(descriptor.endpoint_bead_ids) != 2:
+        return True
+    from_ids, to_ids = descriptor.endpoint_bead_ids
+    return entry.from_bead not in from_ids or entry.to_bead not in to_ids
+
+
+def _choose_bead_pair(descriptor: MatchingDescriptor) -> tuple[str, str]:
+    """Deterministically choose one bead id per endpoint from the matching
+    descriptor's anchor sets. A prose-only plan's edge (empty anchors) has no
+    bead to promote onto -- refused rather than guessed."""
+    if len(descriptor.endpoint_bead_ids) != 2 or any(
+        len(ids) == 0 for ids in descriptor.endpoint_bead_ids
+    ):
+        raise VizError(
+            ErrorCode.VERDICT_NO_BEAD_ANCHOR,
+            "edge fact has no bead-id anchor to promote onto both endpoints",
+            detail={
+                "plan_pair": list(descriptor.plan_pair),
+                "endpoint_bead_ids": [list(ids) for ids in descriptor.endpoint_bead_ids],
+            },
+        )
+    from_ids, to_ids = descriptor.endpoint_bead_ids
+    return min(from_ids), min(to_ids)
+
+
+def _dependency_sidecar_edges(
+    edge_facts: Sequence[FactRecord],
+) -> tuple[SidecarDependencyEdge, ...]:
+    """Every already-promoted `dependency`-kind fact as a `SidecarDependencyEdge`
+    -- the sidecar half of the cycle check's full accepted logical dependency
+    graph (spec §5.3/§5.7), including type-wall `related-to` fallbacks (both
+    tracker edge kinds represent the same logical dependency)."""
+    edges: list[SidecarDependencyEdge] = []
+    for other in edge_facts:
+        if other.matching_descriptor.kind != _DEPENDENCY_KIND:
+            continue
+        ledger = _read_ledger(other)
+        if ledger is None:
+            continue
+        edges.append(SidecarDependencyEdge(from_bead=ledger.from_bead, to_bead=ledger.to_bead))
+    return tuple(edges)
+
+
+def _mint_orphan_flag_id(fact_id: str) -> str:
+    # A distinct namespace from sweep's doubt-flag ids (`flag-{...}`) so an
+    # orphan flag never collides with -- and silently clobbers -- a standing
+    # doubt flag for the same fact.
+    digest = hashlib.sha256(f"orphaned-edge-promotion:{fact_id}".encode()).hexdigest()
+    return f"flag-orphaned-edge-{digest[:16]}"
+
+
+def _orphan_flag(fact_id: str, entry: PromotionLedgerEntry) -> FlagRecord:
+    return FlagRecord(
+        flag_id=_mint_orphan_flag_id(fact_id),
+        fact_id=fact_id,
+        kind=FlagKind.ORPHANED_EDGE_PROMOTION,
+        reason=(
+            f"promoted edge {entry.from_bead}->{entry.to_bead} fell outside "
+            "the fact's current bead anchors after re-synthesis"
+        ),
+    )
+
+
+def _audit_note(fact: FactRecord, *, now: str) -> str:
+    return f"agent-inferred-then-accepted: {now} (fact {fact.fact_id}, basis {fact.basis_hash})"
+
+
+# ---- the promotion decision (typed discriminated result) -------------------
+
+
+@dataclass(frozen=True)
+class _NotYetPromoted:
+    """No ledger entry exists yet -- a fresh promotion is being considered."""
+
+    from_bead: str
+    to_bead: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class _AlreadyPromoted:
+    """A ledger entry already exists -- idempotent no-op, possibly orphaned."""
+
+    entry: PromotionLedgerEntry
+    orphaned: bool
+
+
+_EdgePromotionDecision = _NotYetPromoted | _AlreadyPromoted
+
+
+def _check_dependency_cycle(
+    port: TrackerPort,
+    edge_facts: Sequence[FactRecord],
+    fact: FactRecord,
+    *,
+    from_bead: str,
+    to_bead: str,
+) -> None:
+    sidecar_edges = _dependency_sidecar_edges(edge_facts)
+    result = find_cycle(port, sidecar_edges, ProposedEdge(from_bead=from_bead, to_bead=to_bead))
+    if isinstance(result, CycleRefusal):
+        raise VizError(
+            ErrorCode.VERDICT_CYCLE_REFUSAL,
+            f"accepting {fact.fact_id!r} would close a dependency cycle",
+            detail={"fact_id": fact.fact_id, "cycle": list(result.cycle)},
+        )
+    if not isinstance(result, Safe):
+        raise TypeError(result)
+
+
+class _UnrecognizedEdgeFactKindError(TypeError):
+    """Raised when an edge-class fact's `matching_descriptor.kind` is none of
+    the fixed relation enum (spec §5.2: `dependency`/`overlap`/`conflict`/
+    `synergy`) -- a corrupt or hand-edited `edges.json` record."""
+
+    def __init__(self, kind: str) -> None:
+        super().__init__(f"unrecognized edge fact kind: {kind!r}")
+
+
+def _decide_edge_promotion(
+    port: TrackerPort, edge_facts: Sequence[FactRecord], fact: FactRecord
+) -> _EdgePromotionDecision:
+    existing = _read_ledger(fact)
+    if existing is not None:
+        return _AlreadyPromoted(
+            entry=existing, orphaned=_is_orphaned(existing, fact.matching_descriptor)
+        )
+
+    from_bead, to_bead = _choose_bead_pair(fact.matching_descriptor)
+    kind = fact.matching_descriptor.kind
+    if kind == _DEPENDENCY_KIND:
+        _check_dependency_cycle(port, edge_facts, fact, from_bead=from_bead, to_bead=to_bead)
+    elif kind in _DISCOVERABILITY_KINDS:
+        pass  # conflict/overlap/synergy: no logical dependency, no cycle check
+    else:
+        raise _UnrecognizedEdgeFactKindError(kind)
+
+    return _NotYetPromoted(from_bead=from_bead, to_bead=to_bead, kind=kind)
+
+
+def _write_tracker_edge(port: TrackerPort, decision: _NotYetPromoted) -> DepKind:
+    if decision.kind != _DEPENDENCY_KIND:
+        port.add_edge(decision.from_bead, decision.to_bead, "related-to")
+        return "related-to"
+    try:
+        port.add_edge(decision.from_bead, decision.to_bead, "blocks")
+    except VizError as exc:
+        is_type_wall = (
+            exc.code == ErrorCode.TRACKER_BACKEND_ERROR
+            and exc.detail.get("code") == _TYPE_WALL_BACKEND_CODE
+        )
+        if not is_type_wall:
+            raise
+        port.add_edge(decision.from_bead, decision.to_bead, "related-to")
+        return "related-to"
+    else:
+        return "blocks"
+
+
+def _execute_edge_promotion(
+    port: TrackerPort, fact: FactRecord, decision: _EdgePromotionDecision
+) -> tuple[FactRecord, JsonValue, FlagRecord | None]:
+    """Perform the real tracker/sidecar-payload side effects for `decision`.
+
+    Returns `(possibly-updated fact record, promotion data for the envelope,
+    a newly-raised orphan flag or None)`. The caller only rewrites `edges.json`
+    when the returned fact differs from `fact` (a fresh promotion); an
+    already-promoted no-op never touches the tracker.
+    """
+    if isinstance(decision, _AlreadyPromoted):
+        flag = _orphan_flag(fact.fact_id, decision.entry) if decision.orphaned else None
+        data: JsonValue = {
+            "from_bead": decision.entry.from_bead,
+            "to_bead": decision.entry.to_bead,
+            "tracker_edge_kind": decision.entry.tracker_edge_kind,
+            "already_promoted": True,
+            "orphaned": decision.orphaned,
+        }
+        return fact, data, flag
+    if isinstance(decision, _NotYetPromoted):
+        tracker_edge_kind = _write_tracker_edge(port, decision)
+        note = _audit_note(fact, now=datetime.now(UTC).isoformat())
+        for bead_id in (decision.from_bead, decision.to_bead):
+            port.append_note(bead_id, note)
+        entry = PromotionLedgerEntry(
+            from_bead=decision.from_bead,
+            to_bead=decision.to_bead,
+            tracker_edge_kind=tracker_edge_kind,
+        )
+        updated_fact = replace(
+            fact, payload={**fact.payload, _PROMOTION_PAYLOAD_KEY: _ledger_to_json(entry)}
+        )
+        data = {
+            "from_bead": entry.from_bead,
+            "to_bead": entry.to_bead,
+            "tracker_edge_kind": entry.tracker_edge_kind,
+            "already_promoted": False,
+            "orphaned": False,
+        }
+        return updated_fact, data, None
+    raise TypeError(decision)
+
+
+def _preview_json(decision: _EdgePromotionDecision) -> JsonValue:
+    """The dry-run preview: the exact tracker writes that WOULD happen, with
+    zero mutation. For a fresh dependency promotion the attempted kind is
+    honestly `blocks` -- whether it actually lands as `blocks` or falls back
+    to `related-to` is resolved only by the real `work dep add` call, which
+    dry-run never issues."""
+    if isinstance(decision, _AlreadyPromoted):
+        return {
+            "from_bead": decision.entry.from_bead,
+            "to_bead": decision.entry.to_bead,
+            "already_promoted": True,
+            "orphaned": decision.orphaned,
+            "tracker_writes": [],
+        }
+    if isinstance(decision, _NotYetPromoted):
+        attempted_kind: DepKind = "blocks" if decision.kind == _DEPENDENCY_KIND else "related-to"
+        writes: list[JsonValue] = [
+            {
+                "op": "add_edge",
+                "from_bead": decision.from_bead,
+                "to_bead": decision.to_bead,
+                "kind": attempted_kind,
+            },
+            {"op": "append_note", "bead_id": decision.from_bead},
+            {"op": "append_note", "bead_id": decision.to_bead},
+        ]
+        return {
+            "from_bead": decision.from_bead,
+            "to_bead": decision.to_bead,
+            "already_promoted": False,
+            "orphaned": False,
+            "tracker_writes": writes,
+        }
+    raise TypeError(decision)
+
+
+# ---- fact lookup + dismiss gating -------------------------------------------
+
+
+def _locate_fact(
+    store: SidecarStore, fact_id: str
+) -> tuple[str, FactRecord, tuple[FactRecord, ...]] | None:
+    """Search edges/steps/recommendations for `fact_id`.
+
+    Returns `(fact_class, fact, edge_facts)` -- `edge_facts` is always the full
+    `edges.json` population (the cycle check's sidecar-edge input regardless
+    of which file `fact_id` itself came from) -- or `None` if not found.
+    """
+    edge_facts = store.read_edges()
+    for record in edge_facts:
+        if record.fact_id == fact_id:
+            return "edge", record, edge_facts
+    for record in store.read_steps():
+        if record.fact_id == fact_id:
+            return "step", record, edge_facts
+    for record in store.read_recommendations():
+        if record.fact_id == fact_id:
+            return "recommendation", record, edge_facts
+    return None
+
+
+def _require_fact(
+    store: SidecarStore, fact_id: str, verdict_value: Verdict
+) -> tuple[str, FactRecord, tuple[FactRecord, ...]]:
+    located = _locate_fact(store, fact_id)
+    if located is None:
+        raise VizError(
+            ErrorCode.NOT_FOUND,
+            f"no fact {fact_id!r} found in edges.json/steps.json/recommendations.json",
+            detail={"fact_id": fact_id},
+        )
+    fact_class, fact, edge_facts = located
+    if verdict_value == Verdict.DISMISS and fact_class != "recommendation":
+        raise VizError(
+            ErrorCode.VERDICT_DISMISS_NOT_RECOMMENDATION,
+            f"dismiss is valid only for recommendation-class facts; "
+            f"{fact_id!r} is {fact_class}-class",
+            detail={"fact_id": fact_id, "fact_class": fact_class},
+        )
+    return fact_class, fact, edge_facts
+
+
+# ---- the verb ----------------------------------------------------------------
+
+
+def _verdict_dry_run(
+    store: SidecarStore, port: TrackerPort, fact_id: str, verdict_value: Verdict
+) -> JsonValue:
+    fact_class, fact, edge_facts = _require_fact(store, fact_id, verdict_value)
+
+    promotion_preview: JsonValue = None
+    if verdict_value == Verdict.ACCEPT and fact_class == "edge":
+        decision = _decide_edge_promotion(port, edge_facts, fact)
+        promotion_preview = _preview_json(decision)
+
+    return {
+        "fact_id": fact_id,
+        "verdict": str(verdict_value),
+        "fact_class": fact_class,
+        "dry_run": True,
+        "promotion": promotion_preview,
+    }
+
+
+def _verdict_live(
+    store: SidecarStore, port: TrackerPort, fact_id: str, verdict_value: Verdict
+) -> JsonValue:
+    fact_class, fact, edge_facts = _require_fact(store, fact_id, verdict_value)
+
+    promotion_data: JsonValue = None
+    new_flag: FlagRecord | None = None
+    if verdict_value == Verdict.ACCEPT and fact_class == "edge":
+        decision = _decide_edge_promotion(port, edge_facts, fact)
+        updated_fact, promotion_data, new_flag = _execute_edge_promotion(port, fact, decision)
+        if updated_fact is not fact:
+            store.write_edges(
+                tuple(
+                    updated_fact if record.fact_id == fact_id else record for record in edge_facts
+                )
+            )
+
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id=fact_id, fact_id=fact_id, verdict=verdict_value, basis_hash=fact.basis_hash
+        )
+    )
+
+    existing_flags = store.read_flags()
+    remaining_flags = [flag for flag in existing_flags if flag.fact_id != fact_id]
+    if new_flag is not None:
+        remaining_flags.append(new_flag)
+    if remaining_flags != list(existing_flags):
+        store.write_flags(tuple(remaining_flags))
+
+    return {
+        "fact_id": fact_id,
+        "verdict": str(verdict_value),
+        "fact_class": fact_class,
+        "dry_run": False,
+        "promotion": promotion_data,
+    }
+
+
+def verdict(runners: Runners, args: Namespace) -> JsonValue:
+    """Handle `viz verdict <fact-id> <accept|reject|dismiss> [--dry-run]`."""
+    fact_id: str = args.fact_id
+    verdict_value = Verdict(args.verdict)
+    dry_run: bool = bool(args.dry_run)
+    port = TrackerPort(runners.tracker)
+    store = SidecarStore(Path.cwd())
+
+    if dry_run:
+        return _verdict_dry_run(store, port, fact_id, verdict_value)
+    with store.transaction():
+        return _verdict_live(store, port, fact_id, verdict_value)

--- a/packages/vizsuite/src/vizsuite/verbs/verdict.py
+++ b/packages/vizsuite/src/vizsuite/verbs/verdict.py
@@ -378,6 +378,7 @@ def _preview_json(decision: _EdgePromotionDecision) -> JsonValue:
         return {
             "from_bead": decision.entry.from_bead,
             "to_bead": decision.entry.to_bead,
+            "tracker_edge_kind": decision.entry.tracker_edge_kind,
             "already_promoted": True,
             "orphaned": decision.orphaned,
             "tracker_writes": [],

--- a/packages/vizsuite/src/vizsuite/verbs/verdict.py
+++ b/packages/vizsuite/src/vizsuite/verbs/verdict.py
@@ -30,6 +30,12 @@ tracker edge itself is never auto-removed.
 calls are pure reads, so they still run) but performs zero sidecar or tracker
 mutation: no `store.transaction()` is ever entered, and no `add_edge`/
 `append_note` call is ever issued.
+
+A failure BETWEEN the tracker writes and the ledger persist (the transaction
+is a lock, not a rollback) is recovered by re-running the same verdict: every
+tracker write is re-issuable (`work dep add` upserts idempotently at the
+backend; a duplicated audit note is accepted noise), so the retry converges on
+the same edge -- see `_execute_edge_promotion`.
 """
 
 from __future__ import annotations
@@ -111,6 +117,8 @@ def _parse_ledger_payload(raw: JsonValue) -> PromotionLedgerEntry:
         and isinstance(to_bead, str)
         and isinstance(tracker_edge_kind, str)
     ):
+        raise _MalformedLedgerShapeError
+    if tracker_edge_kind not in ("blocks", "related-to"):
         raise _MalformedLedgerShapeError
     return PromotionLedgerEntry(
         from_bead=from_bead,
@@ -315,6 +323,16 @@ def _execute_edge_promotion(
     a newly-raised orphan flag or None)`. The caller only rewrites `edges.json`
     when the returned fact differs from `fact` (a fresh promotion); an
     already-promoted no-op never touches the tracker.
+
+    Ordering is tracker-writes-then-ledger, deliberately: `store.transaction()`
+    is a lock, not a rollback, so a failure here leaves the tracker mutated
+    with no ledger record. The recovery contract is RE-RUNNING THE SAME
+    VERDICT, which converges because every tracker write is re-issuable --
+    `work dep add` is an idempotent upsert at the backend (bd exits 0 on a
+    duplicate edge, one edge row results) and a re-appended audit note is
+    accepted noise. Persisting the ledger first would invert the hazard into
+    an unrecoverable one: a ledger claiming a promotion that never happened,
+    which the ledger-only idempotency check would then never retry.
     """
     if isinstance(decision, _AlreadyPromoted):
         flag = _orphan_flag(fact.fact_id, decision.entry) if decision.orphaned else None

--- a/packages/vizsuite/tests/conftest.py
+++ b/packages/vizsuite/tests/conftest.py
@@ -11,6 +11,7 @@ from vizsuite.adapters.git.runner import GitRunner
 from vizsuite.adapters.scc.runner import SccRunner
 from vizsuite.cli import main
 from vizsuite.envelope import JsonValue
+from vizsuite.tracker.port import TrackerRunner
 
 
 def run_cli(
@@ -19,6 +20,7 @@ def run_cli(
     git_runner: GitRunner | None = None,
     gh_runner: GhRunner | None = None,
     scc_runner: SccRunner | None = None,
+    tracker_runner: TrackerRunner | None = None,
 ) -> tuple[int, dict[str, JsonValue], str]:
     """Invoke `main()` capturing stdout/stderr; return `(exit_code, envelope, stderr)`.
 
@@ -29,7 +31,13 @@ def run_cli(
     out = StringIO()
     err = StringIO()
     exit_code = main(
-        argv, git_runner=git_runner, gh_runner=gh_runner, scc_runner=scc_runner, out=out, err=err
+        argv,
+        git_runner=git_runner,
+        gh_runner=gh_runner,
+        scc_runner=scc_runner,
+        tracker_runner=tracker_runner,
+        out=out,
+        err=err,
     )
     envelope: dict[str, JsonValue] = json.loads(out.getvalue())
     return exit_code, envelope, err.getvalue()

--- a/packages/vizsuite/tests/unit/test_envelope.py
+++ b/packages/vizsuite/tests/unit/test_envelope.py
@@ -15,6 +15,15 @@ from vizsuite import cli as cli_module
 from vizsuite.envelope import ErrorCode, VizError, emit_failure, emit_success
 
 
+def test_viz_error_str_renders_its_message():
+    # The dataclass-generated __init__ never calls Exception.__init__, so
+    # without __post_init__ wiring, args stays () and str() renders empty --
+    # useless in an uncaught traceback.
+    error = VizError(ErrorCode.NOT_FOUND, "no fact 'edge-1' found")
+
+    assert str(error) == "no fact 'edge-1' found"
+
+
 def test_emit_success_writes_ok_envelope_and_returns_zero():
     out = StringIO()
 

--- a/packages/vizsuite/tests/unit/test_verbs_verdict.py
+++ b/packages/vizsuite/tests/unit/test_verbs_verdict.py
@@ -1,0 +1,783 @@
+"""`viz verdict <fact-id> <accept|reject|dismiss>` — Tier-3 verdict recording
+plus accept-time edge promotion (spec §5.3/§5.7, test items 5/14/17).
+
+Verdicts are recorded exclusively through `SidecarStore.upsert_verdict`; the
+verdict write and the resolution of the fact's pending flag happen atomically
+in one `store.transaction()`. Accepting an edge-class fact (one found in
+`edges.json`) edge-promotes it into beads via `TrackerPort`: a `dependency`
+fact tries a real `blocks` edge first, falling back to `related-to` on a
+type-wall backend error; `conflict`/`overlap`/`synergy` facts always write
+`related-to` directly, sidecar-authoritative on kind. The chosen bead pair is
+recorded on the fact's own `payload["promotion"]` ledger entry; idempotency
+checks that ledger, never re-derivation, so re-accepting an already-promoted
+fact never touches the tracker again. `cycle_guard.find_cycle` runs before
+every `blocks` attempt over the full accepted logical dependency graph (beads
+`blocks` edges plus every other already-promoted `dependency`-kind sidecar
+edge, including type-wall `related-to` fallbacks); a refusal is a typed error
+with no tracker write. `--dry-run` computes the exact same decision (the
+cycle-check read is allowed) but performs zero sidecar or tracker mutation.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedTrackerRunner, tracker_error, tracker_ok, tracker_show_ok
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import (
+    FactRecord,
+    FlagKind,
+    FlagRecord,
+    MatchingDescriptor,
+    Verdict,
+)
+from vizsuite.sidecar.store import SidecarStore
+
+_NOW = "2026-07-15T09:30:00+00:00"
+
+
+def _fact(
+    fact_id: str,
+    *,
+    kind: str = "dependency",
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = (("bead-a",), ("bead-b",)),
+    payload: dict[str, Any] | None = None,
+    basis_hash: str = "basis-1",
+) -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(
+            plan_pair=("plan-a", "plan-b"), kind=kind, endpoint_bead_ids=endpoint_bead_ids
+        ),
+        basis_hash=basis_hash,
+        provenance=Provenance(
+            kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=("spec:5.3",)
+        ),
+        payload=dict(payload) if payload is not None else {},
+    )
+
+
+def _verdict_module() -> Any:
+    # String-target setattr would resolve `vizsuite.verbs.verdict` to the
+    # *function* re-exported by `verbs/__init__` (the established gotcha, see
+    # test_verbs_sweep.py) -- patch the submodule object directly.
+    return importlib.import_module("vizsuite.verbs.verdict")
+
+
+def _freeze_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_verdict_module(), "datetime", _make_fixed_datetime())
+
+
+def _note_text(fact_id: str, basis_hash: str) -> str:
+    return f"agent-inferred-then-accepted: {_NOW} (fact {fact_id}, basis {basis_hash})"
+
+
+def _promotion_tracker(
+    *,
+    from_bead: str = "bead-a",
+    to_bead: str = "bead-b",
+    edge_kind: str = "blocks",
+    fact_id: str = "edge-1",
+    basis_hash: str = "basis-1",
+    show_results: dict[str, Any] | None = None,
+    extra_responses: dict[tuple[str, ...], Any] | None = None,
+) -> ScriptedTrackerRunner:
+    """A `ScriptedTrackerRunner` scripted for a fresh, successful promotion:
+    the `dep add` call plus both audit-note `note` calls it triggers. Requires
+    `_freeze_clock` so the note text (which embeds the wall clock) is
+    deterministic and matchable ahead of time -- `ScriptedTrackerRunner` only
+    answers exact-argv matches, it has no generic "succeed anything" mode.
+    """
+    note = _note_text(fact_id, basis_hash)
+    responses: dict[tuple[str, ...], Any] = {
+        ("dep", "add", from_bead, to_bead, "--type", edge_kind): tracker_ok(None),
+        ("note", from_bead, note): tracker_ok(None),
+        ("note", to_bead, note): tracker_ok(None),
+    }
+    if extra_responses:
+        responses.update(extra_responses)
+    return ScriptedTrackerRunner(show_results=show_results or {}, responses=responses)
+
+
+# ── reject: verdict recorded, no tracker touch, no promotion ────────────────
+
+
+def test_reject_records_verdict_and_never_touches_the_tracker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    # A decoy fact ahead of the target in edges.json so `_locate_fact`'s scan
+    # actually iterates past a non-match before finding "edge-1".
+    store.write_edges((_fact("edge-0"), _fact("edge-1")))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "reject"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert data["verdict"] == "reject"
+    assert data["fact_class"] == "edge"
+    assert data["promotion"] is None
+    (recorded,) = store.read_verdicts()
+    assert recorded.fact_id == "edge-1"
+    assert recorded.verdict == Verdict.REJECT
+    assert tracker.calls == []
+
+
+# ── dependency promotion rows ────────────────────────────────────────────────
+
+
+def test_accept_promotes_a_dependency_fact_to_a_real_blocks_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", endpoint_bead_ids=(("bead-a",), ("bead-b",))),))
+    tracker = _promotion_tracker(show_results={"bead-b": tracker_show_ok("bead-b", deps=[])})
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    promotion = envelope["data"]["promotion"]
+    assert promotion == {
+        "from_bead": "bead-a",
+        "to_bead": "bead-b",
+        "tracker_edge_kind": "blocks",
+        "already_promoted": False,
+        "orphaned": False,
+    }
+    assert ("dep", "add", "bead-a", "bead-b", "--type", "blocks") in tracker.calls
+    note_calls = {call[1]: call[2] for call in tracker.calls if call[0] == "note"}
+    assert note_calls == {
+        "bead-a": _note_text("edge-1", "basis-1"),
+        "bead-b": _note_text("edge-1", "basis-1"),
+    }
+    (updated,) = store.read_edges()
+    assert updated.payload["promotion"] == {
+        "from_bead": "bead-a",
+        "to_bead": "bead-b",
+        "tracker_edge_kind": "blocks",
+    }
+
+
+def test_accept_dependency_fact_falls_back_to_related_to_on_a_type_wall(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", endpoint_bead_ids=(("epic-a",), ("task-b",))),))
+    tracker = _promotion_tracker(
+        from_bead="epic-a",
+        to_bead="task-b",
+        edge_kind="related-to",
+        show_results={"task-b": tracker_show_ok("task-b", deps=[])},
+        extra_responses={
+            ("dep", "add", "epic-a", "task-b", "--type", "blocks"): tracker_error(
+                "E_TYPE_WALL", "blocks: epic may not block task"
+            ),
+        },
+    )
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    promotion = envelope["data"]["promotion"]
+    assert promotion["tracker_edge_kind"] == "related-to"
+    assert ("dep", "add", "epic-a", "task-b", "--type", "blocks") in tracker.calls
+    assert ("dep", "add", "epic-a", "task-b", "--type", "related-to") in tracker.calls
+    (updated,) = store.read_edges()
+    assert updated.payload["promotion"]["tracker_edge_kind"] == "related-to"
+    # sidecar stays authoritative: the fact's own kind is still "dependency"
+    assert updated.matching_descriptor.kind == "dependency"
+
+
+def test_accept_propagates_a_non_type_wall_backend_error_without_a_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner(
+        show_results={"bead-b": tracker_show_ok("bead-b", deps=[])},
+        responses={
+            ("dep", "add", "bead-a", "bead-b", "--type", "blocks"): tracker_error(
+                "E_SOME_OTHER_ERROR", "boom"
+            ),
+        },
+    )
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_TRACKER_BACKEND_ERROR"
+    assert not any(call[-1] == "related-to" for call in tracker.calls if call[0] == "dep")
+    assert store.read_verdicts() == ()
+
+
+# ── conflict/overlap/synergy: related-to directly, no cycle check ──────────
+
+
+@pytest.mark.parametrize("kind", ["conflict", "overlap", "synergy"])
+def test_accept_discoverability_fact_writes_related_to_without_a_cycle_check(
+    kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", kind=kind),))
+    # No show_results scripted at all -- a cycle-check read would raise.
+    tracker = _promotion_tracker(edge_kind="related-to")
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["promotion"]["tracker_edge_kind"] == "related-to"
+    assert not any(call[0] == "show" for call in tracker.calls)
+
+
+def test_accept_raises_on_an_unrecognized_edge_fact_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", kind="mystery"),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "_UnrecognizedEdgeFactKindError" in stderr
+
+
+# ── idempotency ──────────────────────────────────────────────────────────────
+
+
+def test_accept_is_idempotent_no_duplicate_tracker_writes_on_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = _promotion_tracker(show_results={"bead-b": tracker_show_ok("bead-b", deps=[])})
+
+    first_exit, first_envelope, _ = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+    calls_after_first = list(tracker.calls)
+    second_exit, second_envelope, _ = run_cli(
+        ["verdict", "edge-1", "accept"], tracker_runner=tracker
+    )
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert first_envelope["data"]["promotion"]["already_promoted"] is False
+    assert second_envelope["data"]["promotion"]["already_promoted"] is True
+    assert second_envelope["data"]["promotion"]["orphaned"] is False
+    assert tracker.calls == calls_after_first  # zero new tracker calls on replay
+
+
+# ── cycle refusal ────────────────────────────────────────────────────────────
+
+
+def test_accept_refuses_a_dependency_edge_that_would_close_a_cycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", endpoint_bead_ids=(("a",), ("b",))),))
+    tracker = ScriptedTrackerRunner(
+        show_results={"b": tracker_show_ok("b", deps=[("a", "blocks", "open")])}
+    )
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_VERDICT_CYCLE_REFUSAL"
+    assert envelope["error"]["detail"]["cycle"] == ["a", "b", "a"]
+    assert not any(call[0] == "dep" for call in tracker.calls)
+    assert store.read_verdicts() == ()
+
+
+def test_accept_raises_on_an_unrecognized_cycle_check_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_verdict_module(), "find_cycle", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+def test_accept_cycle_check_gathers_other_promoted_dependency_edges_and_skips_others(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The cycle check's sidecar-edge input (spec §5.3/§5.7) is every OTHER
+    # already-promoted `dependency`-kind fact -- a `conflict`-kind fact never
+    # counts (it carries no logical dependency) and an unpromoted dependency
+    # fact contributes nothing yet.
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    already_promoted = _fact(
+        "edge-2",
+        endpoint_bead_ids=(("x",), ("y",)),
+        payload={"promotion": {"from_bead": "x", "to_bead": "y", "tracker_edge_kind": "blocks"}},
+    )
+    unrelated_conflict = _fact("edge-3", kind="conflict", endpoint_bead_ids=(("p",), ("q",)))
+    target = _fact("edge-1", endpoint_bead_ids=(("a",), ("b",)))
+    store.write_edges((already_promoted, unrelated_conflict, target))
+    tracker = _promotion_tracker(
+        from_bead="a",
+        to_bead="b",
+        show_results={"b": tracker_show_ok("b", deps=[])},
+    )
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["promotion"]["tracker_edge_kind"] == "blocks"
+
+
+# ── dismiss gating ───────────────────────────────────────────────────────────
+
+
+def test_dismiss_succeeds_for_a_recommendation_class_fact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    # A decoy fact ahead of the target in recommendations.json so
+    # `_locate_fact`'s scan actually iterates past a non-match.
+    store.write_recommendations(
+        (_fact("rec-0", kind="guardrail"), _fact("rec-1", kind="guardrail"))
+    )
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "rec-1", "dismiss"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["fact_class"] == "recommendation"
+    (recorded,) = store.read_verdicts()
+    assert recorded.verdict == Verdict.DISMISS
+
+
+@pytest.mark.parametrize("write_to", ["edges", "steps"])
+def test_dismiss_is_refused_for_a_non_recommendation_class_fact(
+    write_to: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    fact = _fact("some-fact")
+    getattr(store, f"write_{write_to}")((fact,))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(
+        ["verdict", "some-fact", "dismiss"], tracker_runner=tracker
+    )
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_VERDICT_DISMISS_NOT_RECOMMENDATION"
+    assert store.read_verdicts() == ()
+    assert tracker.calls == []
+
+
+# ── not found ────────────────────────────────────────────────────────────────
+
+
+def test_unknown_fact_id_is_a_typed_not_found_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "ghost", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_NOT_FOUND"
+
+
+# ── non-edge classes: verdict recorded, no promotion attempted ─────────────
+
+
+def test_accept_on_a_step_class_fact_records_verdict_without_promotion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    # A decoy fact ahead of the target in steps.json so `_locate_fact`'s scan
+    # actually iterates past a non-match.
+    store.write_steps((_fact("step-0", kind="waypoint"), _fact("step-1", kind="waypoint")))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "step-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["fact_class"] == "step"
+    assert envelope["data"]["promotion"] is None
+    assert tracker.calls == []
+
+
+def test_accept_on_a_recommendation_class_fact_records_verdict_without_promotion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_fact("rec-1", kind="dependency"),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "rec-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["fact_class"] == "recommendation"
+    assert envelope["data"]["promotion"] is None
+    assert tracker.calls == []
+
+
+# ── no bead anchor ───────────────────────────────────────────────────────────
+
+
+def test_accept_raises_a_typed_error_when_the_edge_has_no_bead_anchor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", endpoint_bead_ids=()),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_VERDICT_NO_BEAD_ANCHOR"
+    assert tracker.calls == []
+
+
+# ── malformed ledger ─────────────────────────────────────────────────────────
+
+
+def test_accept_raises_sidecar_malformed_on_a_corrupt_promotion_ledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", payload={"promotion": "not-an-object"}),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_accept_raises_sidecar_malformed_when_a_ledger_field_is_not_a_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges(
+        (
+            _fact(
+                "edge-1",
+                payload={
+                    "promotion": {
+                        "from_bead": "bead-a",
+                        "to_bead": "bead-b",
+                        "tracker_edge_kind": 42,  # must be a string
+                    }
+                },
+            ),
+        )
+    )
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+# ── orphaned edge promotion ──────────────────────────────────────────────────
+
+
+def test_reaccept_raises_an_orphan_flag_when_resynthesis_moved_the_bead_pair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    ledger_payload = {
+        "promotion": {"from_bead": "bead-a", "to_bead": "bead-b", "tracker_edge_kind": "blocks"}
+    }
+    # The recorded pair (bead-a/bead-b) no longer resolves within the fact's
+    # current anchor sets (bead-c/bead-d) -- as if re-synthesis moved them.
+    resynthesized = _fact(
+        "edge-1", endpoint_bead_ids=(("bead-c",), ("bead-d",)), payload=ledger_payload
+    )
+    store.write_edges((resynthesized,))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    promotion = envelope["data"]["promotion"]
+    assert promotion["already_promoted"] is True
+    assert promotion["orphaned"] is True
+    (flag,) = store.read_flags()
+    assert flag.kind == FlagKind.ORPHANED_EDGE_PROMOTION
+    assert flag.fact_id == "edge-1"
+    assert tracker.calls == []  # idempotent -- no tracker call at all
+
+
+def test_reaccept_is_orphaned_when_resynthesis_collapsed_the_anchor_arity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Re-synthesis can also collapse a fact down to zero bead anchors (a plan
+    # gone prose-only) rather than merely swapping which beads it names --
+    # that is orphaned too, checked structurally before any membership test.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    ledger_payload = {
+        "promotion": {"from_bead": "bead-a", "to_bead": "bead-b", "tracker_edge_kind": "blocks"}
+    }
+    resynthesized = _fact("edge-1", endpoint_bead_ids=(), payload=ledger_payload)
+    store.write_edges((resynthesized,))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    promotion = envelope["data"]["promotion"]
+    assert promotion["already_promoted"] is True
+    assert promotion["orphaned"] is True
+    assert tracker.calls == []
+
+
+def test_reaccepting_the_same_orphan_never_duplicates_the_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    ledger_payload = {
+        "promotion": {"from_bead": "bead-a", "to_bead": "bead-b", "tracker_edge_kind": "blocks"}
+    }
+    resynthesized = _fact(
+        "edge-1", endpoint_bead_ids=(("bead-c",), ("bead-d",)), payload=ledger_payload
+    )
+    store.write_edges((resynthesized,))
+    tracker = ScriptedTrackerRunner()
+
+    run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+    run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert len(store.read_flags()) == 1
+
+
+# ── flags.json resolution ───────────────────────────────────────────────────
+
+
+def test_verdict_resolves_a_pending_doubt_flag_for_the_same_fact_atomically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", kind="conflict"),))
+    store.write_flags(
+        (FlagRecord(flag_id="flag-1", fact_id="edge-1", kind=FlagKind.DOUBT, reason="churned"),)
+    )
+    tracker = _promotion_tracker(edge_kind="related-to")
+
+    exit_code, _envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert store.read_flags() == ()
+
+
+def test_verdict_preserves_unrelated_flags_for_other_facts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1", kind="conflict"), _fact("edge-2", kind="conflict")))
+    unrelated = FlagRecord(flag_id="flag-2", fact_id="edge-2", kind=FlagKind.DOUBT, reason="x")
+    store.write_flags(
+        (
+            FlagRecord(flag_id="flag-1", fact_id="edge-1", kind=FlagKind.DOUBT, reason="churned"),
+            unrelated,
+        )
+    )
+    tracker = _promotion_tracker(edge_kind="related-to")
+
+    exit_code, _envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert store.read_flags() == (unrelated,)
+
+
+# ── dry-run ──────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_previews_a_fresh_dependency_promotion_with_zero_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner(show_results={"bead-b": tracker_show_ok("bead-b", deps=[])})
+
+    exit_code, envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "accept", "--dry-run"], tracker_runner=tracker
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert data["dry_run"] is True
+    preview = data["promotion"]
+    assert preview["from_bead"] == "bead-a"
+    assert preview["to_bead"] == "bead-b"
+    assert preview["already_promoted"] is False
+    assert preview["tracker_writes"]  # non-empty: the exact writes that would happen
+    assert any(call[0] == "show" for call in tracker.calls)  # cycle-check read allowed
+    assert not any(call[0] == "dep" for call in tracker.calls)
+    assert not any(call[0] == "note" for call in tracker.calls)
+    assert store.read_verdicts() == ()
+    assert store.read_edges() == (_fact("edge-1"),)  # byte-for-byte unchanged
+
+
+def test_dry_run_on_reject_reports_no_promotion_and_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "reject", "--dry-run"], tracker_runner=tracker
+    )
+
+    assert exit_code == 0
+    assert envelope["data"]["promotion"] is None
+    assert store.read_verdicts() == ()
+    assert tracker.calls == []
+
+
+def test_dry_run_previews_an_orphaned_already_promoted_edge_without_writing_a_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    ledger_payload = {
+        "promotion": {"from_bead": "bead-a", "to_bead": "bead-b", "tracker_edge_kind": "blocks"}
+    }
+    resynthesized = _fact(
+        "edge-1", endpoint_bead_ids=(("bead-c",), ("bead-d",)), payload=ledger_payload
+    )
+    store.write_edges((resynthesized,))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "accept", "--dry-run"], tracker_runner=tracker
+    )
+
+    assert exit_code == 0
+    preview = envelope["data"]["promotion"]
+    assert preview["already_promoted"] is True
+    assert preview["orphaned"] is True
+    assert preview["tracker_writes"] == []
+    assert store.read_flags() == ()
+    assert tracker.calls == []
+
+
+def test_dry_run_never_enters_a_sidecar_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    setup_store = SidecarStore(tmp_path)
+    setup_store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner(show_results={"bead-b": tracker_show_ok("bead-b", deps=[])})
+
+    def _explode(_self: SidecarStore) -> None:
+        raise AssertionError("dry-run must never acquire the sidecar transaction lock")
+
+    monkeypatch.setattr(SidecarStore, "transaction", _explode)
+
+    exit_code, _envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "accept", "--dry-run"], tracker_runner=tracker
+    )
+
+    assert exit_code == 0
+
+
+def test_accept_raises_on_an_unrecognized_promotion_decision_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_verdict_module(), "_decide_edge_promotion", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+def test_dry_run_raises_on_an_unrecognized_promotion_decision_preview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_verdict_module(), "_decide_edge_promotion", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(
+        ["verdict", "edge-1", "accept", "--dry-run"], tracker_runner=tracker
+    )
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+# ── CLI usage ────────────────────────────────────────────────────────────────
+
+
+def test_verdict_rejects_an_unknown_verdict_value_as_a_usage_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    exit_code, envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "bogus"], tracker_runner=ScriptedTrackerRunner()
+    )
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_USAGE"
+
+
+def _make_fixed_datetime() -> Any:
+    from datetime import UTC, datetime
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # noqa: ARG003 - mirrors datetime.now's signature
+            return datetime(2026, 7, 15, 9, 30, tzinfo=UTC)
+
+    return _FixedDatetime

--- a/packages/vizsuite/tests/unit/test_verbs_verdict.py
+++ b/packages/vizsuite/tests/unit/test_verbs_verdict.py
@@ -795,6 +795,9 @@ def test_dry_run_previews_an_orphaned_already_promoted_edge_without_writing_a_fl
     preview = envelope["data"]["promotion"]
     assert preview["already_promoted"] is True
     assert preview["orphaned"] is True
+    # Parity with the live path's already-promoted data: the preview reports
+    # which kind the existing promotion actually landed as.
+    assert preview["tracker_edge_kind"] == "blocks"
     assert preview["tracker_writes"] == []
     assert store.read_flags() == ()
     assert tracker.calls == []

--- a/packages/vizsuite/tests/unit/test_verbs_verdict.py
+++ b/packages/vizsuite/tests/unit/test_verbs_verdict.py
@@ -223,6 +223,103 @@ def test_accept_propagates_a_non_type_wall_backend_error_without_a_fallback(
     assert store.read_verdicts() == ()
 
 
+# ── partial failure + retry convergence ─────────────────────────────────────
+
+
+def _partial_failure_tracker() -> ScriptedTrackerRunner:
+    """Scripted for a promotion that fails midway: `dep add` and the first
+    audit note land, the second bead's note errors -- the tracker is mutated
+    but the ledger persist is never reached."""
+    note = _note_text("edge-1", "basis-1")
+    return ScriptedTrackerRunner(
+        show_results={"bead-b": tracker_show_ok("bead-b", deps=[])},
+        responses={
+            ("dep", "add", "bead-a", "bead-b", "--type", "blocks"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+            ("note", "bead-b", note): tracker_error("E_NOT_FOUND", "no such bead: bead-b"),
+        },
+    )
+
+
+def test_a_note_failure_after_the_edge_write_commits_nothing_to_the_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = _partial_failure_tracker()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_TRACKER_BACKEND_ERROR"
+    # The tracker edge DID land before the failure (a real external side
+    # effect this module cannot roll back) ...
+    assert ("dep", "add", "bead-a", "bead-b", "--type", "blocks") in tracker.calls
+    # ... but not one sidecar write committed: no ledger, no verdict, no flag.
+    (unchanged,) = store.read_edges()
+    assert "promotion" not in unchanged.payload
+    assert store.read_verdicts() == ()
+    assert store.read_flags() == ()
+
+
+def test_reaccepting_after_a_partial_failure_converges_on_the_same_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The recovery contract for a failure between the tracker write and the
+    ledger persist is re-running the same verdict: `work dep add` is an
+    idempotent upsert at the backend (bd exits 0 on a duplicate edge, one edge
+    row results), the audit notes re-append (accepted noise), and the ledger +
+    verdict then persist. No compensation machinery -- retry converges."""
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_fact("edge-1"),))
+    tracker = _partial_failure_tracker()
+    note = _note_text("edge-1", "basis-1")
+
+    first_exit, _envelope, _stderr = run_cli(
+        ["verdict", "edge-1", "accept"], tracker_runner=tracker
+    )
+    assert first_exit == 1
+    tracker.responses[("note", "bead-b", note)] = tracker_ok(None)
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["promotion"] == {
+        "from_bead": "bead-a",
+        "to_bead": "bead-b",
+        "tracker_edge_kind": "blocks",
+        "already_promoted": False,
+        "orphaned": False,
+    }
+    # `dep add` was issued on BOTH attempts -- the retry leans on the
+    # backend's idempotent upsert, never on a sidecar record that was lost.
+    assert tracker.calls.count(("dep", "add", "bead-a", "bead-b", "--type", "blocks")) == 2
+    (updated,) = store.read_edges()
+    assert updated.payload["promotion"]["tracker_edge_kind"] == "blocks"
+    (recorded,) = store.read_verdicts()
+    assert recorded.verdict == Verdict.ACCEPT
+
+
+def test_a_ledger_with_an_unknown_tracker_edge_kind_is_refused_as_malformed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    ledger = {"from_bead": "bead-a", "to_bead": "bead-b", "tracker_edge_kind": "sideways"}
+    store.write_edges((_fact("edge-1", payload={"promotion": ledger}),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["verdict", "edge-1", "accept"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
 # ── conflict/overlap/synergy: related-to directly, no cycle check ──────────
 
 


### PR DESCRIPTION
## Summary

- Adds **`viz verdict <fact-id> <accept|reject|dismiss>`** — Tier-3 verdict recording plus accept-time edge promotion, the human-gated write path of the review funnel (slice S5 of the sidecar/funnel/review-queue build, after S1 #275, S2 #277, S3 #278, S4 #279):
- `verbs/verdict.py` (new):
  - **Verdict recording** exclusively through `SidecarStore.upsert_verdict`; the verdict write and the resolution of the fact's pending flag commit atomically inside one `store.transaction()`. `dismiss` is gated to recommendation-class facts (typed `E_VERDICT_DISMISS_NOT_RECOMMENDATION` otherwise, no write).
  - **Edge promotion on accepted edge-class facts:** a `dependency` fact runs `cycle_guard.find_cycle` over the full accepted logical dependency graph (beads `blocks` edges plus every already-promoted dependency sidecar edge, including type-wall fallbacks) before attempting a real `blocks` edge via the S4 `TrackerPort`; `conflict`/`overlap`/`synergy` facts write `related-to` directly with no cycle check.
  - **Type-wall handling without rule duplication:** the verb never re-implements workcli's epic/non-epic wall — it attempts `blocks` and reacts to the backend's typed `E_TYPE_WALL` failure by falling back to `related-to`, sidecar staying authoritative on the true kind.
  - **Promotion ledger + idempotency:** the chosen bead pair (deterministic `min()` per endpoint; typed `E_VERDICT_NO_BEAD_ANCHOR` refusal for prose-only endpoints) and the tracker edge kind actually written are recorded on the fact's `payload["promotion"]`; re-accept checks THIS ledger and never touches the tracker again. A ledger whose recorded pair fell outside the fact's current anchors after re-synthesis raises the new `orphaned_edge_promotion` flag (promoted edges are never auto-removed); orphan flag ids use their own namespace so they can't clobber sweep's doubt flags.
  - **Partial-failure recovery contract (pinned by tests):** tracker writes precede the ledger persist and the transaction is a lock, not a rollback — a failure between them commits nothing to the sidecar, and re-running the same verdict converges because `work dep add` upserts idempotently at the backend (verified empirically against bd: duplicate add exits 0, one edge row) and a re-appended audit note is accepted noise. Persisting the ledger first would invert the hazard into an unrecoverable one.
  - **`--dry-run`:** identical decision logic (cycle-check reads still run) with zero sidecar/tracker mutation; the preview reports the honest *attempted* kind for a fresh dependency promotion.
  - Audit note (`agent-inferred-then-accepted`, timestamp, fact fingerprint) appended to both bead endpoints.
- `envelope.py`: three typed verdict error codes; **latent `VizError` bug root-caused** — `frozen=True` on an `Exception` subclass breaks when CPython's contextlib assigns `exc.__traceback__` during nested-contextmanager propagation (masked the real error behind `FrozenInstanceError`); dropped the enforcement, docstring records why.
- `runners.py`/`cli.py`/`conftest.py`: a `TrackerRunner` joins the injected adapter bundle (fourth adapter, same pattern — no module-global client).
- `sidecar/models.py`: `FlagKind.ORPHANED_EDGE_PROMOTION`.
- 36 new tests (332 total): every promotion row, dismiss gating, ledger idempotency + malformed-ledger refusal (including unknown `tracker_edge_kind`), cycle refusal with no tracker write, orphan flag, dry-run zero-writes, partial-failure abort + retry convergence — all against the scripted tracker fake, zero real subprocesses.

Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.3, §5.7; test items 5/14/17.

## Review-gate disposition

HEAVY adversarial gate (6 lenses × 3 rounds, 3-refuter panels, 46 agents) exited at its round cap — **not** a clean-ledger convergence; reported honestly:
- **2 MAJORs (partial failure orphans the tracker edge; retry duplicates it):** the duplicate-edge failure scenario was **refuted empirically** — `bd dep add` is an idempotent upsert, so retry converges; the genuine gap was that nothing tested or documented that contract. Fixed in the second commit: retry-convergence + partial-failure-abort tests, recovery contract in docstrings.
- **1 applied mechanical fix** (unknown `tracker_edge_kind` passes the typed ledger boundary): kept, audited first-hand, and its previously-missing test added.
- **2 reuse minors** (flag-id-minting and fact-lookup duplication across verbs): deferred with rationale to the epic's cleanup ledger — both touch persisted-hash or cross-module compat judgment.

## Test Plan

- [x] TDD red→green: verdict tests written first, failed before the module existed, green after
- [x] `make ci-vizsuite` fully green (exit 0, verified standalone post-gate-fix): ruff, format-check, mypy --strict, 332 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
