### PR TITLE
feat(vizsuite): viz apply — gated, idempotent one-click mutations (S6)

### DIFF
--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -74,6 +74,23 @@ def _add_verdict_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser
     )
 
 
+def _add_apply_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    apply_parser = subparsers.add_parser(
+        "apply",
+        help="execute a one-click recommendation's mutation plan, gated on an accepted verdict",
+    )
+    apply_parser.add_argument(
+        "recommendation_id",
+        metavar="RECOMMENDATION_ID",
+        help="the recommendation fact id to apply",
+    )
+    apply_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="preview the tracker mutations that would happen without writing anything",
+    )
+
+
 def _build_parser() -> _EnvelopeArgumentParser:
     parser = _EnvelopeArgumentParser(prog="viz", description="viz — repo/PR visualization suite")
     parser.add_argument(
@@ -95,6 +112,7 @@ def _build_parser() -> _EnvelopeArgumentParser:
     _add_queue_subparser(subparsers)
     _add_sweep_subparser(subparsers)
     _add_verdict_subparser(subparsers)
+    _add_apply_subparser(subparsers)
     return parser
 
 

--- a/packages/vizsuite/src/vizsuite/envelope.py
+++ b/packages/vizsuite/src/vizsuite/envelope.py
@@ -70,6 +70,23 @@ class ErrorCode(StrEnum):
     # the full accepted logical dependency graph (spec §5.3/§5.7, test item
     # 17) -- refused with the cycle path in `detail`; no tracker edge written.
     VERDICT_CYCLE_REFUSAL = "E_VERDICT_CYCLE_REFUSAL"
+    # apply slice: `viz apply <recommendation-id>` invoked on a fact with no
+    # recorded Tier-3 ACCEPTED verdict for that exact fact id -- a reject/
+    # dismiss verdict, no verdict at all, or a verdict recorded against a
+    # different fact id all refuse identically (spec §5.7: "refuses any
+    # recommendation without a recorded Tier-3 accepted verdict").
+    APPLY_NOT_ACCEPTED = "E_APPLY_NOT_ACCEPTED"
+    # apply slice: a resequence recommendation is `ruling-needed`, never
+    # `one-click` -- the work facade has no resequence verb (spec §5.7).
+    # Refused as a deliberate apply-level decision BEFORE the tracker runner
+    # is ever touched, rather than relying on `TrackerPort.resequence`'s own
+    # `TRACKER_NOT_SUPPORTED` surfacing accidentally.
+    APPLY_RESEQUENCE_NOT_SUPPORTED = "E_APPLY_RESEQUENCE_NOT_SUPPORTED"
+    # apply slice: an `add_edge` mutation writing a `blocks` edge would close
+    # a cycle in the full accepted logical dependency graph (spec §5.3/§5.7,
+    # test item 17) -- refused with the cycle path in `detail`; no tracker
+    # edge written. The `viz apply` analog of `VERDICT_CYCLE_REFUSAL`.
+    APPLY_CYCLE_REFUSAL = "E_APPLY_CYCLE_REFUSAL"
 
 
 @dataclass

--- a/packages/vizsuite/src/vizsuite/verbs/__init__.py
+++ b/packages/vizsuite/src/vizsuite/verbs/__init__.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 
 from vizsuite.envelope import JsonValue
 from vizsuite.runners import Runners
+from vizsuite.verbs.apply import apply
 from vizsuite.verbs.pr import pr
 from vizsuite.verbs.queue import queue
 from vizsuite.verbs.sweep import sweep
@@ -23,4 +24,5 @@ VERBS: dict[str, Callable[[Runners, Namespace], JsonValue]] = {
     "queue": queue,
     "sweep": sweep,
     "verdict": verdict,
+    "apply": apply,
 }

--- a/packages/vizsuite/src/vizsuite/verbs/apply.py
+++ b/packages/vizsuite/src/vizsuite/verbs/apply.py
@@ -1,0 +1,559 @@
+"""`viz apply <recommendation-id> [--dry-run]` — gated, idempotent one-click
+mutation execution (spec §5.7/§10 test items 14/17).
+
+**The gate.** `viz apply` refuses any recommendation without a recorded
+Tier-3 `accept` verdict for that EXACT fact id: no verdict at all, a
+`reject`/`dismiss` verdict, or a verdict recorded against a *different* fact
+id all refuse identically as `VizError(APPLY_NOT_ACCEPTED)` -- an attached
+agent or direct invocation can never mutate the tracker from an unreviewed
+Tier-2 recommendation. A recommendation id absent from `recommendations.json`
+is the existing `VizError(NOT_FOUND)` refusal.
+
+**Mutation classes.** The recommendation's `payload["mutation"]` carries a
+typed mutation plan (spec §5.7's `one-click` set plus the `ruling-needed`
+`resequence` case), parsed with the same strictness as `verdict.py`'s
+`_parse_ledger_payload`: an unrecognized `kind`, a missing required field, an
+extra unknown field, or a wrong field type all refuse as
+`VizError(SIDECAR_MALFORMED)` rather than guessing or defaulting.
+
+- `mint_bead` -- `TrackerPort.mint_bead`, keyed on the recommendation's own
+  `payload["application"]` ledger entry (mirrors verdict.py's
+  `payload["promotion"]`): replay finds the ledger and is a pure no-op,
+  never touching the tracker again.
+- `add_edge` -- `TrackerPort.add_edge`. A `blocks` write runs
+  `cycle_guard.find_cycle` first, over the SAME full accepted logical
+  dependency graph verdict.py's edge promotion checks (beads `blocks` edges
+  plus every already-promoted `dependency`-kind fact in `edges.json`,
+  including type-wall `related-to` fallbacks) -- a refusal
+  (`VizError(APPLY_CYCLE_REFUSAL)`) writes nothing. A `related-to` write
+  skips the check (no logical dependency, mirroring verdict.py). Idempotency
+  here is backend convergence, not a ledger: `work dep add` upserts, so a
+  replay simply re-issues the same call and lands on the same state.
+- `relabel` -- `TrackerPort.relabel`; same backend-convergence idempotency
+  (`work label add/remove` is a no-op on an already-present/absent label).
+- `resequence` -- NOT executable (spec: `ruling-needed`, never `one-click`
+  -- "the work facade has no resequence verb"). Refused as
+  `VizError(APPLY_RESEQUENCE_NOT_SUPPORTED)` before the tracker runner is
+  touched at all -- a deliberate apply-level refusal, never a reliance on
+  `TrackerPort.resequence`'s own `TRACKER_NOT_SUPPORTED` surfacing by
+  accident.
+
+**Mint's ledger-ordering decision.** Edge/relabel writes are safe to repeat
+verbatim on any retry because the backend itself is idempotent for them.
+`work create` is NOT: calling it twice mints two beads. So unlike edge
+promotion's ordering (tracker-writes-then-ledger-persist-LAST, safe only
+because every one of those writes is repeatable), `mint_bead`'s ledger entry
+is persisted the INSTANT `mint_bead` returns an id -- before the audit-note
+append, the only fallible step left. A note-append failure after a
+successful mint therefore still leaves the ledger correctly populated, so a
+retry finds it and treats the mint as already done (never re-attempting
+either the mint or the note, mirroring verdict.py's `_AlreadyPromoted`
+no-op). The accepted residual cost: a note lost to exactly that failure
+window never gets a second attempt (audit-note garnish is not
+correctness-critical; the ledger, not the note, is the actual mutation
+record) -- in exchange for an ironclad no-duplicate-mint guarantee. The one
+remaining unclosable gap -- a process killed in the single in-process
+instant between `mint_bead` returning and the ledger write landing -- has no
+tracker-side idempotency key to close it and is symmetric with the residual
+risk verdict.py's own docstring already accepts ("a transaction is a lock,
+not a rollback").
+
+**`--dry-run`** runs the identical decision logic (`add_edge`'s cycle-check
+read still runs; nothing else does) but performs zero sidecar or tracker
+mutation -- no `store.transaction()` is ever entered, and no `mint_bead`/
+`add_edge`/`relabel`/`append_note`/`write_recommendations` call is ever
+issued. `resequence` is refused identically in both modes, before any of
+that logic runs.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+from vizsuite.envelope import ErrorCode, JsonValue, VizError
+from vizsuite.runners import Runners
+from vizsuite.sidecar.models import FactRecord, Verdict
+from vizsuite.sidecar.store import SidecarStore
+from vizsuite.tracker.cycle_guard import (
+    CycleRefusal,
+    ProposedEdge,
+    Safe,
+    SidecarDependencyEdge,
+    find_cycle,
+)
+from vizsuite.tracker.port import DepKind, TrackerPort
+
+_MUTATION_PAYLOAD_KEY = "mutation"
+_APPLICATION_PAYLOAD_KEY = "application"
+_PROMOTION_PAYLOAD_KEY = "promotion"  # verdict.py's edge-promotion ledger key
+_DEPENDENCY_KIND = "dependency"
+
+_MINT_BEAD_KIND = "mint_bead"
+_ADD_EDGE_KIND = "add_edge"
+_RELABEL_KIND = "relabel"
+_RESEQUENCE_KIND = "resequence"
+
+
+# ---- the typed mutation-plan view over payload["mutation"] -----------------
+
+
+@dataclass(frozen=True)
+class MintBeadMutation:
+    noun: str
+    title: str
+    parent: str | None = None
+    orphan: bool = False
+    description: str | None = None
+    priority: str | None = None
+    acceptance: str | None = None
+
+
+@dataclass(frozen=True)
+class AddEdgeMutation:
+    from_bead: str
+    to_bead: str
+    edge_kind: DepKind
+
+
+@dataclass(frozen=True)
+class RelabelMutation:
+    bead_id: str
+    labels: tuple[str, ...]
+    remove: bool = False
+
+
+@dataclass(frozen=True)
+class ResequenceMutation:
+    reason: str
+
+
+MutationPlan = MintBeadMutation | AddEdgeMutation | RelabelMutation | ResequenceMutation
+
+
+class _MalformedMutationShapeError(TypeError):
+    """Raised when `payload["mutation"]` isn't a recognized mutation plan shape."""
+
+    def __init__(self) -> None:
+        super().__init__("mutation plan payload has an invalid shape")
+
+
+def _as_str_field(value: JsonValue) -> str:
+    if not isinstance(value, str):
+        raise _MalformedMutationShapeError
+    return value
+
+
+def _as_optional_str_field(value: JsonValue) -> str | None:
+    if value is None:
+        return None
+    return _as_str_field(value)
+
+
+def _as_bool_field(value: JsonValue) -> bool:
+    if not isinstance(value, bool):
+        raise _MalformedMutationShapeError
+    return value
+
+
+def _parse_mint_bead(fields: dict[str, JsonValue]) -> MintBeadMutation:
+    if "noun" not in fields or "title" not in fields:
+        raise _MalformedMutationShapeError
+    noun = _as_str_field(fields.pop("noun"))
+    title = _as_str_field(fields.pop("title"))
+    parent = _as_optional_str_field(fields.pop("parent", None))
+    orphan = _as_bool_field(fields.pop("orphan", False))
+    description = _as_optional_str_field(fields.pop("description", None))
+    priority = _as_optional_str_field(fields.pop("priority", None))
+    acceptance = _as_optional_str_field(fields.pop("acceptance", None))
+    if fields:
+        raise _MalformedMutationShapeError
+    return MintBeadMutation(
+        noun=noun,
+        title=title,
+        parent=parent,
+        orphan=orphan,
+        description=description,
+        priority=priority,
+        acceptance=acceptance,
+    )
+
+
+def _parse_add_edge(fields: dict[str, JsonValue]) -> AddEdgeMutation:
+    if "from_bead" not in fields or "to_bead" not in fields or "edge_kind" not in fields:
+        raise _MalformedMutationShapeError
+    from_bead = _as_str_field(fields.pop("from_bead"))
+    to_bead = _as_str_field(fields.pop("to_bead"))
+    edge_kind_raw = _as_str_field(fields.pop("edge_kind"))
+    if fields:
+        raise _MalformedMutationShapeError
+    if edge_kind_raw not in ("blocks", "related-to"):
+        raise _MalformedMutationShapeError
+    return AddEdgeMutation(
+        from_bead=from_bead, to_bead=to_bead, edge_kind=cast("DepKind", edge_kind_raw)
+    )
+
+
+def _parse_relabel(fields: dict[str, JsonValue]) -> RelabelMutation:
+    if "bead_id" not in fields or "labels" not in fields:
+        raise _MalformedMutationShapeError
+    bead_id = _as_str_field(fields.pop("bead_id"))
+    labels_raw = fields.pop("labels")
+    remove = _as_bool_field(fields.pop("remove", False))
+    if fields:
+        raise _MalformedMutationShapeError
+    if not isinstance(labels_raw, list) or len(labels_raw) == 0:
+        raise _MalformedMutationShapeError
+    labels = tuple(_as_str_field(item) for item in labels_raw)
+    return RelabelMutation(bead_id=bead_id, labels=labels, remove=remove)
+
+
+def _parse_resequence(fields: dict[str, JsonValue]) -> ResequenceMutation:
+    reason = _as_str_field(fields.pop("reason", ""))
+    if fields:
+        raise _MalformedMutationShapeError
+    return ResequenceMutation(reason=reason)
+
+
+def _parse_mutation_payload(raw: JsonValue) -> MutationPlan:
+    if not isinstance(raw, dict):
+        raise _MalformedMutationShapeError
+    fields = dict(raw)
+    kind = fields.pop("kind", None)
+    if kind == _MINT_BEAD_KIND:
+        return _parse_mint_bead(fields)
+    if kind == _ADD_EDGE_KIND:
+        return _parse_add_edge(fields)
+    if kind == _RELABEL_KIND:
+        return _parse_relabel(fields)
+    if kind == _RESEQUENCE_KIND:
+        return _parse_resequence(fields)
+    raise _MalformedMutationShapeError
+
+
+def _read_mutation(fact: FactRecord) -> MutationPlan:
+    raw = fact.payload.get(_MUTATION_PAYLOAD_KEY)
+    try:
+        return _parse_mutation_payload(raw)
+    except (KeyError, TypeError) as exc:
+        raise VizError(
+            ErrorCode.SIDECAR_MALFORMED,
+            "a recommendation's mutation plan is not valid",
+            detail={"fact_id": fact.fact_id, "reason": str(exc)},
+        ) from exc
+
+
+# ---- the mint-application ledger (payload["application"]) ------------------
+
+
+def _read_mint_ledger(fact: FactRecord) -> str | None:
+    """Read `fact.payload["application"]["bead_id"]`, or `None` if never minted."""
+    raw = fact.payload.get(_APPLICATION_PAYLOAD_KEY)
+    if raw is None:
+        return None
+    if not isinstance(raw, dict) or not isinstance(raw.get("bead_id"), str):
+        raise VizError(
+            ErrorCode.SIDECAR_MALFORMED,
+            "a recommendation's mint-application ledger entry is not valid",
+            detail={"fact_id": fact.fact_id},
+        )
+    return cast("str", raw["bead_id"])
+
+
+# ---- the cycle check's sidecar-edge input (mirrors verdict.py) ------------
+
+
+def _dependency_sidecar_edges(
+    edge_facts: Sequence[FactRecord],
+) -> tuple[SidecarDependencyEdge, ...]:
+    """Every already-promoted `dependency`-kind fact in `edges.json`, as a
+    `SidecarDependencyEdge` -- the sidecar half of the cycle check's full
+    accepted logical dependency graph (spec §5.3/§5.7), identical in shape and
+    intent to `vizsuite.verbs.verdict._dependency_sidecar_edges` (duplicated
+    here rather than imported: these two call sites are the only ones today,
+    and importing a leading-underscore name across verb modules would couple
+    this module to verdict.py's private internals for a ~15-line helper --
+    revisit if a third caller appears, per the rule of three)."""
+    edges: list[SidecarDependencyEdge] = []
+    for record in edge_facts:
+        if record.matching_descriptor.kind != _DEPENDENCY_KIND:
+            continue
+        raw = record.payload.get(_PROMOTION_PAYLOAD_KEY)
+        if raw is None:
+            continue
+        if not isinstance(raw, dict):
+            raise VizError(
+                ErrorCode.SIDECAR_MALFORMED,
+                "a fact's promotion ledger entry is not valid",
+                detail={"fact_id": record.fact_id},
+            )
+        from_bead, to_bead = raw.get("from_bead"), raw.get("to_bead")
+        if not (isinstance(from_bead, str) and isinstance(to_bead, str)):
+            raise VizError(
+                ErrorCode.SIDECAR_MALFORMED,
+                "a fact's promotion ledger entry is not valid",
+                detail={"fact_id": record.fact_id},
+            )
+        edges.append(SidecarDependencyEdge(from_bead=from_bead, to_bead=to_bead))
+    return tuple(edges)
+
+
+def _check_blocks_cycle(
+    store: SidecarStore, port: TrackerPort, fact: FactRecord, plan: AddEdgeMutation
+) -> None:
+    edge_facts = store.read_edges()
+    sidecar_edges = _dependency_sidecar_edges(edge_facts)
+    result = find_cycle(
+        port, sidecar_edges, ProposedEdge(from_bead=plan.from_bead, to_bead=plan.to_bead)
+    )
+    if isinstance(result, CycleRefusal):
+        raise VizError(
+            ErrorCode.APPLY_CYCLE_REFUSAL,
+            f"applying {fact.fact_id!r} would close a dependency cycle",
+            detail={"fact_id": fact.fact_id, "cycle": list(result.cycle)},
+        )
+    if not isinstance(result, Safe):
+        raise TypeError(result)
+
+
+# ---- fact lookup + the accept-verdict gate ---------------------------------
+
+
+def _require_accepted_recommendation(store: SidecarStore, recommendation_id: str) -> FactRecord:
+    fact = next(
+        (record for record in store.read_recommendations() if record.fact_id == recommendation_id),
+        None,
+    )
+    if fact is None:
+        raise VizError(
+            ErrorCode.NOT_FOUND,
+            f"no recommendation {recommendation_id!r} found in recommendations.json",
+            detail={"fact_id": recommendation_id},
+        )
+    accepted = any(
+        record.fact_id == recommendation_id and record.verdict == Verdict.ACCEPT
+        for record in store.read_verdicts()
+    )
+    if not accepted:
+        raise VizError(
+            ErrorCode.APPLY_NOT_ACCEPTED,
+            f"recommendation {recommendation_id!r} has no recorded Tier-3 accepted verdict",
+            detail={"fact_id": recommendation_id},
+        )
+    return fact
+
+
+def _load_plan(store: SidecarStore, recommendation_id: str) -> tuple[FactRecord, MutationPlan]:
+    fact = _require_accepted_recommendation(store, recommendation_id)
+    plan = _read_mutation(fact)
+    if isinstance(plan, ResequenceMutation):
+        raise VizError(
+            ErrorCode.APPLY_RESEQUENCE_NOT_SUPPORTED,
+            f"recommendation {recommendation_id!r} is a resequence recommendation: "
+            "ruling-needed, never one-click -- the work facade has no resequence verb "
+            "(spec §5.7); refused before touching the tracker",
+            detail={"fact_id": recommendation_id, "reason": plan.reason},
+        )
+    return fact, plan
+
+
+def _audit_note(fact: FactRecord, *, now: str) -> str:
+    return (
+        f"agent-recommendation-applied: {now} "
+        f"(recommendation {fact.fact_id}, basis {fact.basis_hash})"
+    )
+
+
+def _append_audit_notes(
+    port: TrackerPort, bead_ids: Sequence[str], fact: FactRecord, *, now: str
+) -> None:
+    if not bead_ids:
+        return
+    note = _audit_note(fact, now=now)
+    for bead_id in bead_ids:
+        port.append_note(bead_id, note)
+
+
+# ---- live execution per mutation class --------------------------------------
+
+
+def _execute_mint(
+    port: TrackerPort, fact: FactRecord, plan: MintBeadMutation
+) -> tuple[FactRecord, JsonValue, tuple[str, ...]]:
+    existing_id = _read_mint_ledger(fact)
+    if existing_id is not None:
+        data: JsonValue = {"kind": _MINT_BEAD_KIND, "bead_id": existing_id, "already_applied": True}
+        return fact, data, ()
+    bead_id = port.mint_bead(
+        plan.noun,
+        plan.title,
+        parent=plan.parent,
+        orphan=plan.orphan,
+        description=plan.description,
+        priority=plan.priority,
+        acceptance=plan.acceptance,
+    )
+    updated_fact = replace(
+        fact, payload={**fact.payload, _APPLICATION_PAYLOAD_KEY: {"bead_id": bead_id}}
+    )
+    data = {"kind": _MINT_BEAD_KIND, "bead_id": bead_id, "already_applied": False}
+    return updated_fact, data, (bead_id,)
+
+
+def _execute_add_edge(
+    store: SidecarStore, port: TrackerPort, fact: FactRecord, plan: AddEdgeMutation
+) -> tuple[JsonValue, tuple[str, ...]]:
+    if plan.edge_kind == "blocks":
+        _check_blocks_cycle(store, port, fact, plan)
+    port.add_edge(plan.from_bead, plan.to_bead, plan.edge_kind)
+    data: JsonValue = {
+        "kind": _ADD_EDGE_KIND,
+        "from_bead": plan.from_bead,
+        "to_bead": plan.to_bead,
+        "edge_kind": plan.edge_kind,
+    }
+    return data, (plan.from_bead, plan.to_bead)
+
+
+def _execute_relabel(port: TrackerPort, plan: RelabelMutation) -> tuple[JsonValue, tuple[str, ...]]:
+    port.relabel(plan.bead_id, plan.labels, remove=plan.remove)
+    data: JsonValue = {
+        "kind": _RELABEL_KIND,
+        "bead_id": plan.bead_id,
+        "labels": list(plan.labels),
+        "remove": plan.remove,
+    }
+    return data, (plan.bead_id,)
+
+
+def _apply_live(store: SidecarStore, port: TrackerPort, recommendation_id: str) -> JsonValue:
+    fact, plan = _load_plan(store, recommendation_id)
+    now = datetime.now(UTC).isoformat()
+
+    if isinstance(plan, MintBeadMutation):
+        updated_fact, data, touched = _execute_mint(port, fact, plan)
+        if updated_fact is not fact:
+            # Persisted the INSTANT mint_bead returns an id, before the audit
+            # note -- see the module docstring's "mint's ledger-ordering
+            # decision": mint_bead is not repeatable, so nothing fallible may
+            # run before this write commits.
+            store.write_recommendations(
+                tuple(
+                    updated_fact if record.fact_id == recommendation_id else record
+                    for record in store.read_recommendations()
+                )
+            )
+        _append_audit_notes(port, touched, fact, now=now)
+    elif isinstance(plan, AddEdgeMutation):
+        data, touched = _execute_add_edge(store, port, fact, plan)
+        _append_audit_notes(port, touched, fact, now=now)
+    elif isinstance(plan, RelabelMutation):
+        data, touched = _execute_relabel(port, plan)
+        _append_audit_notes(port, touched, fact, now=now)
+    else:
+        raise TypeError(plan)
+
+    return {"fact_id": recommendation_id, "dry_run": False, "mutation": data}
+
+
+# ---- dry-run preview per mutation class -------------------------------------
+
+
+def _preview_mint(fact: FactRecord, plan: MintBeadMutation) -> JsonValue:
+    existing_id = _read_mint_ledger(fact)
+    if existing_id is not None:
+        return {
+            "kind": _MINT_BEAD_KIND,
+            "bead_id": existing_id,
+            "already_applied": True,
+            "tracker_writes": [],
+        }
+    return {
+        "kind": _MINT_BEAD_KIND,
+        "already_applied": False,
+        "tracker_writes": [
+            {
+                "op": "mint_bead",
+                "noun": plan.noun,
+                "title": plan.title,
+                "parent": plan.parent,
+                "orphan": plan.orphan,
+            }
+        ],
+    }
+
+
+def _preview_add_edge(
+    store: SidecarStore, port: TrackerPort, fact: FactRecord, plan: AddEdgeMutation
+) -> JsonValue:
+    if plan.edge_kind == "blocks":
+        _check_blocks_cycle(store, port, fact, plan)
+    return {
+        "kind": _ADD_EDGE_KIND,
+        "from_bead": plan.from_bead,
+        "to_bead": plan.to_bead,
+        "edge_kind": plan.edge_kind,
+        "tracker_writes": [
+            {
+                "op": "add_edge",
+                "from_bead": plan.from_bead,
+                "to_bead": plan.to_bead,
+                "kind": plan.edge_kind,
+            },
+            {"op": "append_note", "bead_id": plan.from_bead},
+            {"op": "append_note", "bead_id": plan.to_bead},
+        ],
+    }
+
+
+def _preview_relabel(plan: RelabelMutation) -> JsonValue:
+    return {
+        "kind": _RELABEL_KIND,
+        "bead_id": plan.bead_id,
+        "labels": list(plan.labels),
+        "remove": plan.remove,
+        "tracker_writes": [
+            {
+                "op": "relabel",
+                "bead_id": plan.bead_id,
+                "labels": list(plan.labels),
+                "remove": plan.remove,
+            },
+            {"op": "append_note", "bead_id": plan.bead_id},
+        ],
+    }
+
+
+def _apply_dry_run(store: SidecarStore, port: TrackerPort, recommendation_id: str) -> JsonValue:
+    fact, plan = _load_plan(store, recommendation_id)
+
+    if isinstance(plan, MintBeadMutation):
+        preview = _preview_mint(fact, plan)
+    elif isinstance(plan, AddEdgeMutation):
+        preview = _preview_add_edge(store, port, fact, plan)
+    elif isinstance(plan, RelabelMutation):
+        preview = _preview_relabel(plan)
+    else:
+        raise TypeError(plan)
+
+    return {"fact_id": recommendation_id, "dry_run": True, "mutation": preview}
+
+
+# ---- the verb ----------------------------------------------------------------
+
+
+def apply(runners: Runners, args: Namespace) -> JsonValue:
+    """Handle `viz apply <recommendation-id> [--dry-run]`."""
+    recommendation_id: str = args.recommendation_id
+    dry_run: bool = bool(args.dry_run)
+    port = TrackerPort(runners.tracker)
+    store = SidecarStore(Path.cwd())
+
+    if dry_run:
+        return _apply_dry_run(store, port, recommendation_id)
+    with store.transaction():
+        return _apply_live(store, port, recommendation_id)

--- a/packages/vizsuite/src/vizsuite/verbs/apply.py
+++ b/packages/vizsuite/src/vizsuite/verbs/apply.py
@@ -213,7 +213,9 @@ def _parse_relabel(fields: dict[str, JsonValue]) -> RelabelMutation:
 
 
 def _parse_resequence(fields: dict[str, JsonValue]) -> ResequenceMutation:
-    reason = _as_str_field(fields.pop("reason", ""))
+    if "reason" not in fields:
+        raise _MalformedMutationShapeError
+    reason = _as_str_field(fields.pop("reason"))
     if fields:
         raise _MalformedMutationShapeError
     return ResequenceMutation(reason=reason)
@@ -482,6 +484,9 @@ def _preview_mint(fact: FactRecord, plan: MintBeadMutation) -> JsonValue:
                 "title": plan.title,
                 "parent": plan.parent,
                 "orphan": plan.orphan,
+                "description": plan.description,
+                "priority": plan.priority,
+                "acceptance": plan.acceptance,
             }
         ],
     }

--- a/packages/vizsuite/src/vizsuite/verbs/apply.py
+++ b/packages/vizsuite/src/vizsuite/verbs/apply.py
@@ -172,6 +172,13 @@ def _parse_mint_bead(fields: dict[str, JsonValue]) -> MintBeadMutation:
     acceptance = _as_optional_str_field(fields.pop("acceptance", None))
     if fields:
         raise _MalformedMutationShapeError
+    # Exactly one bead anchor: `TrackerPort.mint_bead`'s argv builder
+    # prioritizes `--orphan`, so a plan carrying BOTH would silently drop
+    # `parent` before the facade could refuse the conflict; a plan carrying
+    # NEITHER is knowable-bad at parse time (refusing here beats a
+    # tracker-side `E_USAGE` surfacing as a backend error mid-apply).
+    if (parent is not None) == orphan:
+        raise _MalformedMutationShapeError
     return MintBeadMutation(
         noun=noun,
         title=title,
@@ -294,7 +301,14 @@ def _dependency_sidecar_edges(
                 detail={"fact_id": record.fact_id},
             )
         from_bead, to_bead = raw.get("from_bead"), raw.get("to_bead")
-        if not (isinstance(from_bead, str) and isinstance(to_bead, str)):
+        tracker_edge_kind = raw.get("tracker_edge_kind")
+        if not (
+            isinstance(from_bead, str)
+            and isinstance(to_bead, str)
+            and tracker_edge_kind in ("blocks", "related-to")
+        ):
+            # Same allowed-kind set as verdict.py's ledger parser -- the two
+            # verbs must agree on what a valid promotion ledger looks like.
             raise VizError(
                 ErrorCode.SIDECAR_MALFORMED,
                 "a fact's promotion ledger entry is not valid",

--- a/packages/vizsuite/tests/unit/test_verbs_apply.py
+++ b/packages/vizsuite/tests/unit/test_verbs_apply.py
@@ -847,6 +847,51 @@ def test_add_edge_cycle_check_refuses_as_malformed_when_another_promoted_ledger_
     assert tracker.calls == []
 
 
+def test_add_edge_cycle_check_refuses_a_promoted_ledger_with_an_unknown_edge_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Same strictness as verdict.py's ledger parser: a hand-edited/corrupt
+    # `tracker_edge_kind` outside {"blocks", "related-to"} must refuse, not
+    # silently feed the cycle check.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges(
+        (
+            _edge_fact(
+                "edge-corrupt",
+                payload={
+                    "promotion": {
+                        "from_bead": "x",
+                        "to_bead": "y",
+                        "tracker_edge_kind": "sideways",
+                    }
+                },
+            ),
+        )
+    )
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
 def test_add_edge_raises_on_an_unrecognized_cycle_check_result(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1238,6 +1283,35 @@ def test_apply_refuses_an_unrecognized_mutation_kind(
 
     assert exit_code == 1
     assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        # Both anchors set: TrackerPort.mint_bead's argv builder prioritizes
+        # --orphan, so the facade would never see the conflicting --parent --
+        # the silent drop must refuse at the shape boundary instead.
+        {"kind": "mint_bead", "noun": "task", "title": "T", "parent": "epic-1", "orphan": True},
+        # Neither anchor set: knowable at parse time; refusing here beats a
+        # tracker-side E_USAGE surfacing as a backend error mid-apply.
+        {"kind": "mint_bead", "noun": "task", "title": "T"},
+    ],
+    ids=["both-parent-and-orphan", "neither-parent-nor-orphan"],
+)
+def test_apply_refuses_a_mint_payload_without_exactly_one_bead_anchor(
+    mutation: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation=mutation),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
 
 
 @pytest.mark.parametrize(

--- a/packages/vizsuite/tests/unit/test_verbs_apply.py
+++ b/packages/vizsuite/tests/unit/test_verbs_apply.py
@@ -1,0 +1,1467 @@
+"""`viz apply <recommendation-id> [--dry-run]` — gated, idempotent one-click
+mutation execution (spec §5.7/§10 test items 14/17).
+
+`viz apply` refuses any recommendation without a recorded Tier-3 ACCEPTED
+verdict for that exact fact id (typed `E_APPLY_NOT_ACCEPTED` refusal — a
+reject/dismiss verdict, no verdict at all, or a verdict recorded against a
+*different* fact id all refuse identically). A recommendation id absent from
+`recommendations.json` is the existing `E_NOT_FOUND` refusal. The
+recommendation's `payload["mutation"]` carries a typed mutation plan (`kind`:
+`mint_bead` | `add_edge` | `relabel` | `resequence`) parsed with the same
+strictness as `verdict.py`'s `_parse_ledger_payload` — an unrecognized kind,
+a missing required field, an extra unknown field, or a wrong field type all
+refuse as `E_SIDECAR_MALFORMED`.
+
+`add_edge` writing a `blocks` edge runs `cycle_guard.find_cycle` over the full
+accepted logical dependency graph (beads `blocks` edges plus every
+already-promoted `dependency`-kind fact in `edges.json`) before any tracker
+write, refusing as `E_APPLY_CYCLE_REFUSAL` with no mutation on a would-be
+cycle. `resequence` is refused as `E_APPLY_RESEQUENCE_NOT_SUPPORTED` before
+the tracker runner is ever touched (spec: `ruling-needed`, never `one-click`).
+
+Idempotency differs by mutation class: `add_edge`/`relabel` re-issue their
+tracker call on every replay and converge because the backend upserts are
+idempotent (`work dep add`/`work label add`); `mint_bead` is NOT idempotent at
+the backend (`work create` would mint a second bead), so it is keyed on a
+`payload["application"]` ledger entry recording the minted bead id — replay
+finds the ledger and is a pure no-op, never touching the tracker again. That
+ledger is persisted the instant `mint_bead` returns an id and BEFORE the
+audit-note append (unlike edge promotion's tracker-writes-then-ledger-last
+ordering) precisely because the mint call itself cannot be safely repeated;
+see `test_mint_...` below for the crash-window behavior this ordering buys.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedTrackerRunner, tracker_error, tracker_ok, tracker_show_ok
+from vizsuite.scene.model import Freshness, Provenance, ProvenanceKind
+from vizsuite.sidecar.models import FactRecord, MatchingDescriptor, Verdict, VerdictRecord
+from vizsuite.sidecar.store import SidecarStore
+
+_NOW = "2026-07-15T09:30:00+00:00"
+
+
+def _recommendation(
+    fact_id: str,
+    *,
+    mutation: dict[str, Any] | None,
+    payload_extra: dict[str, Any] | None = None,
+    basis_hash: str = "basis-1",
+) -> FactRecord:
+    payload: dict[str, Any] = {}
+    if mutation is not None:
+        payload["mutation"] = mutation
+    if payload_extra:
+        payload.update(payload_extra)
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(plan_pair=("plan-a", "plan-b"), kind="guardrail"),
+        basis_hash=basis_hash,
+        provenance=Provenance(
+            kind=ProvenanceKind.INFERRED, freshness=Freshness.FRESH, citations=("spec:5.7",)
+        ),
+        payload=payload,
+    )
+
+
+def _edge_fact(
+    fact_id: str,
+    *,
+    kind: str = "dependency",
+    endpoint_bead_ids: tuple[tuple[str, ...], ...] = (("x",), ("y",)),
+    payload: dict[str, Any] | None = None,
+) -> FactRecord:
+    return FactRecord(
+        fact_id=fact_id,
+        matching_descriptor=MatchingDescriptor(
+            plan_pair=("plan-a", "plan-b"), kind=kind, endpoint_bead_ids=endpoint_bead_ids
+        ),
+        basis_hash="basis-1",
+        provenance=Provenance(
+            kind=ProvenanceKind.ACCEPTED, freshness=Freshness.FRESH, citations=("spec:5.3",)
+        ),
+        payload=dict(payload) if payload is not None else {},
+    )
+
+
+def _accept(store: SidecarStore, fact_id: str, *, basis_hash: str = "basis-1") -> None:
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id=fact_id, fact_id=fact_id, verdict=Verdict.ACCEPT, basis_hash=basis_hash
+        )
+    )
+
+
+def _apply_module() -> Any:
+    # String-target setattr would resolve `vizsuite.verbs.apply` to the
+    # *function* re-exported by `verbs/__init__` -- patch the submodule object
+    # directly (the established gotcha, see test_verbs_verdict.py).
+    return importlib.import_module("vizsuite.verbs.apply")
+
+
+def _freeze_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_apply_module(), "datetime", _make_fixed_datetime())
+
+
+def _note_text(recommendation_id: str, basis_hash: str) -> str:
+    return (
+        f"agent-recommendation-applied: {_NOW} "
+        f"(recommendation {recommendation_id}, basis {basis_hash})"
+    )
+
+
+def _make_fixed_datetime() -> Any:
+    from datetime import UTC, datetime
+
+    class _FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # noqa: ARG003 - mirrors datetime.now's signature
+            return datetime(2026, 7, 15, 9, 30, tzinfo=UTC)
+
+    return _FixedDatetime
+
+
+# ── gating: no verdict / wrong verdict / verdict for a different fact ──────
+
+
+def test_apply_refuses_a_recommendation_with_no_recorded_verdict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation={"kind": "resequence"}),))
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_NOT_ACCEPTED"
+    assert tracker.calls == []
+
+
+@pytest.mark.parametrize("verdict_value", [Verdict.REJECT, Verdict.DISMISS])
+def test_apply_refuses_a_recommendation_with_a_reject_or_dismiss_verdict(
+    verdict_value: Verdict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation={"kind": "resequence"}),))
+    store.upsert_verdict(
+        VerdictRecord(
+            verdict_id="rec-1", fact_id="rec-1", verdict=verdict_value, basis_hash="basis-1"
+        )
+    )
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_NOT_ACCEPTED"
+    assert tracker.calls == []
+
+
+def test_apply_refuses_when_the_only_accepted_verdict_is_for_a_different_fact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation("rec-1", mutation={"kind": "resequence"}),
+            _recommendation("rec-2", mutation={"kind": "resequence"}),
+        )
+    )
+    _accept(store, "rec-2")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_NOT_ACCEPTED"
+    assert tracker.calls == []
+
+
+def test_apply_on_an_unknown_recommendation_id_is_a_typed_not_found_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "ghost"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_NOT_FOUND"
+    assert tracker.calls == []
+
+
+# ── resequence: refused before touching the runner ──────────────────────────
+
+
+def test_resequence_is_refused_before_touching_the_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (_recommendation("rec-1", mutation={"kind": "resequence", "reason": "dep unscheduled"}),)
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_RESEQUENCE_NOT_SUPPORTED"
+    assert tracker.calls == []
+
+
+def test_resequence_dry_run_is_also_refused_before_touching_the_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (_recommendation("rec-1", mutation={"kind": "resequence", "reason": "dep unscheduled"}),)
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_RESEQUENCE_NOT_SUPPORTED"
+    assert tracker.calls == []
+
+
+# ── mint_bead: fresh mint, idempotent replay, partial-failure ordering ─────
+
+
+def test_mint_bead_mints_a_fresh_bead_and_records_the_ledger_and_audit_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "mint_bead",
+                    "noun": "task",
+                    "title": "Extract shared slice",
+                    "parent": "epic-1",
+                    "orphan": False,
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            ("create", "task", "--title", "Extract shared slice", "--parent", "epic-1"): (
+                tracker_ok({"id": "bead-new"})
+            ),
+            ("note", "bead-new", note): tracker_ok(None),
+        }
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    mutation = envelope["data"]["mutation"]
+    assert mutation == {"kind": "mint_bead", "bead_id": "bead-new", "already_applied": False}
+    assert ("note", "bead-new", note) in tracker.calls
+    (updated,) = store.read_recommendations()
+    assert updated.payload["application"] == {"bead_id": "bead-new"}
+
+
+def test_mint_bead_replay_is_idempotent_no_second_mint_no_second_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    create_argv = ("create", "task", "--title", "T", "--orphan")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            create_argv: tracker_ok({"id": "bead-new"}),
+            ("note", "bead-new", note): tracker_ok(None),
+        }
+    )
+
+    first_exit, first_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+    second_exit, second_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert first_envelope["data"]["mutation"]["already_applied"] is False
+    assert second_envelope["data"]["mutation"]["already_applied"] is True
+    assert tracker.calls.count(create_argv) == 1
+    assert tracker.calls.count(("note", "bead-new", note)) == 1
+
+
+def test_mint_bead_partial_failure_persists_the_ledger_before_the_note_and_never_remints_on_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The crash-window decision this slice makes: `work create` is NOT
+    idempotent at the backend (unlike `dep add`/`label add`), so re-issuing it
+    on replay would mint a SECOND bead. The ledger is therefore persisted the
+    instant `mint_bead` returns an id -- before the audit-note append -- so a
+    failure on the note (the only fallible step left after a successful mint)
+    never leaves the ledger unwritten. Replay then finds the ledger and treats
+    the mint as already done (never re-attempting the mint OR the note, mirror
+    -ing verdict.py's `_AlreadyPromoted` no-op contract) -- the accepted
+    residual cost is that a note lost to this exact failure window never gets
+    a second attempt, in exchange for an ironclad no-duplicate-mint guarantee.
+    """
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    create_argv = ("create", "task", "--title", "T", "--orphan")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            create_argv: tracker_ok({"id": "bead-new"}),
+            ("note", "bead-new", note): tracker_error("E_NOT_FOUND", "no such bead: bead-new"),
+        }
+    )
+
+    first_exit, first_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert first_exit == 1
+    assert first_envelope["error"]["code"] == "E_TRACKER_BACKEND_ERROR"
+    # The ledger DID persist despite the overall failure: mint succeeded and
+    # is recorded before the (fallible) note append was even attempted.
+    (after_first,) = store.read_recommendations()
+    assert after_first.payload["application"] == {"bead_id": "bead-new"}
+
+    second_exit, second_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert second_exit == 0
+    assert second_envelope["data"]["mutation"] == {
+        "kind": "mint_bead",
+        "bead_id": "bead-new",
+        "already_applied": True,
+    }
+    # Exactly ONE create call across both attempts -- mint is never retried.
+    assert tracker.calls.count(create_argv) == 1
+
+
+def test_mint_bead_create_call_failure_leaves_the_ledger_unwritten_and_is_safe_to_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Contrast case: when `mint_bead`'s OWN tracker call fails cleanly (the
+    backend answers `ok:false`, so we know FOR CERTAIN no bead was created),
+    nothing is written to the ledger at all, and a retry is unconditionally
+    safe to attempt the mint again."""
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    create_argv = ("create", "task", "--title", "T", "--orphan")
+    tracker = ScriptedTrackerRunner(
+        responses={create_argv: tracker_error("E_USAGE", "title is required")}
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_TRACKER_BACKEND_ERROR"
+    (unchanged,) = store.read_recommendations()
+    assert "application" not in unchanged.payload
+
+
+def test_mint_bead_optional_fields_are_passed_through_to_the_tracker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "mint_bead",
+                    "noun": "task",
+                    "title": "T",
+                    "parent": "epic-1",
+                    "description": "desc",
+                    "priority": "p1",
+                    "acceptance": "AC",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    create_argv = (
+        "create",
+        "task",
+        "--title",
+        "T",
+        "--parent",
+        "epic-1",
+        "--description",
+        "desc",
+        "--priority",
+        "p1",
+        "--acceptance",
+        "AC",
+    )
+    tracker = ScriptedTrackerRunner(
+        responses={
+            create_argv: tracker_ok({"id": "bead-new"}),
+            ("note", "bead-new", note): tracker_ok(None),
+        }
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["mutation"]["bead_id"] == "bead-new"
+
+
+# ── mint_bead: dry-run ──────────────────────────────────────────────────────
+
+
+def test_dry_run_previews_a_fresh_mint_with_zero_tracker_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    rec = _recommendation(
+        "rec-1", mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True}
+    )
+    store.write_recommendations((rec,))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert data["dry_run"] is True
+    preview = data["mutation"]
+    assert preview["kind"] == "mint_bead"
+    assert preview["already_applied"] is False
+    assert preview["tracker_writes"]
+    assert tracker.calls == []
+    assert store.read_recommendations() == (rec,)
+
+
+def test_dry_run_previews_an_already_minted_recommendation_as_a_no_op(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+                payload_extra={"application": {"bead_id": "bead-existing"}},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    preview = envelope["data"]["mutation"]
+    assert preview == {
+        "kind": "mint_bead",
+        "bead_id": "bead-existing",
+        "already_applied": True,
+        "tracker_writes": [],
+    }
+    assert tracker.calls == []
+
+
+def test_dry_run_never_enters_a_sidecar_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    setup_store = SidecarStore(tmp_path)
+    setup_store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(setup_store, "rec-1")
+    monkeypatch.chdir(tmp_path)
+    tracker = ScriptedTrackerRunner()
+
+    def _explode(_self: SidecarStore) -> None:
+        raise AssertionError("dry-run must never acquire the sidecar transaction lock")
+
+    monkeypatch.setattr(SidecarStore, "transaction", _explode)
+
+    exit_code, _envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+
+
+# ── add_edge: fresh write, cycle guard, idempotent convergence ─────────────
+
+
+def test_add_edge_writes_a_blocks_edge_and_appends_audit_notes_to_both_beads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "bead-a",
+                    "to_bead": "bead-b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        show_results={"bead-b": tracker_show_ok("bead-b", deps=[])},
+        responses={
+            ("dep", "add", "bead-a", "bead-b", "--type", "blocks"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+            ("note", "bead-b", note): tracker_ok(None),
+        },
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["mutation"] == {
+        "kind": "add_edge",
+        "from_bead": "bead-a",
+        "to_bead": "bead-b",
+        "edge_kind": "blocks",
+    }
+    note_calls = {call[1]: call[2] for call in tracker.calls if call[0] == "note"}
+    assert note_calls == {"bead-a": note, "bead-b": note}
+
+
+def test_add_edge_related_to_writes_directly_without_a_cycle_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "bead-a",
+                    "to_bead": "bead-b",
+                    "edge_kind": "related-to",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    # No show_results scripted at all -- a cycle-check read would raise.
+    tracker = ScriptedTrackerRunner(
+        responses={
+            ("dep", "add", "bead-a", "bead-b", "--type", "related-to"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+            ("note", "bead-b", note): tracker_ok(None),
+        }
+    )
+
+    exit_code, _envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert not any(call[0] == "show" for call in tracker.calls)
+
+
+def test_add_edge_replay_reissues_the_tracker_call_and_converges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "bead-a",
+                    "to_bead": "bead-b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        show_results={"bead-b": tracker_show_ok("bead-b", deps=[])},
+        responses={
+            ("dep", "add", "bead-a", "bead-b", "--type", "blocks"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+            ("note", "bead-b", note): tracker_ok(None),
+        },
+    )
+
+    first_exit, _first_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+    second_exit, second_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert tracker.calls.count(("dep", "add", "bead-a", "bead-b", "--type", "blocks")) == 2
+    assert second_envelope["data"]["mutation"]["edge_kind"] == "blocks"
+
+
+def test_add_edge_refuses_a_blocks_write_that_would_close_a_cycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner(
+        show_results={"b": tracker_show_ok("b", deps=[("a", "blocks", "open")])}
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_CYCLE_REFUSAL"
+    assert envelope["error"]["detail"]["cycle"] == ["a", "b", "a"]
+    assert not any(call[0] == "dep" for call in tracker.calls)
+    assert not any(call[0] == "note" for call in tracker.calls)
+
+
+def test_add_edge_cycle_check_gathers_other_promoted_dependency_edges_and_skips_others(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    already_promoted = _edge_fact(
+        "edge-2",
+        endpoint_bead_ids=(("x",), ("y",)),
+        payload={"promotion": {"from_bead": "x", "to_bead": "y", "tracker_edge_kind": "blocks"}},
+    )
+    unpromoted = _edge_fact("edge-3", endpoint_bead_ids=(("m",), ("n",)))
+    unrelated_conflict = _edge_fact("edge-4", kind="conflict", endpoint_bead_ids=(("p",), ("q",)))
+    store.write_edges((already_promoted, unpromoted, unrelated_conflict))
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        show_results={"b": tracker_show_ok("b", deps=[])},
+        responses={
+            ("dep", "add", "a", "b", "--type", "blocks"): tracker_ok(None),
+            ("note", "a", note): tracker_ok(None),
+            ("note", "b", note): tracker_ok(None),
+        },
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["mutation"]["edge_kind"] == "blocks"
+
+
+def test_add_edge_cycle_check_refuses_as_malformed_when_another_promoted_ledger_is_not_a_dict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges((_edge_fact("edge-corrupt", payload={"promotion": "not-a-dict"}),))
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+def test_add_edge_cycle_check_refuses_as_malformed_when_another_promoted_ledger_has_bad_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_edges(
+        (
+            _edge_fact(
+                "edge-corrupt",
+                payload={
+                    "promotion": {"from_bead": 1, "to_bead": "y", "tracker_edge_kind": "blocks"}
+                },
+            ),
+        )
+    )
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+def test_add_edge_raises_on_an_unrecognized_cycle_check_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_apply_module(), "find_cycle", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+# ── add_edge: dry-run ────────────────────────────────────────────────────
+
+
+def test_dry_run_previews_add_edge_running_the_cycle_check_read_with_zero_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "bead-a",
+                    "to_bead": "bead-b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner(show_results={"bead-b": tracker_show_ok("bead-b", deps=[])})
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    preview = envelope["data"]["mutation"]
+    assert preview["tracker_writes"]
+    assert any(call[0] == "show" for call in tracker.calls)
+    assert not any(call[0] == "dep" for call in tracker.calls)
+    assert not any(call[0] == "note" for call in tracker.calls)
+
+
+def test_dry_run_previews_add_edge_related_to_without_a_cycle_check_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "bead-a",
+                    "to_bead": "bead-b",
+                    "edge_kind": "related-to",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    # No show_results scripted at all -- a cycle-check read would raise.
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    preview = envelope["data"]["mutation"]
+    assert preview["edge_kind"] == "related-to"
+    assert preview["tracker_writes"]
+    assert tracker.calls == []
+
+
+def test_dry_run_add_edge_refuses_on_a_would_be_cycle_identically_to_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner(
+        show_results={"b": tracker_show_ok("b", deps=[("a", "blocks", "open")])}
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_APPLY_CYCLE_REFUSAL"
+
+
+def test_dry_run_add_edge_raises_on_an_unrecognized_cycle_check_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "blocks",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_apply_module(), "find_cycle", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+# ── relabel: fresh, idempotent convergence, dry-run ─────────────────────────
+
+
+def test_relabel_adds_a_label_and_appends_an_audit_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "relabel",
+                    "bead_id": "bead-a",
+                    "labels": ["guardrail"],
+                    "remove": False,
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            ("label", "add", "bead-a", "guardrail"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+        }
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["mutation"] == {
+        "kind": "relabel",
+        "bead_id": "bead-a",
+        "labels": ["guardrail"],
+        "remove": False,
+    }
+    assert ("note", "bead-a", note) in tracker.calls
+
+
+def test_relabel_remove_calls_the_remove_action(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "relabel",
+                    "bead_id": "bead-a",
+                    "labels": ["stale"],
+                    "remove": True,
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            ("label", "remove", "bead-a", "stale"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+        }
+    )
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    assert envelope["data"]["mutation"]["remove"] is True
+
+
+def test_relabel_replay_reissues_the_tracker_call_and_converges(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    _freeze_clock(monkeypatch)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "relabel",
+                    "bead_id": "bead-a",
+                    "labels": ["guardrail"],
+                    "remove": False,
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    note = _note_text("rec-1", "basis-1")
+    tracker = ScriptedTrackerRunner(
+        responses={
+            ("label", "add", "bead-a", "guardrail"): tracker_ok(None),
+            ("note", "bead-a", note): tracker_ok(None),
+        }
+    )
+
+    first_exit, _first_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+    second_exit, _second_envelope, _ = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert first_exit == 0
+    assert second_exit == 0
+    assert tracker.calls.count(("label", "add", "bead-a", "guardrail")) == 2
+
+
+def test_dry_run_previews_relabel_with_zero_tracker_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "relabel",
+                    "bead_id": "bead-a",
+                    "labels": ["guardrail"],
+                    "remove": False,
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 0
+    preview = envelope["data"]["mutation"]
+    assert preview["tracker_writes"]
+    assert tracker.calls == []
+
+
+# ── unrecognized mutation-plan type (exhaustiveness else-raise) ────────────
+
+
+def test_apply_raises_on_an_unrecognized_mutation_plan_type_live(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_apply_module(), "_read_mutation", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+def test_apply_raises_on_an_unrecognized_mutation_plan_type_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+    monkeypatch.setattr(_apply_module(), "_read_mutation", lambda *_a, **_kw: object())
+
+    exit_code, envelope, stderr = run_cli(["apply", "rec-1", "--dry-run"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_INTERNAL"
+    assert "TypeError" in stderr
+
+
+# ── malformed mutation payload shapes ────────────────────────────────────────
+
+
+def test_apply_refuses_a_recommendation_whose_payload_has_no_mutation_key_at_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation=None),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_a_mutation_payload_that_is_not_an_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (_recommendation("rec-1", mutation=None, payload_extra={"mutation": "not-an-object"}),)
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_an_unrecognized_mutation_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation={"kind": "levitate"}),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"kind": "mint_bead", "title": "T"},
+        {"kind": "add_edge", "to_bead": "b", "edge_kind": "blocks"},
+        {"kind": "relabel", "labels": ["x"]},
+    ],
+    ids=["mint_bead-missing-noun", "add_edge-missing-from_bead", "relabel-missing-bead_id"],
+)
+def test_apply_refuses_a_mutation_payload_missing_a_required_field(
+    mutation: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation=mutation),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True, "bogus": 1},
+        {
+            "kind": "add_edge",
+            "from_bead": "a",
+            "to_bead": "b",
+            "edge_kind": "blocks",
+            "bogus": 1,
+        },
+        {"kind": "relabel", "bead_id": "a", "labels": ["x"], "bogus": 1},
+        {"kind": "resequence", "reason": "x", "bogus": 1},
+    ],
+    ids=["mint_bead-extra", "add_edge-extra", "relabel-extra", "resequence-extra"],
+)
+def test_apply_refuses_a_mutation_payload_with_an_unknown_extra_field(
+    mutation: dict[str, Any], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation=mutation),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+def test_apply_refuses_mint_bead_with_a_non_bool_orphan_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": "yes"},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_mint_bead_with_a_non_string_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "parent": 42},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_add_edge_with_an_invalid_edge_kind_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={
+                    "kind": "add_edge",
+                    "from_bead": "a",
+                    "to_bead": "b",
+                    "edge_kind": "sideways",
+                },
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_relabel_with_an_empty_labels_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (_recommendation("rec-1", mutation={"kind": "relabel", "bead_id": "a", "labels": []}),)
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_relabel_with_a_non_string_labels_item(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1", mutation={"kind": "relabel", "bead_id": "a", "labels": ["ok", 5]}
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_relabel_with_a_non_bool_remove_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "relabel", "bead_id": "a", "labels": ["x"], "remove": "yes"},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+def test_apply_refuses_resequence_with_a_non_string_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (_recommendation("rec-1", mutation={"kind": "resequence", "reason": 42}),)
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+
+
+# ── malformed mint-application ledger ────────────────────────────────────────
+
+
+def test_apply_refuses_a_mint_application_ledger_that_is_not_an_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+                payload_extra={"application": "not-an-object"},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+def test_apply_refuses_a_mint_application_ledger_whose_bead_id_is_not_a_string(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations(
+        (
+            _recommendation(
+                "rec-1",
+                mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True},
+                payload_extra={"application": {"bead_id": 42}},
+            ),
+        )
+    )
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
+# ── CLI usage ────────────────────────────────────────────────────────────────
+
+
+def test_apply_rejects_missing_positional_argument_as_a_usage_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    exit_code, envelope, _stderr = run_cli(["apply"], tracker_runner=ScriptedTrackerRunner())
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_USAGE"

--- a/packages/vizsuite/tests/unit/test_verbs_apply.py
+++ b/packages/vizsuite/tests/unit/test_verbs_apply.py
@@ -240,6 +240,26 @@ def test_resequence_dry_run_is_also_refused_before_touching_the_runner(
     assert tracker.calls == []
 
 
+def test_apply_refuses_a_resequence_payload_missing_its_reason_as_malformed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # "reason" is a REQUIRED field of the resequence shape (same strict-shape
+    # contract as every other mutation class's required fields): a
+    # reason-less resequence recommendation is a producer bug, refused as
+    # malformed rather than defaulted to an empty rationale.
+    monkeypatch.chdir(tmp_path)
+    store = SidecarStore(tmp_path)
+    store.write_recommendations((_recommendation("rec-1", mutation={"kind": "resequence"}),))
+    _accept(store, "rec-1")
+    tracker = ScriptedTrackerRunner()
+
+    exit_code, envelope, _stderr = run_cli(["apply", "rec-1"], tracker_runner=tracker)
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == "E_SIDECAR_MALFORMED"
+    assert tracker.calls == []
+
+
 # ── mint_bead: fresh mint, idempotent replay, partial-failure ordering ─────
 
 
@@ -328,8 +348,8 @@ def test_mint_bead_partial_failure_persists_the_ledger_before_the_note_and_never
     instant `mint_bead` returns an id -- before the audit-note append -- so a
     failure on the note (the only fallible step left after a successful mint)
     never leaves the ledger unwritten. Replay then finds the ledger and treats
-    the mint as already done (never re-attempting the mint OR the note, mirror
-    -ing verdict.py's `_AlreadyPromoted` no-op contract) -- the accepted
+    the mint as already done (never re-attempting the mint OR the note,
+    mirroring verdict.py's `_AlreadyPromoted` no-op contract) -- the accepted
     residual cost is that a note lost to this exact failure window never gets
     a second attempt, in exchange for an ironclad no-duplicate-mint guarantee.
     """
@@ -466,7 +486,16 @@ def test_dry_run_previews_a_fresh_mint_with_zero_tracker_calls(
     monkeypatch.chdir(tmp_path)
     store = SidecarStore(tmp_path)
     rec = _recommendation(
-        "rec-1", mutation={"kind": "mint_bead", "noun": "task", "title": "T", "orphan": True}
+        "rec-1",
+        mutation={
+            "kind": "mint_bead",
+            "noun": "task",
+            "title": "T",
+            "orphan": True,
+            "description": "why this bead",
+            "priority": "P2",
+            "acceptance": "done when green",
+        },
     )
     store.write_recommendations((rec,))
     _accept(store, "rec-1")
@@ -480,7 +509,20 @@ def test_dry_run_previews_a_fresh_mint_with_zero_tracker_calls(
     preview = data["mutation"]
     assert preview["kind"] == "mint_bead"
     assert preview["already_applied"] is False
-    assert preview["tracker_writes"]
+    # The preview is EXACT: every field live execution would pass to
+    # mint_bead appears, optional ones included.
+    assert preview["tracker_writes"] == [
+        {
+            "op": "mint_bead",
+            "noun": "task",
+            "title": "T",
+            "parent": None,
+            "orphan": True,
+            "description": "why this bead",
+            "priority": "P2",
+            "acceptance": "done when green",
+        }
+    ]
     assert tracker.calls == []
     assert store.read_recommendations() == (rec,)
 


### PR DESCRIPTION
## Summary

- Adds **`viz apply <recommendation-id>`** — the gated, idempotent one-click execution verb (spec §5.7), completing the `.2.3` verb surface (`viz pr` / `queue` / `sweep` / `verdict` / `apply`) after S1 #275, S2 #277, S3 #278, S4 #279, S5 #282:
- `verbs/apply.py` (new):
  - **Verdict gate:** refuses any recommendation without a recorded Tier-3 ACCEPTED verdict for that exact fact id — reject/dismiss verdicts, no verdict, or a verdict on a different fact all refuse identically with typed `E_APPLY_NOT_ACCEPTED`. Unknown recommendation id is the existing `E_NOT_FOUND`.
  - **Typed mutation plans** parsed strictly from the recommendation's `payload` (mirroring the verdict slice's ledger-view strictness — unknown kinds, missing fields, or extra fields refuse as `E_SIDECAR_MALFORMED`): mint-bead, add-edge, relabel, resequence.
  - **Mint bead** via `TrackerPort.mint_bead`, keyed on the recommendation id: the minted bead id persists to `payload["application"]` the INSTANT `mint_bead` returns — before the fallible audit-note appends — because `work create` is the one non-idempotent backend verb; replay finds the ledger and is a full no-op (`already_applied: true`, never re-mints, never re-notes). A failure inside the `create` call itself leaves the ledger unwritten and retries fresh. Both crash windows are pinned by tests.
  - **Add edge** via `TrackerPort.add_edge` with `cycle_guard.find_cycle` before every `blocks` write (typed `E_APPLY_CYCLE_REFUSAL` carrying the cycle path, no tracker write); replays converge on the backend's idempotent upsert — the same documented contract as the verdict slice.
  - **Relabel** via `TrackerPort.relabel`; converges on target state.
  - **Resequence:** typed `E_APPLY_RESEQUENCE_NOT_SUPPORTED` — ruling-needed, never one-click (the work facade has no resequence verb); refused deliberately in plan-loading BEFORE the tracker runner is ever touched.
  - **Audit note** (`agent-recommendation-applied`, timestamp, fact fingerprint) appended to every touched bead; live mutations run inside one `store.transaction()`.
  - **`--dry-run`:** exact per-class mutation preview with zero sidecar/tracker mutation (cycle-check reads allowed).
- `envelope.py`: three typed apply error codes, existing style. `cli.py`/`verbs/__init__.py`: `apply` registered — the verb surface the `.2.4` skill drives is now complete.
- 53 new tests (386 total): verdict-gate refusal matrix, per-class idempotent replay, both mint crash windows, cycle refusal, resequence refusal (runner untouched), dry-run zero-writes, malformed-payload refusals — all against the scripted tracker fake, zero real subprocesses.

Spec: `docs/specs/2026-07-12-visualization-suite-design.md` §5.7 (one-click execution contract), §5.3; work-facade contract spec for the envelope the port speaks.

## Design decision worth review

**Mint orders ledger-first; edges/labels order tracker-first.** `work dep add`/`label add` are idempotent upserts, so the verdict slice's documented retry-convergence contract (tracker writes then ledger, retry re-issues safely) carries over. `work create` is not idempotent — two calls mint two beads — so the mint ledger persists immediately after the id returns, leaving only the benign audit-note append in the crash window. The asymmetry is deliberate and documented in the module docstring.

## Review-gate disposition

HEAVY adversarial gate (4 lenses, 2-refuter panels, 12 agents): **ACCEPTANCE — clean at the major floor after 1 round**, zero fixes applied. Three sub-floor minors flagged, all deferred with rationale to the epic's cleanup ledger: edge/relabel replay re-appends audit notes (consistent with the accepted-noise contract; an `already_applied` parity signal is tracked as UX polish), the cycle-edge builder duplication (documented rule-of-three deferral, this is caller #2), and a redundant recommendations.json re-read (fix threads shared signatures).

## Test Plan

- [x] TDD red→green: 51 of 53 apply tests failed before the module existed, green after
- [x] `make ci-vizsuite` fully green (exit 0, verified standalone): ruff, format-check, mypy --strict, 386 tests, 100.00% line+branch coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
