### PR TITLE
feat(vizsuite): drill drawer + content fidelity — axis bars, churn stats, hover card (fidelity F3)

### DIFF
--- a/packages/vizsuite/src/vizsuite/scene/heat.py
+++ b/packages/vizsuite/src/vizsuite/scene/heat.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 
 from vizsuite.envelope import JsonValue
 from vizsuite.extract.centrality import CentralityAxis
+from vizsuite.extract.churn import FileChurn
 from vizsuite.scene.model import AttributeDescriptor
 
 # Tunable cross-axis mix (spec §6.2). The tested invariants are share-of-
@@ -56,6 +57,7 @@ def combine(
     centrality: CentralityAxis,
     pr_files: Collection[str],
     *,
+    churn: Mapping[str, FileChurn] | None = None,
     weights: Mapping[str, float] | None = None,
 ) -> HeatModel:
     """Fuse the three §6.2 axes into one per-file heat, weighted-average style.
@@ -65,6 +67,12 @@ def combine(
     axis omitted from ``weights`` simply drops out of the mix; an *unknown*
     weight key is a caller error and raises ``ValueError`` (valid axes are
     complexity/load_bearing/consequence).
+
+    ``churn``, when supplied, threads each of its files' added/deleted line
+    counts onto that file's attributes (spec §4.5 PR diff stats). A file
+    absent from ``churn`` — a context file, or simply an unsupplied caller —
+    never fabricates the keys, the same "never fabricate" discipline `in_pr`
+    already follows.
     """
     effective_weights = dict(weights) if weights is not None else dict(DEFAULT_WEIGHTS)
     unknown_axes = set(effective_weights) - set(_INPUT_AXES)
@@ -91,7 +99,12 @@ def combine(
         }
         weighted_sum = sum(active_weights[axis] * values[axis] for axis in active_weights)
         heat_value = weighted_sum / weight_total if weight_total > 0 else 0.0
-        attributes[path] = {**values, "heat": heat_value, "in_pr": path in pr_files}
+        entry: dict[str, JsonValue] = {**values, "heat": heat_value, "in_pr": path in pr_files}
+        file_churn = churn.get(path) if churn is not None else None
+        if file_churn is not None:
+            entry["added"] = file_churn.added
+            entry["deleted"] = file_churn.deleted
+        attributes[path] = entry
 
     descriptors = tuple(
         AttributeDescriptor(name=name, unit=_AXIS_UNIT, direction=_AXIS_DIRECTION)

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -38,8 +38,9 @@
 
   // The three §6.2 input axes, in the same order/names as
   // `vizsuite.scene.heat._INPUT_AXES` — the JS recompute below mirrors that
-  // module's weighted-average formula exactly.
-  var HEAT_AXES = ["complexity", "load_bearing", "consequence"];
+  // module's weighted-average formula exactly. Sourced from views/_shared.js
+  // (window.vizShared.HEAT_AXES) rather than duplicated here.
+  var HEAT_AXES = window.vizShared.HEAT_AXES;
 
   // ---- Heat math: Σ(wᵢ·vᵢ)/Σ(wᵢ) over the *active* axes only (an
   // unavailable axis is excluded from both the sum and the normalizer, so
@@ -68,102 +69,43 @@
   // detected, with an in-memory fallback so the copy-as-JSON button always
   // works even when the origin (a bare `file://` artifact) disables storage.
   // Notes key on `viz:<repo_nwo>:pr:<file-path>` — V1 has no Tier-2 fact ids,
-  // so the file is the annotatable unit. ----
+  // so the file is the annotatable unit. Rebased on the shared localStorage
+  // factory (views/_shared.js), which treemap.js's collapse/focus-state
+  // store now also uses (fidelity F3). ----
   function makeAnnotationStore(repoNwo) {
     var prefix = "viz:" + repoNwo + ":pr:";
-    var available = false;
-    // Probe key carries a NUL delimiter, which no valid repo path can
-    // contain, so it can never collide with a note key (`prefix + <path>`).
-    var probeKey = prefix + "\u0000probe";
-    try {
-      window.localStorage.setItem(probeKey, "1");
-      window.localStorage.removeItem(probeKey);
-      available = true;
-    } catch (err) {
-      available = false;
-    }
-    var memory = Object.create(null);
-    var fallbackHandler = null;
-    var fallbackNotified = false;
-
-    // Fires the registered handler the first time a runtime write falls back
-    // to the in-memory map (e.g. quota exceeded) so the UI can surface the
-    // non-persistence warning that boot-time feature detection would miss.
-    function notifyFallback() {
-      if (fallbackNotified) {
-        return;
-      }
-      fallbackNotified = true;
-      if (typeof fallbackHandler === "function") {
-        fallbackHandler();
-      }
-    }
-
-    function onFallback(handler) {
-      fallbackHandler = handler;
-    }
+    var store = window.vizShared.makeLocalStorageStore(prefix);
 
     function keyFor(path) {
       return prefix + path;
     }
 
     function get(path) {
-      var key = keyFor(path);
-      if (available) {
-        return window.localStorage.getItem(key) || "";
-      }
-      return memory[key] || "";
+      return store.getItem(keyFor(path)) || "";
     }
 
     function set(path, value) {
-      var key = keyFor(path);
-      if (available) {
-        try {
-          if (value) {
-            window.localStorage.setItem(key, value);
-          } else {
-            window.localStorage.removeItem(key);
-          }
-          return;
-        } catch (err) {
-          // Fall through to the in-memory map (e.g. quota exceeded) and
-          // surface the non-persistence warning — notes stopped persisting
-          // mid-session even though storage was available at page-load.
-          notifyFallback();
-        }
-      }
       if (value) {
-        memory[key] = value;
+        store.setItem(keyFor(path), value);
       } else {
-        delete memory[key];
+        store.removeItem(keyFor(path));
       }
     }
 
     function getAll() {
       var out = {};
-      if (available) {
-        for (var i = 0; i < window.localStorage.length; i++) {
-          var k = window.localStorage.key(i);
-          if (k && k.indexOf(prefix) === 0) {
-            out[k] = window.localStorage.getItem(k);
-          }
-        }
-      } else {
-        for (var mk in memory) {
-          if (Object.prototype.hasOwnProperty.call(memory, mk)) {
-            out[mk] = memory[mk];
-          }
-        }
-      }
+      store.keys().forEach(function (key) {
+        out[key] = store.getItem(key);
+      });
       return out;
     }
 
     return {
-      available: available,
+      available: store.available,
       get: get,
       set: set,
       getAll: getAll,
-      onFallback: onFallback
+      onFallback: store.onFallback
     };
   }
 
@@ -443,9 +385,16 @@
     });
   }
 
-  // ---- Drill panel (spec §4.2/§4.5): opaque overlay; Escape closes; the
-  // notes textarea binds via `.value`, never `innerHTML`. ----
-  function makeOpenDrill(panelEl, scene, annotationStore, weights, unavailableAxes, drillState) {
+  // ---- Drill panel (spec §4.2/§4.5): a full-height right-docked drawer
+  // (fidelity F3 — converted from an earlier floating overlay card, prototype
+  // anatomy `#drill`/`showDrill`); Escape closes; the notes textarea binds
+  // via `.value`, never `innerHTML`. `onOpenChange(open)` toggles the
+  // stage-shrink class on `#viz-root` and lets the treemap re-run its layout
+  // against the narrower container (see `viz:drill-panel-toggled` in
+  // views/treemap.js) — the drawer never overlays the diagram. ----
+  function makeOpenDrill(
+    panelEl, scene, annotationStore, weights, unavailableAxes, drillState, onOpenChange
+  ) {
     return function (fileNode) {
       // A prior file's (or the same file's, on a weight-change refresh)
       // sonar render is about to be discarded along with the rest of the
@@ -473,6 +422,7 @@
       closeBtn.addEventListener("click", function () {
         drillState.node = null;
         panelEl.hidden = true;
+        onOpenChange(false);
       });
       panelEl.appendChild(closeBtn);
 
@@ -482,6 +432,29 @@
 
       var attributes =
         (fileNode.orig && fileNode.orig.file && fileNode.orig.file.attributes) || {};
+      var isInPr = Boolean(attributes.in_pr);
+
+      // PR diff stats (spec §4.5, prototype `.stat` chips) + the shared
+      // per-file diff link (views/_shared.js, hoisted out of views/ledger.js)
+      // — both silently absent for a context file or when the churn/repo_nwo
+      // data isn't there (never fabricated).
+      var statsRow = document.createElement("div");
+      statsRow.setAttribute("class", "viz-drill-stats");
+      if (isInPr && typeof attributes.added === "number") {
+        var deleted = typeof attributes.deleted === "number" ? attributes.deleted : 0;
+        var churnChip = document.createElement("span");
+        churnChip.setAttribute("class", "viz-drill-stat");
+        churnChip.textContent = "+" + attributes.added + "/−" + deleted;
+        statsRow.appendChild(churnChip);
+      }
+      var diffLink = window.vizShared.buildDiffLink(scene, fileNode.path, isInPr);
+      if (diffLink) {
+        statsRow.appendChild(diffLink);
+      }
+      if (statsRow.childNodes.length > 0) {
+        panelEl.appendChild(statsRow);
+      }
+
       var activeAxes = HEAT_AXES.filter(function (axis) {
         return unavailableAxes.indexOf(axis) === -1;
       });
@@ -494,6 +467,13 @@
         var raw = typeof attributes[axis] === "number" ? attributes[axis] : 0;
         var share =
           isUnavailable || weightTotal <= 0 ? 0 : (weights[axis] || 0) / weightTotal;
+
+        // Per-axis colored bar (spec §4.5 "mirroring scene colors"), plus the
+        // existing raw × weight% = contribution breakdown text row beneath it
+        // — the bar is new anatomy, the contribution math is unchanged.
+        panelEl.appendChild(
+          window.vizShared.buildMeterRow(axis, axis + (isUnavailable ? " (unavailable)" : ""), raw)
+        );
 
         var row = document.createElement("div");
         row.setAttribute("class", "viz-drill-row");
@@ -534,14 +514,16 @@
       panelEl.appendChild(notes);
 
       panelEl.hidden = false;
+      onOpenChange(true);
     };
   }
 
-  function wireDrillPanelClose(panelEl, drillState) {
+  function wireDrillPanelClose(panelEl, drillState, onOpenChange) {
     document.addEventListener("keydown", function (evt) {
       if (evt.key === "Escape" && !panelEl.hidden) {
         drillState.node = null;
         panelEl.hidden = true;
+        onOpenChange(false);
       }
     });
   }
@@ -680,15 +662,25 @@
       elements.storageWarning.hidden = false;
     }
 
+    // Shared by every localStorage-backed store's onFallback handler (the
+    // annotation store below, and the treemap's collapse/focus-state store —
+    // views/treemap.js reaches this via `state.notifyStorageFallback`) so a
+    // runtime write failure (e.g. quota exceeded) always surfaces the same
+    // visible banner, whichever store hit it.
+    function surfaceStorageFallback(message) {
+      elements.storageWarning.textContent = message;
+      elements.storageWarning.hidden = false;
+    }
+
     // Storage was available at page-load but a later write failed (e.g. quota
     // exceeded) — reveal the same banner so the reviewer sees that notes have
     // stopped persisting mid-session.
     annotationStore.onFallback(function () {
-      elements.storageWarning.textContent =
+      surfaceStorageFallback(
         "Notes have stopped being saved (a localStorage write failed — the " +
-        "browser storage quota may be full). " +
-        "Use “Copy notes as JSON” before closing this tab.";
-      elements.storageWarning.hidden = false;
+          "browser storage quota may be full). " +
+          "Use “Copy notes as JSON” before closing this tab."
+      );
     });
 
     var mountedViews = [];
@@ -698,8 +690,27 @@
     // `sonarHandle` holds the currently-mounted sonar drill (or null), so it
     // can be torn down before the panel rebuilds (spec §4.2).
     var drillState = { node: null, sonarHandle: null };
+
+    // Drawer conversion (fidelity F3): the drawer never overlays the diagram
+    // — `#viz-root`'s `viz-drill-open` class shrinks it (scene.css), and the
+    // `viz:drill-panel-toggled` event lets the treemap re-run its layout
+    // against the new width (views/treemap.js) — a real dimension change,
+    // not the "encoding-only" case reencode() covers.
+    function onDrillOpenChange(open) {
+      elements.root.classList.toggle("viz-drill-open", open);
+      document.dispatchEvent(
+        new CustomEvent("viz:drill-panel-toggled", { detail: { open: open } })
+      );
+    }
+
     var openDrill = makeOpenDrill(
-      elements.drillPanel, scene, annotationStore, weights, unavailableAxes, drillState
+      elements.drillPanel,
+      scene,
+      annotationStore,
+      weights,
+      unavailableAxes,
+      drillState,
+      onDrillOpenChange
     );
 
     function onWeightChange() {
@@ -728,7 +739,8 @@
         unavailableAxes: unavailableAxes,
         computeHeat: computeHeatFactory(weights, unavailableAxes),
         theme: currentThemeName(),
-        openDrill: openDrill
+        openDrill: openDrill,
+        notifyStorageFallback: surfaceStorageFallback
       };
     }
 
@@ -738,7 +750,7 @@
     });
     wireCopyNotesButton(controls.copyButton, controls.copyStatus, annotationStore);
     buildLegend(elements.legend, staleGraph);
-    wireDrillPanelClose(elements.drillPanel, drillState);
+    wireDrillPanelClose(elements.drillPanel, drillState, onDrillOpenChange);
 
     document.addEventListener("viz:theme-changed", reencodeAll);
 

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -38,6 +38,22 @@
   --viz-hue-violet: #4a3aa7;
   --viz-hue-magenta: #e87ba4;
   --viz-hue-orange: #eb6834;
+
+  /* Per-axis meter colors (spec §4.5 "mirroring scene colors", fidelity F3):
+     one token per heat axis, reused verbatim by the drill drawer's meter
+     rows, the hover score card, and the ledger's compact mini-bars — never a
+     bespoke color at any one of those three call sites. Aliases onto the
+     categorical hues above rather than new literals, so a theme edit to
+     `--viz-hue-*` still only lives in one place. */
+  --viz-axis-complexity: var(--viz-hue-blue);
+  --viz-axis-load-bearing: var(--viz-hue-violet);
+  --viz-axis-consequence: var(--viz-hue-orange);
+  --viz-axis-heat: var(--viz-fg);
+
+  /* The drill drawer's fixed width (fidelity F3) — shared by the drawer
+     itself and `#viz-root`'s stage-shrink margin, so the diagram container
+     always narrows by exactly the drawer's own width. */
+  --viz-drill-width: min(24rem, 90vw);
 }
 @media (prefers-color-scheme: dark) {
   :root:not([data-viz-theme="light"]) {
@@ -223,6 +239,14 @@ body {
 /* ---- Estate treemap (spec §6.1). ---- */
 #viz-root {
   margin: 0 0 1rem;
+  transition: margin-right 0.18s ease;
+}
+/* Drawer conversion (fidelity F3, prototype anatomy `#stage.drill-open`):
+   the drill drawer never overlays the diagram — the view stage SHRINKS by
+   exactly the drawer's own width so tiles/rows under it stay fully
+   interactive. Toggled by app.js's `onDrillOpenChange`. */
+#viz-root.viz-drill-open {
+  margin-right: var(--viz-drill-width);
 }
 /* The view's own flow-laid-out chrome (reset control, focus breadcrumb)
    stacks above the absolutely-positioned tile stage — never inside it, so
@@ -392,30 +416,58 @@ body {
   border-width: 2px;
 }
 
-/* ---- Drill panel (spec §4.2/§4.5): opaque overlay, bordered, Escape closes. */
+/* ---- Drill panel (spec §4.2/§4.5): a full-height right-docked drawer
+   (fidelity F3, prototype anatomy `#drill`) — the diagram stays visible and
+   interactive behind it via `#viz-root.viz-drill-open`'s stage-shrink margin
+   (above), so this is never an overlay in the "blocks the content" sense.
+   Escape closes; bordered on its one open edge. */
 .viz-drill-panel {
   position: fixed;
-  top: 10vh;
-  right: 1rem;
-  width: min(24rem, 90vw);
-  max-height: 70vh;
-  overflow: auto;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--viz-drill-width);
+  max-height: none;
+  overflow-y: auto;
   background: var(--viz-overlay-bg);
   opacity: 1;
   color: var(--viz-fg);
-  border: 1px solid var(--viz-border-strong);
-  border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  border-left: 1px solid var(--viz-border-strong);
+  border-radius: 0;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.25);
   padding: 0.75rem 1rem;
-  z-index: 10;
+  z-index: 20;
 }
 .viz-drill-panel[hidden] {
   display: none;
 }
+.viz-drill-panel #viz-drill-panel-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+}
 .viz-drill-panel h2 {
   font-size: 0.95rem;
-  margin: 0 0 0.5rem;
+  margin: 0 2rem 0.5rem 0;
   word-break: break-all;
+}
+/* PR diff stats (spec §4.5, prototype `.stat` chips): the churn chip and the
+   shared per-file diff link (views/_shared.js), flow-laid-out together. */
+.viz-drill-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0 0 0.5rem;
+}
+.viz-drill-stat {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border: 1px solid var(--viz-border);
+  border-radius: 999px;
+  background: var(--viz-surface);
+  font-size: 11px;
+  color: var(--viz-secondary);
 }
 .viz-drill-row {
   display: flex;
@@ -434,6 +486,80 @@ body {
   border: 1px solid var(--viz-border);
   border-radius: 4px;
   padding: 0.35rem;
+}
+
+/* ---- Per-axis meter rows (spec §4.5 "mirroring scene colors", fidelity
+   F3): the shared building block (window.vizShared.buildMeterRow) used by
+   the drill drawer's per-axis breakdown and the hover score card. ---- */
+.viz-meter-row {
+  display: grid;
+  grid-template-columns: 6.5rem 1fr 2.5rem;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 11px;
+  color: var(--viz-secondary);
+  margin: 0.2rem 0;
+}
+.viz-meter-bar {
+  display: block;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--viz-border);
+  overflow: hidden;
+}
+.viz-meter-fill {
+  display: block;
+  height: 100%;
+}
+.viz-meter-value {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+/* The ledger row's compact fill-only variant
+   (window.vizShared.buildMiniBar) — no label/value text. */
+.viz-meter-mini {
+  display: inline-block;
+  width: 14px;
+  height: 6px;
+  border-radius: 2px;
+  background: var(--viz-border);
+  overflow: hidden;
+}
+.viz-meter-mini-fill {
+  display: block;
+  height: 100%;
+}
+
+/* ---- Hover score card (spec §4.5, fidelity F3, prototype anatomy
+   `#tooltip`): a single shared tooltip element (window.vizShared.showTooltip)
+   reused across every view — pointer-events: none so it never itself becomes
+   a hover/click target, following the cursor and flipped near viewport edges
+   in JS. ---- */
+.viz-tooltip {
+  position: fixed;
+  pointer-events: none;
+  z-index: 50;
+  background: var(--viz-overlay-bg);
+  border: 1px solid var(--viz-border-strong);
+  border-radius: 6px;
+  padding: 0.5rem 0.65rem;
+  font-size: 12px;
+  max-width: 22rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  color: var(--viz-fg);
+}
+.viz-tooltip[hidden] {
+  display: none;
+}
+.viz-tooltip-path {
+  font-weight: 600;
+  word-break: break-all;
+  margin-bottom: 0.25rem;
+}
+.viz-tooltip-churn {
+  margin-top: 0.3rem;
+  color: var(--viz-secondary);
+  font-size: 11px;
 }
 
 /* ---- File sonar (spec §6.1): a drill-panel affordance, not a top-level
@@ -597,6 +723,13 @@ body {
   white-space: nowrap;
   font-size: 12.5px;
 }
+/* Compact per-axis mini-bars (spec §4.5, fidelity F3) — between the path and
+   the numeric heat, same color tokens as the drill drawer/hover score card. */
+.viz-ledger-axis-bars {
+  display: flex;
+  flex: none;
+  gap: 2px;
+}
 .viz-ledger-heat {
   min-width: 3rem;
   text-align: right;
@@ -606,11 +739,15 @@ body {
 .viz-ledger-link {
   flex: none;
 }
-.viz-ledger-diff-link {
+/* .viz-diff-link is the shared per-file diff anchor (window.vizShared.
+   buildDiffLink, views/_shared.js) — reused verbatim by the drill drawer's
+   stats row, so its styling lives here rather than under a ledger-specific
+   class name. */
+.viz-diff-link {
   font-size: 12px;
   color: var(--viz-hue-blue);
 }
-.viz-ledger-diff-link:focus-visible {
+.viz-diff-link:focus-visible {
   outline: 2px solid var(--viz-fg);
   outline-offset: 1px;
 }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -36,10 +36,367 @@
 // The one true signal is the Python heat model listing "load_bearing" in
 // render_config.unavailable_axes (scene/heat.py), which happens exactly when
 // the centrality axis fail-softs (graphify absent/stale/torn).
+//
+// makeLocalStorageStore: the feature-detected localStorage probe/fallback
+// pattern (spec §4.5) — a real write always lands somewhere (an in-memory map
+// when storage is unavailable or a runtime write fails, e.g. quota exceeded),
+// and `onFallback` fires the first time a *runtime* write falls back, so a
+// caller can surface a non-persistence warning that boot-time feature
+// detection alone would miss (storage can be available at page-load and fail
+// later). Originally duplicated between app.js's annotation store and
+// treemap.js's collapse/focus-state store (fidelity F3) — both now rebase
+// on this one factory.
+//
+// buildMeterRow/buildMiniBar/axisColorVar: the per-axis colored bar building
+// blocks shared by the drill drawer, the hover score card, and the ledger's
+// compact mini-bars (spec §4.5 "mirroring scene colors") — one color token
+// per axis (`--viz-axis-*`, scene.css), used consistently everywhere an axis
+// value is rendered as a bar.
+//
+// buildDiffLink/showTooltip/hideTooltip/moveTooltip/buildScoreCard: the
+// per-file diff-link builder (hoisted out of views/ledger.js, spec §6.1 G3)
+// and the hover score-card tooltip (spec §4.5), both reused by the treemap
+// and the ledger.
 (function () {
   "use strict";
 
   window.vizShared = window.vizShared || {};
+
+  // The three §6.2 input axes plus the combined heat, in the same order/
+  // names as `vizsuite.scene.heat._INPUT_AXES` (mirrored in app.js's own
+  // HEAT_AXES, which now reads this shared constant instead of duplicating
+  // it).
+  var HEAT_AXES = ["complexity", "load_bearing", "consequence"];
+  window.vizShared.HEAT_AXES = HEAT_AXES;
+
+  function makeLocalStorageStore(prefix) {
+    // A NUL-suffixed probe key so the availability check never reads or
+    // clobbers a real key under this prefix (no valid repo path, and no
+    // fixed non-path key this module mints, ever contains a NUL byte).
+    var probeKey = prefix + "\u0000probe";
+    var available = false;
+    try {
+      window.localStorage.setItem(probeKey, "1");
+      window.localStorage.removeItem(probeKey);
+      available = true;
+    } catch (err) {
+      available = false;
+    }
+    var memory = Object.create(null);
+    var fallbackHandler = null;
+    var fallbackNotified = false;
+
+    function notifyFallback() {
+      if (fallbackNotified) {
+        return;
+      }
+      fallbackNotified = true;
+      if (typeof fallbackHandler === "function") {
+        fallbackHandler();
+      }
+    }
+
+    function onFallback(handler) {
+      fallbackHandler = handler;
+    }
+
+    function getItem(key) {
+      if (available) {
+        return window.localStorage.getItem(key);
+      }
+      return Object.prototype.hasOwnProperty.call(memory, key) ? memory[key] : null;
+    }
+
+    function setItem(key, value) {
+      if (available) {
+        try {
+          window.localStorage.setItem(key, value);
+          return;
+        } catch (err) {
+          // Fall through to the in-memory map (e.g. quota exceeded) and
+          // surface the non-persistence warning via the caller's handler.
+          notifyFallback();
+        }
+      }
+      memory[key] = value;
+    }
+
+    function removeItem(key) {
+      if (available) {
+        try {
+          window.localStorage.removeItem(key);
+          return;
+        } catch (err) {
+          notifyFallback();
+        }
+      }
+      delete memory[key];
+    }
+
+    function keys() {
+      var out = [];
+      if (available) {
+        for (var i = 0; i < window.localStorage.length; i++) {
+          var k = window.localStorage.key(i);
+          if (k && k.indexOf(prefix) === 0) {
+            out.push(k);
+          }
+        }
+      } else {
+        for (var mk in memory) {
+          if (Object.prototype.hasOwnProperty.call(memory, mk)) {
+            out.push(mk);
+          }
+        }
+      }
+      return out;
+    }
+
+    return {
+      available: available,
+      getItem: getItem,
+      setItem: setItem,
+      removeItem: removeItem,
+      keys: keys,
+      onFallback: onFallback
+    };
+  }
+
+  window.vizShared.makeLocalStorageStore = makeLocalStorageStore;
+
+  // ---- Per-axis color tokens (spec §4.5 "mirroring scene colors") — one
+  // `--viz-axis-*` custom property per axis (scene.css), plus a neutral
+  // token for the combined-heat row; unknown axes fall back to `--viz-fg`
+  // rather than rendering an unstyled bar. ----
+  var AXIS_COLOR_VARS = {
+    complexity: "var(--viz-axis-complexity)",
+    load_bearing: "var(--viz-axis-load-bearing)",
+    consequence: "var(--viz-axis-consequence)",
+    heat: "var(--viz-axis-heat)"
+  };
+
+  function axisColorVar(axis) {
+    return AXIS_COLOR_VARS[axis] || "var(--viz-fg)";
+  }
+
+  window.vizShared.axisColorVar = axisColorVar;
+
+  // A labeled row: axis name, a filled bar (0-1 → 0-100%), and the numeric
+  // value — the drill drawer's per-axis breakdown and the hover score card's
+  // shared building block.
+  function buildMeterRow(axis, label, value) {
+    var row = document.createElement("div");
+    row.setAttribute("class", "viz-meter-row");
+    row.setAttribute("data-axis", axis);
+
+    var labelEl = document.createElement("span");
+    labelEl.setAttribute("class", "viz-meter-label");
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+
+    var barEl = document.createElement("span");
+    barEl.setAttribute("class", "viz-meter-bar");
+    var fillEl = document.createElement("span");
+    fillEl.setAttribute("class", "viz-meter-fill");
+    var pct = Math.max(0, Math.min(1, value || 0)) * 100;
+    fillEl.style.width = pct + "%";
+    fillEl.style.backgroundColor = axisColorVar(axis);
+    barEl.appendChild(fillEl);
+    row.appendChild(barEl);
+
+    var valueEl = document.createElement("span");
+    valueEl.setAttribute("class", "viz-meter-value");
+    valueEl.textContent = (value || 0).toFixed(2);
+    row.appendChild(valueEl);
+
+    return row;
+  }
+
+  window.vizShared.buildMeterRow = buildMeterRow;
+
+  // A bare fill-only bar, no label/value text — the ledger row's compact
+  // per-axis mini-bars (spec §4.5), same color tokens as buildMeterRow.
+  function buildMiniBar(axis, value) {
+    var barEl = document.createElement("span");
+    barEl.setAttribute("class", "viz-meter-mini");
+    barEl.setAttribute("data-axis", axis);
+    barEl.setAttribute("aria-hidden", "true");
+    var fillEl = document.createElement("span");
+    fillEl.setAttribute("class", "viz-meter-mini-fill");
+    var pct = Math.max(0, Math.min(1, value || 0)) * 100;
+    fillEl.style.width = pct + "%";
+    fillEl.style.backgroundColor = axisColorVar(axis);
+    barEl.appendChild(fillEl);
+    return barEl;
+  }
+
+  window.vizShared.buildMiniBar = buildMiniBar;
+
+  // ---- Per-file diff link (spec §6.1 G3), hoisted out of views/ledger.js so
+  // the drill drawer can reuse it too (fidelity F3). GitHub's per-file anchor
+  // on a PR's "Files changed" tab is `pull/<n>/files#diff-<sha256hex(path)>`
+  // (current, undocumented scheme). Computing that hash needs SubtleCrypto,
+  // which only exists in a secure context (https, or http://localhost) —
+  // never on a `file://` origin, which is exactly how these artifacts are
+  // normally opened (spec §4.1). Rather than vendor a hand-rolled SHA-256
+  // implementation for an anchor-only affordance, this degrades: a PR-file
+  // caller gets the bare `.../pull/<n>/files` link synchronously (correct,
+  // just not scrolled to the right file), then the `href` upgrades in place
+  // to the anchored form if-and-when a digest resolves. `repo_nwo` absent/
+  // empty (the PR verb couldn't resolve the GitHub remote), or a non-PR
+  // file, never fabricates a URL — returns `null` instead. ----
+  function sha256HexOrNull(text) {
+    var subtle = window.crypto && window.crypto.subtle;
+    if (!subtle || typeof subtle.digest !== "function" || typeof TextEncoder === "undefined") {
+      return null;
+    }
+    var bytes = new TextEncoder().encode(text);
+    return subtle.digest("SHA-256", bytes).then(function (buffer) {
+      var view = new Uint8Array(buffer);
+      var hex = "";
+      for (var i = 0; i < view.length; i++) {
+        var byteHex = view[i].toString(16);
+        hex += byteHex.length === 1 ? "0" + byteHex : byteHex;
+      }
+      return hex;
+    });
+  }
+
+  function buildDiffLink(scene, path, inPr) {
+    if (!inPr || !scene.repo_nwo) {
+      return null; // no PR diff for a context file; never fabricate a URL without repo_nwo
+    }
+    var base = "https://github.com/" + scene.repo_nwo + "/pull/" + scene.pr_number + "/files";
+    var anchor = document.createElement("a");
+    anchor.setAttribute("class", "viz-diff-link");
+    anchor.href = base;
+    anchor.target = "_blank";
+    anchor.rel = "noopener";
+    anchor.setAttribute("aria-label", "View diff for " + path + " on GitHub");
+    anchor.textContent = "Diff";
+    // The anchor is its own activation target — never let its own events
+    // also trigger the host's row/tile-open handler (see wireClickVsDrag-
+    // Activation callers). Stopping the pointer events too (not just click/
+    // keydown) closes the gap a `.closest("a")` exemption alone leaves when
+    // `evt.target` has no `.closest` (a non-Element target).
+    function stopPropagation(evt) {
+      evt.stopPropagation();
+    }
+    ["click", "keydown", "pointerdown", "pointerup"].forEach(function (type) {
+      anchor.addEventListener(type, stopPropagation);
+    });
+
+    var digest = sha256HexOrNull(path);
+    if (digest) {
+      digest.then(
+        function (hex) {
+          anchor.href = base + "#diff-" + hex;
+        },
+        function () {
+          // Fail soft: if hashing rejects, keep the unanchored /files link
+          // rather than surfacing an unhandled promise rejection.
+        }
+      );
+    }
+    return anchor;
+  }
+
+  window.vizShared.buildDiffLink = buildDiffLink;
+
+  // ---- Hover score card (spec §4.5): a single shared tooltip element,
+  // mounted once and reused across every view/re-render — pointer-events:
+  // none, follows the cursor, flips near viewport edges (prototype anatomy:
+  // #tooltip). Content is rebuilt on every `showTooltip` call from
+  // repo-derived data bound via textContent/`.value` only (never innerHTML),
+  // matching the templating layer's DOM-bind invariant (spec §4.6). ----
+  var tooltipEl = null;
+
+  function ensureTooltipEl() {
+    if (!tooltipEl) {
+      tooltipEl = document.createElement("div");
+      tooltipEl.id = "viz-tooltip";
+      tooltipEl.setAttribute("class", "viz-tooltip");
+      tooltipEl.hidden = true;
+      document.body.appendChild(tooltipEl);
+    }
+    return tooltipEl;
+  }
+
+  function positionTooltip(evt) {
+    var el = tooltipEl;
+    if (!el) {
+      return;
+    }
+    var pad = 14;
+    var w = el.offsetWidth;
+    var h = el.offsetHeight;
+    var x = evt.clientX + pad;
+    var y = evt.clientY + pad;
+    if (x + w > window.innerWidth - 8) {
+      x = evt.clientX - w - pad;
+    }
+    if (y + h > window.innerHeight - 8) {
+      y = evt.clientY - h - pad;
+    }
+    el.style.left = x + "px";
+    el.style.top = y + "px";
+  }
+
+  function showTooltip(evt, buildContent) {
+    var el = ensureTooltipEl();
+    while (el.firstChild) {
+      el.removeChild(el.firstChild);
+    }
+    buildContent(el);
+    el.hidden = false;
+    positionTooltip(evt);
+  }
+
+  function moveTooltip(evt) {
+    if (tooltipEl && !tooltipEl.hidden) {
+      positionTooltip(evt);
+    }
+  }
+
+  function hideTooltip() {
+    if (tooltipEl) {
+      tooltipEl.hidden = true;
+    }
+  }
+
+  window.vizShared.showTooltip = showTooltip;
+  window.vizShared.moveTooltip = moveTooltip;
+  window.vizShared.hideTooltip = hideTooltip;
+
+  // The tooltip/drawer-shared content builder: path, one meter row per heat
+  // axis, the combined heat, and — for a PR file whose attributes carry
+  // churn (spec §4.5 PR diff stats) — a trailing +adds/−dels line. `attributes`
+  // is a file's raw scene attributes; `heatValue` is the already-computed
+  // combined heat for this file (the caller's own `computeHeat`/annotated
+  // node value — never recomputed here, so this always matches the tile/row
+  // color it is describing).
+  function buildScoreCard(container, path, attributes, heatValue) {
+    var pathEl = document.createElement("div");
+    pathEl.setAttribute("class", "viz-tooltip-path");
+    pathEl.textContent = path;
+    container.appendChild(pathEl);
+
+    HEAT_AXES.forEach(function (axis) {
+      var value = typeof attributes[axis] === "number" ? attributes[axis] : 0;
+      container.appendChild(buildMeterRow(axis, axis, value));
+    });
+    container.appendChild(buildMeterRow("heat", "heat", heatValue));
+
+    if (attributes.in_pr && typeof attributes.added === "number") {
+      var churnEl = document.createElement("div");
+      churnEl.setAttribute("class", "viz-tooltip-churn");
+      var deleted = typeof attributes.deleted === "number" ? attributes.deleted : 0;
+      churnEl.textContent = "+" + attributes.added + "/−" + deleted;
+      container.appendChild(churnEl);
+    }
+  }
+
+  window.vizShared.buildScoreCard = buildScoreCard;
 
   function wireClickVsDragActivation(el, options) {
     var onActivate = options.onActivate;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -306,10 +306,10 @@
     anchor.setAttribute("aria-label", "View diff for " + path + " on GitHub");
     anchor.textContent = "Diff";
     // The anchor is its own activation target — never let its own events
-    // also trigger the host's row/tile-open handler (see wireClickVsDrag-
-    // Activation callers). Stopping the pointer events too (not just click/
-    // keydown) closes the gap a `.closest("a")` exemption alone leaves when
-    // `evt.target` has no `.closest` (a non-Element target).
+    // also trigger the host's row/tile-open handler (see
+    // wireClickVsDragActivation callers). Stopping the pointer events too
+    // (not just click/keydown) closes the gap a `.closest("a")` exemption
+    // alone leaves when `evt.target` has no `.closest` (a non-Element target).
     function stopPropagation(evt) {
       evt.stopPropagation();
     }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -62,10 +62,10 @@
 
   window.vizShared = window.vizShared || {};
 
-  // The three §6.2 input axes plus the combined heat, in the same order/
-  // names as `vizsuite.scene.heat._INPUT_AXES` (mirrored in app.js's own
-  // HEAT_AXES, which now reads this shared constant instead of duplicating
-  // it).
+  // The three §6.2 input axes only (the combined heat is derived
+  // separately and is NOT included here), in the same order/names as
+  // `vizsuite.scene.heat._INPUT_AXES` (mirrored in app.js's own HEAT_AXES,
+  // which now reads this shared constant instead of duplicating it).
   var HEAT_AXES = ["complexity", "load_bearing", "consequence"];
   window.vizShared.HEAT_AXES = HEAT_AXES;
 

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -82,7 +82,15 @@
     } catch (err) {
       available = false;
     }
+    // The in-memory overlay holds two kinds of entry localStorage never got:
+    // fallback writes (a runtime setItem failed, e.g. quota) and removal
+    // tombstones (a runtime removeItem failed while the value still sits in
+    // localStorage). TOMBSTONE is a unique sentinel distinguishing "removed
+    // after a runtime fallback" from "never written" — getItem/keys consult
+    // the overlay first so writes and removals read back consistently once a
+    // runtime failure has diverged the overlay from localStorage.
     var memory = Object.create(null);
+    var TOMBSTONE = {};
     var fallbackHandler = null;
     var fallbackNotified = false;
 
@@ -101,19 +109,30 @@
     }
 
     function getItem(key) {
+      // Consult the overlay first: a fallback write or a removal tombstone
+      // recorded after a runtime failure must win over the (stale or still-
+      // present) localStorage entry, so values written after a fallback stay
+      // readable and tombstoned removals stay removed.
+      if (Object.prototype.hasOwnProperty.call(memory, key)) {
+        return memory[key] === TOMBSTONE ? null : memory[key];
+      }
       if (available) {
         return window.localStorage.getItem(key);
       }
-      return Object.prototype.hasOwnProperty.call(memory, key) ? memory[key] : null;
+      return null;
     }
 
     function setItem(key, value) {
       if (available) {
         try {
           window.localStorage.setItem(key, value);
+          // localStorage is authoritative for this key again; drop any stale
+          // overlay entry (a prior fallback write or tombstone) so it can't
+          // shadow the fresh value.
+          delete memory[key];
           return;
         } catch (err) {
-          // Fall through to the in-memory map (e.g. quota exceeded) and
+          // Fall through to the in-memory overlay (e.g. quota exceeded) and
           // surface the non-persistence warning via the caller's handler.
           notifyFallback();
         }
@@ -125,9 +144,14 @@
       if (available) {
         try {
           window.localStorage.removeItem(key);
+          delete memory[key];
           return;
         } catch (err) {
+          // The value is still in localStorage; record a tombstone so the
+          // removal is reflected once getItem/keys fall back to the overlay.
           notifyFallback();
+          memory[key] = TOMBSTONE;
+          return;
         }
       }
       delete memory[key];
@@ -135,18 +159,25 @@
 
     function keys() {
       var out = [];
+      var seen = Object.create(null);
       if (available) {
         for (var i = 0; i < window.localStorage.length; i++) {
           var k = window.localStorage.key(i);
-          if (k && k.indexOf(prefix) === 0) {
+          if (k && k.indexOf(prefix) === 0 && memory[k] !== TOMBSTONE) {
             out.push(k);
+            seen[k] = true;
           }
         }
-      } else {
-        for (var mk in memory) {
-          if (Object.prototype.hasOwnProperty.call(memory, mk)) {
-            out.push(mk);
-          }
+      }
+      // Merge overlay keys (fallback writes localStorage never got), deduped
+      // against the localStorage pass and excluding tombstoned removals.
+      for (var mk in memory) {
+        if (
+          Object.prototype.hasOwnProperty.call(memory, mk) &&
+          memory[mk] !== TOMBSTONE &&
+          !seen[mk]
+        ) {
+          out.push(mk);
         }
       }
       return out;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/ledger.js
@@ -7,22 +7,11 @@
 // treemap's tile x/y/width/height), not a flat list's own paint order,
 // which the spec explicitly allows to reflow on re-rank.
 //
-// Diff-link decision (spec §6.1 "attention ledger" / G3): GitHub's per-file
-// anchor on a PR's "Files changed" tab is `pull/<n>/files#diff-<sha256hex
-// (path)>` (current, undocumented scheme). Computing that hash needs
-// SubtleCrypto, which only exists in a secure context (https, or
-// http://localhost) — never on a `file://` origin, which is exactly how
-// these artifacts are normally opened (spec §4.1: double-click, offline,
-// detached from any session). Rather than vendor a hand-rolled SHA-256
-// implementation for an anchor-only affordance, this module degrades: every
-// PR-file row gets the bare `.../pull/<n>/files` link synchronously (correct,
-// just not scrolled to the right file), then upgrades `href` in place to the
-// anchored form if-and-when a digest resolves. A `file://` artifact keeps the
-// still-useful bare-tab link forever; a served/https copy (this repo's
-// playwright checks, or a shared internal copy) gets the precise per-file
-// anchor a tick later. `repo_nwo` absent/empty (the PR verb couldn't resolve
-// the GitHub remote) never fabricates a URL — the file name renders unlinked
-// instead, same as any context (non-PR) file, which has no diff to link to.
+// Diff-link decision (spec §6.1 "attention ledger" / G3): the per-file
+// diff-link builder (GitHub's `pull/<n>/files#diff-<sha256hex(path)>` anchor
+// scheme) is shared with the drill drawer via `window.vizShared.buildDiffLink`
+// (hoisted to views/_shared.js, fidelity F3) — see that module for the full
+// SubtleCrypto/`file://` degrade rationale.
 (function () {
   "use strict";
 
@@ -35,26 +24,6 @@
     sectionContext: "viz-ledger-section-context",
     sectionAll: "viz-ledger-section-all"
   };
-
-  // Returns a Promise<string> (lowercase hex sha256) when SubtleCrypto is
-  // available in this context, or `null` synchronously when it is not, so
-  // the caller never blocks first paint on the digest.
-  function sha256HexOrNull(text) {
-    var subtle = window.crypto && window.crypto.subtle;
-    if (!subtle || typeof subtle.digest !== "function" || typeof TextEncoder === "undefined") {
-      return null;
-    }
-    var bytes = new TextEncoder().encode(text);
-    return subtle.digest("SHA-256", bytes).then(function (buffer) {
-      var view = new Uint8Array(buffer);
-      var hex = "";
-      for (var i = 0; i < view.length; i++) {
-        var byteHex = view[i].toString(16);
-        hex += byteHex.length === 1 ? "0" + byteHex : byteHex;
-      }
-      return hex;
-    });
-  }
 
   // ---- scene.files → ranked rows (spec §6.1): one row per file, heat via
   // the shared computeHeat (never re-derived here), in_pr read straight off
@@ -87,42 +56,25 @@
   function buildDiffLinkHolder(scene, row) {
     var holder = document.createElement("span");
     holder.setAttribute("class", "viz-ledger-link");
-    if (!row.inPr || !scene.repo_nwo) {
-      return holder; // no PR diff for a context file; never fabricate a URL without repo_nwo
-    }
-    var base = "https://github.com/" + scene.repo_nwo + "/pull/" + scene.pr_number + "/files";
-    var anchor = document.createElement("a");
-    anchor.setAttribute("class", "viz-ledger-diff-link");
-    anchor.href = base;
-    anchor.target = "_blank";
-    anchor.rel = "noopener";
-    anchor.setAttribute("aria-label", "View diff for " + row.file.path + " on GitHub");
-    anchor.textContent = "Diff";
-    // The anchor is its own activation target — never let its own events also
-    // trigger the row's drill-open handler (see wireRowActivation). The row
-    // activates on pointerup (with a `fromLink` .closest exemption), so
-    // stopping click/keydown alone leaves the pointer path guarded only by
-    // that exemption, which fails open when evt.target has no `.closest`
-    // (non-Element target). Stop the pointer events that drive row activation
-    // too, so the diff link can never double-fire "open drill" + "open diff".
-    function stopPropagation(evt) {
-      evt.stopPropagation();
-    }
-    ["click", "keydown", "pointerdown", "pointerup"].forEach(function (type) {
-      anchor.addEventListener(type, stopPropagation);
-    });
-    holder.appendChild(anchor);
-
-    var digest = sha256HexOrNull(row.file.path);
-    if (digest) {
-      digest.then(function (hex) {
-        anchor.href = base + "#diff-" + hex;
-      }, function () {
-        // Fail soft: if hashing rejects, keep the unanchored /files link
-        // rather than surfacing an unhandled promise rejection.
-      });
+    var link = window.vizShared.buildDiffLink(scene, row.file.path, row.inPr);
+    if (link) {
+      holder.appendChild(link);
     }
     return holder;
+  }
+
+  // Compact per-axis colored mini-bars (spec §4.5 "mirroring scene colors"),
+  // same color tokens as the drill drawer and hover score card
+  // (window.vizShared.axisColorVar) — one bare fill-only bar per heat axis,
+  // no label/value text so the row stays compact.
+  function buildAxisMiniBars(attributes) {
+    var wrap = document.createElement("span");
+    wrap.setAttribute("class", "viz-ledger-axis-bars");
+    window.vizShared.HEAT_AXES.forEach(function (axis) {
+      var value = typeof attributes[axis] === "number" ? attributes[axis] : 0;
+      wrap.appendChild(window.vizShared.buildMiniBar(axis, value));
+    });
+    return wrap;
   }
 
   // Click-vs-drag threshold (~4px, spec §4.2), via the shared
@@ -137,6 +89,26 @@
       isExempt: function (evt) {
         return Boolean(evt.target.closest && evt.target.closest("a"));
       }
+    });
+  }
+
+  // Hover score card (spec §4.5) — a disjoint event family (pointerenter/
+  // move/leave) from wireRowActivation's own pointerdown/up/click/keydown,
+  // so it never interferes with row activation or the diff link's own
+  // stopPropagation guard.
+  function wireRowTooltip(el, row) {
+    el.addEventListener("pointerenter", function (evt) {
+      window.vizShared.showTooltip(evt, function (container) {
+        window.vizShared.buildScoreCard(
+          container, row.file.path, row.file.attributes || {}, row.heat
+        );
+      });
+    });
+    el.addEventListener("pointermove", function (evt) {
+      window.vizShared.moveTooltip(evt);
+    });
+    el.addEventListener("pointerleave", function () {
+      window.vizShared.hideTooltip();
     });
   }
 
@@ -174,6 +146,8 @@
     pathEl.textContent = row.file.path;
     el.appendChild(pathEl);
 
+    el.appendChild(buildAxisMiniBars(row.file.attributes || {}));
+
     var heatEl = document.createElement("span");
     heatEl.setAttribute("class", "viz-ledger-heat");
     heatEl.textContent = heatText;
@@ -188,6 +162,7 @@
       // any tree-building machinery the ledger doesn't need.
       openDrill({ path: row.file.path, orig: { file: row.file } });
     });
+    wireRowTooltip(el, row);
 
     return el;
   }
@@ -240,6 +215,10 @@
       }
 
       function renderAll() {
+        // A rebuild (mode toggle, weight change) discards the current rows'
+        // DOM without ever firing a real `pointerleave` on a hovered one —
+        // hide unconditionally rather than leaving a dangling tooltip.
+        window.vizShared.hideTooltip();
         while (listEl.firstChild) {
           listEl.removeChild(listEl.firstChild);
         }
@@ -275,6 +254,7 @@
 
       return {
         destroy: function () {
+          window.vizShared.hideTooltip();
           while (container.firstChild) {
             container.removeChild(container.firstChild);
           }

--- a/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/treemap.js
@@ -331,6 +331,31 @@
     });
   }
 
+  // Hover score card (spec §4.5), file tiles only — a directory tile (whether
+  // expanded or collapsed) has no single set of per-axis scores to show.
+  // Pointer hover events (enter/move/leave) are a disjoint event family from
+  // wireClickVsDragActivation's own pointerdown/up/cancel, so this never
+  // interferes with click/drag activation or the tile's aria-label.
+  function wireTileTooltip(el, handlers) {
+    el.addEventListener("pointerenter", function (evt) {
+      var current = d3.select(el).datum();
+      if (!current.data.isFile) {
+        return;
+      }
+      handlers.onFileHoverShow(evt, current.data);
+    });
+    el.addEventListener("pointermove", function (evt) {
+      var current = d3.select(el).datum();
+      if (!current.data.isFile) {
+        return;
+      }
+      handlers.onFileHoverMove(evt);
+    });
+    el.addEventListener("pointerleave", function () {
+      handlers.onFileHoverHide();
+    });
+  }
+
   // Accessible name for a tile (a11y), set via the `aria-label` attribute —
   // repo-derived path strings flow through d3's `.attr()` (never innerHTML), so
   // the textContent/attribute-only binding invariant holds. Recomputed in the
@@ -413,6 +438,12 @@
   }
 
   function renderTiles(stageEl, layoutRoot, collapsed, heatScale, handlers) {
+    // A relayout (collapse toggle, focus, resize) can remove the tile the
+    // hover tooltip is currently describing without ever firing a real
+    // `pointerleave` — hide it unconditionally rather than leaving a
+    // dangling reference to a detached tile (fidelity F3).
+    window.vizShared.hideTooltip();
+
     var rect = stageEl.getBoundingClientRect();
     var width = rect.width || stageEl.clientWidth || 960;
     var height = rect.height || stageEl.clientHeight || 600;
@@ -438,8 +469,14 @@
       .attr("class", function (d) {
         return "viz-tile " + (d.data.isFile ? "viz-tile--file" : "viz-tile--dir");
       })
+      // The synthetic root-group's path (ROOT_GROUP_PATH) carries a NUL
+      // sentinel that must never land in a DOM attribute (spec §3's F3
+      // "accreted item C") — emit its display form instead. Nothing reads
+      // this attribute back (views bind via the D3 datum), so the datum's
+      // own `.path` stays the untouched sentinel for internal use (e.g. the
+      // `.data()` join key above).
       .attr("data-path", function (d) {
-        return d.data.path;
+        return displayPathFor(d.data);
       })
       .attr("data-collapsed", function (d) {
         return d.data.collapsed ? "true" : "false";
@@ -477,6 +514,7 @@
 
     entered.each(function () {
       wireTileInteractions(this, handlers);
+      wireTileTooltip(this, handlers);
     });
 
     applyEncoding(merged, heatScale);
@@ -532,28 +570,20 @@
   }
 
   // ---- Collapse/focus persistence (spec §6.1): localStorage, feature-
-  // detected exactly like app.js's annotation store (in-memory fallback, no
-  // crash on file:// or disabled storage) — a fixed per-repo key (no PR
-  // number in it, matching the annotation store's own per-repo scoping), so a
+  // detected via the shared factory (views/_shared.js) app.js's annotation
+  // store also rebases on (fidelity F3) — a fixed per-repo key (no PR number
+  // in it, matching the annotation store's own per-repo scoping), so a
   // reviewer's collapse/focus choices carry over between PR artifacts of the
-  // same repo. ----
+  // same repo. `onFallback` is wired by the caller (render(), below) to the
+  // same storage-warning banner app.js's annotation store surfaces — a
+  // runtime write failure here (e.g. quota exceeded) is no less worth
+  // telling the reviewer about than a lost note. ----
   function makeTreemapStateStore(repoNwo) {
     var key = "viz:" + repoNwo + ":pr:treemap-state";
-    // A NUL-suffixed probe key so the availability check never reads or
-    // clobbers the one real key this store ever touches.
-    var probeKey = key + "\u0000probe";
-    var available = false;
-    try {
-      window.localStorage.setItem(probeKey, "1");
-      window.localStorage.removeItem(probeKey);
-      available = true;
-    } catch (err) {
-      available = false;
-    }
-    var memoryValue = null;
+    var store = window.vizShared.makeLocalStorageStore(key);
 
     function load() {
-      var raw = available ? window.localStorage.getItem(key) : memoryValue;
+      var raw = store.getItem(key);
       if (!raw) {
         return null;
       }
@@ -566,30 +596,14 @@
     }
 
     function save(state) {
-      var raw = JSON.stringify(state);
-      if (available) {
-        try {
-          window.localStorage.setItem(key, raw);
-          return;
-        } catch (err) {
-          // Fall through to the in-memory fallback (e.g. quota exceeded).
-        }
-      }
-      memoryValue = raw;
+      store.setItem(key, JSON.stringify(state));
     }
 
     function clear() {
-      if (available) {
-        try {
-          window.localStorage.removeItem(key);
-        } catch (err) {
-          // ignore — nothing else to fall back to for a removal
-        }
-      }
-      memoryValue = null;
+      store.removeItem(key);
     }
 
-    return { load: load, save: save, clear: clear };
+    return { load: load, save: save, clear: clear, onFallback: store.onFallback };
   }
 
   window.vizViews.treemap = {
@@ -614,6 +628,12 @@
       });
 
       var stateStore = makeTreemapStateStore(scene.repo_nwo);
+      stateStore.onFallback(function () {
+        current.notifyStorageFallback(
+          "Your treemap view (collapsed groups, focus) has stopped being saved " +
+            "— a localStorage write failed (the browser storage quota may be full)."
+        );
+      });
       var focusPath = null;
 
       // Merge the persisted collapse/expand deltas and focus root over the
@@ -718,6 +738,19 @@
         },
         onFileClick: function (data) {
           current.openDrill(data);
+        },
+        onFileHoverShow: function (evt, data) {
+          window.vizShared.showTooltip(evt, function (el) {
+            window.vizShared.buildScoreCard(
+              el, data.path, (data.orig.file.attributes || {}), data.heat
+            );
+          });
+        },
+        onFileHoverMove: function (evt) {
+          window.vizShared.moveTooltip(evt);
+        },
+        onFileHoverHide: function () {
+          window.vizShared.hideTooltip();
         }
       };
 
@@ -734,8 +767,14 @@
       }
 
       resetBtn.addEventListener("click", function () {
+        // Clone the already-computed `defaultCollapsed` map (accreted item B)
+        // rather than re-walking the whole tree via collectDefaultCollapsed —
+        // the default-collapsed set is fixed for the view's lifetime (see the
+        // comment above `defaultCollapsed`'s own computation).
         collapsed = Object.create(null);
-        collectDefaultCollapsed(tree, collapsed);
+        Object.keys(defaultCollapsed).forEach(function (path) {
+          collapsed[path] = true;
+        });
         focusPath = null;
         stateStore.clear();
         fullRender();
@@ -744,7 +783,7 @@
       fullRender();
 
       var resizeDebounceTimer = null;
-      var resizeHandler = function () {
+      function scheduleRelayout() {
         if (resizeDebounceTimer) {
           clearTimeout(resizeDebounceTimer);
         }
@@ -752,15 +791,23 @@
           resizeDebounceTimer = null;
           fullRender();
         }, 150);
-      };
-      window.addEventListener("resize", resizeHandler);
+      }
+      window.addEventListener("resize", scheduleRelayout);
+      // The drill drawer opening/closing shrinks/restores `#viz-root`
+      // (app.js's `onDrillOpenChange`, scene.css's `viz-drill-open` class) —
+      // a real container-size change, not the "encoding-only" case
+      // reencode() covers, so it gets the same debounced relayout as a
+      // window resize (fidelity F3).
+      document.addEventListener("viz:drill-panel-toggled", scheduleRelayout);
 
       return {
         destroy: function () {
           if (resizeDebounceTimer) {
             clearTimeout(resizeDebounceTimer);
           }
-          window.removeEventListener("resize", resizeHandler);
+          window.removeEventListener("resize", scheduleRelayout);
+          document.removeEventListener("viz:drill-panel-toggled", scheduleRelayout);
+          window.vizShared.hideTooltip();
           d3.select(container).selectAll("*").remove();
         },
         reencode: function (newState) {

--- a/packages/vizsuite/src/vizsuite/verbs/pr.py
+++ b/packages/vizsuite/src/vizsuite/verbs/pr.py
@@ -94,7 +94,12 @@ def pr(runners: Runners, args: Namespace) -> JsonValue:
     allow_stale_graph: bool = args.allow_stale_graph
     centrality = centrality_axis(graph_path, scope.head_oid, allow_stale=allow_stale_graph)
     heat_model = heat.combine(
-        estate_map, complexity_scores, consequence_scores, centrality, set(scope.files)
+        estate_map,
+        complexity_scores,
+        consequence_scores,
+        centrality,
+        set(scope.files),
+        churn=scope.files,
     )
 
     # The centrality axis's own EXTRACTED, intra-file-excluded edges (empty

--- a/packages/vizsuite/tests/unit/test_scene_heat.py
+++ b/packages/vizsuite/tests/unit/test_scene_heat.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from vizsuite.extract.centrality import CentralityAxis
+from vizsuite.extract.churn import FileChurn
 from vizsuite.scene.heat import DEFAULT_WEIGHTS, combine
 
 _ESTATE = {"a.py": "sha_a", "b.py": "sha_b", "c.py": "sha_c"}
@@ -119,6 +120,36 @@ def test_in_pr_membership_reflects_the_net_file_set() -> None:
 
     assert model.attributes["a.py"]["in_pr"] is True
     assert model.attributes["b.py"]["in_pr"] is False
+
+
+def test_combine_threads_added_deleted_onto_pr_files_when_churn_is_supplied() -> None:
+    # F3 (spec §4.5 PR diff stats): a file present in the `churn` map gets its
+    # added/deleted counts threaded onto its attributes; a file absent from it
+    # (a context file, or a PR file the caller didn't supply churn for) never
+    # fabricates the keys — same "never fabricate" discipline as `in_pr`.
+    estate = {"a.py": "sha_a", "b.py": "sha_b"}
+    complexity = {"a.py": 0.5, "b.py": 0.5}
+    consequence = {"a.py": 0.5, "b.py": 0.5}
+    centrality = CentralityAxis.unavailable("no graph")
+    churn = {"a.py": FileChurn(added=12, deleted=3)}
+
+    model = combine(estate, complexity, consequence, centrality, pr_files={"a.py"}, churn=churn)
+
+    assert model.attributes["a.py"]["added"] == 12
+    assert model.attributes["a.py"]["deleted"] == 3
+    assert "added" not in model.attributes["b.py"]
+    assert "deleted" not in model.attributes["b.py"]
+
+
+def test_combine_omits_added_deleted_when_churn_is_not_supplied() -> None:
+    estate = {"a.py": "sha_a"}
+
+    model = combine(
+        estate, {"a.py": 0.5}, {"a.py": 0.5}, CentralityAxis.unavailable("x"), pr_files={"a.py"}
+    )
+
+    assert "added" not in model.attributes["a.py"]
+    assert "deleted" not in model.attributes["a.py"]
 
 
 def test_descriptors_name_all_four_heat_axes_not_in_pr() -> None:

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -236,6 +236,43 @@ def test_render_inlines_constellation_view_bundle_and_playwright_hooks():
     assert "Show dependency constellation (experimental)" in html
 
 
+def test_render_inlines_f3_drawer_meter_tooltip_and_axis_bar_hooks():
+    # Fidelity F3 (drawer + content fidelity, spec §4.5): the drill drawer's
+    # stage-shrink class, the shared per-axis meter row/mini-bar building
+    # blocks, the hoisted diff-link class, and the hover score-card tooltip
+    # element are all JS/CSS source — inlined regardless of scene content,
+    # same convention as every other stable id/class (viz-drill-sonar-toggle,
+    # viz-treemap-reset, ...).
+    html = render_html(
+        _scene(
+            FileNode(path="src/app.py", checksum="aaa"),
+            FileNode(path="README.md", checksum="bbb"),
+        )
+    )
+
+    # Drawer conversion: the stage-shrink class app.js toggles on #viz-root.
+    assert "viz-drill-open" in html
+    # Per-axis meter rows (drill drawer + hover score card) and the ledger's
+    # compact mini-bars — the shared building blocks in views/_shared.js.
+    assert "viz-meter-row" in html
+    assert "viz-meter-mini" in html
+    # The per-axis color tokens those two share (scene.css).
+    assert "--viz-axis-complexity" in html
+    assert "--viz-axis-load-bearing" in html
+    assert "--viz-axis-consequence" in html
+    # The diff link, hoisted out of views/ledger.js into views/_shared.js so
+    # the drawer can reuse it too.
+    assert "viz-diff-link" in html
+    assert "vizsuite/views/_shared.js" in html
+    # PR diff stats chips in the drawer.
+    assert "viz-drill-stats" in html
+    assert "viz-drill-stat" in html
+    # The shared hover score-card tooltip.
+    assert "viz-tooltip" in html
+    # The ledger's compact per-axis mini-bars wrapper.
+    assert "viz-ledger-axis-bars" in html
+
+
 def test_stale_graph_badge_hook_is_inlined_and_scene_data_is_conditional():
     # F1 (spec §6.2 labeled-stale opt-in): the badge's stable playwright hook
     # (spec §4.6) is JS source, so it is inlined regardless of scene content —

--- a/packages/vizsuite/tests/unit/test_verbs_pr.py
+++ b/packages/vizsuite/tests/unit/test_verbs_pr.py
@@ -258,7 +258,20 @@ def test_pr_threads_heat_axes_repo_nwo_and_in_pr_into_the_scene(
     assert names == {"complexity", "load_bearing", "consequence", "heat"}
 
     by_path = {node["path"]: node["attributes"] for node in scene["files"]}
+    # src/app.py is a net PR file — its churn (from `churn_rows` above) threads
+    # onto its attributes; lib/util.py is context-only and never fabricates them.
     assert set(by_path["src/app.py"]) == {
+        "complexity",
+        "load_bearing",
+        "consequence",
+        "heat",
+        "in_pr",
+        "added",
+        "deleted",
+    }
+    assert by_path["src/app.py"]["added"] == 3
+    assert by_path["src/app.py"]["deleted"] == 0
+    assert set(by_path["lib/util.py"]) == {
         "complexity",
         "load_bearing",
         "consequence",


### PR DESCRIPTION
## Summary

Fidelity slice F3 of the V1 checkpoint-1 pass (bead agents-config-yf2ov.2.10; follows F1 #289, F2 #290):

- **Drill overlay → non-blocking side drawer** (prototype pattern from `docs/plans/visualization-suite/prototype/pr-shape-proto-v3.html`): full-height right-docked drawer; the stage shrinks via a `viz-drill-open` class on `#viz-root` (margin-right) so the diagram stays interactive while open; treemap relayouts against the narrower container via a `viz:drill-panel-toggled` document event on the existing debounced-resize path. Escape/close unchanged; all pre-existing stable hooks preserved.
- **Drawer content fidelity** (spec §4.5): per-axis colored meter bars (new `--viz-axis-*` CSS tokens shared across drawer, ledger, tooltip), PR diff-stat chips (+adds/−dels), per-file diff link, alongside the existing raw × weight% = contribution rows.
- **Diff-link hoist**: the anchored-sha256 GitHub diff-URL builder moved from `ledger.js` into `views/_shared.js` (`window.vizShared.buildDiffLink`), reused by ledger rows and the drawer; fail-soft semantics unchanged (no `repo_nwo`/non-PR file → no link; no SubtleCrypto → un-anchored URL).
- **Churn plumbing** (Python): `scene/heat.py combine()` gains an optional `churn` mapping; `verbs/pr.py` passes the reconciler's `PrScope.files` through, so PR files carry `added`/`deleted` in `scene.files[].attributes`. Context files never fabricate the keys. `mypy --strict` clean.
- **Hover score card** (treemap file tiles + ledger rows): shared tooltip in `_shared.js` (pointer-events: none, viewport-edge flip) with path, per-axis meter rows, combined heat, churn line for PR files. Disjoint event family from click/drag activation.
- **Ledger per-axis mini-bars** (checkpoint finding 9): compact colored bars per row replacing the bare-number-only presentation.
- **Round-8 accreted items**: shared localStorage store factory in `_shared.js` (both annotation + treemap stores rebased; treemap store now surfaces the mid-session storage-fallback warning); treemap Reset clones the cached `defaultCollapsed` map instead of re-walking the tree; the `(root)` sentinel's NUL byte no longer lands in the `data-path` DOM attribute (display form emitted; D3 datum untouched).

## Scope

**In scope:** `packages/vizsuite/` — `scene/heat.py`, `verbs/pr.py`, `templates/static/{app.js, scene.css, views/_shared.js, views/ledger.js, views/treemap.js}`, and unit tests.

**Intentionally NOT in this PR (deliberate deferrals, not gaps):**
- §6.2 Tier-2 story content (change-summary headline / why-hot / what-to-check): the render channel is slice F4; generation is bead .2.4 scope. The drawer will render those sections when the payload exists.
- The prototype's per-file `status` chip (modified/added): no upstream datum in the scene contract; out of this bead's scope.

Note: the design spec (`docs/specs/2026-07-12-visualization-suite-design.md`) is a dated point-in-time proposal describing full intent; partial per-PR implementation is expected.

## Ground truth for review claims

- JS behavior is gated via Python string-hook assertions (`tests/unit/test_templates_html.py`) — stable ids/classes are the playwright verification hooks per spec §4.6.
- Repo-derived strings are bound via `textContent`/DOM APIs, never interpolated into innerHTML (spec §4.5). The prototype's `esc()`+innerHTML style was deliberately not copied.

## Test Plan

- [x] `make ci-vizsuite` from the worktree root, standalone: exit 0 — ruff check + format clean, `mypy --strict` clean (47 files), **413 passed, coverage 100.00% line+branch**, pip-audit clean, entry-verify clean.
- [x] New unit tests: churn passthrough (PR file carries added/deleted; context file does not), template hooks for drawer/meter/tooltip/mini-bar anatomy.
- [x] Live browser verification (Playwright, rendered artifact): drawer open/close with stage shrink, sha256-anchored diff link, churn chips, axis meter rows, hover tooltip, ledger mini-bars, NUL-sanitized `(root)` tile; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHQxkmpwDezeDjx2mtzuQg
