### PR TITLE
fix(wait-for-pr-comments): reconcile poll-copilot-review.sh completion detection with merge-eligibility acceptance

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -25,18 +25,30 @@
 # when the list has only request-based identities (e.g. Copilot).
 #
 # Poll completion contract: this script's JSON output also completes without
-# a review object when a bot's pass is clean. When --bot-reviewers is
-# supplied, a `+1` reaction on the PR body, or an issue comment starting with
-# the clean-pass marker "Codex Review: Didn't find any major issues" — each
-# from an allowlisted identity — also counts as completion (the standalone
-# Copilot-substring default never checks either signal). A clean signal is
+# a review object when a bot's pass is clean. A submitted review (state
+# APPROVED or COMMENTED — mirroring check-merge-eligibility.sh's own review
+# path, which accepts both as a legitimate clean pass) always counts as
+# completion. When --bot-reviewers is supplied, two additional clean-pass
+# signals count too: a `+1` reaction on the PR body, or an issue comment
+# starting with the clean-pass marker "Codex Review: Didn't find any major
+# issues" — each from an allowlisted identity (the standalone
+# Copilot-substring default never checks either signal). These two are NOT
+# interchangeable: the `+1` reaction is the real qualifying signal
+# check-merge-eligibility.sh's reaction-path fact requires, so it alone
+# reports completion_kind "clean_reaction"; the marker comment is a genuine
+# "bot responded" signal but not what that fact accepts (comment landed,
+# reaction not yet earned is a real race — Codex posts the marker and earns
+# the reaction via two separate API calls), so it reports the distinct
+# completion_kind "clean_marker" instead, letting callers that must match the
+# floor's stricter criteria branch on the two separately. A clean signal is
 # accepted only when it is fresh: it must post-date --since-timestamp when
 # given, else (the initial poll) the point the current head became HEAD —
 # max( PR head commit's committer date, latest head_ref_force_pushed timeline
 # event ), since a force-push can re-point HEAD at an older commit. If that
 # freshness bound cannot be established, clean signals are rejected that round
 # (fail closed). `completion_kind` distinguishes "review" / "clean_reaction" /
-# "timeout"; only "timeout" should count against a caller's silent-ask budget.
+# "clean_marker" / "timeout"; only "timeout" should count against a caller's
+# silent-ask budget.
 # If a clean-signal endpoint (reactions / issue comments) is FAILING at the
 # deadline, a clean pass and bot silence are indistinguishable — so the script
 # exits 3 (infrastructure error), NOT 1/timeout, and a transport failure is
@@ -50,7 +62,7 @@
 #       endpoint failing at the deadline)
 #
 # Stdout (exit 0):
-#   { "status": "copilot_review_found", "completion_kind": "review"|"clean_reaction", "reviews": [...], "inline_comments": [...], "human_comments": [...] }
+#   { "status": "copilot_review_found", "completion_kind": "review"|"clean_reaction"|"clean_marker", "reviews": [...], "inline_comments": [...], "human_comments": [...] }
 # Stdout (exit 1):
 #   { "status": "copilot_review_timeout", "completion_kind": "timeout" }
 # Stdout (exit 2):
@@ -187,13 +199,19 @@ pr_is_open() {
     [[ "$state" == "open" ]]
 }
 
-# emit_clean_reaction_found — shared stdout payload for both clean-pass
-# completion signals (a `+1` reaction and a marker comment carry no review
-# content, so both report the same empty-arrays shape).
-emit_clean_reaction_found() {
-    jq -n '{
+# emit_clean_signal_found <completion_kind> — shared stdout payload for both
+# clean-pass completion signals (a `+1` reaction and a marker comment carry
+# no review content, so both report the same empty-arrays shape). The kind
+# itself is NOT shared: a `+1` reaction reports "clean_reaction" (the real
+# qualifying signal check-merge-eligibility.sh's reaction-path fact
+# requires); a marker comment alone reports the distinct "clean_marker" —
+# see the header's Poll completion contract for why they must not collapse
+# into one kind.
+emit_clean_signal_found() {
+    local kind="$1"
+    jq -n --arg kind "$kind" '{
         status: "copilot_review_found",
-        completion_kind: "clean_reaction",
+        completion_kind: $kind,
         reviews: [],
         inline_comments: [],
         human_comments: []
@@ -364,7 +382,11 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         reviews="$fresh_reviews"
     fi
 
-    count=$(printf '%s' "$reviews" | jq '[.[] | select(.state == "COMMENTED")] | length')
+    # APPROVED or COMMENTED are both a completed review — mirrors
+    # check-merge-eligibility.sh's own review path (Component 2 part (a)),
+    # which accepts either as a legitimate clean pass. Missing APPROVED here
+    # made a bot's clean first-pass approval indistinguishable from silence.
+    count=$(printf '%s' "$reviews" | jq '[.[] | select(.state == "APPROVED" or .state == "COMMENTED")] | length')
 
     if [[ "$count" -gt 0 ]]; then
         echo "  Copilot review found (attempt ${i})" >&2
@@ -439,7 +461,7 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
             if [[ "$(printf '%s' "$reactions" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass reaction found (attempt ${i})" >&2
-                emit_clean_reaction_found
+                emit_clean_signal_found clean_reaction
                 exit 0
             fi
 
@@ -455,7 +477,7 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
             if [[ "$(printf '%s' "$clean_comments" | jq 'length')" -gt 0 ]]; then
                 echo "  Clean-pass marker comment found (attempt ${i})" >&2
-                emit_clean_reaction_found
+                emit_clean_signal_found clean_marker
                 exit 0
             fi
         fi

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -194,13 +194,37 @@ assert "default Copilot filter does NOT match the non-Copilot bot (timeout, exit
 # A findings review reports completion_kind "review".
 assert "matched review reports completion_kind review" "printf '%s' \"\$out_bot\" | jq -e '.completion_kind == \"review\"' >/dev/null"
 
+# ── Defect 1 (agents-config-abn9.44.11): an APPROVED review must also count
+# as a completion, not just COMMENTED. check-merge-eligibility.sh's own
+# review path already accepts APPROVED as a legitimate clean pass (Component
+# 2 part (a)); before this fix, a bot that approved cleanly on its first pass
+# was never detected as having responded, and the poll ran to a spurious
+# timeout that wrongly spent the retry budget.
+FIXTURE_REVIEWS_APPROVED='[{"user":{"login":"My-Bot[bot]","type":"Bot"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
+
+out_approved=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_APPROVED" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 5 --bot-reviewers '["my-bot[bot]"]' 2>/dev/null)
+rc_approved=$?
+assert "an APPROVED review completes (exit 0), does NOT time out" "[ \$rc_approved -eq 0 ]"
+assert "an APPROVED review reports completion_kind review" "printf '%s' \"\$out_approved\" | jq -e '.completion_kind == \"review\"' >/dev/null"
+
 # ── Poll completion contract (Component 3): clean-pass completion ───────────
 # A clean bot pass submits no review object at all — only a `+1` reaction on
 # the PR body, or a clean-pass marker issue comment, post-dating the ask
-# (--since-timestamp). Both must be recognised as completion (exit 0,
-# completion_kind "clean_reaction"), and ONLY a true timeout may report
-# completion_kind "timeout" — that is the only outcome a caller may count as
-# a silent ask against its retry cap.
+# (--since-timestamp). Both must be recognised as completion (exit 0), and
+# ONLY a true timeout may report completion_kind "timeout" — that is the only
+# outcome a caller may count as a silent ask against its retry cap.
+#
+# Defect 2 (agents-config-abn9.44.11): the two clean signals are NOT
+# interchangeable. completion_kind "clean_reaction" is reserved for the real
+# qualifying `+1` reaction that check-merge-eligibility.sh's reaction-path
+# fact requires. A marker comment alone (comment landed, reaction not yet
+# earned -- a real race, since Codex posts the marker and earns the reaction
+# as two separate API calls) is a genuine "the bot responded" signal but is
+# NOT what the eligibility floor's reaction fact accepts, so it gets its own
+# distinct completion_kind "clean_marker" instead of masquerading as
+# "clean_reaction" -- callers that must match the floor's stricter criteria
+# can branch on the two kinds separately.
 
 CODEX_ID='chatgpt-codex-connector[bot]'
 SINCE_TS='2026-01-01T00:00:00Z'
@@ -226,7 +250,8 @@ out_comment=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED
   --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
 rc_comment=$?
 assert "a post-dating marker comment completes (exit 0)" "[ \$rc_comment -eq 0 ]"
-assert "a post-dating marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_comment\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+assert "a post-dating marker comment reports completion_kind clean_marker" "printf '%s' \"\$out_comment\" | jq -e '.completion_kind == \"clean_marker\"' >/dev/null"
+assert "a post-dating marker comment does NOT report completion_kind clean_reaction (no real +1 present)" "printf '%s' \"\$out_comment\" | jq -e '.completion_kind != \"clean_reaction\"' >/dev/null"
 
 # A `+1` reaction that PREDATES the ask must NOT complete (stale-cache guard,
 # same discipline as the existing review submitted_at filter) — falls through
@@ -500,7 +525,7 @@ out_cc_p2=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" 
   --since-timestamp "$SINCE_TS" --bot-reviewers "[\"$CODEX_ID\"]" 2>/dev/null)
 rc_cc_p2=$?
 assert "a marker comment on page 2 completes (exit 0)" "[ \$rc_cc_p2 -eq 0 ]"
-assert "a page-2 marker comment reports completion_kind clean_reaction" "printf '%s' \"\$out_cc_p2\" | jq -e '.completion_kind == \"clean_reaction\"' >/dev/null"
+assert "a page-2 marker comment reports completion_kind clean_marker" "printf '%s' \"\$out_cc_p2\" | jq -e '.completion_kind == \"clean_marker\"' >/dev/null"
 
 # ── Sub-phase A auto-skip for comment-triggered bot identities (Codex is
 #    never a requested reviewer — it is triggered by an issue comment; see


### PR DESCRIPTION
## Summary
- `poll-copilot-review.sh`'s completion criteria were narrower than `check-merge-eligibility.sh`'s acceptance criteria in two ways: (1) review-completion matched only `state==COMMENTED`, never `APPROVED`, so a bot's clean first-pass approval was indistinguishable from silence and wrongly spent the retry budget; (2) a clean-pass marker issue comment alone reported the same `completion_kind` (`clean_reaction`) as an actual qualifying `+1` reaction, but the eligibility floor's reaction-path fact requires the real `+1`.
- Widens the review-completion state filter to `APPROVED or COMMENTED`, matching `check-merge-eligibility.sh`'s Component 2 part (a).
- Splits the shared clean-signal emitter into a parameterized `emit_clean_signal_found <kind>` so a marker-only completion reports its own distinct `completion_kind` (`clean_marker`) instead of masquerading as `clean_reaction` -- preserves the "bot responded" signal without conflating it with the stricter reaction fact.

## Scope
- In scope: `poll-copilot-review.sh` and its test suite only.
- Out of scope, deliberately deferred (endorsed descope, tracked as `agents-config-abn9.44.12`, blocked on both this PR and a sibling in-flight PR touching the same file): repointing `merge-guard/SKILL.md`'s "Known residual" text, which currently documents these two defects as unfixed and references a stale bead. That file is owned by a different workstream in this repo and has its own open change in flight -- editing it here would be two authors in one file mid-flight, and asserting the fix is done there before this PR merges would put a false statement in a doc agents execute.
- Ground truth: `src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh` (the script and its header doc comments), `poll-copilot-review_test.sh` (regression coverage for both defects).

## Test Plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh` -- 72/72 assertions pass, exit 0
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh` -- 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh` -- 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/compute-rereview-polling_test.sh` -- 0 failures, exit 0 (unaffected sibling)

Bead: agents-config-abn9.44.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuMvZwLNRmUPRJWfDNCm3q