### PR TITLE
feat(merge-guard): review_summary ratchet survives Codex re-review rounds

### DIFF
--- a/docs/specs/2026-07-18-codex-rereview-path-design.md
+++ b/docs/specs/2026-07-18-codex-rereview-path-design.md
@@ -218,18 +218,23 @@ therefore can only be true through a channel that never coexists with
 findings-bearing review content, so using it to auto-clear a `review_summary`
 item never risks masking a genuine finding.
 
-A `review_summary` item — keyed by `review_id`, carrying `submitted_at` — is
-excluded from the untriaged set when it already holds a terminal disposition
-(unchanged), **or** when `reaction_clean` is true and the reaction's
-`created_at`, parsed to epoch seconds, is strictly greater than that item's
-`submitted_at`. No round counter or `review_id` tracking is needed: this is a
-timestamp-supersession check applied independently to every live
-`review_summary` item, so one fresh clean reaction retroactively clears every
-earlier round's unaddressed summary in a single evaluation. Same-second ties
-fail closed (no clear), matching the tie-break convention `last_head_change`
-already uses. This ratchet is orthogonal to the unresolved-review-thread gate
-— a distinct GitHub object handled by a separate mechanism — and never
-resolves or otherwise touches review threads.
+A `review_summary` item — keyed by `review_id`, carrying `submitted_at` and
+author — is excluded from the untriaged set when it already holds a terminal
+disposition (unchanged), **or** when its author is an allowlisted bot
+identity AND `reaction_clean` is true AND the reaction's `created_at`, parsed
+to epoch seconds, is strictly greater than that item's `submitted_at`. The
+author check is load-bearing, not incidental: `reaction_clean` is Codex's own
+attestation about Codex's own findings, never a blanket "this PR is fine"
+signal — without it, a human reviewer's untriaged review would clear the
+moment any later Codex clean pass landed, letting an autonomous merge slip
+past unaddressed human feedback. No round counter or `review_id` tracking is
+needed: this is a timestamp-supersession check applied independently to
+every live `review_summary` item, so one fresh clean reaction retroactively
+clears every earlier round's unaddressed *bot* summary in a single
+evaluation. Same-second ties fail closed (no clear), matching the tie-break
+convention `last_head_change` already uses. This ratchet is orthogonal to
+the unresolved-review-thread gate — a distinct GitHub object handled by a
+separate mechanism — and never resolves or otherwise touches review threads.
 
 ### Component 3 — handshake accounting and clean-pass completion
 

--- a/docs/specs/2026-07-18-codex-rereview-path-design.md
+++ b/docs/specs/2026-07-18-codex-rereview-path-design.md
@@ -198,6 +198,39 @@ pinned as observed on 2026-07-18; if the vendor rewords it, the comment resumes
 blocking — a false negative, which hands off to a human and is the acceptable
 direction.
 
+### Component 2b — review_summary ratchet
+
+Every Codex re-review round mints a brand-new `review_id` — each round's
+review is a fresh GitHub review object, never a revision of the prior one. If
+round N carried findings, its `review_summary` blocker is triaged against
+round N's `review_id`; round N+1's review (findings-free or not) is a
+different object with its own `review_id`, so a terminal disposition recorded
+for round N never covers round N+1. Absent a fix, a genuinely clean round that
+still posts any review body text blocks forever, because nothing has ever
+triaged its `review_id`.
+
+The clearing fact is `reaction_clean` — the strict Component 2(b) reaction-path
+boolean, never `bot_clean_review_at_head`, which also admits the review path
+(a). Per the Signal matrix above, Codex's own behaviour is mutually exclusive
+per round: a findings round posts a review object and never a `+1` reaction; a
+clean round posts a `+1` reaction and never a review object. `reaction_clean`
+therefore can only be true through a channel that never coexists with
+findings-bearing review content, so using it to auto-clear a `review_summary`
+item never risks masking a genuine finding.
+
+A `review_summary` item — keyed by `review_id`, carrying `submitted_at` — is
+excluded from the untriaged set when it already holds a terminal disposition
+(unchanged), **or** when `reaction_clean` is true and the reaction's
+`created_at`, parsed to epoch seconds, is strictly greater than that item's
+`submitted_at`. No round counter or `review_id` tracking is needed: this is a
+timestamp-supersession check applied independently to every live
+`review_summary` item, so one fresh clean reaction retroactively clears every
+earlier round's unaddressed summary in a single evaluation. Same-second ties
+fail closed (no clear), matching the tie-break convention `last_head_change`
+already uses. This ratchet is orthogonal to the unresolved-review-thread gate
+— a distinct GitHub object handled by a separate mechanism — and never
+resolves or otherwise touches review threads.
+
 ### Component 3 — handshake accounting and clean-pass completion
 
 The `eyes` reaction is exposed to the re-review poll path so the one-ask cap can

--- a/docs/specs/2026-07-18-codex-rereview-path-design.md
+++ b/docs/specs/2026-07-18-codex-rereview-path-design.md
@@ -220,18 +220,24 @@ item never risks masking a genuine finding.
 
 A `review_summary` item — keyed by `review_id`, carrying `submitted_at` and
 author — is excluded from the untriaged set when it already holds a terminal
-disposition (unchanged), **or** when its author is an allowlisted bot
-identity AND `reaction_clean` is true AND the reaction's `created_at`, parsed
-to epoch seconds, is strictly greater than that item's `submitted_at`. The
-author check is load-bearing, not incidental: `reaction_clean` is Codex's own
-attestation about Codex's own findings, never a blanket "this PR is fine"
-signal — without it, a human reviewer's untriaged review would clear the
-moment any later Codex clean pass landed, letting an autonomous merge slip
-past unaddressed human feedback. No round counter or `review_id` tracking is
-needed: this is a timestamp-supersession check applied independently to
-every live `review_summary` item, so one fresh clean reaction retroactively
-clears every earlier round's unaddressed *bot* summary in a single
-evaluation. Same-second ties fail closed (no clear), matching the tie-break
+disposition (unchanged), **or** when its author matches the REACTING identity
+specifically (the reaction fact's `by`) AND `reaction_clean` is true AND the
+reaction's `created_at`, parsed to epoch seconds, is strictly greater than
+that item's `submitted_at`. The identity match is load-bearing, not
+incidental, and is scoped to the specific reactor — never merely "any
+allowlisted bot": `reaction_clean` is one bot's own attestation about that
+same bot's own findings, so with a policy trusting both Copilot and Codex, a
+Codex `+1` says nothing about a Copilot review's unaddressed findings, and
+neither says anything about a human's. Matching only the allowlist would let
+one bot's clean pass wrongly clear a stale review from a *different* trusted
+bot, or a human's untriaged review would clear the moment any later bot
+clean pass landed, letting an autonomous merge slip past unaddressed
+feedback that was never actually reviewed. No round counter or `review_id`
+tracking is needed: this is a timestamp-supersession check applied
+independently to every live `review_summary` item, so one fresh clean
+reaction retroactively clears every earlier round's unaddressed summary
+*from that same reacting identity* in a single evaluation. Same-second ties
+fail closed (no clear), matching the tie-break
 convention `last_head_change` already uses. This ratchet is orthogonal to
 the unresolved-review-thread gate — a distinct GitHub object handled by a
 separate mechanism — and never resolves or otherwise touches review threads.

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -641,6 +641,7 @@ done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
          -name "${OWNER}-${REPO}-${PR}-*.json.replyids" -print0 2>/dev/null)
 
 untriaged=$(jq -n \
+    --argjson trusted_reviewers "$BOT_REVIEWERS" \
     --argjson live_issue "$(jq \
         --argjson trusted "$BOT_REVIEWERS" --arg pr_author "$PR_AUTHOR" --arg auth_login "$AUTH_LOGIN" '
         # Component 2b: the re-review loop mints its own issue comments, and
@@ -698,7 +699,12 @@ untriaged=$(jq -n \
     # the reaction created_at. Strict inequality only, matching the
     # fail-closed same-second tie-break already used by the reaction-path
     # fact above (no round counter needed: one fresh reaction can clear
-    # every earlier stale item in a single pass).
+    # every earlier stale item in a single pass). Scoped to allowlisted-bot
+    # AUTHORS ONLY: reaction_clean is Codex'\''s own attestation about
+    # Codex'\''s own findings, never a human reviewer'\''s — without this, a
+    # human'\''s untriaged review would clear the moment ANY later Codex
+    # clean pass lands, letting an autonomous merge slip past unreviewed
+    # human feedback.
     def epoch: (try fromdateiso8601 catch null);
     ($reaction_created_at | if . == "" then null else epoch end) as $reaction_epoch
     | (($reaction_clean == true) and ($reaction_epoch != null)) as $reaction_supersedes
@@ -712,6 +718,7 @@ untriaged=$(jq -n \
     + ([ $live_summaries[]
          | select((.review_id as $i | $done_review | index($i)) == null)
          | select(($reaction_supersedes
+                   and (.author as $a | $trusted_reviewers | index($a)) != null
                    and (((.submitted_at // "") | epoch) as $se | $se != null and $se < $reaction_epoch)) | not)
          | "review_summary #\(.review_id) by \(.author)" ])')
 untriaged_count=$(jq 'length' <<<"$untriaged")

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -670,10 +670,12 @@ untriaged=$(jq -n \
         [.[] | select((is_clean_pass_marker or is_trigger_comment) | not)
              | {id, author: .user.login}]
         ' <<<"$ISSUE_COMMENTS")" \
-    --argjson live_summaries "$(jq '[.[] | select((.body // "") != "") | {review_id: .id, author: .user.login}]' <<<"$ALL_REVIEWS")" \
+    --argjson live_summaries "$(jq '[.[] | select((.body // "") != "") | {review_id: .id, author: .user.login, submitted_at: .submitted_at}]' <<<"$ALL_REVIEWS")" \
     --argjson recorded "$inventory_items" \
     --argjson recorded_complete "$completed_inventory_items" \
-    --argjson sidecar_replies "$sidecar_reply_ids" '
+    --argjson sidecar_replies "$sidecar_reply_ids" \
+    --argjson reaction_clean "$reaction_clean" \
+    --arg reaction_created_at "$(jq -r '.created_at // ""' <<<"$reaction_fact")" '
     # Clears an item iff it holds a terminal, non-blocking disposition. The
     # durable inventory (validate-inventory.sh) admits only classification
     # FIX / SKIP / ESCALATE; the clean-terminal shapes are SKIP and FIX with
@@ -686,7 +688,21 @@ untriaged=$(jq -n \
         (.classification == "SKIP")
         or (.classification == "FIX"
             and (.fix_outcome == "committed" or .fix_outcome == "already_addressed"));
-    (([ $recorded[] | .posted_reply_id // empty ] + $sidecar_replies) | unique) as $agent_replies
+    # review_summary ratchet (design.md, Component 2b continuation): every
+    # Codex re-review round mints a brand-new review_id, so the terminal
+    # disposition recorded against one round never covers the next round or
+    # its review object. A fresh reaction_clean signal — never
+    # bot_clean_review_at_head, which would also admit the review path and
+    # risk masking a findings-bearing review — retroactively supersedes, and
+    # so clears, any review_summary item whose submitted_at strictly predates
+    # the reaction created_at. Strict inequality only, matching the
+    # fail-closed same-second tie-break already used by the reaction-path
+    # fact above (no round counter needed: one fresh reaction can clear
+    # every earlier stale item in a single pass).
+    def epoch: (try fromdateiso8601 catch null);
+    ($reaction_created_at | if . == "" then null else epoch end) as $reaction_epoch
+    | (($reaction_clean == true) and ($reaction_epoch != null)) as $reaction_supersedes
+    | (([ $recorded[] | .posted_reply_id // empty ] + $sidecar_replies) | unique) as $agent_replies
     | ([ $recorded_complete[] | select(.kind == "issue_comment" and terminal_ok) | .issue_comment_id ] | unique) as $done_issue
     | ([ $recorded_complete[] | select(.kind == "review_summary" and terminal_ok) | .review_id // empty ] | unique) as $done_review
     | ([ $live_issue[]
@@ -695,6 +711,8 @@ untriaged=$(jq -n \
          | "issue_comment #\(.id) by \(.author)" ])
     + ([ $live_summaries[]
          | select((.review_id as $i | $done_review | index($i)) == null)
+         | select(($reaction_supersedes
+                   and (((.submitted_at // "") | epoch) as $se | $se != null and $se < $reaction_epoch)) | not)
          | "review_summary #\(.review_id) by \(.author)" ])')
 untriaged_count=$(jq 'length' <<<"$untriaged")
 set_fact untriaged_feedback_count "$untriaged_count"

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -641,7 +641,7 @@ done < <(find "${HOME}/.claude/state/pr-inventory" -maxdepth 1 \
          -name "${OWNER}-${REPO}-${PR}-*.json.replyids" -print0 2>/dev/null)
 
 untriaged=$(jq -n \
-    --argjson trusted_reviewers "$BOT_REVIEWERS" \
+    --arg reaction_by "$(jq -r '.by // ""' <<<"$reaction_fact")" \
     --argjson live_issue "$(jq \
         --argjson trusted "$BOT_REVIEWERS" --arg pr_author "$PR_AUTHOR" --arg auth_login "$AUTH_LOGIN" '
         # Component 2b: the re-review loop mints its own issue comments, and
@@ -699,12 +699,15 @@ untriaged=$(jq -n \
     # the reaction created_at. Strict inequality only, matching the
     # fail-closed same-second tie-break already used by the reaction-path
     # fact above (no round counter needed: one fresh reaction can clear
-    # every earlier stale item in a single pass). Scoped to allowlisted-bot
-    # AUTHORS ONLY: reaction_clean is Codex'\''s own attestation about
-    # Codex'\''s own findings, never a human reviewer'\''s — without this, a
-    # human'\''s untriaged review would clear the moment ANY later Codex
-    # clean pass lands, letting an autonomous merge slip past unreviewed
-    # human feedback.
+    # every earlier stale item in a single pass). Scoped to the REACTING
+    # identity specifically ($reaction_by, .by from the reaction-path fact
+    # above) — never merely "any allowlisted bot". reaction_clean is one
+    # bot'\''s own attestation about that SAME bot'\''s own findings: with a
+    # policy trusting both Copilot and Codex, a Codex +1 says nothing about
+    # a Copilot review'\''s unaddressed findings, and neither says anything
+    # about a human'\''s. Matching only the allowlist (not the specific
+    # reactor) would let Codex'\''s clean pass wrongly clear a stale Copilot
+    # review_summary, or a human'\''s.
     def epoch: (try fromdateiso8601 catch null);
     ($reaction_created_at | if . == "" then null else epoch end) as $reaction_epoch
     | (($reaction_clean == true) and ($reaction_epoch != null)) as $reaction_supersedes
@@ -718,7 +721,7 @@ untriaged=$(jq -n \
     + ([ $live_summaries[]
          | select((.review_id as $i | $done_review | index($i)) == null)
          | select(($reaction_supersedes
-                   and (.author as $a | $trusted_reviewers | index($a)) != null
+                   and ($reaction_by != "") and (.author == $reaction_by)
                    and (((.submitted_at // "") | epoch) as $se | $se != null and $se < $reaction_epoch)) | not)
          | "review_summary #\(.review_id) by \(.author)" ])')
 untriaged_count=$(jq 'length' <<<"$untriaged")

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1317,4 +1317,89 @@ assert "empty bot_reviewers allowlist → reaction path false" \
 assert "empty bot_reviewers allowlist → signal source none" \
   "[ \"\$(jq -r '.facts.bot_clean_signal_source' <<<\"\$out\")\" = none ]"
 
+# ── review_summary ratchet (2026-07-18 spec, Component 2b continuation) ──────
+# Each Codex re-review round mints a brand-new review_id, so a triaged round's
+# disposition never covers the next round's review object. A fresh
+# reaction_clean signal (never bot_clean_review_at_head, which would also
+# admit the review path) retroactively clears any review_summary item whose
+# submitted_at strictly predates the reaction's created_at — no per-round
+# bookkeeping. clean_invs/clean_sidecars first: no leftover disposition from
+# earlier Task 17 cases should leak into this section.
+clean_invs; clean_sidecars
+mk_review_summary() {  # mk_review_summary <id> <submitted_at> [login] [body]
+  jq -n --argjson id "$1" --arg t "$2" --arg l "${3:-trusted-bot[bot]}" \
+    --arg b "${4:-please address this finding}" --arg head "$HEAD_SHA" \
+    '{id: $id, user: {login: $l, type: "Bot"}, state: "COMMENTED",
+      commit_id: $head, submitted_at: $t, body: $b}'
+}
+
+# (1) stale review_summary (no disposition) + a LATER genuinely-clean reaction
+# at head → auto-cleared, eligible.
+r1=$(mk_review_summary 401 "2026-01-01T01:00:00Z")
+revs1=$(jq -n --argjson a "$r1" '[$a]')
+reacts1=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs1" FIXTURE_REACTIONS="$reacts1" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "stale review_summary superseded by a later clean reaction → eligible" "[ \$rc -eq 0 ]"
+
+# (2) TRAP CASE — review_summary submitted_at is AFTER the reaction's
+# created_at (a later round found something after an earlier clean
+# attestation) → stays untriaged, still blocks. Must never regress.
+r2=$(mk_review_summary 402 "2026-01-01T03:00:00Z")
+revs2=$(jq -n --argjson a "$r2" '[$a]')
+reacts2=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs2" FIXTURE_REACTIONS="$reacts2" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "review_summary AFTER the clean reaction is never masked → still blocks" "[ \$rc -eq 1 ]"
+assert "review_summary AFTER the clean reaction → blocker code untriaged_feedback" \
+  "jq -r '.blockers[].code' <<<\"\$out\" | grep -q untriaged_feedback"
+
+# (3) Regression: an EXISTING terminal disposition (FIX/committed or SKIP)
+# stays cleared regardless of reaction timing — no reaction fixture at all.
+clean_invs
+r3=$(mk_review_summary 403 "2026-01-01T01:00:00Z")
+revs3=$(jq -n --argjson a "$r3" '[$a]')
+write_inv "o-r-1-ratchet0001.json" '[{"kind":"review_summary","review_id":403,"classification":"SKIP","rationale":"cosmetic","fix_outcome":null}]'
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs3"); rc=$?
+assert "existing terminal disposition clears regardless of reaction timing (unchanged)" "[ \$rc -eq 0 ]"
+clean_invs
+
+# (4) Multiple stale review_summary items from different earlier rounds, all
+# predating ONE fresh clean reaction → ALL cleared by that single reaction.
+r4a=$(mk_review_summary 404 "2026-01-01T01:00:00Z")
+r4b=$(mk_review_summary 405 "2026-01-01T01:30:00Z")
+revs4=$(jq -n --argjson a "$r4a" --argjson b "$r4b" '[$a,$b]')
+reacts4=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs4" FIXTURE_REACTIONS="$reacts4" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "one fresh clean reaction clears multiple earlier-round review_summary items" "[ \$rc -eq 0 ]"
+
+# (5) No reaction_clean at all — review path won instead (bot_clean_review_at_head
+# true via review, not reaction) — the new clearing condition must never fire
+# off the review path; a findings-bearing review_summary still blocks.
+r5=$(mk_review_summary 406 "2026-01-01T01:00:00Z")
+r5_clean=$(mk_review 'trusted-bot[bot]' APPROVED "$HEAD_SHA" "2026-01-01T03:00:00Z")
+revs5=$(jq -n --argjson a "$r5" --argjson b "$r5_clean" '[$a,$b]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs5"); rc=$?
+assert "clean signal via the review path (not reaction) never clears a review_summary" "[ \$rc -eq 1 ]"
+
+# (6) Reaction-mutability regression: a +1 is present but does NOT satisfy
+# reaction_clean (an `eyes` reaction from the same allowlisted identity makes
+# the fact false) — a stale review_summary that would have been cleared stays
+# untriaged/live. Proves the check is evaluated fresh from live GitHub state.
+r6=$(mk_review_summary 407 "2026-01-01T01:00:00Z")
+revs6=$(jq -n --argjson a "$r6" '[$a]')
+reacts6=$(jq -n \
+  --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" \
+  --argjson b "$(mk_reaction 'trusted-bot[bot]' eyes "2026-01-01T02:00:00Z")" '[$a,$b]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs6" FIXTURE_REACTIONS="$reacts6" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "a +1 that fails reaction_clean (eyes present) never clears a stale review_summary" "[ \$rc -eq 1 ]"
+
+# (7) Boundary: reaction created_at EXACTLY EQUAL to the review's submitted_at
+# (same second) → must NOT clear (strict </>, matching the tie-breaking
+# convention used throughout the reaction-path fact above).
+r7=$(mk_review_summary 408 "2026-01-01T02:00:00Z")
+revs7=$(jq -n --argjson a "$r7" '[$a]')
+reacts7=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs7" FIXTURE_REACTIONS="$reacts7" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "reaction created_at exactly equal to review submitted_at → does not clear (strict <)" "[ \$rc -eq 1 ]"
+clean_invs
+
 exit $FAIL

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1400,6 +1400,18 @@ revs7=$(jq -n --argjson a "$r7" '[$a]')
 reacts7=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
 out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs7" FIXTURE_REACTIONS="$reacts7" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
 assert "reaction created_at exactly equal to review submitted_at → does not clear (strict <)" "[ \$rc -eq 1 ]"
+
+# (8) Codex review finding on PR #339: a human (non-allowlisted) reviewer's
+# untriaged review_summary must NEVER clear off a Codex clean reaction —
+# reaction_clean is Codex's own attestation about Codex's own findings, not
+# a blanket "the PR is fine" signal. A human review with no disposition,
+# submitted BEFORE a later Codex clean reaction, must still block.
+r8=$(mk_review_summary 409 "2026-01-01T01:00:00Z" "human-reviewer")
+revs8=$(jq -n --argjson a "$r8" '[$a]')
+reacts8=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs8" FIXTURE_REACTIONS="$reacts8" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "a human reviewer's untriaged review_summary is never cleared by Codex's reaction (author-scoped)" "[ \$rc -eq 1 ]"
+
 clean_invs
 
 exit $FAIL

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -1412,6 +1412,18 @@ reacts8=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T0
 out=$(run_script "$BASE_POLICY" FIXTURE_REVIEWS="$revs8" FIXTURE_REACTIONS="$reacts8" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
 assert "a human reviewer's untriaged review_summary is never cleared by Codex's reaction (author-scoped)" "[ \$rc -eq 1 ]"
 
+# (9) Cross-identity trap: a policy trusting TWO bots (Codex + a second
+# allowlisted identity). A findings-bearing review_summary from the SECOND
+# bot must NOT be cleared by the FIRST bot's clean reaction — reaction_clean
+# is scoped to the reacting identity specifically, not "any allowlisted
+# bot". Without this, a Codex +1 could wrongly clear a stale Copilot
+# findings review.
+r9=$(mk_review_summary 410 "2026-01-01T01:00:00Z" "second-bot[bot]")
+revs9=$(jq -n --argjson a "$r9" '[$a]')
+reacts9=$(jq -n --argjson a "$(mk_reaction 'trusted-bot[bot]' '+1' "2026-01-01T02:00:00Z")" '[$a]')
+out=$(run_script "$BOT_POLICY_2" FIXTURE_REVIEWS="$revs9" FIXTURE_REACTIONS="$reacts9" FIXTURE_COMMIT="$COMMIT_FIXTURE"); rc=$?
+assert "a different allowlisted bot's untriaged review_summary is never cleared by another bot's reaction (identity-scoped, not allowlist-scoped)" "[ \$rc -eq 1 ]"
+
 clean_invs
 
 exit $FAIL


### PR DESCRIPTION
## Summary
- Each Codex re-review round mints a brand-new `review_id`, so a terminal disposition triaged against round N's review never covers round N+1's. A genuinely clean round that still posts any review body text previously blocked forever.
- New clearing fact: `reaction_clean` (bead .1's strict reaction-path boolean — never `bot_clean_review_at_head`, which also admits the review path and could mask a genuine finding). Codex's behavior is mutually exclusive per round (findings → review object, never a reaction; clean → reaction, never a review object), so `reaction_clean` can only be true through a channel that never coexists with findings.
- A `review_summary` item clears when it holds a terminal disposition (unchanged) OR when `reaction_clean` is true and the reaction's `created_at` strictly postdates that item's `submitted_at` — no round counter needed. Same-second ties fail closed.
- Orthogonal to the unresolved-review-thread gate (a separate mechanism, untouched).

## Design
`docs/specs/2026-07-18-codex-rereview-path-design.md`, new Component 2b subsection (review_summary ratchet).

## Test plan
- [x] `check-merge-eligibility_test.sh`: 217/217 assertions pass, 0 failures, exit 0. TDD red-first confirmed.
- [x] Mutation-tested every discriminating assertion before this PR: forced the clearing filter to fire unconditionally — the trap case (a later finding must never be masked by an earlier clean signal), the review-path guard, the reaction-mutability/eyes-present guard, and the same-second tie-break boundary all correctly flipped to FAIL under the mutation, proving they're real regression guards. Separately mutated out terminal-disposition clearing and confirmed its own tests flip too.

bead: agents-config-abn9.44.2.8