### PR TITLE
fix(wait-for-pr-comments): require the initial poll's review-completion check to match the current PR head

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -31,24 +31,11 @@
 # completion, but ONLY when it is fresh. On a re-review round
 # (--since-timestamp supplied), fresh means submitted_at > SINCE — the same
 # guard used everywhere else in this script. On the INITIAL poll (no
-# --since-timestamp), there is no timestamp bound, so freshness is
-# established instead by requiring the review's own `.commit_id` to equal
-# the CURRENT PR head, fetched fresh each attempt — matching
-# check-merge-eligibility.sh's review-path acceptance in effect, not as a
-# literal line-for-line copy: that script guards a missing key with
-# `(.commit_id // "") == $head`, this filter compares `.commit_id` bare —
-# functionally identical in jq (a missing key is `null`, and `null ==
-# "<sha>"` is `false`), so both fail closed on a reviewer payload lacking
-# the field. This differs
-# in KIND from the reaction/marker clean-pass bound below (a time-based
-# max(committer date, force-push event) window): a review object carries the
-# exact commit it was submitted against, so exact equality is available and
-# strictly more precise than a time-based approximation, whereas a reaction
-# or issue comment carries no commit reference at all and has no equality
-# check available to it. A stale review (commit_id != current head) is a
-# response to code no longer at HEAD and must not complete the poll; an
-# unfetchable head fails closed, rejecting all reviews that round rather than
-# risk accepting a stale one. When --bot-reviewers is supplied, two additional clean-pass
+# --since-timestamp), freshness instead requires the review's own
+# `.commit_id` to equal the current PR head — see the initial-poll filter
+# below for the exact semantics and why reviews get equality while the
+# reaction/marker signals below get a time-based bound instead. When
+# --bot-reviewers is supplied, two additional clean-pass
 # signals count too: a `+1` reaction on the PR body, or an issue comment
 # starting with the clean-pass marker "Codex Review: Didn't find any major
 # issues" — each from an allowlisted identity (the standalone

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -28,7 +28,27 @@
 # a review object when a bot's pass is clean. A submitted review (state
 # APPROVED or COMMENTED — mirroring check-merge-eligibility.sh's own review
 # path, which accepts both as a legitimate clean pass) always counts as
-# completion. When --bot-reviewers is supplied, two additional clean-pass
+# completion, but ONLY when it is fresh. On a re-review round
+# (--since-timestamp supplied), fresh means submitted_at > SINCE — the same
+# guard used everywhere else in this script. On the INITIAL poll (no
+# --since-timestamp), there is no timestamp bound, so freshness is
+# established instead by requiring the review's own `.commit_id` to equal
+# the CURRENT PR head, fetched fresh each attempt — matching
+# check-merge-eligibility.sh's review-path acceptance in effect, not as a
+# literal line-for-line copy: that script guards a missing key with
+# `(.commit_id // "") == $head`, this filter compares `.commit_id` bare —
+# functionally identical in jq (a missing key is `null`, and `null ==
+# "<sha>"` is `false`), so both fail closed on a reviewer payload lacking
+# the field. This differs
+# in KIND from the reaction/marker clean-pass bound below (a time-based
+# max(committer date, force-push event) window): a review object carries the
+# exact commit it was submitted against, so exact equality is available and
+# strictly more precise than a time-based approximation, whereas a reaction
+# or issue comment carries no commit reference at all and has no equality
+# check available to it. A stale review (commit_id != current head) is a
+# response to code no longer at HEAD and must not complete the poll; an
+# unfetchable head fails closed, rejecting all reviews that round rather than
+# risk accepting a stale one. When --bot-reviewers is supplied, two additional clean-pass
 # signals count too: a `+1` reaction on the PR body, or an issue comment
 # starting with the clean-pass marker "Codex Review: Didn't find any major
 # issues" — each from an allowlisted identity (the standalone
@@ -218,14 +238,29 @@ emit_clean_signal_found() {
     }'
 }
 
+# fetch_head_sha — the PR's current head commit SHA, freshly fetched (never
+# cached — a push landing mid-poll is reflected on the NEXT attempt rather
+# than compared against a stale snapshot), or empty stdout on any failure
+# (API error, missing/null .head.sha). Callers checking freshness — the
+# initial-poll review filter and the committer-date bound below — both need
+# this same fetch and share it here rather than duplicating the `gh_api`
+# call, even though they use the SHA for different purposes (equality vs.
+# looking up a commit date) and must remain free to fail independently.
+fetch_head_sha() {
+    local head_sha
+    head_sha=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.head.sha') || return 0
+    [[ -n "$head_sha" && "$head_sha" != "null" ]] || return 0
+    printf '%s' "$head_sha"
+}
+
 # head_committer_epoch — the PR head commit's committer date as epoch seconds,
 # or empty on any failure (unfetchable head SHA, missing/unparseable date).
 # Committer dates are GitHub-API timestamps normalized to UTC `Z`, parsed the
 # same fromdateiso8601 way as the reaction/comment created_at values.
 head_committer_epoch() {
     local head_sha date_iso
-    head_sha=$(gh_api "repos/${OWNER}/${REPO}/pulls/${PR}" --jq '.head.sha') || return 0
-    [[ -n "$head_sha" && "$head_sha" != "null" ]] || return 0
+    head_sha=$(fetch_head_sha)
+    [[ -n "$head_sha" ]] || return 0
     date_iso=$(gh_api "repos/${OWNER}/${REPO}/commits/${head_sha}" --jq '.commit.committer.date') || return 0
     [[ -n "$date_iso" && "$date_iso" != "null" ]] || return 0
     printf '%s' "$date_iso" | jq -Rr 'fromdateiso8601? // empty' 2>/dev/null
@@ -380,6 +415,34 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
             echo "  Attempt ${i}/${MAX_ITERATIONS}: found ${stale_count} stale review(s) (submitted_at <= ${SINCE}), discarding" >&2
         fi
         reviews="$fresh_reviews"
+    else
+        # Initial poll (no --since-timestamp): no timestamp bound exists, so
+        # freshness is established by requiring the review's own `.commit_id`
+        # to equal the CURRENT PR head -- mirrors check-merge-eligibility.sh's
+        # review-path acceptance criteria (`.commit_id == head`) exactly.
+        # Unlike the reaction/marker clean-pass signals below, a review
+        # object carries the exact commit it was submitted against, so exact
+        # equality is available and strictly more precise than a time-based
+        # approximation (agents-config-abn9.44.14). A review whose commit_id
+        # predates the current head is a response to code that is no longer
+        # at HEAD, not a response to what is there now -- it must not
+        # complete the poll. A legitimate review AT the current head is
+        # unaffected: its own commit_id equals the freshly-fetched head, so
+        # first-pass detection has no regression. Fail closed: an unfetchable
+        # head rejects ALL reviews this round rather than risk accepting a
+        # stale one.
+        current_head=$(fetch_head_sha)
+        if [[ -z "$current_head" ]]; then
+            echo "  Attempt ${i}/${MAX_ITERATIONS}: could not fetch current head, rejecting reviews this round (fail closed)" >&2
+            reviews='[]'
+        else
+            fresh_reviews=$(printf '%s' "$reviews" | jq --arg head "$current_head" '[.[] | select(.commit_id == $head)]')
+            stale_count=$(printf '%s' "$reviews" | jq --arg head "$current_head" '[.[] | select(.commit_id != $head)] | length')
+            if [[ "$stale_count" -gt 0 ]]; then
+                echo "  Attempt ${i}/${MAX_ITERATIONS}: found ${stale_count} stale review(s) (commit_id != ${current_head}), discarding" >&2
+            fi
+            reviews="$fresh_reviews"
+        fi
     fi
 
     # APPROVED or COMMENTED are both a completed review — mirrors

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -177,9 +177,14 @@ assert "exits 3 for --bot-reviewers array with a non-string" "[ \$rc_mixed_bots 
 
 # A non-Copilot bot review is found ONLY when its identity is in --bot-reviewers,
 # proving the poll matches by policy allowlist, not the hardcoded Copilot substring.
-FIXTURE_REVIEWS_OTHERBOT='[{"user":{"login":"My-Bot[bot]","type":"Bot"},"state":"COMMENTED","submitted_at":"2026-01-01T00:00:00Z"}]'
+# commit_id matches FIXTURE_PR's head.sha (agents-config-abn9.44.14: the initial
+# poll now requires this match — see the freshness-filter section below).
+CURRENT_HEAD_SHA='deadbeef00000000000000000000000000000000'
+FIXTURE_PR_CURRENT_HEAD="{\"state\":\"open\",\"head\":{\"sha\":\"$CURRENT_HEAD_SHA\"}}"
+FIXTURE_REVIEWS_OTHERBOT="[{\"user\":{\"login\":\"My-Bot[bot]\",\"type\":\"Bot\"},\"state\":\"COMMENTED\",\"submitted_at\":\"2026-01-01T00:00:00Z\",\"commit_id\":\"$CURRENT_HEAD_SHA\"}]"
 
 out_bot=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  FIXTURE_PR="$FIXTURE_PR_CURRENT_HEAD" \
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 5 --bot-reviewers '["my-bot[bot]"]' 2>/dev/null)
 rc_bot=$?
 assert "non-Copilot bot in --bot-reviewers yields a found review (exit 0)" "[ \$rc_bot -eq 0 ]"
@@ -187,6 +192,7 @@ assert "matched review reports copilot_review_found" "printf '%s' \"\$out_bot\" 
 
 # Control: the same bot is invisible to the default Copilot filter → timeout.
 env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  FIXTURE_PR="$FIXTURE_PR_CURRENT_HEAD" \
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 >/dev/null 2>&1
 rc_default=$?
 assert "default Copilot filter does NOT match the non-Copilot bot (timeout, exit 1)" "[ \$rc_default -eq 1 ]"
@@ -200,13 +206,50 @@ assert "matched review reports completion_kind review" "printf '%s' \"\$out_bot\
 # 2 part (a)); before this fix, a bot that approved cleanly on its first pass
 # was never detected as having responded, and the poll ran to a spurious
 # timeout that wrongly spent the retry budget.
-FIXTURE_REVIEWS_APPROVED='[{"user":{"login":"My-Bot[bot]","type":"Bot"},"state":"APPROVED","submitted_at":"2026-01-01T00:00:00Z"}]'
+FIXTURE_REVIEWS_APPROVED="[{\"user\":{\"login\":\"My-Bot[bot]\",\"type\":\"Bot\"},\"state\":\"APPROVED\",\"submitted_at\":\"2026-01-01T00:00:00Z\",\"commit_id\":\"$CURRENT_HEAD_SHA\"}]"
 
 out_approved=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_APPROVED" \
+  FIXTURE_PR="$FIXTURE_PR_CURRENT_HEAD" \
   "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 5 --bot-reviewers '["my-bot[bot]"]' 2>/dev/null)
 rc_approved=$?
 assert "an APPROVED review completes (exit 0), does NOT time out" "[ \$rc_approved -eq 0 ]"
 assert "an APPROVED review reports completion_kind review" "printf '%s' \"\$out_approved\" | jq -e '.completion_kind == \"review\"' >/dev/null"
+
+# ── agents-config-abn9.44.14: the INITIAL poll (no --since-timestamp) must
+# require a review's own `.commit_id` to equal the current PR head, mirroring
+# check-merge-eligibility.sh's review-path acceptance criteria exactly. Before
+# this fix the initial poll applied NO freshness filter at all -- any
+# historical review from a trusted identity, however stale, completed the
+# poll. A stale review is not a response to the code actually at HEAD.
+
+# (m) A review whose commit_id does NOT match the current head must NOT
+#     complete the initial poll -- falls through to a real timeout.
+FIXTURE_REVIEWS_STALE_COMMIT="[{\"user\":{\"login\":\"My-Bot[bot]\",\"type\":\"Bot\"},\"state\":\"APPROVED\",\"submitted_at\":\"2026-01-01T00:00:00Z\",\"commit_id\":\"stalecommit0000000000000000000000000000\"}]"
+
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_STALE_COMMIT" \
+  FIXTURE_PR="$FIXTURE_PR_CURRENT_HEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 --bot-reviewers '["my-bot[bot]"]' >/dev/null 2>&1
+rc_stale_commit=$?
+assert "initial poll: a review against a stale commit does NOT complete (timeout, exit 1)" "[ \$rc_stale_commit -eq 1 ]"
+
+# (n) Regression guard: a legitimate review AT the current head still
+#     completes normally on the first poll -- no regression to first-pass
+#     detection (out_bot/out_approved above already prove this, this is the
+#     bare minimal repro naming the acceptance criterion explicitly).
+out_fresh_commit=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  FIXTURE_PR="$FIXTURE_PR_CURRENT_HEAD" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 5 --bot-reviewers '["my-bot[bot]"]' 2>/dev/null)
+rc_fresh_commit=$?
+assert "initial poll: a review at the current head still completes (exit 0)" "[ \$rc_fresh_commit -eq 0 ]"
+assert "initial poll: a review at the current head reports completion_kind review" "printf '%s' \"\$out_fresh_commit\" | jq -e '.completion_kind == \"review\"' >/dev/null"
+
+# (o) An unfetchable current head fails closed -- rejects reviews this round
+#     rather than risk accepting a stale one. FIXTURE_PR omitted entirely
+#     (stub defaults to '{"state":"open"}', no .head.sha).
+env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" FIXTURE_REVIEWS="$FIXTURE_REVIEWS_OTHERBOT" \
+  "$SCRIPT" --owner o --repo r --pr 1 --skip-request-check --timeout-seconds 1 --bot-reviewers '["my-bot[bot]"]' >/dev/null 2>&1
+rc_no_head=$?
+assert "initial poll: unfetchable current head fails closed (timeout, exit 1)" "[ \$rc_no_head -eq 1 ]"
 
 # ── Poll completion contract (Component 3): clean-pass completion ───────────
 # A clean bot pass submits no review object at all — only a `+1` reaction on


### PR DESCRIPTION
## Summary
- `poll-copilot-review.sh`'s INITIAL poll (invoked without `--since-timestamp` -- the very first poll after a PR opens or a fix is pushed) applied no freshness filter to reviews at all. Only the optional `--since-timestamp` branch, used on re-review rounds, bounded staleness via `submitted_at`. Consequence: any historical review from a trusted bot identity -- including one submitted against a stale commit -- satisfied the review-completion check and ended the poll with `completion_kind: "review"`, even though the code at the current head was never reviewed.
- `check-merge-eligibility.sh` independently applies its own `.commit_id == head` filter, so no unsafe merge results; the actual damage is poll accounting -- a premature `review` completion means the silent-ask retry counter never advances for what is effectively still silence from the current head's perspective.
- Adds `fetch_head_sha` (shared with `head_committer_epoch`, fetched fresh each poll iteration, never cached) and requires a review's own `.commit_id` to equal the current head on the initial poll, matching `check-merge-eligibility.sh`'s acceptance criteria in effect (not a literal line-for-line copy -- see the header note on the `// ""` difference). Fails closed on an unfetchable head. The re-review round's existing `submitted_at` bound is unchanged.

## Scope
- In scope: `poll-copilot-review.sh` and its test suite only.
- Ground truth: `src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh` (the script and its header doc comments), `poll-copilot-review_test.sh` (regression coverage).
- Discovered during Codex review of a prior PR (#359) on the same file; traced and confirmed pre-existing (not introduced there), then filed and fixed as its own bead since it's a distinct defect (absence of any freshness comparison on the initial poll) from a sibling bead (`m5tkg`, an off-by-one on an *existing* comparison elsewhere in the review-loop subsystem) -- not folded together.

## Test Plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh` -- 76/76 assertions pass, exit 0 (measured directly)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh` -- 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh` -- 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/compute-rereview-polling_test.sh` -- 0 failures, exit 0 (unaffected sibling)

Bead: agents-config-abn9.44.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuMvZwLNRmUPRJWfDNCm3q