### PR TITLE
fix(workcli): extend null-vs-absent drift discipline to scalar fields

### DIFF
--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -88,7 +88,7 @@ def _dep_edge_from_raw(entry: dict[str, JsonValue], self_id: str) -> DepEdge:
             )
         return DepEdge(
             id=str(entry["id"]),
-            type=str(entry["dependency_type"]),
+            type=_dep_type(entry, self_id),
             status=str(entry.get("status", "")),
         )
     # list-shape: raw edge row {issue_id, depends_on_id, type}; no status
@@ -106,7 +106,7 @@ def _dep_edge_from_raw(entry: dict[str, JsonValue], self_id: str) -> DepEdge:
             },
         )
     other_id = entry["depends_on_id"] if entry.get("issue_id") == self_id else entry["issue_id"]
-    return DepEdge(id=str(other_id), type=str(entry["type"]), status="")
+    return DepEdge(id=str(other_id), type=_dep_type(entry, self_id), status="")
 
 
 def _dep_type(entry: dict[str, JsonValue], item_id: str) -> str:

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -109,9 +109,24 @@ def _dep_edge_from_raw(entry: dict[str, JsonValue], self_id: str) -> DepEdge:
     return DepEdge(id=str(other_id), type=str(entry["type"]), status="")
 
 
-def _dep_type(entry: dict[str, JsonValue]) -> str:
-    dep_type = entry.get("dependency_type", entry.get("type"))
-    return str(dep_type)
+def _dep_type(entry: dict[str, JsonValue], item_id: str) -> str:
+    """Return the edge's type, preferring `dependency_type` then `type`.
+
+    Same null-vs-absent discipline as `_list_field`: an explicit JSON `null`
+    on whichever key is present is bd model drift and must alarm loudly, not
+    silently fall through to the other key or coerce to the literal string
+    "None".
+    """
+    for key in ("dependency_type", "type"):
+        if key in entry:
+            value = entry[key]
+            if value is None:
+                raise _drift(
+                    f"bd dependency edge's {key} field is null, expected a string",
+                    {"reason": "null_field", "field": key, "id": item_id},
+                )
+            return str(value)
+    return str(None)
 
 
 def _list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> list[Any]:
@@ -138,6 +153,37 @@ def _list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> list[Any]:
             {"reason": "unexpected_field_type", "field": key, "id": item_id},
         )
     return value
+
+
+def _string_field(
+    raw: dict[str, JsonValue], key: str, item_id: str, *, default: str | None = None
+) -> str:
+    """Return `raw[key]` as a `str`, applying the same null-vs-absent discipline
+
+    as `_list_field`: an explicit JSON `null` is bd model drift and must
+    alarm via `WorkError(BACKEND_DRIFT)`, never silently coerce to the
+    literal string "None". An absent key returns `default` when given
+    (callers pass `default=None` -- Python's default -- only for keys whose
+    presence is already guaranteed by `_REQUIRED_ITEM_KEYS`).
+    """
+    if key not in raw:
+        if default is not None:
+            return default
+        raise _drift(
+            f"bd item is missing required key: {key}",
+            {
+                "reason": "missing_required_keys",
+                "missing_keys": cast("list[JsonValue]", [key]),
+                "id": item_id,
+            },
+        )
+    value = raw[key]
+    if value is None:
+        raise _drift(
+            f"bd item's {key} field is null, expected a string",
+            {"reason": "null_field", "field": key, "id": item_id},
+        )
+    return str(value)
 
 
 def _string_list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> list[str]:
@@ -217,26 +263,26 @@ def parse_item(raw: dict[str, JsonValue]) -> Item:
     deps = [
         _dep_edge_from_raw(entry, item_id)
         for entry in dependencies
-        if _dep_type(entry) != "parent-child"
+        if _dep_type(entry, item_id) != "parent-child"
     ]
     children = [
         _dep_edge_from_raw(entry, item_id).id
         for entry in dependents
-        if _dep_type(entry) == "parent-child"
+        if _dep_type(entry, item_id) == "parent-child"
     ]
 
     return Item(
         id=item_id,
         title=str(raw["title"]),
         type=str(raw["issue_type"]),
-        status=str(raw["status"]),
+        status=_string_field(raw, "status", item_id),
         priority=f"P{priority_raw}",
         labels=_string_list_field(raw, "labels", item_id),
         parent=str(raw["parent"]) if raw.get("parent") is not None else None,
         deps=deps,
         children=children,
-        description=str(raw.get("description", "")),
-        notes=str(raw.get("notes", "")),
+        description=_string_field(raw, "description", item_id, default=""),
+        notes=_string_field(raw, "notes", item_id, default=""),
         created=str(raw["created_at"]) if raw.get("created_at") is not None else None,
         updated=str(raw["updated_at"]) if raw.get("updated_at") is not None else None,
     )

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -89,7 +89,7 @@ def _dep_edge_from_raw(entry: dict[str, JsonValue], self_id: str) -> DepEdge:
         return DepEdge(
             id=str(entry["id"]),
             type=_dep_type(entry, self_id),
-            status=str(entry.get("status", "")),
+            status=_string_field(entry, "status", self_id, default=""),
         )
     # list-shape: raw edge row {issue_id, depends_on_id, type}; no status
     # for the other end is available without a second fetch. Same drift
@@ -273,8 +273,8 @@ def parse_item(raw: dict[str, JsonValue]) -> Item:
 
     return Item(
         id=item_id,
-        title=str(raw["title"]),
-        type=str(raw["issue_type"]),
+        title=_string_field(raw, "title", item_id),
+        type=_string_field(raw, "issue_type", item_id),
         status=_string_field(raw, "status", item_id),
         priority=f"P{priority_raw}",
         labels=_string_list_field(raw, "labels", item_id),

--- a/packages/workcli/tests/unit/test_drift_alarm.py
+++ b/packages/workcli/tests/unit/test_drift_alarm.py
@@ -155,6 +155,67 @@ def test_explicit_null_labels_field_raises_backend_drift_not_a_raw_type_error():
     assert error.detail["field"] == "labels"
 
 
+def test_explicit_null_title_field_raises_backend_drift_not_the_literal_string_none():
+    # Codex review finding on PR #314: title/issue_type are required scalars
+    # that shared the same unguarded `str(raw["title"])` gap the null-vs-
+    # absent discipline was meant to close everywhere.
+    raw_item = {
+        "id": "x.1",
+        "title": None,
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "title"
+
+
+def test_explicit_null_issue_type_field_raises_backend_drift_not_the_literal_string_none():
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": None,
+        "status": "open",
+        "priority": 2,
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "issue_type"
+
+
+def test_explicit_null_dependency_edge_status_raises_backend_drift_not_the_literal_string_none():
+    # Codex review finding on PR #314: the show-shape dependency edge's
+    # `status` field went through an unguarded `str(entry.get("status", ""))`
+    # that coerced an explicit null to the literal string "None".
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "dependencies": [{"id": "x.2", "dependency_type": "blocks", "status": None}],
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "status"
+
+
 def test_explicit_null_status_field_raises_backend_drift_not_the_literal_string_none():
     # bd emitting `"status": null` must never silently become the literal
     # string "None" via an unguarded `str(raw["status"])` -- same null-vs-

--- a/packages/workcli/tests/unit/test_drift_alarm.py
+++ b/packages/workcli/tests/unit/test_drift_alarm.py
@@ -351,6 +351,23 @@ def test_dep_list_element_missing_dependency_type_raises_backend_drift():
     assert error.detail["reason"] == "missing_required_keys"
 
 
+def test_dep_list_explicit_null_dependency_type_raises_backend_drift():
+    # `parse_dep_edges` (the `work dep list` path) builds its `DepEdge.type`
+    # straight from `_dep_edge_from_raw` without going through `parse_item`'s
+    # filtering `_dep_type` call -- an explicit null here must still alarm,
+    # not silently coerce to the literal string "None" via an unguarded
+    # `str(entry["dependency_type"])`.
+    raw_entry = {"id": "x.2", "status": "open", "dependency_type": None}
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_dep_edges(json.dumps([raw_entry]), self_id="x.1")
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "dependency_type"
+
+
 def test_show_shape_dependency_edge_missing_id_raises_backend_drift():
     # A `dependencies[]` entry carrying `dependency_type` (show-shape) but no
     # `id` for the other end would raise a raw KeyError -> E_INTERNAL from

--- a/packages/workcli/tests/unit/test_drift_alarm.py
+++ b/packages/workcli/tests/unit/test_drift_alarm.py
@@ -155,6 +155,125 @@ def test_explicit_null_labels_field_raises_backend_drift_not_a_raw_type_error():
     assert error.detail["field"] == "labels"
 
 
+def test_explicit_null_status_field_raises_backend_drift_not_the_literal_string_none():
+    # bd emitting `"status": null` must never silently become the literal
+    # string "None" via an unguarded `str(raw["status"])` -- same null-vs-
+    # absent discipline as `_list_field`, extended to scalar fields.
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": None,
+        "priority": 2,
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "status"
+
+
+def test_explicit_null_description_field_raises_backend_drift_not_the_literal_string_none():
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "description": None,
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "description"
+
+
+def test_missing_description_field_defaults_to_empty_string_not_drift():
+    # Absent is NOT the same as explicit null: an absent `description` key
+    # keeps its "" default, same as `_list_field`'s absent-key behavior.
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+    }
+
+    items = parse_items(json.dumps([raw_item]))
+
+    assert items[0].description == ""
+
+
+def test_explicit_null_notes_field_raises_backend_drift_not_the_literal_string_none():
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "notes": None,
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "notes"
+
+
+def test_explicit_null_dependency_type_field_raises_backend_drift_not_the_literal_string_none():
+    # The show-shape dependency edge's `dependency_type` field going explicitly
+    # null must alarm, never silently coerce to the literal string "None" via
+    # an unguarded `str(entry.get(...))`.
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "dependencies": [{"id": "x.2", "status": "open", "dependency_type": None}],
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "dependency_type"
+
+
+def test_explicit_null_type_field_fallback_raises_backend_drift_not_the_literal_string_none():
+    # The list-shape edge row's `type` field (used as `dependency_type`'s
+    # fallback when the key is absent, not when it's explicitly null) going
+    # null must alarm the same way.
+    raw_item = {
+        "id": "x.1",
+        "title": "t",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "dependencies": [{"issue_id": "x.1", "depends_on_id": "x.2", "type": None}],
+    }
+
+    with pytest.raises(WorkError) as exc_info:
+        parse_items(json.dumps([raw_item]))
+
+    error = exc_info.value
+    assert error.code == ErrorCode.BACKEND_DRIFT
+    assert error.detail["reason"] == "null_field"
+    assert error.detail["field"] == "type"
+
+
 def test_non_string_label_element_raises_backend_drift_not_a_silent_coercion():
     # bd emitting a non-string element in `labels` (a number, an object, ...)
     # where the normalized contract says `string[]` is model drift -- it must


### PR DESCRIPTION
## Summary
- Extends the `_list_field` null-vs-absent drift discipline (already applied to dependencies/dependents/labels) to the scalar fields in `packages/workcli/src/workcli/adapters/bd/parse.py`: `status`, `description`, `notes`, and the `dependency_type`/`type` fallback.
- Adds a `_string_field` helper mirroring `_list_field`'s contract: explicit JSON `null` raises `WorkError(BACKEND_DRIFT)`; an absent key keeps its default (`""` for description/notes, required for status).
- `_dep_type` now guards `null` on whichever of `dependency_type`/`type` is present, instead of silently coercing to the literal string `"None"`.

Closes agents-config-yt9m5.

## Test plan
- [x] New drift tests: explicit-null status/description/notes, explicit-null `dependency_type`, explicit-null `type` fallback, and absent-description-defaults-to-empty-string (non-drift control).
- [x] `make ci-workcli` from the worktree: ruff check/format, mypy --strict, pytest (388 passed, 99.64%% coverage), pip-audit clean, protocol/help smoke checks.