### PR TITLE
feat(wait-for-pr-comments): per-bot re-review dispatch + clean-pass poll completion (abn9.44.1)

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -432,7 +432,16 @@ is the "before" value for each hook's false → true `PushNotification` check.
 Neither hook passes `--silent-cap` — the silent re-request cap is locked at
 the helper's default (1) per spec decision, not a per-repo config knob.
 
-1. **Trigger a fresh review cycle** (idempotency guard):
+1. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`
+   **before** issuing the re-review request in step 2. The downstream `--after`
+   (step 3) and `--since-timestamp` (step 4) filters require the bot signal to be
+   strictly later than this value, so capturing it first bounds the prior round
+   without excluding a fast Codex response that lands while `request-rereview.sh`
+   is still returning (or in the same API-timestamp second). Capturing it after
+   the dispatch would discard that valid `+1` or marker comment as stale and
+   count the ask as a timeout.
+
+2. **Trigger a fresh review cycle** (idempotency guard):
    ```bash
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR" \
@@ -446,8 +455,6 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    re-review ask reaching nobody. (`--add-reviewer` alone is idempotent and
    silently does nothing, which is why the helper still pairs it with
    `--remove-reviewer` for Copilot.)
-
-2. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 
 3. **Launch** `poll-copilot-rereview-start.sh --owner "$OWNER" --repo "$REPO" --pr "$PR" --after <rereview_since_timestamp>` (80s max window:
    20s pre-sleep + 6 × 10s polls). This detects the `copilot_work_started`

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -435,13 +435,17 @@ the helper's default (1) per spec decision, not a per-repo config knob.
 1. **Trigger a fresh review cycle** (idempotency guard):
    ```bash
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
-     --owner "$OWNER" --repo "$REPO" --pr "$PR"
-   # exit 0 on success; exit 1 on gh failure
+     --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+     --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"
+   # exit 0 when at least one ask succeeded; exit 1 when none did
    ```
-   The helper performs the `remove-reviewer` + `add-reviewer` pair which
-   reliably triggers a new `review_requested` event even when Copilot is
-   already on the list. (`--add-reviewer` alone is idempotent and silently
-   does nothing.)
+   `--bot-reviewers` dispatches on each policy-trusted identity's own
+   mechanism (the `remove-reviewer` + `add-reviewer` pair for Copilot, an
+   `@codex review` issue comment for Codex) instead of always performing the
+   Copilot-only dance — omitting it would leave a Codex-reviewed repo's
+   re-review ask reaching nobody. (`--add-reviewer` alone is idempotent and
+   silently does nothing, which is why the helper still pairs it with
+   `--remove-reviewer` for Copilot.)
 
 2. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`.
 
@@ -933,12 +937,13 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 ```
 
-**Request Copilot re-review** (Phase 6 — replaces the legacy remove+add
-reviewer pair):
+**Request a bot re-review** (Phase 6 — per-bot dispatch on the policy's
+`bot_reviewers` allowlist, not just the legacy Copilot remove+add pair):
 
 ```bash
 ${CLAUDE_SKILL_DIR}/request-rereview.sh \
-  --owner "$OWNER" --repo "$REPO" --pr "$PR"
+  --owner "$OWNER" --repo "$REPO" --pr "$PR" \
+  --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"
 ```
 
 **Count unresolved threads** (Phase 9 — replaces the inline GraphQL block):

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -32,12 +32,17 @@
 # freshness bound cannot be established, clean signals are rejected that round
 # (fail closed). `completion_kind` distinguishes "review" / "clean_reaction" /
 # "timeout"; only "timeout" should count against a caller's silent-ask budget.
+# If a clean-signal endpoint (reactions / issue comments) is FAILING at the
+# deadline, a clean pass and bot silence are indistinguishable — so the script
+# exits 3 (infrastructure error), NOT 1/timeout, and a transport failure is
+# never miscounted as a silent bot ask.
 #
 # Exit codes:
 #   0 — Review found (JSON on stdout)
 #   1 — Timeout (no review within --timeout-seconds, default ~10 minutes)
 #   2 — Copilot not requested (not added as reviewer within ~1 minute)
-#   3 — Error (auth failure, invalid args, network issue)
+#   3 — Error (auth failure, invalid args, network issue, or a clean-signal
+#       endpoint failing at the deadline)
 #
 # Stdout (exit 0):
 #   { "status": "copilot_review_found", "completion_kind": "review"|"clean_reaction", "reviews": [...], "inline_comments": [...], "human_comments": [...] }
@@ -45,6 +50,8 @@
 #   { "status": "copilot_review_timeout", "completion_kind": "timeout" }
 # Stdout (exit 2):
 #   { "status": "copilot_not_requested" }
+# Stdout (exit 3, clean-signal endpoint failed at the deadline):
+#   { "status": "copilot_review_error", "completion_kind": "error", "message": "clean-signal endpoint failure: <endpoints>" }
 # Stderr: diagnostic messages
 
 set -euo pipefail
@@ -296,7 +303,16 @@ if [[ -n "$SINCE" ]]; then
     echo "  Filtering for reviews submitted after ${SINCE} (stale-cache guard)" >&2
 fi
 
+# Names the clean-signal endpoint(s) that failed on the CURRENT attempt (reset
+# each iteration). If it is still set when the loop exhausts, clean signals were
+# unobservable at the deadline: a clean pass and bot silence are
+# indistinguishable, so the poll exits 3 (infra error) rather than reporting a
+# timeout the caller would miscount as a silent ask.
+clean_signal_failed_endpoint=""
+
 for i in $(seq 1 "$MAX_ITERATIONS"); do
+    clean_signal_failed_endpoint=""
+
     # Check PR state periodically (every 5th iteration)
     if [[ $((i % 5)) -eq 0 ]]; then
         if ! pr_is_open; then
@@ -390,7 +406,9 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         else
             reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions" \
                 --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
-                echo "Warning: reactions API failed (attempt ${i})" >&2; reactions='[]';
+                echo "Warning: reactions API failed (attempt ${i})" >&2
+                reactions='[]'
+                clean_signal_failed_endpoint="reactions"
             }
             reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
                 '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
@@ -403,7 +421,9 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
             clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments" \
                 --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
-                echo "Warning: issue comments API failed (attempt ${i})" >&2; clean_comments='[]';
+                echo "Warning: issue comments API failed (attempt ${i})" >&2
+                clean_comments='[]'
+                clean_signal_failed_endpoint="${clean_signal_failed_endpoint:+$clean_signal_failed_endpoint, }issue comments"
             }
             clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
                 '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
@@ -421,5 +441,20 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 done
 
 echo "Copilot review not received after ${TIMEOUT_SECONDS}s" >&2
+
+# A clean-signal endpoint failing on the final attempt makes a clean pass
+# indistinguishable from bot silence — report the documented infrastructure
+# error (exit 3) rather than a timeout the caller would burn its silent-ask
+# budget on.
+if [[ -n "$clean_signal_failed_endpoint" ]]; then
+    echo "Error: clean-signal endpoint(s) failed at the deadline (${clean_signal_failed_endpoint}); cannot distinguish a clean pass from bot silence" >&2
+    jq -n --arg ep "$clean_signal_failed_endpoint" '{
+        status: "copilot_review_error",
+        completion_kind: "error",
+        message: ("clean-signal endpoint failure: " + $ep)
+    }'
+    exit 3
+fi
+
 jq -n '{"status": "copilot_review_timeout", "completion_kind": "timeout"}'
 exit 1

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -381,24 +381,21 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     # whose committer date predates a stale reaction. Fail closed: no usable bound
     # rejects clean signals this round; review objects above are unaffected.
     # Comparison is epoch seconds (fromdateiso8601); an unparseable created_at is
-    # rejected per item.
-    #
-    # The bound/created_at comparison is ASYMMETRIC by bound source (both are
-    # second precision, so an equal-second collision is realistic):
-    #   - SINCE (ask timestamp, captured BEFORE dispatch): accept equal-second
-    #     (>=). Causality — capture precedes the ask precedes any response — makes
-    #     an equal-second signal necessarily this round's, and rejecting it would
-    #     drop Codex's one-shot clean signal (no later signal arrives).
-    #   - head-date bound (initial poll): keep strict > — an equal-second reaction
-    #     could belong to the pre-push head (the ~10s tear-down race); spec
-    #     Component 2 pins strictly-greater for this bound.
+    # rejected per item. The bound/created_at comparison is uniformly STRICT >
+    # for both bound sources. Both bounds and created_at are only second-precision,
+    # so an equal-second collision is realistic: capturing SINCE before dispatch
+    # does not establish causality for a signal already present in the same second
+    # (a stale `+1`/marker from the prior clean pass, when a fix is pushed
+    # immediately after, can have created_at == SINCE). Accepting the tie would end
+    # monitoring on a prior-head signal without reviewing the pushed fix — an
+    # unsound false-accept; rejecting it costs at most one poll timeout that hands
+    # off safely. Soundness over liveness on second-precision ties (spec Component 2
+    # pins strictly-greater for the head-date bound; the ask bound follows suit).
     if [[ -n "$BOT_REVIEWERS" ]]; then
         if [[ -n "$SINCE" ]]; then
             clean_bound_epoch=$(printf '%s' "$SINCE" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null) || clean_bound_epoch=""
-            clean_bound_inclusive=true
         else
             clean_bound_epoch=$(head_clean_bound_epoch) || clean_bound_epoch=""
-            clean_bound_inclusive=false
         fi
 
         if [[ -z "$clean_bound_epoch" ]]; then
@@ -410,8 +407,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
                 reactions='[]'
                 clean_signal_failed_endpoint="reactions"
             }
-            reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
-                '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
+            reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" \
+                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
 
             if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass reaction found (attempt ${i})" >&2
@@ -425,8 +422,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
                 clean_comments='[]'
                 clean_signal_failed_endpoint="${clean_signal_failed_endpoint:+$clean_signal_failed_endpoint, }issue comments"
             }
-            clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
-                '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
+            clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" \
+                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
 
             if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass marker comment found (attempt ${i})" >&2

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -26,7 +26,9 @@
 # from an allowlisted identity — also counts as completion (the standalone
 # Copilot-substring default never checks either signal). A clean signal is
 # accepted only when it is fresh: it must post-date --since-timestamp when
-# given, else (the initial poll) the PR head commit's committer date. If that
+# given, else (the initial poll) the point the current head became HEAD —
+# max( PR head commit's committer date, latest head_ref_force_pushed timeline
+# event ), since a force-push can re-point HEAD at an older commit. If that
 # freshness bound cannot be established, clean signals are rejected that round
 # (fail closed). `completion_kind` distinguishes "review" / "clean_reaction" /
 # "timeout"; only "timeout" should count against a caller's silent-ask budget.
@@ -171,8 +173,6 @@ emit_clean_reaction_found() {
 
 # head_committer_epoch — the PR head commit's committer date as epoch seconds,
 # or empty on any failure (unfetchable head SHA, missing/unparseable date).
-# Bounds clean-signal freshness on the initial poll (no --since-timestamp); an
-# empty result makes the caller fail closed and reject clean signals that round.
 # Committer dates are GitHub-API timestamps normalized to UTC `Z`, parsed the
 # same fromdateiso8601 way as the reaction/comment created_at values.
 head_committer_epoch() {
@@ -182,6 +182,46 @@ head_committer_epoch() {
     date_iso=$(gh_api "repos/${OWNER}/${REPO}/commits/${head_sha}" --jq '.commit.committer.date') || return 0
     [[ -n "$date_iso" && "$date_iso" != "null" ]] || return 0
     printf '%s' "$date_iso" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null
+}
+
+# latest_force_push_epoch — created_at (epoch seconds) of the latest
+# head_ref_force_pushed timeline event, or empty stdout when no such event
+# exists (committer date alone then bounds freshness). Returns non-zero to
+# signal a fail-closed condition: a timeline fetch failure, or force-push
+# events present but none carrying a parseable created_at. The timeline is a
+# top-level array paginated the same `--paginate | jq -s 'add // []'` way as the
+# merge-guard reads (real `gh --paginate` streams one array per page).
+latest_force_push_epoch() {
+    local timeline count max_epoch
+    timeline=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/timeline?per_page=100" --paginate | jq -s 'add // []') || return 1
+    count=$(printf '%s' "$timeline" | jq '[.[] | select(.event == "head_ref_force_pushed")] | length') || return 1
+    [[ "$count" =~ ^[0-9]+$ ]] || return 1
+    [[ "$count" -gt 0 ]] || return 0
+    max_epoch=$(printf '%s' "$timeline" | jq -r \
+        '[.[] | select(.event == "head_ref_force_pushed") | .created_at | fromdateiso8601?] | max // empty') || return 1
+    [[ -n "$max_epoch" ]] || return 1
+    printf '%s' "$max_epoch"
+}
+
+# head_clean_bound_epoch — the clean-signal freshness bound on the initial poll
+# (no --since-timestamp): max( head commit committer date, latest
+# head_ref_force_pushed timeline event created_at ) in epoch seconds. Mirrors the
+# merge-guard clean-pass predicate's last_head_change (codex-rereview spec,
+# Component 2): a force-push can re-point HEAD at an older commit, so the committer
+# date alone under-bounds freshness and would accept a stale reaction. Empty on
+# any fail-closed condition — an unfetchable/unparseable committer date, or a
+# timeline fetch failure — so the caller rejects clean signals that round. No
+# force-push event → committer date alone (prior behavior).
+head_clean_bound_epoch() {
+    local committer_epoch force_push_epoch
+    committer_epoch=$(head_committer_epoch)
+    [[ -n "$committer_epoch" ]] || return 0
+    force_push_epoch=$(latest_force_push_epoch) || return 1
+    if [[ -n "$force_push_epoch" && "$force_push_epoch" -gt "$committer_epoch" ]]; then
+        printf '%s' "$force_push_epoch"
+    else
+        printf '%s' "$committer_epoch"
+    fi
 }
 
 # ── Pre-flight checks ────────────────────────────────────────────────────────
@@ -319,15 +359,18 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     # head cannot terminate monitoring for a head that received no review (Codex
     # tears the reaction down when it re-reviews a new head, but not if it is
     # down or rate-limited). With --since-timestamp, SINCE is the (stricter,
-    # later) bound. Without it — the initial poll — bound by the PR head commit's
-    # committer date. Fail closed: no usable bound rejects clean signals this
-    # round; review objects above are unaffected. Comparison is epoch seconds
-    # (fromdateiso8601); an unparseable created_at is rejected per item.
+    # later) bound. Without it — the initial poll — bound by when the current head
+    # became HEAD: max( head commit committer date, latest head_ref_force_pushed
+    # timeline event ), since a force-push can re-point HEAD at an older commit
+    # whose committer date predates a stale reaction. Fail closed: no usable bound
+    # rejects clean signals this round; review objects above are unaffected.
+    # Comparison is epoch seconds (fromdateiso8601); an unparseable created_at is
+    # rejected per item.
     if [[ -n "$BOT_REVIEWERS" ]]; then
         if [[ -n "$SINCE" ]]; then
             clean_bound_epoch=$(printf '%s' "$SINCE" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null) || clean_bound_epoch=""
         else
-            clean_bound_epoch=$(head_committer_epoch) || clean_bound_epoch=""
+            clean_bound_epoch=$(head_clean_bound_epoch) || clean_bound_epoch=""
         fi
 
         if [[ -z "$clean_bound_epoch" ]]; then

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -19,6 +19,16 @@
 # exact-identity allowlist the merge gate enforces. Omit it to keep the
 # standalone Copilot-substring default.
 #
+# Poll completion contract: this script's JSON output also completes without
+# a review object when a bot's pass is clean. When --bot-reviewers is
+# supplied, a `+1` reaction on the PR body, or an issue comment starting with
+# the clean-pass marker "Codex Review: Didn't find any major issues" — each
+# from an allowlisted identity and post-dating --since-timestamp when given —
+# also counts as completion (the standalone Copilot-substring default never
+# checks either signal). `completion_kind` distinguishes "review" /
+# "clean_reaction" / "timeout"; only "timeout" should count against a
+# caller's silent-ask budget.
+#
 # Exit codes:
 #   0 — Review found (JSON on stdout)
 #   1 — Timeout (no review within --timeout-seconds, default ~10 minutes)
@@ -26,9 +36,9 @@
 #   3 — Error (auth failure, invalid args, network issue)
 #
 # Stdout (exit 0):
-#   { "status": "copilot_review_found", "reviews": [...], "inline_comments": [...], "human_comments": [...] }
+#   { "status": "copilot_review_found", "completion_kind": "review"|"clean_reaction", "reviews": [...], "inline_comments": [...], "human_comments": [...] }
 # Stdout (exit 1):
-#   { "status": "copilot_review_timeout" }
+#   { "status": "copilot_review_timeout", "completion_kind": "timeout" }
 # Stdout (exit 2):
 #   { "status": "copilot_not_requested" }
 # Stderr: diagnostic messages
@@ -131,12 +141,30 @@ else
 fi
 COPILOT_REVIEW_FILTER="(.user.type == \"Bot\") and (.user.login | ${COPILOT_LOGIN_FILTER})"
 
+# Clean-pass marker prefix (Component 3) — an issue comment body starting
+# with this, from an allowlisted identity, is a clean-pass completion signal
+# (checked only when --bot-reviewers is supplied; see header).
+CLEAN_PASS_MARKER="Codex Review: Didn't find any major issues"
+
 # ── Helper functions ──────────────────────────────────────────────────────────
 
 pr_is_open() {
     local state
     state=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.state') || return 1
     [[ "$state" == "open" ]]
+}
+
+# emit_clean_reaction_found — shared stdout payload for both clean-pass
+# completion signals (a `+1` reaction and a marker comment carry no review
+# content, so both report the same empty-arrays shape).
+emit_clean_reaction_found() {
+    jq -n '{
+        status: "copilot_review_found",
+        completion_kind: "clean_reaction",
+        reviews: [],
+        inline_comments: [],
+        human_comments: []
+    }'
 }
 
 # ── Pre-flight checks ────────────────────────────────────────────────────────
@@ -216,7 +244,7 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     if [[ $((i % 5)) -eq 0 ]]; then
         if ! pr_is_open; then
             echo "PR #${PR} is no longer open — aborting poll" >&2
-            jq -n '{"status": "copilot_review_timeout"}'
+            jq -n '{"status": "copilot_review_timeout", "completion_kind": "timeout"}'
             exit 1
         fi
     fi
@@ -256,6 +284,7 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
             --argjson human "$human" \
             '{
                 status: "copilot_review_found",
+                completion_kind: "review",
                 reviews: $reviews,
                 inline_comments: $inline,
                 human_comments: $human
@@ -263,10 +292,46 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         exit 0
     fi
 
+    # Clean-pass completion (poll completion contract): a bot can complete
+    # with no findings and thus no review object — a `+1` reaction on the PR
+    # body, or a clean-pass marker issue comment, either post-dating
+    # --since-timestamp when supplied. Only checked in policy mode
+    # (--bot-reviewers set); the standalone Copilot-substring default never
+    # sees either signal.
+    if [[ -n "$BOT_REVIEWERS" ]]; then
+        reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions" \
+            --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
+            echo "Warning: reactions API failed (attempt ${i})" >&2; reactions='[]';
+        }
+        if [[ -n "$SINCE" ]]; then
+            reactions=$(printf '%s' "$reactions" | jq --arg since "$SINCE" '[.[] | select(.created_at > $since)]')
+        fi
+
+        if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
+            echo "  Clean-pass reaction found (attempt ${i})" >&2
+            emit_clean_reaction_found
+            exit 0
+        fi
+
+        clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments" \
+            --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
+            echo "Warning: issue comments API failed (attempt ${i})" >&2; clean_comments='[]';
+        }
+        if [[ -n "$SINCE" ]]; then
+            clean_comments=$(printf '%s' "$clean_comments" | jq --arg since "$SINCE" '[.[] | select(.created_at > $since)]')
+        fi
+
+        if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
+            echo "  Clean-pass marker comment found (attempt ${i})" >&2
+            emit_clean_reaction_found
+            exit 0
+        fi
+    fi
+
     echo "  Attempt ${i}/${MAX_ITERATIONS}: no review yet" >&2
     [[ $i -lt $MAX_ITERATIONS ]] && sleep "$POLL_INTERVAL_SECONDS"
 done
 
 echo "Copilot review not received after ${TIMEOUT_SECONDS}s" >&2
-jq -n '{"status": "copilot_review_timeout"}'
+jq -n '{"status": "copilot_review_timeout", "completion_kind": "timeout"}'
 exit 1

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -401,8 +401,9 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         if [[ -z "$clean_bound_epoch" ]]; then
             echo "  Attempt ${i}/${MAX_ITERATIONS}: no freshness bound for clean signals, rejecting (fail closed)" >&2
         else
-            reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions" \
-                --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
+            reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions?per_page=100" --paginate \
+                | jq -s 'add // []' \
+                | jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
                 echo "Warning: reactions API failed (attempt ${i})" >&2
                 reactions='[]'
                 clean_signal_failed_endpoint="reactions"
@@ -416,8 +417,9 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
                 exit 0
             fi
 
-            clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments" \
-                --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
+            clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments?per_page=100" --paginate \
+                | jq -s 'add // []' \
+                | jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
                 echo "Warning: issue comments API failed (attempt ${i})" >&2
                 clean_comments='[]'
                 clean_signal_failed_endpoint="${clean_signal_failed_endpoint:+$clean_signal_failed_endpoint, }issue comments"

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -23,11 +23,13 @@
 # a review object when a bot's pass is clean. When --bot-reviewers is
 # supplied, a `+1` reaction on the PR body, or an issue comment starting with
 # the clean-pass marker "Codex Review: Didn't find any major issues" — each
-# from an allowlisted identity and post-dating --since-timestamp when given —
-# also counts as completion (the standalone Copilot-substring default never
-# checks either signal). `completion_kind` distinguishes "review" /
-# "clean_reaction" / "timeout"; only "timeout" should count against a
-# caller's silent-ask budget.
+# from an allowlisted identity — also counts as completion (the standalone
+# Copilot-substring default never checks either signal). A clean signal is
+# accepted only when it is fresh: it must post-date --since-timestamp when
+# given, else (the initial poll) the PR head commit's committer date. If that
+# freshness bound cannot be established, clean signals are rejected that round
+# (fail closed). `completion_kind` distinguishes "review" / "clean_reaction" /
+# "timeout"; only "timeout" should count against a caller's silent-ask budget.
 #
 # Exit codes:
 #   0 — Review found (JSON on stdout)
@@ -167,6 +169,21 @@ emit_clean_reaction_found() {
     }'
 }
 
+# head_committer_epoch — the PR head commit's committer date as epoch seconds,
+# or empty on any failure (unfetchable head SHA, missing/unparseable date).
+# Bounds clean-signal freshness on the initial poll (no --since-timestamp); an
+# empty result makes the caller fail closed and reject clean signals that round.
+# Committer dates are GitHub-API timestamps normalized to UTC `Z`, parsed the
+# same fromdateiso8601 way as the reaction/comment created_at values.
+head_committer_epoch() {
+    local head_sha date_iso
+    head_sha=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.head.sha') || return 0
+    [[ -n "$head_sha" && "$head_sha" != "null" ]] || return 0
+    date_iso=$(gh_api "repos/${OWNER}/${REPO}/commits/${head_sha}" --jq '.commit.committer.date') || return 0
+    [[ -n "$date_iso" && "$date_iso" != "null" ]] || return 0
+    printf '%s' "$date_iso" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null
+}
+
 # ── Pre-flight checks ────────────────────────────────────────────────────────
 
 preflight_checks
@@ -294,37 +311,53 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
     # Clean-pass completion (poll completion contract): a bot can complete
     # with no findings and thus no review object — a `+1` reaction on the PR
-    # body, or a clean-pass marker issue comment, either post-dating
-    # --since-timestamp when supplied. Only checked in policy mode
+    # body, or a clean-pass marker issue comment. Only checked in policy mode
     # (--bot-reviewers set); the standalone Copilot-substring default never
     # sees either signal.
+    #
+    # Clean signals need a freshness bound so a `+1`/marker earned by an EARLIER
+    # head cannot terminate monitoring for a head that received no review (Codex
+    # tears the reaction down when it re-reviews a new head, but not if it is
+    # down or rate-limited). With --since-timestamp, SINCE is the (stricter,
+    # later) bound. Without it — the initial poll — bound by the PR head commit's
+    # committer date. Fail closed: no usable bound rejects clean signals this
+    # round; review objects above are unaffected. Comparison is epoch seconds
+    # (fromdateiso8601); an unparseable created_at is rejected per item.
     if [[ -n "$BOT_REVIEWERS" ]]; then
-        reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions" \
-            --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
-            echo "Warning: reactions API failed (attempt ${i})" >&2; reactions='[]';
-        }
         if [[ -n "$SINCE" ]]; then
-            reactions=$(printf '%s' "$reactions" | jq --arg since "$SINCE" '[.[] | select(.created_at > $since)]')
+            clean_bound_epoch=$(printf '%s' "$SINCE" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null) || clean_bound_epoch=""
+        else
+            clean_bound_epoch=$(head_committer_epoch) || clean_bound_epoch=""
         fi
 
-        if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
-            echo "  Clean-pass reaction found (attempt ${i})" >&2
-            emit_clean_reaction_found
-            exit 0
-        fi
+        if [[ -z "$clean_bound_epoch" ]]; then
+            echo "  Attempt ${i}/${MAX_ITERATIONS}: no freshness bound for clean signals, rejecting (fail closed)" >&2
+        else
+            reactions=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions" \
+                --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
+                echo "Warning: reactions API failed (attempt ${i})" >&2; reactions='[]';
+            }
+            reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" \
+                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
 
-        clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments" \
-            --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
-            echo "Warning: issue comments API failed (attempt ${i})" >&2; clean_comments='[]';
-        }
-        if [[ -n "$SINCE" ]]; then
-            clean_comments=$(printf '%s' "$clean_comments" | jq --arg since "$SINCE" '[.[] | select(.created_at > $since)]')
-        fi
+            if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
+                echo "  Clean-pass reaction found (attempt ${i})" >&2
+                emit_clean_reaction_found
+                exit 0
+            fi
 
-        if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
-            echo "  Clean-pass marker comment found (attempt ${i})" >&2
-            emit_clean_reaction_found
-            exit 0
+            clean_comments=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments" \
+                --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
+                echo "Warning: issue comments API failed (attempt ${i})" >&2; clean_comments='[]';
+            }
+            clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" \
+                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
+
+            if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
+                echo "  Clean-pass marker comment found (attempt ${i})" >&2
+                emit_clean_reaction_found
+                exit 0
+            fi
         fi
     fi
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -366,11 +366,23 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     # rejects clean signals this round; review objects above are unaffected.
     # Comparison is epoch seconds (fromdateiso8601); an unparseable created_at is
     # rejected per item.
+    #
+    # The bound/created_at comparison is ASYMMETRIC by bound source (both are
+    # second precision, so an equal-second collision is realistic):
+    #   - SINCE (ask timestamp, captured BEFORE dispatch): accept equal-second
+    #     (>=). Causality — capture precedes the ask precedes any response — makes
+    #     an equal-second signal necessarily this round's, and rejecting it would
+    #     drop Codex's one-shot clean signal (no later signal arrives).
+    #   - head-date bound (initial poll): keep strict > — an equal-second reaction
+    #     could belong to the pre-push head (the ~10s tear-down race); spec
+    #     Component 2 pins strictly-greater for this bound.
     if [[ -n "$BOT_REVIEWERS" ]]; then
         if [[ -n "$SINCE" ]]; then
             clean_bound_epoch=$(printf '%s' "$SINCE" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null) || clean_bound_epoch=""
+            clean_bound_inclusive=true
         else
             clean_bound_epoch=$(head_clean_bound_epoch) || clean_bound_epoch=""
+            clean_bound_inclusive=false
         fi
 
         if [[ -z "$clean_bound_epoch" ]]; then
@@ -380,8 +392,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
                 --jq "[.[] | select(.content == \"+1\" and (.user.login | ${COPILOT_LOGIN_FILTER}))]") || {
                 echo "Warning: reactions API failed (attempt ${i})" >&2; reactions='[]';
             }
-            reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" \
-                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
+            reactions=$(printf '%s' "$reactions" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
+                '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
 
             if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass reaction found (attempt ${i})" >&2
@@ -393,8 +405,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
                 --jq "[.[] | select((.user.login | ${COPILOT_LOGIN_FILTER}) and ((.body // \"\") | startswith(\"${CLEAN_PASS_MARKER}\")))]") || {
                 echo "Warning: issue comments API failed (attempt ${i})" >&2; clean_comments='[]';
             }
-            clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" \
-                '[.[] | select((.created_at | fromdateiso8601? // -1) > $bound)]')
+            clean_comments=$(printf '%s' "$clean_comments" | jq --argjson bound "$clean_bound_epoch" --argjson inclusive "$clean_bound_inclusive" \
+                '[.[] | (.created_at | fromdateiso8601? // -1) as $t | select(if $inclusive then $t >= $bound else $t > $bound end)]')
 
             if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass marker comment found (attempt ${i})" >&2

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -239,32 +239,36 @@ rc_no_policy=$?
 assert "clean-reaction signal is ignored without --bot-reviewers (timeout, exit 1)" "[ \$rc_no_policy -eq 1 ]"
 
 # ── Equal-second clean signal on the ask-bound (--since-timestamp) path ──────
-# SINCE is captured to second precision immediately before dispatch; GitHub
-# reaction/comment created_at is also second precision. A fast Codex clean
-# response created in that same second has created_at == SINCE. Causality — the
-# capture precedes the ask, which precedes any response — makes an equal-second
-# signal necessarily this round's, so the ask-bound path accepts it (>=), where
-# the head-date bound below keeps strict >.
+# SINCE is captured only to whole-second precision immediately before dispatch;
+# GitHub reaction/comment created_at is also second precision. A stale `+1` or
+# marker that already existed BEFORE the ask (e.g. from the prior clean pass,
+# when a fix is pushed immediately after) can therefore have created_at == SINCE.
+# Capturing SINCE before dispatch does not establish causality for an
+# already-present signal in the same second, so equality must be REJECTED (strict
+# >): soundness over liveness on second-precision ties. Accepting the tie would
+# end monitoring on a prior-head signal without reviewing the pushed fix
+# (false-accept, unsound); rejecting it costs at most one poll timeout that hands
+# off safely (false-reject, fail-safe). The head-date bound below rejects the
+# equal-second tie for the same reason — both clean-signal bounds are uniformly
+# strict >.
 
 FIXTURE_REACTIONS_EQUAL="[{\"id\":4,\"content\":\"+1\",\"user\":{\"login\":\"$CODEX_ID\",\"type\":\"Bot\"},\"created_at\":\"$SINCE_TS\"}]"
 
-out_equal_reaction=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
   FIXTURE_REACTIONS="$FIXTURE_REACTIONS_EQUAL" \
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
-  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
 rc_equal_reaction=$?
-assert "ask-bound: +1 created in the ask second completes (exit 0)" "[ \$rc_equal_reaction -eq 0 ]"
-assert "ask-bound: equal-second +1 reports completion_kind clean_reaction" "printf '%s' \"\$out_equal_reaction\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+assert "ask-bound: +1 created in the ask second does NOT complete (timeout, exit 1)" "[ \$rc_equal_reaction -eq 1 ]"
 
 FIXTURE_ISSUE_COMMENTS_EQUAL="[{\"id\":5,\"user\":{\"login\":\"$CODEX_ID\"},\"body\":\"Codex Review: Didn't find any major issues in this PR.\",\"created_at\":\"$SINCE_TS\"}]"
 
-out_equal_comment=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
   FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS="$FIXTURE_ISSUE_COMMENTS_EQUAL" \
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
-  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
 rc_equal_comment=$?
-assert "ask-bound: marker comment created in the ask second completes (exit 0)" "[ \$rc_equal_comment -eq 0 ]"
-assert "ask-bound: equal-second marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_equal_comment\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+assert "ask-bound: marker comment created in the ask second does NOT complete (timeout, exit 1)" "[ \$rc_equal_comment -eq 1 ]"
 
 # Only "timeout" may count as a silent ask against a caller's retry cap: chain
 # the actual accounting helper the skill uses, mapping this script's exit
@@ -323,8 +327,9 @@ assert "initial poll: post-dating +1 reports completion_kind clean_reaction" "pr
 # (b2) A `+1` created in the SAME second as the head committer date is still
 #      REJECTED on the initial poll (no --since-timestamp): the head-date bound
 #      keeps strict > because an equal-second reaction could belong to the
-#      pre-push head (the ~10s tear-down race), per spec Component 2 — the
-#      asymmetric counterpart to the ask-bound path's inclusive >=.
+#      pre-push head (the ~10s tear-down race), per spec Component 2. Both
+#      clean-signal bounds are uniformly strict > — soundness over liveness on
+#      second-precision ties (the ask-bound path above rejects the tie too).
 FIXTURE_REACTIONS_EQUALHEAD='[{"id":12,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:00:00Z"}]'
 
 env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -95,6 +95,11 @@ if [ "$1" = "api" ]; then
     */issues/*/events*)    body="${FIXTURE_EVENTS:-[]}" ;;
     */issues/*/reactions*) body="${FIXTURE_REACTIONS:-[]}" ;;
     */issues/*/comments*)  body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
+    */issues/*/timeline*)
+        if [ "${FIXTURE_TIMELINE_FAIL:-0}" = 1 ]; then
+          echo "gh: 500 Internal Server Error" >&2; exit 1
+        fi
+        body="${FIXTURE_TIMELINE:-[]}" ;;
     */pulls/*/reviews*)    body="${FIXTURE_REVIEWS:-[]}" ;;
     */pulls/*/comments*)   body="${FIXTURE_COMMENTS:-[]}" ;;
     */commits/*)           body="${FIXTURE_COMMIT:-'{}'}" ;;
@@ -290,5 +295,52 @@ env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVI
   --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
 rc_baddate=$?
 assert "initial poll: unparseable head committer date rejects clean signals (fail closed, exit 1)" "[ \$rc_baddate -eq 1 ]"
+
+# ── Initial-poll freshness with a force-push timeline event ─────────────────
+# The bound is max( head committer date, latest head_ref_force_pushed timeline
+# event created_at ) — mirroring the merge-guard clean-pass predicate (codex-
+# rereview spec, Component 2). A force-push can re-point HEAD at an OLDER commit,
+# leaving a prior `+1` later than that commit's committer date yet still stale
+# relative to when the head actually changed. A +1 between the committer date and
+# the force-push event is stale (REJECTED); a +1 after the force-push event is a
+# real clean pass (ACCEPTED). A timeline fetch failure fails closed.
+
+FIXTURE_TIMELINE_FORCEPUSH='[{"event":"head_ref_force_pushed","created_at":"2026-01-01T00:05:00Z"}]'
+
+# (d) A +1 AFTER the committer date but BEFORE the force-push event is stale —
+#     the force-push moved the head later than that reaction.
+FIXTURE_REACTIONS_BETWEEN='[{"id":20,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:02:00Z"}]'
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_TIMELINE="$FIXTURE_TIMELINE_FORCEPUSH" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_BETWEEN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_between=$?
+assert "initial poll: +1 between committer date and force-push event is stale (timeout, exit 1)" "[ \$rc_between -eq 1 ]"
+
+# (e) A +1 AFTER the force-push event is a real clean pass.
+FIXTURE_REACTIONS_AFTERPUSH='[{"id":21,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:10:00Z"}]'
+
+out_afterpush=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_TIMELINE="$FIXTURE_TIMELINE_FORCEPUSH" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_AFTERPUSH" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_afterpush=$?
+assert "initial poll: +1 after the force-push event completes (exit 0)" "[ \$rc_afterpush -eq 0 ]"
+assert "initial poll: +1 after force-push reports completion_kind clean_reaction" "printf '%s' \"\$out_afterpush\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# (f) A timeline fetch failure fails closed — even a would-be-fresh +1 is rejected.
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_TIMELINE_FAIL=1 \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_AFTERPUSH" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_tlfail=$?
+assert "initial poll: timeline fetch failure fails closed (timeout, exit 1)" "[ \$rc_tlfail -eq 1 ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -93,8 +93,16 @@ if [ "$1" = "api" ]; then
   done
   case "$path" in
     */issues/*/events*)    body="${FIXTURE_EVENTS:-[]}" ;;
-    */issues/*/reactions*) body="${FIXTURE_REACTIONS:-[]}" ;;
-    */issues/*/comments*)  body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
+    */issues/*/reactions*)
+        if [ "${FIXTURE_REACTIONS_FAIL:-0}" = 1 ]; then
+          echo "gh: 500 Internal Server Error" >&2; exit 1
+        fi
+        body="${FIXTURE_REACTIONS:-[]}" ;;
+    */issues/*/comments*)
+        if [ "${FIXTURE_ISSUE_COMMENTS_FAIL:-0}" = 1 ]; then
+          echo "gh: 500 Internal Server Error" >&2; exit 1
+        fi
+        body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
     */issues/*/timeline*)
         if [ "${FIXTURE_TIMELINE_FAIL:-0}" = 1 ]; then
           echo "gh: 500 Internal Server Error" >&2; exit 1
@@ -385,5 +393,57 @@ env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVI
   --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
 rc_tlfail=$?
 assert "initial poll: timeline fetch failure fails closed (timeout, exit 1)" "[ \$rc_tlfail -eq 1 ]"
+
+# ── Clean-signal endpoint failure at the deadline is an infra error, not a
+#    silent ask ─────────────────────────────────────────────────────────────
+# When a clean-signal endpoint (reactions / issue comments) is failing at the
+# deadline, a clean pass and bot silence are indistinguishable — so the script
+# must NOT report the ordinary timeout (exit 1, which the caller counts as a
+# silent ask against its one-ask cap). It exits 3 (infrastructure error) with a
+# distinct status naming the failed endpoint, leaving the caller's cap intact.
+# Uses the ask-bound path (--since-timestamp) so the freshness bound is set
+# without touching the head-date/timeline endpoints; only the clean-signal
+# fetches fault.
+
+# (g) A persistently-failing reactions endpoint at the deadline exits 3 (not 1),
+#     and does not report a plain timeout.
+out_rxfail=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS_FAIL=1 FIXTURE_ISSUE_COMMENTS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_rxfail=$?
+assert "reactions endpoint failing at the deadline exits 3 (infra error, not timeout)" "[ \$rc_rxfail -eq 3 ]"
+assert "reactions-endpoint failure does NOT report copilot_review_timeout" "! printf '%s' \"\$out_rxfail\" | grep -q copilot_review_timeout"
+assert "reactions-endpoint failure reports status copilot_review_error" "printf '%s' \"\$out_rxfail\" | jq -e '.status == \"copilot_review_error\"' >/dev/null"
+assert "reactions-endpoint failure does NOT report completion_kind timeout" "printf '%s' \"\$out_rxfail\" | jq -e '.completion_kind != \"timeout\"' >/dev/null"
+
+# (h) The marker-comment (issue comments) endpoint has the same problem: a
+#     persistent failure at the deadline exits 3, not 1.
+out_ccfail=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS_FAIL=1 \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_ccfail=$?
+assert "marker-comment endpoint failing at the deadline exits 3 (infra error, not timeout)" "[ \$rc_ccfail -eq 3 ]"
+assert "marker-comment-endpoint failure reports status copilot_review_error" "printf '%s' \"\$out_ccfail\" | jq -e '.status == \"copilot_review_error\"' >/dev/null"
+
+# (i) An infra-error exit (3) must NOT be counted as a silent ask against the
+#     caller's retry cap — only a real timeout (exit 1) may. Mirrors the Phase 6
+#     accounting: exit 3 maps to --event none (like a clean completion), so the
+#     silent-ask counter does not advance.
+map_to_polling_event_infra() { case "$1" in 1) echo silent ;; *) echo none ;; esac; }
+polling_after_infra=$("$HERE/compute-rereview-polling.sh" --prior-count 0 --prior-exhausted false \
+  --event "$(map_to_polling_event_infra "$rc_rxfail")")
+assert "an infra-error (exit 3) does NOT increment the silent-ask counter" \
+  "[ \"\$(jq '.rereview_round_count' <<<\"\$polling_after_infra\")\" = 0 ]"
+
+# (j) Control: healthy clean-signal endpoints with no signal still time out
+#     (exit 1) — the infra-error path only triggers on an actual endpoint failure.
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_healthy_timeout=$?
+assert "healthy clean-signal endpoints with no signal still time out (exit 1)" "[ \$rc_healthy_timeout -eq 1 ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -97,6 +97,7 @@ if [ "$1" = "api" ]; then
     */issues/*/comments*)  body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
     */pulls/*/reviews*)    body="${FIXTURE_REVIEWS:-[]}" ;;
     */pulls/*/comments*)   body="${FIXTURE_COMMENTS:-[]}" ;;
+    */commits/*)           body="${FIXTURE_COMMIT:-'{}'}" ;;
     */pulls/*)             body="${FIXTURE_PR:-'{"state":"open"}'}" ;;
     *)                     body='{}' ;;
   esac
@@ -240,5 +241,54 @@ polling_after_timeout=$("$HERE/compute-rereview-polling.sh" --prior-count 0 --pr
   --event "$(map_to_polling_event "$rc_timeout")")
 assert "a real timeout DOES increment the silent-ask counter" \
   "[ \"\$(jq '.rereview_round_count' <<<\"\$polling_after_timeout\")\" = 1 ]"
+
+# ── Initial-poll freshness (no --since-timestamp) ────────────────────────────
+# On the initial policy-mode round SINCE is empty, so clean signals must be
+# bounded by the PR head commit's committer date. A `+1`/marker earned by an
+# EARLIER head (Codex tears it down on re-review, but not if it is down or
+# rate-limited) must NOT terminate monitoring for a head that received no
+# review; a signal post-dating the head commit is a real clean pass. An
+# unfetchable/unparseable head date fails closed (rejects clean signals).
+
+HEAD_SHA='abc123def4567890'
+FIXTURE_PR_HEAD="{\"state\":\"open\",\"head\":{\"sha\":\"$HEAD_SHA\"}}"
+FIXTURE_COMMIT_HEADDATE='{"commit":{"committer":{"date":"2026-01-01T00:00:00Z"}}}'
+
+# (a) A `+1` predating the head committer date is NOT accepted on the initial
+#     poll (no --since-timestamp) — falls through to a real timeout.
+FIXTURE_REACTIONS_PREHEAD='[{"id":10,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2025-12-31T23:59:00Z"}]'
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_PREHEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_preheaddate=$?
+assert "initial poll: +1 predating head committer date does NOT complete (timeout, exit 1)" "[ \$rc_preheaddate -eq 1 ]"
+
+# (b) A `+1` post-dating the head committer date IS accepted on the initial poll
+#     (no --since-timestamp), completion_kind clean_reaction.
+FIXTURE_REACTIONS_POSTHEAD='[{"id":11,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:00:10Z"}]'
+
+out_posthead=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_POSTHEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_posthead=$?
+assert "initial poll: +1 post-dating head committer date completes (exit 0)" "[ \$rc_posthead -eq 0 ]"
+assert "initial poll: post-dating +1 reports completion_kind clean_reaction" "printf '%s' \"\$out_posthead\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# (c) An unparseable head committer date rejects clean signals on the initial
+#     poll (fail closed) — even a would-be-fresh `+1`.
+FIXTURE_COMMIT_BADDATE='{"commit":{"committer":{"date":"not-a-date"}}}'
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_BADDATE" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_POSTHEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_baddate=$?
+assert "initial poll: unparseable head committer date rejects clean signals (fail closed, exit 1)" "[ \$rc_baddate -eq 1 ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -88,21 +88,33 @@ if [ "$1" = "api" ]; then
   shift
   path="$1"; shift
   filter=""
+  paginate=0
   while [ $# -gt 0 ]; do
-    case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
+    case "$1" in
+      --jq) filter="$2"; shift 2 ;;
+      --paginate) paginate=1; shift ;;
+      *) shift ;;
+    esac
   done
+  # page2 emulates a real `gh --paginate` stream: one JSON array per page. Only
+  # the clean-signal list endpoints set it; when --paginate is passed the stub
+  # emits page1 then page2 as separate values, exactly what `jq -s 'add // []'`
+  # aggregates. Absent a *_PAGE2 fixture, behavior is single-page (unchanged).
+  page2=""
   case "$path" in
     */issues/*/events*)    body="${FIXTURE_EVENTS:-[]}" ;;
     */issues/*/reactions*)
         if [ "${FIXTURE_REACTIONS_FAIL:-0}" = 1 ]; then
           echo "gh: 500 Internal Server Error" >&2; exit 1
         fi
-        body="${FIXTURE_REACTIONS:-[]}" ;;
+        body="${FIXTURE_REACTIONS:-[]}"
+        page2="${FIXTURE_REACTIONS_PAGE2:-}" ;;
     */issues/*/comments*)
         if [ "${FIXTURE_ISSUE_COMMENTS_FAIL:-0}" = 1 ]; then
           echo "gh: 500 Internal Server Error" >&2; exit 1
         fi
-        body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
+        body="${FIXTURE_ISSUE_COMMENTS:-[]}"
+        page2="${FIXTURE_ISSUE_COMMENTS_PAGE2:-}" ;;
     */issues/*/timeline*)
         if [ "${FIXTURE_TIMELINE_FAIL:-0}" = 1 ]; then
           echo "gh: 500 Internal Server Error" >&2; exit 1
@@ -115,7 +127,15 @@ if [ "$1" = "api" ]; then
     *)                     body='{}' ;;
   esac
   body="${body#\'}"; body="${body%\'}"
-  if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
+  if [ -n "$filter" ]; then
+    printf '%s' "$body" | jq -r "$filter"
+  else
+    printf '%s' "$body"
+    if [ "$paginate" = 1 ] && [ -n "$page2" ]; then
+      page2="${page2#\'}"; page2="${page2%\'}"
+      printf '\n%s' "$page2"
+    fi
+  fi
   exit 0
 fi
 exit 0
@@ -450,5 +470,36 @@ env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVI
   --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
 rc_healthy_timeout=$?
 assert "healthy clean-signal endpoints with no signal still time out (exit 1)" "[ \$rc_healthy_timeout -eq 1 ]"
+
+# ── Clean signals on a later page must be fetched, not missed ─────────────────
+# GitHub list endpoints paginate; a Codex `+1` or marker comment that falls on
+# page 2 is invisible to a single-page fetch, so the poll reports a spurious
+# timeout and the caller burns its silent-ask cap despite a completed clean
+# review. Both clean-signal endpoints must --paginate and aggregate all pages
+# before filtering. Uses the ask-bound path (--since-timestamp) so no head-date
+# or timeline endpoint is involved — only the clean-signal fetches page.
+
+# (k) A `+1` reaction on page 2 (page 1 empty) still completes the poll.
+FIXTURE_REACTIONS_PAGE2_CLEAN='[{"id":30,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:00:10Z"}]'
+
+out_rx_p2=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_REACTIONS_PAGE2="$FIXTURE_REACTIONS_PAGE2_CLEAN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_rx_p2=$?
+assert "a +1 reaction on page 2 completes (exit 0)" "[ \$rc_rx_p2 -eq 0 ]"
+assert "a page-2 +1 reaction reports completion_kind clean_reaction" "printf '%s' \"\$out_rx_p2\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# (l) A marker comment on page 2 (page 1 empty, no reaction) still completes.
+FIXTURE_ISSUE_COMMENTS_PAGE2_CLEAN="[{\"id\":31,\"user\":{\"login\":\"$CODEX_ID\"},\"body\":\"Codex Review: Didn't find any major issues in this PR.\",\"created_at\":\"2026-01-01T00:00:10Z\"}]"
+
+out_cc_p2=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS='[]' \
+  FIXTURE_ISSUE_COMMENTS_PAGE2="$FIXTURE_ISSUE_COMMENTS_PAGE2_CLEAN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_cc_p2=$?
+assert "a marker comment on page 2 completes (exit 0)" "[ \$rc_cc_p2 -eq 0 ]"
+assert "a page-2 marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_cc_p2\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -92,11 +92,13 @@ if [ "$1" = "api" ]; then
     case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
   done
   case "$path" in
-    */issues/*/events*)  body="${FIXTURE_EVENTS:-[]}" ;;
-    */pulls/*/reviews*)  body="${FIXTURE_REVIEWS:-[]}" ;;
-    */pulls/*/comments*) body="${FIXTURE_COMMENTS:-[]}" ;;
-    */pulls/*)           body="${FIXTURE_PR:-'{"state":"open"}'}" ;;
-    *)                   body='{}' ;;
+    */issues/*/events*)    body="${FIXTURE_EVENTS:-[]}" ;;
+    */issues/*/reactions*) body="${FIXTURE_REACTIONS:-[]}" ;;
+    */issues/*/comments*)  body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
+    */pulls/*/reviews*)    body="${FIXTURE_REVIEWS:-[]}" ;;
+    */pulls/*/comments*)   body="${FIXTURE_COMMENTS:-[]}" ;;
+    */pulls/*)             body="${FIXTURE_PR:-'{"state":"open"}'}" ;;
+    *)                     body='{}' ;;
   esac
   body="${body#\'}"; body="${body%\'}"
   if [ -n "$filter" ]; then printf '%s' "$body" | jq -r "$filter"; else printf '%s' "$body"; fi
@@ -154,5 +156,89 @@ env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVI
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 >/dev/null 2>&1
 rc_default=$?
 assert "default Copilot filter does NOT match the non-Copilot bot (timeout, exit 1)" "[ \$rc_default -eq 1 ]"
+
+# A findings review reports completion_kind "review".
+assert "matched review reports completion_kind review" "printf '%s' \"\$out_bot\" | jq -e '.completion_kind == \"review\"' >/dev/null"
+
+# ── Poll completion contract (Component 3): clean-pass completion ───────────
+# A clean bot pass submits no review object at all — only a `+1` reaction on
+# the PR body, or a clean-pass marker issue comment, post-dating the ask
+# (--since-timestamp). Both must be recognised as completion (exit 0,
+# completion_kind "clean_reaction"), and ONLY a true timeout may report
+# completion_kind "timeout" — that is the only outcome a caller may count as
+# a silent ask against its retry cap.
+
+CODEX_ID='chatgpt-codex-connector[bot]'
+SINCE_TS='2026-01-01T00:00:00Z'
+
+# Clean case 1: a `+1` reaction from an allowlisted identity, post-dating the ask.
+FIXTURE_REACTIONS_CLEAN='[{"id":1,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:00:10Z"}]'
+
+out_reaction=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_CLEAN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_reaction=$?
+assert "a post-dating +1 reaction completes (exit 0)" "[ \$rc_reaction -eq 0 ]"
+assert "a post-dating +1 reaction reports completion_kind clean_reaction" "printf '%s' \"\$out_reaction\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# Clean case 2: a clean-pass marker issue comment from an allowlisted identity,
+# post-dating the ask — no reaction present at all.
+FIXTURE_ISSUE_COMMENTS_CLEAN="[{\"id\":2,\"user\":{\"login\":\"$CODEX_ID\"},\"body\":\"Codex Review: Didn't find any major issues in this PR.\",\"created_at\":\"2026-01-01T00:00:10Z\"}]"
+
+out_comment=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS="$FIXTURE_ISSUE_COMMENTS_CLEAN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_comment=$?
+assert "a post-dating marker comment completes (exit 0)" "[ \$rc_comment -eq 0 ]"
+assert "a post-dating marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_comment\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# A `+1` reaction that PREDATES the ask must NOT complete (stale-cache guard,
+# same discipline as the existing review submitted_at filter) — falls through
+# to a real timeout.
+FIXTURE_REACTIONS_STALE='[{"id":3,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2025-12-31T23:59:00Z"}]'
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_STALE" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_stale_reaction=$?
+assert "a pre-dating +1 reaction does NOT complete (timeout, exit 1)" "[ \$rc_stale_reaction -eq 1 ]"
+
+# The inverse: nothing arrives at all → real timeout, completion_kind "timeout".
+out_timeout=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_timeout=$?
+assert "no signal at all times out (exit 1)" "[ \$rc_timeout -eq 1 ]"
+assert "timeout reports completion_kind timeout" "printf '%s' \"\$out_timeout\" | jq -e '.completion_kind == \"timeout\"' >/dev/null"
+
+# Without --bot-reviewers, the clean-reaction/marker-comment checks never run
+# (Copilot never emits either signal) — a fixture that WOULD complete under
+# --bot-reviewers must still time out under the standalone Copilot default.
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_CLEAN" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 >/dev/null 2>&1
+rc_no_policy=$?
+assert "clean-reaction signal is ignored without --bot-reviewers (timeout, exit 1)" "[ \$rc_no_policy -eq 1 ]"
+
+# Only "timeout" may count as a silent ask against a caller's retry cap: chain
+# the actual accounting helper the skill uses, mapping this script's exit
+# code the way SKILL.md Phase 6 does (0 -> --event none, 1 -> --event silent).
+# A clean_reaction completion (exit 0) must NOT advance the silent counter; a
+# real timeout (exit 1) must.
+map_to_polling_event() { [ "$1" -eq 0 ] && echo none || echo silent; }
+
+polling_after_clean=$("$HERE/compute-rereview-polling.sh" --prior-count 0 --prior-exhausted false \
+  --event "$(map_to_polling_event "$rc_reaction")")
+assert "clean_reaction completion does NOT increment the silent-ask counter" \
+  "[ \"\$(jq '.rereview_round_count' <<<\"\$polling_after_clean\")\" = 0 ]"
+
+polling_after_timeout=$("$HERE/compute-rereview-polling.sh" --prior-count 0 --prior-exhausted false \
+  --event "$(map_to_polling_event "$rc_timeout")")
+assert "a real timeout DOES increment the silent-ask counter" \
+  "[ \"\$(jq '.rereview_round_count' <<<\"\$polling_after_timeout\")\" = 1 ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -230,6 +230,34 @@ env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVI
 rc_no_policy=$?
 assert "clean-reaction signal is ignored without --bot-reviewers (timeout, exit 1)" "[ \$rc_no_policy -eq 1 ]"
 
+# ── Equal-second clean signal on the ask-bound (--since-timestamp) path ──────
+# SINCE is captured to second precision immediately before dispatch; GitHub
+# reaction/comment created_at is also second precision. A fast Codex clean
+# response created in that same second has created_at == SINCE. Causality — the
+# capture precedes the ask, which precedes any response — makes an equal-second
+# signal necessarily this round's, so the ask-bound path accepts it (>=), where
+# the head-date bound below keeps strict >.
+
+FIXTURE_REACTIONS_EQUAL="[{\"id\":4,\"content\":\"+1\",\"user\":{\"login\":\"$CODEX_ID\",\"type\":\"Bot\"},\"created_at\":\"$SINCE_TS\"}]"
+
+out_equal_reaction=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_EQUAL" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_equal_reaction=$?
+assert "ask-bound: +1 created in the ask second completes (exit 0)" "[ \$rc_equal_reaction -eq 0 ]"
+assert "ask-bound: equal-second +1 reports completion_kind clean_reaction" "printf '%s' \"\$out_equal_reaction\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+FIXTURE_ISSUE_COMMENTS_EQUAL="[{\"id\":5,\"user\":{\"login\":\"$CODEX_ID\"},\"body\":\"Codex Review: Didn't find any major issues in this PR.\",\"created_at\":\"$SINCE_TS\"}]"
+
+out_equal_comment=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_REACTIONS='[]' FIXTURE_ISSUE_COMMENTS="$FIXTURE_ISSUE_COMMENTS_EQUAL" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_equal_comment=$?
+assert "ask-bound: marker comment created in the ask second completes (exit 0)" "[ \$rc_equal_comment -eq 0 ]"
+assert "ask-bound: equal-second marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_equal_comment\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
 # Only "timeout" may count as a silent ask against a caller's retry cap: chain
 # the actual accounting helper the skill uses, mapping this script's exit
 # code the way SKILL.md Phase 6 does (0 -> --event none, 1 -> --event silent).
@@ -283,6 +311,21 @@ out_posthead=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTE
 rc_posthead=$?
 assert "initial poll: +1 post-dating head committer date completes (exit 0)" "[ \$rc_posthead -eq 0 ]"
 assert "initial poll: post-dating +1 reports completion_kind clean_reaction" "printf '%s' \"\$out_posthead\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+
+# (b2) A `+1` created in the SAME second as the head committer date is still
+#      REJECTED on the initial poll (no --since-timestamp): the head-date bound
+#      keeps strict > because an equal-second reaction could belong to the
+#      pre-push head (the ~10s tear-down race), per spec Component 2 — the
+#      asymmetric counterpart to the ask-bound path's inclusive >=.
+FIXTURE_REACTIONS_EQUALHEAD='[{"id":12,"content":"+1","user":{"login":"chatgpt-codex-connector[bot]","type":"Bot"},"created_at":"2026-01-01T00:00:00Z"}]'
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  FIXTURE_PR="$FIXTURE_PR_HEAD" FIXTURE_COMMIT="$FIXTURE_COMMIT_HEADDATE" \
+  FIXTURE_REACTIONS="$FIXTURE_REACTIONS_EQUALHEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 \
+  --bot-reviewers "[\"$CODEX_ID\"]" >/dev/null 2>&1
+rc_equalhead=$?
+assert "initial poll: +1 in the same second as head committer date does NOT complete (timeout, exit 1)" "[ \$rc_equalhead -eq 1 ]"
 
 # (c) An unparseable head committer date rejects clean signals on the initial
 #     poll (fail closed) — even a would-be-fresh `+1`.

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -1,29 +1,55 @@
 #!/usr/bin/env bash
-# Purpose: request a Copilot re-review via the remove+re-add reviewer
-# idempotency dance. The `gh pr edit --remove-reviewer @copilot && sleep && gh
-# pr edit --add-reviewer @copilot` pattern reliably triggers a new review
-# event even when @copilot is already listed.
+# Purpose: request a re-review from one or more trusted PR bot reviewers,
+# dispatching on reviewer identity — each bot's ask mechanism differs:
+#
+#   Identity                              Mechanism
+#   -------------------------------------  ------------------------------------
+#   Copilot,                               remove+re-add reviewer dance. The
+#   copilot-pull-request-reviewer[bot]     `gh pr edit --remove-reviewer
+#                                           @copilot && sleep && gh pr edit
+#                                           --add-reviewer @copilot` pattern
+#                                           reliably triggers a new review
+#                                           event even when @copilot is already
+#                                           listed. Copilot does not respond to
+#                                           an issue comment.
+#   chatgpt-codex-connector[bot] (Codex)   post an `@codex review` issue
+#                                           comment. Codex does not respond to
+#                                           reviewer-request events at all.
+#
+# An identity with no known mechanism warns to stderr and is skipped without
+# aborting dispatch to its siblings.
 #
 # Inputs:
-#   --owner <o>  repository owner
-#   --repo  <r>  repository name
-#   --pr    <n>  PR number
+#   --owner <o>              repository owner
+#   --repo  <r>              repository name
+#   --pr    <n>              PR number
+#   --bot-reviewers <json>   JSON array of reviewer identities to dispatch to
+#                            (non-empty array of strings; identity matched
+#                            case-insensitively, mirroring
+#                            poll-copilot-review.sh's convention). Omit to
+#                            preserve the legacy Copilot-only dance
+#                            (backward-compatible default, not how the
+#                            wait-for-pr-comments/merge-guard loops run).
 #
 # Outputs:
 #   stdout: (none on success)
 #   exit codes:
-#     0 = re-review requested
-#     1 = gh failure
+#     0 = at least one ask succeeded
+#     1 = no ask succeeded (gh failure on every dispatched identity)
 #     2 = bad flag usage
 #
-# GraphQL projection: none directly; uses `gh pr edit` REST under the hood.
+# GraphQL projection: none directly; uses `gh pr edit` / `gh pr comment` REST
+# under the hood.
 set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") --owner <o> --repo <r> --pr <n>
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> [--bot-reviewers <json-array>]
 
-Removes and re-adds @copilot as a reviewer to trigger a Copilot re-review.
+Requests a re-review from one or more trusted bot reviewers, dispatching on
+identity: Copilot / copilot-pull-request-reviewer[bot] get the remove+re-add
+reviewer dance; chatgpt-codex-connector[bot] gets an '@codex review' issue
+comment. Omit --bot-reviewers to request only Copilot (legacy default).
 EOF
   exit 2
 }
@@ -31,14 +57,16 @@ EOF
 OWNER=""
 REPO=""
 PR=""
+BOT_REVIEWERS=""
 
 [ $# -gt 0 ] || usage
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --owner) OWNER="${2:-}"; shift 2 ;;
-    --repo)  REPO="${2:-}";  shift 2 ;;
-    --pr)    PR="${2:-}";    shift 2 ;;
+    --owner)         OWNER="${2:-}";         shift 2 ;;
+    --repo)          REPO="${2:-}";          shift 2 ;;
+    --pr)            PR="${2:-}";            shift 2 ;;
+    --bot-reviewers) BOT_REVIEWERS="${2:-}"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "error: unknown flag: $1" >&2; usage ;;
   esac
@@ -49,20 +77,70 @@ done
   exit 2
 }
 
+# Validate --bot-reviewers (when provided) as a non-empty JSON array of
+# strings — same convention as poll-copilot-review.sh — then canonicalize via
+# jq so only clean, re-serialized JSON is read below.
+if [ -n "$BOT_REVIEWERS" ]; then
+  BOT_REVIEWERS=$(jq -ce 'if (type == "array" and length > 0 and ([.[] | select(type != "string")] | length) == 0) then . else error("bad") end' <<<"$BOT_REVIEWERS" 2>/dev/null) || {
+    echo "error: --bot-reviewers must be a non-empty JSON array of strings" >&2
+    exit 2
+  }
+fi
+
 PR_REF="$OWNER/$REPO#$PR"
 
 GH_ERR="$(mktemp)"
 trap 'rm -f "$GH_ERR"' EXIT
 
-# Remove @copilot — tolerate "not currently a reviewer" (a common no-op error).
-gh pr edit "$PR" --repo "$OWNER/$REPO" --remove-reviewer @copilot >/dev/null 2>"$GH_ERR" || true
+# request_copilot — remove+re-add @copilot to trigger a fresh review event.
+request_copilot() {
+  # Remove @copilot — tolerate "not currently a reviewer" (a common no-op error).
+  gh pr edit "$PR" --repo "$OWNER/$REPO" --remove-reviewer @copilot >/dev/null 2>"$GH_ERR" || true
 
-sleep 2
+  sleep 2
 
-# Add @copilot — capture stderr so callers (and operators debugging auth /
-# permission / rate-limit / invalid-PR failures) see the underlying gh message,
-# not just a generic exit code.
-if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-reviewer @copilot >/dev/null 2>"$GH_ERR"; then
-  echo "error: gh pr edit --add-reviewer failed for $PR_REF: $(cat "$GH_ERR")" >&2
+  # Add @copilot — capture stderr so callers (and operators debugging auth /
+  # permission / rate-limit / invalid-PR failures) see the underlying gh message,
+  # not just a generic exit code.
+  if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-reviewer @copilot >/dev/null 2>"$GH_ERR"; then
+    echo "error: gh pr edit --add-reviewer failed for $PR_REF: $(cat "$GH_ERR")" >&2
+    return 1
+  fi
+}
+
+# request_codex — post an '@codex review' issue comment. Codex reviews on
+# push, mark-draft-ready, and this comment, but not on a reviewer-request
+# event, so this is its only ask mechanism.
+request_codex() {
+  if ! gh pr comment "$PR" --repo "$OWNER/$REPO" --body "@codex review" >/dev/null 2>"$GH_ERR"; then
+    echo "error: gh pr comment '@codex review' failed for $PR_REF: $(cat "$GH_ERR")" >&2
+    return 1
+  fi
+}
+
+if [ -z "$BOT_REVIEWERS" ]; then
+  # Backward-compatible default: the legacy Copilot-only dance.
+  if request_copilot; then
+    exit 0
+  fi
   exit 1
 fi
+
+SUCCEEDED=0
+while IFS= read -r identity; do
+  lower=$(printf '%s' "$identity" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    copilot|"copilot-pull-request-reviewer[bot]")
+      if request_copilot; then SUCCEEDED=$((SUCCEEDED + 1)); fi
+      ;;
+    "chatgpt-codex-connector[bot]")
+      if request_codex; then SUCCEEDED=$((SUCCEEDED + 1)); fi
+      ;;
+    *)
+      echo "warning: no known re-review mechanism for reviewer identity '$identity' — skipping" >&2
+      ;;
+  esac
+done < <(jq -r '.[]' <<<"$BOT_REVIEWERS")
+
+[ "$SUCCEEDED" -gt 0 ] && exit 0
+exit 1

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -127,18 +127,31 @@ if [ -z "$BOT_REVIEWERS" ]; then
 fi
 
 SUCCEEDED=0
+# Track mechanisms already dispatched this invocation. Multiple aliases can map
+# to the same mechanism (e.g. both `Copilot` and
+# `copilot-pull-request-reviewer[bot]` -> the reviewer dance); dispatching each
+# mechanism at most once avoids a redundant remove+re-add cycle per alias.
+DISPATCHED=""
 while IFS= read -r identity; do
   lower=$(printf '%s' "$identity" | tr '[:upper:]' '[:lower:]')
   case "$lower" in
-    copilot|"copilot-pull-request-reviewer[bot]")
-      if request_copilot; then SUCCEEDED=$((SUCCEEDED + 1)); fi
-      ;;
-    "chatgpt-codex-connector[bot]")
-      if request_codex; then SUCCEEDED=$((SUCCEEDED + 1)); fi
-      ;;
+    copilot|"copilot-pull-request-reviewer[bot]") mechanism=copilot ;;
+    "chatgpt-codex-connector[bot]")               mechanism=codex ;;
     *)
       echo "warning: no known re-review mechanism for reviewer identity '$identity' — skipping" >&2
+      continue
       ;;
+  esac
+
+  # Skip mechanisms already asked this invocation (alias dedup).
+  case " $DISPATCHED " in
+    *" $mechanism "*) continue ;;
+  esac
+  DISPATCHED="$DISPATCHED $mechanism"
+
+  case "$mechanism" in
+    copilot) if request_copilot; then SUCCEEDED=$((SUCCEEDED + 1)); fi ;;
+    codex)   if request_codex;   then SUCCEEDED=$((SUCCEEDED + 1)); fi ;;
   esac
 done < <(jq -r '.[]' <<<"$BOT_REVIEWERS")
 

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -60,4 +60,126 @@ else
   echo "  ok: rejects unknown flag"
 fi
 
+# ── --bot-reviewers (Component 1: per-bot re-review dispatch) ───────────────
+
+assert "accepts --bot-reviewers flag" "grep -q -- '--bot-reviewers' '$SCRIPT'"
+
+# Malformed values must be rejected up front (exit 2 — this script's usage-
+# error code), not silently ignored.
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers 'not-json' 2>/dev/null
+rc_bad_bots=$?
+assert "exits 2 for non-array --bot-reviewers" "[ \$rc_bad_bots -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '[]' 2>/dev/null
+rc_empty_bots=$?
+assert "exits 2 for empty --bot-reviewers array" "[ \$rc_empty_bots -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["ok", 3]' 2>/dev/null
+rc_mixed_bots=$?
+assert "exits 2 for --bot-reviewers array with a non-string" "[ \$rc_mixed_bots -eq 2 ]"
+
+# --- Fake-gh shim (argv capture): logs every invocation; --add-reviewer / `gh
+# pr comment` can be made to fail via FAKE_GH_FAIL_EDIT / FAKE_GH_FAIL_COMMENT
+# so per-identity dispatch failure and the exit-code matrix can be exercised.
+FAKEBIN2="$TMP/bin2"
+mkdir -p "$FAKEBIN2"
+export FAKE_GH_LOG="$TMP/fake-gh.log"
+cat > "$FAKEBIN2/gh" <<'FAKE'
+#!/usr/bin/env bash
+# Fake gh — logs every invocation; --add-reviewer / pr comment can be made to
+# fail via FAKE_GH_FAIL_EDIT / FAKE_GH_FAIL_COMMENT env vars.
+LOG="${FAKE_GH_LOG:-/tmp/fake-gh.log}"
+echo "$@" >> "$LOG"
+for arg in "$@"; do
+  if [ "$arg" = "--add-reviewer" ] && [ "${FAKE_GH_FAIL_EDIT:-0}" = "1" ]; then
+    echo "fake-gh: simulated add-reviewer failure" >&2
+    exit 1
+  fi
+done
+if [ "$1" = "pr" ] && [ "$2" = "comment" ] && [ "${FAKE_GH_FAIL_COMMENT:-0}" = "1" ]; then
+  echo "fake-gh: simulated comment failure" >&2
+  exit 1
+fi
+exit 0
+FAKE
+chmod +x "$FAKEBIN2/gh"
+
+# Per-identity dispatch: Copilot -> remove+re-add reviewer dance.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["Copilot"]' >/dev/null 2>&1
+rc_copilot=$?
+assert "Copilot identity exits 0" "[ \$rc_copilot -eq 0 ]"
+assert "Copilot identity dispatches --remove-reviewer @copilot" "grep -qF -- '--remove-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "Copilot identity dispatches --add-reviewer @copilot" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "Copilot identity does NOT post a codex review comment" "! grep -qF 'pr comment' '$FAKE_GH_LOG'"
+
+# Per-identity dispatch: copilot-pull-request-reviewer[bot] (exact GH login)
+# dispatches the same mechanism as 'Copilot', case-insensitively matched.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["copilot-pull-request-reviewer[bot]"]' >/dev/null 2>&1
+rc_copilot_bot=$?
+assert "copilot-pull-request-reviewer[bot] identity exits 0" "[ \$rc_copilot_bot -eq 0 ]"
+assert "copilot-pull-request-reviewer[bot] identity dispatches the reviewer dance" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+
+# Per-identity dispatch: chatgpt-codex-connector[bot] -> '@codex review' issue comment.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
+rc_codex=$?
+assert "Codex identity exits 0" "[ \$rc_codex -eq 0 ]"
+assert "Codex identity posts an '@codex review' issue comment" "grep -qF -- 'pr comment 1 --repo o/r --body @codex review' '$FAKE_GH_LOG'"
+assert "Codex identity does NOT touch reviewers" "! grep -qF -- '--add-reviewer' '$FAKE_GH_LOG'"
+
+# Case-insensitive identity match (spec: mirrors poll-copilot-review.sh's convention).
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["CHATGPT-CODEX-CONNECTOR[bot]"]' >/dev/null 2>&1
+rc_codex_upper=$?
+assert "uppercase Codex identity still dispatches (case-insensitive match)" "[ \$rc_codex_upper -eq 0 ] && grep -qF 'pr comment' '$FAKE_GH_LOG'"
+
+# Multi-identity dispatch: both known bots asked in one call.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
+rc_multi=$?
+assert "multi-identity dispatch exits 0" "[ \$rc_multi -eq 0 ]"
+assert "multi-identity dispatch asks Copilot" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "multi-identity dispatch asks Codex" "grep -qF 'pr comment' '$FAKE_GH_LOG'"
+
+# Unknown identity: warns to stderr and is skipped WITHOUT aborting siblings.
+: > "$FAKE_GH_LOG"
+err_out=$(PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["some-other-bot[bot]", "Copilot"]' 2>&1 >/dev/null)
+rc_unknown_mixed=$?
+assert "unknown identity mixed with a known one still exits 0" "[ \$rc_unknown_mixed -eq 0 ]"
+assert "unknown identity warns on stderr" "printf '%s' \"\$err_out\" | grep -qiF 'some-other-bot[bot]'"
+assert "unknown identity does not abort dispatch to Copilot" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+
+# All-unknown: exit 1 (no ask succeeded), still no abort/crash.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["totally-unknown-bot"]' >/dev/null 2>&1
+rc_all_unknown=$?
+assert "all-unknown identities exit 1 (none succeeded)" "[ \$rc_all_unknown -eq 1 ]"
+
+# Exit-code matrix: a known identity whose gh call fails still counts as a
+# failed ask; when it is the ONLY identity, exit 1 (none succeeded).
+: > "$FAKE_GH_LOG"
+FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["Copilot"]' >/dev/null 2>&1
+rc_all_fail=$?
+assert "single failing identity exits 1 (none succeeded)" "[ \$rc_all_fail -eq 1 ]"
+
+# Exit-code matrix: one identity fails, the other succeeds -> still exit 0
+# (at least one ask succeeded).
+: > "$FAKE_GH_LOG"
+FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
+rc_partial=$?
+assert "one failing + one succeeding identity exits 0 (at least one succeeded)" "[ \$rc_partial -eq 0 ]"
+
+# Flag-omitted default: still performs the Copilot-only dance, unchanged.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 >/dev/null 2>&1
+rc_default=$?
+assert "omitting --bot-reviewers exits 0 (Copilot default)" "[ \$rc_default -eq 0 ]"
+assert "omitting --bot-reviewers still dispatches the Copilot dance" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "omitting --bot-reviewers never posts a codex review comment" "! grep -qF 'pr comment' '$FAKE_GH_LOG'"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -144,6 +144,16 @@ assert "multi-identity dispatch exits 0" "[ \$rc_multi -eq 0 ]"
 assert "multi-identity dispatch asks Copilot" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
 assert "multi-identity dispatch asks Codex" "grep -qF 'pr comment' '$FAKE_GH_LOG'"
 
+# Alias dedup: both Copilot aliases share one mechanism, so a call listing both
+# must run the remove+re-add dance exactly ONCE — not once per alias.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "copilot-pull-request-reviewer[bot]"]' >/dev/null 2>&1
+rc_alias_dedup=$?
+assert "both Copilot aliases exit 0" "[ \$rc_alias_dedup -eq 0 ]"
+assert "both Copilot aliases remove @copilot exactly once" "[ \$(grep -cF -- '--remove-reviewer @copilot' '$FAKE_GH_LOG') -eq 1 ]"
+assert "both Copilot aliases add @copilot exactly once" "[ \$(grep -cF -- '--add-reviewer @copilot' '$FAKE_GH_LOG') -eq 1 ]"
+
 # Unknown identity: warns to stderr and is skipped WITHOUT aborting siblings.
 : > "$FAKE_GH_LOG"
 err_out=$(PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \


### PR DESCRIPTION
## Summary

- `request-rereview.sh` gains `--bot-reviewers <json-array>` and dispatches per reviewer identity: `Copilot` / `copilot-pull-request-reviewer[bot]` keep the existing remove+re-add reviewer dance; `chatgpt-codex-connector[bot]` posts an `@codex review` issue comment. Unknown identities warn to stderr and are skipped without aborting siblings. Exit codes: 0 if ≥1 ask succeeded, 1 if none, 2 usage. Flag omitted → unchanged Copilot-only behavior.
- `poll-copilot-review.sh` completion contract: completion is now a review object OR a `+1` PR-body reaction post-dating the ask OR a clean-pass marker comment (`Codex Review: Didn't find any major issues` prefix from an allowlisted bot). Emits `completion_kind` (`review` | `clean_reaction` | `timeout`); only `timeout` counts against the silent-ask cap.
- `SKILL.md` Phase 6 step 1 now passes `--bot-reviewers` from the policy allowlist resolved in Phase 1 (the caller edit that makes the flag live).

Delivery PR 1 of 2 for the Codex re-review path (bead agents-config-abn9.44.1).

## Scope

**In scope:** Components 1 and 3 of `docs/specs/2026-07-18-codex-rereview-path-design.md`, files under `src/user/.agents/skills/wait-for-pr-comments/` only.

**Out of scope (delivery PR 2, bead abn9.44.2):** merge-guard Components 2/2b (`bot_clean_review_at_head` reaction disjunction, clean-pass comment exemption, one-ask retry caller edit). Also deferred per the spec's review ledger (M2): `poll-copilot-rereview-start.sh` eyes-reaction generalization and Phase 6 steps 3–5 rewiring.

## Ground truth for review

- Authoritative contract: `docs/specs/2026-07-18-codex-rereview-path-design.md`, Components 1 and 3 and the Testing section (unchanged by this PR).
- The clean-pass reaction/marker checks run only in `--bot-reviewers` (policy) mode, mirroring the script's existing `COPILOT_LOGIN_FILTER` default/policy split — Copilot never emits those signals, so the default path takes no extra API calls. This is intentional, not a gap.

## Known deferred nits (flagged by the HEAVY quality gate, sub-floor severity)

- The `--bot-reviewers` jq validation expression is duplicated between `poll-copilot-review.sh` and `request-rereview.sh`; extracting a shared helper is a design call deferred until a third consumer exists.
- The poll loop filters reactions/clean-comments in two jq passes; folding `--since` into the first pass changes control flow (stale-count logging) and is deferred.

## Test Plan

- [x] All 14 `*_test.sh` suites in the skill directory pass (`bash <suite>` each; 260+ assertions, 0 failures)
- [x] Per-identity dispatch asserted via fake-gh argv capture; unknown-identity skip; exit-code matrix; flag-omitted Copilot default; `--bot-reviewers` validation (non-array / empty / non-string rejected)
- [x] Clean-Codex completion asserts `completion_kind=clean_reaction` and no silent-counter increment (chained through `compute-rereview-polling.sh`); real timeout does increment
- [x] `bash -n` clean on modified scripts (shellcheck unavailable in this environment)
