### PR TITLE
fix(vizsuite): constellation round-2 feedback — drag reheat, full reset, density, blast overlay (yf2ov.2.13)

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -359,12 +359,17 @@
     toggle.textContent = "Show blast radius";
     panelEl.appendChild(toggle);
 
-    // Shared close path for the toggle's own "Hide" click, the overlay's own
-    // close button, and Escape (wireDrillPanelClose below) — every close
-    // fully destroys the sonar render and removes the overlay, rather than
-    // merely hiding it, so the "fresh container per open" contract holds
-    // for every trigger, not just a drawer rebuild.
-    function closeOverlay() {
+    // The one owner of blast-overlay teardown (round-2 fix): every close
+    // trigger — this toggle's own "Hide" click, the overlay's own close
+    // button, Escape (wireDrillPanelClose below), a fresh openDrill call,
+    // and the drawer's own Close button — calls this same function via
+    // `drillState.closeBlastOverlay`, so none of them can strand the
+    // overlay mounted over the canvas with its toggle left showing a stale
+    // "pressed" state. Assigned once, right away, rather than only when the
+    // overlay opens — safe to call at any point while this drill panel is
+    // showing, since the guards below are no-ops when the overlay was never
+    // opened (sonarHandle/sonarOverlayEl already null).
+    function closeBlastOverlay() {
       if (drillState.sonarHandle && typeof drillState.sonarHandle.destroy === "function") {
         drillState.sonarHandle.destroy();
       }
@@ -373,15 +378,15 @@
         drillState.sonarOverlayEl.parentNode.removeChild(drillState.sonarOverlayEl);
       }
       drillState.sonarOverlayEl = null;
-      drillState.closeSonarOverlay = null;
       toggle.setAttribute("aria-pressed", "false");
       toggle.textContent = "Show blast radius";
     }
+    drillState.closeBlastOverlay = closeBlastOverlay;
 
     toggle.addEventListener("click", function () {
       var expanded = toggle.getAttribute("aria-pressed") === "true";
       if (expanded) {
-        closeOverlay();
+        closeBlastOverlay();
         return;
       }
       // Same success-gated-UI-state contract as mountView: a missing sonar
@@ -402,7 +407,7 @@
       closeBtn.type = "button";
       closeBtn.setAttribute("class", "viz-btn viz-blast-overlay-close");
       closeBtn.textContent = "Close blast radius";
-      closeBtn.addEventListener("click", closeOverlay);
+      closeBtn.addEventListener("click", closeBlastOverlay);
       overlay.appendChild(closeBtn);
 
       var mount = document.createElement("div");
@@ -412,7 +417,6 @@
 
       rootEl.appendChild(overlay);
       drillState.sonarOverlayEl = overlay;
-      drillState.closeSonarOverlay = closeOverlay;
       drillState.sonarHandle = window.vizSonar.render(mount, scene, fileNode.path);
 
       toggle.setAttribute("aria-pressed", "true");
@@ -449,21 +453,14 @@
   ) {
     return function (fileNode) {
       // A prior file's (or the same file's, on a weight-change refresh)
-      // sonar render is about to be discarded — destroy it explicitly rather
-      // than relying on the panel DOM removal below (spec §4.2: destroy the
-      // outgoing content, no leaked marks when recentering/reopening). The
-      // blast-radius overlay (round-2 fix) lives under `rootEl`, not
-      // `panelEl`, so wiping the panel's children alone would leave it
-      // behind — remove it explicitly too.
-      if (drillState.sonarHandle && typeof drillState.sonarHandle.destroy === "function") {
-        drillState.sonarHandle.destroy();
+      // sonar render/overlay is about to be discarded — the one owner
+      // (closeBlastOverlay, round-2 fix) tears down the sonar handle and the
+      // overlay element, which lives under `rootEl`, not `panelEl`, so
+      // wiping the panel's children below alone would leave it behind.
+      if (typeof drillState.closeBlastOverlay === "function") {
+        drillState.closeBlastOverlay();
       }
-      drillState.sonarHandle = null;
-      if (drillState.sonarOverlayEl && drillState.sonarOverlayEl.parentNode) {
-        drillState.sonarOverlayEl.parentNode.removeChild(drillState.sonarOverlayEl);
-      }
-      drillState.sonarOverlayEl = null;
-      drillState.closeSonarOverlay = null;
+      drillState.closeBlastOverlay = null;
 
       // Remember the open node so a weight change can recompute the
       // weight-dependent breakdown in place (spec §4.5) — see onWeightChange.
@@ -479,6 +476,13 @@
       closeBtn.setAttribute("class", "viz-btn");
       closeBtn.textContent = "Close";
       closeBtn.addEventListener("click", function () {
+        // Round-2 fix: the drawer's own Close button previously did none of
+        // the blast-overlay teardown the other four triggers did, stranding
+        // the overlay mounted over the canvas with its owning toggle now
+        // invisible and still reporting aria-pressed="true".
+        if (typeof drillState.closeBlastOverlay === "function") {
+          drillState.closeBlastOverlay();
+        }
         drillState.node = null;
         panelEl.hidden = true;
         onOpenChange(false);
@@ -614,8 +618,8 @@
       // (spec: "drawer stays open beside it") — the first Escape closes
       // just the overlay; a second Escape then closes the drawer, same as
       // before the overlay existed.
-      if (drillState.sonarOverlayEl && typeof drillState.closeSonarOverlay === "function") {
-        drillState.closeSonarOverlay();
+      if (drillState.sonarOverlayEl && typeof drillState.closeBlastOverlay === "function") {
+        drillState.closeBlastOverlay();
         return;
       }
       if (!panelEl.hidden) {
@@ -787,14 +791,19 @@
     // null when closed) so a weight change can refresh the open breakdown;
     // `sonarHandle` holds the currently-mounted sonar drill (or null), so it
     // can be torn down before the panel rebuilds (spec §4.2). `sonarOverlayEl`
-    // / `closeSonarOverlay` (round-2 fix) track the full-canvas blast-radius
-    // overlay, which lives outside the drawer under `#viz-root` and so needs
-    // its own explicit teardown (see makeOpenDrill and wireDrillPanelClose).
+    // tracks the full-canvas blast-radius overlay, which lives outside the
+    // drawer under `#viz-root` and so needs its own explicit teardown.
+    // `closeBlastOverlay` (round-2 fix) is the ONE teardown function every
+    // close trigger calls — the toggle's own "Hide" click, the overlay's own
+    // close button, Escape, a fresh openDrill call, and the drawer's own
+    // Close button (see appendSonarAffordance, makeOpenDrill, and
+    // wireDrillPanelClose) — so none of the five can strand the overlay
+    // mounted with its toggle left in a stale pressed state.
     var drillState = {
       node: null,
       sonarHandle: null,
       sonarOverlayEl: null,
-      closeSonarOverlay: null
+      closeBlastOverlay: null
     };
 
     // Drawer conversion (fidelity F3): the drawer never overlays the diagram

--- a/packages/vizsuite/src/vizsuite/templates/static/app.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/app.js
@@ -335,16 +335,19 @@
   }
 
   // ---- Sonar affordance (spec §6.1: file sonar as a drill, not a top-level
-  // view) — a toggle button + mount appended to the drill panel; wired here
-  // rather than in views/sonar.js because it needs the panel's lifecycle
-  // (destroyed and rebuilt fresh on every openDrill call, spec §4.2). The
-  // dependency-graph-unavailable state (the load-bearing axis fail-softed,
-  // per render_config.unavailable_axes) is handled by `window.vizSonar`
-  // itself, which renders the "unavailable" state in place of rings — the
-  // affordance is always present and always safe to open (an available axis
-  // with a legitimately empty edge set renders center-only rings, not the
-  // unavailable state).
-  function appendSonarAffordance(panelEl, scene, fileNode, drillState) {
+  // view) — a toggle button in the drill panel opens the sonar rendering as
+  // a full-canvas overlay (round-2 fix) over `rootEl` (`#viz-root`, the main
+  // scene area) rather than squeezed inside the ~370px drawer — real edge
+  // density needs the room the drawer can't give it. The overlay is its own
+  // fresh container per open (spec §4.2), never a child of the drawer, so it
+  // survives the drawer's own DOM wipe on a later openDrill call — see the
+  // explicit teardown in makeOpenDrill below. The dependency-graph-
+  // unavailable state (the load-bearing axis fail-softed, per
+  // render_config.unavailable_axes) is handled by `window.vizSonar` itself,
+  // which renders the "unavailable" state (or, for a file with zero edges of
+  // its own, an explicit empty-neighborhood state) in place of rings — the
+  // affordance is always present and always safe to open.
+  function appendSonarAffordance(panelEl, rootEl, scene, fileNode, drillState) {
     var toggle = document.createElement("button");
     toggle.id = "viz-drill-sonar-toggle";
     toggle.type = "button";
@@ -356,32 +359,64 @@
     toggle.textContent = "Show blast radius";
     panelEl.appendChild(toggle);
 
-    var mount = document.createElement("div");
-    mount.id = "viz-drill-sonar-mount";
-    mount.setAttribute("class", "viz-drill-sonar-mount");
-    mount.hidden = true;
-    panelEl.appendChild(mount);
+    // Shared close path for the toggle's own "Hide" click, the overlay's own
+    // close button, and Escape (wireDrillPanelClose below) — every close
+    // fully destroys the sonar render and removes the overlay, rather than
+    // merely hiding it, so the "fresh container per open" contract holds
+    // for every trigger, not just a drawer rebuild.
+    function closeOverlay() {
+      if (drillState.sonarHandle && typeof drillState.sonarHandle.destroy === "function") {
+        drillState.sonarHandle.destroy();
+      }
+      drillState.sonarHandle = null;
+      if (drillState.sonarOverlayEl && drillState.sonarOverlayEl.parentNode) {
+        drillState.sonarOverlayEl.parentNode.removeChild(drillState.sonarOverlayEl);
+      }
+      drillState.sonarOverlayEl = null;
+      drillState.closeSonarOverlay = null;
+      toggle.setAttribute("aria-pressed", "false");
+      toggle.textContent = "Show blast radius";
+    }
 
     toggle.addEventListener("click", function () {
       var expanded = toggle.getAttribute("aria-pressed") === "true";
       if (expanded) {
-        toggle.setAttribute("aria-pressed", "false");
-        toggle.textContent = "Show blast radius";
-        mount.hidden = true;
+        closeOverlay();
         return;
       }
       // Same success-gated-UI-state contract as mountView: a missing sonar
       // module (`window.vizSonar` absent) never flips the toggle to "pressed"
-      // over an empty mount.
-      if (!drillState.sonarHandle) {
-        if (!window.vizSonar || typeof window.vizSonar.render !== "function") {
-          return;
-        }
-        drillState.sonarHandle = window.vizSonar.render(mount, scene, fileNode.path);
+      // over an empty overlay.
+      if (!window.vizSonar || typeof window.vizSonar.render !== "function") {
+        return;
       }
+
+      var overlay = document.createElement("div");
+      overlay.id = "viz-blast-overlay";
+      overlay.setAttribute("class", "viz-blast-overlay");
+      overlay.setAttribute("role", "dialog");
+      overlay.setAttribute("aria-label", "Dependency blast radius for " + fileNode.path);
+
+      var closeBtn = document.createElement("button");
+      closeBtn.id = "viz-blast-overlay-close";
+      closeBtn.type = "button";
+      closeBtn.setAttribute("class", "viz-btn viz-blast-overlay-close");
+      closeBtn.textContent = "Close blast radius";
+      closeBtn.addEventListener("click", closeOverlay);
+      overlay.appendChild(closeBtn);
+
+      var mount = document.createElement("div");
+      mount.id = "viz-drill-sonar-mount";
+      mount.setAttribute("class", "viz-drill-sonar-mount");
+      overlay.appendChild(mount);
+
+      rootEl.appendChild(overlay);
+      drillState.sonarOverlayEl = overlay;
+      drillState.closeSonarOverlay = closeOverlay;
+      drillState.sonarHandle = window.vizSonar.render(mount, scene, fileNode.path);
+
       toggle.setAttribute("aria-pressed", "true");
       toggle.textContent = "Hide blast radius";
-      mount.hidden = false;
     });
   }
 
@@ -410,18 +445,25 @@
   // against the narrower container (see `viz:drill-panel-toggled` in
   // views/treemap.js) — the drawer never overlays the diagram. ----
   function makeOpenDrill(
-    panelEl, scene, annotationStore, weights, unavailableAxes, drillState, onOpenChange
+    panelEl, rootEl, scene, annotationStore, weights, unavailableAxes, drillState, onOpenChange
   ) {
     return function (fileNode) {
       // A prior file's (or the same file's, on a weight-change refresh)
-      // sonar render is about to be discarded along with the rest of the
-      // panel's DOM — destroy it explicitly rather than relying on the DOM
-      // removal below (spec §4.2: destroy the outgoing content, no leaked
-      // marks when recentering/reopening).
+      // sonar render is about to be discarded — destroy it explicitly rather
+      // than relying on the panel DOM removal below (spec §4.2: destroy the
+      // outgoing content, no leaked marks when recentering/reopening). The
+      // blast-radius overlay (round-2 fix) lives under `rootEl`, not
+      // `panelEl`, so wiping the panel's children alone would leave it
+      // behind — remove it explicitly too.
       if (drillState.sonarHandle && typeof drillState.sonarHandle.destroy === "function") {
         drillState.sonarHandle.destroy();
       }
       drillState.sonarHandle = null;
+      if (drillState.sonarOverlayEl && drillState.sonarOverlayEl.parentNode) {
+        drillState.sonarOverlayEl.parentNode.removeChild(drillState.sonarOverlayEl);
+      }
+      drillState.sonarOverlayEl = null;
+      drillState.closeSonarOverlay = null;
 
       // Remember the open node so a weight change can recompute the
       // weight-dependent breakdown in place (spec §4.5) — see onWeightChange.
@@ -548,7 +590,7 @@
         panelEl.appendChild(storySection);
       }
 
-      appendSonarAffordance(panelEl, scene, fileNode, drillState);
+      appendSonarAffordance(panelEl, rootEl, scene, fileNode, drillState);
 
       var notes = document.createElement("textarea");
       notes.setAttribute("class", "viz-drill-notes");
@@ -565,7 +607,18 @@
 
   function wireDrillPanelClose(panelEl, drillState, onOpenChange) {
     document.addEventListener("keydown", function (evt) {
-      if (evt.key === "Escape" && !panelEl.hidden) {
+      if (evt.key !== "Escape") {
+        return;
+      }
+      // Round-2 fix: the blast-radius overlay sits "on top" of the drawer
+      // (spec: "drawer stays open beside it") — the first Escape closes
+      // just the overlay; a second Escape then closes the drawer, same as
+      // before the overlay existed.
+      if (drillState.sonarOverlayEl && typeof drillState.closeSonarOverlay === "function") {
+        drillState.closeSonarOverlay();
+        return;
+      }
+      if (!panelEl.hidden) {
         drillState.node = null;
         panelEl.hidden = true;
         onOpenChange(false);
@@ -733,8 +786,16 @@
     // Shared drill-panel state: `node` holds the currently-open file node (or
     // null when closed) so a weight change can refresh the open breakdown;
     // `sonarHandle` holds the currently-mounted sonar drill (or null), so it
-    // can be torn down before the panel rebuilds (spec §4.2).
-    var drillState = { node: null, sonarHandle: null };
+    // can be torn down before the panel rebuilds (spec §4.2). `sonarOverlayEl`
+    // / `closeSonarOverlay` (round-2 fix) track the full-canvas blast-radius
+    // overlay, which lives outside the drawer under `#viz-root` and so needs
+    // its own explicit teardown (see makeOpenDrill and wireDrillPanelClose).
+    var drillState = {
+      node: null,
+      sonarHandle: null,
+      sonarOverlayEl: null,
+      closeSonarOverlay: null
+    };
 
     // Drawer conversion (fidelity F3): the drawer never overlays the diagram
     // — `#viz-root`'s `viz-drill-open` class shrinks it (scene.css), and the
@@ -750,6 +811,7 @@
 
     var openDrill = makeOpenDrill(
       elements.drillPanel,
+      elements.root,
       scene,
       annotationStore,
       weights,

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -922,19 +922,6 @@ body {
   z-index: 1;
 }
 
-/* ---- Reset view transition (round-2 fix): applied only for the duration of
-   a Reset click (views/constellation.js toggles this class, then removes it
-   after RESET_TRANSITION_MS) — outside a reset, node/edge positions are set
-   directly with no transition, so drag and the drag-reheat sub-simulation
-   stay perfectly responsive. ---- */
-.viz-constellation-stage.viz-constellation-resetting .viz-constellation-node,
-.viz-constellation-stage.viz-constellation-resetting .viz-constellation-node-label {
-  transition: left 0.4s ease, top 0.4s ease;
-}
-.viz-constellation-stage.viz-constellation-resetting .viz-constellation-edge {
-  transition: x1 0.4s ease, y1 0.4s ease, x2 0.4s ease, y2 0.4s ease;
-}
-
 /* ---- Constellation legend (spec §4.5 legend completeness): rendered
    inside the view's own container (never the shared #viz-legend — see
    views/constellation.js), so every entry here always has a real referent

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -249,6 +249,12 @@ body {
 
 /* ---- Estate treemap (spec §6.1). ---- */
 #viz-root {
+  /* Positioning context for the blast-radius overlay (round-2 fix, scene.css
+     .viz-blast-overlay below) — an `inset: 0` absolute overlay covers
+     exactly this box, so it already excludes the drawer (which docks
+     outside #viz-root via its own `position: fixed`) without any extra
+     width math. */
+  position: relative;
   margin: 0 0 1rem;
   transition: margin-right 0.18s ease;
 }
@@ -607,7 +613,40 @@ body {
 .viz-drill-sonar-mount[hidden] {
   display: none;
 }
+/* ---- Blast-radius overlay (round-2 fix, app.js's appendSonarAffordance):
+   the toggle opens the sonar rendering as a full-canvas overlay above the
+   main scene area rather than squeezed inside the ~370px drawer — real edge
+   density needs the room. Absolutely positioned over #viz-root (position:
+   relative, above), which already excludes the drawer sitting beside it. ---- */
+.viz-blast-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 15;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  background: var(--viz-overlay-bg);
+  border: 1px solid var(--viz-border-strong);
+  border-radius: 6px;
+}
+.viz-blast-overlay-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+}
 .viz-sonar-unavailable {
+  padding: 0.5rem 0.6rem;
+  border: 1px dashed var(--viz-border-strong);
+  border-radius: 4px;
+  color: var(--viz-secondary);
+  font-size: 12px;
+}
+/* Empty-neighborhood state (round-2 fix): a center file with real
+   dependency-graph data but zero edges of its own — distinct from
+   .viz-sonar-unavailable (the graph itself was never built), same visual
+   treatment since both are "nothing to draw here" states. */
+.viz-sonar-empty {
   padding: 0.5rem 0.6rem;
   border: 1px dashed var(--viz-border-strong);
   border-radius: 4px;
@@ -881,6 +920,19 @@ body {
   outline: 2px solid var(--viz-fg);
   outline-offset: 1px;
   z-index: 1;
+}
+
+/* ---- Reset view transition (round-2 fix): applied only for the duration of
+   a Reset click (views/constellation.js toggles this class, then removes it
+   after RESET_TRANSITION_MS) — outside a reset, node/edge positions are set
+   directly with no transition, so drag and the drag-reheat sub-simulation
+   stay perfectly responsive. ---- */
+.viz-constellation-stage.viz-constellation-resetting .viz-constellation-node,
+.viz-constellation-stage.viz-constellation-resetting .viz-constellation-node-label {
+  transition: left 0.4s ease, top 0.4s ease;
+}
+.viz-constellation-stage.viz-constellation-resetting .viz-constellation-edge {
+  transition: x1 0.4s ease, y1 0.4s ease, x2 0.4s ease, y2 0.4s ease;
 }
 
 /* ---- Constellation legend (spec §4.5 legend completeness): rendered

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -249,11 +249,11 @@ body {
 
 /* ---- Estate treemap (spec §6.1). ---- */
 #viz-root {
-  /* Positioning context for the blast-radius overlay (round-2 fix, scene.css
-     .viz-blast-overlay below) — an `inset: 0` absolute overlay covers
-     exactly this box, so it already excludes the drawer (which docks
-     outside #viz-root via its own `position: fixed`) without any extra
-     width math. */
+  /* Generic positioning context for any absolutely-positioned scene chrome
+     that resolves against the main scene box. The blast-radius overlay no
+     longer relies on this — it anchors to the viewport (`position: fixed`,
+     see .viz-blast-overlay below) so it tracks the visible canvas rather
+     than stretching with #viz-root's flow height in the ledger view. */
   position: relative;
   margin: 0 0 1rem;
   transition: margin-right 0.18s ease;
@@ -613,13 +613,21 @@ body {
 .viz-drill-sonar-mount[hidden] {
   display: none;
 }
-/* ---- Blast-radius overlay (round-2 fix, app.js's appendSonarAffordance):
-   the toggle opens the sonar rendering as a full-canvas overlay above the
-   main scene area rather than squeezed inside the ~370px drawer — real edge
-   density needs the room. Absolutely positioned over #viz-root (position:
-   relative, above), which already excludes the drawer sitting beside it. ---- */
+/* ---- Blast-radius overlay (app.js's appendSonarAffordance): the toggle
+   opens the sonar rendering as a full-viewport modal above the main scene
+   area rather than squeezed inside the ~370px drawer — real edge density
+   needs the room. Anchored to the viewport (`position: fixed`), NOT to
+   #viz-root: in the flow-based ledger view #viz-root grows to the full
+   document height, so an `inset: 0` absolute overlay would span the whole
+   document and strand the centered sonar thousands of pixels off-screen
+   when opened from a low ledger row. Fixed positioning keeps the modal
+   over the visible canvas regardless of #viz-root's flow height. #viz-root
+   has no transformed/filtered/perspective ancestor (its only ancestors are
+   body/html), so `fixed` resolves against the viewport as intended. The
+   modal's role=dialog, z-index:15, and Close button make covering the page
+   header while open the intended, dismissable behavior. ---- */
 .viz-blast-overlay {
-  position: absolute;
+  position: fixed;
   inset: 0;
   z-index: 15;
   display: flex;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -91,6 +91,29 @@
   // never removes its determinism (spec §4.2).
   var LAYOUT_SEED = 1337;
   var DRAG_THRESHOLD = 4; // px; same click-vs-drag threshold as wireClickVsDragActivation
+
+  // ---- Layout density (round-2 fix): caps how far apart two nodes still
+  // push each other, and a weak per-node pull toward the box center — both
+  // consumed by layoutGraph below. Tuning constants, not determinism knobs:
+  // the seed and tick count are untouched, so the same node/edge set still
+  // settles the same way every time. ----
+  var CHARGE_DISTANCE_MAX = 260;
+  var CENTER_FORCE_STRENGTH = 0.045;
+
+  // ---- Drag-time localized reheat (round-2 fix: drag re-orients neighbors,
+  // prototype anatomy variant_B.js's alphaTarget(0.05) drag hold): a low
+  // starting alpha, decaying fast enough to settle well under ~1s after
+  // drop, applied only to the dragged node's own 1-hop neighborhood
+  // sub-simulation (see createLocalReheat below) — every other node is
+  // never added to that sub-simulation, so the global deterministic layout
+  // is never disturbed. ----
+  var REHEAT_ALPHA = 0.3;
+  var REHEAT_ALPHA_DECAY = 0.1;
+
+  // ---- Reset view transition (round-2 fix): shared by the zoom-transform
+  // transition and the node-position CSS transition (.viz-constellation-
+  // resetting, scene.css) so both animate over the same window. ----
+  var RESET_TRANSITION_MS = 400;
   // Double-click un-pin window (ms): a node click's activation (dir focus /
   // file drill) is deferred by this window and cancelled when the un-pin
   // dblclick lands, so the un-pin gesture never also opens the drill (whose
@@ -158,13 +181,20 @@
   }
 
   // ---- dir_of (prototype anatomy: gen_data.py lines ~221-223): a file's
-  // containing directory, capped at 4 path segments deep — a file 6 levels
-  // deep still aggregates into its 4th-level ancestor, not a very-long,
-  // very-specific leaf directory. A root-level file (no "/" in its path)
-  // aggregates into the synthetic "(root)" dir. ----
+  // containing directory, capped at DIR_DEPTH_CAP path segments deep — a
+  // file 6 levels deep still aggregates into its DIR_DEPTH_CAP-th-level
+  // ancestor, not a very-long, very-specific leaf directory. A root-level
+  // file (no "/" in its path) aggregates into the synthetic "(root)" dir.
+  // The fixed cap is an interim heuristic (round-2 fix: raised 4→5 so
+  // packages/<pkg>/src/<pkg>/<subpkg>/* no longer folds into one blob) — an
+  // adaptive per-repo depth is a separate design, not built here.
+  // `findContainingDir` below must walk the identical cap, so both share
+  // this one constant. ----
+  var DIR_DEPTH_CAP = 5;
+
   function dirOf(path) {
     var parts = path.split("/");
-    var segCount = Math.min(parts.length - 1, 4);
+    var segCount = Math.min(parts.length - 1, DIR_DEPTH_CAP);
     var dir = parts.slice(0, segCount).join("/");
     return dir || ROOT_DIR_PATH;
   }
@@ -176,7 +206,7 @@
   // may itself be absent, e.g. every file lives in some real directory). ----
   function findContainingDir(path, dirNodeByPath) {
     var parts = path.split("/");
-    for (var i = Math.min(parts.length - 1, 4); i >= 1; i--) {
+    for (var i = Math.min(parts.length - 1, DIR_DEPTH_CAP); i >= 1; i--) {
       var candidate = parts.slice(0, i).join("/");
       if (dirNodeByPath[candidate]) {
         return dirNodeByPath[candidate];
@@ -401,7 +431,11 @@
   // ---- Pre-settled force layout (spec §4.2): runs to completion
   // synchronously, before this module ever paints a node. ----
   function layoutGraph(nodes, edges) {
-    var side = Math.max(320, Math.round(Math.sqrt(nodes.length) * 90) + 140);
+    // Tightened from an earlier (sqrt(n) * 90 + 140) box (round-2 fix:
+    // layout density) — a smaller box, the charge distanceMax cap, and the
+    // weak x/y centering force below all pull the settled graph in off the
+    // corners, instead of leaving it to spread out with vast whitespace.
+    var side = Math.max(280, Math.round(Math.sqrt(nodes.length) * 70) + 90);
 
     var simulation = d3
       .forceSimulation(nodes)
@@ -426,11 +460,25 @@
       )
       .force(
         "charge",
-        d3.forceManyBody().strength(function (d) {
-          return d.kind === "file" ? -30 : -120;
-        })
+        d3
+          .forceManyBody()
+          .strength(function (d) {
+            return d.kind === "file" ? -24 : -100;
+          })
+          // Caps how far apart two nodes still push each other (round-2 fix:
+          // layout density) — without it, distant pairs keep accumulating
+          // repulsion and drift the graph's outer nodes toward the box
+          // corners.
+          .distanceMax(CHARGE_DISTANCE_MAX)
       )
       .force("center", d3.forceCenter(side / 2, side / 2))
+      // A weak per-node pull toward the box center (round-2 fix: layout
+      // density) — forceCenter above only recenters the graph's
+      // *barycenter*, it applies no restoring pull on any individual
+      // outlier, which is why charge + long weak links alone were settling
+      // nodes out toward the edges.
+      .force("x", d3.forceX(side / 2).strength(CENTER_FORCE_STRENGTH))
+      .force("y", d3.forceY(side / 2).strength(CENTER_FORCE_STRENGTH))
       .force(
         "collide",
         d3.forceCollide(function (d) {
@@ -619,6 +667,63 @@
     return (dirNode.stats.load_bearing || 0) + (dirNode.stats.changed > 0 ? 1 : 0);
   }
 
+  // ---- Label disambiguation (round-2 fix): the culled label set above
+  // often contains several nodes whose *leaf* path segment collides (e.g.
+  // four dirs all named "unit") — a leaf-only label is ambiguous for any of
+  // them. Grouped by leaf, a unique leaf stays leaf-only; a colliding group
+  // extends every member's label by one more trailing path segment at a
+  // time until the group's own labels are mutually unique (or every member
+  // has been extended all the way to its full path, whichever comes
+  // first). Groups never interact with each other here — two different
+  // leaves can never collide after extension, since the leaf itself is the
+  // last segment of every extended label. ----
+  function computeDisambiguatedLabels(labeledNodes) {
+    var groupsByLeaf = Object.create(null);
+    labeledNodes.forEach(function (node) {
+      var displayPath = node.kind === "dir" ? dirDisplayPath(node.path) : node.path;
+      var leaf = basename(displayPath);
+      (groupsByLeaf[leaf] || (groupsByLeaf[leaf] = [])).push({
+        id: node.id,
+        segments: displayPath.split("/")
+      });
+    });
+
+    var labelById = Object.create(null);
+    Object.keys(groupsByLeaf).forEach(function (leaf) {
+      var members = groupsByLeaf[leaf];
+      if (members.length === 1) {
+        labelById[members[0].id] = leaf;
+        return;
+      }
+      var depth = 1;
+      var labelsThisPass;
+      for (;;) {
+        depth += 1;
+        var seen = Object.create(null);
+        var collided = false;
+        labelsThisPass = Object.create(null);
+        members.forEach(function (member) {
+          var suffix = member.segments.slice(Math.max(0, member.segments.length - depth)).join("/");
+          labelsThisPass[member.id] = suffix;
+          if (seen[suffix]) {
+            collided = true;
+          }
+          seen[suffix] = true;
+        });
+        var exhausted = members.every(function (member) {
+          return depth >= member.segments.length;
+        });
+        if (!collided || exhausted) {
+          break;
+        }
+      }
+      members.forEach(function (member) {
+        labelById[member.id] = labelsThisPass[member.id];
+      });
+    });
+    return labelById;
+  }
+
   // ---- Node DOM + click-vs-drag/hover wiring (spec §4.2's activation
   // scaffold, the same one the treemap tile and ledger row use). `handlers`
   // is `{ onActivate(node), onHoverShow(evt, node), onHoverMove(evt),
@@ -626,7 +731,7 @@
   // drill/focus/tooltip wiring specifics. A node outside `labeledIds` gets no
   // label element at all (not merely a hidden one) — still fully
   // identifiable via its `title`/aria-label and the hover card. ----
-  function renderNodes(stage, nodes, labeledIds, handlers, activationGroup) {
+  function renderNodes(stage, nodes, labeledIds, labelTextById, handlers, activationGroup) {
     var entries = [];
     nodes.forEach(function (node) {
       var displayPath = node.kind === "dir" ? dirDisplayPath(node.path) : node.path;
@@ -659,7 +764,11 @@
         label = document.createElement("span");
         label.setAttribute("class", "viz-constellation-node-label");
         label.setAttribute("aria-hidden", "true");
-        label.textContent = basename(displayPath);
+        // Disambiguated (round-2 fix): a unique leaf renders leaf-only; a
+        // colliding leaf (e.g. four dirs all named "unit") renders extended
+        // with parent segments until it reads unambiguously — see
+        // computeDisambiguatedLabels.
+        label.textContent = labelTextById[node.id] || basename(displayPath);
         applyLabelPosition(label, node);
         stage.appendChild(label);
       }
@@ -700,6 +809,128 @@
     return entries;
   }
 
+  // ---- Localized drag reheat (round-2 fix: drag re-orients neighbors,
+  // prototype anatomy variant_B.js's live-simulation drag hold). Builds an
+  // undirected id → [neighbor node] map from the resolved edge list (post-
+  // layoutGraph, `edge.source`/`edge.target` are node object references, not
+  // ids — see renderEdges' own comment on that mutation), so a dragged
+  // node's 1-hop neighborhood (dir-dir coupling *and* satellite tethers,
+  // whichever the dragged node itself participates in) is a plain lookup. ----
+  function buildEdgeAdjacency(edges) {
+    var adjacency = Object.create(null);
+    function link(a, b) {
+      (adjacency[a.id] || (adjacency[a.id] = [])).push(b);
+    }
+    edges.forEach(function (edge) {
+      link(edge.source, edge.target);
+      link(edge.target, edge.source);
+    });
+    return adjacency;
+  }
+
+  // ---- createLocalReheat (round-2 fix): one view-scoped controller, shared
+  // by every node's wireDrag, so starting a new drag always tears down any
+  // still-settling sub-simulation from a previous drag rather than letting
+  // two fight over shared neighbor nodes. The sub-simulation's node set is
+  // exactly [draggedNode].concat(its 1-hop neighbors) — every node outside
+  // that neighborhood is simply never handed to `d3.forceSimulation`, so it
+  // cannot move; the dragged node itself is `fx`/`fy`-pinned to the pointer
+  // so only its neighbors visibly respond, mirroring the prototype's own
+  // drag-time reheat under this module's one-shot (no persistent
+  // simulation) layout contract. ----
+  function createLocalReheat(edges, entriesById, incidentByNodeId) {
+    var adjacency = buildEdgeAdjacency(edges);
+    var activeSim = null;
+
+    function stop() {
+      if (activeSim) {
+        activeSim.stop();
+        activeSim = null;
+      }
+    }
+
+    function start(draggedNode) {
+      stop();
+      var neighbors = adjacency[draggedNode.id] || [];
+      if (neighbors.length === 0) {
+        return;
+      }
+      var subNodes = [draggedNode].concat(neighbors);
+      var subIds = Object.create(null);
+      subNodes.forEach(function (n) {
+        subIds[n.id] = true;
+      });
+      var subEdges = edges.filter(function (edge) {
+        return subIds[edge.source.id] && subIds[edge.target.id];
+      });
+
+      draggedNode.fx = draggedNode.x;
+      draggedNode.fy = draggedNode.y;
+
+      activeSim = d3
+        .forceSimulation(subNodes)
+        .alpha(REHEAT_ALPHA)
+        .alphaDecay(REHEAT_ALPHA_DECAY)
+        .force(
+          "link",
+          d3
+            .forceLink(subEdges)
+            .distance(function (d) {
+              return d.tether ? 18 : 60;
+            })
+            .strength(function (d) {
+              return d.tether ? 0.8 : 0.25;
+            })
+        )
+        .force(
+          "charge",
+          d3.forceManyBody().strength(function (d) {
+            return d.kind === "file" ? -30 : -120;
+          })
+        )
+        .force(
+          "collide",
+          d3.forceCollide(function (d) {
+            return d.r + 3;
+          })
+        )
+        .on("tick", function () {
+          subNodes.forEach(function (n) {
+            var subEntry = entriesById[n.id];
+            if (!subEntry) {
+              return;
+            }
+            applyNodePosition(subEntry.el, n);
+            if (subEntry.labelEl) {
+              applyLabelPosition(subEntry.labelEl, n);
+            }
+            (incidentByNodeId[n.id] || []).forEach(function (incident) {
+              updateEdgeEndpoint(incident.lineEl, incident.role, n);
+            });
+          });
+        })
+        .on("end", function () {
+          draggedNode.fx = null;
+          draggedNode.fy = null;
+          activeSim = null;
+        });
+    }
+
+    // Called on every drag-move so a long-held drag keeps the neighborhood
+    // warm instead of cooling to alphaMin mid-gesture (the sub-simulation's
+    // own timer ticks independently of pointer events, but only while its
+    // alpha stays above alphaMin).
+    function touch(draggedNode) {
+      draggedNode.fx = draggedNode.x;
+      draggedNode.fy = draggedNode.y;
+      if (activeSim) {
+        activeSim.alpha(Math.max(activeSim.alpha(), REHEAT_ALPHA));
+      }
+    }
+
+    return { start: start, touch: touch, stop: stop };
+  }
+
   // ---- Drag-to-reposition + pin-on-drop (spec: drag must coexist with, not
   // replace, wireClickVsDragActivation's own click-vs-drag distinguishing —
   // these are separate listeners on the same element, so both run off the
@@ -707,7 +938,7 @@
   // reads the *live* zoom scale so a drag delta (in screen px) converts back
   // to the node's own untransformed coordinate space — otherwise a dragged
   // node would drift away from the cursor at any zoom level but 1. ----
-  function wireDrag(entry, incidentLines, getScale) {
+  function wireDrag(entry, incidentLines, getScale, localReheat) {
     var node = entry.node;
     var el = entry.el;
     var startX = 0;
@@ -759,6 +990,11 @@
       var dy = evt.clientY - startY;
       if (!dragging && (Math.abs(dx) > DRAG_THRESHOLD || Math.abs(dy) > DRAG_THRESHOLD)) {
         dragging = true;
+        // Drag start (prototype anatomy: d3.drag's own 'start' event) —
+        // reheat the dragged node's 1-hop neighborhood so the drag visibly
+        // re-orients its links, without disturbing the rest of the
+        // deterministic layout.
+        localReheat.start(node);
       }
       if (!dragging) {
         return;
@@ -768,6 +1004,7 @@
       node.y += dy / scale;
       startX = evt.clientX;
       startY = evt.clientY;
+      localReheat.touch(node);
       reposition();
     });
     function endDrag(evt) {
@@ -779,6 +1016,10 @@
       active = false;
       dragging = false;
       activePointerId = null;
+      // The dragged node stays fx/fy-pinned at the drop point (existing
+      // "stays pinned where dropped" behavior) while its localized
+      // sub-simulation keeps settling on its own timer for up to ~1s — see
+      // createLocalReheat's "end" handler for the fx/fy release.
     }
     el.addEventListener("pointerup", endDrag);
     el.addEventListener("pointercancel", endDrag);
@@ -791,6 +1032,9 @@
     // live-simulation reheat-on-unpin available under this contract.
     el.addEventListener("dblclick", function (evt) {
       evt.stopPropagation();
+      localReheat.stop();
+      node.fx = null;
+      node.fy = null;
       node.x = node.origX;
       node.y = node.origY;
       reposition();
@@ -1033,11 +1277,23 @@
 
       // Centered baseline for the current viewport size — recomputed on resize
       // (below) because the drill drawer narrows the viewport after mount.
+      // Round-2 fix (layout density): baseline now also scales the layout
+      // box to fit the viewport (`fitScale`) instead of always showing it at
+      // 1:1 — a graph whose settled box is larger than the viewport starts
+      // zoomed out to fit rather than requiring a manual zoom-out, and a
+      // small graph's box is scaled up to fill the viewport rather than
+      // sitting tiny in the middle. Clamped to the zoom behavior's own
+      // scaleExtent so baseline never starts outside the user's zoom range.
       function computeBaseTransform() {
         var rect = viewport.getBoundingClientRect();
         var width = rect.width || viewport.clientWidth || side;
         var height = rect.height || viewport.clientHeight || side;
-        return d3.zoomIdentity.translate((width - side) / 2, (height - side) / 2);
+        var fitScale = Math.min(width / side, height / side);
+        var scale = Math.max(0.3, Math.min(6, fitScale));
+        return d3.zoomIdentity
+          .translate(width / 2, height / 2)
+          .scale(scale)
+          .translate(-side / 2, -side / 2);
       }
       var baseTransform = computeBaseTransform();
 
@@ -1084,14 +1340,50 @@
         d3.select(viewport).transition().duration(500).call(zoomBehavior.transform, next);
       }
 
+      // ---- Reset view (round-2 fix): restores every displaced/pinned node
+      // to its originally-settled position (origX/origY, captured right
+      // after layoutGraph()) and stops any in-flight localized drag reheat,
+      // in addition to the zoom-transform restore this control already did
+      // — after Reset, the view is pixel-identical to first render.
+      // `resetView` is a hoisted function declaration, so this handler can
+      // reference it even though it (and the `entries`/`edgeEntries`/
+      // `localReheat` it closes over) aren't assigned until further down
+      // this render() call — by the time a user can actually click the
+      // button, render() has long since finished executing. ----
+      function resetView() {
+        localReheat.stop();
+        visual.classList.add("viz-constellation-resetting");
+        graph.nodes.forEach(function (node) {
+          node.fx = null;
+          node.fy = null;
+          node.x = node.origX;
+          node.y = node.origY;
+        });
+        entries.forEach(function (entry) {
+          applyNodePosition(entry.el, entry.node);
+          if (entry.labelEl) {
+            applyLabelPosition(entry.labelEl, entry.node);
+          }
+        });
+        edgeEntries.forEach(function (entry) {
+          updateEdgeEndpoint(entry.lineEl, "source", entry.edge.source);
+          updateEdgeEndpoint(entry.lineEl, "target", entry.edge.target);
+        });
+        window.setTimeout(function () {
+          visual.classList.remove("viz-constellation-resetting");
+        }, RESET_TRANSITION_MS);
+        d3.select(viewport)
+          .transition()
+          .duration(RESET_TRANSITION_MS)
+          .call(zoomBehavior.transform, baseTransform);
+      }
+
       var resetBtn = document.createElement("button");
       resetBtn.id = "viz-constellation-reset";
       resetBtn.type = "button";
       resetBtn.setAttribute("class", "viz-btn viz-constellation-reset");
       resetBtn.textContent = "Reset view";
-      resetBtn.addEventListener("click", function () {
-        d3.select(viewport).transition().duration(400).call(zoomBehavior.transform, baseTransform);
-      });
+      resetBtn.addEventListener("click", resetView);
       viewport.appendChild(resetBtn);
 
       // Pruning affordance (spec: "N unconnected directories hidden") — only
@@ -1130,10 +1422,15 @@
       }
 
       var labeledIds = computeLabeledIds(graph.nodes);
+      var labeledNodes = graph.nodes.filter(function (node) {
+        return Boolean(labeledIds[node.id]);
+      });
+      var labelTextById = computeDisambiguatedLabels(labeledNodes);
       var entries = renderNodes(
         visual,
         graph.nodes,
         labeledIds,
+        labelTextById,
         {
           onActivate: onActivate,
           onHoverShow: onHoverShow,
@@ -1142,10 +1439,23 @@
         },
         activationGroup
       );
+      var entriesById = Object.create(null);
       entries.forEach(function (entry) {
-        wireDrag(entry, incidentByNodeId[entry.node.id] || [], function () {
-          return zoomTransform.k;
-        });
+        entriesById[entry.node.id] = entry;
+      });
+      // One view-scoped localized-reheat controller (round-2 fix: drag
+      // re-orients neighbors), shared by every node's wireDrag — see
+      // createLocalReheat above.
+      var localReheat = createLocalReheat(graph.edges, entriesById, incidentByNodeId);
+      entries.forEach(function (entry) {
+        wireDrag(
+          entry,
+          incidentByNodeId[entry.node.id] || [],
+          function () {
+            return zoomTransform.k;
+          },
+          localReheat
+        );
       });
       applyEncoding(entries, heatScale, current.computeHeat);
 
@@ -1155,6 +1465,9 @@
           if (resizeObserver) {
             resizeObserver.disconnect();
           }
+          // Stop any still-settling localized drag reheat so its timer never
+          // fires into a torn-down view.
+          localReheat.stop();
           // Flush every node's still-pending deferred activation so no timer
           // fires a focus/drill into a torn-down view.
           activationGroup.cancelAll();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -111,8 +111,8 @@
   var REHEAT_ALPHA_DECAY = 0.1;
 
   // ---- Reset view transition (round-2 fix): shared by the zoom-transform
-  // transition and the node-position CSS transition (.viz-constellation-
-  // resetting, scene.css) so both animate over the same window. ----
+  // transition and the rAF node/label/edge tween (createResetTween below) so
+  // both animate over the same window — the ONLY place this duration lives. ----
   var RESET_TRANSITION_MS = 400;
   // Double-click un-pin window (ms): a node click's activation (dir focus /
   // file drill) is deferred by this window and cancelled when the un-pin
@@ -428,6 +428,60 @@
     return { nodes: nodes, edges: edges, droppedDirCount: droppedDirCount };
   }
 
+  // ---- Shared force factories (round-2 fix: single-source the force
+  // config): the initial pre-settled layout (layoutGraph) and the drag-time
+  // localized reheat (createLocalReheat) both need a link/charge/collide
+  // force over the same node/edge shape — before this fix each built its own
+  // copy, and the reheat's copy had drifted onto stale pre-retune charge
+  // strengths (-30/-120 vs. layoutGraph's already-retuned -24/-100) with no
+  // distanceMax cap at all. One factory per force, called from both sites,
+  // so retuning a value can never again leave one call site behind. ----
+  function makeLinkForce(edges) {
+    return d3
+      .forceLink(edges)
+      .distance(function (d) {
+        return d.tether ? 18 : 60;
+      })
+      .strength(function (d) {
+        return d.tether ? 0.8 : 0.25;
+      });
+  }
+
+  function makeChargeForce() {
+    return (
+      d3
+        .forceManyBody()
+        .strength(function (d) {
+          return d.kind === "file" ? -24 : -100;
+        })
+        // Caps how far apart two nodes still push each other (round-2 fix:
+        // layout density) — without it, distant pairs keep accumulating
+        // repulsion and drift the graph's outer nodes toward the box
+        // corners.
+        .distanceMax(CHARGE_DISTANCE_MAX)
+    );
+  }
+
+  function makeCollideForce() {
+    return d3.forceCollide(function (d) {
+      return d.r + 3;
+    });
+  }
+
+  // ---- Node containment (round-2 fix): layoutGraph's own settle clamps
+  // every node into [r, side-r] once, but nothing re-clamped afterward — a
+  // drag (wireDrag) or a drag-reheat tick (createLocalReheat) can push a
+  // node past that box, and the `<svg width=side height=side>` CLIPS edges
+  // at its bounds while the node div itself renders unclipped, so a
+  // dragged/reheated node can float outside the zoom-to-fit baseline with
+  // its own edges guillotined. One shared clamp, called from every path that
+  // can move a node post-layout (drag reposition, reheat tick, reset tween),
+  // and reused here so the logic exists exactly once. ----
+  function clampToBox(node, side) {
+    node.x = Math.min(side - node.r, Math.max(node.r, node.x));
+    node.y = Math.min(side - node.r, Math.max(node.r, node.y));
+  }
+
   // ---- Pre-settled force layout (spec §4.2): runs to completion
   // synchronously, before this module ever paints a node. ----
   function layoutGraph(nodes, edges) {
@@ -446,31 +500,11 @@
       .stop()
       .force(
         "link",
-        d3
-          .forceLink(edges)
-          .id(function (d) {
-            return d.id;
-          })
-          .distance(function (d) {
-            return d.tether ? 18 : 60;
-          })
-          .strength(function (d) {
-            return d.tether ? 0.8 : 0.25;
-          })
+        makeLinkForce(edges).id(function (d) {
+          return d.id;
+        })
       )
-      .force(
-        "charge",
-        d3
-          .forceManyBody()
-          .strength(function (d) {
-            return d.kind === "file" ? -24 : -100;
-          })
-          // Caps how far apart two nodes still push each other (round-2 fix:
-          // layout density) — without it, distant pairs keep accumulating
-          // repulsion and drift the graph's outer nodes toward the box
-          // corners.
-          .distanceMax(CHARGE_DISTANCE_MAX)
-      )
+      .force("charge", makeChargeForce())
       .force("center", d3.forceCenter(side / 2, side / 2))
       // A weak per-node pull toward the box center (round-2 fix: layout
       // density) — forceCenter above only recenters the graph's
@@ -479,12 +513,7 @@
       // nodes out toward the edges.
       .force("x", d3.forceX(side / 2).strength(CENTER_FORCE_STRENGTH))
       .force("y", d3.forceY(side / 2).strength(CENTER_FORCE_STRENGTH))
-      .force(
-        "collide",
-        d3.forceCollide(function (d) {
-          return d.r + 3;
-        })
-      )
+      .force("collide", makeCollideForce())
       .alpha(1)
       .alphaDecay(1 - Math.pow(0.001, 1 / FIXED_TICKS));
 
@@ -496,8 +525,7 @@
     // barycenter toward the stage center but places no hard wall, so a
     // sparse graph can still settle a hair outside the box without this.
     nodes.forEach(function (node) {
-      node.x = Math.min(side - node.r, Math.max(node.r, node.x));
-      node.y = Math.min(side - node.r, Math.max(node.r, node.y));
+      clampToBox(node, side);
     });
 
     return side;
@@ -838,7 +866,7 @@
   // so only its neighbors visibly respond, mirroring the prototype's own
   // drag-time reheat under this module's one-shot (no persistent
   // simulation) layout contract. ----
-  function createLocalReheat(edges, entriesById, incidentByNodeId) {
+  function createLocalReheat(edges, entriesById, incidentByNodeId, side) {
     var adjacency = buildEdgeAdjacency(edges);
     var activeSim = null;
 
@@ -871,31 +899,21 @@
         .forceSimulation(subNodes)
         .alpha(REHEAT_ALPHA)
         .alphaDecay(REHEAT_ALPHA_DECAY)
-        .force(
-          "link",
-          d3
-            .forceLink(subEdges)
-            .distance(function (d) {
-              return d.tether ? 18 : 60;
-            })
-            .strength(function (d) {
-              return d.tether ? 0.8 : 0.25;
-            })
-        )
-        .force(
-          "charge",
-          d3.forceManyBody().strength(function (d) {
-            return d.kind === "file" ? -30 : -120;
-          })
-        )
-        .force(
-          "collide",
-          d3.forceCollide(function (d) {
-            return d.r + 3;
-          })
-        )
+        .force("link", makeLinkForce(subEdges))
+        // Single-sourced with layoutGraph's own charge force (round-2 fix) —
+        // this used to hardcode stale pre-retune -30/-120 strengths with no
+        // distanceMax cap, silently drifting apart from layoutGraph's already-
+        // retuned -24/-100 + CHARGE_DISTANCE_MAX.
+        .force("charge", makeChargeForce())
+        // Deliberately NO "center"/"x"/"y" force here: a local reheat must
+        // only re-orient the dragged node's own 1-hop neighborhood, never
+        // drag it toward the global layout center the way the full settle
+        // does — that would recenter the neighborhood instead of just
+        // settling it around the node that moved.
+        .force("collide", makeCollideForce())
         .on("tick", function () {
           subNodes.forEach(function (n) {
+            clampToBox(n, side);
             var subEntry = entriesById[n.id];
             if (!subEntry) {
               return;
@@ -919,13 +937,21 @@
     // Called on every drag-move so a long-held drag keeps the neighborhood
     // warm instead of cooling to alphaMin mid-gesture (the sub-simulation's
     // own timer ticks independently of pointer events, but only while its
-    // alpha stays above alphaMin).
+    // alpha stays above alphaMin). Round-2 fix: at alphaDecay 0.1 the sub-sim
+    // hits alphaMin — and its "end" handler nulls activeSim — after ~0.9s of
+    // pointer stillness; a drag held longer than that used to freeze the
+    // neighborhood for the rest of the gesture, since bumping `.alpha()`
+    // alone does not restart a d3 timer that has already stopped. Reviving
+    // via `start()` (rather than poking the dead sim) re-stops any stale sim
+    // and re-pins fx/fy from scratch.
     function touch(draggedNode) {
+      if (!activeSim) {
+        start(draggedNode);
+        return;
+      }
       draggedNode.fx = draggedNode.x;
       draggedNode.fy = draggedNode.y;
-      if (activeSim) {
-        activeSim.alpha(Math.max(activeSim.alpha(), REHEAT_ALPHA));
-      }
+      activeSim.alpha(Math.max(activeSim.alpha(), REHEAT_ALPHA)).restart();
     }
 
     return { start: start, touch: touch, stop: stop };
@@ -938,7 +964,7 @@
   // reads the *live* zoom scale so a drag delta (in screen px) converts back
   // to the node's own untransformed coordinate space — otherwise a dragged
   // node would drift away from the cursor at any zoom level but 1. ----
-  function wireDrag(entry, incidentLines, getScale, localReheat) {
+  function wireDrag(entry, incidentLines, getScale, localReheat, resetTween, side) {
     var node = entry.node;
     var el = entry.el;
     var startX = 0;
@@ -993,7 +1019,9 @@
         // Drag start (prototype anatomy: d3.drag's own 'start' event) —
         // reheat the dragged node's 1-hop neighborhood so the drag visibly
         // re-orients its links, without disturbing the rest of the
-        // deterministic layout.
+        // deterministic layout. A drag that starts mid-reset must take over
+        // cleanly, so cancel any in-flight reset tween first (round-2 fix).
+        resetTween.cancel();
         localReheat.start(node);
       }
       if (!dragging) {
@@ -1002,6 +1030,7 @@
       var scale = getScale();
       node.x += dx / scale;
       node.y += dy / scale;
+      clampToBox(node, side);
       startX = evt.clientX;
       startY = evt.clientY;
       localReheat.touch(node);
@@ -1039,6 +1068,86 @@
       node.y = node.origY;
       reposition();
     });
+  }
+
+  // ---- Reset-view tween (round-2 fix): replaces a CSS-transition mechanism
+  // that never actually animated (scene.css declared `transition: x1/y1/x2/
+  // y2` on the SVG `<line>` edges, but those attributes are NOT CSS-mapped
+  // geometry properties — only x/y/width/height/cx/cy/r/rx/ry are — so the
+  // declaration was inert: node/label divs glided on their real `left`/`top`
+  // transition while every edge snapped instantly, visibly detaching from
+  // its nodes). One rAF-driven tween per render, easing every node from its
+  // current (possibly displaced) position to its origX/origY, calling the
+  // same per-frame helpers the drag path uses (applyNodePosition/
+  // applyLabelPosition/updateEdgeEndpoint, plus the shared clampToBox) on
+  // EVERY frame — never just at a CSS transition's start/end — so nodes,
+  // labels, and edges stay glued together throughout. Owned by a handle with
+  // its own `cancel()` so a drag that starts mid-tween (wireDrag) or an
+  // unmount (destroy()) can tear it down cleanly instead of fighting it. ----
+  function createResetTween(entriesById, incidentByNodeId, side) {
+    var rafId = null;
+
+    function cancel() {
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    }
+
+    function easeOutCubic(t) {
+      return 1 - Math.pow(1 - t, 3);
+    }
+
+    function applyFrame(node) {
+      clampToBox(node, side);
+      var entry = entriesById[node.id];
+      if (entry) {
+        applyNodePosition(entry.el, node);
+        if (entry.labelEl) {
+          applyLabelPosition(entry.labelEl, node);
+        }
+      }
+      (incidentByNodeId[node.id] || []).forEach(function (incident) {
+        updateEdgeEndpoint(incident.lineEl, incident.role, node);
+      });
+    }
+
+    function start(nodes) {
+      cancel();
+      var origins = nodes.map(function (node) {
+        return { x: node.x, y: node.y };
+      });
+      var startTime = null;
+
+      function frame(timestamp) {
+        if (startTime === null) {
+          startTime = timestamp;
+        }
+        var t = Math.min(1, (timestamp - startTime) / RESET_TRANSITION_MS);
+        var eased = easeOutCubic(t);
+        var done = t >= 1;
+        nodes.forEach(function (node, i) {
+          if (done) {
+            // Final frame: snap exactly to the settled position and release
+            // any lingering drag-pin, rather than trusting float easing math
+            // to land on the exact value.
+            node.x = node.origX;
+            node.y = node.origY;
+            node.fx = null;
+            node.fy = null;
+          } else {
+            node.x = origins[i].x + (node.origX - origins[i].x) * eased;
+            node.y = origins[i].y + (node.origY - origins[i].y) * eased;
+          }
+          applyFrame(node);
+        });
+        rafId = done ? null : window.requestAnimationFrame(frame);
+      }
+
+      rafId = window.requestAnimationFrame(frame);
+    }
+
+    return { start: start, cancel: cancel };
   }
 
   // ---- Zoom/pan gesture filter: wheel always zooms (regardless of pointer
@@ -1344,34 +1453,18 @@
       // to its originally-settled position (origX/origY, captured right
       // after layoutGraph()) and stops any in-flight localized drag reheat,
       // in addition to the zoom-transform restore this control already did
-      // — after Reset, the view is pixel-identical to first render.
+      // — after Reset, the view is pixel-identical to first render. The
+      // node/label/edge restore runs over the same RESET_TRANSITION_MS
+      // window as the zoom-transform transition via the rAF tween
+      // (createResetTween) rather than snapping instantly.
       // `resetView` is a hoisted function declaration, so this handler can
-      // reference it even though it (and the `entries`/`edgeEntries`/
-      // `localReheat` it closes over) aren't assigned until further down
-      // this render() call — by the time a user can actually click the
-      // button, render() has long since finished executing. ----
+      // reference it even though it (and the `resetTween`/`localReheat` it
+      // closes over) aren't assigned until further down this render() call —
+      // by the time a user can actually click the button, render() has long
+      // since finished executing. ----
       function resetView() {
         localReheat.stop();
-        visual.classList.add("viz-constellation-resetting");
-        graph.nodes.forEach(function (node) {
-          node.fx = null;
-          node.fy = null;
-          node.x = node.origX;
-          node.y = node.origY;
-        });
-        entries.forEach(function (entry) {
-          applyNodePosition(entry.el, entry.node);
-          if (entry.labelEl) {
-            applyLabelPosition(entry.labelEl, entry.node);
-          }
-        });
-        edgeEntries.forEach(function (entry) {
-          updateEdgeEndpoint(entry.lineEl, "source", entry.edge.source);
-          updateEdgeEndpoint(entry.lineEl, "target", entry.edge.target);
-        });
-        window.setTimeout(function () {
-          visual.classList.remove("viz-constellation-resetting");
-        }, RESET_TRANSITION_MS);
+        resetTween.start(graph.nodes);
         d3.select(viewport)
           .transition()
           .duration(RESET_TRANSITION_MS)
@@ -1446,7 +1539,11 @@
       // One view-scoped localized-reheat controller (round-2 fix: drag
       // re-orients neighbors), shared by every node's wireDrag — see
       // createLocalReheat above.
-      var localReheat = createLocalReheat(graph.edges, entriesById, incidentByNodeId);
+      var localReheat = createLocalReheat(graph.edges, entriesById, incidentByNodeId, side);
+      // One view-scoped Reset-view tween controller (round-2 fix), shared by
+      // the Reset button (resetView above) and every node's wireDrag (which
+      // cancels it if a drag starts mid-reset) — see createResetTween above.
+      var resetTween = createResetTween(entriesById, incidentByNodeId, side);
       entries.forEach(function (entry) {
         wireDrag(
           entry,
@@ -1454,7 +1551,9 @@
           function () {
             return zoomTransform.k;
           },
-          localReheat
+          localReheat,
+          resetTween,
+          side
         );
       });
       applyEncoding(entries, heatScale, current.computeHeat);
@@ -1468,6 +1567,9 @@
           // Stop any still-settling localized drag reheat so its timer never
           // fires into a torn-down view.
           localReheat.stop();
+          // Cancel any in-flight Reset-view tween so its rAF callback never
+          // fires into a torn-down view.
+          resetTween.cancel();
           // Flush every node's still-pending deferred activation so no timer
           // fires a focus/drill into a torn-down view.
           activationGroup.cancelAll();

--- a/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
@@ -110,6 +110,20 @@
     container.appendChild(message);
   }
 
+  // ---- Empty-neighborhood state (round-2 fix): a center with real
+  // dependency-graph data but literally zero edges of its own previously
+  // rendered as a lone, unlabeled center dot with no rings — indistinguishable
+  // from a rendering glitch. An explicit message replaces it. Distinct from
+  // renderUnavailable (the graph itself was never built). ----
+  function renderEmptyNeighborhood(container, centerPath) {
+    var message = document.createElement("div");
+    message.id = "viz-sonar-empty";
+    message.setAttribute("class", "viz-sonar-empty");
+    message.textContent =
+      "No known dependents or dependencies in the graph for " + centerPath + ".";
+    container.appendChild(message);
+  }
+
   function renderRings(container, groups, centerPath, onRecenter) {
     var stage = document.createElement("div");
     stage.id = "viz-sonar-rings";
@@ -208,6 +222,10 @@
           return;
         }
         var groups = groupByHop(computeHops(adjacency, path));
+        if (groups.length === 0) {
+          renderEmptyNeighborhood(inner, path);
+          return;
+        }
         renderRings(inner, groups, path, mount);
       }
 

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -488,7 +488,9 @@ def test_render_inlines_blast_radius_overlay_and_empty_state_hooks():
     assert "drillState.closeBlastOverlay" in html
     assert "function renderEmptyNeighborhood" in html
     assert "No known dependents or dependencies in the graph" in html
-    # #viz-root is the overlay's positioning context (round-2 fix).
+    # The blast overlay is a viewport-anchored modal (position: fixed), so it
+    # tracks the visible canvas instead of stretching with #viz-root's flow
+    # height in the ledger view.
     assert ".viz-blast-overlay {" in html
 
 

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -394,6 +394,86 @@ def test_stale_graph_badge_hook_is_inlined_and_scene_data_is_conditional():
     assert "stale_graph" not in fresh_scene_data["render_config"]
 
 
+def test_render_inlines_constellation_round2_drag_reheat_hooks():
+    # Round-2 fix (bead yf2ov.2.13): dragging a node reheats a localized
+    # sub-simulation over its 1-hop neighborhood (prototype anatomy
+    # variant_B.js's alphaTarget drag hold) — every other node is never
+    # handed to the sub-simulation, so the global deterministic layout is
+    # never disturbed. All JS source, so inlined regardless of scene content.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "function createLocalReheat" in html
+    assert "function buildEdgeAdjacency" in html
+    assert "REHEAT_ALPHA_DECAY" in html
+    assert "localReheat.start(node)" in html
+    assert "localReheat.touch(node)" in html
+
+
+def test_render_inlines_constellation_round2_reset_view_hooks():
+    # Round-2 fix: Reset view now restores every displaced/pinned node back
+    # to its originally-settled position (not just the zoom transform), over
+    # the same short transition the zoom-transform restore already used.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "function resetView" in html
+    assert "node.origX" in html and "node.origY" in html
+    assert "viz-constellation-resetting" in html
+    assert "RESET_TRANSITION_MS" in html
+
+
+def test_render_inlines_constellation_round2_layout_density_hooks():
+    # Round-2 fix: the pre-settle forces gained a charge distanceMax cap and
+    # a weak x/y centering force (forceCenter alone only recenters the
+    # barycenter, it never pulls an individual outlier back in), and the
+    # zoom baseline now fits the settled layout to the viewport instead of
+    # always showing it at a fixed 1:1 scale.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "CHARGE_DISTANCE_MAX" in html
+    assert "CENTER_FORCE_STRENGTH" in html
+    assert ".distanceMax(CHARGE_DISTANCE_MAX)" in html
+    assert "d3.forceX(side / 2).strength(CENTER_FORCE_STRENGTH)" in html
+    assert "fitScale" in html
+
+
+def test_render_inlines_constellation_round2_depth_cap_hook():
+    # Round-2 fix: the dir-grouping depth cap raised from 4 to 5 path
+    # segments (interim heuristic — an adaptive per-repo depth is a separate,
+    # not-yet-built design), shared by dirOf and findContainingDir via one
+    # constant so the two can never drift apart.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "DIR_DEPTH_CAP = 5" in html
+    assert "interim heuristic" in html
+
+
+def test_render_inlines_constellation_round2_label_disambiguation_hook():
+    # Round-2 fix: two labeled nodes whose leaf path segment collides (e.g.
+    # four dirs all named "unit") now extend their label with parent
+    # segments until unique; an unambiguous leaf still renders leaf-only.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "function computeDisambiguatedLabels" in html
+    assert "labelTextById[node.id] || basename(displayPath)" in html
+
+
+def test_render_inlines_blast_radius_overlay_and_empty_state_hooks():
+    # Round-2 fix: "Show blast radius" now opens sonar's rings as a
+    # full-canvas overlay over #viz-root (the main scene area) rather than
+    # squeezed inside the drawer, with its own close button and Escape
+    # handling; a file with zero dependency edges of its own gets an
+    # explicit empty-neighborhood message instead of a lone center dot.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    assert "viz-blast-overlay" in html
+    assert "viz-blast-overlay-close" in html
+    assert "drillState.closeSonarOverlay" in html
+    assert "function renderEmptyNeighborhood" in html
+    assert "No known dependents or dependencies in the graph" in html
+    # #viz-root is the overlay's positioning context (round-2 fix).
+    assert ".viz-blast-overlay {" in html
+
+
 def test_hostile_strings_in_paths_and_fact_notes_render_inert():
     # Item 7 (complete): hostile strings in *paths* (a repeat of the slice-1
     # embedding case, now exercised alongside the new channel) and in a

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -402,23 +402,38 @@ def test_render_inlines_constellation_round2_drag_reheat_hooks():
     # never disturbed. All JS source, so inlined regardless of scene content.
     html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
 
-    assert "function createLocalReheat" in html
-    assert "function buildEdgeAdjacency" in html
     assert "REHEAT_ALPHA_DECAY" in html
     assert "localReheat.start(node)" in html
     assert "localReheat.touch(node)" in html
+    # A held drag must keep reheating past the sub-sim's own alphaMin cutoff
+    # instead of freezing the neighborhood — touch() revives a dead sim
+    # rather than merely bumping alpha on one that already stopped.
+    assert "if (!activeSim)" in html
+    # The reheat's charge/link forces are single-sourced with the initial
+    # layout's (round-2 fix: the reheat used to hardcode stale pre-retune
+    # values that had drifted from layoutGraph's own), not each declaring its
+    # own copy.
+    assert "function makeChargeForce" in html
+    assert "function makeLinkForce" in html
 
 
 def test_render_inlines_constellation_round2_reset_view_hooks():
     # Round-2 fix: Reset view now restores every displaced/pinned node back
     # to its originally-settled position (not just the zoom transform), over
-    # the same short transition the zoom-transform restore already used.
+    # the same short transition the zoom-transform restore already used —
+    # driven by a real rAF tween (a CSS transition on SVG line x1/y1/x2/y2
+    # never animates those attributes, since they aren't CSS-mapped geometry
+    # properties, so the earlier mechanism let every edge snap instantly
+    # while its nodes glided).
     html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
 
     assert "function resetView" in html
     assert "node.origX" in html and "node.origY" in html
-    assert "viz-constellation-resetting" in html
+    assert "requestAnimationFrame" in html
+    assert "cancelAnimationFrame" in html
     assert "RESET_TRANSITION_MS" in html
+    # The dead CSS-transition mechanism must not come back.
+    assert "viz-constellation-resetting" not in html
 
 
 def test_render_inlines_constellation_round2_layout_density_hooks():
@@ -432,7 +447,7 @@ def test_render_inlines_constellation_round2_layout_density_hooks():
     assert "CHARGE_DISTANCE_MAX" in html
     assert "CENTER_FORCE_STRENGTH" in html
     assert ".distanceMax(CHARGE_DISTANCE_MAX)" in html
-    assert "d3.forceX(side / 2).strength(CENTER_FORCE_STRENGTH)" in html
+    assert "forceX" in html and "forceY" in html
     assert "fitScale" in html
 
 
@@ -467,7 +482,10 @@ def test_render_inlines_blast_radius_overlay_and_empty_state_hooks():
 
     assert "viz-blast-overlay" in html
     assert "viz-blast-overlay-close" in html
-    assert "drillState.closeSonarOverlay" in html
+    # Round-2 fix: one owner (closeBlastOverlay) handles teardown for every
+    # close trigger (toggle, overlay close button, Escape, a fresh openDrill
+    # call, and the drawer's own Close button) — no per-trigger duplicate.
+    assert "drillState.closeBlastOverlay" in html
     assert "function renderEmptyNeighborhood" in html
     assert "No known dependents or dependencies in the graph" in html
     # #viz-root is the overlay's positioning context (round-2 fix).


### PR DESCRIPTION
## Summary

- Constellation round-2 feedback fixes (bead agents-config-yf2ov.2.13): drag now reheats the dragged node's 1-hop neighborhood via a localized force simulation; Reset View restores all node positions (not just zoom) through a JS rAF tween; layout density tuned with fit-to-content initial transform; directory grouping depth cap raised 4→5; node labels disambiguated; blast-radius sonar promoted from the clipped drawer to a full-canvas overlay with an explicit empty state.
- Defect-fix commit on top (HEAVY gate + independent kimi-k3 review findings): rAF reset tween replaces a silently-inert CSS transition on SVG `<line>` x1/y1/x2/y2 (not CSS-animatable presentation attributes — edges snapped while nodes glided); shared `makeLinkForce`/`makeChargeForce`/`makeCollideForce` factories eliminate charge-constant divergence between initial layout and reheat; `touch()` revives a reheat simulation that previously died mid-drag after ~0.9s of pointer stillness; shared `clampToBox` keeps drag/reheat/tween positions inside the stage; single `closeBlastOverlay()` owner so all five close paths (including drawer Close) dismiss the overlay; test de-ossification — implementation-identifier string pins replaced with behavior hooks.

## Scope

- **In scope:** `packages/vizsuite/src/vizsuite/templates/static/` (`views/constellation.js`, `views/sonar.js`, `app.js`, `scene.css`) and `packages/vizsuite/tests/unit/test_templates_html.py`.
- **Out of scope:** the inferred-edge centrality substrate (merged separately in #313); depth-vs-noise adaptive granularity (parked for a design discussion); blast-overlay zoom/pan and label font-size clamping (round-3 feedback, tracked on bead agents-config-yf2ov.2.15).

## Design constraints for reviewers

- **The reset animation is deliberately a JS rAF tween, not a CSS transition.** Positions live on three surfaces (HTML node left/top, HTML label left/top, SVG line x1..y2). `x1/y1/x2/y2` on `<line>` are not CSS-mapped geometry properties, so a CSS transition animates nodes but snaps edges. Do not "simplify" back to CSS.
- **Deterministic layout is a product property** (seeded PRNG, fixed synchronous ticks). The drag reheat preserves it by simulating only the dragged node's 1-hop neighborhood with everything else pinned; post-drag positions are user state outside the determinism contract.
- **Directory depth cap = 5 is an acknowledged interim heuristic**; adaptive granularity is deliberately deferred pending a design discussion.

## Test plan / evidence

- [x] `make ci-vizsuite` exit 0 from the worktree root: 434 passed, 100% line+branch coverage, pip-audit clean.
- [x] HEAVY quality-gate workflow on the rebased head: acceptance, clean at the major severity floor after 1 adversarial round (4 finder lenses × 2 refuters); single minor flag deferred as factually inaccurate.
- [x] Browser-verified (Chrome, real pointer events, on a `viz pr 307` artifact built from this branch against the current dense graph): node drag moved 375.8px with 12 neighbors reheating, edge attachment gap 0.00px; background pan works; Reset tweened through 8 distinct intermediate frames and settled at 0.00px error with 0.00px final edge gap; console free of errors.

Beads: agents-config-yf2ov.2.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1RgjFBiPgTWWyz5ZaGh8J
