### PR TITLE
feat(merge-guard): reaction-path clean-pass fact (Component 2)

### DIFF
--- a/docs/specs/2026-07-18-codex-rereview-path-design.md
+++ b/docs/specs/2026-07-18-codex-rereview-path-design.md
@@ -73,6 +73,12 @@ solely on explicit asks, so a design that treated it as the primary signal would
 have to post a redundant `@codex review` on every PR whose free auto-review
 already came back clean.
 
+The reacting identity's `user.login` is `chatgpt-codex-connector[bot]`, matching
+the review path's identity; its `user.type` on `issues/{n}/reactions`, however,
+reports `"User"`, not `"Bot"` — GitHub's type field is unreliable for
+connector-style bot accounts. The exact-login allowlist match is therefore the
+sole identity check on both paths; `user.type` is not consulted.
+
 ### Reaction lifecycle
 
 The reaction is torn down and re-earned per head. On a push:
@@ -148,7 +154,8 @@ It is true when **either**:
     1. a reaction with `content == "+1"` exists on the pull-request body —
        endpoint `repos/{owner}/{repo}/issues/{n}/reactions`, fetched with
        `--paginate` — whose `user.login` is in the `bot_reviewers` allowlist
-       (exact match) and whose `user.type` is `"Bot"`; **and**
+       (exact match; `user.type` is not consulted — see Observed Codex
+       behaviour above); **and**
     2. no reaction with `content == "eyes"` from **any** allowlisted identity is
        present in that same fetch (a review is in flight; wait); **and**
     3. that `+1`'s `created_at`, parsed to epoch seconds, is strictly greater
@@ -273,8 +280,9 @@ payloads, asserting both `bot_clean_review_at_head` and
 - a `+1` predating a later `head_ref_force_pushed` timeline event;
 - a `head_ref_force_pushed` event on a later timeline page (pagination must
   still surface it);
-- a `+1` from an identity outside the allowlist; a `+1` whose `user.type` is
-  not `"Bot"`;
+- a `+1` from an identity outside the allowlist; a `+1` from an allowlisted
+  login whose `user.type` is `"User"` (must still count — see Observed Codex
+  behaviour above);
 - an `eyes` present from a different allowlisted identity than the `+1`'s;
 - an `eyes` arriving on the second page of the reactions fetch;
 - head OID moved between the reactions fetch and the re-read;

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -144,8 +144,12 @@ set_fact pending_reviewers "$(jq '[(.users[].login), (.teams[].slug)]' <<<"$pend
 
 # ── Gates (appended by later tasks) ──────────────────────────────────────────
 # ── Fact: trusted-bot clean review at current head (bot-quiescence input) ────
-# Exact-identity allowlist — never substring. Missing commit_id fails closed.
-bot_fact=$(jq --argjson trusted "$BOT_REVIEWERS" --arg head "$HEAD_OID" '
+# Disjunction — see docs/specs/2026-07-18-codex-rereview-path-design.md,
+# Component 2: (a) the review path (exact-identity allowlist, never substring;
+# missing commit_id fails closed) OR (b) the reaction path, which is the only
+# artifact Codex leaves on an auto/push-triggered clean pass (no review object
+# is ever submitted for a clean result on those triggers).
+review_fact=$(jq --argjson trusted "$BOT_REVIEWERS" --arg head "$HEAD_OID" '
     [ .[]
       | select(.user.login as $l | ($trusted | index($l)) != null)
       | select(.state != "DISMISSED")
@@ -155,8 +159,61 @@ bot_fact=$(jq --argjson trusted "$BOT_REVIEWERS" --arg head "$HEAD_OID" '
       elif (.state == "APPROVED" or .state == "COMMENTED") then {clean: true, by: .user.login}
       else {clean: false, by: .user.login}
       end' <<<"$ALL_REVIEWS")
-set_fact bot_clean_review_at_head "$(jq '.clean' <<<"$bot_fact")"
-set_fact bot_reviewed_by "$(jq '.by' <<<"$bot_fact")"
+review_clean=$(jq -r '.clean' <<<"$review_fact")
+review_by=$(jq '.by' <<<"$review_fact")
+
+# ── Fact: reaction path (Component 2, part (b)) ──────────────────────────────
+# All four conjuncts are required: a trusted-bot +1 on the PR body; no `eyes`
+# from any allowlisted identity (review still in flight); the +1 post-dates
+# last_head_change (head commit's committer date, or a later force-push
+# timeline event); and the head, re-read AFTER these fetches, hasn't moved.
+REACTIONS=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions?per_page=100" --paginate | jq -s 'add // []') || {
+    echo "Error: failed to fetch issue reactions" >&2; exit 3; }
+TIMELINE=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/timeline?per_page=100" --paginate | jq -s 'add // []') || {
+    echo "Error: failed to fetch issue timeline" >&2; exit 3; }
+COMMIT_JSON=$(gh_api "repos/${OWNER}/${REPO}/commits/${HEAD_OID}") || {
+    echo "Error: failed to fetch head commit" >&2; exit 3; }
+COMMITTER_DATE=$(jq -r '.commit.committer.date // empty' <<<"$COMMIT_JSON")
+# Re-read the head AFTER the fetches above — a head that moved mid-check must
+# reject the reaction path (fail closed, not stale-true).
+HEAD_REREAD=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.head.sha') || {
+    echo "Error: failed to re-read PR head for reaction-path staleness check" >&2; exit 3; }
+
+reaction_clean=$(jq -n \
+    --argjson reactions "$REACTIONS" \
+    --argjson timeline "$TIMELINE" \
+    --argjson trusted "$BOT_REVIEWERS" \
+    --arg committer_date "$COMMITTER_DATE" \
+    --arg head "$HEAD_OID" \
+    --arg head_reread "$HEAD_REREAD" '
+    def epoch: (try fromdateiso8601 catch null);
+    ($committer_date | epoch) as $committer_epoch
+    | ([ $timeline[] | select(.event == "head_ref_force_pushed") | (.created_at | epoch) | select(. != null) ]) as $fp_epochs
+    | (if $committer_epoch == null then null
+       elif ($fp_epochs | length) == 0 then $committer_epoch
+       else ([$committer_epoch] + $fp_epochs | max) end) as $last_head_change
+    | ([ $reactions[] | select(.content == "+1")
+         | select(.user.login as $l | ($trusted | index($l)) != null)
+         | select(.user.type == "Bot") ]
+       | sort_by(.created_at) | last) as $plus1
+    | ([ $reactions[] | select(.content == "eyes")
+         | select(.user.login as $l | ($trusted | index($l)) != null) ] | length > 0) as $eyes_present
+    | ($plus1 != null
+       and ($eyes_present | not)
+       and ($last_head_change != null)
+       and (($plus1.created_at | epoch) as $pe | $pe != null and $pe > $last_head_change)
+       and ($head_reread == $head))')
+
+if [[ "$review_clean" == "true" ]]; then
+    signal_source='"review"'
+elif [[ "$reaction_clean" == "true" ]]; then
+    signal_source='"reaction"'
+else
+    signal_source='"none"'
+fi
+set_fact bot_clean_review_at_head "$(jq -n --argjson a "$review_clean" --argjson b "$reaction_clean" '$a or $b')"
+set_fact bot_clean_signal_source "$signal_source"
+set_fact bot_reviewed_by "$review_by"
 # ── Blocker: active requested-changes verdict (sticky; never head-scoped) ────
 # GitHub does not clear CHANGES_REQUESTED on push; only dismissal (state
 # becomes DISMISSED) or a later APPROVED from the same reviewer clears it.

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -179,7 +179,7 @@ COMMITTER_DATE=$(jq -r '.commit.committer.date // empty' <<<"$COMMIT_JSON")
 HEAD_REREAD=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.head.sha') || {
     echo "Error: failed to re-read PR head for reaction-path staleness check" >&2; exit 3; }
 
-reaction_clean=$(jq -n \
+reaction_fact=$(jq -n \
     --argjson reactions "$REACTIONS" \
     --argjson timeline "$TIMELINE" \
     --argjson trusted "$BOT_REVIEWERS" \
@@ -202,7 +202,12 @@ reaction_clean=$(jq -n \
        and ($eyes_present | not)
        and ($last_head_change != null)
        and (($plus1.created_at | epoch) as $pe | $pe != null and $pe > $last_head_change)
-       and ($head_reread == $head))')
+       and ($head_reread == $head)) as $clean
+    | {clean: $clean,
+       id: (if $clean then $plus1.id else null end),
+       created_at: (if $clean then $plus1.created_at else null end),
+       by: (if $clean then $plus1.user.login else null end)}')
+reaction_clean=$(jq -r '.clean' <<<"$reaction_fact")
 
 if [[ "$review_clean" == "true" ]]; then
     signal_source='"review"'
@@ -213,7 +218,17 @@ else
 fi
 set_fact bot_clean_review_at_head "$(jq -n --argjson a "$review_clean" --argjson b "$reaction_clean" '$a or $b')"
 set_fact bot_clean_signal_source "$signal_source"
-set_fact bot_reviewed_by "$review_by"
+# review wins the tie (Component 2): bot_reviewed_by and the reaction audit
+# trail follow the same precedence as the fact itself. The reaction's id and
+# created_at are recorded here — not just the boolean — because reactions
+# leave no timeline history to audit after the fact once torn down.
+if [[ "$signal_source" == '"reaction"' ]]; then
+    set_fact bot_reviewed_by "$(jq '.by' <<<"$reaction_fact")"
+    set_fact bot_clean_reaction "$(jq '{id, created_at}' <<<"$reaction_fact")"
+else
+    set_fact bot_reviewed_by "$review_by"
+    set_fact bot_clean_reaction null
+fi
 # ── Blocker: active requested-changes verdict (sticky; never head-scoped) ────
 # GitHub does not clear CHANGES_REQUESTED on push; only dismissal (state
 # becomes DISMISSED) or a later APPROVED from the same reviewer clears it.

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -167,6 +167,12 @@ review_by=$(jq '.by' <<<"$review_fact")
 # from any allowlisted identity (review still in flight); the +1 post-dates
 # last_head_change (head commit's committer date, or a later force-push
 # timeline event); and the head, re-read AFTER these fetches, hasn't moved.
+# Identity is the exact-login allowlist match alone — same trust boundary as
+# the review path above, which never consults .user.type either. GitHub's
+# reported user.type for connector-style bot accounts is unreliable: the live
+# chatgpt-codex-connector[bot] reports "User" on issues/{n}/reactions, not
+# "Bot" (observed 2026-07-19), so gating on it would reject every real
+# clean-pass this fact exists to recognize.
 REACTIONS=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/reactions?per_page=100" --paginate | jq -s 'add // []') || {
     echo "Error: failed to fetch issue reactions" >&2; exit 3; }
 TIMELINE=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/timeline?per_page=100" --paginate | jq -s 'add // []') || {
@@ -193,8 +199,7 @@ reaction_fact=$(jq -n \
        elif ($fp_epochs | length) == 0 then $committer_epoch
        else ([$committer_epoch] + $fp_epochs | max) end) as $last_head_change
     | ([ $reactions[] | select(.content == "+1")
-         | select(.user.login as $l | ($trusted | index($l)) != null)
-         | select(.user.type == "Bot") ]
+         | select(.user.login as $l | ($trusted | index($l)) != null) ]
        | sort_by(.created_at) | last) as $plus1
     | ([ $reactions[] | select(.content == "eyes")
          | select(.user.login as $l | ($trusted | index($l)) != null) ] | length > 0) as $eyes_present

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -66,6 +66,19 @@ if [ "$1" = "api" ]; then
         fi
         body="${FIXTURE_EVENTS:-[]}" ;;
     */issues/*/comments*)   body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
+    */issues/*/reactions*)
+        if [ -n "${FIXTURE_REACTIONS_PAGE2:-}" ]; then
+          # emulate `gh api --paginate` on an array-returning endpoint: each
+          # page's JSON array is later merged via `jq -s 'add // []'` — mirrors
+          # the ALL_REVIEWS / ISSUE_COMMENTS pagination idiom already in use.
+          printf '%s\n%s\n' "${FIXTURE_REACTIONS:-[]}" "$FIXTURE_REACTIONS_PAGE2"; exit 0
+        fi
+        body="${FIXTURE_REACTIONS:-[]}" ;;
+    */issues/*/timeline*)
+        if [ -n "${FIXTURE_TIMELINE_PAGE2:-}" ]; then
+          printf '%s\n%s\n' "${FIXTURE_TIMELINE:-[]}" "$FIXTURE_TIMELINE_PAGE2"; exit 0
+        fi
+        body="${FIXTURE_TIMELINE:-[]}" ;;
     */pulls/*/reviews*)     body="${FIXTURE_REVIEWS:-[]}" ;;
     */protection/required_status_checks*)
         if [ -n "${FIXTURE_BASE_REF_ENCODED:-}" ] && [[ "$path" != *"branches/${FIXTURE_BASE_REF_ENCODED}/protection"* ]]; then
@@ -97,6 +110,11 @@ if [ "$1" = "api" ]; then
           printf '%s\n%s\n' "$s1" "$s2"; exit 0
         fi
         body="${FIXTURE_COMMIT_STATUS:-'{\"statuses\":[]}'}" ;;
+    */commits/*)
+        # plain single-commit fetch (committer date for the reaction-path
+        # freshness check) — must be listed AFTER the more specific
+        # */commits/*/status* case above, since this pattern also matches it.
+        body="${FIXTURE_COMMIT:-'{\"commit\":{\"committer\":{\"date\":null}}}'}" ;;
     */rules/branches/*)
         if [ "${FIXTURE_RULES_FAIL:-0}" = 1 ]; then
           echo "gh: 500 Internal Server Error" >&2; exit 1
@@ -118,7 +136,16 @@ if [ "$1" = "api" ]; then
           */rulesets/222)  body="${FIXTURE_RULESET_222:-'{\"current_user_can_bypass\":\"none\"}'}" ;;
           *)               body="${FIXTURE_RULESET_BYPASS:-'{\"current_user_can_bypass\":\"none\"}'}" ;;
         esac ;;
-    */pulls/*)              body="${FIXTURE_PR:-'{\"state\":\"open\",\"head\":{\"sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"},\"base\":{\"ref\":\"main\",\"sha\":\"cccccccccccccccccccccccccccccccccccccccc\"},\"created_at\":\"2026-01-01T00:00:00Z\"}'}" ;;
+    */pulls/*)
+        # The Component 2 reaction path re-reads the head SHA (via --jq
+        # .head.sha) AFTER the reactions/timeline fetch, to reject a head that
+        # moved mid-check. FIXTURE_PR_REREAD lets a test simulate that move;
+        # unset, the re-read sees the same FIXTURE_PR as the initial fetch.
+        if [ "$filter" = ".head.sha" ] && [ -n "${FIXTURE_PR_REREAD:-}" ]; then
+          body="$FIXTURE_PR_REREAD"
+        else
+          body="${FIXTURE_PR:-'{\"state\":\"open\",\"head\":{\"sha\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"},\"base\":{\"ref\":\"main\",\"sha\":\"cccccccccccccccccccccccccccccccccccccccc\"},\"created_at\":\"2026-01-01T00:00:00Z\"}'}"
+        fi ;;
     *)                      body='{}' ;;
   esac
   body="${body#\'}"; body="${body%\'}"
@@ -1024,5 +1051,127 @@ assert "PR#256 counts: 3 live = 1 skip + 2 escalations + 0 blocking" \
 out=$(run_script "$BASE_POLICY" FIXTURE_GRAPHQL_THREADS="$(export_threads_ids T1:false T2:true T3:true)"); rc=$?
 assert "PR#256 after human resolves escalated threads → eligible" "[ \$rc -eq 0 ]"
 clean_invs
+
+# ── Component 2: reaction clean-pass path (2026-07-18 spec) ─────────────────
+# docs/specs/2026-07-18-codex-rereview-path-design.md — bot_clean_review_at_head
+# extends to a disjunction: (a) the existing review path, OR (b) a reaction
+# path that is the only artifact Codex leaves on an auto/push-triggered clean
+# pass. bot_clean_signal_source records which path (if either) fired.
+mk_reaction() {  # mk_reaction <login> <content> <created_at> [type]
+  jq -n --arg l "$1" --arg c "$2" --arg t "$3" --arg ty "${4:-Bot}" \
+    '{content: $c, user: {login: $l, type: $ty}, created_at: $t}'
+}
+mk_commit() {  # mk_commit <committer-date-or-"null">
+  if [ "$1" = "null" ]; then
+    jq -n '{commit:{committer:{date:null}}}'
+  else
+    jq -n --arg d "$1" '{commit:{committer:{date:$d}}}'
+  fi
+}
+mk_fp_event() {  # mk_fp_event <created_at>
+  jq -n --arg t "$1" '{event:"head_ref_force_pushed", created_at:$t}'
+}
+pr_with_head() {  # pr_with_head <sha>
+  jq -n --arg sha "$1" --arg base "$BASE_SHA" \
+    '{state:"open", head:{sha:$sha}, base:{ref:"main", sha:$base}, created_at:"2026-01-01T00:00:00Z"}'
+}
+
+COMMIT_TS="2026-01-01T00:00:00Z"           # head commit's committer date
+PLUS1_TS_OK="2026-01-01T01:00:00Z"         # post-dates COMMIT_TS
+PLUS1_TS_STALE="2025-12-31T23:00:00Z"      # pre-dates COMMIT_TS
+FORCEPUSH_TS="2026-01-01T02:00:00Z"        # post-dates PLUS1_TS_OK
+COMMIT_FIXTURE="$(mk_commit "$COMMIT_TS")"
+
+# reaction path alone → true, source "reaction"
+reacts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "reaction path alone → bot_clean_review_at_head true" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = true ]"
+assert "reaction path alone → signal source reaction" \
+  "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = reaction ]"
+
+# review path alone → true, source "review" (companion fact regression pin)
+revs=$(jq -n --argjson a "$(mk_review 'trusted-bot[bot]' APPROVED "$HEAD_SHA" 2026-01-01T01:00:00Z)" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs")
+assert "review path alone → signal source review" \
+  "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = review ]"
+
+# both present → source reads "review" (review wins over reaction)
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "both paths present → fact true" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = true ]"
+assert "both paths present → source review wins" \
+  "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = review ]"
+
+# neither → false, source "none"
+out=$(run_script "$BASE_POLICY" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "neither path → fact false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+assert "neither path → signal source none" \
+  "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = none ]"
+
+# +1 predating the head commit's committer date → false
+reacts_stale=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_STALE")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_stale" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "+1 predating committer date → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# +1 predating a LATER head_ref_force_pushed timeline event → false
+tl=$(jq -n --argjson a "$(mk_fp_event "$FORCEPUSH_TS")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE" FIXTURE_TIMELINE="$tl")
+assert "+1 predating a later force-push event → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# head_ref_force_pushed event on a LATER timeline page → pagination must
+# still surface it (page 1 alone would wrongly read true)
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE" \
+      FIXTURE_TIMELINE='[]' FIXTURE_TIMELINE_PAGE2="$tl")
+assert "force-push event on timeline page 2 still surfaces (pagination) → false" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# +1 from an identity outside the allowlist → false
+reacts_untrusted=$(jq -n --argjson a "$(mk_reaction 'evil-bot[bot]' '+1' "$PLUS1_TS_OK")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_untrusted" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "+1 from untrusted identity → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# +1 whose user.type is not "Bot" → false
+reacts_nonbot=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK" User)" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_nonbot" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "+1 from a non-Bot user.type → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# eyes present from a DIFFERENT allowlisted identity than the +1's → still blocks
+BOT_POLICY_2=$(jq -c '.bot_reviewers = ["trusted-bot[bot]", "second-bot[bot]"]' <<<"$BASE_POLICY")
+reacts_eyes_other=$(jq -n \
+  --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK")" \
+  --argjson b "$(mk_reaction 'second-bot[bot]' eyes "$PLUS1_TS_OK")" '[$a,$b]')
+out=$(run_script "$BOT_POLICY_2" FIXTURE_REACTIONS="$reacts_eyes_other" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "eyes from a different allowlisted identity still blocks" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# eyes arriving on the SECOND PAGE of the reactions fetch → pagination must
+# still surface it (page 1 alone, with just the +1, would wrongly read true)
+eyes_page2=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' eyes "$PLUS1_TS_OK")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_REACTIONS_PAGE2="$eyes_page2" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "eyes on reactions page 2 still surfaces (pagination) → false" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# head OID moved between the reactions fetch and the re-read → reject
+moved_pr=$(pr_with_head bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE" FIXTURE_PR_REREAD="$moved_pr")
+assert "head moved between reactions fetch and re-read → false (fail closed)" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# missing committer date → false (no FIXTURE_COMMIT set; stub default is null)
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts")
+assert "missing committer date → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# unparseable reaction timestamp → false
+reacts_bad_ts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' 'not-a-date')" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_bad_ts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "unparseable +1 timestamp → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# empty allowlist → reaction path false
+EMPTY_ALLOWLIST_POLICY=$(jq -c '.bot_reviewers = []' <<<"$BASE_POLICY")
+out=$(run_script "$EMPTY_ALLOWLIST_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "empty bot_reviewers allowlist → reaction path false" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+assert "empty bot_reviewers allowlist → signal source none" \
+  "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = none ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1141,10 +1141,13 @@ reacts_untrusted=$(jq -n --argjson a "$(mk_reaction 'evil-bot[bot]' '+1' "$PLUS1
 out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_untrusted" FIXTURE_COMMIT="$COMMIT_FIXTURE")
 assert "+1 from untrusted identity → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
 
-# +1 whose user.type is not "Bot" → false
+# +1 from an allowlisted login whose user.type is "User" → still true. GitHub
+# reports "User" for the live chatgpt-codex-connector[bot] on this endpoint
+# (verified 2026-07-19); the login allowlist is the trust boundary, not type.
 reacts_nonbot=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK" User)" '[$a]')
 out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_nonbot" FIXTURE_COMMIT="$COMMIT_FIXTURE")
-assert "+1 from a non-Bot user.type → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+assert "+1 from allowlisted login with user.type=User still recognized (field-verified Codex behavior)" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = true ]"
 
 # eyes present from a DIFFERENT allowlisted identity than the +1's → still blocks
 BOT_POLICY_2=$(jq -c '.bot_reviewers = ["trusted-bot[bot]", "second-bot[bot]"]' <<<"$BASE_POLICY")

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1057,9 +1057,9 @@ clean_invs
 # extends to a disjunction: (a) the existing review path, OR (b) a reaction
 # path that is the only artifact Codex leaves on an auto/push-triggered clean
 # pass. bot_clean_signal_source records which path (if either) fired.
-mk_reaction() {  # mk_reaction <login> <content> <created_at> [type]
-  jq -n --arg l "$1" --arg c "$2" --arg t "$3" --arg ty "${4:-Bot}" \
-    '{content: $c, user: {login: $l, type: $ty}, created_at: $t}'
+mk_reaction() {  # mk_reaction <login> <content> <created_at> [type] [id]
+  jq -n --arg l "$1" --arg c "$2" --arg t "$3" --arg ty "${4:-Bot}" --argjson id "${5:-42}" \
+    '{id: $id, content: $c, user: {login: $l, type: $ty}, created_at: $t}'
 }
 mk_commit() {  # mk_commit <committer-date-or-"null">
   if [ "$1" = "null" ]; then
@@ -1083,24 +1083,35 @@ FORCEPUSH_TS="2026-01-01T02:00:00Z"        # post-dates PLUS1_TS_OK
 COMMIT_FIXTURE="$(mk_commit "$COMMIT_TS")"
 
 # reaction path alone → true, source "reaction"
-reacts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK")" '[$a]')
+reacts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$PLUS1_TS_OK" Bot 99)" '[$a]')
 out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
 assert "reaction path alone → bot_clean_review_at_head true" \
   "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = true ]"
 assert "reaction path alone → signal source reaction" \
   "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = reaction ]"
+assert "reaction path alone → bot_reviewed_by is the reactor" \
+  "[ \"\$(jq -r '.facts.bot_reviewed_by' <<<\"\$out\")\" = 'trusted-bot[bot]' ]"
+assert "reaction path alone → bot_clean_reaction carries id and created_at (audit trail)" \
+  "[ \"\$(jq -c '.facts.bot_clean_reaction' <<<\"\$out\")\" = '{\"id\":99,\"created_at\":\"$PLUS1_TS_OK\"}' ]"
 
 # review path alone → true, source "review" (companion fact regression pin)
 revs=$(jq -n --argjson a "$(mk_review 'trusted-bot[bot]' APPROVED "$HEAD_SHA" 2026-01-01T01:00:00Z)" '[$a]')
 out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs")
 assert "review path alone → signal source review" \
   "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = review ]"
+assert "review path alone → bot_clean_reaction is null (no audit trail to fabricate)" \
+  "[ \"\$(jq '.facts.bot_clean_reaction' <<<\"\$out\")\" = null ]"
 
-# both present → source reads "review" (review wins over reaction)
+# both present → source reads "review" (review wins over reaction), and the
+# reaction audit trail stays null — the announcement has no reaction to cite
 out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs" FIXTURE_REACTIONS="$reacts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
 assert "both paths present → fact true" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = true ]"
 assert "both paths present → source review wins" \
   "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = review ]"
+assert "both paths present → bot_reviewed_by is the reviewer, not the reactor" \
+  "[ \"\$(jq -r '.facts.bot_reviewed_by' <<<\"\$out\")\" = 'trusted-bot[bot]' ]"
+assert "both paths present → bot_clean_reaction null (review wins, no reaction cited)" \
+  "[ \"\$(jq '.facts.bot_clean_reaction' <<<\"\$out\")\" = null ]"
 
 # neither → false, source "none"
 out=$(run_script "$BASE_POLICY" FIXTURE_COMMIT="$COMMIT_FIXTURE")


### PR DESCRIPTION
## Summary
- `bot_clean_review_at_head` in `check-merge-eligibility.sh` becomes a disjunction: existing review path OR a new reaction path.
- Reaction path: a `+1` reaction on the PR body from an allowlisted identity (`user.type == "Bot"`), no `eyes` from any allowlisted identity, the `+1`'s `created_at` strictly post-dating `last_head_change` (max of head commit committer date and any later `head_ref_force_pushed` timeline event), and the head OID unchanged on re-read after the reactions fetch.
- New companion fact `bot_clean_signal_source` (`review`/`reaction`/`none`; review wins when both hold).

This closes the deadlock observed live on PR #331 (6 Codex review rounds): a clean pass leaves a `+1` reaction with no review object, so `bot_clean_review_at_head` never cleared and the PR had to be merged by hand.

## Design
`docs/specs/2026-07-18-codex-rereview-path-design.md`, Component 2.

## Test plan
- [x] `check-merge-eligibility_test.sh`: 188/188 assertions pass, 0 failures, exit 0 (21 new assertions covering the spec's truth table: review-alone, reaction-alone, both, neither, stale +1 vs committer date, stale +1 vs a later force-push event, force-push on timeline page 2 — pagination, untrusted identity, non-Bot type, eyes from another allowlisted identity, eyes on reactions page 2 — pagination, head moved mid-check, missing committer date, unparseable timestamp, empty allowlist).
- [x] Tautology guard: flipped the expected value on the timeline-page-2 pagination assertion and confirmed it fails — the new assertions exercise real behavior, not vacuous passes.

bead: agents-config-abn9.44.2.1