### PR TITLE
feat(workcli): capability-disposition seam — ReadySupport/SyncSupport enums + supports_dep_write

### DIFF
--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -36,7 +36,7 @@ from workcli.adapters.bd.parse import (
 )
 from workcli.adapters.bd.retry import run_with_retry
 from workcli.adapters.bd.runner import BdRunner
-from workcli.backend import Capabilities, DepOp
+from workcli.backend import Capabilities, DepOp, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
 
@@ -56,8 +56,10 @@ class BdBackend:
     @property
     def capabilities(self) -> Capabilities:
         # bd has native blocker semantics, typed dep edges, and dolt sync --
-        # every capability flag is true.
-        return Capabilities(supports_ready=True, supports_dep_types=True, supports_sync=True)
+        # every capability is at its native corner.
+        return Capabilities(
+            ready=ReadySupport.NATIVE, sync=SyncSupport.NATIVE, supports_dep_write=True
+        )
 
     def get(self, item_id: str) -> Item:
         return self.batch_get([item_id])[0]

--- a/packages/workcli/src/workcli/backend.py
+++ b/packages/workcli/src/workcli/backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Literal, Protocol
 
 from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
@@ -16,11 +17,23 @@ from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResu
 DepOp = Literal["add", "remove"]
 
 
+class SyncSupport(StrEnum):
+    NATIVE = "native"
+    SERVER_AUTHORITATIVE = "server_authoritative"
+    UNSUPPORTED = "unsupported"
+
+
+class ReadySupport(StrEnum):
+    NATIVE = "native"
+    EMULATED = "emulated"
+    UNSUPPORTED = "unsupported"
+
+
 @dataclass(frozen=True)
 class Capabilities:
-    supports_ready: bool
-    supports_dep_types: bool
-    supports_sync: bool
+    ready: ReadySupport
+    sync: SyncSupport
+    supports_dep_write: bool  # typed dep add/remove; `dep list` is never gated
 
 
 class Backend(Protocol):

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -331,7 +331,7 @@ def main(
         # handshake never touches the runner (spec §5).
         backend = _build_backend(runner, sleep)
 
-        if missing_capability(args.verb, backend.capabilities):
+        if missing_capability(args.verb, backend.capabilities, args):
             return _finish_failure(
                 WorkError(
                     ErrorCode.UNSUPPORTED_CAPABILITY,

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -2,7 +2,9 @@
 
 `VERBS` maps a verb name to its handler: `(Backend, Namespace) -> JsonValue`.
 `REQUIRED_CAPABILITY` maps a verb name to a predicate function over
-`Capabilities` that must return true for the verb to run; a verb absent
+`(Capabilities, Namespace)` that must return true for the verb to run; the
+`Namespace` lets the `dep` predicate distinguish `dep list` (always allowed)
+from `dep add`/`dep remove` (gated on `supports_dep_write`). A verb absent
 from this map has no gate (every v1 backend must
 support it unconditionally). `cli.py`'s dispatch loop checks the gate before
 ever calling the handler, so an unsupported capability never reaches verb
@@ -14,7 +16,7 @@ from __future__ import annotations
 from argparse import Namespace
 from collections.abc import Callable
 
-from workcli.backend import Backend, Capabilities
+from workcli.backend import Backend, Capabilities, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle.create import create_noun
 from workcli.lifecycle.deliver import deliver
@@ -97,16 +99,16 @@ VERBS: dict[str, Callable[[Backend, Namespace], JsonValue]] = {
     "sync": sync,
 }
 
-REQUIRED_CAPABILITY: dict[str, Callable[[Capabilities], bool]] = {
-    "ready": lambda c: c.supports_ready,
-    "sync": lambda c: c.supports_sync,
-    "dep": lambda c: c.supports_dep_types,
+REQUIRED_CAPABILITY: dict[str, Callable[[Capabilities, Namespace], bool]] = {
+    "ready": lambda c, _a: c.ready is not ReadySupport.UNSUPPORTED,
+    "sync": lambda c, _a: c.sync is not SyncSupport.UNSUPPORTED,
+    "dep": lambda c, a: a.action == "list" or c.supports_dep_write,
 }
 
 
-def missing_capability(verb: str, capabilities: Capabilities) -> bool:
+def missing_capability(verb: str, capabilities: Capabilities, args: Namespace) -> bool:
     """True when `verb` declares a required capability `capabilities` lacks."""
     check = REQUIRED_CAPABILITY.get(verb)
     if check is None:
         return False
-    return not check(capabilities)
+    return not check(capabilities, args)

--- a/packages/workcli/src/workcli/verbs/syncing.py
+++ b/packages/workcli/src/workcli/verbs/syncing.py
@@ -9,11 +9,21 @@ import dataclasses
 from argparse import Namespace
 from typing import cast
 
-from workcli.backend import Backend
+from workcli.backend import Backend, SyncSupport
 from workcli.envelope import JsonValue
+from workcli.model import SyncResult
 
 
 def sync(backend: Backend, args: Namespace) -> JsonValue:
-    """`work sync [--pull]` (decision 9): default = commit+push; `--pull` = pull."""
-    result = backend.sync(pull=args.pull)
+    """`work sync [--pull]` (decision 9): default = commit+push; `--pull` = pull.
+
+    `SERVER_AUTHORITATIVE` backends have nothing to sync -- an honest no-op
+    success (`synced: false`, `mode: "noop"`) without ever calling
+    `backend.sync`. `UNSUPPORTED` is already refused at the capability gate
+    before this handler runs, so only `NATIVE` reaches the real call.
+    """
+    if backend.capabilities.sync is SyncSupport.SERVER_AUTHORITATIVE:
+        result = SyncResult(synced=False, mode="noop")
+    else:
+        result = backend.sync(pull=args.pull)
     return cast("dict[str, JsonValue]", dataclasses.asdict(result))

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from workcli.backend import Capabilities, DepOp
+from workcli.backend import Capabilities, DepOp, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, WorkError
 from workcli.model import (
     CreateFields,
@@ -136,7 +136,9 @@ class FakeBackend:
 
     @property
     def capabilities(self) -> Capabilities:
-        return Capabilities(supports_ready=True, supports_dep_types=True, supports_sync=True)
+        return Capabilities(
+            ready=ReadySupport.NATIVE, sync=SyncSupport.NATIVE, supports_dep_write=True
+        )
 
     def get(self, item_id: str) -> Item:
         return self._snapshot(self._require(item_id), lean=False)

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.adapters.bd.backend import BdBackend
 from workcli.adapters.bd.runner import BdResult
+from workcli.backend import ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, WorkError
 from workcli.model import CreateFields, DepEdge, QueryFilters, UpdateFields
 
@@ -25,14 +26,14 @@ def _read(name: str) -> str:
     return (FIXTURES / name).read_text()
 
 
-def test_capabilities_are_all_true_for_bd():
+def test_capabilities_are_all_native_for_bd():
     backend = BdBackend(ScriptedBdRunner(steps=[]))
 
     caps = backend.capabilities
 
-    assert caps.supports_ready is True
-    assert caps.supports_dep_types is True
-    assert caps.supports_sync is True
+    assert caps.ready is ReadySupport.NATIVE
+    assert caps.sync is SyncSupport.NATIVE
+    assert caps.supports_dep_write is True
 
 
 def test_get_sends_show_json_and_returns_the_normalized_item():

--- a/packages/workcli/tests/unit/test_capabilities.py
+++ b/packages/workcli/tests/unit/test_capabilities.py
@@ -1,8 +1,9 @@
 """The capability gate (decision 11): dispatch refuses a verb the backend's
 `Capabilities` declares unsupported, before its handler ever runs.
 
-bd's own `Capabilities` are all `True` (`ready`, `sync`, dep types), so the
-rejection path can only be exercised with a stub backend, never `BdBackend`.
+bd's own `Capabilities` are all native (`ready`, `sync`, `supports_dep_write`),
+so the rejection path can only be exercised with a stub backend, never
+`BdBackend`.
 """
 
 from __future__ import annotations
@@ -11,8 +12,9 @@ import json
 from io import StringIO
 
 from workcli import cli as cli_module
-from workcli.backend import Capabilities
+from workcli.backend import Capabilities, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode
+from workcli.model import DepListing, SyncResult
 
 
 class _StubReadyDenyingBackend:
@@ -20,7 +22,9 @@ class _StubReadyDenyingBackend:
 
     @property
     def capabilities(self) -> Capabilities:
-        return Capabilities(supports_ready=False, supports_dep_types=True, supports_sync=True)
+        return Capabilities(
+            ready=ReadySupport.UNSUPPORTED, sync=SyncSupport.NATIVE, supports_dep_write=True
+        )
 
     def ready(self, _label: str | None) -> list[object]:
         raise AssertionError("capability gate must refuse dispatch before the handler runs")
@@ -29,22 +33,46 @@ class _StubReadyDenyingBackend:
 class _StubSyncDenyingBackend:
     @property
     def capabilities(self) -> Capabilities:
-        return Capabilities(supports_ready=True, supports_dep_types=True, supports_sync=False)
+        return Capabilities(
+            ready=ReadySupport.NATIVE, sync=SyncSupport.UNSUPPORTED, supports_dep_write=True
+        )
 
     def sync(self, *, pull: bool) -> object:  # noqa: ARG002 -- stub proves the gate refuses first
         raise AssertionError("capability gate must refuse dispatch before the handler runs")
 
 
-class _StubDepTypesDenyingBackend:
+class _StubDepWriteDenyingBackend:
+    """`dep list` must reach the handler; `dep add`/`dep remove` must not."""
+
     @property
     def capabilities(self) -> Capabilities:
-        return Capabilities(supports_ready=True, supports_dep_types=False, supports_sync=True)
+        return Capabilities(
+            ready=ReadySupport.NATIVE, sync=SyncSupport.NATIVE, supports_dep_write=False
+        )
+
+    def dep_list(self, _item_id: str) -> DepListing:
+        return DepListing(depends_on=[], dependents=[])
 
     def get(self, _item_id: str) -> object:
         raise AssertionError("capability gate must refuse dispatch before the handler runs")
 
     def dep_mutate(self, *_args: object, **_kwargs: object) -> None:
         raise AssertionError("capability gate must refuse dispatch before the handler runs")
+
+
+class _StubServerAuthoritativeSyncBackend:
+    """`sync` disposition SERVER_AUTHORITATIVE: an honest no-op, `backend.sync` never called."""
+
+    @property
+    def capabilities(self) -> Capabilities:
+        return Capabilities(
+            ready=ReadySupport.NATIVE,
+            sync=SyncSupport.SERVER_AUTHORITATIVE,
+            supports_dep_write=True,
+        )
+
+    def sync(self, *, pull: bool) -> SyncResult:  # noqa: ARG002
+        raise AssertionError("SERVER_AUTHORITATIVE sync must never call backend.sync")
 
 
 def test_ready_dispatch_is_refused_when_the_backend_declares_no_support(monkeypatch):
@@ -79,9 +107,9 @@ def test_sync_dispatch_is_refused_when_the_backend_declares_no_support(monkeypat
     assert envelope["error"]["code"] == str(ErrorCode.UNSUPPORTED_CAPABILITY)
 
 
-def test_dep_dispatch_is_refused_when_the_backend_declares_no_dep_type_support(monkeypatch):
+def test_dep_add_dispatch_is_refused_when_the_backend_denies_dep_write(monkeypatch):
     monkeypatch.setattr(
-        cli_module, "_build_backend", lambda _runner, _sleep: _StubDepTypesDenyingBackend()
+        cli_module, "_build_backend", lambda _runner, _sleep: _StubDepWriteDenyingBackend()
     )
     out = StringIO()
     err = StringIO()
@@ -93,3 +121,37 @@ def test_dep_dispatch_is_refused_when_the_backend_declares_no_dep_type_support(m
     envelope = json.loads(out.getvalue())
     assert envelope["ok"] is False
     assert envelope["error"]["code"] == str(ErrorCode.UNSUPPORTED_CAPABILITY)
+
+
+def test_dep_list_dispatch_is_allowed_when_the_backend_denies_dep_write(monkeypatch):
+    monkeypatch.setattr(
+        cli_module, "_build_backend", lambda _runner, _sleep: _StubDepWriteDenyingBackend()
+    )
+    out = StringIO()
+    err = StringIO()
+
+    exit_code = cli_module.main(["dep", "list", "x.1"], out=out, err=err)
+
+    assert exit_code == 0
+    assert err.getvalue() == ""
+    envelope = json.loads(out.getvalue())
+    assert envelope["ok"] is True
+    assert envelope["data"] == {"depends_on": [], "dependents": []}
+
+
+def test_sync_dispatch_is_an_honest_noop_when_the_backend_is_server_authoritative(monkeypatch):
+    monkeypatch.setattr(
+        cli_module,
+        "_build_backend",
+        lambda _runner, _sleep: _StubServerAuthoritativeSyncBackend(),
+    )
+    out = StringIO()
+    err = StringIO()
+
+    exit_code = cli_module.main(["sync"], out=out, err=err)
+
+    assert exit_code == 0
+    assert err.getvalue() == ""
+    envelope = json.loads(out.getvalue())
+    assert envelope["ok"] is True
+    assert envelope["data"] == {"synced": False, "mode": "noop"}


### PR DESCRIPTION
## Summary
- Reshapes `Backend.capabilities` from three flat booleans to domain-shaped dispositions per `docs/specs/2026-07-17-workcli-contract-hardening.md`, Backend seam Item 1: `ready`/`sync` each become a disposition enum (`ReadySupport`/`SyncSupport`, each `NATIVE`/secondary-state/`UNSUPPORTED`), and `dep` collapses to a single `supports_dep_write: bool` — `dep list` is now always ungated.
- Widens the capability gate to `(Capabilities, Namespace)` so the `dep` predicate can distinguish `dep list` from `dep add`/`dep remove` (uses the real argparse attribute `a.action`, not the spec's illustrative `dep_op`).
- `sync` handler branches on `SyncSupport.SERVER_AUTHORITATIVE` to return an honest no-op (`synced: false, mode: \"noop\"`) without ever calling `backend.sync`.
- `BdBackend` stays at the native corner on every axis; `PROTOCOL_VERSION` unchanged at `1.0` — no envelope/data shape change.

Closes agents-config-38o1v.1.

## Test plan
- [x] AC 1 (grep-verified): no `supports_ready`/`supports_dep_types`/`supports_sync` boolean fields remain anywhere in `packages/workcli/src/` or `packages/workcli/tests/`.
- [x] AC 2-5: new/updated tests in `test_bd_backend.py` and `test_capabilities.py` cover `BdBackend.capabilities`, `dep list` vs `dep add`/`remove` gating, and the `sync` `SERVER_AUTHORITATIVE`/`UNSUPPORTED`/`NATIVE` dispositions.
- [x] `make ci-workcli` from the worktree (post-rebase on fresh main): ruff check/format, mypy --strict, pytest (394 passed, 99.65%% coverage), pip-audit clean, protocol/help smoke checks.