### PR TITLE
chore(live-verify): remove scratch docs

### DIFF
--- a/docs/architecture/live-codex-verification-scratch-a1.md
+++ b/docs/architecture/live-codex-verification-scratch-a1.md
@@ -1,7 +1,0 @@
-# Live Codex Verification Scratch — A1
-
-This file exists only to give scenario A1 (clean-first-pass merge) of a live
-Codex-awareness verification exercise a real, trivial diff to open a PR
-against. It is deleted by a follow-up cleanup commit once the exercise's
-merge scenarios have landed. This document intentionally contains no
-external file references so it can be reviewed in isolation on any branch.

--- a/docs/architecture/live-codex-verification-scratch-a2a.md
+++ b/docs/architecture/live-codex-verification-scratch-a2a.md
@@ -1,6 +1,0 @@
-# Live Codex Verification Scratch — A2a
-
-This scrach file exists to give scenario A2a of a live Codex-awareness
-verification exercise a real diff likely to draw a genuine Codex comment
-(note the deliberate typo above and the inconsistent claim below: this
-file is both temporary and permanent).

--- a/docs/architecture/live-codex-verification-scratch-a2b.md
+++ b/docs/architecture/live-codex-verification-scratch-a2b.md
@@ -1,6 +1,0 @@
-# Live Codex Verification Scratch — A2b
-
-This file exists to give scenario A2b (the review_summary ratchet) of a
-live Codex-awareness verification exercise a real diff likely to draw a
-genuine Codex comment. It contains no external file references and makes
-no claims about its own future removal.


### PR DESCRIPTION
Housekeeping — removes the three scratch docs A1/A2a/A2b left on main from the live codex-awareness verification exercise.