### PR TITLE
fix(wait-for-pr-comments): expose per-identity dispatch outcome in request-rereview.sh

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -486,12 +486,19 @@ the helper's default (1) per spec decision, not a per-repo config knob.
      DISPOSITION_ARGS=(--disposition-table-file "$DISPOSITION_FILE")
    fi
 
-   ${CLAUDE_SKILL_DIR}/request-rereview.sh \
+   RR_OUT=$(${CLAUDE_SKILL_DIR}/request-rereview.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR" \
      --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")" \
      "${DISPOSITION_ARGS[@]}" \
-     --since-sha "<phase4_baseline_sha>"
-   # exit 0 when at least one ask succeeded; exit 1 when none did
+     --since-sha "<phase4_baseline_sha>")
+   RR_EXIT=$?
+   # exit 0 = every dispatched mechanism succeeded; 1 = none did; 3 = partial
+   # (>=1 succeeded, >=1 failed). $RR_OUT is NDJSON, one line per dispatched
+   # mechanism: {identity, mechanism, status}. Filter to the identities that
+   # actually succeeded — DO NOT reuse the full policy list in steps 3/4, or a
+   # never-asked identity (RR_EXIT == 3's failed half) polls as if it had
+   # been asked and reads "timed out silent" instead of "never dispatched".
+   DISPATCHED_OK_REVIEWERS=$(jq -cs '[.[] | select(.status == "success") | .identity]' <<<"$RR_OUT")
    [ -n "$DISPOSITION_FILE" ] && rm -f "$DISPOSITION_FILE"
    ```
    `--bot-reviewers` dispatches on each policy-trusted identity's own
@@ -512,12 +519,21 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    makes Codex re-cite settled findings every round, while a structured
    disposition table (including an explicit REBUT) produced zero re-raises.
 
-3. **Launch** (80s max window: 20s pre-sleep + 6 × 10s polls):
+   **If `RR_EXIT == 1`** (`DISPATCHED_OK_REVIEWERS == []`): no bot was
+   actually asked. Skip steps 3-4 (no re-review start, and nothing, to poll
+   for) and go straight to the "no new review" merge-and-write-back below —
+   but do NOT feed this through the `silent` event, since a dispatch failure
+   is an infrastructure error, not a bot that was asked and stayed quiet;
+   report the dispatch failure instead and leave `rereview_round_count`
+   untouched, mirroring merge-guard's `RR_EXIT == 1` handling.
+
+3. **Launch** (80s max window: 20s pre-sleep + 6 × 10s polls). Only reached
+   when `DISPATCHED_OK_REVIEWERS` is non-empty:
    ```bash
    ${CLAUDE_SKILL_DIR}/poll-copilot-rereview-start.sh \
      --owner "$OWNER" --repo "$REPO" --pr "$PR" \
      --after <rereview_since_timestamp> \
-     --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"
+     --bot-reviewers "$DISPATCHED_OK_REVIEWERS"
    ```
    This detects either signal that a trusted bot has started a re-review:
    the `copilot_work_started` event that follows the fresh
@@ -527,19 +543,24 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    since it responds to the `@codex review` comment in step 2, not a
    reviewer-request event). Passing `--bot-reviewers` is what enables the
    eyes-reaction check; omitting it preserves the script's original
-   Copilot-events-only behavior. Exit 3 (a reactions-endpoint failure that
-   leaves whether Codex started unknown) is an infrastructure error, not
-   "no re-review started" — do not treat it as a silent ask.
+   Copilot-events-only behavior. `--bot-reviewers` is
+   `$DISPATCHED_OK_REVIEWERS`, not the full policy list — a `RR_EXIT == 3`
+   partial dispatch (e.g. Copilot's reviewer-add succeeds, Codex's issue
+   comment fails) must not have this step wait on the identity that was
+   never actually asked. Exit 3 (a reactions-endpoint failure that leaves
+   whether Codex started unknown) is an infrastructure error, not "no
+   re-review started" — do not treat it as a silent ask.
 
 4. **If** step 3 detected a re-review start (either signal), launch
    `poll-copilot-review.sh
    --owner "$OWNER" --repo "$REPO" --pr "$PR"
    --skip-request-check --since-timestamp <rereview_since_timestamp>
-   --bot-reviewers "$(jq -c '.bot_reviewers' <<<"$POLICY_JSON")"`
+   --bot-reviewers "$DISPATCHED_OK_REVIEWERS"`
    to await the actual review. The `--since-timestamp` guard prevents the
    stale-cache bug where the script returns the prior round's review instead
-   of the new one; `--bot-reviewers` keeps re-review detection aligned to the
-   same policy allowlist used in Phase 2. Before this bead, step 4 was gated
+   of the new one; `--bot-reviewers` keeps re-review detection restricted to
+   the identities `request-rereview.sh` actually dispatched successfully,
+   same rationale as step 3. Before this bead, step 4 was gated
    on the Copilot-only `copilot_work_started` event alone, so a Codex-only
    re-review always fell through to "no re-review started" (recording a
    silent ask against the one-ask cap) even when Codex was actively
@@ -581,7 +602,11 @@ PR/head — do not fire again on later invocations once it is already `true`.
 
 If Phase 6 detects no new review (`no_rereview_started` exit), compute the
 updated silent-ask counter and merge it into `POLLING_FILE` before exiting
-Phase 6 normally and proceeding to Phase 7:
+Phase 6 normally and proceeding to Phase 7. This `silent` event does NOT
+apply to step 2's `RR_EXIT == 1` case (no bot was ever dispatched) — that
+path skips straight to Phase 7 with the dispatch failure reported, leaving
+`rereview_round_count`/`bot_review_cap_exhausted` untouched, since no ask
+was made for a bot to have stayed silent on:
 ```bash
 result=$(${CLAUDE_SKILL_DIR}/compute-rereview-polling.sh \
   --prior-count "$(jq -r '.c' <<<"$prior")" \

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh
@@ -19,6 +19,9 @@
 # An identity with no known mechanism warns to stderr and is skipped without
 # aborting dispatch to its siblings.
 #
+# GraphQL projection: none directly; uses `gh pr edit` / `gh pr comment` REST
+# under the hood.
+#
 # Inputs:
 #   --owner <o>              repository owner
 #   --repo  <r>              repository name
@@ -49,14 +52,19 @@
 #                            commits since <sha>" line to the comment body.
 #
 # Outputs:
-#   stdout: (none on success)
+#   stdout: one NDJSON line per dispatched mechanism, never per raw alias
+#     (aliases deduping to one mechanism produce exactly one line):
+#       {"identity": <alias matched>, "mechanism": "copilot"|"codex", "status": "success"|"failure"}
+#     An unknown identity gets a stderr warning only, no stdout line -- it was
+#     never dispatched. Lets callers tell "never asked" (mechanism absent or
+#     "failure") apart from "asked but silent" ("success"). In the legacy
+#     --bot-reviewers-omitted path there is no input alias to echo, so
+#     "identity" is the fixed literal "Copilot", not a value read from input.
 #   exit codes:
-#     0 = at least one ask succeeded
-#     1 = no ask succeeded (gh failure on every dispatched identity)
-#     2 = bad flag usage
-#
-# GraphQL projection: none directly; uses `gh pr edit` / `gh pr comment` REST
-# under the hood.
+#     0 = every dispatched mechanism succeeded; 1 = none succeeded (including
+#     all-unknown-identities); 2 = bad flag usage; 3 = partial (>=1 succeeded
+#     AND >=1 failed) -- so callers don't read a failed identity as an
+#     asked-but-silent bot.
 #
 # Argv-size note: --disposition-table-file takes a PATH, not inline JSON. A
 # round with enough items (or a few verbose rationales) can exceed the OS's
@@ -250,15 +258,27 @@ request_codex() {
   fi
 }
 
+# report_outcome — emit one NDJSON stdout line for a dispatched mechanism.
+report_outcome() {
+  local identity="$1" mechanism="$2" status="$3"
+  jq -nc --arg identity "$identity" --arg mechanism "$mechanism" --arg status "$status" \
+    '{identity: $identity, mechanism: $mechanism, status: $status}'
+}
+
 if [ -z "$BOT_REVIEWERS" ]; then
-  # Backward-compatible default: the legacy Copilot-only dance.
+  # Backward-compatible default: the legacy Copilot-only dance. There is no
+  # input alias to echo here (no --bot-reviewers was given), so "identity"
+  # is the fixed literal "Copilot" -- see the Outputs note above.
   if request_copilot; then
+    report_outcome Copilot copilot success
     exit 0
   fi
+  report_outcome Copilot copilot failure
   exit 1
 fi
 
 SUCCEEDED=0
+DISPATCHED_COUNT=0
 # Track mechanisms already dispatched this invocation. Multiple aliases can map
 # to the same mechanism (e.g. both `Copilot` and
 # `copilot-pull-request-reviewer[bot]` -> the reviewer dance); dispatching each
@@ -280,12 +300,31 @@ while IFS= read -r identity; do
     *" $mechanism "*) continue ;;
   esac
   DISPATCHED="$DISPATCHED $mechanism"
+  DISPATCHED_COUNT=$((DISPATCHED_COUNT + 1))
 
   case "$mechanism" in
-    copilot) if request_copilot; then SUCCEEDED=$((SUCCEEDED + 1)); fi ;;
-    codex)   if request_codex;   then SUCCEEDED=$((SUCCEEDED + 1)); fi ;;
+    copilot)
+      if request_copilot; then
+        SUCCEEDED=$((SUCCEEDED + 1))
+        report_outcome "$identity" copilot success
+      else
+        report_outcome "$identity" copilot failure
+      fi
+      ;;
+    codex)
+      if request_codex; then
+        SUCCEEDED=$((SUCCEEDED + 1))
+        report_outcome "$identity" codex success
+      else
+        report_outcome "$identity" codex failure
+      fi
+      ;;
   esac
 done < <(jq -r '.[]' <<<"$BOT_REVIEWERS")
 
-[ "$SUCCEEDED" -gt 0 ] && exit 0
-exit 1
+if [ "$SUCCEEDED" -eq 0 ]; then
+  exit 1
+elif [ "$SUCCEEDED" -lt "$DISPATCHED_COUNT" ]; then
+  exit 3
+fi
+exit 0

--- a/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh
@@ -187,13 +187,61 @@ FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 -
 rc_all_fail=$?
 assert "single failing identity exits 1 (none succeeded)" "[ \$rc_all_fail -eq 1 ]"
 
-# Exit-code matrix: one identity fails, the other succeeds -> still exit 0
-# (at least one ask succeeded).
+# Exit-code matrix: one identity fails, the other succeeds -> partial success,
+# exit 3 (distinct from 0 = full success and 1 = none succeeded) so callers
+# can tell a partial dispatch from either extreme instead of reading a
+# never-asked identity as merely "timed out silent".
 : > "$FAKE_GH_LOG"
 FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
   --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' >/dev/null 2>&1
 rc_partial=$?
-assert "one failing + one succeeding identity exits 0 (at least one succeeded)" "[ \$rc_partial -eq 0 ]"
+assert "one failing + one succeeding identity exits 3 (partial success)" "[ \$rc_partial -eq 3 ]"
+
+# ── Per-identity dispatch outcome (structured stdout) ────────────────────────
+# stdout carries one NDJSON line per dispatched mechanism -- {identity,
+# mechanism, status} -- so callers can distinguish "never asked" (status !=
+# success for that mechanism) from "asked but silent", instead of inferring
+# outcome from a single aggregate exit code.
+
+: > "$FAKE_GH_LOG"
+out_full=$(PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' 2>/dev/null)
+assert "full-success stdout reports 2 NDJSON lines" "[ \$(printf '%s\n' \"\$out_full\" | grep -c .) -eq 2 ]"
+assert "full-success stdout reports copilot success" \
+  "printf '%s\n' \"\$out_full\" | jq -e 'select(.mechanism==\"copilot\" and .status==\"success\")' >/dev/null"
+assert "full-success stdout reports codex success" \
+  "printf '%s\n' \"\$out_full\" | jq -e 'select(.mechanism==\"codex\" and .status==\"success\")' >/dev/null"
+
+: > "$FAKE_GH_LOG"
+out_partial=$(FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "chatgpt-codex-connector[bot]"]' 2>/dev/null)
+assert "partial stdout reports copilot failure" \
+  "printf '%s\n' \"\$out_partial\" | jq -e 'select(.mechanism==\"copilot\" and .status==\"failure\")' >/dev/null"
+assert "partial stdout reports codex success" \
+  "printf '%s\n' \"\$out_partial\" | jq -e 'select(.mechanism==\"codex\" and .status==\"success\")' >/dev/null"
+
+: > "$FAKE_GH_LOG"
+out_allfail=$(FAKE_GH_FAIL_EDIT=1 PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 --bot-reviewers '["Copilot"]' 2>/dev/null)
+assert "all-fail stdout reports copilot failure" \
+  "printf '%s\n' \"\$out_allfail\" | jq -e 'select(.mechanism==\"copilot\" and .status==\"failure\")' >/dev/null"
+
+# Alias dedup + NDJSON: both Copilot aliases in one call must still emit
+# exactly ONE copilot NDJSON line, mirroring the single dispatch already
+# asserted above via the fake-gh log.
+: > "$FAKE_GH_LOG"
+out_dedup=$(PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["Copilot", "copilot-pull-request-reviewer[bot]"]' 2>/dev/null)
+assert "aliased dedup emits exactly one copilot NDJSON line" \
+  "[ \$(printf '%s\n' \"\$out_dedup\" | jq -c 'select(.mechanism==\"copilot\")' | grep -c .) -eq 1 ]"
+
+# Unknown identity: no NDJSON line for it (it was never dispatched), only a
+# stderr warning -- a mixed call's stdout must contain exactly the one known
+# identity's outcome line, not a second line for the unknown one.
+: > "$FAKE_GH_LOG"
+out_unknown=$(PATH="$FAKEBIN2:$PATH" "$SCRIPT" --owner o --repo r --pr 1 \
+  --bot-reviewers '["some-other-bot[bot]", "Copilot"]' 2>/dev/null)
+assert "unknown identity produces no NDJSON line, only the known one's" \
+  "[ \$(printf '%s\n' \"\$out_unknown\" | grep -c .) -eq 1 ] && printf '%s\n' \"\$out_unknown\" | jq -e 'select(.mechanism==\"copilot\")' >/dev/null"
 
 # Flag-omitted default: still performs the Copilot-only dance, unchanged.
 : > "$FAKE_GH_LOG"


### PR DESCRIPTION
## Summary
- `request-rereview.sh` exited 0 once at least one identity's ask succeeded, so a partial dispatch (e.g. Copilot's reviewer-add succeeds, Codex's issue-comment fails) was indistinguishable from full success — the never-asked identity then read as timed-out-silent at poll time, wrongly spending the one-ask retry budget.
- Emits one NDJSON stdout line per dispatched mechanism (`{identity, mechanism, status}`) and adds exit code 3 for partial success (distinct from 0 = full success and 1 = none succeeded).
- Updates `wait-for-pr-comments` SKILL.md Phase 6 to capture the new signal, filter downstream polling (`poll-copilot-rereview-start.sh` / `poll-copilot-review.sh`) to only the identities actually dispatched successfully, and skip polling entirely on total dispatch failure (`RR_EXIT == 1`) without touching the silent-ask counter.

## Scope
- In scope: `request-rereview.sh`, its test suite, and the `wait-for-pr-comments` SKILL.md Phase 6 caller only.
- Out of scope, deliberately: merge-guard's SKILL.md caller of `request-rereview.sh` (agents-config-abn9.44.2.9's parent notes this touches both callers, but merge-guard's files belong to a different lane in this grind — left untouched, to be updated separately).
- Ground truth: `src/user/.agents/skills/wait-for-pr-comments/request-rereview.sh` (the script), `request-rereview_test.sh` (its NDJSON contract tests), `SKILL.md` Phase 6 (prose caller — not an executable script, no `set -e` context; `RR_OUT=$(...)` then `RR_EXIT=$?` on the next line is a documentation snippet for the agent following the skill to execute one Bash call at a time, not a persisted strict-mode script).

## Test Plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh` — 79/79 assertions pass, exit 0
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh` — 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh` — 0 failures, exit 0 (unaffected sibling)

Bead: agents-config-abn9.44.2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuMvZwLNRmUPRJWfDNCm3q