### PR TITLE
feat(prgroom): usage-line token capture — claude envelope unwrap + codex stderr trailer (25rmt)

### DIFF
--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -27,6 +27,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import threading
@@ -98,6 +99,24 @@ class AgentInvocation:
 
 
 @dataclass(frozen=True, slots=True)
+class UsageFigures:
+    """Token/cost figures parsed from an agent CLI's own output (§3 token capture).
+
+    Population is per-CLI and best-effort: claude's JSON envelope fills
+    ``tokens_in`` (ALL input-side tokens — uncached + cache-creation + cache-read;
+    the envelope's bare ``input_tokens`` is only the uncached slice), ``tokens_out``
+    and ``reported_cost_usd``; codex's stderr trailer fills only ``tokens_total``
+    (no in/out split in exec mode). Absent figures stay ``None`` — telemetry never
+    fails a dispatch.
+    """
+
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    tokens_total: int | None = None
+    reported_cost_usd: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class AgentRunResult:
     """The captured outcome of one agent invocation."""
 
@@ -105,6 +124,7 @@ class AgentRunResult:
     stdout: str
     stderr: str
     duration_ms: int
+    usage: UsageFigures | None = None
 
 
 class AgentTimeoutError(PrgroomError):
@@ -227,7 +247,10 @@ _CLAUDE_WRITE_ALLOWED_TOOLS = "Read Edit Write Bash(git *)"
 def _invocation_for_claude(spec: AgentSpec, prompt: str) -> AgentInvocation:
     # `claude -p <prompt>` runs headless. The contract input path is already inside
     # `prompt` (the agent reads the file) — claude has no --input-file flag.
-    argv = ["claude", "-p", prompt, "--model", spec.model]
+    # --output-format json wraps stdout in the §3.1 result envelope; the runner
+    # unwraps it post-run (see _unwrap_claude_envelope) to expose the payload and
+    # capture token usage.
+    argv = ["claude", "-p", prompt, "--model", spec.model, "--output-format", "json"]
     effort = spec.extra.get("effort")
     if effort:
         argv += ["--effort", str(effort)]
@@ -294,6 +317,79 @@ def build_invocation(spec: AgentSpec, *, prompt: str) -> AgentInvocation:
             ", ".join(unrecognized),
         )
     return invoker(spec, prompt)
+
+
+def _unwrap_claude_envelope(result: AgentRunResult) -> AgentRunResult:
+    """Unwrap claude's ``--output-format json`` envelope into the effective result.
+
+    Keyed on the envelope SHAPE (``"type": "result"`` + a string ``result`` key),
+    never the CLI name alone: plain-text or non-envelope stdout passes through
+    untouched with ``usage=None`` — telemetry never fails a dispatch. The unwrap
+    MUST happen here, before the dispatcher's lenient parse: that parse takes the
+    LAST top-level JSON object in stdout, which with the flag is the envelope
+    itself, not the contract payload. Unwrap and usage capture run regardless of
+    the envelope's ``is_error``/``subtype`` — classification stays the
+    dispatcher's job (§3.1 rule 2).
+    """
+    try:
+        envelope = json.loads(result.stdout)
+    except ValueError:
+        return result
+    if (
+        not isinstance(envelope, dict)
+        or envelope.get("type") != "result"
+        or not isinstance(envelope.get("result"), str)
+    ):
+        return result
+    usage = envelope.get("usage")
+    tokens_in = tokens_out = None
+    if isinstance(usage, dict):
+        in_side = [
+            usage.get(k)
+            for k in ("input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens")
+        ]
+        if any(isinstance(v, int) for v in in_side):
+            tokens_in = sum(v for v in in_side if isinstance(v, int))
+        if isinstance(usage.get("output_tokens"), int):
+            tokens_out = usage["output_tokens"]
+    cost = envelope.get("total_cost_usd")
+    return AgentRunResult(
+        returncode=result.returncode,
+        stdout=envelope["result"],
+        stderr=result.stderr,
+        duration_ms=result.duration_ms,
+        usage=UsageFigures(
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            reported_cost_usd=cost if isinstance(cost, int | float) else None,
+        ),
+    )
+
+
+# codex's stderr trailer count: comma-grouped (`21,631`) or bare (`950`) — §3.2.
+_CODEX_TOKENS_RE = re.compile(r"^(\d{1,3}(?:,\d{3})*|\d+)$")
+
+
+def _parse_codex_usage(result: AgentRunResult) -> AgentRunResult:
+    """Read codex exec's stderr ``tokens used`` trailer into ``usage`` (§3.2).
+
+    The trailer is a ``tokens used`` line followed by an integer with optional
+    comma grouping. codex provides no in/out split in exec mode, so only
+    ``tokens_total`` is filled. No trailer → result passes through with
+    ``usage=None`` — telemetry never fails a dispatch.
+    """
+    lines = [line.strip() for line in result.stderr.splitlines() if line.strip()]
+    for i in range(len(lines) - 1):
+        if lines[i] == "tokens used" and _CODEX_TOKENS_RE.match(lines[i + 1]):
+            total = int(lines[i + 1].replace(",", ""))
+            return AgentRunResult(
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                duration_ms=result.duration_ms,
+                usage=UsageFigures(tokens_total=total),
+            )
+    return result
 
 
 class _PopenHandle:  # pragma: no cover - OS boundary; tests inject a fake handle
@@ -420,7 +516,14 @@ class SubprocessAgentRunner:
             section = _input_section(spec.cli, input_path=input_path, payload=contract_payload)
             prompt = prompt_template.render({**render_data, INPUT_SECTION_KEY: section})
             invocation = build_invocation(spec, prompt=prompt)
-            return self._spawn_and_wait(invocation, time_budget_s=time_budget_s, cancel=cancel)
+            result = self._spawn_and_wait(invocation, time_budget_s=time_budget_s, cancel=cancel)
+            # §3 token capture — per-CLI, best-effort post-processing; the runner
+            # stays classification-free (returncode/stderr pass through untouched).
+            if spec.cli == "claude":
+                result = _unwrap_claude_envelope(result)
+            elif spec.cli == "codex":
+                result = _parse_codex_usage(result)
+            return result
         finally:
             input_path.unlink(missing_ok=True)
 

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -377,7 +377,10 @@ def _parse_codex_usage(result: AgentRunResult) -> AgentRunResult:
     ``usage=None`` — telemetry never fails a dispatch.
     """
     lines = [line.strip() for line in result.stderr.splitlines() if line.strip()]
-    for i in range(len(lines) - 1):
+    # The trailer is terminal (§3.2): scan backward so the LAST adjacent
+    # "tokens used" + integer pair wins. An earlier diagnostic occurrence must
+    # never shadow the real CLI usage trailer.
+    for i in range(len(lines) - 2, -1, -1):
         if lines[i] == "tokens used" and _CODEX_TOKENS_RE.match(lines[i + 1]):
             total = int(lines[i + 1].replace(",", ""))
             return replace(result, usage=UsageFigures(tokens_total=total))

--- a/packages/prgroom/src/prgroom/agent/subprocess_runner.py
+++ b/packages/prgroom/src/prgroom/agent/subprocess_runner.py
@@ -33,7 +33,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -353,11 +353,9 @@ def _unwrap_claude_envelope(result: AgentRunResult) -> AgentRunResult:
         if isinstance(usage.get("output_tokens"), int):
             tokens_out = usage["output_tokens"]
     cost = envelope.get("total_cost_usd")
-    return AgentRunResult(
-        returncode=result.returncode,
+    return replace(
+        result,
         stdout=envelope["result"],
-        stderr=result.stderr,
-        duration_ms=result.duration_ms,
         usage=UsageFigures(
             tokens_in=tokens_in,
             tokens_out=tokens_out,
@@ -382,13 +380,7 @@ def _parse_codex_usage(result: AgentRunResult) -> AgentRunResult:
     for i in range(len(lines) - 1):
         if lines[i] == "tokens used" and _CODEX_TOKENS_RE.match(lines[i + 1]):
             total = int(lines[i + 1].replace(",", ""))
-            return AgentRunResult(
-                returncode=result.returncode,
-                stdout=result.stdout,
-                stderr=result.stderr,
-                duration_ms=result.duration_ms,
-                usage=UsageFigures(tokens_total=total),
-            )
+            return replace(result, usage=UsageFigures(tokens_total=total))
     return result
 
 

--- a/packages/prgroom/src/prgroom/agent/usage.py
+++ b/packages/prgroom/src/prgroom/agent/usage.py
@@ -43,6 +43,13 @@ class UsageRecord:
     """``success`` / ``timeout`` / ``unavailable`` / ``error`` / ``malformed`` /
     ``cancelled`` — the attempt's terminal disposition, one record per chain link
     tried (the dispatcher emits these through its usage hook)."""
+    tokens_total: int | None = None
+    """Undifferentiated total from codex exec's stderr trailer — the only figure
+    that mode exposes (no in/out split). Additive JSONL evolution: readers must
+    tolerate the key's absence in older lines."""
+    reported_cost_usd: float | None = None
+    """claude's envelope ``total_cost_usd`` — the CLI's own authoritative estimate,
+    preferred over rate math whenever present. Additive, nullable."""
 
     def to_dict(self) -> dict[str, Any]:
         """The flat JSONL line. ``pr`` renders as the ``owner/repo#n`` shorthand."""
@@ -56,6 +63,8 @@ class UsageRecord:
             "output_tokens": self.output_tokens,
             "duration_ms": self.duration_ms,
             "outcome": self.outcome,
+            "tokens_total": self.tokens_total,
+            "reported_cost_usd": self.reported_cost_usd,
         }
 
 

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -765,6 +765,23 @@ def test_codex_trailer_without_comma_grouping_parses(tmp_path: Path) -> None:
     assert result.usage.tokens_total == 950
 
 
+def test_codex_usage_reads_final_trailer_not_earlier_diagnostic(tmp_path: Path) -> None:
+    # §3.2: the usage trailer is the FINAL "tokens used" pair. An earlier
+    # diagnostic "tokens used\n100" must not shadow the real CLI trailer —
+    # scan backward so the last adjacent pair wins.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(  # noqa: ARG005
+            returncode=0,
+            stdout="{}",
+            stderr="tokens used\n100\nreconnecting...\nretrying\ntokens used\n21,631\n",
+        ),
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "codex")
+    assert result.usage is not None
+    assert result.usage.tokens_total == 21631
+
+
 def test_claude_envelope_contract_reaches_dispatcher_parse(tmp_path: Path) -> None:
     # The §3.1 interaction trap, end-to-end: the dispatcher's lenient parse takes
     # the LAST top-level JSON object in stdout — with --output-format json that

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -150,6 +150,14 @@ def test_claude_invocation_shape() -> None:
     assert "read /x" in inv.argv  # prompt (carrying the path) is a positional
 
 
+def test_claude_invocation_requests_json_envelope() -> None:
+    # Token capture (§3.1): every claude dispatch asks for the JSON envelope so
+    # the runner can unwrap the result payload and read the usage block.
+    inv = build_invocation(_spec("claude", "haiku"), prompt="P")
+    assert "--output-format" in inv.argv
+    assert "json" in inv.argv
+
+
 def test_claude_write_role_grants_headless_dontask_and_scoped_allowed_tools() -> None:
     # A WRITE-capable claude agent (the fix role) MUST be dispatched headless-correct:
     # `claude -p` in the default permission mode queues Edit/Bash tool calls awaiting
@@ -610,6 +618,176 @@ def test_cancel_escalates_to_sigkill_when_child_survives_sigterm(tmp_path: Path)
             cancel=cancel,
         )
     assert proc.terminated and proc.killed and proc.reaped
+
+
+# ── token capture (§3): claude envelope unwrap + codex stderr trailer ──
+#
+# Fixtures are the live-captured probe outputs from the cost-telemetry spec §3
+# (2026-07-04) — verified formats, not stipulations.
+
+_CLAUDE_ENVELOPE = json.dumps(
+    {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "duration_ms": 2436,
+        "result": '{"clusters": []}',
+        "session_id": "abc",
+        "total_cost_usd": 0.02487,
+        "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 18301,
+            "cache_read_input_tokens": 17757,
+            "output_tokens": 43,
+        },
+    }
+)
+
+
+def _run_cli(runner: SubprocessAgentRunner, cli: str) -> AgentRunResult:
+    return runner.run(
+        _spec(cli, "m"),
+        prompt_template=_PROMPT,
+        render_data={},
+        contract_payload={},
+        time_budget_s=5.0,
+    )
+
+
+def test_claude_envelope_is_unwrapped_and_usage_captured(tmp_path: Path) -> None:
+    # §3.1: the envelope's `result` field IS the contract payload the dispatcher
+    # must see; tokens_in sums ALL input-side fields (uncached + cache-creation +
+    # cache-read — the bare input_tokens alone undercounts by orders of magnitude).
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=0, stdout=_CLAUDE_ENVELOPE),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "claude")
+    assert result.stdout == '{"clusters": []}'
+    assert result.usage is not None
+    assert result.usage.tokens_in == 10 + 18301 + 17757
+    assert result.usage.tokens_out == 43
+    assert result.usage.reported_cost_usd == 0.02487
+    assert result.usage.tokens_total is None  # codex-only field
+
+
+def test_claude_plain_text_stdout_passes_through_with_no_usage(tmp_path: Path) -> None:
+    # §3.1 rule 3: envelope parse failure (plain-text stdout) falls back to
+    # current behavior — raw stdout through, usage=None. Telemetry never fails
+    # a dispatch.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=0, stdout="plain text banner"),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "claude")
+    assert result.stdout == "plain text banner"
+    assert result.usage is None
+
+
+def test_claude_non_envelope_json_passes_through(tmp_path: Path) -> None:
+    # The unwrap is keyed on the envelope SHAPE, not "stdout parses as JSON": a
+    # CLI that emitted the bare contract JSON despite the flag must pass through
+    # untouched, not be mistaken for an envelope.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=0, stdout='{"clusters": []}'),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "claude")
+    assert result.stdout == '{"clusters": []}'
+    assert result.usage is None
+
+
+def test_claude_error_envelope_still_unwraps_and_captures_usage(tmp_path: Path) -> None:
+    # §3.1 rule 2: unwrap + usage capture happen regardless of is_error/subtype.
+    # The envelope's error flag never short-circuits classification — the
+    # dispatcher decides from returncode and parseability, not from the flag.
+    envelope = json.dumps(
+        {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "result": "the model refused",
+            "total_cost_usd": 0.001,
+            "usage": {"input_tokens": 5, "output_tokens": 7},
+        }
+    )
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=0, stdout=envelope),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "claude")
+    assert result.stdout == "the model refused"  # unwrapped despite is_error
+    assert result.usage is not None
+    assert result.usage.tokens_in == 5  # cache fields absent → just the uncached slice
+    assert result.usage.tokens_out == 7
+    assert result.usage.reported_cost_usd == 0.001
+
+
+def test_codex_stderr_trailer_yields_tokens_total(tmp_path: Path) -> None:
+    # §3.2: codex exec emits the reply on stdout and a stderr trailer
+    # "tokens used\n21,631" (comma-grouped). No in/out split in this mode.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(  # noqa: ARG005
+            returncode=0, stdout='{"clusters": []}', stderr="banner\ntokens used\n21,631\n"
+        ),
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "codex")
+    assert result.stdout == '{"clusters": []}'  # stdout untouched
+    assert result.usage is not None
+    assert result.usage.tokens_total == 21631
+    assert result.usage.tokens_in is None
+    assert result.usage.tokens_out is None
+    assert result.usage.reported_cost_usd is None
+
+
+def test_codex_stderr_without_trailer_yields_no_usage(tmp_path: Path) -> None:
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(  # noqa: ARG005
+            returncode=0, stdout="{}", stderr="warning: something else\n"
+        ),
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "codex")
+    assert result.usage is None
+
+
+def test_codex_trailer_without_comma_grouping_parses(tmp_path: Path) -> None:
+    # Counts under 1,000 carry no comma — the pattern accepts both groupings.
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(  # noqa: ARG005
+            returncode=0, stdout="{}", stderr="tokens used\n950\n"
+        ),
+        scratch_dir=tmp_path,
+    )
+    result = _run_cli(runner, "codex")
+    assert result.usage is not None
+    assert result.usage.tokens_total == 950
+
+
+def test_claude_envelope_contract_reaches_dispatcher_parse(tmp_path: Path) -> None:
+    # The §3.1 interaction trap, end-to-end: the dispatcher's lenient parse takes
+    # the LAST top-level JSON object in stdout — with --output-format json that
+    # would be the envelope, not the contract payload. The runner's unwrap must
+    # happen first, or every claude dispatch classifies malformed. A real
+    # SubprocessAgentRunner (fake spawn) feeding a real ClusterDispatcher proves
+    # the contract JSON inside `result` parses.
+    from prgroom.agent.contracts import ClusterInput
+    from prgroom.agent.dispatcher import ClusterDispatcher, ProviderChain
+    from prgroom.prsession.pr_ref import PRRef
+
+    runner = SubprocessAgentRunner(
+        spawn=lambda argv, *, stdin: FakeProcess(returncode=0, stdout=_CLAUDE_ENVELOPE),  # noqa: ARG005
+        scratch_dir=tmp_path,
+    )
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=ProviderChain(providers=[_spec("claude", "haiku")], time_budget_s=5.0),
+    )
+    output = dispatcher.cluster(
+        ClusterInput(pr=PRRef(owner="o", repo="r", number=1), items=[], pr_context_path="/ctx")
+    )
+    assert output.clusters == []  # the payload inside `result`, not the envelope
 
 
 def test_run_builds_the_argv_for_the_specs_cli(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_agent_usage.py
+++ b/packages/prgroom/tests/unit/test_agent_usage.py
@@ -50,6 +50,8 @@ def test_append_writes_schema_line_to_xdg_state_path(
         "output_tokens": 80,
         "duration_ms": 1450,
         "outcome": "success",
+        "tokens_total": None,
+        "reported_cost_usd": None,
     }
 
 
@@ -105,3 +107,58 @@ def test_absent_usage_is_a_noop_not_an_error(
     append_usage(None)
 
     assert not (tmp_path / "prgroom" / "usage.jsonl").exists()
+
+
+def test_additive_token_fields_serialize_in_the_jsonl_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # §3.3 additive JSONL evolution: tokens_total (codex path) and
+    # reported_cost_usd (claude path) join the line schema as nullable fields —
+    # readers tolerate absent keys, writers always emit them.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    record = UsageRecord(
+        ts="2026-07-17T00:00:00+00:00",
+        pr=PRRef(owner="octo", repo="demo", number=7),
+        contract="fix",
+        provider="codex",
+        model="gpt-5.6-terra",
+        input_tokens=None,
+        output_tokens=None,
+        duration_ms=10,
+        outcome="success",
+        tokens_total=21631,
+        reported_cost_usd=None,
+    )
+    append_usage(record)
+
+    line = json.loads(
+        (tmp_path / "prgroom" / "usage.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    )
+    assert line["tokens_total"] == 21631
+    assert line["reported_cost_usd"] is None
+
+
+def test_new_token_fields_default_none_for_existing_call_sites(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Additive means additive: a constructor call that predates the new fields
+    # (the dispatcher's _emit_usage) still works, and the line carries nulls.
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    record = UsageRecord(
+        ts="2026-07-17T00:00:00+00:00",
+        pr=PRRef(owner="octo", repo="demo", number=7),
+        contract="cluster",
+        provider="claude",
+        model="haiku",
+        input_tokens=None,
+        output_tokens=None,
+        duration_ms=5,
+        outcome="success",
+    )
+    append_usage(record)
+
+    line = json.loads(
+        (tmp_path / "prgroom" / "usage.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    )
+    assert line["tokens_total"] is None
+    assert line["reported_cost_usd"] is None


### PR DESCRIPTION
## Summary

- prgroom token capture (spec `docs/specs/2026-07-04-cost-telemetry-and-token-capture.md` §3, bead scope: usage-line parser only):
  - claude invocations now pass `--output-format json`; the runner unwraps the result envelope — shape-keyed (`"type":"result"` + string `result`), before the dispatcher's lenient JSON parse (the §3.1 trap: that parse takes the LAST top-level object, which would be the envelope) — and captures `UsageFigures`: `tokens_in` (uncached + cache-creation + cache-read summed), `tokens_out`, `reported_cost_usd`.
  - codex `exec` stderr `tokens used` trailer parses comma-grouped totals into `tokens_total`.
  - `UsageRecord` gains additive nullable JSONL fields `tokens_total` / `reported_cost_usd`.
  - Plain-text or non-envelope stdout passes through untouched with `usage=None` — telemetry never fails a dispatch.

## Scope — capture-then-wire slice (read before flagging)

This PR is deliberately the **capture** half of the spec's two-bead sequence (§4 interface contract, §8 sequencing). `AgentRunResult.usage` is produced here but **not yet consumed by the dispatcher** — the consumer (threading `usage` through `_try_one` into `_emit_usage`/`UsageRecord`, plus `usage_hook` wiring at both dispatcher build sites) is the immediately-following PR (dispatcher observability). Files in scope: `subprocess_runner.py`, `usage.py`, their tests. `dispatcher.py` is intentionally untouched. Comments proposing to "wire the capture into UsageRecord emission" in this PR are out of scope by design, not an oversight.

## Ground truth

- Spec: `docs/specs/2026-07-04-cost-telemetry-and-token-capture.md` (§3 formats live-captured 2026-07-04; §3.1 rules 1–3; §3.2; §3.3; §8 sequencing)
- Envelope/trailer fixtures in the tests are those captured probe outputs verbatim.

## Test Plan

- [x] Spec §7 tests 1–4: envelope unwrap + summed tokens_in; plain-text passthrough; `is_error` envelope still unwraps + captures; codex trailer comma-grouped and bare; no-trailer → `usage=None`
- [x] End-to-end tracer: envelope through real runner into `ClusterDispatcher` parse (mutation-checked: fails when unwrap is disabled)
- [x] `UsageRecord` JSONL schema pins: new fields serialize; pre-existing constructor call sites unaffected
- [x] `make ci-prgroom` green from the worktree: 992 passed, coverage 99.58%, lint/format/typecheck/audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
