### PR TITLE
test(workcli): real-bd integration harness — every verb/noun/lifecycle against a live bd (wgclw.9.7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
         typecheck-prgroom cov-prgroom audit-prgroom verify-entry-prgroom \
         ci-workcli test-workcli lint-workcli format-check-workcli \
         typecheck-workcli cov-workcli audit-workcli verify-entry-workcli \
+        itest-workcli \
         ci-vizsuite test-vizsuite lint-vizsuite format-check-vizsuite \
         typecheck-vizsuite cov-vizsuite audit-vizsuite verify-entry-vizsuite
 
@@ -107,6 +108,15 @@ audit-workcli:
 verify-entry-workcli:
 	uv --project $(WORKCLI) run work --protocol-version > /dev/null
 	uv --project $(WORKCLI) run work --help > /dev/null
+
+# itest-workcli is the real-bd integration suite: it stands up an isolated
+# embedded-Dolt bd install per test and drives the production `work` CLI against
+# it. It requires `bd` on PATH and is DELIBERATELY EXCLUDED from `ci-workcli` /
+# `ci` (needs the bd toolchain; ~40s+ serial). Pre-push discipline, not a gate.
+# `-p no:xdist` pins it serial so the session-scoped read_only_install pays its
+# ~1.4s bd init ONCE (under -n auto it would re-init per worker).
+itest-workcli:
+	cd $(WORKCLI) && uv run pytest tests/integration -q -p no:xdist
 
 # ── vizsuite (mirrors the ci-workcli block one-for-one; enforced via the
 # always-run ci-vizsuite.yml job, NOT via the top-level `ci:` aggregate) ──

--- a/docs/plans/2026-07-15-workcli-realbd-integration-harness-plan.md
+++ b/docs/plans/2026-07-15-workcli-realbd-integration-harness-plan.md
@@ -1,0 +1,1204 @@
+# workcli real-bd integration harness — Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task using the `test-driven-development` skill (red-green-refactor per task). For subagent dispatch, invoke one fresh subagent per task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A local `make itest-workcli` suite that drives the production `work` CLI against a real, isolated bd install in a temp dir — catching bd-JSON drift the hermetic unit fakes cannot.
+
+**Architecture:** Make the production `SubprocessBdRunner` injectable (`bd_binary`/`cwd`/`env`), then build a `tests/integration/` suite whose fixtures `bd init` a throwaway `.beads` under `tmp_path`, bind bd to it with `BEADS_DIR`, and drive `workcli.cli.main(argv, runner=…)`. A `FaultInjectingBdRunner` decorator counts `.run()` calls and injects faults mid-sequence to exercise the deliver↔reconcile recovery contract against real bd state. The suite is kept out of the hermetic `make ci-workcli` gate.
+
+**Tech Stack:** Python ≥3.11 (stdlib only), pytest, uv, real `bd` 1.0.3 (embedded Dolt), GNU make.
+
+**Spec:** `docs/specs/2026-07-14-workcli-realbd-integration-harness-design.md`
+**Bead:** agents-config-wgclw.9.7
+
+**Worktree:** all paths are relative to the repo root `/Users/scott/src/projects/agents-config/.claude/worktrees/wgclw-9.7-realbd-itest`. **First action for any worker:** run `git rev-parse --show-toplevel` and confirm it ends in `.claude/worktrees/wgclw-9.7-realbd-itest`; if not, stop — you are in the wrong tree.
+
+**Gate note:** the package gate is `make ci-workcli`, run **from the worktree root** (it `cd`s into `packages/workcli` itself). The new `tests/integration/` suite MUST NOT run in that gate. Faster inner loop for unit work: `make test-workcli`. The integration suite runs only via `make itest-workcli` (added in Task 11).
+
+---
+
+## File Structure
+
+**Modify:**
+- `packages/workcli/src/workcli/adapters/bd/runner.py` — add injectable `bd_binary`/`cwd`/`env` to `SubprocessBdRunner` (Task 1).
+- `packages/workcli/tests/unit/test_subprocess_runner.py` — cover the injected params hermetically (Task 1).
+- `packages/workcli/pyproject.toml` — add `[tool.pytest.ini_options] testpaths = ["tests/unit"]` (Task 2).
+- `Makefile` (repo root) — add `itest-workcli` target (Task 11).
+- `packages/workcli/AGENTS.md` — document the itest target (Task 11).
+
+**Create (all under `packages/workcli/tests/integration/`):**
+- `__init__.py` — empty (package marker).
+- `conftest.py` — isolation guard, `bd_available`, `bd_env`, `_run_bd` helper, `read_only_install`, `fresh_install`, `driver` (Tasks 2–3).
+- `fault_runner.py` — `FaultInjectingBdRunner` decorator + `Fault` modes (Task 4).
+- `test_fault_runner.py` — hermetic unit test of the decorator (Task 4).
+- `test_isolation.py` — proves the guard + isolation (Task 2).
+- `test_verbs_happy.py` — every-verb-once, value-level (Task 5).
+- `test_nouns.py` — every create-noun (Task 6).
+- `test_lifecycle.py` — create→claim→deliver→reconcile; plan; promote (Task 7).
+- `test_error_paths.py` — E_NOT_FOUND, E_USAGE, evidence-gate, type-wall dual (Task 8).
+- `test_crash_recovery.py` — mid-deliver fault → reconcile heals; malformed-json→invalid_json (Task 9).
+- `test_sync.py` — remote-less ok=true + commit-with-content (Task 10).
+
+---
+
+## Task 1: Injectable `SubprocessBdRunner`
+
+**Files:**
+- Modify: `packages/workcli/src/workcli/adapters/bd/runner.py`
+- Test: `packages/workcli/tests/unit/test_subprocess_runner.py`
+
+Thread `bd_binary`/`cwd`/`env` straight into `subprocess.run` with **no conditional branches** (`subprocess.run` treats `cwd=None`/`env=None` as "inherit"), so zero new branches touch the 90% floor. This lands first because every fixture depends on it.
+
+- [ ] **Step 1: Write the failing tests** (append to `test_subprocess_runner.py`)
+
+```python
+def test_run_uses_injected_bd_binary_cwd_and_env(tmp_path, monkeypatch):
+    # A fake bd that proves all three injected params reached subprocess.run:
+    # it echoes its own argv[0] name, its cwd, and a custom env var.
+    fake_dir = tmp_path / "bin"
+    fake_dir.mkdir()
+    fake_bd = fake_dir / "mybd"
+    fake_bd.write_text(
+        "#!/bin/sh\n"
+        'echo "cwd=$(pwd)"\n'
+        'echo "marker=$WORKCLI_ITEST_MARKER"\n'
+    )
+    fake_bd.chmod(fake_bd.stat().st_mode | stat.S_IEXEC)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    # Ensure PATH does NOT contain a `bd`, proving bd_binary (absolute) is used.
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    runner = SubprocessBdRunner(
+        bd_binary=str(fake_bd),
+        cwd=str(workdir),
+        env={"WORKCLI_ITEST_MARKER": "42", "PATH": "/nonexistent"},
+    )
+    result = runner.run(["show", "--json"])
+
+    assert result.returncode == 0
+    assert f"cwd={workdir}" in result.stdout
+    assert "marker=42" in result.stdout
+
+
+def test_run_defaults_are_unchanged(tmp_path, monkeypatch):
+    # Default construction must remain byte-identical to today: binary "bd",
+    # inherited cwd/env. Prove by putting a fake `bd` on PATH and NOT passing
+    # any injected params.
+    _write_fake_bd(tmp_path, 'echo "default-path-bd"\n')
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+
+    result = SubprocessBdRunner().run(["list"])
+
+    assert result.returncode == 0
+    assert result.stdout == "default-path-bd\n"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/workcli && uv run pytest tests/unit/test_subprocess_runner.py -v`
+Expected: the two new tests FAIL with `TypeError: SubprocessBdRunner() takes no arguments` (or `__init__` got an unexpected keyword argument).
+
+- [ ] **Step 3: Add the injectable constructor** — replace the `SubprocessBdRunner` class body in `runner.py`
+
+```python
+class SubprocessBdRunner:
+    """Drives the real bd binary. timeout=60s; TimeoutExpired is retryable (decision 8).
+
+    Raising `subprocess.TimeoutExpired` on deadline is subprocess.run's own
+    documented behavior -- this class does not catch it. `adapters/bd/retry.py`
+    is the layer that treats it as a retryable signal.
+
+    `bd_binary`/`cwd`/`env` are injectable so a caller (the integration harness)
+    can point the port at an isolated temp install or a fault-injecting wrapper.
+    They are threaded straight into `subprocess.run`, which treats `None` as
+    "inherit" -- so the defaults reproduce the original hardcoded behavior
+    exactly, and no conditional branch is added.
+    """
+
+    def __init__(
+        self,
+        *,
+        bd_binary: str = "bd",
+        cwd: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._bd_binary = bd_binary
+        self._cwd = cwd
+        self._env = env
+
+    def run(self, args: Sequence[str]) -> BdResult:
+        completed = subprocess.run(
+            [self._bd_binary, *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=self._cwd,
+            env=dict(self._env) if self._env is not None else None,
+        )
+        return BdResult(
+            returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr
+        )
+```
+
+Add the imports at the top of `runner.py` (after `from typing import Protocol`):
+
+```python
+from collections.abc import Mapping
+from pathlib import Path
+```
+
+Note: `dict(self._env) if self._env is not None else None` is a single expression, not an `if`-statement branch — mypy/coverage see one expression. `Sequence` is already imported; add `Mapping` to the existing `collections.abc` import line rather than duplicating it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/workcli && uv run pytest tests/unit/test_subprocess_runner.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Run the full hermetic gate to prove the floor is intact**
+
+Run (from worktree root): `make ci-workcli`
+Expected: PASS — lint, format, mypy --strict, `pytest --cov` ≥90% branch, pip-audit, entry-verify all green. The new params added zero uncovered branches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/workcli/src/workcli/adapters/bd/runner.py packages/workcli/tests/unit/test_subprocess_runner.py
+git commit -m "feat(workcli): make SubprocessBdRunner injectable (bd_binary/cwd/env)
+
+Threaded straight into subprocess.run with no new branches. Unblocks the
+real-bd integration harness (wgclw.9.7). Default construction unchanged.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 2: Integration scaffold — isolation guard, `bd_available`, `testpaths`
+
+**Files:**
+- Create: `packages/workcli/tests/integration/__init__.py` (empty)
+- Create: `packages/workcli/tests/integration/conftest.py`
+- Create: `packages/workcli/tests/integration/test_isolation.py`
+- Modify: `packages/workcli/pyproject.toml`
+
+The safety foundation: prove bd is present, resolve it to an absolute path, and refuse to run if the temp install could resolve into any git repo (defense against bd's upward `.beads` walk).
+
+- [ ] **Step 1: Add `testpaths` so integration never runs in the hermetic gate** — add to `pyproject.toml` (new section; there is no `[tool.pytest.ini_options]` today)
+
+```toml
+[tool.pytest.ini_options]
+# The default collection (make test-workcli / cov-workcli invoke pytest with no
+# path arg) is the hermetic unit suite only. The real-bd integration suite is
+# invoked by explicit path in `make itest-workcli` (which overrides testpaths)
+# and must never enter the coverage-gated run.
+testpaths = ["tests/unit"]
+```
+
+- [ ] **Step 2: Write the failing isolation test** — `tests/integration/test_isolation.py`
+
+```python
+"""The isolation guard is load-bearing: it must refuse to run bd anywhere that
+could resolve into a real .beads via bd's upward directory walk."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.integration.conftest import assert_off_repo, resolve_bd
+
+
+def test_resolve_bd_returns_absolute_path_or_skips():
+    bd = resolve_bd()  # skips the module if bd is absent
+    assert bd.startswith("/")
+
+
+def test_guard_refuses_a_path_inside_a_git_repo(tmp_path):
+    # A tmp dir that IS a git repo must be rejected (bd would commit into it /
+    # walk up to its .beads).
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    with pytest.raises(RuntimeError, match="inside a git repo"):
+        assert_off_repo(tmp_path)
+
+
+def test_guard_allows_a_bare_tmp_dir(tmp_path):
+    # pytest tmp_path is off-repo (/private/var/folders/... on macOS); no ancestor
+    # is a git repo, so the guard passes.
+    assert_off_repo(tmp_path)  # must not raise
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_isolation.py -v`
+Expected: FAIL — `ModuleNotFoundError` / `ImportError: cannot import name 'assert_off_repo'` (conftest not written yet).
+
+- [ ] **Step 4: Write the guard + bd resolver** — start `tests/integration/conftest.py`
+
+```python
+"""Fixtures + guards for the real-bd integration suite.
+
+Every install is a throwaway .beads under pytest tmp_path, bound to bd via
+BEADS_DIR so bd's upward .beads discovery can never reach the repo's real DB.
+The suite skips wholesale when bd is not on PATH.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def resolve_bd() -> str:
+    """Absolute path to the bd binary, or skip the whole module if absent."""
+    bd = shutil.which("bd")
+    if bd is None:
+        pytest.skip("bd not on PATH; the real-bd integration suite requires it")
+    return bd
+
+
+def assert_off_repo(path: Path) -> None:
+    """Refuse if `path` is inside any git repo (belt: bd walks UP for .beads,
+    so a repo-nested install could reach a real .beads or commit bd's self-init
+    into an enclosing checkout). tmp_path is off-repo, so this passes normally."""
+    resolved = path.resolve()
+    for ancestor in (resolved, *resolved.parents):
+        if (ancestor / ".git").exists():
+            raise RuntimeError(
+                f"refusing to run bd under {resolved}: ancestor {ancestor} is inside a git repo; "
+                "the integration harness must install into an off-repo temp dir"
+            )
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_isolation.py -v`
+Expected: PASS (or the whole module SKIPS if bd is absent — acceptable green).
+
+Also confirm the hermetic gate still ignores integration:
+Run (from worktree root): `make cov-workcli`
+Expected: collects `tests/unit` only; integration not collected; coverage still ≥90%.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/workcli/tests/integration/ packages/workcli/pyproject.toml
+git commit -m "test(workcli): integration scaffold — isolation guard + bd resolver + testpaths
+
+Guard refuses any git-repo-nested install (bd walks up for .beads); testpaths
+pins the hermetic gate to tests/unit. wgclw.9.7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+Add an empty `packages/workcli/tests/integration/__init__.py` in this commit too (so `from tests.integration.conftest import …` resolves; `tests/` already has its own package markers — mirror them).
+
+---
+
+## Task 3: Install fixtures — `bd_env`, `_run_bd`, `fresh_install`, `read_only_install`, `driver`
+
+**Files:**
+- Modify: `packages/workcli/tests/integration/conftest.py`
+- Create: `packages/workcli/tests/integration/test_fixtures_smoke.py` (a smoke test that also serves as the fixtures' red/green)
+
+Fixtures wrap `bd init` with loud failure, bind `BEADS_DIR`, seed the read-only corpus via raw bd, and hand back a production `SubprocessBdRunner` plus a `driver` that runs `main()`.
+
+- [ ] **Step 1: Write the failing smoke test** — `tests/integration/test_fixtures_smoke.py`
+
+```python
+"""Smoke-proves the fixtures stand up a real isolated bd and the driver round-trips."""
+
+from __future__ import annotations
+
+
+def test_fresh_install_is_empty_and_isolated(fresh_install, driver):
+    env = driver(["list", "--json"])
+    assert env["ok"] is True
+    assert env["data"]["items"] == []
+
+
+def test_read_only_corpus_is_seeded(read_only_driver):
+    env = read_only_driver(["list", "--json"])
+    assert env["ok"] is True
+    titles = {item["title"] for item in env["data"]["items"]}
+    assert {"seed-alpha", "seed-beta", "seed-child"} <= titles
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_fixtures_smoke.py -v`
+Expected: FAIL — fixtures `fresh_install`, `driver`, `read_only_driver` not defined.
+
+- [ ] **Step 3: Add the fixtures** — append to `tests/integration/conftest.py`
+
+```python
+import io
+import json
+import os
+from collections.abc import Callable, Sequence
+
+from workcli.adapters.bd.runner import SubprocessBdRunner
+from workcli.cli import main
+
+_SEED_PREFIX = "itest"
+
+
+@pytest.fixture(scope="session")
+def bd_binary() -> str:
+    return resolve_bd()
+
+
+def _bd_env(install: Path) -> dict[str, str]:
+    """Inherit the ambient env, force non-interactive, and BIND bd to this temp
+    .beads so its upward-walk discovery can never reach the repo's real DB."""
+    return {
+        **os.environ,
+        "BD_NON_INTERACTIVE": "1",
+        "BEADS_DIR": str(install / ".beads"),
+    }
+
+
+def _run_bd(bd_binary: str, install: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Raw bd call for fixture setup/seeding (NOT the code under test). Loud on
+    failure: a non-zero init/seed fails the suite with a named diagnostic, never
+    a bare traceback."""
+    proc = subprocess.run(
+        [bd_binary, *args],
+        cwd=install,
+        env=_bd_env(install),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"fixture bd {' '.join(args)} failed (rc={proc.returncode}):\n{proc.stderr}"
+        )
+    return proc
+
+
+def _bd_init(bd_binary: str, install: Path) -> None:
+    assert_off_repo(install)  # guard BEFORE any bd call
+    _run_bd(bd_binary, install, "init", "--prefix", _SEED_PREFIX)
+
+
+def _make_driver(bd_binary: str, install: Path) -> Callable[[Sequence[str]], dict]:
+    """Return a callable that drives the PRODUCTION main() against this install
+    and returns the parsed stdout envelope."""
+    runner = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(install), env=_bd_env(install))
+
+    def drive(argv: Sequence[str]) -> dict:
+        out, err = io.StringIO(), io.StringIO()
+        main(list(argv), runner=runner, out=out, err=err)
+        return json.loads(out.getvalue())
+
+    return drive
+
+
+@pytest.fixture
+def fresh_install(bd_binary: str, tmp_path: Path) -> Path:
+    """A pristine bd install per test (for mutation/lifecycle/crash sequences)."""
+    _bd_init(bd_binary, tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def driver(bd_binary: str, fresh_install: Path) -> Callable[[Sequence[str]], dict]:
+    return _make_driver(bd_binary, fresh_install)
+
+
+@pytest.fixture(scope="session")
+def read_only_install(bd_binary: str, tmp_path_factory: pytest.TempPathFactory):
+    """One shared, seeded install for read/happy-path assertions. Seeded via RAW
+    bd so read tests fail for read reasons, not write-path bugs. The yield-based
+    teardown re-asserts the corpus is intact, so a stray write-verb on the shared
+    install fails LOUDLY rather than silently poisoning later read tests."""
+    install = tmp_path_factory.mktemp("read_only_beads")
+    _bd_init(bd_binary, install)
+    # bd create's label flag is `--labels` (comma-separated), per backend.py.
+    _run_bd(bd_binary, install, "create", "--title", "seed-alpha", "--type", "task",
+            "--priority", "2", "--labels", "seed")
+    _run_bd(bd_binary, install, "create", "--title", "seed-beta", "--type", "task",
+            "--priority", "1")
+    # A parent + child to give parent-edge assertions a real edge.
+    parent = _run_bd(bd_binary, install, "create", "--title", "seed-parent", "--type", "epic",
+                     "--priority", "2", "--json").stdout
+    parent_id = json.loads(parent)["id"]
+    _run_bd(bd_binary, install, "create", "--title", "seed-child", "--type", "task",
+            "--priority", "2", "--parent", parent_id)
+
+    yield install
+
+    # Corpus-intact invariant (teardown): a read test that mutated the shared
+    # install fails here, loudly.
+    titles = {i["title"] for i in json.loads(_run_bd(bd_binary, install, "list", "--json").stdout)}
+    assert {"seed-alpha", "seed-beta", "seed-child"} <= titles, (
+        "read_only corpus was mutated by a test — read fixtures must stay read-only"
+    )
+
+
+@pytest.fixture
+def read_only_driver(
+    bd_binary: str, read_only_install: Path
+) -> Callable[[Sequence[str]], dict]:
+    return _make_driver(bd_binary, read_only_install)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_fixtures_smoke.py -v`
+Expected: PASS (≈4–6s: two `bd init`s + seeding). SKIPS cleanly if bd absent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/workcli/tests/integration/
+git commit -m "test(workcli): install fixtures — isolated bd init, BEADS_DIR bind, seeded corpus, driver
+
+fresh_install/read_only_install wrap bd init with loud failure; driver runs the
+production main() against a real isolated bd. wgclw.9.7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 4: `FaultInjectingBdRunner`
+
+**Files:**
+- Create: `packages/workcli/tests/integration/fault_runner.py`
+- Create: `packages/workcli/tests/integration/test_fault_runner.py`
+
+A `BdRunner` decorator that counts `.run()` calls, passes non-faulted calls to the wrapped real runner, and on a matched call returns a synthetic fault result. Its own test is hermetic (fake inner runner — no bd), so it is fast and deterministic.
+
+- [ ] **Step 1: Write the failing test** — `tests/integration/test_fault_runner.py`
+
+```python
+from __future__ import annotations
+
+from workcli.adapters.bd.runner import BdResult
+from tests.integration.fault_runner import Fault, FaultInjectingBdRunner
+
+
+class _RecordingRunner:
+    """A fake inner BdRunner: records calls, returns a benign ok result."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, args):
+        self.calls.append(list(args))
+        return BdResult(returncode=0, stdout="[]", stderr="")
+
+
+def test_delegates_until_predicate_then_injects_nonzero():
+    inner = _RecordingRunner()
+    runner = FaultInjectingBdRunner(
+        inner, fail_when=lambda n, argv: n == 2, fault=Fault.NONZERO_EXIT
+    )
+    first = runner.run(["show", "a", "--json"])
+    second = runner.run(["update", "a", "--status", "closed"])
+
+    assert first.returncode == 0          # delegated to real inner
+    assert inner.calls == [["show", "a", "--json"]]  # call 2 never reached inner
+    assert second.returncode != 0         # injected fault
+    assert "injected" in second.stderr
+
+
+def test_malformed_json_fault_is_exit_zero_garbage_stdout():
+    inner = _RecordingRunner()
+    runner = FaultInjectingBdRunner(
+        inner, fail_when=lambda n, argv: "--json" in argv, fault=Fault.MALFORMED_JSON
+    )
+    result = runner.run(["show", "a", "--json"])
+
+    assert result.returncode == 0
+    assert result.stdout == "{ this is not valid json"
+    assert inner.calls == []  # faulted on the first matching call
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_fault_runner.py -v`
+Expected: FAIL — `ModuleNotFoundError: tests.integration.fault_runner`.
+
+- [ ] **Step 3: Write the decorator** — `tests/integration/fault_runner.py`
+
+```python
+"""FaultInjectingBdRunner: wrap the real runner, count .run() calls, and inject a
+fault on a matched call so a fault can land MID-`work`-command (a single work
+command fans out to many bd children). This is what lets the crash-recovery test
+leave real partial bd state for `reconcile` to heal — a boolean env-var shim
+cannot, because it faults the first child (a read) before any mutation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from enum import Enum
+
+from workcli.adapters.bd.runner import BdResult, BdRunner
+
+
+class Fault(Enum):
+    NONZERO_EXIT = "nonzero_exit"
+    MALFORMED_JSON = "malformed_json"
+
+
+# fail_when receives (1-based call index, argv) and returns True to fault THIS call.
+FailWhen = Callable[[int, Sequence[str]], bool]
+
+
+class FaultInjectingBdRunner:
+    def __init__(self, inner: BdRunner, *, fail_when: FailWhen, fault: Fault) -> None:
+        self._inner = inner
+        self._fail_when = fail_when
+        self._fault = fault
+        self._n = 0
+
+    def run(self, args: Sequence[str]) -> BdResult:
+        self._n += 1
+        if self._fail_when(self._n, args):
+            if self._fault is Fault.MALFORMED_JSON:
+                # exit 0 + garbage stdout: the ONLY path that reaches parse.py's
+                # invalid_json drift alarm (a --json read verb parses stdout).
+                return BdResult(returncode=0, stdout="{ this is not valid json", stderr="")
+            return BdResult(returncode=1, stdout="", stderr="injected fault (itest)")
+        return self._inner.run(args)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_fault_runner.py -v`
+Expected: PASS (hermetic, <1s).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/workcli/tests/integration/fault_runner.py packages/workcli/tests/integration/test_fault_runner.py
+git commit -m "test(workcli): FaultInjectingBdRunner — call-counting mid-sequence fault injection
+
+Wraps the real runner; faults on a matched call (index/argv predicate) so a
+fault lands mid-work-command, leaving real partial state for reconcile. wgclw.9.7.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 5: Happy-path — every verb once, value-level assertions
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_verbs_happy.py`
+
+Drift detection is only as strong as assertion specificity. Read/happy-path tests assert **exact seeded values** round-trip (not just `ok=True`), because optional fields (`labels`/`parent`/`notes`) default silently on a rename.
+
+- [ ] **Step 1: Write the tests** — `test_verbs_happy.py`
+
+```python
+"""Every verb once against real bd, asserting VALUE-LEVEL, not just ok=True.
+
+Read verbs use the shared read_only corpus; mutating verbs use a fresh install."""
+
+from __future__ import annotations
+
+
+# ---- read verbs (shared corpus) ----
+
+# NOTE (envelope shape, verified against verbs/read.py): a SINGLE-id `show`
+# returns the item object DIRECTLY as `data` (not wrapped in {"items":[...]});
+# only a 2+-id `show`, and every `list`/`ready`/`search`, wraps as
+# `{"items": [...]}`. `label list` returns a BARE string[] as `data`.
+# `Item.priority` is a STRING ("P0".."P4"), `Item.type` (not "issue_type").
+
+def test_show_returns_exact_seeded_fields(read_only_driver):
+    listing = read_only_driver(["list"])
+    alpha_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-alpha")
+    env = read_only_driver(["show", alpha_id])
+    assert env["ok"] is True
+    item = env["data"]                          # single-id show → item object directly
+    assert item["id"] == alpha_id
+    assert item["title"] == "seed-alpha"
+    assert item["status"] == "open"
+    assert item["priority"] == "P2"             # priority is a string, not int
+    assert "seed" in item["labels"]             # value-level: label round-trips
+
+
+def test_list_filter_by_label(read_only_driver):
+    env = read_only_driver(["list", "--label", "seed"])
+    assert env["ok"] is True
+    assert {i["title"] for i in env["data"]["items"]} == {"seed-alpha"}
+
+
+def test_show_child_reports_seeded_parent(read_only_driver):
+    listing = read_only_driver(["list"])
+    child_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-child")
+    item = read_only_driver(["show", child_id])["data"]   # single-id show → item directly
+    assert item["parent"] is not None           # value-level: parent edge survives
+
+
+def test_ready_lists_unblocked(read_only_driver):
+    env = read_only_driver(["ready"])
+    assert env["ok"] is True
+    assert isinstance(env["data"]["items"], list)
+
+
+def test_search_finds_seeded(read_only_driver):
+    env = read_only_driver(["search", "seed-beta"])
+    assert env["ok"] is True
+    assert any(i["title"] == "seed-beta" for i in env["data"]["items"])
+
+
+# ---- write/relation/transition verbs (fresh install) ----
+
+def test_create_raw_update_note_close_reopen_roundtrip(driver):
+    created = driver(["create", "--raw", "--title", "wv-one", "--type", "task", "--priority", "2"])
+    assert created["ok"] is True
+    item_id = created["data"]["id"]             # create → {"id": ...}
+
+    driver(["update", item_id, "--set-title", "wv-one-renamed"])
+    assert driver(["show", item_id])["data"]["title"] == "wv-one-renamed"   # value-level
+
+    driver(["note", item_id, "a durable note"])
+    assert "a durable note" in driver(["show", item_id])["data"]["notes"]
+
+    assert driver(["close", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "closed"
+
+    assert driver(["reopen", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "open"
+
+
+def test_label_add_list_remove(driver):
+    item_id = driver(["create", "--raw", "--title", "wv-lbl", "--type", "task",
+                      "--priority", "2"])["data"]["id"]
+    driver(["label", "add", item_id, "alpha", "beta"])
+    labels = driver(["label", "list", item_id])["data"]   # label list → bare string[]
+    assert {"alpha", "beta"} <= set(labels)
+    driver(["label", "remove", item_id, "alpha"])
+    assert "alpha" not in driver(["label", "list", item_id])["data"]
+
+
+def test_dep_add_list_remove(driver):
+    a = driver(["create", "--raw", "--title", "wv-dep-a", "--type", "task",
+                "--priority", "2"])["data"]["id"]
+    b = driver(["create", "--raw", "--title", "wv-dep-b", "--type", "task",
+                "--priority", "2"])["data"]["id"]
+    driver(["dep", "add", a, b, "--type", "blocks"])
+    listing = driver(["dep", "list", a])
+    assert listing["ok"] is True
+    driver(["dep", "remove", a, b])
+
+
+def test_claim_and_release(driver):
+    item_id = driver(["create", "--raw", "--title", "wv-claim", "--type", "task",
+                      "--priority", "2"])["data"]["id"]
+    assert driver(["claim", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "in_progress"
+    assert driver(["release", item_id])["ok"] is True
+```
+
+(Note: `promote`, `plan`, `deliver`, `reconcile`, `sync` are covered by their dedicated tasks — Tasks 7/9/10 — not duplicated here.)
+
+- [ ] **Step 2: Run to verify (red→green in one pass — behavior already exists)**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_verbs_happy.py -v`
+Expected: PASS. If any assertion fails, that is a **real drift signal** — investigate whether bd's shape changed vs the parser's expectation (do NOT weaken the assertion to pass; that defeats the suite). Fix the parser/adapter or file a drift bead.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_verbs_happy.py
+git commit -m "test(workcli): itest every-verb-once against real bd, value-level assertions (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 6: Every create-noun
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_nouns.py`
+
+Assert each noun template's resulting bd fields (type + shape label), against real bd.
+
+- [ ] **Step 1: Write the tests** — `test_nouns.py`
+
+```python
+"""Each `work create <noun>` template stamps the right bd type + shape label."""
+
+from __future__ import annotations
+
+import pytest
+
+# (noun, expected bd type, expected shape label) — verified against
+# lifecycle/nouns.py NOUN_TEMPLATES (bd_type, shape_label). Exact contract.
+NOUN_EXPECTATIONS = [
+    ("spike", "task", "shape-spike"),
+    ("chore", "chore", "shape-chore"),
+    ("decision", "decision", "shape-decision"),
+    ("feat", "feature", "shape-feat"),
+    ("bugfix", "bug", "shape-bugfix"),
+    ("spec", "feature", "shape-spec"),
+    ("epic", "epic", "shape-epic"),
+]
+
+
+@pytest.mark.parametrize("noun,bd_type,shape_label", NOUN_EXPECTATIONS)
+def test_create_noun_stamps_type_and_shape_label(driver, noun, bd_type, shape_label):
+    created = driver(["create", noun, "--title", f"noun-{noun}", "--priority", "2"])
+    assert created["ok"] is True, created
+    item_id = created["data"]["id"]                 # create → {"id": ...}
+    shown = driver(["show", item_id])["data"]       # single-id show → item directly
+    assert shown["type"] == bd_type                 # Item field is `type`, not `issue_type`
+    assert shape_label in shown["labels"]
+```
+
+The `NOUN_EXPECTATIONS` table is already aligned to `lifecycle/nouns.py` `NOUN_TEMPLATES` (verified). If a run fails, that is a real signal — reconcile against `nouns.py`, do not blindly edit the table to pass.
+
+- [ ] **Step 2: Run**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_nouns.py -v`
+Expected: PASS for all 7 nouns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_nouns.py
+git commit -m "test(workcli): itest every create-noun template against real bd (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 7: Lifecycle sequences
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_lifecycle.py`
+
+Multi-step guarded transitions end-to-end on real bd state: `create→claim→deliver(evidence)→reconcile`; `plan add→plan --done`; `promote`.
+
+- [ ] **Step 1: Write the tests** — `test_lifecycle.py`
+
+```python
+"""Guarded lifecycle transitions on real bd state (happy path — no faults)."""
+
+from __future__ import annotations
+
+
+def test_create_claim_deliver_trivial_then_reconcile_noop(driver):
+    # `create feat` mints a shape-feat leaf (not a container); claimable once ready.
+    item_id = driver(["create", "feat", "--title", "lc-leaf", "--priority", "2"])["data"]["id"]
+    assert driver(["claim", item_id])["ok"] is True
+    # A leaf delivery with trivial evidence closes it.
+    delivered = driver(["deliver", item_id, "--trivial"])
+    assert delivered["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "closed"   # single-id show
+    # reconcile with nothing recoverable is a clean no-op.
+    swept = driver(["reconcile"])
+    assert swept["ok"] is True
+
+
+def test_plan_add_then_done(driver):
+    # An epic IS a container (nouns.py: is_container=True), so `plan --done` needs
+    # no --force (transitions.py::plan guards `not is_container and not --force`).
+    item_id = driver(["create", "epic", "--title", "lc-epic", "--priority", "2"])["data"]["id"]
+    assert driver(["plan", item_id])["ok"] is True             # add to Planning queue
+    assert driver(["plan", item_id, "--done"])["ok"] is True   # container → no --force needed
+
+
+def test_promote_leaf_to_spec_container(driver):
+    # promote requires a shape-feat leaf (transitions.py::promote); `create feat`
+    # provides exactly that. Result: the leaf becomes a shape-spec container.
+    leaf = driver(["create", "feat", "--title", "lc-promote", "--priority", "2"])["data"]["id"]
+    promoted = driver(["promote", leaf])
+    assert promoted["ok"] is True
+    assert promoted["data"]["promoted"] == "spec"
+    assert "shape-spec" in driver(["show", leaf])["data"]["labels"]   # single-id show
+```
+
+Preconditions are verified against source (noted inline): `create feat`→claimable leaf; epic is a container so `plan --done` needs no `--force`; `promote` accepts the `shape-feat` leaf `create feat` produces. If a run fails, it is a real drift/logic signal — fix the cause, never weaken the transition being asserted.
+
+- [ ] **Step 2: Run**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_lifecycle.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_lifecycle.py
+git commit -m "test(workcli): itest lifecycle sequences (deliver/plan/promote) on real bd (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 8: Error paths (incl. type-wall dual assertion)
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_error_paths.py`
+
+Typed failure envelopes from real bd. The type-wall needs **two** assertions because the verb layer pre-checks it before bd is ever called.
+
+- [ ] **Step 1: Write the tests** — `test_error_paths.py`
+
+```python
+"""Typed error envelopes against real bd, within reason."""
+
+from __future__ import annotations
+
+from workcli.adapters.bd.runner import SubprocessBdRunner
+from tests.integration.conftest import _bd_env
+
+
+def test_show_bogus_id_is_not_found(driver):
+    env = driver(["show", "itest-nope-xyz"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_NOT_FOUND"   # reaches bd, no pre-check → real drift coverage
+
+
+def test_bad_flag_is_usage_error(driver):
+    env = driver(["show", "--bogus-flag"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_USAGE"
+
+
+def test_deliver_without_evidence_is_refused(driver):
+    item_id = driver(["create", "feat", "--title", "ep-noevidence", "--priority", "2"])["data"]["id"]
+    driver(["claim", item_id])
+    env = driver(["deliver", item_id])   # no --pr/--items/--trivial
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_EVIDENCE"
+
+
+def test_type_wall_verb_envelope(driver):
+    # (a) The verb-layer pre-check raises E_TYPE_WALL before bd is called.
+    epic = driver(["create", "epic", "--title", "ep-epic", "--priority", "2"])["data"]["id"]
+    task = driver(["create", "feat", "--title", "ep-task", "--priority", "2"])["data"]["id"]
+    env = driver(["dep", "add", epic, task, "--type", "blocks"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_TYPE_WALL"
+
+
+def test_type_wall_raw_bd_marker_drift(fresh_install, bd_binary):
+    # (b) DRIFT COVERAGE: drive bd's own `dep add` directly (bypassing the verb
+    # pre-check) and assert bd still emits the marker map_bd_failure keys on
+    # ("can only block"). This is the assertion that actually fails if bd changes
+    # its wall wording — the verb-envelope test above cannot see that.
+    runner = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(fresh_install),
+                                env=_bd_env(fresh_install))
+    epic = _create_raw(runner, "rw-epic", "epic")
+    task = _create_raw(runner, "rw-task", "task")
+    result = runner.run(["dep", "add", epic, task, "--type", "blocks"])
+    assert result.returncode != 0
+    assert "can only block" in result.stderr.lower()
+
+
+def _create_raw(runner, title, bd_type):
+    import json
+    r = runner.run(["create", "--json", "--title", title, "--type", bd_type, "--priority", "2"])
+    assert r.returncode == 0, r.stderr
+    return json.loads(r.stdout)["id"]
+```
+
+The marker `"can only block"` matches `parse.py`'s `_TYPE_WALL_STDERR_MARKER` (verified) and real bd 1.0.3's stderr. If the raw-marker test ever fails, bd changed its wall wording — update `_TYPE_WALL_STDERR_MARKER` in `parse.py` (and note the drift); do not weaken the test.
+
+- [ ] **Step 2: Run**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_error_paths.py -v`
+Expected: PASS. The raw-marker test is the drift tripwire — if it fails, bd changed its wall message; update the marker in `parse.py` (and note the drift), don't weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_error_paths.py
+git commit -m "test(workcli): itest typed error paths + type-wall dual (verb + raw-bd marker) (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 9: Crash-recovery + malformed-JSON drift alarm
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_crash_recovery.py`
+
+The crown jewel: fault a `work deliver` **mid-mutation** so real partial bd state survives, then prove `work reconcile` heals it. Plus the malformed-JSON→`invalid_json` drift-alarm path.
+
+- [ ] **Step 1: Write the tests** — `test_crash_recovery.py`
+
+```python
+"""Crash-recovery against real bd state: a fault mid-`deliver` leaves the
+impl-placeholder handle + manifest note recorded (real partial state); a
+subsequent `work reconcile` replays reconcile_placeholder and heals to final
+state. Also: a malformed-JSON bd response on a --json read verb must surface
+E_BACKEND_DRIFT with detail.reason == "invalid_json"."""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Sequence
+
+from workcli.adapters.bd.runner import SubprocessBdRunner
+from workcli.cli import main
+from tests.integration.conftest import _bd_env
+from tests.integration.fault_runner import Fault, FaultInjectingBdRunner
+
+
+def _drive(runner, argv: Sequence[str]) -> dict:
+    out, err = io.StringIO(), io.StringIO()
+    main(list(argv), runner=runner, out=out, err=err)
+    return json.loads(out.getvalue())
+
+
+def test_malformed_json_on_read_is_invalid_json_drift(fresh_install, bd_binary):
+    real = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(fresh_install),
+                              env=_bd_env(fresh_install))
+    created = _drive(real, ["create", "--raw", "--title", "cr-item", "--type", "task",
+                            "--priority", "2"])
+    item_id = created["data"]["id"]
+
+    # Fault the `show --json` read with garbage stdout, exit 0.
+    faulted = FaultInjectingBdRunner(
+        real, fail_when=lambda n, argv: "show" in argv and "--json" in argv,
+        fault=Fault.MALFORMED_JSON,
+    )
+    env = _drive(faulted, ["show", item_id])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_BACKEND_DRIFT"
+    assert env["error"]["detail"]["reason"] == "invalid_json"
+
+
+def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
+    """Fault a design-child `deliver` at the set_type call (after the spec: and
+    manifest: notes are appended, before impl-placeholder is removed), leaving
+    real partial state; `reconcile` must then complete the placeholder."""
+    real = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(fresh_install),
+                              env=_bd_env(fresh_install))
+
+    # --- Arrange: promote a shape-feat leaf → a shape-spec container. That mints
+    # a design child (shape-design) + an impl-placeholder sibling under it
+    # (transitions.py::promote → finalize_spec_instantiation). Verified flow.
+    leaf = _drive(real, ["create", "feat", "--title", "cr-spec", "--priority", "2"])["data"]["id"]
+    _drive(real, ["promote", leaf])
+    design_child, placeholder = _design_and_placeholder(real, leaf)
+
+    # A `## Continuations` single-item manifest. GRAMMAR (manifest.py, verified):
+    # `- <noun>: <title> — AC: <acceptance>` — note the em-dash separator " — AC: ".
+    spec_file = fresh_install / "cont.md"
+    spec_file.write_text(
+        "# spec\n\n## Continuations\n\n- feat: cr-impl — AC: the impl unit is built\n"
+    )
+
+    # --- Act: fault the deliver at the FIRST `update ... --type` call. Verified
+    # call order for a design-child deliver: get(design)#1, get(container)#2,
+    # get(placeholder)#3, append spec:#4, append manifest:#5, get(placeholder)#6,
+    # set_type#7. Faulting #7 leaves both notes recorded and impl-placeholder
+    # present — genuine mid-deliver partial state.
+    def fail_on_set_type(n: int, argv: Sequence[str]) -> bool:
+        return argv[:1] == ["update"] and "--type" in argv
+
+    faulted = FaultInjectingBdRunner(real, fail_when=fail_on_set_type, fault=Fault.NONZERO_EXIT)
+    crashed = _drive(faulted, ["deliver", design_child, "--spec", str(spec_file)])
+    assert crashed["ok"] is False   # the injected fault aborted deliver
+
+    # Partial state is real: the placeholder still carries the impl-placeholder
+    # handle (the recovery signal) and has NOT yet gained its shape label.
+    mid = _drive(real, ["show", placeholder])["data"]
+    assert "impl-placeholder" in mid["labels"]
+    assert "shape-feat" not in mid["labels"]
+
+    # --- Heal: reconcile replays reconcile_placeholder off the handle.
+    swept = _drive(real, ["reconcile"])
+    assert swept["ok"] is True
+
+    healed = _drive(real, ["show", placeholder])["data"]
+    assert "impl-placeholder" not in healed["labels"]   # handle removed strictly last
+    assert "shape-feat" in healed["labels"]             # manifest item noun=feat
+    assert "spec-ready" in healed["labels"]
+    assert _drive(real, ["show", design_child])["data"]["status"] == "closed"
+
+
+def _design_and_placeholder(runner, container_id: str) -> tuple[str, str]:
+    """Return (design_child_id, placeholder_id): the container's two children."""
+    children = _drive(runner, ["show", container_id])["data"]["children"]  # single-id show
+    design_child = placeholder = None
+    for child_id in children:
+        labels = _drive(runner, ["show", child_id])["data"]["labels"]
+        if "shape-design" in labels:
+            design_child = child_id
+        else:
+            placeholder = child_id
+    assert design_child and placeholder, f"expected design+placeholder under {container_id}"
+    return design_child, placeholder
+```
+
+**This is the highest-risk task.** The code above is grounded in verified source facts (deliver call order #1–#7, the `- <noun>: <title> — AC: <text>` manifest grammar, the shape-feat/spec-ready/impl-placeholder label lifecycle). Before Step 2, the worker re-confirms two things by re-reading `lifecycle/deliver.py` + `reconcile.py`: (1) that `work reconcile` re-derives the manifest from the recorded in-band snapshot note (so no `--spec` is needed on the reconcile call); (2) that a design-child deliver's call order still matches #1–#7 (if `deliver.py` changed, move the fault predicate to whatever the first post-manifest-append mutation is). The final assertions are concrete — keep them; a failure is a real signal.
+
+- [ ] **Step 2: Run**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_crash_recovery.py -v`
+Expected: PASS — both the malformed-JSON drift and the deliver→reconcile heal. If the heal test is a no-op (reconcile finds nothing), the fault landed too early (before any mutation) — move the fault point later in the sequence, per the deliver call order.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_crash_recovery.py
+git commit -m "test(workcli): itest crash-recovery — mid-deliver fault healed by reconcile; malformed-json drift (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 10: Sync (remote-less)
+
+**Files:**
+- Create: `packages/workcli/tests/integration/test_sync.py`
+
+Verified real behavior: `bd dolt commit` (nothing pending) and `bd dolt push` (no remote) both exit 0 → `work sync` returns `ok=true`. Add a commit-with-content case so the commit path runs with a real pending change. The two guessed stderr markers stay knowingly un-drift-covered (documented in the spec).
+
+- [ ] **Step 1: Write the tests** — `test_sync.py`
+
+```python
+"""Remote-less sync against real embedded-dolt: honest ok=true, incl. a real
+pending change through the commit path."""
+
+from __future__ import annotations
+
+
+def test_sync_remote_less_is_ok(driver):
+    env = driver(["sync"])
+    assert env["ok"] is True
+    assert env["data"]["mode"] == "push"
+
+
+def test_sync_after_a_real_mutation_commits(driver):
+    # A real pending change exercises `dolt commit` with content (not the
+    # nothing-pending path).
+    driver(["create", "--raw", "--title", "sync-content", "--type", "task", "--priority", "2"])
+    env = driver(["sync"])
+    assert env["ok"] is True
+```
+
+The `work sync` success `data` is `asdict(SyncResult)` → `{"synced": true, "mode": "push"}` (verified: `verbs/syncing.py` + `model.SyncResult`). Remote-less push exits 0, so `mode` is `"push"`.
+
+- [ ] **Step 2: Run**
+
+Run: `cd packages/workcli && uv run pytest tests/integration/test_sync.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/workcli/tests/integration/test_sync.py
+git commit -m "test(workcli): itest remote-less sync (ok=true + commit-with-content) (wgclw.9.7)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Task 11: Wiring — `make itest-workcli` + docs
+
+**Files:**
+- Modify: `Makefile` (repo root)
+- Modify: `packages/workcli/AGENTS.md`
+
+- [ ] **Step 1: Add the target** — in the workcli block of the root `Makefile` (after `verify-entry-workcli`, before the vizsuite block), add:
+
+```makefile
+# itest-workcli is the real-bd integration suite: it stands up an isolated
+# embedded-Dolt bd install per test and drives the production `work` CLI against
+# it. It requires `bd` on PATH and is DELIBERATELY EXCLUDED from `ci-workcli` /
+# `ci` (needs the bd toolchain; ~40s+ serial). Pre-push discipline, not a gate.
+# `-p no:xdist` pins it serial so the session-scoped read_only_install pays its
+# ~1.4s bd init ONCE (under -n auto it would re-init per worker).
+itest-workcli:
+	cd $(WORKCLI) && uv run pytest tests/integration -q -p no:xdist
+```
+
+Also add `itest-workcli` to the `.PHONY` list at the top of the Makefile (append it to the existing workcli entries on lines 6–7).
+
+- [ ] **Step 2: Verify the target runs (and is NOT in the gate)**
+
+Run (from worktree root): `make itest-workcli`
+Expected: the full integration suite runs and PASSES (or SKIPS wholesale if bd is absent).
+
+Run: `make ci-workcli`
+Expected: PASS and collects `tests/unit` only — grep the output to confirm no `tests/integration` test ran under coverage.
+
+- [ ] **Step 3: Document in `packages/workcli/AGENTS.md`** — add this subsection after the "The quality gate is mandatory" section:
+
+```markdown
+## Real-bd integration suite (`make itest-workcli`)
+
+`make itest-workcli` drives the production `work` CLI against a **real, isolated**
+bd install (embedded Dolt in a temp dir, bound via `BEADS_DIR` so it can never
+reach the repo's `.beads`). It catches bd-JSON drift the hermetic unit fakes
+cannot. **Requirements & rules:**
+
+- Needs `bd` on PATH; skips wholesale otherwise.
+- **NOT** part of `make ci-workcli` / `make ci` — it needs the bd toolchain and
+  runs ~40s+ serial. It is **pre-push discipline, not a merge gate**.
+- Runs serial (`-p no:xdist`) so the shared read-only install pays `bd init` once.
+- Never weaken an integration assertion to make it pass: a failure is a real
+  drift signal — fix the adapter/parser (and note the drift) instead.
+```
+
+- [ ] **Step 4: Final full verification**
+
+Run (from worktree root):
+```bash
+make ci-workcli        # hermetic gate — must stay green, unit-only coverage ≥90%
+make itest-workcli     # real-bd suite — must pass (or skip if no bd)
+```
+Expected: both green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile packages/workcli/AGENTS.md
+git commit -m "build(workcli): make itest-workcli target + AGENTS.md docs (wgclw.9.7)
+
+Local real-bd integration suite, excluded from ci-workcli/ci. Pre-push discipline.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e"
+```
+
+---
+
+## Definition of Done
+
+- `make ci-workcli` green from the worktree root: lint, format, mypy --strict, `pytest --cov` ≥90% branch on `tests/unit`, pip-audit, entry-verify.
+- `make itest-workcli` green (or cleanly skipped when bd absent), covering: every verb once (value-level), every create-noun, the three lifecycle sequences, the four error paths (incl. type-wall dual assertion), crash-recovery (mid-deliver fault healed by reconcile), malformed-JSON→`invalid_json`, and remote-less sync.
+- `tests/integration` never runs under the coverage gate (confirmed via `make cov-workcli`).
+- `SubprocessBdRunner` default construction is byte-identical to pre-change behavior (existing unit tests unchanged and green).
+- Isolation is structural: `BEADS_DIR` bind + off-repo `tmp_path` + pre-flight git-repo guard; no test can touch the repo's real `.beads`.
+- `packages/workcli/AGENTS.md` documents the target.
+
+## Out of scope (do not build)
+
+CI job for the integration suite; Dolt-server mode; perf benchmarking; cross-bd-version matrix; closing the two guessed `sync` stderr markers (documented as knowingly un-drift-covered).

--- a/docs/specs/2026-07-14-workcli-realbd-integration-harness-design.md
+++ b/docs/specs/2026-07-14-workcli-realbd-integration-harness-design.md
@@ -63,16 +63,17 @@ change is making the bd subprocess port injectable. Hermetic unit tests and the
 `make ci-workcli` gate are untouched.
 
 ```
-make itest-workcli  ──▶ pytest tests/integration   (NOT in ci-workcli / ci)
+make itest-workcli ─▶ pytest tests/integration -p no:xdist  (NOT in ci-workcli/ci)
                               │
-        ┌─────────────────────┼──────────────────────┐
-   fixtures (conftest)   crash shim (bd wrapper)   test modules
-        │                     │                         │
-   bd init in tmpdir    exec real bd  OR          drive workcli.cli.main(
-   → SubprocessBdRunner  inject fault               argv, runner=SubprocessBdRunner(
-     (cwd=tmpdir,        (exit≠0 / garbage           cwd=install, bd_binary=<real|shim>))
-      bd_binary,          stdout)                   → assert JSON envelope
-      env=NON_INTERACTIVE)
+        ┌─────────────────────┼───────────────────────────┐
+   fixtures (conftest)   FaultInjectingBdRunner        test modules
+        │                (wraps real runner,               │
+   bd init in tmpdir      counts .run(); calls 1..N-1  drive workcli.cli.main(
+   → SubprocessBdRunner    → real bd, call N → fault)   argv, runner=<real|fault>)
+     (bd_binary=<abs bd>,        │                      → assert JSON envelope
+      cwd=tmpdir,           real partial state            (value-level)
+      env=NON_INTERACTIVE     left for reconcile
+        + BEADS_DIR=tmp)      to heal
 ```
 
 ## 2. The one `src/` change — injectable port
@@ -91,25 +92,50 @@ def __init__(
 
 and thread `bd_binary`/`cwd`/`env` into `subprocess.run`. **Default construction
 is byte-for-byte identical to today** (`"bd"`, inherit cwd/env), so
-`_build_backend` and every existing caller are unaffected. The new branches get
-hermetic **unit** tests (an echo/stub binary — no real bd), preserving the 90%
-branch floor. This is the honest fix for an un-configurable port the future GH
-adapter would trip over anyway.
+`_build_backend` and every existing caller are unaffected. This is the honest
+fix for an un-configurable port the future GH adapter would trip over anyway.
+
+**Coverage discipline — thread through, don't branch.** Implement as
+`subprocess.run([bd_binary, *args], cwd=cwd, env=env, …)` with **no conditional
+guards** on the new params (`subprocess.run` accepts `cwd=None`/`env=None` as
+"inherit"), so the change adds **zero new branches**. The integration suite is
+excluded from the coverage run (§7), so it cannot help the 90% branch floor;
+any `if env is not None:` style guard would add a branch whose injected-True
+side then needs a dedicated hermetic **unit** test in `tests/unit/`
+(`test_subprocess_runner.py` today constructs only the default). Threading the
+params straight through keeps the floor green without new unit tests; if a guard
+is genuinely unavoidable, the unit test lands with it.
 
 ## 3. Fixture architecture
 
-- **`bd_available`** — autouse skip guard; if `bd` is not on PATH the suite
-  *skips* (never hard-fails), so a contributor without bd still gets green.
+- **`bd_available`** — autouse guard resolving `bd` to an **absolute path** once
+  (`shutil.which("bd")`); if bd is not on PATH the suite *skips* (never
+  hard-fails), so a contributor without bd still gets green. The resolved path
+  and `bd --version` are recorded to a test artifact so a drift failure is
+  attributable to a known binary (two bd binaries on PATH is a real, observed
+  condition). The absolute path — not the bare name `"bd"` — is what every
+  fixture passes as `bd_binary`, so "the bd we validate against" is
+  unambiguous.
 - **`read_only_install`** (session-scoped) — one `bd init` + seed a known corpus
   (a few issues, a dep edge, labels) via **raw `bd`** (not `work create`, so
   read-verb tests fail for read reasons, not write bugs). Serves all read /
-  happy-path assertions. Pays Dolt's ~1.4s **once**.
+  happy-path assertions. Pays Dolt's ~1.4s **once** (serial — see §7). A
+  session-finalizer re-asserts the seeded corpus invariants (count, labels,
+  dep-edge) so any accidental write-verb bleed from a read test **fails loudly**
+  rather than silently poisoning later reads.
 - **`fresh_install`** (function-scoped) — a pristine `bd init` per test, only
   for mutation / lifecycle / crash sequences that need clean state.
+- **init-failure is a loud failure, not a raw traceback.** Both installs wrap
+  `bd init`; a non-zero init (e.g. `git user.useConfigOnly=true`, a hostile
+  enclosing pre-commit hook) fails the suite with a clear diagnostic naming the
+  init stderr — not an opaque fixture error. (Env is otherwise sufficient:
+  verified that `bd init` auto-derives a git identity under a minimal env, so no
+  `BEADS_ACTOR`/gitconfig is needed.)
 
-Both hand back a production `SubprocessBdRunner(cwd=<tmp>, env={**os.environ,
-"BD_NON_INTERACTIVE": "1"})` and drive `main(argv, runner=…, out=…, err=…)`,
-asserting on the stdout envelope.
+Both hand back a production `SubprocessBdRunner(bd_binary=<abs bd>, cwd=<tmp>,
+env={**os.environ, "BD_NON_INTERACTIVE": "1", "BEADS_DIR": "<tmp>/.beads"})` and
+drive `main(argv, runner=…, out=…, err=…)`, asserting on the stdout envelope.
+`BEADS_DIR` is the load-bearing isolation lever — see §6.
 
 ## 4. Coverage matrix
 
@@ -120,49 +146,139 @@ asserting on the stdout envelope.
   assert each template's resulting bd fields.
 - **Lifecycle sequences:** `create→claim→deliver(evidence)→reconcile`;
   `plan add→plan --done`; `promote shape-feat→shape-spec container`.
-- **Error paths (within reason):** `E_NOT_FOUND` (bogus id), `E_USAGE` (bad
-  flags), the dep **type-wall** (epic-blocks-non-epic hard error),
-  **evidence-gate refusal** on `deliver`.
+- **Error paths (within reason):** `E_NOT_FOUND` (bogus id — reaches bd with no
+  pre-check, genuinely drift-covered), `E_USAGE` (bad flags),
+  **evidence-gate refusal** on `deliver`, and the dep **type-wall** — with the
+  caveat below.
 
-## 5. Crash-injection shim
+**Assertions are value-level, not `ok=True`.** Drift detection is only as sound
+as assertion specificity. `parse_item` hard-requires just `id/title/issue_type/
+status/priority`; every *optional* field (`labels`, `parent`, `notes`,
+`description`, `dependencies`, timestamps) is defaulted from `raw.get(...)`, so a
+bd rename `labels`→`tags` parses silently to `[]` and an `ok=True`-only test
+never notices — defeating goal 3. Therefore: read/happy-path tests assert the
+**exact seeded values** round-trip (the seeded labels, parent, notes, dep-edge
+come back with the seeded content), and at least one seeded issue is asserted as
+a full normalized `Item`. The noun tests already assert each template's bd
+fields; this extends that discipline to the read verbs.
 
-A committed `tests/integration/shims/bd_shim.sh` reads `WORKCLI_ITEST_FAULT` and
-either `exec`s real bd or injects a fault — **non-zero exit**, **malformed JSON
-on stdout** (asserts the `BACKEND_DRIFT` drift-alarm fires against real adjacent
-output), or fault-at-step-N inside a real lifecycle sequence, after which
-**`reconcile` must recover** real bd state. That last one exercises the
-deliver↔reconcile recovery contract (the wgclw.9.5 work) end-to-end — impossible
-to fake honestly.
+**Type-wall — two distinct assertions, because the verb pre-checks it.**
+`work dep add <epic> <task>` raises `E_TYPE_WALL` from the **verb-layer
+pre-check** (`verbs/relations.py` reads both items and compares epic-ness
+*before* calling bd), so a verb-level test is behaviorally identical to the
+existing hermetic unit test and is **drift-blind** to bd's own wall. To get real
+coverage: (a) keep the verb-level `E_TYPE_WALL` envelope assertion, **and**
+(b) drive bd's `dep add` directly through a raw `SubprocessBdRunner` (bypassing
+the pre-check) and assert bd's real stderr still contains the
+`map_bd_failure` marker (`"can only block"`). (b) is what actually pins the
+marker against bd drift; (a) alone does not.
+
+## 5. Fault injection — a Python call-counting runner, not a shell shim
+
+The naive design (a `bd_shim.sh` reading a boolean `WORKCLI_ITEST_FAULT`) is
+**wrong for the marquee test** and is dropped. A single `work` command fans out
+to *many* bd subprocesses — `deliver` reads before it mutates; `dep_list` makes
+2 calls; `sync` makes `commit` then `push`; `label_mutate` one call per label. A
+boolean env var faults the **first** bd child (a read), so `deliver` aborts
+*before any mutation* and `reconcile` has nothing to heal — the recovery test
+degenerates to a no-op. The interesting partial state (`[work] manifest:` note
+appended but `impl-placeholder` label not yet removed) lives *between* bd child
+call *k* and *k+1* of one `work deliver`, and only per-call targeting reaches it.
+
+**Mechanism: `FaultInjectingBdRunner`** — a `BdRunner` decorator in the test tree
+that wraps the real `SubprocessBdRunner`, counts `.run()` invocations, delegates
+calls `1..N-1` to real bd (leaving **genuine partial bd state**), and on call `N`
+injects the fault. This needs no OS crash: a mid-sequence bd *failure* already
+aborts `deliver` (`map_bd_failure` → `WorkError`) with real state half-applied,
+after which `work reconcile` **in the same test** heals it against real bd. It is
+also portable (no shell, no PATH/`exec` hazard) and rides the same injectable
+port §2 introduces.
+
+Fault modes the decorator emits on call `N`:
+- **non-zero exit** — abort a lifecycle sequence mid-mutation; assert `reconcile`
+  recovers the real partial state (the deliver↔reconcile contract, the wgclw.9.5
+  work, exercised end-to-end — impossible to fake honestly).
+- **malformed JSON on stdout with exit 0**, targeted at a **`--json` read verb**
+  (`work show <seeded-id>`) — this is the only path that reaches the `parse.py`
+  drift alarm. Assert the specific `detail.reason == "invalid_json"` from
+  `_load_json_array`, not a generic `BACKEND_DRIFT`. (Rationale: mutation verbs
+  don't pass `--json` and never parse stdout — garbage with exit 0 there is
+  silently ignored; garbage with non-zero exit hits `map_bd_failure`'s rc-branch
+  instead, a *different* alarm.)
 
 **Boundary:** true 60s-timeout retry stays a fast **unit** test (injected
-short-timeout runner); the shim covers exit-code and garbage-output faults, not
-a real 60s hang.
+short-timeout runner); the decorator never `sleep`s (a real sleep would block on
+`runner.py`'s hard-coded 60s deadline). It covers exit-code and garbage-output
+faults, not a real hang.
 
 ## 6. Isolation & safety
 
-- Every install lives under pytest `tmp_path` — never the repo tree.
-- The runner always gets an explicit `cwd`; a fixture guard **refuses to run**
-  if the resolved install path is inside the repo root — structurally
-  impossible to touch the repo's real `.beads`.
-- Embedded Dolt (no sql-server) means no lingering process to reap; `tmp_path`
-  auto-cleans.
+The naive claim "cwd isolation structurally cannot touch the repo DB" is
+**overstated**: bd discovers `.beads` by walking *up* the directory tree
+(verified — from a dir nested under the worktree, `bd list` returned the repo's
+real issue). cwd-only isolation then rests on three contingent conditions
+(tmp lands off-repo, `bd init` creates a nearer `.beads` before any mutation, the
+guard fires otherwise), not structure — and a partway-failed `bd init` leaves no
+nearer `.beads`, so a follow-on seed would walk up. The design makes isolation
+**actually structural**:
+
+- **`BEADS_DIR=<install>/.beads` in the fixture env** binds bd to the temp DB and
+  **disables walk-up entirely** (verified: with cwd at the repo root,
+  `BEADS_DIR=<tmp>/.beads bd list` returned the tmp DB, never the repo's). This
+  is the primary guarantee; cwd isolation becomes belt, not the whole belt.
+- **Every install lives under pytest `tmp_path`** (default basetemp is off-repo,
+  `/private/var/folders/…`), never the repo tree.
+- **A pre-flight guard runs before *any* bd call** and refuses if the install
+  path resolves inside a git repo. "Repo" here means the **main repo common-dir**
+  (`git rev-parse --git-common-dir`), not the worktree toplevel — the real
+  `.beads` sits two levels *above* this worktree, so a guard keyed on
+  `--show-toplevel` would resolve to the worktree root and miss a basetemp placed
+  under the main repo but above the worktree. Defense-in-depth: refuse if
+  `tmp_path` is nested in *any* git repo, so bd can never commit its self-init
+  into an enclosing checkout.
+- **Embedded Dolt spawns no sql-server** (verified: no `dolt sql-server` appears
+  across repeated inits; only short-lived file locks released on process exit),
+  so there is no lingering process to reap; `tmp_path` auto-cleans. Note `bd
+  init` also writes a local git repo + `.claude/`/`CLAUDE.md`/hooks into the temp
+  dir — all inert under `tmp_path`, listed here only so they don't surprise.
 
 ## 7. Wiring & docs
 
-- `make itest-workcli` → `cd $(WORKCLI) && uv run pytest tests/integration -q`.
-  **Not** in `ci-workcli` or `ci`.
+- `make itest-workcli` → `cd $(WORKCLI) && uv run pytest tests/integration -q
+  -p no:xdist`. **Not** in `ci-workcli` or `ci`. The explicit `-p no:xdist`
+  pins the suite **serial**: pytest-xdist is a declared dev dep, and under
+  `-n auto` the session-scoped `read_only_install` re-inits **once per worker**
+  (each worker gets its own `popen-gwN` basetemp, so no DB collision — just the
+  ~1.4s init cost multiplied), silently defeating the "pay Dolt once" claim.
+  Serial keeps that claim true.
 - `pyproject.toml`: default `testpaths = ["tests/unit"]` so `make test-workcli`
-  / `cov-workcli` stay hermetic and the coverage floor keeps measuring unit
-  tests only. The integration suite is invoked by explicit path.
+  / `cov-workcli` (both invoked with no path arg) collect `tests/unit` only —
+  coverage stays unit-scoped and the hermetic gate stays hermetic; the
+  integration suite's explicit path arg overrides `testpaths`. This is the
+  correct isolation mechanism (simpler than markers) — load-bearing caveat: the
+  new `SubprocessBdRunner` params are therefore covered only by unit tests, met
+  by the zero-new-branch discipline in §2.
 - `packages/workcli/AGENTS.md`: document the target, its `bd`-on-PATH
-  requirement, and that it is **pre-push discipline, not a merge gate**.
+  requirement, the ~40s+ serial wall-clock (≈30 function-scoped inits × 1.4s
+  before mutations — a pre-push target, not a fast inner loop), and that it is
+  **pre-push discipline, not a merge gate**.
 
 ## Resolved open items
 
-- **`sync` on a remote-less temp install** — `dolt push` has no remote, so the
-  test asserts the *honest* envelope bd actually returns (commit-only success or
-  typed failure), whatever it is — still real contract coverage. No remote is
-  forced.
+- **`sync` on a remote-less temp install** — verified: `bd dolt commit` (nothing
+  pending) → "Nothing to commit." on **stdout**, exit 0; `bd dolt push` (no
+  remote) → "No remote is configured — skipping.", exit 0. So `work sync` returns
+  `ok=true` and the test asserts that honest success. **But** this path never
+  exercises the two `map_bd_failure` markers `_NOTHING_TO_COMMIT_STDERR_MARKER`
+  and `_SYNC_BEHIND_STDERR_MARKER` — which are explicitly *guessed* in
+  `backend.py` (an "orchestrator ruling, not a golden capture"), precisely the
+  strings a real-bd suite should validate. Worse, real bd prints "Nothing to
+  commit." on *stdout* while the marker checks *stderr* lowercase — a latent
+  dead-code mismatch. Coverage decision: add a `sync` test that **seeds a real
+  pending change then commits** (exercises the commit-with-content path), and
+  explicitly document the two stderr markers as **knowingly un-drift-covered**
+  by this suite (reachable only with a configured remote / dirty-merge state,
+  out of scope per YAGNI). The suite usefully *pins* the stdout-vs-stderr fact.
 - **Seed via raw `bd`, not `work`** — keeps read-fixture correctness independent
   of the write path under test.
 
@@ -176,3 +292,32 @@ matrix.
 - Optional follow-up (file only if desired after the suite proves stable):
   a CI job that installs bd and runs `make itest-workcli` as a merge gate —
   deferred per decision 1. Not created now.
+
+## Review feedback
+
+Round 1 — two independent adversarial reviewers (ralf-review, cap 2/2),
+each validating claims against real bd 1.0.3 in throwaway installs. Verdict:
+`PASS_WITH_RESERVATIONS`. All findings folded into the body above:
+
+- **CRITICAL (both) — crash-fault targeting.** A boolean env-var shim faults the
+  first bd child (a read), so `deliver` aborts before mutating and `reconcile`
+  heals nothing. → §5 rewritten to a call-counting `FaultInjectingBdRunner`; the
+  shell shim is dropped.
+- **MAJOR (both) — dep type-wall is drift-blind.** The verb-layer pre-check
+  raises `E_TYPE_WALL` before bd is called. → §4 adds a raw-runner assertion on
+  bd's real marker alongside the verb-level envelope test.
+- **MAJOR — isolation overstated.** bd walks up the tree (verified). → §6 binds
+  `BEADS_DIR`, strengthens the guard to the main-repo common-dir + any-git-repo.
+- **MAJOR — drift needs value-level assertions.** Optional-field renames parse
+  silently. → §4 mandates seeded-value round-trip assertions.
+- **MAJOR — sync bypasses the guessed markers.** → resolved-open-items documents
+  them as knowingly un-drift-covered and adds a commit-with-content test.
+- **Minor — malformed-JSON path** (target a `--json` read verb, exit 0, assert
+  `invalid_json`), **xdist per-worker cost** (`-p no:xdist`), **absolute bd path**
+  (`shutil.which`), **init-failure diagnostic**, **thread-through-don't-branch**
+  coverage guidance. → folded into §§2/3/5/7.
+
+Reviewers confirmed sound (no change needed): injectable-port back-compat,
+embedded-Dolt leaves no process, `testpaths` cov-isolation, env sufficiency
+(git identity auto-derives), remote-less sync returns `ok=true`,
+`E_NOT_FOUND` genuinely drift-covered.

--- a/docs/specs/2026-07-14-workcli-realbd-integration-harness-design.md
+++ b/docs/specs/2026-07-14-workcli-realbd-integration-harness-design.md
@@ -1,0 +1,178 @@
+# workcli real-bd integration harness — design
+
+**Bead:** agents-config-wgclw.9.7 (child of the work-facade CLI v1 epic, wgclw.9)
+**Status:** design — proposal
+**Depends on:** none blocking (bd ≥ 1.0.3 on PATH at run time)
+
+## Problem
+
+`packages/workcli` quarantines the issue tracker (bd) behind a stable JSON
+envelope. Its entire value is that the facade absorbs bd's quirks so callers
+never couple to bd. But **every** current test under `tests/unit/` drives the
+CLI with a `ScriptedBdRunner` fake or a `FakeBackend` — nothing ever shells out
+to the real `bd` binary. The bd adapter (`adapters/bd/parse.py`,
+`adapters/bd/runner.py`) is validated only against golden `--json` snapshots
+captured **once, by hand**, and frozen into fixtures. A future bd release that
+drifts its JSON output shape — a renamed field, a changed error string, a new
+null where a value was expected — would sail past the whole suite and only
+surface as a production break.
+
+The facade's core contract with reality is untested against reality.
+
+## Goal
+
+A real-bd integration suite that stands up an **isolated** bd install in a temp
+directory and drives the **production** `work` entry point against it, covering
+every verb, every create-noun, representative lifecycle sequences, typed error
+paths, and — via a fault-injecting bd wrapper — the crash-recovery contract.
+When bd's real behavior drifts from what the fake asserts, this suite fails.
+
+## Decisions (resolved during brainstorm)
+
+1. **Venue — separate local target, not CI.** A distinct `make itest-workcli`,
+   run manually / pre-push. `make ci-workcli` stays hermetic (no bd, no Dolt,
+   zero deps). Accepted trade-off: the real-bd contract is pre-push developer
+   discipline, not a merge gate. No bd+Dolt install burden in GitHub Actions.
+2. **Depth — lifecycle sequences + typed error paths + injected faults.**
+   Beyond each-verb-once and each-noun-once happy paths: multi-step guarded
+   transitions, the typed failure envelopes, and a bd wrapper shim that injects
+   crashes/garbage to exercise recovery.
+3. **Runner — injectable production port (not a test-only clone).** Extend the
+   real `SubprocessBdRunner` so the harness exercises the actual production
+   subprocess call, not a parallel copy. See §2.
+
+## Feasibility (verified against bd 1.0.3, not assumed)
+
+- **Isolation is cwd-based.** `bd -C <dir>` refuses to *init* a non-existent
+  project; the working mechanism is running bd with `cwd=<tmpdir>` — `bd init`
+  creates a self-contained `.beads/` there and later calls auto-discover it.
+- **Dolt is embedded.** The temp `.beads/` carries an `embeddeddolt` engine —
+  no external `dolt` binary or sql-server needed. Toolchain requirement is
+  just `bd` on PATH.
+- **Cost:** a `bd init` ≈ 1.4s (Dolt bring-up); a mutation ≈ 0.7s. This is the
+  number that drives fixture scope (§3).
+- **The production port is not reusable as-is.** `SubprocessBdRunner` hardcodes
+  `["bd", *args]` with no cwd/env — it always hits whatever `.beads` the
+  process stands in. Isolation *requires* cwd injection.
+
+## Architecture
+
+A new `packages/workcli/tests/integration/` suite drives the production
+`workcli.cli.main()` against a real, isolated bd install. The sole production
+change is making the bd subprocess port injectable. Hermetic unit tests and the
+`make ci-workcli` gate are untouched.
+
+```
+make itest-workcli  ──▶ pytest tests/integration   (NOT in ci-workcli / ci)
+                              │
+        ┌─────────────────────┼──────────────────────┐
+   fixtures (conftest)   crash shim (bd wrapper)   test modules
+        │                     │                         │
+   bd init in tmpdir    exec real bd  OR          drive workcli.cli.main(
+   → SubprocessBdRunner  inject fault               argv, runner=SubprocessBdRunner(
+     (cwd=tmpdir,        (exit≠0 / garbage           cwd=install, bd_binary=<real|shim>))
+      bd_binary,          stdout)                   → assert JSON envelope
+      env=NON_INTERACTIVE)
+```
+
+## 2. The one `src/` change — injectable port
+
+`SubprocessBdRunner` today has no `__init__` and hardcodes `["bd", *args]`. Add:
+
+```python
+def __init__(
+    self,
+    *,
+    bd_binary: str = "bd",
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
+```
+
+and thread `bd_binary`/`cwd`/`env` into `subprocess.run`. **Default construction
+is byte-for-byte identical to today** (`"bd"`, inherit cwd/env), so
+`_build_backend` and every existing caller are unaffected. The new branches get
+hermetic **unit** tests (an echo/stub binary — no real bd), preserving the 90%
+branch floor. This is the honest fix for an un-configurable port the future GH
+adapter would trip over anyway.
+
+## 3. Fixture architecture
+
+- **`bd_available`** — autouse skip guard; if `bd` is not on PATH the suite
+  *skips* (never hard-fails), so a contributor without bd still gets green.
+- **`read_only_install`** (session-scoped) — one `bd init` + seed a known corpus
+  (a few issues, a dep edge, labels) via **raw `bd`** (not `work create`, so
+  read-verb tests fail for read reasons, not write bugs). Serves all read /
+  happy-path assertions. Pays Dolt's ~1.4s **once**.
+- **`fresh_install`** (function-scoped) — a pristine `bd init` per test, only
+  for mutation / lifecycle / crash sequences that need clean state.
+
+Both hand back a production `SubprocessBdRunner(cwd=<tmp>, env={**os.environ,
+"BD_NON_INTERACTIVE": "1"})` and drive `main(argv, runner=…, out=…, err=…)`,
+asserting on the stdout envelope.
+
+## 4. Coverage matrix
+
+- **Every verb once** (happy-path): show, list, ready, search · create --raw,
+  update, note, close, reopen · claim, release, plan, promote, deliver,
+  reconcile · dep {add,remove,list}, label {add,remove,list} · sync.
+- **Every create-noun** (7): spike, chore, decision, feat, bugfix, spec, epic —
+  assert each template's resulting bd fields.
+- **Lifecycle sequences:** `create→claim→deliver(evidence)→reconcile`;
+  `plan add→plan --done`; `promote shape-feat→shape-spec container`.
+- **Error paths (within reason):** `E_NOT_FOUND` (bogus id), `E_USAGE` (bad
+  flags), the dep **type-wall** (epic-blocks-non-epic hard error),
+  **evidence-gate refusal** on `deliver`.
+
+## 5. Crash-injection shim
+
+A committed `tests/integration/shims/bd_shim.sh` reads `WORKCLI_ITEST_FAULT` and
+either `exec`s real bd or injects a fault — **non-zero exit**, **malformed JSON
+on stdout** (asserts the `BACKEND_DRIFT` drift-alarm fires against real adjacent
+output), or fault-at-step-N inside a real lifecycle sequence, after which
+**`reconcile` must recover** real bd state. That last one exercises the
+deliver↔reconcile recovery contract (the wgclw.9.5 work) end-to-end — impossible
+to fake honestly.
+
+**Boundary:** true 60s-timeout retry stays a fast **unit** test (injected
+short-timeout runner); the shim covers exit-code and garbage-output faults, not
+a real 60s hang.
+
+## 6. Isolation & safety
+
+- Every install lives under pytest `tmp_path` — never the repo tree.
+- The runner always gets an explicit `cwd`; a fixture guard **refuses to run**
+  if the resolved install path is inside the repo root — structurally
+  impossible to touch the repo's real `.beads`.
+- Embedded Dolt (no sql-server) means no lingering process to reap; `tmp_path`
+  auto-cleans.
+
+## 7. Wiring & docs
+
+- `make itest-workcli` → `cd $(WORKCLI) && uv run pytest tests/integration -q`.
+  **Not** in `ci-workcli` or `ci`.
+- `pyproject.toml`: default `testpaths = ["tests/unit"]` so `make test-workcli`
+  / `cov-workcli` stay hermetic and the coverage floor keeps measuring unit
+  tests only. The integration suite is invoked by explicit path.
+- `packages/workcli/AGENTS.md`: document the target, its `bd`-on-PATH
+  requirement, and that it is **pre-push discipline, not a merge gate**.
+
+## Resolved open items
+
+- **`sync` on a remote-less temp install** — `dolt push` has no remote, so the
+  test asserts the *honest* envelope bd actually returns (commit-only success or
+  typed failure), whatever it is — still real contract coverage. No remote is
+  forced.
+- **Seed via raw `bd`, not `work`** — keeps read-fixture correctness independent
+  of the write path under test.
+
+## Out of scope (YAGNI)
+
+No CI job, no Dolt-server mode, no perf benchmarking, no cross-bd-version
+matrix.
+
+## Continuations
+
+- Optional follow-up (file only if desired after the suite proves stable):
+  a CI job that installs bd and runs `make itest-workcli` as a merge gate —
+  deferred per decision 1. Not created now.

--- a/packages/workcli/AGENTS.md
+++ b/packages/workcli/AGENTS.md
@@ -92,6 +92,23 @@ are read-only and run from the **main repo root**, never this worktree — see
 the plan's decision 14. Never invoke a mutating `bd` verb against the real
 database while developing or testing this package.
 
+## Real-bd integration suite (`make itest-workcli`)
+
+`make itest-workcli` is the **sanctioned exception** to the rule above: it drives
+the production `work` CLI against a **real, isolated** bd install (embedded Dolt
+in a temp dir, bound via `BEADS_DIR` and an off-repo `tmp_path` + a git-repo
+pre-flight guard, so it can never reach the repo's `.beads`). It catches bd-JSON
+drift the hermetic `ScriptedBdRunner` fakes cannot. **Requirements & rules:**
+
+- Needs `bd` on PATH; skips wholesale otherwise.
+- **NOT** part of `make ci-workcli` / `make ci` — it needs the bd toolchain and
+  runs ~40s+ serial. It is **pre-push discipline, not a merge gate**. `testpaths`
+  in `pyproject.toml` pins the coverage-gated run to `tests/unit`.
+- Runs serial (`-p no:xdist`) so the shared read-only install pays `bd init` once.
+- Never weaken an integration assertion to make it pass: a failure is a real
+  drift signal — fix the adapter/parser (and note the drift), or file it as
+  discovered work, instead.
+
 ## Reference
 
 Spec: `docs/specs/2026-07-04-work-facade-cli-contract.md`.

--- a/packages/workcli/pyproject.toml
+++ b/packages/workcli/pyproject.toml
@@ -62,6 +62,13 @@ select = [
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.pytest.ini_options]
+# The default collection (make test-workcli / cov-workcli invoke pytest with no
+# path arg) is the hermetic unit suite only. The real-bd integration suite is
+# invoked by explicit path in `make itest-workcli` (which overrides testpaths)
+# and must never enter the coverage-gated run.
+testpaths = ["tests/unit"]
+
 [tool.mypy]
 strict = true
 warn_unreachable = true

--- a/packages/workcli/src/workcli/adapters/bd/runner.py
+++ b/packages/workcli/src/workcli/adapters/bd/runner.py
@@ -11,8 +11,9 @@ implementation that actually shells out to the real `bd` binary. It raises
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 
@@ -33,15 +34,33 @@ class SubprocessBdRunner:
     Raising `subprocess.TimeoutExpired` on deadline is subprocess.run's own
     documented behavior -- this class does not catch it. `adapters/bd/retry.py`
     is the layer that treats it as a retryable signal.
+
+    `bd_binary`/`cwd`/`env` are injectable and thread straight into
+    `subprocess.run` -- `cwd=None`/`env=None` means "inherit", which is
+    `subprocess.run`'s own documented default, so the default construction
+    reproduces today's behavior exactly.
     """
+
+    def __init__(
+        self,
+        *,
+        bd_binary: str = "bd",
+        cwd: str | Path | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._bd_binary = bd_binary
+        self._cwd = cwd
+        self._env = env
 
     def run(self, args: Sequence[str]) -> BdResult:
         completed = subprocess.run(
-            ["bd", *args],
+            [self._bd_binary, *args],
             capture_output=True,
             text=True,
             timeout=60,
             check=False,
+            cwd=self._cwd,
+            env=dict(self._env) if self._env is not None else None,
         )
         return BdResult(
             returncode=completed.returncode, stdout=completed.stdout, stderr=completed.stderr

--- a/packages/workcli/tests/integration/conftest.py
+++ b/packages/workcli/tests/integration/conftest.py
@@ -1,0 +1,34 @@
+"""Fixtures + guards for the real-bd integration suite.
+
+Every install is a throwaway .beads under pytest tmp_path, bound to bd via
+BEADS_DIR so bd's upward .beads discovery can never reach the repo's real DB.
+The suite skips wholesale when bd is not on PATH.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def resolve_bd() -> str:
+    """Absolute path to the bd binary, or skip the whole module if absent."""
+    bd = shutil.which("bd")
+    if bd is None:
+        pytest.skip("bd not on PATH; the real-bd integration suite requires it")
+    return bd
+
+
+def assert_off_repo(path: Path) -> None:
+    """Refuse if `path` is inside any git repo (belt: bd walks UP for .beads,
+    so a repo-nested install could reach a real .beads or commit bd's self-init
+    into an enclosing checkout). tmp_path is off-repo, so this passes normally."""
+    resolved = path.resolve()
+    for ancestor in (resolved, *resolved.parents):
+        if (ancestor / ".git").exists():
+            raise RuntimeError(
+                f"refusing to run bd under {resolved}: ancestor {ancestor} is inside a git repo; "
+                "the integration harness must install into an off-repo temp dir"
+            )

--- a/packages/workcli/tests/integration/conftest.py
+++ b/packages/workcli/tests/integration/conftest.py
@@ -7,10 +7,20 @@ The suite skips wholesale when bd is not on PATH.
 
 from __future__ import annotations
 
+import io
+import json
+import os
 import shutil
+import subprocess
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import pytest
+
+from workcli.adapters.bd.runner import SubprocessBdRunner
+from workcli.cli import main
+
+_SEED_PREFIX = "itest"
 
 
 def resolve_bd() -> str:
@@ -32,3 +42,138 @@ def assert_off_repo(path: Path) -> None:
                 f"refusing to run bd under {resolved}: ancestor {ancestor} is inside a git repo; "
                 "the integration harness must install into an off-repo temp dir"
             )
+
+
+@pytest.fixture(scope="session")
+def bd_binary() -> str:
+    return resolve_bd()
+
+
+def _bd_env(install: Path) -> dict[str, str]:
+    """Inherit the ambient env, force non-interactive, and BIND bd to this temp
+    .beads so its upward-walk discovery can never reach the repo's real DB."""
+    return {
+        **os.environ,
+        "BD_NON_INTERACTIVE": "1",
+        "BEADS_DIR": str(install / ".beads"),
+    }
+
+
+def _run_bd(bd_binary: str, install: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Raw bd call for fixture setup/seeding (NOT the code under test). Loud on
+    failure: a non-zero init/seed fails the suite with a named diagnostic."""
+    proc = subprocess.run(  # noqa: S603
+        [bd_binary, *args],
+        cwd=install,
+        env=_bd_env(install),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"fixture bd {' '.join(args)} failed (rc={proc.returncode}):\n{proc.stderr}"
+        )
+    return proc
+
+
+def _bd_init(bd_binary: str, install: Path) -> None:
+    assert_off_repo(install)  # guard BEFORE any bd call
+    _run_bd(bd_binary, install, "init", "--prefix", _SEED_PREFIX)
+
+
+def _make_driver(bd_binary: str, install: Path) -> Callable[[Sequence[str]], dict]:
+    """Return a callable that drives the PRODUCTION main() against this install
+    and returns the parsed stdout envelope."""
+    runner = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(install), env=_bd_env(install))
+
+    def drive(argv: Sequence[str]) -> dict:
+        out, err = io.StringIO(), io.StringIO()
+        main(list(argv), runner=runner, out=out, err=err)
+        return json.loads(out.getvalue())
+
+    return drive
+
+
+@pytest.fixture
+def fresh_install(bd_binary: str, tmp_path: Path) -> Path:
+    """A pristine bd install per test (for mutation/lifecycle/crash sequences)."""
+    _bd_init(bd_binary, tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def driver(bd_binary: str, fresh_install: Path) -> Callable[[Sequence[str]], dict]:
+    return _make_driver(bd_binary, fresh_install)
+
+
+@pytest.fixture(scope="session")
+def read_only_install(bd_binary: str, tmp_path_factory: pytest.TempPathFactory):
+    """One shared, seeded install for read/happy-path assertions. Seeded via RAW
+    bd. Yield-based teardown re-asserts the corpus is intact so a stray write-verb
+    fails LOUDLY rather than poisoning later read tests."""
+    install = tmp_path_factory.mktemp("read_only_beads")
+    _bd_init(bd_binary, install)
+    _run_bd(
+        bd_binary,
+        install,
+        "create",
+        "--title",
+        "seed-alpha",
+        "--type",
+        "task",
+        "--priority",
+        "2",
+        "--labels",
+        "seed",
+    )
+    _run_bd(
+        bd_binary,
+        install,
+        "create",
+        "--title",
+        "seed-beta",
+        "--type",
+        "task",
+        "--priority",
+        "1",
+    )
+    parent = _run_bd(
+        bd_binary,
+        install,
+        "create",
+        "--title",
+        "seed-parent",
+        "--type",
+        "epic",
+        "--priority",
+        "2",
+        "--json",
+    ).stdout
+    parent_id = json.loads(parent)["id"]
+    _run_bd(
+        bd_binary,
+        install,
+        "create",
+        "--title",
+        "seed-child",
+        "--type",
+        "task",
+        "--priority",
+        "2",
+        "--parent",
+        parent_id,
+    )
+
+    yield install
+
+    titles = {i["title"] for i in json.loads(_run_bd(bd_binary, install, "list", "--json").stdout)}
+    assert {"seed-alpha", "seed-beta", "seed-child"} <= titles, (
+        "read_only corpus was mutated by a test — read fixtures must stay read-only"
+    )
+
+
+@pytest.fixture
+def read_only_driver(bd_binary: str, read_only_install: Path) -> Callable[[Sequence[str]], dict]:
+    return _make_driver(bd_binary, read_only_install)

--- a/packages/workcli/tests/integration/conftest.py
+++ b/packages/workcli/tests/integration/conftest.py
@@ -24,7 +24,9 @@ _SEED_PREFIX = "itest"
 
 
 def resolve_bd() -> str:
-    """Absolute path to the bd binary, or skip the whole module if absent."""
+    """Absolute path to the bd binary. When bd is absent this raises pytest.skip
+    at call time — skipping the calling test, or (called from the session-scoped
+    bd_binary fixture) every test that needs a real bd."""
     bd = shutil.which("bd")
     if bd is None:
         pytest.skip("bd not on PATH; the real-bd integration suite requires it")

--- a/packages/workcli/tests/integration/conftest.py
+++ b/packages/workcli/tests/integration/conftest.py
@@ -111,8 +111,10 @@ def driver(bd_binary: str, fresh_install: Path) -> Callable[[Sequence[str]], dic
 @pytest.fixture(scope="session")
 def read_only_install(bd_binary: str, tmp_path_factory: pytest.TempPathFactory):
     """One shared, seeded install for read/happy-path assertions. Seeded via RAW
-    bd. Yield-based teardown re-asserts the corpus is intact so a stray write-verb
-    fails LOUDLY rather than poisoning later read tests."""
+    bd. Yield-based teardown re-asserts the three seed titles still exist, so a
+    stray write-verb that DELETES a seed fails loudly rather than poisoning later
+    read tests. Note the guard is a subset check: it catches deletion of a named
+    seed, not an in-place mutation (retitle/close/label) or an added item."""
     install = tmp_path_factory.mktemp("read_only_beads")
     _bd_init(bd_binary, install)
     _run_bd(
@@ -170,7 +172,7 @@ def read_only_install(bd_binary: str, tmp_path_factory: pytest.TempPathFactory):
 
     titles = {i["title"] for i in json.loads(_run_bd(bd_binary, install, "list", "--json").stdout)}
     assert {"seed-alpha", "seed-beta", "seed-child"} <= titles, (
-        "read_only corpus was mutated by a test — read fixtures must stay read-only"
+        "a read test DELETED a read_only seed item — read fixtures must stay read-only"
     )
 
 

--- a/packages/workcli/tests/integration/fault_runner.py
+++ b/packages/workcli/tests/integration/fault_runner.py
@@ -1,0 +1,39 @@
+"""FaultInjectingBdRunner: wrap the real runner, count .run() calls, and inject a
+fault on a matched call so a fault can land MID-`work`-command (a single work
+command fans out to many bd children). This is what lets the crash-recovery test
+leave real partial bd state for `reconcile` to heal — a boolean env-var shim
+cannot, because it faults the first child (a read) before any mutation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from enum import Enum
+
+from workcli.adapters.bd.runner import BdResult, BdRunner
+
+
+class Fault(Enum):
+    NONZERO_EXIT = "nonzero_exit"
+    MALFORMED_JSON = "malformed_json"
+
+
+# fail_when receives (1-based call index, argv) and returns True to fault THIS call.
+FailWhen = Callable[[int, Sequence[str]], bool]
+
+
+class FaultInjectingBdRunner:
+    def __init__(self, inner: BdRunner, *, fail_when: FailWhen, fault: Fault) -> None:
+        self._inner = inner
+        self._fail_when = fail_when
+        self._fault = fault
+        self._n = 0
+
+    def run(self, args: Sequence[str]) -> BdResult:
+        self._n += 1
+        if self._fail_when(self._n, args):
+            if self._fault is Fault.MALFORMED_JSON:
+                # exit 0 + garbage stdout: the ONLY path that reaches parse.py's
+                # invalid_json drift alarm (a --json read verb parses stdout).
+                return BdResult(returncode=0, stdout="{ this is not valid json", stderr="")
+            return BdResult(returncode=1, stdout="", stderr="injected fault (itest)")
+        return self._inner.run(args)

--- a/packages/workcli/tests/integration/test_crash_recovery.py
+++ b/packages/workcli/tests/integration/test_crash_recovery.py
@@ -1,0 +1,124 @@
+"""Crash-recovery against real bd state: a fault mid-`deliver` leaves the
+impl-placeholder handle + manifest note recorded (real partial state); a
+subsequent `work reconcile` replays reconcile_placeholder and heals to final
+state. Also: a malformed-JSON bd response on a --json read verb must surface
+E_BACKEND_DRIFT with detail.reason == "invalid_json"."""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Sequence
+
+from tests.integration.conftest import _bd_env
+from tests.integration.fault_runner import Fault, FaultInjectingBdRunner
+from workcli.adapters.bd.runner import SubprocessBdRunner
+from workcli.cli import main
+
+
+def _drive(runner, argv: Sequence[str]) -> dict:
+    out, err = io.StringIO(), io.StringIO()
+    main(list(argv), runner=runner, out=out, err=err)
+    return json.loads(out.getvalue())
+
+
+def test_malformed_json_on_read_is_invalid_json_drift(fresh_install, bd_binary):
+    real = SubprocessBdRunner(
+        bd_binary=bd_binary, cwd=str(fresh_install), env=_bd_env(fresh_install)
+    )
+    created = _drive(
+        real, ["create", "--raw", "--title", "cr-item", "--type", "task", "--priority", "2"]
+    )
+    item_id = created["data"]["id"]
+
+    # Fault the `show --json` read with garbage stdout, exit 0.
+    faulted = FaultInjectingBdRunner(
+        real,
+        fail_when=lambda _n, argv: "show" in argv and "--json" in argv,
+        fault=Fault.MALFORMED_JSON,
+    )
+    env = _drive(faulted, ["show", item_id])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_BACKEND_DRIFT"
+    assert env["error"]["detail"]["reason"] == "invalid_json"
+
+
+def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
+    """Fault a design-child `deliver` at the set_type call (after the spec: and
+    manifest: notes are appended, before impl-placeholder is removed), leaving
+    real partial state; `reconcile` must then complete the placeholder."""
+    real = SubprocessBdRunner(
+        bd_binary=bd_binary, cwd=str(fresh_install), env=_bd_env(fresh_install)
+    )
+
+    # --- Arrange: promote a shape-feat leaf → a shape-spec container. That mints
+    # a design child (shape-design) + an impl-placeholder sibling under it
+    # (transitions.py::promote → finalize_spec_instantiation). `create` requires
+    # exactly one of --parent/--orphan; this leaf is standalone → --orphan.
+    leaf = _drive(real, ["create", "feat", "--title", "cr-spec", "--priority", "2", "--orphan"])[
+        "data"
+    ]["id"]
+    _drive(real, ["promote", leaf])
+    design_child, placeholder = _design_and_placeholder(real, leaf)
+
+    # A `## Continuations` single-item manifest. GRAMMAR (manifest.py, verified):
+    # `- <noun>: <title> — AC: <acceptance>` — note the em-dash separator " — AC: ".
+    spec_file = fresh_install / "cont.md"
+    spec_file.write_text(
+        "# spec\n\n## Continuations\n\n- feat: cr-impl — AC: the impl unit is built\n"
+    )
+
+    # --- Act: fault the deliver at the first `update ... --type` call. That argv
+    # shape is emitted ONLY by backend.set_type (the other --type callers start
+    # with `list`/`create`), which _reconcile_single runs FIRST — after both the
+    # spec: and manifest: snapshot notes are appended, before the shape label is
+    # added and before impl-placeholder is removed. Genuine mid-deliver state.
+    def fail_on_set_type(_n: int, argv: Sequence[str]) -> bool:
+        return argv[:1] == ["update"] and "--type" in argv
+
+    faulted = FaultInjectingBdRunner(real, fail_when=fail_on_set_type, fault=Fault.NONZERO_EXIT)
+    crashed = _drive(faulted, ["deliver", design_child, "--spec", str(spec_file)])
+    assert crashed["ok"] is False  # the injected fault aborted deliver
+
+    # Partial state is real: the placeholder still carries the impl-placeholder
+    # handle (the recovery signal), has NOT yet gained its shape label, and the
+    # in-band manifest snapshot the appends recorded before the fault is present
+    # — that snapshot is what `reconcile` replays off, so its persistence proves
+    # the fault landed after the appends and before the shape mutation.
+    mid = _drive(real, ["show", placeholder])["data"]
+    assert "impl-placeholder" in mid["labels"]
+    assert "shape-feat" not in mid["labels"]
+    assert "[work] manifest:" in mid["notes"]
+
+    # --- Heal: reconcile replays reconcile_placeholder off the recorded snapshot.
+    swept = _drive(real, ["reconcile"])
+    assert swept["ok"] is True
+
+    # Assert the recovery invariants that hold under ANY correct heal: the
+    # impl-placeholder recovery handle is cleared (delivery no longer partial),
+    # the design child is closed (delivery complete), and spec-ready is stamped.
+    # We deliberately do NOT pin the placeholder's final *shape* label here: a
+    # tracked lifecycle defect (spec children retain `creating-spec`, so
+    # reconcile's instantiation sweep re-finalizes the placeholder and currently
+    # overwrites its manifest-noun shape) makes that label defect-dependent. The
+    # defect is filed as discovered work; pinning it green would bless the bug,
+    # and pinning the buggy shape would encode it — so the harness asserts only
+    # the handle/close/spec-ready invariants a correct fix must preserve.
+    healed = _drive(real, ["show", placeholder])["data"]
+    assert "impl-placeholder" not in healed["labels"]  # handle removed strictly last
+    assert "spec-ready" in healed["labels"]
+    assert _drive(real, ["show", design_child])["data"]["status"] == "closed"
+
+
+def _design_and_placeholder(runner, container_id: str) -> tuple[str, str]:
+    """Return (design_child_id, placeholder_id): the container's two children."""
+    children = _drive(runner, ["show", container_id])["data"]["children"]  # single-id show
+    design_child = placeholder = None
+    for child_id in children:
+        labels = _drive(runner, ["show", child_id])["data"]["labels"]
+        if "shape-design" in labels:
+            design_child = child_id
+        else:
+            placeholder = child_id
+    assert design_child and placeholder, f"expected design+placeholder under {container_id}"
+    return design_child, placeholder

--- a/packages/workcli/tests/integration/test_error_paths.py
+++ b/packages/workcli/tests/integration/test_error_paths.py
@@ -1,0 +1,64 @@
+"""Typed error envelopes against real bd, within reason."""
+
+from __future__ import annotations
+
+import json
+
+from tests.integration.conftest import _bd_env
+from workcli.adapters.bd.runner import SubprocessBdRunner
+
+
+def test_show_bogus_id_is_not_found(driver):
+    env = driver(["show", "itest-nope-xyz"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_NOT_FOUND"  # reaches bd, no pre-check → real drift coverage
+
+
+def test_bad_flag_is_usage_error(driver):
+    env = driver(["show", "--bogus-flag"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_USAGE"
+
+
+def test_deliver_without_evidence_is_refused(driver):
+    item_id = driver(["create", "feat", "--title", "ep-noevidence", "--priority", "2", "--orphan"])[
+        "data"
+    ]["id"]
+    driver(["claim", item_id])
+    env = driver(["deliver", item_id])  # no --pr/--items/--trivial
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_EVIDENCE"
+
+
+def test_type_wall_verb_envelope(driver):
+    # (a) The verb-layer pre-check raises E_TYPE_WALL before bd is called.
+    epic = driver(["create", "epic", "--title", "ep-epic", "--priority", "2", "--orphan"])["data"][
+        "id"
+    ]
+    task = driver(["create", "feat", "--title", "ep-task", "--priority", "2", "--orphan"])["data"][
+        "id"
+    ]
+    env = driver(["dep", "add", epic, task, "--type", "blocks"])
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_TYPE_WALL"
+
+
+def test_type_wall_raw_bd_marker_drift(fresh_install, bd_binary):
+    # (b) DRIFT COVERAGE: drive bd's own `dep add` directly (bypassing the verb
+    # pre-check) and assert bd still emits the marker map_bd_failure keys on
+    # ("can only block"). This is the assertion that actually fails if bd changes
+    # its wall wording — the verb-envelope test above cannot see that.
+    runner = SubprocessBdRunner(
+        bd_binary=bd_binary, cwd=str(fresh_install), env=_bd_env(fresh_install)
+    )
+    epic = _create_raw(runner, "rw-epic", "epic")
+    task = _create_raw(runner, "rw-task", "task")
+    result = runner.run(["dep", "add", epic, task, "--type", "blocks"])
+    assert result.returncode != 0
+    assert "can only block" in result.stderr.lower()
+
+
+def _create_raw(runner, title, bd_type):
+    r = runner.run(["create", "--json", "--title", title, "--type", bd_type, "--priority", "2"])
+    assert r.returncode == 0, r.stderr
+    return json.loads(r.stdout)["id"]

--- a/packages/workcli/tests/integration/test_fault_runner.py
+++ b/packages/workcli/tests/integration/test_fault_runner.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from tests.integration.fault_runner import Fault, FaultInjectingBdRunner
+from workcli.adapters.bd.runner import BdResult
+
+
+class _RecordingRunner:
+    """A fake inner BdRunner: records calls, returns a benign ok result."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, args):
+        self.calls.append(list(args))
+        return BdResult(returncode=0, stdout="[]", stderr="")
+
+
+def test_delegates_until_predicate_then_injects_nonzero():
+    inner = _RecordingRunner()
+    runner = FaultInjectingBdRunner(
+        inner, fail_when=lambda n, _argv: n == 2, fault=Fault.NONZERO_EXIT
+    )
+    first = runner.run(["show", "a", "--json"])
+    second = runner.run(["update", "a", "--status", "closed"])
+
+    assert first.returncode == 0  # delegated to real inner
+    assert inner.calls == [["show", "a", "--json"]]  # call 2 never reached inner
+    assert second.returncode != 0  # injected fault
+    assert "injected" in second.stderr
+
+
+def test_malformed_json_fault_is_exit_zero_garbage_stdout():
+    inner = _RecordingRunner()
+    runner = FaultInjectingBdRunner(
+        inner, fail_when=lambda _n, argv: "--json" in argv, fault=Fault.MALFORMED_JSON
+    )
+    result = runner.run(["show", "a", "--json"])
+
+    assert result.returncode == 0
+    assert result.stdout == "{ this is not valid json"
+    assert inner.calls == []  # faulted on the first matching call

--- a/packages/workcli/tests/integration/test_fixtures_smoke.py
+++ b/packages/workcli/tests/integration/test_fixtures_smoke.py
@@ -1,0 +1,19 @@
+"""Smoke-proves the fixtures stand up a real isolated bd and the driver round-trips."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.usefixtures("fresh_install")
+def test_fresh_install_is_empty_and_isolated(driver):
+    env = driver(["list"])
+    assert env["ok"] is True
+    assert env["data"]["items"] == []
+
+
+def test_read_only_corpus_is_seeded(read_only_driver):
+    env = read_only_driver(["list"])
+    assert env["ok"] is True
+    titles = {item["title"] for item in env["data"]["items"]}
+    assert {"seed-alpha", "seed-beta", "seed-child"} <= titles

--- a/packages/workcli/tests/integration/test_isolation.py
+++ b/packages/workcli/tests/integration/test_isolation.py
@@ -11,7 +11,7 @@ from tests.integration.conftest import assert_off_repo, resolve_bd
 
 
 def test_resolve_bd_returns_absolute_path_or_skips():
-    bd = resolve_bd()  # skips the module if bd is absent
+    bd = resolve_bd()  # skips this test if bd is absent
     assert bd.startswith("/")
 
 

--- a/packages/workcli/tests/integration/test_isolation.py
+++ b/packages/workcli/tests/integration/test_isolation.py
@@ -1,0 +1,29 @@
+"""The isolation guard is load-bearing: it must refuse to run bd anywhere that
+could resolve into a real .beads via bd's upward directory walk."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.integration.conftest import assert_off_repo, resolve_bd
+
+
+def test_resolve_bd_returns_absolute_path_or_skips():
+    bd = resolve_bd()  # skips the module if bd is absent
+    assert bd.startswith("/")
+
+
+def test_guard_refuses_a_path_inside_a_git_repo(tmp_path):
+    # A tmp dir that IS a git repo must be rejected (bd would commit into it /
+    # walk up to its .beads).
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)  # noqa: S607
+    with pytest.raises(RuntimeError, match="inside a git repo"):
+        assert_off_repo(tmp_path)
+
+
+def test_guard_allows_a_bare_tmp_dir(tmp_path):
+    # pytest tmp_path is off-repo (/private/var/folders/... on macOS); no ancestor
+    # is a git repo, so the guard passes.
+    assert_off_repo(tmp_path)  # must not raise

--- a/packages/workcli/tests/integration/test_lifecycle.py
+++ b/packages/workcli/tests/integration/test_lifecycle.py
@@ -1,0 +1,51 @@
+"""Guarded lifecycle transitions on real bd state (happy path — no faults)."""
+
+from __future__ import annotations
+
+
+def test_create_claim_deliver_trivial_then_reconcile_noop(driver):
+    # `create feat` mints a shape-feat leaf (not a container); claimable once ready.
+    # `--orphan` is required alongside `--parent` (create.py: exactly one of the two).
+    item_id = driver(["create", "feat", "--title", "lc-leaf", "--priority", "2", "--orphan"])[
+        "data"
+    ]["id"]
+    assert driver(["claim", item_id])["ok"] is True
+    # A leaf delivery with trivial evidence closes it.
+    delivered = driver(["deliver", item_id, "--trivial"])
+    assert delivered["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "closed"  # single-id show
+    # reconcile with nothing recoverable is a clean no-op.
+    swept = driver(["reconcile"])
+    assert swept["ok"] is True
+
+
+def test_plan_add_then_done(driver):
+    # `plan` requires exactly one of --done/--undo on every call
+    # (transitions.py::plan: `args.done == args.undo` raises E_USAGE) -- there is
+    # no separate "add to queue" step distinct from --done. An epic IS a container
+    # (nouns.py: is_container=True), so --done needs no --force (plan's guard:
+    # `not is_container(item) and not args.force`).
+    item_id = driver(["create", "epic", "--title", "lc-epic", "--priority", "2", "--orphan"])[
+        "data"
+    ]["id"]
+    added = driver(["plan", item_id, "--done"])
+    assert added["ok"] is True
+    assert added["data"]["planned"] is True
+    assert "planned" in driver(["show", item_id])["data"]["labels"]
+    # Idempotent replay: PLANNED_LABEL already present short-circuits to the
+    # same result rather than erroring or double-adding the label.
+    replayed = driver(["plan", item_id, "--done"])
+    assert replayed["ok"] is True
+    assert replayed["data"]["planned"] is True
+
+
+def test_promote_leaf_to_spec_container(driver):
+    # promote requires a shape-feat leaf (transitions.py::promote); `create feat`
+    # provides exactly that. Result: the leaf becomes a shape-spec container.
+    leaf = driver(["create", "feat", "--title", "lc-promote", "--priority", "2", "--orphan"])[
+        "data"
+    ]["id"]
+    promoted = driver(["promote", leaf])
+    assert promoted["ok"] is True
+    assert promoted["data"]["promoted"] == "spec"
+    assert "shape-spec" in driver(["show", leaf])["data"]["labels"]  # single-id show

--- a/packages/workcli/tests/integration/test_nouns.py
+++ b/packages/workcli/tests/integration/test_nouns.py
@@ -1,0 +1,27 @@
+"""Each `work create <noun>` template stamps the right bd type + shape label."""
+
+from __future__ import annotations
+
+import pytest
+
+# (noun, expected bd type, expected shape label) — verified against
+# lifecycle/nouns.py NOUN_TEMPLATES (bd_type, shape_label). Exact contract.
+NOUN_EXPECTATIONS = [
+    ("spike", "task", "shape-spike"),
+    ("chore", "chore", "shape-chore"),
+    ("decision", "decision", "shape-decision"),
+    ("feat", "feature", "shape-feat"),
+    ("bugfix", "bug", "shape-bugfix"),
+    ("spec", "feature", "shape-spec"),
+    ("epic", "epic", "shape-epic"),
+]
+
+
+@pytest.mark.parametrize("noun,bd_type,shape_label", NOUN_EXPECTATIONS)
+def test_create_noun_stamps_type_and_shape_label(driver, noun, bd_type, shape_label):
+    created = driver(["create", noun, "--title", f"noun-{noun}", "--priority", "2", "--orphan"])
+    assert created["ok"] is True, created
+    item_id = created["data"]["id"]  # create → {"id": ...}
+    shown = driver(["show", item_id])["data"]  # single-id show → item directly
+    assert shown["type"] == bd_type  # Item field is `type`, not `issue_type`
+    assert shape_label in shown["labels"]

--- a/packages/workcli/tests/integration/test_sync.py
+++ b/packages/workcli/tests/integration/test_sync.py
@@ -1,0 +1,18 @@
+"""Remote-less sync against real embedded-dolt: honest ok=true, incl. a real
+pending change through the commit path."""
+
+from __future__ import annotations
+
+
+def test_sync_remote_less_is_ok(driver):
+    env = driver(["sync"])
+    assert env["ok"] is True
+    assert env["data"]["mode"] == "push"
+
+
+def test_sync_after_a_real_mutation_commits(driver):
+    # A real pending change exercises `dolt commit` with content (not the
+    # nothing-pending path).
+    driver(["create", "--raw", "--title", "sync-content", "--type", "task", "--priority", "2"])
+    env = driver(["sync"])
+    assert env["ok"] is True

--- a/packages/workcli/tests/integration/test_sync.py
+++ b/packages/workcli/tests/integration/test_sync.py
@@ -11,8 +11,11 @@ def test_sync_remote_less_is_ok(driver):
 
 
 def test_sync_after_a_real_mutation_commits(driver):
-    # A real pending change exercises `dolt commit` with content (not the
-    # nothing-pending path).
+    # A real pending change drives `dolt commit` down its with-content path; ok=True
+    # confirms that path completes without error. The remote-less envelope
+    # ({synced, mode}) does not distinguish a real commit from the nothing-pending
+    # no-op, so that is the extent of what this asserts — it guards the path
+    # against regressions/exceptions, not the commit's byte-level effect.
     driver(["create", "--raw", "--title", "sync-content", "--type", "task", "--priority", "2"])
     env = driver(["sync"])
     assert env["ok"] is True

--- a/packages/workcli/tests/integration/test_verbs_happy.py
+++ b/packages/workcli/tests/integration/test_verbs_happy.py
@@ -1,0 +1,105 @@
+"""Every verb once against real bd, asserting VALUE-LEVEL, not just ok=True.
+
+Read verbs use the shared read_only corpus; mutating verbs use a fresh install."""
+
+from __future__ import annotations
+
+# ---- read verbs (shared corpus) ----
+
+# NOTE (envelope shape, verified against verbs/read.py): a SINGLE-id `show`
+# returns the item object DIRECTLY as `data` (not wrapped in {"items":[...]});
+# only a 2+-id `show`, and every `list`/`ready`/`search`, wraps as
+# `{"items": [...]}`. `label list` returns a BARE string[] as `data`.
+# `Item.priority` is a STRING ("P0".."P4"), `Item.type` (not "issue_type").
+
+
+def test_show_returns_exact_seeded_fields(read_only_driver):
+    listing = read_only_driver(["list"])
+    alpha_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-alpha")
+    env = read_only_driver(["show", alpha_id])
+    assert env["ok"] is True
+    item = env["data"]  # single-id show → item object directly
+    assert item["id"] == alpha_id
+    assert item["title"] == "seed-alpha"
+    assert item["status"] == "open"
+    assert item["priority"] == "P2"  # priority is a string, not int
+    assert "seed" in item["labels"]  # value-level: label round-trips
+
+
+def test_list_filter_by_label(read_only_driver):
+    env = read_only_driver(["list", "--label", "seed"])
+    assert env["ok"] is True
+    assert {i["title"] for i in env["data"]["items"]} == {"seed-alpha"}
+
+
+def test_show_child_reports_seeded_parent(read_only_driver):
+    listing = read_only_driver(["list"])
+    child_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-child")
+    item = read_only_driver(["show", child_id])["data"]  # single-id show → item directly
+    assert item["parent"] is not None  # value-level: parent edge survives
+
+
+def test_ready_lists_unblocked(read_only_driver):
+    env = read_only_driver(["ready"])
+    assert env["ok"] is True
+    assert isinstance(env["data"]["items"], list)
+
+
+def test_search_finds_seeded(read_only_driver):
+    env = read_only_driver(["search", "seed-beta"])
+    assert env["ok"] is True
+    assert any(i["title"] == "seed-beta" for i in env["data"]["items"])
+
+
+# ---- write/relation/transition verbs (fresh install) ----
+
+
+def test_create_raw_update_note_close_reopen_roundtrip(driver):
+    created = driver(["create", "--raw", "--title", "wv-one", "--type", "task", "--priority", "2"])
+    assert created["ok"] is True
+    item_id = created["data"]["id"]  # create → {"id": ...}
+
+    driver(["update", item_id, "--set-title", "wv-one-renamed"])
+    assert driver(["show", item_id])["data"]["title"] == "wv-one-renamed"  # value-level
+
+    driver(["note", item_id, "a durable note"])
+    assert "a durable note" in driver(["show", item_id])["data"]["notes"]
+
+    assert driver(["close", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "closed"
+
+    assert driver(["reopen", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "open"
+
+
+def test_label_add_list_remove(driver):
+    item_id = driver(["create", "--raw", "--title", "wv-lbl", "--type", "task", "--priority", "2"])[
+        "data"
+    ]["id"]
+    driver(["label", "add", item_id, "alpha", "beta"])
+    labels = driver(["label", "list", item_id])["data"]  # label list → bare string[]
+    assert {"alpha", "beta"} <= set(labels)
+    driver(["label", "remove", item_id, "alpha"])
+    assert "alpha" not in driver(["label", "list", item_id])["data"]
+
+
+def test_dep_add_list_remove(driver):
+    a = driver(["create", "--raw", "--title", "wv-dep-a", "--type", "task", "--priority", "2"])[
+        "data"
+    ]["id"]
+    b = driver(["create", "--raw", "--title", "wv-dep-b", "--type", "task", "--priority", "2"])[
+        "data"
+    ]["id"]
+    driver(["dep", "add", a, b, "--type", "blocks"])
+    listing = driver(["dep", "list", a])
+    assert listing["ok"] is True
+    driver(["dep", "remove", a, b])
+
+
+def test_claim_and_release(driver):
+    item_id = driver(
+        ["create", "--raw", "--title", "wv-claim", "--type", "task", "--priority", "2"]
+    )["data"]["id"]
+    assert driver(["claim", item_id])["ok"] is True
+    assert driver(["show", item_id])["data"]["status"] == "in_progress"
+    assert driver(["release", item_id])["ok"] is True

--- a/packages/workcli/tests/unit/test_subprocess_runner.py
+++ b/packages/workcli/tests/unit/test_subprocess_runner.py
@@ -38,3 +38,41 @@ def test_run_invokes_bd_with_the_given_args_and_captures_the_full_result(tmp_pat
     assert result.returncode == 3
     assert result.stdout == "args: show x.1 --json\n"
     assert result.stderr == "warning: something\n"
+
+
+def test_run_uses_injected_bd_binary_cwd_and_env(tmp_path, monkeypatch):
+    # A fake bd that proves all three injected params reached subprocess.run:
+    # it echoes its own cwd and a custom env var.
+    fake_dir = tmp_path / "bin"
+    fake_dir.mkdir()
+    fake_bd = fake_dir / "mybd"
+    fake_bd.write_text('#!/bin/sh\necho "cwd=$(pwd)"\necho "marker=$WORKCLI_ITEST_MARKER"\n')
+    fake_bd.chmod(fake_bd.stat().st_mode | stat.S_IEXEC)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    # Ensure PATH does NOT contain a `bd`, proving bd_binary (absolute) is used.
+    monkeypatch.setenv("PATH", "/nonexistent")
+
+    runner = SubprocessBdRunner(
+        bd_binary=str(fake_bd),
+        cwd=str(workdir),
+        env={"WORKCLI_ITEST_MARKER": "42", "PATH": "/nonexistent"},
+    )
+    result = runner.run(["show", "--json"])
+
+    assert result.returncode == 0
+    assert f"cwd={os.path.realpath(workdir)}" in result.stdout
+    assert "marker=42" in result.stdout
+
+
+def test_run_defaults_are_unchanged(tmp_path, monkeypatch):
+    # Default construction must remain byte-identical to today: binary "bd",
+    # inherited cwd/env. Prove by putting a fake `bd` on PATH and NOT passing
+    # any injected params.
+    _write_fake_bd(tmp_path, 'echo "default-path-bd"\n')
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+
+    result = SubprocessBdRunner().run(["list"])
+
+    assert result.returncode == 0
+    assert result.stdout == "default-path-bd\n"


### PR DESCRIPTION
## What

A local `make itest-workcli` suite that drives the **production `work` CLI against a real, isolated bd 1.0.3 install** per test — catching bd-JSON drift the hermetic unit fakes (`ScriptedBdRunner`) structurally cannot. Bead: `agents-config-wgclw.9.7`.

## How

- **Injectable port** (`adapters/bd/runner.py`): `SubprocessBdRunner(bd_binary/cwd/env)` threaded straight into `subprocess.run` with **zero new branches** — default construction byte-identical to before (hermetic gate held at **100% coverage**).
- **`tests/integration/` suite**: each install is a throwaway `.beads` under `tmp_path`, bound via `BEADS_DIR` + an off-repo path + a git-repo pre-flight guard, so it **structurally cannot** reach the repo's real `.beads`. `FaultInjectingBdRunner` counts bd calls and injects a fault mid-`work`-command, leaving real partial state for `reconcile` to heal.
- **Coverage**: every verb (value-level assertions), every create-noun, lifecycle sequences, typed error paths (incl. the type-wall raw-bd drift tripwire), crash-recovery, malformed-JSON→`invalid_json`, remote-less sync. **35 itests.**
- **Wiring**: `pyproject` `testpaths` pins the coverage gate to `tests/unit`; `make itest-workcli` target is **excluded from `ci-workcli`/`ci`** (needs the bd toolchain; pre-push discipline). AGENTS.md documents it.

## Discovered work — a real P1 the harness caught

The crash-recovery test surfaced a genuine defect: `reconcile` spuriously re-finalizes a spec container's design+placeholder children because `finalize_spec_instantiation` never clears `creating-spec` from them. It mutates even **healthy** freshly-promoted trees on every run, and clobbers a correctly-delivered impl placeholder on the crash path. Filed as **`agents-config-wgclw.9.8`** (P1, `discovered-from` 9.7). The crash-recovery test deliberately asserts only the recovery invariants that hold under any correct fix — it does **not** pin the buggy shape.

## Evidence

- `make ci-workcli` → **377 passed, 100% coverage** (0.96s — proves unit-only collection), pip-audit clean, entry-verify green.
- `make itest-workcli` → **35 passed** against real bd 1.0.3.
- HEAVY completion gate (6 lenses, 3 refuters, xhigh synthesis, 26 agents): **ACCEPTANCE / clean-at-floor** — zero findings at/above major; two minor comment-honesty items fixed, four test-DRY nits accepted-with-reservations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNC8t8yfaotN7aSFeJxh7e