### PR TITLE
feat(workcli): multi-step partial-progress contract — StepProgress + idempotent label/sync retry

### DIFF
--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -37,7 +37,7 @@ from workcli.adapters.bd.parse import (
 from workcli.adapters.bd.retry import run_with_retry
 from workcli.adapters.bd.runner import BdRunner
 from workcli.backend import Capabilities, DepOp, ReadySupport, SyncSupport
-from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.envelope import ErrorCode, JsonValue, StepProgress, WorkError, with_progress
 from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
 
 # Decision 9's exact stderr wording (orchestrator ruling, not a golden capture
@@ -46,6 +46,19 @@ from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResu
 # working set, are asserted to log these substrings to stderr.
 _NOTHING_TO_COMMIT_STDERR_MARKER = "nothing to commit"
 _SYNC_BEHIND_STDERR_MARKER = "cannot merge with uncommitted changes"
+
+# Speculative markers, not a golden capture -- and unlike
+# _NOTHING_TO_COMMIT_STDERR_MARKER above, live-verified as currently
+# unreachable: `bd label add`/`bd label remove` (bd 1.0.3, confirmed by
+# running both commands twice against a scratch issue) exit 0 unconditionally
+# on a repeat add/remove, with no stderr at all -- bd is already idempotent
+# here without this adapter's help. This branch stays as defense-in-depth for
+# a future bd version that starts erroring on a no-op label mutation (the
+# contract hardening spec, "Multi-step mutation partial-progress", rule 1,
+# requires the seam to absorb that outcome as success if it ever appears);
+# the exact wording is a guess until a real error is captured.
+_LABEL_ALREADY_PRESENT_STDERR_MARKER = "already has label"
+_LABEL_ABSENT_STDERR_MARKER = "does not have label"
 
 
 class BdBackend:
@@ -249,12 +262,33 @@ class BdBackend:
 
     def label_mutate(self, op: str, item_id: str, labels: Sequence[str]) -> None:
         # bd's own `label add`/`label remove` accept exactly one label per
-        # invocation -- one bd call per label (orchestrator ruling).
-        for one_label in labels:
+        # invocation -- one bd call per label (orchestrator ruling). A
+        # mid-sequence failure is wrapped with the labels already applied so
+        # far (StepProgress) UNLESS nothing applied yet (the first label
+        # failing stays a plain, unwrapped WorkError -- "absence means
+        # atomic").
+        idempotent_marker = (
+            _LABEL_ALREADY_PRESENT_STDERR_MARKER if op == "add" else _LABEL_ABSENT_STDERR_MARKER
+        )
+        applied: list[str] = []
+        for index, one_label in enumerate(labels):
             argv = ["label", op, item_id, one_label]
             result = run_with_retry(self._runner, argv, sleep=self._sleep)
-            if result.returncode != 0:
-                raise map_bd_failure(argv, result)
+            if result.returncode != 0 and idempotent_marker not in result.stderr:
+                err = map_bd_failure(argv, result)
+                if applied:
+                    err = with_progress(
+                        err,
+                        StepProgress(
+                            operation="label_mutate",
+                            steps_total=len(labels),
+                            completed=tuple(applied),
+                            failed=one_label,
+                            remaining=tuple(labels[index + 1 :]),
+                        ),
+                    )
+                raise err
+            applied.append(one_label)
 
     def labels(self, item_id: str) -> list[str]:
         argv = ["label", "list", item_id, "--json"]
@@ -289,5 +323,15 @@ class BdBackend:
         push_argv = ["dolt", "push"]
         push_result = run_with_retry(self._runner, push_argv, sleep=self._sleep)
         if push_result.returncode != 0:
-            raise map_bd_failure(push_argv, push_result)
+            err = with_progress(
+                map_bd_failure(push_argv, push_result),
+                StepProgress(
+                    operation="sync",
+                    steps_total=2,
+                    completed=("commit",),
+                    failed="push",
+                    remaining=(),
+                ),
+            )
+            raise err
         return SyncResult(synced=True, mode="push")

--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -273,21 +273,33 @@ class BdBackend:
         applied: list[str] = []
         for index, one_label in enumerate(labels):
             argv = ["label", op, item_id, one_label]
-            result = run_with_retry(self._runner, argv, sleep=self._sleep)
+
+            def progress(
+                err: WorkError, *, one_label: str = one_label, index: int = index
+            ) -> WorkError:
+                if not applied:
+                    return err
+                return with_progress(
+                    err,
+                    StepProgress(
+                        operation="label_mutate",
+                        steps_total=len(labels),
+                        completed=tuple(applied),
+                        failed=one_label,
+                        remaining=tuple(labels[index + 1 :]),
+                    ),
+                )
+
+            # `run_with_retry` itself raises `WorkError` on retry exhaustion
+            # (E_TIMEOUT/E_LOCK_CONTENTION) rather than returning a result --
+            # that path needs the same partial-progress wrap as a mapped
+            # non-zero exit, or labels already applied before it go unreported.
+            try:
+                result = run_with_retry(self._runner, argv, sleep=self._sleep)
+            except WorkError as exc:
+                raise progress(exc) from exc
             if result.returncode != 0 and idempotent_marker not in result.stderr:
-                err = map_bd_failure(argv, result)
-                if applied:
-                    err = with_progress(
-                        err,
-                        StepProgress(
-                            operation="label_mutate",
-                            steps_total=len(labels),
-                            completed=tuple(applied),
-                            failed=one_label,
-                            remaining=tuple(labels[index + 1 :]),
-                        ),
-                    )
-                raise err
+                raise progress(map_bd_failure(argv, result))
             applied.append(one_label)
 
     def labels(self, item_id: str) -> list[str]:
@@ -320,11 +332,9 @@ class BdBackend:
         ):
             raise map_bd_failure(commit_argv, commit_result)
 
-        push_argv = ["dolt", "push"]
-        push_result = run_with_retry(self._runner, push_argv, sleep=self._sleep)
-        if push_result.returncode != 0:
-            err = with_progress(
-                map_bd_failure(push_argv, push_result),
+        def push_progress(err: WorkError) -> WorkError:
+            return with_progress(
+                err,
                 StepProgress(
                     operation="sync",
                     steps_total=2,
@@ -333,5 +343,16 @@ class BdBackend:
                     remaining=(),
                 ),
             )
+
+        push_argv = ["dolt", "push"]
+        # As above: `run_with_retry` raising WorkError on retry exhaustion
+        # needs the same partial-progress wrap -- the commit already
+        # succeeded by the time push is attempted.
+        try:
+            push_result = run_with_retry(self._runner, push_argv, sleep=self._sleep)
+        except WorkError as exc:
+            raise push_progress(exc) from exc
+        if push_result.returncode != 0:
+            err = push_progress(map_bd_failure(push_argv, push_result))
             raise err
         return SyncResult(synced=True, mode="push")

--- a/packages/workcli/src/workcli/envelope.py
+++ b/packages/workcli/src/workcli/envelope.py
@@ -4,7 +4,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TextIO
+from typing import TextIO, cast
 
 from workcli import PROTOCOL_VERSION
 
@@ -37,6 +37,45 @@ class WorkError(Exception):
     code: ErrorCode
     message: str
     detail: dict[str, JsonValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StepProgress:
+    """A `label_mutate`/`sync` mid-sequence failure's replayable progress.
+
+    The seam's only two irreducibly multi-call `Backend` primitives
+    (`label_mutate` -- one `bd label` call per label; `sync` --
+    `dolt commit` then `dolt push`) can fail after some sub-steps already
+    applied. `with_progress` attaches this record to the raised `WorkError`
+    so a caller can tell "nothing applied" (no `partial_progress` key --
+    contract per decision "absence means atomic") from "these sub-steps
+    already applied, retry from the top is safe" (this record present).
+    """
+
+    operation: str  # "label_mutate" | "sync"
+    steps_total: int
+    completed: tuple[str, ...]  # replayable sub-step ids (labels applied; ["commit"])
+    failed: str  # the sub-step that failed
+    remaining: tuple[str, ...]
+
+    def as_detail(self) -> dict[str, JsonValue]:
+        payload: dict[str, JsonValue] = {
+            "operation": self.operation,
+            "steps_total": self.steps_total,
+            "completed": cast("list[JsonValue]", list(self.completed)),
+            "failed": self.failed,
+            "remaining": cast("list[JsonValue]", list(self.remaining)),
+        }
+        return {"partial_progress": payload}
+
+
+def with_progress(err: WorkError, progress: StepProgress) -> WorkError:
+    """Attach `progress` to `err.detail`, preserving `err`'s cause unchanged.
+
+    The cause (`code`/`message`) is preserved, not replaced -- only `detail`
+    gains the additive `partial_progress` key.
+    """
+    return WorkError(err.code, err.message, {**err.detail, **progress.as_detail()})
 
 
 def emit_success(data: JsonValue, out: TextIO = sys.stdout) -> int:

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -842,6 +842,36 @@ def test_label_mutate_wraps_a_mid_sequence_failure_with_partial_progress():
         }
 
 
+def test_label_mutate_wraps_retry_exhaustion_with_partial_progress():
+    # Codex review finding on PR #319: run_with_retry itself raises WorkError
+    # on retry exhaustion (E_LOCK_CONTENTION/E_TIMEOUT) rather than returning
+    # a BdResult -- that path bypassed the `returncode != 0` branch entirely,
+    # so a label already applied before it went unreported.
+    locked = BdResult(returncode=1, stdout="", stderr="database is locked")
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "add"), locked),
+            ScriptedStep(("label", "add"), locked),
+            ScriptedStep(("label", "add"), locked),
+        ]
+    )
+    backend = BdBackend(runner, sleep=lambda _seconds: None)
+
+    try:
+        backend.label_mutate("add", "x.1", ["a", "b", "c"])
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert error.code == ErrorCode.LOCK_CONTENTION
+        assert error.detail["partial_progress"] == {
+            "operation": "label_mutate",
+            "steps_total": 3,
+            "completed": ["a"],
+            "failed": "b",
+            "remaining": ["c"],
+        }
+
+
 def test_label_mutate_failing_on_the_first_label_carries_no_partial_progress():
     # AC 9: "absence means atomic" applies even to the first sub-step of a
     # multi-step op when nothing preceded it.
@@ -1041,6 +1071,36 @@ def test_sync_push_failure_wraps_with_partial_progress_commit_completed():
         backend.sync(pull=False)
         raise AssertionError("expected WorkError")
     except WorkError as error:
+        assert error.detail["partial_progress"] == {
+            "operation": "sync",
+            "steps_total": 2,
+            "completed": ["commit"],
+            "failed": "push",
+            "remaining": [],
+        }
+
+
+def test_sync_wraps_push_retry_exhaustion_with_partial_progress():
+    # Codex review finding on PR #319: run_with_retry itself raises WorkError
+    # on retry exhaustion rather than returning a BdResult -- that path
+    # bypassed the `returncode != 0` branch, leaving out `completed:["commit"]`
+    # even though the commit had already succeeded.
+    locked = BdResult(returncode=1, stdout="", stderr="database is locked")
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("dolt", "commit"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("dolt", "push"), locked),
+            ScriptedStep(("dolt", "push"), locked),
+            ScriptedStep(("dolt", "push"), locked),
+        ]
+    )
+    backend = BdBackend(runner, sleep=lambda _seconds: None)
+
+    try:
+        backend.sync(pull=False)
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert error.code == ErrorCode.LOCK_CONTENTION
         assert error.detail["partial_progress"] == {
             "operation": "sync",
             "steps_total": 2,

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -820,6 +820,117 @@ def test_label_mutate_maps_no_issue_found_stderr_to_not_found_error():
         assert error.code == ErrorCode.NOT_FOUND
 
 
+def test_label_mutate_wraps_a_mid_sequence_failure_with_partial_progress():
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "add"), BdResult(returncode=1, stdout="", stderr="boom")),
+        ]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.label_mutate("add", "x.1", ["a", "b", "c"])
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert error.detail["partial_progress"] == {
+            "operation": "label_mutate",
+            "steps_total": 3,
+            "completed": ["a"],
+            "failed": "b",
+            "remaining": ["c"],
+        }
+
+
+def test_label_mutate_failing_on_the_first_label_carries_no_partial_progress():
+    # AC 9: "absence means atomic" applies even to the first sub-step of a
+    # multi-step op when nothing preceded it.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("label", "add"), BdResult(returncode=1, stdout="", stderr="boom"))]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.label_mutate("add", "x.1", ["a", "b"])
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert "partial_progress" not in error.detail
+
+
+def test_label_mutate_reinvocation_after_partial_failure_heals_and_completes():
+    # Retry-from-top after a partial failure: label "a" is re-applied (bd
+    # absorbs the already-present case) and "b"/"c" succeed this time.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("label", "add"),
+                BdResult(returncode=1, stdout="", stderr="issue x.1 already has label a\n"),
+            ),
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("label", "add"), BdResult(returncode=0, stdout="", stderr="")),
+        ]
+    )
+    backend = BdBackend(runner)
+
+    backend.label_mutate("add", "x.1", ["a", "b", "c"])  # must not raise
+
+    assert runner.calls == [
+        ("label", "add", "x.1", "a"),
+        ("label", "add", "x.1", "b"),
+        ("label", "add", "x.1", "c"),
+    ]
+
+
+def test_label_mutate_add_absorbs_already_present_stderr_as_success():
+    # Marker text is speculative (live-verified against bd 1.0.3 as currently
+    # unreachable -- a repeat `label add` exits 0 with no stderr; see the
+    # marker constant's comment). Proves the absorption mechanism works if a
+    # future bd version ever does error on this outcome.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("label", "add"),
+                BdResult(returncode=1, stdout="", stderr="issue x.1 already has label a\n"),
+            )
+        ]
+    )
+    backend = BdBackend(runner)
+
+    backend.label_mutate("add", "x.1", ["a"])  # must not raise
+
+    assert runner.calls == [("label", "add", "x.1", "a")]
+
+
+def test_label_mutate_remove_absorbs_absent_stderr_as_success():
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("label", "remove"),
+                BdResult(returncode=1, stdout="", stderr="issue x.1 does not have label stale\n"),
+            )
+        ]
+    )
+    backend = BdBackend(runner)
+
+    backend.label_mutate("remove", "x.1", ["stale"])  # must not raise
+
+    assert runner.calls == [("label", "remove", "x.1", "stale")]
+
+
+def test_set_status_failure_carries_no_partial_progress():
+    # AC 9: a single-call primitive's WorkError never carries partial_progress.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("update",), BdResult(returncode=1, stdout="", stderr="boom"))]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.set_status("x.1", "closed")
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert "partial_progress" not in error.detail
+
+
 def test_labels_sends_label_list_json_and_returns_the_flat_array():
     runner = ScriptedBdRunner(
         steps=[
@@ -915,6 +1026,59 @@ def test_sync_push_failure_raises_backend_drift():
         raise AssertionError("expected WorkError")
     except WorkError as error:
         assert error.code == ErrorCode.BACKEND_DRIFT
+
+
+def test_sync_push_failure_wraps_with_partial_progress_commit_completed():
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("dolt", "commit"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("dolt", "push"), BdResult(returncode=1, stdout="", stderr="boom")),
+        ]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.sync(pull=False)
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert error.detail["partial_progress"] == {
+            "operation": "sync",
+            "steps_total": 2,
+            "completed": ["commit"],
+            "failed": "push",
+            "remaining": [],
+        }
+
+
+def test_sync_commit_failure_carries_no_partial_progress():
+    # AC 9: a multi-step primitive failing on step 1 (nothing completed) also
+    # carries no partial_progress key.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("dolt", "commit"), BdResult(returncode=1, stdout="", stderr="boom"))]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.sync(pull=False)
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert "partial_progress" not in error.detail
+
+
+def test_sync_reinvocation_after_push_failure_completes():
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("dolt", "commit"), BdResult(returncode=1, stdout="", stderr="nothing to commit\n")
+            ),
+            ScriptedStep(("dolt", "push"), BdResult(returncode=0, stdout="", stderr="")),
+        ]
+    )
+    backend = BdBackend(runner)
+
+    result = backend.sync(pull=False)  # must not raise: re-commit is a no-op, push succeeds
+
+    assert result.synced is True
 
 
 def test_sync_pull_sends_dolt_pull_and_returns_pull_mode():

--- a/packages/workcli/tests/unit/test_envelope.py
+++ b/packages/workcli/tests/unit/test_envelope.py
@@ -10,7 +10,14 @@ from io import StringIO
 from tests.fakes import ScriptedBdRunner
 from workcli import PROTOCOL_VERSION
 from workcli import cli as cli_module
-from workcli.envelope import ErrorCode, WorkError, emit_failure, emit_success
+from workcli.envelope import (
+    ErrorCode,
+    StepProgress,
+    WorkError,
+    emit_failure,
+    emit_success,
+    with_progress,
+)
 
 
 def test_emit_success_writes_ok_envelope_and_returns_zero():
@@ -107,6 +114,42 @@ def test_handler_raising_work_error_yields_that_errors_envelope(monkeypatch):
         "code": "E_NOT_FOUND",
         "message": "no such item",
         "detail": {"id": "x.1"},
+    }
+
+
+def test_step_progress_as_detail_shapes_the_partial_progress_record():
+    progress = StepProgress(
+        operation="label_mutate", steps_total=3, completed=("a",), failed="b", remaining=("c",)
+    )
+
+    assert progress.as_detail() == {
+        "partial_progress": {
+            "operation": "label_mutate",
+            "steps_total": 3,
+            "completed": ["a"],
+            "failed": "b",
+            "remaining": ["c"],
+        }
+    }
+
+
+def test_with_progress_preserves_the_original_code_and_message_and_merges_detail():
+    err = WorkError(ErrorCode.BACKEND_DRIFT, "bd exited weird", detail={"argv": ["x"]})
+    progress = StepProgress(
+        operation="sync", steps_total=2, completed=("commit",), failed="push", remaining=()
+    )
+
+    wrapped = with_progress(err, progress)
+
+    assert wrapped.code == ErrorCode.BACKEND_DRIFT
+    assert wrapped.message == "bd exited weird"
+    assert wrapped.detail["argv"] == ["x"]
+    assert wrapped.detail["partial_progress"] == {
+        "operation": "sync",
+        "steps_total": 2,
+        "completed": ["commit"],
+        "failed": "push",
+        "remaining": [],
     }
 
 


### PR DESCRIPTION
## Summary
- Adds `StepProgress` + `with_progress` (`envelope.py`, alongside `WorkError`) per `docs/specs/2026-07-17-workcli-contract-hardening.md`, Backend seam Item 2.
- `label_mutate`/`sync` mid-sequence failures now carry `detail.partial_progress` (completed/failed/remaining sub-steps); a first-step or single-call failure carries no key at all ("absence means atomic").
- `label_mutate` absorbs bd's already-present/absent outcomes as idempotent success via speculative stderr markers. Verified live against the installed bd 1.0.3 binary: a repeat `label add`/`label remove` currently exits 0 with no stderr at all, so this absorption path is confirmed unreachable today — kept as documented defense-in-depth per the spec's stated contract, not presented as a golden capture.

Closes agents-config-38o1v.2.

## Test plan
- [x] AC 7: mid-sequence `label_mutate` failure carries the exact `partial_progress` shape the spec specifies; re-invocation after a scripted heal completes with no error.
- [x] AC 8: `sync` push-phase failure carries `completed:[\"commit\"], failed:\"push\"`.
- [x] AC 9: `set_status` (single-call) and a first-label `label_mutate` failure both carry no `partial_progress` key.
- [x] AC 10: label-idempotency absorption asserted against a scripted runner (marker wording flagged above as currently unreachable against real bd, verified live this session).
- [x] `make ci-workcli` from the worktree (post-rebase on fresh main, stacked cleanly after #314/#318): ruff check/format, mypy --strict, pytest (405 passed, 99.65%% coverage), pip-audit clean, protocol/help smoke checks.