### PR TITLE
feat(vizsuite): constellation parity restoration — prototype variant_B anatomy (yf2ov.2.11)

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -578,7 +578,11 @@ body {
   word-break: break-all;
   margin-bottom: 0.25rem;
 }
-.viz-tooltip-churn {
+/* Also the dir hover tooltip's files/changed counts line
+   (views/constellation.js's buildDirTooltip) — same secondary-line
+   treatment as this file score card's churn line. */
+.viz-tooltip-churn,
+.viz-constellation-dir-counts {
   margin-top: 0.3rem;
   color: var(--viz-secondary);
   font-size: 11px;
@@ -815,16 +819,21 @@ body {
 }
 .viz-constellation-edge {
   stroke: var(--viz-border-strong);
-  stroke-width: 1.25;
+  opacity: 0.65;
 }
+.viz-constellation-edge--tether {
+  stroke-dasharray: 3, 3;
+  opacity: 0.75;
+}
+/* Node width/height/left/top are per-node (a dir's radius scales with its
+   load-bearing score; a satellite is always small) — set inline by
+   views/constellation.js, never by this fixed rule. */
 .viz-constellation-node {
   position: absolute;
   transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.7rem;
-  height: 1.7rem;
   border-radius: 50%;
   border: 1px solid var(--viz-border-strong);
   background: var(--viz-surface);
@@ -871,13 +880,6 @@ body {
   align-items: center;
   gap: 0.35rem;
 }
-.viz-constellation-legend-swatch {
-  display: inline-block;
-  width: 0.85rem;
-  height: 0.85rem;
-  border-radius: 50%;
-  border: 1px solid var(--viz-border-strong);
-}
 .viz-constellation-legend-ring {
   display: inline-block;
   width: 0.85rem;
@@ -886,11 +888,27 @@ body {
   border: 3px solid var(--viz-fg);
   background: transparent;
 }
-.viz-constellation-legend-line {
+/* Color swatch (spec: "Color = composite heat") — the same ramp anchors
+   heatScale itself resolves, so the legend never drifts from what is
+   actually rendered. */
+.viz-constellation-legend-color {
   display: inline-block;
-  width: 1rem;
-  height: 0;
-  border-top: 1.25px solid var(--viz-border-strong);
+  width: 1.25rem;
+  height: 0.6rem;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--viz-heat-cold), var(--viz-heat-mid), var(--viz-heat-hot));
+}
+
+/* ---- Pruning affordance (spec: unconnected dir nodes hidden) — bottom-left
+   caption, present only when the connectivity prune actually dropped a
+   dir. ---- */
+.viz-constellation-hidden-caption {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  z-index: 2;
+  font-size: 11px;
+  color: var(--viz-muted);
 }
 
 #viz-footer {

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -27,6 +27,13 @@
   --viz-heat-cold: #0ca30c;
   --viz-heat-mid: #fab219;
   --viz-heat-hot: #d03b3b;
+  /* Intermediate stops (cosmetic parity fidelity): extend the same ramp with
+     two in-between anchors — a refinement of cold/mid/hot, never a competing
+     palette — so the constellation view's 5-stop piecewise LAB heat scale
+     (views/constellation.js) has a higher-resolution ramp than the treemap/
+     ledger's 3-stop scale without diverging from it at the shared anchors. */
+  --viz-heat-cold-mid: #83aa12;
+  --viz-heat-mid-hot: #e5762a;
   --viz-label-on-dark-fill: #ffffff;
   --viz-label-on-light-fill: #0b0b0b;
 
@@ -69,6 +76,8 @@
     --viz-heat-cold: #0ca30c;
     --viz-heat-mid: #fab219;
     --viz-heat-hot: #e66767;
+    --viz-heat-cold-mid: #83aa12;
+    --viz-heat-mid-hot: #f08c40;
 
     --viz-hue-blue: #3987e5;
     --viz-hue-aqua: #199e70;
@@ -90,6 +99,8 @@
   --viz-heat-cold: #0ca30c;
   --viz-heat-mid: #fab219;
   --viz-heat-hot: #e66767;
+  --viz-heat-cold-mid: #83aa12;
+  --viz-heat-mid-hot: #f08c40;
 
   --viz-hue-blue: #3987e5;
   --viz-hue-aqua: #199e70;
@@ -896,7 +907,17 @@ body {
   width: 1.25rem;
   height: 0.6rem;
   border-radius: 3px;
-  background: linear-gradient(90deg, var(--viz-heat-cold), var(--viz-heat-mid), var(--viz-heat-hot));
+  /* Same five stops as the JS ramp's own anchors (HEAT_RAMP_STOPS in
+     views/constellation.js) — the legend swatch must never drift from what
+     heatScale() actually renders. */
+  background: linear-gradient(
+    90deg,
+    var(--viz-heat-cold),
+    var(--viz-heat-cold-mid),
+    var(--viz-heat-mid),
+    var(--viz-heat-mid-hot),
+    var(--viz-heat-hot)
+  );
 }
 
 /* ---- Pruning affordance (spec: unconnected dir nodes hidden) — bottom-left

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -855,14 +855,23 @@ body {
 .viz-constellation-node[data-in-pr="true"] {
   border: 3px solid var(--viz-fg);
 }
+/* The label is a separate stage sibling positioned ABOVE its node mark
+   (left/top set inline by views/constellation.js), never a child clipped
+   inside the round .viz-constellation-node (which sets overflow: hidden and
+   leaves a satellite only a ~4px content box). translate(-50%, -100%)
+   centers it horizontally on the node and anchors its bottom edge at the
+   inline top. pointer-events: none so it never steals the node's hover/drag;
+   a fixed muted color since it sits over the stage background, not the fill. */
 .viz-constellation-node-label {
+  position: absolute;
+  transform: translate(-50%, -100%);
   padding: 0 2px;
   font-size: 8px;
   line-height: 1.1;
   text-align: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+  pointer-events: none;
+  color: var(--viz-secondary);
 }
 /* Keyboard focus affordance (a11y), same treatment as the sonar ring mark:
    the base rule is already `position: absolute`, so z-index alone suffices

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -776,15 +776,36 @@ body {
 
 /* ---- Dependency constellation (spec §6.1, evaluation-gated §11): PR files
    + context graph over scene.edges, a pre-settled force layout — no re-sim
-   on slider drag. The stage self-sizes from the node count, like the sonar
-   stage, so no max-width constraint applies to this JS-sized stage inside
-   the scrolling panel (see .viz-sonar-stage precedent). */
+   on slider drag or on zoom/pan/drag interaction. The layout stage
+   self-sizes from the node count (like the sonar stage), independent of the
+   viewport's own on-screen size — `.viz-constellation-viewport` is the fixed,
+   clipped window a d3.zoom transform pans/scales the stage within, so a
+   large graph never overflows into the surrounding page. */
 .viz-constellation-inner {
   margin: 0 0 1rem;
 }
-.viz-constellation-stage {
+.viz-constellation-viewport {
   position: relative;
-  margin: 0 auto;
+  overflow: hidden;
+  height: min(70vh, 640px);
+  border: 1px solid var(--viz-border);
+  border-radius: 6px;
+  cursor: grab;
+  /* Let d3.zoom own every wheel/pointer gesture in here — the browser's own
+     touch-scroll/pinch handling would otherwise fight it. */
+  touch-action: none;
+}
+.viz-constellation-stage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+}
+.viz-constellation-reset {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 2;
 }
 .viz-constellation-edges {
   position: absolute;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -20,12 +20,24 @@
 // `options.isExempt(evt)`, if given, opts an event out of activation (the
 // ledger row's diff-link guard) — omitted, every candidate event activates.
 //
-// Activation is always synchronous — there is deliberately NO deferred
-// (debounced double-click) path in this helper. An earlier revision deferred
-// `onActivate()` behind a timer to make room for a double-click gesture, and
-// the pending timer leaked activations through every gesture edge
-// (keyboard, nested controls, drag-after-click, pointercancel). Fill-screen
-// focus is an explicit per-tile control in the treemap instead (spec §6.1).
+// `options.dblclickWindowMs` (default off — omitted by the treemap tile,
+// ledger row, and sonar mark, which all activate synchronously) opts a
+// pointer click into a DEFERRED activation: `onActivate()` is held for a
+// window (a fixed ms, or a per-gesture function evaluated at pointerup) and
+// cancelled if a `dblclick` lands inside it, so a double-click gesture
+// (constellation's un-pin) never also fires the primary action. Keyboard
+// activation (Enter/Space) never defers.
+//
+// `options.activationGroup` (a `createActivationGroup()` handle, default off)
+// makes deferred-activation cancellation VIEW-scoped instead of element-
+// scoped: every wired node registers its pending-timer clear into the one
+// group, and any competing gesture — another node's pointerdown, a keyboard
+// activation, the view's own zoom/pan handler, or view teardown — calls
+// `group.cancelAll()` to drop every node's still-pending activation, so a
+// stale `onActivate()` can never fire mid-gesture or after unmount. Without a
+// group a node cancels only its own pending timers (enough for the single-
+// deferred-target callers). `wireClickVsDragActivation` returns a
+// `{ cancelPending }` handle for a caller that wants a per-element disposer.
 //
 // isDependencyGraphUnavailable: the shared "is the dependency graph
 // unavailable?" predicate for the graph-shaped views (constellation, file
@@ -429,6 +441,27 @@
 
   window.vizShared.buildScoreCard = buildScoreCard;
 
+  // A view-scoped registry of deferred-activation cancellers. Each node wired
+  // with `activationGroup` set registers its own pending-timer clear here;
+  // `cancelAll()` flushes every node's pending activation at once — the single
+  // surface a view's competing gestures (zoom/pan, another node's press) and
+  // its destroy() call to guarantee no stale deferred activation survives.
+  function createActivationGroup() {
+    var disposers = [];
+    return {
+      register: function (fn) {
+        disposers.push(fn);
+      },
+      cancelAll: function () {
+        disposers.forEach(function (fn) {
+          fn();
+        });
+      }
+    };
+  }
+
+  window.vizShared.createActivationGroup = createActivationGroup;
+
   function wireClickVsDragActivation(el, options) {
     var onActivate = options.onActivate;
     var isExempt = options.isExempt;
@@ -444,6 +477,10 @@
     // keyboard activation (Enter/Space) has no double-press gesture and must
     // stay instant.
     var dblclickWindowMs = options.dblclickWindowMs;
+    // Optional view-scoped cancellation registry (createActivationGroup). When
+    // present, every preempting gesture flushes ALL nodes' pending activations,
+    // not just this element's — see preemptPending below.
+    var activationGroup = options.activationGroup;
     var pendingTimers = [];
     // Cancel every deferred activation still waiting on its window. Called when
     // a `dblclick` lands (the gesture is a double-click, so the primary action
@@ -453,6 +490,21 @@
     function clearPendingActivations() {
       pendingTimers.forEach(clearTimeout);
       pendingTimers.length = 0;
+    }
+    // Register this element's clear into the shared group (if any) so the
+    // view's teardown and competing gestures can flush it alongside its peers.
+    if (activationGroup) {
+      activationGroup.register(clearPendingActivations);
+    }
+    // Preempt pending activations at the start of any gesture that must not
+    // let a stale deferred activation fire: view-scoped when a group is shared
+    // (every node's pending clears), else just this element's.
+    function preemptPending() {
+      if (activationGroup) {
+        activationGroup.cancelAll();
+      } else {
+        clearPendingActivations();
+      }
     }
     var startX = 0;
     var startY = 0;
@@ -465,8 +517,10 @@
     el.addEventListener("pointerdown", function (evt) {
       // A new press starts here; drop any activation still deferred from the
       // previous click so a drag-after-click (or a slow second click) never
-      // fires the stale primary action mid-gesture.
-      clearPendingActivations();
+      // fires the stale primary action mid-gesture. With a shared group this
+      // also preempts a DIFFERENT node's still-pending activation, so a press
+      // elsewhere in the view never lets a stale focus/drill fire.
+      preemptPending();
       startX = evt.clientX;
       startY = evt.clientY;
       moved = false;
@@ -522,7 +576,7 @@
       pendingTimers.push(timer);
     });
     if (dblclickWindowMs) {
-      el.addEventListener("dblclick", clearPendingActivations);
+      el.addEventListener("dblclick", preemptPending);
     }
     // A cancelled gesture (browser-initiated, e.g. scroll takeover) must not
     // leave the helper armed for a later stray pointerup.
@@ -539,8 +593,16 @@
         return;
       }
       evt.preventDefault();
+      // Keyboard activation is instant, but it must still preempt any pointer-
+      // deferred activation (this node's, or — with a shared group — any node's)
+      // so a click-then-Enter within the double-click window fires only once.
+      preemptPending();
       onActivate();
     });
+
+    return {
+      cancelPending: clearPendingActivations
+    };
   }
 
   window.vizShared.wireClickVsDragActivation = wireClickVsDragActivation;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -432,6 +432,15 @@
   function wireClickVsDragActivation(el, options) {
     var onActivate = options.onActivate;
     var isExempt = options.isExempt;
+    // Opt-in double-click suppression (default off, so every other caller —
+    // treemap tile, ledger row, sonar — keeps activating synchronously). When
+    // set (ms), a pointer click's activation is DEFERRED by this window and
+    // cancelled if a `dblclick` lands inside it, so a double-click gesture
+    // (constellation's un-pin) does not also fire the primary activation. Only
+    // the pointer path defers — keyboard activation (Enter/Space) has no
+    // double-press gesture and must stay instant.
+    var dblclickWindowMs = options.dblclickWindowMs;
+    var pendingTimers = [];
     var startX = 0;
     var startY = 0;
     var moved = false;
@@ -475,8 +484,28 @@
       if (isExempt && isExempt(evt)) {
         return;
       }
-      onActivate();
+      if (!dblclickWindowMs) {
+        onActivate();
+        return;
+      }
+      // Defer: hold activation open for the double-click window; a `dblclick`
+      // (fired after the second pointerup) clears every pending timer, so a
+      // double-click gesture activates zero times instead of twice.
+      var timer = setTimeout(function () {
+        var idx = pendingTimers.indexOf(timer);
+        if (idx !== -1) {
+          pendingTimers.splice(idx, 1);
+        }
+        onActivate();
+      }, dblclickWindowMs);
+      pendingTimers.push(timer);
     });
+    if (dblclickWindowMs) {
+      el.addEventListener("dblclick", function () {
+        pendingTimers.forEach(clearTimeout);
+        pendingTimers.length = 0;
+      });
+    }
     // A cancelled gesture (browser-initiated, e.g. scroll takeover) must not
     // leave the helper armed for a later stray pointerup.
     el.addEventListener("pointercancel", function () {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/_shared.js
@@ -434,13 +434,26 @@
     var isExempt = options.isExempt;
     // Opt-in double-click suppression (default off, so every other caller —
     // treemap tile, ledger row, sonar — keeps activating synchronously). When
-    // set (ms), a pointer click's activation is DEFERRED by this window and
+    // provided, a pointer click's activation is DEFERRED by a window (ms) and
     // cancelled if a `dblclick` lands inside it, so a double-click gesture
-    // (constellation's un-pin) does not also fire the primary activation. Only
-    // the pointer path defers — keyboard activation (Enter/Space) has no
-    // double-press gesture and must stay instant.
+    // (constellation's un-pin) does not also fire the primary activation. The
+    // option is either a fixed number of ms, or a function evaluated at
+    // pointerup that returns the window for THIS gesture (0/false = activate
+    // instantly) — letting a caller defer only when the double-click gesture is
+    // actually meaningful for the target. Only the pointer path defers —
+    // keyboard activation (Enter/Space) has no double-press gesture and must
+    // stay instant.
     var dblclickWindowMs = options.dblclickWindowMs;
     var pendingTimers = [];
+    // Cancel every deferred activation still waiting on its window. Called when
+    // a `dblclick` lands (the gesture is a double-click, so the primary action
+    // must NOT fire) and on each new pointerdown (a second press — a drag or a
+    // second click — must not let the prior press's stale activation fire
+    // mid-gesture).
+    function clearPendingActivations() {
+      pendingTimers.forEach(clearTimeout);
+      pendingTimers.length = 0;
+    }
     var startX = 0;
     var startY = 0;
     var moved = false;
@@ -450,6 +463,10 @@
     var armed = false;
 
     el.addEventListener("pointerdown", function (evt) {
+      // A new press starts here; drop any activation still deferred from the
+      // previous click so a drag-after-click (or a slow second click) never
+      // fires the stale primary action mid-gesture.
+      clearPendingActivations();
       startX = evt.clientX;
       startY = evt.clientY;
       moved = false;
@@ -484,7 +501,11 @@
       if (isExempt && isExempt(evt)) {
         return;
       }
-      if (!dblclickWindowMs) {
+      // Resolve the window for THIS gesture: a function is evaluated now (at
+      // pointerup) so the caller can decide per-gesture; a number is fixed.
+      var windowMs =
+        typeof dblclickWindowMs === "function" ? dblclickWindowMs(evt) : dblclickWindowMs;
+      if (!windowMs) {
         onActivate();
         return;
       }
@@ -497,14 +518,11 @@
           pendingTimers.splice(idx, 1);
         }
         onActivate();
-      }, dblclickWindowMs);
+      }, windowMs);
       pendingTimers.push(timer);
     });
     if (dblclickWindowMs) {
-      el.addEventListener("dblclick", function () {
-        pendingTimers.forEach(clearTimeout);
-        pendingTimers.length = 0;
-      });
+      el.addEventListener("dblclick", clearPendingActivations);
     }
     // A cancelled gesture (browser-initiated, e.g. scroll takeover) must not
     // leave the helper armed for a later stray pointerup.

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -626,7 +626,7 @@
   // drill/focus/tooltip wiring specifics. A node outside `labeledIds` gets no
   // label element at all (not merely a hidden one) — still fully
   // identifiable via its `title`/aria-label and the hover card. ----
-  function renderNodes(stage, nodes, labeledIds, handlers) {
+  function renderNodes(stage, nodes, labeledIds, handlers, activationGroup) {
     var entries = [];
     nodes.forEach(function (node) {
       var displayPath = node.kind === "dir" ? dirDisplayPath(node.path) : node.path;
@@ -678,7 +678,11 @@
           return node.x !== node.origX || node.y !== node.origY
             ? DBLCLICK_ACTIVATION_WINDOW_MS
             : 0;
-        }
+        },
+        // Share the view's one cancellation registry, so any competing gesture
+        // (another node's press, keyboard activation, a zoom/pan, or destroy())
+        // flushes this node's still-pending deferred activation.
+        activationGroup: activationGroup
       });
       el.addEventListener("pointerenter", function (evt) {
         handlers.onHoverShow(evt, node);
@@ -710,6 +714,11 @@
     var startY = 0;
     var dragging = false;
     var active = false;
+    // Latch the first pointerdown's id so a second simultaneous pointer on the
+    // same node can't overwrite startX/startY mid-drag and teleport the node —
+    // every move/up/cancel from a non-owning pointer is ignored until the
+    // owning gesture ends.
+    var activePointerId = null;
 
     function reposition() {
       applyNodePosition(el, node);
@@ -725,6 +734,11 @@
     }
 
     el.addEventListener("pointerdown", function (evt) {
+      // A gesture already owns this node — ignore a second simultaneous pointer.
+      if (active) {
+        return;
+      }
+      activePointerId = evt.pointerId;
       startX = evt.clientX;
       startY = evt.clientY;
       dragging = false;
@@ -738,7 +752,7 @@
       }
     });
     el.addEventListener("pointermove", function (evt) {
-      if (!active) {
+      if (!active || evt.pointerId !== activePointerId) {
         return;
       }
       var dx = evt.clientX - startX;
@@ -756,9 +770,15 @@
       startY = evt.clientY;
       reposition();
     });
-    function endDrag() {
+    function endDrag(evt) {
+      // Only the owning pointer ends the gesture; a stray up/cancel from a
+      // second pointer must not release the latch mid-drag.
+      if (evt.pointerId !== activePointerId) {
+        return;
+      }
       active = false;
       dragging = false;
+      activePointerId = null;
     }
     el.addEventListener("pointerup", endDrag);
     el.addEventListener("pointercancel", endDrag);
@@ -779,18 +799,24 @@
 
   // ---- Zoom/pan gesture filter: wheel always zooms (regardless of pointer
   // target); a double-click never zooms (explicit, so a node's own
-  // double-click-to-unpin never also resets the view); any other gesture
-  // that started on a node belongs to that node's own drag, not the canvas
-  // pan — node dragging must never also pan the canvas. Otherwise mirrors
-  // d3-zoom's own documented default filter (`(!event.ctrlKey ||
-  // event.type === 'wheel') && !event.button`). ----
+  // double-click-to-unpin never also resets the view); any other gesture that
+  // started on a node — or on the view's own chrome (the Reset-view button) —
+  // belongs to that target, not the canvas pan, so node dragging and a Reset
+  // click never also pan the canvas (a pan begun on the button would be undone
+  // by the release-click's reset anyway). Otherwise mirrors d3-zoom's own
+  // documented default filter (`(!event.ctrlKey || event.type === 'wheel') &&
+  // !event.button`). ----
   function zoomFilter(event) {
     if (event.type === "dblclick") {
       return false;
     }
     if (event.type !== "wheel") {
       var target = event.target;
-      if (target && typeof target.closest === "function" && target.closest(".viz-constellation-node")) {
+      if (
+        target &&
+        typeof target.closest === "function" &&
+        target.closest(".viz-constellation-node, .viz-constellation-reset")
+      ) {
         return false;
       }
     }
@@ -967,6 +993,12 @@
       var current = state;
       var heatScale = makeHeatColorScale();
 
+      // One view-scoped registry of every node's pending deferred activation
+      // (see renderNodes' wireClickVsDragActivation). The zoom handler and
+      // destroy() below flush it, so a pan/zoom mid-window or an unmount can
+      // never let a stale focus/drill fire.
+      var activationGroup = window.vizShared.createActivationGroup();
+
       // ---- Zoom/pan (spec: scaleExtent [0.3, 6], wheel zoom + background
       // drag pans, double-click zoom disabled, transform persisted across
       // reencode — trivially true since reencode() never touches
@@ -989,6 +1021,14 @@
           zoomTransform = event.transform;
           visual.style.transform =
             "translate(" + zoomTransform.x + "px," + zoomTransform.y + "px) scale(" + zoomTransform.k + ")";
+          // A wheel-zoom or background pan is a competing gesture: drop any
+          // node's still-pending deferred activation so a stale focus/drill
+          // never fires mid-gesture.
+          activationGroup.cancelAll();
+          // The stage just moved under a possibly-stationary cursor; hide the
+          // shared hover card (pointerleave won't fire until the next pointer
+          // event), so it doesn't float orphaned over the wrong node.
+          window.vizShared.hideTooltip();
         });
 
       // Centered baseline for the current viewport size — recomputed on resize
@@ -1090,12 +1130,18 @@
       }
 
       var labeledIds = computeLabeledIds(graph.nodes);
-      var entries = renderNodes(visual, graph.nodes, labeledIds, {
-        onActivate: onActivate,
-        onHoverShow: onHoverShow,
-        onHoverMove: onHoverMove,
-        onHoverHide: onHoverHide
-      });
+      var entries = renderNodes(
+        visual,
+        graph.nodes,
+        labeledIds,
+        {
+          onActivate: onActivate,
+          onHoverShow: onHoverShow,
+          onHoverMove: onHoverMove,
+          onHoverHide: onHoverHide
+        },
+        activationGroup
+      );
       entries.forEach(function (entry) {
         wireDrag(entry, incidentByNodeId[entry.node.id] || [], function () {
           return zoomTransform.k;
@@ -1109,6 +1155,13 @@
           if (resizeObserver) {
             resizeObserver.disconnect();
           }
+          // Flush every node's still-pending deferred activation so no timer
+          // fires a focus/drill into a torn-down view.
+          activationGroup.cancelAll();
+          // Interrupt any in-flight viewport zoom transition (focusOnNode /
+          // Reset view) so it stops mutating a detached DOM / dead closure
+          // after unmount.
+          d3.select(viewport).interrupt();
           destroyContainer();
         },
         reencode: function (newState) {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -91,6 +91,13 @@
   // never removes its determinism (spec §4.2).
   var LAYOUT_SEED = 1337;
   var DRAG_THRESHOLD = 4; // px; same click-vs-drag threshold as wireClickVsDragActivation
+  // Double-click un-pin window (ms): a node click's activation (dir focus /
+  // file drill) is deferred by this window and cancelled when the un-pin
+  // dblclick lands, so the un-pin gesture never also opens the drill (whose
+  // viewport resize would otherwise shift the baseline mid-gesture). Scoped to
+  // constellation nodes only — every node here carries the dblclick un-pin
+  // gesture. Keyboard activation is unaffected (stays instant).
+  var DBLCLICK_ACTIVATION_WINDOW_MS = 275;
 
   // ---- Node sizing (prototype anatomy `variant_B.js`): a dir's radius grows
   // with its rolled-up load-bearing score; a satellite is always the same
@@ -655,7 +662,10 @@
       window.vizShared.wireClickVsDragActivation(el, {
         onActivate: function () {
           handlers.onActivate(node);
-        }
+        },
+        // Defer + cancel-on-dblclick so the un-pin gesture (see wireDrag's
+        // dblclick handler) does not also fire dir focus / file drill.
+        dblclickWindowMs: DBLCLICK_ACTIVATION_WINDOW_MS
       });
       el.addEventListener("pointerenter", function (evt) {
         handlers.onHoverShow(evt, node);

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -529,21 +529,14 @@
     };
   }
 
-  function labelColorFor(colorString) {
-    var rgb = d3.rgb(colorString);
-    var luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
-    return luminance > 0.6 ? "var(--viz-label-on-light-fill)" : "var(--viz-label-on-dark-fill)";
-  }
-
   function applyEncoding(entries, heatScale, computeHeat) {
     entries.forEach(function (entry) {
       var heat = computeHeat(entry.node.attributes);
       var color = heatScale(heat);
       entry.el.style.backgroundColor = color;
-      // A culled (unlabeled) node has no labelEl at all — see renderNodes.
-      if (entry.labelEl) {
-        entry.labelEl.style.color = labelColorFor(color);
-      }
+      // The label rides above the mark over the stage background (not on the
+      // node fill), so its color is a fixed muted CSS value, not a
+      // fill-contrast computation — nothing to repaint on reencode.
       // The aria-label's heat figure must track the same reencode a weight
       // change drives, or a screen-reader user reads a stale value while a
       // sighted user sees the fill already updated.
@@ -569,6 +562,17 @@
   function applyNodePosition(el, node) {
     el.style.left = node.x + "px";
     el.style.top = node.y + "px";
+  }
+
+  // A label sits centered just above its node mark (prototype anatomy
+  // variant_B.js's `labelSel` at `y = d.y - d.r - 4`). Placed in the same
+  // transformed stage as the node, so it pans/zooms with the layout and
+  // follows the node when dragged (see wireDrag's reposition). CSS
+  // translate(-50%, -100%) centers it horizontally and anchors its bottom
+  // edge at this top coordinate.
+  function applyLabelPosition(labelEl, node) {
+    labelEl.style.left = node.x + "px";
+    labelEl.style.top = node.y - node.r - 4 + "px";
   }
 
   // ---- Label culling (spec: cosmetic parity fidelity, prototype anatomy
@@ -634,10 +638,18 @@
 
       var label = null;
       if (labeledIds[node.id]) {
+        // The visual label rides ABOVE the mark as a separate stage sibling,
+        // never a child of the node div — .viz-constellation-node clips
+        // overflow (needed for the round mark), so a label nested inside the
+        // ~4px content box of a satellite would be invisible. Presentational
+        // only: the node element already carries the path via title/aria-label,
+        // so aria-hidden keeps a screen reader from reading it twice.
         label = document.createElement("span");
         label.setAttribute("class", "viz-constellation-node-label");
+        label.setAttribute("aria-hidden", "true");
         label.textContent = basename(displayPath);
-        el.appendChild(label);
+        applyLabelPosition(label, node);
+        stage.appendChild(label);
       }
 
       window.vizShared.wireClickVsDragActivation(el, {
@@ -678,6 +690,12 @@
 
     function reposition() {
       applyNodePosition(el, node);
+      // The label is a separate stage sibling, so a drag/un-pin must move it
+      // in lockstep with the node (a culled node has no label — see
+      // renderNodes).
+      if (entry.labelEl) {
+        applyLabelPosition(entry.labelEl, node);
+      }
       incidentLines.forEach(function (incident) {
         updateEdgeEndpoint(incident.lineEl, incident.role, node);
       });

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -496,20 +496,34 @@
     }
   }
 
-  // ---- Heat color scale (spec §4.3): mirrors the treemap view's own scale
-  // (same `:root` custom-property anchors), resolved fresh on every render
-  // and reencode so a theme change picks up its own twin. ----
+  // ---- Heat color scale (spec §4.3, cosmetic parity fidelity): a 5-stop
+  // piecewise LAB ramp (prototype anatomy: variant_B.js's `rebuildRamp`,
+  // `d3.piecewise(d3.interpolateLab, [...])`) — LAB interpolation is
+  // perceptually smoother than the treemap/ledger's 3-stop RGB scale, and
+  // the two extra intermediate stops give this view's much larger heat-color
+  // range (every dir + every satellite, vs. a handful of drill-panel bars) a
+  // higher-resolution ramp. Anchors are still the shared `--viz-heat-*`
+  // custom properties (resolved fresh on every render/reencode so a theme
+  // change picks up its own twin) — extended with two intermediate stops
+  // rather than a bespoke palette, so this view's ramp stays a strict
+  // refinement of the shared cold/mid/hot anchors, never a competing one. ----
+  var HEAT_RAMP_STOPS = [
+    "--viz-heat-cold",
+    "--viz-heat-cold-mid",
+    "--viz-heat-mid",
+    "--viz-heat-mid-hot",
+    "--viz-heat-hot"
+  ];
+
   function makeHeatColorScale() {
     var style = getComputedStyle(document.documentElement);
-    var cold = style.getPropertyValue("--viz-heat-cold").trim();
-    var mid = style.getPropertyValue("--viz-heat-mid").trim();
-    var hot = style.getPropertyValue("--viz-heat-hot").trim();
-    return d3
-      .scaleLinear()
-      .domain([0, 0.5, 1])
-      .range([cold, mid, hot])
-      .interpolate(d3.interpolateRgb)
-      .clamp(true);
+    var stops = HEAT_RAMP_STOPS.map(function (token) {
+      return style.getPropertyValue(token).trim();
+    });
+    var ramp = d3.piecewise(d3.interpolateLab, stops);
+    return function (heat) {
+      return ramp(Math.max(0, Math.min(1, heat)));
+    };
   }
 
   function labelColorFor(colorString) {
@@ -523,7 +537,10 @@
       var heat = computeHeat(entry.node.attributes);
       var color = heatScale(heat);
       entry.el.style.backgroundColor = color;
-      entry.labelEl.style.color = labelColorFor(color);
+      // A culled (unlabeled) node has no labelEl at all — see renderNodes.
+      if (entry.labelEl) {
+        entry.labelEl.style.color = labelColorFor(color);
+      }
       // The aria-label's heat figure must track the same reencode a weight
       // change drives, or a screen-reader user reads a stale value while a
       // sighted user sees the fill already updated.
@@ -551,12 +568,46 @@
     el.style.top = node.y + "px";
   }
 
+  // ---- Label culling (spec: cosmetic parity fidelity, prototype anatomy
+  // variant_B.js's separate `labelNodes` selection): only the top-20 dir
+  // nodes by (load_bearing + a changed-in-PR bonus) plus every satellite are
+  // labeled — everything else is unlabeled (still identifiable via hover and
+  // its aria-label). Ranked by load_bearing/changed only, both weight-
+  // independent, so a weight-slider drag never re-ranks or re-culls labels
+  // (only applyEncoding's recolor runs on reencode). ----
+  var LABEL_TOP_DIR_COUNT = 20;
+
+  function computeLabeledIds(nodes) {
+    var dirNodes = nodes.filter(function (node) {
+      return node.kind === "dir";
+    });
+    var ranked = dirNodes.slice().sort(function (a, b) {
+      return labelRank(b) - labelRank(a);
+    });
+    var labeled = Object.create(null);
+    ranked.slice(0, LABEL_TOP_DIR_COUNT).forEach(function (node) {
+      labeled[node.id] = true;
+    });
+    nodes.forEach(function (node) {
+      if (node.kind === "file") {
+        labeled[node.id] = true;
+      }
+    });
+    return labeled;
+  }
+
+  function labelRank(dirNode) {
+    return (dirNode.stats.load_bearing || 0) + (dirNode.stats.changed > 0 ? 1 : 0);
+  }
+
   // ---- Node DOM + click-vs-drag/hover wiring (spec §4.2's activation
   // scaffold, the same one the treemap tile and ledger row use). `handlers`
   // is `{ onActivate(node), onHoverShow(evt, node), onHoverMove(evt),
   // onHoverHide() }` — supplied by render() so this stays agnostic of
-  // drill/focus/tooltip wiring specifics. ----
-  function renderNodes(stage, nodes, handlers) {
+  // drill/focus/tooltip wiring specifics. A node outside `labeledIds` gets no
+  // label element at all (not merely a hidden one) — still fully
+  // identifiable via its `title`/aria-label and the hover card. ----
+  function renderNodes(stage, nodes, labeledIds, handlers) {
     var entries = [];
     nodes.forEach(function (node) {
       var displayPath = node.kind === "dir" ? dirDisplayPath(node.path) : node.path;
@@ -578,10 +629,13 @@
       el.style.width = 2 * node.r + "px";
       el.style.height = 2 * node.r + "px";
 
-      var label = document.createElement("span");
-      label.setAttribute("class", "viz-constellation-node-label");
-      label.textContent = basename(displayPath);
-      el.appendChild(label);
+      var label = null;
+      if (labeledIds[node.id]) {
+        label = document.createElement("span");
+        label.setAttribute("class", "viz-constellation-node-label");
+        label.textContent = basename(displayPath);
+        el.appendChild(label);
+      }
 
       window.vizShared.wireClickVsDragActivation(el, {
         onActivate: function () {
@@ -957,7 +1011,8 @@
         window.vizShared.hideTooltip();
       }
 
-      var entries = renderNodes(visual, graph.nodes, {
+      var labeledIds = computeLabeledIds(graph.nodes);
+      var entries = renderNodes(visual, graph.nodes, labeledIds, {
         onActivate: onActivate,
         onHoverShow: onHoverShow,
         onHoverMove: onHoverMove,

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -4,14 +4,27 @@
 // toggle). Obeys the §4.2 view-module interface: render(container, scene,
 // state) → handle, with handle.destroy() and handle.reencode(state).
 //
-// Node set (spec §6.1 "PR files + context graph"): every PR-touched file
-// (attributes.in_pr) is always a node, even with zero edges of its own — an
-// isolated PR file still belongs on the graph; a context (non-PR) file is a
-// node only when scene.edges actually connects it to something, otherwise it
-// isn't part of "the graph" at all. `scene.files` is the *whole estate*
-// (assemble.py), so building the node set from PR files ∪ edge endpoints —
-// never from every scene.files entry — is what keeps this a small, legible
-// PR-shape subgraph instead of a second treemap.
+// Node model (prototype anatomy `variant_B.js`, structural parity): two
+// kinds of node, both derived client-side from the scene JSON (no Python
+// changes) —
+//   - dir super-nodes: every directory (gen_data.py's `dir_of`: up to 4 path
+//     segments, deepest level capped) over the *whole estate* (scene.files),
+//     with per-dir metrics the MAX over its member files' complexity/
+//     load_bearing/consequence, plus files/changed counts. A dir with too
+//     little going on (fewer than 2 files AND no changed files AND
+//     load_bearing < 0.05) never becomes a node at all (noise threshold); a
+//     surviving dir with no coupling edge and no tethered satellite is
+//     still dropped (connectivity prune) and counted toward the "N
+//     unconnected directories hidden" caption.
+//   - satellites: every in-PR (changed) file is always a fixed-size node,
+//     tethered by a dashed line to its containing dir node (walking up to 4
+//     path-segment ancestors, per `findContainingDir`, falling back to the
+//     synthetic "(root)" dir) — never gated by the connectivity prune above,
+//     since a satellite's own presence is what makes its dir "connected".
+// Dir-dir coupling edges are the scene's deduped file-level dependency edges
+// (this view never encodes import direction) rolled up to distinct
+// (dir, dir) pairs, excluding same-dir pairs, weighted by how many file
+// edges rolled into each pair.
 //
 // Layout (spec §4.2 "deterministic pre-settled layout … force simulations
 // run N ticks synchronously with a fixed seed"): d3-force (bundled as part
@@ -26,7 +39,7 @@
 // our controlled sequence rather than the library's own internal default —
 // explicit determinism, not a reliance on an undocumented library default.
 // Node order feeds d3-force's index-based initial phyllotaxis spiral, so the
-// node list is sorted by path before layout runs (spec test item 6: the same
+// node list is sorted by id before layout runs (spec test item 6: the same
 // scene always settles the same graph). `handle.reencode(state)` repaints
 // node fill colors only — it never re-creates the simulation or touches
 // node.x/node.y (spec §4.2 "no re-sim on slider drag"), and interaction
@@ -35,7 +48,10 @@
 //
 // Interaction parity (fidelity, prototype anatomy `variant_B.js`):
 //   - Hover score card: the same shared tooltip (views/_shared.js
-//     showTooltip/buildScoreCard) the treemap tile and ledger row use.
+//     showTooltip/buildScoreCard) the treemap tile and ledger row use, for
+//     file/satellite nodes; a dir node gets its own bespoke (hover-only —
+//     a dir has no story/diff to drill into) tooltip built from its rolled-up
+//     stats, via the same shared meter-row building block.
 //   - Zoom/pan: a `.viz-constellation-viewport` clipping window wraps the
 //     layout stage; d3.zoom drives its CSS transform (scaleExtent [0.3, 6]),
 //     never the layout itself — panning/zooming is purely a view transform,
@@ -51,18 +67,18 @@
 //     layoutGraph()) — the closest faithful analog available to the
 //     prototype's "un-pin + brief reheat", since this module deliberately
 //     has no persistent simulation to reheat.
-//   - Click-to-focus: an explicit `focusOnNode` zoom-to mechanism (min scale
-//     1.5, ~500ms), wired to node activation once dir nodes exist.
+//   - Click-to-focus: a dir node's activation animates center+zoom to it
+//     (min scale 1.5, ~500ms); a file/satellite node's activation opens the
+//     drill panel, unchanged from before dir nodes existed.
 //
 // Legend (spec §4.5 "legend completeness"): rendered *inside* this module's
 // own container, never into the shared `#viz-legend` app.js owns for
 // treemap/ledger — the view-module contract forbids styling/rendering
-// outside the fresh container a view was handed (spec §4.2), and this view's
-// encodings (heat fill, the PR-ring, the dependency edge line) differ from
-// treemap/ledger's, so a legend of its own is the only way to keep every
-// entry backed by a real referent.
+// outside the fresh container a view was handed (spec §4.2). The prototype's
+// five entries (size, color, edge width, ringed dot, satellites) are what is
+// actually rendered here — every entry has a real referent.
 //
-// Every repo-derived string (a file path) is bound via `textContent`/
+// Every repo-derived string (a file/dir path) is bound via `textContent`/
 // `title`/`aria-label` attribute, never `innerHTML`, matching the DOM-bind
 // invariant the other view modules hold.
 (function () {
@@ -74,8 +90,29 @@
   // Any fixed constant works; changing it changes the settled layout but
   // never removes its determinism (spec §4.2).
   var LAYOUT_SEED = 1337;
-  var NODE_RADIUS = 13; // px; approximates the CSS node mark's 1.7rem box for layout math only
   var DRAG_THRESHOLD = 4; // px; same click-vs-drag threshold as wireClickVsDragActivation
+
+  // ---- Node sizing (prototype anatomy `variant_B.js`): a dir's radius grows
+  // with its rolled-up load-bearing score; a satellite is always the same
+  // small fixed size (it is the tethered detail, never the focal point). ----
+  var DIR_RADIUS_BASE = 4;
+  var DIR_RADIUS_SCALE = 14;
+  var SATELLITE_RADIUS = 5;
+
+  // ---- Dir noise threshold (prototype anatomy: gen_data.py's dir_of +
+  // variant_B.js's dirNodes filter): a directory with too few files, no
+  // changes, and negligible load-bearing never becomes a node — it would be
+  // pure clutter. ----
+  var NOISE_MIN_FILES = 2;
+  var NOISE_MIN_CENTRALITY = 0.05;
+
+  // The synthetic root-group directory (files at repo root, no "/" in their
+  // path) — a NUL-prefixed sentinel key (a real git path can never contain a
+  // NUL byte) so it can never collide with an actual top-level directory
+  // that happens to be named "(root)" (same guard views/treemap.js's own
+  // ROOT_GROUP_PATH uses for its synthetic root node).
+  var ROOT_DIR_NAME = "(root)";
+  var ROOT_DIR_PATH = "\u0000(root)";
 
   // ---- Seeded PRNG (mulberry32): injected via `simulation.randomSource`
   // so the layout is a pure, reproducible function of the node/edge set,
@@ -97,49 +134,119 @@
     return parts[parts.length - 1];
   }
 
-  // ---- scene.files + scene.edges → { nodes, edges } for the layout. Always
-  // builds a graph: the "dependency graph unavailable" state is decided by the
-  // caller from render_config.unavailable_axes (the load-bearing axis
-  // fail-softed), NOT from an empty edge set. An available axis with zero
-  // cross-file edges still yields the PR-file node set (isolated nodes), the
-  // legitimately-empty rendering — same disambiguation file sonar makes. ----
-  function buildGraph(scene) {
-    var rawEdges = scene.edges || [];
+  function numberOr0(value) {
+    return typeof value === "number" ? value : 0;
+  }
 
-    var fileByPath = Object.create(null);
-    scene.files.forEach(function (file) {
-      fileByPath[file.path] = file;
-    });
+  // A dir path never surfaces its NUL sentinel to the DOM — this is the one
+  // place that translation happens, mirroring views/treemap.js's own
+  // displayPathFor for its synthetic root group.
+  function dirDisplayPath(path) {
+    return path === ROOT_DIR_PATH ? ROOT_DIR_NAME : path;
+  }
 
-    var nodeSet = Object.create(null);
-    var nodePaths = [];
-    function addNode(path) {
-      if (!nodeSet[path]) {
-        nodeSet[path] = true;
-        nodePaths.push(path);
+  // ---- dir_of (prototype anatomy: gen_data.py lines ~221-223): a file's
+  // containing directory, capped at 4 path segments deep — a file 6 levels
+  // deep still aggregates into its 4th-level ancestor, not a very-long,
+  // very-specific leaf directory. A root-level file (no "/" in its path)
+  // aggregates into the synthetic "(root)" dir. ----
+  function dirOf(path) {
+    var parts = path.split("/");
+    var segCount = Math.min(parts.length - 1, 4);
+    var dir = parts.slice(0, segCount).join("/");
+    return dir || ROOT_DIR_PATH;
+  }
+
+  // ---- findContainingDir (prototype anatomy: variant_B.js): a satellite's
+  // tether target. `dir_of(path)`'s own dir may have been dropped by the
+  // noise threshold, so this walks shorter path prefixes looking for the
+  // nearest *surviving* ancestor dir, falling back to the root dir (which
+  // may itself be absent, e.g. every file lives in some real directory). ----
+  function findContainingDir(path, dirNodeByPath) {
+    var parts = path.split("/");
+    for (var i = Math.min(parts.length - 1, 4); i >= 1; i--) {
+      var candidate = parts.slice(0, i).join("/");
+      if (dirNodeByPath[candidate]) {
+        return dirNodeByPath[candidate];
       }
     }
+    return dirNodeByPath[ROOT_DIR_PATH] || null;
+  }
 
-    // PR files are always nodes, even isolated ones (spec: "PR files +
-    // context graph" — a PR-touched file belongs on the graph regardless of
-    // whether this run's edge set happens to connect it to anything).
-    scene.files.forEach(function (file) {
-      if (file.attributes && file.attributes.in_pr) {
-        addNode(file.path);
+  // ---- Per-dir aggregation (prototype anatomy: gen_data.py lines ~225-233):
+  // MAX over member files' heat axes, plus file/changed counts — over the
+  // *whole estate* (scene.files), never just the PR files, so a dir's
+  // rolled-up context reflects everything living under it. ----
+  function computeDirStats(files) {
+    var stats = Object.create(null);
+    files.forEach(function (file) {
+      var dirPath = dirOf(file.path);
+      var attributes = file.attributes || {};
+      var entry = stats[dirPath];
+      if (!entry) {
+        entry = {
+          path: dirPath,
+          files: 0,
+          changed: 0,
+          complexity: 0,
+          load_bearing: 0,
+          consequence: 0
+        };
+        stats[dirPath] = entry;
       }
+      entry.files += 1;
+      if (attributes.in_pr) {
+        entry.changed += 1;
+      }
+      entry.complexity = Math.max(entry.complexity, numberOr0(attributes.complexity));
+      entry.load_bearing = Math.max(entry.load_bearing, numberOr0(attributes.load_bearing));
+      entry.consequence = Math.max(entry.consequence, numberOr0(attributes.consequence));
     });
+    return stats;
+  }
 
-    // Context files are nodes only via an edge (that's what makes them part
-    // of "the graph" rather than the whole estate); dedup by unordered pair
-    // so an A→B/B→A pair (or an exact repeat) draws one line, not two
-    // indistinguishable overlapping ones — this view never encodes import
-    // direction (same "either direction" stance file sonar takes for its
-    // blast-radius hops).
+  function isNoiseDir(stats) {
+    return (
+      stats.files < NOISE_MIN_FILES && stats.changed === 0 && stats.load_bearing < NOISE_MIN_CENTRALITY
+    );
+  }
+
+  function makeDirNode(stats) {
+    return {
+      id: "dir:" + stats.path,
+      kind: "dir",
+      path: stats.path,
+      stats: stats,
+      attributes: {
+        complexity: stats.complexity,
+        load_bearing: stats.load_bearing,
+        consequence: stats.consequence
+      },
+      r: DIR_RADIUS_BASE + DIR_RADIUS_SCALE * Math.sqrt(stats.load_bearing || 0)
+    };
+  }
+
+  function makeSatelliteNode(file, dirNode) {
+    return {
+      id: "file:" + file.path,
+      kind: "file",
+      path: file.path,
+      file: file,
+      attributes: file.attributes || {},
+      inPr: true,
+      r: SATELLITE_RADIUS,
+      dir: dirNode
+    };
+  }
+
+  // Deduped by unordered pair (this view never encodes import direction, the
+  // same "either direction" stance file sonar takes for its blast-radius
+  // hops) — an A→B/B→A pair (or an exact repeat) rolls up as one file edge,
+  // not two.
+  function buildDedupedFileEdges(rawEdges) {
     var seenPairs = Object.create(null);
     var edges = [];
     rawEdges.forEach(function (edge) {
-      addNode(edge.source);
-      addNode(edge.target);
       var key =
         edge.source < edge.target
           ? edge.source + "\0" + edge.target
@@ -150,30 +257,130 @@
       seenPairs[key] = true;
       edges.push({ source: edge.source, target: edge.target });
     });
+    return edges;
+  }
+
+  // ---- Dir-dir coupling edges (prototype anatomy: gen_data.py lines
+  // ~235-239): roll the deduped file-level edges up to distinct dir pairs,
+  // excluding same-dir pairs (an edge wholly inside one directory says
+  // nothing about coupling *between* directories), weighted by how many
+  // file edges rolled into each pair. Only pairs where BOTH dirs survived
+  // the noise threshold are considered — the connectivity prune (in
+  // buildGraph) runs as a second pass over this result. ----
+  function rollUpDirEdges(fileEdges, dirNodeByPath) {
+    var counts = Object.create(null);
+    var order = [];
+    fileEdges.forEach(function (edge) {
+      var a = dirOf(edge.source);
+      var b = dirOf(edge.target);
+      if (a === b) {
+        return;
+      }
+      if (!dirNodeByPath[a] || !dirNodeByPath[b]) {
+        return;
+      }
+      var lo = a < b ? a : b;
+      var hi = a < b ? b : a;
+      var key = lo + "\0" + hi;
+      if (!counts[key]) {
+        counts[key] = { source: lo, target: hi, n: 0 };
+        order.push(key);
+      }
+      counts[key].n += 1;
+    });
+    return order.map(function (key) {
+      var entry = counts[key];
+      return {
+        source: dirNodeByPath[entry.source].id,
+        target: dirNodeByPath[entry.target].id,
+        n: entry.n,
+        tether: false
+      };
+    });
+  }
+
+  // ---- scene.files + scene.edges → { nodes, edges, droppedDirCount } for
+  // the layout. Always builds a graph: the "dependency graph unavailable"
+  // state is decided by the caller from render_config.unavailable_axes (the
+  // load-bearing axis fail-softed), NOT from an empty edge set — dir
+  // coupling edges derive from that same dependency graph, so the whole
+  // structural view depends on it exactly as file-level edges did before. ----
+  function buildGraph(scene) {
+    var dirStats = computeDirStats(scene.files);
+    var dirPaths = Object.keys(dirStats).sort();
+
+    var allDirNodes = dirPaths
+      .filter(function (path) {
+        return !isNoiseDir(dirStats[path]);
+      })
+      .map(function (path) {
+        return makeDirNode(dirStats[path]);
+      });
+
+    var dirNodeByPath = Object.create(null);
+    allDirNodes.forEach(function (node) {
+      dirNodeByPath[node.path] = node;
+    });
+
+    var fileEdges = buildDedupedFileEdges(scene.edges || []);
+    var dirEdges = rollUpDirEdges(fileEdges, dirNodeByPath);
+
+    var satelliteNodes = scene.files
+      .filter(function (file) {
+        return Boolean(file.attributes && file.attributes.in_pr);
+      })
+      .map(function (file) {
+        return makeSatelliteNode(file, findContainingDir(file.path, dirNodeByPath));
+      })
+      .sort(function (a, b) {
+        return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+      });
+
+    // Connectivity prune (spec: unconnected dir nodes hidden): a dir that
+    // survived the noise threshold above still needs a real relationship to
+    // the rest of the graph — a coupling edge, or at least one tethered
+    // satellite — or it is dropped and counted toward the "N unconnected
+    // directories hidden" caption.
+    var connectedDirIds = Object.create(null);
+    dirEdges.forEach(function (edge) {
+      connectedDirIds[edge.source] = true;
+      connectedDirIds[edge.target] = true;
+    });
+    satelliteNodes.forEach(function (sat) {
+      if (sat.dir) {
+        connectedDirIds[sat.dir.id] = true;
+      }
+    });
+
+    var survivingDirNodes = allDirNodes.filter(function (node) {
+      return Boolean(connectedDirIds[node.id]);
+    });
+    var droppedDirCount = allDirNodes.length - survivingDirNodes.length;
+    var survivingIds = Object.create(null);
+    survivingDirNodes.forEach(function (node) {
+      survivingIds[node.id] = true;
+    });
+
+    var finalDirEdges = dirEdges.filter(function (edge) {
+      return survivingIds[edge.source] && survivingIds[edge.target];
+    });
+    var tetherLinks = satelliteNodes
+      .filter(function (sat) {
+        return sat.dir && survivingIds[sat.dir.id];
+      })
+      .map(function (sat) {
+        return { source: sat.id, target: sat.dir.id, tether: true };
+      });
 
     // Sorted so the node list — and therefore d3-force's index-based initial
     // phyllotaxis spiral — is a pure function of the node identities, never
     // of incidental scene.files/scene.edges iteration order.
-    var nodes = nodePaths
-      .slice()
-      .sort()
-      .map(function (path) {
-        // A context path absent from scene.files would be a scene data-
-        // integrity bug upstream (every edge endpoint should be a tracked
-        // estate path per assemble.py) — default to an empty-attribute file
-        // rather than crash, so the graph still renders the node's identity.
-        var file = fileByPath[path] || { path: path, checksum: "", attributes: {} };
-        var attributes = file.attributes || {};
-        return {
-          id: "file:" + path,
-          kind: "file",
-          path: path,
-          file: file,
-          inPr: Boolean(attributes.in_pr)
-        };
-      });
+    var nodes = survivingDirNodes.concat(satelliteNodes).sort(function (a, b) {
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+    var edges = finalDirEdges.concat(tetherLinks);
 
-    return { nodes: nodes, edges: edges };
+    return { nodes: nodes, edges: edges, droppedDirCount: droppedDirCount };
   }
 
   // ---- Pre-settled force layout (spec §4.2): runs to completion
@@ -195,12 +402,26 @@
           .id(function (d) {
             return d.id;
           })
-          .distance(64)
-          .strength(0.5)
+          .distance(function (d) {
+            return d.tether ? 18 : 60;
+          })
+          .strength(function (d) {
+            return d.tether ? 0.8 : 0.25;
+          })
       )
-      .force("charge", d3.forceManyBody().strength(-160))
+      .force(
+        "charge",
+        d3.forceManyBody().strength(function (d) {
+          return d.kind === "file" ? -30 : -120;
+        })
+      )
       .force("center", d3.forceCenter(side / 2, side / 2))
-      .force("collide", d3.forceCollide(NODE_RADIUS + 8))
+      .force(
+        "collide",
+        d3.forceCollide(function (d) {
+          return d.r + 3;
+        })
+      )
       .alpha(1)
       .alphaDecay(1 - Math.pow(0.001, 1 / FIXED_TICKS));
 
@@ -212,8 +433,8 @@
     // barycenter toward the stage center but places no hard wall, so a
     // sparse graph can still settle a hair outside the box without this.
     nodes.forEach(function (node) {
-      node.x = Math.min(side - NODE_RADIUS, Math.max(NODE_RADIUS, node.x));
-      node.y = Math.min(side - NODE_RADIUS, Math.max(NODE_RADIUS, node.y));
+      node.x = Math.min(side - node.r, Math.max(node.r, node.x));
+      node.y = Math.min(side - node.r, Math.max(node.r, node.y));
     });
 
     return side;
@@ -244,15 +465,20 @@
     var entries = edges.map(function (edge) {
       // Post-layout, d3.forceLink has replaced these string endpoints with
       // node object references (standard d3-force behavior) — the fresh
-      // `{source, target}` copies buildGraph() made are what absorbed that
-      // mutation, never scene.edges itself, so sonar's later reads of
-      // scene.edges (string source/target) are untouched.
+      // edge objects buildGraph() made are what absorbed that mutation,
+      // never scene.edges itself.
       var line = document.createElementNS(SVG_NS, "line");
-      line.setAttribute("class", "viz-constellation-edge");
+      line.setAttribute(
+        "class",
+        "viz-constellation-edge" + (edge.tether ? " viz-constellation-edge--tether" : "")
+      );
       line.setAttribute("x1", String(edge.source.x));
       line.setAttribute("y1", String(edge.source.y));
       line.setAttribute("x2", String(edge.target.x));
       line.setAttribute("y2", String(edge.target.y));
+      // Coupling-edge width scales with rolled-up count (spec: "edge width =
+      // coupling strength"); a tether is always a thin fixed line.
+      line.style.strokeWidth = (edge.tether ? 1 : 1 + Math.log1p(edge.n || 1)) + "px";
       svg.appendChild(line);
       return { edge: edge, lineEl: line };
     });
@@ -294,7 +520,7 @@
 
   function applyEncoding(entries, heatScale, computeHeat) {
     entries.forEach(function (entry) {
-      var heat = computeHeat(entry.node.file.attributes || {});
+      var heat = computeHeat(entry.node.attributes);
       var color = heatScale(heat);
       entry.el.style.backgroundColor = color;
       entry.labelEl.style.color = labelColorFor(color);
@@ -306,12 +532,18 @@
   }
 
   function nodeAriaLabel(node, heat) {
-    return (
-      node.path +
-      (node.inPr ? " (changed in this PR)" : " (context file)") +
-      ", heat " +
-      heat.toFixed(2)
-    );
+    if (node.kind === "dir") {
+      return (
+        dirDisplayPath(node.path) +
+        " (directory, " +
+        node.stats.files +
+        " files, " +
+        node.stats.changed +
+        " changed), heat " +
+        heat.toFixed(2)
+      );
+    }
+    return node.path + " (changed in this PR), heat " + heat.toFixed(2);
   }
 
   function applyNodePosition(el, node) {
@@ -327,11 +559,13 @@
   function renderNodes(stage, nodes, handlers) {
     var entries = [];
     nodes.forEach(function (node) {
+      var displayPath = node.kind === "dir" ? dirDisplayPath(node.path) : node.path;
       var el = document.createElement("div");
       el.setAttribute("class", "viz-constellation-node");
-      el.setAttribute("data-path", node.path);
-      el.setAttribute("data-in-pr", node.inPr ? "true" : "false");
-      el.setAttribute("title", node.path);
+      el.setAttribute("data-kind", node.kind);
+      el.setAttribute("data-path", displayPath);
+      el.setAttribute("data-in-pr", node.kind === "file" ? "true" : "false");
+      el.setAttribute("title", displayPath);
       // Keyboard reachability + screen-reader semantics (a11y), same
       // contract as the treemap tile, ledger row, and sonar ring mark.
       // aria-label (with its heat figure) is applyEncoding's job, called
@@ -341,10 +575,12 @@
       el.setAttribute("role", "button");
       el.setAttribute("tabindex", "0");
       applyNodePosition(el, node);
+      el.style.width = 2 * node.r + "px";
+      el.style.height = 2 * node.r + "px";
 
       var label = document.createElement("span");
       label.setAttribute("class", "viz-constellation-node-label");
-      label.textContent = basename(node.path);
+      label.textContent = basename(displayPath);
       el.appendChild(label);
 
       window.vizShared.wireClickVsDragActivation(el, {
@@ -456,49 +692,114 @@
     return (!event.ctrlKey || event.type === "wheel") && !event.button;
   }
 
-  // ---- Legend (spec §4.5): every encoding this view renders, in its own
-  // container — heat fill, the PR-ring, and the dependency edge line. ----
+  // ---- Dir hover tooltip (prototype anatomy: variant_B.js's dir `mousemove`
+  // branch) — hover-only, never a drill: a dir has no story/diff to show, so
+  // fabricating a drill-panel record for it would be inventing content the
+  // scene never attached. Built from the same shared meter-row block the
+  // file score card uses (views/_shared.js), so a dir's bars mirror a file's
+  // exactly. ----
+  function buildDirTooltip(container, node, heatValue) {
+    var pathEl = document.createElement("div");
+    pathEl.setAttribute("class", "viz-tooltip-path");
+    pathEl.textContent = dirDisplayPath(node.path);
+    container.appendChild(pathEl);
+
+    var countsEl = document.createElement("div");
+    countsEl.setAttribute("class", "viz-constellation-dir-counts");
+    countsEl.textContent = node.stats.files + " files · " + node.stats.changed + " changed";
+    container.appendChild(countsEl);
+
+    window.vizShared.HEAT_AXES.forEach(function (axis) {
+      container.appendChild(window.vizShared.buildMeterRow(axis, axis, node.attributes[axis] || 0));
+    });
+    container.appendChild(window.vizShared.buildMeterRow("heat", "heat", heatValue));
+  }
+
+  function svgEl(tag, attrs) {
+    var el = document.createElementNS(SVG_NS, tag);
+    Object.keys(attrs).forEach(function (key) {
+      el.setAttribute(key, attrs[key]);
+    });
+    return el;
+  }
+
+  function buildSizeSwatch() {
+    var svg = svgEl("svg", { width: "22", height: "14" });
+    svg.appendChild(svgEl("circle", { cx: "5", cy: "7", r: "2.5", fill: "var(--viz-muted)" }));
+    svg.appendChild(svgEl("circle", { cx: "16", cy: "7", r: "5.5", fill: "var(--viz-muted)" }));
+    return svg;
+  }
+
+  function buildColorSwatch() {
+    var span = document.createElement("span");
+    span.setAttribute("class", "viz-constellation-legend-color");
+    return span;
+  }
+
+  function buildEdgeWidthSwatch() {
+    var svg = svgEl("svg", { width: "22", height: "14" });
+    svg.appendChild(
+      svgEl("line", { x1: "1", y1: "11", x2: "21", y2: "11", stroke: "var(--viz-muted)", "stroke-width": "1" })
+    );
+    svg.appendChild(
+      svgEl("line", { x1: "1", y1: "5", x2: "21", y2: "5", stroke: "var(--viz-muted)", "stroke-width": "3" })
+    );
+    return svg;
+  }
+
+  function buildSatelliteSwatch() {
+    var svg = svgEl("svg", { width: "22", height: "14" });
+    svg.appendChild(svgEl("circle", { cx: "5", cy: "7", r: "4", fill: "var(--viz-muted)" }));
+    svg.appendChild(
+      svgEl("line", {
+        x1: "9",
+        y1: "7",
+        x2: "17",
+        y2: "7",
+        stroke: "var(--viz-muted)",
+        "stroke-width": "1",
+        "stroke-dasharray": "2,2"
+      })
+    );
+    svg.appendChild(
+      svgEl("circle", {
+        cx: "19",
+        cy: "7",
+        r: "2.5",
+        fill: "var(--viz-heat-mid)",
+        stroke: "var(--viz-fg)",
+        "stroke-width": "1.5"
+      })
+    );
+    return svg;
+  }
+
+  function legendItem(swatchEl, labelText) {
+    var item = document.createElement("span");
+    item.setAttribute("class", "viz-constellation-legend-item");
+    item.appendChild(swatchEl);
+    var label = document.createElement("span");
+    label.textContent = labelText;
+    item.appendChild(label);
+    return item;
+  }
+
+  // ---- Legend (spec §4.5): the prototype's five entries — every encoding
+  // this view actually renders (size, color, edge width, the PR-ring, and
+  // the satellite tether), never an orphan entry. ----
   function buildLegend(container) {
     var legend = document.createElement("div");
     legend.setAttribute("class", "viz-constellation-legend");
 
-    var heatStops = [
-      { token: "heat-cold", label: "low attention" },
-      { token: "heat-mid", label: "medium attention" },
-      { token: "heat-hot", label: "high attention" }
-    ];
-    heatStops.forEach(function (stop) {
-      var item = document.createElement("span");
-      item.setAttribute("class", "viz-constellation-legend-item");
-      var swatch = document.createElement("span");
-      swatch.setAttribute("class", "viz-constellation-legend-swatch");
-      swatch.style.background = "var(--viz-" + stop.token + ")";
-      var label = document.createElement("span");
-      label.textContent = stop.label;
-      item.appendChild(swatch);
-      item.appendChild(label);
-      legend.appendChild(item);
-    });
+    legend.appendChild(legendItem(buildSizeSwatch(), "Size = load-bearing (in-degree)"));
+    legend.appendChild(legendItem(buildColorSwatch(), "Color = composite heat"));
+    legend.appendChild(legendItem(buildEdgeWidthSwatch(), "Edge width = coupling strength"));
 
-    var prItem = document.createElement("span");
-    prItem.setAttribute("class", "viz-constellation-legend-item");
-    var prRing = document.createElement("span");
-    prRing.setAttribute("class", "viz-constellation-legend-ring");
-    var prLabel = document.createElement("span");
-    prLabel.textContent = "file changed in this PR";
-    prItem.appendChild(prRing);
-    prItem.appendChild(prLabel);
-    legend.appendChild(prItem);
+    var ring = document.createElement("span");
+    ring.setAttribute("class", "viz-constellation-legend-ring");
+    legend.appendChild(legendItem(ring, "Ringed dot = changed in PR"));
 
-    var edgeItem = document.createElement("span");
-    edgeItem.setAttribute("class", "viz-constellation-legend-item");
-    var edgeLine = document.createElement("span");
-    edgeLine.setAttribute("class", "viz-constellation-legend-line");
-    var edgeLabel = document.createElement("span");
-    edgeLabel.textContent = "file dependency";
-    edgeItem.appendChild(edgeLine);
-    edgeItem.appendChild(edgeLabel);
-    legend.appendChild(edgeItem);
+    legend.appendChild(legendItem(buildSatelliteSwatch(), "Satellites = the PR's changed files"));
 
     container.appendChild(legend);
   }
@@ -621,14 +922,32 @@
       });
       viewport.appendChild(resetBtn);
 
+      // Pruning affordance (spec: "N unconnected directories hidden") — only
+      // present when the connectivity prune actually dropped something.
+      if (graph.droppedDirCount > 0) {
+        var hiddenCaption = document.createElement("div");
+        hiddenCaption.setAttribute("class", "viz-constellation-hidden-caption");
+        hiddenCaption.textContent = graph.droppedDirCount + " unconnected directories hidden";
+        viewport.appendChild(hiddenCaption);
+      }
+
+      // File/satellite click keeps the existing openDrill path unchanged; a
+      // dir click has no story/diff to drill into, so it only focuses.
       function onActivate(node) {
+        if (node.kind === "dir") {
+          focusOnNode(node);
+          return;
+        }
         current.openDrill({ path: node.path, orig: { file: node.file } });
       }
       function onHoverShow(evt, node) {
         window.vizShared.showTooltip(evt, function (el) {
-          window.vizShared.buildScoreCard(
-            el, node.path, node.file.attributes || {}, current.computeHeat(node.file.attributes || {})
-          );
+          var heat = current.computeHeat(node.attributes);
+          if (node.kind === "dir") {
+            buildDirTooltip(el, node, heat);
+          } else {
+            window.vizShared.buildScoreCard(el, node.path, node.attributes, heat);
+          }
         });
       }
       function onHoverMove(evt) {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -264,21 +264,24 @@
   // ~235-239): roll the deduped file-level edges up to distinct dir pairs,
   // excluding same-dir pairs (an edge wholly inside one directory says
   // nothing about coupling *between* directories), weighted by how many
-  // file edges rolled into each pair. Only pairs where BOTH dirs survived
-  // the noise threshold are considered — the connectivity prune (in
-  // buildGraph) runs as a second pass over this result. ----
+  // file edges rolled into each pair. Each endpoint resolves through the
+  // same nearest-surviving-ancestor walk satellites use (findContainingDir),
+  // so an edge rooted in a noise-pruned leaf dir rolls up to that leaf's
+  // surviving ancestor instead of silently vanishing; the same-dir check
+  // runs on the *resolved* dirs, so an edge between two pruned subdirs of
+  // one surviving ancestor correctly reads as intra-dir. The connectivity
+  // prune (in buildGraph) runs as a second pass over this result. ----
   function rollUpDirEdges(fileEdges, dirNodeByPath) {
     var counts = Object.create(null);
     var order = [];
     fileEdges.forEach(function (edge) {
-      var a = dirOf(edge.source);
-      var b = dirOf(edge.target);
-      if (a === b) {
+      var srcDir = findContainingDir(edge.source, dirNodeByPath);
+      var tgtDir = findContainingDir(edge.target, dirNodeByPath);
+      if (!srcDir || !tgtDir || srcDir === tgtDir) {
         return;
       }
-      if (!dirNodeByPath[a] || !dirNodeByPath[b]) {
-        return;
-      }
+      var a = srcDir.path;
+      var b = tgtDir.path;
       var lo = a < b ? a : b;
       var hi = a < b ? b : a;
       var key = lo + "\0" + hi;
@@ -685,6 +688,13 @@
       startY = evt.clientY;
       dragging = false;
       active = true;
+      // Capture the pointer so pointermove/pointerup keep targeting `el` even
+      // after the cursor leaves it mid-gesture (small nodes + fast drags
+      // otherwise silently freeze tracking). Mirrors wireClickVsDragActivation
+      // in _shared.js; capture releases implicitly on pointerup/pointercancel.
+      if (el.setPointerCapture) {
+        el.setPointerCapture(evt.pointerId);
+      }
     });
     el.addEventListener("pointermove", function (evt) {
       if (!active) {
@@ -753,20 +763,13 @@
   // file score card uses (views/_shared.js), so a dir's bars mirror a file's
   // exactly. ----
   function buildDirTooltip(container, node, heatValue) {
-    var pathEl = document.createElement("div");
-    pathEl.setAttribute("class", "viz-tooltip-path");
-    pathEl.textContent = dirDisplayPath(node.path);
-    container.appendChild(pathEl);
+    window.vizShared.buildScoreCard(container, dirDisplayPath(node.path), node.attributes, heatValue);
 
     var countsEl = document.createElement("div");
     countsEl.setAttribute("class", "viz-constellation-dir-counts");
     countsEl.textContent = node.stats.files + " files · " + node.stats.changed + " changed";
-    container.appendChild(countsEl);
-
-    window.vizShared.HEAT_AXES.forEach(function (axis) {
-      container.appendChild(window.vizShared.buildMeterRow(axis, axis, node.attributes[axis] || 0));
-    });
-    container.appendChild(window.vizShared.buildMeterRow("heat", "heat", heatValue));
+    var pathEl = container.querySelector(".viz-tooltip-path");
+    container.insertBefore(countsEl, pathEl.nextSibling);
   }
 
   function svgEl(tag, attrs) {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -934,7 +934,11 @@
       // "identity" here means this render's own computed centered baseline
       // (the layout's barycenter, side/2,side/2, centered in the viewport) —
       // not literal d3.zoomIdentity, which would just show the layout box's
-      // top-left corner. Reset view restores exactly this same baseline. ----
+      // top-left corner. The viewport's on-screen size DOES change when the
+      // drill drawer opens/closes (scene.css narrows #viz-root via
+      // .viz-drill-open), so the baseline is recomputed on viewport resize
+      // (see the ResizeObserver below) and Reset view restores whatever the
+      // current baseline is. ----
       var zoomTransform = d3.zoomIdentity;
       var zoomBehavior = d3
         .zoom()
@@ -946,16 +950,46 @@
             "translate(" + zoomTransform.x + "px," + zoomTransform.y + "px) scale(" + zoomTransform.k + ")";
         });
 
-      var viewportRect = viewport.getBoundingClientRect();
-      var viewportWidth = viewportRect.width || viewport.clientWidth || side;
-      var viewportHeight = viewportRect.height || viewport.clientHeight || side;
-      var baseTransform = d3.zoomIdentity.translate(
-        (viewportWidth - side) / 2,
-        (viewportHeight - side) / 2
-      );
+      // Centered baseline for the current viewport size — recomputed on resize
+      // (below) because the drill drawer narrows the viewport after mount.
+      function computeBaseTransform() {
+        var rect = viewport.getBoundingClientRect();
+        var width = rect.width || viewport.clientWidth || side;
+        var height = rect.height || viewport.clientHeight || side;
+        return d3.zoomIdentity.translate((width - side) / 2, (height - side) / 2);
+      }
+      var baseTransform = computeBaseTransform();
+
+      // True while the stage is still parked exactly on the computed baseline
+      // (no user pan/zoom since the last baseline apply). d3 assigns the target
+      // transform's numeric fields verbatim, so exact equality is reliable here.
+      function atBaseline() {
+        return (
+          zoomTransform.k === baseTransform.k &&
+          zoomTransform.x === baseTransform.x &&
+          zoomTransform.y === baseTransform.y
+        );
+      }
 
       d3.select(viewport).call(zoomBehavior).on("dblclick.zoom", null);
       d3.select(viewport).call(zoomBehavior.transform, baseTransform);
+
+      // Recenter when the viewport resizes (drill drawer open/close). If the
+      // user is still on the baseline, slide to the freshly centered baseline;
+      // if they have panned/zoomed away, leave their transform untouched but
+      // retarget Reset view to the new baseline. Feature-guarded like the
+      // setPointerCapture guard above.
+      var resizeObserver = null;
+      if (typeof ResizeObserver === "function") {
+        resizeObserver = new ResizeObserver(function () {
+          var wasBaseline = atBaseline();
+          baseTransform = computeBaseTransform();
+          if (wasBaseline) {
+            d3.select(viewport).call(zoomBehavior.transform, baseTransform);
+          }
+        });
+        resizeObserver.observe(viewport);
+      }
 
       function focusOnNode(node) {
         var rect = viewport.getBoundingClientRect();
@@ -1028,8 +1062,14 @@
       });
       applyEncoding(entries, heatScale, current.computeHeat);
 
+      var destroyContainer = makeDestroy(container);
       return {
-        destroy: makeDestroy(container),
+        destroy: function () {
+          if (resizeObserver) {
+            resizeObserver.disconnect();
+          }
+          destroyContainer();
+        },
         reencode: function (newState) {
           current = newState;
           heatScale = makeHeatColorScale();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -29,7 +29,30 @@
 // node list is sorted by path before layout runs (spec test item 6: the same
 // scene always settles the same graph). `handle.reencode(state)` repaints
 // node fill colors only — it never re-creates the simulation or touches
-// node.x/node.y (spec §4.2 "no re-sim on slider drag").
+// node.x/node.y (spec §4.2 "no re-sim on slider drag"), and interaction
+// (drag/pin, zoom/pan transform) never runs a fresh simulation tick either —
+// there is no persistent simulation after the initial synchronous settle.
+//
+// Interaction parity (fidelity, prototype anatomy `variant_B.js`):
+//   - Hover score card: the same shared tooltip (views/_shared.js
+//     showTooltip/buildScoreCard) the treemap tile and ledger row use.
+//   - Zoom/pan: a `.viz-constellation-viewport` clipping window wraps the
+//     layout stage; d3.zoom drives its CSS transform (scaleExtent [0.3, 6]),
+//     never the layout itself — panning/zooming is purely a view transform,
+//     so it composes with the "no re-sim" contract above for free. Node
+//     interactions (drag, click, hover) must never also pan the canvas —
+//     `zoomFilter` rejects any non-wheel gesture that started on a node.
+//   - Drag-to-reposition + pin-on-drop: dragging a node moves node.x/node.y
+//     (and its incident edge endpoints) directly; because there is no
+//     persistent simulation to spring it back, a dropped node simply stays
+//     wherever it lands — "pinned" is the resting state, not a flag to
+//     maintain. Double-click restores the node's originally-settled
+//     position (`node.origX`/`node.origY`, captured right after
+//     layoutGraph()) — the closest faithful analog available to the
+//     prototype's "un-pin + brief reheat", since this module deliberately
+//     has no persistent simulation to reheat.
+//   - Click-to-focus: an explicit `focusOnNode` zoom-to mechanism (min scale
+//     1.5, ~500ms), wired to node activation once dir nodes exist.
 //
 // Legend (spec §4.5 "legend completeness"): rendered *inside* this module's
 // own container, never into the shared `#viz-legend` app.js owns for
@@ -40,7 +63,7 @@
 // entry backed by a real referent.
 //
 // Every repo-derived string (a file path) is bound via `textContent`/
-// `title`/`aria-label` attribute, never `innerHTML` — matching the DOM-bind
+// `title`/`aria-label` attribute, never `innerHTML`, matching the DOM-bind
 // invariant the other view modules hold.
 (function () {
   "use strict";
@@ -52,6 +75,7 @@
   // never removes its determinism (spec §4.2).
   var LAYOUT_SEED = 1337;
   var NODE_RADIUS = 13; // px; approximates the CSS node mark's 1.7rem box for layout math only
+  var DRAG_THRESHOLD = 4; // px; same click-vs-drag threshold as wireClickVsDragActivation
 
   // ---- Seeded PRNG (mulberry32): injected via `simulation.randomSource`
   // so the layout is a pure, reproducible function of the node/edge set,
@@ -141,6 +165,8 @@
         var file = fileByPath[path] || { path: path, checksum: "", attributes: {} };
         var attributes = file.attributes || {};
         return {
+          id: "file:" + path,
+          kind: "file",
           path: path,
           file: file,
           inPr: Boolean(attributes.in_pr)
@@ -167,7 +193,7 @@
         d3
           .forceLink(edges)
           .id(function (d) {
-            return d.path;
+            return d.id;
           })
           .distance(64)
           .strength(0.5)
@@ -207,12 +233,15 @@
 
   var SVG_NS = "http://www.w3.org/2000/svg";
 
+  // Returns the created `{ edge, lineEl }` pairs so the caller can index
+  // incident lines per node id for live repositioning during drag — the
+  // svg itself is never needed again once appended.
   function renderEdges(stage, side, edges) {
     var svg = document.createElementNS(SVG_NS, "svg");
     svg.setAttribute("class", "viz-constellation-edges");
     svg.setAttribute("width", String(side));
     svg.setAttribute("height", String(side));
-    edges.forEach(function (edge) {
+    var entries = edges.map(function (edge) {
       // Post-layout, d3.forceLink has replaced these string endpoints with
       // node object references (standard d3-force behavior) — the fresh
       // `{source, target}` copies buildGraph() made are what absorbed that
@@ -225,8 +254,20 @@
       line.setAttribute("x2", String(edge.target.x));
       line.setAttribute("y2", String(edge.target.y));
       svg.appendChild(line);
+      return { edge: edge, lineEl: line };
     });
     stage.appendChild(svg);
+    return entries;
+  }
+
+  function updateEdgeEndpoint(lineEl, role, node) {
+    if (role === "source") {
+      lineEl.setAttribute("x1", String(node.x));
+      lineEl.setAttribute("y1", String(node.y));
+    } else {
+      lineEl.setAttribute("x2", String(node.x));
+      lineEl.setAttribute("y2", String(node.y));
+    }
   }
 
   // ---- Heat color scale (spec §4.3): mirrors the treemap view's own scale
@@ -273,7 +314,17 @@
     );
   }
 
-  function renderNodes(stage, nodes, openDrill) {
+  function applyNodePosition(el, node) {
+    el.style.left = node.x + "px";
+    el.style.top = node.y + "px";
+  }
+
+  // ---- Node DOM + click-vs-drag/hover wiring (spec §4.2's activation
+  // scaffold, the same one the treemap tile and ledger row use). `handlers`
+  // is `{ onActivate(node), onHoverShow(evt, node), onHoverMove(evt),
+  // onHoverHide() }` — supplied by render() so this stays agnostic of
+  // drill/focus/tooltip wiring specifics. ----
+  function renderNodes(stage, nodes, handlers) {
     var entries = [];
     nodes.forEach(function (node) {
       var el = document.createElement("div");
@@ -289,8 +340,7 @@
       // otherwise have to remember to overwrite.
       el.setAttribute("role", "button");
       el.setAttribute("tabindex", "0");
-      el.style.left = node.x + "px";
-      el.style.top = node.y + "px";
+      applyNodePosition(el, node);
 
       var label = document.createElement("span");
       label.setAttribute("class", "viz-constellation-node-label");
@@ -299,14 +349,111 @@
 
       window.vizShared.wireClickVsDragActivation(el, {
         onActivate: function () {
-          openDrill({ path: node.path, orig: { file: node.file } });
+          handlers.onActivate(node);
         }
+      });
+      el.addEventListener("pointerenter", function (evt) {
+        handlers.onHoverShow(evt, node);
+      });
+      el.addEventListener("pointermove", function (evt) {
+        handlers.onHoverMove(evt);
+      });
+      el.addEventListener("pointerleave", function () {
+        handlers.onHoverHide();
       });
 
       stage.appendChild(el);
       entries.push({ node: node, el: el, labelEl: label });
     });
     return entries;
+  }
+
+  // ---- Drag-to-reposition + pin-on-drop (spec: drag must coexist with, not
+  // replace, wireClickVsDragActivation's own click-vs-drag distinguishing —
+  // these are separate listeners on the same element, so both run off the
+  // same pointer gesture without interfering with each other). `getScale()`
+  // reads the *live* zoom scale so a drag delta (in screen px) converts back
+  // to the node's own untransformed coordinate space — otherwise a dragged
+  // node would drift away from the cursor at any zoom level but 1. ----
+  function wireDrag(entry, incidentLines, getScale) {
+    var node = entry.node;
+    var el = entry.el;
+    var startX = 0;
+    var startY = 0;
+    var dragging = false;
+    var active = false;
+
+    function reposition() {
+      applyNodePosition(el, node);
+      incidentLines.forEach(function (incident) {
+        updateEdgeEndpoint(incident.lineEl, incident.role, node);
+      });
+    }
+
+    el.addEventListener("pointerdown", function (evt) {
+      startX = evt.clientX;
+      startY = evt.clientY;
+      dragging = false;
+      active = true;
+    });
+    el.addEventListener("pointermove", function (evt) {
+      if (!active) {
+        return;
+      }
+      var dx = evt.clientX - startX;
+      var dy = evt.clientY - startY;
+      if (!dragging && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
+        dragging = true;
+      }
+      if (!dragging) {
+        return;
+      }
+      var scale = getScale();
+      node.x += dx / scale;
+      node.y += dy / scale;
+      startX = evt.clientX;
+      startY = evt.clientY;
+      reposition();
+    });
+    function endDrag() {
+      active = false;
+      dragging = false;
+    }
+    el.addEventListener("pointerup", endDrag);
+    el.addEventListener("pointercancel", endDrag);
+    // Double-click un-pins: this module's layout is a one-shot pre-settled
+    // simulation with no persistent forces to release a node back into (the
+    // simulation is stopped and discarded right after layoutGraph() settles
+    // it — spec §4.2's "no re-sim" contract) — so "un-pin" here means
+    // snapping the node back to its originally-settled position
+    // (node.origX/origY), the closest faithful analog to the prototype's
+    // live-simulation reheat-on-unpin available under this contract.
+    el.addEventListener("dblclick", function (evt) {
+      evt.stopPropagation();
+      node.x = node.origX;
+      node.y = node.origY;
+      reposition();
+    });
+  }
+
+  // ---- Zoom/pan gesture filter: wheel always zooms (regardless of pointer
+  // target); a double-click never zooms (explicit, so a node's own
+  // double-click-to-unpin never also resets the view); any other gesture
+  // that started on a node belongs to that node's own drag, not the canvas
+  // pan — node dragging must never also pan the canvas. Otherwise mirrors
+  // d3-zoom's own documented default filter (`(!event.ctrlKey ||
+  // event.type === 'wheel') && !event.button`). ----
+  function zoomFilter(event) {
+    if (event.type === "dblclick") {
+      return false;
+    }
+    if (event.type !== "wheel") {
+      var target = event.target;
+      if (target && typeof target.closest === "function" && target.closest(".viz-constellation-node")) {
+        return false;
+      }
+    }
+    return (!event.ctrlKey || event.type === "wheel") && !event.button;
   }
 
   // ---- Legend (spec §4.5): every encoding this view renders, in its own
@@ -358,6 +505,7 @@
 
   function makeDestroy(container) {
     return function () {
+      window.vizShared.hideTooltip();
       while (container.firstChild) {
         container.removeChild(container.firstChild);
       }
@@ -384,18 +532,123 @@
       var graph = buildGraph(scene);
       buildLegend(stage);
 
+      var viewport = document.createElement("div");
+      viewport.setAttribute("class", "viz-constellation-viewport");
+      stage.appendChild(viewport);
+
       var visual = document.createElement("div");
       visual.setAttribute("class", "viz-constellation-stage");
       var side = layoutGraph(graph.nodes, graph.edges);
       visual.style.width = side + "px";
       visual.style.height = side + "px";
-      stage.appendChild(visual);
+      viewport.appendChild(visual);
 
-      renderEdges(visual, side, graph.edges);
+      // Captured once, right after the settle — the un-pin (dblclick)
+      // target position for every node (see wireDrag above).
+      graph.nodes.forEach(function (node) {
+        node.origX = node.x;
+        node.origY = node.y;
+      });
+
+      var edgeEntries = renderEdges(visual, side, graph.edges);
+      var incidentByNodeId = Object.create(null);
+      edgeEntries.forEach(function (entry) {
+        var srcId = entry.edge.source.id;
+        var tgtId = entry.edge.target.id;
+        (incidentByNodeId[srcId] || (incidentByNodeId[srcId] = [])).push({
+          lineEl: entry.lineEl,
+          role: "source"
+        });
+        (incidentByNodeId[tgtId] || (incidentByNodeId[tgtId] = [])).push({
+          lineEl: entry.lineEl,
+          role: "target"
+        });
+      });
 
       var current = state;
       var heatScale = makeHeatColorScale();
-      var entries = renderNodes(visual, graph.nodes, current.openDrill);
+
+      // ---- Zoom/pan (spec: scaleExtent [0.3, 6], wheel zoom + background
+      // drag pans, double-click zoom disabled, transform persisted across
+      // reencode — trivially true since reencode() never touches
+      // `zoomTransform` below). The layout box (`side`) is sized from node
+      // count, independent of the viewport's own on-screen size, so
+      // "identity" here means this render's own computed centered baseline
+      // (the layout's barycenter, side/2,side/2, centered in the viewport) —
+      // not literal d3.zoomIdentity, which would just show the layout box's
+      // top-left corner. Reset view restores exactly this same baseline. ----
+      var zoomTransform = d3.zoomIdentity;
+      var zoomBehavior = d3
+        .zoom()
+        .scaleExtent([0.3, 6])
+        .filter(zoomFilter)
+        .on("zoom", function (event) {
+          zoomTransform = event.transform;
+          visual.style.transform =
+            "translate(" + zoomTransform.x + "px," + zoomTransform.y + "px) scale(" + zoomTransform.k + ")";
+        });
+
+      var viewportRect = viewport.getBoundingClientRect();
+      var viewportWidth = viewportRect.width || viewport.clientWidth || side;
+      var viewportHeight = viewportRect.height || viewport.clientHeight || side;
+      var baseTransform = d3.zoomIdentity.translate(
+        (viewportWidth - side) / 2,
+        (viewportHeight - side) / 2
+      );
+
+      d3.select(viewport).call(zoomBehavior).on("dblclick.zoom", null);
+      d3.select(viewport).call(zoomBehavior.transform, baseTransform);
+
+      function focusOnNode(node) {
+        var rect = viewport.getBoundingClientRect();
+        var width = rect.width || viewport.clientWidth || side;
+        var height = rect.height || viewport.clientHeight || side;
+        var scale = Math.max(zoomTransform.k, 1.5);
+        var next = d3.zoomIdentity
+          .translate(width / 2, height / 2)
+          .scale(scale)
+          .translate(-node.x, -node.y);
+        d3.select(viewport).transition().duration(500).call(zoomBehavior.transform, next);
+      }
+
+      var resetBtn = document.createElement("button");
+      resetBtn.id = "viz-constellation-reset";
+      resetBtn.type = "button";
+      resetBtn.setAttribute("class", "viz-btn viz-constellation-reset");
+      resetBtn.textContent = "Reset view";
+      resetBtn.addEventListener("click", function () {
+        d3.select(viewport).transition().duration(400).call(zoomBehavior.transform, baseTransform);
+      });
+      viewport.appendChild(resetBtn);
+
+      function onActivate(node) {
+        current.openDrill({ path: node.path, orig: { file: node.file } });
+      }
+      function onHoverShow(evt, node) {
+        window.vizShared.showTooltip(evt, function (el) {
+          window.vizShared.buildScoreCard(
+            el, node.path, node.file.attributes || {}, current.computeHeat(node.file.attributes || {})
+          );
+        });
+      }
+      function onHoverMove(evt) {
+        window.vizShared.moveTooltip(evt);
+      }
+      function onHoverHide() {
+        window.vizShared.hideTooltip();
+      }
+
+      var entries = renderNodes(visual, graph.nodes, {
+        onActivate: onActivate,
+        onHoverShow: onHoverShow,
+        onHoverMove: onHoverMove,
+        onHoverHide: onHoverHide
+      });
+      entries.forEach(function (entry) {
+        wireDrag(entry, incidentByNodeId[entry.node.id] || [], function () {
+          return zoomTransform.k;
+        });
+      });
       applyEncoding(entries, heatScale, current.computeHeat);
 
       return {

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -94,10 +94,15 @@
   // Double-click un-pin window (ms): a node click's activation (dir focus /
   // file drill) is deferred by this window and cancelled when the un-pin
   // dblclick lands, so the un-pin gesture never also opens the drill (whose
-  // viewport resize would otherwise shift the baseline mid-gesture). Scoped to
-  // constellation nodes only — every node here carries the dblclick un-pin
-  // gesture. Keyboard activation is unaffected (stays instant).
-  var DBLCLICK_ACTIVATION_WINDOW_MS = 275;
+  // viewport resize would otherwise shift the baseline mid-gesture). The OS/
+  // browser double-click interval is not readable from the web platform, so we
+  // use 500ms — the common OS default — as the best available proxy; a window
+  // shorter than the user's real interval lets the first click's deferred
+  // activation fire before the cancelling dblclick arrives. The deferral is
+  // applied per-gesture (see the dblclickWindowMs function below), only to a
+  // node currently displaced from its settled position, so an un-displaced
+  // node still activates instantly. Keyboard activation is unaffected.
+  var DBLCLICK_ACTIVATION_WINDOW_MS = 500;
 
   // ---- Node sizing (prototype anatomy `variant_B.js`): a dir's radius grows
   // with its rolled-up load-bearing score; a satellite is always the same
@@ -664,8 +669,16 @@
           handlers.onActivate(node);
         },
         // Defer + cancel-on-dblclick so the un-pin gesture (see wireDrag's
-        // dblclick handler) does not also fire dir focus / file drill.
-        dblclickWindowMs: DBLCLICK_ACTIVATION_WINDOW_MS
+        // dblclick handler) does not also fire dir focus / file drill. Scoped
+        // per-gesture: only a node displaced from its settled position carries
+        // a meaningful un-pin dblclick, so only that node's activation defers —
+        // an un-displaced node (whose dblclick un-pin is a no-op) activates
+        // instantly, sparing every normal click the double-click latency.
+        dblclickWindowMs: function () {
+          return node.x !== node.origX || node.y !== node.origY
+            ? DBLCLICK_ACTIVATION_WINDOW_MS
+            : 0;
+        }
       });
       el.addEventListener("pointerenter", function (evt) {
         handlers.onHoverShow(evt, node);

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -254,6 +254,30 @@ def test_render_inlines_constellation_interaction_hooks():
     assert html.count("window.vizShared.buildScoreCard(") == 3
 
 
+def test_render_inlines_constellation_structural_hooks():
+    # Structural parity (prototype anatomy variant_B.js): dir super-nodes,
+    # satellites, dir-dir coupling edges, the pruning-affordance caption
+    # text, and the prototype's five legend entries — all JS/CSS source, so
+    # inlined regardless of scene content, same convention as every other
+    # stable hook.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    # Node-kind hooks (dir super-node vs. satellite/file).
+    assert 'data-kind", node.kind' in html
+    assert "viz-constellation-edge--tether" in html
+    # Pruning affordance (spec: "N unconnected directories hidden").
+    assert "unconnected directories hidden" in html
+    # The prototype's five legend entries.
+    assert "Size = load-bearing (in-degree)" in html
+    assert "Color = composite heat" in html
+    assert "Edge width = coupling strength" in html
+    assert "Ringed dot = changed in PR" in html
+    assert "Satellites = the PR's changed files" in html
+    # The dir hover tooltip (hover-only, never a drill — a dir has no
+    # story/diff to show).
+    assert "viz-constellation-dir-counts" in html
+
+
 def test_render_inlines_f3_drawer_meter_tooltip_and_axis_bar_hooks():
     # Fidelity F3 (drawer + content fidelity, spec §4.5): the drill drawer's
     # stage-shrink class, the shared per-axis meter row/mini-bar building

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -278,6 +278,21 @@ def test_render_inlines_constellation_structural_hooks():
     assert "viz-constellation-dir-counts" in html
 
 
+def test_render_inlines_constellation_cosmetic_hooks():
+    # Cosmetic parity (prototype anatomy variant_B.js's `rebuildRamp`): the
+    # 5-stop piecewise LAB heat ramp (extending the shared cold/mid/hot
+    # anchors with two intermediate stops) and the label-culling constant —
+    # all JS/CSS source, so inlined regardless of scene content.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "d3.piecewise(d3.interpolateLab, stops)" in html
+    assert "--viz-heat-cold-mid" in html
+    assert "--viz-heat-mid-hot" in html
+    # Label culling: only the top-20 dir nodes (by load-bearing + a changed
+    # bonus) plus every satellite are labeled.
+    assert "LABEL_TOP_DIR_COUNT = 20" in html
+
+
 def test_render_inlines_f3_drawer_meter_tooltip_and_axis_bar_hooks():
     # Fidelity F3 (drawer + content fidelity, spec §4.5): the drill drawer's
     # stage-shrink class, the shared per-axis meter row/mini-bar building

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -261,6 +261,16 @@ def test_render_inlines_constellation_interaction_hooks():
     # dblclick un-pin gesture cancels the deferred dir-focus/file-drill instead
     # of firing it (which would resize the viewport mid-gesture).
     assert "dblclickWindowMs" in html
+    # Deferred activations are cancelled view-scoped, not element-scoped: every
+    # node registers its pending-timer clear into one createActivationGroup()
+    # registry that the zoom handler and destroy() flush, so a competing
+    # gesture (pan/zoom, another node's press, keyboard) or an unmount can never
+    # let a stale focus/drill fire.
+    assert "createActivationGroup" in html
+    # A drag begun on the view's own Reset-view chrome must not pan the canvas
+    # (the release-click would then reset it, undoing the pan) — the zoom filter
+    # excludes the reset button alongside the node exclusion.
+    assert ".viz-constellation-node, .viz-constellation-reset" in html
 
 
 def test_render_inlines_constellation_structural_hooks():

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -256,6 +256,11 @@ def test_render_inlines_constellation_interaction_hooks():
     # and dir tooltip all call the shared hover score-card builder — four
     # call sites, inlined into the same bundle (item 6: bundle markers).
     assert html.count("window.vizShared.buildScoreCard(") == 4
+    # Un-pin does not double as a file open: constellation opts its nodes into
+    # the shared activation helper's double-click suppression window, so the
+    # dblclick un-pin gesture cancels the deferred dir-focus/file-drill instead
+    # of firing it (which would resize the viewport mid-gesture).
+    assert "dblclickWindowMs" in html
 
 
 def test_render_inlines_constellation_structural_hooks():

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -248,10 +248,10 @@ def test_render_inlines_constellation_interaction_hooks():
     assert "viz-constellation-viewport" in html
     assert "viz-constellation-reset" in html
     assert "Reset view" in html
-    # The treemap tile, the ledger row, and now the constellation node all
-    # call the shared hover score-card builder — one call site each, inlined
-    # into the same bundle (item 6: bundle markers).
-    assert html.count("window.vizShared.buildScoreCard(") == 3
+    # The treemap tile, the ledger row, and the constellation's file node
+    # and dir tooltip all call the shared hover score-card builder — four
+    # call sites, inlined into the same bundle (item 6: bundle markers).
+    assert html.count("window.vizShared.buildScoreCard(") == 4
 
 
 def test_render_inlines_constellation_structural_hooks():

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -236,6 +236,24 @@ def test_render_inlines_constellation_view_bundle_and_playwright_hooks():
     assert "Show dependency constellation (experimental)" in html
 
 
+def test_render_inlines_constellation_interaction_hooks():
+    # Interaction parity (fidelity, prototype anatomy variant_B.js): the
+    # zoom/pan viewport clip, the reset-view control (same playwright-hook
+    # convention as the treemap's viz-treemap-reset), and the hover
+    # score-card wiring (reusing views/_shared.js's showTooltip/
+    # buildScoreCard, the same call the treemap tile makes) are all JS/CSS
+    # source — inlined regardless of scene content.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "viz-constellation-viewport" in html
+    assert "viz-constellation-reset" in html
+    assert "Reset view" in html
+    # The treemap tile, the ledger row, and now the constellation node all
+    # call the shared hover score-card builder — one call site each, inlined
+    # into the same bundle (item 6: bundle markers).
+    assert html.count("window.vizShared.buildScoreCard(") == 3
+
+
 def test_render_inlines_f3_drawer_meter_tooltip_and_axis_bar_hooks():
     # Fidelity F3 (drawer + content fidelity, spec §4.5): the drill drawer's
     # stage-shrink class, the shared per-axis meter row/mini-bar building

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -248,6 +248,10 @@ def test_render_inlines_constellation_interaction_hooks():
     assert "viz-constellation-viewport" in html
     assert "viz-constellation-reset" in html
     assert "Reset view" in html
+    # Recenter-on-resize wiring: the drill drawer narrows the viewport after
+    # mount, so the centered baseline is recomputed via a feature-guarded
+    # ResizeObserver and Reset view retargets the fresh baseline.
+    assert "ResizeObserver" in html
     # The treemap tile, the ledger row, and the constellation's file node
     # and dir tooltip all call the shared hover score-card builder — four
     # call sites, inlined into the same bundle (item 6: bundle markers).


### PR DESCRIPTION
## Summary

Bead `agents-config-yf2ov.2.11` — restore the V1 constellation view to functional parity with its prototype, per the 2026-07-18 conditional-keep verdict on the constellation eval (`.2.7`). Four commits, all scoped to `packages/vizsuite` static templates + their HTML smoke tests:

- **Commit 1 (interaction parity):** shared hover score card on nodes (same `showTooltip`/`buildScoreCard` wiring the treemap and ledger use), d3.zoom pan/zoom (scaleExtent [0.3, 6], dblclick-zoom disabled, node drags never pan), a "Reset view" control, drag-to-reposition with pin-on-drop and dblclick restore-to-settled-position, and a `focusOnNode` zoom-to mechanism.
- **Commit 2 (structural parity):** the prototype's core anatomy, derived entirely client-side from the scene JSON (no Python changes): directory super-nodes (MAX-aggregated axis stats over the whole estate, noise threshold + connectivity prune with an "N unconnected directories hidden" caption), dir–dir coupling edges rolled up from file-level dependency edges (width 1+log1p(n)), changed-file satellites tethered to their containing dir by dashed lines, and the prototype's five-entry legend.
- **Commit 3 (cosmetic parity):** 5-stop piecewise-LAB heat ramp (two new CSS tokens extending the existing cold/mid/hot anchors) and label culling (top-20 dirs by weight-independent load-bearing + changed-bonus, plus all satellites).
- **Commit 4 (HEAVY-gate fixes):** pointer capture in `wireDrag` (fast drags on small nodes no longer lose tracking), `buildDirTooltip` reuses `buildScoreCard` instead of duplicating its structure, and `rollUpDirEdges` resolves edge endpoints through the same nearest-surviving-ancestor walk satellites use, so coupling rooted in a noise-pruned leaf dir rolls up instead of vanishing.

## Ground truth for reviewers

- **Binding UX reference:** `docs/plans/visualization-suite/prototype/variant_B.js` (+ `shell.html` harness, `gen_data.py` lines ~225–256 for the dir-aggregation semantics). The implementation deliberately mirrors that anatomy; comments cite it.
- **Scope:** `packages/vizsuite/src/vizsuite/templates/static/views/constellation.js`, `.../static/scene.css`, `packages/vizsuite/tests/unit/test_templates_html.py`. Nothing else.
- **Deliberately preserved (do not flag as inconsistencies):** the default-off experimental constellation toggle (spec §6.1/§11 evaluation gate), the deterministic seeded layout (`mulberry32(1337)` + fixed-tick pre-settle) and the reencode-never-moves-nodes view contract, keyboard accessibility, unavailable-axis fail-soft, stale-graph badge.
- **Documented deviations from the literal prototype** (architecture-driven, intentional): dblclick un-pin snaps back to the originally-settled position instead of reheating a live simulation (this module has no persistent sim by contract); "Reset view" restores the render's computed centered baseline rather than a literal identity transform (layout box is sized from node count, not viewport); dir click focuses + shows the stats card rather than pushing a directory pseudo-record through the file drill panel (sonar/diff-link machinery is file-scoped).
- The design spec and implementation plan under `docs/` are dated point-in-time proposals; partial implementation relative to them is expected and not a defect.

## Testing

Static JS has no JS test runner in this repo; coverage is via the assembled-HTML smoke tests (`test_templates_html.py`, extended with interaction/structural/cosmetic hook assertions), `node --check` syntax verification, and a throwaway Node harness exercising the graph-building functions against synthetic scenes during development.

## Test Plan

- [x] `make ci-vizsuite` from the worktree root: 425 passed, 100.00% line+branch coverage, pip-audit clean, exit 0.
- [x] `make ci` aggregate from the worktree root: exit 0.
- [x] HEAVY quality-gate workflow (4 finder lenses × 2-refuter panels, 3 rounds): 2 applied fixes audited first-hand, 1 flagged major applied, 1 minor deferred with rationale on the bead, 1 stale finding dismissed with first-hand evidence.
- [x] Previously-red call-site assertion re-verified green after the score-card reuse (3→4 call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mww7th8A7MppZvL6J2rUcv
