### PR TITLE
feat(workcli): track layer slice B — create gate + work track set ±cascade

### DIFF
--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -83,6 +83,7 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
     create_parser.add_argument("--spec")
     create_parser.add_argument("--trivial", action="store_true")
     create_parser.add_argument("--acceptance")
+    create_parser.add_argument("--track", metavar="NAME")
 
     update_parser = subparsers.add_parser(
         "update", help="update title/priority/description (replace semantics only)"

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -157,6 +157,16 @@ def _add_relations_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentPar
     label_parser.add_argument("labels", nargs="*", metavar="LABELS")
 
 
+def _add_track_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    track_parser = subparsers.add_parser(
+        "track", help="track assignment: track set ID NAME [--cascade]"
+    )
+    track_parser.add_argument("action", choices=["set"])
+    track_parser.add_argument("id", metavar="ID")
+    track_parser.add_argument("name", metavar="NAME")
+    track_parser.add_argument("--cascade", action="store_true")
+
+
 def _add_sync_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
     sync_parser = subparsers.add_parser(
         "sync", help="sync with the backend (bd: dolt commit+push, or --pull)"
@@ -192,6 +202,7 @@ def _build_parser() -> _EnvelopeArgumentParser:
     _add_write_subparsers(subparsers)
     _add_transition_subparsers(subparsers)
     _add_relations_subparsers(subparsers)
+    _add_track_subparsers(subparsers)
     _add_sync_subparser(subparsers)
     return parser
 

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -26,9 +26,12 @@ from workcli.lifecycle.nouns import (
     NounTemplate,
 )
 from workcli.model import CreateFields
+from workcli.tracks import derive_track, require_known_track, track_label
 
 
-def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> tuple[str, str]:
+def instantiate_spec_shape(
+    backend: Backend, container_id: str, title: str, track: str | None = None
+) -> tuple[str, str]:
     """Find-or-create the design child + blocked placeholder under a container.
 
     Returns (design_child_id, placeholder_id). **Idempotent** (spec §6, L16):
@@ -37,10 +40,21 @@ def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> t
     re-run) that replays an interrupted instantiation mints only what a partial
     crash left missing. Does NOT stamp `planned` or touch `creating-spec` -- the
     caller owns that ordering (planned last, `creating-spec` removed after).
+
+    `track` defaults to None for the `promote`/`reconcile`/crash-replay call
+    sites, which self-derive from the container's own labels below -- a
+    tracked container finished by those paths still stamps its children
+    (pure derivation, no config needed).
     """
+    container = backend.get(container_id)
+    if track is None:
+        # promote/reconcile/crash-replay path: children inherit the
+        # container's own derived track so an interrupted tracked create
+        # never mints lint violations (config-free derivation).
+        track = derive_track(container.labels)
     design_child_id: str | None = None
     placeholder_id: str | None = None
-    for child_id in backend.get(container_id).children:
+    for child_id in container.children:
         child = backend.get(child_id)
         if DESIGN_CHILD_LABEL in child.labels:
             design_child_id = child_id
@@ -53,7 +67,7 @@ def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> t
                 title=f"Design: {title}",
                 type="task",
                 parent=container_id,
-                labels=(DESIGN_CHILD_LABEL,),
+                labels=(DESIGN_CHILD_LABEL,) + ((track_label(track),) if track is not None else ()),
             )
         )
     if placeholder_id is None:
@@ -62,14 +76,17 @@ def instantiate_spec_shape(backend: Backend, container_id: str, title: str) -> t
                 title=f"[Impl] {title} (scope: per spec)",
                 type="task",
                 parent=container_id,
-                labels=(IMPL_PLACEHOLDER_LABEL,),
+                labels=(IMPL_PLACEHOLDER_LABEL,)
+                + ((track_label(track),) if track is not None else ()),
                 blocked_by=design_child_id,
             )
         )
     return design_child_id, placeholder_id
 
 
-def finalize_spec_instantiation(backend: Backend, container_id: str, title: str) -> tuple[str, str]:
+def finalize_spec_instantiation(
+    backend: Backend, container_id: str, title: str, track: str | None = None
+) -> tuple[str, str]:
     """Idempotently complete a spec container born under `creating-spec`.
 
     The single source of the L16 completion tail shared by `create spec`,
@@ -90,7 +107,7 @@ def finalize_spec_instantiation(backend: Backend, container_id: str, title: str)
     """
     backend.label_mutate("add", container_id, ["shape-spec"])
     backend.label_mutate("remove", container_id, ["shape-feat"])
-    design_child_id, placeholder_id = instantiate_spec_shape(backend, container_id, title)
+    design_child_id, placeholder_id = instantiate_spec_shape(backend, container_id, title, track)
     backend.label_mutate("add", container_id, [PLANNED_LABEL])
     backend.label_mutate("remove", container_id, [CREATING_SPEC_LABEL])
     return design_child_id, placeholder_id
@@ -131,9 +148,64 @@ def _check_duplicate_title(backend: Backend, title: str) -> None:
         )
 
 
+def _resolve_track(
+    backend: Backend, args: Namespace, parent: str | None
+) -> tuple[str | None, list[str]]:
+    """Track resolution for `work create <noun>`: derive, else enforce (track spec §4).
+
+    Explicit --track wins; else a tracked parent's derived track is inherited
+    (a track-less parent falls through); else enforcement decides. A repo with
+    no resolvable config behaves exactly as before the track layer existed
+    (criterion 17); an INVALID config skips the gate with a warning instead of
+    breaking `create` (spec §3: a broken config fails only the track layer).
+    """
+    try:
+        config = args.load_config()
+    except WorkError as not_configured:
+        if not_configured.code is not ErrorCode.NOT_CONFIGURED or args.track is not None:
+            raise
+        if not_configured.detail.get("reason") == "invalid":
+            return None, [f"track gate skipped: {not_configured.message}"]
+        return None, []
+    if args.track is not None:
+        require_known_track(args.track, config)
+        return args.track, []
+    warnings: list[str] = []
+    if parent is not None:
+        parent_track = derive_track(backend.get(parent).labels)
+        if parent_track is not None:
+            if parent_track in config.names:
+                return parent_track, []
+            # An out-of-vocabulary parent track (raw label writes) is never
+            # inherited: it would be invisible to list --track and
+            # unrepairable through track set. Fall through to enforcement.
+            warnings.append(
+                f"parent {parent} carries unknown track {parent_track!r}; not "
+                "inherited -- repair the parent via work track set"
+            )
+    if config.enforcement == "required":
+        raise WorkError(
+            ErrorCode.TRACK_REQUIRED,
+            "track is required: pass --track NAME or create under a parent with a "
+            f"configured track (configured tracks: {', '.join(config.names)})",
+        )
+    warnings.append("created untracked: no --track and no tracked parent (advisory mode)")
+    return None, warnings
+
+
+def _with_warnings(data: dict[str, JsonValue], warnings: list[str]) -> JsonValue:
+    if warnings:
+        data["warnings"] = list(warnings)
+    return data
+
+
 def _create_spec_container(
-    backend: Backend, args: Namespace, template: NounTemplate, parent: str | None
-) -> JsonValue:
+    backend: Backend,
+    args: Namespace,
+    template: NounTemplate,
+    parent: str | None,
+    track: str | None,
+) -> dict[str, JsonValue]:
     container_id = backend.create(
         CreateFields(
             title=args.title,
@@ -141,7 +213,8 @@ def _create_spec_container(
             type=template.bd_type,
             priority=args.priority,
             parent=parent,
-            labels=(template.shape_label, CREATING_SPEC_LABEL),
+            labels=(template.shape_label, CREATING_SPEC_LABEL)
+            + ((track_label(track),) if track is not None else ()),
             acceptance=args.acceptance,
         )
     )
@@ -153,7 +226,9 @@ def _create_spec_container(
     # container that is NOT `planned` and still carries `creating-spec`: it
     # self-reports into the Planning queue (visible) AND is finished by the sweep
     # through the handle (auto-recoverable). Both nets fire.
-    design_child_id, placeholder_id = finalize_spec_instantiation(backend, container_id, args.title)
+    design_child_id, placeholder_id = finalize_spec_instantiation(
+        backend, container_id, args.title, track
+    )
     return {"id": container_id, "design_child": design_child_id, "placeholder": placeholder_id}
 
 
@@ -166,13 +241,18 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     _check_duplicate_title(backend, args.title)
 
     parent = None if args.orphan else args.parent
+    track, warnings = _resolve_track(backend, args, parent)
 
     if noun is Noun.SPEC:
-        return _create_spec_container(backend, args, template, parent)
+        return _with_warnings(
+            _create_spec_container(backend, args, template, parent, track), warnings
+        )
 
     labels = [template.shape_label]
     if template.expects_evidence and (args.spec is not None or args.trivial):
         labels.append(SPEC_READY_LABEL)
+    if track is not None:
+        labels.append(track_label(track))
 
     new_id = backend.create(
         CreateFields(
@@ -187,4 +267,4 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     )
     if args.orphan:
         backend.append_note(new_id, ORPHAN_MARKER)
-    return {"id": new_id}
+    return _with_warnings({"id": new_id}, warnings)

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -33,9 +33,10 @@ def _raw_incompatible_flags(args: Namespace) -> list[str]:
 
     `create_raw` reads only title/description/type/priority/parent/labels; the
     positional noun and the lifecycle flags below (`--orphan`/`--spec`/
-    `--trivial`/`--acceptance`) are silently ignored under `--raw`. `--orphan`
-    in particular changes placement intent yet never records the orphan marker,
-    so an ignored combination is a surprising no-op rather than a harmless one.
+    `--trivial`/`--acceptance`/`--track`) are silently ignored under `--raw`.
+    `--orphan` in particular changes placement intent yet never records the
+    orphan marker, so an ignored combination is a surprising no-op rather than
+    a harmless one.
     """
     offenders: list[str] = []
     if args.noun is not None:
@@ -48,6 +49,8 @@ def _raw_incompatible_flags(args: Namespace) -> list[str]:
         offenders.append("--trivial")
     if args.acceptance is not None:
         offenders.append("--acceptance")
+    if args.track is not None:
+        offenders.append("--track")
     return offenders
 
 

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -25,6 +25,7 @@ from workcli.lifecycle.transitions import claim, plan, promote, release
 from workcli.verbs.read import list_, ready, search, show
 from workcli.verbs.relations import dep, label
 from workcli.verbs.syncing import sync
+from workcli.verbs.tracks import track
 from workcli.verbs.write import close, create_raw, note, reopen, update
 
 
@@ -100,6 +101,7 @@ VERBS: dict[str, Callable[[Backend, Namespace], JsonValue]] = {
     "dep": dep,
     "label": label,
     "sync": sync,
+    "track": track,
 }
 
 REQUIRED_CAPABILITY: dict[str, Callable[[Capabilities, Namespace], bool]] = {

--- a/packages/workcli/src/workcli/verbs/tracks.py
+++ b/packages/workcli/src/workcli/verbs/tracks.py
@@ -33,6 +33,30 @@ def _swap_track_label(
         backend.label_mutate("add", item_id, [target])
 
 
+def _cascade(
+    backend: Backend, root_id: str, previous: str | None, new_name: str
+) -> tuple[int, list[str]]:
+    """Relabel descendants on the root's PRE-change track (plus untracked ones);
+    skip-and-report everything else -- cross-track parenting is legal and a
+    descendant deliberately on another track is never clobbered (spec §4).
+    Whole-subtree traversal: a skipped child's own descendants are still
+    evaluated by the same one rule."""
+    relabeled = 0
+    skipped: list[str] = []
+    queue: list[str] = list(backend.get(root_id).children)
+    while queue:
+        child_id = queue.pop(0)
+        child = backend.get(child_id)
+        queue.extend(child.children)
+        child_track = derive_track(child.labels)
+        if child_track == previous or child_track is None:
+            _swap_track_label(backend, child.labels, child_id, new_name)
+            relabeled += 1
+        else:
+            skipped.append(child_id)
+    return relabeled, skipped
+
+
 def track(backend: Backend, args: Namespace) -> JsonValue:
     """Dispatch `work track ACTION`; v1 ships `set` only (argparse pins choices)."""
     config = args.load_config()
@@ -42,6 +66,8 @@ def track(backend: Backend, args: Namespace) -> JsonValue:
     _swap_track_label(backend, root.labels, args.id, args.name)
     relabeled = 0
     skipped: list[str] = []
+    if args.cascade:
+        relabeled, skipped = _cascade(backend, args.id, previous, args.name)
     return {
         "id": args.id,
         "track": args.name,

--- a/packages/workcli/src/workcli/verbs/tracks.py
+++ b/packages/workcli/src/workcli/verbs/tracks.py
@@ -1,0 +1,57 @@
+"""`work track set ID NAME [--cascade]` -- validated track reassignment.
+
+Its own verb family: `update` stays scalar-replace-only per the contract's
+layering (labels are not `UpdateFields`). The two underlying label operations
+are NOT transactional -- an interruption can leave the bead track-less, which
+lint invariant 1 surfaces (track spec §4: lint-recoverable, not atomic). Raw
+`work label add track:<anything>` stays possible and unvalidated by design:
+lint is the net, `track set` is the gate.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from workcli.backend import Backend
+from workcli.envelope import JsonValue
+from workcli.tracks import TRACK_PREFIX, derive_track, require_known_track, track_label
+
+
+def _swap_track_label(
+    backend: Backend, current_labels: list[str], item_id: str, new_name: str
+) -> None:
+    """Remove stale `track:*` labels, then add the target (spec §4 ordering:
+    a crash between the two leaves the bead track-less -- lint's case --
+    never double-tracked)."""
+    target = track_label(new_name)
+    stale = [
+        label for label in current_labels if label.startswith(TRACK_PREFIX) and label != target
+    ]
+    if stale:
+        backend.label_mutate("remove", item_id, stale)
+    if target not in current_labels:
+        backend.label_mutate("add", item_id, [target])
+
+
+def track(backend: Backend, args: Namespace) -> JsonValue:
+    """Dispatch `work track ACTION`; v1 ships `set` only (argparse pins choices)."""
+    config = args.load_config()
+    require_known_track(args.name, config)
+    root = backend.get(args.id)
+    previous = derive_track(root.labels)
+    _swap_track_label(backend, root.labels, args.id, args.name)
+    relabeled = 0
+    skipped: list[str] = []
+    return {
+        "id": args.id,
+        "track": args.name,
+        "previous": previous,
+        # Both COUNTS per the track spec's cascade contract ("reports
+        # relabeled and skipped counts"); skipped_ids carries the detail.
+        "relabeled": relabeled,
+        "skipped": len(skipped),
+        # list() wrap: a NAMED list[str] local is not assignable to a
+        # JsonValue slot under mypy --strict (invariance); the constructor
+        # call re-infers from context. Same idiom as the bd adapter.
+        "skipped_ids": list(skipped),
+    }

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -14,8 +14,21 @@ import json
 from tests.conftest import run_cli, run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.adapters.bd.runner import BdResult
-from workcli.envelope import ErrorCode
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
 from workcli.lifecycle import ORPHAN_MARKER
+
+
+def _not_found_config_loader(_explicit_path: str | None) -> TrackLayerConfig:
+    # These tests are byte-identical to pre-track-layer behavior (criterion
+    # 17): NOT_CONFIGURED/"not-found" makes the gate a no-op. Injecting a
+    # *valid* config would issue an unscripted `bd show <parent>` between
+    # `search` and `create` and break the call log below.
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
 
 
 def _create_result(new_id: str) -> BdResult:
@@ -63,7 +76,9 @@ def test_create_spike_with_parent_sends_search_then_one_create_call():
     )
 
     exit_code, envelope, _ = run_cli_with_runner(
-        ["create", "spike", "--title", "T", "--parent", "P"], runner
+        ["create", "spike", "--title", "T", "--parent", "P"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -96,7 +111,9 @@ def test_create_chore_with_orphan_creates_with_no_parent_and_records_orphan_note
     )
 
     exit_code, envelope, _ = run_cli_with_runner(
-        ["create", "chore", "--title", "T", "--orphan"], runner
+        ["create", "chore", "--title", "T", "--orphan"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -180,7 +197,9 @@ def test_create_feat_with_spec_evidence_adds_spec_ready_label():
     )
 
     exit_code, _, _ = run_cli_with_runner(
-        ["create", "feat", "--title", "T", "--parent", "P", "--spec", "S"], runner
+        ["create", "feat", "--title", "T", "--parent", "P", "--spec", "S"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -211,7 +230,9 @@ def test_create_feat_without_evidence_omits_spec_ready_label():
     )
 
     exit_code, _, _ = run_cli_with_runner(
-        ["create", "feat", "--title", "T", "--parent", "P"], runner
+        ["create", "feat", "--title", "T", "--parent", "P"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -242,7 +263,9 @@ def test_create_feat_with_trivial_adds_spec_ready_label():
     )
 
     exit_code, _, _ = run_cli_with_runner(
-        ["create", "feat", "--title", "T", "--parent", "P", "--trivial"], runner
+        ["create", "feat", "--title", "T", "--parent", "P", "--trivial"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -296,7 +319,9 @@ def test_create_epic_sends_one_create_with_epic_type_and_shape_label():
     )
 
     exit_code, envelope, _ = run_cli_with_runner(
-        ["create", "epic", "--title", "T", "--parent", "P"], runner
+        ["create", "epic", "--title", "T", "--parent", "P"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -341,7 +366,9 @@ def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
     )
 
     exit_code, envelope, _ = run_cli_with_runner(
-        ["create", "spec", "--title", "T", "--parent", "P"], runner
+        ["create", "spec", "--title", "T", "--parent", "P"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0
@@ -422,7 +449,9 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
     )
 
     exit_code, envelope, _ = run_cli_with_runner(
-        ["create", "spec", "--title", "T", "--orphan"], runner
+        ["create", "spec", "--title", "T", "--orphan"],
+        runner,
+        config_loader=_not_found_config_loader,
     )
 
     assert exit_code == 0

--- a/packages/workcli/tests/unit/test_create_track_gate.py
+++ b/packages/workcli/tests/unit/test_create_track_gate.py
@@ -1,0 +1,22 @@
+"""create track gate (track spec §4; criteria 1-5, 9, 17)."""
+
+from __future__ import annotations
+
+import json
+
+from tests.conftest import run_cli
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+
+
+def test_create_raw_refuses_track_flag() -> None:
+    # --raw is the documented track bypass; a silently-ignored --track would
+    # look tracked while creating an untracked bead. E_USAGE, creates nothing.
+    exit_code, envelope, _ = run_cli(
+        ["create", "--raw", "--title", "T", "--track", "alpha"], []
+    )
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "E_USAGE"
+    assert "--track" in str(error["message"])

--- a/packages/workcli/tests/unit/test_create_track_gate.py
+++ b/packages/workcli/tests/unit/test_create_track_gate.py
@@ -3,20 +3,244 @@
 from __future__ import annotations
 
 import json
+from argparse import Namespace
+
+import pytest
 
 from tests.conftest import run_cli
+from tests.fake_backend import FakeBackend
 from tests.fakes import ScriptedStep
 from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+from workcli.lifecycle.create import create_noun, instantiate_spec_shape
 
 
 def test_create_raw_refuses_track_flag() -> None:
     # --raw is the documented track bypass; a silently-ignored --track would
     # look tracked while creating an untracked bead. E_USAGE, creates nothing.
-    exit_code, envelope, _ = run_cli(
-        ["create", "--raw", "--title", "T", "--track", "alpha"], []
-    )
+    exit_code, envelope, _ = run_cli(["create", "--raw", "--title", "T", "--track", "alpha"], [])
     assert exit_code == 1
     error = envelope["error"]
     assert isinstance(error, dict)
     assert error["code"] == "E_USAGE"
     assert "--track" in str(error["message"])
+
+
+def _config(enforcement: str) -> TrackLayerConfig:
+    return TrackLayerConfig(
+        names=("alpha", "beta"),
+        organizing_only=(),
+        enforcement=enforcement,
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+    )
+
+
+def _create_args(
+    *,
+    noun: str = "chore",
+    parent: str | None = None,
+    track: str | None = None,
+    load_config: object,
+) -> Namespace:
+    return Namespace(
+        noun=noun,
+        raw=False,
+        title="New work",
+        description=None,
+        type=None,
+        priority=None,
+        parent=parent,
+        label=[],
+        orphan=parent is None,
+        spec=None,
+        trivial=False,
+        acceptance=None,
+        track=track,
+        load_config=load_config,
+    )
+
+
+@pytest.mark.parametrize("enforcement", ["advisory", "required"])
+def test_tracked_parent_inherits_track_without_flag(enforcement: str) -> None:
+    backend = FakeBackend()
+    backend.add("epic-1", type="epic", labels=["track:alpha"])
+    data = create_noun(
+        backend,
+        _create_args(parent="epic-1", load_config=lambda: _config(enforcement)),
+    )
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    assert "track:alpha" in backend.labels(new_id)
+    assert "warnings" not in data
+
+
+def test_required_mode_underivable_fails_and_creates_nothing() -> None:
+    backend = FakeBackend()
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(load_config=lambda: _config("required")))
+    assert exc_info.value.code is ErrorCode.TRACK_REQUIRED
+    assert backend.ids() == []
+
+
+@pytest.mark.parametrize("enforcement", ["advisory"])
+def test_advisory_underivable_succeeds_untracked_with_warning(enforcement: str) -> None:
+    # Criterion 4's create leg rides on config parsing: an omitted enforcement
+    # key already parses to "advisory" (test_config_loading), so this single
+    # behavior covers both spellings.
+    backend = FakeBackend()
+    data = create_noun(backend, _create_args(load_config=lambda: _config(enforcement)))
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    assert all(not label.startswith("track:") for label in backend.labels(new_id))
+    warnings = data["warnings"]
+    assert isinstance(warnings, list)
+    assert any("untracked" in str(warning) for warning in warnings)
+
+
+def test_unknown_track_flag_fails_with_vocabulary() -> None:
+    backend = FakeBackend()
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(
+            backend,
+            _create_args(track="gamma", load_config=lambda: _config("advisory")),
+        )
+    assert exc_info.value.code is ErrorCode.UNKNOWN_TRACK
+    assert "alpha" in exc_info.value.message
+    assert backend.ids() == []
+
+
+def test_explicit_track_flag_wins_over_parent() -> None:
+    backend = FakeBackend()
+    backend.add("epic-1", type="epic", labels=["track:alpha"])
+    data = create_noun(
+        backend,
+        _create_args(parent="epic-1", track="beta", load_config=lambda: _config("required")),
+    )
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    assert "track:beta" in backend.labels(new_id)
+
+
+def _not_found_loader() -> TrackLayerConfig:
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
+
+
+def _invalid_loader() -> TrackLayerConfig:
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: malformed TOML in project-config.toml",
+        detail={"reason": "invalid"},
+    )
+
+
+def test_unconfigured_repo_creates_exactly_as_before() -> None:
+    backend = FakeBackend()
+    data = create_noun(backend, _create_args(load_config=_not_found_loader))
+    assert isinstance(data, dict)
+    assert "warnings" not in data
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    assert all(not label.startswith("track:") for label in backend.labels(new_id))
+
+
+def test_unconfigured_repo_fails_explicit_track_flag() -> None:
+    backend = FakeBackend()
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(track="alpha", load_config=_not_found_loader))
+    assert exc_info.value.code is ErrorCode.NOT_CONFIGURED
+    assert backend.ids() == []
+
+
+def test_invalid_config_skips_gate_with_warning_never_breaks_create() -> None:
+    backend = FakeBackend()
+    data = create_noun(backend, _create_args(load_config=_invalid_loader))
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    warnings = data["warnings"]
+    assert isinstance(warnings, list)
+    assert any("track gate skipped" in str(warning) for warning in warnings)
+
+
+def test_raw_milestone_create_bypasses_gate_even_in_required_mode() -> None:
+    # Milestones are track-exempt (track spec §3) and enter via --raw; the
+    # gate must not touch this path regardless of enforcement. The exploding
+    # loader proves --raw never even loads config.
+    def explode(_explicit_path: str | None) -> TrackLayerConfig:
+        raise AssertionError("--raw create must not load config")
+
+    step = ScriptedStep(
+        ("create",),
+        BdResult(returncode=0, stdout=json.dumps({"id": "w-9"}), stderr=""),
+    )
+    exit_code, envelope, _ = run_cli(
+        ["create", "--raw", "--title", "M9", "--type", "milestone"],
+        [step],
+        config_loader=explode,
+    )
+    assert exit_code == 0
+    assert envelope["ok"] is True
+
+
+def test_spec_container_children_inherit_resolved_track() -> None:
+    backend = FakeBackend()
+    backend.add("epic-1", type="epic", labels=["track:alpha"])
+    data = create_noun(
+        backend,
+        _create_args(noun="spec", parent="epic-1", load_config=lambda: _config("advisory")),
+    )
+    assert isinstance(data, dict)
+    for key in ("id", "design_child", "placeholder"):
+        bead_id = data[key]
+        assert isinstance(bead_id, str)
+        assert "track:alpha" in backend.labels(bead_id)
+
+
+def test_unknown_parent_track_not_inherited_advisory_warns() -> None:
+    backend = FakeBackend()
+    backend.add("epic-1", type="epic", labels=["track:ghost"])
+    data = create_noun(
+        backend, _create_args(parent="epic-1", load_config=lambda: _config("advisory"))
+    )
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    assert all(not label.startswith("track:") for label in backend.labels(new_id))
+    warnings = data["warnings"]
+    assert isinstance(warnings, list)
+    assert any("ghost" in str(warning) for warning in warnings)
+
+
+def test_unknown_parent_track_required_mode_refuses() -> None:
+    # required mode must not mint a bead whose track is invisible to
+    # list --track and unrepairable via track set.
+    backend = FakeBackend()
+    backend.add("epic-1", type="epic", labels=["track:ghost"])
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(parent="epic-1", load_config=lambda: _config("required")))
+    assert exc_info.value.code is ErrorCode.TRACK_REQUIRED
+    assert backend.ids() == ["epic-1"]
+
+
+def test_replayed_instantiation_on_tracked_container_stamps_children() -> None:
+    # The reconcile/promote path calls instantiate_spec_shape with no track;
+    # a tracked container's children must inherit its derived track anyway,
+    # or an interrupted tracked create replays into lint violations.
+    backend = FakeBackend()
+    backend.add(
+        "cont-1",
+        type="feature",
+        labels=["shape-spec", "creating-spec", "track:alpha"],
+    )
+    design_id, placeholder_id = instantiate_spec_shape(backend, "cont-1", "T")
+    assert "track:alpha" in backend.labels(design_id)
+    assert "track:alpha" in backend.labels(placeholder_id)

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -12,6 +12,7 @@ belong to that verb's own granular test file (`test_show_normalization.py`,
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,7 +22,20 @@ from tests.conftest import run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli import PROTOCOL_VERSION
 from workcli.adapters.bd.runner import BdResult
-from workcli.envelope import ErrorCode
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+
+
+def _not_found_config_loader(_explicit_path: str | None) -> TrackLayerConfig:
+    # Byte-identical to pre-track-layer behavior (criterion 17): keeps the
+    # lifecycle `create_noun` case from making an unscripted `bd show
+    # <parent>` call against this repo's own real project-config.toml.
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
+
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
 
@@ -101,6 +115,7 @@ class VerbCase:
     success_steps: list[ScriptedStep]
     failure_argv: list[str]
     failure_steps: list[ScriptedStep]
+    config_loader: Callable[[str | None], TrackLayerConfig] | None = None
 
 
 VERB_CASES: list[VerbCase] = [
@@ -219,6 +234,7 @@ VERB_CASES: list[VerbCase] = [
         ],
         ["create", "feat", "--title", "Existing Feature", "--parent", "P"],
         [ScriptedStep(("search",), _search_result(_item_raw("f.9", "Existing Feature")))],
+        config_loader=_not_found_config_loader,
     ),
     VerbCase(
         "claim",
@@ -308,14 +324,18 @@ VERB_CASES: list[VerbCase] = [
 TYPED_ERROR_CODES = {str(code) for code in ErrorCode}
 
 
-def _assert_stdout_is_exactly_one_envelope(runner: ScriptedBdRunner, argv: list[str]) -> dict:
+def _assert_stdout_is_exactly_one_envelope(
+    runner: ScriptedBdRunner,
+    argv: list[str],
+    config_loader: Callable[[str | None], TrackLayerConfig] | None = None,
+) -> dict:
     from io import StringIO
 
     from workcli.cli import main
 
     out = StringIO()
     err = StringIO()
-    exit_code = main(argv, runner=runner, out=out, err=err)
+    exit_code = main(argv, runner=runner, out=out, err=err, config_loader=config_loader)
     stdout_text = out.getvalue()
     # Exactly one JSON value on stdout, nothing before or after it: a
     # trailing newline is the only thing besides the envelope permitted.
@@ -329,7 +349,9 @@ def _assert_stdout_is_exactly_one_envelope(runner: ScriptedBdRunner, argv: list[
 @pytest.mark.parametrize("case", VERB_CASES, ids=lambda c: c.verb)
 def test_success_case_yields_a_uniform_ok_envelope(case: VerbCase) -> None:
     runner = ScriptedBdRunner(steps=list(case.success_steps))
-    exit_code, envelope = _assert_stdout_is_exactly_one_envelope(runner, case.success_argv)
+    exit_code, envelope = _assert_stdout_is_exactly_one_envelope(
+        runner, case.success_argv, case.config_loader
+    )
 
     assert exit_code == 0
     assert envelope["protocol"] == PROTOCOL_VERSION
@@ -340,7 +362,9 @@ def test_success_case_yields_a_uniform_ok_envelope(case: VerbCase) -> None:
 @pytest.mark.parametrize("case", VERB_CASES, ids=lambda c: c.verb)
 def test_failure_case_yields_a_uniform_error_envelope(case: VerbCase) -> None:
     runner = ScriptedBdRunner(steps=list(case.failure_steps))
-    exit_code, envelope = _assert_stdout_is_exactly_one_envelope(runner, case.failure_argv)
+    exit_code, envelope = _assert_stdout_is_exactly_one_envelope(
+        runner, case.failure_argv, case.config_loader
+    )
 
     assert exit_code == 1
     assert envelope["protocol"] == PROTOCOL_VERSION
@@ -360,5 +384,7 @@ def test_protocol_version_data_matches_every_other_verbs_protocol_field() -> Non
 
     for case in VERB_CASES:
         runner = ScriptedBdRunner(steps=list(case.success_steps))
-        _, envelope = _assert_stdout_is_exactly_one_envelope(runner, case.success_argv)
+        _, envelope = _assert_stdout_is_exactly_one_envelope(
+            runner, case.success_argv, case.config_loader
+        )
         assert envelope["protocol"] == handshake_envelope["data"]["protocol"]

--- a/packages/workcli/tests/unit/test_track_set.py
+++ b/packages/workcli/tests/unit/test_track_set.py
@@ -1,0 +1,75 @@
+"""work track set: validated label swap; cascade in Task 10 (criteria 6-7)."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+from workcli.verbs.tracks import track
+
+from tests.fake_backend import FakeBackend
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+
+CONFIG = TrackLayerConfig(
+    names=("alpha", "beta"),
+    organizing_only=(),
+    enforcement="advisory",
+    milestone_wip_cap=None,
+    wip_exempt_milestones=(),
+)
+
+
+def _track_args(item_id: str, name: str, *, cascade: bool = False) -> Namespace:
+    return Namespace(
+        action="set",
+        id=item_id,
+        name=name,
+        cascade=cascade,
+        load_config=lambda: CONFIG,
+    )
+
+
+def _track_labels(backend: FakeBackend, item_id: str) -> list[str]:
+    return [label for label in backend.labels(item_id) if label.startswith("track:")]
+
+
+def test_set_swaps_to_exactly_one_track_label() -> None:
+    backend = FakeBackend()
+    backend.add("w-1", labels=["planned", "track:alpha"])
+    data = track(backend, _track_args("w-1", "beta"))
+    assert _track_labels(backend, "w-1") == ["track:beta"]
+    assert "planned" in backend.labels(backend.ids()[0])
+    assert isinstance(data, dict)
+    assert data["previous"] == "alpha"
+
+
+def test_set_on_untracked_bead_is_a_pure_add() -> None:
+    backend = FakeBackend()
+    backend.add("w-1", labels=["planned"])
+    data = track(backend, _track_args("w-1", "alpha"))
+    assert _track_labels(backend, "w-1") == ["track:alpha"]
+    assert isinstance(data, dict)
+    assert data["previous"] is None
+
+
+def test_set_heals_a_multi_label_bead_to_exactly_one() -> None:
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:alpha", "track:beta"])
+    track(backend, _track_args("w-1", "alpha"))
+    assert _track_labels(backend, "w-1") == ["track:alpha"]
+
+
+def test_unknown_name_fails_and_mutates_nothing() -> None:
+    backend = FakeBackend()
+    backend.add("w-1", labels=["track:alpha"])
+    with pytest.raises(WorkError) as exc_info:
+        track(backend, _track_args("w-1", "gamma"))
+    assert exc_info.value.code is ErrorCode.UNKNOWN_TRACK
+    assert _track_labels(backend, "w-1") == ["track:alpha"]
+
+
+def test_missing_bead_is_not_found() -> None:
+    with pytest.raises(WorkError) as exc_info:
+        track(FakeBackend(), _track_args("ghost", "alpha"))
+    assert exc_info.value.code is ErrorCode.NOT_FOUND

--- a/packages/workcli/tests/unit/test_track_set.py
+++ b/packages/workcli/tests/unit/test_track_set.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from argparse import Namespace
 
 import pytest
-from workcli.verbs.tracks import track
 
 from tests.fake_backend import FakeBackend
 from workcli.config import TrackLayerConfig
 from workcli.envelope import ErrorCode, WorkError
+from workcli.verbs.tracks import track
 
 CONFIG = TrackLayerConfig(
     names=("alpha", "beta"),
@@ -73,3 +73,57 @@ def test_missing_bead_is_not_found() -> None:
     with pytest.raises(WorkError) as exc_info:
         track(FakeBackend(), _track_args("ghost", "alpha"))
     assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
+def _tree_backend() -> FakeBackend:
+    """root(alpha) -> child-same(alpha), child-other(beta), child-untracked;
+    child-other -> grandchild-same(alpha) [cross-track subtrees still traversed]."""
+    backend = FakeBackend()
+    backend.add("root", labels=["track:alpha"])
+    backend.add("child-same", parent="root", labels=["track:alpha"])
+    backend.add("child-other", parent="root", labels=["track:beta"])
+    backend.add("child-untracked", parent="root", labels=[])
+    backend.add("grandchild-same", parent="child-other", labels=["track:alpha"])
+    return backend
+
+
+def test_cascade_relabels_matching_and_untracked_skips_other_tracks() -> None:
+    backend = _tree_backend()
+    data = track(backend, _track_args("root", "beta", cascade=True))
+    assert _track_labels(backend, "child-same") == ["track:beta"]
+    assert _track_labels(backend, "child-untracked") == ["track:beta"]
+    assert _track_labels(backend, "grandchild-same") == ["track:beta"]
+    assert _track_labels(backend, "child-other") == ["track:beta"]  # already the target
+    assert isinstance(data, dict)
+    assert data["relabeled"] == 3
+    assert data["skipped"] == 1
+    assert data["skipped_ids"] == ["child-other"]
+
+
+def test_cascade_skips_and_reports_descendants_on_a_third_track() -> None:
+    backend = FakeBackend()
+    backend.add("root", labels=["track:alpha"])
+    backend.add("child-loyal", parent="root", labels=["track:beta"])
+    data = track(
+        backend,
+        Namespace(
+            action="set",
+            id="root",
+            name="alpha",
+            cascade=True,
+            load_config=lambda: CONFIG,
+        ),
+    )
+    # Deliberately-cross-track child is never clobbered, only reported.
+    assert _track_labels(backend, "child-loyal") == ["track:beta"]
+    assert isinstance(data, dict)
+    assert data["relabeled"] == 0
+    assert data["skipped"] == 1
+    assert data["skipped_ids"] == ["child-loyal"]
+
+
+def test_without_cascade_descendants_are_untouched() -> None:
+    backend = _tree_backend()
+    track(backend, _track_args("root", "beta"))
+    assert _track_labels(backend, "child-same") == ["track:alpha"]
+    assert _track_labels(backend, "child-untracked") == []


### PR DESCRIPTION
## Summary
- Slice B of the workcli track-partition layer: `create --track` flag plumbing (`--raw` refuses it), the create-time track-resolution gate (derive from explicit flag or tracked parent, else enforce advisory/required per repo config), and `work track set ID NAME [--cascade]` for post-hoc reassignment.
- The gate covers spec-noun containers (stamps the resolved track on both template children) and the crash-replay/promote/reconcile path (a tracked container self-derives its track for children when none is passed).
- Cascade relabels descendants matching the root's PRE-change track (or untracked); anything else is skipped and reported, never clobbered — closed descendants are included since the spec exempts closed beads from invariants, not from an explicit human-invoked relabel.
- Implements Tasks 7-10 of docs/plans/2026-07-17-workcli-track-layer.md against docs/specs/2026-07-15-workcli-track-partition-design.md §4 (criteria 1-7, 9's create leg).
- Bead: agents-config-ey4rl.

## Test plan
- [x] `make ci-workcli` green: 451 tests, mypy --strict clean, 99.28% branch coverage, pip-audit clean, entry verify
- [x] Full diff reviewed against the plan task-by-task

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>