### PR TITLE
chore(workcli): MINOR protocol bump to 1.2 — advertise capability-disposition surface

### DIFF
--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -89,8 +89,8 @@ only their envelope/error-code vocabulary above).
 JSON envelope on stdout, always, exit code mirrors `ok`:
 
 ```json
-{"protocol": "1.1", "ok": true, "data": { ... }, "error": null}
-{"protocol": "1.1", "ok": false, "data": null,
+{"protocol": "1.2", "ok": true, "data": { ... }, "error": null}
+{"protocol": "1.2", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y", "dep_type": "blocks"}}}
 ```
@@ -132,7 +132,7 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
 - Every envelope carries `protocol` (semver `MAJOR.MINOR`). Additive fields bump
   MINOR; any breaking change to envelope or `data` shapes bumps MAJOR.
 - `work --protocol-version` returns a standard success envelope on stdout
-  (`ok: true`, `data: {"protocol": "1.1"}`, exit 0) — no exception to the
+  (`ok: true`, `data: {"protocol": "1.2"}`, exit 0) — no exception to the
   "stdout is always a JSON envelope" invariant (§4). It is the consumer
   handshake at adapter init (prgroom/PDLC pin a major and refuse a mismatch at
   startup rather than mis-parsing mid-run).
@@ -145,13 +145,18 @@ query(filters), ready, dep_mutate, dep_list, label_mutate, labels, search, sync`
 The verb layer owns normalization, typed errors, and retries; adapters own only
 backend I/O and concept mapping. v1 ships the `bd` adapter alone.
 
-Capability flags per adapter (`supports_ready`, `supports_dep_types`,
-`supports_sync`): a verb a backend cannot honor returns
-`E_UNSUPPORTED_CAPABILITY` rather than emulating silently — with two declared
-exceptions: `ready` is computed client-side from `query` + dep edges when the
-backend lacks blocker semantics (both JIRA and GH need this; bd does not), and
-`sync` on a server-authoritative backend succeeds honestly as a declared no-op
-(`data.synced: false`) since there is nothing to synchronize.
+Capability disposition per adapter (`Capabilities.ready: ReadySupport`,
+`Capabilities.sync: SyncSupport`, `Capabilities.supports_dep_write: bool`;
+1.2 amendment, superseding the original three-boolean design): a verb a
+backend cannot honor returns `E_UNSUPPORTED_CAPABILITY` rather than emulating
+silently — with two declared exceptions matched by the disposition enums
+themselves: `ReadySupport.EMULATED` computes `ready` client-side from `query`
++ dep edges when the backend lacks blocker semantics (both JIRA and GH need
+this; bd does not), and `SyncSupport.SERVER_AUTHORITATIVE` succeeds honestly
+as a declared no-op (`data.synced: false`) since there is nothing to
+synchronize. `dep list` is never gated — only typed dep writes are, via
+`supports_dep_write` — since every seam-target backend can at least
+enumerate relationships.
 
 ## 7. Seam validation on paper (no code): JIRA and GitHub Issues
 

--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -154,7 +154,10 @@ themselves: `ReadySupport.EMULATED` computes `ready` client-side from `query`
 + dep edges when the backend lacks blocker semantics (both JIRA and GH need
 this; bd does not), and `SyncSupport.SERVER_AUTHORITATIVE` succeeds honestly
 as a declared no-op (`data.synced: false`) since there is nothing to
-synchronize. `dep list` is never gated — only typed dep writes are, via
+synchronize. The `EMULATED` ready computation is a forward contract, not
+shipped code: the verb layer gains that branch with the first adapter that
+declares it (today's sole adapter, bd, is `NATIVE` on every disposition, so
+no emulation path exists yet). `dep list` is never gated — only typed dep writes are, via
 `supports_dep_write` — since every seam-target backend can at least
 enumerate relationships.
 
@@ -166,8 +169,10 @@ after a partial failure completes safely; the adapter absorbs bd's
 already-applied/already-absent outcomes as success. Second, structured
 partial-progress on failure — a mid-sequence `WorkError` carries a
 `detail.partial_progress` record (`operation`, `steps_total`, `completed`,
-`failed`, `remaining`) naming exactly what already applied, so `work
-reconcile` can prioritize a resumable failure over a from-scratch retry.
+`failed`, `remaining`) naming exactly what already applied, so the caller
+can tell a resumable failure from a from-scratch one. (The record is
+caller-facing only: `work reconcile`'s sweep is lifecycle-scoped and does
+not consume it.)
 Absence of the key is the contract signal that nothing applied yet: a
 single-call primitive's `WorkError`, or a first-sub-step failure, never
 carries it — though because both primitives are idempotent as a whole,

--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -158,6 +158,21 @@ synchronize. `dep list` is never gated — only typed dep writes are, via
 `supports_dep_write` — since every seam-target backend can at least
 enumerate relationships.
 
+Multi-step mutation partial-progress (1.2 amendment): the seam's two
+irreducibly multi-call primitives, `label_mutate` (one `bd label` call per
+label) and `sync` (`dolt commit` then `dolt push`), are each pinned to a
+two-part contract. First, idempotent as a whole — re-invoking the same call
+after a partial failure completes safely; the adapter absorbs bd's
+already-applied/already-absent outcomes as success. Second, structured
+partial-progress on failure — a mid-sequence `WorkError` carries a
+`detail.partial_progress` record (`operation`, `steps_total`, `completed`,
+`failed`, `remaining`) naming exactly what already applied, so `work
+reconcile` can prioritize a resumable failure over a from-scratch retry.
+Absence of the key is the contract signal that nothing applied yet: a
+single-call primitive's `WorkError`, or a first-sub-step failure, never
+carries it — though because both primitives are idempotent as a whole,
+retrying from the top is always safe either way.
+
 ## 7. Seam validation on paper (no code): JIRA and GitHub Issues
 
 | Facade concept | bd | JIRA (mapping only) | GitHub Issues |

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -76,8 +76,8 @@ applied so a caller can resume safely instead of guessing. Both primitives
 are idempotent as a whole (the adapter absorbs bd's already-applied/already-
 absent outcomes as success), so retrying from the top after any failure —
 with or without a `partial_progress` key — always completes safely; the
-key's presence is diagnostic detail for `work reconcile` to prioritize, not
-a safety gate. Absence of the key is the contract signal that nothing
+key's presence is caller-facing diagnostic detail, not a safety gate
+(`work reconcile`'s sweep is lifecycle-scoped and does not consume it). Absence of the key is the contract signal that nothing
 applied yet: a single-call primitive's `WorkError`, or a `label_mutate`/
 `sync` failure on its first sub-step, never carries it.
 

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -53,13 +53,17 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work reconcile [--dry-run]` | bd-observable recovery sweep: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol is `"1.1"` — additive-only bumps (new `ErrorCode` members, the
-derived `Item.track` field) never change an existing envelope or data shape.
-The finer capability-model split (an honest
-server-authoritative `sync` no-op; read-only dep listing surviving
-`supports_dep_types=False`) is deferred to the future non-bd (GH) adapter
-bead — bd itself declares every capability `True`, so nothing in this
-package needs it yet.
+Protocol is `"1.2"` — additive-only bumps (new `ErrorCode` members, the
+derived `Item.track` field, the capability-disposition model below) never
+change an existing envelope or data shape. `Capabilities` splits `ready` and
+`sync` into a `ReadySupport`/`SyncSupport` disposition each (`NATIVE` |
+`EMULATED`/`SERVER_AUTHORITATIVE` | `UNSUPPORTED`) instead of a single
+boolean, and `dep` gates only typed writes via `supports_dep_write` — `dep
+list` is never gated, even when writes are unsupported. bd itself declares
+every disposition `NATIVE` (`supports_dep_write=True`), so nothing in this
+package needs the finer split yet; it exists for the future non-bd (GH)
+adapter bead, which can declare an honest server-authoritative `sync` no-op
+or an emulated `ready` computed client-side from `query` + dep edges.
 
 ## Envelope contract
 
@@ -71,13 +75,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.1", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.2", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.1", "ok": false, "data": null,
+{"protocol": "1.2", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -109,7 +113,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.1", "ok": true, "data": {"protocol": "1.1"}, "error": null}
+{"protocol": "1.2", "ok": true, "data": {"protocol": "1.2"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -130,7 +134,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.1"}`.
+- `--protocol-version` → `{"protocol": "1.2"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -54,16 +54,32 @@ selected by whether a noun positional or `--raw` is given.
 | `work reconcile [--dry-run]` | bd-observable recovery sweep: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
 Protocol is `"1.2"` — additive-only bumps (new `ErrorCode` members, the
-derived `Item.track` field, the capability-disposition model below) never
-change an existing envelope or data shape. `Capabilities` splits `ready` and
-`sync` into a `ReadySupport`/`SyncSupport` disposition each (`NATIVE` |
-`EMULATED`/`SERVER_AUTHORITATIVE` | `UNSUPPORTED`) instead of a single
-boolean, and `dep` gates only typed writes via `supports_dep_write` — `dep
-list` is never gated, even when writes are unsupported. bd itself declares
-every disposition `NATIVE` (`supports_dep_write=True`), so nothing in this
-package needs the finer split yet; it exists for the future non-bd (GH)
-adapter bead, which can declare an honest server-authoritative `sync` no-op
-or an emulated `ready` computed client-side from `query` + dep edges.
+derived `Item.track` field, the capability-disposition model and
+`partial_progress` detail below) never change an existing envelope or data
+shape. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+`SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
+| `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
+writes via `supports_dep_write` — `dep list` is never gated, even when
+writes are unsupported. bd itself declares every disposition `NATIVE`
+(`supports_dep_write=True`), so nothing in this package needs the finer
+split yet; it exists for the future non-bd (GH) adapter bead, which can
+declare an honest server-authoritative `sync` no-op or an emulated `ready`
+computed client-side from `query` + dep edges.
+
+The seam's two irreducibly multi-call `Backend` primitives (`label_mutate` —
+one `bd label` call per label; `sync` — `dolt commit` then `dolt push`) can
+fail after some sub-steps already applied. A mid-sequence failure's
+`WorkError` carries a `detail.partial_progress` record —
+`{"operation": "label_mutate" | "sync", "steps_total": int, "completed":
+[...], "failed": ..., "remaining": [...]}` — naming exactly what already
+applied so a caller can resume safely instead of guessing. Both primitives
+are idempotent as a whole (the adapter absorbs bd's already-applied/already-
+absent outcomes as success), so retrying from the top after any failure —
+with or without a `partial_progress` key — always completes safely; the
+key's presence is diagnostic detail for `work reconcile` to prioritize, not
+a safety gate. Absence of the key is the contract signal that nothing
+applied yet: a single-call primitive's `WorkError`, or a `label_mutate`/
+`sync` failure on its first sub-step, never carries it.
 
 ## Envelope contract
 
@@ -94,7 +110,7 @@ Failure:
 | `E_TYPE_WALL` | a `blocks` dep between an epic and a non-epic (pre-checked before any mutation reaches the backend) |
 | `E_DEP_CYCLE` | the backend rejected a dep edge as a cycle |
 | `E_FIELD_CLOBBER_GUARD` | an attempt to replace notes via `update` instead of appending via `note` |
-| `E_LOCK_CONTENTION` | backend lock contention survived the bounded retry |
+| `E_LOCK_CONTENTION` | backend lock contention survived the bounded retry — from `label_mutate`/`sync`, may carry `detail.partial_progress` |
 | `E_SYNC_BEHIND` | `sync --pull` with uncommitted local changes |
 | `E_BACKEND_DRIFT` | the backend's output or behavior failed the facade's own model — the drift alarm |
 | `E_UNSUPPORTED_CAPABILITY` | the verb is not supported by the active backend's declared `Capabilities` |
@@ -104,7 +120,7 @@ Failure:
 | `E_NOT_CLAIMABLE` | `claim` refused a container, a blocked leaf, or a closed item |
 | `E_EVIDENCE` | `deliver` has no verifiable evidence (`--pr`/`--items`/`--trivial` missing, or `--items` didn't resolve) |
 | `E_MANIFEST` | a spec's `## Continuations` section is missing, empty, or fails the manifest grammar |
-| `E_TIMEOUT` | a non-idempotent bd mutation (`create`/`note`) timed out; it may have partially applied — run `work reconcile` |
+| `E_TIMEOUT` | a non-idempotent bd mutation (`create`/`note`) timed out; it may have partially applied — run `work reconcile`. A retryable mutation (`label_mutate`/`sync`) surfaces this only after retry exhaustion, and may carry `detail.partial_progress` |
 
 ## Consumer handshake
 

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.1"
+PROTOCOL_VERSION = "1.2"

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -60,4 +60,4 @@ def test_protocol_wire_value_is_pinned() -> None:
     # The serialization boundary pins the literal wire value; every other
     # test references PROTOCOL_VERSION. Bumping the protocol means updating
     # this one assertion deliberately.
-    assert PROTOCOL_VERSION == "1.1"
+    assert PROTOCOL_VERSION == "1.2"


### PR DESCRIPTION
## Summary
- Bumps `PROTOCOL_VERSION` 1.1 -> 1.2 per `docs/specs/2026-07-17-workcli-contract-hardening.md` continuations: the capability-disposition model (`ReadySupport`/`SyncSupport` enums, `supports_dep_write`) shipped in #318 is an additive-only Backend-seam change the protocol version had not yet advertised.
- Corrects the README's protocol section, which still described the pre-#318 boolean capability model (`supports_dep_types=False`) — it now documents the actual shipped `ReadySupport`/`SyncSupport`/`supports_dep_write` shape.
- Updates the pinned handshake test and every hardcoded `"1.1"` literal in the README's envelope examples.

**Scope note:** the spec's continuation text frames this bump as advertising both the capability-disposition surface AND `partial_progress` (Item 2). `partial_progress` (38o1v.2, PR #319) is still in review, not yet merged — documenting an unshipped capability as shipped would be dishonest, so this bump and its README prose cover only what's actually on `main` today. A follow-up bump can extend the README once #319 lands.

Closes agents-config-38o1v.4.

## Test plan
- [x] `test_protocol_wire_value_is_pinned` updated to assert `"1.2"`.
- [x] `make ci-workcli` from the worktree (post-rebase on fresh main): ruff check/format, mypy --strict, pytest (495 passed, 99.16%% coverage), pip-audit clean, protocol/help smoke checks.