### PR TITLE
feat(merge-guard): review_wait.bot recognizes Codex's reaction-based signals

### DIFF
--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -504,13 +504,22 @@ set_fact admin_bypass "$(jq -n \
 # that concluded clean — both read "no blocker" on every other row. Block
 # until the expected review arrives at the current head or its wait window
 # closes. Timing out ends the wait; it never satisfies the positive fact.
+# Copilot and Codex leave different vocabularies for the same two signals, so
+# both "arrived" and "latest_ref" below OR in the Codex-shaped equivalent:
+# reaction_clean (Component 2b, computed above) is the reaction-path analogue
+# of a matching review object, and a trusted `eyes` reaction is the Codex
+# analogue of Copilot's copilot_work_started event — Codex is comment-
+# triggered and posts neither a review_requested target nor a "started work"
+# event, so without these a Codex-only PR either never reads satisfied (no
+# review object ever lands on a clean pass) or goes stale mid-review (the
+# clock never advances past PR creation while Codex is actively working).
 review_wait_bot="not_expected"
 if [[ "$BOT_EXPECTED" == "true" ]]; then
     arrived=$(jq --argjson trusted "$BOT_REVIEWERS" --arg head "$HEAD_OID" '
         [ .[] | select((.user.login as $l | ($trusted | index($l)) != null)
                        and ((.commit_id // "") == $head)
                        and .state != "DISMISSED") ] | length' <<<"$ALL_REVIEWS")
-    if [[ "$arrived" -gt 0 ]]; then
+    if [[ "$arrived" -gt 0 || "$reaction_clean" == "true" ]]; then
         review_wait_bot="satisfied"
     else
         # Events feed only this wait computation — fetched here (not up top)
@@ -521,11 +530,15 @@ if [[ "$BOT_EXPECTED" == "true" ]]; then
         EVENTS=$(gh_api "repos/${OWNER}/${REPO}/issues/${PR}/events?per_page=100" --paginate | jq -s 'add // []') || {
             echo "Error: failed to fetch issue events" >&2; exit 3; }
         latest_ref=$(jq -rn --argjson ev "$EVENTS" --argjson rv "$ALL_REVIEWS" \
+            --argjson reactions "$REACTIONS" \
             --argjson trusted "$BOT_REVIEWERS" --arg pr_created "$PR_CREATED" '
             ( [ $ev[] | select(.event == "review_requested"
                                and (((.requested_reviewer.login // "") as $l | ($trusted | index($l)) != null)))
                       | .created_at ]
             + [ $ev[] | select(.event == "copilot_work_started") | .created_at ]
+            + [ $reactions[] | select(.content == "eyes")
+                              | select(.user.login as $l | ($trusted | index($l)) != null)
+                              | .created_at ]
             + [ $rv[] | select((.user.login as $l | ($trusted | index($l)) != null)) | .submitted_at ]
             + [ $pr_created ] ) | max')
         bot_age=$(jq -rn --arg ts "$latest_ref" '(now - ($ts | fromdateiso8601)) | floor')

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -519,6 +519,46 @@ revs=$(jq -n --argjson a "$(mk_review 'trusted-bot[bot]' COMMENTED "$HEAD_SHA" 2
 out=$(run_script "$BOT_POLICY" FIXTURE_REVIEWS="$revs" FIXTURE_PR="$old_pr"); rc=$?
 assert "arrived bot review → satisfied, eligible" "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.review_wait.bot' <<<\"\$out\")\" = satisfied ]"
 
+# ── review_wait.bot recognizes Codex's reaction-based signals (2026-07-18
+# codex-rereview-path-design), not just Copilot's review-object/event
+# vocabulary. "arrived" must also fire off the already-computed
+# reaction_clean fact (Component 2b) — Codex's clean auto/push-triggered pass
+# leaves a +1 reaction, never a review object — and latest_ref's freshness
+# clock must also advance on a trusted `eyes` reaction, the Codex analogue of
+# Copilot's copilot_work_started event.
+
+# Codex-only PR: no review object, no review_requested/copilot_work_started
+# events, just a qualifying clean +1 reaction at head → satisfied via the
+# reaction path (arrived must OR in reaction_clean).
+commit_recent=$(jq -n '{commit:{committer:{date:"2026-01-01T00:00:00Z"}}}')
+reacts_plus1=$(jq -n --arg t "2026-01-01T01:00:00Z" \
+  '[{id:1, content:"+1", user:{login:"trusted-bot[bot]", type:"Bot"}, created_at:$t}]')
+out=$(run_script "$BOT_POLICY" FIXTURE_REACTIONS="$reacts_plus1" FIXTURE_COMMIT="$commit_recent"); rc=$?
+assert "codex-only clean +1 reaction → review_wait.bot satisfied (reaction path)" \
+    "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.review_wait.bot' <<<\"\$out\")\" = satisfied ]"
+
+# Load-bearing regression: an `eyes` reaction from a trusted identity resets
+# the freshness clock. PR age alone (old_pr, 2h old) would exceed
+# BOT_TIMEOUT, but a recent `eyes` must push latest_ref forward so the wait
+# reads "waiting", not "timed_out" — Codex is comment-triggered and never
+# emits review_requested/copilot_work_started, so without this the wait
+# always reads stale mid-review.
+reacts_eyes_only=$(jq -n --arg t "$TS_RECENT" \
+  '[{id:2, content:"eyes", user:{login:"trusted-bot[bot]", type:"Bot"}, created_at:$t}]')
+out=$(run_script "$BOT_POLICY" FIXTURE_REACTIONS="$reacts_eyes_only" FIXTURE_PR="$old_pr"); rc=$?
+assert "trusted eyes reaction resets freshness clock → waiting, not timed_out" \
+    "[ \$rc -eq 1 ] && [ \"\$(jq -r '.facts.review_wait.bot' <<<\"\$out\")\" = waiting ]"
+
+# Non-allowlisted identity's eyes/+1 must not feed into arrived or
+# latest_ref — same allowlist-exact-match discipline as the rest of the
+# reaction path. Old PR, only untrusted reactions → still timed_out.
+reacts_untrusted=$(jq -n --arg t "$TS_RECENT" \
+  '[{id:3, content:"eyes", user:{login:"evil-bot[bot]", type:"Bot"}, created_at:$t},
+    {id:4, content:"+1", user:{login:"evil-bot[bot]", type:"Bot"}, created_at:$t}]')
+out=$(run_script "$BOT_POLICY" FIXTURE_REACTIONS="$reacts_untrusted" FIXTURE_PR="$old_pr"); rc=$?
+assert "non-allowlisted eyes/+1 reactions ignored → still timed_out" \
+    "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.review_wait.bot' <<<\"\$out\")\" = timed_out ]"
+
 # humans required, none yet, no timeout → blocks indefinitely
 H_POLICY=$(jq -c '.human_approvers_required = 1' <<<"$BASE_POLICY")
 out=$(run_script "$H_POLICY" FIXTURE_PR="$old_pr"); rc=$?


### PR DESCRIPTION
## Summary
- `review_wait.bot`'s `arrived`/`latest_ref` computation was Copilot-shaped (review objects + review_requested/copilot_work_started events). Codex is comment-triggered and emits neither.
- `arrived` now also fires on `reaction_clean` (bead .1's already-computed Component 2b clean-pass boolean) — a Codex clean pass often leaves only a +1 reaction, never a review object.
- `latest_ref`'s freshness clock now also advances on trusted `eyes` reaction timestamps — the Codex analogue of `copilot_work_started` — so a Codex-only PR actively being reviewed does not get wrongly `timed_out` mid-review.

No widening of what counts as a clean merge signal: this only touches `review_wait.bot` / the `review_in_flight` blocker, reusing the same `reaction_clean` boolean that already gates `bot_clean_review_at_head`.

## Design
`docs/specs/2026-07-18-codex-rereview-path-design.md` — carried ralf-review finding M2.

## Test plan
- [x] `check-merge-eligibility_test.sh`: 209/209 assertions pass, 0 failures, exit 0. TDD red-first confirmed (2 of 3 new tests failed pre-implementation).
- [x] New tests: Codex-only clean +1 reaction satisfies via the reaction path; a trusted `eyes` reaction resets the freshness clock (load-bearing — an old PR that would otherwise time out reads `waiting` instead); non-allowlisted `eyes`/`+1` reactions ignored (still times out), matching the file's allowlist-exact-match discipline.
- [x] Existing Copilot-shaped tests unchanged and still pass — additive, not a replacement.

bead: agents-config-abn9.44.2.4