### PR TITLE
fix(prgroom): stop phantom empty-body review comment flood (abn9.8.40)

### DIFF
--- a/packages/prgroom/AGENTS.md
+++ b/packages/prgroom/AGENTS.md
@@ -77,6 +77,10 @@ exists.
 - Behavioural, not tautological — each test pins a coded decision, never the
   language/stdlib. Drive lifecycle functions through the fake `gh`/`git`/`Store`
   adapters and assert against observed calls/state.
+- Per-file Gh fakes are deliberate: each test module defines its own small
+  `GhClient`-level fake tailored to what it asserts (`_RecordingGh`, `FakeGh`,
+  …). Do not centralize them or cross-import a sibling test module's fake —
+  `tests/fakes.py` is scoped to the subprocess seam (`CommandRunner`) only.
 - Coverage floor is 90% branch (enforced by `pytest --cov`).
 
 ## Not installed by the installer

--- a/packages/prgroom/src/prgroom/lifecycle/poll.py
+++ b/packages/prgroom/src/prgroom/lifecycle/poll.py
@@ -223,6 +223,15 @@ def _ingest_items(
         (ItemKind.REVIEW_THREAD, raw_review_comments, "created_at"),
     ):
         for entry in raw:
+            if kind is ItemKind.REVIEW_SUMMARY and not str(entry.get("body") or "").strip():
+                # GitHub wraps every inline comment posted outside a formal review in a
+                # synthetic COMMENTED review with an empty body; that wrapper's id is
+                # minted server-side and never returned to the comment POST, so the
+                # own_replies ledger structurally cannot cover it. An empty-body review
+                # carries nothing reviewable regardless of author or state — a real
+                # verdict still lands via _terminal_review_verdicts, which reads the
+                # full reviews response, not the ingested items.
+                continue
             item = _to_item(kind, entry, ts_field, now=now, thread_id_map=thread_id_map)
             if item.identity.gh_id in own_replies:
                 continue  # our own posted reply — never re-ingest (self-reply prevention)

--- a/packages/prgroom/src/prgroom/lifecycle/reply.py
+++ b/packages/prgroom/src/prgroom/lifecycle/reply.py
@@ -50,6 +50,12 @@ _REPLYABLE = frozenset(
         DispositionKind.ESCALATED,
     }
 )
+# SKIPPED/DEFERRED are internal bookkeeping. On a review thread the rationale belongs
+# as a threaded explanation, but a threadless item (review summary / issue comment)
+# takes the top-level issue-comment route — minting a fresh gh id no ledger recognizes,
+# one new bookkeeping comment per skipped item per cycle (the phantom-review comment
+# flood). Suppress the post; the disposition itself is the record.
+_BOOKKEEPING_ONLY = frozenset({DispositionKind.SKIPPED, DispositionKind.DEFERRED})
 
 
 def _render_body(disp: Disposition) -> str:
@@ -192,6 +198,15 @@ def reply_pr(
             if item.replied or item.disposition is None:
                 continue
             if item.disposition.kind not in _REPLYABLE:
+                continue
+            if (
+                item.kind is not ItemKind.REVIEW_THREAD
+                and item.disposition.kind in _BOOKKEEPING_ONLY
+            ):
+                # Finalized without a post — bookkeeping stays internal (see
+                # _BOOKKEEPING_ONLY). `replied` marks the reply step done so the
+                # item is never revisited.
+                item.replied = True
                 continue
             body = _render_body(item.disposition)
             if not body.strip():

--- a/packages/prgroom/tests/unit/test_phantom_review_flood.py
+++ b/packages/prgroom/tests/unit/test_phantom_review_flood.py
@@ -1,0 +1,189 @@
+"""Reproduces the phantom-review-flood bug: two composing defects that turn each
+of prgroom's own out-of-review inline replies into an ever-growing stream of
+bookkeeping noise on the PR.
+
+Defect 1 (poll-side, ``poll_pr`` / ``_ingest_items`` in ``lifecycle/poll.py``):
+GitHub wraps every inline reply posted outside a formal review in a synthetic
+``COMMENTED`` review carrying an **empty body**. The self-reply filter
+(``own_replies``) only excludes a gh id already recorded on some item's
+``own_reply_id`` -- but that ledger records the wrapped REPLY COMMENT's id, never
+the id GitHub assigns to the synthetic wrapper REVIEW. Each such wrapper is a
+brand-new, previously-unseen id, so it sails past the dedup key and is ingested
+as a fresh ``REVIEW_SUMMARY`` feedback item with no real content.
+
+Defect 2 (reply-side, ``reply_pr`` in ``lifecycle/reply.py``): the fix agent
+dispositions these phantom (and other) items ``SKIPPED`` with its reasoning as
+rationale. ``_REPLYABLE`` treats ``SKIPPED`` as postable, and ``_post_reply``
+routes any non-``REVIEW_THREAD`` item to the issue-comments endpoint -- so a
+``SKIPPED`` ``REVIEW_SUMMARY`` (which has no thread to reply on) posts its
+rationale as a brand-new **top-level issue comment**. That comment is itself a
+gh id no ledger recognizes, so the flood compounds every cycle.
+
+Both tests below assert the DESIRED behavior and are expected to fail today.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from prgroom.config import PrgroomConfig
+from prgroom.deps import Deps
+from prgroom.gh import GhCli
+from prgroom.lifecycle import poll_pr
+from prgroom.lifecycle.reply import reply_pr
+from prgroom.proc import CommandResult
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    PRGroomingState,
+    QuiescenceState,
+    ReviewItem,
+    bootstrap_state,
+)
+from tests.conftest import FixedRandomness, FrozenClock
+from tests.fakes import RecordedRunner
+
+_REF = PRRef(owner="octo", repo="demo", number=7)
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+# ── defect 1: poll ingests a phantom empty-body COMMENTED review ──
+
+
+def _ok(payload: object) -> CommandResult:
+    return CommandResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+def _gh_with_reviews(reviews: list[dict[str, object]]) -> GhCli:
+    """The fixed poll_pr read sequence (head/PR/issue/reviews/review-comments/CI)
+    with the caller-supplied ``reviews`` payload standing in for the reviews list.
+    """
+    results = [
+        _ok({"headRefOid": "same"}),
+        _ok({"state": "open", "merged_at": None}),
+        _ok([]),  # issue comments
+        _ok(reviews),  # reviews
+        _ok([]),  # review comments (no thread-id GraphQL read needed)
+        _ok({"total_count": 1, "check_runs": [{"status": "completed", "conclusion": "success"}]}),
+    ]
+    return GhCli(RecordedRunner(results))
+
+
+def _deps() -> Deps:
+    return Deps(clock=FrozenClock(_T0), randomness=FixedRandomness())
+
+
+def _poll_state() -> PRGroomingState:
+    state = PRGroomingState(
+        pr=_REF,
+        phase=PRPhase.AWAITING_REVIEW,
+        pr_review_retries_used=0,
+        last_polled_at=_T0,
+        last_activity_at=_T0,
+        quiescence=QuiescenceState(),
+        last_poll_sha="same",
+        last_pushed_head_sha="",
+        reviewers={},
+    )
+    # A prior cycle already replied to an inline thread; the ledger records the
+    # wrapped REPLY COMMENT's own id (9001) -- NOT the id of any wrapper review
+    # GitHub may have synthesized around it.
+    state.items.append(
+        ReviewItem(
+            kind=ItemKind.REVIEW_THREAD,
+            identity=Identity(gh_id="31"),
+            author="octo-bot",
+            body_excerpt="nit",
+            seen_at=_T0,
+            replied=True,
+            own_reply_id=9001,
+        )
+    )
+    return state
+
+
+def test_phantom_empty_body_commented_review_not_ingested() -> None:
+    # GitHub's synthetic wrapper review carries a brand-new id (5555) that no
+    # ledger has ever seen, an empty body, and state COMMENTED -- the exact shape
+    # GitHub produces when it wraps an inline reply posted outside a review.
+    phantom_review = {
+        "id": 5555,
+        "user": {"login": "octo-bot"},
+        "state": "COMMENTED",
+        "body": "",
+        "submitted_at": "2026-06-09T12:05:00Z",
+    }
+    state = poll_pr(
+        _poll_state(),
+        ref=_REF,
+        gh=_gh_with_reviews([phantom_review]),
+        deps=_deps(),
+        config=PrgroomConfig(),
+    )
+    phantom_ids = {
+        item.identity.gh_id
+        for item in state.items
+        if item.kind is ItemKind.REVIEW_SUMMARY and not item.body_excerpt
+    }
+    assert phantom_ids == set(), (
+        f"empty-body COMMENTED review(s) {phantom_ids} were ingested as a "
+        "review_summary feedback item; a phantom GitHub wrapper carries no "
+        "reviewer content and must be dropped, not re-triaged"
+    )
+
+
+# ── defect 2: reply posts a top-level issue comment for a SKIPPED review_summary ──
+
+
+class _RecordingGh:
+    def __init__(self) -> None:
+        self.rest_calls: list[tuple[str, str, dict]] = []
+        self.graphql_calls: list[tuple[str, dict]] = []
+
+    def rest(self, method: str, path: str, *, fields=None):
+        self.rest_calls.append((method, path, dict(fields or {})))
+        return {}
+
+    def graphql(self, query: str, variables: dict):
+        self.graphql_calls.append((query, dict(variables)))
+        return {}
+
+
+def _reply_ref() -> PRRef:
+    return PRRef(owner="o", repo="r", number=7)
+
+
+def _skipped_review_summary_state() -> PRGroomingState:
+    state = bootstrap_state(_reply_ref(), now=_T0)
+    state.phase = PRPhase.FIXES_PENDING
+    state.items = [
+        ReviewItem(
+            kind=ItemKind.REVIEW_SUMMARY,
+            identity=Identity(gh_id="5555"),
+            author="octo-bot",
+            body_excerpt="",
+            seen_at=_T0,
+            disposition=Disposition(
+                kind=DispositionKind.SKIPPED,
+                decided_at=_T0,
+                decided_by="agent",
+                rationale="empty-body synthetic review; nothing actionable",
+            ),
+        )
+    ]
+    return state
+
+
+def test_skipped_review_summary_does_not_post_top_level_issue_comment() -> None:
+    # REVIEW_SUMMARY carries no thread to reply on. Posting the SKIPPED rationale
+    # as a top-level issue comment mints a brand-new gh id no ledger recognizes,
+    # so it compounds into a fresh bookkeeping comment every subsequent cycle.
+    gh = _RecordingGh()
+    reply_pr(_skipped_review_summary_state(), gh=gh, ref=_reply_ref())
+    assert gh.rest_calls == [], (
+        "expected no top-level issue comment for a SKIPPED review_summary "
+        f"disposition, got {gh.rest_calls}"
+    )

--- a/packages/prgroom/tests/unit/test_phantom_review_flood.py
+++ b/packages/prgroom/tests/unit/test_phantom_review_flood.py
@@ -19,7 +19,7 @@ routes any non-``REVIEW_THREAD`` item to the issue-comments endpoint -- so a
 rationale as a brand-new **top-level issue comment**. That comment is itself a
 gh id no ledger recognizes, so the flood compounds every cycle.
 
-Both tests below assert the DESIRED behavior and are expected to fail today.
+Both tests below assert the DESIRED behavior and guard against regression.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Fixes the phantom-review comment flood found on PR #281 (bead agents-config-abn9.8.40): every prgroom inline reply (and operator-posted inline comment) was re-ingested next poll as a phantom feedback item, triaged SKIPPED, and its rationale posted as a new top-level PR comment — ~N bookkeeping comments per cycle for N inline replies.

Two composing defects, both fixed:

- **Poll-side** (`packages/prgroom/src/prgroom/lifecycle/poll.py`): GitHub wraps every inline comment posted outside a formal review in a synthetic `COMMENTED` review with an empty body. That wrapper's id is minted server-side and never returned to the comment POST, so the `own_replies` ledger structurally cannot exclude it. Fix: drop empty-body review submissions at `_ingest_items` admission — they carry nothing reviewable. Terminal verdicts (APPROVED/CHANGES_REQUESTED) are unaffected: `_terminal_review_verdicts` reads the full raw reviews response, not the ingested items.
- **Reply-side** (`packages/prgroom/src/prgroom/lifecycle/reply.py`): SKIPPED/DEFERRED dispositions on threadless items (review summaries, issue comments) posted their rationale as a top-level issue comment — internal bookkeeping made public, each minting a fresh unledgered gh id. Fix: suppress the post for these (`_BOOKKEEPING_ONLY`) and finalize the item with `replied = True`. Threaded SKIPPED/DEFERRED explanations still post into their thread as before; FIXED / ALREADY_ADDRESSED / WONT_FIX / ESCALATED replies are unchanged.

The reply-side guard also handles legacy state: PRs whose stores already contain ingested phantom items stop posting about them — no state migration needed.

## Scope

- In scope: `lifecycle/poll.py` (one admission filter), `lifecycle/reply.py` (one suppression set + guard), new repro tests, one AGENTS.md test-convention note.
- Out of scope: the fix agent's clustering/dispositioning of empty items (moot once poll stops ingesting them), the legacy inventory export, any `own_replies` ledger redesign.

## Ground truth for review

- `packages/prgroom/src/prgroom/lifecycle/poll.py` — `_ingest_items`, `_terminal_review_verdicts`, `_observe_engagement`
- `packages/prgroom/src/prgroom/lifecycle/reply.py` — `_REPLYABLE`, `_BOOKKEEPING_ONLY`, `reply_pr`
- `packages/prgroom/tests/unit/test_phantom_review_flood.py` — one red→green repro per defect

Note on test style: the local `_RecordingGh` fake in the new test file is deliberate — per-file GhClient fakes are the package's convention (10 sibling test modules do the same); `tests/fakes.py` is scoped to the subprocess seam only. This PR documents that convention in `packages/prgroom/AGENTS.md`.

## Test Plan

- [x] Repro test: empty-body `COMMENTED` review is not ingested as a review_summary item (red before fix, green after)
- [x] Repro test: SKIPPED review_summary disposition posts no top-level issue comment (red before fix, green after)
- [x] `make ci-prgroom` from the worktree root: 981 passed, 99.65% coverage, lint/format/typecheck/audit clean, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xvhkg6q4nHQrJnwxBuQtyD
