### PR TITLE
feat(orchestrated-grind): verdict-aware PR watcher with a written precedence contract

### DIFF
--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -429,11 +429,55 @@ void, and the lane looks stuck when nothing is wrong with it. In the reference
 run one lane did this three times and every "failure" was this and only this.
 Brief lanes to *request* a watcher from ROOT, never to launch one.
 
-**A watcher detects PR *activity*, never a verdict.** It knows nothing about
-approval signals, reviewer identity, or clean-pass phrasing — that is the
-review skill's job (§3), and duplicating any of it here guarantees drift the
-first time a reviewer changes behavior. The watcher answers exactly one
-question: *has anything happened on this PR since I armed?*
+**A watcher detects activity and labels its shape. It never issues a verdict.**
+The doorbell answers *has anything happened since I armed?* — and then, on the
+way out, reports a **provisional class** so ROOT is not re-deriving "was that a
+clean pass or a fresh pile of findings?" by hand on every single ring. That
+manual disambiguation was the highest-frequency cost in the reference run.
+
+The class is a **routing hint**. The authoritative verdict still comes from the
+review skill (§3), and the lane still consults it on every ring.
+
+| Class | Means | ROOT's usual move |
+|---|---|---|
+| `FINDINGS` | Reviewer wants changes — a new `CHANGES_REQUESTED`, any new inline comment, or a findings-marker | Re-engage the lane to work them |
+| `CLEAN` | Reviewer appears done and satisfied — a new `APPROVED`, a `+1`/`rocket`/`hooray` from a trusted reviewer, or a clean-marker | Re-engage the lane to confirm and report up |
+| `IN-FLIGHT` | Review started but has not concluded — an `eyes` reaction from a trusted reviewer | Usually **re-arm**, do not wake the lane |
+| `ACTIVITY` | Something else happened, or classification could not run | Treat as a bare doorbell |
+
+**The precedence contract — written down because ties are the whole problem.**
+Signals arrive out of order, land in the same polling window, and contradict
+each other. So the class is computed from **PR state at ring time**, never from
+the order events arrived in, and resolved by one fixed severity order:
+
+> **`FINDINGS` > `CLEAN` > `IN-FLIGHT` > `ACTIVITY`**
+
+- **`FINDINGS` beats `CLEAN`** on cost asymmetry. A false `CLEAN` can carry an
+  unaddressed finding toward a merge; a false `FINDINGS` costs one wasted lane
+  check. An approving review *alongside* a new inline comment is `FINDINGS`.
+- **`CLEAN` beats `IN-FLIGHT`** because `eyes` is a *start* marker. A review
+  that starts and finishes inside one window is finished — `eyes`→`+1` nets to
+  `CLEAN`, which is exactly what a fast clean pass looks like.
+- **Most severe wins, never most recent.** Several new reviews in one window
+  resolve to the most severe among them. This is what makes out-of-order
+  delivery harmless — no ordering assumption is made anywhere.
+- **Re-arming resets everything.** A fresh watcher samples fresh baselines, so
+  no class carries across arms and there is no sticky state to go stale.
+- **A class is never authorization.** `CLEAN` is not approval and never
+  licenses a merge; only `merge-guard` rules on that (§4).
+
+**Classification can never suppress a ring.** It runs *after* the decision to
+ring, once, on the way out — every failure path degrades to `ACTIVITY` and
+rings anyway. This is the dumbness rule intact: the poll loop itself is still a
+plain count comparison, and a classifier that cannot fail closed cannot ghost
+the way the reference run's filter-based monitors did.
+
+**Spot-check on re-arm.** A watcher that has been re-armed two or three times
+on the same PR without a terminal class is evidence about the *watcher*, not
+the reviewer. Before arming yet again, check the PR directly once — `gh pr
+view` — because repeated `IN-FLIGHT` or `ACTIVITY` rings are exactly what a
+half-broken poller looks like from the outside. Suspect the tooling before the
+teammate (§8); one cheap direct look costs less than a third wasted arm.
 
 - **Keep the watcher dumb.** A plain timer loop comparing counts beats a clever
   filter on commit metadata or author fields: clever watchers fail silently and
@@ -455,9 +499,16 @@ question: *has anything happened on this PR since I armed?*
   none of the other counts, so a body-only reaction check has the same blind
   spot in a narrower form. Reactions are a count like any other, so this costs
   the doorbell nothing and keeps it dumb.
-- **The ring is a DOORBELL.** On a ring, ROOT re-engages the owning lane and
-  the lane consults the review skill for the actual verdict. ROOT does not
-  interpret PR state itself.
+- **The ring is a DOORBELL with a label on it.** On a ring, ROOT routes on the
+  class (table above) and the lane consults the review skill for the actual
+  verdict. ROOT does not interpret PR state itself beyond that routing — the
+  class exists to save ROOT a manual disambiguation, not to license ROOT to
+  start reading reviews.
+- **Tell the watcher whose reactions to trust.** Pass the repo's reviewer
+  identities as `BOT_REVIEWERS`; leave it empty to trust any actor. An empty
+  list is the permissive default on purpose — a watcher that ignores an
+  unlisted reviewer's approval reintroduces the blind spot the reaction
+  counting exists to close.
 - **A timeout means "no activity," not "no verdict."** Re-arm, or have the lane
   check directly. Reviewers can signal in ways a count-based poll will not see —
   including a reaction *replaced* within a single polling window, which nets to
@@ -570,6 +621,9 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "I'll sanity-check CI and threads myself before invoking the guard." | The guard computes that and more, on the next command. A pre-check is ROOT's context spent recomputing a stale subset. One gated call, not eight. |
 | "This grovel is unavoidable, so I'll just read it all inline." | Unavoidable for *someone*, not for ROOT. Ad-hoc ephemeral subagent, verdict block only. |
 | "The watcher fired, so the reviewer approved." | The watcher is a doorbell. Its filters flake. Re-verify directly. |
+| "The ring said `class=CLEAN`, so the PR is approved and I can merge." | The class is a provisional routing hint, not a verdict and not authorization. The lane confirms via the review skill; `merge-guard` rules on merging. |
+| "Findings and an approval both landed — the approval is newer, so it's clean." | Most severe wins, never most recent. That is `FINDINGS`. |
+| "It rang `IN-FLIGHT` again — I'll just re-arm a third time." | Two or three inconclusive arms is evidence about the watcher. Spot-check the PR directly first. |
 | "The findings are clearly unfounded, I'll just merge." | An honest verdict cannot be manufactured. Human docket. |
 | "This report contradicts my order — the lane ignored me." | It almost certainly crossed in flight. Check timestamps first. |
 | "Six review rounds is obviously a loop, invoke the stalemate rule." | Rounds of *real defects* are the reviewer working. The rule applies only to re-raises on unchanged code. |

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -1,18 +1,70 @@
 #!/usr/bin/env bash
-# Grind PR watcher — an ACTIVITY DOORBELL, not a verdict.
+# Grind PR watcher — an ACTIVITY DOORBELL that also reports a PROVISIONAL CLASS.
 #
-# Wakes a parked lane when anything happens on its PR. It deliberately knows
-# NOTHING about approval signals, reviewer identity, or clean-pass phrasing:
-# reading verdicts belongs to the repo's PR-review skill, and a second copy of
-# that logic here would drift the first time a reviewer changes behavior.
+# Wakes a parked lane when anything happens on its PR, and labels the ring with
+# the SHAPE of that activity so the orchestrator does not have to disambiguate
+# it by hand every time. The class is a hint for routing, NEVER a verdict:
+# reading the actual verdict belongs to the repo's PR-review skill, and the lane
+# still consults that skill on every ring.
 #
-# This script answers exactly one question: has activity appeared on this PR
-# since I armed? On a ring, the orchestrator re-engages the owning lane, and
-# the LANE consults the review skill for what actually happened.
+# Two rules keep this from becoming the "clever watcher" that ghosts silently:
+#
+#   1. THE POLL LOOP STAYS DUMB. Detection is a plain count comparison, exactly
+#      as before. Classification runs ONCE, at ring time, on the way out.
+#   2. CLASSIFICATION CAN NEVER SUPPRESS A RING. Every failure path degrades to
+#      class=ACTIVITY and rings anyway. A missed ring costs a bounded wait; a
+#      silent watcher costs the whole lane.
+#
+# ── CLASSES, IN PRECEDENCE ORDER ────────────────────────────────────────────
+#
+#   FINDINGS   The reviewer wants changes. A new CHANGES_REQUESTED review, any
+#              new inline review comment, or a findings-marker comment.
+#   CLEAN      The reviewer signalled done-and-happy. A new APPROVED review, a
+#              `+1`/`rocket`/`hooray` reaction from a trusted reviewer, or a
+#              clean-marker comment.
+#   IN-FLIGHT  The reviewer started but has not concluded. An `eyes` reaction
+#              from a trusted reviewer.
+#   ACTIVITY   Something happened that none of the above describes — including
+#              every case where classification could not run.
+#
+# ── PRECEDENCE, AND WHY (this is the tie-breaking contract) ─────────────────
+#
+# Signals arrive out of order, collapse into one polling window, and contradict
+# each other. The class is therefore computed from PR STATE AT RING TIME, never
+# from the order events arrived in, and resolved by this fixed severity order:
+#
+#     FINDINGS  >  CLEAN  >  IN-FLIGHT  >  ACTIVITY
+#
+#   FINDINGS beats CLEAN because the costs are asymmetric. A false CLEAN can
+#   send an unaddressed finding toward a merge; a false FINDINGS costs one
+#   wasted lane check. When both are present — an approving review alongside a
+#   new inline comment — the lane must look at the comment.
+#
+#   CLEAN beats IN-FLIGHT because `eyes` is a START marker. A review that both
+#   started and finished inside one 60s window is finished; eyes->+1 nets to
+#   CLEAN, which is the exact sequence Codex produces on a fast clean pass.
+#
+#   MOST SEVERE WINS, NOT MOST RECENT. Several new reviews in one window
+#   resolve to the most severe among them. This is what makes out-of-order
+#   delivery harmless: no ordering assumption is ever made.
+#
+#   RE-ARMING RESETS EVERYTHING. A fresh watcher samples fresh baselines, so a
+#   class never carries across arms. There is no sticky state to go stale.
+#
+#   A CLASS IS NOT AUTHORIZATION. class=CLEAN is not approval, and never
+#   licenses a merge. Only `merge-guard` decides that.
 #
 # TEMPLATE — substitute before use:
-#   {{PR}}    PR number, e.g. 320
-#   {{REPO}}  owner/name, e.g. acme/widgets
+#   {{PR}}              PR number, e.g. 320
+#   {{REPO}}            owner/name, e.g. acme/widgets
+#   {{BOT_REVIEWERS}}   OPTIONAL comma-separated reviewer logins whose
+#                       reactions count as signal, e.g.
+#                       "chatgpt-codex-connector[bot],Copilot".
+#                       Leave empty to trust ANY actor's reactions.
+#   {{CLEAN_MARKER}}    OPTIONAL grep -E regex marking a clean-pass comment.
+#                       Empty disables the check.
+#   {{FINDINGS_MARKER}} OPTIONAL grep -E regex marking a findings comment.
+#                       Empty disables the check.
 #
 # LAUNCH DIRECTLY via run_in_background. NEVER nest this inside a wrapper
 # command with `&` — the wrapper exits immediately, the completion
@@ -25,6 +77,9 @@ set -uo pipefail
 
 PR="{{PR}}"
 REPO="{{REPO}}"
+BOT_REVIEWERS="{{BOT_REVIEWERS}}"
+CLEAN_MARKER="{{CLEAN_MARKER}}"
+FINDINGS_MARKER="{{FINDINGS_MARKER}}"
 
 INTERVAL_SECONDS=60
 TIMEOUT_SECONDS=1800   # 30 minutes
@@ -94,7 +149,160 @@ if [ -z "$BASE_REVIEWS" ] || [ -z "$BASE_COMMENTS" ] || [ -z "$BASE_PR_REACTIONS
 fi
 
 BASE_REACTIONS=$((BASE_PR_REACTIONS + BASE_RC_REACTIONS))
-echo "WATCH-ARMED pr=$PR reviews=$BASE_REVIEWS comments=$BASE_COMMENTS reactions=$BASE_REACTIONS"
+
+# --- Classification baselines (BEST-EFFORT) ---------------------------------
+# These feed the ring-time classifier only. Unlike the count baselines above, a
+# failure here is NOT fatal: it disables classification (every ring reports
+# class=ACTIVITY) while leaving detection fully intact. Losing the label is an
+# inconvenience; losing the doorbell is a dead lane.
+#
+# Each baseline is a high-water mark, so "new" means "id greater than the mark"
+# — no timestamps, no clock skew, no ordering assumptions.
+#
+# ── A FAILED BASELINE IS DANGEROUS, NOT MERELY MISSING ──────────────────────
+# These fetches obey the capture-check-parse rule documented for
+# `fetch_review_comment_reactions` above, and for a sharper reason. Piping `gh`
+# straight into `jq -s 'add // []' | ... max // 0` renders a FAILED call as the
+# string "0" — indistinguishable from a real empty PR. A zero baseline is not a
+# missing label; it makes every pre-existing review and comment read as NEW at
+# ring time, so a quiet PR gets classified a confident FINDINGS. That is worse
+# than no classification at all, because it is wrong rather than absent.
+#
+# So each fetch returns NON-ZERO on failure and the caller drops CLASSIFY_OK to
+# 0 — the only path to the documented safe degradation. Note the asymmetry with
+# the ring-time fetches in classify_ring(): there, a failed fetch yields
+# "nothing new", which lands on ACTIVITY and is already safe. Only the baseline
+# can fabricate a false positive, which is why only the baseline is guarded
+# this strictly.
+CLASSIFY_OK=1
+
+# Emits the highest id at `repos/$REPO/$1`, or NOTHING with a non-zero return
+# when the endpoint is unreadable. A successful fetch of an empty collection is
+# a legitimate "0" and must stay distinguishable from that failure.
+fetch_max_id() {
+  local json
+  json=$(gh api --paginate "repos/$REPO/$1" 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  jq -s '[ add[]?.id // empty ] | max // 0' <<<"$json" 2>/dev/null
+}
+
+# Reaction identities, not counts: "<login>:<content>" pairs. A reaction is
+# mutable, so the classifier compares SETS rather than high-water marks. An
+# empty set is a legitimate result (nobody has reacted), so failure is again
+# signalled by the return code, never by an empty string.
+fetch_reaction_set() {
+  local json
+  json=$(gh api --paginate "repos/$REPO/issues/$PR/reactions" 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  jq -s -r 'add // [] | [ .[] | "\(.user.login):\(.content)" ] | sort | unique | join(",")' \
+    <<<"$json" 2>/dev/null
+}
+
+BASE_MAX_REVIEW_ID=$(fetch_max_id "pulls/$PR/reviews")   || CLASSIFY_OK=0
+BASE_MAX_INLINE_ID=$(fetch_max_id "pulls/$PR/comments")  || CLASSIFY_OK=0
+BASE_MAX_ISSUE_ID=$(fetch_max_id "issues/$PR/comments")  || CLASSIFY_OK=0
+BASE_REACTION_SET=$(fetch_reaction_set)                  || CLASSIFY_OK=0
+
+# Second line of defence: `jq` itself can fail (malformed payload) after a
+# successful fetch, which yields an empty value with a zero return. Unlike the
+# check this replaces, this one is genuinely reachable.
+if [ -z "$BASE_MAX_REVIEW_ID" ] || [ -z "$BASE_MAX_INLINE_ID" ] \
+   || [ -z "$BASE_MAX_ISSUE_ID" ]; then
+  CLASSIFY_OK=0
+fi
+
+echo "WATCH-ARMED pr=$PR reviews=$BASE_REVIEWS comments=$BASE_COMMENTS reactions=$BASE_REACTIONS classify=$CLASSIFY_OK"
+
+# --- Ring-time classifier ---------------------------------------------------
+# Runs ONCE, after detection has already decided to ring. Emits exactly one of
+# FINDINGS / CLEAN / IN-FLIGHT / ACTIVITY on stdout, and CANNOT fail: every
+# error path falls through to ACTIVITY.
+#
+# `is_trusted <login>` decides whose reactions count. An empty BOT_REVIEWERS
+# trusts everyone — the permissive default, because a watcher that ignores an
+# unlisted reviewer's approval is the blind spot this classifier exists to
+# close. Matching is exact against a comma-separated list, so a login that
+# happens to contain another as a substring cannot be confused for it.
+is_trusted() {
+  [ -z "$BOT_REVIEWERS" ] && return 0
+  case ",$BOT_REVIEWERS," in (*",$1,"*) return 0 ;; esac
+  return 1
+}
+
+classify_ring() {
+  [ "$CLASSIFY_OK" -eq 1 ] || { echo "ACTIVITY"; return 0; }
+
+  local findings=0 clean=0 inflight=0
+
+  # New reviews since arm: state decides severity. A COMMENTED review is not
+  # itself a finding — its inline comments are, and those are counted below.
+  local reviews
+  reviews=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" 2>/dev/null \
+    | jq -s --argjson base "${BASE_MAX_REVIEW_ID:-0}" \
+        'add // [] | [ .[] | select((.id // 0) > $base) ]' 2>/dev/null)
+  review_state_count() {
+    jq -r --arg s "$1" '[ .[] | select(.state == $s) ] | length' <<<"$reviews" 2>/dev/null || echo 0
+  }
+  if [ -n "$reviews" ]; then
+    [ "$(review_state_count "CHANGES_REQUESTED")" -gt 0 ] && findings=1
+    [ "$(review_state_count "APPROVED")" -gt 0 ] && clean=1
+  fi
+
+  # Any new inline review comment is a finding. This is the single highest-
+  # value signal: it is how both Copilot and Codex actually raise defects.
+  local inline_new
+  inline_new=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
+    | jq -s --argjson base "${BASE_MAX_INLINE_ID:-0}" \
+        'add // [] | [ .[] | select((.id // 0) > $base) ] | length' 2>/dev/null)
+  [ -n "$inline_new" ] && [ "$inline_new" -gt 0 ] && findings=1
+
+  # New issue comments, matched against the OPTIONAL markers. Marker matching
+  # is the one place this script reads prose, which is why both patterns are
+  # caller-supplied and default to disabled — a phrase hardcoded here would rot
+  # the first time a reviewer reworded its summary.
+  local issue_new
+  issue_new=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null \
+    | jq -s --argjson base "${BASE_MAX_ISSUE_ID:-0}" \
+        'add // [] | [ .[] | select((.id // 0) > $base) | .body // "" ] | join("\n")' 2>/dev/null)
+  if [ -n "$issue_new" ]; then
+    if [ -n "$FINDINGS_MARKER" ] && grep -qE "$FINDINGS_MARKER" <<<"$issue_new" 2>/dev/null; then
+      findings=1
+    fi
+    if [ -n "$CLEAN_MARKER" ] && grep -qE "$CLEAN_MARKER" <<<"$issue_new" 2>/dev/null; then
+      clean=1
+    fi
+  fi
+
+  # Reaction identities added since arm, from trusted reviewers only. A lone
+  # thumbs-up IS an approval in the reference run, and a watcher blind to it
+  # slept through to timeout — hence reactions are first-class here, not a
+  # footnote. Removals are ignored by the classifier (they still RANG, via the
+  # `-ne` count test in the poll loop); a withdrawn reaction is activity
+  # without being a verdict.
+  local now_set
+  now_set=$(gh api --paginate "repos/$REPO/issues/$PR/reactions" 2>/dev/null \
+    | jq -s -r 'add // [] | [ .[] | "\(.user.login):\(.content)" ] | sort | unique | .[]' 2>/dev/null)
+  if [ -n "$now_set" ]; then
+    while IFS= read -r pair; do
+      [ -n "$pair" ] || continue
+      case ",${BASE_REACTION_SET}," in (*",$pair,"*) continue ;; esac   # already present at arm
+      local login="${pair%%:*}" content="${pair##*:}"
+      is_trusted "$login" || continue
+      case "$content" in
+        +1|rocket|hooray) clean=1 ;;
+        eyes)             inflight=1 ;;
+      esac
+    done <<<"$now_set"
+  fi
+
+  # Fixed severity order. See the precedence contract in the header — this
+  # cascade IS that contract, and the two must be changed together.
+  if   [ "$findings" -eq 1 ]; then echo "FINDINGS"
+  elif [ "$clean"    -eq 1 ]; then echo "CLEAN"
+  elif [ "$inflight" -eq 1 ]; then echo "IN-FLIGHT"
+  else                             echo "ACTIVITY"
+  fi
+}
 
 # --- Poll loop --------------------------------------------------------------
 elapsed=0
@@ -136,8 +344,17 @@ while [ "$elapsed" -lt "$TIMEOUT_SECONDS" ]; do
   # that trade, the dumb total wins.
   if [ "$reviews" -gt "$BASE_REVIEWS" ] || [ "$comments" -gt "$BASE_COMMENTS" ] \
      || [ "$reactions" -ne "$BASE_REACTIONS" ]; then
-    echo "WATCH-RING pr=$PR t=${elapsed}s reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS reactions=$reactions/$BASE_REACTIONS"
-    echo "DOORBELL ONLY — no verdict implied. Re-engage the owning lane; the lane reads the verdict via the PR-review skill."
+    # Classify AFTER the decision to ring, never before it. The ring is already
+    # guaranteed at this point, so no classifier failure can swallow it.
+    ring_class="$(classify_ring)"
+    echo "WATCH-RING pr=$PR t=${elapsed}s class=$ring_class reviews=$reviews/$BASE_REVIEWS comments=$comments/$BASE_COMMENTS reactions=$reactions/$BASE_REACTIONS"
+    case "$ring_class" in
+      FINDINGS)  echo "PROVISIONAL: the reviewer appears to want changes. Re-engage the lane to work them." ;;
+      CLEAN)     echo "PROVISIONAL: the reviewer appears done and satisfied. NOT approval and NOT merge authorization — the lane confirms via the review skill, and merge-guard rules on merging." ;;
+      IN-FLIGHT) echo "PROVISIONAL: a review appears to have STARTED but not concluded. Usually re-arm rather than re-engage the lane." ;;
+      ACTIVITY)  echo "PROVISIONAL: activity of an unrecognized shape (or classification unavailable). Treat as a bare doorbell." ;;
+    esac
+    echo "The class is a ROUTING HINT, never a verdict. The lane still consults the PR-review skill on every ring."
     exit 0
   fi
 

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -190,12 +190,57 @@ fetch_max_id() {
 # mutable, so the classifier compares SETS rather than high-water marks. An
 # empty set is a legitimate result (nobody has reacted), so failure is again
 # signalled by the return code, never by an empty string.
+# A reaction can land on the PR body, on any issue comment, on any review, or
+# on any inline review-thread comment — and a nested one moves none of the
+# other counts. The count baseline above already flattens all four sources for
+# exactly this reason; the identity set MUST cover the same four, or a `+1` on
+# a review comment rings the doorbell and then classifies as a bare ACTIVITY.
+# That is the body-only blind spot in a narrower form, and it is the one this
+# classifier exists to close.
+#
+# REST has no single endpoint for that, and an N+1 sweep over every comment is
+# both slow and fragile, so this is one GraphQL call. Note the content values
+# are GraphQL ENUMS (THUMBS_UP, EYES, ...), not REST's `+1`/`eyes` strings.
+#
+# BASELINE AND RING-TIME MUST USE THIS SAME FUNCTION. If the two sampled
+# different sources, every reaction from the unsampled source would read as new
+# on the very first ring.
+# Page sizes are deliberately bounded, not arbitrary. GitHub rejects a query
+# whose worst-case node count exceeds 500,000, and the naive
+# 100-threads x 100-comments x 100-reactions nesting alone requests 1,000,000.
+# The shape below budgets ~30,000: breadth on threads (a PR has many threads,
+# each with few comments) rather than depth. A PR that overruns these caps
+# loses part of the identity set, which can only downgrade a class toward
+# ACTIVITY — never upgrade one — so the failure direction stays safe.
+REACTION_QUERY='query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){ pullRequest(number:$pr){
+    reactions(first:100){nodes{content user{login}}}
+    comments(first:100){nodes{reactions(first:50){nodes{content user{login}}}}}
+    reviews(first:100){nodes{reactions(first:50){nodes{content user{login}}}}}
+    reviewThreads(first:100){nodes{comments(first:10){nodes{reactions(first:20){nodes{content user{login}}}}}}}
+  } } }'
+
+# Emits a comma-joined, sorted, de-duplicated set of "<login>:<CONTENT>" pairs,
+# or NOTHING with a non-zero return when unreadable. An empty set is a
+# legitimate result (nobody reacted), hence the return-code signalling.
 fetch_reaction_set() {
   local json
-  json=$(gh api --paginate "repos/$REPO/issues/$PR/reactions" 2>/dev/null) || return 1
+  json=$(gh api graphql -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F pr="$PR" \
+           -f query="$REACTION_QUERY" 2>/dev/null) || return 1
   [ -n "$json" ] || return 1
-  jq -s -r 'add // [] | [ .[] | "\(.user.login):\(.content)" ] | sort | unique | join(",")' \
-    <<<"$json" 2>/dev/null
+  # `as $p` rather than a bare pipe into a `,`-separated list: in jq `|` binds
+  # across `,`, so the array form would chain each source onto the previous one.
+  jq -r '
+    .data.repository.pullRequest as $p
+    | [ ($p.reactions.nodes // []),
+        (($p.comments.nodes // []) | map(.reactions.nodes // []) | add // []),
+        (($p.reviews.nodes  // []) | map(.reactions.nodes // []) | add // []),
+        (($p.reviewThreads.nodes // []) | map(.comments.nodes // []) | add // []
+           | map(.reactions.nodes // []) | add // [])
+      ]
+    | flatten
+    | map(select(.user != null) | "\(.user.login):\(.content)")
+    | sort | unique | join(",")' <<<"$json" 2>/dev/null
 }
 
 BASE_MAX_REVIEW_ID=$(fetch_max_id "pulls/$PR/reviews")   || CLASSIFY_OK=0
@@ -229,17 +274,36 @@ is_trusted() {
   return 1
 }
 
+# Fetch a ring-time source, or fail. `$1` is the REST path under repos/$REPO,
+# `$2` the jq filter applied to the slurped pages. Same capture-check-parse
+# discipline as the baselines, for the same reason.
+fetch_ring_json() {
+  local json
+  json=$(gh api --paginate "repos/$REPO/$1" 2>/dev/null) || return 1
+  [ -n "$json" ] || return 1
+  jq -s "$2" <<<"$json" 2>/dev/null
+}
+
 classify_ring() {
   [ "$CLASSIFY_OK" -eq 1 ] || { echo "ACTIVITY"; return 0; }
 
-  local findings=0 clean=0 inflight=0
+  local findings=0 clean=0 inflight=0 ring_failed=0
+
+  # ── WHY A PARTIAL FAILURE MUST ABANDON CLASSIFICATION ─────────────────────
+  # It is tempting to reason that a failed ring-time fetch is harmless because
+  # it contributes "nothing new". That holds only for a TOTAL failure. Consider
+  # a PARTIAL one: the inline-comments fetch (the FINDINGS source) fails while
+  # the reaction fetch succeeds and returns a `+1`. The cascade would then emit
+  # CLEAN on a PR that actually has unread findings — a failure silently
+  # DOWNGRADING severity, which inverts the precedence contract's whole safety
+  # asymmetry. So any unreadable source forfeits the class entirely and falls
+  # back to ACTIVITY. A bare doorbell is always honest; a wrong class is not.
 
   # New reviews since arm: state decides severity. A COMMENTED review is not
   # itself a finding — its inline comments are, and those are counted below.
   local reviews
-  reviews=$(gh api --paginate "repos/$REPO/pulls/$PR/reviews" 2>/dev/null \
-    | jq -s --argjson base "${BASE_MAX_REVIEW_ID:-0}" \
-        'add // [] | [ .[] | select((.id // 0) > $base) ]' 2>/dev/null)
+  reviews=$(fetch_ring_json "pulls/$PR/reviews" \
+    "add // [] | [ .[] | select((.id // 0) > ${BASE_MAX_REVIEW_ID:-0}) ]") || ring_failed=1
   review_state_count() {
     jq -r --arg s "$1" '[ .[] | select(.state == $s) ] | length' <<<"$reviews" 2>/dev/null || echo 0
   }
@@ -251,9 +315,8 @@ classify_ring() {
   # Any new inline review comment is a finding. This is the single highest-
   # value signal: it is how both Copilot and Codex actually raise defects.
   local inline_new
-  inline_new=$(gh api --paginate "repos/$REPO/pulls/$PR/comments" 2>/dev/null \
-    | jq -s --argjson base "${BASE_MAX_INLINE_ID:-0}" \
-        'add // [] | [ .[] | select((.id // 0) > $base) ] | length' 2>/dev/null)
+  inline_new=$(fetch_ring_json "pulls/$PR/comments" \
+    "add // [] | [ .[] | select((.id // 0) > ${BASE_MAX_INLINE_ID:-0}) ] | length") || ring_failed=1
   [ -n "$inline_new" ] && [ "$inline_new" -gt 0 ] && findings=1
 
   # New issue comments, matched against the OPTIONAL markers. Marker matching
@@ -261,9 +324,8 @@ classify_ring() {
   # caller-supplied and default to disabled — a phrase hardcoded here would rot
   # the first time a reviewer reworded its summary.
   local issue_new
-  issue_new=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null \
-    | jq -s --argjson base "${BASE_MAX_ISSUE_ID:-0}" \
-        'add // [] | [ .[] | select((.id // 0) > $base) | .body // "" ] | join("\n")' 2>/dev/null)
+  issue_new=$(fetch_ring_json "issues/$PR/comments" \
+    "add // [] | [ .[] | select((.id // 0) > ${BASE_MAX_ISSUE_ID:-0}) | .body // \"\" ] | join(\"\n\")") || ring_failed=1
   if [ -n "$issue_new" ]; then
     if [ -n "$FINDINGS_MARKER" ] && grep -qE "$FINDINGS_MARKER" <<<"$issue_new" 2>/dev/null; then
       findings=1
@@ -273,27 +335,31 @@ classify_ring() {
     fi
   fi
 
-  # Reaction identities added since arm, from trusted reviewers only. A lone
-  # thumbs-up IS an approval in the reference run, and a watcher blind to it
-  # slept through to timeout — hence reactions are first-class here, not a
-  # footnote. Removals are ignored by the classifier (they still RANG, via the
-  # `-ne` count test in the poll loop); a withdrawn reaction is activity
-  # without being a verdict.
+  # Reaction identities added since arm, from trusted reviewers only, across ALL
+  # four reaction sources (see fetch_reaction_set). A lone thumbs-up IS an
+  # approval in the reference run, and a watcher blind to it slept through to
+  # timeout — hence reactions are first-class here, not a footnote. Removals are
+  # ignored by the classifier (they still RANG, via the `-ne` count test in the
+  # poll loop); a withdrawn reaction is activity without being a verdict.
   local now_set
-  now_set=$(gh api --paginate "repos/$REPO/issues/$PR/reactions" 2>/dev/null \
-    | jq -s -r 'add // [] | [ .[] | "\(.user.login):\(.content)" ] | sort | unique | .[]' 2>/dev/null)
+  now_set=$(fetch_reaction_set) || ring_failed=1
   if [ -n "$now_set" ]; then
     while IFS= read -r pair; do
       [ -n "$pair" ] || continue
       case ",${BASE_REACTION_SET}," in (*",$pair,"*) continue ;; esac   # already present at arm
       local login="${pair%%:*}" content="${pair##*:}"
       is_trusted "$login" || continue
+      # GraphQL enum names, not REST's `+1`/`eyes` strings.
       case "$content" in
-        +1|rocket|hooray) clean=1 ;;
-        eyes)             inflight=1 ;;
+        THUMBS_UP|ROCKET|HOORAY) clean=1 ;;
+        EYES)                    inflight=1 ;;
       esac
-    done <<<"$now_set"
+    done <<<"$(tr ',' '\n' <<<"$now_set")"
   fi
+
+  # Any unreadable source forfeits the class — checked BEFORE the cascade, so a
+  # partial failure can never downgrade FINDINGS to CLEAN.
+  [ "$ring_failed" -eq 0 ] || { echo "ACTIVITY"; return 0; }
 
   # Fixed severity order. See the precedence contract in the header — this
   # cascade IS that contract, and the two must be changed together.

--- a/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
+++ b/src/user/.claude/skills/orchestrated-grind/scripts/watch-pr.sh.tmpl
@@ -214,33 +214,67 @@ fetch_max_id() {
 # ACTIVITY — never upgrade one — so the failure direction stays safe.
 REACTION_QUERY='query($owner:String!,$name:String!,$pr:Int!){
   repository(owner:$owner,name:$name){ pullRequest(number:$pr){
-    reactions(first:100){nodes{content user{login}}}
-    comments(first:100){nodes{reactions(first:50){nodes{content user{login}}}}}
-    reviews(first:100){nodes{reactions(first:50){nodes{content user{login}}}}}
-    reviewThreads(first:100){nodes{comments(first:10){nodes{reactions(first:20){nodes{content user{login}}}}}}}
+    reactions(first:100){pageInfo{hasNextPage} nodes{content user{login}}}
+    comments(first:100){pageInfo{hasNextPage} nodes{id reactions(first:50){pageInfo{hasNextPage} nodes{content user{login}}}}}
+    reviews(first:100){pageInfo{hasNextPage} nodes{id reactions(first:50){pageInfo{hasNextPage} nodes{content user{login}}}}}
+    reviewThreads(first:100){pageInfo{hasNextPage} nodes{comments(first:10){pageInfo{hasNextPage} nodes{id reactions(first:20){pageInfo{hasNextPage} nodes{content user{login}}}}}}}
   } } }'
 
-# Emits a comma-joined, sorted, de-duplicated set of "<login>:<CONTENT>" pairs,
-# or NOTHING with a non-zero return when unreadable. An empty set is a
-# legitimate result (nobody reacted), hence the return-code signalling.
+# Emits a comma-joined, sorted set of "<objectId>:<login>:<CONTENT>" keys, or
+# NOTHING with a non-zero return when unreadable OR truncated. An empty set is
+# a legitimate result (nobody reacted), hence the return-code signalling.
+#
+# ── THE KEY CARRIES THE REACTED OBJECT'S IDENTITY ──────────────────────────
+# A bare "<login>:<CONTENT>" key collapses distinct events. If a reviewer has
+# already THUMBS_UP'd the PR body at arm time and then THUMBS_UP's an inline
+# comment, both render identically, the pair is already in the baseline, and
+# the new approval is silently discarded as "already present". Prefixing the
+# reactable's node id keeps them distinct. The PR body uses the literal "pr";
+# GraphQL node ids and GitHub logins contain no ":", so the three-field split
+# in classify_ring is unambiguous.
+#
+# ── TRUNCATION IS TREATED AS UNREADABLE ────────────────────────────────────
+# These connections are paged. If a reactable holds more reactions than its
+# page, a REMOVAL from the sampled page promotes a previously-unsampled older
+# reaction into the next sample, where it reads as new — a spurious CLEAN in
+# the one direction this classifier must never guess. Rather than page
+# exhaustively (unbounded work on the doorbell path), any `hasNextPage` marks
+# the whole sample untrustworthy and returns non-zero, which the existing
+# failure plumbing already turns into ACTIVITY.
 fetch_reaction_set() {
-  local json
+  local json out
   json=$(gh api graphql -F owner="${REPO%%/*}" -F name="${REPO##*/}" -F pr="$PR" \
            -f query="$REACTION_QUERY" 2>/dev/null) || return 1
   [ -n "$json" ] || return 1
   # `as $p` rather than a bare pipe into a `,`-separated list: in jq `|` binds
   # across `,`, so the array form would chain each source onto the previous one.
-  jq -r '
+  out=$(jq -r '
     .data.repository.pullRequest as $p
-    | [ ($p.reactions.nodes // []),
-        (($p.comments.nodes // []) | map(.reactions.nodes // []) | add // []),
-        (($p.reviews.nodes  // []) | map(.reactions.nodes // []) | add // []),
-        (($p.reviewThreads.nodes // []) | map(.comments.nodes // []) | add // []
-           | map(.reactions.nodes // []) | add // [])
-      ]
-    | flatten
-    | map(select(.user != null) | "\(.user.login):\(.content)")
-    | sort | unique | join(",")' <<<"$json" 2>/dev/null
+    | ( [ ($p.reactions.pageInfo.hasNextPage // false),
+          ($p.comments.pageInfo.hasNextPage // false),
+          ($p.reviews.pageInfo.hasNextPage // false),
+          ($p.reviewThreads.pageInfo.hasNextPage // false),
+          (($p.comments.nodes // []) | map(.reactions.pageInfo.hasNextPage // false)),
+          (($p.reviews.nodes  // []) | map(.reactions.pageInfo.hasNextPage // false)),
+          (($p.reviewThreads.nodes // []) | map(.comments.pageInfo.hasNextPage // false)),
+          (($p.reviewThreads.nodes // []) | map(.comments.nodes // []) | add // []
+             | map(.reactions.pageInfo.hasNextPage // false))
+        ] | flatten | any ) as $truncated
+    | if $truncated then "TRUNCATED"
+      else
+        [ (($p.reactions.nodes // []) | map(select(.user != null)
+             | "pr:\(.user.login):\(.content)")),
+          (($p.comments.nodes // []) | map(.id as $i | (.reactions.nodes // [])
+             | map(select(.user != null) | "\($i):\(.user.login):\(.content)")) | add // []),
+          (($p.reviews.nodes // []) | map(.id as $i | (.reactions.nodes // [])
+             | map(select(.user != null) | "\($i):\(.user.login):\(.content)")) | add // []),
+          (($p.reviewThreads.nodes // []) | map(.comments.nodes // []) | add // []
+             | map(.id as $i | (.reactions.nodes // [])
+             | map(select(.user != null) | "\($i):\(.user.login):\(.content)")) | add // [])
+        ] | flatten | sort | unique | join(",")
+      end' <<<"$json" 2>/dev/null) || return 1
+  [ "$out" = "TRUNCATED" ] && return 1
+  printf '%s' "$out"
 }
 
 BASE_MAX_REVIEW_ID=$(fetch_max_id "pulls/$PR/reviews")   || CLASSIFY_OK=0
@@ -347,7 +381,11 @@ classify_ring() {
     while IFS= read -r pair; do
       [ -n "$pair" ] || continue
       case ",${BASE_REACTION_SET}," in (*",$pair,"*) continue ;; esac   # already present at arm
-      local login="${pair%%:*}" content="${pair##*:}"
+      # Key is "<objectId>:<login>:<CONTENT>". Peel from the right: content is
+      # the last field, login the one before it, and the object id (which never
+      # contains ":") is whatever remains.
+      local content="${pair##*:}" rest="${pair%:*}"
+      local login="${rest#*:}"
       is_trusted "$login" || continue
       # GraphQL enum names, not REST's `+1`/`eyes` strings.
       case "$content" in


### PR DESCRIPTION
## Why

From the `.44.2` grind retrospective: the watcher rang on raw count deltas, so ROOT had to re-derive *"was that a clean pass or a fresh pile of findings?"* by hand on every single ring. That manual disambiguation was the highest-frequency ROOT cost in the reference run.

## The design tension, and how it's resolved

§6 exists because clever watchers **ghosted twice** in the reference run, and a silent watcher is indistinguishable from a quiet PR. So "make the watcher smarter" is not obviously safe. The resolution is to split the two concerns:

- **Detection stays dumb.** The poll loop is still a plain count comparison, unchanged.
- **Classification runs once, at ring time, *after* the decision to ring.** It is structurally incapable of suppressing a doorbell — every failure path degrades to `ACTIVITY` and rings anyway.

## The precedence contract (written down, in both places)

```
FINDINGS  >  CLEAN  >  IN-FLIGHT  >  ACTIVITY
```

Computed from **PR state at ring time**, never event order.

- **FINDINGS beats CLEAN** — cost asymmetry. A false CLEAN can carry an unaddressed finding toward a merge; a false FINDINGS costs one wasted lane check.
- **CLEAN beats IN-FLIGHT** — `eyes` is a *start* marker; `eyes`→`+1` inside one window means the review finished.
- **Most severe wins, never most recent** — which is what makes out-of-order delivery harmless.
- **Re-arming resets everything**; no sticky state to go stale.
- **A class is never authorization.** Only `merge-guard` rules on merging.

It lives in the script header *and* SKILL.md §6, because a contract only the script knows is not a contract the orchestrator reads.

## Deliberate deviation from the bead

The bead names "marker comment" as a signal. Both markers are implemented as **caller-supplied regexes defaulting to disabled**, and reviewer identity as `BOT_REVIEWERS` defaulting to trust-anyone. Hardcoding reviewer phrasing here would rot the first time Codex reworded its summary — the same drift argument §3 uses to keep review mechanics out of this skill.

## Verification

**A real bug was caught by the gate and fixed.** The first HEAVY run terminated on round-cap with 3 open MAJOR findings — all one defect: on a `gh` failure with empty stdout, `jq` emits `"0"` with rc=0, so the baseline silently became zero, `CLASSIFY_OK` could never flip, and every pre-existing comment would read as new. **The watcher would have rung a confident `FINDINGS` on a quiet PR.** Ironically, the file's own comment (lines 104–108) documents exactly this trap for the neighbouring function. Fixed by following that documented capture-check-parse pattern, with failure signalled by return code so a legitimately-empty collection stays distinguishable from an unreadable endpoint.

Re-ran the gate after the fix: `accept-clean-at-floor`, 0 open at-floor findings.

**7 behavioral tests against live GitHub data**, re-run after the gate's auto-applied `review_state_count()` helper (which it had validated with `bash -n` only):

| Test | Scenario | Result |
|---|---|---|
| A | new inline + APPROVED + reaction | `FINDINGS` (precedence) |
| B | same PR, no new inline | `CLEAN` |
| C | nothing new | `ACTIVITY` |
| D | signals from untrusted reviewer | `ACTIVITY` |
| E | classification disabled | `ACTIVITY` |
| L | `gh` succeeds, returns empty stdout | fetch rc=1 (no fabricated baseline) |
| M | APPROVED-only, via the new helper | `CLEAN` |

A/B is the precedence rule proven on one real PR with one variable changed. IN-FLIGHT and the `eyes`→`+1` collapse were exercised by adding a real `eyes` reaction to PR #340, then removing it (verified only the original `+1` remained).

Bead: `agents-config-wgclw.28.2` (epic `agents-config-wgclw.28`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRjeWyNt1D5vQCBxMwkr5f