### PR TITLE
fix(orchestrated-grind): restore lost escalation rungs and reaction-blind watcher

### DIFF
--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -120,7 +120,8 @@ Rules that are not negotiable:
    the page in the browser **exactly once**.
 4. **Spawn the lieutenants**, one message each, carrying: the lane's queue, the
    worktree naming convention, the review protocol (§3), the post-merge leg
-   (§8), and the instruction to report **reviewed-clean** rather than merging.
+   (§8), the instruction to report **reviewed-clean** rather than merging, and
+   the instruction to **request** a watcher from ROOT rather than arm one (§6).
 5. **Record the roster** — you will need it for the compaction handoff (§7).
 
 Brief every lieutenant with **worktree-absolute paths**. A bare or relative
@@ -180,12 +181,49 @@ who runs it, and where a verdict goes:
   the lane.
 - **The lane reports the terminal verdict up** — reviewed-clean, or blocked and
   why. It never merges (§4).
+- **If the repo has no usable review skill, ROOT supplies one inline.** The repo
+  may have none, or its skill may be undeployed or banned for this run. Settle
+  that at setup, not mid-review: ROOT briefs every lane with an explicit verdict
+  protocol — how a re-review is requested, what counts as a clean pass, how
+  threads get replied to and resolved, and what the terminal verdict looks like.
+  A lane improvising its own is how two lanes end up with two different
+  definitions of "reviewed-clean," which §4 then merges on.
 
 **Stalemate rule.** A re-raise round on **unchanged code** gets one final
-disposition round, then the lane stops and puts the PR on the human's docket
-via ROOT. Round count alone is not evidence of a loop; unchanged code under
-re-raise is. A reviewer finding *genuine defects* round after round is earning
-its keep, not looping.
+disposition round, then the **do-not-relitigate round** below, and only then
+does the lane stop and put the PR on the human's docket via ROOT. Round count
+alone is not evidence of a loop; unchanged code under re-raise is. A reviewer
+finding *genuine defects* round after round is earning its keep, not looping.
+
+**The do-not-relitigate round — try this before the human docket.** Before
+escalating a stalemate, spend **one** more review round that hands the reviewer
+the settled dispositions and their evidence, via the review skill's re-review
+path. A stalemate earns one evidence-bearing round before it costs the human a
+decision.
+
+- Spend it even when you expect the reviewer to hold. In the reference run one
+  such round suppressed the settled noise *and* surfaced a genuine remaining
+  bug — the outcome the plain escalation path throws away.
+- Once. If the reviewer re-raises settled threads *after* being handed the
+  dispositions, that is a malfunction (below) or a genuine fork — escalate.
+
+**Reviewer malfunction — diagnose before you escalate.** A reviewer that
+re-flags something already fixed is not stalemated with you; it is reviewing the
+wrong state. Distinguish the two, because they have different exits:
+
+1. **Verify the fix exists at the commit the reviewer claims it reviewed** —
+   `git show <sha>:<path>`. Not at HEAD, and not in the PR diff: if the reviewer
+   is reading a stale head, HEAD proves nothing about what it saw.
+2. If the fix **is** there, hand the reviewer that evidence through the review
+   skill's reply path — one evidence-forward nudge, not an argument. A
+   do-not-relitigate round already spent **is** that nudge; do not spend a
+   second one.
+3. If the reviewer re-flags the **same** finding a second time against that same
+   evidence, stop. It is malfunctioning, further rounds are free tokens spent on
+   noise, and the PR goes to ROOT for the human's docket labelled as a
+   *malfunction* — which is a different ask of the human than a genuine fork.
+4. If the fix is **not** there, the reviewer is right and you have a real
+   finding. This is the branch that makes step 1 non-optional.
 
 **When a round cap and a productive reviewer collide, ROOT rules.** A PR-review
 skill may cap re-review rounds and escalate past the cap — a sound default
@@ -227,6 +265,23 @@ when the guard says to.
 **Verify the lane's claim before invoking the guard.** "Reviewed-clean" is a
 report, and §8's standing rule applies to it like any other: confirm it
 directly. The guard checks eligibility, not whether your lieutenant was right.
+
+**When the guard itself is broken, the floor does not move.** A grind sometimes
+runs with `merge-guard` structurally unavailable — misconfigured, mid-refactor,
+missing a credential — and the human grants merge authority for the session
+directly instead. That grant replaces the *authorization* the guard would have
+resolved; it does not replace the *eligibility* it would have computed. Verify
+three facts yourself, per PR, before every such merge:
+
+1. **CI green at the head commit** you are about to merge — not at an earlier one.
+2. **Reviewer approval at that same head** — an approval of a superseded head is
+   not an approval of this one.
+3. **Zero unresolved review threads.**
+
+Any one missing and the PR goes to the human's docket, session grant or not.
+Record in the handoff (§7) that the guard was bypassed and on what authority —
+a grant nobody wrote down is indistinguishable, later, from a lane that merged
+on its own initiative.
 
 **An honest verdict cannot be manufactured.** If the reviewer will not approve
 and you judge its findings unfounded, that is the human's call. Merging around
@@ -283,6 +338,16 @@ Parked lieutenants cannot self-wake, so when a lane is waiting on review
 activity ROOT arms one background poll script per awaited PR, from
 `scripts/watch-pr.sh.tmpl`.
 
+**ROOT arms every watcher. A lane NEVER arms its own.** This is the same
+structural fact stated from the other side, and it is worth stating explicitly
+because the inverse looks so reasonable: the lane owns the PR, so surely it
+should watch it. It cannot. A lane that arms its own watcher then parks, and a
+parked agent cannot hear its own background task complete — the completion wakes
+ROOT, which has no idea what the ring was for. The watcher runs, rings into the
+void, and the lane looks stuck when nothing is wrong with it. In the reference
+run one lane did this three times and every "failure" was this and only this.
+Brief lanes to *request* a watcher from ROOT, never to launch one.
+
 **A watcher detects PR *activity*, never a verdict.** It knows nothing about
 approval signals, reviewer identity, or clean-pass phrasing — that is the
 review skill's job (§3), and duplicating any of it here guarantees drift the
@@ -299,8 +364,13 @@ question: *has anything happened on this PR since I armed?*
   wrapper command with `&`. The wrapper exits immediately, the completion
   notification fires for the *wrapper*, and the real watcher is orphaned —
   running, unwatched, and silent.
-- **Triggers on a count increase** in reviews, review comments, or issue
-  comments against baselines sampled at arm time. Counts, not contents.
+- **Triggers on a count increase** in reviews, review comments, issue comments,
+  or **reactions** against baselines sampled at arm time. Counts, not contents.
+- **Count reactions too.** A reviewer can signal entirely through a reaction —
+  in the reference run one approval arrived as a lone thumbs-up on the PR body,
+  with no review object and no comment, and a watcher blind to reactions slept
+  through it to timeout. Reactions are a count like any other, so this costs the
+  doorbell nothing and keeps it dumb.
 - **The ring is a DOORBELL.** On a ring, ROOT re-engages the owning lane and
   the lane consults the review skill for the actual verdict. ROOT does not
   interpret PR state itself.
@@ -387,8 +457,12 @@ stale inode, where writes go somewhere other than where it thinks. If teardown
 cannot be done safely from outside, defer it and record it in the handoff for a
 main-tree owner to finish.
 
-**Escalate to the human ONLY for:** merge-authority grants, reviewer
-stalemates and malfunctions, and genuine scope forks. Everything else is
+**Escalate to the human ONLY for:** merge-authority grants, genuine scope
+forks, and reviewer stalemates or malfunctions that have run out §3's ladder —
+a stalemate after its do-not-relitigate round, a malfunction after its one
+evidence-forward nudge. The two are different diagnoses with different exits,
+not steps in one chain: a confirmed malfunction escalates on its own path
+without first spending the stalemate rounds. Everything else is
 decide-in-scope or verify-facts — decide it.
 
 **Workers self-flag deviations** — TDD compromises, fixture fixes, plan drift —
@@ -405,6 +479,11 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "The findings are clearly unfounded, I'll just merge." | An honest verdict cannot be manufactured. Human docket. |
 | "This report contradicts my order — the lane ignored me." | It almost certainly crossed in flight. Check timestamps first. |
 | "Six review rounds is obviously a loop, invoke the stalemate rule." | Rounds of *real defects* are the reviewer working. The rule applies only to re-raises on unchanged code. |
+| "Stalemate confirmed — straight to the human's docket." | One do-not-relitigate round first: re-review with every settled disposition and its evidence. It broke four of four in the reference run. |
+| "The reviewer keeps re-flagging a fix I know I made — it's stalemated." | Check `git show <sha>:<file>` at the commit it claims it reviewed. A reviewer reading a stale head is malfunctioning, which is a different escalation. |
+| "I'll have the lane watch its own PR — it owns it." | A parked lane cannot hear its own watcher ring; the ring wakes ROOT. ROOT owns every watcher. |
+| "The watcher's been quiet, so nothing has happened." | Only if it counts reactions. A lone thumbs-up approval is invisible to a reviews-and-comments watcher. |
+| "merge-guard is broken and I have a session grant, so I can merge." | The grant replaces authorization, not eligibility. CI green at head, approval at head, zero unresolved — verify all three yourself. |
 | "The lane says it is fine, and re-checking would cost me context." | Verify anyway before anything irreversible, and whenever report and world disagree. Everywhere else, trust the lane. |
 | "I have context to spare, I will just review the diff myself." | You are the manager, not the reviewer. Re-running the lane's gate spends the one resource the run cannot replace. |
 | "The lane has retried this four times, it will get there." | Two rounds without progress is ROOT's cue to intervene. Unbounded retrying is the most expensive failure mode in a long run. |
@@ -425,7 +504,13 @@ punished; a worker that hides a compromise costs far more than one that admits i
 - You are dispatching a worker without setting model and effort.
 - You are writing review-bot mechanics into this skill instead of delegating
   to the repo's PR-review skill (§3).
-- You are about to merge without `merge-guard` resolving the policy (§4).
+- You are about to merge without `merge-guard` resolving the policy (§4) — or,
+  where the guard is broken, without verifying the three-fact floor yourself.
+- You are sending a PR to the human's docket as a stalemate without having run
+  the do-not-relitigate round (§3).
+- You are treating a re-flagged fix as a stalemate without having checked the
+  commit the reviewer claims it reviewed (§3).
+- A lane is arming its own watcher (§6).
 - You are re-opening the dashboard in a browser.
 - Your last three actions were implementation work. You are ROOT — you manage,
   decide, and unblock. Hand it to a lane.

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -276,45 +276,33 @@ missing a credential — and the human grants merge authority for the session
 directly instead. That grant replaces the *authorization* the guard would have
 resolved; it does not replace the *eligibility* it would have computed.
 
-**Prefer the canonical eligibility check over a hand-rolled one.** The guard is
-more than its policy resolver; if its eligibility script still runs, run it and
-use its verdict. Reconstructing eligibility from memory is how a blocker that
-exists in the canonical check quietly goes missing from the grind's copy.
+**Run the canonical eligibility check — do not reconstruct one.** The guard is
+more than its policy resolver, so if its eligibility script still runs, run it
+and use its verdict even when the authorization half is dead.
 
-Only when nothing of the guard is operable do you verify by hand — and then
-understand what you are holding. **The list below is a floor, not the whole
-eligibility check.** A hand pass cannot faithfully reproduce the canonical one,
-so treat these as necessary, never as sufficient:
+**When nothing of the guard runs, ROOT does not merge.** The PR goes to the
+human's docket, session grant or not. This is not caution for its own sake: the
+canonical check's blocker set is larger than anyone remembers and it *grows* —
+requested-changes verdicts, in-flight reviews, pending escalations, untriaged
+feedback, blockers contributed by other tooling in the repo. Any list written
+here is a snapshot that silently rots, and a hand-rolled floor that looks
+complete is more dangerous than an honest handoff, because it authorizes a
+merge on a check nobody maintains. So the floor is not reproduced here.
 
-1. **CI green at the head commit** you are about to merge — not at an earlier one.
-2. **Reviewer approval at that same head** — an approval of a superseded head is
-   not an approval of this one.
-3. **Zero unresolved review threads.**
-4. **No active requested-changes verdict from any reviewer.** This one is
-   **sticky and not head-scoped**: a push does not clear it, and another
-   reviewer's approval does not override it. It clears only by dismissal or by
-   a later approval from *the same* reviewer. Check it separately — the other
-   three can all pass while one reviewer is still blocking.
-5. **No expected review still in flight, no pending escalation, and no
-   untriaged feedback** — the canonical check blocks on each of these, and
-   every one of them can coexist with a green 1–4. If you cannot establish all
-   three, you have not cleared the floor.
+What ROOT owes the human is a **useful docket entry**, not a verdict. Gather
+what you can establish cheaply — CI state at the head you would merge, whether
+an approval exists at *that same* head, unresolved thread count, and whether any
+reviewer has an active requested-changes verdict (sticky and not head-scoped: a
+push does not clear it, and another reviewer's approval does not override it).
+Report those as **facts you checked, not as clearance**, and name the guard as
+inoperable so the human knows the usual gate did not run.
 
-**Pin the merge to the head you checked.** Every fact above is a statement about
-one specific SHA, and a lane can push between your check and your merge. Pass
-the checked head to the merge command so the merge fails rather than silently
-retargeting — this is the race the guard's head-pinned command exists to close,
-and hand-verifying without pinning reintroduces it.
-
-Because a hand pass cannot guarantee completeness, a **wholly inoperable guard
-is itself a reason to prefer the human's docket** over merging on the session
-grant alone. Clearing 1–5 earns a merge; ambiguity on any of them is a ruling
-for the human, not a judgment call for ROOT.
-
-Any one missing and the PR goes to the human's docket, session grant or not.
-The docket is not a dead end: once there, the human may rule on that PR
-specifically, and their ruling supersedes the floor — merging despite a missing
-fact is a call they are allowed to make and ROOT is not. Record the ruling with
+The human then rules on that PR. Their ruling supersedes the floor — merging
+with the guard down is a call they are allowed to make and ROOT is not. If the
+ruling is to merge, **pin the merge to the head that was checked**, so a lane
+pushing in between fails the merge rather than silently retargeting it; that
+race is exactly what the guard's head-pinned command exists to close. Record the
+ruling with
 the merge. Likewise record in the handoff (§7) that the guard was bypassed and
 on what authority — a grant nobody wrote down is indistinguishable, later, from
 a lane that merged on its own initiative.
@@ -522,8 +510,8 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "The reviewer keeps re-flagging a fix I know I made — it's stalemated." | Check `git show <sha>:<file>` at the commit it claims it reviewed. A reviewer reading a stale head is malfunctioning, which is a different escalation. |
 | "I'll have the lane watch its own PR — it owns it." | A parked lane cannot hear its own watcher ring; the ring wakes ROOT. ROOT owns every watcher. |
 | "The watcher's been quiet, so nothing has happened." | Only if it counts reactions. A lone thumbs-up approval is invisible to a reviews-and-comments watcher. |
-| "merge-guard is broken and I have a session grant, so I can merge." | The grant replaces authorization, not eligibility. Run the canonical eligibility check if any of it still runs; hand-verify §4's floor only if none of it does, and pin the merge to the head you checked. |
-| "I checked the four facts, so I can merge." | They are a floor, not the whole eligibility check — an in-flight review, a pending escalation, or untriaged feedback blocks a merge with all four green. |
+| "merge-guard is broken and I have a session grant, so I can merge." | The grant replaces authorization, not eligibility. Run the canonical eligibility check if any of it still runs; if none of it does, ROOT does not merge — the PR goes to the human's docket. |
+| "I checked CI, approval, and threads myself — that's the floor." | It isn't. The canonical blocker set is larger than anyone remembers and grows over time. Those are facts for the docket entry, not clearance to merge. |
 | "The lane says it is fine, and re-checking would cost me context." | Verify anyway before anything irreversible, and whenever report and world disagree. Everywhere else, trust the lane. |
 | "I have context to spare, I will just review the diff myself." | You are the manager, not the reviewer. Re-running the lane's gate spends the one resource the run cannot replace. |
 | "The lane has retried this four times, it will get there." | Two rounds without progress is ROOT's cue to intervene. Unbounded retrying is the most expensive failure mode in a long run. |
@@ -545,8 +533,8 @@ punished; a worker that hides a compromise costs far more than one that admits i
 - You are writing review-bot mechanics into this skill instead of delegating
   to the repo's PR-review skill (§3).
 - You are about to merge without `merge-guard` resolving the policy (§4) — or,
-  where the guard is broken, without clearing §4's floor yourself and pinning
-  the merge to the head you checked.
+  where the guard is wholly inoperable, at all — that PR belongs on the human's
+  docket (§4).
 - You are sending a PR to the human's docket as a stalemate without having run
   the do-not-relitigate round (§3).
 - You are treating a re-flagged fix as a stalemate without having checked the

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -402,7 +402,12 @@ question: *has anything happened on this PR since I armed?*
   the lane consults the review skill for the actual verdict. ROOT does not
   interpret PR state itself.
 - **A timeout means "no activity," not "no verdict."** Re-arm, or have the lane
-  check directly. Reviewers can signal in ways a count-based poll will not see.
+  check directly. Reviewers can signal in ways a count-based poll will not see —
+  including a reaction *replaced* within a single polling window, which nets to
+  no change in a count. Closing that particular gap would take per-user reaction
+  identities diffed across polls, and a clever watcher that dies silently costs
+  far more than a dumb one that occasionally makes a lane wait out its timeout.
+  The dumbness rule wins here on purpose; the timeout is the backstop.
 
 ## 7. Compaction safety
 

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -213,7 +213,11 @@ wrong state. Distinguish the two, because they have different exits:
 
 1. **Verify the fix exists at the commit the reviewer claims it reviewed** —
    `git show <sha>:<path>`. Not at HEAD, and not in the PR diff: if the reviewer
-   is reading a stale head, HEAD proves nothing about what it saw.
+   is reading a stale head, HEAD proves nothing about what it saw. A path that
+   is **absent** at that commit is not yet an answer — deleting or renaming the
+   file can *be* the fix. On a missing path, check the commit's diff or tree
+   before concluding anything, and read step 4 as applying only once you have
+   confirmed the flagged code genuinely survives.
 2. If the fix **is** there, hand the reviewer that evidence through the review
    skill's reply path — one evidence-forward nudge, not an argument. A
    do-not-relitigate round already spent **is** that nudge; do not spend a
@@ -270,18 +274,32 @@ directly. The guard checks eligibility, not whether your lieutenant was right.
 runs with `merge-guard` structurally unavailable — misconfigured, mid-refactor,
 missing a credential — and the human grants merge authority for the session
 directly instead. That grant replaces the *authorization* the guard would have
-resolved; it does not replace the *eligibility* it would have computed. Verify
-three facts yourself, per PR, before every such merge:
+resolved; it does not replace the *eligibility* it would have computed.
+
+**Prefer the canonical eligibility check over a hand-rolled one.** The guard is
+more than its policy resolver; if its eligibility script still runs, run it and
+use its verdict. Reconstructing eligibility from memory is how a blocker that
+exists in the canonical check quietly goes missing from the grind's copy. Only
+when nothing of the guard is operable do you verify by hand, and then all four
+of these facts, per PR, before every such merge:
 
 1. **CI green at the head commit** you are about to merge — not at an earlier one.
 2. **Reviewer approval at that same head** — an approval of a superseded head is
    not an approval of this one.
 3. **Zero unresolved review threads.**
+4. **No active requested-changes verdict from any reviewer.** This one is
+   **sticky and not head-scoped**: a push does not clear it, and another
+   reviewer's approval does not override it. It clears only by dismissal or by
+   a later approval from *the same* reviewer. Check it separately — the other
+   three can all pass while one reviewer is still blocking.
 
 Any one missing and the PR goes to the human's docket, session grant or not.
-Record in the handoff (§7) that the guard was bypassed and on what authority —
-a grant nobody wrote down is indistinguishable, later, from a lane that merged
-on its own initiative.
+The docket is not a dead end: once there, the human may rule on that PR
+specifically, and their ruling supersedes the floor — merging despite a missing
+fact is a call they are allowed to make and ROOT is not. Record the ruling with
+the merge. Likewise record in the handoff (§7) that the guard was bypassed and
+on what authority — a grant nobody wrote down is indistinguishable, later, from
+a lane that merged on its own initiative.
 
 **An honest verdict cannot be manufactured.** If the reviewer will not approve
 and you judge its findings unfounded, that is the human's call. Merging around
@@ -366,11 +384,14 @@ question: *has anything happened on this PR since I armed?*
   running, unwatched, and silent.
 - **Triggers on a count increase** in reviews, review comments, issue comments,
   or **reactions** against baselines sampled at arm time. Counts, not contents.
-- **Count reactions too.** A reviewer can signal entirely through a reaction —
-  in the reference run one approval arrived as a lone thumbs-up on the PR body,
-  with no review object and no comment, and a watcher blind to reactions slept
-  through it to timeout. Reactions are a count like any other, so this costs the
-  doorbell nothing and keeps it dumb.
+- **Count reactions too, including nested ones.** A reviewer can signal entirely
+  through a reaction — in the reference run one approval arrived as a lone
+  thumbs-up, with no review object and no comment, and a watcher blind to
+  reactions slept through it to timeout. Count reactions on the PR body *and* on
+  each individual comment and review: a reaction on an existing comment moves
+  none of the other counts, so a body-only reaction check has the same blind
+  spot in a narrower form. Reactions are a count like any other, so this costs
+  the doorbell nothing and keeps it dumb.
 - **The ring is a DOORBELL.** On a ring, ROOT re-engages the owning lane and
   the lane consults the review skill for the actual verdict. ROOT does not
   interpret PR state itself.

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -279,9 +279,12 @@ resolved; it does not replace the *eligibility* it would have computed.
 **Prefer the canonical eligibility check over a hand-rolled one.** The guard is
 more than its policy resolver; if its eligibility script still runs, run it and
 use its verdict. Reconstructing eligibility from memory is how a blocker that
-exists in the canonical check quietly goes missing from the grind's copy. Only
-when nothing of the guard is operable do you verify by hand, and then all four
-of these facts, per PR, before every such merge:
+exists in the canonical check quietly goes missing from the grind's copy.
+
+Only when nothing of the guard is operable do you verify by hand — and then
+understand what you are holding. **The list below is a floor, not the whole
+eligibility check.** A hand pass cannot faithfully reproduce the canonical one,
+so treat these as necessary, never as sufficient:
 
 1. **CI green at the head commit** you are about to merge — not at an earlier one.
 2. **Reviewer approval at that same head** — an approval of a superseded head is
@@ -292,6 +295,21 @@ of these facts, per PR, before every such merge:
    reviewer's approval does not override it. It clears only by dismissal or by
    a later approval from *the same* reviewer. Check it separately — the other
    three can all pass while one reviewer is still blocking.
+5. **No expected review still in flight, no pending escalation, and no
+   untriaged feedback** — the canonical check blocks on each of these, and
+   every one of them can coexist with a green 1–4. If you cannot establish all
+   three, you have not cleared the floor.
+
+**Pin the merge to the head you checked.** Every fact above is a statement about
+one specific SHA, and a lane can push between your check and your merge. Pass
+the checked head to the merge command so the merge fails rather than silently
+retargeting — this is the race the guard's head-pinned command exists to close,
+and hand-verifying without pinning reintroduces it.
+
+Because a hand pass cannot guarantee completeness, a **wholly inoperable guard
+is itself a reason to prefer the human's docket** over merging on the session
+grant alone. Clearing 1–5 earns a merge; ambiguity on any of them is a ruling
+for the human, not a judgment call for ROOT.
 
 Any one missing and the PR goes to the human's docket, session grant or not.
 The docket is not a dead end: once there, the human may rule on that PR
@@ -504,7 +522,8 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "The reviewer keeps re-flagging a fix I know I made — it's stalemated." | Check `git show <sha>:<file>` at the commit it claims it reviewed. A reviewer reading a stale head is malfunctioning, which is a different escalation. |
 | "I'll have the lane watch its own PR — it owns it." | A parked lane cannot hear its own watcher ring; the ring wakes ROOT. ROOT owns every watcher. |
 | "The watcher's been quiet, so nothing has happened." | Only if it counts reactions. A lone thumbs-up approval is invisible to a reviews-and-comments watcher. |
-| "merge-guard is broken and I have a session grant, so I can merge." | The grant replaces authorization, not eligibility. CI green at head, approval at head, zero unresolved — verify all three yourself. |
+| "merge-guard is broken and I have a session grant, so I can merge." | The grant replaces authorization, not eligibility. Run the canonical eligibility check if any of it still runs; hand-verify §4's floor only if none of it does, and pin the merge to the head you checked. |
+| "I checked the four facts, so I can merge." | They are a floor, not the whole eligibility check — an in-flight review, a pending escalation, or untriaged feedback blocks a merge with all four green. |
 | "The lane says it is fine, and re-checking would cost me context." | Verify anyway before anything irreversible, and whenever report and world disagree. Everywhere else, trust the lane. |
 | "I have context to spare, I will just review the diff myself." | You are the manager, not the reviewer. Re-running the lane's gate spends the one resource the run cannot replace. |
 | "The lane has retried this four times, it will get there." | Two rounds without progress is ROOT's cue to intervene. Unbounded retrying is the most expensive failure mode in a long run. |
@@ -526,7 +545,8 @@ punished; a worker that hides a compromise costs far more than one that admits i
 - You are writing review-bot mechanics into this skill instead of delegating
   to the repo's PR-review skill (§3).
 - You are about to merge without `merge-guard` resolving the policy (§4) — or,
-  where the guard is broken, without verifying the three-fact floor yourself.
+  where the guard is broken, without clearing §4's floor yourself and pinning
+  the merge to the head you checked.
 - You are sending a PR to the human's docket as a stalemate without having run
   the do-not-relitigate round (§3).
 - You are treating a re-flagged fix as a stalemate without having checked the

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -37,29 +37,35 @@ TIMEOUT_SECONDS=1800   # 30 minutes
 # GraphQL-only connection and is rejected here — verify any field you add
 # against a real `gh` before shipping, not against a stub.
 fetch_pr() {
-  gh pr view "$PR" --repo "$REPO" --json reviews,comments 2>/dev/null
+  gh pr view "$PR" --repo "$REPO" --json reviews,comments,reactionGroups 2>/dev/null
 }
 
 read_counts() {
-  # stdin: PR JSON. stdout: "<reviews> <comments>"
+  # stdin: PR JSON. stdout: "<reviews> <comments> <reactions>"
   # Each array element is fully parenthesized: in jq `|` binds across `,`, so
   # bare `A | length, B | length` chains the second expression onto the first.
+  # Reactions are counted because a reviewer can approve with nothing but a
+  # thumbs-up on the PR body: no review object, no comment, and a watcher
+  # blind to reactions sleeps through it to timeout. `reactionGroups` is one
+  # entry per emoji, so sum the per-group user totals rather than taking
+  # `length` — a second thumbs-up on an existing group must still register.
   jq -r '
     [ ((.reviews // []) | length),
-      ((.comments // []) | length)
+      ((.comments // []) | length),
+      ([ (.reactionGroups // [])[] | (.users.totalCount // 0) ] | add // 0)
     ] | @tsv' 2>/dev/null | tr '\t' ' '
 }
 
-read -r BASE_REVIEWS BASE_COMMENTS <<<"$(fetch_pr | read_counts)"
+read -r BASE_REVIEWS BASE_COMMENTS BASE_REACTIONS <<<"$(fetch_pr | read_counts)"
 
 # An unreadable baseline would make every later comparison meaningless, so
 # fail loud rather than arming a watcher that can only produce noise.
-if [ -z "$BASE_REVIEWS" ] || [ -z "$BASE_COMMENTS" ]; then
+if [ -z "$BASE_REVIEWS" ] || [ -z "$BASE_COMMENTS" ] || [ -z "$BASE_REACTIONS" ]; then
   echo "WATCH-ERROR pr=$PR could not sample baselines (gh unavailable or PR unreadable)"
   exit 2
 fi
 
-echo "WATCH-ARMED pr=$PR reviews=$BASE_REVIEWS comments=$BASE_COMMENTS"
+echo "WATCH-ARMED pr=$PR reviews=$BASE_REVIEWS comments=$BASE_COMMENTS reactions=$BASE_REACTIONS"
 
 # --- Poll loop --------------------------------------------------------------
 elapsed=0
@@ -67,23 +73,24 @@ while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
   sleep "$INTERVAL_SECONDS"
   elapsed=$((elapsed + INTERVAL_SECONDS))
 
-  read -r reviews comments <<<"$(fetch_pr | read_counts)"
+  read -r reviews comments reactions <<<"$(fetch_pr | read_counts)"
 
   # An empty read is a flake, not a signal. Skip the round; do not treat a
   # missing value as zero — that would read as a count DECREASE and mask a
   # real increase on the following poll.
-  if [ -z "$reviews" ] || [ -z "$comments" ]; then
+  if [ -z "$reviews" ] || [ -z "$comments" ] || [ -z "$reactions" ]; then
     echo "WATCH-FLAKE pr=$PR t=${elapsed}s (empty read, skipping round)"
     continue
   fi
 
-  if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ]; then
-    echo "WATCH-RING pr=$PR t=${elapsed}s reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS"
+  if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ] \
+     || [ "$reactions" -gt "$BASE_REACTIONS" ]; then
+    echo "WATCH-RING pr=$PR t=${elapsed}s reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS reactions=$reactions/$BASE_REACTIONS"
     echo "DOORBELL ONLY — no verdict implied. Re-engage the owning lane; the lane reads the verdict via the PR-review skill."
     exit 0
   fi
 
-  echo "WATCH-QUIET pr=$PR t=${elapsed}s reviews=$reviews comments=$comments"
+  echo "WATCH-QUIET pr=$PR t=${elapsed}s reviews=$reviews comments=$comments reactions=$reactions"
 done
 
 # Timeout means NO ACTIVITY, not "no verdict" — a reviewer can signal in ways a

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -44,10 +44,18 @@ fetch_pr() {
 # review-thread comments live on a different endpoint and carry their own
 # reactions. A reaction there moves no other count, so without this second
 # fetch a thumbs-up on a review comment is still invisible. Emits a bare
-# integer, or empty on failure (treated as a flake by the caller).
+# integer, or NOTHING on failure (treated as unreadable by the caller).
+#
+# The failure path must stay distinguishable from a real zero. Piping straight
+# into `jq -s` cannot do that: a failed `gh` produces an empty stream, which
+# `jq -s ... // 0` happily renders as a successful "0" — fabricating a zero
+# baseline, defeating the WATCH-ERROR/WATCH-FLAKE guards, and setting up a
+# false ring when the endpoint recovers. So capture first, check, then parse.
 fetch_review_comment_reactions() {
-  gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
-    | jq -s -r '[ .[][] | (.reactions.total_count // 0) ] | add // 0' 2>/dev/null
+  local json
+  json=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  jq -s -r '[ .[][] | (.reactions.total_count // 0) ] | add // 0' <<<"$json" 2>/dev/null
 }
 
 read_counts() {
@@ -107,8 +115,16 @@ while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
   fi
   reactions=$((pr_reactions + rc_reactions))
 
+  # Reviews and comments only ever accumulate, so `-gt` is the right test for
+  # them. Reactions are MUTABLE — they can be removed — so `-gt` would miss
+  # activity whenever a removal offsets an addition: baseline 1, a reviewer
+  # withdraws theirs (0), another reacts before the next poll (1), and both
+  # rounds compare equal while two reaction events went by. Any change is
+  # activity, so reactions test `-ne`. A removal on its own is a ring too;
+  # this is a doorbell, and someone taking a reaction back is something
+  # happening.
   if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ] \
-     || [ "$reactions" -gt "$BASE_REACTIONS" ]; then
+     || [ "$reactions" -ne "$BASE_REACTIONS" ]; then
     echo "WATCH-RING pr=$PR t=${elapsed}s reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS reactions=$reactions/$BASE_REACTIONS"
     echo "DOORBELL ONLY — no verdict implied. Re-engage the owning lane; the lane reads the verdict via the PR-review skill."
     exit 0

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -123,6 +123,17 @@ while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
   # activity, so reactions test `-ne`. A removal on its own is a ring too;
   # this is a doorbell, and someone taking a reaction back is something
   # happening.
+  #
+  # KNOWN LIMIT — accepted, not overlooked. A total cannot see a replacement
+  # that completes INSIDE one 60s window (one reviewer's reaction removed and
+  # another's added before the next sample nets to zero). Catching that needs
+  # per-user reaction identities diffed across polls, which is exactly the
+  # "clever watcher" this script's header rejects: in the reference run a
+  # filter-based monitor ghosted twice and each time the lane looked stuck when
+  # the monitor had died. A missed ring costs a bounded wait — the timeout is
+  # documented as "no activity," never "no verdict," and the lane re-arms or
+  # checks the PR directly. A silently dead watcher costs the whole lane. Given
+  # that trade, the dumb total wins.
   if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ] \
      || [ "$reactions" -ne "$BASE_REACTIONS" ]; then
     echo "WATCH-RING pr=$PR t=${elapsed}s reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS reactions=$reactions/$BASE_REACTIONS"

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -40,31 +40,52 @@ fetch_pr() {
   gh pr view "$PR" --repo "$REPO" --json reviews,comments,reactionGroups 2>/dev/null
 }
 
+# `gh pr view --json comments` returns ISSUE comments only — inline
+# review-thread comments live on a different endpoint and carry their own
+# reactions. A reaction there moves no other count, so without this second
+# fetch a thumbs-up on a review comment is still invisible. Emits a bare
+# integer, or empty on failure (treated as a flake by the caller).
+fetch_review_comment_reactions() {
+  gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
+    | jq -s -r '[ .[][] | (.reactions.total_count // 0) ] | add // 0' 2>/dev/null
+}
+
 read_counts() {
   # stdin: PR JSON. stdout: "<reviews> <comments> <reactions>"
   # Each array element is fully parenthesized: in jq `|` binds across `,`, so
   # bare `A | length, B | length` chains the second expression onto the first.
   # Reactions are counted because a reviewer can approve with nothing but a
-  # thumbs-up on the PR body: no review object, no comment, and a watcher
-  # blind to reactions sleeps through it to timeout. `reactionGroups` is one
-  # entry per emoji, so sum the per-group user totals rather than taking
-  # `length` — a second thumbs-up on an existing group must still register.
+  # thumbs-up: no review object, no comment, and a watcher blind to reactions
+  # sleeps through it to timeout. Two subtleties:
+  #   - `reactionGroups` is one entry per emoji, so sum the per-group user
+  #     totals rather than taking `length` — a second thumbs-up on an existing
+  #     group must still register.
+  #   - A reaction can land on the PR body OR on any individual comment or
+  #     review, and those nested reactions move none of the other counts.
+  #     `comments[]` and `reviews[]` each carry their own reactionGroups, so
+  #     all three sources are flattened into one total.
   jq -r '
     [ ((.reviews // []) | length),
       ((.comments // []) | length),
-      ([ (.reactionGroups // [])[] | (.users.totalCount // 0) ] | add // 0)
+      ([ (.reactionGroups // []),
+         ((.comments // []) | map(.reactionGroups // []) | add // []),
+         ((.reviews  // []) | map(.reactionGroups // []) | add // [])
+       ] | flatten | map(.users.totalCount // 0) | add // 0)
     ] | @tsv' 2>/dev/null | tr '\t' ' '
 }
 
-read -r BASE_REVIEWS BASE_COMMENTS BASE_REACTIONS <<<"$(fetch_pr | read_counts)"
+read -r BASE_REVIEWS BASE_COMMENTS BASE_PR_REACTIONS <<<"$(fetch_pr | read_counts)"
+BASE_RC_REACTIONS="$(fetch_review_comment_reactions)"
 
 # An unreadable baseline would make every later comparison meaningless, so
 # fail loud rather than arming a watcher that can only produce noise.
-if [ -z "$BASE_REVIEWS" ] || [ -z "$BASE_COMMENTS" ] || [ -z "$BASE_REACTIONS" ]; then
+if [ -z "$BASE_REVIEWS" ] || [ -z "$BASE_COMMENTS" ] || [ -z "$BASE_PR_REACTIONS" ] \
+   || [ -z "$BASE_RC_REACTIONS" ]; then
   echo "WATCH-ERROR pr=$PR could not sample baselines (gh unavailable or PR unreadable)"
   exit 2
 fi
 
+BASE_REACTIONS=$((BASE_PR_REACTIONS + BASE_RC_REACTIONS))
 echo "WATCH-ARMED pr=$PR reviews=$BASE_REVIEWS comments=$BASE_COMMENTS reactions=$BASE_REACTIONS"
 
 # --- Poll loop --------------------------------------------------------------
@@ -73,15 +94,18 @@ while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
   sleep "$INTERVAL_SECONDS"
   elapsed=$((elapsed + INTERVAL_SECONDS))
 
-  read -r reviews comments reactions <<<"$(fetch_pr | read_counts)"
+  read -r reviews comments pr_reactions <<<"$(fetch_pr | read_counts)"
+  rc_reactions="$(fetch_review_comment_reactions)"
 
   # An empty read is a flake, not a signal. Skip the round; do not treat a
   # missing value as zero — that would read as a count DECREASE and mask a
   # real increase on the following poll.
-  if [ -z "$reviews" ] || [ -z "$comments" ] || [ -z "$reactions" ]; then
+  if [ -z "$reviews" ] || [ -z "$comments" ] || [ -z "$pr_reactions" ] \
+     || [ -z "$rc_reactions" ]; then
     echo "WATCH-FLAKE pr=$PR t=${elapsed}s (empty read, skipping round)"
     continue
   fi
+  reactions=$((pr_reactions + rc_reactions))
 
   if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ] \
      || [ "$reactions" -gt "$BASE_REACTIONS" ]; then


### PR DESCRIPTION
Applies field feedback on `orchestrated-grind` from an agent that ran a full multi-lane grind against the skill as merged in #329. Six items: four findings and two minor notes. All six were assessed as valid — two are structural gaps the merged skill cannot recover from elsewhere, one is a mechanical bug confirmed against live PR data.

## What changed

| Item | Gap | Fix |
|---|---|---|
| F1 | Stalemate ladder had no middle rung | §3 gains the **do-not-relitigate round** between the final disposition round and the human docket |
| F2 | Reviewer-malfunction diagnostic survived only as a category name | §3 gains the 4-step diagnostic; step 1 checks the fix at the commit the reviewer *claims it reviewed*, not HEAD |
| F3 | Watcher blind to reaction-only signals | `watch-pr.sh.tmpl` counts reactions via `reactionGroups` |
| F4 | Only the positive watcher rule was stated | §6 explicitly forbids lanes self-arming watchers; briefing line + rationalization row |
| m1 | §3 assumed a usable repo review skill exists | Fallback: ROOT briefs an inline verdict protocol at setup |
| m2 | §4 silent on the broken-guard mode | Three-fact eligibility floor named as the minimum |

## The one with actual code in it (F3)

An approval can arrive as a lone thumbs-up — no review object, no comment. The watcher counted only reviews and comments, so it slept through that to timeout.

Two things worth flagging in the fix:

- It sums `users.totalCount` across `reactionGroups` rather than taking `length`. `length` counts *emoji kinds*, so a second thumbs-up on an existing group would have registered as no change — a subtle version of the same bug.
- Verified against live data, not assumed: PR #322 currently reads `reviews=0 comments=0 reactions=1`, the exact blind spot reported. `reactionGroups` was also confirmed to compose with `reviews,comments` in a single `gh` call.

This keeps the doorbell's counts-not-contents philosophy intact — it adds a count, not an interpretation.

## Adversarial review caught three defects in the first draft

The HEAVY quality gate came back clean-at-floor, but its own residual-risk report noted that a zero-finding round is indistinguishable from finders that never engaged the risky part. The correctness and simplify lenses had returned empty on the *design* question, so a targeted adversarial pass was dispatched on the specific worry: do F1/F2 smuggle review-bot mechanics into a skill that explicitly forbids them? It found three real problems, all now fixed:

1. **Payload spec leak.** The first draft dictated the re-review request's field schema and justified it with a per-bot behavioral claim ("each round starts from the diff rather than the conversation"). Both are on §3's banned list. Rewritten to carry the *budget* — a stalemate earns one evidence-bearing round — and delegate the mechanism.
2. **Reply-body leak.** "Reply quoting the fixed lines" is thread reply-and-resolve, named verbatim in the banned list. Now routed through the review skill's reply path.
3. **§8 flattened a branch into a chain** (the serious one). §3 treats stalemate and malfunction as different diagnoses with different exits; §8 as first drafted read as a serial ladder, which would have barred a confirmed malfunction from escalating until the stalemate rounds were spent. §8 now states the branch explicitly, and the malfunction diagnostic notes that a do-not-relitigate round already spent *is* its one nudge.

## Verification

Neither changed file falls under any `make ci` package gate (`ci` covers `packages/*` only), so there is no suite to run here. Evidence gathered directly:

- `bash -n` clean on the substituted template
- Ring logic exercised both directions: rings on a reaction-only signal, quiet on no change
- `reactionGroups` confirmed as a real `gh pr view` field and confirmed to compose with `reviews,comments`
- PR #322 sampled live at `reviews=0 comments=0 reactions=1`
- Grep sweep for banned-mechanics leaks: only pre-existing legitimate hits

**`shellcheck` is not installed on this machine, so that check did not run.** Not claiming it passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBwPzq1pYxN65EZbr8K8QF
