### PR TITLE
fix(prgroom): crash-idempotent reply effects — markers + pre-flight adoption (z4m2h)

### DIFF
--- a/packages/prgroom/AGENTS.md
+++ b/packages/prgroom/AGENTS.md
@@ -77,10 +77,14 @@ exists.
 - Behavioural, not tautological — each test pins a coded decision, never the
   language/stdlib. Drive lifecycle functions through the fake `gh`/`git`/`Store`
   adapters and assert against observed calls/state.
-- Per-file Gh fakes are deliberate: each test module defines its own small
+- Per-file Gh fakes are the default: each test module defines its own small
   `GhClient`-level fake tailored to what it asserts (`_RecordingGh`, `FakeGh`,
-  …). Do not centralize them or cross-import a sibling test module's fake —
-  `tests/fakes.py` is scoped to the subprocess seam (`CommandRunner`) only.
+  …). Do not cross-import a sibling test module's fake. `tests/fakes.py` hosts
+  exactly two shared fakes: the subprocess seam (`CommandRunner`) and
+  `RecordingGh`, the reply-surface `GhClient` recorder shared by the reply
+  test modules — it records every call and those tests assert exact call
+  lists, so the permissive-default masking risk per-file fakes guard against
+  does not apply. Don't grow it into a general-purpose Gh fake.
 - Coverage floor is 90% branch (enforced by `pytest --cov`).
 
 ## Not installed by the installer

--- a/packages/prgroom/src/prgroom/gh/client.py
+++ b/packages/prgroom/src/prgroom/gh/client.py
@@ -83,6 +83,29 @@ class GhClient(Protocol):
     def add_label(self, ref: PRRef, label: str) -> None: ...  # pragma: no cover
 
 
+def _merge_paginated_output(out: str) -> Any:
+    """Merge ``gh api --paginate`` output into one list.
+
+    gh emits each page as its own JSON document back-to-back (``[...][...]``),
+    not one concatenated array — a bare ``json.loads`` raises ``Extra data`` on
+    page 2. Decode document-by-document and merge; a single page returns as-is.
+    """
+    decoder = json.JSONDecoder()
+    docs: list[Any] = []
+    idx, end = 0, len(out)
+    while idx < end:
+        doc, idx = decoder.raw_decode(out, idx)
+        docs.append(doc)
+        while idx < end and out[idx].isspace():
+            idx += 1
+    if len(docs) == 1:
+        return docs[0]
+    merged: list[Any] = []
+    for doc in docs:
+        merged.extend(doc)  # pages are arrays by the rest() paginate contract
+    return merged
+
+
 def _classify_gh_failure(stdout: str, stderr: str) -> PrgroomError | GhNotFoundError:
     """Map a failed ``gh`` invocation to its registry error (§3.6/§3.7)."""
     matches = _HTTP_STATUS.findall(stderr)
@@ -161,18 +184,22 @@ class GhCli:
     ) -> Any:
         argv = ["gh", "api", "--method", method, path]
         if paginate:
-            # gh walks every page and concatenates the JSON arrays into one, so a list
-            # read returns ALL items — not just GitHub's first 30. Only valid on GET
-            # collection endpoints (the callers that opt in); object endpoints must not
-            # set it (gh would emit one object per page, breaking json.loads).
+            # gh walks every page so a list read returns ALL items — not just
+            # GitHub's first 30. Only valid on GET collection endpoints (the
+            # callers that opt in); each page arrives as its OWN JSON array
+            # document, merged below.
             argv.append("--paginate")
         for key, value in (fields or {}).items():
             argv += ["-f", f"{key}={value}"]
         out = self._run(argv)
+        if not out.strip():
+            # An empty body (e.g. a 204) normalizes to {}.
+            return {}
+        if paginate:
+            return _merge_paginated_output(out)
         # gh api returns a JSON object, array, or primitive depending on the
-        # endpoint — the caller (which knows the endpoint) narrows. An empty body
-        # (e.g. a 204) normalizes to {}.
-        return json.loads(out) if out.strip() else {}
+        # endpoint — the caller (which knows the endpoint) narrows.
+        return json.loads(out)
 
     def graphql(self, query: str, variables: JsonObj) -> JsonObj:
         argv = ["gh", "api", "graphql", "-f", f"query={query}"]

--- a/packages/prgroom/src/prgroom/lifecycle/idempotency.py
+++ b/packages/prgroom/src/prgroom/lifecycle/idempotency.py
@@ -1,0 +1,88 @@
+"""Idempotency markers for remote reply effects (verb-atomicity spec §4).
+
+Pure helpers, no I/O. Every non-idempotent comment-creating call in ``reply_pr``
+appends a hidden, content-stable HTML-comment marker to the posted body; a
+pre-flight scan of the PR's comment listings adopts already-posted effects
+(records the id, flips the flag, skips the call) so a rerun from any stale
+pre-call state converges without duplicates. GitHub — not the local state file —
+is the source of truth for "was this posted". ``poll`` uses the same grammar as a
+state-independent ingest backstop (never re-ingest prgroom's own posted effect).
+
+The ``prgroom:`` namespace extends the existing ``<!-- prgroom:decisions:start -->``
+sentinel family. Matching is strict full-grammar everywhere — prose *mentioning* a
+marker cannot be mis-adopted or mis-skipped.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from prgroom.prsession.state import ReviewItem, RoutedMemory
+
+JsonObj = dict[str, Any]
+
+_MARKER_RE = re.compile(r"<!-- prgroom:(?:reply|mem):\S+ -->")
+
+
+def reply_marker(item: ReviewItem) -> str:
+    """Stable marker for the one reply this item ever gets.
+
+    Keyed on the logical effect identity — the ``(kind, gh_id)`` natural key —
+    not body content: ``replied`` is monotonic, so one item gets at most one POST
+    over its lifetime, while bodies may legally differ across cycles (the
+    empty-rationale → later-rationale path). Adoption is body-independent.
+    """
+    return f"<!-- prgroom:reply:{item.kind.value}:{item.identity.gh_id} -->"
+
+
+def memory_marker(rm: RoutedMemory) -> str:
+    """Globally-unique marker for one routed-memory thread reply.
+
+    A readable batch-key prefix (whitespace-sanitized for marker-grammar safety)
+    plus a content digest that carries the identity: ``(retry, source_item)`` is
+    only batch-unique (the ordinal restarts per resolve call; cluster ids are
+    LLM-minted), so the sha256 digest over ``(retry, source_item, target_hint,
+    content)`` restores global uniqueness. It is crash-stable — a rerun replays
+    the same persisted entries verbatim, so the digest re-derives byte-identically.
+    Entries identical in all four fields collide by construction; skipping such a
+    duplicate is correct dedup, not loss.
+    """
+    digest = hashlib.sha256(
+        f"{rm.retry}\x1f{rm.source_item}\x1f{rm.target_hint or ''}\x1f{rm.content}".encode()
+    ).hexdigest()[:12]
+    prefix = re.sub(r"\s+", "-", f"r{rm.retry}:{rm.source_item}")
+    return f"<!-- prgroom:mem:{prefix}:{digest} -->"
+
+
+def with_marker(body: str, marker: str) -> str:
+    """Append the hidden marker on its own trailing paragraph."""
+    return f"{body}\n\n{marker}"
+
+
+def scan_markers(*comment_lists: list[JsonObj]) -> dict[str, int]:
+    """Map each full marker string found in any comment body to that comment's id.
+
+    First occurrence wins — the earliest (original) comment claims the marker;
+    listing order is ascending (§11 ledger). Entries with a missing/zero/unusable
+    ``id`` are skipped: an adoption must record a real comment id or not happen.
+    """
+    found: dict[str, int] = {}
+    for comments in comment_lists:
+        for entry in comments:
+            try:
+                comment_id = int(entry.get("id"))  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+            if not comment_id:
+                continue
+            for match in _MARKER_RE.finditer(str(entry.get("body") or "")):
+                found.setdefault(match.group(0), comment_id)
+    return found
+
+
+def carries_own_marker(body: str) -> bool:
+    """True iff ``body`` contains a full-grammar prgroom idempotency marker."""
+    return bool(_MARKER_RE.search(body))

--- a/packages/prgroom/src/prgroom/lifecycle/poll.py
+++ b/packages/prgroom/src/prgroom/lifecycle/poll.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 from prgroom.gh.client import GhNotFoundError
 from prgroom.gh.review_threads import fetch_thread_id_map
 from prgroom.lifecycle.gh_errors import vanished_pr_terminal
+from prgroom.lifecycle.idempotency import carries_own_marker
 from prgroom.lifecycle.predicates import flip_stale_required_reviews
 from prgroom.lifecycle.quiescence import evaluate_reviewer_timeouts
 from prgroom.prsession.enums import ItemKind, PRPhase, ReviewerStatus
@@ -231,6 +232,12 @@ def _ingest_items(
                 # carries nothing reviewable regardless of author or state — a real
                 # verdict still lands via _terminal_review_verdicts, which reads the
                 # full reviews response, not the ingested items.
+                continue
+            if carries_own_marker(str(entry.get("body") or "")):
+                # prgroom's own posted effect — never ingest, ledger or no ledger.
+                # The state-independent backstop for the crash window where a POST
+                # landed but the persist recording own_reply_id was discarded
+                # (verb-atomicity §6). Content-keyed, never author-keyed.
                 continue
             item = _to_item(kind, entry, ts_field, now=now, thread_id_map=thread_id_map)
             if item.identity.gh_id in own_replies:

--- a/packages/prgroom/src/prgroom/lifecycle/reply.py
+++ b/packages/prgroom/src/prgroom/lifecycle/reply.py
@@ -211,15 +211,17 @@ def _route_memory(
     state: PRGroomingState, *, gh: GhClient, ref: PRRef, markers: Mapping[str, int]
 ) -> None:
     thread_less: list[RoutedMemory] = []
+    posted: set[str] = set()  # the pre-flight snapshot can't see this pass's own POSTs
     for rm in state.pending_memory:
         if rm.target_hint is not None:
             marker = memory_marker(rm)
-            if marker in markers:
-                continue  # already posted on a prior partial pass — adopt, don't re-post
+            if marker in markers or marker in posted:
+                continue  # already posted (prior partial pass, or earlier this pass)
             gh.graphql(
                 _ADD_THREAD_REPLY,
                 {"threadId": rm.target_hint, "body": with_marker(rm.content, marker)},
             )
+            posted.add(marker)
         else:
             thread_less.append(rm)
     if thread_less:

--- a/packages/prgroom/src/prgroom/lifecycle/reply.py
+++ b/packages/prgroom/src/prgroom/lifecycle/reply.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from prgroom.agent.prompt_loader import PromptTemplate
 from prgroom.gh.client import GhNotFoundError
 from prgroom.lifecycle.gh_errors import vanished_pr_terminal
+from prgroom.lifecycle.idempotency import memory_marker, reply_marker, scan_markers, with_marker
 from prgroom.lifecycle.snapshot import (
     DECISIONS_END,
     DECISIONS_START,
@@ -18,6 +19,8 @@ from prgroom.prsession.enums import DispositionKind, ItemKind
 from prgroom.prsession.state import RoutedMemory
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from prgroom.gh.client import GhClient
     from prgroom.prsession.pr_ref import PRRef
     from prgroom.prsession.state import Disposition, PRGroomingState, ReviewItem
@@ -157,11 +160,66 @@ def merge_decisions_block(body: str, entries: list[RoutedMemory]) -> str:
     return _splice_block(body, block)
 
 
-def _route_memory(state: PRGroomingState, *, gh: GhClient, ref: PRRef) -> None:
+def _needs_post(item: ReviewItem) -> bool:
+    """True iff this invocation may POST a reply for ``item`` (the §5 surface gate).
+
+    Mirrors the item-loop gates minus the render: an unreplied item with a
+    replyable disposition off the bookkeeping-only no-post path. An item whose
+    body will render empty still counts — one tolerated over-fetch beats a
+    pre-render pass (assumption ledger).
+    """
+    return (
+        not item.replied
+        and item.disposition is not None
+        and item.disposition.kind in _REPLYABLE
+        and not (
+            item.kind is not ItemKind.REVIEW_THREAD and item.disposition.kind in _BOOKKEEPING_ONLY
+        )
+    )
+
+
+def _reply_surfaces(state: PRGroomingState) -> tuple[bool, bool]:
+    """``(need_issue_comments, need_review_comments)`` for this invocation.
+
+    ``REVIEW_THREAD`` items and target-hinted ``pending_memory`` entries post to
+    the review-comment surface (thread replies land in ``pulls/{n}/comments``);
+    every other replyable item posts to the issue-comment surface. Thread-less
+    memory routes via the PR-body PATCH, which needs no scan (content-addressed).
+    """
+    need_issue = any(_needs_post(i) and i.kind is not ItemKind.REVIEW_THREAD for i in state.items)
+    need_review = any(_needs_post(i) and i.kind is ItemKind.REVIEW_THREAD for i in state.items)
+    need_review = need_review or any(rm.target_hint is not None for rm in state.pending_memory)
+    return need_issue, need_review
+
+
+def _existing_markers(gh: GhClient, ref: PRRef, *, issue: bool, review: bool) -> dict[str, int]:
+    """Pre-flight scan (§5): map already-posted effect markers to their comment ids.
+
+    At most two paginated reads; zero gh calls when neither surface is needed —
+    the no-op-when-all-replied contract survives at zero cost.
+    """
+    listings: list[list[dict[str, object]]] = []
+    base = f"repos/{ref.owner}/{ref.repo}"
+    if issue:
+        listings.append(gh.rest("GET", f"{base}/issues/{ref.number}/comments", paginate=True))
+    if review:
+        listings.append(gh.rest("GET", f"{base}/pulls/{ref.number}/comments", paginate=True))
+    return scan_markers(*listings) if listings else {}
+
+
+def _route_memory(
+    state: PRGroomingState, *, gh: GhClient, ref: PRRef, markers: Mapping[str, int]
+) -> None:
     thread_less: list[RoutedMemory] = []
     for rm in state.pending_memory:
         if rm.target_hint is not None:
-            gh.graphql(_ADD_THREAD_REPLY, {"threadId": rm.target_hint, "body": rm.content})
+            marker = memory_marker(rm)
+            if marker in markers:
+                continue  # already posted on a prior partial pass — adopt, don't re-post
+            gh.graphql(
+                _ADD_THREAD_REPLY,
+                {"threadId": rm.target_hint, "body": with_marker(rm.content, marker)},
+            )
         else:
             thread_less.append(rm)
     if thread_less:
@@ -194,6 +252,8 @@ def reply_pr(
     """
     state = copy.deepcopy(state)
     try:
+        need_issue, need_review = _reply_surfaces(state)
+        markers = _existing_markers(gh, ref, issue=need_issue, review=need_review)
         for item in state.items:
             if item.replied or item.disposition is None:
                 continue
@@ -208,6 +268,16 @@ def reply_pr(
                 # item is never revisited.
                 item.replied = True
                 continue
+            marker = reply_marker(item)
+            adopted = markers.get(marker)
+            if adopted is not None:
+                # A prior partial pass already posted this reply; the persist that
+                # would have recorded it was discarded. GitHub is the source of
+                # truth — adopt the effect. This also recovers the real comment id
+                # when the original POST response was malformed (id degraded to 0).
+                item.own_reply_id = adopted
+                item.replied = True
+                continue
             body = _render_body(item.disposition)
             if not body.strip():
                 # A rationale-rendered disposition (SKIPPED/DEFERRED/WONT_FIX) with an empty
@@ -215,9 +285,9 @@ def reply_pr(
                 # --rationale). Posting "" fails the GitHub API; skip it and leave `replied`
                 # False so a later rationale can still reply.
                 continue
-            item.own_reply_id = _post_reply(gh, ref, item, body)
+            item.own_reply_id = _post_reply(gh, ref, item, with_marker(body, marker))
             item.replied = True
-        _route_memory(state, gh=gh, ref=ref)
+        _route_memory(state, gh=gh, ref=ref, markers=markers)
     except GhNotFoundError as exc:
         raise vanished_pr_terminal(ref) from exc
     return state

--- a/packages/prgroom/src/prgroom/lifecycle/run.py
+++ b/packages/prgroom/src/prgroom/lifecycle/run.py
@@ -19,6 +19,16 @@ without gh/git — production wires :meth:`Verbs.system`; tests pass fakes. The 
 flush hooks (``escalate_if_needed`` + ``request_human_review_if_needed``) fire at
 exactly two dedup-safe sites: the loop-top terminal-for-CLI check, and immediately
 before each ``PROPAGATE`` re-raise.
+
+**Effect-idempotency invariant:** every remote mutation a verb issues must be safe
+to re-issue on a rerun from the pre-call state: naturally idempotent server-side
+(``resolve``'s ``resolveReviewThread``), guarded by a natural existence check
+(``push``'s ``has_queued_fix_commits``), content-addressed (the Decisions-block
+merge), or marker-guarded via pre-flight existence adoption (``reply``'s item POSTs
+and memory thread replies — ``lifecycle/idempotency.py``). The single-persist
+contract discards a raising verb's progress by design; each effect must tolerate
+that. A future verb adding a remote mutation must name its mechanism against this
+invariant at design time.
 """
 
 from __future__ import annotations

--- a/packages/prgroom/tests/fakes.py
+++ b/packages/prgroom/tests/fakes.py
@@ -1,18 +1,21 @@
-"""Test fakes for the subprocess boundary (§7.6).
+"""Test fakes for the subprocess and gh-protocol boundaries (§7.6).
 
 The gh/git adapters reach the outside world through a single seam — the
 :class:`~prgroom.proc.CommandRunner` Protocol. These fakes structurally satisfy
 that Protocol so adapter tests inject recorded responses instead of mocking code
 we own. This is the spec's "mock only at the system boundary" discipline: the
 boundary is the subprocess call, and a runner is the smallest honest stand-in
-for it.
+for it. :class:`RecordingGh` is the protocol-seam sibling for lifecycle verbs
+that take a :class:`~prgroom.gh.client.GhClient` directly.
 """
 
 from __future__ import annotations
 
 import subprocess
 from collections.abc import Sequence
+from typing import Any
 
+from prgroom.errors import ErrorCode, PrgroomError, Tier
 from prgroom.proc import CommandResult
 
 
@@ -46,6 +49,67 @@ class RecordedRunner:
             msg = f"RecordedRunner exhausted: unexpected call {list(argv)!r}"
             raise AssertionError(msg)
         return self._results.pop(0)
+
+
+class RecordingGh:
+    """A :class:`~prgroom.gh.client.GhClient`-protocol fake for reply/verb tests.
+
+    Records ``rest_calls`` / ``graphql_calls``. Constructor knobs:
+
+    - ``post_reply_id`` — the ``id`` every POST response carries (``None`` → ``{}``,
+      the malformed-response shape).
+    - ``pr_body`` — the ``GET pulls/{n}`` body (the Decisions-block read).
+    - ``listed`` — GET path → canned comment listing; unlisted list-paths (any
+      path ending ``/comments``) return ``[]``.
+    - ``fail_at`` — ``(surface, n)``: raise a transient gh error on the n-th call
+      of the named surface (``"post"`` | ``"graphql"``), modelling a mid-loop
+      partial failure.
+    """
+
+    def __init__(
+        self,
+        post_reply_id: int | None = None,
+        pr_body: str = "",
+        listed: dict[str, list[dict[str, Any]]] | None = None,
+        fail_at: tuple[str, int] | None = None,
+    ) -> None:
+        self.rest_calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.graphql_calls: list[tuple[str, dict[str, Any]]] = []
+        self._post_reply_id = post_reply_id
+        self._pr_body = pr_body
+        self._listed = dict(listed or {})
+        self._fail_at = fail_at
+        self._surface_counts = {"post": 0, "graphql": 0}
+
+    def _maybe_fail(self, surface: str) -> None:
+        self._surface_counts[surface] += 1
+        if self._fail_at is not None and (surface, self._surface_counts[surface]) == self._fail_at:
+            raise PrgroomError(tier=Tier.RUNTIME_TRANSIENT, code=ErrorCode.RUNTIME_GH_TRANSIENT)
+
+    def rest(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict[str, Any] | None = None,
+        paginate: bool = False,  # noqa: ARG002  # part of the Protocol signature; recorded calls suffice
+    ) -> Any:
+        self.rest_calls.append((method, path, dict(fields or {})))
+        if method == "POST":
+            self._maybe_fail("post")
+            return {"id": self._post_reply_id} if self._post_reply_id is not None else {}
+        if method == "GET":
+            if path in self._listed:
+                return self._listed[path]
+            if path.endswith("/comments"):
+                return []
+            return {"body": self._pr_body}
+        return {}
+
+    def graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        self.graphql_calls.append((query, dict(variables)))
+        self._maybe_fail("graphql")
+        return {}
 
 
 class TimeoutRunner:

--- a/packages/prgroom/tests/unit/test_cli_reply_resolve_escalated.py
+++ b/packages/prgroom/tests/unit/test_cli_reply_resolve_escalated.py
@@ -26,7 +26,7 @@ from prgroom.prsession.state import (
     QuiescenceState,
     ReviewItem,
 )
-from tests.fakes import RecordedRunner
+from tests.fakes import RecordedRunner, RecordingGh
 
 runner = CliRunner()
 
@@ -39,31 +39,6 @@ class _FakeGit:
 
     def config_user(self) -> str:
         return "tester"
-
-
-class _RecordingGh:
-    """Minimal ``GhClient`` stand-in recording the reply POST; reply_pr ignores returns."""
-
-    def __init__(self) -> None:
-        self.rest_calls: list[tuple[str, str, dict]] = []
-        self.graphql_calls: list[tuple[str, dict]] = []
-
-    def rest(
-        self,
-        method: str,
-        path: str,
-        *,
-        fields: dict | None = None,
-        paginate: bool = False,  # noqa: ARG002  # Protocol signature; the pre-flight scan passes it
-    ) -> dict | list:
-        self.rest_calls.append((method, path, dict(fields or {})))
-        if method == "GET" and path.endswith("/comments"):
-            return []  # the idempotency pre-flight scan reads an empty listing
-        return {}
-
-    def graphql(self, query: str, variables: dict) -> dict:
-        self.graphql_calls.append((query, dict(variables)))
-        return {}
 
 
 def _fixed_item() -> ReviewItem:
@@ -129,7 +104,7 @@ def test_reply_posts_and_persists_replied(
 ) -> None:
     # Happy path: the lock wrapper reads state, runs the real reply_pr (which POSTs),
     # and writes the replied flag back. Proves the CLI wiring, not just the no-state gate.
-    gh = _RecordingGh()
+    gh = RecordingGh()
     monkeypatch.setattr(cli, "_build_gh", lambda: gh)
     state = PRGroomingState(
         pr=_REF,

--- a/packages/prgroom/tests/unit/test_cli_reply_resolve_escalated.py
+++ b/packages/prgroom/tests/unit/test_cli_reply_resolve_escalated.py
@@ -48,8 +48,17 @@ class _RecordingGh:
         self.rest_calls: list[tuple[str, str, dict]] = []
         self.graphql_calls: list[tuple[str, dict]] = []
 
-    def rest(self, method: str, path: str, *, fields: dict | None = None) -> dict:
+    def rest(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict | None = None,
+        paginate: bool = False,  # noqa: ARG002  # Protocol signature; the pre-flight scan passes it
+    ) -> dict | list:
         self.rest_calls.append((method, path, dict(fields or {})))
+        if method == "GET" and path.endswith("/comments"):
+            return []  # the idempotency pre-flight scan reads an empty listing
         return {}
 
     def graphql(self, query: str, variables: dict) -> dict:
@@ -135,7 +144,13 @@ def test_reply_posts_and_persists_replied(
     result = runner.invoke(cli.app, ["reply", "octo/demo#7"])
     assert result.exit_code == 0, result.output
     assert gh.rest_calls == [
-        ("POST", "repos/octo/demo/pulls/7/comments/555/replies", {"body": "Fixed in abc1234."})
+        # The pre-flight idempotency scan reads the review-comments surface first.
+        ("GET", "repos/octo/demo/pulls/7/comments", {}),
+        (
+            "POST",
+            "repos/octo/demo/pulls/7/comments/555/replies",
+            {"body": "Fixed in abc1234.\n\n<!-- prgroom:reply:review_thread:555 -->"},
+        ),
     ]
     assert patched.read(_REF).items[0].replied is True
 

--- a/packages/prgroom/tests/unit/test_gh_fit.py
+++ b/packages/prgroom/tests/unit/test_gh_fit.py
@@ -321,6 +321,26 @@ def test_permissions_403_mentioning_rate_limit_stays_terminal() -> None:
 # ── REST empty-body (204) ──
 
 
+def test_rest_paginate_merges_page_delimited_output() -> None:
+    # Real ``gh api --paginate`` emits each page as its OWN JSON document
+    # back-to-back (``[...][...]``) — not one concatenated array. A bare
+    # ``json.loads`` raises JSONDecodeError on the second document, so a
+    # multi-page listing froze every paginated caller. rest() must parse the
+    # page-delimited stream and merge the page arrays into one list.
+    runner = RecordedRunner([_ok('[{"id": 1}, {"id": 2}]\n[{"id": 3}]')])
+    client = GhCli(runner)
+    out = client.rest("GET", "repos/octo/demo/pulls/7/comments", paginate=True)
+    assert out == [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert "--paginate" in runner.calls[0]
+
+
+def test_rest_paginate_single_page_returns_the_array() -> None:
+    # One page (the common case) is a single well-formed array — returned as-is.
+    runner = RecordedRunner([_ok('[{"id": 9}]')])
+    client = GhCli(runner)
+    assert client.rest("GET", "repos/octo/demo/pulls/7/comments", paginate=True) == [{"id": 9}]
+
+
 def test_rest_empty_body_returns_empty_dict() -> None:
     # A 204 No Content (e.g. DELETE) returns an empty stdout; rest() must yield {}.
     runner = RecordedRunner([_ok("")])

--- a/packages/prgroom/tests/unit/test_lifecycle_poll.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_poll.py
@@ -368,6 +368,42 @@ def test_own_posted_reply_is_not_ingested_as_new_item() -> None:
     assert "12" in ingested_ids  # a different comment still ingested (no over-filter)
 
 
+def test_ingest_skips_marker_bearing_comment_without_ledger_entry() -> None:
+    # Verb-atomicity §6 / behavior 9 — the PR #211 recursive-echo regression guard
+    # (the ledger-lost window): a crash after a POST but before persist loses
+    # own_reply_id, so the ledger set cannot exclude the posted comment. The
+    # idempotency marker in its body is the state-independent backstop: never
+    # ingest prgroom's own posted effect, ledger or no ledger.
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    marked = {
+        "id": 500,
+        "user": {"login": "some-bot"},
+        "body": "Fixed in abc1234.\n\n<!-- prgroom:reply:issue_comment:12 -->",
+        "created_at": "2026-06-09T11:00:00Z",
+    }
+    gh = _gh(head_oid="same", issue_comments=[marked, _issue_comment(12)])
+    state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
+    ingested_ids = {i.identity.gh_id for i in state.items}
+    assert "500" not in ingested_ids  # marker-bearing == our own effect, dropped
+    assert "12" in ingested_ids
+
+
+def test_ingest_keeps_marker_free_comments_from_any_author() -> None:
+    # Verb-atomicity §6 / behavior 10: strict full-grammar matching — a comment
+    # merely MENTIONING "prgroom:reply" in prose (any author) still ingests.
+    # Exclusion stays content-keyed, never author-keyed.
+    start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")
+    prose = {
+        "id": 600,
+        "user": {"login": "copilot"},
+        "body": "the prgroom:reply:issue_comment:12 marker convention looks fine to me",
+        "created_at": "2026-06-09T11:00:00Z",
+    }
+    gh = _gh(head_oid="same", issue_comments=[prose])
+    state = poll_pr(start, ref=_REF, gh=gh, deps=_deps(), config=_config())
+    assert {i.identity.gh_id for i in state.items} == {"600"}
+
+
 def test_top_level_review_comment_has_no_parent() -> None:
     # A top-level inline comment carries no in_reply_to_id → reply_to_comment_id 0.
     start = _state(phase=PRPhase.AWAITING_REVIEW, last_poll_sha="same")

--- a/packages/prgroom/tests/unit/test_lifecycle_resolve.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_resolve.py
@@ -106,6 +106,39 @@ def test_resolve_skips_an_already_resolved_thread() -> None:
     assert out.items[0].resolved is True
 
 
+def test_resolve_rerun_reissues_idempotent_mutation_after_midloop_failure() -> None:
+    # Verb-atomicity §3 audit / behavior 11: resolveReviewThread is idempotent
+    # server-side, so resolve needs no markers — a mid-loop failure discards the
+    # deepcopy, and the rerun harmlessly re-issues BOTH mutations. This pins the
+    # reasoning resolve.py documents, which had zero retry-path coverage.
+    import pytest
+
+    from prgroom.errors import PrgroomError
+
+    def fresh_state() -> PRGroomingState:
+        return _state(
+            _item(gh_id="1", thread_id="PRRT_a", disposition=_disp(DispositionKind.FIXED)),
+            _item(gh_id="2", thread_id="PRRT_b", disposition=_disp(DispositionKind.FIXED)),
+        )
+
+    failing = CommandResult(
+        returncode=1,
+        stdout=json.dumps({"message": "boom", "status": "500"}),
+        stderr="gh: boom (HTTP 500)",
+    )
+    state = fresh_state()
+    run1 = RecordedRunner([_resolved_ok(), failing])
+    with pytest.raises(PrgroomError):
+        resolve_pr(state, gh=GhCli(run1))
+    assert len(run1.calls) == 2  # first resolved, second raised
+    assert [i.resolved for i in state.items] == [False, False]  # deepcopy discarded
+
+    run2 = RecordedRunner([_resolved_ok(), _resolved_ok()])
+    out = resolve_pr(state, gh=GhCli(run2))
+    assert len(run2.calls) == 2  # both re-issued — server-side idempotency absorbs it
+    assert [i.resolved for i in out.items] == [True, True]
+
+
 def test_resolve_ignores_non_resolvable_dispositions() -> None:
     runner = RecordedRunner([])
     out = resolve_pr(

--- a/packages/prgroom/tests/unit/test_lifecycle_resolve.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_resolve.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+import pytest
+
+from prgroom.errors import PrgroomError
 from prgroom.gh import GhCli
 from prgroom.lifecycle.resolve import resolve_pr
 from prgroom.proc import CommandResult
@@ -111,9 +114,6 @@ def test_resolve_rerun_reissues_idempotent_mutation_after_midloop_failure() -> N
     # server-side, so resolve needs no markers — a mid-loop failure discards the
     # deepcopy, and the rerun harmlessly re-issues BOTH mutations. This pins the
     # reasoning resolve.py documents, which had zero retry-path coverage.
-    import pytest
-
-    from prgroom.errors import PrgroomError
 
     def fresh_state() -> PRGroomingState:
         return _state(

--- a/packages/prgroom/tests/unit/test_lifecycle_run.py
+++ b/packages/prgroom/tests/unit/test_lifecycle_run.py
@@ -81,8 +81,10 @@ class FakeGh:
     def add_label(self, ref: PRRef, label: str) -> None:
         self.added.append((ref, label))
 
-    def rest(self, method: str, path: str, *, fields=None) -> dict:
+    def rest(self, method: str, path: str, *, fields=None, paginate: bool = False) -> dict | list:  # noqa: ARG002
         self.rest_calls.append((method, path, dict(fields or {})))
+        if method == "GET" and path.endswith("/comments"):
+            return []  # the idempotency pre-flight scan reads an empty listing
         return {}
 
 
@@ -637,7 +639,13 @@ def test_run_drives_real_reply_posts_for_replyable_item() -> None:
     assert out.phase is PRPhase.QUIESCED
     assert out.items[0].replied is True
     assert gh.rest_calls == [
-        ("POST", "repos/octo/demo/pulls/7/comments/1/replies", {"body": "Fixed in abc1234."})
+        # The pre-flight idempotency scan reads the review-comments surface first.
+        ("GET", "repos/octo/demo/pulls/7/comments", {}),
+        (
+            "POST",
+            "repos/octo/demo/pulls/7/comments/1/replies",
+            {"body": "Fixed in abc1234.\n\n<!-- prgroom:reply:review_thread:1 -->"},
+        ),
     ]
 
 

--- a/packages/prgroom/tests/unit/test_reply_memory_routing.py
+++ b/packages/prgroom/tests/unit/test_reply_memory_routing.py
@@ -110,6 +110,23 @@ def test_thread_hint_routes_via_graphql_and_clears() -> None:
     assert out.pending_memory == []
 
 
+def test_identical_pending_memory_posts_once_within_a_pass() -> None:
+    # Two identical target-hinted entries (same retry/source/hint/content — e.g. two
+    # fix dispatches in one retry reusing a minted cluster id) derive the SAME marker.
+    # The pre-flight snapshot can't see this pass's own first POST, so an in-pass
+    # seen set must absorb the second entry: one GraphQL reply, not two.
+    gh = RecordingGh()
+    dup = [
+        RoutedMemory(
+            content="why", retry=1, source_item="c1#0", decided_by="a", target_hint="PRRT_abc"
+        )
+        for _ in range(2)
+    ]
+    out = reply_pr(_state_with_pending(dup), gh=gh, ref=_ref())
+    assert len(gh.graphql_calls) == 1
+    assert out.pending_memory == []
+
+
 def test_thread_less_routes_via_patch_and_clears() -> None:
     gh = _RecordingGh(body="orig body")
     state = _state_with_pending(

--- a/packages/prgroom/tests/unit/test_reply_memory_routing.py
+++ b/packages/prgroom/tests/unit/test_reply_memory_routing.py
@@ -1,10 +1,12 @@
 from datetime import UTC, datetime
 
+from prgroom.lifecycle.idempotency import memory_marker, with_marker
 from prgroom.lifecycle.reply import _sanitize, merge_decisions_block, reply_pr
 from prgroom.lifecycle.snapshot import DECISIONS_START, extract_decisions_block
 from prgroom.prsession.enums import PRPhase
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import RoutedMemory, bootstrap_state
+from tests.fakes import RecordingGh
 
 _NOW = datetime(2026, 6, 19, tzinfo=UTC)
 
@@ -96,17 +98,15 @@ def test_merge_appends_distinct_same_retry_keys() -> None:
 
 
 def test_thread_hint_routes_via_graphql_and_clears() -> None:
-    gh = _RecordingGh()
-    state = _state_with_pending(
-        [
-            RoutedMemory(
-                content="why", retry=1, source_item="c1#0", decided_by="a", target_hint="PRRT_abc"
-            )
-        ]
+    # Uses the shared RecordingGh: a target-hinted entry triggers the pre-flight
+    # review-comments scan, and the posted body carries the §4 memory marker.
+    gh = RecordingGh()
+    rm = RoutedMemory(
+        content="why", retry=1, source_item="c1#0", decided_by="a", target_hint="PRRT_abc"
     )
-    out = reply_pr(state, gh=gh, ref=_ref())
+    out = reply_pr(_state_with_pending([rm]), gh=gh, ref=_ref())
     assert gh.graphql_calls and gh.graphql_calls[0][1]["threadId"] == "PRRT_abc"
-    assert gh.graphql_calls[0][1]["body"] == "why"
+    assert gh.graphql_calls[0][1]["body"] == with_marker("why", memory_marker(rm))
     assert out.pending_memory == []
 
 

--- a/packages/prgroom/tests/unit/test_reply_partial_failure.py
+++ b/packages/prgroom/tests/unit/test_reply_partial_failure.py
@@ -1,0 +1,259 @@
+"""Partial-failure crash-idempotency for ``reply_pr`` (verb-atomicity spec §5/§10.1).
+
+The single-persist contract discards a raising verb's progress; these tests pin the
+marker + pre-flight-adoption mechanism that makes every remote reply effect safe to
+re-issue from the pre-call state. The gh seam is :class:`tests.fakes.RecordingGh`
+(protocol fake, never a live call); a "run" is one ``reply_pr`` invocation whose
+raise discards its return value exactly as ``_execute_step`` would.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from prgroom.errors import PrgroomError
+from prgroom.lifecycle.idempotency import (
+    memory_marker,
+    reply_marker,
+    scan_markers,
+    with_marker,
+)
+from prgroom.lifecycle.reply import reply_pr
+from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
+from prgroom.prsession.pr_ref import PRRef
+from prgroom.prsession.state import (
+    Disposition,
+    Identity,
+    ReviewItem,
+    RoutedMemory,
+    bootstrap_state,
+)
+from tests.fakes import RecordingGh
+
+_NOW = datetime(2026, 6, 19, tzinfo=UTC)
+_REF = PRRef(owner="o", repo="r", number=7)
+_ISSUE_COMMENTS = "repos/o/r/issues/7/comments"
+_REVIEW_COMMENTS = "repos/o/r/pulls/7/comments"
+
+
+def _item(kind: ItemKind, gh_id: str, disp: DispositionKind, **disp_kw: object) -> ReviewItem:
+    return ReviewItem(
+        kind=kind,
+        identity=Identity(gh_id=gh_id),
+        author="rev",
+        body_excerpt="b",
+        seen_at=_NOW,
+        disposition=Disposition(kind=disp, decided_at=_NOW, decided_by="agent", **disp_kw),  # type: ignore[arg-type]
+    )
+
+
+def _state(items: list[ReviewItem], pending: list[RoutedMemory] | None = None):
+    s = bootstrap_state(_REF, now=_NOW)
+    s.phase = PRPhase.FIXES_PENDING
+    s.items = items
+    s.pending_memory = pending or []
+    return s
+
+
+def test_partial_failure_rerun_does_not_duplicate_posted_reply() -> None:
+    # §10.1 behavior 1 — THE bead's required partial-failure regression test (the
+    # PR #211 duplicate-reply shape). Run 1: item A's POST succeeds (id 91), item
+    # B's POST raises transient → reply_pr raises; its return value is discarded
+    # exactly as _execute_step discards a raising verb's deepcopy. Run 2 from the
+    # UNCHANGED pre-call state: the pre-flight scan finds A's marker on GitHub and
+    # adopts it — exactly one POST for A across both runs, B posts on run 2.
+    def fresh_items() -> list[ReviewItem]:
+        return [
+            _item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.FIXED, commits=["abc1234"]),
+            _item(ItemKind.ISSUE_COMMENT, "13", DispositionKind.FIXED, commits=["def5678"]),
+        ]
+
+    state = _state(fresh_items())
+    gh1 = RecordingGh(post_reply_id=91, fail_at=("post", 2))
+    with pytest.raises(PrgroomError):
+        reply_pr(state, gh=gh1, ref=_REF)
+    # The raise discarded the deepcopy; the caller's state is byte-unchanged.
+    assert [i.replied for i in state.items] == [False, False]
+
+    marker_a = reply_marker(state.items[0])
+    gh2 = RecordingGh(
+        post_reply_id=92,
+        listed={_ISSUE_COMMENTS: [{"id": 91, "body": with_marker("Fixed in abc1234.", marker_a)}]},
+    )
+    out = reply_pr(state, gh=gh2, ref=_REF)
+
+    posts_run1 = [(m, p) for m, p, _ in gh1.rest_calls if m == "POST"]
+    posts_run2 = [(m, p) for m, p, _ in gh2.rest_calls if m == "POST"]
+    # Run 1 attempted two POSTs (A succeeded, B raised); run 2 posts ONLY B.
+    assert len(posts_run1) == 2
+    assert len(posts_run2) == 1
+    assert [i.replied for i in out.items] == [True, True]
+    assert out.items[0].own_reply_id == 91  # adopted from the listing, not re-posted
+    assert out.items[1].own_reply_id == 92
+
+
+def test_posted_reply_body_carries_item_marker() -> None:
+    # §10.1 behavior 2: the wire contract the scan and the poll backstop both
+    # depend on — every posted reply body ends with the full-grammar marker.
+    # Contract-pinning, not tautology.
+    thread = ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id="55", reply_to_comment_id=55),
+        author="rev",
+        body_excerpt="b",
+        seen_at=_NOW,
+        disposition=Disposition(
+            kind=DispositionKind.FIXED, decided_at=_NOW, decided_by="agent", commits=["abc1234"]
+        ),
+    )
+    issue = _item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)
+    gh = RecordingGh(post_reply_id=1)
+    reply_pr(_state([thread, issue]), gh=gh, ref=_REF)
+    bodies = [f["body"] for m, _, f in gh.rest_calls if m == "POST"]
+    assert bodies[0].endswith("\n\n<!-- prgroom:reply:review_thread:55 -->")
+    assert bodies[1].endswith("\n\n<!-- prgroom:reply:issue_comment:12 -->")
+
+
+def test_adoption_recovers_reply_id_lost_to_malformed_post_response() -> None:
+    # §10.1 behavior 3: run 1's POST response had no usable id (own_reply_id
+    # degraded to 0, the ledger blind spot); run 2's listing carries the marker
+    # with the real id → adoption records it without a POST.
+    state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.FIXED)])
+    marker = reply_marker(state.items[0])
+    gh = RecordingGh(listed={_ISSUE_COMMENTS: [{"id": 77, "body": with_marker("Fixed.", marker)}]})
+    out = reply_pr(state, gh=gh, ref=_REF)
+    assert [(m, p) for m, p, _ in gh.rest_calls if m == "POST"] == []
+    assert out.items[0].own_reply_id == 77
+    assert out.items[0].replied is True
+
+
+def test_noop_reply_makes_zero_gh_calls() -> None:
+    # §10.1 behavior 4 (cost pin): all items replied, no pending memory → no GET,
+    # no POST, no GraphQL — the no-op contract survives the pre-flight scan.
+    item = _item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.FIXED)
+    item.replied = True
+    gh = RecordingGh()
+    reply_pr(_state([item]), gh=gh, ref=_REF)
+    assert gh.rest_calls == []
+    assert gh.graphql_calls == []
+
+
+def test_scan_fetches_only_needed_surfaces() -> None:
+    # §10.1 behavior 5: the scan reads exactly the surfaces this invocation posts to.
+    issue_only = RecordingGh(post_reply_id=1)
+    reply_pr(
+        _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.FIXED)]),
+        gh=issue_only,
+        ref=_REF,
+    )
+    gets = [p for m, p, _ in issue_only.rest_calls if m == "GET"]
+    assert gets == [_ISSUE_COMMENTS]
+
+    thread_only = RecordingGh(post_reply_id=1)
+    thread = ReviewItem(
+        kind=ItemKind.REVIEW_THREAD,
+        identity=Identity(gh_id="55", reply_to_comment_id=55),
+        author="rev",
+        body_excerpt="b",
+        seen_at=_NOW,
+        disposition=Disposition(kind=DispositionKind.FIXED, decided_at=_NOW, decided_by="agent"),
+    )
+    reply_pr(_state([thread]), gh=thread_only, ref=_REF)
+    gets = [p for m, p, _ in thread_only.rest_calls if m == "GET"]
+    assert gets == [_REVIEW_COMMENTS]
+
+
+def test_partial_failure_rerun_does_not_duplicate_memory_thread_reply() -> None:
+    # §10.1 behavior 6: two target-hinted entries; run 1's second GraphQL mutation
+    # raises → pending_memory survives on the pre-call state; run 2 with the first
+    # entry's marker visible fires GraphQL only for the second entry.
+    def fresh_pending() -> list[RoutedMemory]:
+        return [
+            RoutedMemory(
+                content="A", retry=1, source_item="c1#0", decided_by="x", target_hint="T1"
+            ),
+            RoutedMemory(
+                content="B", retry=1, source_item="c1#1", decided_by="x", target_hint="T2"
+            ),
+        ]
+
+    state = _state([], pending=fresh_pending())
+    gh1 = RecordingGh(fail_at=("graphql", 2))
+    with pytest.raises(PrgroomError):
+        reply_pr(state, gh=gh1, ref=_REF)
+    assert len(state.pending_memory) == 2  # pre-call state untouched by the raise
+
+    marker_a = memory_marker(state.pending_memory[0])
+    gh2 = RecordingGh(listed={_REVIEW_COMMENTS: [{"id": 41, "body": with_marker("A", marker_a)}]})
+    out = reply_pr(state, gh=gh2, ref=_REF)
+    assert len(gh1.graphql_calls) == 2  # first ok, second raised
+    assert len(gh2.graphql_calls) == 1  # only the never-posted entry fires
+    assert gh2.graphql_calls[0][1]["threadId"] == "T2"
+    assert out.pending_memory == []
+
+
+def test_memory_thread_reply_body_carries_memory_marker() -> None:
+    # §10.1 behavior 7: the GraphQL body is with_marker(content, memory_marker(rm))
+    # and round-trips through the scanner grammar.
+    from prgroom.lifecycle.idempotency import carries_own_marker
+
+    rm = RoutedMemory(content="why", retry=1, source_item="c1#0", decided_by="x", target_hint="T")
+    gh = RecordingGh()
+    reply_pr(_state([], pending=[rm]), gh=gh, ref=_REF)
+    body = gh.graphql_calls[0][1]["body"]
+    assert body == with_marker("why", memory_marker(rm))
+    assert carries_own_marker(body)
+
+
+def test_colliding_batch_keys_with_distinct_content_both_post() -> None:
+    # §10.1 behavior 13: two entries sharing (retry, source_item) — the §4 batch-key
+    # collision (ordinal restart + LLM-reused cluster id) — but distinct content.
+    # The first already posted → the second must still fire. Regression guard
+    # against silent adopt-skip of a never-posted reply.
+    first = RoutedMemory(content="A", retry=1, source_item="c1#0", decided_by="x", target_hint="T")
+    second = RoutedMemory(content="B", retry=1, source_item="c1#0", decided_by="x", target_hint="T")
+    gh = RecordingGh(
+        listed={_REVIEW_COMMENTS: [{"id": 41, "body": with_marker("A", memory_marker(first))}]}
+    )
+    out = reply_pr(_state([], pending=[first, second]), gh=gh, ref=_REF)
+    assert len(gh.graphql_calls) == 1
+    assert gh.graphql_calls[0][1]["body"] == with_marker("B", memory_marker(second))
+    assert out.pending_memory == []
+
+
+def test_scan_markers_maps_first_occurrence_and_ignores_non_grammar() -> None:
+    # §10.1 behavior 12: earliest comment claims the marker (the original — listing
+    # order is ascending); non-grammar marker-like prose never matches; entries with
+    # a missing or zero id are skipped.
+    marker = "<!-- prgroom:reply:issue_comment:12 -->"
+    listing = [
+        {"id": 3, "body": "prose mentioning prgroom:reply:issue_comment:12 without grammar"},
+        {"id": 5, "body": with_marker("Fixed.", marker)},
+        {"id": 9, "body": with_marker("Fixed again (duplicate).", marker)},
+        {"id": 0, "body": with_marker("zero id", "<!-- prgroom:mem:r1:c9#0:aaaaaaaaaaaa -->")},
+        {"body": with_marker("no id", "<!-- prgroom:mem:r1:c9#1:bbbbbbbbbbbb -->")},
+    ]
+    assert scan_markers(listing) == {marker: 5}
+
+
+def test_scan_markers_merges_multiple_listings() -> None:
+    # The pre-flight scan merges the issue-comment and review-comment surfaces into
+    # one map; a marker found in either listing is adopted.
+    issue_marker = "<!-- prgroom:reply:issue_comment:12 -->"
+    review_marker = "<!-- prgroom:reply:review_thread:55 -->"
+    issue = [{"id": 91, "body": with_marker("a", issue_marker)}]
+    review = [{"id": 77, "body": with_marker("b", review_marker)}]
+    assert scan_markers(issue, review) == {issue_marker: 91, review_marker: 77}
+
+
+def test_memory_marker_digest_distinguishes_content() -> None:
+    # §4: (retry, source_item) is only batch-unique — two distinct entries can share
+    # the batch key; the content digest restores global uniqueness, and identical
+    # entries collide by construction (correct dedup).
+    a = RoutedMemory(content="A", retry=1, source_item="c1#0", decided_by="x", target_hint="T")
+    b = RoutedMemory(content="B", retry=1, source_item="c1#0", decided_by="x", target_hint="T")
+    a2 = RoutedMemory(content="A", retry=1, source_item="c1#0", decided_by="y", target_hint="T")
+    assert memory_marker(a) != memory_marker(b)
+    assert memory_marker(a) == memory_marker(a2)  # decided_by is not part of the effect

--- a/packages/prgroom/tests/unit/test_reply_per_item.py
+++ b/packages/prgroom/tests/unit/test_reply_per_item.py
@@ -1,30 +1,19 @@
 from datetime import UTC, datetime
 
+from prgroom.lifecycle.idempotency import reply_marker, with_marker
 from prgroom.lifecycle.reply import reply_pr
 from prgroom.prsession.enums import DispositionKind, ItemKind, PRPhase
 from prgroom.prsession.pr_ref import PRRef
 from prgroom.prsession.state import Disposition, Identity, ReviewItem, bootstrap_state
+from tests.fakes import RecordingGh
 
 _NOW = datetime(2026, 6, 19, tzinfo=UTC)
 
 
-class _RecordingGh:
-    def __init__(self, post_reply_id: int | None = None) -> None:
-        self.rest_calls: list[tuple[str, str, dict]] = []
-        self.graphql_calls: list[tuple[str, dict]] = []
-        self._post_reply_id = post_reply_id
-
-    def rest(self, method: str, path: str, *, fields=None):
-        self.rest_calls.append((method, path, dict(fields or {})))
-        # A reply/comment POST returns the new comment object carrying its numeric id;
-        # the ledger captures it so a later poll can exclude our own reply.
-        if method == "POST" and self._post_reply_id is not None:
-            return {"id": self._post_reply_id}
-        return {}
-
-    def graphql(self, query: str, variables: dict):
-        self.graphql_calls.append((query, dict(variables)))
-        return {}
+def _first_post(gh: RecordingGh) -> tuple[str, str, dict]:
+    """The first POST call — the pre-flight GET occupies index 0 whenever a
+    surface is needed, so positional ``rest_calls[0]`` reads select the scan."""
+    return next((m, p, f) for m, p, f in gh.rest_calls if m == "POST")
 
 
 def _ref() -> PRRef:
@@ -56,12 +45,10 @@ def _state(items):
 
 
 def test_fixed_top_level_review_thread_reply() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [_item(ItemKind.REVIEW_THREAD, "555", DispositionKind.FIXED, commits=["abc1234"])]
-    )
-    out = reply_pr(state, gh=gh, ref=_ref())
-    method, path, fields = gh.rest_calls[0]
+    gh = RecordingGh()
+    item = _item(ItemKind.REVIEW_THREAD, "555", DispositionKind.FIXED, commits=["abc1234"])
+    out = reply_pr(_state([item]), gh=gh, ref=_ref())
+    method, path, fields = _first_post(gh)
     assert method == "POST"
     assert path == "repos/o/r/pulls/7/comments/555/replies"
     assert fields["body"].startswith("Fixed in abc1234.")
@@ -69,141 +56,125 @@ def test_fixed_top_level_review_thread_reply() -> None:
 
 
 def test_fixed_with_rationale_appends_it() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.REVIEW_THREAD,
-                "555",
-                DispositionKind.FIXED,
-                commits=["abc1234"],
-                rationale="tightened the bound",
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.REVIEW_THREAD,
+        "555",
+        DispositionKind.FIXED,
+        commits=["abc1234"],
+        rationale="tightened the bound",
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"] == "Fixed in abc1234. tightened the bound"
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"] == with_marker(
+        "Fixed in abc1234. tightened the bound", reply_marker(item)
+    )
 
 
 def test_fixed_empty_commits_renders_grammatical() -> None:
     # A FIXED disposition with no commits (reachable via `resolve-escalated --as fixed`
     # with no --commits) must not post the broken "Fixed in ." — it drops the sha clause.
-    gh = _RecordingGh()
-    state = _state([_item(ItemKind.REVIEW_THREAD, "1", DispositionKind.FIXED)])
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"] == "Fixed."
+    gh = RecordingGh()
+    item = _item(ItemKind.REVIEW_THREAD, "1", DispositionKind.FIXED)
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"] == with_marker("Fixed.", reply_marker(item))
 
 
 def test_fixed_empty_commits_with_rationale() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.REVIEW_THREAD,
-                "1",
-                DispositionKind.FIXED,
-                rationale="manual human resolution",
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.REVIEW_THREAD,
+        "1",
+        DispositionKind.FIXED,
+        rationale="manual human resolution",
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"] == "Fixed. manual human resolution"
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"] == with_marker(
+        "Fixed. manual human resolution", reply_marker(item)
+    )
 
 
 def test_already_addressed_empty_commits_renders_grammatical() -> None:
     # Same defect class as FIXED: no commits must not post "Already addressed in .".
-    gh = _RecordingGh()
-    state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)])
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"] == "Already addressed."
+    gh = RecordingGh()
+    item = _item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"] == with_marker("Already addressed.", reply_marker(item))
 
 
 def test_escalated_cap_variant_when_rationale_names_cap() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.REVIEW_THREAD,
-                "7",
-                DispositionKind.ESCALATED,
-                rationale="PR-review retry budget exhausted",
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.REVIEW_THREAD,
+        "7",
+        DispositionKind.ESCALATED,
+        rationale="PR-review retry budget exhausted",
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"] == (
-        "Round limit reached on this PR; deferring further iterations to a human reviewer."
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"] == with_marker(
+        "Round limit reached on this PR; deferring further iterations to a human reviewer.",
+        reply_marker(item),
     )
 
 
 def test_escalated_substring_cap_does_not_trigger_cap_variant() -> None:
     # "captured" contains "cap" as a substring but NOT as a standalone word — it must
     # render the normal escalated body, not the cap variant (word-boundary match).
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.REVIEW_THREAD,
-                "8",
-                DispositionKind.ESCALATED,
-                rationale="captured the edge case for a human",
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.REVIEW_THREAD,
+        "8",
+        DispositionKind.ESCALATED,
+        rationale="captured the edge case for a human",
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    assert gh.rest_calls[0][2]["body"].startswith("Captured for follow-up")
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    assert _first_post(gh)[2]["body"].startswith("Captured for follow-up")
 
 
 def test_empty_rendered_body_skips_post_and_keeps_replied_false() -> None:
     # SKIPPED/DEFERRED/WONT_FIX render from rationale; an empty rationale (reachable via
     # `resolve-escalated --as skipped` with no --rationale) renders "". Posting "" fails the
     # GitHub API — skip the POST and leave replied False so a later rationale can still reply.
-    gh = _RecordingGh()
+    # The pre-flight surface GET still fires (tolerated over-fetch, §11 ledger).
+    gh = RecordingGh()
     out = reply_pr(
         _state([_item(ItemKind.REVIEW_THREAD, "9", DispositionKind.SKIPPED, rationale="")]),
         gh=gh,
         ref=_ref(),
     )
-    assert gh.rest_calls == []
+    assert [m for m, _, _ in gh.rest_calls if m == "POST"] == []
     assert out.items[0].replied is False
 
 
 def test_nested_reply_uses_reply_to_comment_id() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.REVIEW_THREAD,
-                "999",
-                DispositionKind.SKIPPED,
-                reply_to=555,
-                rationale="out of scope",
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.REVIEW_THREAD,
+        "999",
+        DispositionKind.SKIPPED,
+        reply_to=555,
+        rationale="out of scope",
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    _, path, fields = gh.rest_calls[0]
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    _, path, fields = _first_post(gh)
     assert path == "repos/o/r/pulls/7/comments/555/replies"
-    assert fields["body"] == "out of scope"
+    assert fields["body"] == with_marker("out of scope", reply_marker(item))
 
 
 def test_issue_comment_endpoint() -> None:
-    gh = _RecordingGh()
-    state = _state(
-        [
-            _item(
-                ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED, commits=["def5678"]
-            )
-        ]
+    gh = RecordingGh()
+    item = _item(
+        ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED, commits=["def5678"]
     )
-    reply_pr(state, gh=gh, ref=_ref())
-    _, path, fields = gh.rest_calls[0]
+    reply_pr(_state([item]), gh=gh, ref=_ref())
+    _, path, fields = _first_post(gh)
     assert path == "repos/o/r/issues/7/comments"
-    assert fields["body"] == "Already addressed in def5678."
+    assert fields["body"] == with_marker("Already addressed in def5678.", reply_marker(item))
 
 
 def test_failed_item_gets_no_reply() -> None:
-    gh = _RecordingGh()
+    # FAILED is not replyable → no surface is needed → no scan GET either (this
+    # doubles as the §5 no-surface/no-GET pin).
+    gh = RecordingGh()
     state = _state([_item(ItemKind.REVIEW_THREAD, "1", DispositionKind.FAILED)])
     reply_pr(state, gh=gh, ref=_ref())
     assert gh.rest_calls == []
@@ -211,19 +182,19 @@ def test_failed_item_gets_no_reply() -> None:
 
 
 def test_escalated_replied_regardless_of_escalation_filed() -> None:
-    gh = _RecordingGh()
+    gh = RecordingGh()
     item = _item(ItemKind.REVIEW_THREAD, "2", DispositionKind.ESCALATED)
     item.disposition = Disposition(
         kind=DispositionKind.ESCALATED, decided_at=_NOW, decided_by="a", escalation_filed=True
     )
     reply_pr(_state([item]), gh=gh, ref=_ref())
-    assert "Captured for follow-up" in gh.rest_calls[0][2]["body"]
+    assert "Captured for follow-up" in _first_post(gh)[2]["body"]
 
 
 def test_reply_captures_own_reply_id_from_post_response() -> None:
     # The POST response carries the new comment's numeric id; reply_pr records it on
     # own_reply_id so a later poll can drop our own reply (recursive-self-reply fix).
-    gh = _RecordingGh(post_reply_id=424242)
+    gh = RecordingGh(post_reply_id=424242)
     state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)])
     out = reply_pr(state, gh=gh, ref=_ref())
     assert out.items[0].replied is True
@@ -232,7 +203,7 @@ def test_reply_captures_own_reply_id_from_post_response() -> None:
 
 def test_reply_own_reply_id_stays_zero_when_response_lacks_id() -> None:
     # Defensive: a POST response with no usable "id" leaves own_reply_id at 0.
-    gh = _RecordingGh(post_reply_id=None)
+    gh = RecordingGh(post_reply_id=None)
     state = _state([_item(ItemKind.ISSUE_COMMENT, "12", DispositionKind.ALREADY_ADDRESSED)])
     out = reply_pr(state, gh=gh, ref=_ref())
     assert out.items[0].replied is True
@@ -240,7 +211,8 @@ def test_reply_own_reply_id_stays_zero_when_response_lacks_id() -> None:
 
 
 def test_idempotent_skips_already_replied() -> None:
-    gh = _RecordingGh()
+    # Already replied → no surface is needed → zero gh calls (no-surface/no-GET pin).
+    gh = RecordingGh()
     item = _item(ItemKind.REVIEW_THREAD, "3", DispositionKind.FIXED, commits=["a"])
     item.replied = True
     reply_pr(_state([item]), gh=gh, ref=_ref())

--- a/packages/prgroom/tests/unit/test_run_cycle_reply_resolve_e2e.py
+++ b/packages/prgroom/tests/unit/test_run_cycle_reply_resolve_e2e.py
@@ -46,9 +46,20 @@ class _RecordingGh:
         self._body = body
         self.ops: list[tuple[str, ...]] = []
 
-    def rest(self, method: str, path: str, *, fields: dict | None = None) -> dict:  # noqa: ARG002
+    def rest(
+        self,
+        method: str,
+        path: str,
+        *,
+        fields: dict | None = None,  # noqa: ARG002
+        paginate: bool = False,  # noqa: ARG002
+    ) -> dict | list:
         self.ops.append(("rest", method, path))
         if method == "GET":
+            # Path-keyed dispatch: comment listings (the pre-flight idempotency
+            # scan) return an empty page; the PR resource returns the body.
+            if path.endswith("/comments"):
+                return []
             return {"body": self._body}
         return {}
 


### PR DESCRIPTION
## Summary

Fixes the duplicate-reply-on-retry defect (bead z4m2h; incident: PR #211 double replies). Every prgroom verb runs deepcopy → remote effects → single persist, so a crash mid-`reply` discards local progress while the POSTs stand — the rerun re-posts everything. Per spec `docs/specs/2026-07-16-prgroom-verb-atomicity.md`:

- **Idempotency markers** (`lifecycle/idempotency.py`, new): every comment-creating POST appends a hidden HTML-comment marker — `<!-- prgroom:reply:{kind}:{gh_id} -->` (identity-keyed, body-independent) for item replies; `<!-- prgroom:mem:{prefix}:{sha256-12} -->` (content-digest over retry/source_item/target_hint/content) for routed-memory thread replies.
- **Pre-flight adoption** (`lifecycle/reply.py`): before posting, reply scans only the comment surfaces it will actually write to (≤2 paginated GETs, zero when nothing needs posting), and adopts any already-posted effect — records the real comment id, flips the flag, skips the POST. GitHub, not the state file, is the source of truth.
- **Poll ingest backstop** (`lifecycle/poll.py`): a marker-bearing comment is never ingested as review feedback (content-keyed, never author-keyed), so a crash between POST and persist can't echo our own reply back as a new item.
- **resolve stays markerless** — `resolveReviewThread` is server-idempotent; a rerun harmlessly re-issues it (now pinned by a retry-path test).
- **Effect-idempotency invariant** documented in `lifecycle/run.py`'s module docstring, naming each verb's mechanism.

No schema changes, no public-signature changes (`reply_pr(state, *, gh, ref)` unchanged).

## Scope

- In: `packages/prgroom/src/prgroom/lifecycle/{idempotency,reply,poll,run}.py`, `tests/fakes.py` (shared `RecordingGh`), test files listed in the spec's §10.2 migration table.
- Also migrated (stragglers absent from §10.2's table, same mechanical shape): `test_cli_reply_resolve_escalated.py`, `test_lifecycle_run.py` — their local gh fakes needed the `paginate` kwarg + pre-flight GET dispatch, and their exact call-list pins gained the GET + marker-suffixed POST body.
- Out: any consumer of markers beyond reply/poll; retry/backoff policy; the spec's deferred alternatives (§2).

## Test plan (13 spec behaviors, TDD)

- Behavior 1 (born red — the PR #211 regression): partial-failure rerun posts no duplicate; behavior 3: adoption recovers a reply id lost to a malformed POST response.
- Behaviors 2, 4–7, 12, 13: marker suffix on posted bodies; no-op ⇒ zero gh calls; surface-scoped GETs; memory-thread dedup; marker round-trip; scan grammar/first-occurrence/zero-id; colliding batch keys with distinct content both post.
- Behaviors 9 (born red) & 10: poll never ingests a full-grammar marker comment; prose merely mentioning a marker still ingests.
- Behavior 11: resolve rerun re-issues both mutations after a mid-loop failure (server-side idempotency pinned).
- Mutation checks on born-green pins: 4 mutations (sever memory adoption; batch-key-only marker; always-fetch-both-surfaces; strip marker from POST) — all killed.
- `make ci-prgroom`: 1023 passed, 99.50% coverage, pip-audit clean.

## Notes for review

- The `_needs_post` predicate deliberately mirrors (and over-approximates) the reply loop's gating — the docstring signposts it; the error direction is a harmless over-fetch. Flagged by the internal gate as a minor DRY nit; left as-is.
- The marker prefix whitespace-collapse is the anti-forgery defense: a forged full-grammar marker cannot be constructed through `memory_marker` (grammar requires literal spaces the sanitizer removes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
