### PR TITLE
feat(installer): CLI-deploy registry, port, and additive receipt field (wgclw.9.9 PR1/3)

### DIFF
--- a/packages/installer/src/installer/core/clis.py
+++ b/packages/installer/src/installer/core/clis.py
@@ -9,6 +9,11 @@ authorizes an uninstall.
 from __future__ import annotations
 
 import hashlib
+import os
+import re
+import shutil
+import subprocess
+import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -196,3 +201,117 @@ class ScriptedCliDeploy:
             msg = "ScriptedCliDeploy smokes queue exhausted"
             raise RuntimeError(msg)
         return self._smokes.pop(0)
+
+
+_INSTALL_TIMEOUT = 300  # cold uv cache + dependency resolution can be slow
+_SMOKE_TIMEOUT = 30
+_QUERY_TIMEOUT = 10
+
+
+class UvCliDeploy:
+    """Real CliDeployPort backed by uv subprocesses. The ONLY module code
+    that shells out for CLI deploys; everything above it stays pure."""
+
+    def _run(self, cmd: list[str], timeout: int) -> CommandResult:
+        try:
+            proc = subprocess.run(  # noqa: S603  # fixed argv, no shell
+                cmd, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except subprocess.TimeoutExpired:
+            return CommandResult(ok=False, output=f"timed out after {timeout}s: {' '.join(cmd)}")
+        except FileNotFoundError as exc:
+            return CommandResult(ok=False, output=f"not found: {exc}")
+        output = (proc.stdout or "") + (proc.stderr or "")
+        return CommandResult(ok=proc.returncode == 0, output=output)
+
+    def uv_version(self) -> tuple[int, ...] | None:
+        result = self._run(["uv", "--version"], _QUERY_TIMEOUT)
+        match = re.search(r"\buv (\d+)\.(\d+)\.(\d+)", result.output) if result.ok else None
+        return tuple(int(g) for g in match.groups()) if match else None
+
+    def bin_dir(self) -> Path:
+        result = self._run(["uv", "tool", "dir", "--bin"], _QUERY_TIMEOUT)
+        if result.ok and result.output.strip():
+            return Path(result.output.strip().splitlines()[0])
+        # uv's documented resolution order, in full (spec §4; item 17).
+        if env := os.environ.get("UV_TOOL_BIN_DIR"):
+            return Path(env)
+        if env := os.environ.get("XDG_BIN_HOME"):
+            return Path(env)
+        if env := os.environ.get("XDG_DATA_HOME"):
+            return (Path(env) / ".." / "bin").resolve()
+        return Path.home() / ".local" / "bin"
+
+    def shim_path(self, binary: str) -> Path | None:
+        candidate = self.bin_dir() / binary
+        return candidate if candidate.is_file() else None
+
+    def tool_list(self) -> Mapping[str, frozenset[str]] | None:
+        result = self._run(["uv", "tool", "list"], _QUERY_TIMEOUT)
+        if not result.ok:
+            return None
+        tools: dict[str, set[str]] = {}
+        current: str | None = None
+        for line in result.output.splitlines():
+            if line.startswith("- ") and current is not None:
+                tools[current].add(line[2:].strip())
+            else:
+                match = re.match(r"^(\S+) v\S+", line)
+                if match:
+                    current = match.group(1)
+                    tools[current] = set()
+        return {name: frozenset(exes) for name, exes in tools.items()}
+
+    def tool_install(self, package_dir: Path, *, force: bool) -> CommandResult:
+        cmd = ["uv", "tool", "install"]
+        if force:
+            cmd.append("--force")
+        lock = package_dir / "uv.lock"
+        if not lock.is_file():
+            cmd.append(str(package_dir))
+            return self._run(cmd, _INSTALL_TIMEOUT)
+        # Single lock-guarded block: mypy --strict (possibly-undefined) rejects
+        # binding `constraints` under one `if lock.is_file()` and reading it
+        # under a second; try/finally also cleans up on every return path.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as tmp:
+            constraints = Path(tmp.name)
+        try:
+            export = self._run(
+                [
+                    "uv",
+                    "export",
+                    "--frozen",
+                    "--no-dev",
+                    "--no-emit-project",
+                    "--project",
+                    str(package_dir),
+                    "-o",
+                    str(constraints),
+                ],
+                _QUERY_TIMEOUT,
+            )
+            if not export.ok:
+                return export
+            cmd.extend(["--constraints", str(constraints), str(package_dir)])
+            return self._run(cmd, _INSTALL_TIMEOUT)
+        finally:
+            constraints.unlink(missing_ok=True)
+
+    def tool_uninstall(self, name: str) -> CommandResult:
+        return self._run(["uv", "tool", "uninstall", name], _QUERY_TIMEOUT)
+
+    def update_shell(self) -> CommandResult:
+        result = self._run(["uv", "tool", "update-shell"], _QUERY_TIMEOUT)
+        # uv exits non-zero when the shell config already contains the PATH
+        # entry; that expected steady state counts as success (spec §6 /
+        # item 20 — repeat installs from an un-restarted shell stay green).
+        if not result.ok and "already" in result.output.lower():
+            return CommandResult(ok=True, output=result.output)
+        return result
+
+    def which(self, binary: str) -> Path | None:
+        found = shutil.which(binary)
+        return Path(found) if found else None
+
+    def smoke(self, shim: Path, args: tuple[str, ...]) -> CommandResult:
+        return self._run([str(shim), *args], _SMOKE_TIMEOUT)

--- a/packages/installer/src/installer/core/clis.py
+++ b/packages/installer/src/installer/core/clis.py
@@ -1,0 +1,77 @@
+"""CLI-deploy registry, source digest, and subprocess port (spec: installer-cli-deploy).
+
+The registry is CLOSED (like the Tool enum, unlike the plugins dir-scan):
+packages/ contains early packages that must not auto-deploy. Uninstall
+authority is bounded by CLI_PACKAGES | RETIRED_CLIS — the receipt alone never
+authorizes an uninstall.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from installer.core.hashing import sha256_file
+
+MIN_UV_VERSION: tuple[int, ...] = (0, 10, 4)
+
+
+@dataclass(frozen=True, slots=True)
+class CliSpec:
+    """One deployable CLI package. ``name`` is the uv tool name; ``binary``
+    the console-script it provides; ``smoke_args`` a cheap no-backend
+    invocation proving the shim executes."""
+
+    name: str
+    package_dir: str  # repo-relative
+    binary: str
+    smoke_args: tuple[str, ...]
+
+
+CLI_PACKAGES: tuple[CliSpec, ...] = (
+    CliSpec("workcli", "packages/workcli", "work", ("--protocol-version",)),
+    CliSpec("prgroom", "packages/prgroom", "prgroom", ("--help",)),
+)
+
+RETIRED_CLIS: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Outcome of one port subprocess: ``output`` is merged stdout+stderr,
+    surfaced verbatim on failure."""
+
+    ok: bool
+    output: str
+
+
+def cli_source_digest(package_dir: Path) -> str:
+    """Deterministic ``sha256:<hex>`` over the package's deployable source.
+
+    Inputs: pyproject.toml (required — missing means the registry points at a
+    non-package: fail fast), uv.lock (omitted when absent), and src/** minus
+    __pycache__/*.pyc. tests/README/AGENTS.md are deliberately excluded — a
+    docs-only change must not force a reinstall (spec §5)."""
+    pyproject = package_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        msg = f"not a deployable CLI package (no pyproject.toml): {package_dir}"
+        raise FileNotFoundError(msg)
+    files = [pyproject]
+    lock = package_dir / "uv.lock"
+    if lock.is_file():
+        files.append(lock)
+    src = package_dir / "src"
+    if src.is_dir():
+        files.extend(
+            p
+            for p in src.rglob("*")
+            if p.is_file() and "__pycache__" not in p.parts and p.suffix != ".pyc"
+        )
+    h = hashlib.sha256()
+    for f in sorted(files):
+        h.update(str(f.relative_to(package_dir)).encode("utf-8", "surrogateescape"))
+        h.update(b"\0")
+        h.update(sha256_file(f))
+        h.update(b"\0")
+    return "sha256:" + h.hexdigest()

--- a/packages/installer/src/installer/core/clis.py
+++ b/packages/installer/src/installer/core/clis.py
@@ -9,8 +9,10 @@ authorizes an uninstall.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from installer.core.hashing import sha256_file
 
@@ -75,3 +77,122 @@ def cli_source_digest(package_dir: Path) -> str:
         h.update(sha256_file(f))
         h.update(b"\0")
     return "sha256:" + h.hexdigest()
+
+
+@runtime_checkable
+class CliDeployPort(Protocol):
+    """Injected subprocess seam for uv-tool deploys. All installed-state
+    decisions are PATH-independent (bin_dir/shim_path/tool_list); ``which``
+    serves only the reachability invariant (spec §4)."""
+
+    def uv_version(self) -> tuple[int, ...] | None: ...  # pragma: no cover
+    def bin_dir(self) -> Path: ...  # pragma: no cover
+    def shim_path(self, binary: str) -> Path | None: ...  # pragma: no cover
+    def tool_list(self) -> Mapping[str, frozenset[str]] | None: ...  # pragma: no cover
+    def tool_install(
+        self, package_dir: Path, *, force: bool
+    ) -> CommandResult: ...  # pragma: no cover
+    def tool_uninstall(self, name: str) -> CommandResult: ...  # pragma: no cover
+    def update_shell(self) -> CommandResult: ...  # pragma: no cover
+    def which(self, binary: str) -> Path | None: ...  # pragma: no cover
+    def smoke(self, shim: Path, args: tuple[str, ...]) -> CommandResult: ...  # pragma: no cover
+
+
+class ScriptedCliDeploy:
+    """Test fake for CliDeployPort.
+
+    Idempotent queries (uv_version / bin_dir / tool_list / which) return
+    STABLE configured values — they model repeatable reads, so tests never
+    have to count the engine's internal call sites for them. State-bearing
+    calls (shim_path, whose answer legitimately changes across an install;
+    tool_install / tool_uninstall / update_shell / smoke) pop per-method
+    queues; a pop on an empty queue raises naming the queue
+    (self-diagnosing, mirroring ScriptedIO). shim_path queue budget per
+    CLI: one decision read, plus one post-install re-read only when a
+    tool_install succeeded."""
+
+    def __init__(
+        self,
+        *,
+        uv_version: tuple[int, ...] | None = None,
+        bin_dir: Path | None = None,
+        tool_list: Mapping[str, frozenset[str]] | None = None,
+        which_map: Mapping[str, Path | None] | None = None,
+        shims: list[Path | None] | None = None,
+        installs: list[CommandResult] | None = None,
+        uninstalls: list[CommandResult] | None = None,
+        update_shells: list[CommandResult] | None = None,
+        smokes: list[CommandResult] | None = None,
+    ) -> None:
+        self._uv_version = uv_version
+        self._bin_dir = bin_dir
+        self._tool_list = tool_list
+        self._which_map = dict(which_map or {})
+        self._shims = list(shims or [])
+        self._installs = list(installs or [])
+        self._uninstalls = list(uninstalls or [])
+        self._update_shells = list(update_shells or [])
+        self._smokes = list(smokes or [])
+        self.transcript: list[tuple[object, ...]] = []
+
+    # -- idempotent queries: stable values --
+
+    def uv_version(self) -> tuple[int, ...] | None:
+        self.transcript.append(("uv_version",))
+        return self._uv_version
+
+    def bin_dir(self) -> Path:
+        self.transcript.append(("bin_dir",))
+        if self._bin_dir is None:
+            msg = "ScriptedCliDeploy bin_dir not configured"
+            raise RuntimeError(msg)
+        return self._bin_dir
+
+    def tool_list(self) -> Mapping[str, frozenset[str]] | None:
+        self.transcript.append(("tool_list",))
+        return self._tool_list
+
+    def which(self, binary: str) -> Path | None:
+        self.transcript.append(("which", binary))
+        return self._which_map.get(binary)
+
+    # -- state-bearing calls: queues --
+
+    def shim_path(self, binary: str) -> Path | None:
+        self.transcript.append(("shim_path", binary))
+        if not self._shims:
+            msg = "ScriptedCliDeploy shims queue exhausted"
+            raise RuntimeError(msg)
+        return self._shims.pop(0)
+
+    def tool_install(self, package_dir: Path, *, force: bool) -> CommandResult:
+        self.transcript.append(("tool_install", str(package_dir), force))
+        if not self._installs:
+            msg = "ScriptedCliDeploy installs queue exhausted"
+            raise RuntimeError(msg)
+        return self._installs.pop(0)
+
+    def tool_uninstall(self, name: str) -> CommandResult:
+        self.transcript.append(("tool_uninstall", name))
+        if not self._uninstalls:
+            msg = "ScriptedCliDeploy uninstalls queue exhausted"
+            raise RuntimeError(msg)
+        return self._uninstalls.pop(0)
+
+    def update_shell(self) -> CommandResult:
+        self.transcript.append(("update_shell",))
+        if not self._update_shells:
+            msg = "ScriptedCliDeploy update_shells queue exhausted"
+            raise RuntimeError(msg)
+        return self._update_shells.pop(0)
+
+    def smoke(
+        self,
+        shim: Path,
+        args: tuple[str, ...],  # noqa: ARG002  # protocol parameter; fake records only shim
+    ) -> CommandResult:
+        self.transcript.append(("smoke", str(shim)))
+        if not self._smokes:
+            msg = "ScriptedCliDeploy smokes queue exhausted"
+            raise RuntimeError(msg)
+        return self._smokes.pop(0)

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -35,12 +35,23 @@ class ReceiptEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class CliReceiptEntry:
+    """One installer-deployed uv tool (spec §7). ``name`` is the registry /
+    uv tool name; ``digest`` is ``cli_source_digest`` at deploy time."""
+
+    name: str
+    binary: str
+    digest: str
+
+
+@dataclass(frozen=True, slots=True)
 class Receipt:
     """The whole receipt. ``roots`` is the persisted install-root allowlist."""
 
     schema_version: int = SCHEMA_VERSION
     roots: tuple[Path, ...] = ()
     entries: tuple[ReceiptEntry, ...] = ()
+    clis: tuple[CliReceiptEntry, ...] = ()
     integrity: str | None = field(default=None)
 
 
@@ -56,6 +67,13 @@ def canonical_bytes(receipt: Receipt) -> bytes:
         "roots": sorted(str(r) for r in receipt.roots),
         "entries": [_entry_canonical(e) for e in entries],
     }
+    # Included only when non-empty — a receipt written before this field
+    # existed hashes byte-identically, so its persisted integrity still
+    # validates (the dir_digest compatibility precedent, dict-key form).
+    if receipt.clis:
+        payload["clis"] = [
+            [c.name, c.binary, c.digest] for c in sorted(receipt.clis, key=lambda c: c.name)
+        ]
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 

--- a/packages/installer/src/installer/core/receipt_build.py
+++ b/packages/installer/src/installer/core/receipt_build.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 from installer.core.model import FileKind, InstallOutcome, Outcome, StagingPlan
 from installer.core.ownership import PRUNE_NAMESPACES, entry_for, route_entry_for
-from installer.core.receipt import Receipt, ReceiptEntry, dir_content_digest
+from installer.core.receipt import CliReceiptEntry, Receipt, ReceiptEntry, dir_content_digest
 
 if TYPE_CHECKING:
     from installer.plugins.base import PluginAdapter
@@ -82,6 +82,34 @@ def entries_from_route_outcomes(
     return out
 
 
+def merge_clis(
+    *,
+    prior_clis: tuple[CliReceiptEntry, ...],
+    registry_names: frozenset[str],
+    deployed: dict[str, CliReceiptEntry],
+    uninstalled_names: set[str],
+    relinquished_names: set[str],
+) -> tuple[CliReceiptEntry, ...]:
+    """Union merge over registry CLIs and prior entries (spec §7).
+
+    Registry CLI -> the new entry when this run deployed it, else the
+    retained prior entry (skip/decline/failure keep the old record).
+    Non-registry prior entry (retired) -> dropped iff its uninstall
+    completed or it was relinquished (foreign name — never ours to
+    uninstall), else retained so retirement is retried next prune."""
+    prior_by_name = {c.name: c for c in prior_clis}
+    out: list[CliReceiptEntry] = []
+    for name in sorted(registry_names | set(prior_by_name)):
+        if name in deployed:
+            out.append(deployed[name])
+        elif name in registry_names:
+            if name in prior_by_name:
+                out.append(prior_by_name[name])
+        elif name not in uninstalled_names and name not in relinquished_names:
+            out.append(prior_by_name[name])
+    return tuple(out)
+
+
 def merge_receipt(
     prior: Receipt,
     *,
@@ -89,6 +117,7 @@ def merge_receipt(
     pruned_paths: set[Path],
     relinquished_paths: set[Path],
     live_roots: set[Path],
+    clis: tuple[CliReceiptEntry, ...] | None = None,
 ) -> Receipt:
     """Mirrors-disk receipt: ``(prior - pruned - relinquished) | installed``.
 
@@ -96,7 +125,11 @@ def merge_receipt(
     partial run (e.g. ``--tools=claude``) never erases an untargeted tool's or a
     still-present plugin's recorded entries. ``installed`` wins on a path clash
     (it carries the freshly-computed sha256). ``roots`` accumulates the prior and
-    live install roots (the persisted allowlist only grows)."""
+    live install roots (the persisted allowlist only grows). ``clis`` is passed
+    by the caller as the already-computed ``merge_clis`` result; ``None``
+    preserves the prior value unchanged (the ``_run_project`` path never passes
+    it, so a project-local receipt's ``clis`` — none in practice — is
+    untouched; spec §7)."""
     by_path: dict[Path, ReceiptEntry] = {
         e.path: e
         for e in prior.entries
@@ -105,7 +138,11 @@ def merge_receipt(
     for e in installed:
         by_path[e.path] = e
     roots = tuple(sorted(set(prior.roots) | live_roots, key=str))
-    return Receipt(roots=roots, entries=tuple(by_path.values()))
+    return Receipt(
+        roots=roots,
+        entries=tuple(by_path.values()),
+        clis=prior.clis if clis is None else clis,
+    )
 
 
 def desired_staged_keys(

--- a/packages/installer/src/installer/core/receipt_store.py
+++ b/packages/installer/src/installer/core/receipt_store.py
@@ -13,7 +13,13 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 
-from installer.core.receipt import SCHEMA_VERSION, Receipt, ReceiptEntry, compute_integrity
+from installer.core.receipt import (
+    SCHEMA_VERSION,
+    CliReceiptEntry,
+    Receipt,
+    ReceiptEntry,
+    compute_integrity,
+)
 
 
 class ReadStatus(Enum):
@@ -90,13 +96,31 @@ def _entry_from_json(d: object) -> ReceiptEntry:
     )
 
 
+def _cli_entry_from_json(d: object) -> CliReceiptEntry:
+    if not isinstance(d, dict):
+        raise ValueError("cli entry is not an object")  # noqa: TRY003, TRY004  # caught -> CORRUPT
+    name, binary, digest = d.get("name"), d.get("binary"), d.get("digest")
+    # Non-string fields fail closed -> CORRUPT: a malformed entry must not
+    # drive deploy/prune decisions (spec §7).
+    if not (isinstance(name, str) and isinstance(binary, str) and isinstance(digest, str)):
+        raise ValueError(  # noqa: TRY003, TRY004  # caught -> CORRUPT; subclass not justified
+            "cli entry name/binary/digest must be strings"
+        )
+    return CliReceiptEntry(name=name, binary=binary, digest=digest)
+
+
 def to_json_obj(receipt: Receipt) -> dict[str, object]:
-    return {
+    out: dict[str, object] = {
         "schema_version": receipt.schema_version,
         "integrity": receipt.integrity,
         "roots": [str(r) for r in receipt.roots],
         "entries": [_entry_to_json(e) for e in receipt.entries],
     }
+    if receipt.clis:
+        out["clis"] = [
+            {"name": c.name, "binary": c.binary, "digest": c.digest} for c in receipt.clis
+        ]
+    return out
 
 
 def _receipt_from_json(data: object) -> Receipt:
@@ -114,10 +138,14 @@ def _receipt_from_json(data: object) -> Receipt:
     # to a path whose digest still matches. Validate the element type -> CORRUPT.
     if not all(isinstance(r, str) for r in roots_raw):
         raise ValueError("roots must be a list of strings")  # noqa: TRY003  # caught -> CORRUPT; subclass not justified
+    clis_raw = data.get("clis", [])
+    if not isinstance(clis_raw, list):
+        raise ValueError("clis must be a list")  # noqa: TRY003, TRY004  # caught -> CORRUPT
     return Receipt(
         schema_version=SCHEMA_VERSION,
         roots=tuple(Path(r) for r in roots_raw),
         entries=tuple(_entry_from_json(e) for e in entries_raw),
+        clis=tuple(_cli_entry_from_json(c) for c in clis_raw),
         integrity=(str(data["integrity"]) if data.get("integrity") is not None else None),
     )
 

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 from installer.core.model import Counters, InstallOutcome, Outcome, Tool
 from installer.core.prune_flow import run_prune
 from installer.core.prune_hash import is_safe_to_prune, partition_file_orphans
-from installer.core.receipt import Receipt, ReceiptEntry
+from installer.core.receipt import CliReceiptEntry, Receipt, ReceiptEntry
 from installer.core.receipt_build import (
     desired_route_keys,
     desired_staged_keys,
@@ -204,6 +204,7 @@ def record_receipt(
     plugin_outcomes: dict[str, list[InstallOutcome]],
     pruned_paths: set[Path],
     relinquished_paths: set[Path],
+    cli_entries: tuple[CliReceiptEntry, ...] | None = None,
 ) -> None:
     """Write the receipt to mirror disk after an install+prune pass.
 
@@ -237,6 +238,7 @@ def record_receipt(
         pruned_paths=pruned_paths,
         relinquished_paths=all_relinquished,
         live_roots=live_roots,
+        clis=cli_entries,
     )
     write_receipt(receipt_path, new)
 

--- a/packages/installer/tests/unit/test_clis_port.py
+++ b/packages/installer/tests/unit/test_clis_port.py
@@ -1,10 +1,11 @@
 """Tests for the CliDeployPort fake and real implementation (spec §4)."""
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from installer.core.clis import CommandResult, ScriptedCliDeploy
+from installer.core.clis import CommandResult, ScriptedCliDeploy, UvCliDeploy
 
 
 def test_scripted_fake_stable_reads_and_stateful_queues(tmp_path: Path) -> None:
@@ -58,3 +59,216 @@ def test_scripted_fake_exhaustion_is_loud(tmp_path: Path) -> None:
         fake.tool_install(tmp_path / "pkg", force=True)
     with pytest.raises(RuntimeError, match="shims"):
         fake.shim_path("work")
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_uv_version_parses_semver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Given `uv --version` printing 'uv 0.10.4 (Homebrew 2026-02-17)'
+    When uv_version() runs
+    Then it returns (0, 10, 4); an unparseable output returns None.
+
+    Pins spec §4/§6: the MIN_UV_VERSION guard input.
+    """
+    port = UvCliDeploy()
+    monkeypatch.setattr(
+        subprocess, "run", lambda *_a, **_k: _FakeCompleted(stdout="uv 0.10.4 (Homebrew)")
+    )
+    assert port.uv_version() == (0, 10, 4)
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _FakeCompleted(stdout="garbage"))
+    assert port.uv_version() is None
+
+
+def test_bin_dir_fallback_chain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Given `uv tool dir --bin` failing
+    When bin_dir() resolves
+    Then it honors UV_TOOL_BIN_DIR, then XDG_BIN_HOME, then
+    XDG_DATA_HOME/../bin, then ~/.local/bin.
+
+    Pins spec §4 / item 17 (full documented uv precedence).
+    """
+
+    def _boom(*_a: object, **_k: object) -> _FakeCompleted:
+        raise FileNotFoundError("uv")
+
+    port = UvCliDeploy()
+    monkeypatch.setattr(subprocess, "run", _boom)
+    for var in ("UV_TOOL_BIN_DIR", "XDG_BIN_HOME", "XDG_DATA_HOME"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("UV_TOOL_BIN_DIR", str(tmp_path / "uvbin"))
+    assert port.bin_dir() == tmp_path / "uvbin"
+    monkeypatch.delenv("UV_TOOL_BIN_DIR")
+    monkeypatch.setenv("XDG_BIN_HOME", str(tmp_path / "xdgbin"))
+    assert port.bin_dir() == tmp_path / "xdgbin"
+    monkeypatch.delenv("XDG_BIN_HOME")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    assert port.bin_dir() == (tmp_path / "data" / ".." / "bin").resolve()
+    monkeypatch.delenv("XDG_DATA_HOME")
+    assert port.bin_dir() == Path.home() / ".local" / "bin"
+
+
+def test_tool_list_parses_names_and_executables(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Given `uv tool list` output with tools and '- exe' lines
+    When tool_list() runs
+    Then it returns {tool: frozenset(executables)}; a failed query returns
+    None.
+
+    Pins spec §4: the provenance mapping gating promptless heal (item 19).
+    """
+    out = "workcli v0.1.0\n- work\nprgroom v0.1.0\n- prgroom\n"
+    port = UvCliDeploy()
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _FakeCompleted(stdout=out))
+    assert port.tool_list() == {
+        "workcli": frozenset({"work"}),
+        "prgroom": frozenset({"prgroom"}),
+    }
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _FakeCompleted(returncode=2))
+    assert port.tool_list() is None
+
+
+def test_tool_install_exports_constraints_when_lock_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Given a package dir with a uv.lock
+    When tool_install runs
+    Then it first runs `uv export --frozen --no-dev --no-emit-project`, then
+    `uv tool install --constraints <file> <dir>`; force=True adds --force;
+    a lock-less package installs unconstrained.
+
+    Pins spec §4 / items 16, 18 (lock-respecting + non-forcing fresh).
+    """
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_k: object) -> _FakeCompleted:
+        calls.append(cmd)
+        return _FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", _record)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "uv.lock").write_text("lock")
+    port = UvCliDeploy()
+    assert port.tool_install(pkg, force=False).ok
+    assert calls[0][:2] == ["uv", "export"]
+    assert "--frozen" in calls[0] and "--no-emit-project" in calls[0]
+    assert calls[1][:3] == ["uv", "tool", "install"]
+    assert "--constraints" in calls[1] and "--force" not in calls[1]
+
+    calls.clear()
+    lockless = tmp_path / "lockless"
+    lockless.mkdir()
+    assert port.tool_install(lockless, force=True).ok
+    assert calls[0][:3] == ["uv", "tool", "install"]
+    assert "--force" in calls[0] and "--constraints" not in calls[0]
+
+
+def test_subprocess_failures_map_to_not_ok(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Given TimeoutExpired / FileNotFoundError / non-zero exit from uv
+    When tool_uninstall or smoke runs
+    Then CommandResult(ok=False, output=...) is returned, never an exception.
+
+    Pins spec §4/§8: fail loud via the result, no exception leakage.
+    """
+    port = UvCliDeploy()
+
+    def _timeout(*_a: object, **_k: object) -> _FakeCompleted:
+        raise subprocess.TimeoutExpired(cmd="uv", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", _timeout)
+    assert not port.tool_uninstall("workcli").ok
+
+    def _missing(*_a: object, **_k: object) -> _FakeCompleted:
+        raise FileNotFoundError("no shim")  # noqa: TRY003  # test double
+
+    monkeypatch.setattr(subprocess, "run", _missing)
+    assert not port.smoke(tmp_path / "bin" / "work", ("--protocol-version",)).ok
+    monkeypatch.setattr(
+        subprocess, "run", lambda *_a, **_k: _FakeCompleted(returncode=1, stderr="boom")
+    )
+    result = port.tool_uninstall("workcli")
+    assert not result.ok and "boom" in result.output
+
+
+def test_update_shell_already_configured_counts_as_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Given `uv tool update-shell` exiting non-zero because the shell config
+    already contains the PATH entry
+    When update_shell() runs
+    Then the result is ok=True (expected steady state — repeat installs
+    from an un-restarted shell stay green); a genuinely different failure
+    stays ok=False.
+
+    Pins spec §6 already-configured classification / item 20 (real-impl
+    branch; the stage-level behavior is driven through the fake in Task 9).
+    """
+    port = UvCliDeploy()
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_k: _FakeCompleted(returncode=1, stderr="PATH entry already exists"),
+    )
+    assert port.update_shell().ok
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_a, **_k: _FakeCompleted(returncode=1, stderr="permission denied"),
+    )
+    assert not port.update_shell().ok
+
+
+def test_bin_dir_uses_uv_tool_dir_when_available(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Given `uv tool dir --bin` succeeding
+    When bin_dir() resolves
+    Then the printed path wins over every env fallback.
+
+    Pins spec §4: the uv query is the primary source; the env chain is
+    fallback only (success arm of item 17).
+    """
+    monkeypatch.setenv("UV_TOOL_BIN_DIR", str(tmp_path / "ignored"))
+    monkeypatch.setattr(
+        subprocess, "run", lambda *_a, **_k: _FakeCompleted(stdout=f"{tmp_path / 'uvdir'}\n")
+    )
+    assert UvCliDeploy().bin_dir() == tmp_path / "uvdir"
+
+
+def test_tool_install_export_failure_aborts_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    Given a locked package whose `uv export` fails
+    When tool_install runs
+    Then the failing export result is returned and `uv tool install` never
+    runs — a lock-respecting install refuses to proceed unconstrained.
+
+    Pins spec §4 / item 16 export-failure arm.
+    """
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_k: object) -> _FakeCompleted:
+        calls.append(cmd)
+        if cmd[:2] == ["uv", "export"]:
+            return _FakeCompleted(returncode=1, stderr="lock out of date")
+        return _FakeCompleted()
+
+    monkeypatch.setattr(subprocess, "run", _record)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "uv.lock").write_text("lock")
+    result = UvCliDeploy().tool_install(pkg, force=False)
+    assert not result.ok and "lock out of date" in result.output
+    assert all(c[:3] != ["uv", "tool", "install"] for c in calls)

--- a/packages/installer/tests/unit/test_clis_port.py
+++ b/packages/installer/tests/unit/test_clis_port.py
@@ -1,0 +1,60 @@
+"""Tests for the CliDeployPort fake and real implementation (spec §4)."""
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.clis import CommandResult, ScriptedCliDeploy
+
+
+def test_scripted_fake_stable_reads_and_stateful_queues(tmp_path: Path) -> None:
+    """
+    Given a ScriptedCliDeploy configured with stable query values and
+    mutation queues
+    When port methods are called
+    Then idempotent queries (uv_version/bin_dir/tool_list/which) return the
+    SAME configured value on every call (repeatable reads — tests never
+    count internal call sites for them), state-bearing calls
+    (shim_path/install/smoke/...) pop per-method queues, and the transcript
+    records (method, key-arg) tuples.
+
+    Pins spec §4 fake contract (queue semantics reserved for calls whose
+    sequence matters — ralf plan-review cycle 1 M3).
+    """
+    bin_dir = tmp_path / "bin"
+    fake = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=bin_dir,
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": bin_dir / "work"},
+        shims=[bin_dir / "work"],
+        installs=[CommandResult(ok=True, output="")],
+        smokes=[CommandResult(ok=True, output="")],
+    )
+    assert fake.uv_version() == (0, 10, 4)
+    assert fake.uv_version() == (0, 10, 4)  # stable, not consumed
+    assert fake.bin_dir() == bin_dir
+    assert fake.bin_dir() == bin_dir  # stable, not consumed
+    assert fake.tool_list() == {"workcli": frozenset({"work"})}
+    assert fake.which("work") == bin_dir / "work"
+    assert fake.which("unknown") is None  # missing key -> not on PATH
+    assert fake.shim_path("work") == bin_dir / "work"
+    assert fake.tool_install(tmp_path / "pkg", force=False).ok
+    assert fake.smoke(bin_dir / "work", ("--protocol-version",)).ok
+    assert ("tool_install", str(tmp_path / "pkg"), False) in fake.transcript
+    assert ("smoke", str(bin_dir / "work")) in fake.transcript
+
+
+def test_scripted_fake_exhaustion_is_loud(tmp_path: Path) -> None:
+    """
+    Given a fake with an empty installs queue (and an empty shims queue)
+    When tool_install / shim_path are called
+    Then each raises with a message naming the exhausted queue.
+
+    Pins spec §4: exhaustion-error self-diagnosis mirrors ScriptedIO.
+    """
+    fake = ScriptedCliDeploy()
+    with pytest.raises(RuntimeError, match="installs"):
+        fake.tool_install(tmp_path / "pkg", force=True)
+    with pytest.raises(RuntimeError, match="shims"):
+        fake.shim_path("work")

--- a/packages/installer/tests/unit/test_clis_registry.py
+++ b/packages/installer/tests/unit/test_clis_registry.py
@@ -1,0 +1,98 @@
+"""Tests for the CLI-deploy registry and source digest (spec §3, §5)."""
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.clis import CLI_PACKAGES, RETIRED_CLIS, CliSpec, cli_source_digest
+
+
+def _seed(path: Path, content: bytes = b"x") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _package(tmp_path: Path) -> Path:
+    pkg = tmp_path / "pkg"
+    _seed(pkg / "pyproject.toml", b"[project]\nname='p'\n")
+    _seed(pkg / "src" / "p" / "__init__.py", b"")
+    return pkg
+
+
+def test_registry_is_exactly_workcli_and_prgroom() -> None:
+    """
+    Given the shipped registry
+    When CLI_PACKAGES is consulted
+    Then it contains exactly workcli->work and prgroom->prgroom, and
+    RETIRED_CLIS is empty.
+
+    Pins spec §3: closed registry; pdlc/holding-place/vizsuite must NOT
+    auto-deploy.
+    """
+    assert [s.name for s in CLI_PACKAGES] == ["workcli", "prgroom"]
+    by_name = {s.name: s for s in CLI_PACKAGES}
+    assert by_name["workcli"] == CliSpec(
+        "workcli", "packages/workcli", "work", ("--protocol-version",)
+    )
+    assert by_name["prgroom"] == CliSpec("prgroom", "packages/prgroom", "prgroom", ("--help",))
+    assert RETIRED_CLIS == ()
+
+
+def test_digest_missing_pyproject_raises(tmp_path: Path) -> None:
+    """
+    Given a directory without pyproject.toml
+    When cli_source_digest runs
+    Then it raises FileNotFoundError naming the dir.
+
+    Pins spec §5 / item 15: a registry entry at a non-package is a wiring
+    bug — fail fast.
+    """
+    with pytest.raises(FileNotFoundError):
+        cli_source_digest(tmp_path)
+
+
+def test_digest_missing_lock_omitted_and_later_lock_changes_digest(tmp_path: Path) -> None:
+    """
+    Given a package without uv.lock
+    When a uv.lock is added later
+    Then the digest changes (lock participates when present, is silently
+    omitted when absent).
+
+    Pins spec §5 / item 15.
+    """
+    pkg = _package(tmp_path)
+    before = cli_source_digest(pkg)
+    _seed(pkg / "uv.lock", b"lock")
+    assert cli_source_digest(pkg) != before
+
+
+def test_digest_ignores_tests_pycache_and_pyc(tmp_path: Path) -> None:
+    """
+    Given a package
+    When files under tests/**, __pycache__/, or *.pyc change
+    Then the digest does not change.
+
+    Pins spec §5 / item 15: docs/tests/build churn is not a reason to
+    reinstall.
+    """
+    pkg = _package(tmp_path)
+    before = cli_source_digest(pkg)
+    _seed(pkg / "tests" / "test_x.py", b"t")
+    _seed(pkg / "src" / "p" / "__pycache__" / "m.cpython-311.pyc", b"c")
+    _seed(pkg / "src" / "p" / "stray.pyc", b"c")
+    assert cli_source_digest(pkg) == before
+
+
+def test_digest_changes_on_src_change(tmp_path: Path) -> None:
+    """
+    Given a package
+    When a file under src/** changes
+    Then the digest changes.
+
+    Pins spec §5: src/** is deployable source.
+    """
+    pkg = _package(tmp_path)
+    before = cli_source_digest(pkg)
+    _seed(pkg / "src" / "p" / "__init__.py", b"changed")
+    assert cli_source_digest(pkg) != before

--- a/packages/installer/tests/unit/test_receipt_clis.py
+++ b/packages/installer/tests/unit/test_receipt_clis.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from installer.core.receipt import CliReceiptEntry, Receipt, canonical_bytes, compute_integrity
+from installer.core.receipt_build import merge_clis
 from installer.core.receipt_store import ReadStatus, read_receipt, write_receipt
 
 _ENTRY = CliReceiptEntry(name="workcli", binary="work", digest="sha256:ab")
@@ -78,3 +79,47 @@ def test_malformed_clis_entry_reads_corrupt(tmp_path: Path) -> None:
     raw["integrity"] = compute_integrity(coerced)
     path.write_text(json.dumps(raw))
     assert read_receipt(path).status is ReadStatus.CORRUPT
+
+
+def _e(name: str, digest: str = "sha256:aa") -> CliReceiptEntry:
+    return CliReceiptEntry(name=name, binary=name[0:4], digest=digest)
+
+
+def test_merge_clis_union_rule() -> None:
+    """
+    Given prior entries {workcli, oldtool} and registry {workcli, prgroom}
+    When this run deployed prgroom and uninstalled oldtool
+    Then the merge keeps workcli's prior entry (skip retains), adds
+    prgroom's new entry, and drops oldtool.
+
+    Pins spec §7 union merge rule (registry -> new-if-deployed else
+    retained; non-registry -> dropped iff uninstalled).
+    """
+    merged = merge_clis(
+        prior_clis=(_e("workcli"), _e("oldtool")),
+        registry_names=frozenset({"workcli", "prgroom"}),
+        deployed={"prgroom": _e("prgroom", "sha256:new")},
+        uninstalled_names={"oldtool"},
+        relinquished_names=set(),
+    )
+    assert {c.name for c in merged} == {"workcli", "prgroom"}
+    assert next(c for c in merged if c.name == "prgroom").digest == "sha256:new"
+
+
+def test_merge_clis_declined_uninstall_retained_foreign_relinquished() -> None:
+    """
+    Given a retired entry whose uninstall was declined and a foreign entry
+    When merged
+    Then the declined one is retained (retried next prune) and the
+    relinquished foreign one is dropped without uninstall.
+
+    Pins spec §7 (decline retains; foreign names relinquished — item 10).
+    """
+    merged = merge_clis(
+        prior_clis=(_e("oldtool"), _e("ruff")),
+        registry_names=frozenset({"workcli"}),
+        deployed={},
+        uninstalled_names=set(),
+        relinquished_names={"ruff"},
+    )
+    assert {c.name for c in merged} == {"oldtool"}

--- a/packages/installer/tests/unit/test_receipt_clis.py
+++ b/packages/installer/tests/unit/test_receipt_clis.py
@@ -1,0 +1,80 @@
+"""Tests for the additive Receipt.clis field (spec §7, item 11)."""
+
+import json
+from pathlib import Path
+
+from installer.core.receipt import CliReceiptEntry, Receipt, canonical_bytes, compute_integrity
+from installer.core.receipt_store import ReadStatus, read_receipt, write_receipt
+
+_ENTRY = CliReceiptEntry(name="workcli", binary="work", digest="sha256:ab")
+
+
+def test_clis_round_trip(tmp_path: Path) -> None:
+    """
+    Given a receipt with one clis entry
+    When written and re-read
+    Then status is OK and the entry survives intact.
+
+    Pins spec §7 / item 11: receipt_store round-trips the field.
+    """
+    path = tmp_path / "install-receipt.json"
+    write_receipt(path, Receipt(clis=(_ENTRY,)))
+    result = read_receipt(path)
+    assert result.status is ReadStatus.OK
+    assert result.receipt is not None and result.receipt.clis == (_ENTRY,)
+
+
+def test_legacy_receipt_without_clis_still_validates(tmp_path: Path) -> None:
+    """
+    Given a receipt written before the clis field existed
+    When read by the new code
+    Then it reads OK (integrity still validates) with clis == ().
+
+    Pins spec §7: canonical_bytes includes "clis" only when non-empty, so a
+    legacy receipt hashes byte-identically (item 11).
+    """
+    path = tmp_path / "install-receipt.json"
+    legacy = Receipt()  # no clis
+    write_receipt(path, legacy)
+    raw = json.loads(path.read_text())
+    assert "clis" not in raw  # emitted only when non-empty
+    result = read_receipt(path)
+    assert result.status is ReadStatus.OK
+    assert result.receipt is not None and result.receipt.clis == ()
+
+
+def test_empty_clis_hashes_identically_to_absent() -> None:
+    """
+    Given two receipts, one default and one with explicit empty clis
+    When canonical_bytes runs
+    Then the bytes are identical (no integrity break for legacy receipts).
+
+    Pins spec §7 omit-when-empty.
+    """
+    assert canonical_bytes(Receipt()) == canonical_bytes(Receipt(clis=()))
+    assert compute_integrity(Receipt()) == compute_integrity(Receipt(clis=()))
+
+
+def test_malformed_clis_entry_reads_corrupt(tmp_path: Path) -> None:
+    """
+    Given a receipt whose clis entry has a non-string digest, with integrity
+    restamped as a coercing (non-validating) reader would have computed it
+    When read
+    Then status is CORRUPT (fail closed — only the clis type validation can
+    produce this, since the restamped integrity MATCHES the coerced value).
+
+    Pins spec §7 validation / item 11: the fail-closed type check in
+    _cli_entry_from_json — not a stale integrity — is what rejects the entry.
+    """
+    path = tmp_path / "install-receipt.json"
+    write_receipt(path, Receipt(clis=(_ENTRY,)))
+    raw = json.loads(path.read_text())
+    raw["clis"][0]["digest"] = 42
+    # Restamp integrity as a coercing (non-validating) reader would compute it:
+    # digest 42 coerced to "42" makes integrity MATCH, so the ONLY thing that
+    # can flag CORRUPT is the fail-closed type validation itself. (The coerced
+    # receipt mirrors the persisted one — default roots/entries, digest coerced.)
+    coerced = Receipt(clis=(CliReceiptEntry(name=_ENTRY.name, binary=_ENTRY.binary, digest="42"),))
+    raw["integrity"] = compute_integrity(coerced)
+    path.write_text(json.dumps(raw))
+    assert read_receipt(path).status is ReadStatus.CORRUPT


### PR DESCRIPTION
## Summary
- Tasks 1-5 of the installer CLI-deploy plan (docs/plans/2026-07-16-installer-cli-deploy-plan.md), scoped in this repo's Lane 2 installer-deploy track.
- Adds the closed CLI registry (workcli/prgroom), `cli_source_digest`, the `CliDeployPort` seam (`UvCliDeploy` real / `ScriptedCliDeploy` fake) in `packages/installer/src/installer/core/clis.py`.
- Adds the additive `Receipt.clis` field (`CliReceiptEntry`) with omit-when-empty integrity compatibility, and the `merge_clis` union-merge rule threaded through `record_receipt`/`merge_receipt`.
- Pure plumbing — no wiring into `cli.py` yet (that's PR2/PR3 of this split); nothing changes installer runtime behavior in this PR.

## Test plan
- [x] `make ci-installer` from the worktree: ruff, ruff format --check, mypy --strict, pytest (855 passed, 1 pre-existing unrelated skip), coverage 97.95% (floor 90%), pip-audit clean, entry-verify OK.

bead: agents-config-wgclw.9.9 (part 1 of 3)