### PR TITLE
feat(workcli): work triggers — extraction pressure/eligibility evaluation

### DIFF
--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -173,6 +173,7 @@ def _add_report_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser
         "graph", help="bulk node/edge export for visualization consumers"
     )
     graph_parser.add_argument("--json", action="store_true", dest="json_output")
+    subparsers.add_parser("triggers", help="extraction pressure/eligibility per track (advisory)")
 
 
 def _add_sync_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:

--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -32,6 +32,14 @@ class TrackLayerConfig:
         int | None
     )  # None: [operating-model] absent/key omitted -> lint skips WIP check
     wip_exempt_milestones: tuple[str, ...]
+    extraction_max_track_backlog: (
+        int | None
+    )  # None: [extraction.pressure] absent/key omitted -> backlog pressure never fires
+    extraction_external_consumer_tracks: tuple[str, ...]
+    extraction_independent_release_tracks: tuple[str, ...]
+    extraction_max_cross_track_edges: (
+        int | None
+    )  # None: [extraction.eligibility] absent/key omitted -> eligibility never proven (fail-safe)
 
 
 def _not_configured(problem: str, reason: Reason) -> WorkError:
@@ -146,10 +154,54 @@ def _validate(raw: dict[str, object], path: Path) -> TrackLayerConfig:
         "[operating-model].wip-exempt-milestones",
         path,
     )
+    extraction = raw.get("extraction")
+    if extraction is not None and not isinstance(extraction, dict):
+        raise _not_configured(f"[extraction] must be a table in {path}", "invalid")
+    extraction_table = extraction if isinstance(extraction, dict) else {}
+
+    pressure = extraction_table.get("pressure")
+    if pressure is not None and not isinstance(pressure, dict):
+        raise _not_configured(f"[extraction.pressure] must be a table in {path}", "invalid")
+    pressure_table = pressure if isinstance(pressure, dict) else {}
+    max_track_backlog = pressure_table.get("max-track-backlog")
+    if max_track_backlog is not None and (
+        isinstance(max_track_backlog, bool) or not isinstance(max_track_backlog, int)
+    ):
+        raise _not_configured(
+            f"[extraction.pressure].max-track-backlog must be an integer in {path}", "invalid"
+        )
+    external_consumer_tracks = _string_tuple(
+        pressure_table.get("external-consumer-tracks", []),
+        "[extraction.pressure].external-consumer-tracks",
+        path,
+    )
+    independent_release_tracks = _string_tuple(
+        pressure_table.get("independent-release-tracks", []),
+        "[extraction.pressure].independent-release-tracks",
+        path,
+    )
+
+    eligibility = extraction_table.get("eligibility")
+    if eligibility is not None and not isinstance(eligibility, dict):
+        raise _not_configured(f"[extraction.eligibility] must be a table in {path}", "invalid")
+    eligibility_table = eligibility if isinstance(eligibility, dict) else {}
+    max_cross_track_edges = eligibility_table.get("max-cross-track-edges")
+    if max_cross_track_edges is not None and (
+        isinstance(max_cross_track_edges, bool) or not isinstance(max_cross_track_edges, int)
+    ):
+        raise _not_configured(
+            f"[extraction.eligibility].max-cross-track-edges must be an integer in {path}",
+            "invalid",
+        )
+
     return TrackLayerConfig(
         names=names,
         organizing_only=organizing_only,
         enforcement=str(enforcement),
         milestone_wip_cap=cap,
         wip_exempt_milestones=exempt,
+        extraction_max_track_backlog=max_track_backlog,
+        extraction_external_consumer_tracks=external_consumer_tracks,
+        extraction_independent_release_tracks=independent_release_tracks,
+        extraction_max_cross_track_edges=max_cross_track_edges,
     )

--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -175,11 +175,25 @@ def _validate(raw: dict[str, object], path: Path) -> TrackLayerConfig:
         "[extraction.pressure].external-consumer-tracks",
         path,
     )
+    unknown_external_consumer = [name for name in external_consumer_tracks if name not in names]
+    if unknown_external_consumer:
+        raise _not_configured(
+            "[extraction.pressure].external-consumer-tracks entries not in names: "
+            f"{unknown_external_consumer} in {path}",
+            "invalid",
+        )
     independent_release_tracks = _string_tuple(
         pressure_table.get("independent-release-tracks", []),
         "[extraction.pressure].independent-release-tracks",
         path,
     )
+    unknown_independent_release = [name for name in independent_release_tracks if name not in names]
+    if unknown_independent_release:
+        raise _not_configured(
+            "[extraction.pressure].independent-release-tracks entries not in names: "
+            f"{unknown_independent_release} in {path}",
+            "invalid",
+        )
 
     eligibility = extraction_table.get("eligibility")
     if eligibility is not None and not isinstance(eligibility, dict):

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -24,7 +24,7 @@ from workcli.lifecycle.reconcile import reconcile
 from workcli.lifecycle.transitions import claim, plan, promote, release
 from workcli.verbs.read import list_, ready, search, show
 from workcli.verbs.relations import dep, label
-from workcli.verbs.report import graph, lint
+from workcli.verbs.report import graph, lint, triggers
 from workcli.verbs.syncing import sync
 from workcli.verbs.tracks import track
 from workcli.verbs.write import close, create_raw, note, reopen, update
@@ -105,6 +105,7 @@ VERBS: dict[str, Callable[[Backend, Namespace], JsonValue]] = {
     "track": track,
     "lint": lint,
     "graph": graph,
+    "triggers": triggers,
 }
 
 REQUIRED_CAPABILITY: dict[str, Callable[[Capabilities, Namespace], bool]] = {

--- a/packages/workcli/src/workcli/verbs/report.py
+++ b/packages/workcli/src/workcli/verbs/report.py
@@ -1,9 +1,12 @@
-"""`work lint` + `work graph --json` -- the repo-wide reporting verbs.
+"""`work lint` + `work graph --json` + `work triggers` -- the repo-wide
+reporting verbs.
 
-Both are defined as aggregations over tracks (track spec §4's
+All three are defined as aggregations over tracks (track spec §4's
 split-portability rule): one sweep, pure reducers, no single-DB semantics in
 the contract. Advisory in v1: lint always exits 0 (spec §9 defers CI-gating);
-violations live in the envelope, not the exit code.
+violations live in the envelope, not the exit code. `triggers` (spec §5) is
+likewise advisory-only -- it evaluates extraction pressure/eligibility and
+never edits config or splits anything.
 """
 
 from __future__ import annotations
@@ -202,3 +205,100 @@ def graph(backend: Backend, args: Namespace) -> JsonValue:
             edges.append({"from": node_item.id, "to": node_item.parent, "type": "parent-child"})
 
     return {"nodes": [_node(item) for item in (*items, *ancestors)], "edges": edges}
+
+
+def _backlog_counts(swept: list[Item], config: TrackLayerConfig) -> dict[str, int]:
+    """Every configured track name -> count of non-closed beads whose derived
+    track equals it (spec §4). Beads with zero or 2+ track labels derive to
+    `None` and count toward no track -- lint invariant 1 is the net for those."""
+    counts = dict.fromkeys(config.names, 0)
+    for item in swept:
+        track_name = derive_track(item.labels)
+        if track_name in counts:
+            counts[track_name] += 1
+    return counts
+
+
+def _cross_track_edge_counts(
+    backend: Backend, items: list[Item], by_id: dict[str, Item]
+) -> dict[str, int]:
+    """Spec §5: for every raw (non-parent-child) dep edge between two
+    non-closed beads whose tracks differ, +1 to each endpoint's track total --
+    both directions counted independently via the two endpoints of one edge.
+    A dep target outside the sweep (closed, or absent from the batch) is
+    resolved with `backend.get()`; a closed endpoint excludes the edge
+    entirely, mirroring `graph()`'s `_closed_ancestors` fetch-on-miss pattern."""
+    resolved: dict[str, Item] = {}
+    counts: dict[str, int] = {}
+    for item in items:
+        from_track = derive_track(item.labels)
+        if from_track is None:
+            continue
+        for edge in item.deps:
+            to_item = by_id.get(edge.id)
+            if to_item is None:
+                if edge.id not in resolved:
+                    resolved[edge.id] = backend.get(edge.id)
+                to_item = resolved[edge.id]
+            if to_item.status == "closed":
+                continue
+            to_track = derive_track(to_item.labels)
+            if to_track is None or to_track == from_track:
+                continue
+            counts[from_track] = counts.get(from_track, 0) + 1
+            counts[to_track] = counts.get(to_track, 0) + 1
+    return counts
+
+
+def _extraction_status(*, pressure: bool, eligible: bool) -> str:
+    if not pressure:
+        return "no-pressure"
+    return "pressured-eligible" if eligible else "pressured-ineligible"
+
+
+def _review_question(config: TrackLayerConfig) -> str:
+    external = ", ".join(config.extraction_external_consumer_tracks)
+    independent = ", ".join(config.extraction_independent_release_tracks)
+    return (
+        "Still accurate? external-consumer-tracks: "
+        f"[{external}]; independent-release-tracks: [{independent}]"
+    )
+
+
+def triggers(backend: Backend, args: Namespace) -> JsonValue:
+    """`work triggers` -- extraction pressure/eligibility per track (track
+    spec §5, criterion 13). Organizing-only tracks appear in `backlog_counts`
+    but never receive an extraction status. An unconfigured eligibility
+    ceiling (`max-cross-track-edges` omitted) can never prove eligibility --
+    a deliberate fail-safe, never a false `pressured-eligible`."""
+    config = args.load_config()
+    swept = _sweep(backend)
+    items = backend.batch_get([item.id for item in swept])  # full detail: deps
+    by_id = {item.id: item for item in items}
+    backlog_counts = _backlog_counts(swept, config)
+    edge_counts = _cross_track_edge_counts(backend, items, by_id)
+
+    statuses: dict[str, JsonValue] = {}
+    for name in config.names:
+        if name in config.organizing_only:
+            continue
+        over_backlog_cap = (
+            config.extraction_max_track_backlog is not None
+            and backlog_counts[name] > config.extraction_max_track_backlog
+        )
+        pressure = (
+            over_backlog_cap
+            or name in config.extraction_external_consumer_tracks
+            or name in config.extraction_independent_release_tracks
+        )
+        eligible = (
+            config.extraction_max_cross_track_edges is not None
+            and edge_counts.get(name, 0) <= config.extraction_max_cross_track_edges
+        )
+        statuses[name] = _extraction_status(pressure=pressure, eligible=eligible)
+
+    return {
+        "backlog_counts": dict(backlog_counts.items()),
+        "statuses": statuses,
+        "review_question": _review_question(config),
+    }

--- a/packages/workcli/src/workcli/verbs/report.py
+++ b/packages/workcli/src/workcli/verbs/report.py
@@ -277,6 +277,11 @@ def triggers(backend: Backend, args: Namespace) -> JsonValue:
     by_id = {item.id: item for item in items}
     backlog_counts = _backlog_counts(swept, config)
     edge_counts = _cross_track_edge_counts(backend, items, by_id)
+    # Densify to every configured track (same shape as backlog_counts) so a
+    # track with zero cross-track edges reports 0, not an absent key --
+    # callers triaging a pressured-ineligible track need the actual count,
+    # not just the three-state reduction (Codex finding).
+    cross_track_edges = {name: edge_counts.get(name, 0) for name in config.names}
 
     statuses: dict[str, JsonValue] = {}
     for name in config.names:
@@ -293,12 +298,13 @@ def triggers(backend: Backend, args: Namespace) -> JsonValue:
         )
         eligible = (
             config.extraction_max_cross_track_edges is not None
-            and edge_counts.get(name, 0) <= config.extraction_max_cross_track_edges
+            and cross_track_edges[name] <= config.extraction_max_cross_track_edges
         )
         statuses[name] = _extraction_status(pressure=pressure, eligible=eligible)
 
     return {
         "backlog_counts": dict(backlog_counts.items()),
+        "cross_track_edges": dict(cross_track_edges.items()),
         "statuses": statuses,
         "review_question": _review_question(config),
     }

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -176,3 +176,107 @@ def test_git_file_marker_counts_as_root(tmp_path: Path) -> None:
     (root / "project-config.toml").write_text(VALID_TRACKS, encoding="utf-8")
 
     assert load_config(root).names == ("alpha", "beta", "gamma")
+
+
+# -- [extraction.pressure] / [extraction.eligibility] (extraction policy §5) --
+
+
+def test_extraction_tables_absent_yield_safe_defaults(tmp_path: Path) -> None:
+    root = _repo(tmp_path, config_text='[tracks]\nnames = ["alpha"]\n')
+    config = load_config(root)
+    assert config.extraction_max_track_backlog is None
+    assert config.extraction_external_consumer_tracks == ()
+    assert config.extraction_independent_release_tracks == ()
+    assert config.extraction_max_cross_track_edges is None
+
+
+def test_extraction_pressure_and_eligibility_parsed(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text="""
+[tracks]
+names = ["alpha", "beta"]
+
+[extraction.pressure]
+max-track-backlog = 100
+external-consumer-tracks = ["alpha"]
+independent-release-tracks = ["beta"]
+
+[extraction.eligibility]
+max-cross-track-edges = 3
+""",
+    )
+    config = load_config(root)
+    assert config.extraction_max_track_backlog == 100
+    assert config.extraction_external_consumer_tracks == ("alpha",)
+    assert config.extraction_independent_release_tracks == ("beta",)
+    assert config.extraction_max_cross_track_edges == 3
+
+
+def test_non_table_extraction_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='extraction = "bad"\n[tracks]\nnames = ["alpha"]\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "[extraction]" in exc_info.value.message
+
+
+def test_non_table_extraction_pressure_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n[extraction]\npressure = "bad"\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "[extraction.pressure]" in exc_info.value.message
+
+
+def test_non_table_extraction_eligibility_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n[extraction]\neligibility = "bad"\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "[extraction.eligibility]" in exc_info.value.message
+
+
+def test_max_track_backlog_bool_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n'
+        "[extraction.pressure]\nmax-track-backlog = true\n",
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "max-track-backlog" in exc_info.value.message
+
+
+def test_max_cross_track_edges_bool_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n'
+        "[extraction.eligibility]\nmax-cross-track-edges = false\n",
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "max-cross-track-edges" in exc_info.value.message
+
+
+def test_external_consumer_tracks_non_list_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n'
+        '[extraction.pressure]\nexternal-consumer-tracks = "alpha"\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "external-consumer-tracks" in exc_info.value.message

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -213,6 +213,35 @@ max-cross-track-edges = 3
     assert config.extraction_max_cross_track_edges == 3
 
 
+def test_external_consumer_tracks_outside_names_is_invalid(tmp_path: Path) -> None:
+    # REGRESSION PIN (Codex finding): a typo'd track name in a declared
+    # pressure list must fail loud, not silently produce zero pressure
+    # signal -- mirrors [tracks].organizing-only's existing vocabulary check.
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n'
+        '[extraction.pressure]\nexternal-consumer-tracks = ["prgoom"]\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "external-consumer-tracks" in exc_info.value.message
+    assert "prgoom" in exc_info.value.message
+
+
+def test_independent_release_tracks_outside_names_is_invalid(tmp_path: Path) -> None:
+    root = _repo(
+        tmp_path,
+        config_text='[tracks]\nnames = ["alpha"]\n'
+        '[extraction.pressure]\nindependent-release-tracks = ["ghost"]\n',
+    )
+    with pytest.raises(WorkError) as exc_info:
+        load_config(root)
+    assert exc_info.value.detail["reason"] == "invalid"
+    assert "independent-release-tracks" in exc_info.value.message
+    assert "ghost" in exc_info.value.message
+
+
 def test_non_table_extraction_is_invalid(tmp_path: Path) -> None:
     root = _repo(
         tmp_path,

--- a/packages/workcli/tests/unit/test_create_track_gate.py
+++ b/packages/workcli/tests/unit/test_create_track_gate.py
@@ -34,6 +34,10 @@ def _config(enforcement: str) -> TrackLayerConfig:
         enforcement=enforcement,
         milestone_wip_cap=None,
         wip_exempt_milestones=(),
+        extraction_max_track_backlog=None,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=None,
     )
 
 

--- a/packages/workcli/tests/unit/test_graph.py
+++ b/packages/workcli/tests/unit/test_graph.py
@@ -21,6 +21,10 @@ CONFIG = TrackLayerConfig(
     enforcement="advisory",
     milestone_wip_cap=None,
     wip_exempt_milestones=(),
+    extraction_max_track_backlog=None,
+    extraction_external_consumer_tracks=(),
+    extraction_independent_release_tracks=(),
+    extraction_max_cross_track_edges=None,
 )
 
 

--- a/packages/workcli/tests/unit/test_lint.py
+++ b/packages/workcli/tests/unit/test_lint.py
@@ -19,6 +19,10 @@ CONFIG = TrackLayerConfig(
     enforcement="advisory",
     milestone_wip_cap=1,
     wip_exempt_milestones=("m-exempt",),
+    extraction_max_track_backlog=None,
+    extraction_external_consumer_tracks=(),
+    extraction_independent_release_tracks=(),
+    extraction_max_cross_track_edges=None,
 )
 
 

--- a/packages/workcli/tests/unit/test_list_track_filter.py
+++ b/packages/workcli/tests/unit/test_list_track_filter.py
@@ -21,6 +21,10 @@ CONFIG = TrackLayerConfig(
     enforcement="advisory",
     milestone_wip_cap=None,
     wip_exempt_milestones=(),
+    extraction_max_track_backlog=None,
+    extraction_external_consumer_tracks=(),
+    extraction_independent_release_tracks=(),
+    extraction_max_cross_track_edges=None,
 )
 
 

--- a/packages/workcli/tests/unit/test_track_set.py
+++ b/packages/workcli/tests/unit/test_track_set.py
@@ -17,6 +17,10 @@ CONFIG = TrackLayerConfig(
     enforcement="advisory",
     milestone_wip_cap=None,
     wip_exempt_milestones=(),
+    extraction_max_track_backlog=None,
+    extraction_external_consumer_tracks=(),
+    extraction_independent_release_tracks=(),
+    extraction_max_cross_track_edges=None,
 )
 
 

--- a/packages/workcli/tests/unit/test_triggers.py
+++ b/packages/workcli/tests/unit/test_triggers.py
@@ -1,0 +1,305 @@
+"""`work triggers`: extraction pressure/eligibility evaluation (track spec §5, criterion 13)."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from tests.conftest import run_cli
+from tests.fake_backend import FakeBackend
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+from workcli.model import DepEdge
+from workcli.verbs.report import triggers
+
+CONFIG = TrackLayerConfig(
+    names=("alpha", "beta", "gamma", "org-only"),
+    organizing_only=("org-only",),
+    enforcement="advisory",
+    milestone_wip_cap=None,
+    wip_exempt_milestones=(),
+    extraction_max_track_backlog=2,
+    extraction_external_consumer_tracks=("beta",),
+    extraction_independent_release_tracks=(),
+    extraction_max_cross_track_edges=3,
+)
+
+
+def _args(config: TrackLayerConfig = CONFIG) -> Namespace:
+    return Namespace(load_config=lambda: config)
+
+
+def _fixture() -> FakeBackend:
+    """Exercises all three statuses, an organizing-only track, and bidirectional
+    cross-track edge counting with a closed-endpoint edge excluded."""
+    backend = FakeBackend()
+
+    # alpha: over backlog cap (3 > 2) -> pressure; 1 cross-track edge to beta
+    # (both directions counted independently) -> eligible (1 <= 3).
+    backend.add("alpha-1", labels=["track:alpha"])
+    backend.add("alpha-2", labels=["track:alpha"])
+    backend.add(
+        "alpha-3",
+        labels=["track:alpha"],
+        deps=[DepEdge(id="beta-1", type="blocks", status="open")],
+    )
+
+    # beta: declared external-consumer -> pressure; receives the alpha->beta
+    # edge above (1) plus an edge to a CLOSED bead (excluded) -> total 1,
+    # eligible.
+    backend.add(
+        "beta-1",
+        labels=["track:beta"],
+        deps=[DepEdge(id="closed-gamma", type="blocks", status="closed")],
+    )
+    backend.add("closed-gamma", status="closed", labels=["track:gamma"])
+
+    # gamma: no backlog pressure, not declared -> no-pressure regardless of edges.
+    backend.add("gamma-1", labels=["track:gamma"])
+
+    # org-only: organizing-only track, present in backlog_counts, absent from statuses.
+    backend.add("org-1", labels=["track:org-only"])
+
+    return backend
+
+
+def test_backlog_counts_cover_every_configured_track() -> None:
+    report = triggers(_fixture(), _args())
+    assert isinstance(report, dict)
+    counts = report["backlog_counts"]
+    assert counts == {"alpha": 3, "beta": 1, "gamma": 1, "org-only": 1}
+
+
+def test_organizing_only_track_excluded_from_statuses() -> None:
+    report = triggers(_fixture(), _args())
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert "org-only" not in statuses
+    assert set(statuses) == {"alpha", "beta", "gamma"}
+
+
+def test_pressured_eligible_from_backlog_pressure() -> None:
+    report = triggers(_fixture(), _args())
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["alpha"] == "pressured-eligible"
+
+
+def test_pressured_eligible_from_declared_external_consumer() -> None:
+    report = triggers(_fixture(), _args())
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["beta"] == "pressured-eligible"
+
+
+def test_no_pressure_track() -> None:
+    report = triggers(_fixture(), _args())
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["gamma"] == "no-pressure"
+
+
+def test_pressured_ineligible_when_edges_exceed_ceiling() -> None:
+    config = TrackLayerConfig(
+        names=("alpha", "beta"),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=0,
+    )
+    backend = FakeBackend()
+    backend.add(
+        "alpha-1",
+        labels=["track:alpha"],
+        deps=[DepEdge(id="beta-1", type="blocks", status="open")],
+    )
+    backend.add("beta-1", labels=["track:beta"])
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["alpha"] == "pressured-ineligible"
+
+
+def test_unconfigured_ceiling_never_yields_eligible() -> None:
+    # Fail-safe: max-cross-track-edges omitted -> eligibility can never be
+    # proven, so even a track with zero cross-track edges stays ineligible.
+    config = TrackLayerConfig(
+        names=("alpha",),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=None,
+    )
+    backend = FakeBackend()
+    backend.add("alpha-1", labels=["track:alpha"])
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["alpha"] == "pressured-ineligible"
+
+
+def test_parent_child_edges_not_counted_as_cross_track() -> None:
+    # A synthesized parent-child edge must never inflate the cross-track
+    # count -- only raw `item.deps` entries count (spec §5).
+    config = TrackLayerConfig(
+        names=("alpha", "beta"),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=0,
+    )
+    backend = FakeBackend()
+    backend.add("alpha-1", labels=["track:alpha"])
+    backend.add("beta-1", labels=["track:beta"], parent="alpha-1")
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    # No raw dep edges anywhere -> both tracks report pressured but eligible
+    # (0 cross-track edges <= ceiling 0).
+    assert statuses["alpha"] == "pressured-eligible"
+    assert statuses["beta"] == "pressured-eligible"
+
+
+def test_same_track_dep_edge_not_counted_as_cross_track() -> None:
+    config = TrackLayerConfig(
+        names=("alpha",),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=0,
+    )
+    backend = FakeBackend()
+    backend.add(
+        "alpha-1",
+        labels=["track:alpha"],
+        deps=[DepEdge(id="alpha-2", type="blocks", status="open")],
+    )
+    backend.add("alpha-2", labels=["track:alpha"])
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    # Same-track edge contributes 0 -> eligible against ceiling 0.
+    assert statuses["alpha"] == "pressured-eligible"
+
+
+def test_untracked_dep_source_contributes_no_edges() -> None:
+    config = TrackLayerConfig(
+        names=("alpha",),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=0,
+    )
+    backend = FakeBackend()
+    # No track label -> derive_track is None -> its deps never contribute.
+    backend.add(
+        "untracked-1",
+        labels=[],
+        deps=[DepEdge(id="alpha-1", type="blocks", status="open")],
+    )
+    backend.add("alpha-1", labels=["track:alpha"])
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    assert statuses["alpha"] == "pressured-eligible"
+
+
+def test_repeated_dep_target_resolved_once_via_cache() -> None:
+    config = TrackLayerConfig(
+        names=("alpha", "beta"),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=0,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=5,
+    )
+    backend = FakeBackend()
+    # Two alpha beads both dep on the same out-of-sweep (closed) target --
+    # the resolver's cache must be consulted for the second lookup.
+    backend.add(
+        "alpha-1",
+        labels=["track:alpha"],
+        deps=[DepEdge(id="closed-target", type="blocks", status="closed")],
+    )
+    backend.add(
+        "alpha-2",
+        labels=["track:alpha"],
+        deps=[DepEdge(id="closed-target", type="blocks", status="closed")],
+    )
+    backend.add("closed-target", status="closed", labels=["track:beta"])
+
+    report = triggers(backend, _args(config))
+    statuses = report["statuses"]
+    assert isinstance(statuses, dict)
+    # Both edges point at a closed bead -> excluded entirely.
+    assert statuses["alpha"] == "pressured-eligible"
+
+
+def test_review_question_present_and_echoes_declared_lists() -> None:
+    report = triggers(_fixture(), _args())
+    question = report["review_question"]
+    assert isinstance(question, str)
+    assert "beta" in question
+
+
+def test_review_question_present_even_with_empty_declared_lists() -> None:
+    config = TrackLayerConfig(
+        names=("alpha",),
+        organizing_only=(),
+        enforcement="advisory",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        extraction_max_track_backlog=None,
+        extraction_external_consumer_tracks=(),
+        extraction_independent_release_tracks=(),
+        extraction_max_cross_track_edges=None,
+    )
+    backend = FakeBackend()
+    backend.add("alpha-1", labels=["track:alpha"])
+
+    report = triggers(backend, _args(config))
+    assert isinstance(report["review_question"], str)
+    assert report["review_question"] != ""
+
+
+def _not_configured_loader(_explicit_path: str | None) -> TrackLayerConfig:
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
+
+
+def test_triggers_without_config_is_e_not_configured() -> None:
+    exit_code, envelope, _ = run_cli(["triggers"], [], config_loader=_not_configured_loader)
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "E_NOT_CONFIGURED"

--- a/packages/workcli/tests/unit/test_triggers.py
+++ b/packages/workcli/tests/unit/test_triggers.py
@@ -69,6 +69,18 @@ def test_backlog_counts_cover_every_configured_track() -> None:
     assert counts == {"alpha": 3, "beta": 1, "gamma": 1, "org-only": 1}
 
 
+def test_cross_track_edges_densified_to_every_configured_track() -> None:
+    # REGRESSION PIN (Codex finding): a track with zero cross-track edges
+    # must report 0, not an absent key -- callers triaging a
+    # pressured-ineligible track need the actual count, not just the
+    # three-state status reduction.
+    report = triggers(_fixture(), _args())
+    edges = report["cross_track_edges"]
+    assert isinstance(edges, dict)
+    assert set(edges) == {"alpha", "beta", "gamma", "org-only"}
+    assert edges["gamma"] == 0
+
+
 def test_organizing_only_track_excluded_from_statuses() -> None:
     report = triggers(_fixture(), _args())
     statuses = report["statuses"]


### PR DESCRIPTION
## Summary
- PR 1 of 2 for bead agents-config-djcr5 (work triggers + work groom): implements `work triggers`, which evaluates the §5 extraction policy at each Backlog Grooming — per-track pressure signals (backlog count vs configured cap, human-declared external-consumer/independent-release lists) AND eligibility (cross-track dependency edge count vs a configured ceiling, counted bidirectionally) — emitting `no-pressure` / `pressured-ineligible` / `pressured-eligible` per track. Nothing splits automatically; it's advisory-only.
- Extends `TrackLayerConfig` to parse `[extraction.pressure]`/`[extraction.eligibility]`, which the repo's `project-config.toml` has shipped since the track-layer PRs but which `config.py` never actually parsed until now.
- Organizing-only tracks appear in `backlog_counts` but are excluded from `statuses` entirely (criterion 13). An unconfigured eligibility ceiling is a deliberate fail-safe — never proven eligible, never a false `pressured-eligible`.
- Implements docs/specs/2026-07-15-workcli-track-partition-design.md §4/§5, acceptance criterion 13.
- Bead: agents-config-djcr5.

## Deliberately out of scope
- The spec's optional "propose extraction candidates from a local scan of sibling manifests / install receipts" sub-feature is descoped: advisory-only, zero acceptance-criteria coverage, no test target. Recorded on the bead; revive as its own bead if wanted.

## Test plan
- [x] `make ci-workcli` green: 479 tests, mypy --strict clean, 99.14% branch coverage, pip-audit clean, entry verify
- [x] Full diff reviewed against the pinned envelope contract

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>