### PR TITLE
fix(wait-for-pr-comments): make Phase 2 entry gate bot-reviewer-aware

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -141,7 +141,12 @@ Background bash — zero Anthropic tokens during the wait.
 1. **Quick check** whether Copilot is already a requested reviewer (a
     Copilot-specific convenience glance to decide `--skip-request-check`; the
     launched script in step 3 does the authoritative policy-allowlist matching,
-    so this substring probe need not generalize to non-Copilot bots):
+    so this substring probe need not generalize to non-Copilot bots). This
+    glance is only relevant for request-based bots (Copilot) — comment-triggered
+    bots (e.g. Codex) are never added as a requested reviewer, so the script
+    itself auto-skips its requested-reviewer precondition when the resolved
+    policy's `bot_reviewers` includes a comment-triggered identity; the caller
+    need not special-case that here:
     ```
     gh api repos/<owner>/<repo>/issues/<n>/events \
       --jq '[.[] | select(

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -17,7 +17,12 @@
 # any bot the merge policy trusts. Callers should pass the resolved review
 # policy's bot_reviewers list (see merge-guard/resolve_policy.py); the same
 # exact-identity allowlist the merge gate enforces. Omit it to keep the
-# standalone Copilot-substring default.
+# standalone Copilot-substring default. If it contains a comment-triggered
+# identity (currently chatgpt-codex-connector[bot]/Codex — never a requested
+# reviewer, mirrors request-rereview.sh's identity dispatch table), Sub-phase
+# A's requested-reviewer probe auto-skips (as if --skip-request-check were
+# passed) instead of risking a spurious copilot_not_requested exit; no effect
+# when the list has only request-based identities (e.g. Copilot).
 #
 # Poll completion contract: this script's JSON output also completes without
 # a review object when a bot's pass is clean. When --bot-reviewers is
@@ -157,6 +162,23 @@ COPILOT_REVIEW_FILTER="(.user.type == \"Bot\") and (.user.login | ${COPILOT_LOGI
 # (checked only when --bot-reviewers is supplied; see header).
 CLEAN_PASS_MARKER="Codex Review: Didn't find any major issues"
 
+# Comment-triggered bot identities (mirrors request-rereview.sh's identity
+# dispatch table) — these bots are never added as a requested reviewer; they
+# are triggered by an '@codex review' issue comment instead. When
+# --bot-reviewers includes one of these, Sub-phase A's requested-reviewer
+# probe is not a valid precondition for the whole policy (see Sub-phase A
+# below).
+COMMENT_TRIGGERED_BOTS='["chatgpt-codex-connector[bot]"]'
+
+HAS_COMMENT_TRIGGERED_BOT=false
+if [[ -n "$BOT_REVIEWERS" ]]; then
+    if jq -e --argjson known "$COMMENT_TRIGGERED_BOTS" \
+        '(map(ascii_downcase)) as $mine | ($known | map(ascii_downcase)) as $known_lc | any($mine[]; . as $m | $known_lc | index($m) != null)' \
+        <<<"$BOT_REVIEWERS" >/dev/null 2>&1; then
+        HAS_COMMENT_TRIGGERED_BOT=true
+    fi
+fi
+
 # ── Helper functions ──────────────────────────────────────────────────────────
 
 pr_is_open() {
@@ -237,7 +259,7 @@ preflight_checks
 
 # ── Sub-phase A: Request detection (20s × 3, max ~1 minute) ──────────────────
 
-if [[ "$SKIP_REQUEST" == false ]]; then
+if [[ "$SKIP_REQUEST" == false && "$HAS_COMMENT_TRIGGERED_BOT" == false ]]; then
     echo "Sub-phase A: Checking if Copilot was requested as reviewer..." >&2
     copilot_requested=false
 
@@ -265,7 +287,11 @@ if [[ "$SKIP_REQUEST" == false ]]; then
         exit 2
     fi
 else
-    echo "Sub-phase A: Skipped (--skip-request-check)" >&2
+    if [[ "$SKIP_REQUEST" == true ]]; then
+        echo "Sub-phase A: Skipped (--skip-request-check)" >&2
+    else
+        echo "Sub-phase A: Skipped (--bot-reviewers includes a comment-triggered identity; requested-reviewer probe is not a precondition)" >&2
+    fi
 fi
 
 # ── Sub-phase B: Start detection (20s × 3, max ~1 minute) ────────────────────

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -502,4 +502,49 @@ rc_cc_p2=$?
 assert "a marker comment on page 2 completes (exit 0)" "[ \$rc_cc_p2 -eq 0 ]"
 assert "a page-2 marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_cc_p2\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
 
+# ── Sub-phase A auto-skip for comment-triggered bot identities (Codex is
+#    never a requested reviewer — it is triggered by an issue comment; see
+#    request-rereview.sh's identity dispatch table) ──────────────────────────
+# When --bot-reviewers includes a comment-triggered identity, the Sub-phase A
+# requested-reviewer precondition does not apply to it — the poll must
+# proceed straight to Sub-phase B/C as if --skip-request-check were passed,
+# without exiting 2 (copilot_not_requested), even when the events API never
+# returns a review_requested match. FIXTURE_EVENTS_STARTED (defined above) has
+# zero review_requested events but a copilot_work_started event, so
+# Sub-phase B (when reached) resolves on its first attempt without a real
+# sleep.
+
+# (m) --bot-reviewers is Codex-only, no --skip-request-check: must NOT exit 2
+#     and must NOT report copilot_not_requested — Sub-phase A auto-skips.
+out_codex_only=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --timeout-seconds 1 --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
+rc_codex_only=$?
+assert "Codex-only --bot-reviewers does not exit 2 (auto-skips Sub-phase A)" "[ \$rc_codex_only -ne 2 ]"
+assert "Codex-only --bot-reviewers does not report copilot_not_requested" "! printf '%s' \"\$out_codex_only\" | grep -q copilot_not_requested"
+
+# (n) --bot-reviewers is Copilot-only, no --skip-request-check, events API has
+#     zero review_requested matches: existing behavior is unchanged — exits 2
+#     after the real ~1-minute Sub-phase A probe.
+out_copilot_only=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --timeout-seconds 1 --bot-reviewers '["Copilot"]' 2>/dev/null)
+rc_copilot_only=$?
+assert "Copilot-only --bot-reviewers still exits 2 when not requested (unchanged)" "[ \$rc_copilot_only -eq 2 ]"
+assert "Copilot-only --bot-reviewers reports copilot_not_requested" "printf '%s' \"\$out_copilot_only\" | grep -q copilot_not_requested"
+
+# (o) No --bot-reviewers at all (standalone default), events API zero matches,
+#     no --skip-request-check: legacy default behavior is unchanged — exits 2
+#     after the real ~1-minute Sub-phase A probe.
+out_no_policy_default=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --timeout-seconds 1 2>/dev/null)
+rc_no_policy_default=$?
+assert "standalone default (no --bot-reviewers) still exits 2 when not requested (unchanged)" "[ \$rc_no_policy_default -eq 2 ]"
+
+# (p) Mixed --bot-reviewers (Copilot + Codex), zero review_requested matches:
+#     presence of the comment-triggered identity lifts the precondition for
+#     the whole policy — must NOT exit 2.
+out_mixed=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS='[]' \
+  "$SCRIPT" --owner o --repo r --pr 1 --timeout-seconds 1 --bot-reviewers "[\"Copilot\", \"$CODEX_ID\"]" 2>/dev/null)
+rc_mixed=$?
+assert "mixed Copilot+Codex --bot-reviewers does not exit 2 (comment-triggered identity present)" "[ \$rc_mixed -ne 2 ]"
+
 exit $FAIL


### PR DESCRIPTION
## Summary
- `poll-copilot-review.sh` Sub-phase A probed GitHub for Copilot as a requested reviewer as a precondition before ever reaching the poll loop. Codex is never a requested reviewer -- it triggers on an `@codex review` issue comment -- so on a Codex-only PR the script always timed out Sub-phase A and exited 2 (`copilot_not_requested`), aborting before Sub-phase C's already-correct Codex handling. Field-discovered on PR #331 (six manual `--skip-request-check` workarounds).
- Sub-phase A now auto-skips its requested-reviewer probe when `--bot-reviewers` includes a comment-triggered identity (currently `chatgpt-codex-connector[bot]`), mirroring `request-rereview.sh`'s identity dispatch table. Copilot-only and no-policy (standalone default) behavior is unchanged.
- SKILL.md Phase 2 step 1's convenience-glance prose updated to match (Phase 6, edited by sibling beads 44.2.5/44.2.6, is untouched).

## Test plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh` -- 69/69 ok, exit 0
- [x] New cases: Codex-only `--bot-reviewers` auto-skips (no exit 2); Copilot-only still gates (unchanged); no-policy default still gates (unchanged); mixed Copilot+Codex auto-skips (comment-triggered identity present is sufficient)
- [x] All pre-existing cases unchanged (no regressions)

bd: agents-config-abn9.44.2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)