### PR TITLE
fix(merge-guard): union Ruleset-sourced required status checks into CI-green blocker

### DIFF
--- a/docs/architecture/review-merge-policy/design.md
+++ b/docs/architecture/review-merge-policy/design.md
@@ -185,17 +185,28 @@ cannot pick unsafe defaults.
 
 **CI-green** (eligibility floor):
 
-- *Required set* = the branch-protection required status checks for the
-  target branch, fetched independently from branch protection. Each entry
-  carries a context **name** and, where branch protection pins one, an
-  expected **source** (the specific GitHub App the check must come from) —
+- *Required set* = the **union** of two independently-fetched sources: the
+  classic branch-protection required status checks for the target branch,
+  and any `required_status_checks`-type rule returned by the same
+  `rules/branches/{branch}` ruleset listing `admin-bypass availability`
+  below also consumes. A repo enforcing CI via a Ruleset instead of classic
+  branch protection 404s the classic endpoint; that 404 empties only the
+  classic side of the union, never the ruleset side — the two sources are
+  deduplicated by context name + source, not preferred one over the other.
+  Each entry carries a context **name** and, where its source pins one, an
+  expected **source** (the specific GitHub App the check must come from —
+  `app_id` on the classic side, `integration_id` on the ruleset side) —
   GitHub's own trust boundary against a different integration posting a
   same-named status. **Never derived from** `statusCheckRollup` — the rollup
   lists only contexts that have actually reported, so filtering *it* down to
   "the required ones" silently omits any required context that has not
   started yet, which is exactly the race this gate exists to prevent. If
-  branch protection defines **no** required checks, the required set is
-  empty.
+  **neither** source defines a required check (both endpoints 404), the
+  required set is empty.
+- A hard (non-404) fetch failure on *either* source fails the whole
+  eligibility check closed (exit 3, no verdict) — see the `rules/branches`
+  hard-failure note under `admin-bypass availability` below for why that
+  fetch's failure handling is no longer purely informational.
 - *Green* iff every required entry has a matching `statusCheckRollup` entry
   that concluded `SUCCESS`, matched by context name **and**, when that entry
   pins a source, by the same source — a same-named `SUCCESS` from a
@@ -311,14 +322,22 @@ an already-authorized merge, not *whether* one is eligible):
 - *Not applicable* (`review_rule_active = false`) when no `pull_request` rule
   with a positive required-approving-review count targets the branch — the
   fact carries no opinion, since there is nothing for `--admin` to bypass.
-- A fetch failure on this fact never aborts eligibility. Because
-  `admin_bypass` gates no entry in `blockers[]`, denying a merge that may not
-  even need `--admin` over a transient GitHub/API error would be wrong. The
-  branch-rules list fetch (a non-404 failure) degrades to the inert "no
-  rulesets" state (`review_rule_active = false`); an individual ruleset detail
-  fetch failure degrades to non-bypassable (`current_actor_can_bypass = false`,
-  the fail-closed default for the `--admin` decision) and continues. Both warn
-  on stderr; neither silently assumes "bypassable."
+- The `rules/branches/{branch}` list fetch is fetched once and shared with
+  CI-green's required-set union above — it is no longer purely informational
+  to this fact alone. A 404 (no rulesets target the branch) still resolves
+  to the inert "no rulesets" state (`review_rule_active = false`) for this
+  fact and an empty ruleset-side required-check set for CI-green. A hard
+  (non-404) failure on that shared fetch now **aborts eligibility entirely**
+  (exit 3, no verdict) rather than degrading `admin_bypass` alone to inert —
+  because the same failure would otherwise silently empty CI-green's
+  ruleset-side required set on a ruleset-only repo, recreating the exact
+  vacuous-green gap this design closes. This is a deliberate departure from
+  the "fetch failure never aborts eligibility" default that still holds for
+  every fact below this one: an individual ruleset *detail* fetch failure
+  (fetched per-`ruleset_id`, one call per matching rule, never shared with
+  CI-green) still only degrades that ruleset to non-bypassable
+  (`current_actor_can_bypass = false`, the fail-closed default for the
+  `--admin` decision) and continues, warning on stderr rather than aborting.
 - This predicate certifies only that the `pull_request` rule(s) are
   bypassable — `current_user_can_bypass` is reported **per ruleset**, and a
   ruleset commonly bundles unrelated rule types (this repo's own ruleset also

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility.sh
@@ -373,12 +373,48 @@ if [[ "$(jq '.escalations | length' <<<"$thread_partition")" -gt 0 ]]; then
              | (.id // "unknown-thread") + " (" + $why + ")" ]
            | join("; "))' <<<"$thread_partition")"
 fi
+# ── Fetch: branch rules (rules/branches/{base}) ──────────────────────────────
+# Shared across two consumers below: the CI-green blocker's required-checks
+# union (a required_status_checks-type rule) and the admin_bypass fact (a
+# pull_request-type rule). Fetched once, up front, so a ruleset-enforced repo
+# with no classic branch protection isn't read as having no CI requirement.
+# Because this fetch now feeds the CI blocker (not just the informational
+# admin_bypass fact), a hard failure fails the whole script closed — exactly
+# like the classic protection endpoint's own hard-failure branch below — never
+# silently degrade to "no rulesets", which would risk a ruleset-only required
+# check reading vacuously green.
+rules_stderr=$(mktemp)
+if rules_json=$(gh api "repos/${OWNER}/${REPO}/rules/branches/${BASE_REF_ENC}" 2>"$rules_stderr"); then
+    :
+else
+    if grep -qiE 'HTTP 404|Not Found' "$rules_stderr"; then
+        rules_json='[]'   # no rulesets target this branch
+    else
+        # Named explicitly (endpoint + framing) so a human or agent hitting
+        # this during a GitHub API incident diagnoses it in one read instead
+        # of hunting a phantom permissions problem — this repo has a
+        # documented history of transient 5xx/degraded-auth gh responses that
+        # read like authNZ failures but aren't. Still a real condition to
+        # fail closed on (exit 3, hand off per SKILL.md — never blind retry);
+        # it just isn't this identity's fault, so don't chase token scopes first.
+        echo "Error: failed to fetch required-status-check rules from repos/${OWNER}/${REPO}/rules/branches/${BASE_REF_ENC} — likely a transient GitHub API failure, not a permissions problem: $(cat "$rules_stderr")" >&2
+        rm -f "$rules_stderr"; exit 3
+    fi
+fi
+rm -f "$rules_stderr"
+
 # ── Blocker: required CI checks not green ────────────────────────────────────
-# Required set from branch protection — NEVER derived from the rollup (the
-# rollup lists only contexts that already reported; filtering it would hide a
-# required check that never started). 404 / no protection = empty set =
-# vacuously green. A source-pinned (app_id) requirement is only satisfied by
-# a run from that app — name alone is not a trust boundary.
+# Required set is the UNION of classic branch protection and a GitHub
+# Ruleset's required_status_checks-type rule — NEVER derived from the rollup
+# (the rollup lists only contexts that already reported; filtering it would
+# hide a required check that never started). A repo enforcing CI via a
+# Ruleset instead of classic protection 404s the classic endpoint; that 404
+# must empty only the classic side, not the ruleset side (both sides' hard
+# failures already fail the whole script closed above/below — a 404 is the
+# only way either side legitimately empties). Both 404 = no requirement
+# anywhere = vacuously green. A source-pinned (app_id / integration_id)
+# requirement is only satisfied by a run from that app — name alone is not a
+# trust boundary.
 prot=""
 prot_stderr=$(mktemp)
 if prot=$(gh api "repos/${OWNER}/${REPO}/branches/${BASE_REF_ENC}/protection/required_status_checks" 2>"$prot_stderr"); then
@@ -400,8 +436,13 @@ else
     fi
 fi
 rm -f "$prot_stderr"
-required_checks=$(jq -c '[.checks[]? | {context, app_id}]' <<<"${prot:-null}" 2>/dev/null || echo '[]')
-[[ "$required_checks" == "null" ]] && required_checks='[]'
+classic_checks=$(jq -c '[.checks[]? | {context, app_id}]' <<<"${prot:-null}" 2>/dev/null || echo '[]')
+[[ "$classic_checks" == "null" ]] && classic_checks='[]'
+ruleset_checks=$(jq -c '[ .[]? | select(.type == "required_status_checks")
+    | .parameters.required_status_checks[]? | {context, app_id: (.integration_id // null)} ]' \
+    <<<"$rules_json")
+required_checks=$(jq -c -n --argjson a "$classic_checks" --argjson b "$ruleset_checks" \
+    '($a + $b) | unique_by([.context, .app_id])')
 
 # No required checks → vacuously green; skip the check-run/status fetches
 # whose results ci_eval would never consult.
@@ -458,22 +499,7 @@ fi
 # rejection with --admin for a merge this policy has already authorized —
 # never to invent a new override. Never a blocker: it does not gate
 # eligibility, only how Step 5 in merge-guard SKILL.md issues the merge.
-rules_stderr=$(mktemp)
-if rules_json=$(gh api "repos/${OWNER}/${REPO}/rules/branches/${BASE_REF_ENC}" 2>"$rules_stderr"); then
-    :
-else
-    if grep -qiE 'HTTP 404|Not Found' "$rules_stderr"; then
-        rules_json='[]'   # no rulesets target this branch
-    else
-        # admin_bypass never gates a blocker, so a transient fetch failure on
-        # it must not deny a merge that may not even need --admin. Degrade to
-        # the inert "no rulesets" state and warn rather than abort eligibility.
-        echo "Warning: failed to fetch branch rules (admin_bypass degraded to inert): $(cat "$rules_stderr")" >&2
-        rules_json='[]'
-    fi
-fi
-rm -f "$rules_stderr"
-
+# (rules_json was already fetched above, shared with the CI-green blocker.)
 review_rulesets=$(jq -c '[ .[]? | select(.type == "pull_request") ]' <<<"$rules_json")
 required_approving_review_count=$(jq '[ .[].parameters.required_approving_review_count? // 0 ] | (max // 0)' <<<"$review_rulesets")
 review_rule_active=false

--- a/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
+++ b/src/user/.agents/skills/merge-guard/check-merge-eligibility_test.sh
@@ -429,6 +429,47 @@ out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=0 FIXTURE_REQUIRED_CHECKS
 assert "required legacy context on a later status page is seen → eligible, green" \
   "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.ci_state' <<<\"\$out\")\" = green ]"
 
+# ── ruleset-sourced required status checks (rules/branches/{base}, a
+#    required_status_checks-type rule) — a repo enforcing CI via a GitHub
+#    Ruleset instead of classic branch protection 404s the classic endpoint;
+#    that 404 must NOT collapse the required set to empty when the modern
+#    endpoint lists a real requirement. ────────────────────────────────────
+RULES_CI_ONE='[{"type":"required_status_checks","ruleset_id":333,"parameters":{"required_status_checks":[{"context":"ci","integration_id":15368}]}}]'
+run_ci_ok()        { jq -n '{check_runs:[{name:"ci",status:"completed",conclusion:"success",app:{id:15368}}]}'; }
+run_ci_wrong_app() { jq -n '{check_runs:[{name:"ci",status:"completed",conclusion:"success",app:{id:99999}}]}'; }
+
+# classic endpoint 404s (no classic protection), ruleset alone requires "ci",
+# satisfied by a pinned-app success → green, eligible
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_CI_ONE" FIXTURE_CHECK_RUNS="$(run_ci_ok)"); rc=$?
+assert "ruleset-only required check satisfied → ci_state green, eligible" \
+  "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.ci_state' <<<\"\$out\")\" = green ]"
+
+# ruleset-only required check never started → blocked, never vacuously green
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_CI_ONE" FIXTURE_CHECK_RUNS='{"check_runs":[]}'); rc=$?
+assert "ruleset-only required check absent → blocked (rc 1)" "[ \$rc -eq 1 ]"
+assert "blocker code ci_not_green (ruleset-sourced)" "jq -r '.blockers[].code' <<<\"\$out\" | grep -q ci_not_green"
+
+# a same-named success from a DIFFERENT app than the ruleset's integration_id
+# pin is not satisfied — the ruleset source pins trust exactly like the
+# classic-endpoint app_id pin does
+out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_CI_ONE" FIXTURE_CHECK_RUNS="$(run_ci_wrong_app)"); rc=$?
+assert "ruleset-pinned wrong-app success → blocked" "[ \$rc -eq 1 ]"
+
+# union: classic protection requires ci/build, ruleset separately requires
+# ci — BOTH sources' requirements must be evaluated, not just whichever
+# endpoint answered. Only ci/build's check run exists → still blocked on the
+# ruleset-sourced "ci" requirement.
+out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=0 FIXTURE_REQUIRED_CHECKS="$REQ_ONE" \
+      FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_CI_ONE" FIXTURE_CHECK_RUNS="$(run_ok)"); rc=$?
+assert "union of classic+ruleset required checks, ruleset one unmet → blocked" "[ \$rc -eq 1 ]"
+
+# union satisfied from both sources → green
+out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=0 FIXTURE_REQUIRED_CHECKS="$REQ_ONE" \
+      FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES_CI_ONE" \
+      FIXTURE_CHECK_RUNS='{"check_runs":[{"name":"ci/build","status":"completed","conclusion":"success","app":{"id":15368}},{"name":"ci","status":"completed","conclusion":"success","app":{"id":15368}}]}'); rc=$?
+assert "union of classic+ruleset required checks, both met → green, eligible" \
+  "[ \$rc -eq 0 ] && [ \"\$(jq -r '.facts.ci_state' <<<\"\$out\")\" = green ]"
+
 # ── admin-bypass fact: authenticated identity's standing bypass grant on a
 #    GitHub ruleset's required-approving-review rule (separate from Axis 1) ──
 # no rules apply to this branch (default 404) → inert, not required
@@ -481,12 +522,20 @@ out=$(run_script "$BASE_POLICY" FIXTURE_RULES_404=0 FIXTURE_BRANCH_RULES="$RULES
 assert "null ruleset_id with active count → eligible, current_actor_can_bypass false (fail closed for --admin)" \
     "[ \$rc -eq 0 ] && [ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = false ]"
 
-# rules/branches fetch fails for a reason other than 404 → admin_bypass degrades
-# to the inert "no rulesets" state (never aborts eligibility over an
-# informational fact)
+# rules/branches now also sources the CI-green blocker's required-checks
+# union (not just the informational admin_bypass fact), so a hard failure on
+# it must fail closed exactly like the classic protection endpoint's own
+# hard-failure branch — never silently degrade to "no rulesets" and risk a
+# ruleset-only required check reading vacuously green.
 out=$(run_script "$BASE_POLICY" FIXTURE_RULES_FAIL=1); rc=$?
-assert "branch-rules fetch hard failure → eligible, admin_bypass inert (review_rule_active false, current_actor_can_bypass null)" \
-    "[ \$rc -eq 0 ] && [ \"\$(jq '.facts.admin_bypass.review_rule_active' <<<\"\$out\")\" = false ] && [ \"\$(jq '.facts.admin_bypass.current_actor_can_bypass' <<<\"\$out\")\" = null ]"
+assert "branch-rules fetch hard failure → fails closed (exit 3)" "[ \$rc -eq 3 ]"
+assert "branch-rules fetch hard failure → prints no verdict" "[ -z \"\$out\" ]"
+
+# classic protection legitimately absent (404, ruleset-only repo) AND the
+# rules/branches fetch hard-fails → must NOT read as vacuous green (the
+# original bug relocated to this endpoint's failure path)
+out=$(run_script "$BASE_POLICY" FIXTURE_PROTECTION_404=1 FIXTURE_RULES_FAIL=1); rc=$?
+assert "classic 404 + rules hard failure → fails closed, not vacuous green (exit 3)" "[ \$rc -eq 3 ]"
 
 # a ruleset's own detail fetch fails after being listed → degrade to
 # non-bypassable (fail closed for --admin) and continue rather than abort


### PR DESCRIPTION
## Summary
- `check-merge-eligibility.sh`'s `ci_not_green` blocker previously sourced required status checks ONLY from the classic branch-protection endpoint (`branches/{base}/protection/required_status_checks`). On a repo enforcing CI via a GitHub Ruleset instead of classic branch protection, that endpoint 404s, and the existing fallback treated the 404 as "no CI requirement configured" -> `required_checks=[]` -> vacuously green, even when a ruleset genuinely requires a status check. Live-confirmed on this repo itself (agents-config uses a ruleset, not classic protection).
- Fix: hoist the existing `rules/branches/{base}` fetch (previously only consumed later, for the informational `admin_bypass` fact) earlier in the script, and union its `required_status_checks`-type rule contexts (`{context, app_id: integration_id}`) with the classic-protection-derived set via `unique_by([.context, .app_id])`.
- Because `rules_json` now feeds the CI blocker (a real gate) and not just the informational `admin_bypass` fact, a **hard failure on that fetch now fails the whole script closed (exit 3)** — mirroring the classic endpoint's own hard-failure branch exactly, rather than silently degrading to "no rulesets" (which would reopen the same vacuous-green bug via a different trigger). This intentionally supersedes the prior test contract where a hard `rules/branches` failure degraded `admin_bypass` to inert while returning `eligible` (rc 0) — that endpoint is no longer purely informational.
- Improved the exit-3 stderr message to name the failing endpoint and flag the condition as likely transient/not-a-permissions-problem, given this repo's documented history of GitHub API 5xx responses that read like authNZ failures.

Fixes agents-config-abn9.44.3.

## Scope
- In scope: `src/user/.agents/skills/merge-guard/check-merge-eligibility.sh` and its co-located test `check-merge-eligibility_test.sh`.
- Out of scope: the `quality-gate` workflow's own cwd-inheritance defect discovered while gating this PR (filed separately as `agents-config-wgclw.31`, P0, not part of this change).

## Ground truth
- Exit-code contract (0 eligible / 1 blocked / 3 error) is pre-existing and documented in the script's own header comment; this change adds one more exit-3 site under that existing convention, it does not introduce a new contract.
- `merge-guard/SKILL.md` already treats exit 3 as "fail closed, hand off, never retry blind" at multiple call sites — callers already distinguish infra failure from a genuine ineligible verdict.

## Test Plan
- [x] `bash check-merge-eligibility_test.sh` — 227/227 assertions pass, exit 0 (up from 220 baseline; 7 net new/modified assertions covering ruleset-only satisfied/absent/wrong-app, classic+ruleset union unmet/met, and the fail-closed hard-failure paths).
- [x] `bash -n check-merge-eligibility.sh` — syntax OK.
- [x] Manually verified the exit-3 stderr message content by invoking the script directly against the test stub with `FIXTURE_RULES_FAIL=1` (bypassing the test harness's stderr-swallowing convention, which no existing test in this file overrides).
- [x] Reviewed by `quality-reviewer` (sonnet), which found and this PR fixes one BLOCKING defect (fail-open rules_json fetch reintroducing vacuous-green risk via a new trigger).
- [x] HEAVY `quality-gate` workflow run against this branch's actual diff (verified non-hollow via independent finder audit) — clean.