### PR TITLE
feat(merge-guard): Component 2b clean-pass/trigger-comment exemptions

### DIFF
--- a/docs/specs/2026-07-18-codex-rereview-path-design.md
+++ b/docs/specs/2026-07-18-codex-rereview-path-design.md
@@ -254,6 +254,11 @@ Base-branch drift is likewise accepted, at parity with the existing review path:
 neither a review object nor a reaction is invalidated when the base advances and
 the effective diff changes without a head push.
 
+An ordinary (non-force) push carrying an attacker- or tool-backdated
+`GIT_COMMITTER_DATE` earlier than a surviving stale `+1` is explicitly out of
+scope per "Scope of the guarantee" (a cooperative loop, not adversarial git
+metadata) — accepted explicitly rather than left implicit.
+
 ## Testing
 
 `request-rereview_test.sh` extends the existing fake-`gh`-on-`PATH` shim. New

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -124,6 +124,10 @@ pr_state=$(jq -r '.state' <<<"$PR_JSON")
 # SHA the merge must be issued against (pt. 3).
 HEAD_OID=$(jq -r '.head.sha' <<<"$PR_JSON")
 [[ -n "$HEAD_OID" && "$HEAD_OID" != "null" ]] || { echo "Error: no head SHA on PR" >&2; exit 3; }
+# PR author login — one of the two identities the trigger-comment exemption
+# (Component 2b, part b) matches against; a missing/null author never
+# matches anything, so the exemption just doesn't fire (fail closed).
+PR_AUTHOR=$(jq -r '.user.login // ""' <<<"$PR_JSON")
 # The base SHA the head is judged against and the merge must re-confirm
 # (Step 5). Fetched here so the whole floor binds to one live PR read.
 BASE_OID=$(jq -r '.base.sha' <<<"$PR_JSON")
@@ -593,6 +597,16 @@ set_fact bot_review_cap_exhausted "$bot_cap_exhausted"
 ISSUE_COMMENTS=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/comments?per_page=100" --paginate | jq -s 'add // []') || {
     echo "Error: failed to fetch issue comments" >&2; exit 3; }
 
+# Current authenticated session identity — the second of the two identities
+# the trigger-comment exemption (Component 2b, part b) matches against,
+# alongside $PR_AUTHOR (covers both a human re-asking for review and an
+# agent re-asking as the CLI's own authenticated user). Never gates
+# eligibility on its own, so a lookup failure degrades to an unmatchable
+# empty string rather than exit 3: the exemption just doesn't fire, and the
+# trigger comment falls back to blocking like any other untriaged item
+# (fail closed, same direction as every other exemption in this block).
+AUTH_LOGIN=$(gh_api user --jq '.login') || AUTH_LOGIN=""
+
 # inventory_items / completed_inventory_items were collected once, above the
 # thread partition — both unions are shared with it.
 
@@ -614,7 +628,33 @@ done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
          -name "${OWNER}-${REPO}-${PR}-*.json.replyids" -print0 2>/dev/null)
 
 untriaged=$(jq -n \
-    --argjson live_issue "$(jq '[.[] | {id, author: .user.login}]' <<<"$ISSUE_COMMENTS")" \
+    --argjson live_issue "$(jq \
+        --argjson trusted "$BOT_REVIEWERS" --arg pr_author "$PR_AUTHOR" --arg auth_login "$AUTH_LOGIN" '
+        # Component 2b: the re-review loop mints its own issue comments, and
+        # both shapes below are loop machinery, not feedback needing triage —
+        # excluded from live_issue entirely (same effect as terminal triage).
+        # Everything else, bot-authored or not, still blocks as today.
+        #
+        # (1) Clean-pass announcement: an allowlisted bot identity (exact
+        # login match, same allowlist convention as every other bot check in
+        # this file) whose body begins with the pinned marker. The prefix is
+        # pinned exactly as observed 2026-07-18 — a vendor reword resumes
+        # blocking (false negative, hands off to a human; accepted).
+        def is_clean_pass_marker:
+            (.user.login as $l | ($trusted | index($l)) != null)
+            and ((.body // "") | startswith("Codex Review: Didn'\''t find any major issues"));
+        # (2) Trigger comment: the literal "@codex review" ask this repo'\''s
+        # own lieutenant workflow posts via `gh pr comment` to request a
+        # re-review — authored by either the PR author (a human re-asking)
+        # or the currently authenticated session identity (an agent
+        # re-asking as the CLI user). Matched on the same prefix
+        # request-rereview.sh posts verbatim.
+        def is_trigger_comment:
+            ((.user.login == $pr_author) or (.user.login == $auth_login))
+            and ((.body // "") | startswith("@codex review"));
+        [.[] | select((is_clean_pass_marker or is_trigger_comment) | not)
+             | {id, author: .user.login}]
+        ' <<<"$ISSUE_COMMENTS")" \
     --argjson live_summaries "$(jq '[.[] | select((.body // "") != "") | {review_id: .id, author: .user.login}]' <<<"$ALL_REVIEWS")" \
     --argjson recorded "$inventory_items" \
     --argjson recorded_complete "$completed_inventory_items" \

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -643,15 +643,17 @@ untriaged=$(jq -n \
         def is_clean_pass_marker:
             (.user.login as $l | ($trusted | index($l)) != null)
             and ((.body // "") | startswith("Codex Review: Didn'\''t find any major issues"));
-        # (2) Trigger comment: the literal "@codex review" ask this repo'\''s
-        # own lieutenant workflow posts via `gh pr comment` to request a
-        # re-review — authored by either the PR author (a human re-asking)
-        # or the currently authenticated session identity (an agent
-        # re-asking as the CLI user). Matched on the same prefix
-        # request-rereview.sh posts verbatim.
+        # (2) Trigger comment: the exact "@codex review" ask
+        # request-rereview.sh posts via `gh pr comment --body "@codex
+        # review"` (verbatim, no trailing text) to request a re-review —
+        # authored by either the PR author (a human re-asking) or the
+        # currently authenticated session identity (an agent re-asking as
+        # the CLI user). EXACT match only, whitespace-trimmed — a prefix
+        # match would exempt "@codex review, also fix the race below" and
+        # silently drop the appended feedback from triage.
         def is_trigger_comment:
             ((.user.login == $pr_author) or (.user.login == $auth_login))
-            and ((.body // "") | startswith("@codex review"));
+            and (((.body // "") | gsub("^\\s+|\\s+$"; "")) == "@codex review");
         [.[] | select((is_clean_pass_marker or is_trigger_comment) | not)
              | {id, author: .user.login}]
         ' <<<"$ISSUE_COMMENTS")" \

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -59,6 +59,11 @@ if [ "$1" = "api" ]; then
     case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
   done
   case "$path" in
+    user)
+        if [ "${FIXTURE_AUTH_LOGIN_FAIL:-0}" = 1 ]; then
+          echo "gh: 401 Unauthorized" >&2; exit 1
+        fi
+        body="${FIXTURE_AUTH_LOGIN_JSON:-'{\"login\":\"session-user\"}'}" ;;
     */requested_reviewers)  body="${FIXTURE_REQUESTED_REVIEWERS:-'{\"users\":[],\"teams\":[]}'}" ;;
     */issues/*/events*)
         if [ "${FIXTURE_EVENTS_FAIL:-0}" = 1 ]; then
@@ -67,6 +72,9 @@ if [ "$1" = "api" ]; then
         body="${FIXTURE_EVENTS:-[]}" ;;
     */issues/*/comments*)   body="${FIXTURE_ISSUE_COMMENTS:-[]}" ;;
     */issues/*/reactions*)
+        if [ "${FIXTURE_REACTIONS_FAIL:-0}" = 1 ]; then
+          echo "gh: 502 Bad Gateway" >&2; exit 1
+        fi
         if [ -n "${FIXTURE_REACTIONS_PAGE2:-}" ]; then
           # emulate `gh api --paginate` on an array-returning endpoint: each
           # page's JSON array is later merged via `jq -s 'add // []'` — mirrors
@@ -566,6 +574,66 @@ assert "recorded posted_reply_id excluded → eligible" "[ \$rc -eq 0 ]"
 IC2='[{"id": 900, "user": {"login": "operator"}, "body": "agent reply"}, {"id": 901, "user": {"login": "operator"}, "body": "actually, one more thing"}]'
 out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC2"); rc=$?
 assert "same-account manual comment (unrecorded id) blocks" "[ \$rc -eq 1 ]"
+
+# ── Component 2b (2026-07-18 spec): loop-generated comments are not feedback ──
+# Both the clean-pass announcement and the "@codex review" trigger comment are
+# artifacts of the re-review loop itself, not human/bot feedback needing
+# triage — excluded from live_issue entirely (same effect as terminal triage).
+clean_invs
+
+# (1) Clean-pass marker from an allowlisted bot → excluded, eligible
+IC_CLEAN='[{"id": 950, "user": {"login": "trusted-bot[bot]"}, "body": "Codex Review: Didn'\''t find any major issues here, LGTM"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_CLEAN"); rc=$?
+assert "clean-pass marker from allowlisted bot excluded → eligible" "[ \$rc -eq 0 ]"
+
+# (2) Same marker text from a NON-allowlisted author still blocks — the
+# exemption is a bot-identity + marker conjunction, not a marker-alone match
+IC_CLEAN_UNTRUSTED='[{"id": 951, "user": {"login": "random-user"}, "body": "Codex Review: Didn'\''t find any major issues here"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_CLEAN_UNTRUSTED"); rc=$?
+assert "clean-pass marker text from non-allowlisted author still blocks" "[ \$rc -eq 1 ]"
+
+# (3) A bot comment that merely CONTAINS the marker, not starting with it,
+# still blocks — prefix match only, never substring
+IC_CLEAN_NOTPREFIX='[{"id": 952, "user": {"login": "trusted-bot[bot]"}, "body": "FYI: Codex Review: Didn'\''t find any major issues here"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_CLEAN_NOTPREFIX"); rc=$?
+assert "marker not at body start still blocks (prefix match only)" "[ \$rc -eq 1 ]"
+
+# (4) An unrelated bot comment still blocks — bot identity alone is never
+# the exemption, only bot identity + marker together
+IC_BOT_OTHER='[{"id": 953, "user": {"login": "trusted-bot[bot]"}, "body": "please rename this variable"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_BOT_OTHER"); rc=$?
+assert "unrelated bot comment still blocks" "[ \$rc -eq 1 ]"
+
+# (5) Trigger comment authored by the PR author → excluded, eligible
+PR_AUTHOR_JSON='{"state":"open","head":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"base":{"ref":"main","sha":"cccccccccccccccccccccccccccccccccccccccc"},"created_at":"2026-01-01T00:00:00Z","user":{"login":"pr-author"}}'
+IC_TRIGGER_AUTHOR='[{"id": 960, "user": {"login": "pr-author"}, "body": "@codex review"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_PR="$PR_AUTHOR_JSON" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_AUTHOR"); rc=$?
+assert "trigger comment from PR author excluded → eligible" "[ \$rc -eq 0 ]"
+
+# (6) Trigger comment authored by the authenticated session identity (the
+# CLI's own re-ask) → excluded, eligible. Default FIXTURE_PR carries no
+# `user`, so $pr_author is empty here — isolates the auth-login match.
+IC_TRIGGER_SESSION='[{"id": 961, "user": {"login": "session-user"}, "body": "@codex review"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_SESSION"); rc=$?
+assert "trigger comment from authenticated session identity excluded → eligible" "[ \$rc -eq 0 ]"
+
+# (7) Trigger comment from neither identity still blocks
+IC_TRIGGER_OTHER='[{"id": 962, "user": {"login": "operator"}, "body": "@codex review"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_OTHER"); rc=$?
+assert "trigger comment from unrelated identity still blocks" "[ \$rc -eq 1 ]"
+
+# (8) The trigger phrase must be at the body start too — prefix match only
+IC_TRIGGER_NOTPREFIX='[{"id": 963, "user": {"login": "pr-author"}, "body": "please do @codex review this again"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_PR="$PR_AUTHOR_JSON" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_NOTPREFIX"); rc=$?
+assert "trigger phrase not at body start still blocks (prefix match only)" "[ \$rc -eq 1 ]"
+
+# (9) A failed `gh api user` lookup never aborts the run (it does not gate
+# eligibility) — it degrades AUTH_LOGIN to an unmatchable empty string, so
+# the session-identity exemption just doesn't fire and the comment blocks
+# like any other untriaged item (fail closed).
+out=$(run_script "$BASE_POLICY" FIXTURE_AUTH_LOGIN_FAIL=1 FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_SESSION"); rc=$?
+assert "authenticated-identity lookup failure does not abort the script" "[ \$rc -ne 3 ]"
+assert "authenticated-identity lookup failure degrades the exemption (blocks)" "[ \$rc -eq 1 ]"
 
 # an APPROVED bot review with a non-empty body needs triage too
 clean_invs
@@ -1179,6 +1247,20 @@ assert "missing committer date → false" "[ \"\$(jq '.facts.bot_clean_review_at
 reacts_bad_ts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' 'not-a-date')" '[$a]')
 out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_bad_ts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
 assert "unparseable +1 timestamp → false" "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# a +1 whose created_at EQUALS last_head_change to the exact second must be
+# rejected — the predicate requires strict >, pinning that a future refactor
+# can't accidentally loosen it to >=
+reacts_exact_ts=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "$COMMIT_TS")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS="$reacts_exact_ts" FIXTURE_COMMIT="$COMMIT_FIXTURE")
+assert "+1 created_at equal to last_head_change → false (strict >, not >=)" \
+  "[ \"\$(jq '.facts.bot_clean_review_at_head' <<<\"\$out\")\" = false ]"
+
+# a failing reactions fetch is infrastructure error, not a false fact — the
+# whole script exits 3 (fail-closed `gh_api ... || { ...; exit 3; }` idiom),
+# same as every other required fetch in this file
+out=$(run_script "$BASE_POLICY" FIXTURE_REACTIONS_FAIL=1 FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "reactions fetch failure exits 3 (fail-closed, infrastructure error)" "[ \$rc -eq 3 ]"
 
 # empty allowlist → reaction path false
 EMPTY_ALLOWLIST_POLICY=$(jq -c '.bot_reviewers = []' <<<"$BASE_POLICY")

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -622,10 +622,17 @@ IC_TRIGGER_OTHER='[{"id": 962, "user": {"login": "operator"}, "body": "@codex re
 out=$(run_script "$BASE_POLICY" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_OTHER"); rc=$?
 assert "trigger comment from unrelated identity still blocks" "[ \$rc -eq 1 ]"
 
-# (8) The trigger phrase must be at the body start too — prefix match only
+# (8) The trigger phrase must be at the body start too — not a substring
 IC_TRIGGER_NOTPREFIX='[{"id": 963, "user": {"login": "pr-author"}, "body": "please do @codex review this again"}]'
 out=$(run_script "$BASE_POLICY" FIXTURE_PR="$PR_AUTHOR_JSON" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_NOTPREFIX"); rc=$?
-assert "trigger phrase not at body start still blocks (prefix match only)" "[ \$rc -eq 1 ]"
+assert "trigger phrase not at body start still blocks (not a substring match)" "[ \$rc -eq 1 ]"
+
+# (8b) The body must be EXACTLY the trigger phrase, not merely start with it —
+# a prefix match would let real feedback appended after "@codex review" ride
+# through unexamined (Codex review finding on PR #335, round 1).
+IC_TRIGGER_PLUS_FEEDBACK='[{"id": 964, "user": {"login": "pr-author"}, "body": "@codex review — please also fix the race described below"}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_PR="$PR_AUTHOR_JSON" FIXTURE_ISSUE_COMMENTS="$IC_TRIGGER_PLUS_FEEDBACK"); rc=$?
+assert "trigger phrase plus appended feedback still blocks (exact match only)" "[ \$rc -eq 1 ]"
 
 # (9) A failed `gh api user` lookup never aborts the run (it does not gate
 # eligibility) — it degrades AUTH_LOGIN to an unmatchable empty string, so


### PR DESCRIPTION
## Summary
- `untriaged_feedback` blocker now exempts two shapes of issue comment the Codex re-review loop itself generates: (1) the clean-pass announcement (allowlisted bot identity + pinned marker prefix), (2) the `@codex review` trigger comment (PR author or the authenticated session identity). Without this, asking for review or getting a clean pass trips the blocker it exists to satisfy.
- Two hardening tests added for the already-merged (.1) reaction-path predicate: a `gh api` failure fixture (exit 3, fail-closed), and a `+1 created_at == last_head_change` boundary case (must reject — strict `>` only).
- One-line spec residual note: a non-force push with a backdated `GIT_COMMITTER_DATE` is out of the cooperative-loop threat model — accepted explicitly.

## Split out
The review_summary ratchet (bead .2's original part (c) — each Codex round mints a new review_summary id, so a triage inventory from round N never covers round N+1) is split into sibling bead `agents-config-abn9.44.2.8`. It roughly doubles this diff and needs a new fact (a genuinely-clean signal distinct from `bot_clean_review_at_head`, which only means "APPROVED/COMMENTED", not "no findings") plus round-ordering tests — a design cycle, not a fold-in.

## Design
`docs/specs/2026-07-18-codex-rereview-path-design.md`, Component 2b.

## Test plan
- [x] `check-merge-eligibility_test.sh`: 205/205 assertions pass, 0 failures, exit 0.
- [x] Verified the `AUTH_LOGIN` lookup-failure degradation is fail-closed for the merge gate: on failure it becomes `""`, which can never match a real GitHub login, so the trigger-comment exemption simply does not fire and the comment stays counted as live/untriaged (blocks, never wrongly unblocks).

bead: agents-config-abn9.44.2.2