### PR TITLE
feat(wait-for-pr-comments): structured do-not-relitigate context for Codex re-review asks

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -446,11 +446,31 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    the dispatch would discard that valid `+1` or marker comment as stale and
    count the ask as a timeout.
 
-2. **Trigger a fresh review cycle** (idempotency guard):
+2. **Trigger a fresh review cycle** (idempotency guard). Assemble the
+   do-not-relitigate context from the current round's already-classified
+   inventory items before dispatching — every FIX item contributes its
+   `fix_commit_sha` as `detail`; every SKIP item contributes its `rationale`
+   as `detail`, classified `REBUT` when the rationale is a substantive
+   disagreement with the finding (the "agent disagrees with rationale,
+   defensible counterargument" case from the classification table above) and
+   `SKIP` otherwise (out of scope, FYI/praise) — this REBUT/SKIP split is a
+   judgment call made when writing each item's `rationale`, not a separate
+   inventory field:
    ```bash
+   disposition_table=$(jq -c '[.items[] | select(.classification == "FIX" or .classification == "SKIP") |
+     if .classification == "FIX"
+     then {finding: .body_excerpt, classification: "FIX", detail: .fix_commit_sha}
+     else {finding: .body_excerpt, classification: "SKIP", detail: .rationale}
+     end]' "$HOME/.claude/state/pr-inventory/<owner>-<repo>-<n>-<head_sha_after_push>.json")
+   # Re-tag any SKIP entries that are substantive rebuttals to "REBUT" by hand
+   # (or via a review of each item's rationale) before dispatching, per the
+   # split above.
+
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR" \
-     --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"
+     --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")" \
+     --disposition-table "$disposition_table" \
+     --since-sha "<phase4_baseline_sha>"
    # exit 0 when at least one ask succeeded; exit 1 when none did
    ```
    `--bot-reviewers` dispatches on each policy-trusted identity's own
@@ -459,7 +479,13 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    Copilot-only dance — omitting it would leave a Codex-reviewed repo's
    re-review ask reaching nobody. (`--add-reviewer` alone is idempotent and
    silently does nothing, which is why the helper still pairs it with
-   `--remove-reviewer` for Copilot.)
+   `--remove-reviewer` for Copilot.) `--disposition-table` and `--since-sha`
+   are Codex-only do-not-relitigate context — they render into the `@codex
+   review` comment as a structured markdown table plus a "focus on commits
+   since `<sha>`" line, and are silently ignored by the Copilot mechanism.
+   Confirmed across PR #317 and PR #331: a bare re-ask makes Codex re-cite
+   settled findings every round, while a structured disposition table
+   (including an explicit REBUT) produced zero re-raises.
 
 3. **Launch** `poll-copilot-rereview-start.sh --owner "$OWNER" --repo "$REPO" --pr "$PR" --after <rereview_since_timestamp>` (80s max window:
    20s pre-sleep + 6 × 10s polls). This detects the `copilot_work_started`

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -447,29 +447,41 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    count the ask as a timeout.
 
 2. **Trigger a fresh review cycle** (idempotency guard). Assemble the
-   do-not-relitigate context from the current round's already-classified
-   inventory items before dispatching — every FIX item contributes its
-   `fix_commit_sha` as `detail`; every SKIP item contributes its `rationale`
-   as `detail`, classified `REBUT` when the rationale is a substantive
-   disagreement with the finding (the "agent disagrees with rationale,
-   defensible counterargument" case from the classification table above) and
-   `SKIP` otherwise (out of scope, FYI/praise) — this REBUT/SKIP split is a
-   judgment call made when writing each item's `rationale`, not a separate
-   inventory field:
+   do-not-relitigate context from `$ITEMS_FILE` — the current round's
+   already-classified in-memory items — before dispatching. Read from
+   `$ITEMS_FILE`, not the on-disk inventory at
+   `<head_sha_after_push>.json`: Phase 6 runs before Phase 7 writes that
+   file, so on a normal first pass it does not exist yet. Every FIX item
+   contributes its `fix_commit_sha` as `detail`; every SKIP item contributes
+   its `rationale` as `detail`, classified `REBUT` when the rationale is a
+   substantive disagreement with the finding (the "agent disagrees with
+   rationale, defensible counterargument" case from the classification table
+   above) and `SKIP` otherwise (out of scope, FYI/praise) — this REBUT/SKIP
+   split is a judgment call made when writing each item's `rationale`, not a
+   separate inventory field:
    ```bash
-   disposition_table=$(jq -c '[.items[] | select(.classification == "FIX" or .classification == "SKIP") |
+   disposition_table=$(jq -c '[.[] | select(.classification == "FIX" or .classification == "SKIP") |
      if .classification == "FIX"
      then {finding: .body_excerpt, classification: "FIX", detail: .fix_commit_sha}
      else {finding: .body_excerpt, classification: "SKIP", detail: .rationale}
-     end]' "$HOME/.claude/state/pr-inventory/<owner>-<repo>-<n>-<head_sha_after_push>.json")
+     end]' "$ITEMS_FILE")
    # Re-tag any SKIP entries that are substantive rebuttals to "REBUT" by hand
    # (or via a review of each item's rationale) before dispatching, per the
    # split above.
 
+   # An empty table (e.g. an autonomous run where every finding escalated,
+   # leaving no FIX/SKIP items) is not valid input to --disposition-table —
+   # omit the flag rather than pass "[]", or the whole re-review request
+   # (Codex AND Copilot) aborts before either ask is dispatched.
+   DISPOSITION_ARGS=()
+   if [ "$(jq 'length' <<<"$disposition_table")" -gt 0 ]; then
+     DISPOSITION_ARGS=(--disposition-table "$disposition_table")
+   fi
+
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR" \
      --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")" \
-     --disposition-table "$disposition_table" \
+     "${DISPOSITION_ARGS[@]}" \
      --since-sha "<phase4_baseline_sha>"
    # exit 0 when at least one ask succeeded; exit 1 when none did
    ```

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -474,9 +474,16 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    # — omit the flag rather than write/pass "[]", or the whole re-review
    # request (Codex AND Copilot) aborts before either ask is dispatched.
    DISPOSITION_ARGS=()
+   DISPOSITION_FILE=""
    if [ "$(jq 'length' <<<"$disposition_table")" -gt 0 ]; then
-     printf '%s' "$disposition_table" > /tmp/pr-rereview-disposition-<n>.json
-     DISPOSITION_ARGS=(--disposition-table-file /tmp/pr-rereview-disposition-<n>.json)
+     # mktemp, not a PR-number-keyed fixed path: two concurrent Phase 6 runs
+     # for the SAME PR number in DIFFERENT repos would otherwise share one
+     # global path and race — overwriting, reading, or deleting each other's
+     # table between this write and request-rereview.sh's read, leaking one
+     # PR's findings/rationales into another's Codex ask.
+     DISPOSITION_FILE="$(mktemp)"
+     printf '%s' "$disposition_table" > "$DISPOSITION_FILE"
+     DISPOSITION_ARGS=(--disposition-table-file "$DISPOSITION_FILE")
    fi
 
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
@@ -485,7 +492,7 @@ the helper's default (1) per spec decision, not a per-repo config knob.
      "${DISPOSITION_ARGS[@]}" \
      --since-sha "<phase4_baseline_sha>"
    # exit 0 when at least one ask succeeded; exit 1 when none did
-   rm -f /tmp/pr-rereview-disposition-<n>.json
+   [ -n "$DISPOSITION_FILE" ] && rm -f "$DISPOSITION_FILE"
    ```
    `--bot-reviewers` dispatches on each policy-trusted identity's own
    mechanism (the `remove-reviewer` + `add-reviewer` pair for Copilot, an

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -987,8 +987,15 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
   > /tmp/pr-inventory-build-<n>.json
 ```
 
-**Request a bot re-review** (Phase 6 — per-bot dispatch on the policy's
-`bot_reviewers` allowlist, not just the legacy Copilot remove+add pair):
+**Request a bot re-review** (per-bot dispatch on the policy's
+`bot_reviewers` allowlist, not just the legacy Copilot remove+add pair).
+This is the bare form; **Phase 6 step 2 is the authoritative invocation** —
+it additionally assembles `--disposition-table`/`--since-sha` from the
+current round's classified items so the Codex ask carries do-not-relitigate
+context. Do not call the bare form below for Phase 6 — it omits that
+context and reopens the settled-finding relitigation this mechanism exists
+to prevent. It remains valid for a caller with no round context to draw
+from (e.g. merge-guard's one-ask retry):
 
 ```bash
 ${CLAUDE_SKILL_DIR}/request-rereview.sh \

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -470,12 +470,13 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    # split above.
 
    # An empty table (e.g. an autonomous run where every finding escalated,
-   # leaving no FIX/SKIP items) is not valid input to --disposition-table —
-   # omit the flag rather than pass "[]", or the whole re-review request
-   # (Codex AND Copilot) aborts before either ask is dispatched.
+   # leaving no FIX/SKIP items) is not valid input to --disposition-table-file
+   # — omit the flag rather than write/pass "[]", or the whole re-review
+   # request (Codex AND Copilot) aborts before either ask is dispatched.
    DISPOSITION_ARGS=()
    if [ "$(jq 'length' <<<"$disposition_table")" -gt 0 ]; then
-     DISPOSITION_ARGS=(--disposition-table "$disposition_table")
+     printf '%s' "$disposition_table" > /tmp/pr-rereview-disposition-<n>.json
+     DISPOSITION_ARGS=(--disposition-table-file /tmp/pr-rereview-disposition-<n>.json)
    fi
 
    ${CLAUDE_SKILL_DIR}/request-rereview.sh \
@@ -484,6 +485,7 @@ the helper's default (1) per spec decision, not a per-repo config knob.
      "${DISPOSITION_ARGS[@]}" \
      --since-sha "<phase4_baseline_sha>"
    # exit 0 when at least one ask succeeded; exit 1 when none did
+   rm -f /tmp/pr-rereview-disposition-<n>.json
    ```
    `--bot-reviewers` dispatches on each policy-trusted identity's own
    mechanism (the `remove-reviewer` + `add-reviewer` pair for Copilot, an
@@ -491,13 +493,17 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    Copilot-only dance — omitting it would leave a Codex-reviewed repo's
    re-review ask reaching nobody. (`--add-reviewer` alone is idempotent and
    silently does nothing, which is why the helper still pairs it with
-   `--remove-reviewer` for Copilot.) `--disposition-table` and `--since-sha`
-   are Codex-only do-not-relitigate context — they render into the `@codex
-   review` comment as a structured markdown table plus a "focus on commits
-   since `<sha>`" line, and are silently ignored by the Copilot mechanism.
-   Confirmed across PR #317 and PR #331: a bare re-ask makes Codex re-cite
-   settled findings every round, while a structured disposition table
-   (including an explicit REBUT) produced zero re-raises.
+   `--remove-reviewer` for Copilot.) `--disposition-table-file` and
+   `--since-sha` are Codex-only do-not-relitigate context — they render into
+   the `@codex review` comment as a structured markdown table plus a "focus
+   on commits since `<sha>`" line, and are silently ignored by the Copilot
+   mechanism. The table is passed as a **file**, not inline JSON: a round
+   with enough items can exceed the OS's per-argument exec limit (Linux caps
+   a single argv/environ string at 128 KiB) — passing it inline fails the
+   `exec` itself, before `request-rereview.sh`'s own size handling ever gets
+   a chance to run. Confirmed across PR #317 and PR #331: a bare re-ask
+   makes Codex re-cite settled findings every round, while a structured
+   disposition table (including an explicit REBUT) produced zero re-raises.
 
 3. **Launch** `poll-copilot-rereview-start.sh --owner "$OWNER" --repo "$REPO" --pr "$PR" --after <rereview_since_timestamp>` (80s max window:
    20s pre-sleep + 6 × 10s polls). This detects the `copilot_work_started`
@@ -990,7 +996,7 @@ ${CLAUDE_SKILL_DIR}/build-inventory-body.sh \
 **Request a bot re-review** (per-bot dispatch on the policy's
 `bot_reviewers` allowlist, not just the legacy Copilot remove+add pair).
 This is the bare form; **Phase 6 step 2 is the authoritative invocation** —
-it additionally assembles `--disposition-table`/`--since-sha` from the
+it additionally assembles `--disposition-table-file`/`--since-sha` from the
 current round's classified items so the Codex ask carries do-not-relitigate
 context. Do not call the bare form below for Phase 6 — it omits that
 context and reopens the settled-finding relitigation this mechanism exists

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -85,6 +85,7 @@ REPO=""
 PR=""
 BOT_REVIEWERS=""
 DISPOSITION_TABLE=""
+DISPOSITION_TABLE_FILE_GIVEN=false
 SINCE_SHA=""
 
 [ $# -gt 0 ] || usage
@@ -99,6 +100,7 @@ while [ $# -gt 0 ]; do
       [ -n "${2:-}" ] || { echo "error: --disposition-table-file requires a value" >&2; usage; }
       [ -r "$2" ] || { echo "error: --disposition-table-file '$2' is not a readable file" >&2; exit 2; }
       DISPOSITION_TABLE="$(cat "$2")"
+      DISPOSITION_TABLE_FILE_GIVEN=true
       shift 2
       ;;
     --since-sha)
@@ -126,12 +128,17 @@ if [ -n "$BOT_REVIEWERS" ]; then
   }
 fi
 
-# Validate --disposition-table-file's content (when provided) as a non-empty
-# JSON array of objects, each with a "finding" string, a "classification" of
-# FIX/SKIP/REBUT, and a "detail" string (commit SHA for FIX, rationale for
-# SKIP/REBUT) — same fail-closed convention as --bot-reviewers, then
-# canonicalize via jq.
-if [ -n "$DISPOSITION_TABLE" ]; then
+# Validate --disposition-table-file's content (when the flag was given) as a
+# non-empty JSON array of objects, each with a "finding" string, a
+# "classification" of FIX/SKIP/REBUT, and a "detail" string (commit SHA for
+# FIX, rationale for SKIP/REBUT) — same fail-closed convention as
+# --bot-reviewers, then canonicalize via jq. Gated on
+# DISPOSITION_TABLE_FILE_GIVEN, not on "$DISPOSITION_TABLE" being non-empty:
+# a supplied file that reads back EMPTY (e.g. a zero-byte file) must still
+# fail this check — checking non-emptiness of the variable would instead
+# treat it exactly like the flag being omitted, silently dropping the
+# do-not-relitigate context the caller explicitly asked to attach.
+if [ "$DISPOSITION_TABLE_FILE_GIVEN" = true ]; then
   DISPOSITION_TABLE=$(jq -ce '
     if (type == "array" and length > 0 and
         ([.[] | select(

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -158,11 +158,33 @@ request_copilot() {
   fi
 }
 
+# GitHub issue-comment bodies are capped at 65536 characters. A disposition
+# table has no per-item length bound (a verbose SKIP rationale, or enough
+# FIX/SKIP items in one round, can exceed it), and gh's comment call would
+# then fail outright, leaving a Codex-only policy with no successful
+# re-review ask at all — worse than a plain, un-contextualized one. This
+# threshold leaves comfortable margin for the surrounding prose.
+MAX_CODEX_COMMENT_CHARS=60000
+
 # build_codex_comment_body — bare '@codex review' by default; when
 # --disposition-table and/or --since-sha are supplied, renders them as a
-# structured markdown table + focus line instead. This do-not-relitigate
-# context is Codex-only — request_copilot never sees it.
+# structured markdown table + focus line instead. Falls back to the bare
+# string (dropping the do-not-relitigate context, not the ask itself) when
+# the rendered body would exceed MAX_CODEX_COMMENT_CHARS. This do-not-
+# relitigate context is Codex-only — request_copilot never sees it.
 build_codex_comment_body() {
+  local full
+  full="$(_render_codex_comment_body)"
+  if [ "${#full}" -gt "$MAX_CODEX_COMMENT_CHARS" ]; then
+    echo "@codex review"
+    echo
+    echo "(do-not-relitigate context omitted: exceeded ${MAX_CODEX_COMMENT_CHARS} characters)"
+    return
+  fi
+  printf '%s' "$full"
+}
+
+_render_codex_comment_body() {
   if [ -z "$DISPOSITION_TABLE" ] && [ -z "$SINCE_SHA" ]; then
     echo "@codex review"
     return
@@ -181,8 +203,13 @@ build_codex_comment_body() {
     # cannot terminate or shift a row — free-text review excerpts and
     # rationales routinely contain both, and a shifted row breaks the
     # finding-to-classification association this table exists to preserve.
+    # Backslashes are escaped FIRST, before pipes: a cell containing a
+    # pre-existing '\|' (e.g. a regex excerpt) would otherwise have its own
+    # backslash consume the escape this function adds for the pipe,
+    # un-escaping it in the rendered Markdown and re-opening the same
+    # row-splitting hazard.
     jq -r '
-      def cell: gsub("\r\n|\r|\n"; " ") | gsub("\\|"; "\\|");
+      def cell: gsub("\r\n|\r|\n"; " ") | gsub("\\\\"; "\\\\") | gsub("\\|"; "\\|");
       .[] | "| " + (.finding | cell) + " | " + .classification + " | " + (.detail | cell) + " |"
     ' <<<"$DISPOSITION_TABLE"
     echo

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -86,8 +86,16 @@ while [ $# -gt 0 ]; do
     --repo)               REPO="${2:-}";                shift 2 ;;
     --pr)                 PR="${2:-}";                  shift 2 ;;
     --bot-reviewers)      BOT_REVIEWERS="${2:-}";       shift 2 ;;
-    --disposition-table)  DISPOSITION_TABLE="${2:-}";   shift 2 ;;
-    --since-sha)          SINCE_SHA="${2:-}";            shift 2 ;;
+    --disposition-table)
+      [ -n "${2:-}" ] || { echo "error: --disposition-table requires a value" >&2; usage; }
+      DISPOSITION_TABLE="$2"
+      shift 2
+      ;;
+    --since-sha)
+      [ -n "${2:-}" ] || { echo "error: --since-sha requires a value" >&2; usage; }
+      SINCE_SHA="$2"
+      shift 2
+      ;;
     -h|--help) usage ;;
     *) echo "error: unknown flag: $1" >&2; usage ;;
   esac
@@ -168,7 +176,15 @@ build_codex_comment_body() {
     echo
     echo "| Finding | Classification | Commit / Rationale |"
     echo "| --- | --- | --- |"
-    jq -r '.[] | "| " + .finding + " | " + .classification + " | " + .detail + " |"' <<<"$DISPOSITION_TABLE"
+    # Sanitize each cell before interpolation: collapse embedded newlines to
+    # spaces and escape literal "|" so a finding/rationale containing either
+    # cannot terminate or shift a row — free-text review excerpts and
+    # rationales routinely contain both, and a shifted row breaks the
+    # finding-to-classification association this table exists to preserve.
+    jq -r '
+      def cell: gsub("\r\n|\r|\n"; " ") | gsub("\\|"; "\\|");
+      .[] | "| " + (.finding | cell) + " | " + .classification + " | " + (.detail | cell) + " |"
+    ' <<<"$DISPOSITION_TABLE"
     echo
   fi
 

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -30,18 +30,20 @@
 #                            preserve the legacy Copilot-only dance
 #                            (backward-compatible default, not how the
 #                            wait-for-pr-comments/merge-guard loops run).
-#   --disposition-table <json>
+#   --disposition-table-file <path>
 #                            Do-not-relitigate context for the Codex ask ONLY
 #                            (Copilot is unaffected, gets neither this nor
-#                            --since-sha). Non-empty JSON array of objects:
-#                            {finding, classification: FIX|SKIP|REBUT, detail}
-#                            — detail is the fixing commit SHA for FIX, a
-#                            rationale for SKIP/REBUT. Renders as a markdown
+#                            --since-sha). Path to a file containing a
+#                            non-empty JSON array of objects: {finding,
+#                            classification: FIX|SKIP|REBUT, detail} — detail
+#                            is the fixing commit SHA for FIX, a rationale
+#                            for SKIP/REBUT. A FILE, not inline JSON — see
+#                            "Argv-size note" below. Renders as a markdown
 #                            table in the '@codex review' comment instead of
 #                            the bare string, so Codex does not re-raise
 #                            settled findings next round (confirmed PR #317,
-#                            #331 — bare re-ask re-cites SKIP/fixed items;
-#                            a disposition table does not, and can carry a
+#                            #331 — bare re-ask re-cites SKIP/fixed items; a
+#                            disposition table does not, and can carry a
 #                            REBUT Codex accepts instead of re-flagging).
 #   --since-sha <sha>        Optional. Codex-only: appends a "focus on
 #                            commits since <sha>" line to the comment body.
@@ -55,18 +57,25 @@
 #
 # GraphQL projection: none directly; uses `gh pr edit` / `gh pr comment` REST
 # under the hood.
+#
+# Argv-size note: --disposition-table-file takes a PATH, not inline JSON. A
+# round with enough items (or a few verbose rationales) can exceed the OS's
+# per-argument exec limit (Linux caps a single argv/environ string at 128
+# KiB) well before it exceeds anything this script controls — passing the
+# JSON inline would fail the `exec` itself, before this script's own
+# comment-size fallback (below) ever got a chance to run.
 set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> [--bot-reviewers <json-array>] [--disposition-table <json-array>] [--since-sha <sha>]
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> [--bot-reviewers <json-array>] [--disposition-table-file <path>] [--since-sha <sha>]
 
 Requests a re-review from one or more trusted bot reviewers, dispatching on
 identity: Copilot / copilot-pull-request-reviewer[bot] get the remove+re-add
 reviewer dance; chatgpt-codex-connector[bot] gets an '@codex review' issue
 comment. Omit --bot-reviewers to request only Copilot (legacy default).
---disposition-table and --since-sha add do-not-relitigate context to the
-Codex ask only; they have no effect on the Copilot mechanism.
+--disposition-table-file and --since-sha add do-not-relitigate context to
+the Codex ask only; they have no effect on the Copilot mechanism.
 EOF
   exit 2
 }
@@ -86,9 +95,10 @@ while [ $# -gt 0 ]; do
     --repo)               REPO="${2:-}";                shift 2 ;;
     --pr)                 PR="${2:-}";                  shift 2 ;;
     --bot-reviewers)      BOT_REVIEWERS="${2:-}";       shift 2 ;;
-    --disposition-table)
-      [ -n "${2:-}" ] || { echo "error: --disposition-table requires a value" >&2; usage; }
-      DISPOSITION_TABLE="$2"
+    --disposition-table-file)
+      [ -n "${2:-}" ] || { echo "error: --disposition-table-file requires a value" >&2; usage; }
+      [ -r "$2" ] || { echo "error: --disposition-table-file '$2' is not a readable file" >&2; exit 2; }
+      DISPOSITION_TABLE="$(cat "$2")"
       shift 2
       ;;
     --since-sha)
@@ -116,10 +126,11 @@ if [ -n "$BOT_REVIEWERS" ]; then
   }
 fi
 
-# Validate --disposition-table (when provided) as a non-empty JSON array of
-# objects, each with a "finding" string, a "classification" of FIX/SKIP/REBUT,
-# and a "detail" string (commit SHA for FIX, rationale for SKIP/REBUT) — same
-# fail-closed convention as --bot-reviewers, then canonicalize via jq.
+# Validate --disposition-table-file's content (when provided) as a non-empty
+# JSON array of objects, each with a "finding" string, a "classification" of
+# FIX/SKIP/REBUT, and a "detail" string (commit SHA for FIX, rationale for
+# SKIP/REBUT) — same fail-closed convention as --bot-reviewers, then
+# canonicalize via jq.
 if [ -n "$DISPOSITION_TABLE" ]; then
   DISPOSITION_TABLE=$(jq -ce '
     if (type == "array" and length > 0 and
@@ -132,7 +143,7 @@ if [ -n "$DISPOSITION_TABLE" ]; then
         )] | length) == 0)
     then . else error("bad") end
   ' <<<"$DISPOSITION_TABLE" 2>/dev/null) || {
-    echo "error: --disposition-table must be a non-empty JSON array of objects, each with a string 'finding', a 'classification' of FIX/SKIP/REBUT, and a string 'detail' (commit SHA for FIX, rationale for SKIP/REBUT)" >&2
+    echo "error: --disposition-table-file's content must be a non-empty JSON array of objects, each with a string 'finding', a 'classification' of FIX/SKIP/REBUT, and a string 'detail' (commit SHA for FIX, rationale for SKIP/REBUT)" >&2
     exit 2
   }
 fi
@@ -167,7 +178,7 @@ request_copilot() {
 MAX_CODEX_COMMENT_CHARS=60000
 
 # build_codex_comment_body — bare '@codex review' by default; when
-# --disposition-table and/or --since-sha are supplied, renders them as a
+# --disposition-table-file and/or --since-sha are supplied, renders them as a
 # structured markdown table + focus line instead. Falls back to the bare
 # string (dropping the do-not-relitigate context, not the ask itself) when
 # the rendered body would exceed MAX_CODEX_COMMENT_CHARS. This do-not-

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -30,6 +30,21 @@
 #                            preserve the legacy Copilot-only dance
 #                            (backward-compatible default, not how the
 #                            wait-for-pr-comments/merge-guard loops run).
+#   --disposition-table <json>
+#                            Do-not-relitigate context for the Codex ask ONLY
+#                            (Copilot is unaffected, gets neither this nor
+#                            --since-sha). Non-empty JSON array of objects:
+#                            {finding, classification: FIX|SKIP|REBUT, detail}
+#                            — detail is the fixing commit SHA for FIX, a
+#                            rationale for SKIP/REBUT. Renders as a markdown
+#                            table in the '@codex review' comment instead of
+#                            the bare string, so Codex does not re-raise
+#                            settled findings next round (confirmed PR #317,
+#                            #331 — bare re-ask re-cites SKIP/fixed items;
+#                            a disposition table does not, and can carry a
+#                            REBUT Codex accepts instead of re-flagging).
+#   --since-sha <sha>        Optional. Codex-only: appends a "focus on
+#                            commits since <sha>" line to the comment body.
 #
 # Outputs:
 #   stdout: (none on success)
@@ -44,12 +59,14 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> [--bot-reviewers <json-array>]
+Usage: $(basename "$0") --owner <o> --repo <r> --pr <n> [--bot-reviewers <json-array>] [--disposition-table <json-array>] [--since-sha <sha>]
 
 Requests a re-review from one or more trusted bot reviewers, dispatching on
 identity: Copilot / copilot-pull-request-reviewer[bot] get the remove+re-add
 reviewer dance; chatgpt-codex-connector[bot] gets an '@codex review' issue
 comment. Omit --bot-reviewers to request only Copilot (legacy default).
+--disposition-table and --since-sha add do-not-relitigate context to the
+Codex ask only; they have no effect on the Copilot mechanism.
 EOF
   exit 2
 }
@@ -58,15 +75,19 @@ OWNER=""
 REPO=""
 PR=""
 BOT_REVIEWERS=""
+DISPOSITION_TABLE=""
+SINCE_SHA=""
 
 [ $# -gt 0 ] || usage
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --owner)         OWNER="${2:-}";         shift 2 ;;
-    --repo)          REPO="${2:-}";          shift 2 ;;
-    --pr)            PR="${2:-}";            shift 2 ;;
-    --bot-reviewers) BOT_REVIEWERS="${2:-}"; shift 2 ;;
+    --owner)              OWNER="${2:-}";              shift 2 ;;
+    --repo)               REPO="${2:-}";                shift 2 ;;
+    --pr)                 PR="${2:-}";                  shift 2 ;;
+    --bot-reviewers)      BOT_REVIEWERS="${2:-}";       shift 2 ;;
+    --disposition-table)  DISPOSITION_TABLE="${2:-}";   shift 2 ;;
+    --since-sha)          SINCE_SHA="${2:-}";            shift 2 ;;
     -h|--help) usage ;;
     *) echo "error: unknown flag: $1" >&2; usage ;;
   esac
@@ -83,6 +104,27 @@ done
 if [ -n "$BOT_REVIEWERS" ]; then
   BOT_REVIEWERS=$(jq -ce 'if (type == "array" and length > 0 and ([.[] | select(type != "string")] | length) == 0) then . else error("bad") end' <<<"$BOT_REVIEWERS" 2>/dev/null) || {
     echo "error: --bot-reviewers must be a non-empty JSON array of strings" >&2
+    exit 2
+  }
+fi
+
+# Validate --disposition-table (when provided) as a non-empty JSON array of
+# objects, each with a "finding" string, a "classification" of FIX/SKIP/REBUT,
+# and a "detail" string (commit SHA for FIX, rationale for SKIP/REBUT) — same
+# fail-closed convention as --bot-reviewers, then canonicalize via jq.
+if [ -n "$DISPOSITION_TABLE" ]; then
+  DISPOSITION_TABLE=$(jq -ce '
+    if (type == "array" and length > 0 and
+        ([.[] | select(
+          (type == "object") and
+          (has("finding") and (.finding | type) == "string") and
+          (has("classification") and (.classification as $c | ["FIX","SKIP","REBUT"] | index($c) != null)) and
+          (has("detail") and (.detail | type) == "string")
+          | not
+        )] | length) == 0)
+    then . else error("bad") end
+  ' <<<"$DISPOSITION_TABLE" 2>/dev/null) || {
+    echo "error: --disposition-table must be a non-empty JSON array of objects, each with a string 'finding', a 'classification' of FIX/SKIP/REBUT, and a string 'detail' (commit SHA for FIX, rationale for SKIP/REBUT)" >&2
     exit 2
   }
 fi
@@ -108,11 +150,40 @@ request_copilot() {
   fi
 }
 
+# build_codex_comment_body — bare '@codex review' by default; when
+# --disposition-table and/or --since-sha are supplied, renders them as a
+# structured markdown table + focus line instead. This do-not-relitigate
+# context is Codex-only — request_copilot never sees it.
+build_codex_comment_body() {
+  if [ -z "$DISPOSITION_TABLE" ] && [ -z "$SINCE_SHA" ]; then
+    echo "@codex review"
+    return
+  fi
+
+  echo "@codex review"
+  echo
+
+  if [ -n "$DISPOSITION_TABLE" ]; then
+    echo "Prior-round findings — do not re-raise FIX/SKIP/REBUT items below:"
+    echo
+    echo "| Finding | Classification | Commit / Rationale |"
+    echo "| --- | --- | --- |"
+    jq -r '.[] | "| " + .finding + " | " + .classification + " | " + .detail + " |"' <<<"$DISPOSITION_TABLE"
+    echo
+  fi
+
+  if [ -n "$SINCE_SHA" ]; then
+    echo "Focus on commits since $SINCE_SHA."
+  fi
+}
+
 # request_codex — post an '@codex review' issue comment. Codex reviews on
 # push, mark-draft-ready, and this comment, but not on a reviewer-request
 # event, so this is its only ask mechanism.
 request_codex() {
-  if ! gh pr comment "$PR" --repo "$OWNER/$REPO" --body "@codex review" >/dev/null 2>"$GH_ERR"; then
+  local body
+  body="$(build_codex_comment_body)"
+  if ! gh pr comment "$PR" --repo "$OWNER/$REPO" --body "$body" >/dev/null 2>"$GH_ERR"; then
     echo "error: gh pr comment '@codex review' failed for $PR_REF: $(cat "$GH_ERR")" >&2
     return 1
   fi

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -18,6 +18,17 @@ assert() {
   fi
 }
 
+# dtfile — write a disposition-table JSON payload to a fresh file under $TMP
+# and echo its path, for --disposition-table-file (the table is transported
+# as a file, never inline JSON — see request-rereview.sh's header).
+DT_COUNTER=0
+dtfile() {
+  DT_COUNTER=$((DT_COUNTER + 1))
+  local f="$TMP/disposition-$DT_COUNTER.json"
+  printf '%s' "$1" > "$f"
+  printf '%s' "$f"
+}
+
 echo "[request-rereview_test]"
 
 assert "script file exists" "[ -f '$SCRIPT' ]"
@@ -192,44 +203,54 @@ assert "omitting --bot-reviewers exits 0 (Copilot default)" "[ \$rc_default -eq 
 assert "omitting --bot-reviewers still dispatches the Copilot dance" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
 assert "omitting --bot-reviewers never posts a codex review comment" "! grep -qF 'pr comment' '$FAKE_GH_LOG'"
 
-# ── --disposition-table / --since-sha (do-not-relitigate context) ───────────
+# ── --disposition-table-file / --since-sha (do-not-relitigate context) ──────
+# The table is transported as a FILE, never inline JSON: enough items (or a
+# few verbose rationales) can exceed the OS's per-argument exec limit (Linux
+# caps a single argv/environ string at 128 KiB), which would fail the exec
+# itself before request-rereview.sh ever ran — see the header for the field
+# evidence (a 400-entry table reproduced this on the reviewer's platform).
 
-assert "accepts --disposition-table flag" "grep -q -- '--disposition-table' '$SCRIPT'"
+assert "accepts --disposition-table-file flag" "grep -q -- '--disposition-table-file' '$SCRIPT'"
 assert "accepts --since-sha flag" "grep -q -- '--since-sha' '$SCRIPT'"
 
-# Malformed --disposition-table must be rejected up front (exit 2), same
-# convention as --bot-reviewers.
-"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table 'not-json' 2>/dev/null
+# A missing/unreadable --disposition-table-file path is a usage error (exit 2).
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$TMP/does-not-exist.json" 2>/dev/null
+rc_missing_file=$?
+assert "exits 2 for a --disposition-table-file path that does not exist" "[ \$rc_missing_file -eq 2 ]"
+
+# Malformed file CONTENT must be rejected up front (exit 2), same convention
+# as --bot-reviewers.
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$(dtfile 'not-json')" 2>/dev/null
 rc_bad_table=$?
-assert "exits 2 for non-array --disposition-table" "[ \$rc_bad_table -eq 2 ]"
+assert "exits 2 for non-array disposition-table-file content" "[ \$rc_bad_table -eq 2 ]"
 
-"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table '[]' 2>/dev/null
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$(dtfile '[]')" 2>/dev/null
 rc_empty_table=$?
-assert "exits 2 for empty --disposition-table array" "[ \$rc_empty_table -eq 2 ]"
+assert "exits 2 for empty disposition-table-file array" "[ \$rc_empty_table -eq 2 ]"
 
-"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table '["not-an-object"]' 2>/dev/null
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$(dtfile '["not-an-object"]')" 2>/dev/null
 rc_nonobj_table=$?
-assert "exits 2 for --disposition-table array with a non-object member" "[ \$rc_nonobj_table -eq 2 ]"
+assert "exits 2 for disposition-table-file array with a non-object member" "[ \$rc_nonobj_table -eq 2 ]"
 
 "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table '[{"finding":"x","classification":"WRONG","detail":"y"}]' 2>/dev/null
+  --disposition-table-file "$(dtfile '[{"finding":"x","classification":"WRONG","detail":"y"}]')" 2>/dev/null
 rc_badclass_table=$?
-assert "exits 2 for --disposition-table entry with bad classification" "[ \$rc_badclass_table -eq 2 ]"
+assert "exits 2 for disposition-table-file entry with bad classification" "[ \$rc_badclass_table -eq 2 ]"
 
 "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table '[{"classification":"FIX","detail":"abc123"}]' 2>/dev/null
+  --disposition-table-file "$(dtfile '[{"classification":"FIX","detail":"abc123"}]')" 2>/dev/null
 rc_missingfield_table=$?
-assert "exits 2 for --disposition-table entry missing a required field" "[ \$rc_missingfield_table -eq 2 ]"
+assert "exits 2 for disposition-table-file entry missing a required field" "[ \$rc_missingfield_table -eq 2 ]"
 
-err_out=$("$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table 'not-json' 2>&1 >/dev/null)
-assert "malformed --disposition-table gives a clear stderr message" "printf '%s' \"\$err_out\" | grep -qiF 'disposition-table'"
+err_out=$("$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$(dtfile 'not-json')" 2>&1 >/dev/null)
+assert "malformed disposition-table-file content gives a clear stderr message" "printf '%s' \"\$err_out\" | grep -qiF 'disposition-table-file'"
 
-# --disposition-table / --since-sha as the final argument with no value must
-# be a usage error (exit 2), matching the script's documented contract —
+# --disposition-table-file / --since-sha as the final argument with no value
+# must be a usage error (exit 2), matching the script's documented contract —
 # not a silent exit 1 from `shift 2` running out of positional args.
-"$SCRIPT" --owner o --repo r --pr 1 --disposition-table 2>/dev/null
+"$SCRIPT" --owner o --repo r --pr 1 --disposition-table-file 2>/dev/null
 rc_missing_dt_val=$?
-assert "exits 2 when --disposition-table has no value" "[ \$rc_missing_dt_val -eq 2 ]"
+assert "exits 2 when --disposition-table-file has no value" "[ \$rc_missing_dt_val -eq 2 ]"
 
 "$SCRIPT" --owner o --repo r --pr 1 --since-sha 2>/dev/null
 rc_missing_ss_val=$?
@@ -242,10 +263,10 @@ export FAKE_GH_STDIN_LOG="$TMP/fake-gh-stdin.log"
 DISPOSITION='[{"finding":"missing null check","classification":"FIX","detail":"abc1234"},{"finding":"style nit","classification":"SKIP","detail":"cosmetic, out of scope"},{"finding":"race condition claim","classification":"REBUT","detail":"lock is held across the whole critical section, see line 42"}]'
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table "$DISPOSITION" \
+  --disposition-table-file "$(dtfile "$DISPOSITION")" \
   --since-sha deadbeef >/dev/null 2>&1
 rc_table=$?
-assert "disposition-table dispatch exits 0" "[ \$rc_table -eq 0 ]"
+assert "disposition-table-file dispatch exits 0" "[ \$rc_table -eq 0 ]"
 assert "codex comment body contains the FIX finding" "grep -qF -- 'missing null check' '$FAKE_GH_LOG'"
 assert "codex comment body contains the SKIP rationale" "grep -qF -- 'cosmetic, out of scope' '$FAKE_GH_LOG'"
 assert "codex comment body contains the REBUT rationale" "grep -qF -- 'lock is held across the whole critical section' '$FAKE_GH_LOG'"
@@ -257,19 +278,19 @@ assert "codex comment body is NOT the bare '@codex review' string" "[ \$(wc -l <
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
 rc_bare=$?
-assert "no disposition-table/since-sha exits 0" "[ \$rc_bare -eq 0 ]"
-assert "no disposition-table/since-sha posts the bare '@codex review' string" "grep -qF -- 'pr comment 1 --repo o/r --body @codex review' '$FAKE_GH_LOG'"
+assert "no disposition-table-file/since-sha exits 0" "[ \$rc_bare -eq 0 ]"
+assert "no disposition-table-file/since-sha posts the bare '@codex review' string" "grep -qF -- 'pr comment 1 --repo o/r --body @codex review' '$FAKE_GH_LOG'"
 
 # (d) the flags have no effect on the Copilot mechanism: both bots dispatched,
-# disposition-table supplied -> Copilot still gets the plain remove+re-add dance.
+# disposition-table-file supplied -> Copilot still gets the plain remove+re-add dance.
 : > "$FAKE_GH_LOG"
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' \
-  --disposition-table "$DISPOSITION" \
+  --disposition-table-file "$(dtfile "$DISPOSITION")" \
   --since-sha deadbeef >/dev/null 2>&1
 rc_both=$?
-assert "disposition-table with both bots exits 0" "[ \$rc_both -eq 0 ]"
-assert "Copilot mechanism unaffected by --disposition-table" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "disposition-table-file with both bots exits 0" "[ \$rc_both -eq 0 ]"
+assert "Copilot mechanism unaffected by --disposition-table-file" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
 assert "Codex mechanism still carries the disposition table when both bots dispatched" "grep -qF -- 'missing null check' '$FAKE_GH_LOG'"
 
 # (e) a finding/detail containing "|" and an embedded newline must not
@@ -280,9 +301,9 @@ assert "Codex mechanism still carries the disposition table when both bots dispa
 DISPOSITION_ESC='[{"finding":"a | b\nc","classification":"SKIP","detail":"line1\nline2 | pipe"}]'
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table "$DISPOSITION_ESC" >/dev/null 2>&1
+  --disposition-table-file "$(dtfile "$DISPOSITION_ESC")" >/dev/null 2>&1
 rc_esc=$?
-assert "disposition-table with pipe/newline in cells exits 0" "[ \$rc_esc -eq 0 ]"
+assert "disposition-table-file with pipe/newline in cells exits 0" "[ \$rc_esc -eq 0 ]"
 assert "embedded newlines collapse and literal pipes are escaped, keeping the row intact on one line" \
   "grep -qF -- 'a \\| b c | SKIP | line1 line2 \\| pipe |' '$FAKE_GH_LOG'"
 
@@ -294,29 +315,35 @@ assert "embedded newlines collapse and literal pipes are escaped, keeping the ro
 DISPOSITION_BS='[{"finding":"regex \\| here","classification":"SKIP","detail":"n/a"}]'
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table "$DISPOSITION_BS" >/dev/null 2>&1
+  --disposition-table-file "$(dtfile "$DISPOSITION_BS")" >/dev/null 2>&1
 rc_bs=$?
-assert "disposition-table with a pre-existing backslash-pipe exits 0" "[ \$rc_bs -eq 0 ]"
+assert "disposition-table-file with a pre-existing backslash-pipe exits 0" "[ \$rc_bs -eq 0 ]"
 assert "the pre-existing backslash is escaped before the pipe, so the pipe stays escaped" \
   "grep -qF -- 'regex \\\\\\| here' '$FAKE_GH_LOG'"
 
 # (g) a disposition table large enough to push the rendered comment past
 # GitHub's issue-comment size limit falls back to a short, valid
-# '@codex review' body instead of failing the gh call outright.
+# '@codex review' body instead of failing the gh call outright. Also proves
+# the file-based transport: a 400-entry table (>128 KiB, well past Linux's
+# single-argv-string limit) is passed as a short file PATH, not inline JSON,
+# so this never risks the exec-time argv failure the header documents.
 : > "$FAKE_GH_LOG"
 BIG_DISPOSITION=$(python3 -c "
 import json
 items = [{'finding': 'x' * 200, 'classification': 'SKIP', 'detail': 'y' * 200} for _ in range(400)]
 print(json.dumps(items))
 ")
+BIG_DISPOSITION_FILE="$(dtfile "$BIG_DISPOSITION")"
+assert "the oversized disposition-table fixture itself exceeds Linux's 128 KiB single-argv-string limit" \
+  "[ \$(wc -c < '$BIG_DISPOSITION_FILE') -gt 131072 ]"
 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
-  --disposition-table "$BIG_DISPOSITION" >/dev/null 2>&1
+  --disposition-table-file "$BIG_DISPOSITION_FILE" >/dev/null 2>&1
 rc_big=$?
-assert "oversized disposition-table still exits 0" "[ \$rc_big -eq 0 ]"
-assert "oversized disposition-table posts the '@codex review' ask (not aborted)" \
+assert "oversized disposition-table-file still exits 0" "[ \$rc_big -eq 0 ]"
+assert "oversized disposition-table-file posts the '@codex review' ask (not aborted)" \
   "grep -qF -- '@codex review' '$FAKE_GH_LOG'"
-assert "oversized disposition-table falls back to a short body, not the full table" \
+assert "oversized disposition-table-file falls back to a short body, not the full table" \
   "[ \$(wc -c < '$FAKE_GH_LOG') -lt 1000 ]"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -286,4 +286,37 @@ assert "disposition-table with pipe/newline in cells exits 0" "[ \$rc_esc -eq 0 
 assert "embedded newlines collapse and literal pipes are escaped, keeping the row intact on one line" \
   "grep -qF -- 'a \\| b c | SKIP | line1 line2 \\| pipe |' '$FAKE_GH_LOG'"
 
+# (f) a cell containing a PRE-EXISTING literal backslash-pipe (e.g. a regex
+# excerpt) must have its backslash escaped BEFORE the pipe is escaped, or the
+# cell's own backslash consumes the added escape and the pipe still splits
+# the row.
+: > "$FAKE_GH_LOG"
+DISPOSITION_BS='[{"finding":"regex \\| here","classification":"SKIP","detail":"n/a"}]'
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table "$DISPOSITION_BS" >/dev/null 2>&1
+rc_bs=$?
+assert "disposition-table with a pre-existing backslash-pipe exits 0" "[ \$rc_bs -eq 0 ]"
+assert "the pre-existing backslash is escaped before the pipe, so the pipe stays escaped" \
+  "grep -qF -- 'regex \\\\\\| here' '$FAKE_GH_LOG'"
+
+# (g) a disposition table large enough to push the rendered comment past
+# GitHub's issue-comment size limit falls back to a short, valid
+# '@codex review' body instead of failing the gh call outright.
+: > "$FAKE_GH_LOG"
+BIG_DISPOSITION=$(python3 -c "
+import json
+items = [{'finding': 'x' * 200, 'classification': 'SKIP', 'detail': 'y' * 200} for _ in range(400)]
+print(json.dumps(items))
+")
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table "$BIG_DISPOSITION" >/dev/null 2>&1
+rc_big=$?
+assert "oversized disposition-table still exits 0" "[ \$rc_big -eq 0 ]"
+assert "oversized disposition-table posts the '@codex review' ask (not aborted)" \
+  "grep -qF -- '@codex review' '$FAKE_GH_LOG'"
+assert "oversized disposition-table falls back to a short body, not the full table" \
+  "[ \$(wc -c < '$FAKE_GH_LOG') -lt 1000 ]"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -224,6 +224,17 @@ assert "exits 2 for --disposition-table entry missing a required field" "[ \$rc_
 err_out=$("$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table 'not-json' 2>&1 >/dev/null)
 assert "malformed --disposition-table gives a clear stderr message" "printf '%s' \"\$err_out\" | grep -qiF 'disposition-table'"
 
+# --disposition-table / --since-sha as the final argument with no value must
+# be a usage error (exit 2), matching the script's documented contract —
+# not a silent exit 1 from `shift 2` running out of positional args.
+"$SCRIPT" --owner o --repo r --pr 1 --disposition-table 2>/dev/null
+rc_missing_dt_val=$?
+assert "exits 2 when --disposition-table has no value" "[ \$rc_missing_dt_val -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --since-sha 2>/dev/null
+rc_missing_ss_val=$?
+assert "exits 2 when --since-sha has no value" "[ \$rc_missing_ss_val -eq 2 ]"
+
 # (a) both flags supplied: the posted Codex comment carries the structured
 # table and the since-sha line, not the bare '@codex review' string.
 : > "$FAKE_GH_LOG"
@@ -260,5 +271,19 @@ rc_both=$?
 assert "disposition-table with both bots exits 0" "[ \$rc_both -eq 0 ]"
 assert "Copilot mechanism unaffected by --disposition-table" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
 assert "Codex mechanism still carries the disposition table when both bots dispatched" "grep -qF -- 'missing null check' '$FAKE_GH_LOG'"
+
+# (e) a finding/detail containing "|" and an embedded newline must not
+# terminate or shift the markdown table row — both are routine in review
+# excerpts and rationales, and a shifted row breaks the finding-to-
+# classification association the table exists to preserve.
+: > "$FAKE_GH_LOG"
+DISPOSITION_ESC='[{"finding":"a | b\nc","classification":"SKIP","detail":"line1\nline2 | pipe"}]'
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table "$DISPOSITION_ESC" >/dev/null 2>&1
+rc_esc=$?
+assert "disposition-table with pipe/newline in cells exits 0" "[ \$rc_esc -eq 0 ]"
+assert "embedded newlines collapse and literal pipes are escaped, keeping the row intact on one line" \
+  "grep -qF -- 'a \\| b c | SKIP | line1 line2 \\| pipe |' '$FAKE_GH_LOG'"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -218,6 +218,15 @@ assert "accepts --since-sha flag" "grep -q -- '--since-sha' '$SCRIPT'"
 rc_missing_file=$?
 assert "exits 2 for a --disposition-table-file path that does not exist" "[ \$rc_missing_file -eq 2 ]"
 
+# A SUPPLIED file that reads back empty (e.g. zero bytes) must still fail
+# validation, not be silently treated as if the flag were omitted — the flag
+# was given, so its content is required to be a non-empty JSON array
+# regardless of what the file happens to contain.
+: > "$TMP/empty-disposition.json"
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$TMP/empty-disposition.json" 2>/dev/null
+rc_empty_file=$?
+assert "exits 2 for a --disposition-table-file that reads back empty" "[ \$rc_empty_file -eq 2 ]"
+
 # Malformed file CONTENT must be rejected up front (exit 2), same convention
 # as --bot-reviewers.
 "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table-file "$(dtfile 'not-json')" 2>/dev/null

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -192,4 +192,73 @@ assert "omitting --bot-reviewers exits 0 (Copilot default)" "[ \$rc_default -eq 
 assert "omitting --bot-reviewers still dispatches the Copilot dance" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
 assert "omitting --bot-reviewers never posts a codex review comment" "! grep -qF 'pr comment' '$FAKE_GH_LOG'"
 
+# ── --disposition-table / --since-sha (do-not-relitigate context) ───────────
+
+assert "accepts --disposition-table flag" "grep -q -- '--disposition-table' '$SCRIPT'"
+assert "accepts --since-sha flag" "grep -q -- '--since-sha' '$SCRIPT'"
+
+# Malformed --disposition-table must be rejected up front (exit 2), same
+# convention as --bot-reviewers.
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table 'not-json' 2>/dev/null
+rc_bad_table=$?
+assert "exits 2 for non-array --disposition-table" "[ \$rc_bad_table -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table '[]' 2>/dev/null
+rc_empty_table=$?
+assert "exits 2 for empty --disposition-table array" "[ \$rc_empty_table -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table '["not-an-object"]' 2>/dev/null
+rc_nonobj_table=$?
+assert "exits 2 for --disposition-table array with a non-object member" "[ \$rc_nonobj_table -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table '[{"finding":"x","classification":"WRONG","detail":"y"}]' 2>/dev/null
+rc_badclass_table=$?
+assert "exits 2 for --disposition-table entry with bad classification" "[ \$rc_badclass_table -eq 2 ]"
+
+"$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table '[{"classification":"FIX","detail":"abc123"}]' 2>/dev/null
+rc_missingfield_table=$?
+assert "exits 2 for --disposition-table entry missing a required field" "[ \$rc_missingfield_table -eq 2 ]"
+
+err_out=$("$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["chatgpt-codex-connector[bot]"]' --disposition-table 'not-json' 2>&1 >/dev/null)
+assert "malformed --disposition-table gives a clear stderr message" "printf '%s' \"\$err_out\" | grep -qiF 'disposition-table'"
+
+# (a) both flags supplied: the posted Codex comment carries the structured
+# table and the since-sha line, not the bare '@codex review' string.
+: > "$FAKE_GH_LOG"
+export FAKE_GH_STDIN_LOG="$TMP/fake-gh-stdin.log"
+DISPOSITION='[{"finding":"missing null check","classification":"FIX","detail":"abc1234"},{"finding":"style nit","classification":"SKIP","detail":"cosmetic, out of scope"},{"finding":"race condition claim","classification":"REBUT","detail":"lock is held across the whole critical section, see line 42"}]'
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["chatgpt-codex-connector[bot]"]' \
+  --disposition-table "$DISPOSITION" \
+  --since-sha deadbeef >/dev/null 2>&1
+rc_table=$?
+assert "disposition-table dispatch exits 0" "[ \$rc_table -eq 0 ]"
+assert "codex comment body contains the FIX finding" "grep -qF -- 'missing null check' '$FAKE_GH_LOG'"
+assert "codex comment body contains the SKIP rationale" "grep -qF -- 'cosmetic, out of scope' '$FAKE_GH_LOG'"
+assert "codex comment body contains the REBUT rationale" "grep -qF -- 'lock is held across the whole critical section' '$FAKE_GH_LOG'"
+assert "codex comment body contains the since-sha line" "grep -qiF -- 'since deadbeef' '$FAKE_GH_LOG'"
+assert "codex comment body is NOT the bare '@codex review' string" "[ \$(wc -l < '$FAKE_GH_LOG') -gt 1 ]"
+
+# (c) neither flag supplied: comment body is still the bare string (regression guard).
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
+rc_bare=$?
+assert "no disposition-table/since-sha exits 0" "[ \$rc_bare -eq 0 ]"
+assert "no disposition-table/since-sha posts the bare '@codex review' string" "grep -qF -- 'pr comment 1 --repo o/r --body @codex review' '$FAKE_GH_LOG'"
+
+# (d) the flags have no effect on the Copilot mechanism: both bots dispatched,
+# disposition-table supplied -> Copilot still gets the plain remove+re-add dance.
+: > "$FAKE_GH_LOG"
+PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' \
+  --disposition-table "$DISPOSITION" \
+  --since-sha deadbeef >/dev/null 2>&1
+rc_both=$?
+assert "disposition-table with both bots exits 0" "[ \$rc_both -eq 0 ]"
+assert "Copilot mechanism unaffected by --disposition-table" "grep -qF -- '--add-reviewer @copilot' '$FAKE_GH_LOG'"
+assert "Codex mechanism still carries the disposition table when both bots dispatched" "grep -qF -- 'missing null check' '$FAKE_GH_LOG'"
+
 exit $FAIL


### PR DESCRIPTION
## Summary
- A bare `@codex review` re-ask makes Codex re-cite settled findings every round (confirmed on PR #317 and PR #331, 3-6 rounds each). A structured disposition table -- finding / classification (FIX/SKIP/REBUT) / commit-or-rationale -- produced zero re-raises across both sessions, including one where Codex accepted a REBUT instead of re-flagging a declined finding.
- `request-rereview.sh` gains `--disposition-table <json-array>` and `--since-sha <sha>`, both Codex-only (Copilot's remove+re-add dance is unaffected, gets neither). Omitting both flags leaves behavior unchanged -- bare `@codex review`, exactly as today.
- SKILL.md Phase 6 step 2 (only) shows how the caller assembles the table from the round's already-classified inventory items -- FIX items carry their `fix_commit_sha`, SKIP items carry their `rationale`; REBUT is a manual re-tag of a defensible-rebuttal subset of SKIP at dispatch time, not a new inventory field (the inventory's FIX/SKIP/ESCALATE classification is unchanged).

## Test plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh` -- 59/59 ok, exit 0
- [x] Red-first confirmed: new-flag assertions failed against the unmodified script
- [x] New cases: disposition-table + since-sha renders a structured comment body; malformed disposition-table rejected (exit 2, mirrors `--bot-reviewers` validation); neither flag -> bare `@codex review` unchanged; flags have no effect on the Copilot mechanism
- [x] All pre-existing cases unchanged (no regressions)

bd: agents-config-abn9.44.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)