### PR TITLE
feat(vizsuite): Tier-2 drill-story render channel — schema + drawer sections (fidelity F4)

### DIFF
--- a/packages/vizsuite/src/vizsuite/scene/assemble.py
+++ b/packages/vizsuite/src/vizsuite/scene/assemble.py
@@ -22,6 +22,7 @@ from vizsuite.scene.model import (
     Edge,
     Fact,
     FileNode,
+    FileStory,
     Fingerprints,
     RenderConfig,
     Scene,
@@ -57,6 +58,7 @@ def assemble(
     facts: Sequence[Fact] = (),
     descriptors: Sequence[AttributeDescriptor] = (),
     attributes: dict[str, dict[str, JsonValue]] | None = None,
+    stories: dict[str, FileStory] | None = None,
     render_config: RenderConfig | None = None,
     repo_nwo: str = "",
     edges: Sequence[Edge] = (),
@@ -75,12 +77,22 @@ def assemble(
     `edges` (typically the EXTRACTED centrality axis's file-dependency pairs,
     tagged `kind="dependency"` by the caller) threads onto the scene as-is —
     `scene_to_json` is the sort point, not this function.
+    `stories` (keyed by path, Tier-2 §6.2 drill-story payloads) attaches to
+    each matching `FileNode`; a path with no entry keeps `story=None` — no
+    generator exists yet (bead .2.4), so callers only pass this when they
+    already have a payload in hand.
     """
     _validate_facts(facts)
 
     file_attributes = attributes or {}
+    file_stories = stories or {}
     files = tuple(
-        FileNode(path=path, checksum=blob_sha, attributes=dict(file_attributes.get(path, {})))
+        FileNode(
+            path=path,
+            checksum=blob_sha,
+            attributes=dict(file_attributes.get(path, {})),
+            story=file_stories.get(path),
+        )
         for path, blob_sha in sorted(estate_map.items())
     )
     fingerprints = Fingerprints(

--- a/packages/vizsuite/src/vizsuite/scene/model.py
+++ b/packages/vizsuite/src/vizsuite/scene/model.py
@@ -22,10 +22,29 @@ from vizsuite.envelope import JsonValue
 
 
 @dataclass(frozen=True)
+class FileStory:
+    """Tier-2 per-file drill story (spec §6.2 drill-story channel).
+
+    `change_summary` is the one-line accent-colored headline; `why_hot` and
+    `what_to_check` are bullet lists rendered under their own headings in the
+    drill drawer (prototype anatomy, pr-shape-proto-v3.html `showDrill`).
+    Mechanically-catchable content — deleted assertions, lint-class findings —
+    is excluded from stories; that rule is enforced at GENERATION time (bead
+    .2.4, not yet built), never here. A `FileNode` with no story simply omits
+    this field (`None`) — never a story with empty/fabricated bullets.
+    """
+
+    change_summary: str
+    why_hot: tuple[str, ...] = ()
+    what_to_check: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class FileNode:
     path: str
     checksum: str  # git blob SHA at the snapshot (spec §0.1 / §3.5.1)
     attributes: dict[str, JsonValue] = field(default_factory=dict)  # heat axes (§6.2), via .2.2
+    story: FileStory | None = None  # Tier-2 drill story (§6.2), via .2.10; absent = no payload
 
 
 class ProvenanceKind(StrEnum):
@@ -179,6 +198,14 @@ def provenance_to_json(provenance: Provenance) -> dict[str, JsonValue]:
     }
 
 
+def _file_story_to_json(story: FileStory) -> dict[str, JsonValue]:
+    return {
+        "change_summary": story.change_summary,
+        "why_hot": list(story.why_hot),
+        "what_to_check": list(story.what_to_check),
+    }
+
+
 def _fact_to_json(fact: Fact) -> dict[str, JsonValue]:
     return {
         "id": fact.id,
@@ -224,10 +251,16 @@ def scene_to_json(scene: Scene) -> dict[str, JsonValue]:
     function of its inputs, so `templates.html.render_html` is byte-stable modulo
     the `generated_at` stamp (spec test item 6).
     """
-    files_json: list[JsonValue] = [
-        {"path": node.path, "checksum": node.checksum, "attributes": node.attributes}
-        for node in sorted(scene.files, key=lambda node: node.path)
-    ]
+    files_json: list[JsonValue] = []
+    for node in sorted(scene.files, key=lambda node: node.path):
+        file_json: dict[str, JsonValue] = {
+            "path": node.path,
+            "checksum": node.checksum,
+            "attributes": node.attributes,
+        }
+        if node.story is not None:
+            file_json["story"] = _file_story_to_json(node.story)
+        files_json.append(file_json)
     facts_json: list[JsonValue] = [
         _fact_to_json(fact) for fact in sorted(scene.facts, key=lambda fact: fact.id)
     ]

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -503,6 +503,49 @@
       heatRow.appendChild(heatValue);
       panelEl.appendChild(heatRow);
 
+      // Tier-2 drill story (spec §6.2 drill-story channel, prototype
+      // anatomy: showDrill's `f.story` branch) — headline + "Why it's hot" +
+      // "What to check" bullets, rendered only when the scene attached a
+      // story to this file. Mechanically-catchable content (deleted
+      // assertions, lint-class findings) is excluded from stories at
+      // GENERATION time (bead .2.4, not built yet) — this render side never
+      // filters, it only shows what's there. All content is bound via
+      // textContent, never innerHTML (spec §4.5 drill-panel DOM-bind
+      // invariant) — repo/agent-derived story text is untrusted.
+      var story = fileNode.orig && fileNode.orig.file && fileNode.orig.file.story;
+      if (story) {
+        var storySection = document.createElement("div");
+        storySection.id = "viz-drill-story";
+        storySection.setAttribute("class", "viz-drill-story");
+
+        var headlineEl = document.createElement("div");
+        headlineEl.setAttribute("class", "viz-drill-story-headline");
+        headlineEl.textContent = story.change_summary;
+        storySection.appendChild(headlineEl);
+
+        function appendBulletList(titleText, items, listClass) {
+          if (!items || items.length === 0) {
+            return;
+          }
+          var titleEl = document.createElement("h3");
+          titleEl.textContent = titleText;
+          storySection.appendChild(titleEl);
+          var listEl = document.createElement("ul");
+          listEl.setAttribute("class", listClass);
+          items.forEach(function (item) {
+            var itemEl = document.createElement("li");
+            itemEl.textContent = item;
+            listEl.appendChild(itemEl);
+          });
+          storySection.appendChild(listEl);
+        }
+
+        appendBulletList("Why it's hot", story.why_hot, "viz-drill-story-why");
+        appendBulletList("What to check", story.what_to_check, "viz-drill-story-check");
+
+        panelEl.appendChild(storySection);
+      }
+
       appendSonarAffordance(panelEl, scene, fileNode, drillState);
 
       var notes = document.createElement("textarea");

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -385,6 +385,23 @@
     });
   }
 
+  function appendBulletList(storySection, titleText, items, listClass) {
+    if (!items || items.length === 0) {
+      return;
+    }
+    var titleEl = document.createElement("h3");
+    titleEl.textContent = titleText;
+    storySection.appendChild(titleEl);
+    var listEl = document.createElement("ul");
+    listEl.setAttribute("class", listClass);
+    items.forEach(function (item) {
+      var itemEl = document.createElement("li");
+      itemEl.textContent = item;
+      listEl.appendChild(itemEl);
+    });
+    storySection.appendChild(listEl);
+  }
+
   // ---- Drill panel (spec §4.2/§4.5): a full-height right-docked drawer
   // (fidelity F3 — converted from an earlier floating overlay card, prototype
   // anatomy `#drill`/`showDrill`); Escape closes; the notes textarea binds
@@ -523,25 +540,10 @@
         headlineEl.textContent = story.change_summary;
         storySection.appendChild(headlineEl);
 
-        function appendBulletList(titleText, items, listClass) {
-          if (!items || items.length === 0) {
-            return;
-          }
-          var titleEl = document.createElement("h3");
-          titleEl.textContent = titleText;
-          storySection.appendChild(titleEl);
-          var listEl = document.createElement("ul");
-          listEl.setAttribute("class", listClass);
-          items.forEach(function (item) {
-            var itemEl = document.createElement("li");
-            itemEl.textContent = item;
-            listEl.appendChild(itemEl);
-          });
-          storySection.appendChild(listEl);
-        }
-
-        appendBulletList("Why it's hot", story.why_hot, "viz-drill-story-why");
-        appendBulletList("What to check", story.what_to_check, "viz-drill-story-check");
+        appendBulletList(storySection, "Why it's hot", story.why_hot, "viz-drill-story-why");
+        appendBulletList(
+          storySection, "What to check", story.what_to_check, "viz-drill-story-check"
+        );
 
         panelEl.appendChild(storySection);
       }

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -476,6 +476,28 @@ body {
   padding: 0.15rem 0;
   border-bottom: 1px solid var(--viz-border);
 }
+/* Tier-2 drill story (spec §6.2 drill-story channel): headline + "Why it's
+   hot" / "What to check" bullets, prototype anatomy pr-shape-proto-v3.html
+   showDrill(). Hidden entirely (no DOM) when a file carries no story. */
+.viz-drill-story {
+  margin: 0.5rem 0;
+}
+.viz-drill-story-headline {
+  font-weight: 600;
+  color: var(--viz-axis-heat);
+  margin: 0.5rem 0;
+}
+.viz-drill-story h3 {
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0.25rem;
+}
+.viz-drill-story-why,
+.viz-drill-story-check {
+  margin: 0 0 0.5rem;
+  padding-left: 1.1rem;
+  font-size: 12px;
+  color: var(--viz-secondary);
+}
 .viz-drill-notes {
   width: 100%;
   min-height: 4rem;

--- a/packages/vizsuite/tests/unit/test_scene_assemble.py
+++ b/packages/vizsuite/tests/unit/test_scene_assemble.py
@@ -13,7 +13,14 @@ serialized shape so a later slice (.2.2/.2.3) never breaks the contract.
 from __future__ import annotations
 
 from vizsuite.scene.assemble import assemble
-from vizsuite.scene.model import AttributeDescriptor, Edge, RenderConfig, StaleGraph, scene_to_json
+from vizsuite.scene.model import (
+    AttributeDescriptor,
+    Edge,
+    FileStory,
+    RenderConfig,
+    StaleGraph,
+    scene_to_json,
+)
 
 _ESTATE = {"src/a.py": "sha_a", "src/b.py": "sha_b"}
 
@@ -131,6 +138,43 @@ def test_attributes_thread_into_matching_file_nodes_by_path():
     }
     # a file with no entry in the attribute map keeps the pre-.2.2 empty shape.
     assert by_path["src/b.py"] == {}
+
+
+def test_story_thread_into_matching_file_node_and_round_trips_through_json():
+    scene = assemble(
+        _ESTATE,
+        pr_number=1,
+        generated_at="2020-01-01T00:00:00+00:00",
+        generator="g",
+        base_oid="base000",
+        head_oid="head111",
+        stories={
+            "src/a.py": FileStory(
+                change_summary="Tightened the retry backoff window.",
+                why_hot=("Touches the shared retry loop.", "No test coverage on the new branch."),
+                what_to_check=("Confirm the backoff cap still matches the SLA doc.",),
+            )
+        },
+    )
+
+    by_path = {node.path: node.story for node in scene.files}
+    assert by_path["src/a.py"] == FileStory(
+        change_summary="Tightened the retry backoff window.",
+        why_hot=("Touches the shared retry loop.", "No test coverage on the new branch."),
+        what_to_check=("Confirm the backoff cap still matches the SLA doc.",),
+    )
+    # a file with no entry in the story map keeps story=None (never fabricated).
+    assert by_path["src/b.py"] is None
+
+    payload = scene_to_json(scene)
+    files_by_path = {f["path"]: f for f in payload["files"]}
+    assert files_by_path["src/a.py"]["story"] == {
+        "change_summary": "Tightened the retry backoff window.",
+        "why_hot": ["Touches the shared retry loop.", "No test coverage on the new branch."],
+        "what_to_check": ["Confirm the backoff cap still matches the SLA doc."],
+    }
+    # absent story = absent key, never a null/empty placeholder.
+    assert "story" not in files_by_path["src/b.py"]
 
 
 def test_render_config_and_repo_nwo_thread_into_the_serialized_envelope():

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -273,6 +273,22 @@ def test_render_inlines_f3_drawer_meter_tooltip_and_axis_bar_hooks():
     assert "viz-ledger-axis-bars" in html
 
 
+def test_render_inlines_f4_drill_story_hooks():
+    # Fidelity F4 (Tier-2 drill-story channel, spec §6.2): the story section's
+    # stable hooks are JS/CSS source — inlined regardless of scene content,
+    # same convention as every other conditionally-rendered feature's hook
+    # (viz-drill-sonar-toggle, viz-stale-graph-badge, ...).
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "viz-drill-story" in html
+    assert "viz-drill-story-headline" in html
+    assert "viz-drill-story-why" in html
+    assert "viz-drill-story-check" in html
+    # "Why it's hot" / "What to check" section headings.
+    assert "Why it's hot" in html
+    assert "What to check" in html
+
+
 def test_stale_graph_badge_hook_is_inlined_and_scene_data_is_conditional():
     # F1 (spec §6.2 labeled-stale opt-in): the badge's stable playwright hook
     # (spec §4.6) is JS source, so it is inlined regardless of scene content —


### PR DESCRIPTION
## Summary

Fidelity slice F4 — final slice of the V1 checkpoint-1 pass (bead agents-config-yf2ov.2.10; follows F1 #289, F2 #290, F3 #295). Ships the Tier-2 drill-story **render channel** (spec §6.2): schema + drawer rendering only — story **generation** is deliberately out of scope (a separate skill-side work item).

- **Scene schema channel**: new frozen `FileStory` dataclass (`change_summary: str`, `why_hot: tuple[str, ...]`, `what_to_check: tuple[str, ...]`) as a typed optional `story` field on `FileNode` — a distinct narrative payload, not a key in the numeric `attributes` bag, so `mypy --strict` stays meaningful. `assemble()` gains an optional `stories` mapping threaded per path. `scene_to_json` emits the `"story"` key only when the payload exists — an absent story is an absent key, never fabricated empties.
- **Drawer render sections** (prototype anatomy `pr-shape-proto-v3.html` `showDrill`): when a file's story is present the drawer renders the accent headline, "Why it's hot" bullets, and "What to check" bullets; empty lists and absent stories render nothing (no empty headers). All content is bound via `createElement`/`textContent` — never innerHTML (spec §4.5).
- **Attention-bar rule documented** in the channel schema (docstring + render-side comment): mechanically-catchable content is excluded from stories, enforced at generation time — not here.
- Post-review refactor from the quality gate: `appendBulletList` hoisted to module scope.

## Scope

**In scope:** `packages/vizsuite/` — `scene/model.py`, `scene/assemble.py`, `templates/static/app.js`, `templates/static/scene.css`, and unit tests.

**Intentionally NOT in this PR (deliberate deferrals, not gaps):**
- Story generation + attention-bar enforcement — separate work item; no generator, heuristics, or placeholder content is built here.
- Intra-file hotspot detail (prototype `f.story.hotspots`) — no upstream datum in this slice.

Note: the design spec (`docs/specs/2026-07-12-visualization-suite-design.md`) is a dated point-in-time proposal describing full intent; partial per-PR implementation is expected.

## Ground truth for review claims

- JS behavior is gated via Python string-hook assertions (`tests/unit/test_templates_html.py`); new stable hooks: `viz-drill-story`, `viz-drill-story-headline`, `viz-drill-story-why`, `viz-drill-story-check`.
- `test_scene_assemble.py` covers story threading by path, story-absent files staying `None`, and the JSON round-trip including the absent-key assertion.

## Test Plan

- [x] `make ci-vizsuite` from the worktree root, standalone: exit 0 — ruff check + format clean, `mypy --strict` clean (47 files), **415 passed, coverage 100.00% line+branch**, pip-audit clean, entry-verify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHQxkmpwDezeDjx2mtzuQg
