### PR TITLE
chore(policy): trust Codex as a merge-gate review bot

### DIFF
--- a/project-config.toml
+++ b/project-config.toml
@@ -80,16 +80,13 @@ command = ""   # no lint auto-fix for this project
 # ---------------------------------------------------------------------------
 [review-expectations]
 bot-review-expected      = true
-bot-reviewers            = ["Copilot", "copilot-pull-request-reviewer[bot]"]  # exact identities, never substrings
+bot-reviewers            = ["Copilot", "copilot-pull-request-reviewer[bot]", "chatgpt-codex-connector[bot]"]  # exact identities, never substrings; Codex = Copilot-equivalent (owner directive 2026-07-17), trigger via "@codex review" comment
 human-approvers-required = 0     # override per bead: review-exit-human-approvers-<n>
 
 [merge-policy]
 # This repo auto-merges on a clean trusted-bot review — a deliberate, named choice.
 merge-authorization = "rule-based"
 merge-rule          = "bot-quiescence"
-# Trusted review-bot identities. Codex reviews count the same as Copilot's
-# (owner directive 2026-07-17); trigger one with a "@codex review" PR comment.
-bot-reviewers       = ["Copilot", "copilot-pull-request-reviewer[bot]", "chatgpt-codex-connector[bot]"]
 
 [merge-policy.approver]
 # Opt-in: a GitHub-App-attested approving review satisfies branch protection's

--- a/project-config.toml
+++ b/project-config.toml
@@ -84,9 +84,12 @@ bot-reviewers            = ["Copilot", "copilot-pull-request-reviewer[bot]"]  # 
 human-approvers-required = 0     # override per bead: review-exit-human-approvers-<n>
 
 [merge-policy]
-# This repo auto-merges on a clean Copilot review — a deliberate, named choice.
+# This repo auto-merges on a clean trusted-bot review — a deliberate, named choice.
 merge-authorization = "rule-based"
 merge-rule          = "bot-quiescence"
+# Trusted review-bot identities. Codex reviews count the same as Copilot's
+# (owner directive 2026-07-17); trigger one with a "@codex review" PR comment.
+bot-reviewers       = ["Copilot", "copilot-pull-request-reviewer[bot]", "chatgpt-codex-connector[bot]"]
 
 [merge-policy.approver]
 # Opt-in: a GitHub-App-attested approving review satisfies branch protection's


### PR DESCRIPTION
Adds `chatgpt-codex-connector[bot]` to `[review-expectations]` `bot-reviewers` so Codex reviews (triggered with a "@codex review" PR comment) satisfy the bot-quiescence merge rule — same standing as Copilot, per owner directive 2026-07-17. Copilot's review budget is exhausted until 2026-08-01, so Codex is the active reviewer in that window.

Resolver validated: `resolve_policy.py` emits the three-identity allowlist from this config.

**Bootstrap note (rollout):** merge-guard deliberately resolves policy from the *base* ref, so this PR itself is evaluated under the parent allowlist (Copilot-only) and cannot self-merge on a Codex review. It lands via the owner-merge bootstrap: the repo owner's explicit in-session directive of 2026-07-17 ("treat codex reviews just like copilot reviews") authorizes this merge directly. Every subsequent PR reads the merged allowlist from base and proceeds mechanically. The re-review-trigger gap (the retry path only knows how to re-request Copilot) is tracked in the repo's work tracker and does not change this PR's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYiw9n199ChDS3HvwFw5mp