### PR TITLE
feat(installer): deploy_clis + prune_clis decision engines (wgclw.9.9 PR2/3)

### DIFF
--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from installer.core.clis import MIN_UV_VERSION, cli_source_digest
+from installer.core.consent import require_consent
 from installer.core.model import Counters, InstallOutcome, Outcome, Tool
 from installer.core.prune_flow import run_prune
 from installer.core.prune_hash import is_safe_to_prune, partition_file_orphans
@@ -40,8 +42,9 @@ from installer.core.receipt_store import write_receipt
 from installer.core.sync import sync_plan, sync_routes
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
 
+    from installer.core.clis import CliDeployPort, CliSpec
     from installer.core.io_port import IOPort
     from installer.core.model import StagingPlan
     from installer.plugins.base import PluginAdapter
@@ -347,3 +350,220 @@ def install_plugin_routes(
         if outcomes_by_plugin is not None:
             outcomes_by_plugin[plugin.name] = plugin_outcomes if plugin_outcomes is not None else []
     return result
+
+
+@dataclass(frozen=True, slots=True)
+class CliDeployOutcome:
+    """What the CLI deploy half did. ``deployed`` holds only this run's
+    smoked-OK installs (keyed by registry name) — the merge rule retains
+    prior entries for everything else. ``any_failed`` drives _run's exit
+    code (spec §6 failure surfacing)."""
+
+    deployed: dict[str, CliReceiptEntry]
+    counters: dict[str, Counters]
+    any_failed: bool
+
+
+def deploy_clis(
+    specs: tuple[CliSpec, ...],
+    *,
+    repo_root: Path,
+    prior: Receipt,
+    deploy: CliDeployPort,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+) -> CliDeployOutcome:
+    """The CLI deploy half (spec §6): registry order, PATH-independent
+    decision signals, consent on any unproven overwrite, reachability
+    invariant per bin dir."""
+    deployed: dict[str, CliReceiptEntry] = {}
+    counters: dict[str, Counters] = {}
+    any_failed = False
+
+    version = deploy.uv_version()
+    if version is None or version < MIN_UV_VERSION:
+        need = ".".join(str(p) for p in MIN_UV_VERSION)
+        got = ".".join(str(p) for p in version) if version else "unknown"
+        io.err(
+            f"CLI deploys need uv >= {need} (found {got}); "
+            f"upgrade uv (e.g. `brew upgrade uv`) and re-run"
+        )
+        return CliDeployOutcome(deployed={}, counters={}, any_failed=True)
+
+    prior_by_name = {c.name: c for c in prior.clis}
+    tools = deploy.tool_list()
+    reach_ok_dirs: set[Path] = set()  # memoized update-shell success per bin dir
+
+    for spec in specs:
+        target = f"cli:{spec.name}"
+        counters[target] = Counters()
+        package_dir = repo_root / spec.package_dir
+        failed, shim_present = _deploy_one(
+            spec, package_dir=package_dir, prior_entry=prior_by_name.get(spec.name),
+            tools=tools, deploy=deploy, io=io, dry_run=dry_run, auto_yes=auto_yes,
+            deployed=deployed, c=counters[target],
+        )
+        any_failed = any_failed or failed
+        # Reachability gate reuses the decision/install outcome — it never
+        # re-reads shim_path, keeping the fake's queue budget deterministic
+        # (1 decision read + 1 re-read per successful install).
+        if not dry_run and shim_present:
+            ok = _check_reachability(
+                spec.binary, deploy=deploy, io=io, auto_yes=auto_yes,
+                resolved_dirs=reach_ok_dirs,
+            )
+            any_failed = any_failed or not ok
+    return CliDeployOutcome(deployed=deployed, counters=counters, any_failed=any_failed)
+
+
+def _deploy_one(
+    spec: CliSpec,
+    *,
+    package_dir: Path,
+    prior_entry: CliReceiptEntry | None,
+    tools: Mapping[str, frozenset[str]] | None,
+    deploy: CliDeployPort,
+    io: IOPort,
+    dry_run: bool,
+    auto_yes: bool,
+    deployed: dict[str, CliReceiptEntry],
+    c: Counters,
+) -> tuple[bool, bool]:
+    """Run the §6 decision table for one CLI.
+
+    Returns (failed, shim_present_at_end); the caller's reachability gate
+    keys off the second element instead of re-reading shim_path."""
+    digest = cli_source_digest(package_dir)
+    shim = deploy.shim_path(spec.binary)
+    env_present = tools is not None and spec.name in tools
+    # Provenance: the registered env currently provides the registered
+    # binary. Unproven (tools is None) is never provenance (spec §6).
+    provenance = tools is not None and spec.binary in tools.get(spec.name, frozenset())
+    evidence = shim is not None or env_present or tools is None
+
+    def _done(failed: bool, installed: bool) -> tuple[bool, bool]:
+        return failed, (shim is not None) or installed
+
+    if prior_entry is not None:
+        if provenance or (tools is not None and not env_present and shim is None):
+            # Owned per receipt AND (live provenance, or nothing there at
+            # all — a user uninstall). Promptless paths.
+            if shim is not None and prior_entry.digest == digest:
+                if dry_run:
+                    io.info(f"cli:{spec.name}: would skip (up to date)")
+                    c.skipped += 1
+                    return _done(False, False)
+                smoke = deploy.smoke(shim, spec.smoke_args)
+                if smoke.ok:
+                    c.skipped += 1
+                    return _done(False, False)
+                io.warn(f"cli:{spec.name}: installed copy fails smoke; healing\n{smoke.output}")
+                return _done(*_install(
+                    spec, package_dir, digest, force=True, deploy=deploy, io=io,
+                    deployed=deployed, c=c, counter_attr="created",
+                ))
+            if shim is None:
+                # Heal. force only when our env is provably still there.
+                if dry_run:
+                    io.info(f"cli:{spec.name}: would reinstall (shim missing)")
+                    return _done(False, False)
+                return _done(*_install(
+                    spec, package_dir, digest, force=provenance, deploy=deploy, io=io,
+                    deployed=deployed, c=c, counter_attr="created",
+                ))
+            # shim present, digest differs -> upgrade (consent).
+            return _done(*_consented_install(
+                spec, package_dir, digest, prompt=f"Upgrade CLI '{spec.binary}' "
+                f"({spec.name})?", deploy=deploy, io=io, dry_run=dry_run,
+                auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
+                would="would upgrade",
+            ))
+        # Receipt present but provenance mismatch (foreign env/shim) ->
+        # takeover consent (spec §6 provenance precondition / item 19).
+        return _done(*_consented_install(
+            spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}' "
+            f"(not provably {spec.name}'s)?", deploy=deploy, io=io, dry_run=dry_run,
+            auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
+            would="would take over",
+        ))
+
+    if not evidence:
+        # Fresh: non-forcing; an already-exists failure re-routes to
+        # takeover consent (spec §6 fresh row / item 18).
+        if dry_run:
+            io.info(f"cli:{spec.name}: would install")
+            return _done(False, False)
+        result = deploy.tool_install(package_dir, force=False)
+        if result.ok:
+            return _done(*_finish_install(spec, digest, deploy=deploy, io=io,
+                                          deployed=deployed, c=c, counter_attr="created"))
+        io.warn(f"cli:{spec.name}: install found existing state; asking to take over")
+        return _done(*_consented_install(
+            spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}'?",
+            deploy=deploy, io=io, dry_run=dry_run, auto_yes=auto_yes,
+            deployed=deployed, c=c, counter_attr="updated", would="would take over",
+        ))
+    return _done(*_consented_install(
+        spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}' "
+        f"(manual install detected)?", deploy=deploy, io=io, dry_run=dry_run,
+        auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
+        would="would take over",
+    ))
+
+
+def _consented_install(
+    spec: CliSpec, package_dir: Path, digest: str, *, prompt: str,
+    deploy: CliDeployPort, io: IOPort, dry_run: bool, auto_yes: bool,
+    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str, would: str,
+) -> tuple[bool, bool]:
+    if dry_run:
+        io.info(f"cli:{spec.name}: {would}")
+        return False, False
+    require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
+    if not auto_yes and not io.confirm(prompt, default=False):
+        c.skipped += 1
+        return False, False
+    return _install(spec, package_dir, digest, force=True, deploy=deploy, io=io,
+                    deployed=deployed, c=c, counter_attr=counter_attr)
+
+
+def _install(
+    spec: CliSpec, package_dir: Path, digest: str, *, force: bool,
+    deploy: CliDeployPort, io: IOPort,
+    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str,
+) -> tuple[bool, bool]:
+    result = deploy.tool_install(package_dir, force=force)
+    if not result.ok:
+        io.err(f"cli:{spec.name}: install failed\n{result.output}")
+        return True, False
+    return _finish_install(spec, digest, deploy=deploy, io=io, deployed=deployed,
+                           c=c, counter_attr=counter_attr)
+
+
+def _finish_install(
+    spec: CliSpec, digest: str, *, deploy: CliDeployPort, io: IOPort,
+    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str,
+) -> tuple[bool, bool]:
+    shim = deploy.shim_path(spec.binary)
+    if shim is None:
+        io.err(f"cli:{spec.name}: install reported ok but produced no shim")
+        return True, False
+    smoke = deploy.smoke(shim, spec.smoke_args)
+    if not smoke.ok:
+        io.err(f"cli:{spec.name}: smoke failed\n{smoke.output}")
+        # The shim exists on disk, but the deploy FAILED — installed=False
+        # keeps the reachability gate off this CLI; the failure is already
+        # the run's signal.
+        return True, False
+    deployed[spec.name] = CliReceiptEntry(name=spec.name, binary=spec.binary, digest=digest)
+    setattr(c, counter_attr, getattr(c, counter_attr) + 1)
+    io.ok(f"cli:{spec.name}: deployed '{spec.binary}'")
+    return False, True
+
+
+def _check_reachability(
+    binary: str, *, deploy: CliDeployPort, io: IOPort, auto_yes: bool,
+    resolved_dirs: set[Path],
+) -> bool:
+    return True  # completed in Task 9 (reachability invariant)

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -681,4 +681,36 @@ def _check_reachability(
     auto_yes: bool,
     resolved_dirs: set[Path],
 ) -> bool:
-    return True  # completed in Task 9 (reachability invariant)
+    """PATH-reachability invariant (spec §6): a property of the bin dir,
+    evaluated once per dir per run; update-shell repair memoized. Returns
+    False only on a genuine deployment failure."""
+    bin_dir = deploy.bin_dir()
+    found = deploy.which(binary)
+    if found is not None:
+        if found.parent == bin_dir:
+            return True
+        shim = bin_dir / binary
+        io.err(
+            f"'{binary}' on PATH resolves to {found}, shadowing the deployed {shim}; "
+            "remove/rename the foreign binary or reorder PATH"
+        )
+        return False
+    if bin_dir in resolved_dirs:
+        return True
+    # Reachability is never evaluated under dry-run: deploy_clis gates this call
+    # with `if not dry_run and shim_present` (Task 6 loop), so dry_run is always
+    # False here — the literal below routes the no-TTY convention at this consent
+    # point (raises ConsentRequiredError iff non-interactive AND not --yes).
+    require_consent(io, dry_run=False, auto_yes=auto_yes)
+    accepted = auto_yes or io.confirm(
+        f"{bin_dir} is not on PATH — run `uv tool update-shell`?", default=False
+    )
+    if accepted:
+        result = deploy.update_shell()
+        if result.ok:
+            resolved_dirs.add(bin_dir)
+            io.info(f"PATH updated for new shells (restart or re-source to pick up {bin_dir})")
+            return True
+        io.err(f"uv tool update-shell failed:\n{result.output}")
+    io.err(f'{bin_dir} is not on PATH; add it (e.g. export PATH="{bin_dir}:$PATH")')
+    return False

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -714,3 +714,63 @@ def _check_reachability(
         io.err(f"uv tool update-shell failed:\n{result.output}")
     io.err(f'{bin_dir} is not on PATH; add it (e.g. export PATH="{bin_dir}:$PATH")')
     return False
+
+
+@dataclass(frozen=True, slots=True)
+class CliPruneOutcome:
+    """CLI prune half result: names whose uninstall completed (drop from the
+    receipt), names relinquished (foreign — drop without uninstall), and
+    per-target counters."""
+
+    uninstalled_names: set[str]
+    relinquished_names: set[str]
+    counters: dict[str, Counters]
+
+
+def prune_clis(
+    prior: Receipt,
+    *,
+    registry_names: frozenset[str],
+    retired: frozenset[str],
+    deploy: CliDeployPort,
+    io: IOPort,
+    dry_run: bool = False,
+    auto_yes: bool = False,
+) -> CliPruneOutcome:
+    """Retire prior CLI entries no longer in the registry (spec §7).
+
+    Uninstall authority is bounded by ``registry_names | retired`` — the
+    receipt's integrity digest is tamper-evidence, not authentication, so a
+    foreign name is warned about and relinquished, never uninstalled."""
+    uninstalled: set[str] = set()
+    relinquished: set[str] = set()
+    counters: dict[str, Counters] = {}
+    for entry in prior.clis:
+        if entry.name in registry_names:
+            continue
+        target = f"cli:{entry.name}"
+        counters.setdefault(target, Counters())
+        if entry.name not in retired:
+            io.warn(
+                f"receipt names CLI '{entry.name}' which this installer never shipped; "
+                "dropping the record without uninstalling"
+            )
+            relinquished.add(entry.name)
+            continue
+        if dry_run:
+            io.info(f"cli:{entry.name}: would uninstall (retired)")
+            continue
+        require_consent(io, dry_run=dry_run, auto_yes=auto_yes)
+        if not auto_yes and not io.confirm(
+            f"Uninstall retired CLI '{entry.name}' ({entry.binary})?", default=False
+        ):
+            continue
+        result = deploy.tool_uninstall(entry.name)
+        if result.ok or "not installed" in result.output:
+            uninstalled.add(entry.name)
+            counters[target].pruned += 1
+        else:
+            io.err(f"cli:{entry.name}: uninstall failed\n{result.output}")
+    return CliPruneOutcome(
+        uninstalled_names=uninstalled, relinquished_names=relinquished, counters=counters
+    )

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -400,9 +400,16 @@ def deploy_clis(
         counters[target] = Counters()
         package_dir = repo_root / spec.package_dir
         failed, shim_present = _deploy_one(
-            spec, package_dir=package_dir, prior_entry=prior_by_name.get(spec.name),
-            tools=tools, deploy=deploy, io=io, dry_run=dry_run, auto_yes=auto_yes,
-            deployed=deployed, c=counters[target],
+            spec,
+            package_dir=package_dir,
+            prior_entry=prior_by_name.get(spec.name),
+            tools=tools,
+            deploy=deploy,
+            io=io,
+            dry_run=dry_run,
+            auto_yes=auto_yes,
+            deployed=deployed,
+            c=counters[target],
         )
         any_failed = any_failed or failed
         # Reachability gate reuses the decision/install outcome — it never
@@ -410,7 +417,10 @@ def deploy_clis(
         # (1 decision read + 1 re-read per successful install).
         if not dry_run and shim_present:
             ok = _check_reachability(
-                spec.binary, deploy=deploy, io=io, auto_yes=auto_yes,
+                spec.binary,
+                deploy=deploy,
+                io=io,
+                auto_yes=auto_yes,
                 resolved_dirs=reach_ok_dirs,
             )
             any_failed = any_failed or not ok
@@ -459,34 +469,72 @@ def _deploy_one(
                     c.skipped += 1
                     return _done(False, False)
                 io.warn(f"cli:{spec.name}: installed copy fails smoke; healing\n{smoke.output}")
-                return _done(*_install(
-                    spec, package_dir, digest, force=True, deploy=deploy, io=io,
-                    deployed=deployed, c=c, counter_attr="created",
-                ))
+                return _done(
+                    *_install(
+                        spec,
+                        package_dir,
+                        digest,
+                        force=True,
+                        deploy=deploy,
+                        io=io,
+                        deployed=deployed,
+                        c=c,
+                        counter_attr="created",
+                    )
+                )
             if shim is None:
                 # Heal. force only when our env is provably still there.
                 if dry_run:
                     io.info(f"cli:{spec.name}: would reinstall (shim missing)")
                     return _done(False, False)
-                return _done(*_install(
-                    spec, package_dir, digest, force=provenance, deploy=deploy, io=io,
-                    deployed=deployed, c=c, counter_attr="created",
-                ))
+                return _done(
+                    *_install(
+                        spec,
+                        package_dir,
+                        digest,
+                        force=provenance,
+                        deploy=deploy,
+                        io=io,
+                        deployed=deployed,
+                        c=c,
+                        counter_attr="created",
+                    )
+                )
             # shim present, digest differs -> upgrade (consent).
-            return _done(*_consented_install(
-                spec, package_dir, digest, prompt=f"Upgrade CLI '{spec.binary}' "
-                f"({spec.name})?", deploy=deploy, io=io, dry_run=dry_run,
-                auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
-                would="would upgrade",
-            ))
+            return _done(
+                *_consented_install(
+                    spec,
+                    package_dir,
+                    digest,
+                    prompt=f"Upgrade CLI '{spec.binary}' ({spec.name})?",
+                    deploy=deploy,
+                    io=io,
+                    dry_run=dry_run,
+                    auto_yes=auto_yes,
+                    deployed=deployed,
+                    c=c,
+                    counter_attr="updated",
+                    would="would upgrade",
+                )
+            )
         # Receipt present but provenance mismatch (foreign env/shim) ->
         # takeover consent (spec §6 provenance precondition / item 19).
-        return _done(*_consented_install(
-            spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}' "
-            f"(not provably {spec.name}'s)?", deploy=deploy, io=io, dry_run=dry_run,
-            auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
-            would="would take over",
-        ))
+        return _done(
+            *_consented_install(
+                spec,
+                package_dir,
+                digest,
+                prompt=f"Take over existing '{spec.binary}' (not provably {spec.name}'s)?",
+                deploy=deploy,
+                io=io,
+                dry_run=dry_run,
+                auto_yes=auto_yes,
+                deployed=deployed,
+                c=c,
+                counter_attr="updated",
+                would="would take over",
+            )
+        )
 
     if not evidence:
         # Fresh: non-forcing; an already-exists failure re-routes to
@@ -496,26 +544,66 @@ def _deploy_one(
             return _done(False, False)
         result = deploy.tool_install(package_dir, force=False)
         if result.ok:
-            return _done(*_finish_install(spec, digest, deploy=deploy, io=io,
-                                          deployed=deployed, c=c, counter_attr="created"))
+            return _done(
+                *_finish_install(
+                    spec,
+                    digest,
+                    deploy=deploy,
+                    io=io,
+                    deployed=deployed,
+                    c=c,
+                    counter_attr="created",
+                )
+            )
         io.warn(f"cli:{spec.name}: install found existing state; asking to take over")
-        return _done(*_consented_install(
-            spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}'?",
-            deploy=deploy, io=io, dry_run=dry_run, auto_yes=auto_yes,
-            deployed=deployed, c=c, counter_attr="updated", would="would take over",
-        ))
-    return _done(*_consented_install(
-        spec, package_dir, digest, prompt=f"Take over existing '{spec.binary}' "
-        f"(manual install detected)?", deploy=deploy, io=io, dry_run=dry_run,
-        auto_yes=auto_yes, deployed=deployed, c=c, counter_attr="updated",
-        would="would take over",
-    ))
+        return _done(
+            *_consented_install(
+                spec,
+                package_dir,
+                digest,
+                prompt=f"Take over existing '{spec.binary}'?",
+                deploy=deploy,
+                io=io,
+                dry_run=dry_run,
+                auto_yes=auto_yes,
+                deployed=deployed,
+                c=c,
+                counter_attr="updated",
+                would="would take over",
+            )
+        )
+    return _done(
+        *_consented_install(
+            spec,
+            package_dir,
+            digest,
+            prompt=f"Take over existing '{spec.binary}' (manual install detected)?",
+            deploy=deploy,
+            io=io,
+            dry_run=dry_run,
+            auto_yes=auto_yes,
+            deployed=deployed,
+            c=c,
+            counter_attr="updated",
+            would="would take over",
+        )
+    )
 
 
 def _consented_install(
-    spec: CliSpec, package_dir: Path, digest: str, *, prompt: str,
-    deploy: CliDeployPort, io: IOPort, dry_run: bool, auto_yes: bool,
-    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str, would: str,
+    spec: CliSpec,
+    package_dir: Path,
+    digest: str,
+    *,
+    prompt: str,
+    deploy: CliDeployPort,
+    io: IOPort,
+    dry_run: bool,
+    auto_yes: bool,
+    deployed: dict[str, CliReceiptEntry],
+    c: Counters,
+    counter_attr: str,
+    would: str,
 ) -> tuple[bool, bool]:
     if dry_run:
         io.info(f"cli:{spec.name}: {would}")
@@ -524,26 +612,49 @@ def _consented_install(
     if not auto_yes and not io.confirm(prompt, default=False):
         c.skipped += 1
         return False, False
-    return _install(spec, package_dir, digest, force=True, deploy=deploy, io=io,
-                    deployed=deployed, c=c, counter_attr=counter_attr)
+    return _install(
+        spec,
+        package_dir,
+        digest,
+        force=True,
+        deploy=deploy,
+        io=io,
+        deployed=deployed,
+        c=c,
+        counter_attr=counter_attr,
+    )
 
 
 def _install(
-    spec: CliSpec, package_dir: Path, digest: str, *, force: bool,
-    deploy: CliDeployPort, io: IOPort,
-    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str,
+    spec: CliSpec,
+    package_dir: Path,
+    digest: str,
+    *,
+    force: bool,
+    deploy: CliDeployPort,
+    io: IOPort,
+    deployed: dict[str, CliReceiptEntry],
+    c: Counters,
+    counter_attr: str,
 ) -> tuple[bool, bool]:
     result = deploy.tool_install(package_dir, force=force)
     if not result.ok:
         io.err(f"cli:{spec.name}: install failed\n{result.output}")
         return True, False
-    return _finish_install(spec, digest, deploy=deploy, io=io, deployed=deployed,
-                           c=c, counter_attr=counter_attr)
+    return _finish_install(
+        spec, digest, deploy=deploy, io=io, deployed=deployed, c=c, counter_attr=counter_attr
+    )
 
 
 def _finish_install(
-    spec: CliSpec, digest: str, *, deploy: CliDeployPort, io: IOPort,
-    deployed: dict[str, CliReceiptEntry], c: Counters, counter_attr: str,
+    spec: CliSpec,
+    digest: str,
+    *,
+    deploy: CliDeployPort,
+    io: IOPort,
+    deployed: dict[str, CliReceiptEntry],
+    c: Counters,
+    counter_attr: str,
 ) -> tuple[bool, bool]:
     shim = deploy.shim_path(spec.binary)
     if shim is None:
@@ -563,7 +674,11 @@ def _finish_install(
 
 
 def _check_reachability(
-    binary: str, *, deploy: CliDeployPort, io: IOPort, auto_yes: bool,
+    binary: str,
+    *,
+    deploy: CliDeployPort,
+    io: IOPort,
+    auto_yes: bool,
     resolved_dirs: set[Path],
 ) -> bool:
     return True  # completed in Task 9 (reachability invariant)

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -283,3 +283,127 @@ def test_stale_receipt_foreign_provenance_requires_takeover(tmp_path: Path) -> N
     )
     assert outcome.counters["cli:workcli"].skipped == 1
     assert not any(t[0] == "tool_install" for t in deploy.transcript)
+
+
+def test_smoke_failure_after_install_fails_run_no_entry(tmp_path: Path) -> None:
+    """
+    Given a fresh install whose post-install smoke fails
+    When deploy_clis runs
+    Then any_failed is True, err carries the smoke output, and no deployed
+    entry is recorded (next run retries).
+
+    Pins spec §6 failure surfacing / item 7.
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        shims=[None, shim],
+        installs=[_OK], smokes=[CommandResult(ok=False, output="kaboom")],
+    )
+    io = ScriptedIO()
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.any_failed and "workcli" not in outcome.deployed
+    assert any(e.channel == "err" and "kaboom" in e.message for e in io.transcript)
+
+
+def test_install_ok_but_no_shim_is_failure(tmp_path: Path) -> None:
+    """
+    Given an install that reports ok but produces no shim
+    When deploy_clis runs
+    Then it is a failure (err), not a silent success.
+
+    Pins spec §6 / item 7 (install-ok-but-no-shim).
+    """
+    _pkg(tmp_path)
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        shims=[None, None], installs=[_OK],
+    )
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=ScriptedIO(), dry_run=False, auto_yes=False,
+    )
+    assert outcome.any_failed
+
+
+def test_one_broken_cli_does_not_block_the_other(tmp_path: Path) -> None:
+    """
+    Given two registry CLIs where the first reaches a genuine hard install
+    failure (receipt-owned heal whose force install fails) and the second
+    is a clean fresh install
+    When deploy_clis runs
+    Then the second still deploys and any_failed is True.
+
+    Pins spec §6/§8: record-and-continue, exit 1 at the end / item 8.
+    CLI1 path: verify (digest equal, provenance ok) -> smoke fail -> heal
+    force install FAILS -> hard failure, no consent involved. CLI2: fresh
+    success. Shim budgets: CLI1 = 1 (decision; failed install, no re-read),
+    CLI2 = 2.
+    """
+    pkg2 = tmp_path / "packages" / "prgroom"
+    (pkg2 / "src").mkdir(parents=True)
+    (pkg2 / "pyproject.toml").write_bytes(b"[project]\n")
+    spec2 = CliSpec("prgroom", "packages/prgroom", "prgroom", ("--help",))
+    prior = _prior_with_current_digest(tmp_path)  # also creates workcli pkg
+    shim1 = tmp_path / "bin" / "work"
+    shim2 = tmp_path / "bin" / "prgroom"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": shim1, "prgroom": shim2},
+        shims=[shim1, None, shim2],
+        installs=[CommandResult(ok=False, output="resolver exploded"), _OK],
+        smokes=[CommandResult(ok=False, output="stale"), _OK],
+    )
+    io = ScriptedIO()
+    outcome = deploy_clis(
+        (_SPEC, spec2), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.any_failed
+    assert "prgroom" in outcome.deployed and "workcli" not in outcome.deployed
+    assert any(e.channel == "err" and "resolver exploded" in e.message for e in io.transcript)
+
+
+def test_dry_run_previews_every_branch_without_subprocess(tmp_path: Path) -> None:
+    """
+    Given each decision-table state under --dry-run
+    When deploy_clis runs
+    Then each reports its would-X line and never calls
+    tool_install/smoke/update_shell.
+
+    Pins spec §6 dry-run / item 6 (each branch reports would-X).
+    """
+    prior_current = _prior_with_current_digest(tmp_path)
+    prior_stale = Receipt(
+        clis=(CliReceiptEntry(name="workcli", binary="work", digest="sha256:stale"),)
+    )
+    shim = tmp_path / "bin" / "work"
+    prov = {"workcli": frozenset({"work"})}
+    cases: list[tuple[Receipt, list[Path | None], object, str]] = [
+        (Receipt(), [None], {}, "would install"),
+        (prior_current, [shim], prov, "would skip"),
+        (prior_current, [None], {}, "would reinstall"),
+        (prior_stale, [shim], prov, "would upgrade"),
+        (Receipt(), [shim], {}, "would take over"),
+    ]
+    for prior, shims, tool_list, expected in cases:
+        deploy = ScriptedCliDeploy(
+            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+            tool_list=tool_list,  # type: ignore[arg-type]
+            shims=shims,
+        )
+        io = ScriptedIO()
+        outcome = deploy_clis(
+            (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+            io=io, dry_run=True, auto_yes=False,
+        )
+        assert not outcome.any_failed, expected
+        assert any(expected in e.message for e in io.transcript), expected
+        assert not any(
+            t[0] in ("tool_install", "smoke", "update_shell") for t in deploy.transcript
+        ), expected

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -51,8 +51,13 @@ def test_verify_skip_smokes_and_skips(tmp_path: Path) -> None:
         smokes=[_OK],
     )
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=ScriptedIO(), dry_run=False, auto_yes=True,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=ScriptedIO(),
+        dry_run=False,
+        auto_yes=True,
     )
     assert not outcome.any_failed
     assert outcome.counters["cli:workcli"].skipped == 1
@@ -84,8 +89,13 @@ def test_verify_smoke_failure_heals_with_force(tmp_path: Path) -> None:
     )
     io = ScriptedIO()
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert not outcome.any_failed
     assert ("tool_install", str(tmp_path / "packages" / "workcli"), True) in deploy.transcript
@@ -116,8 +126,13 @@ def test_heal_missing_shim_reinstalls_without_prompt(tmp_path: Path) -> None:
     )
     io = ScriptedIO()
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].created == 1
     assert ("tool_install", str(tmp_path / "packages" / "workcli"), False) in deploy.transcript
@@ -145,8 +160,13 @@ def test_fresh_install_no_evidence_no_prompt(tmp_path: Path) -> None:
         smokes=[_OK],
     )
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=ScriptedIO(), dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=ScriptedIO(),
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].created == 1
     assert ("tool_install", str(tmp_path / "packages" / "workcli"), False) in deploy.transcript
@@ -177,20 +197,32 @@ def test_upgrade_consent_accept_and_decline(tmp_path: Path) -> None:
     )
     io = ScriptedIO(confirms=[True])
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=accept,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=accept,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].updated == 1
     assert ("tool_install", str(pkg), True) in accept.transcript
 
     decline = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
-        tool_list={"workcli": frozenset({"work"})}, which_map={"work": shim},
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": shim},
         shims=[shim],
     )
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=decline,
-        io=ScriptedIO(confirms=[False]), dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=decline,
+        io=ScriptedIO(confirms=[False]),
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].skipped == 1
     assert not any(t[0] == "tool_install" for t in decline.transcript)
@@ -216,12 +248,19 @@ def test_takeover_triggers_all_three_evidence_forms(tmp_path: Path) -> None:
     ]
     for case in cases:
         deploy = ScriptedCliDeploy(
-            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", **case,  # type: ignore[arg-type]
+            uv_version=(0, 10, 4),
+            bin_dir=tmp_path / "bin",
+            **case,  # type: ignore[arg-type]
         )
         io = ScriptedIO(confirms=[False])
         outcome = deploy_clis(
-            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-            io=io, dry_run=False, auto_yes=False,
+            (_SPEC,),
+            repo_root=tmp_path,
+            prior=Receipt(),
+            deploy=deploy,
+            io=io,
+            dry_run=False,
+            auto_yes=False,
         )
         assert outcome.counters["cli:workcli"].skipped == 1, case
         assert any(e.channel == "confirm" for e in io.transcript), case
@@ -252,8 +291,13 @@ def test_fresh_toctou_already_exists_reroutes_to_takeover(tmp_path: Path) -> Non
     )
     io = ScriptedIO(confirms=[True])
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     installs = [t for t in deploy.transcript if t[0] == "tool_install"]
     assert installs == [("tool_install", str(pkg), False), ("tool_install", str(pkg), True)]
@@ -272,14 +316,21 @@ def test_stale_receipt_foreign_provenance_requires_takeover(tmp_path: Path) -> N
     shim = tmp_path / "bin" / "work"
     prior = _prior_with_current_digest(tmp_path)  # creates the package dir itself
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
-        tool_list={"other-tool": frozenset({"work"})}, which_map={"work": shim},
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={"other-tool": frozenset({"work"})},
+        which_map={"work": shim},
         shims=[shim],
     )
     io = ScriptedIO(confirms=[False])
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].skipped == 1
     assert not any(t[0] == "tool_install" for t in deploy.transcript)
@@ -297,14 +348,22 @@ def test_smoke_failure_after_install_fails_run_no_entry(tmp_path: Path) -> None:
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
         shims=[None, shim],
-        installs=[_OK], smokes=[CommandResult(ok=False, output="kaboom")],
+        installs=[_OK],
+        smokes=[CommandResult(ok=False, output="kaboom")],
     )
     io = ScriptedIO()
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.any_failed and "workcli" not in outcome.deployed
     assert any(e.channel == "err" and "kaboom" in e.message for e in io.transcript)
@@ -320,12 +379,20 @@ def test_install_ok_but_no_shim_is_failure(tmp_path: Path) -> None:
     """
     _pkg(tmp_path)
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
-        shims=[None, None], installs=[_OK],
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
+        shims=[None, None],
+        installs=[_OK],
     )
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=ScriptedIO(), dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=ScriptedIO(),
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.any_failed
 
@@ -352,7 +419,8 @@ def test_one_broken_cli_does_not_block_the_other(tmp_path: Path) -> None:
     shim1 = tmp_path / "bin" / "work"
     shim2 = tmp_path / "bin" / "prgroom"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
         tool_list={"workcli": frozenset({"work"})},
         which_map={"work": shim1, "prgroom": shim2},
         shims=[shim1, None, shim2],
@@ -361,8 +429,13 @@ def test_one_broken_cli_does_not_block_the_other(tmp_path: Path) -> None:
     )
     io = ScriptedIO()
     outcome = deploy_clis(
-        (_SPEC, spec2), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC, spec2),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.any_failed
     assert "prgroom" in outcome.deployed and "workcli" not in outcome.deployed
@@ -393,14 +466,20 @@ def test_dry_run_previews_every_branch_without_subprocess(tmp_path: Path) -> Non
     ]
     for prior, shims, tool_list, expected in cases:
         deploy = ScriptedCliDeploy(
-            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+            uv_version=(0, 10, 4),
+            bin_dir=tmp_path / "bin",
             tool_list=tool_list,  # type: ignore[arg-type]
             shims=shims,
         )
         io = ScriptedIO()
         outcome = deploy_clis(
-            (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-            io=io, dry_run=True, auto_yes=False,
+            (_SPEC,),
+            repo_root=tmp_path,
+            prior=prior,
+            deploy=deploy,
+            io=io,
+            dry_run=True,
+            auto_yes=False,
         )
         assert not outcome.any_failed, expected
         assert any(expected in e.message for e in io.transcript), expected
@@ -422,14 +501,18 @@ def test_uv_version_guard_blocks_all_cli_work(tmp_path: Path) -> None:
         deploy = ScriptedCliDeploy(uv_version=version)
         io = ScriptedIO()
         outcome = deploy_clis(
-            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-            io=io, dry_run=False, auto_yes=True,
+            (_SPEC,),
+            repo_root=tmp_path,
+            prior=Receipt(),
+            deploy=deploy,
+            io=io,
+            dry_run=False,
+            auto_yes=True,
         )
         assert outcome.any_failed
         assert any(e.channel == "err" and "uv" in e.message for e in io.transcript)
         assert not any(
-            t[0] in ("tool_install", "tool_uninstall", "update_shell")
-            for t in deploy.transcript
+            t[0] in ("tool_install", "tool_uninstall", "update_shell") for t in deploy.transcript
         )
 
 
@@ -446,25 +529,41 @@ def test_reachability_which_none_update_shell_consent(tmp_path: Path) -> None:
     shim = tmp_path / "bin" / "work"
 
     accept = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
-        shims=[None, shim], installs=[_OK], smokes=[_OK],
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
+        shims=[None, shim],
+        installs=[_OK],
+        smokes=[_OK],
         update_shells=[CommandResult(ok=True, output="")],
     )
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(),
-        deploy=accept, io=ScriptedIO(confirms=[True]),
-        dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=accept,
+        io=ScriptedIO(confirms=[True]),
+        dry_run=False,
+        auto_yes=False,
     )
     assert not outcome.any_failed
 
     io = ScriptedIO(confirms=[False])
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(),
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
         deploy=ScriptedCliDeploy(
-            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
-            shims=[None, shim], installs=[_OK], smokes=[_OK],
+            uv_version=(0, 10, 4),
+            bin_dir=tmp_path / "bin",
+            tool_list={},
+            shims=[None, shim],
+            installs=[_OK],
+            smokes=[_OK],
         ),
-        io=io, dry_run=False, auto_yes=False,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.any_failed
     assert any(e.channel == "err" and "PATH" in e.message for e in io.transcript)
@@ -483,14 +582,23 @@ def test_reachability_shadow_is_hard_error(tmp_path: Path) -> None:
     shim = tmp_path / "bin" / "work"
     foreign = tmp_path / "other" / "work"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
         which_map={"work": foreign},
-        shims=[None, shim], installs=[_OK], smokes=[_OK],
+        shims=[None, shim],
+        installs=[_OK],
+        smokes=[_OK],
     )
     io = ScriptedIO()
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.any_failed
     assert any(
@@ -516,15 +624,23 @@ def test_reachability_memoized_per_bin_dir(tmp_path: Path) -> None:
     spec2 = CliSpec("prgroom", "packages/prgroom", "prgroom", ("--help",))
     shim1, shim2 = tmp_path / "bin" / "work", tmp_path / "bin" / "prgroom"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
         shims=[None, shim1, None, shim2],
-        installs=[_OK, _OK], smokes=[_OK, _OK],
+        installs=[_OK, _OK],
+        smokes=[_OK, _OK],
         update_shells=[CommandResult(ok=True, output="")],
     )
     io = ScriptedIO(confirms=[True])
     outcome = deploy_clis(
-        (_SPEC, spec2), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC, spec2),
+        repo_root=tmp_path,
+        prior=Receipt(),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert not outcome.any_failed
     assert sum(1 for t in deploy.transcript if t[0] == "update_shell") == 1
@@ -543,14 +659,21 @@ def test_reachability_fires_on_steady_state_skip_run(tmp_path: Path) -> None:
     prior = _prior_with_current_digest(tmp_path)
     shim = tmp_path / "bin" / "work"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
         tool_list={"workcli": frozenset({"work"})},
-        shims=[shim], smokes=[_OK],
+        shims=[shim],
+        smokes=[_OK],
     )
     io = ScriptedIO(confirms=[False])
     outcome = deploy_clis(
-        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
-        io=io, dry_run=False, auto_yes=False,
+        (_SPEC,),
+        repo_root=tmp_path,
+        prior=prior,
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
     )
     assert outcome.counters["cli:workcli"].skipped == 1
     assert outcome.any_failed
@@ -572,11 +695,20 @@ def test_reachability_no_tty_without_yes_raises(tmp_path: Path) -> None:
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
     deploy = ScriptedCliDeploy(
-        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
-        shims=[None, shim], installs=[_OK], smokes=[_OK],
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
+        shims=[None, shim],
+        installs=[_OK],
+        smokes=[_OK],
     )
     with pytest.raises(ConsentRequiredError):
         deploy_clis(
-            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
-            io=ScriptedIO(interactive=False), dry_run=False, auto_yes=False,
+            (_SPEC,),
+            repo_root=tmp_path,
+            prior=Receipt(),
+            deploy=deploy,
+            io=ScriptedIO(interactive=False),
+            dry_run=False,
+            auto_yes=False,
         )

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -151,3 +151,135 @@ def test_fresh_install_no_evidence_no_prompt(tmp_path: Path) -> None:
     assert outcome.counters["cli:workcli"].created == 1
     assert ("tool_install", str(tmp_path / "packages" / "workcli"), False) in deploy.transcript
     assert "workcli" in outcome.deployed
+
+
+def test_upgrade_consent_accept_and_decline(tmp_path: Path) -> None:
+    """
+    Given a receipt entry with a STALE digest, shim present, provenance ok
+    When deploy_clis runs with an accepting (then declining) confirm
+    Then accept -> force install + updated counter; decline -> skipped and
+    no install.
+
+    Pins spec §6 upgrade row / item 4. Shim budgets: accept 2, decline 1.
+    """
+    pkg = _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    prior = Receipt(clis=(CliReceiptEntry(name="workcli", binary="work", digest="sha256:stale"),))
+
+    accept = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": shim},
+        shims=[shim, shim],
+        installs=[_OK],
+        smokes=[_OK],
+    )
+    io = ScriptedIO(confirms=[True])
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=accept,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].updated == 1
+    assert ("tool_install", str(pkg), True) in accept.transcript
+
+    decline = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})}, which_map={"work": shim},
+        shims=[shim],
+    )
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=decline,
+        io=ScriptedIO(confirms=[False]), dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].skipped == 1
+    assert not any(t[0] == "tool_install" for t in decline.transcript)
+
+
+def test_takeover_triggers_all_three_evidence_forms(tmp_path: Path) -> None:
+    """
+    Given no receipt entry, and (a) shim present, (b) env present shimless,
+    (c) tool_list None
+    When deploy_clis runs with declining confirms
+    Then each form prompts for takeover and no install fires on decline.
+
+    Pins spec §6 takeover row / item 5. Case (a) leaves the shim present,
+    so the reachability gate runs — which_map keeps it green; cases (b)/(c)
+    end shimless, no gate.
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    cases: list[dict[str, object]] = [
+        {"shims": [shim], "tool_list": {}, "which_map": {"work": shim}},
+        {"shims": [None], "tool_list": {"workcli": frozenset({"work"})}},
+        {"shims": [None], "tool_list": None},
+    ]
+    for case in cases:
+        deploy = ScriptedCliDeploy(
+            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", **case,  # type: ignore[arg-type]
+        )
+        io = ScriptedIO(confirms=[False])
+        outcome = deploy_clis(
+            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+            io=io, dry_run=False, auto_yes=False,
+        )
+        assert outcome.counters["cli:workcli"].skipped == 1, case
+        assert any(e.channel == "confirm" for e in io.transcript), case
+        assert not any(t[0] == "tool_install" for t in deploy.transcript), case
+
+
+def test_fresh_toctou_already_exists_reroutes_to_takeover(tmp_path: Path) -> None:
+    """
+    Given a clean fresh decision whose non-forcing install fails (tool
+    appeared concurrently)
+    When deploy_clis runs with an accepting confirm
+    Then a takeover consent fires and the retry uses force=True.
+
+    Pins spec §6 fresh row TOCTOU re-route / item 18. Shim budget: 2
+    (decision None + post-install re-read after the consented force
+    install; the FAILED non-forcing install triggers no re-read).
+    """
+    pkg = _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
+        which_map={"work": shim},
+        shims=[None, shim],
+        installs=[CommandResult(ok=False, output="already installed"), _OK],
+        smokes=[_OK],
+    )
+    io = ScriptedIO(confirms=[True])
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    installs = [t for t in deploy.transcript if t[0] == "tool_install"]
+    assert installs == [("tool_install", str(pkg), False), ("tool_install", str(pkg), True)]
+    assert outcome.counters["cli:workcli"].updated == 1
+
+
+def test_stale_receipt_foreign_provenance_requires_takeover(tmp_path: Path) -> None:
+    """
+    Given a receipt entry but tool_list showing a DIFFERENT tool providing
+    'work' (our env gone)
+    When deploy_clis runs with a declining confirm
+    Then no promptless heal fires — takeover consent, decline skips.
+
+    Pins spec §6 provenance precondition / item 19.
+    """
+    shim = tmp_path / "bin" / "work"
+    prior = _prior_with_current_digest(tmp_path)  # creates the package dir itself
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        tool_list={"other-tool": frozenset({"work"})}, which_map={"work": shim},
+        shims=[shim],
+    )
+    io = ScriptedIO(confirms=[False])
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].skipped == 1
+    assert not any(t[0] == "tool_install" for t in deploy.transcript)

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -407,3 +407,176 @@ def test_dry_run_previews_every_branch_without_subprocess(tmp_path: Path) -> Non
         assert not any(
             t[0] in ("tool_install", "smoke", "update_shell") for t in deploy.transcript
         ), expected
+
+
+def test_uv_version_guard_blocks_all_cli_work(tmp_path: Path) -> None:
+    """
+    Given uv older than MIN_UV_VERSION (or unparseable)
+    When deploy_clis runs
+    Then one actionable err fires, zero install/uninstall/update_shell
+    calls happen, and any_failed is True.
+
+    Pins spec §6 version guard / item 21.
+    """
+    for version in [(0, 9, 0), None]:
+        deploy = ScriptedCliDeploy(uv_version=version)
+        io = ScriptedIO()
+        outcome = deploy_clis(
+            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+            io=io, dry_run=False, auto_yes=True,
+        )
+        assert outcome.any_failed
+        assert any(e.channel == "err" and "uv" in e.message for e in io.transcript)
+        assert not any(
+            t[0] in ("tool_install", "tool_uninstall", "update_shell")
+            for t in deploy.transcript
+        )
+
+
+def test_reachability_which_none_update_shell_consent(tmp_path: Path) -> None:
+    """
+    Given a deployed CLI whose binary which() cannot find
+    When the invariant runs with an accepting confirm and update_shell ok
+    Then the run resolves (not failed) with an info notice; decline instead
+    -> err + failure.
+
+    Pins spec §6 reachability / item 9. which_map deliberately empty (miss).
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+
+    accept = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        shims=[None, shim], installs=[_OK], smokes=[_OK],
+        update_shells=[CommandResult(ok=True, output="")],
+    )
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(),
+        deploy=accept, io=ScriptedIO(confirms=[True]),
+        dry_run=False, auto_yes=False,
+    )
+    assert not outcome.any_failed
+
+    io = ScriptedIO(confirms=[False])
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(),
+        deploy=ScriptedCliDeploy(
+            uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+            shims=[None, shim], installs=[_OK], smokes=[_OK],
+        ),
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.any_failed
+    assert any(e.channel == "err" and "PATH" in e.message for e in io.transcript)
+
+
+def test_reachability_shadow_is_hard_error(tmp_path: Path) -> None:
+    """
+    Given which() resolving OUTSIDE bin_dir (foreign shadow)
+    When the invariant runs
+    Then err names both paths and the run fails; update_shell is never
+    offered (it cannot fix PATH order).
+
+    Pins spec §6 shadowing / item 9.
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    foreign = tmp_path / "other" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        which_map={"work": foreign},
+        shims=[None, shim], installs=[_OK], smokes=[_OK],
+    )
+    io = ScriptedIO()
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.any_failed
+    assert any(
+        e.channel == "err" and str(foreign) in e.message and str(shim) in e.message
+        for e in io.transcript
+    )
+    assert not any(t[0] == "update_shell" for t in deploy.transcript)
+
+
+def test_reachability_memoized_per_bin_dir(tmp_path: Path) -> None:
+    """
+    Given two CLIs sharing one bin_dir, PATH unconfigured
+    When deploy_clis runs with ONE accepting confirm
+    Then update_shell runs exactly once and the second CLI reuses the
+    memoized success (no second prompt, no failure).
+
+    Pins spec §6 memoization / item 20.
+    """
+    pkg2 = tmp_path / "packages" / "prgroom"
+    (pkg2 / "src").mkdir(parents=True)
+    (pkg2 / "pyproject.toml").write_bytes(b"[project]\n")
+    _pkg(tmp_path)
+    spec2 = CliSpec("prgroom", "packages/prgroom", "prgroom", ("--help",))
+    shim1, shim2 = tmp_path / "bin" / "work", tmp_path / "bin" / "prgroom"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        shims=[None, shim1, None, shim2],
+        installs=[_OK, _OK], smokes=[_OK, _OK],
+        update_shells=[CommandResult(ok=True, output="")],
+    )
+    io = ScriptedIO(confirms=[True])
+    outcome = deploy_clis(
+        (_SPEC, spec2), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert not outcome.any_failed
+    assert sum(1 for t in deploy.transcript if t[0] == "update_shell") == 1
+    assert sum(1 for e in io.transcript if e.channel == "confirm") == 1
+
+
+def test_reachability_fires_on_steady_state_skip_run(tmp_path: Path) -> None:
+    """
+    Given a healthy verify/skip CLI whose bin dir is NOT on PATH
+    When deploy_clis runs and the update-shell offer is declined
+    Then the run FAILS — the invariant fires on SKIPPED_IDENTICAL runs,
+    not only after a deploy.
+
+    Pins spec §6 steady-state enforcement / item 9.
+    """
+    prior = _prior_with_current_digest(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        shims=[shim], smokes=[_OK],
+    )
+    io = ScriptedIO(confirms=[False])
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].skipped == 1
+    assert outcome.any_failed
+    assert any(e.channel == "err" and "PATH" in e.message for e in io.transcript)
+
+
+def test_reachability_no_tty_without_yes_raises(tmp_path: Path) -> None:
+    """
+    Given a freshly deployed CLI whose bin dir is not on PATH, on a
+    non-interactive session without --yes (and without --dry-run)
+    When the reachability invariant reaches its update-shell consent point
+    Then ConsentRequiredError raises (the caller maps it to exit 1) — the
+    reachability consent point honors the same no-TTY convention as every
+    other consent point, never silently returning a failure.
+
+    Pins spec §6 no-TTY / item 12 (reachability side; symmetric with the
+    prune side's test_prune_no_tty_without_yes_raises).
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4), bin_dir=tmp_path / "bin", tool_list={},
+        shims=[None, shim], installs=[_OK], smokes=[_OK],
+    )
+    with pytest.raises(ConsentRequiredError):
+        deploy_clis(
+            (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+            io=ScriptedIO(interactive=False), dry_run=False, auto_yes=False,
+        )

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -1,0 +1,153 @@
+"""Tests for the deploy_clis decision engine (spec §6)."""
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.clis import CliSpec, CommandResult, ScriptedCliDeploy
+from installer.core.consent import ConsentRequiredError
+from installer.core.io_port import ScriptedIO
+from installer.core.receipt import CliReceiptEntry, Receipt
+from installer.core.run import deploy_clis
+
+_SPEC = CliSpec("workcli", "packages/workcli", "work", ("--protocol-version",))
+_OK = CommandResult(ok=True, output="")
+
+
+def _pkg(tmp_path: Path) -> Path:
+    pkg = tmp_path / "packages" / "workcli"
+    (pkg / "src").mkdir(parents=True, exist_ok=True)  # idempotent: helpers layer on it
+    (pkg / "pyproject.toml").write_bytes(b"[project]\n")
+    (pkg / "src" / "m.py").write_bytes(b"pass")
+    return pkg
+
+
+def _prior_with_current_digest(tmp_path: Path) -> Receipt:
+    from installer.core.clis import cli_source_digest
+
+    digest = cli_source_digest(_pkg(tmp_path))
+    return Receipt(clis=(CliReceiptEntry(name="workcli", binary="work", digest=digest),))
+
+
+def test_verify_skip_smokes_and_skips(tmp_path: Path) -> None:
+    """
+    Given a receipt entry with the current digest, shim present, provenance
+    proven, smoke passing
+    When deploy_clis runs
+    Then no install fires, the smoke ran against the absolute shim path,
+    and the counter is skipped.
+
+    Pins spec §6 verify row / item 1. Shim budget: 1 (decision read only —
+    no install happened).
+    """
+    prior = _prior_with_current_digest(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": shim},
+        shims=[shim],
+        smokes=[_OK],
+    )
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=ScriptedIO(), dry_run=False, auto_yes=True,
+    )
+    assert not outcome.any_failed
+    assert outcome.counters["cli:workcli"].skipped == 1
+    assert ("smoke", str(shim)) in deploy.transcript
+    assert not any(t[0] == "tool_install" for t in deploy.transcript)
+
+
+def test_verify_smoke_failure_heals_with_force(tmp_path: Path) -> None:
+    """
+    Given digest-equal receipt + shim present + provenance proven, but smoke
+    failing
+    When deploy_clis runs
+    Then a force=True reinstall fires without a consent prompt, then
+    re-smokes; the entry is refreshed.
+
+    Pins spec §6 verify row heal-on-fail / item 1. Shim budget: 2 (decision
+    + post-install re-read after the successful heal install).
+    """
+    prior = _prior_with_current_digest(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={"workcli": frozenset({"work"})},
+        which_map={"work": shim},
+        shims=[shim, shim],
+        smokes=[CommandResult(ok=False, output="boom"), _OK],
+        installs=[_OK],
+    )
+    io = ScriptedIO()
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert not outcome.any_failed
+    assert ("tool_install", str(tmp_path / "packages" / "workcli"), True) in deploy.transcript
+    assert not any(e.channel == "confirm" for e in io.transcript)
+    assert "workcli" in outcome.deployed
+
+
+def test_heal_missing_shim_reinstalls_without_prompt(tmp_path: Path) -> None:
+    """
+    Given a receipt entry, shim missing, env absent entirely
+    When deploy_clis runs
+    Then it reinstalls without a prompt (created counter) — env absent uses
+    force=False.
+
+    Pins spec §6 heal row + provenance-absent exception / items 3, 19.
+    Shim budget: 2 (decision None + post-install re-read).
+    """
+    prior = _prior_with_current_digest(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},  # env absent entirely -> non-forcing heal
+        which_map={"work": shim},
+        shims=[None, shim],
+        installs=[_OK],
+        smokes=[_OK],
+    )
+    io = ScriptedIO()
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=prior, deploy=deploy,
+        io=io, dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].created == 1
+    assert ("tool_install", str(tmp_path / "packages" / "workcli"), False) in deploy.transcript
+    assert not any(e.channel == "confirm" for e in io.transcript)
+
+
+def test_fresh_install_no_evidence_no_prompt(tmp_path: Path) -> None:
+    """
+    Given no receipt entry, no shim, tool_list proving the env absent
+    When deploy_clis runs
+    Then a force=False install fires with no prompt; created counter; entry
+    recorded after smoke.
+
+    Pins spec §6 fresh row / items 2, 18. Shim budget: 2.
+    """
+    _pkg(tmp_path)
+    shim = tmp_path / "bin" / "work"
+    deploy = ScriptedCliDeploy(
+        uv_version=(0, 10, 4),
+        bin_dir=tmp_path / "bin",
+        tool_list={},
+        which_map={"work": shim},
+        shims=[None, shim],
+        installs=[_OK],
+        smokes=[_OK],
+    )
+    outcome = deploy_clis(
+        (_SPEC,), repo_root=tmp_path, prior=Receipt(), deploy=deploy,
+        io=ScriptedIO(), dry_run=False, auto_yes=False,
+    )
+    assert outcome.counters["cli:workcli"].created == 1
+    assert ("tool_install", str(tmp_path / "packages" / "workcli"), False) in deploy.transcript
+    assert "workcli" in outcome.deployed

--- a/packages/installer/tests/unit/test_prune_clis.py
+++ b/packages/installer/tests/unit/test_prune_clis.py
@@ -1,0 +1,164 @@
+"""Tests for the CLI prune half (spec §7, item 10)."""
+
+from pathlib import Path
+
+import pytest
+
+from installer.core.clis import CommandResult, ScriptedCliDeploy
+from installer.core.consent import ConsentRequiredError
+from installer.core.io_port import ScriptedIO
+from installer.core.receipt import CliReceiptEntry, Receipt
+from installer.core.run import prune_clis
+
+_OK = CommandResult(ok=True, output="")
+
+
+def _prior(*names: str) -> Receipt:
+    return Receipt(
+        clis=tuple(CliReceiptEntry(name=n, binary=n[:4], digest="sha256:aa") for n in names)
+    )
+
+
+def test_retired_allowlisted_cli_uninstalled_with_consent() -> None:
+    """
+    Given a prior entry not in the registry but in RETIRED_CLIS
+    When prune_clis runs with an accepting confirm
+    Then uv tool uninstall fires, pruned counter increments, and the name
+    lands in uninstalled_names.
+
+    Pins spec §7 / item 10.
+    """
+    deploy = ScriptedCliDeploy(uninstalls=[_OK])
+    io = ScriptedIO(confirms=[True])
+    outcome = prune_clis(
+        _prior("oldtool"),
+        registry_names=frozenset({"workcli"}),
+        retired=frozenset({"oldtool"}),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=False,
+    )
+    assert outcome.uninstalled_names == {"oldtool"}
+    assert outcome.counters["cli:oldtool"].pruned == 1
+    assert ("tool_uninstall", "oldtool") in deploy.transcript
+
+
+def test_declined_uninstall_retains_entry() -> None:
+    """
+    Given a retired allowlisted entry and a declining confirm
+    When prune_clis runs
+    Then no uninstall fires and the name is NOT in uninstalled_names
+    (retirement retried next prune).
+
+    Pins spec §7 decline / item 10.
+    """
+    deploy = ScriptedCliDeploy()
+    outcome = prune_clis(
+        _prior("oldtool"),
+        registry_names=frozenset({"workcli"}),
+        retired=frozenset({"oldtool"}),
+        deploy=deploy,
+        io=ScriptedIO(confirms=[False]),
+        dry_run=False,
+        auto_yes=False,
+    )
+    assert outcome.uninstalled_names == set()
+    assert not any(t[0] == "tool_uninstall" for t in deploy.transcript)
+
+
+def test_foreign_name_never_uninstalled_relinquished_instead() -> None:
+    """
+    Given a prior entry naming a tool outside CLI_PACKAGES | RETIRED_CLIS
+    (e.g. a tampered receipt naming 'ruff')
+    When prune_clis runs with auto_yes
+    Then NO uninstall fires even under --yes; the name is warned about and
+    relinquished.
+
+    Pins spec §7 closed uninstall authority / item 10 (tampered receipt).
+    """
+    deploy = ScriptedCliDeploy()
+    io = ScriptedIO()
+    outcome = prune_clis(
+        _prior("ruff"),
+        registry_names=frozenset({"workcli"}),
+        retired=frozenset(),
+        deploy=deploy,
+        io=io,
+        dry_run=False,
+        auto_yes=True,
+    )
+    assert outcome.relinquished_names == {"ruff"}
+    assert outcome.uninstalled_names == set()
+    assert not any(t[0] == "tool_uninstall" for t in deploy.transcript)
+    assert any(e.channel == "warn" and "ruff" in e.message for e in io.transcript)
+
+
+def test_uninstall_of_absent_tool_counts_as_success() -> None:
+    """
+    Given a retired entry whose uv uninstall fails with 'not installed'
+    When prune_clis runs (auto_yes)
+    Then the outcome treats it as uninstalled (desired state: absent).
+
+    Pins spec §7 / item 10.
+    """
+    deploy = ScriptedCliDeploy(
+        uninstalls=[CommandResult(ok=False, output="`oldtool` is not installed")]
+    )
+    outcome = prune_clis(
+        _prior("oldtool"),
+        registry_names=frozenset({"workcli"}),
+        retired=frozenset({"oldtool"}),
+        deploy=deploy,
+        io=ScriptedIO(),
+        dry_run=False,
+        auto_yes=True,
+    )
+    assert outcome.uninstalled_names == {"oldtool"}
+
+
+def test_dry_run_previews_no_uninstall() -> None:
+    """
+    Given a retired allowlisted entry under --dry-run
+    When prune_clis runs
+    Then it reports would-uninstall and calls nothing.
+
+    Pins spec §7 dry-run / item 10.
+    """
+    deploy = ScriptedCliDeploy()
+    io = ScriptedIO()
+    outcome = prune_clis(
+        _prior("oldtool"),
+        registry_names=frozenset({"workcli"}),
+        retired=frozenset({"oldtool"}),
+        deploy=deploy,
+        io=io,
+        dry_run=True,
+        auto_yes=False,
+    )
+    assert outcome.uninstalled_names == set()
+    assert any("would uninstall" in e.message for e in io.transcript)
+    assert not deploy.transcript or not any(t[0] == "tool_uninstall" for t in deploy.transcript)
+
+
+def test_prune_no_tty_without_yes_raises() -> None:
+    """
+    Given a retired allowlisted entry on a non-interactive session without
+    --yes or --dry-run
+    When prune_clis reaches its consent point
+    Then ConsentRequiredError raises (the caller maps it to exit 1) — the
+    prune side honors the same no-TTY convention as the deploy side.
+
+    Pins spec §7 no-TTY / item 12 (prune side).
+    """
+    deploy = ScriptedCliDeploy()
+    with pytest.raises(ConsentRequiredError):
+        prune_clis(
+            _prior("oldtool"),
+            registry_names=frozenset({"workcli"}),
+            retired=frozenset({"oldtool"}),
+            deploy=deploy,
+            io=ScriptedIO(interactive=False),
+            dry_run=False,
+            auto_yes=False,
+        )

--- a/packages/installer/tests/unit/test_prune_clis.py
+++ b/packages/installer/tests/unit/test_prune_clis.py
@@ -1,7 +1,5 @@
 """Tests for the CLI prune half (spec §7, item 10)."""
 
-from pathlib import Path
-
 import pytest
 
 from installer.core.clis import CommandResult, ScriptedCliDeploy


### PR DESCRIPTION
## Summary
- Tasks 6-10 of the installer CLI-deploy plan (docs/plans/2026-07-16-installer-cli-deploy-plan.md), built on PR1 (#315, merged).
- Adds `deploy_clis` — the §6 decision engine (verify/heal/fresh, upgrade/takeover consent, TOCTOU re-route, provenance precondition, uv version guard, PATH-reachability invariant) — and `prune_clis` — the §7 retirement half (allowlist-bounded uninstall authority, decline-retains, foreign-name relinquish).
- Pure engine code in `packages/installer/src/installer/core/run.py` — still not wired into `cli.py` (that's PR3).

## Test plan
- [x] `make ci-installer` from the worktree, rebased onto current main: ruff, ruff format --check, mypy --strict, pytest (878 passed, 1 pre-existing unrelated skip), coverage 98.11% (floor 90%), pip-audit clean, entry-verify OK.
- [x] Every guard branch mutate-verified (deliberately broken, confirmed the right test failed, restored) per the plan's Task 7/9 discipline.

bead: agents-config-wgclw.9.9 (part 2 of 3)