### PR TITLE
feat(orchestration): bare-idle discipline and an explicit dashboard-open mechanism

### DIFF
--- a/src/user/.agents/agents/tech-lead.md
+++ b/src/user/.agents/agents/tech-lead.md
@@ -95,6 +95,16 @@ three agents directly).
 - Spawn agents with clear, specific instructions and success criteria, including how you want them to report success, progress, or exceptions such as needing help from another agent or from the user
   - Spawn multiple agents to run in parallel where possible
 - Monitor agent outputs for quality and completeness
+- **Ignore bare idle notifications.** A dispatched agent that goes quiet without
+  content is *parked* — not done, not stuck, not asking for you. A bare idle is
+  the absence of an event, so never let one trigger anything: do not reply to
+  it, do not ping the agent about it, do not log or narrate it. Idles are the
+  most frequent signal in a multi-agent run and the least informative; treating
+  each as a prompt spends your context reporting that nothing happened. Act on
+  real signals only — a completion, a handoff, a report, an explicit request for
+  help. If you genuinely need to know a parked agent's state, read ground truth
+  (version control, the tracker, the artifacts it was to produce) rather than
+  asking it.
 - Facilitate information flow between agents when needed
 - Adjust the plan based on intermediate results
 - Maintain a clear status of overall progress

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -80,6 +80,15 @@ Rules that are not negotiable:
 - **Lieutenants park after dispatching.** A bare idle notification means
   *parked*. It never means "done" and never means "stuck." Do not nudge on an
   idle notification alone.
+- **A bare idle is not an event — it is the absence of one.** Never let an idle
+  *itself* be the trigger for anything. Do not reply to it, do not `SendMessage`
+  the parked agent about it, do not narrate it to the human, and **do not write
+  it to `state.json` or the dashboard**. Idles are the most frequent
+  notification in a long run and the least informative; a run that logs them
+  buries the real signals in noise and spends ROOT's scarcest resource —
+  context — on the fact that nothing happened. Act on *real* signals instead: a
+  worker's completion notification, a watcher ring, a lane report, a handoff.
+  The one thing a bare idle may trigger is silence.
 - **Sizing every dispatch is ROOT's judgment, not a lookup.** ROOT decides the
   model and effort each lane and each worker runs at, from what that task
   actually demands: mechanical work (extraction, file surveys, format
@@ -117,7 +126,8 @@ Rules that are not negotiable:
    unconfirmed partition is expensive to unwind once four agents are live.
 3. **Spawn the bookkeeper first**, with the dashboard template and the state
    schema. It writes the initial `state.json` and `dashboard.html`, and opens
-   the page in the browser **exactly once**.
+   the page in the browser **exactly once**, via the OS handler named in §5
+   (`open` / `xdg-open` — never browser automation).
 4. **Spawn the lieutenants**, one message each, carrying: the lane's queue, the
    worktree naming convention, the review protocol (§3), the post-merge leg
    (§8), the instruction to report **reviewed-clean** rather than merging, and
@@ -405,6 +415,30 @@ on updates.** If the page looks stale to the human, the suspect is the refresh
 toggle or a stale tab — the files are ground truth. Check `state.json`'s
 timestamp before blaming the bookkeeper.
 
+**Open it with the OS handler, never with browser automation.** The one
+permitted mechanism is the platform's own opener, handing the file to whatever
+browser the human already uses:
+
+```bash
+# macOS
+open "<abs-path>/dashboard.html"
+# Linux / BSD
+xdg-open "<abs-path>/dashboard.html"
+```
+
+Branch on `uname` (`Darwin` → `open`, otherwise `xdg-open`) rather than
+guessing, and pass an absolute path — the bookkeeper's cwd is not the human's.
+
+**Browser-automation MCP servers — Playwright, claude-in-chrome, or any
+successor — are prohibited for this.** They are the wrong tool in a way that
+is not obvious in the moment, which is exactly why an agent reaches for one
+when it happens to be loaded: the page they render lives in an automation-owned
+browser the human is not looking at, so the dashboard is "opened" and yet never
+seen. They also cost a tool round-trip and tokens for what a one-line shell
+command does, hold a session open behind the run, and can block on a dialog. If
+the opener is unavailable or fails, **say so and print the path** — a human who
+can read the path can open the page themselves. Do not fall back to automation.
+
 The rendered dashboard **inlines its state** rather than fetching it, so it
 works from a `file://` URL with no server. Do not introduce one. Because the
 state is spliced into an inline `<script>` block and carries text from outside
@@ -617,6 +651,9 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | Excuse | Reality |
 |--------|---------|
 | "The lieutenant is idle, so it's stuck — I'll nudge it." | Bare idle means parked. Verify with `gh`/`git` before nudging. |
+| "I won't nudge, but I'll log the idle so the dashboard is complete." | An idle is the absence of an event. Logging it buries real signals and spends context proving nothing happened. Record state changes, not silence. |
+| "I'll just acknowledge the idle so the lane knows I'm here." | The lane is parked and cannot use the reassurance. The reply costs two turns of context and changes nothing. |
+| "Five idles in a row means something is wrong." | Five idles is one fact repeated: the lane is parked. Only `gh`/`git`/`bd` can tell you whether that is correct. |
 | "The lane reported reviewed-clean, so I can merge." | A lane report is a claim, not eligibility. Invoke `merge-guard`: its eligibility run verifies the claim, and its policy resolution — a separate axis — decides whether merging is authorized at all. Clean is not permission. |
 | "I'll sanity-check CI and threads myself before invoking the guard." | The guard computes that and more, on the next command. A pre-check is ROOT's context spent recomputing a stale subset. One gated call, not eight. |
 | "This grovel is unavoidable, so I'll just read it all inline." | Unavoidable for *someone*, not for ROOT. Ad-hoc ephemeral subagent, verdict block only. |
@@ -641,6 +678,7 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "I'll wrap the watcher in a helper script with `&`, it's tidier." | The wrapper exits, the notification fires for it, the watcher is orphaned. Launch directly. |
 | "I'll write the compaction handoff when compaction is close." | By then you are composing from degraded context. Write it early. |
 | "The dashboard looks stale, I'll re-open it in the browser." | Open exactly once. Check `state.json`'s timestamp instead. |
+| "Playwright is already loaded, I'll open the dashboard with it." | It renders into an automation browser the human never sees — opened, yet unseen. `open`/`xdg-open`, or print the path. |
 | "Both lanes need the version bump, they'll sort it out." | They will collide. ROOT sequences version bumps explicitly. |
 
 ## Red flags — stop and re-verify
@@ -661,7 +699,9 @@ punished; a worker that hides a compromise costs far more than one that admits i
 - You are treating a re-flagged fix as a stalemate without having checked the
   commit the reviewer claims it reviewed (§3).
 - A lane is arming its own watcher (§6).
-- You are re-opening the dashboard in a browser.
+- You are re-opening the dashboard in a browser, or reaching for a
+  browser-automation tool to open it at all (§5).
+- You are about to reply to, narrate, or record a bare idle notification (§1).
 - Your last three actions were implementation work. You are ROOT — you manage,
   decide, and unblock. Hand it to a lane.
 - You are reading a diff, or re-running a gate a lane already ran.

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -683,7 +683,7 @@ punished; a worker that hides a compromise costs far more than one that admits i
 | "I'll wrap the watcher in a helper script with `&`, it's tidier." | The wrapper exits, the notification fires for it, the watcher is orphaned. Launch directly. |
 | "I'll write the compaction handoff when compaction is close." | By then you are composing from degraded context. Write it early. |
 | "The dashboard looks stale, I'll re-open it in the browser." | Open exactly once. Check `state.json`'s timestamp instead. |
-| "Playwright is already loaded, I'll open the dashboard with it." | It renders into an automation browser the human never sees — opened, yet unseen. `open`/`xdg-open`, or print the path. |
+| "Playwright is already loaded, I'll open the dashboard with it." | It renders into an automation browser the human never sees — opened, yet unseen. The platform opener (§5), or print the path. |
 | "Both lanes need the version bump, they'll sort it out." | They will collide. ROOT sequences version bumps explicitly. |
 
 ## Red flags — stop and re-verify

--- a/src/user/.claude/skills/orchestrated-grind/SKILL.md
+++ b/src/user/.claude/skills/orchestrated-grind/SKILL.md
@@ -126,8 +126,8 @@ Rules that are not negotiable:
    unconfirmed partition is expensive to unwind once four agents are live.
 3. **Spawn the bookkeeper first**, with the dashboard template and the state
    schema. It writes the initial `state.json` and `dashboard.html`, and opens
-   the page in the browser **exactly once**, via the OS handler named in §5
-   (`open` / `xdg-open` — never browser automation).
+   the page in the browser **exactly once**, via the platform opener named in
+   §5 (`open` / `start` / `xdg-open` — never browser automation).
 4. **Spawn the lieutenants**, one message each, carrying: the lane's queue, the
    worktree naming convention, the review protocol (§3), the post-merge leg
    (§8), the instruction to report **reviewed-clean** rather than merging, and
@@ -424,10 +424,15 @@ browser the human already uses:
 open "<abs-path>/dashboard.html"
 # Linux / BSD
 xdg-open "<abs-path>/dashboard.html"
+# Windows — the "" is the window-title arg, so the path must follow it
+start "" "<abs-path>\dashboard.html"
 ```
 
-Branch on `uname` (`Darwin` → `open`, otherwise `xdg-open`) rather than
-guessing, and pass an absolute path — the bookkeeper's cwd is not the human's.
+Pick the opener from the actual platform rather than guessing — `Darwin` →
+`open`, Windows → `start`, otherwise `xdg-open`. Note that `uname` alone does
+not identify native Windows (it is absent outside a POSIX shim), so a bare
+`uname` branch would fall through to `xdg-open` and fail there. Always pass an
+absolute path, quoted — the bookkeeper's cwd is not the human's.
 
 **Browser-automation MCP servers — Playwright, claude-in-chrome, or any
 successor — are prohibited for this.** They are the wrong tool in a way that

--- a/src/user/.claude/skills/orchestrated-grind/references/state-schema.md
+++ b/src/user/.claude/skills/orchestrated-grind/references/state-schema.md
@@ -6,8 +6,9 @@ the dashboard works from a `file://` URL with no server.
 
 **The bookkeeper's update cycle:** receive a delta from ROOT → merge it into
 `state.json` → re-render `dashboard.html` with the new state inlined → stop.
-Never open a browser except on first creation — and open it with the OS handler
-(`open` on macOS, `xdg-open` elsewhere), never a browser-automation MCP.
+Never open a browser except on first creation — and open it with the platform's
+own opener (`open` on macOS, `start` on Windows, `xdg-open` elsewhere), never a
+browser-automation MCP.
 
 **Serialization contract.** State strings carry text from outside the grind —
 PR titles, review-comment excerpts, branch names. Serialize with a real JSON

--- a/src/user/.claude/skills/orchestrated-grind/references/state-schema.md
+++ b/src/user/.claude/skills/orchestrated-grind/references/state-schema.md
@@ -6,7 +6,8 @@ the dashboard works from a `file://` URL with no server.
 
 **The bookkeeper's update cycle:** receive a delta from ROOT → merge it into
 `state.json` → re-render `dashboard.html` with the new state inlined → stop.
-Never open a browser except on first creation.
+Never open a browser except on first creation — and open it with the OS handler
+(`open` on macOS, `xdg-open` elsewhere), never a browser-automation MCP.
 
 **Serialization contract.** State strings carry text from outside the grind —
 PR titles, review-comment excerpts, branch names. Serialize with a real JSON

--- a/src/user/.claude/skills/orchestrating-subagents/SKILL.md
+++ b/src/user/.claude/skills/orchestrating-subagents/SKILL.md
@@ -86,8 +86,16 @@ three short strings per parked worker: name, child `agentId`, path.
 
 ## Orchestrator duties when running nested workers
 
-- **Expect the bare idle.** A parked worker emits no content on its own — only a handoff if you
-  briefed it to send one. A silent idle means "check on me," not "I'm done."
+- **Expect the bare idle, and do nothing with it.** A parked worker emits no content on its own —
+  only a handoff if you briefed it to send one. An idle therefore means *parked*: not "done," not
+  "stuck," not "waiting on you."
+- **A bare idle is not an event — it is the absence of one.** Never let an idle *itself* trigger
+  anything: do not reply to it, do not `SendMessage` the parked worker about it, do not log or
+  narrate it. Idles are the most frequent notification in a nested run and carry the least
+  information; treating each one as a prompt spends the orchestrator's context on the news that
+  nothing happened. Act on **real** signals — a child's completion notification, a handoff, a
+  report, a watcher ring. The orchestrator *does* re-engage a parked worker, but because a child
+  completed, never because the parent went quiet.
 - **Verify ground truth before resuming.** A worker's narration is a claim, not a fact — read
   git/gh/bd to learn the true state, then re-engage precisely.
 - **A child's completion arriving to YOU means the parent did not see it** — that is your cue to
@@ -98,6 +106,7 @@ three short strings per parked worker: name, child `agentId`, path.
 | Mistake | Consequence | Fix |
 |---|---|---|
 | Brief a worker to spawn an agent when it could do the job inline | Needless nesting + stall risk | Rung 1: brief it to spawn nothing |
+| Reply to, or log, a bare idle notification | Context burned narrating that nothing happened; real signals buried | Treat the idle as silence; act only on completions, handoffs, and reports |
 | Brief a worker to "spawn an agent and wait" | Stalls forever | Rung 3, or the handoff |
 | Worker arms `run_in_background`/`Monitor` to await its child | Never re-invoked; still stalls | Hand off and end the turn, or rung 1/2 |
 | Child returns its full payload | Orchestrator context bloats on relay | Child returns only the filename |


### PR DESCRIPTION
Closes the last two children of epic `agents-config-wgclw.28` (grind orchestration hardening — retro fixes from the overnight-grind retrospective). Folded into one PR at Scott's direction: both are skill-text changes converging on `orchestrated-grind`, so separate PRs would fight each other.

## `.28.3` — bare-idle discipline

A parked agent that goes quiet emits a bare idle notification. The run was treating each one as a prompt — replying to it, narrating it, logging it to state — which spends the orchestrator's scarcest resource (context) to report that *nothing happened*, and buries real signals under the most frequent and least informative notification in a long run.

Audit found the rule unevenly present:

| File | Before | Now |
|---|---|---|
| `tech-lead.md` | **absent entirely** — dispatches and monitors agents with zero idle guidance | rule added under Execution Coordination |
| `orchestrating-subagents/SKILL.md` | partial — had "parked, not done", no prohibition | prohibition + Common-mistakes row |
| `orchestrated-grind/SKILL.md` | partial — had "do not nudge", lacked the *logging* ban | logging ban + context-cost framing, 3 rationalization rows, 1 red flag |

### Deliberate deviation from the bead's wording

`orchestrating-subagents` said a silent idle means **"check on me"** — the direct opposite of the bead's "do not respond." I did **not** simply overwrite it, because the behavior it described is real: orchestrators genuinely do re-engage parked workers. Reconciled instead:

> **A bare idle is not an event — it is the absence of one.** Never let an idle *itself* be the trigger. The orchestrator *does* re-engage a parked worker — but because a **child completed**, never because the parent went quiet.

Both frames survive; only the trigger moved. Flagging this explicitly since it departs from the bead's literal text.

## `.28.4` — dashboard open mechanism

The skill mandated opening the dashboard exactly once but never said *how*, so an agent reached for whatever browser tool happened to be loaded (observed in the reference run: Playwright MCP). That fails in a non-obvious way: the page renders into an automation-owned browser the human is not looking at — opened, yet never seen.

- `open` (macOS) / `xdg-open` (elsewhere), branched on `uname`, absolute path
- Browser-automation MCP (Playwright, claude-in-chrome, successors) explicitly prohibited, **with the reason** so it isn't cargo-culted
- Fallback on failure is **print the path**, never automation
- Cross-referenced from the bookkeeper spawn step and `references/state-schema.md`

## Verification

- **Gate: `HEAVY`** (4 files / 70 LOC, all docs — `src/**` floors everything via `.critical-paths`). Exit `acceptance` / clean-at-floor, 14 agents, 0 errors, **0 auto-applied fixes**.
- One sub-floor **minor deferred with rationale**: the idle paragraph is duplicated across three files. That duplication is *required* — there is no include mechanism spanning them, `tech-lead.md` installs to every tool while both SKILLs are Claude-only, and each loads independently. De-duplicating would leave an agent loading only one of them with no rule at all, which is the exact `.28.3` defect.
- Cross-reference targets confirmed: §1 = Topology and the roster, §5 = The bookkeeper and the dashboard.
- No files under `packages/` — code gates unaffected.

### Honest caveat on gate coverage

The gate's report names "~347 lines of `watch-pr.sh.tmpl`" as its largest untested surface. **That file is not in this diff** — it is PR #341's already-merged work. The finders inherited a stale local `main` (one merge behind), so some effort went to already-merged code and coverage of these 70 prose lines is thinner than the agent count implies. Not a defect in the change; a discount on the assurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRjeWyNt1D5vQCBxMwkr5f
