### PR TITLE
feat(prgroom): dispatcher observability — Dispatched envelope, usage wiring, fallback signal (abn9.8.26)

### DIFF
--- a/packages/prgroom/AGENTS.md
+++ b/packages/prgroom/AGENTS.md
@@ -96,6 +96,24 @@ Never invoke `prgroom run`/`push`/`reply`/`resolve` against a real PR to "try it
 out" — those verbs mutate GitHub. The gate's `prgroom --help` entry-verify is
 the only sanctioned automatic invocation.
 
+## Observability channels
+
+Every prgroom output belongs to exactly one of four channels, chosen by **who
+must do what with it** — not by severity, not by module:
+
+| Channel | Job | Writers | Reader |
+|---|---|---|---|
+| `usage.jsonl` (`append_usage`) | Durable, machine-readable, **per-attempt** dispatch telemetry: what ran, how long, what outcome | the dispatcher's `usage_hook` | post-hoc analysis; cost/routing tuning (sibling `spend.jsonl` holds per-**dispatch** cost) |
+| `EscalationSink` (`escalation.py`) | **Human-judgment events**: something a human or external watcher must eventually act on — blocker dispositions, chain exhaustion, audit violations, lifecycle gates | `agent/fix.py`, `lifecycle/escalation.py` | operator / monitor-pr / future `bd` adapter |
+| stdlib logging → stderr | **Operational diagnostics**: noteworthy but requiring no tracked action — config-key warnings, best-effort bridge failures, partial-fallback events | module-level `getLogger(__name__)`; root config in `main()` only | whoever watches the process (human or driving agent) |
+| `warn` callbacks (`lifecycle/warn.py`) | Grandfathered injected-callable variant of the logging channel, used by lifecycle verbs as a test seam | existing lifecycle code only | same as logging |
+
+Two standing rules: **stdout is reserved for contract output** (the
+`status --json` envelope and the human `status` rendering); every diagnostic
+goes to stderr. **No new channels**: a new observability need slots into one of
+the four jobs above; new code preferring a diagnostic stream uses stdlib
+logging, not a new `warn` plumbing.
+
 ## Reference
 
 Architecture: `docs/architecture/prgroom/index.md`.

--- a/packages/prgroom/src/prgroom/agent/cluster.py
+++ b/packages/prgroom/src/prgroom/agent/cluster.py
@@ -12,9 +12,7 @@ the coverage invariant — even a totally-unavailable agent yields a usable
 clustering, built directly without any dispatch.
 
 8.7 boundary: this returns a :class:`ClusterRunResult`; it never mutates
-``PRGroomingState`` or transitions phases. ``now`` / ``decided_by`` are part of
-the uniform 8.7 signature; clustering itself decides no disposition, so it does
-not use them (the fix path does).
+``PRGroomingState`` or transitions phases.
 """
 
 from __future__ import annotations
@@ -27,8 +25,6 @@ from prgroom.agent.contracts import ClusterOutput, ClusterResult
 from prgroom.agent.dispatcher import AllProvidersFailedError
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from prgroom.agent.contracts import ClusterContract, ClusterInput
 
 _DEGENERATE_RATIONALE = "degenerate fallback: agent clustering failed twice; one cluster per item"
@@ -81,21 +77,20 @@ def _try_dispatch(req: ClusterInput, dispatcher: ClusterContract) -> ClusterOutp
     breach: a ``None`` that drives the caller toward retry/fallback.
     """
     try:
-        out = dispatcher.cluster(req)
+        dispatched = dispatcher.cluster(req)
     except AllProvidersFailedError:
         return None
+    out = dispatched.output
     return out if not audit_cluster(req, out) else None
 
 
-def run_cluster(
-    req: ClusterInput,
-    dispatcher: ClusterContract,
-    *,
-    now: datetime,
-    decided_by: str,
-) -> ClusterRunResult:
-    """Dispatch → audit → retry-once → degenerate fallback (§5). Pure of state."""
-    del now, decided_by  # uniform 8.7 signature; clustering decides no disposition
+def run_cluster(req: ClusterInput, dispatcher: ClusterContract) -> ClusterRunResult:
+    """Dispatch → audit → retry-once → degenerate fallback (§5). Pure of state.
+
+    Clustering decides no disposition, so it records no provenance: the
+    degenerate path never dispatched, and an audit-rejected dispatch's winner
+    is discarded with its output.
+    """
     for attempt in (1, 2):
         out = _try_dispatch(req, dispatcher)
         if out is not None:

--- a/packages/prgroom/src/prgroom/agent/contracts.py
+++ b/packages/prgroom/src/prgroom/agent/contracts.py
@@ -15,11 +15,16 @@ in later beads.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from prgroom.prsession.enums import DispositionKind
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import ReviewItem
+
+if TYPE_CHECKING:
+    # Annotation-only: dispatcher.py imports this module at runtime, so the
+    # reverse edge must never execute (no runtime cycle).
+    from prgroom.agent.dispatcher import Dispatched
 
 CONTRACT_VERSION = 1
 
@@ -83,7 +88,7 @@ class ClusterOutput:
 class ClusterContract(Protocol):
     """The cluster dispatch surface. A provider groups items into fix-bundles."""
 
-    def cluster(self, request: ClusterInput) -> ClusterOutput: ...  # pragma: no cover
+    def cluster(self, request: ClusterInput) -> Dispatched[ClusterOutput]: ...  # pragma: no cover
 
 
 # ───────────────────────── Fix contract ─────────────────────────
@@ -208,4 +213,4 @@ class FixOutput:
 class FixContract(Protocol):
     """The fix dispatch surface. A provider decides disposition AND implements."""
 
-    def fix(self, request: FixInput) -> FixOutput: ...  # pragma: no cover
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]: ...  # pragma: no cover

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -48,8 +48,10 @@ from prgroom.agent.prompt_loader import PromptTemplate, load_prompt
 from prgroom.agent.subprocess_runner import (
     AgentCancelledError,
     AgentRunner,
+    AgentRunResult,
     AgentSpec,
     AgentTimeoutError,
+    UsageFigures,
 )
 from prgroom.agent.usage import UsageRecord
 from prgroom.config import read_toml, subtable
@@ -248,11 +250,17 @@ class LinkFailure:
     summary — so collapse all whitespace once, centrally, here. ``kind`` is the
     usage-telemetry outcome tag for the failed attempt (``timeout`` /
     ``unavailable`` / ``error`` / ``malformed``).
+
+    ``usage`` carries any token/cost figures the runner parsed from the failed
+    attempt — a non-zero-exit CLI still ran and can report usage — so the failed
+    attempt's :class:`UsageRecord` does not lose that data. ``None`` for the
+    result-less triggers (timeout, binary-absent, spawn error).
     """
 
     spec: AgentSpec
     reason: str
     kind: str
+    usage: UsageFigures | None = None
 
     def __post_init__(self) -> None:
         # Collapse all whitespace (one-line guarantee), then cap so a huge agent
@@ -353,27 +361,34 @@ class _Dispatcher:
                 outcome = self._try_one(spec, payload)
             except AgentCancelledError:
                 # The abort-everything path still leaves a telemetry trace of the
-                # attempt before propagating past the ladder.
+                # attempt before propagating past the ladder. No result reached us,
+                # so the record is usage-less.
                 self._emit_usage(spec, payload, started=started, outcome="cancelled")
                 raise
             if isinstance(outcome, LinkFailure):
-                self._emit_usage(spec, payload, started=started, outcome=outcome.kind)
+                self._emit_usage(
+                    spec, payload, started=started, outcome=outcome.kind, usage=outcome.usage
+                )
                 self._warn_link_failure(outcome)
                 failures.append(outcome)
                 continue
+            stdout = outcome.stdout
             try:
-                parsed = parse(outcome)
+                parsed = parse(stdout)
             except (KeyError, TypeError, ValueError) as exc:
                 # ValueError subsumes json.JSONDecodeError AND an out-of-enum
                 # DispositionKind (StrEnum raises ValueError): a model emitting bogus
                 # JSON or a bogus disposition is THIS provider's malformed output —
-                # fall through to the next link, never crash the whole dispatch.
-                self._emit_usage(spec, payload, started=started, outcome="malformed")
+                # fall through to the next link, never crash the whole dispatch. The
+                # CLI still ran, so carry its parsed usage onto the failed record.
+                self._emit_usage(
+                    spec, payload, started=started, outcome="malformed", usage=outcome.usage
+                )
                 failure = LinkFailure(spec, f"malformed output: {exc}", kind="malformed")
                 self._warn_link_failure(failure)
                 failures.append(failure)
                 continue
-            self._emit_usage(spec, payload, started=started, outcome="success")
+            self._emit_usage(spec, payload, started=started, outcome="success", usage=outcome.usage)
             if failures:
                 # The greppable partial-fallback signal: a dispatcher-layer fact
                 # ("this dispatch resolved at rung N"), deliberately not "decided
@@ -403,9 +418,20 @@ class _Dispatcher:
         )
 
     def _emit_usage(
-        self, spec: AgentSpec, payload: dict[str, Any], *, started: float, outcome: str
+        self,
+        spec: AgentSpec,
+        payload: dict[str, Any],
+        *,
+        started: float,
+        outcome: str,
+        usage: UsageFigures | None = None,
     ) -> None:
         """Push one per-attempt :class:`UsageRecord` through the hook, if wired.
+
+        ``usage`` is the runner's parsed token/cost figures for the attempt (claude
+        envelope / codex trailer), threaded onto the record so the §5 usage log
+        keeps the captured data; ``None`` (result-less triggers) leaves the token
+        and cost fields null.
 
         A hook failure (unwritable XDG dir, full disk) is an expected
         environmental failure, not a contract breach: the modeled handling is a
@@ -419,18 +445,25 @@ class _Dispatcher:
             contract=self._contract,
             provider=spec.cli,
             model=spec.model,
-            input_tokens=None,
-            output_tokens=None,
+            input_tokens=usage.tokens_in if usage else None,
+            output_tokens=usage.tokens_out if usage else None,
             duration_ms=int((self._clock() - started) * 1000),
             outcome=outcome,
+            tokens_total=usage.tokens_total if usage else None,
+            reported_cost_usd=usage.reported_cost_usd if usage else None,
         )
         try:
             self._usage_hook(record)
         except Exception as exc:  # telemetry must never fail a dispatch
             _logger.warning("usage hook failed (%s attempt record dropped): %s", outcome, exc)
 
-    def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> str | LinkFailure:
-        """Run one provider; return its stdout on a 0-exit, else a :class:`LinkFailure`."""
+    def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> AgentRunResult | LinkFailure:
+        """Run one provider; return its full result on a 0-exit, else a
+        :class:`LinkFailure`.
+
+        Returning the whole :class:`AgentRunResult` (not just its stdout) keeps the
+        runner's parsed ``usage`` figures reachable so the caller can thread them
+        onto the attempt's :class:`UsageRecord`."""
         try:
             result = self._runner.run(
                 spec,
@@ -456,9 +489,15 @@ class _Dispatcher:
             # the same provider-unavailable trigger as a missing one — fall through.
             return LinkFailure(spec, f"spawn failed: {exc}", kind="unavailable")
         if result.returncode != 0:
-            # LinkFailure normalizes whitespace + caps length centrally.
-            return LinkFailure(spec, f"exit {result.returncode}: {result.stderr}", kind="error")
-        return result.stdout
+            # LinkFailure normalizes whitespace + caps length centrally. A failed
+            # CLI can still have reported usage, so carry it onto the failure.
+            return LinkFailure(
+                spec,
+                f"exit {result.returncode}: {result.stderr}",
+                kind="error",
+                usage=result.usage,
+            )
+        return result
 
 
 def _loads_lenient(stdout: str) -> Any:

--- a/packages/prgroom/src/prgroom/agent/dispatcher.py
+++ b/packages/prgroom/src/prgroom/agent/dispatcher.py
@@ -29,13 +29,14 @@ or-fall-through; it parses the output shape but does not validate its invariants
 from __future__ import annotations
 
 import json
+import logging
 import threading
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from prgroom.agent.contracts import (
     ClusterInput,
@@ -54,6 +55,8 @@ from prgroom.agent.usage import UsageRecord
 from prgroom.config import read_toml, subtable
 from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.prsession.pr_ref import PRRef
+
+_logger = logging.getLogger(__name__)
 
 ContractName = Literal["cluster", "fix"]
 
@@ -235,8 +238,9 @@ def _utc_now_iso() -> str:
 
 
 @dataclass(frozen=True, slots=True)
-class _LinkFailure:
-    """One chain link's failure, recorded for the both-fail escalation detail.
+class LinkFailure:
+    """One chain link's failure — the both-fail escalation detail and, on a
+    fallback success, an entry in :attr:`Dispatched.failures`.
 
     ``reason`` is normalized to a single line at construction: every source (an
     agent stderr, a timeout ``detail``, a parse exception message) may contain
@@ -260,6 +264,36 @@ class _LinkFailure:
             tail_chars = _REASON_MAX_CHARS - _REASON_HEAD_CHARS - len(_REASON_ELLIPSIS)
             collapsed = collapsed[:_REASON_HEAD_CHARS] + _REASON_ELLIPSIS + collapsed[-tail_chars:]
         object.__setattr__(self, "reason", collapsed)
+
+
+@dataclass(frozen=True, slots=True)
+class Dispatched(Generic[T]):
+    """One resolved dispatch: the parsed output plus which chain link produced it.
+
+    The success shape only — chain exhaustion stays the typed
+    :class:`AllProvidersFailedError`. ``rung`` is derived, not stored: every link
+    before the winner either appended a :class:`LinkFailure` and continued, or
+    returned, so ``rung == len(failures)`` is a ladder invariant with one source
+    of truth (and exactly the rung index the spend bridge needs).
+    """
+
+    output: T
+    winner: AgentSpec
+    failures: tuple[LinkFailure, ...] = ()
+
+    @property
+    def rung(self) -> int:
+        """Index of the winning link in the chain."""
+        return len(self.failures)
+
+    @property
+    def fell_back(self) -> bool:
+        return bool(self.failures)
+
+    @property
+    def decided_by(self) -> str:
+        """The persisted-provenance string, in the established ``<cli> <model>`` format."""
+        return f"{self.winner.cli} {self.winner.model}"
 
 
 class _Dispatcher:
@@ -294,22 +328,25 @@ class _Dispatcher:
         # contract surfaces (cluster()/fix()) carry no parameter for it.
         self._cancel = cancel
         # §5 usage logging: one UsageRecord per ATTEMPT (failed links included) is
-        # pushed through this hook — the lifecycle wires it to usage.append_usage.
-        # Token counts stay None until a usage-line parser exists. `clock` (monotonic,
-        # durations) and `now` (wall, the ts field) are injectable so tests never sleep.
+        # pushed through this hook — the production dispatcher builders in the CLI
+        # wire it to usage.append_usage; None (tests, embedders) disables emission.
+        # `clock` (monotonic, durations) and `now` (wall, the ts field) are
+        # injectable so tests never sleep.
         self._usage_hook = usage_hook
         self._clock = clock
         self._now = now
 
-    def _run_chain(self, payload: dict[str, Any], parse: Callable[[str], T]) -> T:
-        """Try each provider; return the first parseable output, else raise both-fail.
+    def _run_chain(self, payload: dict[str, Any], parse: Callable[[str], T]) -> Dispatched[T]:
+        """Try each provider; return the first parseable output in its
+        :class:`Dispatched` envelope — winner + prior-link failures — else raise
+        both-fail.
 
         Per-link failures — binary absent, non-zero exit (quota/auth/network),
         budget timeout, or 0-exit-but-unparseable output — fall through to the next
         link. An exhausted chain raises :class:`AllProvidersFailedError` naming every
         link's rejection (§5 both-fail → failed disposition + escalation).
         """
-        failures: list[_LinkFailure] = []
+        failures: list[LinkFailure] = []
         for spec in self._chain.providers:
             started = self._clock()
             try:
@@ -319,8 +356,9 @@ class _Dispatcher:
                 # attempt before propagating past the ladder.
                 self._emit_usage(spec, payload, started=started, outcome="cancelled")
                 raise
-            if isinstance(outcome, _LinkFailure):
+            if isinstance(outcome, LinkFailure):
                 self._emit_usage(spec, payload, started=started, outcome=outcome.kind)
+                self._warn_link_failure(outcome)
                 failures.append(outcome)
                 continue
             try:
@@ -331,34 +369,68 @@ class _Dispatcher:
                 # JSON or a bogus disposition is THIS provider's malformed output —
                 # fall through to the next link, never crash the whole dispatch.
                 self._emit_usage(spec, payload, started=started, outcome="malformed")
-                failures.append(_LinkFailure(spec, f"malformed output: {exc}", kind="malformed"))
+                failure = LinkFailure(spec, f"malformed output: {exc}", kind="malformed")
+                self._warn_link_failure(failure)
+                failures.append(failure)
                 continue
             self._emit_usage(spec, payload, started=started, outcome="success")
-            return parsed
+            if failures:
+                # The greppable partial-fallback signal: a dispatcher-layer fact
+                # ("this dispatch resolved at rung N"), deliberately not "decided
+                # by" — a cluster caller may still discard the winning output.
+                _logger.warning(
+                    "%s dispatch fell back to %s:%s (rung %d); failed: %s",
+                    self._contract,
+                    spec.cli,
+                    spec.model,
+                    len(failures),
+                    _render_links(failures),
+                )
+            return Dispatched(output=parsed, winner=spec, failures=tuple(failures))
         raise AllProvidersFailedError(detail=_render_failures(self._contract, failures))
+
+    def _warn_link_failure(self, failure: LinkFailure) -> None:
+        """Stream one WARNING at failure time — a fix link's budget is up to 30
+        minutes, so an operator learns of the primary's failure when it happens,
+        not when the fallback finishes."""
+        _logger.warning(
+            "%s link %s:%s failed (%s): %s",
+            self._contract,
+            failure.spec.cli,
+            failure.spec.model,
+            failure.kind,
+            failure.reason,
+        )
 
     def _emit_usage(
         self, spec: AgentSpec, payload: dict[str, Any], *, started: float, outcome: str
     ) -> None:
-        """Push one per-attempt :class:`UsageRecord` through the hook, if wired."""
+        """Push one per-attempt :class:`UsageRecord` through the hook, if wired.
+
+        A hook failure (unwritable XDG dir, full disk) is an expected
+        environmental failure, not a contract breach: the modeled handling is a
+        logged drop — never an aborted dispatch, never a silent one.
+        """
         if self._usage_hook is None:
             return
-        self._usage_hook(
-            UsageRecord(
-                ts=self._now(),
-                pr=PRRef.from_dict(payload["pr"]),
-                contract=self._contract,
-                provider=spec.cli,
-                model=spec.model,
-                input_tokens=None,
-                output_tokens=None,
-                duration_ms=int((self._clock() - started) * 1000),
-                outcome=outcome,
-            )
+        record = UsageRecord(
+            ts=self._now(),
+            pr=PRRef.from_dict(payload["pr"]),
+            contract=self._contract,
+            provider=spec.cli,
+            model=spec.model,
+            input_tokens=None,
+            output_tokens=None,
+            duration_ms=int((self._clock() - started) * 1000),
+            outcome=outcome,
         )
+        try:
+            self._usage_hook(record)
+        except Exception as exc:  # telemetry must never fail a dispatch
+            _logger.warning("usage hook failed (%s attempt record dropped): %s", outcome, exc)
 
-    def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> str | _LinkFailure:
-        """Run one provider; return its stdout on a 0-exit, else a :class:`_LinkFailure`."""
+    def _try_one(self, spec: AgentSpec, payload: dict[str, Any]) -> str | LinkFailure:
+        """Run one provider; return its stdout on a 0-exit, else a :class:`LinkFailure`."""
         try:
             result = self._runner.run(
                 spec,
@@ -376,16 +448,16 @@ class _Dispatcher:
                 cancel=self._cancel,
             )
         except AgentTimeoutError as exc:
-            return _LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}", kind="timeout")
+            return LinkFailure(spec, f"timeout: {exc.detail or exc.code.value}", kind="timeout")
         except FileNotFoundError:
-            return _LinkFailure(spec, "binary not on PATH", kind="unavailable")
+            return LinkFailure(spec, "binary not on PATH", kind="unavailable")
         except OSError as exc:
             # Present-but-unspawnable (non-executable binary, exec-format error) is
             # the same provider-unavailable trigger as a missing one — fall through.
-            return _LinkFailure(spec, f"spawn failed: {exc}", kind="unavailable")
+            return LinkFailure(spec, f"spawn failed: {exc}", kind="unavailable")
         if result.returncode != 0:
-            # _LinkFailure normalizes whitespace + caps length centrally.
-            return _LinkFailure(spec, f"exit {result.returncode}: {result.stderr}", kind="error")
+            # LinkFailure normalizes whitespace + caps length centrally.
+            return LinkFailure(spec, f"exit {result.returncode}: {result.stderr}", kind="error")
         return result.stdout
 
 
@@ -427,7 +499,7 @@ class ClusterDispatcher(_Dispatcher):
 
     _contract: ContractName = "cluster"
 
-    def cluster(self, request: ClusterInput) -> ClusterOutput:
+    def cluster(self, request: ClusterInput) -> Dispatched[ClusterOutput]:
         return self._run_chain(
             request.to_dict(), lambda s: ClusterOutput.from_dict(_loads_lenient(s))
         )
@@ -438,11 +510,16 @@ class FixDispatcher(_Dispatcher):
 
     _contract: ContractName = "fix"
 
-    def fix(self, request: FixInput) -> FixOutput:
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]:
         return self._run_chain(request.to_dict(), lambda s: FixOutput.from_dict(_loads_lenient(s)))
 
 
-def _render_failures(contract: ContractName, failures: list[_LinkFailure]) -> str:
+def _render_links(failures: list[LinkFailure]) -> str:
+    """The shared per-link rendering: ``cli:model (reason); …`` — used by both the
+    exhaustion detail and the partial-fallback summary line."""
+    return "; ".join(f"{f.spec.cli}:{f.spec.model} ({f.reason})" for f in failures)
+
+
+def _render_failures(contract: ContractName, failures: list[LinkFailure]) -> str:
     """A one-line summary of every link's rejection for the escalation detail."""
-    parts = [f"{f.spec.cli}:{f.spec.model} ({f.reason})" for f in failures]
-    return f"{contract} chain exhausted: " + "; ".join(parts)
+    return f"{contract} chain exhausted: " + _render_links(failures)

--- a/packages/prgroom/src/prgroom/agent/fix.py
+++ b/packages/prgroom/src/prgroom/agent/fix.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
 # the scheduler retries on the next cadence (see AllProvidersFailedError's tier).
 _BOTH_FAIL_SEVERITY = Severity.WARN
 
+# The both-fail provenance stamp: no agent produced output — the ladder itself
+# decided FAILED. Consistent with the empty-chain degradation to "prgroom".
+_BOTH_FAIL_DECIDED_BY = "prgroom"
+
 
 @dataclass(frozen=True, slots=True)
 class FixRunResult:
@@ -73,6 +77,7 @@ class FixRunResult:
     dispositions: dict[str, Disposition]
     escalations: list[Escalation]
     stashed: bool
+    decided_by: str
     deferred_memory: list[MemoryEntry] = field(default_factory=list)
     contextual_memory: list[MemoryEntry] = field(default_factory=list)
     unwritten: list[str] = field(default_factory=list)
@@ -84,7 +89,6 @@ def run_fix(
     git: GitClient,
     *,
     now: datetime,
-    decided_by: str,
     known_thread_ids: set[str] | None = None,
 ) -> FixRunResult:
     """Dispatch the fix contract, audit the output, and isolate contamination.
@@ -95,9 +99,10 @@ def run_fix(
     """
     pre = git.head_sha()
     try:
-        out = dispatcher.fix(req)
+        dispatched = dispatcher.fix(req)
     except AllProvidersFailedError as exc:
-        return _both_fail_result(req, exc, now=now, decided_by=decided_by)
+        return _both_fail_result(req, exc, now=now)
+    out = dispatched.output
 
     post = git.head_sha()
     ancestors_of_pre = set(git.rev_list(pre))
@@ -125,7 +130,7 @@ def run_fix(
         out,
         git,
         now=now,
-        decided_by=decided_by,
+        decided_by=dispatched.decided_by,
         item_violations=item_violations,
         orphan=orphan,
         memory_violations=memory.violations,
@@ -146,11 +151,11 @@ def _items_by_gh(req: FixInput) -> dict[str, ReviewItem]:
 
 
 def _both_fail_result(
-    req: FixInput, exc: AllProvidersFailedError, *, now: datetime, decided_by: str
+    req: FixInput, exc: AllProvidersFailedError, *, now: datetime
 ) -> FixRunResult:
     by_gh = _items_by_gh(req)
     dispositions = {
-        gh_id: provider_failure_disposition(exc.detail, now=now, decided_by=decided_by)
+        gh_id: provider_failure_disposition(exc.detail, now=now, decided_by=_BOTH_FAIL_DECIDED_BY)
         for gh_id in req.item_gh_ids
     }
     escalations = [
@@ -159,7 +164,12 @@ def _both_fail_result(
         )
         for gh_id in req.item_gh_ids
     ]
-    return FixRunResult(dispositions=dispositions, escalations=escalations, stashed=False)
+    return FixRunResult(
+        dispositions=dispositions,
+        escalations=escalations,
+        stashed=False,
+        decided_by=_BOTH_FAIL_DECIDED_BY,
+    )
 
 
 def _build_result(
@@ -244,6 +254,7 @@ def _build_result(
         dispositions=dispositions,
         escalations=escalations,
         stashed=cluster_flip,
+        decided_by=decided_by,
         deferred_memory=deferred_memory,
         contextual_memory=memory_routable,
         unwritten=unwritten,

--- a/packages/prgroom/src/prgroom/agent/usage.py
+++ b/packages/prgroom/src/prgroom/agent/usage.py
@@ -1,9 +1,13 @@
-"""Per-invocation token-usage JSONL emitter (§5 token-usage logging).
+"""Per-attempt usage JSONL emitter (§5 token-usage logging).
 
-The CLI logs **per-contract token usage** to ``$XDG_STATE_HOME/prgroom/usage.jsonl``
-when the agent CLI emits a usage line (Claude and Codex CLIs both do). This is
-**MVP baseline-capture only** — one JSON line per invocation, no aggregation, no
-analysis — so future cost-optimization work has data to start from.
+One row per **chain-link attempt** — failures included — lands in
+``$XDG_STATE_HOME/prgroom/usage.jsonl`` via the dispatcher's ``usage_hook``
+(the production dispatcher builders wire it to :func:`append_usage`). Rows are
+appended under an exclusive ``flock`` because concurrent per-PR prgroom
+processes share the one global file. Token fields ride the CLI's own output
+when captured (claude envelope / codex trailer); absent figures stay ``None``.
+This is **MVP baseline-capture only** — no aggregation, no analysis — so future
+cost-optimization work has data to start from.
 
 The XDG state directory is resolved through :func:`prgroom.prsession.file.resolve_state_dir`,
 the single source of truth for ``$XDG_STATE_HOME/prgroom`` (shared with the file
@@ -12,6 +16,7 @@ Store), so usage data and state land in the same place under the same env rule.
 
 from __future__ import annotations
 
+import fcntl
 import json
 from dataclasses import dataclass
 from typing import Any
@@ -81,4 +86,10 @@ def append_usage(record: UsageRecord | None) -> None:
     path = resolve_state_dir() / USAGE_FILENAME
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
+        # Exclusive flock on the DATA descriptor (kernel-released on process
+        # death): prgroom's per-PR locking still allows concurrent runs on
+        # different PRs, and all of them append to this one global file. The
+        # file is append-only (never os.replace'd), so locking its own fd is
+        # sound — no sidecar needed, unlike the FileStore.
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
         fh.write(json.dumps(record.to_dict()) + "\n")

--- a/packages/prgroom/src/prgroom/cli.py
+++ b/packages/prgroom/src/prgroom/cli.py
@@ -15,6 +15,7 @@ Verb names with underscores in the function name render as hyphenated commands
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -28,10 +29,10 @@ from prgroom.agent.contracts import ClusterContract, FixContract
 from prgroom.agent.dispatcher import (
     ClusterDispatcher,
     FixDispatcher,
-    ProviderChain,
     load_chain,
 )
 from prgroom.agent.subprocess_runner import SubprocessAgentRunner
+from prgroom.agent.usage import append_usage
 from prgroom.config import PrgroomConfig
 from prgroom.deps import Deps
 from prgroom.errors import ErrorCode, PreconditionError, PrgroomError, exit_code_for_tier
@@ -119,54 +120,34 @@ def _git_user() -> str:
     return _build_git().config_user()
 
 
-def _decided_by(chain: ProviderChain) -> str:
-    """Derive ``decided_by`` from a resolved chain's primary provider (``"<cli> <model>"``).
-
-    The primary (first) provider is the one prgroom prefers; its ``cli`` + ``model``
-    name the deciding agent on every disposition this run stamps (e.g.
-    ``"claude opus[1m]"``). An empty chain (a misconfig the dispatcher would reject
-    on dispatch) degrades to ``"prgroom"`` so the field is never blank.
-    """
-    if not chain.providers:
-        return "prgroom"
-    head = chain.providers[0]
-    return f"{head.cli} {head.model}"
-
-
-def _build_cluster_dispatcher() -> tuple[ClusterContract, str]:
+def _build_cluster_dispatcher() -> ClusterContract:
     """Resolve the cluster provider chain + a dispatcher.
 
-    A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
-    ``decided_by``. Production wires a :class:`ClusterDispatcher` over the real
+    A seam: tests monkeypatch this to inject a stub dispatcher. Production wires
+    a :class:`ClusterDispatcher` over the real
     :class:`SubprocessAgentRunner`. It calls :func:`load_chain` with
     ``repo_config=None`` / ``model_override=None``, so the shipped DEFAULT chain is
     used today: no verb resolves the per-repo ``.prgroom.toml`` path yet (poll/status
     pass ``None`` too — there is no resolver), so ``[agents.cluster]`` overrides and a
     ``--cluster-model`` flag stay inert pending that cross-verb config-path wiring.
     """
-    chain = load_chain("cluster", repo_config=None, model_override=None)  # pragma: no cover
-    dispatcher = ClusterDispatcher(  # pragma: no cover - production wiring
-        runner=SubprocessAgentRunner(), chain=chain
-    )
-    return dispatcher, _decided_by(chain)  # pragma: no cover - production wiring
+    chain = load_chain("cluster", repo_config=None, model_override=None)
+    return ClusterDispatcher(runner=SubprocessAgentRunner(), chain=chain, usage_hook=append_usage)
 
 
-def _build_fix_dispatcher() -> tuple[FixContract, str]:
+def _build_fix_dispatcher() -> FixContract:
     """Resolve the fix provider chain + a dispatcher.
 
-    A seam: tests monkeypatch this to inject a stub dispatcher + a fixed
-    ``decided_by``. Production wires a :class:`FixDispatcher` over the real
+    A seam: tests monkeypatch this to inject a stub dispatcher. Production wires
+    a :class:`FixDispatcher` over the real
     :class:`SubprocessAgentRunner`. It calls :func:`load_chain` with
     ``repo_config=None`` / ``model_override=None``, so the shipped DEFAULT chain is
     used today: no verb resolves the per-repo ``.prgroom.toml`` path yet (poll/status
     pass ``None`` too — there is no resolver), so ``[agents.fix]`` overrides and a
     ``--fix-model`` flag stay inert pending that cross-verb config-path wiring.
     """
-    chain = load_chain("fix", repo_config=None, model_override=None)  # pragma: no cover
-    dispatcher = FixDispatcher(  # pragma: no cover - production wiring
-        runner=SubprocessAgentRunner(), chain=chain
-    )
-    return dispatcher, _decided_by(chain)  # pragma: no cover - production wiring
+    chain = load_chain("fix", repo_config=None, model_override=None)
+    return FixDispatcher(runner=SubprocessAgentRunner(), chain=chain, usage_hook=append_usage)
 
 
 def _build_sink() -> Sink:
@@ -298,7 +279,7 @@ def cluster(
                 raise PreconditionError(ErrorCode.PRECONDITION_NO_ITEMS, detail=ref.display())
             if not _needs_clustering(state.items):
                 return  # already clustered / all processed → idempotent no-op exit 0
-            dispatcher, decided_by = _build_cluster_dispatcher()
+            dispatcher = _build_cluster_dispatcher()
             with tempfile.TemporaryDirectory(prefix="prgroom-cluster-") as scratch:
                 state = cluster_pr(
                     state,
@@ -308,7 +289,6 @@ def cluster(
                     deps=deps,
                     config=config,
                     dispatcher=dispatcher,
-                    decided_by=decided_by,
                     scratch_dir=Path(scratch),
                 )
             store.write(ref, state)
@@ -353,7 +333,7 @@ def fix(
                 if state.items and all(item.disposition is not None for item in state.items):
                     return
                 raise PreconditionError(ErrorCode.PRECONDITION_NO_CLUSTERS, detail=ref.display())
-            dispatcher, decided_by = _build_fix_dispatcher()
+            dispatcher = _build_fix_dispatcher()
             sink = _build_sink()
             with tempfile.TemporaryDirectory(prefix="prgroom-fix-") as scratch:
                 state = fix_pr(
@@ -365,7 +345,6 @@ def fix(
                     config=config,
                     dispatcher=dispatcher,
                     sink=sink,
-                    decided_by=decided_by,
                     scratch_dir=Path(scratch),
                 )
             store.write(ref, state)
@@ -673,8 +652,8 @@ def run(
         ref = PRRef.parse(pr)
     except PrgroomError as err:
         raise typer.Exit(code=handle_cli_error(err)) from err
-    cluster_dispatcher, cluster_decided_by = _build_cluster_dispatcher()
-    fix_dispatcher, fix_decided_by = _build_fix_dispatcher()
+    cluster_dispatcher = _build_cluster_dispatcher()
+    fix_dispatcher = _build_fix_dispatcher()
     code = run_lifecycle(
         store=store,
         ref=ref,
@@ -685,9 +664,7 @@ def run(
         sink=_build_sink(),
         mode=Mode.INTERACTIVE if interactive else Mode.AUTONOMOUS,
         cluster_dispatcher=cluster_dispatcher,
-        cluster_decided_by=cluster_decided_by,
         fix_dispatcher=fix_dispatcher,
-        fix_decided_by=fix_decided_by,
     )
     if code != 0:
         raise typer.Exit(code=code)
@@ -734,13 +711,38 @@ def handle_cli_error(err: PrgroomError, *, stderr: IO[str] | None = None) -> int
     return exit_code_for_tier(err)
 
 
+def _resolve_log_level(raw: str | None) -> tuple[int, str | None]:
+    """Map ``PRGROOM_LOG_LEVEL`` to a stdlib level, fail-lateral on garbage.
+
+    A typo'd env var must never take down an autonomous overnight run: an
+    unrecognized value degrades to WARNING with a one-line notice (the loud
+    part), never an exception.
+    """
+    if not raw:
+        return logging.WARNING, None
+    level = logging.getLevelNamesMapping().get(raw.upper())
+    if level is None:
+        return logging.WARNING, f"prgroom: unknown PRGROOM_LOG_LEVEL {raw!r}; using WARNING"
+    return level, None
+
+
 def main() -> None:
     """Console-script entry point (``prgroom``).
 
     Wraps the typer app so a tier-tagged :class:`PrgroomError` raised by a verb
     is rendered through :func:`handle_cli_error` and turned into the documented
-    exit code, rather than surfacing as an uncaught traceback.
+    exit code, rather than surfacing as an uncaught traceback. Configures the
+    root logging handler ONCE, here — stdout stays reserved for contract output;
+    every diagnostic goes to stderr. Library modules only ever
+    ``getLogger(__name__)``; ``basicConfig`` no-ops when a root handler already
+    exists (embedding-safe).
     """
+    level, notice = _resolve_log_level(os.environ.get("PRGROOM_LOG_LEVEL"))
+    if notice is not None:
+        print(notice, file=sys.stderr)  # pre-logging bootstrap notice
+    logging.basicConfig(
+        stream=sys.stderr, level=level, format="prgroom %(levelname)s %(name)s: %(message)s"
+    )
     try:
         app()
     except PrgroomError as err:

--- a/packages/prgroom/src/prgroom/lifecycle/cluster.py
+++ b/packages/prgroom/src/prgroom/lifecycle/cluster.py
@@ -16,9 +16,6 @@ contract).
 prgroom does the gh/git legwork for the light PR-context file the cluster
 contract passes (``pr_context_path``): the PR title/body + recent commits + the
 poll-derived CI summary, written under the caller-provided scratch dir.
-``decided_by`` is part of the uniform ``run_cluster``/``run_fix`` signature;
-clustering decides no disposition, so ``run_cluster`` ignores it (it is threaded
-through for signature symmetry with the fix path).
 """
 
 from __future__ import annotations
@@ -54,7 +51,6 @@ def cluster_pr(
     deps: Deps,
     config: PrgroomConfig,
     dispatcher: ClusterContract,
-    decided_by: str,
     scratch_dir: Path,
 ) -> PRGroomingState:
     """Cluster the unclustered items, applying the assignments to a state copy.
@@ -64,7 +60,7 @@ def cluster_pr(
     caller to persist. Idempotent: a no-op when every item is already clustered.
     No disposition, no phase change (§3.2 cluster row).
     """
-    del config  # cluster reads no config knob today; kept for signature symmetry
+    del config, deps  # cluster reads no config knob and no clock today; kept for signature symmetry
     state = copy.deepcopy(state)
     pending = _unclustered_unprocessed(state.items)
     if not pending:
@@ -72,7 +68,7 @@ def cluster_pr(
 
     context_path = _write_pr_context(ref, gh, git, scratch_dir, ci_state=state.quiescence.ci_state)
     req = ClusterInput(pr=ref, items=pending, pr_context_path=str(context_path))
-    result = run_cluster(req, dispatcher, now=deps.clock.now(), decided_by=decided_by)
+    result = run_cluster(req, dispatcher)
 
     for item in pending:
         cluster_id = result.assignments.get(item.identity.gh_id)

--- a/packages/prgroom/src/prgroom/lifecycle/fix.py
+++ b/packages/prgroom/src/prgroom/lifecycle/fix.py
@@ -65,7 +65,6 @@ def fix_pr(
     config: PrgroomConfig,
     dispatcher: FixContract,
     sink: Sink,
-    decided_by: str,
     scratch_dir: Path,
     warn: Callable[[str], None] = default_warn,
 ) -> PRGroomingState:
@@ -94,7 +93,6 @@ def fix_pr(
             dispatcher=dispatcher,
             sink=sink,
             now=now,
-            decided_by=decided_by,
             scratch_dir=scratch_dir,
             warn=warn,
         )
@@ -112,7 +110,6 @@ def _fix_one_cluster(
     dispatcher: FixContract,
     sink: Sink,
     now: datetime,
-    decided_by: str,
     scratch_dir: Path,
     warn: Callable[[str], None],
 ) -> None:
@@ -134,13 +131,15 @@ def _fix_one_cluster(
         memory_dir=snapshot.memory_dir,
         response_outbox_dir=snapshot.response_outbox_dir,
     )
-    result = run_fix(req, dispatcher, git, now=now, decided_by=decided_by)
+    result = run_fix(req, dispatcher, git, now=now)
 
+    # Post-return stamps use the dispatch's own provenance (the winning link, or
+    # "prgroom" on both-fail) — the same authority run_fix stamped its rows with.
     routed, blocked = resolve_routed_memory(
         result.contextual_memory,
         memory_dir=snapshot.memory_dir,
         retry=state.pr_review_retries_used,
-        decided_by=decided_by,
+        decided_by=result.decided_by,
         cluster_id=cluster_id,
         warn=warn,
     )
@@ -151,7 +150,9 @@ def _fix_one_cluster(
             code=ErrorCode.CONTRACT_FIX_AUDIT_FAILED, detail=blocked, severity=Severity.BLOCK
         )
         for cluster_item in cluster_items:
-            cluster_item.disposition = failed_disposition(violation, now=now, decided_by=decided_by)
+            cluster_item.disposition = failed_disposition(
+                violation, now=now, decided_by=result.decided_by
+            )
         sink.emit(escalation_for(violation, pr=ref))
         git.stash()
         return

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -149,11 +149,9 @@ class Verbs:
         cls,
         *,
         cluster_dispatcher: ClusterContract,
-        cluster_decided_by: str,
         fix_dispatcher: FixContract,
-        fix_decided_by: str,
     ) -> Verbs:
-        """Wire the production verbs; cluster/fix capture their dispatchers + decided_by."""
+        """Wire the production verbs; cluster/fix capture their dispatchers."""
 
         def cluster(ctx: RunContext) -> PRGroomingState:
             with TemporaryDirectory(prefix="prgroom-cluster-") as scratch:
@@ -165,7 +163,6 @@ class Verbs:
                     deps=ctx.deps,
                     config=ctx.config,
                     dispatcher=cluster_dispatcher,
-                    decided_by=cluster_decided_by,
                     scratch_dir=Path(scratch),
                 )
 
@@ -180,7 +177,6 @@ class Verbs:
                     config=ctx.config,
                     dispatcher=fix_dispatcher,
                     sink=ctx.sink,
-                    decided_by=fix_decided_by,
                     scratch_dir=Path(scratch),
                 )
 
@@ -251,9 +247,7 @@ def run_lifecycle(
     sink: Sink,
     mode: Mode,
     cluster_dispatcher: ClusterContract,
-    cluster_decided_by: str,
     fix_dispatcher: FixContract,
-    fix_decided_by: str,
 ) -> int:
     """Run the lifecycle under one lock; return the §3.3 exit code (the CLI entry).
 
@@ -277,9 +271,7 @@ def run_lifecycle(
     )
     verbs = Verbs.system(
         cluster_dispatcher=cluster_dispatcher,
-        cluster_decided_by=cluster_decided_by,
         fix_dispatcher=fix_dispatcher,
-        fix_decided_by=fix_decided_by,
     )
     handlers = _signal_handlers(cancel) if mode is Mode.AUTONOMOUS else nullcontext()
     with handlers:

--- a/packages/prgroom/tests/unit/test_agent_cluster.py
+++ b/packages/prgroom/tests/unit/test_agent_cluster.py
@@ -3,9 +3,8 @@
 ``run_cluster`` dispatches, audits, and on failure retries once; a second
 failure (or a both-fail) falls back to per-item degenerate clusters that are
 coverage-complete by construction. It is pure of state — it returns a
-:class:`ClusterRunResult`, never mutating ``PRGroomingState``. ``now`` is unused
-by clustering (ids derive from gh_id, not the clock) but is part of the uniform
-8.7 signature; the fakes mirror the ``ClusterContract`` Protocol exactly.
+:class:`ClusterRunResult`, never mutating ``PRGroomingState``. The fakes mirror
+the ``ClusterContract`` Protocol exactly.
 """
 
 from __future__ import annotations
@@ -14,7 +13,8 @@ from datetime import UTC, datetime
 
 from prgroom.agent.cluster import run_cluster
 from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
-from prgroom.agent.dispatcher import AllProvidersFailedError
+from prgroom.agent.dispatcher import AllProvidersFailedError, Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.prsession.enums import ItemKind
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import Identity, ReviewItem
@@ -50,13 +50,13 @@ class ScriptedClusterDispatcher:
         self._outcomes = list(outcomes)
         self.calls = 0
 
-    def cluster(self, request: ClusterInput) -> ClusterOutput:
+    def cluster(self, request: ClusterInput) -> Dispatched[ClusterOutput]:
         del request  # scripted by call order; mirrors the ClusterContract Protocol
         self.calls += 1
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Exception):
             raise outcome
-        return outcome
+        return Dispatched(output=outcome, winner=AgentSpec(cli="ollama", model="gemma4"))
 
 
 def _one_cluster(req: ClusterInput, *, rationale: str = "all of them") -> ClusterOutput:
@@ -74,7 +74,7 @@ def _one_cluster(req: ClusterInput, *, rationale: str = "all of them") -> Cluste
 def test_clean_first_attempt_passes_through() -> None:
     req = _req("C_1", "C_2")
     disp = ScriptedClusterDispatcher([_one_cluster(req)])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert disp.calls == 1
     assert result.attempts == 1
     assert result.degenerate is False
@@ -88,7 +88,7 @@ def test_retry_once_succeeds_on_second_attempt() -> None:
         clusters=[ClusterResult(cluster_id="c-1", item_gh_ids=["C_1"], rationale="")]
     )
     disp = ScriptedClusterDispatcher([bad, _one_cluster(req)])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert disp.calls == 2
     assert result.attempts == 2
     assert result.degenerate is False
@@ -99,7 +99,7 @@ def test_two_audit_failures_fall_back_to_degenerate() -> None:
     req = _req("C_1", "C_2")
     bad = ClusterOutput(clusters=[])  # coverage-empty — fails audit twice
     disp = ScriptedClusterDispatcher([bad, bad])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert disp.calls == 2
     assert result.degenerate is True
     # One cluster per item, coverage-complete by construction.
@@ -111,7 +111,7 @@ def test_both_fail_twice_falls_back_to_degenerate_without_agent() -> None:
     req = _req("C_1")
     err = AllProvidersFailedError(detail="ollama down; haiku down")
     disp = ScriptedClusterDispatcher([err, err])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert disp.calls == 2
     assert result.degenerate is True
     assert set(result.assignments) == {"C_1"}
@@ -121,7 +121,7 @@ def test_degenerate_cluster_id_derives_from_gh_id_not_clock() -> None:
     req = _req("C_1")
     err = AllProvidersFailedError(detail="down")
     disp = ScriptedClusterDispatcher([err, err])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     # Deterministic: the id is a pure function of the gh_id (no counter+clock).
     assert result.assignments["C_1"] == "degen-C_1"
 
@@ -131,7 +131,7 @@ def test_degenerate_clusters_each_carry_a_rationale() -> None:
     req = _req("C_1", "C_2")
     err = AllProvidersFailedError(detail="down")
     disp = ScriptedClusterDispatcher([err, err])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert all(c.rationale.strip() for c in result.clusters)
     assert {c.cluster_id for c in result.clusters} == {"degen-C_1", "degen-C_2"}
 
@@ -141,7 +141,7 @@ def test_first_attempt_both_fail_then_clean_retry_succeeds() -> None:
     # go degenerate — retry-once covers the transient case.
     req = _req("C_1")
     disp = ScriptedClusterDispatcher([AllProvidersFailedError(detail="blip"), _one_cluster(req)])
-    result = run_cluster(req, disp, now=_NOW, decided_by="prgroom")
+    result = run_cluster(req, disp)
     assert disp.calls == 2
     assert result.degenerate is False
     assert result.assignments == {"C_1": "c-1"}

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -349,7 +349,7 @@ def test_primary_success_uses_first_provider_only() -> None:
         runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
     )
     out = dispatcher.cluster(_cluster_input())
-    assert out.clusters == []
+    assert out.output.clusters == []
     assert [s.cli for s in runner.specs_tried] == ["ollama"]  # fallback never touched
 
 
@@ -524,7 +524,7 @@ def test_banner_wrapped_json_still_parses() -> None:
     runner = FakeAgentRunner([Succeeds(noisy)])
     dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
     out = dispatcher.cluster(_cluster_input())
-    assert out.clusters == []
+    assert out.output.clusters == []
 
 
 def test_stray_brace_in_banner_noise_is_skipped() -> None:
@@ -534,7 +534,7 @@ def test_stray_brace_in_banner_noise_is_skipped() -> None:
     runner = FakeAgentRunner([Succeeds(noisy)])
     dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
     out = dispatcher.cluster(_cluster_input())
-    assert out.clusters == []
+    assert out.output.clusters == []
 
 
 def test_last_json_object_wins_when_stdout_carries_several() -> None:
@@ -542,14 +542,14 @@ def test_last_json_object_wins_when_stdout_carries_several() -> None:
     runner = FakeAgentRunner([Succeeds(noisy)])
     dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
     out = dispatcher.cluster(_cluster_input())
-    assert out.clusters == []  # the LAST object is the contract output
+    assert out.output.clusters == []  # the LAST object is the contract output
 
 
 def test_fix_dispatcher_parses_fix_output() -> None:
     runner = FakeAgentRunner([Succeeds(FIX_OK)])
     dispatcher = FixDispatcher(runner=runner, chain=_chain(AgentSpec("claude", "opus[1m]")))
     out = dispatcher.fix(_fix_input())
-    assert out.items == []
+    assert out.output.items == []
 
 
 def test_fix_out_of_enum_disposition_falls_through_not_crashes() -> None:
@@ -563,7 +563,7 @@ def test_fix_out_of_enum_disposition_falls_through_not_crashes() -> None:
         chain=_chain(AgentSpec("claude", "opus[1m]"), AgentSpec("codex", "gpt-5.6-terra")),
     )
     out = dispatcher.fix(_fix_input())
-    assert out.items == []  # the second provider's good output was parsed
+    assert out.output.items == []  # the second provider's good output was parsed
     assert [s.cli for s in runner.specs_tried] == ["claude", "codex"]  # fell through
 
 
@@ -661,3 +661,100 @@ def test_fix_dispatcher_satisfies_fix_contract() -> None:
     chain = _chain(AgentSpec("claude", "opus[1m]"))
     dispatcher: FixContract = FixDispatcher(runner=runner, chain=chain)
     assert isinstance(dispatcher, FixContract)
+
+
+# ── winner provenance: the Dispatched envelope (observability spec §3) ──
+
+
+def test_fallback_success_carries_winner_and_failures() -> None:
+    # The root regression guard for decided_by misattribution: the ladder now
+    # returns WHO won and what failed on the way, not the bare parsed output.
+    fallback = AgentSpec("claude", "haiku")
+    runner = FakeAgentRunner([TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), fallback)
+    )
+    dispatched = dispatcher.cluster(_cluster_input())
+    assert dispatched.output.clusters == []
+    assert dispatched.winner == fallback
+    assert dispatched.rung == 1
+    assert dispatched.fell_back is True
+    assert len(dispatched.failures) == 1
+    assert dispatched.failures[0].kind == "timeout"
+    assert dispatched.decided_by == "claude haiku"
+
+
+def test_partial_fallback_logs_per_link_warning_and_one_summary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # §5: streaming per-link WARNING at failure time (an operator should learn of
+    # the primary's timeout when it happens), plus exactly one greppable
+    # "fell back to" summary naming the winner and rung.
+    runner = FakeAgentRunner(
+        [ExitsWith(returncode=3, stderr="quota exceeded"), Succeeds(CLUSTER_OK)]
+    )
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with caplog.at_level("WARNING"):
+        dispatched = dispatcher.cluster(_cluster_input())
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    link_lines = [m for m in warnings if "link ollama:gemma4 failed (error)" in m]
+    assert len(link_lines) == 1
+    assert "quota exceeded" in link_lines[0]
+    assert "cluster" in link_lines[0]
+    summaries = [m for m in warnings if "fell back to" in m]
+    assert len(summaries) == 1
+    assert "claude:haiku" in summaries[0]
+    assert "rung 1" in summaries[0]
+    assert "ollama:gemma4" in summaries[0]  # the failed-links rendering
+    assert dispatched.rung == 1
+
+
+def test_clean_primary_dispatch_logs_nothing(caplog: pytest.LogCaptureFixture) -> None:
+    # The no-noise guard: rung 0 emits zero log lines.
+    runner = FakeAgentRunner([Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(runner=runner, chain=_chain(AgentSpec("ollama", "gemma4")))
+    with caplog.at_level("WARNING"):
+        dispatched = dispatcher.cluster(_cluster_input())
+    assert dispatched.rung == 0
+    assert dispatched.fell_back is False
+    assert dispatched.failures == ()
+    assert not caplog.records
+
+
+def test_exhaustion_logs_per_link_but_no_summary(caplog: pytest.LogCaptureFixture) -> None:
+    # Both-fail: every link logged its own failure at failure time; the summary
+    # line belongs to success-after-fallback only (the Sink carries exhaustion).
+    runner = FakeAgentRunner([TimesOut(), ExitsWith(returncode=1, stderr="down")])
+    dispatcher = ClusterDispatcher(
+        runner=runner, chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku"))
+    )
+    with caplog.at_level("WARNING"), pytest.raises(AllProvidersFailedError) as excinfo:
+        dispatcher.cluster(_cluster_input())
+    assert excinfo.value.tier is Tier.RUNTIME_TRANSIENT
+    assert excinfo.value.code is ErrorCode.RUNTIME_AGENT_UNAVAILABLE
+    warnings = [r.message for r in caplog.records]
+    assert len([m for m in warnings if "failed (" in m]) == 2  # one per link
+    assert not [m for m in warnings if "fell back to" in m]
+
+
+def test_usage_hook_failure_is_contained_and_warned(caplog: pytest.LogCaptureFixture) -> None:
+    # Telemetry never fails a dispatch: a raising hook drops the record with a
+    # WARNING per attempt and the dispatch still resolves.
+    def bad_hook(record: UsageRecord) -> None:
+        del record
+        msg = "disk full"
+        raise OSError(msg)
+
+    runner = FakeAgentRunner([TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "gemma4"), AgentSpec("claude", "haiku")),
+        usage_hook=bad_hook,
+    )
+    with caplog.at_level("WARNING"):
+        dispatched = dispatcher.cluster(_cluster_input())
+    assert dispatched.winner == AgentSpec("claude", "haiku")
+    hook_warnings = [r.message for r in caplog.records if "usage hook failed" in r.message]
+    assert len(hook_warnings) == 2  # one per dropped attempt (timeout + success)

--- a/packages/prgroom/tests/unit/test_agent_dispatcher.py
+++ b/packages/prgroom/tests/unit/test_agent_dispatcher.py
@@ -35,6 +35,7 @@ from prgroom.agent.subprocess_runner import (
     AgentRunResult,
     AgentSpec,
     AgentTimeoutError,
+    UsageFigures,
 )
 from prgroom.agent.usage import UsageRecord
 from prgroom.errors import ErrorCode, PrgroomError, Tier, exit_code_for_tier
@@ -48,16 +49,20 @@ class _Outcome:
 
 
 class Succeeds(_Outcome):
-    def __init__(self, stdout: str) -> None:
+    def __init__(self, stdout: str, usage: UsageFigures | None = None) -> None:
         self.stdout = stdout
+        self.usage = usage
 
 
 class ExitsWith(_Outcome):
     """A non-zero process exit (quota/auth/network) — a fallback trigger."""
 
-    def __init__(self, returncode: int, stderr: str = "") -> None:
+    def __init__(
+        self, returncode: int, stderr: str = "", usage: UsageFigures | None = None
+    ) -> None:
         self.returncode = returncode
         self.stderr = stderr
+        self.usage = usage
 
 
 class TimesOut(_Outcome):
@@ -114,10 +119,20 @@ class FakeAgentRunner:
         )
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Succeeds):
-            return AgentRunResult(returncode=0, stdout=outcome.stdout, stderr="", duration_ms=1)
+            return AgentRunResult(
+                returncode=0,
+                stdout=outcome.stdout,
+                stderr="",
+                duration_ms=1,
+                usage=outcome.usage,
+            )
         if isinstance(outcome, ExitsWith):
             return AgentRunResult(
-                returncode=outcome.returncode, stdout="", stderr=outcome.stderr, duration_ms=1
+                returncode=outcome.returncode,
+                stdout="",
+                stderr=outcome.stderr,
+                duration_ms=1,
+                usage=outcome.usage,
             )
         if isinstance(outcome, TimesOut):
             raise AgentTimeoutError(
@@ -626,6 +641,52 @@ def test_usage_hook_tags_unavailable_error_and_malformed_attempts() -> None:
     )
     dispatcher.cluster(_cluster_input())
     assert [r.outcome for r in records] == ["unavailable", "error", "malformed", "success"]
+
+
+def test_success_record_carries_runner_reported_token_and_cost_figures() -> None:
+    # The runner attaches parsed usage (claude envelope / codex trailer) to its
+    # result; the success UsageRecord must thread those figures through — not
+    # hard-code the token/cost fields to None and lose the captured data.
+    records: list[UsageRecord] = []
+    figs = UsageFigures(tokens_in=100, tokens_out=5, tokens_total=105, reported_cost_usd=0.01)
+    runner = FakeAgentRunner([Succeeds(CLUSTER_OK, usage=figs)])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "gemma4")),
+        usage_hook=records.append,
+    )
+    dispatcher.cluster(_cluster_input())
+    (rec,) = records
+    assert rec.outcome == "success"
+    assert rec.input_tokens == 100
+    assert rec.output_tokens == 5
+    assert rec.tokens_total == 105
+    assert rec.reported_cost_usd == 0.01
+
+
+def test_error_record_carries_usage_while_timeout_stays_all_none() -> None:
+    # A non-zero-exit link can still have reported usage (the CLI ran, then failed)
+    # — its "error" record must carry those figures. A timeout attempt produced no
+    # result, so its record stays all-None.
+    records: list[UsageRecord] = []
+    figs = UsageFigures(tokens_in=50, tokens_out=2, reported_cost_usd=0.02)
+    runner = FakeAgentRunner([ExitsWith(1, "quota", usage=figs), TimesOut(), Succeeds(CLUSTER_OK)])
+    dispatcher = ClusterDispatcher(
+        runner=runner,
+        chain=_chain(AgentSpec("ollama", "g"), AgentSpec("claude", "h"), AgentSpec("codex", "m")),
+        usage_hook=records.append,
+    )
+    dispatcher.cluster(_cluster_input())
+    error_rec, timeout_rec = records[0], records[1]
+    assert error_rec.outcome == "error"
+    assert error_rec.input_tokens == 50
+    assert error_rec.output_tokens == 2
+    assert error_rec.reported_cost_usd == 0.02
+    assert timeout_rec.outcome == "timeout"
+    assert timeout_rec.input_tokens is None
+    assert timeout_rec.output_tokens is None
+    assert timeout_rec.tokens_total is None
+    assert timeout_rec.reported_cost_usd is None
 
 
 def test_usage_hook_records_a_cancelled_attempt_before_the_abort() -> None:

--- a/packages/prgroom/tests/unit/test_agent_fix.py
+++ b/packages/prgroom/tests/unit/test_agent_fix.py
@@ -12,10 +12,12 @@ Protocols exactly.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEntry
-from prgroom.agent.dispatcher import AllProvidersFailedError
+from prgroom.agent.dispatcher import AllProvidersFailedError, Dispatched, LinkFailure
 from prgroom.agent.fix import run_fix
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.escalation import Severity
 from prgroom.prsession.enums import DispositionKind, GateStrength, ItemKind
 from prgroom.prsession.pr_ref import PRRef
@@ -55,12 +57,12 @@ class FixDispatcherStub:
         self._outcome = outcome
         self.calls = 0
 
-    def fix(self, request: FixInput) -> FixOutput:
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]:
         del request  # canned outcome; mirrors the FixContract Protocol signature
         self.calls += 1
         if isinstance(self._outcome, Exception):
             raise self._outcome
-        return self._outcome
+        return Dispatched(output=self._outcome, winner=AgentSpec(cli="claude", model="opus[1m]"))
 
 
 class FakeGit:
@@ -113,7 +115,7 @@ def test_both_fail_flips_every_item_to_failed_with_escalation_and_no_stash() -> 
     req = _req("C_1", "C_2")
     disp = FixDispatcherStub(AllProvidersFailedError(detail="ollama down; opus down"))
     git = _git()
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert {g: d.kind for g, d in res.dispositions.items()} == {
         "C_1": DispositionKind.FAILED,
         "C_2": DispositionKind.FAILED,
@@ -129,7 +131,7 @@ def test_both_fail_does_not_read_head_or_rev_list() -> None:
     req = _req("C_1")
     disp = FixDispatcherStub(AllProvidersFailedError(detail="down"))
     git = FakeGit(pre="pre", post="post", ancestors=["pre"], new=[])
-    run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    run_fix(req, disp, git, now=_NOW)
     # head_sha was read once (pre); post was never consumed because the both-fail
     # short-circuit returns before computing the commit sets.
     assert git.head_calls == 1
@@ -155,7 +157,7 @@ def test_clean_output_maps_dispositions_straight_through() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     c1 = res.dispositions["C_1"]
     assert c1.kind is DispositionKind.FIXED
     assert c1.commits == ["n1"]
@@ -163,7 +165,7 @@ def test_clean_output_maps_dispositions_straight_through() -> None:
     assert c1.gate is GateStrength.FULL
     assert c1.response_path == "/o/C_1.md"
     assert c1.decided_at == _NOW
-    assert c1.decided_by == "prgroom"
+    assert c1.decided_by == "claude opus[1m]"  # the stub's winner, not a static config
     assert res.dispositions["C_2"].kind is DispositionKind.WONT_FIX
     assert res.escalations == []
     assert res.stashed is False
@@ -178,7 +180,7 @@ def test_fixed_row_with_missing_gate_flips_to_failed_end_to_end() -> None:
         items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["n1"])]
     )
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, FixDispatcherStub(out), git, now=_NOW)
     d = res.dispositions["C_1"]
     assert d.kind is DispositionKind.FAILED
     assert "recommended_gate" in d.rationale
@@ -199,7 +201,7 @@ def test_clean_non_fixed_row_with_garbage_gate_parses_to_none() -> None:
             )
         ]
     )
-    res = run_fix(req, FixDispatcherStub(out), _git(), now=_NOW, decided_by="prgroom")
+    res = run_fix(req, FixDispatcherStub(out), _git(), now=_NOW)
     d = res.dispositions["C_1"]
     assert d.kind is DispositionKind.SKIPPED
     assert d.gate is None
@@ -225,7 +227,7 @@ def test_item_with_audit_violation_flips_to_failed_only_for_that_item() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["C_1"].kind is DispositionKind.FIXED
     assert res.dispositions["C_2"].kind is DispositionKind.FAILED
     assert any(e.item is not None and e.item.identity.gh_id == "C_2" for e in res.escalations)
@@ -251,7 +253,7 @@ def test_cluster_flip_rationale_carries_the_hard_violation_detail() -> None:
         ]
     )
     git = _git(ancestors=["pre"], new=["n1", "n2"])
-    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
+    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW)
     assert res.stashed is True
     flipped = res.dispositions["C_1"]
     assert flipped.kind is DispositionKind.FAILED
@@ -275,7 +277,7 @@ def test_swept_item_rationale_is_the_spec_string_with_no_added_prefix() -> None:
         memory_writes=["/etc/passwd"],  # escapes memory_dir → hard containment BLOCK
     )
     git = _git(ancestors=["pre"], new=["n1"])  # n1 claimed → no orphan, only containment
-    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
+    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW)
     assert res.stashed is True
     assert res.dispositions["C_1"].rationale == "memory containment violation: /etc/passwd"
 
@@ -290,7 +292,7 @@ def test_ghost_row_cannot_suppress_orphan_detection() -> None:
         ]
     )
     git = _git(ancestors=["pre"], new=["n1", "n2"])
-    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW, decided_by="prgroom")
+    res = run_fix(_req("C_1"), FixDispatcherStub(out), git, now=_NOW)
     assert res.stashed is True  # orphan detected despite the GHOST's claim
     assert "GHOST" not in res.dispositions  # unrequested rows are never dispositioned
 
@@ -321,7 +323,7 @@ def test_requested_item_missing_from_output_gets_failed_disposition_and_escalati
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     # Keys are exactly the authoritative requested set.
     assert set(res.dispositions) == {"A", "B"}
     assert res.dispositions["A"].kind is DispositionKind.FIXED
@@ -350,7 +352,7 @@ def test_extra_unrequested_item_escalates_but_gets_no_disposition() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert set(res.dispositions) == {"A"}  # GHOST is NOT disposed
     assert res.dispositions["A"].kind is DispositionKind.FIXED
     # GHOST is surfaced for visibility.
@@ -369,7 +371,7 @@ def test_duplicate_gh_id_in_output_fails_that_item_with_one_disposition() -> Non
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert set(res.dispositions) == {"A"}  # exactly one disposition for the id
     assert res.dispositions["A"].kind is DispositionKind.FAILED
     assert any(e.item is not None and e.item.identity.gh_id == "A" for e in res.escalations)
@@ -388,7 +390,7 @@ def test_duplicate_with_real_audit_violation_keeps_the_richer_violation_detail()
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=[])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["A"].kind is DispositionKind.FAILED
     # The per-item audit detail (no commits) is preserved, not overwritten by the
     # duplicate-shape message.
@@ -414,7 +416,7 @@ def test_orphan_flips_all_cluster_items_to_failed_and_stashes_once() -> None:
     disp = FixDispatcherStub(out)
     # n2 is a new commit no item claimed → orphan.
     git = _git(ancestors=["pre"], new=["n1", "n2"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["C_1"].kind is DispositionKind.FAILED
     assert res.dispositions["C_2"].kind is DispositionKind.FAILED
     assert res.stashed is True
@@ -435,7 +437,7 @@ def test_containment_violation_flips_cluster_and_stashes() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=[])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["C_1"].kind is DispositionKind.FAILED
     assert res.dispositions["C_2"].kind is DispositionKind.FAILED
     assert res.stashed is True
@@ -465,7 +467,7 @@ def test_warn_memory_violation_surfaces_escalation_without_flip_or_stash() -> No
     )
     disp = FixDispatcherStub(out)
     git = _git(ancestors=["pre"], new=["n1"])
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     # Items keep their agent dispositions — the WARN did not flip them.
     assert res.dispositions["C_1"].kind is DispositionKind.FIXED
     assert res.dispositions["C_2"].kind is DispositionKind.WONT_FIX
@@ -487,7 +489,7 @@ def test_non_contextual_memory_is_returned_as_deferred() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git()
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert [m.classification for m in res.deferred_memory] == ["PROJECT"]
     assert res.dispositions["C_1"].kind is DispositionKind.SKIPPED  # not a failure
 
@@ -503,7 +505,7 @@ def test_declared_but_unwritten_path_does_not_fail_the_cluster() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git()
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["C_1"].kind is DispositionKind.SKIPPED
     assert res.stashed is False
     assert res.unwritten == []  # MVP declared==written: soft-warning list is empty
@@ -519,7 +521,8 @@ def test_run_fix_signature_takes_no_state_object() -> None:
 
     params = set(inspect.signature(run_fix).parameters)
     assert "state" not in params
-    assert {"req", "dispatcher", "git", "now", "decided_by"} <= params
+    assert {"req", "dispatcher", "git", "now"} <= params
+    assert "decided_by" not in params  # provenance now comes from the Dispatched envelope
 
 
 def test_known_thread_ids_default_to_item_thread_ids() -> None:
@@ -532,7 +535,7 @@ def test_known_thread_ids_default_to_item_thread_ids() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git()
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom")
+    res = run_fix(req, disp, git, now=_NOW)
     assert res.dispositions["C_1"].kind is DispositionKind.SKIPPED  # hint resolved, no failure
 
 
@@ -546,5 +549,53 @@ def test_explicit_known_thread_ids_override_item_thread_ids() -> None:
     )
     disp = FixDispatcherStub(out)
     git = _git()
-    res = run_fix(req, disp, git, now=_NOW, decided_by="prgroom", known_thread_ids={"PRT_OTHER"})
+    res = run_fix(req, disp, git, now=_NOW, known_thread_ids={"PRT_OTHER"})
     assert res.dispositions["C_1"].kind is DispositionKind.SKIPPED  # override resolved the hint
+
+
+# ── winner provenance stamps dispositions (observability spec §3, behaviors 7-9) ──
+
+
+def _dispatched_stub(out: FixOutput, winner: AgentSpec, *failures: LinkFailure) -> Any:
+    class _Stub:
+        def fix(self, request: FixInput) -> Dispatched[FixOutput]:
+            del request
+            return Dispatched(output=out, winner=winner, failures=tuple(failures))
+
+    return _Stub()
+
+
+def test_winner_stamps_every_disposition_and_the_result() -> None:
+    # The bead-item-2 regression: under the old code decided_by read the CONFIGURED
+    # chain head; it must read the link that actually produced the output.
+    winner = AgentSpec(cli="codex", model="gpt-5.6-terra")
+    out = FixOutput(
+        items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["n1"])]
+    )
+    timeout = LinkFailure(AgentSpec("claude", "opus[1m]"), "timeout: budget", kind="timeout")
+    disp = _dispatched_stub(out, winner, timeout)
+    res = run_fix(_req("C_1"), disp, _git(new=["n1"]), now=_NOW)
+    assert res.dispositions["C_1"].decided_by == "codex gpt-5.6-terra"
+    assert res.decided_by == "codex gpt-5.6-terra"
+
+
+def test_synthesized_and_flipped_rows_stamp_the_winner_too() -> None:
+    # The winning agent produced the output being audited; prgroom's audit
+    # rejecting it does not change who decided. C_2 is synthesized (omitted from
+    # the output); C_1 is flipped FAILED (claimed commit not in the new set).
+    winner = AgentSpec(cli="claude", model="haiku")
+    out = FixOutput(
+        items=[FixItemResult(gh_id="C_1", disposition=DispositionKind.FIXED, commit_shas=["ghost"])]
+    )
+    res = run_fix(_req("C_1", "C_2"), _dispatched_stub(out, winner), _git(new=["n1"]), now=_NOW)
+    assert res.dispositions["C_1"].kind == DispositionKind.FAILED  # audit-flipped
+    assert res.dispositions["C_2"].kind == DispositionKind.FAILED  # synthesized
+    assert all(d.decided_by == "claude haiku" for d in res.dispositions.values())
+
+
+def test_both_fail_stamps_prgroom() -> None:
+    # No agent produced output — the ladder itself decided FAILED.
+    disp = FixDispatcherStub(AllProvidersFailedError(detail="all down"))
+    res = run_fix(_req("C_1"), disp, _git(), now=_NOW)
+    assert res.dispositions["C_1"].decided_by == "prgroom"
+    assert res.decided_by == "prgroom"

--- a/packages/prgroom/tests/unit/test_agent_fix_contextual_memory.py
+++ b/packages/prgroom/tests/unit/test_agent_fix_contextual_memory.py
@@ -1,7 +1,9 @@
 from datetime import UTC, datetime
 
 from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEntry
+from prgroom.agent.dispatcher import Dispatched
 from prgroom.agent.fix import run_fix
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.prsession.enums import DispositionKind, ItemKind
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import Identity, ReviewItem
@@ -27,7 +29,7 @@ class _Dispatcher:
 
     def fix(self, request: FixInput) -> FixOutput:
         del request  # canned outcome; mirrors the FixContract Protocol signature
-        return self._out
+        return Dispatched(output=self._out, winner=AgentSpec(cli="claude", model="opus[1m]"))
 
 
 def _item(gh_id: str, thread_id: str = "") -> ReviewItem:
@@ -59,7 +61,7 @@ def test_contextual_memory_carried_for_cluster_thread() -> None:
         items=[FixItemResult(gh_id="100", disposition=DispositionKind.FIXED, commit_shas=["s1"])],
         memory=[MemoryEntry(classification="CONTEXTUAL", content="why", target_hint="PRRT_a")],
     )
-    res = run_fix(_req([item]), _Dispatcher(out), _FakeGit(), now=_NOW, decided_by="agent")
+    res = run_fix(_req([item]), _Dispatcher(out), _FakeGit(), now=_NOW)
     assert [e.content for e in res.contextual_memory] == ["why"]
 
 
@@ -69,5 +71,5 @@ def test_non_cluster_target_hint_not_routed() -> None:
         items=[FixItemResult(gh_id="100", disposition=DispositionKind.FIXED, commit_shas=["s1"])],
         memory=[MemoryEntry(classification="CONTEXTUAL", content="x", target_hint="PRRT_other")],
     )
-    res = run_fix(_req([item]), _Dispatcher(out), _FakeGit(), now=_NOW, decided_by="agent")
+    res = run_fix(_req([item]), _Dispatcher(out), _FakeGit(), now=_NOW)
     assert res.contextual_memory == []  # unknown-thread hint -> audit violation, not routed

--- a/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
+++ b/packages/prgroom/tests/unit/test_agent_subprocess_runner.py
@@ -801,10 +801,10 @@ def test_claude_envelope_contract_reaches_dispatcher_parse(tmp_path: Path) -> No
         runner=runner,
         chain=ProviderChain(providers=[_spec("claude", "haiku")], time_budget_s=5.0),
     )
-    output = dispatcher.cluster(
+    dispatched = dispatcher.cluster(
         ClusterInput(pr=PRRef(owner="o", repo="r", number=1), items=[], pr_context_path="/ctx")
     )
-    assert output.clusters == []  # the payload inside `result`, not the envelope
+    assert dispatched.output.clusters == []  # the payload inside `result`, not the envelope
 
 
 def test_run_builds_the_argv_for_the_specs_cli(tmp_path: Path) -> None:

--- a/packages/prgroom/tests/unit/test_cli_cluster.py
+++ b/packages/prgroom/tests/unit/test_cli_cluster.py
@@ -19,6 +19,8 @@ from typer.testing import CliRunner
 
 from prgroom import cli
 from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
+from prgroom.agent.dispatcher import Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.gh import GhCli
 from prgroom.proc import CommandResult
 from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
@@ -70,10 +72,13 @@ class ClusterDispatcherStub:
         self._clusters = clusters
         self.calls = 0
 
-    def cluster(self, request: ClusterInput) -> ClusterOutput:
+    def cluster(self, request: ClusterInput) -> Dispatched[ClusterOutput]:
         del request
         self.calls += 1
-        return ClusterOutput(clusters=self._clusters)
+        return Dispatched(
+            output=ClusterOutput(clusters=self._clusters),
+            winner=AgentSpec(cli="ollama", model="gemma4"),
+        )
 
 
 def _item(
@@ -118,7 +123,7 @@ def patched(monkeypatch: pytest.MonkeyPatch) -> InMemoryStore:
 
 
 def _wire_dispatcher(monkeypatch: pytest.MonkeyPatch, dispatcher: ClusterDispatcherStub) -> None:
-    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (dispatcher, "ollama gemma4"))
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: dispatcher)
 
 
 def test_cluster_applies_and_persists(

--- a/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
+++ b/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
@@ -20,7 +20,7 @@ import pytest
 
 import prgroom.cli as cli
 from prgroom.agent.prompt_loader import PromptTemplate
-from prgroom.agent.subprocess_runner import AgentRunResult, AgentSpec
+from prgroom.agent.subprocess_runner import AgentRunResult, AgentSpec, UsageFigures
 from prgroom.lifecycle.warn import default_warn
 
 
@@ -48,6 +48,7 @@ class _ScriptedRunner:
                 stdout='{"contract_version": 1, "items": []}',
                 stderr="",
                 duration_ms=1,
+                usage=UsageFigures(tokens_in=100, tokens_out=5, reported_cost_usd=0.01),
             ),
         ]
 
@@ -94,6 +95,15 @@ def test_production_fix_builder_appends_usage_rows(
     rows = [json.loads(line) for line in lines]
     assert [r["outcome"] for r in rows] == ["error", "success"]
     assert all(r["contract"] == "fix" for r in rows)
+    # The success row threads the runner result's parsed usage figures through
+    # (the reviewer-flagged regression: they were hard-coded to null before).
+    error_row, success_row = rows[0], rows[1]
+    assert success_row["input_tokens"] == 100
+    assert success_row["output_tokens"] == 5
+    assert success_row["reported_cost_usd"] == 0.01
+    # The error link produced no usage in this script -> its tokens stay null.
+    assert error_row["input_tokens"] is None
+    assert error_row["output_tokens"] is None
 
 
 def test_resolve_log_level_default_and_named_levels() -> None:

--- a/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
+++ b/packages/prgroom/tests/unit/test_cli_dispatcher_helpers.py
@@ -1,37 +1,27 @@
-"""Tests for the decided-by + soft-warning helpers (§5, §8, §8.15).
+"""Tests for the CLI dispatcher-build seams + logging helpers (§4, §5).
 
-``cli._decided_by`` derives the disposition author string from a resolved provider
-chain's primary; ``lifecycle.warn.default_warn`` is the shared default soft-warning
-stderr sink the verb internals fall back to. Both are small pure-ish helpers; the
-production dispatcher-build seams themselves are boundary wiring (monkeypatched in
-the verb tests), so these pin the logic the seams delegate to.
+The production dispatcher builders wire ``usage_hook=append_usage`` — the
+bead-item-1 regression guard here drives a dispatch through the REAL
+``_build_fix_dispatcher()`` construction line (fake runner, real hook, tmp XDG
+state dir) and asserts rows land in ``usage.jsonl``. ``_resolve_log_level`` pins
+the fail-lateral env-knob choice; ``lifecycle.warn.default_warn`` is the shared
+default soft-warning stderr sink.
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
 import pytest
 
-from prgroom.agent.dispatcher import ProviderChain
-from prgroom.agent.subprocess_runner import AgentSpec
-from prgroom.cli import _decided_by
+import prgroom.cli as cli
+from prgroom.agent.prompt_loader import PromptTemplate
+from prgroom.agent.subprocess_runner import AgentRunResult, AgentSpec
 from prgroom.lifecycle.warn import default_warn
-
-
-def test_decided_by_uses_primary_cli_and_model() -> None:
-    chain = ProviderChain(
-        providers=[
-            AgentSpec(cli="claude", model="opus[1m]"),
-            AgentSpec(cli="codex", model="gpt-5.6-terra"),
-        ],
-        time_budget_s=1.0,
-    )
-    # The primary (first) provider names the deciding agent: "<cli> <model>".
-    assert _decided_by(chain) == "claude opus[1m]"
-
-
-def test_decided_by_empty_chain_degrades_to_prgroom() -> None:
-    # A misconfigured empty chain never yields a blank decided_by.
-    assert _decided_by(ProviderChain(providers=[], time_budget_s=1.0)) == "prgroom"
 
 
 def test_default_warn_writes_a_one_line_prgroom_notice(
@@ -41,3 +31,81 @@ def test_default_warn_writes_a_one_line_prgroom_notice(
     # so an operator can grep soft warnings out of stderr.
     default_warn("a soft warning")
     assert capsys.readouterr().err == "prgroom: a soft warning\n"
+
+
+class _ScriptedRunner:
+    """Stands in for ``SubprocessAgentRunner`` at the production build seam.
+
+    Constructed with no args (mirroring the builder's call), it replays a
+    fail-then-succeed script so the dispatch exercises the fallback ladder.
+    """
+
+    def __init__(self) -> None:
+        self._outcomes = [
+            AgentRunResult(returncode=1, stdout="", stderr="quota", duration_ms=1),
+            AgentRunResult(
+                returncode=0,
+                stdout='{"contract_version": 1, "items": []}',
+                stderr="",
+                duration_ms=1,
+            ),
+        ]
+
+    def run(
+        self,
+        spec: AgentSpec,
+        *,
+        prompt_template: PromptTemplate,
+        render_data: dict[str, str],
+        contract_payload: dict[str, Any],
+        time_budget_s: float,
+        cancel: threading.Event | None = None,
+    ) -> AgentRunResult:
+        del spec, prompt_template, render_data, contract_payload, time_budget_s, cancel
+        return self._outcomes.pop(0)
+
+
+def test_production_fix_builder_appends_usage_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The bead-item-1 regression guard: this drives the EXACT construction line
+    # that used to omit usage_hook. One row per chain-link attempt must land in
+    # usage.jsonl — failures included.
+    from prgroom.agent.contracts import FixInput
+    from prgroom.prsession.pr_ref import PRRef
+
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setattr(cli, "SubprocessAgentRunner", _ScriptedRunner)
+    dispatcher = cli._build_fix_dispatcher()
+    dispatched = dispatcher.fix(
+        FixInput(
+            pr=PRRef(owner="octo", repo="demo", number=7),
+            cluster_id="c-1",
+            item_gh_ids=[],
+            items=[],
+            pr_detail_path="/d",
+            branch_state_path="/b",
+            memory_dir="/m",
+            response_outbox_dir="/o",
+        )
+    )
+    assert dispatched.rung == 1  # the scripted fallback actually happened
+    lines = (tmp_path / "prgroom" / "usage.jsonl").read_text(encoding="utf-8").splitlines()
+    rows = [json.loads(line) for line in lines]
+    assert [r["outcome"] for r in rows] == ["error", "success"]
+    assert all(r["contract"] == "fix" for r in rows)
+
+
+def test_resolve_log_level_default_and_named_levels() -> None:
+    assert cli._resolve_log_level(None) == (logging.WARNING, None)
+    assert cli._resolve_log_level("") == (logging.WARNING, None)
+    assert cli._resolve_log_level("info") == (logging.INFO, None)
+    assert cli._resolve_log_level("DEBUG") == (logging.DEBUG, None)
+
+
+def test_resolve_log_level_garbage_degrades_loudly() -> None:
+    # Fail-lateral by design: a typo'd env var must never take down an
+    # autonomous overnight run — it degrades to WARNING with a notice.
+    level, notice = cli._resolve_log_level("verbose")
+    assert level == logging.WARNING
+    assert notice is not None and "verbose" in notice

--- a/packages/prgroom/tests/unit/test_cli_fix.py
+++ b/packages/prgroom/tests/unit/test_cli_fix.py
@@ -18,6 +18,8 @@ from typer.testing import CliRunner
 
 from prgroom import cli
 from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput
+from prgroom.agent.dispatcher import Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.gh import GhCli
 from prgroom.proc import CommandResult
 from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
@@ -69,10 +71,10 @@ class FixDispatcherStub:
         self._output = output
         self.calls = 0
 
-    def fix(self, request: FixInput) -> FixOutput:
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]:
         del request
         self.calls += 1
-        return self._output
+        return Dispatched(output=self._output, winner=AgentSpec(cli="claude", model="opus[1m]"))
 
 
 def _item(
@@ -118,7 +120,7 @@ def patched(monkeypatch: pytest.MonkeyPatch) -> InMemoryStore:
 
 
 def _wire_dispatcher(monkeypatch: pytest.MonkeyPatch, dispatcher: FixDispatcherStub) -> None:
-    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (dispatcher, "claude opus[1m]"))
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: dispatcher)
 
 
 def test_fix_applies_and_persists(patched: InMemoryStore, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/prgroom/tests/unit/test_cli_run.py
+++ b/packages/prgroom/tests/unit/test_cli_run.py
@@ -37,8 +37,8 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(cli, "_build_gh", lambda: object())
     monkeypatch.setattr(cli, "_build_git", lambda: object())
     monkeypatch.setattr(cli, "_build_sink", lambda: object())
-    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (_StubDispatcher(), "claude"))
-    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: _StubDispatcher())
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: _StubDispatcher())
     box: dict[str, Any] = {}
 
     def fake_run_lifecycle(**kwargs: Any) -> int:
@@ -117,8 +117,8 @@ def test_run_integration_merged_pr_reaches_terminal(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(cli, "_build_store", lambda _name: store)
     monkeypatch.setattr(cli, "_build_gh", lambda: _MergedGh())
     monkeypatch.setattr(cli, "_build_git", lambda: object())  # unused: never reaches push
-    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: (_StubDispatcher(), "claude"))
-    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: (_StubDispatcher(), "claude"))
+    monkeypatch.setattr(cli, "_build_cluster_dispatcher", lambda: _StubDispatcher())
+    monkeypatch.setattr(cli, "_build_fix_dispatcher", lambda: _StubDispatcher())
     # Drives the REAL run_lifecycle -> _run -> poll_pr -> flush via Verbs.system.
     result = runner.invoke(cli.app, ["run", "octo/demo#7", "--autonomous"])
     assert result.exit_code == 0, result.output

--- a/packages/prgroom/tests/unit/test_lifecycle_cluster.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_cluster.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import pytest
 
 from prgroom.agent.contracts import ClusterInput, ClusterOutput, ClusterResult
+from prgroom.agent.dispatcher import Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.config import PrgroomConfig
 from prgroom.deps import Deps
 from prgroom.errors import ErrorCode, PrgroomError, Tier
@@ -111,10 +113,13 @@ class ClusterDispatcherStub:
         self.calls = 0
         self.last_request: ClusterInput | None = None
 
-    def cluster(self, request: ClusterInput) -> ClusterOutput:
+    def cluster(self, request: ClusterInput) -> Dispatched[ClusterOutput]:
         self.calls += 1
         self.last_request = request
-        return ClusterOutput(clusters=self._clusters)
+        return Dispatched(
+            output=ClusterOutput(clusters=self._clusters),
+            winner=AgentSpec(cli="ollama", model="gemma4"),
+        )
 
 
 def _run(
@@ -132,7 +137,6 @@ def _run(
         deps=_deps(),
         config=PrgroomConfig(),
         dispatcher=dispatcher,
-        decided_by="ollama gemma4",
         scratch_dir=scratch_dir,
     )
 

--- a/packages/prgroom/tests/unit/test_lifecycle_fix.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix.py
@@ -16,7 +16,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEntry
-from prgroom.agent.dispatcher import AllProvidersFailedError
+from prgroom.agent.dispatcher import AllProvidersFailedError, Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.config import PrgroomConfig
 from prgroom.deps import Deps
 from prgroom.escalation import Escalation
@@ -125,18 +126,21 @@ class FakeGit:
 class FixDispatcherStub:
     """A ``FixContract`` fake returning a canned output (or raising) per cluster call."""
 
-    def __init__(self, outcomes: list[FixOutput | Exception]) -> None:
+    def __init__(
+        self, outcomes: list[FixOutput | Exception], *, winner: AgentSpec | None = None
+    ) -> None:
         self._outcomes = list(outcomes)
+        self._winner = winner if winner is not None else AgentSpec(cli="claude", model="opus[1m]")
         self.calls = 0
         self.requests: list[FixInput] = []
 
-    def fix(self, request: FixInput) -> FixOutput:
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]:
         self.calls += 1
         self.requests.append(request)
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Exception):
             raise outcome
-        return outcome
+        return Dispatched(output=outcome, winner=self._winner)
 
 
 class RecordingSink:
@@ -173,7 +177,6 @@ def _run(
         config=PrgroomConfig(),
         dispatcher=dispatcher,
         sink=sink,
-        decided_by="claude opus[1m]",
         scratch_dir=scratch_dir,
     )
     return out, sink, git
@@ -351,7 +354,6 @@ def test_fix_logs_deferred_memory_via_warn_seam(tmp_path: Path) -> None:
         config=PrgroomConfig(),
         dispatcher=dispatcher,
         sink=RecordingSink(),
-        decided_by="claude opus[1m]",
         scratch_dir=tmp_path,
         warn=warnings.append,
     )
@@ -380,7 +382,6 @@ def test_fix_logs_unwritten_paths_via_warn_seam(tmp_path: Path) -> None:
         config=PrgroomConfig(),
         dispatcher=dispatcher,
         sink=RecordingSink(),
-        decided_by="claude opus[1m]",
         scratch_dir=tmp_path,
         warn=warnings.append,
     )

--- a/packages/prgroom/tests/unit/test_lifecycle_fix_memory_routing.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_fix_memory_routing.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from prgroom.agent.contracts import FixInput, FixItemResult, FixOutput, MemoryEntry
+from prgroom.agent.dispatcher import Dispatched
+from prgroom.agent.subprocess_runner import AgentSpec
 from prgroom.config import PrgroomConfig
 from prgroom.lifecycle.fix import fix_pr, resolve_routed_memory
 from prgroom.prsession.enums import DispositionKind
@@ -183,7 +185,7 @@ class _SymlinkPlantingDispatcher:
         self.calls = 0
         self.requests: list[FixInput] = []
 
-    def fix(self, request: FixInput) -> FixOutput:
+    def fix(self, request: FixInput) -> Dispatched[FixOutput]:
         self.calls += 1
         self.requests.append(request)
         mem = Path(request.memory_dir)
@@ -191,7 +193,7 @@ class _SymlinkPlantingDispatcher:
         secret.write_text("TOPSECRET", encoding="utf-8")
         link = mem / "evil"  # lexically INSIDE memory_dir
         link.symlink_to(secret)
-        return FixOutput(
+        out = FixOutput(
             items=[
                 FixItemResult(
                     gh_id=self.gh_id,
@@ -202,6 +204,7 @@ class _SymlinkPlantingDispatcher:
             ],
             memory=[MemoryEntry(classification="CONTEXTUAL", path=str(link))],
         )
+        return Dispatched(output=out, winner=AgentSpec(cli="claude", model="opus[1m]"))
 
 
 def test_symlink_escape_flips_cluster_and_routes_nothing(tmp_path: Path) -> None:
@@ -222,7 +225,6 @@ def test_symlink_escape_flips_cluster_and_routes_nothing(tmp_path: Path) -> None
         config=PrgroomConfig(),
         dispatcher=dispatcher,
         sink=sink,
-        decided_by="claude opus[1m]",
         scratch_dir=tmp_path,
     )
     for item in out.items:
@@ -231,3 +233,27 @@ def test_symlink_escape_flips_cluster_and_routes_nothing(tmp_path: Path) -> None
     assert out.pending_memory == []
     assert len(sink.emitted) >= 1
     assert git.stash_calls == 1
+
+
+def test_lifecycle_stamps_the_dispatches_own_provenance(tmp_path: Path) -> None:
+    # Behavior 13: the post-return stamps (RoutedMemory here) use the dispatch's
+    # winner — a FALLBACK link, not the configured chain head. Under the old code
+    # this read a static configured-primary string.
+    fallback_winner = AgentSpec(cli="codex", model="gpt-5.6-terra")
+    a = _item("a")
+    dispatcher = FixDispatcherStub(
+        [
+            _out(
+                FixItemResult(
+                    gh_id="a",
+                    disposition=DispositionKind.FIXED,
+                    commit_shas=["s1"],
+                    recommended_gate="full",
+                ),
+                memory=[MemoryEntry(classification="CONTEXTUAL", content="why")],
+            )
+        ],
+        winner=fallback_winner,
+    )
+    out, _sink, _git = _run(_state(a), dispatcher, tmp_path, git=FakeGit(new_commits=["s1"]))
+    assert [m.decided_by for m in out.pending_memory] == ["codex gpt-5.6-terra"]

--- a/packages/prgroom/tests/unit/test_lifecycle_run.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_run.py
@@ -659,9 +659,7 @@ def test_run_lifecycle_lock_held_returns_75() -> None:
             sink=RecordingSink(),  # type: ignore[arg-type]
             mode=Mode.INTERACTIVE,
             cluster_dispatcher=object(),  # type: ignore[arg-type] - never reached
-            cluster_decided_by="x",
             fix_dispatcher=object(),  # type: ignore[arg-type]
-            fix_decided_by="x",
         )
     finally:
         store.release(_REF)
@@ -697,9 +695,7 @@ def test_verbs_system_adapters_delegate_to_real_verbs(monkeypatch: pytest.Monkey
 
     verbs = Verbs.system(
         cluster_dispatcher=object(),  # type: ignore[arg-type]
-        cluster_decided_by="claude",
         fix_dispatcher=object(),  # type: ignore[arg-type]
-        fix_decided_by="claude",
     )
     ctx = _ctx(_quiescent_state())
     for adapter in (


### PR DESCRIPTION
## Summary

Dispatcher fallback observability (spec `docs/specs/2026-07-16-prgroom-dispatcher-observability.md`, all of §3–§6):

- **Winner provenance (§3):** `_run_chain` returns a `Dispatched[T]` envelope (`output` + `winner` + `failures`; `rung`/`fell_back`/`decided_by` derived) instead of the bare parsed output. `Disposition.decided_by` now names the chain link that actually produced the winning output — `"prgroom"` on chain exhaustion — instead of the statically configured chain head. `cli._decided_by` is deleted; `run_fix`/`run_cluster`/lifecycle/`Verbs.system` drop their `decided_by` threading; `FixRunResult.decided_by` carries the stamp for post-return consumers (realpath containment flip, `RoutedMemory`).
- **usage.jsonl wiring (§4):** both production dispatcher builders pass `usage_hook=append_usage` — one `UsageRecord` per chain-link attempt (failures included) now lands in `$XDG_STATE_HOME/prgroom/usage.jsonl`. Appends take an exclusive `flock` on the data descriptor (concurrent different-PR processes share the one global file; the file is append-only, so no sidecar). Hook failures are contained to a logged drop — telemetry never fails a dispatch.
- **Partial-fallback signal (§5):** per-link WARNING at failure time (streaming — a fix link's budget is 30 min) plus exactly one `"fell back to"` summary naming winner and rung on success-after-fallback. Clean dispatch: zero lines. Exhaustion: no extra summary (the Sink carries both-fail). Root logging config lives in `main()` only (`PRGROOM_LOG_LEVEL`, fail-lateral on garbage values).
- **Docs (§6):** dispatcher/usage docstrings corrected to current fact; the four-channel observability story recorded in `packages/prgroom/AGENTS.md`.

## Ground truth

- Spec: `docs/specs/2026-07-16-prgroom-dispatcher-observability.md` (Approved). §9 defines the 13 behaviors + the exhaustive existing-test ripple table this PR applies.
- Interface contracts honored: no `UsageRecord` schema fields added (those belong to the token-parser change, already merged in #304); dispatcher constructor args stay keyword-only for the future `spend_hook`.

## Notes for review

- `CONTRACT_VERSION` stays 1 deliberately: the envelope changes Python signatures only; agent-facing JSON payloads are byte-identical.
- `_warn_link_failure` logs the link's failure reason (which includes capped agent stderr). Reviewed by the HEAVY quality gate: same text already flows to the escalation channel, whitespace-collapsed and length-capped at construction — accepted as designed per spec §5; a redaction layer was rejected as machinery without evidence of need.
- The `resolve-escalated` human path (`decided_by = "human:<git-user>"`) is untouched — separate, correct-by-construction provenance.

## Test Plan

- [x] Spec behaviors 1–13, one red-green cycle each (born-green pins mutation-checked: the production-wiring guard fails when `usage_hook` is dropped)
- [x] Existing-test ripple applied per the §9 table across 13 test files; straggler grep sweep clean (`Disposition(decided_by=…)` constructions untouched by design)
- [x] `make ci-prgroom` from the worktree root: **1003 passed, 99.47% coverage**, ruff/format/mypy-strict/pip-audit clean, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
