### PR TITLE
feat(vizsuite): stale-graph opt-in with labeled staleness badge (fidelity F1)

### DIFF
--- a/docs/specs/2026-07-12-visualization-suite-design.md
+++ b/docs/specs/2026-07-12-visualization-suite-design.md
@@ -537,10 +537,14 @@ semantics per §4.5):
   churn only heats, never cools. Replaces the prototype's fabricated scores.
 - **Load-bearing** — Tier 1: graph centrality from graphify, behind a
   **preflight**: the graph's build-commit marker must match the target
-  revision (refresh if the tool is available, else fail loud or render the
-  axis explicitly unavailable — weight controls exclude it; never report a
-  stale graph as post-PR centrality; graphify is an optional dependency,
-  not an assumed one). Two binding corrections: (a) **projected post-PR centrality** — computed on
+  revision. Three outcomes, in order: refresh if the tool is available;
+  else, only on an explicit `--allow-stale-graph` opt-in, accept the stale
+  graph and score it, with a visible staleness label (the build commit and
+  commits-behind count) carried in the artifact — never silent; absent
+  either, render the axis explicitly unavailable — weight controls exclude
+  it. Never report a stale graph as current post-PR centrality without that
+  visible label; graphify is an optional dependency, not an assumed one.
+  Two binding corrections: (a) **projected post-PR centrality** — computed on
   the dependency graph *as the PR leaves it* (changed imports included),
   because history-based centrality scores brand-new load-bearing code at
   zero; (b) **consistent edge set** — intra-file self-edges excluded from

--- a/packages/vizsuite/src/vizsuite/cli.py
+++ b/packages/vizsuite/src/vizsuite/cli.py
@@ -47,6 +47,14 @@ class _EnvelopeArgumentParser(ArgumentParser):
 def _add_pr_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
     pr_parser = subparsers.add_parser("pr", help="build the PR-shape HTML artifact")
     pr_parser.add_argument("number", type=int, metavar="N", help="the pull-request number")
+    pr_parser.add_argument(
+        "--allow-stale-graph",
+        action="store_true",
+        help=(
+            "accept a graphify graph whose build commit differs from the PR head, "
+            "labeling the load-bearing axis visibly stale instead of unavailable"
+        ),
+    )
 
 
 def _add_queue_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:

--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -27,6 +27,7 @@ still fails soft to unavailable regardless of the flag.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,9 @@ import networkx as nx
 # relations (`contains`, `rationale_for`, ...) never contribute (item 9).
 DEP_RELATIONS = frozenset({"calls", "uses", "imports_from", "inherits", "implements"})
 _EXTRACTED = "EXTRACTED"  # Tier-1 determinism boundary (R3-1)
+# The only build-commit marker shape the labeled-stale opt-in trusts: a full
+# lowercase 40-hex object id (the marker reaches `git rev-list` argv downstream).
+_FULL_HEX_OID_RE = re.compile(r"[0-9a-f]{40}")
 
 
 @dataclass(frozen=True)
@@ -113,11 +117,17 @@ def centrality_axis(
     built_at_commit = raw.get("built_at_commit")
     is_stale = built_at_commit != head_oid
     # A stale graph is only ever accepted when the caller opted in AND the
-    # build-commit marker itself is a real, non-empty string — a graph missing
-    # that marker entirely has nothing trustworthy to label as stale, so it
-    # stays on the loud unavailable path even with the opt-in on.
+    # build-commit marker is a full lowercase 40-hex object id. The accepted
+    # marker flows into `git rev-list <marker>..<head>` argv downstream
+    # (verbs/pr.py `_commits_behind`), and no `--` placement can stop git from
+    # option-parsing a leading-dash revision token — so this boundary is the
+    # injection guard: anything not OID-shaped (missing, garbage, abbreviated,
+    # option-shaped) stays on the loud unavailable path even with the opt-in on.
     accepted_stale = bool(
-        is_stale and allow_stale and isinstance(built_at_commit, str) and built_at_commit
+        is_stale
+        and allow_stale
+        and isinstance(built_at_commit, str)
+        and _FULL_HEX_OID_RE.fullmatch(built_at_commit)
     )
     if is_stale and not accepted_stale:
         return CentralityAxis.unavailable("graph build-commit != PR head")  # never stale-as-fresh

--- a/packages/vizsuite/src/vizsuite/extract/centrality.py
+++ b/packages/vizsuite/src/vizsuite/extract/centrality.py
@@ -15,6 +15,13 @@ graphify is an optional dependency: an absent `graphify-out/`, a stale build
 (`built_at_commit != head_oid`), unparseable/torn JSON, or valid JSON of the
 wrong shape (non-object payload, malformed nodes/links) all fail soft to
 `CentralityAxis.unavailable(...)` — never a crash, never stale-as-fresh.
+
+A caller may opt in to a labeled-stale path (`allow_stale=True`, spec §6.2):
+a graph whose `built_at_commit` differs from `head_oid` is scored exactly like
+a fresh one, with `CentralityAxis.stale_built_at_commit` set to the graph's own
+build commit so the caller can render a visible staleness label. The opt-in
+only bypasses the commit-identity check — an absent/unreadable/malformed graph
+still fails soft to unavailable regardless of the flag.
 """
 
 from __future__ import annotations
@@ -42,11 +49,17 @@ class CentralityAxis:
     `edges` is the same file-level `DiGraph`'s EXTRACTED, intra-file-excluded
     edge list the scores were derived from (one graph build, kept together);
     it is empty whenever the axis is unavailable — never a stale edge set.
+    `stale_built_at_commit` is the graph's own build commit exactly when the
+    caller opted into the labeled-stale path (`allow_stale=True`) and the
+    graph's `built_at_commit` differed from the target revision; it is `None`
+    for a fresh graph or an unavailable axis — never a marker with no graph
+    behind it.
     """
 
     scores: dict[str, float] | None
     unavailable_reason: str | None = None
     edges: tuple[tuple[str, str], ...] = ()
+    stale_built_at_commit: str | None = None
 
     @property
     def is_available(self) -> bool:
@@ -58,7 +71,10 @@ class CentralityAxis:
 
     @staticmethod
     def from_indegree(
-        indegree: dict[str, int], edges: tuple[tuple[str, str], ...] = ()
+        indegree: dict[str, int],
+        edges: tuple[tuple[str, str], ...] = (),
+        *,
+        stale_built_at_commit: str | None = None,
     ) -> CentralityAxis:
         """Normalize raw file-level in-degree counts to a 0-1 axis."""
         max_degree = max(indegree.values(), default=0)
@@ -66,14 +82,24 @@ class CentralityAxis:
             path: (degree / max_degree if max_degree > 0 else 0.0)
             for path, degree in indegree.items()
         }
-        return CentralityAxis(scores=scores, edges=edges)
+        return CentralityAxis(
+            scores=scores, edges=edges, stale_built_at_commit=stale_built_at_commit
+        )
 
 
-def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
+def centrality_axis(
+    graph_path: Path, head_oid: str, *, allow_stale: bool = False
+) -> CentralityAxis:
     """Load-bearing axis from graphify. Tier-1 determinism: `EXTRACTED` edges
     only (`INFERRED` graph edges are Tier-2, out of scope for `.2.1`). Intra-file
     edges are dropped; projected post-PR centrality via the head-graph preflight
     (no overlay — a head-built graph already contains new code's edges).
+
+    `allow_stale=True` (spec §6.2 explicit opt-in) accepts a graph whose
+    `built_at_commit` differs from `head_oid`, scoring it exactly like a fresh
+    graph but stamping `stale_built_at_commit` with the graph's own build
+    commit. The opt-in never bypasses the parse guards below it: an absent,
+    unreadable, or wrong-shape graph is unavailable either way.
     """
     if not graph_path.exists():
         return CentralityAxis.unavailable("graphify-out absent")  # optional dep, fail soft
@@ -83,7 +109,17 @@ def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
         return CentralityAxis.unavailable("graph.json unreadable (torn mid-write?)")  # fail soft
     if not isinstance(raw, dict):
         return CentralityAxis.unavailable("graph.json malformed (not a JSON object)")
-    if raw.get("built_at_commit") != head_oid:
+
+    built_at_commit = raw.get("built_at_commit")
+    is_stale = built_at_commit != head_oid
+    # A stale graph is only ever accepted when the caller opted in AND the
+    # build-commit marker itself is a real, non-empty string — a graph missing
+    # that marker entirely has nothing trustworthy to label as stale, so it
+    # stays on the loud unavailable path even with the opt-in on.
+    accepted_stale = bool(
+        is_stale and allow_stale and isinstance(built_at_commit, str) and built_at_commit
+    )
+    if is_stale and not accepted_stale:
         return CentralityAxis.unavailable("graph build-commit != PR head")  # never stale-as-fresh
 
     # The whole rollup + graph build is one fail-soft boundary: graphify's JSON
@@ -116,4 +152,8 @@ def centrality_axis(graph_path: Path, head_oid: str) -> CentralityAxis:
     # Ordering is left to the downstream `scene_to_json` sort — no need to
     # sort twice.
     edges = tuple(graph.edges())
-    return CentralityAxis.from_indegree(dict(graph.in_degree()), edges=edges)
+    return CentralityAxis.from_indegree(
+        dict(graph.in_degree()),
+        edges=edges,
+        stale_built_at_commit=built_at_commit if accepted_stale else None,
+    )

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -121,17 +121,37 @@ class Fingerprints:
 
 
 @dataclass(frozen=True)
+class StaleGraph:
+    """The visible staleness label for an explicitly-accepted stale graph (spec §6.2).
+
+    Present on `RenderConfig.stale_graph` only when the caller opted into the
+    labeled-stale centrality path (`viz pr --allow-stale-graph`) and the
+    graphify build actually was stale — never a marker with no stale graph
+    behind it. `commits_behind` is `None` when the count itself could not be
+    computed (e.g. the build commit is unknown locally) — a soft failure of
+    the count, not of the build.
+    """
+
+    built_at_commit: str
+    commits_behind: int | None
+
+
+@dataclass(frozen=True)
 class RenderConfig:
     """Slider/legend render hints for the cross-axis heat mix (spec §4.5/§6.2).
 
     `default_weights` seeds each weight slider's starting position;
     `unavailable_axes` disables the slider(s) whose axis could not be computed
     (e.g. a stale/absent graphify build) — never silently reporting a stale
-    value as current (spec §6.2).
+    value as current (spec §6.2). `stale_graph` is set only when the
+    load-bearing axis was computed from an explicitly-accepted stale graph
+    (spec §6.2's labeled-stale path); a fresh or unavailable axis never
+    carries one.
     """
 
     default_weights: dict[str, float]
     unavailable_axes: tuple[str, ...] = ()
+    stale_graph: StaleGraph | None = None
 
 
 @dataclass(frozen=True)
@@ -185,10 +205,16 @@ def _fingerprints_to_json(fingerprints: Fingerprints) -> dict[str, JsonValue]:
 
 
 def _render_config_to_json(render_config: RenderConfig) -> dict[str, JsonValue]:
-    return {
+    payload: dict[str, JsonValue] = {
         "default_weights": dict(render_config.default_weights),
         "unavailable_axes": list(render_config.unavailable_axes),
     }
+    if render_config.stale_graph is not None:
+        payload["stale_graph"] = {
+            "built_at_commit": render_config.stale_graph.built_at_commit,
+            "commits_behind": render_config.stale_graph.commits_behind,
+        }
+    return payload
 
 
 def scene_to_json(scene: Scene) -> dict[str, JsonValue]:

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -318,7 +318,8 @@
     var shortSha = String(staleGraph.built_at_commit).slice(0, 7);
     var text = "graph @ " + shortSha + " (stale";
     if (typeof staleGraph.commits_behind === "number") {
-      text += ", " + staleGraph.commits_behind + " commits behind PR head";
+      var noun = staleGraph.commits_behind === 1 ? "commit" : "commits";
+      text += ", " + staleGraph.commits_behind + " " + noun + " behind PR head";
     }
     return text + ")";
   }

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -20,7 +20,9 @@
     treemapView: "viz-view-treemap",
     ledgerView: "viz-view-ledger",
     constellationView: "viz-view-constellation",
-    constellationToggle: "viz-constellation-toggle"
+    constellationToggle: "viz-constellation-toggle",
+    staleGraphBadge: "viz-stale-graph-badge",
+    header: "viz-header"
   };
 
   // Stable, action-naming accessible name (spec §4.5 toggle convention: the
@@ -307,10 +309,35 @@
     });
   }
 
+  // ---- Stale-graph badge (spec §6.2 `--allow-stale-graph` opt-in): a header
+  // badge naming the exact build commit the load-bearing axis was scored
+  // from, so an accepted-stale graph is never mistaken for a fresh one.
+  // Present only when `scene.render_config.stale_graph` is present — a fresh
+  // or unavailable axis carries no `stale_graph`, so no badge renders. ----
+  function staleGraphBadgeText(staleGraph) {
+    var shortSha = String(staleGraph.built_at_commit).slice(0, 7);
+    var text = "graph @ " + shortSha + " (stale";
+    if (typeof staleGraph.commits_behind === "number") {
+      text += ", " + staleGraph.commits_behind + " commits behind PR head";
+    }
+    return text + ")";
+  }
+
+  function appendStaleGraphBadge(headerEl, staleGraph) {
+    if (!staleGraph) {
+      return;
+    }
+    var badge = document.createElement("div");
+    badge.id = IDS.staleGraphBadge;
+    badge.setAttribute("class", "viz-stale-graph-badge");
+    badge.textContent = staleGraphBadgeText(staleGraph);
+    headerEl.appendChild(badge);
+  }
+
   // ---- Legend (spec §4.5: every encoding present in the scene appears
   // here; no orphan entries) — the heat scale, the PR-touched marker, and
   // the default-collapsed marker are the only encodings this view renders. ----
-  function buildLegend(container) {
+  function buildLegend(container, staleGraph) {
     var heatStops = [
       { token: "heat-cold", label: "low attention" },
       { token: "heat-mid", label: "medium attention" },
@@ -348,6 +375,19 @@
     collapseItem.appendChild(collapseGlyph);
     collapseItem.appendChild(collapseLabel);
     container.appendChild(collapseItem);
+
+    if (staleGraph) {
+      var staleItem = document.createElement("span");
+      staleItem.setAttribute("class", "viz-legend-item");
+      var staleSwatch = document.createElement("span");
+      staleSwatch.setAttribute("class", "viz-legend-badge viz-legend-badge--stale");
+      var staleLabel = document.createElement("span");
+      staleLabel.textContent =
+        staleGraphBadgeText(staleGraph) + " — accepted via --allow-stale-graph";
+      staleItem.appendChild(staleSwatch);
+      staleItem.appendChild(staleLabel);
+      container.appendChild(staleItem);
+    }
   }
 
   // ---- Sonar affordance (spec §6.1: file sonar as a drill, not a top-level
@@ -617,6 +657,7 @@
     });
     var unavailableAxes =
       (scene.render_config && scene.render_config.unavailable_axes) || [];
+    var staleGraph = (scene.render_config && scene.render_config.stale_graph) || null;
 
     var annotationStore = makeAnnotationStore(scene.repo_nwo);
 
@@ -625,8 +666,10 @@
       controls: document.getElementById(IDS.controls),
       legend: document.getElementById(IDS.legend),
       root: document.getElementById(IDS.root),
-      drillPanel: document.getElementById(IDS.drillPanel)
+      drillPanel: document.getElementById(IDS.drillPanel),
+      header: document.getElementById(IDS.header)
     };
+    appendStaleGraphBadge(elements.header, staleGraph);
 
     if (!annotationStore.available) {
       elements.storageWarning.textContent =
@@ -692,7 +735,7 @@
       document.dispatchEvent && dispatchThemeChanged();
     });
     wireCopyNotesButton(controls.copyButton, controls.copyStatus, annotationStore);
-    buildLegend(elements.legend);
+    buildLegend(elements.legend, staleGraph);
     wireDrillPanelClose(elements.drillPanel, drillState);
 
     document.addEventListener("viz:theme-changed", reencodeAll);

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -101,6 +101,20 @@ body {
   font-size: 12px;
 }
 
+/* ---- Stale-graph badge (spec §6.2 `--allow-stale-graph` opt-in): flow
+   layout in the header, never absolute positioning — a labeled fact about
+   the artifact, not an overlay. ---- */
+.viz-stale-graph-badge {
+  display: inline-block;
+  margin-top: 0.35rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--viz-heat-mid);
+  border-radius: 4px;
+  color: var(--viz-fg);
+  background: color-mix(in srgb, var(--viz-heat-mid) 15%, var(--viz-surface));
+  font-size: 11px;
+}
+
 /* ---- Annotation fallback banner (spec §4.5): visible, never silent. ---- */
 .viz-warning-banner {
   margin: 0.75rem 0;
@@ -199,6 +213,11 @@ body {
   border-radius: 50%;
   border: 2px solid var(--viz-fg);
   background: transparent;
+}
+.viz-legend-badge--stale {
+  border-radius: 2px;
+  border-color: var(--viz-heat-mid);
+  background: color-mix(in srgb, var(--viz-heat-mid) 15%, var(--viz-surface));
 }
 
 /* ---- Estate treemap (spec §6.1). ---- */

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -8,9 +8,13 @@ dirty working copy can never leak in). The load-bearing axis reads
 `graphify-out/graph.json` from the **live working tree** (it is gitignored,
 so it is never in the materialized snapshot), head-guarded by
 `centrality_axis` itself; an absent/stale graph fails soft to an unavailable
-axis, never a crash and never stale-as-fresh (§6.2). The three axes fuse into
-one per-file heat (`scene.heat.combine`), thread into scene node attributes,
-and the scene assembles into one self-contained HTML file at
+axis, never a crash and never stale-as-fresh, unless the operator explicitly
+opts in via `--allow-stale-graph` (§6.2) — that opt-in scores the stale graph
+like a fresh one and labels the scene with the build commit it actually got,
+plus how many commits behind head it is (best-effort; a local
+`git rev-list`/count miss fails soft to `None`, never a crash). The three axes
+fuse into one per-file heat (`scene.heat.combine`), thread into scene node
+attributes, and the scene assembles into one self-contained HTML file at
 `.viz/out/pr-<n>.html`.
 """
 
@@ -24,8 +28,9 @@ from typing import cast
 
 from vizsuite import __version__
 from vizsuite.adapters.critical_paths import read_critical_paths
+from vizsuite.adapters.git.runner import GitRunner
 from vizsuite.adapters.scc.parse import parse_scc
-from vizsuite.envelope import JsonValue
+from vizsuite.envelope import JsonValue, VizError
 from vizsuite.extract.centrality import centrality_axis
 from vizsuite.extract.complexity import complexity
 from vizsuite.extract.consequence import consequence
@@ -36,8 +41,24 @@ from vizsuite.reconcile.snapshot import materialize
 from vizsuite.runners import Runners
 from vizsuite.scene import heat
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import Edge, RenderConfig
+from vizsuite.scene.model import Edge, RenderConfig, StaleGraph
 from vizsuite.templates.html import render_html
+
+
+def _commits_behind(git: GitRunner, built_at_commit: str, head_oid: str) -> int | None:
+    """How many commits `head_oid` is ahead of the stale graph's build commit.
+
+    Reuses the same `rev_list` seam `reconcile.pr_scope` already shells git
+    through (never a bespoke subprocess call) — the count is just the length
+    of that commit list. The build commit can be unknown locally (e.g. a
+    since-rebased-away commit), which surfaces as a typed `ADAPTER_FAILURE`;
+    that failure is soft here — a missing count is cosmetic, never a reason to
+    fail the whole artifact build.
+    """
+    try:
+        return len(git.rev_list(built_at_commit, head_oid))
+    except VizError:
+        return None
 
 
 def pr(runners: Runners, args: Namespace) -> JsonValue:
@@ -67,9 +88,11 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
 
     # The load-bearing axis reads the LIVE working tree's `graphify-out/graph.json`
     # (gitignored — never in the materialized snapshot); `centrality_axis` itself
-    # guards staleness against `scope.head_oid` and fails soft to unavailable.
+    # guards staleness against `scope.head_oid` and fails soft to unavailable,
+    # unless `--allow-stale-graph` opted into the labeled-stale path (§6.2).
     graph_path = Path.cwd() / "graphify-out" / "graph.json"
-    centrality = centrality_axis(graph_path, scope.head_oid)
+    allow_stale_graph: bool = args.allow_stale_graph
+    centrality = centrality_axis(graph_path, scope.head_oid, allow_stale=allow_stale_graph)
     heat_model = heat.combine(
         estate_map, complexity_scores, consequence_scores, centrality, set(scope.files)
     )
@@ -79,6 +102,15 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
     edges = tuple(
         Edge(source=source, target=target, kind="dependency") for source, target in centrality.edges
     )
+
+    stale_graph: StaleGraph | None = None
+    if centrality.stale_built_at_commit is not None:
+        stale_graph = StaleGraph(
+            built_at_commit=centrality.stale_built_at_commit,
+            commits_behind=_commits_behind(
+                runners.git, centrality.stale_built_at_commit, scope.head_oid
+            ),
+        )
 
     scene = assemble(
         estate_map,
@@ -92,6 +124,7 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
         render_config=RenderConfig(
             default_weights=heat_model.default_weights,
             unavailable_axes=heat_model.unavailable_axes,
+            stale_graph=stale_graph,
         ),
         repo_nwo=scope.meta.repo_nwo,
         edges=edges,

--- a/packages/vizsuite/tests/fakes.py
+++ b/packages/vizsuite/tests/fakes.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from vizsuite.adapters.gh.runner import GhResult
 from vizsuite.adapters.git.runner import LsTreeRow, ModifiedFileRow
 from vizsuite.adapters.scc.runner import SccResult
+from vizsuite.envelope import VizError
 from vizsuite.tracker.port import TrackerResult
 
 
@@ -43,6 +44,12 @@ class ScriptedGitRunner:
     fetch_brings: set[str] = field(default_factory=set)
     diff_files: list[str] = field(default_factory=list)
     rev_list_oids: list[str] = field(default_factory=list)
+    # Keyed by the exact `(base, head)` args a call should fail for (e.g. a
+    # commits-behind lookup against a build commit unknown locally) — every
+    # other `(base, head)` pair still returns `rev_list_oids` normally, so a
+    # test can script one `rev_list` call to fail without breaking reconcile's
+    # own `(base_oid, head_oid)` call in the same run.
+    rev_list_errors: dict[tuple[str, str], VizError] = field(default_factory=dict)
     # Snapshot seam (slice 3): the tar bytes every `archive_tar(oid)` call returns.
     archive_tar_bytes: bytes = b""
     calls: list[tuple[str, ...]] = field(default_factory=list)
@@ -65,6 +72,9 @@ class ScriptedGitRunner:
 
     def rev_list(self, base: str, head: str) -> list[str]:
         self.calls.append(("rev_list", base, head))
+        error = self.rev_list_errors.get((base, head))
+        if error is not None:
+            raise error
         return list(self.rev_list_oids)
 
     def archive_tar(self, oid: str) -> bytes:

--- a/packages/vizsuite/tests/unit/test_extract_centrality.py
+++ b/packages/vizsuite/tests/unit/test_extract_centrality.py
@@ -20,6 +20,9 @@ import pytest
 from vizsuite.extract.centrality import DEP_RELATIONS, CentralityAxis, centrality_axis
 
 HEAD_OID = "head1234"
+# A full lowercase 40-hex OID — the only marker shape the labeled-stale
+# opt-in trusts (it flows into `git rev-list` argv downstream).
+STALE_OID = "6505d208fee1dfa6d82555437571cfe35d1778aa"
 
 
 def _node(node_id: str, source_file: str) -> dict[str, Any]:
@@ -218,7 +221,7 @@ def test_allow_stale_accepts_mismatched_commit_and_surfaces_the_build_commit(
     tmp_path: Path,
 ) -> None:
     payload = _graph_json(
-        built_at_commit="some-other-commit",
+        built_at_commit=STALE_OID,
         nodes=[_node("a", "a.py"), _node("b", "b.py")],
         links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
     )
@@ -230,7 +233,37 @@ def test_allow_stale_accepts_mismatched_commit_and_surfaces_the_build_commit(
     assert axis.scores is not None
     assert axis.scores["b.py"] == 1.0  # scored exactly like the fresh path
     assert axis.edges == (("a.py", "b.py"),)
-    assert axis.stale_built_at_commit == "some-other-commit"
+    assert axis.stale_built_at_commit == STALE_OID
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "--glob=refs/heads/*..",  # option-shaped: would reach `git rev-list` argv downstream
+        "some-other-commit",  # not a hex OID at all
+        "ABC123" + "0" * 34,  # uppercase hex — git OIDs are lowercase
+        "6505d208",  # abbreviated — only a full 40-hex OID is trusted
+    ],
+)
+def test_allow_stale_rejects_a_marker_that_is_not_a_full_hex_oid(
+    tmp_path: Path, marker: str
+) -> None:
+    # The accepted-stale marker flows into `git rev-list <marker>..<head>`
+    # (verbs/pr.py `_commits_behind`), so the boundary here trusts nothing but
+    # a full lowercase 40-hex object id — an option-shaped or garbage marker
+    # stays on the unavailable path even with the opt-in on.
+    payload = _graph_json(
+        built_at_commit=marker,
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=True)
+
+    assert not axis.is_available
+    assert axis.unavailable_reason == "graph build-commit != PR head"
+    assert axis.stale_built_at_commit is None
 
 
 def test_allow_stale_with_matching_commit_is_fresh_not_stale(tmp_path: Path) -> None:

--- a/packages/vizsuite/tests/unit/test_extract_centrality.py
+++ b/packages/vizsuite/tests/unit/test_extract_centrality.py
@@ -192,6 +192,95 @@ def test_stale_build_commit_is_unavailable_never_stale_as_fresh(tmp_path: Path) 
 
     assert not axis.is_available
     assert axis.scores is None
+    # default (flag omitted) is byte-identical to `allow_stale=False`: the
+    # opt-in must never be silently on.
+    assert axis.stale_built_at_commit is None
+
+
+def test_allow_stale_false_with_mismatched_commit_is_still_unavailable(tmp_path: Path) -> None:
+    # Explicit `allow_stale=False` regression pin: identical outcome to the
+    # flag-omitted case above — the opt-in is off by default and off means off.
+    payload = _graph_json(
+        built_at_commit="some-other-commit",
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=False)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.unavailable_reason == "graph build-commit != PR head"
+
+
+def test_allow_stale_accepts_mismatched_commit_and_surfaces_the_build_commit(
+    tmp_path: Path,
+) -> None:
+    payload = _graph_json(
+        built_at_commit="some-other-commit",
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=True)
+
+    assert axis.is_available
+    assert axis.scores is not None
+    assert axis.scores["b.py"] == 1.0  # scored exactly like the fresh path
+    assert axis.edges == (("a.py", "b.py"),)
+    assert axis.stale_built_at_commit == "some-other-commit"
+
+
+def test_allow_stale_with_matching_commit_is_fresh_not_stale(tmp_path: Path) -> None:
+    # A fresh graph never gets stamped stale just because the caller opted in —
+    # the opt-in only matters when it is actually needed.
+    payload = _graph_json(
+        built_at_commit=HEAD_OID,
+        nodes=[_node("a", "a.py"), _node("b", "b.py")],
+        links=[_link("a", "b", relation="calls", confidence="EXTRACTED")],
+    )
+    graph_path = _write_graph(tmp_path, payload)
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=True)
+
+    assert axis.is_available
+    assert axis.stale_built_at_commit is None
+
+
+def test_allow_stale_absent_graphify_out_is_still_unavailable(tmp_path: Path) -> None:
+    missing_path = tmp_path / "graphify-out" / "graph.json"
+
+    axis = centrality_axis(missing_path, HEAD_OID, allow_stale=True)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.stale_built_at_commit is None
+
+
+def test_allow_stale_truncated_invalid_json_is_still_unavailable(tmp_path: Path) -> None:
+    graph_path = tmp_path / "graphify-out" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text('{"built_at_commit": "some-other-commit", "nodes": [', encoding="utf-8")
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=True)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.stale_built_at_commit is None
+
+
+def test_allow_stale_missing_nodes_or_links_is_still_unavailable(tmp_path: Path) -> None:
+    # The opt-in only bypasses the commit-identity check, never the parse
+    # guards: a stale graph that is ALSO malformed still fails soft.
+    graph_path = _write_graph(tmp_path, {"built_at_commit": "some-other-commit"})
+
+    axis = centrality_axis(graph_path, HEAD_OID, allow_stale=True)
+
+    assert not axis.is_available
+    assert axis.scores is None
+    assert axis.stale_built_at_commit is None
 
 
 def test_truncated_invalid_json_is_unavailable_not_a_crash(tmp_path: Path) -> None:
@@ -285,11 +374,13 @@ def test_centrality_axis_unavailable_and_from_indegree_helpers() -> None:
     assert unavailable.unavailable_reason == "no graphify-out"
     assert not unavailable.is_available
     assert unavailable.edges == ()  # fail-soft means empty edges too, never stale ones
+    assert unavailable.stale_built_at_commit is None
 
     available = CentralityAxis.from_indegree({"a.py": 2, "b.py": 1, "c.py": 0})
     assert available.is_available
     assert available.scores == {"a.py": 1.0, "b.py": 0.5, "c.py": 0.0}
     assert available.edges == ()  # edges is opt-in via the `edges=` kwarg
+    assert available.stale_built_at_commit is None  # opt-in via the `stale_built_at_commit=` kwarg
 
     empty = CentralityAxis.from_indegree({})
     assert empty.is_available
@@ -297,3 +388,6 @@ def test_centrality_axis_unavailable_and_from_indegree_helpers() -> None:
 
     edged = CentralityAxis.from_indegree({"a.py": 1}, edges=(("x.py", "a.py"),))
     assert edged.edges == (("x.py", "a.py"),)
+
+    staled = CentralityAxis.from_indegree({"a.py": 1}, stale_built_at_commit="deadbeef")
+    assert staled.stale_built_at_commit == "deadbeef"

--- a/packages/vizsuite/tests/unit/test_scene_assemble.py
+++ b/packages/vizsuite/tests/unit/test_scene_assemble.py
@@ -13,7 +13,7 @@ serialized shape so a later slice (.2.2/.2.3) never breaks the contract.
 from __future__ import annotations
 
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import AttributeDescriptor, Edge, RenderConfig, scene_to_json
+from vizsuite.scene.model import AttributeDescriptor, Edge, RenderConfig, StaleGraph, scene_to_json
 
 _ESTATE = {"src/a.py": "sha_a", "src/b.py": "sha_b"}
 
@@ -211,6 +211,72 @@ def test_edges_thread_through_assemble_and_serialize_sorted_and_deterministicall
         edges=edges,
     )
     assert scene_to_json(scene_b)["edges"] == payload["edges"]
+
+
+def test_render_config_stale_graph_serializes_only_when_present():
+    render_config = RenderConfig(
+        default_weights={"complexity": 0.4, "load_bearing": 0.35, "consequence": 0.25},
+        stale_graph=StaleGraph(built_at_commit="deadbeef123", commits_behind=4),
+    )
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        render_config=render_config,
+    )
+
+    payload = scene_to_json(scene)
+    render_config_json = payload["render_config"]
+    assert isinstance(render_config_json, dict)
+    assert render_config_json["stale_graph"] == {
+        "built_at_commit": "deadbeef123",
+        "commits_behind": 4,
+    }
+
+
+def test_render_config_stale_graph_commits_behind_none_serializes_as_null():
+    render_config = RenderConfig(
+        default_weights={},
+        stale_graph=StaleGraph(built_at_commit="deadbeef123", commits_behind=None),
+    )
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        render_config=render_config,
+    )
+
+    payload = scene_to_json(scene)
+    render_config_json = payload["render_config"]
+    assert isinstance(render_config_json, dict)
+    stale_graph_json = render_config_json["stale_graph"]
+    assert isinstance(stale_graph_json, dict)
+    assert stale_graph_json["commits_behind"] is None
+
+
+def test_render_config_stale_graph_key_absent_when_fresh():
+    # Fresh (no `stale_graph`) render configs never carry the key at all — not
+    # even as a null — so a consumer can key its badge purely off presence.
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        render_config=RenderConfig(default_weights={}),
+    )
+
+    payload = scene_to_json(scene)
+    render_config_json = payload["render_config"]
+    assert isinstance(render_config_json, dict)
+    assert "stale_graph" not in render_config_json
 
 
 def test_render_config_and_repo_nwo_default_when_omitted():

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -11,7 +11,16 @@ from __future__ import annotations
 
 import json
 
-from vizsuite.scene.model import Fact, FileNode, Fingerprints, Provenance, ProvenanceKind, Scene
+from vizsuite.scene.model import (
+    Fact,
+    FileNode,
+    Fingerprints,
+    Provenance,
+    ProvenanceKind,
+    RenderConfig,
+    Scene,
+    StaleGraph,
+)
 from vizsuite.templates.html import _fill_template, render_html, scene_to_script_json
 
 _SCENE_OPEN = '<script id="viz-scene" type="application/json">'
@@ -23,7 +32,11 @@ _HOSTILE_STRINGS = (
 )
 
 
-def _scene(*files: FileNode, facts: tuple[Fact, ...] = ()) -> Scene:
+def _scene(
+    *files: FileNode,
+    facts: tuple[Fact, ...] = (),
+    render_config: RenderConfig | None = None,
+) -> Scene:
     return Scene(
         schema_version="1",
         generated_at="2020-01-01T00:00:00+00:00",
@@ -32,6 +45,9 @@ def _scene(*files: FileNode, facts: tuple[Fact, ...] = ()) -> Scene:
         files=tuple(files),
         fingerprints=Fingerprints(base_oid="base000", head_oid="head111"),
         facts=facts,
+        render_config=render_config
+        if render_config is not None
+        else RenderConfig(default_weights={}),
     )
 
 
@@ -202,6 +218,35 @@ def test_render_inlines_constellation_view_bundle_and_playwright_hooks():
     # the accessible name never flips with state) is the exact wording the
     # spec's "gated concretely" section names verbatim.
     assert "Show dependency constellation (experimental)" in html
+
+
+def test_stale_graph_badge_hook_is_inlined_and_scene_data_is_conditional():
+    # F1 (spec §6.2 labeled-stale opt-in): the badge's stable playwright hook
+    # (spec §4.6) is JS source, so it is inlined regardless of scene content —
+    # same convention as every other conditionally-rendered feature's id
+    # (viz-drill-sonar-toggle, viz-constellation-toggle, ...). What actually
+    # varies with the scene is the embedded `render_config.stale_graph` data
+    # the badge logic reads at runtime to decide whether to render.
+    stale_scene = _scene(
+        FileNode(path="src/app.py", checksum="aaa"),
+        render_config=RenderConfig(
+            default_weights={"complexity": 0.4, "load_bearing": 0.35, "consequence": 0.25},
+            stale_graph=StaleGraph(built_at_commit="deadbeef123", commits_behind=4),
+        ),
+    )
+    html = render_html(stale_scene)
+
+    assert "viz-stale-graph-badge" in html
+
+    scene_data = json.loads(_inlined_scene_block(html))
+    assert scene_data["render_config"]["stale_graph"] == {
+        "built_at_commit": "deadbeef123",
+        "commits_behind": 4,
+    }
+
+    fresh_html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+    fresh_scene_data = json.loads(_inlined_scene_block(fresh_html))
+    assert "stale_graph" not in fresh_scene_data["render_config"]
 
 
 def test_hostile_strings_in_paths_and_fact_notes_render_inert():

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -351,7 +351,7 @@ def test_pr_flag_off_with_mismatched_graph_commit_is_still_unavailable_regressio
     scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
     _write_graph(
         tmp_path,
-        built_at_commit="stale000",
+        built_at_commit="57a1e00000000000000000000000000000000000",
         nodes=[{"id": "s1", "source_file": "src/app.py"}],
         links=[],
     )
@@ -383,7 +383,7 @@ def test_pr_allow_stale_graph_flag_accepts_mismatched_commit_and_labels_it(
     scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
     _write_graph(
         tmp_path,
-        built_at_commit="stale000",
+        built_at_commit="57a1e00000000000000000000000000000000000",
         nodes=[{"id": "s1", "source_file": "src/app.py"}],
         links=[],
     )
@@ -403,12 +403,12 @@ def test_pr_allow_stale_graph_flag_accepts_mismatched_commit_and_labels_it(
     assert scene["render_config"]["unavailable_axes"] == []
     assert data["heat_axes_available"] == ["complexity", "consequence", "load_bearing"]
     assert scene["render_config"]["stale_graph"] == {
-        "built_at_commit": "stale000",
+        "built_at_commit": "57a1e00000000000000000000000000000000000",
         "commits_behind": 4,
     }
     # the commits-behind lookup went through the same git-runner seam
     # (`rev_list`), never a bespoke subprocess call.
-    assert ("rev_list", "stale000", "head111") in git.calls
+    assert ("rev_list", "57a1e00000000000000000000000000000000000", "head111") in git.calls
 
 
 def test_pr_allow_stale_graph_flag_with_fresh_graph_has_no_stale_graph_key(
@@ -480,13 +480,15 @@ def test_pr_stale_graph_commits_behind_fails_soft_to_none_when_rev_list_raises(
     )
     git = _pr_git(
         rev_list_errors={
-            ("stale000", "head111"): VizError(ErrorCode.ADAPTER_FAILURE, "unknown revision")
+            ("57a1e00000000000000000000000000000000000", "head111"): VizError(
+                ErrorCode.ADAPTER_FAILURE, "unknown revision"
+            )
         }
     )
     scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
     _write_graph(
         tmp_path,
-        built_at_commit="stale000",
+        built_at_commit="57a1e00000000000000000000000000000000000",
         nodes=[{"id": "s1", "source_file": "src/app.py"}],
         links=[],
     )
@@ -502,6 +504,6 @@ def test_pr_stale_graph_commits_behind_fails_soft_to_none_when_rev_list_raises(
     scene = _extract_scene(artifact.read_text(encoding="utf-8"))
 
     assert scene["render_config"]["stale_graph"] == {
-        "built_at_commit": "stale000",
+        "built_at_commit": "57a1e00000000000000000000000000000000000",
         "commits_behind": None,
     }

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -31,6 +31,7 @@ from tests.fakes import (
     tar_of,
 )
 from vizsuite.adapters.git.runner import ModifiedFileRow
+from vizsuite.envelope import ErrorCode, VizError
 
 _SCENE_SCRIPT_RE = re.compile(
     r'<script id="viz-scene" type="application/json">(.*?)</script>', re.DOTALL
@@ -311,3 +312,196 @@ def test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent(
     assert by_path["src/app.py"]["load_bearing"] == 0.0
     # fail-soft: an unavailable centrality axis threads an empty edge set too.
     assert scene["edges"] == []
+
+
+def _pr_git(**overrides: Any) -> ScriptedGitRunner:
+    """A `ScriptedGitRunner` for the fidelity-F1 (`--allow-stale-graph`) tests.
+
+    All of these tests share the same one-file PR shape; only the
+    `rev_list_oids`/`rev_list_errors` seam varies per test (the commits-behind
+    lookup), so this centralizes the boilerplate the F1 slice added.
+    """
+    defaults: dict[str, Any] = {
+        "present_oids": {"base000", "head111"},
+        "diff_files": ["src/app.py"],
+        "rev_list_oids": ["c1"],
+        "churn_rows": [
+            ModifiedFileRow(new_path="src/app.py", old_path="src/app.py", added=3, deleted=0)
+        ],
+        "ls_tree_rows": [blob("src/app.py", "aaa111")],
+        "archive_tar_bytes": tar_of({"src/app.py": "x = 1\n"}),
+    }
+    defaults.update(overrides)
+    return ScriptedGitRunner(**defaults)
+
+
+def test_pr_flag_off_with_mismatched_graph_commit_is_still_unavailable_regression_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # F1 regression pin: with `--allow-stale-graph` omitted, a graph whose
+    # build commit disagrees with the PR head must produce the exact same
+    # envelope as today (byte-identical to
+    # test_pr_fails_soft_to_unavailable_load_bearing_when_graphify_out_is_absent's
+    # assertions) — the opt-in changes nothing about the default path.
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = _pr_git()
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+    _write_graph(
+        tmp_path,
+        built_at_commit="stale000",
+        nodes=[{"id": "s1", "source_file": "src/app.py"}],
+        links=[],
+    )
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "13"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["render_config"]["unavailable_axes"] == ["load_bearing"]
+    assert "stale_graph" not in scene["render_config"]
+    assert data["heat_axes_available"] == ["complexity", "consequence"]
+    assert scene["edges"] == []
+
+
+def test_pr_allow_stale_graph_flag_accepts_mismatched_commit_and_labels_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=4)
+    )
+    git = _pr_git(rev_list_oids=["c1", "c2", "c3", "c4"])
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+    _write_graph(
+        tmp_path,
+        built_at_commit="stale000",
+        nodes=[{"id": "s1", "source_file": "src/app.py"}],
+        links=[],
+    )
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "14", "--allow-stale-graph"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    # load_bearing is available (accepted-stale scores exactly like fresh), so
+    # it drops out of unavailable_axes and back into the available-axes mirror.
+    assert scene["render_config"]["unavailable_axes"] == []
+    assert data["heat_axes_available"] == ["complexity", "consequence", "load_bearing"]
+    assert scene["render_config"]["stale_graph"] == {
+        "built_at_commit": "stale000",
+        "commits_behind": 4,
+    }
+    # the commits-behind lookup went through the same git-runner seam
+    # (`rev_list`), never a bespoke subprocess call.
+    assert ("rev_list", "stale000", "head111") in git.calls
+
+
+def test_pr_allow_stale_graph_flag_with_fresh_graph_has_no_stale_graph_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The opt-in is inert when the graph is already fresh — no stale_graph key,
+    # no extra rev_list call for a commits-behind count nobody needs.
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = _pr_git()
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+    _write_graph(
+        tmp_path,
+        built_at_commit="head111",
+        nodes=[{"id": "s1", "source_file": "src/app.py"}],
+        links=[],
+    )
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "15", "--allow-stale-graph"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["render_config"]["unavailable_axes"] == []
+    assert "stale_graph" not in scene["render_config"]
+    assert ("rev_list", "head111", "head111") not in git.calls
+
+
+def test_pr_allow_stale_graph_flag_with_absent_graph_stays_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)  # no graphify-out/ written — the optional-dep absent case
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = _pr_git()
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "16", "--allow-stale-graph"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["render_config"]["unavailable_axes"] == ["load_bearing"]
+    assert "stale_graph" not in scene["render_config"]
+
+
+def test_pr_stale_graph_commits_behind_fails_soft_to_none_when_rev_list_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The build-commit is unknown locally (e.g. a merged/rebased-away commit),
+    # so `git rev-list <built>..<head>` fails — the count fails soft to
+    # `None`, and the build still succeeds with a labeled-but-uncounted badge.
+    monkeypatch.chdir(tmp_path)
+    gh = ScriptedGhRunner(
+        gh_pr_result(base_oid="base000", head_oid="head111", changed_files=1, commit_count=1)
+    )
+    git = _pr_git(
+        rev_list_errors={
+            ("stale000", "head111"): VizError(ErrorCode.ADAPTER_FAILURE, "unknown revision")
+        }
+    )
+    scc = ScriptedSccRunner(scc_result({"src/app.py": 5}))
+    _write_graph(
+        tmp_path,
+        built_at_commit="stale000",
+        nodes=[{"id": "s1", "source_file": "src/app.py"}],
+        links=[],
+    )
+
+    exit_code, envelope, _stderr = run_cli(
+        ["pr", "17", "--allow-stale-graph"], git_runner=git, gh_runner=gh, scc_runner=scc
+    )
+
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    artifact = Path(str(data["artifact"]))
+    scene = _extract_scene(artifact.read_text(encoding="utf-8"))
+
+    assert scene["render_config"]["stale_graph"] == {
+        "built_at_commit": "stale000",
+        "commits_behind": None,
+    }


### PR DESCRIPTION
## Summary

Fidelity-pass slice F1 (bead `agents-config-yf2ov.2.10`): an explicit stale-graph opt-in for `viz pr`, so the load-bearing axis and the dependency-graph views (constellation, sonar) work on merged PRs.

- `viz pr N --allow-stale-graph`: accepts a graphify graph whose `built_at_commit` differs from the PR head, scoring it exactly like the fresh path, and labels the result. Default (no flag) behavior is byte-identical to before, pinned by a regression test.
- Rationale: the centrality preflight checks commit *identity* (`built_at_commit == PR head`), and squash merges guarantee a merged PR's head sha never equals any main commit — so the axis was unavailable for every merged PR. The spec forbids stale-as-*fresh*; this adds stale-as-*labeled* behind the explicit opt-in (spec §6.2 amended in place).
- Envelope: `render_config.stale_graph = {built_at_commit, commits_behind}` (behind-count via the existing `GitRunner.rev_list` seam, fail-soft to `null` when the build commit is unknown locally), present only on the stale-accepted path; `load_bearing` then leaves `unavailable_axes`.
- Artifact: header badge (`#viz-stale-graph-badge`) + legend entry reading `graph @ <sha7> (stale, N commits behind PR head)`; all strings bound via `textContent`.
- Hardening (HEAVY-gate finding): the accepted marker flows into `git rev-list` argv, and no `--` placement protects a leading-dash revision token — so the parse boundary trusts only a full lowercase 40-hex object id; option-shaped/garbage/abbreviated markers stay unavailable even with the opt-in on.

## Scope

In scope: `extract/centrality.py`, `verbs/pr.py`, `cli.py`, `scene/model.py` + assembly, `templates/static/app.js`/`scene.css`, spec §6.2 load-bearing bullet, tests. Out of scope: the remaining fidelity-pass slices (treemap interactions, drawer content, Tier-2 channel) — tracked on the same bead.

Note for review: `docs/specs/2026-07-12-visualization-suite-design.md` is a dated design spec describing full intent; partially built areas are expected and not defects of this PR.

## Test plan

- `make ci-vizsuite`: exit 0 — 409 passed, 100.00% line+branch coverage; lint, format-check, mypy --strict, pip-audit, entry-verify clean.
- Regression pins: flag-off behavior identical; fresh graph never labeled stale; absent/malformed graph unavailable regardless of flag.
- Injection guard: parametrized refusals for option-shaped (`--glob=…`), non-hex, uppercase, and abbreviated markers.
- Empirical: `viz pr 284 --allow-stale-graph` on this repo yields `heat_axes_available: [complexity, consequence, load_bearing]` and the artifact carries the badge + `stale_graph {built_at_commit…, commits_behind: 95}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w
