### PR TITLE
docs(specs): grind-dashboard design pick — Control Room + mission header, with prototypes (wgclw.30.3)

### DIFF
--- a/docs/prototypes/grind-dashboard/README.md
+++ b/docs/prototypes/grind-dashboard/README.md
@@ -1,0 +1,97 @@
+# Grind dashboard — UI prototypes
+
+Three radically different single-file renderings of one shared fixture state,
+built to the prototyping plan in `docs/specs/2026-07-19-grind-dashboard-renderer.md`
+(input State shape per `docs/specs/2026-07-19-event-sourced-grind-runtime.md`).
+Open `index.html` to switch between them from one page; each variation also
+stands alone from `file://`.
+
+## The chosen design
+
+**Variation A — Control Room**, amended with the mission-brief header line from
+Variation C (the topbar carries `state.mission` beneath the title). Recorded in
+the renderer spec's UX section; B and C are retained for reference.
+
+## The fixture
+
+`fixture-state.json` is one fold `State` built to exercise everything the UX
+section requires:
+
+- **All nine statuses** — items cover queued / in-progress / pr-open /
+  in-review / merged / done / blocked / waiting-human; `standing-down` appears
+  as the status of Lane 6 (it is lane-only vocabulary per the runtime spec).
+- **All four parking kinds** — discovered-work, human-gated, later-wave, deferred.
+- **Active review with findings and open threads** — `wgclw.30.1` (codex round 2,
+  3 open threads, 1 wont-fix, 4 findings with severities + dispositions).
+- **A stalemate** — `wgclw.31.2` (codex round 4, 0 open threads, `stalemate:
+  true`, waiting-human with a `why`, mirrored in the attention list).
+- **Paused-banner variant flag** — `pause.paused: true` with reason and a
+  resume checklist. To see the running variant, flip `paused` to `false` in an
+  inlined `STATE` block (or in the fixture before re-splicing).
+- **Seven lanes** (≥6) to exercise horizontal overflow, plus long titles.
+- **LESSON and ERROR observations** — two lessons feed the lessons panel; the
+  ERROR observation's attention entry is in the attention list, as the fold
+  would have placed it.
+- **Serialization probe** — `disc-3`'s title contains the literal text
+  `</script>`. In `fixture-state.json` it is raw (so CI can prove the renderer
+  escapes it); in each HTML it is inlined with every `<` escaped as the
+  JSON escape `\\u003c`.
+  All three dashboards render it as inert text — view-source on the state
+  block shows the escaped form.
+- `merged_ledger` / `closed_ledger` are present for State fidelity; per UX
+  requirement 6 **no variation renders a Merged or Closed panel**.
+
+## Variation A — Control Room (`variation-a.html`)
+
+**Thesis:** the dashboard is a wall monitor — at a glance you should read the
+whole grind from across the room. **Axes:** column-per-lane kanban ·
+icon-forward (large status glyphs, colored column-top strips, small text
+pills) · control-room density (12.5px base, tight cards, everything visible at
+once: findings, blockers, observations tickertape). Parking, lessons, and the
+observation log dock in a three-panel strip under the board. Collapsed lanes
+are exactly half width (170px vs 340px) and show icon + id + title + PR# only.
+
+## Variation B — Ops Review (`variation-b.html`)
+
+**Thesis:** the dashboard is a document you read top-to-bottom over coffee —
+calm beats dense, words beat glyphs. **Axes:** row-per-lane horizontal
+swimlanes · text-forward (status words in small caps, prose review lines,
+spelled-out agent ownership; icons accompany, never carry alone) · calm and
+spacious (15px base, serif headings, generous whitespace). Each lane's item
+strip scrolls horizontally on overflow rather than squeezing cards; the
+observation log tucks into a `<details>` disclosure; lessons render as
+margin-note quotes. Collapsed lanes compress to a ~half-height band of slim
+chips (icon + id + title + PR#) — the row-layout analogue of the 50% rule.
+
+## Variation C — Mission Log (`variation-c.html`)
+
+**Thesis:** the dashboard is a mission brief plus a ship's log — summarize
+first, drill on demand. **Axes:** summary-grid with drill-down · neither
+column- nor row-board: a clickable stat-deck (all nine statuses counted,
+click to filter the register), an operations register grouped by lane with
+per-item drill-down drawers (findings table, review detail, related log
+entries), and a chronological observation timeline in the rail. Status lamps
+(PAUSED / ATTENTION ×N / RUNNING) headline the brief. Collapsed lane groups
+show half-width slim rows (icon + id + title + PR#). Medium density,
+monospace accents.
+
+## Shared contract behavior (all three)
+
+- Light theme only; self-contained `file://` pages; no fetches, no CDNs.
+- Last-generated timestamp comes from `state.last_generated` (the log's last
+  event ts), never a wall clock.
+- Red ATTENTION banner, hidden when empty; pause banner when `pause.paused`.
+- Horizontal scroll on overflow (A: the board; B: each lane's item strip;
+  C: the register table) — lanes never squeeze into illegibility.
+- Unknown statuses degrade to a neutral gray pill + question-mark icon; the
+  board never breaks.
+- 15s auto-refresh with a visible toggle and countdown; the reload is a no-op
+  `location.reload()` in these static prototypes.
+- Per-lane collapse toggles on **every** lane; `done` lanes auto-collapse by
+  default. Collapse and refresh prefs persist in `localStorage`, keyed per
+  variation (`grindproto.{a,b,c}.*`) so exploring one never disturbs another.
+- Review-thread pills read as full labels ("1 open thread" / "N open threads")
+  with `review.detail` in the `title` tooltip; round badges never render on
+  `done` items (a high round count survives as a LESSON).
+- PR links derive from the repo slug; `wgclw.32.1` demonstrates the explicit
+  `url` override; all hrefs are scheme-checked.

--- a/docs/prototypes/grind-dashboard/fixture-state.json
+++ b/docs/prototypes/grind-dashboard/fixture-state.json
@@ -1,0 +1,304 @@
+{
+  "title": "Discipline-Layer Grind — wgclw",
+  "repo": "scotthamilton77/agents-config",
+  "mission": "Re-architect the discipline layer around an event-sourced grind runtime; retire the bookkeeper agent and the hand-written ORCHESTRATION-STATE.md. Out of scope: PDLC-orchestrator design, PORT-track machine setup.",
+  "protocols": {
+    "review_protocol": "codex adversarial review, gpt-5.6-sol, --wait",
+    "merge_policy": "explicit — human instruction required",
+    "watcher_conventions": "dumb background pollers; ROOT interprets",
+    "session_grants": "one worktree per lane; no cross-lane writes"
+  },
+  "last_generated": "2026-07-19T04:12:08Z",
+  "pause": {
+    "paused": true,
+    "reason": "Human is picking a dashboard design from the wgclw.30.3 prototypes; implementation lanes hold until the renderer spec's UX section is amended with the choice.",
+    "resume_checklist": [
+      "Open prototypes/grind-dashboard/index.html and pick a winner (or a merge)",
+      "Amend the renderer spec's UX section with the chosen design",
+      "grind log grind_resumed"
+    ]
+  },
+  "attention": [
+    {
+      "text": "PR #346 reviewer stalemate — codex round 4 on unchanged head 9f31c2e with zero open threads. Merge ruling needed.",
+      "item": "wgclw.31.2"
+    },
+    {
+      "text": "Fold anomaly on wgclw.30.1 round 2: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 — recorded applied:false, counts use the latest event. Auto-raised by ERROR observation.",
+      "item": "wgclw.30.1"
+    },
+    {
+      "text": "Dashboard prototype pick outstanding — variation A, B, or C (or a merge). The pause holds until the UX section is amended."
+    }
+  ],
+  "lanes": [
+    {
+      "id": "lane-installer",
+      "name": "Lane 1 — installer",
+      "agent": "lt-installer",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "done",
+      "queue": [
+        {
+          "id": "wgclw.28.4",
+          "title": "Open the dashboard exactly once via the platform opener",
+          "status": "done",
+          "pr": { "number": 338, "url": null }
+        },
+        {
+          "id": "wgclw.29.2",
+          "title": "Receipt-tracked uv tool installs with prune-on-retire",
+          "status": "done",
+          "pr": { "number": 339, "url": null }
+        }
+      ]
+    },
+    {
+      "id": "lane-runtime",
+      "name": "Lane 2 — event runtime",
+      "agent": "lt-runtime",
+      "model": "opus",
+      "effort": "high",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "wgclw.30.1",
+          "title": "Event schema + pure fold with transition table and anomaly policy",
+          "status": "in-review",
+          "pr": { "number": 344, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 2,
+            "open_threads": 3,
+            "wont_fix_count": 1,
+            "stalemate": false,
+            "detail": "codex round 2 on 4b1a9d1: 3 open threads — torn-tail repair must fsync the quarantine sidecar; derived-unblock path lacks a cross-lane edge test; applied:false events vanish from the status envelope on replay. 1 wont-fix: unknown payload keys are tolerated by design.",
+            "findings": [
+              { "severity": "high", "summary": "Torn-tail repair moves the fragment to quarantine but never fsyncs the sidecar", "disposition": "fixed", "thread_url": null },
+              { "severity": "medium", "summary": "Derived unblocking is untested for edges that cross lane boundaries", "disposition": "deferred", "thread_url": null },
+              { "severity": "low", "summary": "Envelope validator silently tolerates unknown payload keys", "disposition": "wont-fix", "thread_url": null },
+              { "severity": "medium", "summary": "applied:false events vanish from the status envelope on replay", "disposition": "escalated", "thread_url": null }
+            ]
+          },
+          "note": "round 2 verdict: findings — triage in flight"
+        },
+        {
+          "id": "wgclw.30.2",
+          "title": "CLI verbs over the fold: create, log, status, render, check, finish",
+          "status": "queued"
+        },
+        {
+          "id": "wgclw.30.5",
+          "title": "Emit-back envelope + condition vocabulary",
+          "status": "blocked",
+          "blocked_on": ["wgclw.30.1"],
+          "note": "needs the fold contract to settle first"
+        }
+      ]
+    },
+    {
+      "id": "lane-dashboard",
+      "name": "Lane 3 — dashboard renderer",
+      "agent": "lt-dashboard",
+      "model": "sonnet",
+      "effort": "high",
+      "status": "in-progress",
+      "queue": [
+        {
+          "id": "wgclw.30.3",
+          "title": "grind render: deterministic projection from folded state to self-contained HTML",
+          "status": "in-progress",
+          "note": "prototyping session — this board is rendering its own fixture"
+        },
+        {
+          "id": "wgclw.30.4",
+          "title": "Observation routing: ERROR → attention, LESSON → lessons panel",
+          "status": "pr-open",
+          "pr": { "number": 345, "url": null }
+        },
+        {
+          "id": "wgclw.30.6",
+          "title": "Staleness watchdog: grind check + watchdog arming guidance",
+          "status": "merged",
+          "pr": { "number": 342, "url": null },
+          "note": "post-merge teardown leg outstanding"
+        }
+      ]
+    },
+    {
+      "id": "lane-watchers",
+      "name": "Lane 4 — watchers & probes",
+      "agent": "lt-watchers-2",
+      "model": "sonnet",
+      "effort": "low",
+      "status": "waiting-human",
+      "queue": [
+        {
+          "id": "wgclw.31.2",
+          "title": "Verdict-aware PR watcher with a written precedence contract",
+          "status": "waiting-human",
+          "pr": { "number": 346, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 4,
+            "open_threads": 0,
+            "wont_fix_count": 2,
+            "stalemate": true,
+            "detail": "codex round 4 re-raised 2 wont-fix items as new threads on unchanged head 9f31c2e — stalemate declared per the review skill's §3 rule. Awaiting the human's merge ruling."
+          },
+          "why": "Stalemate ruling needed: accept the reviewer's re-raise and rework, or merge over it with a recorded rationale."
+        },
+        {
+          "id": "wgclw.31.7",
+          "title": "Reconcile the shutdown ledger against the tracker directly when the grind's own projection disagrees with bead state at teardown time",
+          "status": "queued"
+        }
+      ]
+    },
+    {
+      "id": "lane-handoff",
+      "name": "Lane 5 — handoff & skill integration",
+      "agent": "lt-handoff",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "blocked",
+      "queue": [
+        {
+          "id": "disc-2",
+          "title": "Amend the renderer spec's UX section with the chosen prototype design",
+          "status": "queued",
+          "note": "surfaced by the .30.3 prototyping session"
+        },
+        {
+          "id": "wgclw.30.7",
+          "title": "SKILL.md integration: retire the bookkeeper and ORCHESTRATION-STATE.md",
+          "status": "blocked",
+          "blocked_on": ["wgclw.31.2"],
+          "note": "chain: wgclw.30.7 → wgclw.31.2 (waiting-human) — blocked_chain evidence"
+        }
+      ]
+    },
+    {
+      "id": "lane-port",
+      "name": "Lane 6 — portable layer",
+      "agent": "lt-port",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "standing-down",
+      "queue": []
+    },
+    {
+      "id": "lane-docs",
+      "name": "Lane 7 — docs & hardening",
+      "agent": "lt-docs",
+      "model": "haiku",
+      "effort": "low",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "disc-3",
+          "title": "Serializer hardening: a work-item title containing \\\"</script>\\\" must render as inert text, never execute",
+          "status": "queued",
+          "note": "this very title is the serialization-contract probe"
+        },
+        {
+          "id": "wgclw.32.1",
+          "title": "User guide: run the opinionated agentic SDLC on the grind runtime — configuration, watchers, and overnight operations",
+          "status": "in-review",
+          "pr": { "number": 51, "url": "https://git.internal.example/scott/agents-config/pull/51" },
+          "review": {
+            "kind": "human",
+            "round": 1,
+            "open_threads": 1,
+            "wont_fix_count": 0,
+            "stalemate": false,
+            "detail": "human round 1: 1 open thread — tighten the watchdog arming prose; the dumb-poller rationale is buried in a footnote."
+          },
+          "note": "explicit PR url override — non-GitHub remote"
+        }
+      ]
+    }
+  ],
+  "parking_lot": [
+    {
+      "id": "disc-1",
+      "title": "Unify the prgroom and workcli envelope validators behind one shared module",
+      "kind": "discovered-work",
+      "note": "surfaced by PR #341 review; parked pending triage"
+    },
+    {
+      "id": "wgclw.33.1",
+      "title": "Supervised installer backfill sweep across both work machines",
+      "kind": "human-gated",
+      "note": "needs the human in the room"
+    },
+    {
+      "id": "uxns2.4",
+      "title": "PORT-track skill parity audit for Gemini and OpenCode",
+      "kind": "later-wave",
+      "note": "wave-2 scope, parked at partition"
+    },
+    {
+      "id": "vaac.9",
+      "title": "Merge-guard judge prompt v3 tuning against the last twenty rulings",
+      "kind": "deferred",
+      "note": "current judge passing; revisit post-M3"
+    }
+  ],
+  "observations": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "level": "LESSON",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6",
+      "lane": "lane-dashboard"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "level": "LESSON",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    },
+    {
+      "ts": "2026-07-19T02:58:11Z",
+      "level": "INFO",
+      "message": "lane_handover recorded on lane-watchers: lt-watchers → lt-watchers-2 (haiku·low → sonnet·low), reason: context exhaustion.",
+      "lane": "lane-watchers"
+    },
+    {
+      "ts": "2026-07-19T03:40:02Z",
+      "level": "WARN",
+      "message": "stale_item condition fired for disc-2 — no events referencing it for 47m (threshold 45m).",
+      "item": "disc-2",
+      "lane": "lane-handoff"
+    },
+    {
+      "ts": "2026-07-19T03:52:44Z",
+      "level": "ERROR",
+      "message": "Anomaly: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 for wgclw.30.1 round 2 — recorded applied:false; counts use the latest event.",
+      "item": "wgclw.30.1",
+      "lane": "lane-runtime"
+    }
+  ],
+  "lessons": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    }
+  ],
+  "merged_ledger": [
+    { "pr": 338, "title": "Open the dashboard exactly once via the platform opener", "sha": "8c21de4", "lane": "lane-installer" },
+    { "pr": 339, "title": "Receipt-tracked uv tool installs with prune-on-retire", "sha": "b07a1c9", "lane": "lane-installer" },
+    { "pr": 342, "title": "Staleness watchdog: grind check + watchdog arming guidance", "sha": "9f31c2e", "lane": "lane-dashboard" }
+  ],
+  "closed_ledger": [
+    { "id": "wgclw.29.9", "title": "Spike: incremental fold mode", "pr": 337, "reason": "superseded — refold-from-zero won on simplicity" }
+  ]
+}

--- a/docs/prototypes/grind-dashboard/index.html
+++ b/docs/prototypes/grind-dashboard/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<!--
+  Grind dashboard prototype chooser.
+  One page, three radically different renderings of the SAME fixture state
+  (fixture-state.json). Pick a winner — or a merge — then amend the renderer
+  spec's UX section. Self-contained; works from file://. Light theme only.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Grind dashboard — prototype chooser</title>
+<style>
+  :root {
+    --bg: #eef0f4; --panel: #ffffff; --border: #d3d9e1;
+    --ink: #171c24; --muted: #4d5766; --accent: #2f5fd6;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    display: flex; flex-direction: column;
+  }
+  .bar {
+    display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+    background: var(--panel); border-bottom: 1px solid var(--border);
+    padding: 10px 16px;
+  }
+  .bar h1 { font-size: 15px; margin: 0; font-weight: 650; }
+  .bar .hint { font-size: 12px; color: var(--muted); }
+  .switcher { display: flex; gap: 8px; flex-wrap: wrap; }
+  .vbtn {
+    display: flex; flex-direction: column; align-items: flex-start; gap: 1px;
+    border: 1px solid var(--border); background: var(--panel); border-radius: 8px;
+    padding: 6px 12px; cursor: pointer; font: inherit; text-align: left; min-width: 190px;
+  }
+  .vbtn .vname { font-weight: 700; font-size: 13px; }
+  .vbtn .vthesis { font-size: 11px; color: var(--muted); }
+  .vbtn:hover { background: #f4f6f9; }
+  .vbtn.active { border-color: var(--accent); outline: 2px solid rgba(47,95,214,0.35); }
+  .vbtn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .open-link { font-size: 12px; color: var(--accent); text-decoration: none; margin-left: auto; }
+  .open-link:hover { text-decoration: underline; }
+  iframe { flex: 1 1 auto; width: 100%; border: none; background: var(--bg); }
+</style>
+</head>
+<body>
+  <div class="bar">
+    <h1>Grind dashboard prototypes</h1>
+    <span class="hint">same fixture state, three designs — click to switch. Collapse &amp; refresh prefs persist per variation.</span>
+    <div class="switcher" role="tablist" aria-label="Variations">
+      <button type="button" class="vbtn" data-v="a" role="tab" aria-selected="false">
+        <span class="vname">A — Control Room</span>
+        <span class="vthesis">column-per-lane kanban · icon-forward · dense</span>
+      </button>
+      <button type="button" class="vbtn" data-v="b" role="tab" aria-selected="false">
+        <span class="vname">B — Ops Review</span>
+        <span class="vthesis">row-per-lane swimlanes · text-forward · calm</span>
+      </button>
+      <button type="button" class="vbtn" data-v="c" role="tab" aria-selected="false">
+        <span class="vname">C — Mission Log</span>
+        <span class="vthesis">stat-deck + register + timeline · drill-down</span>
+      </button>
+    </div>
+    <a class="open-link" id="open-link" href="variation-a.html" target="_blank" rel="noopener">open full page ↗</a>
+  </div>
+  <iframe id="frame" src="variation-a.html" title="Grind dashboard prototype preview"></iframe>
+
+<script>
+"use strict";
+const SOURCES = { a: "variation-a.html", b: "variation-b.html", c: "variation-c.html" };
+const frame = document.getElementById("frame");
+const openLink = document.getElementById("open-link");
+const buttons = Array.prototype.slice.call(document.querySelectorAll(".vbtn"));
+
+function select(v, updateHash) {
+  if (!SOURCES[v]) v = "a";
+  frame.src = SOURCES[v];
+  openLink.href = SOURCES[v];
+  buttons.forEach(b => {
+    const on = b.getAttribute("data-v") === v;
+    b.classList.toggle("active", on);
+    b.setAttribute("aria-selected", on ? "true" : "false");
+  });
+  if (updateHash !== false) {
+    try { history.replaceState(null, "", "#" + v); } catch (e) {}
+  }
+}
+
+buttons.forEach(b => b.addEventListener("click", () => select(b.getAttribute("data-v"))));
+select((location.hash || "").replace("#", "") || "a", false);
+</script>
+</body>
+</html>

--- a/docs/prototypes/grind-dashboard/variation-a.html
+++ b/docs/prototypes/grind-dashboard/variation-a.html
@@ -458,7 +458,7 @@ const STATE = {
       "queue": [
         {
           "id": "disc-3",
-          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "title": "Serializer hardening: a work-item title containing \\\"\u003c/script\u003e\\\" must render as inert text, never execute",
           "status": "queued",
           "note": "this very title is the serialization-contract probe"
         },

--- a/docs/prototypes/grind-dashboard/variation-a.html
+++ b/docs/prototypes/grind-dashboard/variation-a.html
@@ -643,7 +643,7 @@ function reviewBits(review, itemStatus) {
     out += '<span class="pill pill-threads"' + tip + ">" + label + "</span>";
   }
   const wf = Number(review.wont_fix_count) || 0;
-  if (wf > 0) out += '<span class="pill pill-wontfix">' + wf + (wf === 1 ? " wont-fix" : " wont-fix") + "</span>";
+  if (wf > 0) out += '<span class="pill pill-wontfix">' + wf + (wf === 1 ? " wont-fix" : " wont-fix items") + "</span>";
   return out;
 }
 

--- a/docs/prototypes/grind-dashboard/variation-a.html
+++ b/docs/prototypes/grind-dashboard/variation-a.html
@@ -1,0 +1,834 @@
+<!DOCTYPE html>
+<!--
+  VARIATION A — "CONTROL ROOM"
+  Column-per-lane kanban board. Icon-forward, control-room density.
+  Same fixture state as variations B and C, inlined below with every
+  less-than sign in the JSON escaped as the JSON escape backslash-u003c
+  (the grind serialization contract — a raw splice of the probe title
+  would close this block early and execute). Light theme only.
+  Self-contained: no fetches, no CDNs; works from file://.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Grind — Control Room</title>
+<style>
+  :root {
+    --bg: #eef0f4;
+    --panel: #ffffff;
+    --panel-2: #f4f6f9;
+    --border: #d3d9e1;
+    --text: #171c24;
+    --text-dim: #4d5766;
+    --accent: #2f5fd6;
+    --red: #c62828;
+    --lane-w: 340px;
+    --lane-w-collapsed: 170px; /* exactly 50% of expanded */
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 12.5px; line-height: 1.45; padding: 14px 18px 24px;
+  }
+  a { color: var(--accent); }
+  a:focus-visible, button:focus-visible, input:focus-visible + span,
+  summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+
+  /* ---- status palette: one --c per status, everything keys off it ---- */
+  .st-queued        { --c: #6e7681; --cbg: rgba(110,118,129,0.13); }
+  .st-in-progress   { --c: #2f5fd6; --cbg: rgba(47,95,214,0.12); }
+  .st-pr-open       { --c: #7c3aed; --cbg: rgba(124,58,237,0.12); }
+  .st-in-review     { --c: #9a6c00; --cbg: rgba(154,108,0,0.13); }
+  .st-merged        { --c: #1e8e3e; --cbg: rgba(30,142,62,0.12); }
+  .st-done          { --c: #0f7b3f; --cbg: rgba(15,123,63,0.18); }
+  .st-blocked       { --c: #c62828; --cbg: rgba(198,40,40,0.12); }
+  .st-waiting-human { --c: #b45309; --cbg: rgba(180,83,9,0.13); }
+  .st-standing-down { --c: #64748b; --cbg: rgba(100,116,139,0.16); }
+  .st-unknown       { --c: #8a94a3; --cbg: rgba(138,148,163,0.14); }
+
+  .icon { vertical-align: -2px; }
+
+  /* ---- top bar ---- */
+  .topbar {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; flex-wrap: wrap; margin-bottom: 12px;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 10px 14px;
+  }
+  .brand { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+  .topbar .mission { flex-basis: 100%; margin: 2px 0 0; color: var(--text-dim); font-size: 12px; line-height: 1.45; max-width: 1000px; }
+  .brand .sigil {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-weight: 700; font-size: 11px; letter-spacing: 1px;
+    background: #171c24; color: #fff; border-radius: 4px; padding: 3px 7px;
+  }
+  h1 { font-size: 17px; margin: 0; font-weight: 650; letter-spacing: 0.1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .topmeta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .repo-chip, .gen-chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px; color: var(--text-dim);
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 3px 7px;
+  }
+  .refresh-control {
+    display: flex; align-items: center; gap: 7px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px;
+  }
+  .refresh-control label { display: flex; align-items: center; gap: 6px; cursor: pointer; user-select: none; font-size: 12px; }
+  #refresh-status { font-variant-numeric: tabular-nums; min-width: 74px; color: var(--text-dim); font-size: 11.5px; }
+
+  /* ---- banners ---- */
+  #attention-banner {
+    display: none; background: #fdeaea; border: 1px solid var(--red); border-left-width: 5px;
+    color: #7a1a1a; border-radius: 8px; padding: 10px 14px; margin-bottom: 12px;
+  }
+  #attention-banner.show { display: block; }
+  #attention-banner h2 { margin: 0 0 6px; font-size: 12px; letter-spacing: 1px; color: var(--red); text-transform: uppercase; }
+  #attention-banner ul { margin: 0; padding-left: 18px; }
+  #attention-banner li { margin-bottom: 4px; }
+  .attn-item-chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px;
+    background: #fff; border: 1px solid rgba(198,40,40,0.4); border-radius: 3px; padding: 0 5px; margin-left: 5px;
+  }
+  #pause-banner {
+    display: none; background: #fff7e6; border: 1px solid #d9a514; border-left-width: 5px;
+    color: #6b4e00; border-radius: 8px; padding: 10px 14px; margin-bottom: 12px;
+  }
+  #pause-banner.show { display: block; }
+  #pause-banner h2 { margin: 0 0 4px; font-size: 12px; letter-spacing: 1px; color: #8a6500; text-transform: uppercase; }
+  #pause-banner .reason { margin: 0 0 6px; }
+  #pause-banner ol { margin: 0; padding-left: 20px; font-size: 12px; color: #6b4e00; }
+
+  /* ---- board: columns scroll horizontally, never squeeze ---- */
+  .board { display: flex; gap: 10px; overflow-x: auto; align-items: stretch; padding-bottom: 10px; margin-bottom: 14px; }
+  .lane {
+    flex: 0 0 var(--lane-w); min-width: var(--lane-w);
+    background: var(--panel); border: 1px solid var(--border); border-top: 3px solid var(--c, var(--border));
+    border-radius: 8px; display: flex; flex-direction: column;
+  }
+  .lane.collapsed { flex-basis: var(--lane-w-collapsed); min-width: var(--lane-w-collapsed); background: var(--panel-2); }
+  .lane-head { display: flex; align-items: center; gap: 7px; padding: 9px 10px 7px; }
+  .lane-head .lane-icon { color: var(--c); flex: none; display: inline-flex; }
+  .lane-titles { min-width: 0; flex: 1 1 auto; }
+  .lane-titles h2 { margin: 0; font-size: 13px; font-weight: 650; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .lane-sub { color: var(--text-dim); font-size: 10.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .lane.collapsed .lane-sub { display: none; } /* collapsed drops the agent/activity line */
+  .lane.collapsed .lane-head .pill { display: none; } /* icon carries status at half width */
+  .lane-toggle {
+    flex: none; border: 1px solid var(--border); background: var(--panel); color: var(--text-dim);
+    border-radius: 5px; width: 22px; height: 22px; cursor: pointer; font-size: 13px; line-height: 1; padding: 0;
+  }
+  .lane-toggle:hover { background: var(--panel-2); color: var(--text); }
+  .lane-body { padding: 2px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
+  .queue-empty { color: var(--text-dim); font-size: 11.5px; font-style: italic; padding: 4px 2px; }
+
+  /* ---- pills & chips ---- */
+  .pill {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 1px 7px; border-radius: 999px; font-size: 10.5px; font-weight: 600;
+    background: var(--cbg); color: var(--c); white-space: nowrap;
+  }
+  .pill-round { background: rgba(47,95,214,0.10); color: var(--accent); font-variant-numeric: tabular-nums; }
+  .pill-round.is-stalemate { background: rgba(198,40,40,0.12); color: var(--red); }
+  .pill-stalemate { background: var(--red); color: #fff; text-transform: uppercase; letter-spacing: 0.6px; font-size: 9.5px; }
+  .pill-threads { background: rgba(154,108,0,0.12); color: #9a6c00; cursor: help; border-bottom: 1px dotted #9a6c00; }
+  .pill-wontfix { background: rgba(110,118,129,0.14); color: #525c69; }
+  .chip {
+    display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 10px; padding: 1px 6px; border-radius: 4px; border: 1px solid var(--border);
+    background: var(--panel-2); color: var(--text-dim);
+  }
+  .chip-blocker { border-color: rgba(198,40,40,0.45); color: var(--red); background: rgba(198,40,40,0.07); }
+  .kind { font-family: inherit; font-size: 10px; font-weight: 700; letter-spacing: 0.4px; text-transform: uppercase; border-radius: 3px; padding: 2px 6px; }
+  .kind-discovered-work { background: rgba(15,118,110,0.13); color: #0f766e; }
+  .kind-human-gated     { background: rgba(190,18,60,0.11); color: #be123c; }
+  .kind-later-wave      { background: rgba(67,56,202,0.11); color: #4338ca; }
+  .kind-deferred        { background: rgba(82,82,82,0.13);  color: #525252; }
+  .kind-unknown         { background: rgba(138,148,163,0.15); color: #6e7681; }
+
+  /* ---- item cards ---- */
+  .item { border: 1px solid var(--border); border-left: 3px solid var(--c); border-radius: 6px; padding: 7px 9px; background: #fff; }
+  .item-top { display: flex; align-items: center; gap: 6px; margin-bottom: 3px; }
+  .item-top .icon { color: var(--c); flex: none; }
+  .item-id { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px; color: var(--text-dim); flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .pr-link { font-size: 11px; text-decoration: none; font-variant-numeric: tabular-nums; flex: none; }
+  .pr-link:hover { text-decoration: underline; }
+  .pr-plain { color: var(--text-dim); font-size: 11px; }
+  .item-title { font-weight: 600; font-size: 12px; margin-bottom: 5px; overflow-wrap: break-word; }
+  .item-badges { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+  .item-note { color: var(--text-dim); font-size: 11px; margin-top: 5px; }
+  .item-why {
+    margin-top: 5px; font-size: 11px; color: #8a4a08;
+    background: rgba(180,83,9,0.09); border: 1px solid rgba(180,83,9,0.3); border-radius: 5px; padding: 4px 7px;
+  }
+  .item-blockers { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px; align-items: center; font-size: 10.5px; color: var(--text-dim); }
+  .findings { list-style: none; margin: 6px 0 0; padding: 5px 0 0; border-top: 1px dashed var(--border); }
+  .findings li { display: flex; gap: 6px; align-items: baseline; font-size: 10.5px; padding: 2px 0; color: var(--text); }
+  .sev { flex: none; font-size: 9px; font-weight: 800; letter-spacing: 0.5px; text-transform: uppercase; border-radius: 3px; padding: 1px 4px; }
+  .sev-high { background: rgba(198,40,40,0.13); color: var(--red); }
+  .sev-medium { background: rgba(154,108,0,0.13); color: #9a6c00; }
+  .sev-low { background: rgba(110,118,129,0.14); color: #525c69; }
+  .sev-unknown { background: rgba(138,148,163,0.15); color: #6e7681; }
+  .disp { flex: none; margin-left: auto; font-size: 9.5px; font-weight: 700; color: var(--text-dim); font-style: italic; }
+  .disp-fixed { color: #0f7b3f; } .disp-wont-fix { color: #525c69; }
+  .disp-deferred { color: #4338ca; } .disp-escalated { color: #b45309; }
+
+  /* ---- collapsed item rows: icon + id + title + PR#, nothing else ---- */
+  .item-slim { display: flex; align-items: center; gap: 5px; padding: 4px 2px; border-bottom: 1px dashed var(--border); }
+  .item-slim:last-child { border-bottom: none; }
+  .item-slim .icon { color: var(--c); flex: none; }
+  .item-slim .item-id { flex: none; max-width: 62px; }
+  .item-slim .t { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; }
+  .item-slim .pr-link, .item-slim .pr-plain { font-size: 10.5px; }
+
+  /* ---- bottom dock ---- */
+  .dock { display: flex; gap: 10px; flex-wrap: wrap; }
+  .dock-panel { flex: 1 1 300px; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
+  .dock-panel h2 { margin: 0 0 8px; font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); display: flex; align-items: center; gap: 7px; }
+  .count-tag { font-size: 10px; font-weight: 700; background: var(--panel-2); border: 1px solid var(--border); color: var(--text-dim); padding: 0 7px; border-radius: 999px; }
+  .obs-list { list-style: none; margin: 0; padding: 0; max-height: 170px; overflow-y: auto; }
+  .obs-list li { display: flex; gap: 7px; align-items: baseline; padding: 3px 0; border-bottom: 1px dashed rgba(0,0,0,0.06); font-size: 11px; color: var(--text); }
+  .obs-list li:last-child { border-bottom: none; }
+  .obs-list .ts { flex: none; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 9.5px; color: #8a94a3; }
+  .lvl { flex: none; font-size: 9px; font-weight: 800; letter-spacing: 0.5px; border-radius: 3px; padding: 1px 5px; }
+  .lvl-INFO { background: rgba(47,95,214,0.11); color: var(--accent); }
+  .lvl-WARN { background: rgba(154,108,0,0.13); color: #9a6c00; }
+  .lvl-ERROR { background: rgba(198,40,40,0.13); color: var(--red); }
+  .lvl-LESSON { background: rgba(15,118,110,0.13); color: #0f766e; }
+  .parking-list { list-style: none; margin: 0; padding: 0; }
+  .parking-list li { display: flex; gap: 8px; align-items: baseline; padding: 6px 8px; border: 1px solid var(--border); border-radius: 6px; margin-bottom: 6px; background: #fff; }
+  .parking-list .pt { flex: 1 1 auto; min-width: 0; }
+  .parking-list .pt .pid { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; color: var(--text-dim); margin-right: 6px; }
+  .parking-list .pn { display: block; color: var(--text-dim); font-size: 10.5px; margin-top: 2px; }
+  .lesson-list { list-style: none; margin: 0; padding: 0; }
+  .lesson-list li { padding: 6px 8px; border-left: 3px solid #0f766e; background: rgba(15,118,110,0.06); border-radius: 0 6px 6px 0; margin-bottom: 6px; font-size: 11.5px; }
+  .lesson-list .lts { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 9.5px; color: #8a94a3; margin-right: 6px; }
+  .lesson-list .litem { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; color: #0f766e; }
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="brand">
+    <span class="sigil">GRIND</span>
+    <h1 id="title">Grind</h1>
+  </div>
+  <div class="topmeta">
+    <span class="repo-chip" id="repo"></span>
+    <span class="gen-chip" id="last-generated" title="Timestamp of the last folded event — the board is as fresh as its log, never fresher."></span>
+    <div class="refresh-control">
+      <label><input type="checkbox" id="refresh-toggle"><span>auto-refresh</span></label>
+      <span id="refresh-status">off</span>
+    </div>
+  </div>
+  <p class="mission" id="mission"></p>
+</header>
+
+<div id="pause-banner" role="status">
+  <h2>⏸ Grind paused</h2>
+  <p class="reason" id="pause-reason"></p>
+  <ol id="pause-checklist"></ol>
+</div>
+
+<div id="attention-banner" role="alert">
+  <h2>⚠ Attention — needs the human</h2>
+  <ul id="attention-list"></ul>
+</div>
+
+<main class="board" id="board" aria-label="Lanes"></main>
+
+<div class="dock">
+  <section class="dock-panel" aria-label="Observations">
+    <h2>Observations <span class="count-tag" id="obs-count">0</span></h2>
+    <ul class="obs-list" id="obs-list"></ul>
+  </section>
+  <section class="dock-panel" aria-label="Parking lot">
+    <h2>Parking lot <span class="count-tag" id="park-count">0</span></h2>
+    <ul class="parking-list" id="parking-list"></ul>
+  </section>
+  <section class="dock-panel" aria-label="Lessons learned">
+    <h2>Lessons learned <span class="count-tag" id="lesson-count">0</span></h2>
+    <ul class="lesson-list" id="lesson-list"></ul>
+  </section>
+</div>
+
+<script id="grind-state">
+// Inlined fold State. SERIALIZATION CONTRACT: every less-than sign in the JSON
+// below is escaped as backslash-u003c before splicing, exactly as `grind render`
+// emits it. The disc-3 probe title proves the round-trip: it renders as inert
+// text below, it does not execute.
+const STATE = {
+  "title": "Discipline-Layer Grind — wgclw",
+  "repo": "scotthamilton77/agents-config",
+  "mission": "Re-architect the discipline layer around an event-sourced grind runtime; retire the bookkeeper agent and the hand-written ORCHESTRATION-STATE.md. Out of scope: PDLC-orchestrator design, PORT-track machine setup.",
+  "protocols": {
+    "review_protocol": "codex adversarial review, gpt-5.6-sol, --wait",
+    "merge_policy": "explicit — human instruction required",
+    "watcher_conventions": "dumb background pollers; ROOT interprets",
+    "session_grants": "one worktree per lane; no cross-lane writes"
+  },
+  "last_generated": "2026-07-19T04:12:08Z",
+  "pause": {
+    "paused": true,
+    "reason": "Human is picking a dashboard design from the wgclw.30.3 prototypes; implementation lanes hold until the renderer spec's UX section is amended with the choice.",
+    "resume_checklist": [
+      "Open prototypes/grind-dashboard/index.html and pick a winner (or a merge)",
+      "Amend the renderer spec's UX section with the chosen design",
+      "grind log grind_resumed"
+    ]
+  },
+  "attention": [
+    {
+      "text": "PR #346 reviewer stalemate — codex round 4 on unchanged head 9f31c2e with zero open threads. Merge ruling needed.",
+      "item": "wgclw.31.2"
+    },
+    {
+      "text": "Fold anomaly on wgclw.30.1 round 2: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 — recorded applied:false, counts use the latest event. Auto-raised by ERROR observation.",
+      "item": "wgclw.30.1"
+    },
+    {
+      "text": "Dashboard prototype pick outstanding — variation A, B, or C (or a merge). The pause holds until the UX section is amended."
+    }
+  ],
+  "lanes": [
+    {
+      "id": "lane-installer",
+      "name": "Lane 1 — installer",
+      "agent": "lt-installer",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "done",
+      "queue": [
+        {
+          "id": "wgclw.28.4",
+          "title": "Open the dashboard exactly once via the platform opener",
+          "status": "done",
+          "pr": { "number": 338, "url": null }
+        },
+        {
+          "id": "wgclw.29.2",
+          "title": "Receipt-tracked uv tool installs with prune-on-retire",
+          "status": "done",
+          "pr": { "number": 339, "url": null }
+        }
+      ]
+    },
+    {
+      "id": "lane-runtime",
+      "name": "Lane 2 — event runtime",
+      "agent": "lt-runtime",
+      "model": "opus",
+      "effort": "high",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "wgclw.30.1",
+          "title": "Event schema + pure fold with transition table and anomaly policy",
+          "status": "in-review",
+          "pr": { "number": 344, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 2,
+            "open_threads": 3,
+            "wont_fix_count": 1,
+            "stalemate": false,
+            "detail": "codex round 2 on 4b1a9d1: 3 open threads — torn-tail repair must fsync the quarantine sidecar; derived-unblock path lacks a cross-lane edge test; applied:false events vanish from the status envelope on replay. 1 wont-fix: unknown payload keys are tolerated by design.",
+            "findings": [
+              { "severity": "high", "summary": "Torn-tail repair moves the fragment to quarantine but never fsyncs the sidecar", "disposition": "fixed", "thread_url": null },
+              { "severity": "medium", "summary": "Derived unblocking is untested for edges that cross lane boundaries", "disposition": "deferred", "thread_url": null },
+              { "severity": "low", "summary": "Envelope validator silently tolerates unknown payload keys", "disposition": "wont-fix", "thread_url": null },
+              { "severity": "medium", "summary": "applied:false events vanish from the status envelope on replay", "disposition": "escalated", "thread_url": null }
+            ]
+          },
+          "note": "round 2 verdict: findings — triage in flight"
+        },
+        {
+          "id": "wgclw.30.2",
+          "title": "CLI verbs over the fold: create, log, status, render, check, finish",
+          "status": "queued"
+        },
+        {
+          "id": "wgclw.30.5",
+          "title": "Emit-back envelope + condition vocabulary",
+          "status": "blocked",
+          "blocked_on": ["wgclw.30.1"],
+          "note": "needs the fold contract to settle first"
+        }
+      ]
+    },
+    {
+      "id": "lane-dashboard",
+      "name": "Lane 3 — dashboard renderer",
+      "agent": "lt-dashboard",
+      "model": "sonnet",
+      "effort": "high",
+      "status": "in-progress",
+      "queue": [
+        {
+          "id": "wgclw.30.3",
+          "title": "grind render: deterministic projection from folded state to self-contained HTML",
+          "status": "in-progress",
+          "note": "prototyping session — this board is rendering its own fixture"
+        },
+        {
+          "id": "wgclw.30.4",
+          "title": "Observation routing: ERROR → attention, LESSON → lessons panel",
+          "status": "pr-open",
+          "pr": { "number": 345, "url": null }
+        },
+        {
+          "id": "wgclw.30.6",
+          "title": "Staleness watchdog: grind check + watchdog arming guidance",
+          "status": "merged",
+          "pr": { "number": 342, "url": null },
+          "note": "post-merge teardown leg outstanding"
+        }
+      ]
+    },
+    {
+      "id": "lane-watchers",
+      "name": "Lane 4 — watchers & probes",
+      "agent": "lt-watchers-2",
+      "model": "sonnet",
+      "effort": "low",
+      "status": "waiting-human",
+      "queue": [
+        {
+          "id": "wgclw.31.2",
+          "title": "Verdict-aware PR watcher with a written precedence contract",
+          "status": "waiting-human",
+          "pr": { "number": 346, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 4,
+            "open_threads": 0,
+            "wont_fix_count": 2,
+            "stalemate": true,
+            "detail": "codex round 4 re-raised 2 wont-fix items as new threads on unchanged head 9f31c2e — stalemate declared per the review skill's §3 rule. Awaiting the human's merge ruling."
+          },
+          "why": "Stalemate ruling needed: accept the reviewer's re-raise and rework, or merge over it with a recorded rationale."
+        },
+        {
+          "id": "wgclw.31.7",
+          "title": "Reconcile the shutdown ledger against the tracker directly when the grind's own projection disagrees with bead state at teardown time",
+          "status": "queued"
+        }
+      ]
+    },
+    {
+      "id": "lane-handoff",
+      "name": "Lane 5 — handoff & skill integration",
+      "agent": "lt-handoff",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "blocked",
+      "queue": [
+        {
+          "id": "disc-2",
+          "title": "Amend the renderer spec's UX section with the chosen prototype design",
+          "status": "queued",
+          "note": "surfaced by the .30.3 prototyping session"
+        },
+        {
+          "id": "wgclw.30.7",
+          "title": "SKILL.md integration: retire the bookkeeper and ORCHESTRATION-STATE.md",
+          "status": "blocked",
+          "blocked_on": ["wgclw.31.2"],
+          "note": "chain: wgclw.30.7 → wgclw.31.2 (waiting-human) — blocked_chain evidence"
+        }
+      ]
+    },
+    {
+      "id": "lane-port",
+      "name": "Lane 6 — portable layer",
+      "agent": "lt-port",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "standing-down",
+      "queue": []
+    },
+    {
+      "id": "lane-docs",
+      "name": "Lane 7 — docs & hardening",
+      "agent": "lt-docs",
+      "model": "haiku",
+      "effort": "low",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "disc-3",
+          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "status": "queued",
+          "note": "this very title is the serialization-contract probe"
+        },
+        {
+          "id": "wgclw.32.1",
+          "title": "User guide: run the opinionated agentic SDLC on the grind runtime — configuration, watchers, and overnight operations",
+          "status": "in-review",
+          "pr": { "number": 51, "url": "https://git.internal.example/scott/agents-config/pull/51" },
+          "review": {
+            "kind": "human",
+            "round": 1,
+            "open_threads": 1,
+            "wont_fix_count": 0,
+            "stalemate": false,
+            "detail": "human round 1: 1 open thread — tighten the watchdog arming prose; the dumb-poller rationale is buried in a footnote."
+          },
+          "note": "explicit PR url override — non-GitHub remote"
+        }
+      ]
+    }
+  ],
+  "parking_lot": [
+    {
+      "id": "disc-1",
+      "title": "Unify the prgroom and workcli envelope validators behind one shared module",
+      "kind": "discovered-work",
+      "note": "surfaced by PR #341 review; parked pending triage"
+    },
+    {
+      "id": "wgclw.33.1",
+      "title": "Supervised installer backfill sweep across both work machines",
+      "kind": "human-gated",
+      "note": "needs the human in the room"
+    },
+    {
+      "id": "uxns2.4",
+      "title": "PORT-track skill parity audit for Gemini and OpenCode",
+      "kind": "later-wave",
+      "note": "wave-2 scope, parked at partition"
+    },
+    {
+      "id": "vaac.9",
+      "title": "Merge-guard judge prompt v3 tuning against the last twenty rulings",
+      "kind": "deferred",
+      "note": "current judge passing; revisit post-M3"
+    }
+  ],
+  "observations": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "level": "LESSON",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6",
+      "lane": "lane-dashboard"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "level": "LESSON",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    },
+    {
+      "ts": "2026-07-19T02:58:11Z",
+      "level": "INFO",
+      "message": "lane_handover recorded on lane-watchers: lt-watchers → lt-watchers-2 (haiku·low → sonnet·low), reason: context exhaustion.",
+      "lane": "lane-watchers"
+    },
+    {
+      "ts": "2026-07-19T03:40:02Z",
+      "level": "WARN",
+      "message": "stale_item condition fired for disc-2 — no events referencing it for 47m (threshold 45m).",
+      "item": "disc-2",
+      "lane": "lane-handoff"
+    },
+    {
+      "ts": "2026-07-19T03:52:44Z",
+      "level": "ERROR",
+      "message": "Anomaly: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 for wgclw.30.1 round 2 — recorded applied:false; counts use the latest event.",
+      "item": "wgclw.30.1",
+      "lane": "lane-runtime"
+    }
+  ],
+  "lessons": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    }
+  ],
+  "merged_ledger": [
+    { "pr": 338, "title": "Open the dashboard exactly once via the platform opener", "sha": "8c21de4", "lane": "lane-installer" },
+    { "pr": 339, "title": "Receipt-tracked uv tool installs with prune-on-retire", "sha": "b07a1c9", "lane": "lane-installer" },
+    { "pr": 342, "title": "Staleness watchdog: grind check + watchdog arming guidance", "sha": "9f31c2e", "lane": "lane-dashboard" }
+  ],
+  "closed_ledger": [
+    { "id": "wgclw.29.9", "title": "Spike: incremental fold mode", "pr": 337, "reason": "superseded — refold-from-zero won on simplicity" }
+  ]
+};
+</script>
+
+<script>
+"use strict";
+
+// ---------- status vocabulary + icons (all nine statuses, neutral fallback) ----------
+const KNOWN_STATUSES = ["queued","in-progress","pr-open","in-review","merged","done","blocked","waiting-human","standing-down"];
+function statusCls(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? "st-" + k : "st-unknown";
+}
+const ICONS = {
+  "queued": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/>',
+  "in-progress": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/><path d="M8 2.5A5.5 5.5 0 0 1 8 13.5Z" fill="currentColor"/>',
+  "pr-open": '<circle cx="5" cy="4.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="5" cy="11.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="11" cy="8" r="2" fill="currentColor"/><path d="M5 6.5v3M6.8 8h2.2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "in-review": '<path d="M1.8 8C4 4.8 12 4.8 14.2 8 12 11.2 4 11.2 1.8 8Z" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="8" cy="8" r="1.9" fill="currentColor"/>',
+  "merged": '<circle cx="5" cy="4" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="11.5" cy="12" r="1.9" fill="currentColor"/><path d="M5 6v4M5 9.5c0 1.6 2 1 4 1.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "done": '<circle cx="8" cy="8" r="6.4" fill="currentColor"/><path d="M5.1 8.3l2 2 3.8-4.2" fill="none" stroke="#ffffff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>',
+  "blocked": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M4.2 11.8 11.8 4.2" stroke="currentColor" stroke-width="2"/>',
+  "waiting-human": '<circle cx="8" cy="5" r="2.5" fill="currentColor"/><path d="M3.2 13.4c.4-2.8 2.4-4.2 4.8-4.2s4.4 1.4 4.8 4.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  "standing-down": '<path d="M4.5 14V2.6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M4.5 3.2h7.6l-2.2 2.9 2.2 2.9H4.5Z" fill="currentColor"/>',
+  "unknown": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M6.4 6.3c.3-1.1 1-1.7 1.7-1.7 1 0 1.7.6 1.7 1.5 0 1.3-1.7 1.5-1.7 2.8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="8.1" cy="11.5" r="1" fill="currentColor"/>'
+};
+function iconName(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? k : "unknown";
+}
+function iconSvg(status, size) {
+  const s = size || 14;
+  return '<svg class="icon" width="' + s + '" height="' + s + '" viewBox="0 0 16 16" aria-hidden="true" focusable="false">' +
+    (ICONS[iconName(status)] || ICONS.unknown) + '</svg>';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+// Explicit url wins (scheme-checked); otherwise derive from the repo slug; else plain text.
+function safeHref(url) {
+  try {
+    const scheme = new URL(url, "https://github.com").protocol;
+    return (scheme === "https:" || scheme === "http:") ? url : null;
+  } catch (e) { return null; }
+}
+function prUrl(pr, repo) {
+  if (!pr) return null;
+  if (typeof pr.url === "string" && pr.url.trim() !== "") {
+    const safe = safeHref(pr.url.trim());
+    if (safe) return safe;
+  }
+  if (repo) return "https://github.com/" + repo + "/pull/" + pr.number;
+  return null;
+}
+function prLink(pr, repo) {
+  if (!pr) return "";
+  const url = prUrl(pr, repo);
+  const label = "#" + escapeHtml(pr.number);
+  return url
+    ? '<a class="pr-link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener">' + label + '</a>'
+    : '<span class="pr-plain">' + label + '</span>';
+}
+
+// Review bits: round badge (hidden at done — a high round count survives as a
+// LESSON, not a badge on finished work), stalemate flag, full-label open-thread
+// pill with the review detail as its tooltip, wont-fix count.
+function reviewBits(review, itemStatus) {
+  if (!review) return "";
+  let out = "";
+  const stale = !!review.stalemate;
+  if (String(itemStatus).toLowerCase() !== "done") {
+    out += '<span class="pill pill-round' + (stale ? " is-stalemate" : "") + '">' +
+      escapeHtml(review.kind || "review") + " · round " + (Number(review.round) || 0) + "</span>";
+  }
+  if (stale) out += '<span class="pill pill-stalemate">stalemate</span>';
+  const n = Number(review.open_threads) || 0;
+  if (n > 0) {
+    const label = n === 1 ? "1 open thread" : n + " open threads";
+    const tip = review.detail ? ' title="' + escapeHtml(review.detail) + '"' : "";
+    out += '<span class="pill pill-threads"' + tip + ">" + label + "</span>";
+  }
+  const wf = Number(review.wont_fix_count) || 0;
+  if (wf > 0) out += '<span class="pill pill-wontfix">' + wf + (wf === 1 ? " wont-fix" : " wont-fix") + "</span>";
+  return out;
+}
+
+const KNOWN_KINDS = ["discovered-work","human-gated","later-wave","deferred"];
+function kindChip(kind) {
+  const k = String(kind || "").toLowerCase();
+  const cls = KNOWN_KINDS.indexOf(k) >= 0 ? "kind-" + k : "kind-unknown";
+  return '<span class="kind ' + cls + '">' + escapeHtml(kind || "unknown") + "</span>";
+}
+function sevChip(sev) {
+  const k = String(sev || "").toLowerCase();
+  const cls = ["high","medium","low"].indexOf(k) >= 0 ? "sev-" + k : "sev-unknown";
+  return '<span class="sev ' + cls + '">' + escapeHtml(sev || "?") + "</span>";
+}
+function dispTag(d) {
+  const k = String(d || "").toLowerCase();
+  return '<span class="disp disp-' + escapeHtml(k) + '">' + escapeHtml(d || "") + "</span>";
+}
+
+// ---------- per-lane collapse, persisted (done lanes auto-collapse by default) ----------
+const LS_COLLAPSE = "grindproto.a.collapsed.v1";
+let collapsePrefs = {};
+try { collapsePrefs = JSON.parse(localStorage.getItem(LS_COLLAPSE) || "{}") || {}; } catch (e) { collapsePrefs = {}; }
+function laneById(id) { return (STATE.lanes || []).find(l => l.id === id); }
+function isCollapsed(lane) {
+  if (Object.prototype.hasOwnProperty.call(collapsePrefs, lane.id)) return !!collapsePrefs[lane.id];
+  return String(lane.status).toLowerCase() === "done";
+}
+function toggleLane(id) {
+  const lane = laneById(id);
+  if (!lane) return;
+  collapsePrefs[id] = !isCollapsed(lane);
+  try { localStorage.setItem(LS_COLLAPSE, JSON.stringify(collapsePrefs)); } catch (e) {}
+  renderBoard();
+}
+
+// ---------- renderers ----------
+function renderItemExpanded(q) {
+  const cls = statusCls(q.status);
+  let html = '<article class="item ' + cls + '">' +
+    '<div class="item-top">' + iconSvg(q.status) +
+      '<span class="item-id">' + escapeHtml(q.id) + "</span>" + prLink(q.pr, STATE.repo) + "</div>" +
+    '<div class="item-title">' + escapeHtml(q.title) + "</div>" +
+    '<div class="item-badges"><span class="pill ' + cls + '">' + escapeHtml(q.status) + "</span>" +
+      reviewBits(q.review, q.status) + "</div>";
+  if (q.why) html += '<div class="item-why"><strong>Awaiting human:</strong> ' + escapeHtml(q.why) + "</div>";
+  if (q.note) html += '<div class="item-note">' + escapeHtml(q.note) + "</div>";
+  if (q.blocked_on && q.blocked_on.length) {
+    html += '<div class="item-blockers">blocked on ' +
+      q.blocked_on.map(b => '<span class="chip chip-blocker">' + escapeHtml(b) + "</span>").join(" ") + "</div>";
+  }
+  if (q.review && q.review.findings && q.review.findings.length) {
+    html += '<ul class="findings">' + q.review.findings.map(f =>
+      "<li>" + sevChip(f.severity) + "<span>" + escapeHtml(f.summary) + "</span>" + dispTag(f.disposition) + "</li>"
+    ).join("") + "</ul>";
+  }
+  return html + "</article>";
+}
+
+// Collapsed anatomy: status icon + work-item id + title + PR# — notes and the
+// agent/activity line dropped, column at exactly half width.
+function renderItemSlim(q) {
+  return '<div class="item-slim ' + statusCls(q.status) + '">' + iconSvg(q.status, 12) +
+    '<span class="item-id">' + escapeHtml(q.id) + "</span>" +
+    '<span class="t" title="' + escapeHtml(q.title) + '">' + escapeHtml(q.title) + "</span>" +
+    prLink(q.pr, STATE.repo) + "</div>";
+}
+
+function renderBoard() {
+  const board = document.getElementById("board");
+  board.innerHTML = "";
+  (STATE.lanes || []).forEach(lane => {
+    const collapsed = isCollapsed(lane);
+    const cls = statusCls(lane.status);
+    const sec = document.createElement("section");
+    sec.className = "lane " + cls + (collapsed ? " collapsed" : "");
+    sec.setAttribute("aria-label", lane.name);
+    const bodyId = "lane-body-" + lane.id;
+    const items = (lane.queue || []);
+    const body = items.length
+      ? items.map(q => collapsed ? renderItemSlim(q) : renderItemExpanded(q)).join("")
+      : '<div class="queue-empty">queue empty — wrapping up</div>';
+    sec.innerHTML =
+      '<header class="lane-head">' +
+        '<span class="lane-icon">' + iconSvg(lane.status, 16) + "</span>" +
+        '<div class="lane-titles"><h2>' + escapeHtml(lane.name) + "</h2>" +
+        '<div class="lane-sub">' + escapeHtml(lane.agent) + " · " + escapeHtml(lane.model || "") + " · " + escapeHtml(lane.effort || "") + " effort</div></div>" +
+        '<span class="pill ' + cls + '">' + escapeHtml(lane.status) + "</span>" +
+        '<button type="button" class="lane-toggle" aria-expanded="' + (collapsed ? "false" : "true") + '" aria-controls="' + bodyId + '" ' +
+          'title="' + (collapsed ? "Expand " : "Collapse ") + escapeHtml(lane.name) + '" data-lane="' + escapeHtml(lane.id) + '">' +
+          (collapsed ? "»" : "«") + "</button>" +
+      "</header>" +
+      '<div class="lane-body" id="' + bodyId + '">' + body + "</div>";
+    board.appendChild(sec);
+  });
+  board.querySelectorAll(".lane-toggle").forEach(btn =>
+    btn.addEventListener("click", () => toggleLane(btn.getAttribute("data-lane"))));
+}
+
+function renderDock() {
+  const obs = (STATE.observations || []).slice().reverse();
+  document.getElementById("obs-count").textContent = obs.length;
+  document.getElementById("obs-list").innerHTML = obs.map(o =>
+    "<li><span class='ts'>" + escapeHtml((o.ts || "").replace("T", " ")) + "</span>" +
+    '<span class="lvl lvl-' + escapeHtml(o.level || "INFO") + '">' + escapeHtml(o.level || "INFO") + "</span>" +
+    "<span>" + escapeHtml(o.message) +
+      (o.item ? ' <span class="chip">' + escapeHtml(o.item) + "</span>" : "") + "</span></li>"
+  ).join("");
+
+  const parked = STATE.parking_lot || [];
+  document.getElementById("park-count").textContent = parked.length;
+  document.getElementById("parking-list").innerHTML = parked.map(p =>
+    "<li>" + kindChip(p.kind) +
+    '<span class="pt"><span class="pid">' + escapeHtml(p.id) + "</span>" + escapeHtml(p.title) +
+    (p.note ? '<span class="pn">' + escapeHtml(p.note) + "</span>" : "") + "</span></li>"
+  ).join("");
+
+  const lessons = STATE.lessons || [];
+  document.getElementById("lesson-count").textContent = lessons.length;
+  document.getElementById("lesson-list").innerHTML = lessons.map(l =>
+    "<li><span class='lts'>" + escapeHtml(l.ts || "") + "</span>" +
+    (l.item ? '<span class="litem">' + escapeHtml(l.item) + "</span> " : "") +
+    escapeHtml(l.message) + "</li>"
+  ).join("");
+}
+
+function render() {
+  document.title = (STATE.title || "Grind") + " — Control Room";
+  document.getElementById("title").textContent = STATE.title || "Grind";
+  document.getElementById("mission").textContent = STATE.mission || "";
+  document.getElementById("repo").textContent = STATE.repo || "no repo slug";
+  // From state, never a wall clock: the board is as fresh as its log.
+  document.getElementById("last-generated").textContent = "log @ " + (STATE.last_generated || "—");
+
+  const pause = STATE.pause;
+  const pb = document.getElementById("pause-banner");
+  if (pause && pause.paused) {
+    pb.classList.add("show");
+    document.getElementById("pause-reason").textContent = pause.reason || "";
+    document.getElementById("pause-checklist").innerHTML =
+      (pause.resume_checklist || []).map(c => "<li>" + escapeHtml(c) + "</li>").join("");
+  } else { pb.classList.remove("show"); }
+
+  const attn = STATE.attention || [];
+  const ab = document.getElementById("attention-banner");
+  const al = document.getElementById("attention-list");
+  if (attn.length) {
+    ab.classList.add("show");
+    al.innerHTML = attn.map(a =>
+      "<li>" + escapeHtml(a.text) + (a.item ? '<span class="attn-item-chip">' + escapeHtml(a.item) + "</span>" : "") + "</li>"
+    ).join("");
+  } else { ab.classList.remove("show"); al.innerHTML = ""; }
+
+  renderBoard();
+  renderDock();
+}
+
+render();
+
+// ---------- auto-refresh (15s, visible toggle, persisted; reload is a no-op in this static prototype) ----------
+const REFRESH_SECONDS = 15;
+const LS_REFRESH = "grindproto.a.autorefresh.v1";
+const toggle = document.getElementById("refresh-toggle");
+const statusEl = document.getElementById("refresh-status");
+let countdown = REFRESH_SECONDS, tickTimer = null;
+function updateStatusText() { statusEl.textContent = toggle.checked ? ("on — " + countdown + "s") : "off"; }
+function startTicking() {
+  if (tickTimer) clearInterval(tickTimer);
+  countdown = REFRESH_SECONDS; updateStatusText();
+  tickTimer = setInterval(() => {
+    countdown -= 1;
+    if (countdown <= 0) { location.reload(); return; }
+    updateStatusText();
+  }, 1000);
+}
+function stopTicking() { if (tickTimer) clearInterval(tickTimer); tickTimer = null; updateStatusText(); }
+let savedRefresh = null;
+try { savedRefresh = localStorage.getItem(LS_REFRESH); } catch (e) { savedRefresh = null; }
+toggle.checked = savedRefresh === null ? true : savedRefresh === "true";
+toggle.addEventListener("change", () => {
+  try { localStorage.setItem(LS_REFRESH, toggle.checked ? "true" : "false"); } catch (e) {}
+  if (toggle.checked) startTicking(); else stopTicking();
+});
+if (toggle.checked) startTicking(); else stopTicking();
+</script>
+
+</body>
+</html>

--- a/docs/prototypes/grind-dashboard/variation-b.html
+++ b/docs/prototypes/grind-dashboard/variation-b.html
@@ -1,0 +1,815 @@
+<!DOCTYPE html>
+<!--
+  VARIATION B — "OPS REVIEW"
+  Row-per-lane horizontal swimlanes. Text-forward, calm and spacious:
+  serif headings, generous whitespace, prose-like review summaries.
+  Same fixture state as variations A and C, inlined below with every
+  less-than sign in the JSON escaped as the JSON escape backslash-u003c
+  (the grind serialization contract). Light theme only.
+  Self-contained: no fetches, no CDNs; works from file://.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Grind — Ops Review</title>
+<style>
+  :root {
+    --paper: #faf9f6;
+    --card: #ffffff;
+    --ink: #23272e;
+    --muted: #5b6470;
+    --faint: #8a93a0;
+    --line: #e3e1db;
+    --accent: #2f5fd6;
+    --red: #b3322c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 15px; line-height: 1.6;
+  }
+  .wrap { max-width: 1180px; margin: 0 auto; padding: 40px 32px 64px; }
+  a { color: var(--accent); }
+  a:focus-visible, button:focus-visible, summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+
+  /* status palette — one --c per status; unknown degrades to neutral gray */
+  .st-queued        { --c: #6e7681; --cbg: rgba(110,118,129,0.10); }
+  .st-in-progress   { --c: #2f5fd6; --cbg: rgba(47,95,214,0.09); }
+  .st-pr-open       { --c: #7c3aed; --cbg: rgba(124,58,237,0.09); }
+  .st-in-review     { --c: #96700a; --cbg: rgba(150,112,10,0.10); }
+  .st-merged        { --c: #1e8e3e; --cbg: rgba(30,142,62,0.09); }
+  .st-done          { --c: #0f7b3f; --cbg: rgba(15,123,63,0.13); }
+  .st-blocked       { --c: #b3322c; --cbg: rgba(179,50,44,0.09); }
+  .st-waiting-human { --c: #a34d0e; --cbg: rgba(163,77,14,0.10); }
+  .st-standing-down { --c: #64748b; --cbg: rgba(100,116,139,0.12); }
+  .st-unknown       { --c: #8a93a0; --cbg: rgba(138,147,160,0.12); }
+
+  .icon { vertical-align: -2px; }
+
+  /* ---- masthead ---- */
+  .kicker {
+    font-size: 11px; letter-spacing: 2.5px; text-transform: uppercase;
+    color: var(--faint); margin: 0 0 6px;
+  }
+  h1 {
+    font-family: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    font-size: 34px; font-weight: 600; margin: 0 0 10px; letter-spacing: 0.2px;
+  }
+  .masthead .sub { color: var(--muted); margin: 0 0 6px; }
+  .masthead .sub .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+  .masthead { border-bottom: 1px solid var(--line); padding-bottom: 22px; margin-bottom: 22px; }
+  .refresh-line { display: flex; align-items: center; gap: 10px; margin-top: 12px; color: var(--muted); font-size: 13.5px; }
+  .refresh-line label { display: flex; align-items: center; gap: 7px; cursor: pointer; user-select: none; }
+  #refresh-status { font-variant-numeric: tabular-nums; color: var(--faint); }
+
+  /* ---- notices ---- */
+  .notice { border-radius: 10px; padding: 16px 20px; margin-bottom: 18px; background: var(--card); border: 1px solid var(--line); }
+  .notice h2 { font-family: Georgia, serif; font-size: 18px; margin: 0 0 6px; }
+  #attention-banner { display: none; border: 1px solid rgba(179,50,44,0.55); border-left: 5px solid var(--red); background: #fdf3f2; }
+  #attention-banner.show { display: block; }
+  #attention-banner h2 { color: var(--red); }
+  #attention-banner ul { margin: 6px 0 0; padding-left: 20px; }
+  #attention-banner li { margin-bottom: 6px; }
+  .attn-item-chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px;
+    background: #fff; border: 1px solid rgba(179,50,44,0.4); border-radius: 4px; padding: 0 6px; margin-left: 6px;
+  }
+  #pause-banner { display: none; border: 1px solid rgba(150,112,10,0.5); border-left: 5px solid #96700a; background: #fdf9ec; }
+  #pause-banner.show { display: block; }
+  #pause-banner h2 { color: #7a5d08; }
+  #pause-banner .reason { margin: 0 0 8px; color: #5b4a10; }
+  #pause-banner ol { margin: 0; padding-left: 20px; color: #5b4a10; font-size: 13.5px; }
+
+  /* ---- swimlanes ---- */
+  .swim { background: var(--card); border: 1px solid var(--line); border-radius: 12px; margin-bottom: 16px; overflow: hidden; }
+  .swim-head {
+    display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+    padding: 18px 22px 12px; border-bottom: 1px solid var(--line);
+  }
+  .swim-head h2 { font-family: Georgia, serif; font-size: 20px; font-weight: 600; margin: 0; }
+  .swim-head .owner { color: var(--muted); font-size: 13px; }
+  .swim-head .lane-state { margin-left: auto; display: flex; align-items: center; gap: 8px; color: var(--c); }
+  .status-word {
+    font-size: 12px; font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase;
+    color: var(--c); background: var(--cbg); border-radius: 999px; padding: 3px 11px;
+  }
+  .lane-toggle {
+    border: 1px solid var(--line); background: var(--paper); color: var(--muted);
+    border-radius: 6px; padding: 4px 12px; cursor: pointer; font-size: 12.5px;
+  }
+  .lane-toggle:hover { color: var(--ink); border-color: var(--faint); }
+
+  /* item strip: horizontal flow, scrolls sideways rather than squeezing */
+  .swim-items { display: flex; gap: 14px; padding: 18px 22px 20px; overflow-x: auto; }
+  .card {
+    flex: 0 0 320px; min-width: 320px; border: 1px solid var(--line); border-radius: 10px;
+    padding: 14px 16px; background: #fff; border-top: 3px solid var(--c);
+  }
+  .card .pos { font-family: Georgia, serif; font-style: italic; color: var(--faint); font-size: 12.5px; }
+  .card h3 { font-size: 15px; font-weight: 650; margin: 2px 0 8px; line-height: 1.4; overflow-wrap: break-word; }
+  .card .idline { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color: var(--faint); margin-bottom: 8px; }
+  .card .stateline { display: flex; align-items: center; gap: 7px; color: var(--c); margin-bottom: 8px; flex-wrap: wrap; }
+  .card .stateline .status-word { font-size: 11px; }
+  .pr-link { font-size: 13px; text-decoration: none; }
+  .pr-link:hover { text-decoration: underline; }
+  .pr-plain { color: var(--faint); font-size: 13px; }
+  .reviewline { font-size: 13.5px; color: var(--muted); margin: 6px 0 0; }
+  .reviewline .kind { font-weight: 650; color: var(--ink); }
+  .pill-threads {
+    display: inline-block; font-size: 12px; font-weight: 600; color: #7a5d08;
+    background: rgba(150,112,10,0.10); border-bottom: 1px dotted #96700a;
+    border-radius: 4px; padding: 1px 7px; cursor: help;
+  }
+  .pill-wontfix { display: inline-block; font-size: 12px; color: var(--muted); background: rgba(110,118,129,0.12); border-radius: 4px; padding: 1px 7px; }
+  .pill-stalemate {
+    display: inline-block; font-size: 11px; font-weight: 800; letter-spacing: 1px; text-transform: uppercase;
+    color: #fff; background: var(--red); border-radius: 4px; padding: 2px 8px;
+  }
+  .roundbadge { font-variant-numeric: tabular-nums; }
+  .roundbadge.is-stalemate { color: var(--red); }
+  .findings { margin: 10px 0 0; padding: 10px 0 0; border-top: 1px dashed var(--line); list-style: none; }
+  .findings li { font-size: 12.5px; color: var(--muted); padding: 3px 0 3px 14px; position: relative; }
+  .findings li::before { content: ""; position: absolute; left: 0; top: 10px; width: 6px; height: 6px; border-radius: 50%; background: var(--faint); }
+  .findings li.sev-high::before { background: var(--red); }
+  .findings li.sev-medium::before { background: #96700a; }
+  .findings li.sev-low::before { background: var(--faint); }
+  .findings .disp { font-style: italic; color: var(--faint); }
+  .note { font-size: 13px; color: var(--muted); font-style: italic; margin: 8px 0 0; }
+  .why {
+    font-size: 13px; color: #7a4a08; background: rgba(163,77,14,0.08);
+    border: 1px solid rgba(163,77,14,0.35); border-radius: 8px; padding: 7px 10px; margin-top: 10px;
+  }
+  .blockers { font-size: 12.5px; color: var(--red); margin-top: 8px; }
+  .blockers .chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11.5px;
+    border: 1px solid rgba(179,50,44,0.45); border-radius: 4px; padding: 0 6px; background: rgba(179,50,44,0.06);
+  }
+  .queue-empty { color: var(--faint); font-style: italic; padding: 18px 22px 20px; }
+
+  /* collapsed swimlane: one calm line, ~half the height, slim chips only */
+  .swim.collapsed .swim-head { border-bottom: none; padding: 12px 22px; }
+  .swim.collapsed .swim-items { padding: 0 22px 12px; gap: 8px; overflow-x: auto; }
+  .slim {
+    flex: none; display: inline-flex; align-items: center; gap: 6px;
+    border: 1px solid var(--line); border-radius: 999px; padding: 3px 10px;
+    font-size: 12.5px; color: var(--muted); max-width: 340px; background: #fff;
+  }
+  .slim .icon { color: var(--c); }
+  .slim .sid { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11px; color: var(--faint); }
+  .slim .st2 { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  .swim.collapsed .owner { display: none; } /* collapsed drops the agent/activity line */
+
+  /* ---- below the lanes ---- */
+  .twocol { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
+  @media (max-width: 860px) { .twocol { grid-template-columns: 1fr; } }
+  .panel { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 20px 22px; }
+  .panel h2 { font-family: Georgia, serif; font-size: 20px; margin: 0 0 4px; }
+  .panel .subtitle { color: var(--faint); font-size: 13px; margin: 0 0 14px; }
+  .kind { display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; border-radius: 4px; padding: 2px 8px; }
+  .kind-discovered-work { background: rgba(15,118,110,0.12); color: #0f766e; }
+  .kind-human-gated     { background: rgba(190,18,60,0.10); color: #a11240; }
+  .kind-later-wave      { background: rgba(67,56,202,0.10); color: #4338ca; }
+  .kind-deferred        { background: rgba(82,82,82,0.12);  color: #4c4c4c; }
+  .kind-unknown         { background: rgba(138,147,160,0.14); color: #6e7681; }
+  .parking-list { list-style: none; margin: 0; padding: 0; }
+  .parking-list li { padding: 10px 0; border-bottom: 1px solid var(--line); }
+  .parking-list li:last-child { border-bottom: none; }
+  .parking-list .pid { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color: var(--faint); margin-right: 8px; }
+  .parking-list .pn { display: block; color: var(--muted); font-size: 13px; margin-top: 3px; }
+  .lesson-list { list-style: none; margin: 0; padding: 0; }
+  .lesson-list li {
+    font-family: Georgia, serif; font-size: 15px; line-height: 1.55;
+    padding: 10px 0 10px 18px; border-left: 3px solid #0f766e; margin-bottom: 10px; color: #333a44;
+  }
+  .lesson-list .lmeta { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11px; color: var(--faint); margin-top: 5px; }
+  details.logbook { margin-top: 16px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 14px 22px; }
+  details.logbook summary { cursor: pointer; font-family: Georgia, serif; font-size: 17px; color: var(--muted); }
+  .obs-list { list-style: none; margin: 12px 0 4px; padding: 0; }
+  .obs-list li { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; border-bottom: 1px dashed var(--line); font-size: 13.5px; }
+  .obs-list li:last-child { border-bottom: none; }
+  .obs-list .ts { flex: none; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11.5px; color: var(--faint); }
+  .lvl { flex: none; font-size: 10px; font-weight: 800; letter-spacing: 0.8px; border-radius: 4px; padding: 2px 7px; }
+  .lvl-INFO { background: rgba(47,95,214,0.10); color: var(--accent); }
+  .lvl-WARN { background: rgba(150,112,10,0.12); color: #7a5d08; }
+  .lvl-ERROR { background: rgba(179,50,44,0.12); color: var(--red); }
+  .lvl-LESSON { background: rgba(15,118,110,0.12); color: #0f766e; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="masthead">
+    <p class="kicker">Grind operations review</p>
+    <h1 id="title">Grind</h1>
+    <p class="sub">
+      <span class="mono" id="repo"></span> ·
+      generated from the event log at <span class="mono" id="last-generated" title="Timestamp of the last folded event — the board is as fresh as its log, never fresher."></span>
+    </p>
+    <div class="refresh-line">
+      <label><input type="checkbox" id="refresh-toggle"> auto-refresh every 15s</label>
+      <span id="refresh-status">off</span>
+    </div>
+  </header>
+
+  <section id="pause-banner" class="notice" role="status">
+    <h2>This grind is paused</h2>
+    <p class="reason" id="pause-reason"></p>
+    <ol id="pause-checklist"></ol>
+  </section>
+
+  <section id="attention-banner" class="notice" role="alert">
+    <h2>Needs the human</h2>
+    <ul id="attention-list"></ul>
+  </section>
+
+  <main id="lanes" aria-label="Lanes"></main>
+
+  <div class="twocol">
+    <section class="panel" aria-label="Parking lot">
+      <h2>Parking lot</h2>
+      <p class="subtitle">Waiting, not blocked — deliberately excluded from this run.</p>
+      <ul class="parking-list" id="parking-list"></ul>
+    </section>
+    <section class="panel" aria-label="Lessons learned">
+      <h2>Lessons learned</h2>
+      <p class="subtitle">LESSON-level observations, captured as the grind runs.</p>
+      <ul class="lesson-list" id="lesson-list"></ul>
+    </section>
+  </div>
+
+  <details class="logbook">
+    <summary>Observation log (<span id="obs-count">0</span>)</summary>
+    <ul class="obs-list" id="obs-list"></ul>
+  </details>
+
+</div>
+
+<script id="grind-state">
+// Inlined fold State. SERIALIZATION CONTRACT: every less-than sign in the JSON
+// below is escaped as backslash-u003c before splicing, exactly as `grind render`
+// emits it. The disc-3 probe title proves the round-trip: it renders as inert
+// text below, it does not execute.
+const STATE = {
+  "title": "Discipline-Layer Grind — wgclw",
+  "repo": "scotthamilton77/agents-config",
+  "mission": "Re-architect the discipline layer around an event-sourced grind runtime; retire the bookkeeper agent and the hand-written ORCHESTRATION-STATE.md. Out of scope: PDLC-orchestrator design, PORT-track machine setup.",
+  "protocols": {
+    "review_protocol": "codex adversarial review, gpt-5.6-sol, --wait",
+    "merge_policy": "explicit — human instruction required",
+    "watcher_conventions": "dumb background pollers; ROOT interprets",
+    "session_grants": "one worktree per lane; no cross-lane writes"
+  },
+  "last_generated": "2026-07-19T04:12:08Z",
+  "pause": {
+    "paused": true,
+    "reason": "Human is picking a dashboard design from the wgclw.30.3 prototypes; implementation lanes hold until the renderer spec's UX section is amended with the choice.",
+    "resume_checklist": [
+      "Open prototypes/grind-dashboard/index.html and pick a winner (or a merge)",
+      "Amend the renderer spec's UX section with the chosen design",
+      "grind log grind_resumed"
+    ]
+  },
+  "attention": [
+    {
+      "text": "PR #346 reviewer stalemate — codex round 4 on unchanged head 9f31c2e with zero open threads. Merge ruling needed.",
+      "item": "wgclw.31.2"
+    },
+    {
+      "text": "Fold anomaly on wgclw.30.1 round 2: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 — recorded applied:false, counts use the latest event. Auto-raised by ERROR observation.",
+      "item": "wgclw.30.1"
+    },
+    {
+      "text": "Dashboard prototype pick outstanding — variation A, B, or C (or a merge). The pause holds until the UX section is amended."
+    }
+  ],
+  "lanes": [
+    {
+      "id": "lane-installer",
+      "name": "Lane 1 — installer",
+      "agent": "lt-installer",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "done",
+      "queue": [
+        {
+          "id": "wgclw.28.4",
+          "title": "Open the dashboard exactly once via the platform opener",
+          "status": "done",
+          "pr": { "number": 338, "url": null }
+        },
+        {
+          "id": "wgclw.29.2",
+          "title": "Receipt-tracked uv tool installs with prune-on-retire",
+          "status": "done",
+          "pr": { "number": 339, "url": null }
+        }
+      ]
+    },
+    {
+      "id": "lane-runtime",
+      "name": "Lane 2 — event runtime",
+      "agent": "lt-runtime",
+      "model": "opus",
+      "effort": "high",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "wgclw.30.1",
+          "title": "Event schema + pure fold with transition table and anomaly policy",
+          "status": "in-review",
+          "pr": { "number": 344, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 2,
+            "open_threads": 3,
+            "wont_fix_count": 1,
+            "stalemate": false,
+            "detail": "codex round 2 on 4b1a9d1: 3 open threads — torn-tail repair must fsync the quarantine sidecar; derived-unblock path lacks a cross-lane edge test; applied:false events vanish from the status envelope on replay. 1 wont-fix: unknown payload keys are tolerated by design.",
+            "findings": [
+              { "severity": "high", "summary": "Torn-tail repair moves the fragment to quarantine but never fsyncs the sidecar", "disposition": "fixed", "thread_url": null },
+              { "severity": "medium", "summary": "Derived unblocking is untested for edges that cross lane boundaries", "disposition": "deferred", "thread_url": null },
+              { "severity": "low", "summary": "Envelope validator silently tolerates unknown payload keys", "disposition": "wont-fix", "thread_url": null },
+              { "severity": "medium", "summary": "applied:false events vanish from the status envelope on replay", "disposition": "escalated", "thread_url": null }
+            ]
+          },
+          "note": "round 2 verdict: findings — triage in flight"
+        },
+        {
+          "id": "wgclw.30.2",
+          "title": "CLI verbs over the fold: create, log, status, render, check, finish",
+          "status": "queued"
+        },
+        {
+          "id": "wgclw.30.5",
+          "title": "Emit-back envelope + condition vocabulary",
+          "status": "blocked",
+          "blocked_on": ["wgclw.30.1"],
+          "note": "needs the fold contract to settle first"
+        }
+      ]
+    },
+    {
+      "id": "lane-dashboard",
+      "name": "Lane 3 — dashboard renderer",
+      "agent": "lt-dashboard",
+      "model": "sonnet",
+      "effort": "high",
+      "status": "in-progress",
+      "queue": [
+        {
+          "id": "wgclw.30.3",
+          "title": "grind render: deterministic projection from folded state to self-contained HTML",
+          "status": "in-progress",
+          "note": "prototyping session — this board is rendering its own fixture"
+        },
+        {
+          "id": "wgclw.30.4",
+          "title": "Observation routing: ERROR → attention, LESSON → lessons panel",
+          "status": "pr-open",
+          "pr": { "number": 345, "url": null }
+        },
+        {
+          "id": "wgclw.30.6",
+          "title": "Staleness watchdog: grind check + watchdog arming guidance",
+          "status": "merged",
+          "pr": { "number": 342, "url": null },
+          "note": "post-merge teardown leg outstanding"
+        }
+      ]
+    },
+    {
+      "id": "lane-watchers",
+      "name": "Lane 4 — watchers & probes",
+      "agent": "lt-watchers-2",
+      "model": "sonnet",
+      "effort": "low",
+      "status": "waiting-human",
+      "queue": [
+        {
+          "id": "wgclw.31.2",
+          "title": "Verdict-aware PR watcher with a written precedence contract",
+          "status": "waiting-human",
+          "pr": { "number": 346, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 4,
+            "open_threads": 0,
+            "wont_fix_count": 2,
+            "stalemate": true,
+            "detail": "codex round 4 re-raised 2 wont-fix items as new threads on unchanged head 9f31c2e — stalemate declared per the review skill's §3 rule. Awaiting the human's merge ruling."
+          },
+          "why": "Stalemate ruling needed: accept the reviewer's re-raise and rework, or merge over it with a recorded rationale."
+        },
+        {
+          "id": "wgclw.31.7",
+          "title": "Reconcile the shutdown ledger against the tracker directly when the grind's own projection disagrees with bead state at teardown time",
+          "status": "queued"
+        }
+      ]
+    },
+    {
+      "id": "lane-handoff",
+      "name": "Lane 5 — handoff & skill integration",
+      "agent": "lt-handoff",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "blocked",
+      "queue": [
+        {
+          "id": "disc-2",
+          "title": "Amend the renderer spec's UX section with the chosen prototype design",
+          "status": "queued",
+          "note": "surfaced by the .30.3 prototyping session"
+        },
+        {
+          "id": "wgclw.30.7",
+          "title": "SKILL.md integration: retire the bookkeeper and ORCHESTRATION-STATE.md",
+          "status": "blocked",
+          "blocked_on": ["wgclw.31.2"],
+          "note": "chain: wgclw.30.7 → wgclw.31.2 (waiting-human) — blocked_chain evidence"
+        }
+      ]
+    },
+    {
+      "id": "lane-port",
+      "name": "Lane 6 — portable layer",
+      "agent": "lt-port",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "standing-down",
+      "queue": []
+    },
+    {
+      "id": "lane-docs",
+      "name": "Lane 7 — docs & hardening",
+      "agent": "lt-docs",
+      "model": "haiku",
+      "effort": "low",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "disc-3",
+          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "status": "queued",
+          "note": "this very title is the serialization-contract probe"
+        },
+        {
+          "id": "wgclw.32.1",
+          "title": "User guide: run the opinionated agentic SDLC on the grind runtime — configuration, watchers, and overnight operations",
+          "status": "in-review",
+          "pr": { "number": 51, "url": "https://git.internal.example/scott/agents-config/pull/51" },
+          "review": {
+            "kind": "human",
+            "round": 1,
+            "open_threads": 1,
+            "wont_fix_count": 0,
+            "stalemate": false,
+            "detail": "human round 1: 1 open thread — tighten the watchdog arming prose; the dumb-poller rationale is buried in a footnote."
+          },
+          "note": "explicit PR url override — non-GitHub remote"
+        }
+      ]
+    }
+  ],
+  "parking_lot": [
+    {
+      "id": "disc-1",
+      "title": "Unify the prgroom and workcli envelope validators behind one shared module",
+      "kind": "discovered-work",
+      "note": "surfaced by PR #341 review; parked pending triage"
+    },
+    {
+      "id": "wgclw.33.1",
+      "title": "Supervised installer backfill sweep across both work machines",
+      "kind": "human-gated",
+      "note": "needs the human in the room"
+    },
+    {
+      "id": "uxns2.4",
+      "title": "PORT-track skill parity audit for Gemini and OpenCode",
+      "kind": "later-wave",
+      "note": "wave-2 scope, parked at partition"
+    },
+    {
+      "id": "vaac.9",
+      "title": "Merge-guard judge prompt v3 tuning against the last twenty rulings",
+      "kind": "deferred",
+      "note": "current judge passing; revisit post-M3"
+    }
+  ],
+  "observations": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "level": "LESSON",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6",
+      "lane": "lane-dashboard"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "level": "LESSON",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    },
+    {
+      "ts": "2026-07-19T02:58:11Z",
+      "level": "INFO",
+      "message": "lane_handover recorded on lane-watchers: lt-watchers → lt-watchers-2 (haiku·low → sonnet·low), reason: context exhaustion.",
+      "lane": "lane-watchers"
+    },
+    {
+      "ts": "2026-07-19T03:40:02Z",
+      "level": "WARN",
+      "message": "stale_item condition fired for disc-2 — no events referencing it for 47m (threshold 45m).",
+      "item": "disc-2",
+      "lane": "lane-handoff"
+    },
+    {
+      "ts": "2026-07-19T03:52:44Z",
+      "level": "ERROR",
+      "message": "Anomaly: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 for wgclw.30.1 round 2 — recorded applied:false; counts use the latest event.",
+      "item": "wgclw.30.1",
+      "lane": "lane-runtime"
+    }
+  ],
+  "lessons": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    }
+  ],
+  "merged_ledger": [
+    { "pr": 338, "title": "Open the dashboard exactly once via the platform opener", "sha": "8c21de4", "lane": "lane-installer" },
+    { "pr": 339, "title": "Receipt-tracked uv tool installs with prune-on-retire", "sha": "b07a1c9", "lane": "lane-installer" },
+    { "pr": 342, "title": "Staleness watchdog: grind check + watchdog arming guidance", "sha": "9f31c2e", "lane": "lane-dashboard" }
+  ],
+  "closed_ledger": [
+    { "id": "wgclw.29.9", "title": "Spike: incremental fold mode", "pr": 337, "reason": "superseded — refold-from-zero won on simplicity" }
+  ]
+};
+</script>
+
+<script id="grind-renderer">
+"use strict";
+// ---------- status vocabulary + icons (all nine statuses, neutral fallback) ----------
+const KNOWN_STATUSES = ["queued","in-progress","pr-open","in-review","merged","done","blocked","waiting-human","standing-down"];
+function statusCls(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? "st-" + k : "st-unknown";
+}
+const ICONS = {
+  "queued": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/>',
+  "in-progress": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/><path d="M8 2.5A5.5 5.5 0 0 1 8 13.5Z" fill="currentColor"/>',
+  "pr-open": '<circle cx="5" cy="4.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="5" cy="11.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="11" cy="8" r="2" fill="currentColor"/><path d="M5 6.5v3M6.8 8h2.2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "in-review": '<path d="M1.8 8C4 4.8 12 4.8 14.2 8 12 11.2 4 11.2 1.8 8Z" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="8" cy="8" r="1.9" fill="currentColor"/>',
+  "merged": '<circle cx="5" cy="4" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="11.5" cy="12" r="1.9" fill="currentColor"/><path d="M5 6v4M5 9.5c0 1.6 2 1 4 1.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "done": '<circle cx="8" cy="8" r="6.4" fill="currentColor"/><path d="M5.1 8.3l2 2 3.8-4.2" fill="none" stroke="#ffffff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>',
+  "blocked": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M4.2 11.8 11.8 4.2" stroke="currentColor" stroke-width="2"/>',
+  "waiting-human": '<circle cx="8" cy="5" r="2.5" fill="currentColor"/><path d="M3.2 13.4c.4-2.8 2.4-4.2 4.8-4.2s4.4 1.4 4.8 4.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  "standing-down": '<path d="M4.5 14V2.6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M4.5 3.2h7.6l-2.2 2.9 2.2 2.9H4.5Z" fill="currentColor"/>',
+  "unknown": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M6.4 6.3c.3-1.1 1-1.7 1.7-1.7 1 0 1.7.6 1.7 1.5 0 1.3-1.7 1.5-1.7 2.8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="8.1" cy="11.5" r="1" fill="currentColor"/>'
+};
+function iconName(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? k : "unknown";
+}
+function iconSvg(status, size) {
+  const s = size || 15;
+  return '<svg class="icon" width="' + s + '" height="' + s + '" viewBox="0 0 16 16" aria-hidden="true" focusable="false">' +
+    (ICONS[iconName(status)] || ICONS.unknown) + '</svg>';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+// Explicit url wins (scheme-checked); otherwise derive from the repo slug; else plain text.
+function safeHref(url) {
+  try {
+    const scheme = new URL(url, "https://github.com").protocol;
+    return (scheme === "https:" || scheme === "http:") ? url : null;
+  } catch (e) { return null; }
+}
+function prUrl(pr, repo) {
+  if (!pr) return null;
+  if (typeof pr.url === "string" && pr.url.trim() !== "") {
+    const safe = safeHref(pr.url.trim());
+    if (safe) return safe;
+  }
+  if (repo) return "https://github.com/" + repo + "/pull/" + pr.number;
+  return null;
+}
+function prLink(pr, repo) {
+  if (!pr) return "";
+  const url = prUrl(pr, repo);
+  const label = "PR #" + escapeHtml(pr.number);
+  return url
+    ? '<a class="pr-link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener">' + label + '</a>'
+    : '<span class="pr-plain">' + label + '</span>';
+}
+
+// Review summary: kind · round badge (hidden at done), stalemate flag,
+// full-label open-thread pill with the review detail as tooltip, wont-fix count.
+function reviewLine(review, itemStatus) {
+  if (!review) return "";
+  const parts = [];
+  const stale = !!review.stalemate;
+  if (String(itemStatus).toLowerCase() !== "done") {
+    parts.push('<span class="kind">' + escapeHtml(review.kind || "review") + '</span> review · <span class="roundbadge' +
+      (stale ? " is-stalemate" : "") + '">round ' + (Number(review.round) || 0) + "</span>");
+  }
+  const n = Number(review.open_threads) || 0;
+  if (n > 0) {
+    const label = n === 1 ? "1 open thread" : n + " open threads";
+    const tip = review.detail ? ' title="' + escapeHtml(review.detail) + '"' : "";
+    parts.push('<span class="pill-threads"' + tip + ">" + label + "</span>");
+  }
+  const wf = Number(review.wont_fix_count) || 0;
+  if (wf > 0) parts.push('<span class="pill-wontfix">' + wf + " wont-fix</span>");
+  if (stale) parts.push('<span class="pill-stalemate">stalemate</span>');
+  return parts.length ? '<p class="reviewline">' + parts.join(" · ") + "</p>" : "";
+}
+
+const KNOWN_KINDS = ["discovered-work","human-gated","later-wave","deferred"];
+function kindChip(kind) {
+  const k = String(kind || "").toLowerCase();
+  const cls = KNOWN_KINDS.indexOf(k) >= 0 ? "kind-" + k : "kind-unknown";
+  return '<span class="kind ' + cls + '">' + escapeHtml(kind || "unknown") + "</span>";
+}
+
+// ---------- per-lane collapse, persisted (done lanes auto-collapse by default) ----------
+const LS_COLLAPSE = "grindproto.b.collapsed.v1";
+let collapsePrefs = {};
+try { collapsePrefs = JSON.parse(localStorage.getItem(LS_COLLAPSE) || "{}") || {}; } catch (e) { collapsePrefs = {}; }
+function laneById(id) { return (STATE.lanes || []).find(l => l.id === id); }
+function isCollapsed(lane) {
+  if (Object.prototype.hasOwnProperty.call(collapsePrefs, lane.id)) return !!collapsePrefs[lane.id];
+  return String(lane.status).toLowerCase() === "done";
+}
+function toggleLane(id) {
+  const lane = laneById(id);
+  if (!lane) return;
+  collapsePrefs[id] = !isCollapsed(lane);
+  try { localStorage.setItem(LS_COLLAPSE, JSON.stringify(collapsePrefs)); } catch (e) {}
+  renderLanes();
+}
+
+// ---------- renderers ----------
+function renderCard(q, pos) {
+  const cls = statusCls(q.status);
+  let html = '<article class="card ' + cls + '">' +
+    '<span class="pos">queue position ' + pos + "</span>" +
+    "<h3>" + escapeHtml(q.title) + "</h3>" +
+    '<div class="idline">' + escapeHtml(q.id) + (q.pr ? " · " : "") + prLink(q.pr, STATE.repo) + "</div>" +
+    '<div class="stateline">' + iconSvg(q.status) + '<span class="status-word">' + escapeHtml(q.status) + "</span></div>" +
+    reviewLine(q.review, q.status);
+  if (q.why) html += '<div class="why"><strong>Awaiting human:</strong> ' + escapeHtml(q.why) + "</div>";
+  if (q.note) html += '<p class="note">' + escapeHtml(q.note) + "</p>";
+  if (q.blocked_on && q.blocked_on.length) {
+    html += '<div class="blockers">blocked on ' + q.blocked_on.map(b => '<span class="chip">' + escapeHtml(b) + "</span>").join(" ") + "</div>";
+  }
+  if (q.review && q.review.findings && q.review.findings.length) {
+    html += '<ul class="findings">' + q.review.findings.map(f => {
+      const sev = String(f.severity || "").toLowerCase();
+      const sevCls = ["high","medium","low"].indexOf(sev) >= 0 ? "sev-" + sev : "";
+      return '<li class="' + sevCls + '">' + escapeHtml(f.summary) +
+        ' <span class="disp">— ' + escapeHtml(f.disposition || "") + "</span></li>";
+    }).join("") + "</ul>";
+  }
+  return html + "</article>";
+}
+
+// Collapsed anatomy: status icon + work-item id + title + PR# — notes and the
+// agent/activity line dropped; the band compresses to roughly half height.
+function renderSlim(q) {
+  return '<span class="slim ' + statusCls(q.status) + '">' + iconSvg(q.status, 13) +
+    '<span class="sid">' + escapeHtml(q.id) + "</span>" +
+    '<span class="st2" title="' + escapeHtml(q.title) + '">' + escapeHtml(q.title) + "</span>" +
+    prLink(q.pr, STATE.repo) + "</span>";
+}
+
+function renderLanes() {
+  const host = document.getElementById("lanes");
+  host.innerHTML = "";
+  (STATE.lanes || []).forEach(lane => {
+    const collapsed = isCollapsed(lane);
+    const cls = statusCls(lane.status);
+    const sec = document.createElement("section");
+    sec.className = "swim " + cls + (collapsed ? " collapsed" : "");
+    sec.setAttribute("aria-label", lane.name);
+    const items = lane.queue || [];
+    const bodyId = "swim-items-" + lane.id;
+    let itemsHtml;
+    if (!items.length) {
+      itemsHtml = collapsed ? "" : '<div class="queue-empty">Queue empty — this lane is wrapping up.</div>';
+    } else if (collapsed) {
+      itemsHtml = items.map(renderSlim).join("");
+    } else {
+      itemsHtml = items.map((q, i) => renderCard(q, i + 1)).join("");
+    }
+    sec.innerHTML =
+      '<header class="swim-head">' +
+        "<h2>" + escapeHtml(lane.name) + "</h2>" +
+        '<span class="owner">owned by ' + escapeHtml(lane.agent) + " — " + escapeHtml(lane.model || "") + " · " + escapeHtml(lane.effort || "") + " effort</span>" +
+        '<span class="lane-state">' + iconSvg(lane.status, 16) + '<span class="status-word">' + escapeHtml(lane.status) + "</span></span>" +
+        '<button type="button" class="lane-toggle" aria-expanded="' + (collapsed ? "false" : "true") + '" aria-controls="' + bodyId + '" data-lane="' + escapeHtml(lane.id) + '">' +
+          (collapsed ? "Expand" : "Collapse") + "</button>" +
+      "</header>" +
+      '<div class="swim-items" id="' + bodyId + '">' + itemsHtml + "</div>";
+    host.appendChild(sec);
+  });
+  host.querySelectorAll(".lane-toggle").forEach(btn =>
+    btn.addEventListener("click", () => toggleLane(btn.getAttribute("data-lane"))));
+}
+
+function renderPanels() {
+  const parked = STATE.parking_lot || [];
+  document.getElementById("parking-list").innerHTML = parked.map(p =>
+    "<li>" + kindChip(p.kind) + ' <span class="pid">' + escapeHtml(p.id) + "</span>" + escapeHtml(p.title) +
+    (p.note ? '<span class="pn">' + escapeHtml(p.note) + "</span>" : "") + "</li>"
+  ).join("");
+
+  const lessons = STATE.lessons || [];
+  document.getElementById("lesson-list").innerHTML = lessons.map(l =>
+    "<li>" + escapeHtml(l.message) +
+    '<span class="lmeta">' + escapeHtml(l.ts || "") + (l.item ? " · " + escapeHtml(l.item) : "") + (l.lane ? " · " + escapeHtml(l.lane) : "") + "</span></li>"
+  ).join("");
+
+  const obs = (STATE.observations || []).slice().reverse();
+  document.getElementById("obs-count").textContent = obs.length;
+  document.getElementById("obs-list").innerHTML = obs.map(o =>
+    '<li><span class="ts">' + escapeHtml(o.ts || "") + "</span>" +
+    '<span class="lvl lvl-' + escapeHtml(o.level || "INFO") + '">' + escapeHtml(o.level || "INFO") + "</span>" +
+    "<span>" + escapeHtml(o.message) + (o.item ? " · " + escapeHtml(o.item) : "") + "</span></li>"
+  ).join("");
+}
+
+function render() {
+  document.title = (STATE.title || "Grind") + " — Ops Review";
+  document.getElementById("title").textContent = STATE.title || "Grind";
+  document.getElementById("repo").textContent = STATE.repo || "no repo slug";
+  // From state, never a wall clock: the board is as fresh as its log.
+  document.getElementById("last-generated").textContent = STATE.last_generated || "—";
+
+  const pause = STATE.pause;
+  const pb = document.getElementById("pause-banner");
+  if (pause && pause.paused) {
+    pb.classList.add("show");
+    document.getElementById("pause-reason").textContent = pause.reason || "";
+    document.getElementById("pause-checklist").innerHTML =
+      (pause.resume_checklist || []).map(c => "<li>" + escapeHtml(c) + "</li>").join("");
+  } else { pb.classList.remove("show"); }
+
+  const attn = STATE.attention || [];
+  const ab = document.getElementById("attention-banner");
+  const al = document.getElementById("attention-list");
+  if (attn.length) {
+    ab.classList.add("show");
+    al.innerHTML = attn.map(a =>
+      "<li>" + escapeHtml(a.text) + (a.item ? '<span class="attn-item-chip">' + escapeHtml(a.item) + "</span>" : "") + "</li>"
+    ).join("");
+  } else { ab.classList.remove("show"); al.innerHTML = ""; }
+
+  renderLanes();
+  renderPanels();
+}
+
+render();
+
+// ---------- auto-refresh (15s, visible toggle, persisted; reload is a no-op in this static prototype) ----------
+const REFRESH_SECONDS = 15;
+const LS_REFRESH = "grindproto.b.autorefresh.v1";
+const toggle = document.getElementById("refresh-toggle");
+const statusEl = document.getElementById("refresh-status");
+let countdown = REFRESH_SECONDS, tickTimer = null;
+function updateStatusText() { statusEl.textContent = toggle.checked ? ("on — reloading in " + countdown + "s") : "off"; }
+function startTicking() {
+  if (tickTimer) clearInterval(tickTimer);
+  countdown = REFRESH_SECONDS; updateStatusText();
+  tickTimer = setInterval(() => {
+    countdown -= 1;
+    if (countdown <= 0) { location.reload(); return; }
+    updateStatusText();
+  }, 1000);
+}
+function stopTicking() { if (tickTimer) clearInterval(tickTimer); tickTimer = null; updateStatusText(); }
+let savedRefresh = null;
+try { savedRefresh = localStorage.getItem(LS_REFRESH); } catch (e) { savedRefresh = null; }
+toggle.checked = savedRefresh === null ? true : savedRefresh === "true";
+toggle.addEventListener("change", () => {
+  try { localStorage.setItem(LS_REFRESH, toggle.checked ? "true" : "false"); } catch (e) {}
+  if (toggle.checked) startTicking(); else stopTicking();
+});
+if (toggle.checked) startTicking(); else stopTicking();
+</script>
+
+</body>
+</html>

--- a/docs/prototypes/grind-dashboard/variation-b.html
+++ b/docs/prototypes/grind-dashboard/variation-b.html
@@ -451,7 +451,7 @@ const STATE = {
       "queue": [
         {
           "id": "disc-3",
-          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "title": "Serializer hardening: a work-item title containing \\\"\u003c/script\u003e\\\" must render as inert text, never execute",
           "status": "queued",
           "note": "this very title is the serialization-contract probe"
         },

--- a/docs/prototypes/grind-dashboard/variation-c.html
+++ b/docs/prototypes/grind-dashboard/variation-c.html
@@ -487,7 +487,7 @@ const STATE = {
       "queue": [
         {
           "id": "disc-3",
-          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "title": "Serializer hardening: a work-item title containing \\\"\u003c/script\u003e\\\" must render as inert text, never execute",
           "status": "queued",
           "note": "this very title is the serialization-contract probe"
         },

--- a/docs/prototypes/grind-dashboard/variation-c.html
+++ b/docs/prototypes/grind-dashboard/variation-c.html
@@ -1,0 +1,959 @@
+<!DOCTYPE html>
+<!--
+  VARIATION C — "MISSION LOG"
+  Not a lane board at all: a mission-brief header with status lamps, a
+  stat-deck of clickable summary tiles, an operations register grouped by
+  lane with per-item drill-down, and a chronological ship's-log rail.
+  Same fixture state as variations A and B, inlined below with every
+  less-than sign in the JSON escaped as the JSON escape backslash-u003c
+  (the grind serialization contract). Light theme only.
+  Self-contained: no fetches, no CDNs; works from file://.
+-->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Grind — Mission Log</title>
+<style>
+  :root {
+    --bg: #f2f5f9; --panel: #ffffff; --panel-2: #eef2f7;
+    --border: #d2dae4; --ink: #16213a; --muted: #4d5a70; --faint: #7d8899;
+    --accent: #1d4fd7; --teal: #0f766e; --red: #c22f2f; --amber: #92670a;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 13.5px; line-height: 1.5; padding: 18px 22px 30px;
+  }
+  a { color: var(--accent); }
+  a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
+  .mono { font-family: var(--mono); }
+  .icon { vertical-align: -2px; }
+
+  .st-queued        { --c: #6e7681; --cbg: rgba(110,118,129,0.12); }
+  .st-in-progress   { --c: #1d4fd7; --cbg: rgba(29,79,215,0.11); }
+  .st-pr-open       { --c: #7c3aed; --cbg: rgba(124,58,237,0.11); }
+  .st-in-review     { --c: #92670a; --cbg: rgba(146,103,10,0.12); }
+  .st-merged        { --c: #1e8e3e; --cbg: rgba(30,142,62,0.11); }
+  .st-done          { --c: #0f7b3f; --cbg: rgba(15,123,63,0.16); }
+  .st-blocked       { --c: #c22f2f; --cbg: rgba(194,47,47,0.11); }
+  .st-waiting-human { --c: #a34d0e; --cbg: rgba(163,77,14,0.12); }
+  .st-standing-down { --c: #64748b; --cbg: rgba(100,116,139,0.14); }
+  .st-unknown       { --c: #8a93a0; --cbg: rgba(138,147,160,0.13); }
+
+  /* ---- mission brief header ---- */
+  .brief {
+    display: flex; justify-content: space-between; gap: 20px; flex-wrap: wrap;
+    background: var(--panel); border: 1px solid var(--border); border-left: 5px solid var(--ink);
+    border-radius: 10px; padding: 16px 20px; margin-bottom: 12px;
+  }
+  .kicker { font-family: var(--mono); font-size: 10.5px; letter-spacing: 2px; color: var(--faint); margin: 0 0 5px; }
+  h1 { font-size: 22px; margin: 0 0 6px; font-weight: 700; }
+  .mission { margin: 0 0 8px; color: var(--muted); max-width: 720px; font-size: 13px; }
+  .brief-meta { margin: 0; color: var(--faint); font-size: 12px; }
+  .brief-meta .mono { font-size: 11.5px; }
+  .brief-side { display: flex; flex-direction: column; gap: 10px; align-items: flex-end; }
+  .lamps { display: flex; gap: 8px; }
+  .lamp {
+    font-family: var(--mono); font-size: 10.5px; font-weight: 700; letter-spacing: 1px;
+    border: 1px solid var(--border); border-radius: 5px; padding: 4px 9px;
+    color: var(--faint); background: var(--panel-2);
+  }
+  .lamp.on-pause { color: #6b4e00; background: #fff3d6; border-color: #d9a514; }
+  .lamp.on-attn { color: #fff; background: var(--red); border-color: var(--red); }
+  .lamp.on-run { color: #0f7b3f; background: rgba(15,123,63,0.10); border-color: rgba(15,123,63,0.4); }
+  .refresh-control {
+    display: flex; align-items: center; gap: 7px;
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px; font-size: 12px;
+  }
+  .refresh-control label { display: flex; align-items: center; gap: 6px; cursor: pointer; user-select: none; }
+  #refresh-status { font-variant-numeric: tabular-nums; min-width: 74px; color: var(--muted); font-size: 11.5px; }
+
+  /* ---- banners ---- */
+  #attention-banner {
+    display: none; background: #fdeaea; border: 1px solid var(--red); border-left-width: 5px;
+    color: #7a1a1a; border-radius: 8px; padding: 10px 16px; margin-bottom: 12px;
+  }
+  #attention-banner.show { display: block; }
+  #attention-banner h2 { margin: 0 0 6px; font-size: 12px; letter-spacing: 1px; color: var(--red); text-transform: uppercase; }
+  #attention-banner ul { margin: 0; padding-left: 18px; }
+  #attention-banner li { margin-bottom: 4px; }
+  .attn-item-chip { font-family: var(--mono); font-size: 10.5px; background: #fff; border: 1px solid rgba(194,47,47,0.4); border-radius: 3px; padding: 0 5px; margin-left: 5px; }
+  #pause-banner {
+    display: none; background: #fff7e6; border: 1px solid #d9a514; border-left-width: 5px;
+    color: #6b4e00; border-radius: 8px; padding: 10px 16px; margin-bottom: 12px;
+  }
+  #pause-banner.show { display: block; }
+  #pause-banner h2 { margin: 0 0 4px; font-size: 12px; letter-spacing: 1px; color: #8a6500; text-transform: uppercase; }
+  #pause-banner .reason { margin: 0 0 6px; }
+  #pause-banner ol { margin: 0; padding-left: 20px; font-size: 12px; }
+
+  /* ---- stat deck ---- */
+  .statdeck { display: grid; grid-template-columns: repeat(auto-fill, minmax(128px, 1fr)); gap: 8px; margin-bottom: 14px; }
+  .tile {
+    background: var(--panel); border: 1px solid var(--border); border-top: 3px solid var(--c, var(--border));
+    border-radius: 8px; padding: 9px 11px; cursor: pointer; text-align: left;
+    font: inherit; color: inherit;
+  }
+  .tile:hover { background: var(--panel-2); }
+  .tile.active { outline: 2px solid var(--accent); outline-offset: 1px; }
+  .tile .num { font-size: 22px; font-weight: 750; font-variant-numeric: tabular-nums; color: var(--c, var(--ink)); }
+  .tile .lbl { display: flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 650; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .tile .sub { font-size: 10.5px; color: var(--faint); }
+
+  /* ---- split: register + rail ---- */
+  .split { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 12px; align-items: start; }
+  @media (max-width: 980px) { .split { grid-template-columns: 1fr; } }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; margin-bottom: 12px; }
+  .panel h2 { margin: 0 0 10px; font-size: 12px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--muted); display: flex; align-items: center; gap: 7px; }
+  .count-tag { font-size: 10px; font-weight: 700; background: var(--panel-2); border: 1px solid var(--border); color: var(--muted); padding: 0 7px; border-radius: 999px; }
+
+  /* ---- operations register ---- */
+  .reg-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+  .reg-head h2 { margin: 0; font-size: 15px; }
+  #filter-note { font-size: 11.5px; color: var(--accent); }
+  #filter-note button { border: none; background: none; color: var(--accent); cursor: pointer; font: inherit; text-decoration: underline; padding: 0; }
+  .reg-group { border: 1px solid var(--border); border-radius: 8px; margin-bottom: 8px; overflow: hidden; background: var(--panel); }
+  .group-head {
+    display: flex; align-items: center; gap: 9px; width: 100%; text-align: left;
+    background: var(--panel-2); border: none; border-left: 4px solid var(--c, var(--border));
+    padding: 9px 12px; cursor: pointer; font: inherit; color: inherit;
+  }
+  .group-head:hover { background: #e6ecf4; }
+  .group-head .twisty { color: var(--faint); font-size: 11px; width: 12px; }
+  .group-head .gicon { color: var(--c); display: inline-flex; }
+  .group-head .gname { font-weight: 700; font-size: 13px; }
+  .group-head .gagent { color: var(--faint); font-size: 11px; }
+  .group-head .gcount { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .pill {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 1px 7px; border-radius: 999px; font-size: 10.5px; font-weight: 650;
+    background: var(--cbg); color: var(--c); white-space: nowrap;
+  }
+  .pill-round { background: rgba(29,79,215,0.10); color: var(--accent); font-variant-numeric: tabular-nums; }
+  .pill-round.is-stalemate { background: rgba(194,47,47,0.12); color: var(--red); }
+  .pill-stalemate { background: var(--red); color: #fff; text-transform: uppercase; letter-spacing: 0.6px; font-size: 9.5px; }
+  .pill-threads { background: rgba(146,103,10,0.12); color: var(--amber); cursor: help; border-bottom: 1px dotted var(--amber); }
+  .pill-wontfix { background: rgba(110,118,129,0.14); color: #525c69; }
+  .table-scroll { overflow-x: auto; }
+  .reg-table { width: 100%; min-width: 860px; border-collapse: collapse; font-size: 12.5px; }
+  .reg-table th {
+    text-align: left; font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px;
+    color: var(--faint); font-weight: 600; padding: 6px 10px; border-bottom: 1px solid var(--border);
+  }
+  .reg-table td { padding: 7px 10px; border-bottom: 1px solid var(--panel-2); vertical-align: top; }
+  .reg-table tr.item-row:last-child td { border-bottom: none; }
+  .reg-table tr.item-row { cursor: pointer; }
+  .reg-table tr.item-row:hover td { background: #f6f9fd; }
+  .reg-table tr.item-row.drilled td { background: #eef4fd; }
+  .reg-table .c-icon { width: 26px; color: var(--c); }
+  .reg-table .c-id { font-family: var(--mono); font-size: 11px; color: var(--muted); white-space: nowrap; }
+  .reg-table .c-title { min-width: 220px; }
+  .reg-table .c-title .sub-note { display: block; font-size: 11px; color: var(--faint); font-style: italic; }
+  .reg-table .c-review { min-width: 200px; }
+  .reg-table .c-review .pill { margin: 0 3px 3px 0; }
+  .reg-table .c-drill { width: 30px; text-align: right; color: var(--faint); }
+  .reg-table tr.hidden-by-filter { display: none; }
+  .reg-group.hidden-by-filter { display: none; }
+  .pr-link { font-size: 12px; text-decoration: none; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .pr-link:hover { text-decoration: underline; }
+  .pr-plain { color: var(--faint); font-size: 12px; }
+
+  /* drill-down drawer */
+  tr.drill td { background: #f6f9fd; border-bottom: 1px solid var(--border); padding: 10px 14px 12px 36px; }
+  .drill-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  @media (max-width: 1100px) { .drill-grid { grid-template-columns: 1fr; } }
+  .drill h4 { margin: 0 0 5px; font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.7px; color: var(--faint); }
+  .drill p { margin: 0 0 8px; font-size: 12.5px; color: var(--muted); }
+  .drill .why { color: #7a4a08; background: rgba(163,77,14,0.08); border: 1px solid rgba(163,77,14,0.35); border-radius: 6px; padding: 6px 9px; font-size: 12px; }
+  .chip-blocker { font-family: var(--mono); font-size: 10.5px; border: 1px solid rgba(194,47,47,0.45); color: var(--red); background: rgba(194,47,47,0.06); border-radius: 4px; padding: 1px 6px; }
+  .f-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .f-table th { text-align: left; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--faint); padding: 3px 8px 3px 0; border-bottom: 1px solid var(--border); }
+  .f-table td { padding: 4px 8px 4px 0; border-bottom: 1px dashed var(--panel-2); vertical-align: top; }
+  .sev { font-size: 9px; font-weight: 800; letter-spacing: 0.5px; text-transform: uppercase; border-radius: 3px; padding: 1px 5px; }
+  .sev-high { background: rgba(194,47,47,0.13); color: var(--red); }
+  .sev-medium { background: rgba(146,103,10,0.13); color: var(--amber); }
+  .sev-low { background: rgba(110,118,129,0.14); color: #525c69; }
+  .disp { font-style: italic; color: var(--muted); font-size: 11px; }
+  .detail-quote { border-left: 3px solid var(--accent); padding: 4px 10px; background: rgba(29,79,215,0.05); border-radius: 0 6px 6px 0; font-size: 12px; color: var(--muted); }
+  .obs-mini { list-style: none; margin: 0; padding: 0; font-size: 11.5px; color: var(--muted); }
+  .obs-mini li { padding: 3px 0; border-bottom: 1px dashed var(--panel-2); }
+  .obs-mini li:last-child { border-bottom: none; }
+
+  /* collapsed register group: slim rows at ~50% width — icon + id + title + PR# */
+  .slimrows { padding: 6px 10px 10px; display: flex; flex-direction: column; gap: 4px; }
+  .slimrow {
+    display: flex; align-items: center; gap: 7px; width: 50%; min-width: 300px;
+    border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px; background: #fff; font-size: 12px;
+  }
+  .slimrow .icon { color: var(--c); flex: none; }
+  .slimrow .c-id { flex: none; }
+  .slimrow .t { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .queue-empty { color: var(--faint); font-style: italic; padding: 8px 12px; font-size: 12px; }
+
+  /* ---- rail ---- */
+  .kind { display: inline-block; font-size: 9.5px; font-weight: 750; letter-spacing: 0.5px; text-transform: uppercase; border-radius: 3px; padding: 2px 6px; }
+  .kind-discovered-work { background: rgba(15,118,110,0.13); color: var(--teal); }
+  .kind-human-gated     { background: rgba(190,18,60,0.11); color: #a11240; }
+  .kind-later-wave      { background: rgba(67,56,202,0.11); color: #4338ca; }
+  .kind-deferred        { background: rgba(82,82,82,0.13);  color: #4c4c4c; }
+  .kind-unknown         { background: rgba(138,147,160,0.15); color: #6e7681; }
+  .parking-list { list-style: none; margin: 0; padding: 0; }
+  .parking-list li { padding: 7px 0; border-bottom: 1px solid var(--panel-2); font-size: 12px; }
+  .parking-list li:last-child { border-bottom: none; }
+  .parking-list .pid { font-family: var(--mono); font-size: 10px; color: var(--faint); margin: 0 5px 0 4px; }
+  .parking-list .pn { display: block; color: var(--faint); font-size: 11px; margin: 2px 0 0; }
+  .log-list { list-style: none; margin: 0; padding: 0; max-height: 420px; overflow-y: auto; }
+  .log-list li { display: flex; gap: 8px; align-items: baseline; padding: 6px 0; border-bottom: 1px dashed var(--panel-2); font-size: 12px; }
+  .log-list li:last-child { border-bottom: none; }
+  .log-list .ts { flex: none; font-family: var(--mono); font-size: 9.5px; color: var(--faint); }
+  .lvl { flex: none; font-size: 9px; font-weight: 800; letter-spacing: 0.5px; border-radius: 3px; padding: 1px 5px; }
+  .lvl-INFO { background: rgba(29,79,215,0.11); color: var(--accent); }
+  .lvl-WARN { background: rgba(146,103,10,0.13); color: var(--amber); }
+  .lvl-ERROR { background: rgba(194,47,47,0.13); color: var(--red); }
+  .lvl-LESSON { background: rgba(15,118,110,0.13); color: var(--teal); }
+  .lesson-list { list-style: none; margin: 0; padding: 0; }
+  .lesson-list li { padding: 7px 9px; border-left: 3px solid var(--teal); background: rgba(15,118,110,0.06); border-radius: 0 6px 6px 0; margin-bottom: 6px; font-size: 12px; }
+  .lesson-list .lmeta { display: block; font-family: var(--mono); font-size: 9.5px; color: var(--faint); margin-top: 3px; }
+</style>
+</head>
+<body>
+
+<header class="brief">
+  <div class="brief-main">
+    <p class="kicker">MISSION BRIEF · GRIND RUN</p>
+    <h1 id="title">Grind</h1>
+    <p class="mission" id="mission"></p>
+    <p class="brief-meta">
+      <span class="mono" id="repo"></span> ·
+      log ts <span class="mono" id="last-generated" title="Timestamp of the last folded event — the board is as fresh as its log, never fresher."></span>
+    </p>
+  </div>
+  <div class="brief-side">
+    <div class="lamps">
+      <span class="lamp" id="lamp-run">RUNNING</span>
+      <span class="lamp" id="lamp-pause">PAUSED</span>
+      <span class="lamp" id="lamp-attn">ATTENTION ×0</span>
+    </div>
+    <div class="refresh-control">
+      <label><input type="checkbox" id="refresh-toggle"><span>auto-refresh</span></label>
+      <span id="refresh-status">off</span>
+    </div>
+  </div>
+</header>
+
+<div id="pause-banner" role="status">
+  <h2>⏸ Grind paused</h2>
+  <p class="reason" id="pause-reason"></p>
+  <ol id="pause-checklist"></ol>
+</div>
+
+<div id="attention-banner" role="alert">
+  <h2>⚠ Attention — needs the human</h2>
+  <ul id="attention-list"></ul>
+</div>
+
+<section class="statdeck" id="statdeck" aria-label="Status summary — click a tile to filter the register"></section>
+
+<div class="split">
+  <main class="panel register" aria-label="Operations register" style="padding: 14px 14px;">
+    <div class="reg-head">
+      <h2>Operations register</h2>
+      <span id="filter-note"></span>
+    </div>
+    <div id="register"></div>
+  </main>
+
+  <aside class="rail">
+    <section class="panel" aria-label="Parking lot">
+      <h2>Parking lot <span class="count-tag" id="park-count">0</span></h2>
+      <ul class="parking-list" id="parking-list"></ul>
+    </section>
+    <section class="panel" aria-label="Ship's log">
+      <h2>Ship's log <span class="count-tag" id="obs-count">0</span></h2>
+      <ul class="log-list" id="obs-list"></ul>
+    </section>
+    <section class="panel" aria-label="Lessons learned">
+      <h2>Lessons learned <span class="count-tag" id="lesson-count">0</span></h2>
+      <ul class="lesson-list" id="lesson-list"></ul>
+    </section>
+  </aside>
+</div>
+
+<script id="grind-state">
+// Inlined fold State. SERIALIZATION CONTRACT: every less-than sign in the JSON
+// below is escaped as backslash-u003c before splicing, exactly as `grind render`
+// emits it. The disc-3 probe title proves the round-trip: it renders as inert
+// text below, it does not execute.
+const STATE = {
+  "title": "Discipline-Layer Grind — wgclw",
+  "repo": "scotthamilton77/agents-config",
+  "mission": "Re-architect the discipline layer around an event-sourced grind runtime; retire the bookkeeper agent and the hand-written ORCHESTRATION-STATE.md. Out of scope: PDLC-orchestrator design, PORT-track machine setup.",
+  "protocols": {
+    "review_protocol": "codex adversarial review, gpt-5.6-sol, --wait",
+    "merge_policy": "explicit — human instruction required",
+    "watcher_conventions": "dumb background pollers; ROOT interprets",
+    "session_grants": "one worktree per lane; no cross-lane writes"
+  },
+  "last_generated": "2026-07-19T04:12:08Z",
+  "pause": {
+    "paused": true,
+    "reason": "Human is picking a dashboard design from the wgclw.30.3 prototypes; implementation lanes hold until the renderer spec's UX section is amended with the choice.",
+    "resume_checklist": [
+      "Open prototypes/grind-dashboard/index.html and pick a winner (or a merge)",
+      "Amend the renderer spec's UX section with the chosen design",
+      "grind log grind_resumed"
+    ]
+  },
+  "attention": [
+    {
+      "text": "PR #346 reviewer stalemate — codex round 4 on unchanged head 9f31c2e with zero open threads. Merge ruling needed.",
+      "item": "wgclw.31.2"
+    },
+    {
+      "text": "Fold anomaly on wgclw.30.1 round 2: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 — recorded applied:false, counts use the latest event. Auto-raised by ERROR observation.",
+      "item": "wgclw.30.1"
+    },
+    {
+      "text": "Dashboard prototype pick outstanding — variation A, B, or C (or a merge). The pause holds until the UX section is amended."
+    }
+  ],
+  "lanes": [
+    {
+      "id": "lane-installer",
+      "name": "Lane 1 — installer",
+      "agent": "lt-installer",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "done",
+      "queue": [
+        {
+          "id": "wgclw.28.4",
+          "title": "Open the dashboard exactly once via the platform opener",
+          "status": "done",
+          "pr": { "number": 338, "url": null }
+        },
+        {
+          "id": "wgclw.29.2",
+          "title": "Receipt-tracked uv tool installs with prune-on-retire",
+          "status": "done",
+          "pr": { "number": 339, "url": null }
+        }
+      ]
+    },
+    {
+      "id": "lane-runtime",
+      "name": "Lane 2 — event runtime",
+      "agent": "lt-runtime",
+      "model": "opus",
+      "effort": "high",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "wgclw.30.1",
+          "title": "Event schema + pure fold with transition table and anomaly policy",
+          "status": "in-review",
+          "pr": { "number": 344, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 2,
+            "open_threads": 3,
+            "wont_fix_count": 1,
+            "stalemate": false,
+            "detail": "codex round 2 on 4b1a9d1: 3 open threads — torn-tail repair must fsync the quarantine sidecar; derived-unblock path lacks a cross-lane edge test; applied:false events vanish from the status envelope on replay. 1 wont-fix: unknown payload keys are tolerated by design.",
+            "findings": [
+              { "severity": "high", "summary": "Torn-tail repair moves the fragment to quarantine but never fsyncs the sidecar", "disposition": "fixed", "thread_url": null },
+              { "severity": "medium", "summary": "Derived unblocking is untested for edges that cross lane boundaries", "disposition": "deferred", "thread_url": null },
+              { "severity": "low", "summary": "Envelope validator silently tolerates unknown payload keys", "disposition": "wont-fix", "thread_url": null },
+              { "severity": "medium", "summary": "applied:false events vanish from the status envelope on replay", "disposition": "escalated", "thread_url": null }
+            ]
+          },
+          "note": "round 2 verdict: findings — triage in flight"
+        },
+        {
+          "id": "wgclw.30.2",
+          "title": "CLI verbs over the fold: create, log, status, render, check, finish",
+          "status": "queued"
+        },
+        {
+          "id": "wgclw.30.5",
+          "title": "Emit-back envelope + condition vocabulary",
+          "status": "blocked",
+          "blocked_on": ["wgclw.30.1"],
+          "note": "needs the fold contract to settle first"
+        }
+      ]
+    },
+    {
+      "id": "lane-dashboard",
+      "name": "Lane 3 — dashboard renderer",
+      "agent": "lt-dashboard",
+      "model": "sonnet",
+      "effort": "high",
+      "status": "in-progress",
+      "queue": [
+        {
+          "id": "wgclw.30.3",
+          "title": "grind render: deterministic projection from folded state to self-contained HTML",
+          "status": "in-progress",
+          "note": "prototyping session — this board is rendering its own fixture"
+        },
+        {
+          "id": "wgclw.30.4",
+          "title": "Observation routing: ERROR → attention, LESSON → lessons panel",
+          "status": "pr-open",
+          "pr": { "number": 345, "url": null }
+        },
+        {
+          "id": "wgclw.30.6",
+          "title": "Staleness watchdog: grind check + watchdog arming guidance",
+          "status": "merged",
+          "pr": { "number": 342, "url": null },
+          "note": "post-merge teardown leg outstanding"
+        }
+      ]
+    },
+    {
+      "id": "lane-watchers",
+      "name": "Lane 4 — watchers & probes",
+      "agent": "lt-watchers-2",
+      "model": "sonnet",
+      "effort": "low",
+      "status": "waiting-human",
+      "queue": [
+        {
+          "id": "wgclw.31.2",
+          "title": "Verdict-aware PR watcher with a written precedence contract",
+          "status": "waiting-human",
+          "pr": { "number": 346, "url": null },
+          "review": {
+            "kind": "codex",
+            "round": 4,
+            "open_threads": 0,
+            "wont_fix_count": 2,
+            "stalemate": true,
+            "detail": "codex round 4 re-raised 2 wont-fix items as new threads on unchanged head 9f31c2e — stalemate declared per the review skill's §3 rule. Awaiting the human's merge ruling."
+          },
+          "why": "Stalemate ruling needed: accept the reviewer's re-raise and rework, or merge over it with a recorded rationale."
+        },
+        {
+          "id": "wgclw.31.7",
+          "title": "Reconcile the shutdown ledger against the tracker directly when the grind's own projection disagrees with bead state at teardown time",
+          "status": "queued"
+        }
+      ]
+    },
+    {
+      "id": "lane-handoff",
+      "name": "Lane 5 — handoff & skill integration",
+      "agent": "lt-handoff",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "blocked",
+      "queue": [
+        {
+          "id": "disc-2",
+          "title": "Amend the renderer spec's UX section with the chosen prototype design",
+          "status": "queued",
+          "note": "surfaced by the .30.3 prototyping session"
+        },
+        {
+          "id": "wgclw.30.7",
+          "title": "SKILL.md integration: retire the bookkeeper and ORCHESTRATION-STATE.md",
+          "status": "blocked",
+          "blocked_on": ["wgclw.31.2"],
+          "note": "chain: wgclw.30.7 → wgclw.31.2 (waiting-human) — blocked_chain evidence"
+        }
+      ]
+    },
+    {
+      "id": "lane-port",
+      "name": "Lane 6 — portable layer",
+      "agent": "lt-port",
+      "model": "sonnet",
+      "effort": "medium",
+      "status": "standing-down",
+      "queue": []
+    },
+    {
+      "id": "lane-docs",
+      "name": "Lane 7 — docs & hardening",
+      "agent": "lt-docs",
+      "model": "haiku",
+      "effort": "low",
+      "status": "in-review",
+      "queue": [
+        {
+          "id": "disc-3",
+          "title": "Serializer hardening: a work-item title containing \\\"\\u003c/script\\u003e\\\" must render as inert text, never execute",
+          "status": "queued",
+          "note": "this very title is the serialization-contract probe"
+        },
+        {
+          "id": "wgclw.32.1",
+          "title": "User guide: run the opinionated agentic SDLC on the grind runtime — configuration, watchers, and overnight operations",
+          "status": "in-review",
+          "pr": { "number": 51, "url": "https://git.internal.example/scott/agents-config/pull/51" },
+          "review": {
+            "kind": "human",
+            "round": 1,
+            "open_threads": 1,
+            "wont_fix_count": 0,
+            "stalemate": false,
+            "detail": "human round 1: 1 open thread — tighten the watchdog arming prose; the dumb-poller rationale is buried in a footnote."
+          },
+          "note": "explicit PR url override — non-GitHub remote"
+        }
+      ]
+    }
+  ],
+  "parking_lot": [
+    {
+      "id": "disc-1",
+      "title": "Unify the prgroom and workcli envelope validators behind one shared module",
+      "kind": "discovered-work",
+      "note": "surfaced by PR #341 review; parked pending triage"
+    },
+    {
+      "id": "wgclw.33.1",
+      "title": "Supervised installer backfill sweep across both work machines",
+      "kind": "human-gated",
+      "note": "needs the human in the room"
+    },
+    {
+      "id": "uxns2.4",
+      "title": "PORT-track skill parity audit for Gemini and OpenCode",
+      "kind": "later-wave",
+      "note": "wave-2 scope, parked at partition"
+    },
+    {
+      "id": "vaac.9",
+      "title": "Merge-guard judge prompt v3 tuning against the last twenty rulings",
+      "kind": "deferred",
+      "note": "current judge passing; revisit post-M3"
+    }
+  ],
+  "observations": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "level": "LESSON",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6",
+      "lane": "lane-dashboard"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "level": "LESSON",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    },
+    {
+      "ts": "2026-07-19T02:58:11Z",
+      "level": "INFO",
+      "message": "lane_handover recorded on lane-watchers: lt-watchers → lt-watchers-2 (haiku·low → sonnet·low), reason: context exhaustion.",
+      "lane": "lane-watchers"
+    },
+    {
+      "ts": "2026-07-19T03:40:02Z",
+      "level": "WARN",
+      "message": "stale_item condition fired for disc-2 — no events referencing it for 47m (threshold 45m).",
+      "item": "disc-2",
+      "lane": "lane-handoff"
+    },
+    {
+      "ts": "2026-07-19T03:52:44Z",
+      "level": "ERROR",
+      "message": "Anomaly: review_round head_sha 4b1a9d0 disagrees with review_verdict head_sha 4b1a9d1 for wgclw.30.1 round 2 — recorded applied:false; counts use the latest event.",
+      "item": "wgclw.30.1",
+      "lane": "lane-runtime"
+    }
+  ],
+  "lessons": [
+    {
+      "ts": "2026-07-19T01:14:30Z",
+      "message": "Six codex rounds on PR #341 each found real defects — a high round count is reviewer health, not loop smell; stalemate is the only bad signal.",
+      "item": "wgclw.30.6"
+    },
+    {
+      "ts": "2026-07-19T02:31:19Z",
+      "message": "Hand-merged state drifted twice when lieutenants reported deltas out of order; refold-from-zero makes report order irrelevant.",
+      "lane": "lane-runtime"
+    }
+  ],
+  "merged_ledger": [
+    { "pr": 338, "title": "Open the dashboard exactly once via the platform opener", "sha": "8c21de4", "lane": "lane-installer" },
+    { "pr": 339, "title": "Receipt-tracked uv tool installs with prune-on-retire", "sha": "b07a1c9", "lane": "lane-installer" },
+    { "pr": 342, "title": "Staleness watchdog: grind check + watchdog arming guidance", "sha": "9f31c2e", "lane": "lane-dashboard" }
+  ],
+  "closed_ledger": [
+    { "id": "wgclw.29.9", "title": "Spike: incremental fold mode", "pr": 337, "reason": "superseded — refold-from-zero won on simplicity" }
+  ]
+};
+</script>
+
+<script id="grind-renderer">
+"use strict";
+// ---------- status vocabulary + icons (all nine statuses, neutral fallback) ----------
+const KNOWN_STATUSES = ["queued","in-progress","pr-open","in-review","merged","done","blocked","waiting-human","standing-down"];
+function statusCls(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? "st-" + k : "st-unknown";
+}
+const ICONS = {
+  "queued": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/>',
+  "in-progress": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/><path d="M8 2.5A5.5 5.5 0 0 1 8 13.5Z" fill="currentColor"/>',
+  "pr-open": '<circle cx="5" cy="4.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="5" cy="11.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="11" cy="8" r="2" fill="currentColor"/><path d="M5 6.5v3M6.8 8h2.2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "in-review": '<path d="M1.8 8C4 4.8 12 4.8 14.2 8 12 11.2 4 11.2 1.8 8Z" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="8" cy="8" r="1.9" fill="currentColor"/>',
+  "merged": '<circle cx="5" cy="4" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/><circle cx="11.5" cy="12" r="1.9" fill="currentColor"/><path d="M5 6v4M5 9.5c0 1.6 2 1 4 1.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "done": '<circle cx="8" cy="8" r="6.4" fill="currentColor"/><path d="M5.1 8.3l2 2 3.8-4.2" fill="none" stroke="#ffffff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"/>',
+  "blocked": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M4.2 11.8 11.8 4.2" stroke="currentColor" stroke-width="2"/>',
+  "waiting-human": '<circle cx="8" cy="5" r="2.5" fill="currentColor"/><path d="M3.2 13.4c.4-2.8 2.4-4.2 4.8-4.2s4.4 1.4 4.8 4.2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  "standing-down": '<path d="M4.5 14V2.6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M4.5 3.2h7.6l-2.2 2.9 2.2 2.9H4.5Z" fill="currentColor"/>',
+  "unknown": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/><path d="M6.4 6.3c.3-1.1 1-1.7 1.7-1.7 1 0 1.7.6 1.7 1.5 0 1.3-1.7 1.5-1.7 2.8" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/><circle cx="8.1" cy="11.5" r="1" fill="currentColor"/>'
+};
+function iconName(status) {
+  const k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? k : "unknown";
+}
+function iconSvg(status, size) {
+  const s = size || 14;
+  return '<svg class="icon" width="' + s + '" height="' + s + '" viewBox="0 0 16 16" aria-hidden="true" focusable="false">' +
+    (ICONS[iconName(status)] || ICONS.unknown) + '</svg>';
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+// Explicit url wins (scheme-checked); otherwise derive from the repo slug; else plain text.
+function safeHref(url) {
+  try {
+    const scheme = new URL(url, "https://github.com").protocol;
+    return (scheme === "https:" || scheme === "http:") ? url : null;
+  } catch (e) { return null; }
+}
+function prUrl(pr, repo) {
+  if (!pr) return null;
+  if (typeof pr.url === "string" && pr.url.trim() !== "") {
+    const safe = safeHref(pr.url.trim());
+    if (safe) return safe;
+  }
+  if (repo) return "https://github.com/" + repo + "/pull/" + pr.number;
+  return null;
+}
+function prLink(pr, repo) {
+  if (!pr) return '<span class="pr-plain">—</span>';
+  const url = prUrl(pr, repo);
+  const label = "#" + escapeHtml(pr.number);
+  return url
+    ? '<a class="pr-link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener">' + label + '</a>'
+    : '<span class="pr-plain">' + label + '</span>';
+}
+
+// Review bits: round badge (hidden at done), stalemate flag, full-label
+// open-thread pill with the review detail as tooltip, wont-fix count.
+function reviewBits(review, itemStatus) {
+  if (!review) return '<span class="pr-plain">—</span>';
+  let out = "";
+  const stale = !!review.stalemate;
+  if (String(itemStatus).toLowerCase() !== "done") {
+    out += '<span class="pill pill-round' + (stale ? " is-stalemate" : "") + '">' +
+      escapeHtml(review.kind || "review") + " · round " + (Number(review.round) || 0) + "</span>";
+  }
+  if (stale) out += '<span class="pill pill-stalemate">stalemate</span>';
+  const n = Number(review.open_threads) || 0;
+  if (n > 0) {
+    const label = n === 1 ? "1 open thread" : n + " open threads";
+    const tip = review.detail ? ' title="' + escapeHtml(review.detail) + '"' : "";
+    out += '<span class="pill pill-threads"' + tip + ">" + label + "</span>";
+  }
+  const wf = Number(review.wont_fix_count) || 0;
+  if (wf > 0) out += '<span class="pill pill-wontfix">' + wf + " wont-fix</span>";
+  return out || '<span class="pr-plain">—</span>';
+}
+
+const KNOWN_KINDS = ["discovered-work","human-gated","later-wave","deferred"];
+function kindChip(kind) {
+  const k = String(kind || "").toLowerCase();
+  const cls = KNOWN_KINDS.indexOf(k) >= 0 ? "kind-" + k : "kind-unknown";
+  return '<span class="kind ' + cls + '">' + escapeHtml(kind || "unknown") + "</span>";
+}
+
+// ---------- per-lane collapse + drill-down + filter state ----------
+const LS_COLLAPSE = "grindproto.c.collapsed.v1";
+let collapsePrefs = {};
+try { collapsePrefs = JSON.parse(localStorage.getItem(LS_COLLAPSE) || "{}") || {}; } catch (e) { collapsePrefs = {}; }
+const drilled = new Set();
+let filterStatus = null;
+function laneById(id) { return (STATE.lanes || []).find(l => l.id === id); }
+function isCollapsed(lane) {
+  if (Object.prototype.hasOwnProperty.call(collapsePrefs, lane.id)) return !!collapsePrefs[lane.id];
+  return String(lane.status).toLowerCase() === "done";
+}
+function toggleLane(id) {
+  const lane = laneById(id);
+  if (!lane) return;
+  collapsePrefs[id] = !isCollapsed(lane);
+  try { localStorage.setItem(LS_COLLAPSE, JSON.stringify(collapsePrefs)); } catch (e) {}
+  renderRegister();
+}
+function toggleDrill(itemId) {
+  if (drilled.has(itemId)) drilled.delete(itemId); else drilled.add(itemId);
+  renderRegister();
+}
+function setFilter(status) {
+  filterStatus = (filterStatus === status) ? null : status;
+  renderStatdeck();
+  renderRegister();
+}
+
+// ---------- stat deck ----------
+function allItems() {
+  const out = [];
+  (STATE.lanes || []).forEach(l => (l.queue || []).forEach(q => out.push(q)));
+  return out;
+}
+function renderStatdeck() {
+  const items = allItems();
+  const deck = document.getElementById("statdeck");
+  const tiles = KNOWN_STATUSES.map(st => {
+    let count, sub;
+    if (st === "standing-down") {
+      count = (STATE.lanes || []).filter(l => String(l.status).toLowerCase() === "standing-down").length;
+      sub = count === 1 ? "lane" : "lanes";
+    } else {
+      count = items.filter(q => String(q.status).toLowerCase() === st).length;
+      sub = count === 1 ? "item" : "items";
+    }
+    return { st, count, sub };
+  });
+  deck.innerHTML = tiles.map(t =>
+    '<button type="button" class="tile ' + statusCls(t.st) + (filterStatus === t.st ? " active" : "") +
+      '" data-status="' + t.st + '" aria-pressed="' + (filterStatus === t.st) + '" title="Filter the register to ' + t.st + '">' +
+      '<span class="num">' + t.count + "</span>" +
+      '<span class="lbl">' + iconSvg(t.st, 12) + " " + t.st + "</span>" +
+      '<span class="sub">' + t.sub + "</span></button>"
+  ).join("") +
+  '<div class="tile" style="cursor:default;border-top-color:var(--teal);"><span class="num" style="color:var(--teal);">' +
+    (STATE.parking_lot || []).length + '</span><span class="lbl">parked</span><span class="sub">waiting, not blocked</span></div>' +
+  '<div class="tile" style="cursor:default;border-top-color:var(--teal);"><span class="num" style="color:var(--teal);">' +
+    (STATE.lessons || []).length + '</span><span class="lbl">lessons</span><span class="sub">LESSON observations</span></div>' +
+  '<div class="tile" style="cursor:default;border-top-color:var(--red);"><span class="num" style="color:var(--red);">' +
+    (STATE.attention || []).length + '</span><span class="lbl">attention</span><span class="sub">needs the human</span></div>';
+  deck.querySelectorAll("button.tile").forEach(btn =>
+    btn.addEventListener("click", () => setFilter(btn.getAttribute("data-status"))));
+  document.getElementById("filter-note").innerHTML = filterStatus
+    ? 'showing only <strong>' + escapeHtml(filterStatus) + '</strong> — <button type="button" id="clear-filter">clear filter</button>'
+    : "";
+  const cf = document.getElementById("clear-filter");
+  if (cf) cf.addEventListener("click", () => setFilter(filterStatus));
+}
+
+// ---------- operations register ----------
+function drillRowHtml(q) {
+  const cells = [];
+  let left = "", right = "";
+  if (q.why) left += '<h4>Awaiting human</h4><p class="why">' + escapeHtml(q.why) + "</p>";
+  if (q.blocked_on && q.blocked_on.length) {
+    left += '<h4>Blocked on</h4><p>' + q.blocked_on.map(b => '<span class="chip-blocker">' + escapeHtml(b) + "</span>").join(" ") + "</p>";
+  }
+  if (q.note) left += '<h4>Note</h4><p>' + escapeHtml(q.note) + "</p>";
+  if (q.review && q.review.detail) {
+    left += '<h4>Review detail (also the open-thread pill tooltip)</h4><p class="detail-quote">' + escapeHtml(q.review.detail) + "</p>";
+  }
+  if (q.review && q.review.findings && q.review.findings.length) {
+    right += '<h4>Findings — ' + escapeHtml(q.review.kind || "review") + " round " + (Number(q.review.round) || 0) + "</h4>" +
+      '<table class="f-table"><thead><tr><th>Severity</th><th>Finding</th><th>Disposition</th></tr></thead><tbody>' +
+      q.review.findings.map(f => {
+        const sev = String(f.severity || "").toLowerCase();
+        const sevCls = ["high","medium","low"].indexOf(sev) >= 0 ? "sev-" + sev : "sev-low";
+        return "<tr><td><span class='sev " + sevCls + "'>" + escapeHtml(f.severity || "?") + "</span></td><td>" +
+          escapeHtml(f.summary) + "</td><td><span class='disp'>" + escapeHtml(f.disposition || "") + "</span></td></tr>";
+      }).join("") + "</tbody></table>";
+  }
+  const related = (STATE.observations || []).filter(o => o.item === q.id);
+  if (related.length) {
+    right += '<h4>Log entries referencing ' + escapeHtml(q.id) + "</h4><ul class='obs-mini'>" +
+      related.map(o => "<li>" + escapeHtml(o.ts || "") + " · " + escapeHtml(o.level || "") + " — " + escapeHtml(o.message) + "</li>").join("") + "</ul>";
+  }
+  if (!left && !right) left = "<p>Nothing further on the books for this item.</p>";
+  cells.push('<div class="drill-grid"><div>' + left + "</div><div>" + right + "</div></div>");
+  return '<tr class="drill"><td colspan="7">' + cells.join("") + "</td></tr>";
+}
+
+// standing-down is lane-only vocabulary: filtering to it matches lane status,
+// not item status (no item ever carries it).
+function rowHidden(q, lane) {
+  if (!filterStatus) return false;
+  if (filterStatus === "standing-down") return String(lane.status).toLowerCase() !== "standing-down";
+  return String(q.status).toLowerCase() !== filterStatus;
+}
+
+function itemRowHtml(q, lane) {
+  const cls = statusCls(q.status);
+  const hidden = rowHidden(q, lane);
+  const open = drilled.has(q.id);
+  let html = '<tr class="item-row ' + cls + (hidden ? " hidden-by-filter" : "") + (open ? " drilled" : "") +
+    '" data-item="' + escapeHtml(q.id) + '" tabindex="0" aria-expanded="' + open + '">' +
+    '<td class="c-icon">' + iconSvg(q.status) + "</td>" +
+    '<td class="c-id">' + escapeHtml(q.id) + "</td>" +
+    '<td class="c-title">' + escapeHtml(q.title) + "</td>" +
+    '<td><span class="pill ' + cls + '">' + escapeHtml(q.status) + "</span></td>" +
+    "<td>" + prLink(q.pr, STATE.repo) + "</td>" +
+    '<td class="c-review">' + reviewBits(q.review, q.status) + "</td>" +
+    '<td class="c-drill">' + (open ? "▾" : "▸") + "</td></tr>";
+  if (open) html += drillRowHtml(q);
+  return html;
+}
+
+// Collapsed anatomy: status icon + work-item id + title + PR# — notes and the
+// agent/activity line dropped; rows at half width.
+function slimRowHtml(q, lane) {
+  const hidden = rowHidden(q, lane);
+  return '<div class="slimrow ' + statusCls(q.status) + (hidden ? " hidden-by-filter" : "") + '">' +
+    iconSvg(q.status, 12) + '<span class="c-id">' + escapeHtml(q.id) + "</span>" +
+    '<span class="t" title="' + escapeHtml(q.title) + '">' + escapeHtml(q.title) + "</span>" +
+    prLink(q.pr, STATE.repo) + "</div>";
+}
+
+function renderRegister() {
+  const host = document.getElementById("register");
+  host.innerHTML = "";
+  (STATE.lanes || []).forEach(lane => {
+    const collapsed = isCollapsed(lane);
+    const cls = statusCls(lane.status);
+    const items = lane.queue || [];
+    const sdLaneMatch = filterStatus === "standing-down" && String(lane.status).toLowerCase() === "standing-down";
+    const visibleCount = !filterStatus
+      ? items.length
+      : (filterStatus === "standing-down"
+          ? (sdLaneMatch ? 1 : 0)
+          : items.filter(q => !rowHidden(q, lane)).length);
+    const sec = document.createElement("section");
+    sec.className = "reg-group " + cls + (visibleCount === 0 && filterStatus ? " hidden-by-filter" : "");
+    let body;
+    if (!items.length) {
+      body = collapsed ? "" : '<div class="queue-empty">queue empty — wrapping up</div>';
+    } else if (collapsed) {
+      body = '<div class="slimrows">' + items.map(q => slimRowHtml(q, lane)).join("") + "</div>";
+    } else {
+      body = '<div class="table-scroll"><table class="reg-table"><thead><tr>' +
+        "<th></th><th>Item</th><th>Title</th><th>Status</th><th>PR</th><th>Review</th><th></th>" +
+        "</tr></thead><tbody>" + items.map(q => itemRowHtml(q, lane)).join("") + "</tbody></table></div>";
+    }
+    sec.innerHTML =
+      '<button type="button" class="group-head" data-lane="' + escapeHtml(lane.id) + '" aria-expanded="' + (!collapsed) + '">' +
+        '<span class="twisty">' + (collapsed ? "▸" : "▾") + "</span>" +
+        '<span class="gicon">' + iconSvg(lane.status, 15) + "</span>" +
+        '<span class="gname">' + escapeHtml(lane.name) + "</span>" +
+        (collapsed ? "" : '<span class="gagent mono">' + escapeHtml(lane.agent) + " · " + escapeHtml(lane.model || "") + "/" + escapeHtml(lane.effort || "") + "</span>") +
+        '<span class="pill ' + cls + '">' + escapeHtml(lane.status) + "</span>" +
+        '<span class="gcount">' + items.length + (items.length === 1 ? " item" : " items") + "</span>" +
+      "</button>" + body;
+    host.appendChild(sec);
+  });
+  host.querySelectorAll(".group-head").forEach(btn =>
+    btn.addEventListener("click", () => toggleLane(btn.getAttribute("data-lane"))));
+  host.querySelectorAll("tr.item-row").forEach(row => {
+    const id = row.getAttribute("data-item");
+    row.addEventListener("click", () => toggleDrill(id));
+    row.addEventListener("keydown", ev => { if (ev.key === "Enter" || ev.key === " ") { ev.preventDefault(); toggleDrill(id); } });
+  });
+}
+
+function renderRail() {
+  const parked = STATE.parking_lot || [];
+  document.getElementById("park-count").textContent = parked.length;
+  document.getElementById("parking-list").innerHTML = parked.map(p =>
+    "<li>" + kindChip(p.kind) + '<span class="pid">' + escapeHtml(p.id) + "</span>" + escapeHtml(p.title) +
+    (p.note ? '<span class="pn">' + escapeHtml(p.note) + "</span>" : "") + "</li>"
+  ).join("");
+
+  const obs = (STATE.observations || []).slice().reverse();
+  document.getElementById("obs-count").textContent = obs.length;
+  document.getElementById("obs-list").innerHTML = obs.map(o =>
+    '<li><span class="ts">' + escapeHtml((o.ts || "").slice(5, 16).replace("T", " ")) + "</span>" +
+    '<span class="lvl lvl-' + escapeHtml(o.level || "INFO") + '">' + escapeHtml(o.level || "INFO") + "</span>" +
+    "<span>" + escapeHtml(o.message) + (o.item ? ' <span class="mono" style="color:var(--faint);">' + escapeHtml(o.item) + "</span>" : "") + "</span></li>"
+  ).join("");
+
+  const lessons = STATE.lessons || [];
+  document.getElementById("lesson-count").textContent = lessons.length;
+  document.getElementById("lesson-list").innerHTML = lessons.map(l =>
+    "<li>" + escapeHtml(l.message) +
+    '<span class="lmeta">' + escapeHtml(l.ts || "") + (l.item ? " · " + escapeHtml(l.item) : "") + (l.lane ? " · " + escapeHtml(l.lane) : "") + "</span></li>"
+  ).join("");
+}
+
+function render() {
+  document.title = (STATE.title || "Grind") + " — Mission Log";
+  document.getElementById("title").textContent = STATE.title || "Grind";
+  document.getElementById("mission").textContent = STATE.mission || "";
+  document.getElementById("repo").textContent = STATE.repo || "no repo slug";
+  // From state, never a wall clock: the board is as fresh as its log.
+  document.getElementById("last-generated").textContent = STATE.last_generated || "—";
+
+  const pause = STATE.pause;
+  const paused = !!(pause && pause.paused);
+  document.getElementById("lamp-pause").className = "lamp" + (paused ? " on-pause" : "");
+  document.getElementById("lamp-run").className = "lamp" + (paused ? "" : " on-run");
+  const attn = STATE.attention || [];
+  const attnLamp = document.getElementById("lamp-attn");
+  attnLamp.textContent = "ATTENTION ×" + attn.length;
+  attnLamp.className = "lamp" + (attn.length ? " on-attn" : "");
+
+  const pb = document.getElementById("pause-banner");
+  if (paused) {
+    pb.classList.add("show");
+    document.getElementById("pause-reason").textContent = pause.reason || "";
+    document.getElementById("pause-checklist").innerHTML =
+      (pause.resume_checklist || []).map(c => "<li>" + escapeHtml(c) + "</li>").join("");
+  } else { pb.classList.remove("show"); }
+
+  const ab = document.getElementById("attention-banner");
+  const al = document.getElementById("attention-list");
+  if (attn.length) {
+    ab.classList.add("show");
+    al.innerHTML = attn.map(a =>
+      "<li>" + escapeHtml(a.text) + (a.item ? '<span class="attn-item-chip">' + escapeHtml(a.item) + "</span>" : "") + "</li>"
+    ).join("");
+  } else { ab.classList.remove("show"); al.innerHTML = ""; }
+
+  renderStatdeck();
+  renderRegister();
+  renderRail();
+}
+
+render();
+
+// ---------- auto-refresh (15s, visible toggle, persisted; reload is a no-op in this static prototype) ----------
+const REFRESH_SECONDS = 15;
+const LS_REFRESH = "grindproto.c.autorefresh.v1";
+const toggle = document.getElementById("refresh-toggle");
+const statusEl = document.getElementById("refresh-status");
+let countdown = REFRESH_SECONDS, tickTimer = null;
+function updateStatusText() { statusEl.textContent = toggle.checked ? ("on — " + countdown + "s") : "off"; }
+function startTicking() {
+  if (tickTimer) clearInterval(tickTimer);
+  countdown = REFRESH_SECONDS; updateStatusText();
+  tickTimer = setInterval(() => {
+    countdown -= 1;
+    if (countdown <= 0) { location.reload(); return; }
+    updateStatusText();
+  }, 1000);
+}
+function stopTicking() { if (tickTimer) clearInterval(tickTimer); tickTimer = null; updateStatusText(); }
+let savedRefresh = null;
+try { savedRefresh = localStorage.getItem(LS_REFRESH); } catch (e) { savedRefresh = null; }
+toggle.checked = savedRefresh === null ? true : savedRefresh === "true";
+toggle.addEventListener("change", () => {
+  try { localStorage.setItem(LS_REFRESH, toggle.checked ? "true" : "false"); } catch (e) {}
+  if (toggle.checked) startTicking(); else stopTicking();
+});
+if (toggle.checked) startTicking(); else stopTicking();
+</script>
+
+</body>
+</html>

--- a/docs/specs/2026-07-19-grind-dashboard-renderer.md
+++ b/docs/specs/2026-07-19-grind-dashboard-renderer.md
@@ -1,12 +1,13 @@
 # Grind dashboard renderer — design
 
 **Bead:** `agents-config-wgclw.30.3`
-**Status:** draft — UI design intentionally open pending a prototyping session
+**Status:** accepted — visual design chosen (UX §9); implementation proceeds under `.30.3`
 
 Companion to the event-sourced grind runtime spec (same date), which defines
 the event log, fold, and `grind` CLI this renderer projects from. This spec is
-split out so the visual design can be explored through UI prototypes before
-implementation; the *contract* below is settled, the *look* is not.
+split out so the visual design could be explored through UI prototypes before
+implementation; the contract below is settled, and the chosen look is
+recorded in UX §9.
 
 ## Problem
 
@@ -70,11 +71,20 @@ New, from the runtime spec:
    "1 open"), with a `title`-attribute tooltip carrying `review.detail`.
 8. **Review round badge hides at `done`** — a high round count survives as a
    LESSON, not a badge on finished work.
+9. **Chosen visual design — "Control Room"**: column-per-lane kanban board,
+   icon-forward status (large glyphs, colored column-top strips, small text
+   pills), control-room density, with the parking lot / lessons / observation
+   log docked as a panel strip beneath the board — and a **mission line in
+   the header**: the topbar carries `state.mission` as a muted full-width
+   line under the title row. Reference prototype:
+   `docs/prototypes/grind-dashboard/variation-a.html` (mission header
+   included); shared fixture: `docs/prototypes/grind-dashboard/fixture-state.json`.
 
 ## Input
 
 The renderer consumes the fold's `State` (runtime spec) — it never reads
-`events.jsonl`. Fields it draws from: grind header (title, repo, pause),
+`events.jsonl`. Fields it draws from: grind header (title, repo, mission,
+pause),
 lanes with derived statuses and queues, per-item review state (kind, round,
 derived `open_threads` / `wont_fix_count`, stalemate flag, `detail`),
 parking lot with kinds, attention list, lessons, `last_generated`.
@@ -83,23 +93,19 @@ Review counts and item statuses arrive **pre-derived** — the renderer
 computes nothing about the domain, it only lays out typed fields. Any place
 the current template parses prose out of a note is a defect to delete.
 
-## Prototyping plan (open — the follow-up session)
+## Prototypes
 
-The visual design will be chosen from prototypes, not specified here. A
-follow-up session uses the `prototype` skill (UI-variations branch) to
-produce **3–4 radically different single-file variations**, all rendering the
-same fixture state, toggleable from one page:
+Three radically different single-file variations live at
+`docs/prototypes/grind-dashboard/` (chooser: `index.html`; per-variation
+design theses: `README.md`), all rendering the shared `fixture-state.json`.
+The chosen design is UX §9's Control Room (variation A, mission header
+included); the other variations are retained for reference.
 
-- Candidate axes to differentiate: column-board vs. row-per-lane layouts;
-  icon-forward vs. text-forward status; density (control-room vs. calm);
-  where the parking lot / lessons / attention live relative to lanes.
-- **Fixture state** (built once, shared by prototypes and later by CI): all
-  nine statuses represented, every parking kind, an active review with
-  findings, a stalemate, a paused banner variant, ≥6 lanes (to exercise
-  overflow), long titles, and a `</script>`-bearing title (to prove the
-  serialization contract).
-- Scott picks a winner (or a merge); the choice is recorded by amending this
-  spec's UX section, and implementation proceeds under `.30.3`.
+The **fixture state** is built once and shared by the prototypes and the CI
+smoke test: all nine statuses represented, every parking kind, an active
+review with findings, a stalemate, a paused banner variant, ≥6 lanes (to
+exercise overflow), long titles, and a `</script>`-bearing title (to prove
+the serialization contract).
 
 ## Testing
 
@@ -113,6 +119,5 @@ same fixture state, toggleable from one page:
 ## Continuations
 
 - none beyond the existing bead — `agents-config-wgclw.30.3` implements this
-  spec once the prototyping session amends the UX section with the chosen
-  design. The prototyping session itself is session-work, not a bead: it
-  starts from this spec and the `prototype` skill.
+  spec; the chosen visual design is recorded in UX §9 and referenced from
+  `docs/prototypes/grind-dashboard/`.

--- a/src/user/.agents/rules/worktrees.md
+++ b/src/user/.agents/rules/worktrees.md
@@ -5,3 +5,12 @@ Create worktrees in your native worktree tool's preferred location, or — absen
 - No native tool: `git worktree add .worktrees/<name> -b <branch>` from the repo root.
 - Agents collaborate on one workspace, so know the per-agent convention to find and enter each other's worktrees: Claude Code uses `<repo-root>/.claude/worktrees/` (via its native tool); every other agent uses `<repo-root>/.worktrees/`.
 - Post-merge cleanup: run from the main repo root, never inside the worktree. After a squash-merge git reads the branch as unmerged — use `git branch -D`, and remove the worktree only once the work is confirmed on main.
+- One committer per worktree at a time. Never dispatch concurrent subagents that
+  each commit into the same worktree — serialize them, or give each its own
+  worktree. A shared index means `git add -A`/`commit -a` can swallow a sibling's
+  in-flight files, and any post-commit HEAD read can return a sibling's commit.
+- Capture your commit SHA from the commit itself, never from a later read. The
+  `git commit` output banner (`[branch abc1234] ...`) is the only SHA that is
+  provably yours; `git rev-parse HEAD` / `git log -1` after the fact report
+  whatever landed last, which under concurrency may not be you. Before reporting
+  a SHA, confirm it matches your own commit banner's short SHA and file stats.


### PR DESCRIPTION
## Summary
- Records the chosen visual design for the grind dashboard renderer, per the renderer spec's own prototyping plan: **Variation A (Control Room)** — column-per-lane kanban, icon-forward, control-room density — amended with the mission-brief header line from Variation C (topbar renders `state.mission`).
- Amends `docs/specs/2026-07-19-grind-dashboard-renderer.md`: status → accepted, UX §9 chosen design, renderer Input gains `mission`, prototyping section records the assets.
- Commits the three prototype variations + chooser + README + shared `fixture-state.json` under `docs/prototypes/grind-dashboard/` — the fixture is reused by .30.3's CI smoke test.

## Scope
- Docs + static prototype assets only; no production code. The prototypes are reference artifacts (self-contained file:// pages, hand-rolled JS, light theme) — implementation happens under bead .30.3 against the amended spec.
- Ground truth: the two 2026-07-19 grind specs; `state.mission` exists in the runtime spec's State header.
- Intentional: `merged_ledger`/`closed_ledger` appear in the fixture for State fidelity but are deliberately never rendered (UX requirement 6); variations B and C are retained as reference, not dead code.

## Test Plan
- [x] fixture-state.json parses; all nine statuses, all four parking kinds, stalemate, pause, `</script>`-bearing title present
- [x] All three variations inline state with `<` escaped as `\u003c`; zero external fetches/CDNs
- [x] HEAVY adversarial gate: acceptance clean-at-floor; its one finding (dead pluralization ternary) fixed in `5ccae98`