### PR TITLE
feat(workcli): track layer slice A — config discovery, Item.track, list --track (protocol 1.1)

### DIFF
--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -80,13 +80,17 @@ Twelve verbs; "~10 coarse" per the bead. `epic`/`stats`/`compact`/`delete` are
 deliberately excluded from v1 — no programmatic consumer observed; direct `bd`
 remains available for humans.
 
+`track set`, `lint`, `graph --json`, and the `--track`/`--config` flags are
+specified in the 2026-07-15 track-partition design spec, §4 (this spec owns
+only their envelope/error-code vocabulary above).
+
 ## 4. Output contract (bead open-Q2)
 
 JSON envelope on stdout, always, exit code mirrors `ok`:
 
 ```json
-{"protocol": "1.0", "ok": true, "data": { ... }, "error": null}
-{"protocol": "1.0", "ok": false, "data": null,
+{"protocol": "1.1", "ok": true, "data": { ... }, "error": null}
+{"protocol": "1.1", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y", "dep_type": "blocks"}}}
 ```
@@ -95,6 +99,11 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
   returns an object (never a single-element array); dep edges are lean
   (`{id, type, status}`, never full embedded beads); labels are always
   `string[]`; multi-line fields are proper JSON strings.
+- `Item` payloads on every read verb carry a derived, nullable `track` field —
+  the name of the item's single `track:*` label, `null` on zero or multiple
+  (contract pinned by the 2026-07-15 track-partition design, §4). `create`
+  responses MAY carry an optional `warnings: [string]` array (advisory-mode
+  track gate).
 - Human-readable output is opt-in (`--format human`), for direct human use only:
   it renders the human view to **stderr** while stdout still carries the JSON
   envelope, so the "stdout, always" invariant above holds and consumers MUST
@@ -107,6 +116,11 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
   the shape is unparseable or the failure is simply unrecognized),
   `E_UNSUPPORTED_CAPABILITY` (semantics defined in §6), `E_USAGE`, `E_INTERNAL`
   (an unexpected facade fault — the envelope invariant holds even on internal bugs).
+  Track-layer surfaces only (raised by `create`/`list --track`/`track set`/`lint`,
+  never a pre-existing verb): `E_TRACK_REQUIRED` (a required-mode create with no
+  track label), `E_UNKNOWN_TRACK` (a `--track` name outside the configured
+  vocabulary), `E_NOT_CONFIGURED` (no resolvable/valid `project-config.toml`
+  `[tracks]` table).
 - Lock-contention retry: bounded backoff inside the facade; only after
   exhaustion does `E_LOCK_CONTENTION` surface (quirk-shim inventory, last rows).
 - Exception: `--help`/`-h` (root and per-verb) is a human affordance — it prints
@@ -118,7 +132,7 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
 - Every envelope carries `protocol` (semver `MAJOR.MINOR`). Additive fields bump
   MINOR; any breaking change to envelope or `data` shapes bumps MAJOR.
 - `work --protocol-version` returns a standard success envelope on stdout
-  (`ok: true`, `data: {"protocol": "1.0"}`, exit 0) — no exception to the
+  (`ok: true`, `data: {"protocol": "1.1"}`, exit 0) — no exception to the
   "stdout is always a JSON envelope" invariant (§4). It is the consumer
   handshake at adapter init (prgroom/PDLC pin a major and refuse a mismatch at
   startup rather than mis-parsing mid-run).

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -53,9 +53,9 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work reconcile [--dry-run]` | bd-observable recovery sweep: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol stays `"1.0"` — the lifecycle layer only added `ErrorCode` members
-(additive within `1.0`, exactly like `E_INTERNAL`); no existing envelope or
-data shape changed. The finer capability-model split (an honest
+Protocol is `"1.1"` — additive-only bumps (new `ErrorCode` members, the
+derived `Item.track` field) never change an existing envelope or data shape.
+The finer capability-model split (an honest
 server-authoritative `sync` no-op; read-only dep listing surviving
 `supports_dep_types=False`) is deferred to the future non-bd (GH) adapter
 bead — bd itself declares every capability `True`, so nothing in this
@@ -71,13 +71,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.0", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.1", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.0", "ok": false, "data": null,
+{"protocol": "1.1", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -109,7 +109,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.0", "ok": true, "data": {"protocol": "1.0"}, "error": null}
+{"protocol": "1.1", "ok": true, "data": {"protocol": "1.1"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -130,7 +130,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.0"}`.
+- `--protocol-version` → `{"protocol": "1.1"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -29,7 +29,7 @@ Twelve verbs; each is a subcommand of `work`.
 | `work label {add,remove,list} ID [LABELS...]` | multi-label in one call |
 | `work search QUERY` | — |
 | `work sync [--pull]` | — |
-| global | `--format {json,human}` (human renders to **stderr**; stdout envelope unchanged), `--protocol-version` |
+| global | `--format {json,human}` (human renders to **stderr**; stdout envelope unchanged), `--protocol-version`, `--config PATH` (explicit `project-config.toml`; overrides the upward search — track-layer surfaces only, see below) |
 
 `epic`/`stats`/`compact`/`delete` are deliberately out of scope for v1 — no
 programmatic consumer observed; use `bd` directly for those.

--- a/packages/workcli/pyproject.toml
+++ b/packages/workcli/pyproject.toml
@@ -58,6 +58,10 @@ select = [
 # it's a contract-violation diagnostic (Finding 2), same specificity
 # rationale as parse.py's drift alarm above.
 "src/workcli/adapters/bd/backend.py" = ["TRY003"]
+# Every E_NOT_CONFIGURED message must name the specific config problem and
+# path inline (spec §3: "a message naming the specific problem") -- same
+# specificity rationale as parse.py's drift alarm above.
+"src/workcli/config.py" = ["TRY003"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.0"
+PROTOCOL_VERSION = "1.1"

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -51,6 +51,7 @@ def _add_read_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser])
     list_parser.add_argument("--parent")
     list_parser.add_argument("--type")
     list_parser.add_argument("--limit", type=int, default=None)
+    list_parser.add_argument("--track", metavar="NAME")
 
     ready_parser = subparsers.add_parser("ready", help="list ready-to-work items, unbounded")
     ready_parser.add_argument("--label")

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -21,6 +21,7 @@ from typing import NoReturn, TextIO
 from workcli import PROTOCOL_VERSION
 from workcli.adapters.bd.backend import BdBackend
 from workcli.adapters.bd.runner import BdRunner, SubprocessBdRunner
+from workcli.config import TrackLayerConfig, load_config
 from workcli.envelope import ErrorCode, JsonValue, WorkError, emit_failure, emit_success
 from workcli.lifecycle.nouns import Noun
 from workcli.render import render_human
@@ -174,6 +175,12 @@ def _build_parser() -> _EnvelopeArgumentParser:
         default="json",
         help="human rendering goes to stderr; stdout always carries the JSON envelope",
     )
+    parser.add_argument(
+        "--config",
+        default=None,
+        metavar="PATH",
+        help="explicit project-config.toml path; overrides the upward search",
+    )
     # `parser_class` propagates the raise-don't-exit `error()` override to
     # every subparser too -- a bad flag inside `work show --bogus` must reach
     # main()'s WorkError handling exactly like a bad top-level flag does,
@@ -268,6 +275,11 @@ def _default_read_file(path: str) -> str:
         ) from read_error
 
 
+def _default_config_loader(explicit_path: str | None) -> TrackLayerConfig:
+    """The real track-layer config resolution: upward search from cwd (track spec §3)."""
+    return load_config(Path.cwd(), explicit_path)
+
+
 def _build_backend(runner: BdRunner | None, sleep: Callable[[float], None] | None) -> BdBackend:
     return BdBackend(
         runner if runner is not None else SubprocessBdRunner(),
@@ -283,6 +295,7 @@ def main(
     err: TextIO | None = None,
     sleep: Callable[[float], None] | None = None,
     read_file: Callable[[str], str] | None = None,
+    config_loader: Callable[[str | None], TrackLayerConfig] | None = None,
 ) -> int:
     if out is None:
         out = sys.stdout
@@ -301,6 +314,12 @@ def main(
     # `(Backend, Namespace) -> JsonValue` signature (plan L12), so this
     # travels as an `args` attribute rather than an extra handler parameter.
     args.read_file = read_file if read_file is not None else _default_read_file
+
+    # Same args-attachment precedent as read_file: resolved once, loaded
+    # LAZILY -- only a track-layer surface calls args.load_config(), so
+    # pre-existing verbs never trigger config resolution (track spec §3).
+    resolved_config_loader = config_loader if config_loader is not None else _default_config_loader
+    args.load_config = lambda: resolved_config_loader(args.config)
 
     if args.protocol_version:
         return _finish_success({"protocol": PROTOCOL_VERSION}, out, err, args.format)

--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -1,0 +1,151 @@
+"""Track-layer config: discovery, parsing, validation (track spec §3).
+
+Loaded lazily -- only when a track-layer surface (a §4 flag, verb, or gate)
+needs it -- so pre-existing verbs never trigger a load. Every failure is the
+single typed `E_NOT_CONFIGURED`, its message naming the specific parse or
+validation problem; `detail.reason` distinguishes "not-found" from "invalid"
+so the create gate can stay fail-safe (spec §3: a broken config fails only
+the track layer, never an existing verb). Parse and validate once here;
+everything inward trusts the frozen dataclass.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from workcli.envelope import ErrorCode, WorkError
+
+CONFIG_FILENAME = "project-config.toml"
+
+Reason = Literal["not-found", "invalid"]
+
+
+@dataclass(frozen=True)
+class TrackLayerConfig:
+    names: tuple[str, ...]
+    organizing_only: tuple[str, ...]
+    enforcement: str  # "advisory" | "required"; omitted key parses to "advisory"
+    milestone_wip_cap: (
+        int | None
+    )  # None: [operating-model] absent/key omitted -> lint skips WIP check
+    wip_exempt_milestones: tuple[str, ...]
+
+
+def _not_configured(problem: str, reason: Reason) -> WorkError:
+    return WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        f"track layer not configured: {problem}",
+        detail={"reason": reason},
+    )
+
+
+def _find_config(start_dir: Path) -> Path | None:
+    """Upward search from `start_dir`, bounded by the enclosing git root (spec §3).
+
+    The git root is located FIRST: with no git root on the walk -- the working
+    directory lies outside any repo -- the search finds nothing, even when a
+    project-config.toml exists in some parent directory (adopting an unrelated
+    parent config would be the fail-unsafe path). The directory containing
+    `.git` (a dir, or a file in linked worktrees) is the last one searched.
+    """
+    current = start_dir.resolve()
+    lineage = (current, *current.parents)
+    git_root = next(
+        (candidate_dir for candidate_dir in lineage if (candidate_dir / ".git").exists()),
+        None,
+    )
+    if git_root is None:
+        return None
+    for candidate_dir in lineage:
+        candidate = candidate_dir / CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+        if candidate_dir == git_root:
+            break
+    return None
+
+
+def load_config(start_dir: Path, explicit_path: str | None = None) -> TrackLayerConfig:
+    """Resolve, parse, and validate `[tracks]`/`[operating-model]`.
+
+    `explicit_path` (the `--config` flag) overrides the search in every case.
+    """
+    if explicit_path is not None:
+        config_path = Path(explicit_path)
+        if not config_path.is_file():
+            raise _not_configured(f"--config path not found: {explicit_path}", "not-found")
+    else:
+        found = _find_config(start_dir)
+        if found is None:
+            raise _not_configured(
+                f"no {CONFIG_FILENAME} between {start_dir} and the enclosing git root",
+                "not-found",
+            )
+        config_path = found
+    try:
+        raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except OSError as read_error:
+        raise _not_configured(f"cannot read {config_path}: {read_error}", "invalid") from read_error
+    except tomllib.TOMLDecodeError as parse_error:
+        raise _not_configured(
+            f"malformed TOML in {config_path}: {parse_error}", "invalid"
+        ) from parse_error
+    return _validate(raw, config_path)
+
+
+def _string_tuple(value: object, where: str, path: Path) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(entry, str) for entry in value):
+        raise _not_configured(f"{where} must be a list of strings in {path}", "invalid")
+    return tuple(value)
+
+
+def _validate(raw: dict[str, object], path: Path) -> TrackLayerConfig:
+    tracks = raw.get("tracks")
+    if not isinstance(tracks, dict):
+        raise _not_configured(f"no [tracks] table in {path}", "not-found")
+    names = _string_tuple(tracks.get("names", []), "[tracks].names", path)
+    if not names:
+        raise _not_configured(f"[tracks].names is empty or missing in {path}", "invalid")
+    organizing_only = _string_tuple(
+        tracks.get("organizing-only", []), "[tracks].organizing-only", path
+    )
+    unknown_organizing = [name for name in organizing_only if name not in names]
+    if unknown_organizing:
+        raise _not_configured(
+            f"[tracks].organizing-only entries not in names: {unknown_organizing} in {path}",
+            "invalid",
+        )
+    enforcement = tracks.get("enforcement", "advisory")
+    if enforcement not in ("advisory", "required"):
+        raise _not_configured(
+            f"[tracks].enforcement must be 'advisory' or 'required', got {enforcement!r} in {path}",
+            "invalid",
+        )
+
+    operating = raw.get("operating-model")
+    if operating is not None and not isinstance(operating, dict):
+        # A non-table [operating-model] is malformed config, not an omitted
+        # optional section -- silently ignoring it would silently disable
+        # the lint WIP check.
+        raise _not_configured(f"[operating-model] must be a table in {path}", "invalid")
+    operating_table = operating if isinstance(operating, dict) else {}
+    cap = operating_table.get("milestone-wip-cap")
+    if cap is not None and (isinstance(cap, bool) or not isinstance(cap, int)):
+        raise _not_configured(
+            f"[operating-model].milestone-wip-cap must be an integer in {path}", "invalid"
+        )
+    exempt = _string_tuple(
+        operating_table.get("wip-exempt-milestones", []),
+        "[operating-model].wip-exempt-milestones",
+        path,
+    )
+    return TrackLayerConfig(
+        names=names,
+        organizing_only=organizing_only,
+        enforcement=str(enforcement),
+        milestone_wip_cap=cap,
+        wip_exempt_milestones=exempt,
+    )

--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -89,6 +89,10 @@ def load_config(start_dir: Path, explicit_path: str | None = None) -> TrackLayer
         raw = tomllib.loads(config_path.read_text(encoding="utf-8"))
     except OSError as read_error:
         raise _not_configured(f"cannot read {config_path}: {read_error}", "invalid") from read_error
+    except UnicodeDecodeError as decode_error:
+        raise _not_configured(
+            f"{config_path} is not valid UTF-8: {decode_error}", "invalid"
+        ) from decode_error
     except tomllib.TOMLDecodeError as parse_error:
         raise _not_configured(
             f"malformed TOML in {config_path}: {parse_error}", "invalid"

--- a/packages/workcli/src/workcli/envelope.py
+++ b/packages/workcli/src/workcli/envelope.py
@@ -27,6 +27,9 @@ class ErrorCode(StrEnum):
     EVIDENCE = "E_EVIDENCE"
     MANIFEST = "E_MANIFEST"
     TIMEOUT = "E_TIMEOUT"
+    TRACK_REQUIRED = "E_TRACK_REQUIRED"
+    UNKNOWN_TRACK = "E_UNKNOWN_TRACK"
+    NOT_CONFIGURED = "E_NOT_CONFIGURED"
 
 
 @dataclass(frozen=True)

--- a/packages/workcli/src/workcli/tracks.py
+++ b/packages/workcli/src/workcli/tracks.py
@@ -1,0 +1,37 @@
+"""Track derivation and vocabulary validation (track spec §4).
+
+Derivation is config-free by design -- a pure function over labels -- so the
+`Item.track` envelope field appears on every read verb regardless of config
+state. Only *validation* (`require_known_track`) needs the vocabulary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+
+TRACK_PREFIX = "track:"
+
+
+def derive_track(labels: Sequence[str]) -> str | None:
+    """Exactly one `track:*` label -> its name; zero or 2+ -> None (spec §4)."""
+    names = [label[len(TRACK_PREFIX) :] for label in labels if label.startswith(TRACK_PREFIX)]
+    if len(names) == 1:
+        return names[0]
+    return None
+
+
+def track_label(name: str) -> str:
+    return f"{TRACK_PREFIX}{name}"
+
+
+def require_known_track(name: str, config: TrackLayerConfig) -> None:
+    """Unknown names fail with E_UNKNOWN_TRACK naming the vocabulary -- never a new label."""
+    if name not in config.names:
+        raise WorkError(
+            ErrorCode.UNKNOWN_TRACK,
+            f"unknown track {name!r}; configured tracks: {', '.join(config.names)}",
+            detail={"track": name, "names": list(config.names)},
+        )

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -14,7 +14,7 @@ from typing import cast
 from workcli.backend import Backend
 from workcli.envelope import JsonValue
 from workcli.model import Item, QueryFilters
-from workcli.tracks import derive_track
+from workcli.tracks import derive_track, require_known_track
 
 
 def _serialize_item(item: Item) -> dict[str, JsonValue]:
@@ -40,7 +40,33 @@ def show(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def list_(backend: Backend, args: Namespace) -> JsonValue:
-    """`work list [--status --label --parent --type --limit]` — unbounded unless `--limit`."""
+    """`work list [--status --label --parent --type --limit --track]`.
+
+    `--track` filters on the DERIVED `Item.track` (never raw label presence),
+    so filter and envelope field always agree: zero-or-multi-label beads
+    derive to null and match nothing (track spec §4). Validated against the
+    vocabulary for parity with `create --track` -- a typo returns
+    E_UNKNOWN_TRACK, not a silently-empty result. Ordering matters twice:
+    config loads BEFORE the backend query (E_NOT_CONFIGURED must precede any
+    backend error, and an unconfigured call must not read the tracker), and
+    --limit applies AFTER the track filter (a bd-side limit would truncate
+    the candidate set before filtering and undercount matches).
+    """
+    if args.track is not None:
+        require_known_track(args.track, args.load_config())
+        unbounded = QueryFilters(
+            status=args.status,
+            label=args.label,
+            parent=args.parent,
+            type=args.type,
+            limit=None,
+        )
+        items = [
+            item for item in backend.query(unbounded) if derive_track(item.labels) == args.track
+        ]
+        if args.limit is not None:
+            items = items[: args.limit]
+        return _serialize_items(items)
     filters = QueryFilters(
         status=args.status,
         label=args.label,

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -53,7 +53,10 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
     the candidate set before filtering and undercount matches). `--limit 0`
     is the existing unbounded sentinel (mirrored from the bd adapter, which
     sends "0" for both an omitted limit and an explicit 0) -- it must not
-    slice the filtered set down to zero items.
+    slice the filtered set down to zero items. A negative limit is never
+    meaningful either -- unlike bd-side slicing, Python's `items[:n]` with a
+    negative `n` silently drops trailing items rather than erroring, so
+    zero-or-negative both mean unbounded here.
     """
     if args.track is not None:
         require_known_track(args.track, args.load_config())
@@ -67,7 +70,7 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
         items = [
             item for item in backend.query(unbounded) if derive_track(item.labels) == args.track
         ]
-        if args.limit:
+        if args.limit is not None and args.limit > 0:
             items = items[: args.limit]
         return _serialize_items(items)
     filters = QueryFilters(

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -50,7 +50,10 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
     config loads BEFORE the backend query (E_NOT_CONFIGURED must precede any
     backend error, and an unconfigured call must not read the tracker), and
     --limit applies AFTER the track filter (a bd-side limit would truncate
-    the candidate set before filtering and undercount matches).
+    the candidate set before filtering and undercount matches). `--limit 0`
+    is the existing unbounded sentinel (mirrored from the bd adapter, which
+    sends "0" for both an omitted limit and an explicit 0) -- it must not
+    slice the filtered set down to zero items.
     """
     if args.track is not None:
         require_known_track(args.track, args.load_config())
@@ -64,7 +67,7 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
         items = [
             item for item in backend.query(unbounded) if derive_track(item.labels) == args.track
         ]
-        if args.limit is not None:
+        if args.limit:
             items = items[: args.limit]
         return _serialize_items(items)
     filters = QueryFilters(

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -14,12 +14,17 @@ from typing import cast
 from workcli.backend import Backend
 from workcli.envelope import JsonValue
 from workcli.model import Item, QueryFilters
+from workcli.tracks import derive_track
 
 
 def _serialize_item(item: Item) -> dict[str, JsonValue]:
     # `dataclasses.asdict` recurses into the nested `DepEdge` list too, so
     # `deps` comes out already lean (`{id, type, status}`) with no extra work.
-    return cast("dict[str, JsonValue]", dataclasses.asdict(item))
+    serialized = cast("dict[str, JsonValue]", dataclasses.asdict(item))
+    # Derived in the verb layer, config-free, so every read envelope carries
+    # it regardless of config state (track spec §4; the 1.1 additive field).
+    serialized["track"] = derive_track(item.labels)
+    return serialized
 
 
 def _serialize_items(items: list[Item]) -> JsonValue:

--- a/packages/workcli/tests/conftest.py
+++ b/packages/workcli/tests/conftest.py
@@ -8,6 +8,7 @@ from io import StringIO
 
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.cli import main
+from workcli.config import TrackLayerConfig
 from workcli.envelope import JsonValue
 
 
@@ -29,12 +30,17 @@ def fake_reader(paths: dict[str, str]) -> Callable[[str], str]:
 _NO_READS = fake_reader({})
 
 
+def _no_config_loads(_explicit_path: str | None) -> TrackLayerConfig:
+    raise AssertionError("config loader unexpectedly invoked; inject config_loader= explicitly")
+
+
 def run_cli(
     argv: Sequence[str],
     steps: Sequence[ScriptedStep],
     *,
     sleep: Callable[[float], None] | None = None,
     read_file: Callable[[str], str] | None = None,
+    config_loader: Callable[[str | None], TrackLayerConfig] | None = None,
 ) -> tuple[int, dict[str, JsonValue], str]:
     """Invoke `main()` against a `ScriptedBdRunner`, capturing stdout/stderr.
 
@@ -58,6 +64,7 @@ def run_cli(
         err=err,
         sleep=sleep,
         read_file=read_file if read_file is not None else _NO_READS,
+        config_loader=config_loader if config_loader is not None else _no_config_loads,
     )
     envelope: dict[str, JsonValue] = json.loads(out.getvalue())
     return exit_code, envelope, err.getvalue()
@@ -69,6 +76,7 @@ def run_cli_with_runner(
     *,
     sleep: Callable[[float], None] | None = None,
     read_file: Callable[[str], str] | None = None,
+    config_loader: Callable[[str | None], TrackLayerConfig] | None = None,
 ) -> tuple[int, dict[str, JsonValue], str]:
     """Like `run_cli`, but takes a caller-built `ScriptedBdRunner`.
 
@@ -85,6 +93,7 @@ def run_cli_with_runner(
         err=err,
         sleep=sleep,
         read_file=read_file if read_file is not None else _NO_READS,
+        config_loader=config_loader if config_loader is not None else _no_config_loads,
     )
     envelope: dict[str, JsonValue] = json.loads(out.getvalue())
     return exit_code, envelope, err.getvalue()

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -1,0 +1,165 @@
+"""Behavioral tests for workcli.config.load_config (track spec §3, criterion 16/17)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from workcli.config import load_config
+from workcli.envelope import ErrorCode, WorkError
+
+VALID_TRACKS = """
+[tracks]
+names = ["alpha", "beta", "gamma"]
+organizing-only = ["gamma"]
+enforcement = "advisory"
+
+[operating-model]
+milestone-wip-cap = 2
+wip-exempt-milestones = ["proj-m1"]
+"""
+
+
+def _repo(tmp_path: Path, config_text: str | None = VALID_TRACKS) -> Path:
+    """A fake git repo root: .git marker + optional project-config.toml."""
+    (tmp_path / ".git").mkdir()
+    if config_text is not None:
+        (tmp_path / "project-config.toml").write_text(config_text, encoding="utf-8")
+    return tmp_path
+
+
+def test_finds_config_upward_from_repo_subdirectory(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    subdir = root / "packages" / "workcli"
+    subdir.mkdir(parents=True)
+
+    config = load_config(subdir)
+
+    assert config.names == ("alpha", "beta", "gamma")
+    assert config.organizing_only == ("gamma",)
+    assert config.enforcement == "advisory"
+    assert config.milestone_wip_cap == 2
+    assert config.wip_exempt_milestones == ("proj-m1",)
+
+
+def test_search_stops_at_git_root(tmp_path: Path) -> None:
+    # Config ABOVE the git root must not be found: the root bounds the search.
+    (tmp_path / "project-config.toml").write_text(VALID_TRACKS, encoding="utf-8")
+    root = tmp_path / "repo"
+    root.mkdir()
+    (root / ".git").mkdir()
+
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+    assert exc_info.value.detail["reason"] == "not-found"
+
+
+def test_outside_any_git_repo_is_not_configured(tmp_path: Path) -> None:
+    # No .git anywhere on the walk -> treated as "no config found" (spec §3),
+    # even when a project-config.toml exists in a parent dir. REGRESSION PIN:
+    # a naive walk that checks for the config file before establishing a git
+    # root adopts that unrelated parent config instead of failing safe --
+    # this test is the tripwire for that ordering bug.
+    (tmp_path / "project-config.toml").write_text(VALID_TRACKS, encoding="utf-8")
+    workdir = tmp_path / "nested"
+    workdir.mkdir()
+
+    with pytest.raises(WorkError) as exc_info:
+        load_config(workdir)
+    assert exc_info.value.detail["reason"] == "not-found"
+
+
+def test_explicit_config_flag_overrides_search(tmp_path: Path) -> None:
+    root = _repo(tmp_path)  # valid config at root...
+    elsewhere = tmp_path / "elsewhere.toml"
+    elsewhere.write_text(
+        VALID_TRACKS.replace('"alpha", "beta", "gamma"', '"delta"').replace('["gamma"]', "[]"),
+        encoding="utf-8",
+    )
+
+    config = load_config(root, explicit_path=str(elsewhere))
+    assert config.names == ("delta",)
+
+
+def test_explicit_config_flag_missing_path_is_not_configured(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root, explicit_path=str(tmp_path / "nope.toml"))
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+
+
+def test_malformed_toml_is_invalid_and_names_the_problem(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text="[tracks\nnames = not toml")
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "malformed TOML" in exc_info.value.message
+
+
+def test_missing_tracks_table_reads_as_not_found(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text='[project]\nname = "x"\n')
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "not-found"
+
+
+def test_non_list_names_is_invalid(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text='[tracks]\nnames = "alpha"\n')
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "[tracks].names" in exc_info.value.message
+
+
+def test_enforcement_omitted_defaults_to_advisory(tmp_path: Path) -> None:
+    # Criterion 4's config-layer leg: omitted key parses as advisory.
+    root = _repo(tmp_path, config_text='[tracks]\nnames = ["alpha"]\n')
+    assert load_config(root).enforcement == "advisory"
+
+
+def test_bogus_enforcement_value_is_invalid(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text='[tracks]\nnames = ["alpha"]\nenforcement = "yolo"\n')
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+
+
+def test_organizing_only_outside_names_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\norganizing-only = ["beta"]\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+
+
+def test_operating_model_absent_yields_no_wip_cap(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text='[tracks]\nnames = ["alpha"]\n')
+    config = load_config(root)
+    assert config.milestone_wip_cap is None
+    assert config.wip_exempt_milestones == ()
+
+
+def test_non_table_operating_model_is_invalid(tmp_path: Path) -> None:
+    # Malformed, not omitted: must fail loud, never silently disable lint's
+    # WIP check. (Top-level key must precede the [tracks] table in TOML.)
+    root = _repo(tmp_path, config_text='operating-model = "bad"\n[tracks]\nnames = ["alpha"]\n')
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "[operating-model]" in exc_info.value.message
+
+
+def test_git_file_marker_counts_as_root(tmp_path: Path) -> None:
+    # Linked worktrees have a .git FILE, not a dir -- the search must still
+    # treat that directory as the root boundary.
+    root = tmp_path / "wt"
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    (root / "project-config.toml").write_text(VALID_TRACKS, encoding="utf-8")
+
+    assert load_config(root).names == ("alpha", "beta", "gamma")

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -99,6 +99,19 @@ def test_malformed_toml_is_invalid_and_names_the_problem(tmp_path: Path) -> None
     assert "malformed TOML" in exc_info.value.message
 
 
+def test_non_utf8_config_is_invalid_not_a_crash(tmp_path: Path) -> None:
+    # REGRESSION PIN (Codex finding): read_text(encoding="utf-8") raises
+    # UnicodeDecodeError on undecodable bytes -- uncaught, that would surface
+    # as E_INTERNAL instead of the track layer's own typed failure.
+    root = _repo(tmp_path, config_text=None)
+    (root / "project-config.toml").write_bytes(b"[tracks]\nnames = [\xff\xfe]\n")
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "not valid UTF-8" in exc_info.value.message
+
+
 def test_missing_tracks_table_reads_as_not_found(tmp_path: Path) -> None:
     root = _repo(tmp_path, config_text='[project]\nname = "x"\n')
     with pytest.raises(WorkError) as exc_info:

--- a/packages/workcli/tests/unit/test_config_seam.py
+++ b/packages/workcli/tests/unit/test_config_seam.py
@@ -1,0 +1,47 @@
+"""The config-loader seam: injected, lazy, --config passthrough (track spec §3)."""
+
+from __future__ import annotations
+
+import json
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+
+
+def _exploding_loader(_explicit_path: str | None) -> TrackLayerConfig:
+    # Underscore-prefixed unused param: house convention for test doubles
+    # (ruff ARG001 is enabled package-wide).
+    raise AssertionError("config loader invoked by a pre-existing verb (must be lazy)")
+
+
+def test_pre_existing_verbs_never_touch_the_config_loader() -> None:
+    # Criterion 17's laziness leg: `show` with no track flags must complete
+    # without the loader ever running -- even with --config on the command line.
+    step = ScriptedStep(
+        ("show",),
+        BdResult(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "id": "w-1",
+                        "title": "T",
+                        "issue_type": "task",
+                        "status": "open",
+                        "priority": 2,
+                        "labels": [],
+                    }
+                ]
+            ),
+            stderr="",
+        ),
+    )
+    exit_code, envelope, _ = run_cli(
+        ["--config", "/tmp/anything.toml", "show", "w-1"],  # noqa: S108 -- never read; loader is fail-loud
+        [step],
+        config_loader=_exploding_loader,
+    )
+    assert exit_code == 0
+    assert envelope["ok"] is True

--- a/packages/workcli/tests/unit/test_item_track_field.py
+++ b/packages/workcli/tests/unit/test_item_track_field.py
@@ -1,0 +1,82 @@
+"""Item.track envelope field on all read verbs (track spec §4, criterion 8)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+
+
+def _bd_item(item_id: str, labels: list[str]) -> dict[str, object]:
+    """Minimal bd show/list JSON record accepted by adapters/bd/parse.py.
+
+    Mirror the fixture fields used in test_show_normalization.py; extend only
+    if parse_items rejects the record (its drift alarm names what's missing).
+    """
+    return {
+        "id": item_id,
+        "title": "T",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "labels": labels,
+    }
+
+
+def _show_step(item_id: str, labels: list[str]) -> ScriptedStep:
+    return ScriptedStep(
+        ("show",),
+        BdResult(returncode=0, stdout=json.dumps([_bd_item(item_id, labels)]), stderr=""),
+    )
+
+
+def test_show_carries_derived_track() -> None:
+    exit_code, envelope, _ = run_cli(
+        ["show", "w-1"], [_show_step("w-1", ["track:installer", "planned"])]
+    )
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert data["track"] == "installer"
+
+
+def test_show_zero_or_multi_track_labels_carry_null() -> None:
+    exit_code, envelope, _ = run_cli(["show", "w-1"], [_show_step("w-1", ["track:a", "track:b"])])
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    assert data["track"] is None
+
+
+@pytest.mark.parametrize(
+    ("argv", "prefix"),
+    [
+        (["list"], ("list",)),
+        (["ready"], ("ready",)),
+        (["search", "T"], ("search",)),
+    ],
+)
+def test_every_list_shaped_read_verb_carries_track(
+    argv: list[str], prefix: tuple[str, ...]
+) -> None:
+    step = ScriptedStep(
+        prefix,
+        BdResult(
+            returncode=0,
+            stdout=json.dumps([_bd_item("w-1", ["track:prgroom"])]),
+            stderr="",
+        ),
+    )
+    exit_code, envelope, _ = run_cli(argv, [step])
+    assert exit_code == 0
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    first = items[0]
+    assert isinstance(first, dict)
+    assert first["track"] == "prgroom"

--- a/packages/workcli/tests/unit/test_list_track_filter.py
+++ b/packages/workcli/tests/unit/test_list_track_filter.py
@@ -118,6 +118,23 @@ def test_limit_zero_is_the_unbounded_sentinel() -> None:
     assert ids == ["w-1", "w-2"]
 
 
+def test_limit_negative_is_also_unbounded() -> None:
+    # REGRESSION PIN (Codex finding): argparse accepts negative ints, and
+    # Python's items[:-1] silently drops the last element rather than
+    # erroring -- a negative --limit must mean unbounded here too, same as 0.
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:alpha"])
+    backend.add("w-2", labels=["track:alpha"])
+    args = _list_args("alpha", lambda: CONFIG)
+    args.limit = -1
+    data = list_(backend, args)
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    ids = [item["id"] for item in items if isinstance(item, dict)]
+    assert ids == ["w-1", "w-2"]
+
+
 def test_config_flag_reaches_the_loader_verbatim() -> None:
     # main()'s seam threads --config through to the loader untouched;
     # list --track is the first surface that triggers a load.

--- a/packages/workcli/tests/unit/test_list_track_filter.py
+++ b/packages/workcli/tests/unit/test_list_track_filter.py
@@ -1,0 +1,122 @@
+"""list --track filters on DERIVED Item.track, not raw label presence (criterion 8)."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fake_backend import FakeBackend
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+from workcli.verbs.read import list_
+
+CONFIG = TrackLayerConfig(
+    names=("alpha", "beta"),
+    organizing_only=(),
+    enforcement="advisory",
+    milestone_wip_cap=None,
+    wip_exempt_milestones=(),
+)
+
+
+def _list_args(track: str | None, load_config: object) -> Namespace:
+    return Namespace(
+        status=None,
+        label=None,
+        parent=None,
+        type=None,
+        limit=None,
+        track=track,
+        load_config=load_config,
+    )
+
+
+def _backend() -> FakeBackend:
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:alpha"])
+    backend.add("w-2", labels=["track:beta"])
+    backend.add("w-3", labels=[])  # untracked -> null
+    backend.add("w-4", labels=["track:alpha", "track:beta"])  # multi -> null
+    return backend
+
+
+def test_filters_on_derived_track_value() -> None:
+    data = list_(_backend(), _list_args("alpha", lambda: CONFIG))
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    ids = [item["id"] for item in items if isinstance(item, dict)]
+    # w-4 carries a track:alpha LABEL but derives to null -> must not match.
+    assert ids == ["w-1"]
+
+
+def test_unknown_track_name_fails_naming_vocabulary() -> None:
+    with pytest.raises(WorkError) as exc_info:
+        list_(_backend(), _list_args("gamma", lambda: CONFIG))
+    assert exc_info.value.code is ErrorCode.UNKNOWN_TRACK
+    assert "alpha" in exc_info.value.message  # names the configured vocabulary
+
+
+def test_no_track_flag_never_loads_config() -> None:
+    def explode() -> TrackLayerConfig:
+        raise AssertionError("plain list must not load config")
+
+    data = list_(_backend(), _list_args(None, explode))
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    assert len(items) == 4
+
+
+def test_unconfigured_repo_fails_track_flag_with_e_not_configured() -> None:
+    def not_configured() -> TrackLayerConfig:
+        raise WorkError(ErrorCode.NOT_CONFIGURED, "track layer not configured: nope")
+
+    with pytest.raises(WorkError) as exc_info:
+        list_(_backend(), _list_args("alpha", not_configured))
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+
+
+def test_limit_applies_after_track_filtering() -> None:
+    # REGRESSION PIN: a bd-side --limit truncates the candidate set BEFORE
+    # the track filter -- here the first bead is on another track, so a
+    # pre-filter limit of 1 would return zero alpha beads.
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:beta"])
+    backend.add("w-2", labels=["track:alpha"])
+    backend.add("w-3", labels=["track:alpha"])
+    args = _list_args("alpha", lambda: CONFIG)
+    args.limit = 1
+    data = list_(backend, args)
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    ids = [item["id"] for item in items if isinstance(item, dict)]
+    assert ids == ["w-2"]
+
+
+def test_config_flag_reaches_the_loader_verbatim() -> None:
+    # main()'s seam threads --config through to the loader untouched;
+    # list --track is the first surface that triggers a load.
+    seen: list[str | None] = []
+
+    def recording_loader(explicit_path: str | None) -> TrackLayerConfig:
+        seen.append(explicit_path)
+        return CONFIG
+
+    step = ScriptedStep(
+        ("list",),
+        BdResult(returncode=0, stdout=json.dumps([]), stderr=""),
+    )
+    exit_code, _, _ = run_cli(
+        ["--config", "/etc/custom.toml", "list", "--track", "alpha"],
+        [step],
+        config_loader=recording_loader,
+    )
+    assert exit_code == 0
+    assert seen == ["/etc/custom.toml"]

--- a/packages/workcli/tests/unit/test_list_track_filter.py
+++ b/packages/workcli/tests/unit/test_list_track_filter.py
@@ -100,6 +100,24 @@ def test_limit_applies_after_track_filtering() -> None:
     assert ids == ["w-2"]
 
 
+def test_limit_zero_is_the_unbounded_sentinel() -> None:
+    # REGRESSION PIN (Codex finding): the bd adapter sends "--limit 0" for
+    # both an omitted limit and an explicit `--limit 0`, so 0 is the
+    # existing unbounded sentinel repo-wide -- it must not slice the
+    # track-filtered set down to zero items.
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:alpha"])
+    backend.add("w-2", labels=["track:alpha"])
+    args = _list_args("alpha", lambda: CONFIG)
+    args.limit = 0
+    data = list_(backend, args)
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    ids = [item["id"] for item in items if isinstance(item, dict)]
+    assert ids == ["w-1", "w-2"]
+
+
 def test_config_flag_reaches_the_loader_verbatim() -> None:
     # main()'s seam threads --config through to the loader untouched;
     # list --track is the first surface that triggers a load.

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -54,3 +54,10 @@ def test_entry_exits_zero_and_writes_handshake_to_real_stdout(monkeypatch, capsy
     assert exc_info.value.code == 0
     envelope = json.loads(capsys.readouterr().out)
     assert envelope["data"] == {"protocol": PROTOCOL_VERSION}
+
+
+def test_protocol_wire_value_is_pinned() -> None:
+    # The serialization boundary pins the literal wire value; every other
+    # test references PROTOCOL_VERSION. Bumping the protocol means updating
+    # this one assertion deliberately.
+    assert PROTOCOL_VERSION == "1.1"

--- a/packages/workcli/tests/unit/test_track_derivation.py
+++ b/packages/workcli/tests/unit/test_track_derivation.py
@@ -1,0 +1,22 @@
+"""derive_track: the single label->track rule every consumer shares (track spec §4)."""
+
+from __future__ import annotations
+
+from workcli.tracks import derive_track
+
+
+def test_single_track_label_derives_its_name() -> None:
+    assert derive_track(["shape-task", "track:installer", "planned"]) == "installer"
+
+
+def test_no_track_label_derives_none() -> None:
+    assert derive_track(["shape-task", "planned"]) is None
+
+
+def test_multiple_track_labels_derive_none() -> None:
+    # Reachable via raw label writes; spec §4 pins null, lint invariant 1 flags it.
+    assert derive_track(["track:installer", "track:prgroom"]) is None
+
+
+def test_non_track_prefix_lookalikes_ignored() -> None:
+    assert derive_track(["tracking:x", "track", "backtrack:y"]) is None

--- a/project-config.toml
+++ b/project-config.toml
@@ -110,6 +110,33 @@ heavy_min_subsystems = 3
 trivial_max_loc      = 3   # SKIP ceiling; hard-capped at 20 on load
 
 # ---------------------------------------------------------------------------
+# [tracks] / [operating-model] / [extraction] — work-tracker track partition
+# Read by: workcli (work create gate, work list --track, work track set,
+#          work lint, work graph) and, when they ship, work triggers/groom.
+# Contract: docs/specs/2026-07-15-workcli-track-partition-design.md §3
+# ---------------------------------------------------------------------------
+[tracks]
+names = ["installer", "prgroom", "workcli", "pdlc-orchestrator",
+         "holding-place", "vizsuite", "skills-discipline",
+         "portability", "ops-meta"]
+organizing-only = ["skills-discipline", "portability", "ops-meta"]
+enforcement = "advisory"   # flip to "required" is agents-config-63nm3, gated on backfill
+
+[operating-model]
+milestone-wip-cap = 2
+wip-exempt-milestones = ["agents-config-uxns2"]  # PORT — bead id, never display name
+backlog-groom-nag-days = 7
+groom-state-bead = ""   # minted by the backfill migration (spec §7)
+
+[extraction.pressure]
+max-track-backlog = 100
+external-consumer-tracks = []
+independent-release-tracks = []
+
+[extraction.eligibility]
+max-cross-track-edges = 3
+
+# ---------------------------------------------------------------------------
 # [foreign-cli] — foreign-CLI binary paths and model selections
 # Read by: red-tests (Codex adversarial test review),
 #          green-loop (RALF-IT foreign-eyes iterations),


### PR DESCRIPTION
## Summary
- Slice A of the workcli track-partition layer: lazy config discovery (`workcli/config.py`), pure track derivation (`workcli/tracks.py`), the derived nullable `Item.track` envelope field on every read verb, a `--config` flag + injected lazy-loader seam, `work list --track`, and the repo's `[tracks]`/`[operating-model]`/`[extraction]` config (enforcement: advisory).
- Protocol bumped 1.0 -> 1.1 (additive field only); work-facade contract spec amended to match (envelope examples, 3 new track-layer error codes, verb-inventory pointer).
- Implements Tasks 1-6 of docs/plans/2026-07-17-workcli-track-layer.md against docs/specs/2026-07-15-workcli-track-partition-design.md §4 (criteria 8, 16, 17).
- Bead: agents-config-ey4rl.

## Test plan
- [x] cd packages/workcli && uv run ruff check
All checks passed!
cd packages/workcli && uv run ruff format --check
82 files already formatted
cd packages/workcli && uv run mypy --strict src
Success: no issues found in 26 source files
cd packages/workcli && uv run pytest --cov --cov-report=term-missing
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/scott/src/projects/agents-config/.claude/worktrees/trunk-slice-a/packages/workcli
configfile: pyproject.toml
testpaths: tests/unit
plugins: cov-7.1.0, xdist-3.8.0
collected 413 items

tests/unit/test_batch_get_edges.py ...                                   [  0%]
tests/unit/test_bd_backend.py .......................................... [ 10%]
............                                                             [ 13%]
tests/unit/test_bd_parse.py ...........                                  [ 16%]
tests/unit/test_capabilities.py ...                                      [ 17%]
tests/unit/test_cli_dispatch.py .....                                    [ 18%]
tests/unit/test_config_loading.py ..............                         [ 21%]
tests/unit/test_config_seam.py .                                         [ 22%]
tests/unit/test_create_noun.py ...............                           [ 25%]
tests/unit/test_create_raw.py ............                               [ 28%]
tests/unit/test_default_read_file.py ....                                [ 29%]
tests/unit/test_deliver.py ...................                           [ 34%]
tests/unit/test_dep_type_wall.py ...........                             [ 36%]
tests/unit/test_drift_alarm.py ....................                      [ 41%]
tests/unit/test_envelope.py .......                                      [ 43%]
tests/unit/test_envelope_invariants.py ................................. [ 51%]
......                                                                   [ 52%]
tests/unit/test_fake_backend.py ....                                     [ 53%]
tests/unit/test_format_human.py .....                                    [ 54%]
tests/unit/test_help_exemption.py ..                                     [ 55%]
tests/unit/test_internal_guard.py .                                      [ 55%]
tests/unit/test_item_track_field.py .....                                [ 56%]
tests/unit/test_label_verbs.py .....                                     [ 58%]
tests/unit/test_list_track_filter.py ......                              [ 59%]
tests/unit/test_list_unbounded.py .....                                  [ 60%]
tests/unit/test_lock_retry.py ......                                     [ 62%]
tests/unit/test_manifest.py ..........................                   [ 68%]
tests/unit/test_note_append_only.py ....                                 [ 69%]
tests/unit/test_nouns.py .......                                         [ 71%]
tests/unit/test_protocol_handshake.py ....                               [ 72%]
tests/unit/test_recovery.py ........................................     [ 81%]
tests/unit/test_render_human.py ........                                 [ 83%]
tests/unit/test_retry_safety.py ...........                              [ 86%]
tests/unit/test_seam_lifecycle.py ..........                             [ 88%]
tests/unit/test_search.py .                                              [ 89%]
tests/unit/test_show_normalization.py .....                              [ 90%]
tests/unit/test_subprocess_runner.py ...                                 [ 91%]
tests/unit/test_sync.py .....                                            [ 92%]
tests/unit/test_track_derivation.py ....                                 [ 93%]
tests/unit/test_transitions.py ....................                      [ 98%]
tests/unit/test_write_verbs.py ........                                  [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.14.3-final-0 _______________

Name                              Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------
src/workcli/cli.py                  167      1     14      0    99%   281
src/workcli/config.py                73      3     28      3    94%   62->68, 91, 111, 137
src/workcli/lifecycle/create.py      64      1     28      1    98%   111
src/workcli/tracks.py                15      1      4      0    95%   27
-----------------------------------------------------------------------------
TOTAL                              1352      6    448      4    99%

22 files skipped due to complete coverage.
Required test coverage of 90.0% reached. Total coverage: 99.44%
============================= 413 passed in 0.94s ==============================
cd packages/workcli && uv sync --frozen && uv run pip-audit
Name    Skip Reason
------- ----------------------------------------------------------------------
workcli Dependency not found on PyPI and could not be audited: workcli (0.1.0)
uv --project packages/workcli run work --protocol-version > /dev/null
uv --project packages/workcli run work --help > /dev/null green: 413 tests, mypy --strict clean, 99.44% branch coverage, pip-audit clean, entry verify
- [x] Full diff reviewed against the plan task-by-task

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>