### PR TITLE
feat(vizsuite): treemap interaction pass — focus, reset, persistence (fidelity F2)

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -372,7 +372,8 @@
     var collapseGlyph = document.createElement("span");
     collapseGlyph.textContent = "▸";
     var collapseLabel = document.createElement("span");
-    collapseLabel.textContent = "collapsed group (no PR-touched files by default)";
+    collapseLabel.textContent =
+      "collapsed group (no PR-touched files by default) — area ∝ file count, compressed";
     collapseItem.appendChild(collapseGlyph);
     collapseItem.appendChild(collapseLabel);
     container.appendChild(collapseItem);

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -287,6 +287,8 @@ body {
   top: 0;
   left: 0;
   right: 0;
+  /* Rendered box (height + border-bottom) must equal DIR_HEADER_PX in
+     views/treemap.js — the treemap layout reserves exactly that much room. */
   height: 18px;
   display: flex;
   align-items: center;

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -348,8 +348,11 @@ body {
 /* PR-touched border (spec §6.1): thickened from an earlier 2px so it still
    reads at estate scale among hundreds of small tiles. */
 .viz-tile[data-in-pr="true"] {
-  outline: 3px solid var(--viz-fg);
-  outline-offset: -3px;
+  /* Inset ring, not `outline`: the :focus-visible rule below also sets
+     `outline` at equal specificity, so an outline-based PR marker would
+     vanish whenever a PR-touched tile takes keyboard focus. box-shadow and
+     outline coexist — focused PR tiles show both rings. */
+  box-shadow: inset 0 0 0 3px var(--viz-fg);
 }
 /* Keyboard focus affordance (a11y): a visible, theme-aware ring on the
    focused tile. `--viz-fg` is the highest-contrast token in both themes

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -341,7 +341,10 @@ body {
   padding: 0 2px;
 }
 .viz-tile-focus-btn:hover {
-  color: var(--viz-fg);
+  /* Emphasis without a color change: the button inherits the tile label's
+     luminance-computed contrast color, and forcing --viz-fg here would lose
+     contrast on dark heat-colored tiles. */
+  font-weight: 600;
 }
 .viz-tile-focus-btn:focus-visible {
   outline: 2px solid var(--viz-fg);

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -224,7 +224,40 @@ body {
 #viz-root {
   margin: 0 0 1rem;
 }
+/* The view's own flow-laid-out chrome (reset control, focus breadcrumb)
+   stacks above the absolutely-positioned tile stage — never inside it, so
+   the stage's own size (measured for the treemap layout) never has to
+   account for the chrome's height. */
 .viz-treemap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.viz-treemap-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+.viz-treemap-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 12px;
+  color: var(--viz-secondary);
+}
+.viz-treemap-breadcrumb[hidden] {
+  display: none;
+}
+.viz-treemap-crumb-sep {
+  color: var(--viz-muted);
+}
+.viz-treemap-crumb--current {
+  color: var(--viz-fg);
+  font-weight: 600;
+}
+.viz-treemap-stage {
   position: relative;
   width: 100%;
   height: 70vh;
@@ -244,19 +277,27 @@ body {
 .viz-tile--dir {
   background: var(--viz-surface);
 }
+/* Expanded directory header: deliberately distinct "structural chrome" (a
+   stronger-contrast fill, bold text, a bottom border) from a collapsed
+   tile's flat heat-colored fill — the ▸/▾ glyph flip below is not, on its
+   own, enough for a second click to read as "collapse" rather than a dead
+   expand. */
 .viz-tile--dir > .viz-tile-header {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  height: 16px;
+  height: 18px;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0 4px;
-  background: var(--viz-border);
+  gap: 0.3rem;
+  padding: 0 5px;
+  background: var(--viz-border-strong);
+  color: var(--viz-fg);
   font-size: 10px;
+  font-weight: 600;
   white-space: nowrap;
+  border-bottom: 1px solid var(--viz-border-strong);
 }
 .viz-tile--file {
   display: flex;
@@ -272,12 +313,43 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Inside the header's flex row (glyph + label + fill-screen button), the
+   label must shrink instead of claiming the general rule's 100% width — a
+   flex item's specified width otherwise becomes its used flex-basis and
+   would push the trailing button out of the tile's clipped bounds. */
+.viz-tile-header > .viz-tile-label {
+  width: auto;
+  flex: 1 1 auto;
+  min-width: 0;
+}
 .viz-tile-label--hidden {
   display: none;
 }
-.viz-tile[data-in-pr="true"] {
+.viz-tile-focus-btn {
+  flex: none;
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 9px;
+  font-weight: 400;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0 2px;
+}
+.viz-tile-focus-btn:hover {
+  color: var(--viz-fg);
+}
+.viz-tile-focus-btn:focus-visible {
   outline: 2px solid var(--viz-fg);
-  outline-offset: -2px;
+  outline-offset: 1px;
+}
+/* PR-touched border (spec §6.1): thickened from an earlier 2px so it still
+   reads at estate scale among hundreds of small tiles. */
+.viz-tile[data-in-pr="true"] {
+  outline: 3px solid var(--viz-fg);
+  outline-offset: -3px;
 }
 /* Keyboard focus affordance (a11y): a visible, theme-aware ring on the
    focused tile. `--viz-fg` is the highest-contrast token in both themes
@@ -290,14 +362,24 @@ body {
   outline-offset: 1px;
   z-index: 1;
 }
+.viz-collapse-glyph {
+  flex: none;
+  font-weight: 700;
+}
 .viz-tile[data-collapsed="true"] .viz-collapse-glyph::before {
   content: "▸";
 }
 .viz-tile:not([data-collapsed="true"]) .viz-collapse-glyph::before {
   content: "▾";
 }
+/* A collapsed directory's dashed border marks it as a compressed stand-in
+   for many files — visually distinct from both an expanded dir's header bar
+   and a flat (solid-bordered) file tile at a glance; the legend's
+   "collapsed group" entry describes exactly this rectangle. */
 .viz-tile--dir[data-collapsed="true"] {
   background: var(--viz-surface);
+  border-style: dashed;
+  border-width: 2px;
 }
 
 /* ---- Drill panel (spec §4.2/§4.5): opaque overlay, bordered, Escape closes. */

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -345,7 +345,9 @@ body {
 }
 .viz-tile-focus-btn:focus-visible {
   outline: 2px solid var(--viz-fg);
-  outline-offset: 1px;
+  /* Inward: .viz-tile clips overflow, so an outward ring near the tile edge
+     would be cut off. */
+  outline-offset: -2px;
 }
 /* PR-touched border (spec §6.1): thickened from an earlier 2px so it still
    reads at estate scale among hundreds of small tiles. */

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -20,6 +20,20 @@
 // `options.isExempt(evt)`, if given, opts an event out of activation (the
 // ledger row's diff-link guard) — omitted, every candidate event activates.
 //
+// `options.onDoubleActivate()` (optional; used by the treemap's directory
+// fill-screen focus, spec §6.1): a second qualifying pointer activation
+// arriving within
+// `DOUBLE_ACTIVATE_WINDOW_MS` of the first fires this instead of a second
+// `onActivate()` — mirroring the reacted-to prototype's own debounce-the-
+// single-click-then-cancel-on-a-second-click treatment (docs/plans/
+// visualization-suite/prototype/variant_A.js), so a double-click's single-
+// click side effect never also fires. Every existing call site (the ledger
+// row, the sonar ring mark) omits this option, so `onActivate()` keeps firing
+// synchronously for them — this branch is purely additive. Keyboard
+// activation (Enter/Space) never participates in this debounce: it always
+// fires `onActivate()` immediately, since a keyboard user reaches the
+// double-activate behavior via its own dedicated control instead.
+//
 // isDependencyGraphUnavailable: the shared "is the dependency graph
 // unavailable?" predicate for the graph-shaped views (constellation, file
 // sonar). The answer is NOT "scene.edges is empty" — an *available*
@@ -34,8 +48,14 @@
 
   window.vizShared = window.vizShared || {};
 
+  // A second qualifying pointer activation within this window of the first
+  // counts as a double-activation rather than two singles — the same ~300ms
+  // ballpark most desktop OSes use for double-click detection.
+  var DOUBLE_ACTIVATE_WINDOW_MS = 320;
+
   function wireClickVsDragActivation(el, options) {
     var onActivate = options.onActivate;
+    var onDoubleActivate = options.onDoubleActivate;
     var isExempt = options.isExempt;
     var startX = 0;
     var startY = 0;
@@ -44,6 +64,33 @@
     // element, rejecting a stray pointerup from a gesture begun elsewhere
     // (whose `moved` would still read false).
     var armed = false;
+    // Pending single-activate timer (only ever set when `onDoubleActivate`
+    // is given — every other call site's `onActivate` still fires inline,
+    // with zero added latency, exactly as before this option existed).
+    var pendingActivateTimer = null;
+
+    function firePointerActivate() {
+      if (!onDoubleActivate) {
+        onActivate();
+        return;
+      }
+      if (pendingActivateTimer !== null) {
+        clearTimeout(pendingActivateTimer);
+        pendingActivateTimer = null;
+        onDoubleActivate();
+        return;
+      }
+      pendingActivateTimer = setTimeout(function () {
+        pendingActivateTimer = null;
+        // The element may have been removed from the DOM (e.g. a resize or
+        // collapse re-render pruned this tile) between the first click and
+        // this timer firing — never act on a stale, detached element.
+        if (el.isConnected === false) {
+          return;
+        }
+        onActivate();
+      }, DOUBLE_ACTIVATE_WINDOW_MS);
+    }
 
     el.addEventListener("pointerdown", function (evt) {
       startX = evt.clientX;
@@ -80,7 +127,7 @@
       if (isExempt && isExempt(evt)) {
         return;
       }
-      onActivate();
+      firePointerActivate();
     });
     // A cancelled gesture (browser-initiated, e.g. scroll takeover) must not
     // leave the helper armed for a later stray pointerup.

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -144,6 +144,13 @@
         return;
       }
       evt.preventDefault();
+      // A pointer click may have scheduled a deferred onActivate() just
+      // before this keypress — fire once, not twice: the keyboard activation
+      // supersedes the pending pointer one.
+      if (pendingActivateTimer !== null) {
+        clearTimeout(pendingActivateTimer);
+        pendingActivateTimer = null;
+      }
       onActivate();
     });
   }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -20,19 +20,12 @@
 // `options.isExempt(evt)`, if given, opts an event out of activation (the
 // ledger row's diff-link guard) — omitted, every candidate event activates.
 //
-// `options.onDoubleActivate()` (optional; used by the treemap's directory
-// fill-screen focus, spec §6.1): a second qualifying pointer activation
-// arriving within
-// `DOUBLE_ACTIVATE_WINDOW_MS` of the first fires this instead of a second
-// `onActivate()` — mirroring the reacted-to prototype's own debounce-the-
-// single-click-then-cancel-on-a-second-click treatment (docs/plans/
-// visualization-suite/prototype/variant_A.js), so a double-click's single-
-// click side effect never also fires. Every existing call site (the ledger
-// row, the sonar ring mark) omits this option, so `onActivate()` keeps firing
-// synchronously for them — this branch is purely additive. Keyboard
-// activation (Enter/Space) never participates in this debounce: it always
-// fires `onActivate()` immediately, since a keyboard user reaches the
-// double-activate behavior via its own dedicated control instead.
+// Activation is always synchronous — there is deliberately NO deferred
+// (debounced double-click) path in this helper. An earlier revision deferred
+// `onActivate()` behind a timer to make room for a double-click gesture, and
+// the pending timer leaked activations through every gesture edge
+// (keyboard, nested controls, drag-after-click, pointercancel). Fill-screen
+// focus is an explicit per-tile control in the treemap instead (spec §6.1).
 //
 // isDependencyGraphUnavailable: the shared "is the dependency graph
 // unavailable?" predicate for the graph-shaped views (constellation, file
@@ -48,14 +41,8 @@
 
   window.vizShared = window.vizShared || {};
 
-  // A second qualifying pointer activation within this window of the first
-  // counts as a double-activation rather than two singles — the same ~300ms
-  // ballpark most desktop OSes use for double-click detection.
-  var DOUBLE_ACTIVATE_WINDOW_MS = 320;
-
   function wireClickVsDragActivation(el, options) {
     var onActivate = options.onActivate;
-    var onDoubleActivate = options.onDoubleActivate;
     var isExempt = options.isExempt;
     var startX = 0;
     var startY = 0;
@@ -64,33 +51,6 @@
     // element, rejecting a stray pointerup from a gesture begun elsewhere
     // (whose `moved` would still read false).
     var armed = false;
-    // Pending single-activate timer (only ever set when `onDoubleActivate`
-    // is given — every other call site's `onActivate` still fires inline,
-    // with zero added latency, exactly as before this option existed).
-    var pendingActivateTimer = null;
-
-    function firePointerActivate() {
-      if (!onDoubleActivate) {
-        onActivate();
-        return;
-      }
-      if (pendingActivateTimer !== null) {
-        clearTimeout(pendingActivateTimer);
-        pendingActivateTimer = null;
-        onDoubleActivate();
-        return;
-      }
-      pendingActivateTimer = setTimeout(function () {
-        pendingActivateTimer = null;
-        // The element may have been removed from the DOM (e.g. a resize or
-        // collapse re-render pruned this tile) between the first click and
-        // this timer firing — never act on a stale, detached element.
-        if (el.isConnected === false) {
-          return;
-        }
-        onActivate();
-      }, DOUBLE_ACTIVATE_WINDOW_MS);
-    }
 
     el.addEventListener("pointerdown", function (evt) {
       startX = evt.clientX;
@@ -127,7 +87,7 @@
       if (isExempt && isExempt(evt)) {
         return;
       }
-      firePointerActivate();
+      onActivate();
     });
     // A cancelled gesture (browser-initiated, e.g. scroll takeover) must not
     // leave the helper armed for a later stray pointerup.
@@ -144,13 +104,6 @@
         return;
       }
       evt.preventDefault();
-      // A pointer click may have scheduled a deferred onActivate() just
-      // before this keypress — fire once, not twice: the keyboard activation
-      // supersedes the pending pointer one.
-      if (pendingActivateTimer !== null) {
-        clearTimeout(pendingActivateTimer);
-        pendingActivateTimer = null;
-      }
       onActivate();
     });
   }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -15,17 +15,85 @@
 
   window.vizViews = window.vizViews || {};
 
-  // ---- Flat scene.files paths → a nested dir/file tree. ----
+  // ---- Root-files grouping (spec §6.1): loose files at repo root (no "/" in
+  // their path) live under a synthetic "(root)" directory node — a real,
+  // collapsible tree node, not a rendering special case. Its identity key is
+  // `ROOT_GROUP_PATH`, a NUL-prefixed sentinel no real git path can ever
+  // equal (git paths cannot contain a NUL byte), so it can never collide with
+  // — or silently absorb — an actual top-level directory that happens to be
+  // named "(root)"; that real directory keeps its own ordinary path and
+  // renders as a second, distinct tile. `ROOT_GROUP_INDEX_KEY` is likewise
+  // NUL-prefixed so it can never collide with a real directory's bare name in
+  // `_index`. ----
+  var ROOT_GROUP_NAME = "(root)";
+  var ROOT_GROUP_PATH = "\u0000(root)";
+  var ROOT_GROUP_INDEX_KEY = "\u0000(root)-group";
+
+  // The full path (or, for the synthetic root group, its display name) for
+  // human-facing text — aria-labels and the fill-screen control's label need
+  // the full path; tile/breadcrumb text elsewhere already uses `.name` (the
+  // synthetic node's own name is already the clean "(root)" string).
+  function displayPathFor(data) {
+    return data.path === ROOT_GROUP_PATH ? ROOT_GROUP_NAME : data.path;
+  }
+
+  // ---- Flat scene.files paths → a nested dir/file tree. Every node keeps a
+  // `parent` pointer (root's is null) so a focused directory's ancestor
+  // chain can be walked directly off the tree, never re-derived by splitting
+  // path strings (which would mishandle the root-group's NUL-prefixed path,
+  // among other things). ----
   function buildTree(files) {
-    var root = { name: "", path: "", isFile: false, children: [], _index: Object.create(null) };
+    var root = {
+      name: "",
+      path: "",
+      isFile: false,
+      parent: null,
+      children: [],
+      _index: Object.create(null)
+    };
+
+    function ensureRootGroup() {
+      var existing = root._index[ROOT_GROUP_INDEX_KEY];
+      if (!existing) {
+        existing = {
+          name: ROOT_GROUP_NAME,
+          path: ROOT_GROUP_PATH,
+          isFile: false,
+          parent: root,
+          children: [],
+          _index: Object.create(null)
+        };
+        root._index[ROOT_GROUP_INDEX_KEY] = existing;
+        root.children.push(existing);
+      }
+      return existing;
+    }
+
     files.forEach(function (file) {
       var parts = file.path.split("/");
+      if (parts.length === 1) {
+        var rootGroup = ensureRootGroup();
+        rootGroup.children.push({
+          name: parts[0],
+          path: file.path,
+          isFile: true,
+          parent: rootGroup,
+          file: file
+        });
+        return;
+      }
       var node = root;
       for (var i = 0; i < parts.length; i++) {
         var part = parts[i];
         var isLeaf = i === parts.length - 1;
         if (isLeaf) {
-          node.children.push({ name: part, path: file.path, isFile: true, file: file });
+          node.children.push({
+            name: part,
+            path: file.path,
+            isFile: true,
+            parent: node,
+            file: file
+          });
           continue;
         }
         var existing = node._index[part];
@@ -34,6 +102,7 @@
             name: part,
             path: node.path ? node.path + "/" + part : part,
             isFile: false,
+            parent: node,
             children: [],
             _index: Object.create(null)
           };
@@ -85,10 +154,43 @@
     }
   }
 
+  // ---- path → node lookup, every node except the true estate root (whose
+  // path is "") — resolves a persisted or focused path string back to a real
+  // tree node without re-walking the tree from scratch each time. ----
+  function indexTreeByPath(node, index) {
+    if (node.path) {
+      index[node.path] = node;
+    }
+    if (node.children) {
+      node.children.forEach(function (child) {
+        indexTreeByPath(child, index);
+      });
+    }
+  }
+
+  // Ancestor chain from (but excluding) the true estate root down to `node`,
+  // in breadcrumb reading order — walked via the real tree's `parent`
+  // pointers, never by splitting `node.path` (which would mishandle the
+  // root-group's NUL-prefixed sentinel).
+  function collectAncestorChain(node) {
+    var chain = [];
+    var current = node;
+    while (current && current.path !== "") {
+      chain.unshift(current);
+      current = current.parent;
+    }
+    return chain;
+  }
+
   // ---- Prune the tree for layout: a collapsed directory becomes a leaf
   // (sized by its file count, colored by its rolled-up heat) so the treemap
-  // reflows — siblings absorb the freed space (spec §6.1). ----
-  function pruneForLayout(node, collapsed) {
+  // reflows — siblings absorb the freed space (spec §6.1). `isLayoutRoot` is
+  // true only for the top node handed to this render pass (the whole estate,
+  // or — while a directory is focused — that directory) so it is never
+  // itself treated as collapsed regardless of its own entry in `collapsed`:
+  // it has just become the effective root filling the canvas, and its own
+  // collapse bookkeeping is left untouched for when focus pops back out. ----
+  function pruneForLayout(node, collapsed, isLayoutRoot) {
     if (node.isFile) {
       return {
         name: node.name,
@@ -101,7 +203,7 @@
         orig: node
       };
     }
-    var isCollapsed = Boolean(node.path) && Boolean(collapsed[node.path]);
+    var isCollapsed = !isLayoutRoot && Boolean(node.path) && Boolean(collapsed[node.path]);
     if (isCollapsed) {
       return {
         name: node.name,
@@ -128,7 +230,7 @@
       heat: node.heat,
       inPr: node.inPr,
       children: node.children.map(function (child) {
-        return pruneForLayout(child, collapsed);
+        return pruneForLayout(child, collapsed, false);
       }),
       orig: node
     };
@@ -203,12 +305,21 @@
     });
   }
 
-  // Click-vs-drag threshold (~4px, spec §4.2), via the shared
-  // `window.vizShared.wireClickVsDragActivation` (also used by the ledger
-  // row and the sonar ring mark — see views/_shared.js): reads the *live*
-  // bound datum at activation time (never a captured snapshot), so a tile
-  // that has survived several re-layouts always acts on its current data.
+  // Click-vs-drag(-vs-double-click) threshold (~4px, spec §4.2), via the
+  // shared `window.vizShared.wireClickVsDragActivation` (also used by the
+  // ledger row and the sonar ring mark — see views/_shared.js): reads the
+  // *live* bound datum at activation time (never a captured snapshot), so a
+  // tile that has survived several re-layouts always acts on its current
+  // data. A directory tile's kind (file vs. directory) never changes across
+  // its lifetime — a given path is either a blob or a tree, never both — so
+  // deciding once, at wiring time, whether to offer double-activation is
+  // safe: file tiles never get it (their single-click drill-open keeps firing
+  // with zero added latency, exactly as before this option existed);
+  // directory tiles do, promoting the directory to the fill-screen focus
+  // root (spec §6.1).
   function wireTileInteractions(el, handlers) {
+    var initialDatum = d3.select(el).datum();
+    var isDir = !initialDatum.data.isFile;
     window.vizShared.wireClickVsDragActivation(el, {
       onActivate: function () {
         var current = d3.select(el).datum();
@@ -217,7 +328,15 @@
         } else {
           handlers.onDirClick(current.data);
         }
-      }
+      },
+      onDoubleActivate: isDir
+        ? function () {
+            var current = d3.select(el).datum();
+            if (!current.data.isFile) {
+              handlers.onDirFocus(current.data);
+            }
+          }
+        : undefined
     });
   }
 
@@ -232,12 +351,28 @@
       return data.path;
     }
     if (data.collapsed) {
-      return data.path + " (collapsed directory, " + data.count + " files)";
+      return displayPathFor(data) + " (collapsed directory, " + data.count + " files)";
     }
-    return data.path + " (directory)";
+    return displayPathFor(data) + " (directory)";
   }
 
-  function buildTileContent(wrapper, d) {
+  function wireFocusButton(button, wrapperNode, handlers) {
+    // The button is its own activation target — never let its own events
+    // also trigger the tile's own click-vs-drag activation (collapse
+    // toggle), the same guard views/ledger.js uses for its diff-link nested
+    // inside an activatable row.
+    ["click", "keydown", "pointerdown", "pointerup"].forEach(function (type) {
+      button.addEventListener(type, function (evt) {
+        evt.stopPropagation();
+      });
+    });
+    button.addEventListener("click", function () {
+      var current = d3.select(wrapperNode).datum();
+      handlers.onDirFocus(current.data);
+    });
+  }
+
+  function buildTileContent(wrapper, d, handlers) {
     if (d.data.isFile) {
       wrapper.append("span").attr("class", "viz-tile-label").text(function (d) { return d.data.name; });
       return;
@@ -258,20 +393,33 @@
       .text(function (d) {
         return d.data.name;
       });
+    // Explicit fill-screen control (spec §6.1), alongside double-clicking the
+    // tile itself — only ever present on an *expanded* directory's own header
+    // (a collapsed directory has no header at all; double-click on its leaf-
+    // style tile is still its own path to focus).
+    var focusBtn = header
+      .append("button")
+      .attr("type", "button")
+      .attr("class", "viz-tile-focus-btn")
+      .text("Focus")
+      .attr("aria-label", function (d) {
+        return "Fill the screen with " + displayPathFor(d.data);
+      });
+    wireFocusButton(focusBtn.node(), wrapper.node(), handlers);
   }
 
-  function renderTiles(container, tree, collapsed, heatScale, handlers) {
-    var rect = container.getBoundingClientRect();
-    var width = rect.width || container.clientWidth || 960;
-    var height = rect.height || container.clientHeight || 600;
-    var pruned = pruneForLayout(tree, collapsed);
+  function renderTiles(stageEl, layoutRoot, collapsed, heatScale, handlers) {
+    var rect = stageEl.getBoundingClientRect();
+    var width = rect.width || stageEl.clientWidth || 960;
+    var height = rect.height || stageEl.clientHeight || 600;
+    var pruned = pruneForLayout(layoutRoot, collapsed, true);
     var hierarchyRoot = layoutTreemap(pruned, width, height);
     var nodes = hierarchyRoot.descendants().filter(function (d) {
       return d.depth > 0;
     });
 
     var sel = d3
-      .select(container)
+      .select(stageEl)
       .selectAll("div.viz-tile")
       .data(nodes, function (d) {
         return d.data.path;
@@ -320,7 +468,7 @@
     merged.each(function (d) {
       var wrapper = d3.select(this);
       wrapper.selectAll("*").remove();
-      buildTileContent(wrapper, d);
+      buildTileContent(wrapper, d, handlers);
     });
 
     entered.each(function () {
@@ -330,16 +478,208 @@
     applyEncoding(merged, heatScale);
   }
 
+  // ---- Breadcrumb strip (spec §6.1): visible only while a directory is
+  // focused as the temporary layout root. "Whole estate" always pops focus
+  // entirely; every other crumb re-focuses on that ancestor (a partial pop);
+  // the last crumb (the current focus) is plain text, not a no-op button. ----
+  function renderBreadcrumb(breadcrumbEl, pathIndex, focusPath, onNavigate) {
+    while (breadcrumbEl.firstChild) {
+      breadcrumbEl.removeChild(breadcrumbEl.firstChild);
+    }
+    var focusNode = focusPath ? pathIndex[focusPath] : null;
+    if (!focusNode || focusNode.isFile) {
+      breadcrumbEl.hidden = true;
+      return;
+    }
+    breadcrumbEl.hidden = false;
+
+    var homeCrumb = document.createElement("button");
+    homeCrumb.type = "button";
+    homeCrumb.setAttribute("class", "viz-btn");
+    homeCrumb.textContent = "Whole estate";
+    homeCrumb.addEventListener("click", function () {
+      onNavigate(null);
+    });
+    breadcrumbEl.appendChild(homeCrumb);
+
+    var chain = collectAncestorChain(focusNode);
+    chain.forEach(function (ancestor, index) {
+      var sep = document.createElement("span");
+      sep.setAttribute("class", "viz-treemap-crumb-sep");
+      sep.textContent = "/";
+      breadcrumbEl.appendChild(sep);
+
+      if (index === chain.length - 1) {
+        var current = document.createElement("span");
+        current.setAttribute("class", "viz-treemap-crumb--current");
+        current.textContent = ancestor.name;
+        breadcrumbEl.appendChild(current);
+        return;
+      }
+      var crumb = document.createElement("button");
+      crumb.type = "button";
+      crumb.setAttribute("class", "viz-btn");
+      crumb.textContent = ancestor.name;
+      crumb.addEventListener("click", function () {
+        onNavigate(ancestor.path);
+      });
+      breadcrumbEl.appendChild(crumb);
+    });
+  }
+
+  // ---- Collapse/focus persistence (spec §6.1): localStorage, feature-
+  // detected exactly like app.js's annotation store (in-memory fallback, no
+  // crash on file:// or disabled storage) — a fixed per-repo key (no PR
+  // number in it, matching the annotation store's own per-repo scoping), so a
+  // reviewer's collapse/focus choices carry over between PR artifacts of the
+  // same repo. ----
+  function makeTreemapStateStore(repoNwo) {
+    var key = "viz:" + repoNwo + ":pr:treemap-state";
+    // A NUL-suffixed probe key so the availability check never reads or
+    // clobbers the one real key this store ever touches.
+    var probeKey = key + "\u0000probe";
+    var available = false;
+    try {
+      window.localStorage.setItem(probeKey, "1");
+      window.localStorage.removeItem(probeKey);
+      available = true;
+    } catch (err) {
+      available = false;
+    }
+    var memoryValue = null;
+
+    function load() {
+      var raw = available ? window.localStorage.getItem(key) : memoryValue;
+      if (!raw) {
+        return null;
+      }
+      try {
+        var parsed = JSON.parse(raw);
+        return parsed && typeof parsed === "object" ? parsed : null;
+      } catch (err) {
+        return null;
+      }
+    }
+
+    function save(state) {
+      var raw = JSON.stringify(state);
+      if (available) {
+        try {
+          window.localStorage.setItem(key, raw);
+          return;
+        } catch (err) {
+          // Fall through to the in-memory fallback (e.g. quota exceeded).
+        }
+      }
+      memoryValue = raw;
+    }
+
+    function clear() {
+      if (available) {
+        try {
+          window.localStorage.removeItem(key);
+        } catch (err) {
+          // ignore — nothing else to fall back to for a removal
+        }
+      }
+      memoryValue = null;
+    }
+
+    return { load: load, save: save, clear: clear };
+  }
+
   window.vizViews.treemap = {
     render: function (container, scene, state) {
       var tree = buildTree(scene.files);
       var current = state;
       annotate(tree, current.computeHeat);
 
+      var pathIndex = Object.create(null);
+      indexTreeByPath(tree, pathIndex);
+
       var collapsed = Object.create(null);
       collectDefaultCollapsed(tree, collapsed);
 
+      var stateStore = makeTreemapStateStore(scene.repo_nwo);
+      var focusPath = null;
+
+      // Merge the persisted collapse/expand deltas and focus root over the
+      // freshly-computed defaults (spec §6.1) — a path the current scene no
+      // longer has (or that is no longer a directory) is pruned silently
+      // rather than applied.
+      var persisted = stateStore.load();
+      if (persisted) {
+        var delta =
+          persisted.collapseDelta && typeof persisted.collapseDelta === "object"
+            ? persisted.collapseDelta
+            : {};
+        Object.keys(delta).forEach(function (path) {
+          var node = pathIndex[path];
+          if (!node || node.isFile) {
+            return;
+          }
+          if (delta[path]) {
+            collapsed[path] = true;
+          } else {
+            delete collapsed[path];
+          }
+        });
+        if (typeof persisted.focusRoot === "string") {
+          var focusNode = pathIndex[persisted.focusRoot];
+          if (focusNode && !focusNode.isFile) {
+            focusPath = persisted.focusRoot;
+          }
+        }
+      }
+
       var heatScale = makeHeatColorScale();
+
+      // ---- Chrome: a reset control and the focus breadcrumb strip, flow-
+      // laid-out above the absolutely-positioned tile stage — scoped to this
+      // view's own container, so switching to another view removes them
+      // along with everything else this module owns (spec §4.2). ----
+      var controlsRow = document.createElement("div");
+      controlsRow.setAttribute("class", "viz-treemap-controls");
+      var resetBtn = document.createElement("button");
+      resetBtn.id = "viz-treemap-reset";
+      resetBtn.type = "button";
+      resetBtn.setAttribute("class", "viz-btn");
+      resetBtn.textContent = "Reset view";
+      controlsRow.appendChild(resetBtn);
+      container.appendChild(controlsRow);
+
+      var breadcrumbEl = document.createElement("div");
+      breadcrumbEl.id = "viz-treemap-breadcrumb";
+      breadcrumbEl.setAttribute("class", "viz-treemap-breadcrumb");
+      breadcrumbEl.hidden = true;
+      container.appendChild(breadcrumbEl);
+
+      var stageEl = document.createElement("div");
+      stageEl.setAttribute("class", "viz-treemap-stage");
+      container.appendChild(stageEl);
+
+      function persistState() {
+        var defaults = Object.create(null);
+        collectDefaultCollapsed(tree, defaults);
+        var delta = {};
+        Object.keys(collapsed).forEach(function (path) {
+          if (!defaults[path]) {
+            delta[path] = true;
+          }
+        });
+        Object.keys(defaults).forEach(function (path) {
+          if (!collapsed[path]) {
+            delta[path] = false;
+          }
+        });
+        stateStore.save({ collapseDelta: delta, focusRoot: focusPath });
+      }
+
+      function setFocus(path) {
+        focusPath = path;
+        persistState();
+        fullRender();
+      }
 
       var handlers = {
         onDirClick: function (data) {
@@ -348,7 +688,11 @@
           } else {
             collapsed[data.path] = true;
           }
+          persistState();
           fullRender();
+        },
+        onDirFocus: function (data) {
+          setFocus(data.path);
         },
         onFileClick: function (data) {
           current.openDrill(data);
@@ -356,8 +700,24 @@
       };
 
       function fullRender() {
-        renderTiles(container, tree, collapsed, heatScale, handlers);
+        var layoutRoot = tree;
+        if (focusPath) {
+          var focusNode = pathIndex[focusPath];
+          if (focusNode && !focusNode.isFile) {
+            layoutRoot = focusNode;
+          }
+        }
+        renderTiles(stageEl, layoutRoot, collapsed, heatScale, handlers);
+        renderBreadcrumb(breadcrumbEl, pathIndex, focusPath, setFocus);
       }
+
+      resetBtn.addEventListener("click", function () {
+        collapsed = Object.create(null);
+        collectDefaultCollapsed(tree, collapsed);
+        focusPath = null;
+        stateStore.clear();
+        fullRender();
+      });
 
       fullRender();
 
@@ -385,7 +745,7 @@
           current = newState;
           annotate(tree, current.computeHeat);
           heatScale = makeHeatColorScale();
-          var selection = d3.select(container).selectAll("div.viz-tile");
+          var selection = d3.select(stageEl).selectAll("div.viz-tile");
           selection.each(function (d) {
             d.data.heat = d.data.orig.heat;
           });

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -620,8 +620,10 @@
       // Merge the persisted collapse/expand deltas and focus root over the
       // freshly-computed defaults (spec §6.1) — a path the current scene no
       // longer has (or that is no longer a directory) is pruned silently
-      // rather than applied.
+      // rather than applied, and the cleaned state is written back once so
+      // stale keys don't linger in storage until the next user interaction.
       var persisted = stateStore.load();
+      var prunedStale = false;
       if (persisted) {
         var delta =
           persisted.collapseDelta && typeof persisted.collapseDelta === "object"
@@ -630,6 +632,7 @@
         Object.keys(delta).forEach(function (path) {
           var node = pathIndex[path];
           if (!node || node.isFile) {
+            prunedStale = true;
             return;
           }
           if (delta[path]) {
@@ -642,8 +645,16 @@
           var focusNode = pathIndex[persisted.focusRoot];
           if (focusNode && !focusNode.isFile) {
             focusPath = persisted.focusRoot;
+          } else {
+            prunedStale = true;
           }
         }
+      }
+      if (prunedStale) {
+        // persistState is a hoisted declaration below; it recomputes the
+        // delta from the live (already-cleaned) maps, so this one write
+        // replaces the stored blob with exactly the surviving state.
+        persistState();
       }
 
       var heatScale = makeHeatColorScale();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -602,15 +602,17 @@
       var pathIndex = Object.create(null);
       indexTreeByPath(tree, pathIndex);
 
-      var collapsed = Object.create(null);
-      collectDefaultCollapsed(tree, collapsed);
-
       // Cached once: the tree is fixed for the lifetime of this view, so the
       // default-collapsed set never changes — recomputing it via a full tree
       // walk on every persistState() call (i.e. every collapse/expand click)
-      // would be wasted work.
+      // would be wasted work. `collapsed` starts as a mutable copy of it.
       var defaultCollapsed = Object.create(null);
       collectDefaultCollapsed(tree, defaultCollapsed);
+
+      var collapsed = Object.create(null);
+      Object.keys(defaultCollapsed).forEach(function (path) {
+        collapsed[path] = true;
+      });
 
       var stateStore = makeTreemapStateStore(scene.repo_nwo);
       var focusPath = null;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -600,6 +600,13 @@
       var collapsed = Object.create(null);
       collectDefaultCollapsed(tree, collapsed);
 
+      // Cached once: the tree is fixed for the lifetime of this view, so the
+      // default-collapsed set never changes — recomputing it via a full tree
+      // walk on every persistState() call (i.e. every collapse/expand click)
+      // would be wasted work.
+      var defaultCollapsed = Object.create(null);
+      collectDefaultCollapsed(tree, defaultCollapsed);
+
       var stateStore = makeTreemapStateStore(scene.repo_nwo);
       var focusPath = null;
 
@@ -659,15 +666,13 @@
       container.appendChild(stageEl);
 
       function persistState() {
-        var defaults = Object.create(null);
-        collectDefaultCollapsed(tree, defaults);
         var delta = {};
         Object.keys(collapsed).forEach(function (path) {
-          if (!defaults[path]) {
+          if (!defaultCollapsed[path]) {
             delta[path] = true;
           }
         });
-        Object.keys(defaults).forEach(function (path) {
+        Object.keys(defaultCollapsed).forEach(function (path) {
           if (!collapsed[path]) {
             delta[path] = false;
           }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -236,6 +236,11 @@
     };
   }
 
+  // Layout space reserved for an expanded directory's header strip: must
+  // equal .viz-tile-header's rendered box in scene.css (height 18px +
+  // border-bottom 1px) or child tiles overlap the header.
+  var DIR_HEADER_PX = 19;
+
   function layoutTreemap(root, width, height) {
     var hierarchyRoot = d3
       .hierarchy(root, function (d) {
@@ -252,7 +257,7 @@
       .size([width, height])
       .paddingOuter(2)
       .paddingTop(function (d) {
-        return d.children ? 16 : 0;
+        return d.children ? DIR_HEADER_PX : 0;
       })
       .paddingInner(1)
       .round(true)(hierarchyRoot);

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -310,18 +310,14 @@
     });
   }
 
-  // Click-vs-drag(-vs-double-click) threshold (~4px, spec §4.2), via the
-  // shared `window.vizShared.wireClickVsDragActivation` (also used by the
-  // ledger row and the sonar ring mark — see views/_shared.js): reads the
-  // *live* bound datum at activation time (never a captured snapshot), so a
-  // tile that has survived several re-layouts always acts on its current
-  // data. A directory tile's kind (file vs. directory) never changes across
-  // its lifetime — a given path is either a blob or a tree, never both — so
-  // deciding once, at wiring time, whether to offer double-activation is
-  // safe: file tiles never get it (their single-click drill-open keeps firing
-  // with zero added latency, exactly as before this option existed);
-  // directory tiles do, promoting the directory to the fill-screen focus
-  // root (spec §6.1).
+  // Click-vs-drag threshold (~4px, spec §4.2), via the shared
+  // `window.vizShared.wireClickVsDragActivation` (also used by the ledger
+  // row and the sonar ring mark — see views/_shared.js): reads the *live*
+  // bound datum at activation time (never a captured snapshot), so a tile
+  // that has survived several re-layouts always acts on its current data.
+  // Activation is single-click only — a file tile opens its drill, a
+  // directory tile toggles collapse; fill-screen focus (spec §6.1) is the
+  // explicit Focus button wired in buildTileContent, never a gesture here.
   function wireTileInteractions(el, handlers) {
     window.vizShared.wireClickVsDragActivation(el, {
       onActivate: function () {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -323,8 +323,6 @@
   // directory tiles do, promoting the directory to the fill-screen focus
   // root (spec §6.1).
   function wireTileInteractions(el, handlers) {
-    var initialDatum = d3.select(el).datum();
-    var isDir = !initialDatum.data.isFile;
     window.vizShared.wireClickVsDragActivation(el, {
       onActivate: function () {
         var current = d3.select(el).datum();
@@ -333,15 +331,7 @@
         } else {
           handlers.onDirClick(current.data);
         }
-      },
-      onDoubleActivate: isDir
-        ? function () {
-            var current = d3.select(el).datum();
-            if (!current.data.isFile) {
-              handlers.onDirFocus(current.data);
-            }
-          }
-        : undefined
+      }
     });
   }
 
@@ -388,6 +378,20 @@
       label.append("span").text(function (d) {
         return " " + d.data.name + " (" + d.data.count + ")";
       });
+      // Fill-screen focus is an explicit control on collapsed tiles too —
+      // nested inside the label span so the label-declutter rule hides it
+      // along with the label on tiles too small to hold either. On a tile
+      // that small, the path to focus is expand-first, then the header
+      // control.
+      var collapsedFocusBtn = label
+        .append("button")
+        .attr("type", "button")
+        .attr("class", "viz-tile-focus-btn")
+        .text("Focus")
+        .attr("aria-label", function (d) {
+          return "Fill the screen with " + displayPathFor(d.data);
+        });
+      wireFocusButton(collapsedFocusBtn.node(), wrapper.node(), handlers);
       return;
     }
     var header = wrapper.append("div").attr("class", "viz-tile-header");
@@ -398,10 +402,9 @@
       .text(function (d) {
         return d.data.name;
       });
-    // Explicit fill-screen control (spec §6.1), alongside double-clicking the
-    // tile itself — only ever present on an *expanded* directory's own header
-    // (a collapsed directory has no header at all; double-click on its leaf-
-    // style tile is still its own path to focus).
+    // Explicit fill-screen control (spec §6.1) — the ONLY focus gesture;
+    // there is deliberately no double-click path (a deferred single-click
+    // timer leaked activations through gesture edges; see views/_shared.js).
     var focusBtn = header
       .append("button")
       .attr("type", "button")

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -142,6 +142,22 @@ def test_render_inlines_vendored_d3_scene_css_app_and_treemap_bundles():
     assert ".text(function (d) { return d.data.name; })" in html
 
 
+def test_render_inlines_treemap_interaction_playwright_hooks():
+    # The treemap's reset-view control and focus breadcrumb strip are stable
+    # playwright hooks (spec §4.6) — JS source, so inlined regardless of scene
+    # content, same convention as every other conditionally-rendered feature's
+    # id (viz-drill-sonar-toggle, viz-constellation-toggle, ...).
+    html = render_html(
+        _scene(
+            FileNode(path="src/app.py", checksum="aaa"),
+            FileNode(path="README.md", checksum="bbb"),
+        )
+    )
+
+    assert "viz-treemap-reset" in html
+    assert "viz-treemap-breadcrumb" in html
+
+
 def test_render_inlines_ledger_view_bundle_and_playwright_hooks():
     # Slice 3 (spec §6.1 attention ledger): the ledger view module is its own
     # file under templates/static/views/, picked up by the same dynamic glob


### PR DESCRIPTION
## Summary

Fidelity-pass slice F2 (bead `agents-config-yf2ov.2.10`): the treemap interaction pass, fixing the checkpoint-1 usability findings and closing the spec §6.1 expand-group-to-fill-screen mandate.

- **Reset-view control** (`#viz-treemap-reset`): restores the default collapse set, clears focus and the persisted state; rendered only while the treemap view is active.
- **Expand-group-to-fill-screen** (§6.1): the explicit "Focus" button in a directory tile's header (present on expanded and collapsed tiles) promotes that directory to the temporary layout root; a breadcrumb strip (`#viz-treemap-breadcrumb`) walks real parent pointers and pops focus per crumb. Tile-body activation is single-click collapse/expand only — there is deliberately no double-click or deferred-activation gesture. Focus and collapse state are orthogonal: focusing never mutates the collapse map.
- **Distinct expand/collapse chrome**: direction-flipping glyph (▸ collapsed / ▾ expanded), dashed collapsed-dir border, distinct expanded-header treatment — a second click on an expanded header now reads as an intentional collapse, not a dead expand.
- **PR-touched marker** thickened 2px → 3px, rendered as an inset box-shadow so it stays visible alongside the keyboard `:focus-visible` outline (hue kept at the shared neutral `--viz-fg` for cross-view consistency with the ledger/constellation "changed in PR" treatment).
- **Legend**: collapsed-group entry now states the area ∝ file-count (compressed) semantic.
- **Collapse persistence**: minimal delta (`collapseDelta` + `focusRoot`) in localStorage under `viz:<repo>:pr:treemap-state`, feature-detected with in-memory fallback, merged over defaults on load; persisted paths that no longer resolve in the scene are pruned silently.
- **Root-files grouping**: loose repo-root files group under a synthetic "(root)" container (collision-safe sentinel path — a JS `` prefix no git path can carry), collapsible like any directory.
- `wireClickVsDragActivation` keeps its `{ onActivate, isExempt }` contract; the deferred double-click machinery explored mid-review was removed entirely — activation fires synchronously on pointerup/keydown.
- Perf: the default-collapse set is computed once per view build instead of re-walking the tree on every click.

## Scope

In scope: `templates/static/views/treemap.js`, `views/_shared.js`, `app.js` (one legend line), `scene.css`, `tests/unit/test_templates_html.py`. Out of scope: drill panel/drawer content and ledger rows (slice F3), Tier-2 stories (F4).

Note for review: `docs/specs/2026-07-12-visualization-suite-design.md` is a dated design spec describing full intent; partially built areas are expected and not defects of this PR.

## Test plan

- `make ci-vizsuite`: exit 0 — 410 passed, 100.00% line+branch (Python); new template test pins the `viz-treemap-reset`/`viz-treemap-breadcrumb` verification hooks.
- Headless (playwright, served artifact from `viz pr 278 --allow-stale-graph`, zero console errors): expand flips glyph; the Focus button re-roots the layout + shows the breadcrumb without side-toggling collapse; reset restores defaults and clears storage; reload preserves a collapse delta; view-switch to ledger removes treemap-only controls; PR tiles carry the 3px inset box-shadow marker; dark theme legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuJ9STKvfun4N47gLtoA3w

