### PR TITLE
feat(grind): create/log/status/finish CLI over the event log (wgclw.30.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,7 @@ verify-entry-vizsuite:
 	uv --project $(VIZSUITE) run viz --help > /dev/null
 
 # ── grind (mirrors the ci-workcli block one-for-one; enforced via the
-# top-level `ci:` aggregate). No console-script entry point yet -- this bead
-# (wgclw.30.1) ships the event schema + FSM fold only; `grind` verbs land in
-# wgclw.30.2. verify-entry-grind checks the package imports cleanly instead of
-# invoking a CLI that doesn't exist yet. ──
+# top-level `ci:` aggregate). ──
 ci-grind: lint-grind format-check-grind typecheck-grind \
           cov-grind audit-grind verify-entry-grind
 
@@ -162,5 +159,8 @@ cov-grind:
 	cd $(GRIND) && uv run pytest --cov --cov-report=term-missing
 audit-grind:
 	cd $(GRIND) && uv sync --frozen && uv run pip-audit
+# verify-entry-grind asserts the console-script entry point resolves and the
+# CLI root parses (`grind --help` exits 0). Run via `uv --project` so the
+# grind venv where the entry point is installed is selected.
 verify-entry-grind:
-	uv --project $(GRIND) run python -c "import grind; import grind.fold; import grind.derive; import grind.log"
+	uv --project $(GRIND) run grind --help > /dev/null

--- a/packages/grind/pyproject.toml
+++ b/packages/grind/pyproject.toml
@@ -5,6 +5,9 @@ description = "grind — event schema + FSM fold for the event-sourced grind run
 requires-python = ">=3.11"
 dependencies = []
 
+[project.scripts]
+grind = "grind.cli:entry"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -50,6 +53,11 @@ select = [
 # "call a message-builder" TRY003 wants.
 "src/grind/fold.py" = ["TRY003"]
 "src/grind/log.py" = ["TRY003"]
+# GrindError's message IS the self-contained command-error reason surfaced
+# verbatim in the CLI's error envelope -- same rationale as fold.py/log.py.
+"src/grind/verbs.py" = ["TRY003"]
+"src/grind/store.py" = ["TRY003"]
+"src/grind/cli.py" = ["TRY003"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/packages/grind/pyproject.toml
+++ b/packages/grind/pyproject.toml
@@ -58,6 +58,9 @@ select = [
 "src/grind/verbs.py" = ["TRY003"]
 "src/grind/store.py" = ["TRY003"]
 "src/grind/cli.py" = ["TRY003"]
+# NonFiniteJsonError's message names the exact rejected constant -- a
+# self-contained boundary-failure reason, same rationale as the modules above.
+"src/grind/jsonio.py" = ["TRY003"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -1,0 +1,150 @@
+"""`grind` CLI -- argparse wiring and the dispatch loop over `grind.verbs`.
+
+`main()` is the single injectable entry point: argv, stdout/stderr, the wall
+clock, and the seed-file reader all arrive as arguments, never a module
+global (same seam precedent as workcli's `cli.py`). Every command emits
+exactly one JSON envelope on stdout and exits 0 unless the command itself
+failed (spec CLI contract: "exit code 0 unless the command itself failed -- an
+anomalous event still exits 0, it was recorded").
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from argparse import ArgumentParser, Namespace
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NoReturn, TextIO
+
+from grind.envelope import GrindError
+from grind.model import JsonValue
+from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
+
+
+class _RaisingArgumentParser(ArgumentParser):
+    """Raises `GrindError` on a parse failure instead of printing usage and
+    calling `sys.exit` -- keeps the "stdout is always exactly one JSON
+    envelope" invariant on a bad flag or unknown verb (same precedent as
+    workcli's `_EnvelopeArgumentParser`)."""
+
+    def error(self, message: str) -> NoReturn:
+        raise GrindError(message)
+
+
+def _build_parser() -> _RaisingArgumentParser:
+    parser = _RaisingArgumentParser(
+        prog="grind", description="grind — event-sourced grind runtime CLI"
+    )
+    subparsers = parser.add_subparsers(dest="verb", parser_class=_RaisingArgumentParser)
+
+    create_parser = subparsers.add_parser("create", help="seed a new grind from a seed file")
+    create_parser.add_argument("--file", required=True, metavar="PATH")
+    create_parser.add_argument("--dir", default=".", metavar="DIR")
+
+    log_parser = subparsers.add_parser("log", help="append a typed event and refold")
+    log_parser.add_argument("type", metavar="TYPE")
+    log_parser.add_argument("--json", required=True, dest="payload_json", metavar="JSON")
+    log_parser.add_argument("--dir", default=".", metavar="DIR")
+
+    status_parser = subparsers.add_parser("status", help="report the folded state")
+    status_parser.add_argument("--full", action="store_true")
+    status_parser.add_argument("--dir", default=".", metavar="DIR")
+
+    finish_parser = subparsers.add_parser("finish", help="append grind_finished and final-fold")
+    finish_parser.add_argument("--summary", required=True, metavar="TEXT")
+    finish_parser.add_argument("--dir", default=".", metavar="DIR")
+
+    return parser
+
+
+def _read_seed_file(path: str, read_file: Callable[[str], str]) -> JsonValue:
+    try:
+        text = read_file(path)
+    except OSError as read_error:
+        raise GrindError(f"cannot read seed file {path}: {read_error}") from read_error
+    try:
+        return json.loads(text)  # type: ignore[no-any-return]
+    except json.JSONDecodeError as decode_error:
+        raise GrindError(f"seed file {path} is not valid JSON: {decode_error}") from decode_error
+
+
+def _parse_json_payload(raw: str) -> JsonValue:
+    try:
+        return json.loads(raw)  # type: ignore[no-any-return]
+    except json.JSONDecodeError as decode_error:
+        raise GrindError(f"--json is not valid JSON: {decode_error}") from decode_error
+
+
+def _dispatch(
+    args: Namespace, now: Callable[[], datetime], read_file: Callable[[str], str]
+) -> JsonValue:
+    grind_dir = Path(args.dir)
+
+    if args.verb == "create":
+        seed = _read_seed_file(args.file, read_file)
+        if not isinstance(seed, dict):
+            raise GrindError(f"seed file {args.file} must contain a JSON object")
+        return cmd_create(grind_dir, seed, now=now)
+
+    if args.verb == "log":
+        payload = _parse_json_payload(args.payload_json)
+        if not isinstance(payload, dict):
+            raise GrindError("--json must contain a JSON object")
+        return cmd_log(grind_dir, args.type, payload, now=now)
+
+    if args.verb == "status":
+        return cmd_status(grind_dir, full=args.full)
+
+    if args.verb == "finish":
+        return cmd_finish(grind_dir, args.summary, now=now)
+
+    raise GrindError("no verb given; choose one of: create, log, status, finish")
+
+
+def _default_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _default_read_file(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    out: TextIO | None = None,
+    err: TextIO | None = None,
+    now: Callable[[], datetime] | None = None,
+    read_file: Callable[[str], str] | None = None,
+) -> int:
+    if out is None:
+        out = sys.stdout
+    if err is None:
+        err = sys.stderr
+    resolved_now = now if now is not None else _default_now
+    resolved_read_file = read_file if read_file is not None else _default_read_file
+
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else None)
+        data = _dispatch(args, resolved_now, resolved_read_file)
+    except GrindError as command_error:
+        json.dump({"ok": False, "error": {"message": command_error.message}}, out)
+        out.write("\n")
+        return 1
+    except Exception:  # every path still yields exactly one envelope, never a bare traceback
+        traceback.print_exc(file=err)
+        json.dump({"ok": False, "error": {"message": "internal error"}}, out)
+        out.write("\n")
+        return 1
+
+    json.dump(data, out)
+    out.write("\n")
+    return 0
+
+
+def entry() -> None:
+    sys.exit(main())

--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import NoReturn, TextIO
 
 from grind.envelope import GrindError
+from grind.jsonio import NonFiniteJsonError, loads
 from grind.model import JsonValue
 from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
 
@@ -66,15 +67,15 @@ def _read_seed_file(path: str, read_file: Callable[[str], str]) -> JsonValue:
     except OSError as read_error:
         raise GrindError(f"cannot read seed file {path}: {read_error}") from read_error
     try:
-        return json.loads(text)  # type: ignore[no-any-return]
-    except json.JSONDecodeError as decode_error:
+        return loads(text)
+    except (json.JSONDecodeError, NonFiniteJsonError) as decode_error:
         raise GrindError(f"seed file {path} is not valid JSON: {decode_error}") from decode_error
 
 
 def _parse_json_payload(raw: str) -> JsonValue:
     try:
-        return json.loads(raw)  # type: ignore[no-any-return]
-    except json.JSONDecodeError as decode_error:
+        return loads(raw)
+    except (json.JSONDecodeError, NonFiniteJsonError) as decode_error:
         raise GrindError(f"--json is not valid JSON: {decode_error}") from decode_error
 
 
@@ -141,7 +142,7 @@ def main(
         out.write("\n")
         return 1
 
-    json.dump(data, out)
+    json.dump(data, out, allow_nan=False)
     out.write("\n")
     return 0
 

--- a/packages/grind/src/grind/envelope.py
+++ b/packages/grind/src/grind/envelope.py
@@ -1,0 +1,16 @@
+"""`GrindError` -- the one typed command-error exception every verb raises for
+a boundary failure (malformed payload, refused `create`). `cli.py` is the only
+catcher: it turns this into the `{"ok": false, "error": {...}}` envelope with
+a non-zero exit code (spec: "a malformed payload is a command error, exit
+code != 0, nothing appended"). An *illegal-but-well-formed* event is never a
+`GrindError` -- that's the fold's accept-and-flag anomaly, exit 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GrindError(Exception):
+    message: str

--- a/packages/grind/src/grind/jsonio.py
+++ b/packages/grind/src/grind/jsonio.py
@@ -1,0 +1,32 @@
+"""Strict JSON decoding at grind's boundaries.
+
+Python's stdlib `json.loads` accepts three non-standard constants -- `NaN`,
+`Infinity`, and `-Infinity` -- that RFC 8259 forbids, and `json.dumps` re-emits
+them by default. A grind whose seed or `--json` payload smuggled one in would
+propagate it into `events.jsonl`, `state.json`, and the stdout envelope, which
+standards-compliant JSON consumers cannot parse. Every grind decode boundary
+funnels through `loads` here so a non-finite constant is refused exactly like
+any other malformed input; the matching `json.dumps` callers pass
+`allow_nan=False` as defense in depth on the write side.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import NoReturn
+
+from grind.model import JsonValue
+
+
+class NonFiniteJsonError(ValueError):
+    """A JSON document contained a non-finite constant (`NaN`, `Infinity`, or
+    `-Infinity`) -- non-standard JSON grind refuses at the decode boundary."""
+
+
+def _reject_non_finite(constant: str) -> NoReturn:
+    raise NonFiniteJsonError(f"non-finite JSON constant {constant!r} is not permitted")
+
+
+def loads(text: str) -> JsonValue:
+    """`json.loads` that rejects the non-standard non-finite constants."""
+    return json.loads(text, parse_constant=_reject_non_finite)  # type: ignore[no-any-return]

--- a/packages/grind/src/grind/log.py
+++ b/packages/grind/src/grind/log.py
@@ -15,6 +15,7 @@ import json
 from dataclasses import dataclass, field
 
 from grind.fold import fold
+from grind.jsonio import NonFiniteJsonError, loads
 from grind.model import AnomalyRecord, AttentionEntry, JsonValue, Observation, RawEvent, State
 
 
@@ -46,8 +47,8 @@ def parse_event_log(text: str) -> ParsedLog:
         if line.strip() == "":
             continue
         try:
-            parsed: JsonValue = json.loads(line)
-        except json.JSONDecodeError as exc:
+            parsed: JsonValue = loads(line)
+        except (json.JSONDecodeError, NonFiniteJsonError) as exc:
             if index == last_index:
                 torn_tail = True
                 continue

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -1,0 +1,365 @@
+"""Per-type payload shape validation -- the CLI boundary (spec: "validated
+per-type at the CLI boundary ... parse once, trust inward").
+
+This is the malformed/illegal seam: a payload failing these checks is a
+command error (nothing appended); a payload that passes but is illegal from
+the entity's current status still appends and folds as an anomaly
+(accept-and-flag, `grind.fold`'s job, not this module's). Required-field sets
+are taken from the event taxonomy table in the event-sourced grind runtime
+spec -- no field is invented here that the spec doesn't name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from grind.model import RawEvent
+
+Validator = Callable[[RawEvent], list[str]]
+
+_REVIEW_KINDS = {"codex", "copilot", "ralf", "human"}
+_VERDICTS = {"clean", "findings", "stalemate"}
+_DISPOSITIONS = {"fixed", "wont-fix", "deferred", "escalated"}
+_PARK_KINDS = {"discovered-work", "human-gated", "later-wave", "deferred"}
+_PR_CLOSED_NEXT = {"in-progress", "queued", "parked"}
+_OBSERVATION_LEVELS = {"INFO", "WARN", "ERROR", "LESSON"}
+_WORK_DISPOSITIONS = {"parked", "enqueued"}
+
+
+def _is_str(payload: RawEvent, key: str) -> bool:
+    value = payload.get(key)
+    return isinstance(value, str) and value != ""
+
+
+def _is_int(payload: RawEvent, key: str) -> bool:
+    value = payload.get(key)
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_dict(payload: RawEvent, key: str) -> bool:
+    return isinstance(payload.get(key), dict)
+
+
+def _is_list_of_str(payload: RawEvent, key: str) -> bool:
+    value = payload.get(key)
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _is_enum(payload: RawEvent, key: str, choices: set[str]) -> bool:
+    return payload.get(key) in choices
+
+
+def _require(errors: list[str], ok: bool, message: str) -> None:
+    if not ok:
+        errors.append(message)
+
+
+def _require_str(errors: list[str], payload: RawEvent, key: str) -> None:
+    _require(errors, _is_str(payload, key), f"{key} is required and must be a non-empty string")
+
+
+def _optional_str(errors: list[str], payload: RawEvent, key: str) -> None:
+    if key in payload and payload[key] is not None:
+        _require(errors, isinstance(payload[key], str), f"{key} must be a string when present")
+
+
+def _validate_grind_created(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "title")
+    _require_str(errors, payload, "repo")
+    _require(errors, _is_dict(payload, "mission"), "mission is required and must be an object")
+    _require(errors, _is_dict(payload, "protocols"), "protocols is required and must be an object")
+    if "config" in payload and payload["config"] is not None:
+        _require(errors, _is_dict(payload, "config"), "config must be an object when present")
+
+    lanes = payload.get("lanes")
+    if not isinstance(lanes, list):
+        errors.append("lanes is required and must be an array")
+        return errors
+    for lane_index, lane in enumerate(lanes):
+        if not isinstance(lane, dict) or not _is_str(lane, "id"):
+            errors.append(f"lanes[{lane_index}] must be an object with a non-empty string id")
+            continue
+        if "queue" not in lane:
+            continue
+        queue = lane.get("queue")
+        if not isinstance(queue, list):
+            errors.append(f"lanes[{lane_index}].queue must be an array when present")
+            continue
+        for item_index, item in enumerate(queue):
+            if not isinstance(item, dict) or not _is_str(item, "id"):
+                errors.append(
+                    f"lanes[{lane_index}].queue[{item_index}] must be an object "
+                    "with a non-empty string id"
+                )
+    return errors
+
+
+def _validate_grind_paused(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "reason")
+    if "resume_checklist" in payload:
+        _require(
+            errors,
+            _is_list_of_str(payload, "resume_checklist"),
+            "resume_checklist must be an array of strings when present",
+        )
+    return errors
+
+
+def _validate_grind_resumed(_payload: RawEvent) -> list[str]:
+    return []
+
+
+def _validate_grind_finished(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "summary")
+    return errors
+
+
+def _validate_lane_standing_down(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "lane")
+    return errors
+
+
+def _validate_lane_handover(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "lane")
+    _require_str(errors, payload, "from_agent")
+    _require_str(errors, payload, "to_agent")
+    _require_str(errors, payload, "reason")
+    _optional_str(errors, payload, "to_model")
+    _optional_str(errors, payload, "to_effort")
+    return errors
+
+
+def _validate_item_started(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    return errors
+
+
+def _validate_pr_opened(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(errors, _is_int(payload, "pr"), "pr is required and must be an integer")
+    _optional_str(errors, payload, "url")
+    return errors
+
+
+def _validate_review_round(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(
+        errors,
+        _is_enum(payload, "kind", _REVIEW_KINDS),
+        "kind must be one of codex|copilot|ralf|human",
+    )
+    _require(errors, _is_int(payload, "round"), "round is required and must be an integer")
+    _require_str(errors, payload, "head_sha")
+    _optional_str(errors, payload, "detail")
+    return errors
+
+
+def _validate_findings(errors: list[str], payload: RawEvent) -> None:
+    if "findings" not in payload:
+        return
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        errors.append("findings must be an array when present")
+        return
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            errors.append(f"findings[{index}] must be an object")
+            continue
+        if not _is_str(finding, "severity"):
+            errors.append(f"findings[{index}].severity is required and must be a non-empty string")
+        if not _is_str(finding, "summary"):
+            errors.append(f"findings[{index}].summary is required and must be a non-empty string")
+        if not _is_enum(finding, "disposition", _DISPOSITIONS):
+            errors.append(
+                f"findings[{index}].disposition must be one of fixed|wont-fix|deferred|escalated"
+            )
+
+
+def _validate_review_verdict(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(
+        errors,
+        _is_enum(payload, "kind", _REVIEW_KINDS),
+        "kind must be one of codex|copilot|ralf|human",
+    )
+    _require(errors, _is_int(payload, "round"), "round is required and must be an integer")
+    _require_str(errors, payload, "head_sha")
+    _require(
+        errors,
+        _is_enum(payload, "verdict", _VERDICTS),
+        "verdict must be one of clean|findings|stalemate",
+    )
+    _validate_findings(errors, payload)
+    return errors
+
+
+def _validate_pr_closed(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(errors, _is_int(payload, "pr"), "pr is required and must be an integer")
+    _require_str(errors, payload, "reason")
+    _require(
+        errors,
+        _is_enum(payload, "next", _PR_CLOSED_NEXT),
+        "next must be one of in-progress|queued|parked",
+    )
+    return errors
+
+
+def _validate_item_blocked(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(
+        errors, _is_list_of_str(payload, "on"), "on is required and must be an array of strings"
+    )
+    _optional_str(errors, payload, "note")
+    return errors
+
+
+def _validate_item_waiting_human(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require_str(errors, payload, "why")
+    return errors
+
+
+def _validate_item_resumed(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require_str(errors, payload, "ruling")
+    return errors
+
+
+def _validate_item_merged(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(errors, _is_int(payload, "pr"), "pr is required and must be an integer")
+    _require_str(errors, payload, "sha")
+    return errors
+
+
+def _validate_item_done(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    return errors
+
+
+def _validate_item_parked(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(
+        errors,
+        _is_enum(payload, "kind", _PARK_KINDS),
+        "kind must be one of discovered-work|human-gated|later-wave|deferred",
+    )
+    _require_str(errors, payload, "note")
+    return errors
+
+
+def _validate_item_enqueued(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require_str(errors, payload, "lane")
+    if "position" in payload:
+        _require(errors, _is_int(payload, "position"), "position must be an integer when present")
+    return errors
+
+
+def _validate_discovered_work(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require_str(errors, payload, "description")
+    _require_str(errors, payload, "source")
+    _require_str(errors, payload, "rationale")
+    _optional_str(errors, payload, "bead")
+    disposition = payload.get("disposition")
+    if disposition not in _WORK_DISPOSITIONS:
+        errors.append("disposition must be one of parked|enqueued")
+        return errors
+    if disposition == "parked":
+        _require(
+            errors,
+            _is_enum(payload, "kind", _PARK_KINDS),
+            "kind is required when disposition is parked, and must be one of "
+            "discovered-work|human-gated|later-wave|deferred",
+        )
+    else:
+        _require_str(errors, payload, "lane")
+    return errors
+
+
+def _validate_observation(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require(
+        errors,
+        _is_enum(payload, "level", _OBSERVATION_LEVELS),
+        "level must be one of INFO|WARN|ERROR|LESSON",
+    )
+    _require_str(errors, payload, "message")
+    _optional_str(errors, payload, "item")
+    _optional_str(errors, payload, "lane")
+    return errors
+
+
+def _validate_attention_raised(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "text")
+    return errors
+
+
+def _validate_attention_cleared(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require(
+        errors,
+        _is_str(payload, "text") or _is_str(payload, "item"),
+        "attention_cleared requires a text or item to match",
+    )
+    return errors
+
+
+_VALIDATORS: dict[str, Validator] = {
+    "grind_created": _validate_grind_created,
+    "grind_paused": _validate_grind_paused,
+    "grind_resumed": _validate_grind_resumed,
+    "grind_finished": _validate_grind_finished,
+    "lane_standing_down": _validate_lane_standing_down,
+    "lane_handover": _validate_lane_handover,
+    "item_started": _validate_item_started,
+    "pr_opened": _validate_pr_opened,
+    "review_round": _validate_review_round,
+    "review_verdict": _validate_review_verdict,
+    "pr_closed": _validate_pr_closed,
+    "item_blocked": _validate_item_blocked,
+    "item_waiting_human": _validate_item_waiting_human,
+    "item_resumed": _validate_item_resumed,
+    "item_merged": _validate_item_merged,
+    "item_done": _validate_item_done,
+    "item_parked": _validate_item_parked,
+    "item_enqueued": _validate_item_enqueued,
+    "discovered_work": _validate_discovered_work,
+    "observation": _validate_observation,
+    "attention_raised": _validate_attention_raised,
+    "attention_cleared": _validate_attention_cleared,
+}
+
+
+def validate_payload(event_type: str, payload: RawEvent) -> list[str]:
+    """Shape-validate `payload` for `event_type`, returning error strings (empty = valid).
+
+    An unrecognized `event_type` has no validator -- it is forward-compatible
+    per spec ("unknown types append fine and fold as anomalies"), so shape is
+    never checked and this always returns `[]` for one.
+    """
+    validator = _VALIDATORS.get(event_type)
+    if validator is None:
+        return []
+    return validator(payload)

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -63,6 +63,26 @@ def _optional_str(errors: list[str], payload: RawEvent, key: str) -> None:
         _require(errors, isinstance(payload[key], str), f"{key} must be a string when present")
 
 
+def _optional_nested_str(errors: list[str], container: RawEvent, key: str, prefix: str) -> None:
+    if container.get(key) is not None:
+        _require(
+            errors,
+            isinstance(container[key], str),
+            f"{prefix}.{key} must be a string when present",
+        )
+
+
+def _optional_nested_list_of_str(
+    errors: list[str], container: RawEvent, key: str, prefix: str
+) -> None:
+    if container.get(key) is not None:
+        _require(
+            errors,
+            _is_list_of_str(container, key),
+            f"{prefix}.{key} must be an array of strings when present",
+        )
+
+
 def _validate_grind_created(payload: RawEvent) -> list[str]:
     errors: list[str] = []
     _require_str(errors, payload, "title")
@@ -80,18 +100,22 @@ def _validate_grind_created(payload: RawEvent) -> list[str]:
         if not isinstance(lane, dict) or not _is_str(lane, "id"):
             errors.append(f"lanes[{lane_index}] must be an object with a non-empty string id")
             continue
+        lane_prefix = f"lanes[{lane_index}]"
+        for field in ("name", "agent", "model", "effort"):
+            _optional_nested_str(errors, lane, field, lane_prefix)
         if "queue" not in lane:
             continue
         queue = lane.get("queue")
         if not isinstance(queue, list):
-            errors.append(f"lanes[{lane_index}].queue must be an array when present")
+            errors.append(f"{lane_prefix}.queue must be an array when present")
             continue
         for item_index, item in enumerate(queue):
+            item_prefix = f"{lane_prefix}.queue[{item_index}]"
             if not isinstance(item, dict) or not _is_str(item, "id"):
-                errors.append(
-                    f"lanes[{lane_index}].queue[{item_index}] must be an object "
-                    "with a non-empty string id"
-                )
+                errors.append(f"{item_prefix} must be an object with a non-empty string id")
+                continue
+            _optional_nested_str(errors, item, "title", item_prefix)
+            _optional_nested_list_of_str(errors, item, "on", item_prefix)
     return errors
 
 

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -1,0 +1,178 @@
+"""State -> JsonValue: `state.json`, `status --full`, and `status`'s default summary.
+
+Explicit field-by-field serializers rather than `dataclasses.asdict` -- the
+house typed-boundary discipline (no untyped dict/any at a module boundary)
+applies to output shape too, not just input parsing.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from grind.derive import lane_status
+from grind.model import (
+    AnomalyRecord,
+    AttentionEntry,
+    ClosedEntry,
+    DiscoveredWork,
+    Item,
+    ItemReview,
+    JsonValue,
+    Lane,
+    MergedEntry,
+    Observation,
+    ParkingEntry,
+    PrRef,
+    State,
+)
+
+
+def _pr_ref_json(pr: PrRef | None) -> JsonValue:
+    if pr is None:
+        return None
+    return {"number": pr.number, "url": pr.url}
+
+
+def _item_review_json(review: ItemReview) -> JsonValue:
+    return {
+        "round": review.round,
+        "kind": review.kind,
+        "head_sha": review.head_sha,
+        "detail": review.detail,
+        "verdict": review.verdict,
+        "open_threads": review.open_threads,
+        "wont_fix_count": review.wont_fix_count,
+        "stalemate": review.stalemate,
+    }
+
+
+def _parking_entry_json(parked: ParkingEntry | None) -> JsonValue:
+    if parked is None:
+        return None
+    return {"kind": parked.kind, "note": parked.note}
+
+
+def _discovered_work_json(discovered: DiscoveredWork | None) -> JsonValue:
+    if discovered is None:
+        return None
+    return {"source": discovered.source, "rationale": discovered.rationale}
+
+
+def _item_json(item: Item) -> JsonValue:
+    return {
+        "id": item.id,
+        "lane": item.lane,
+        "title": item.title,
+        "status": item.status,
+        "bead": item.bead,
+        "blocked_on": list(item.blocked_on),
+        "blocked_note": item.blocked_note,
+        "pr": _pr_ref_json(item.pr),
+        "review": _item_review_json(item.review),
+        "parked": _parking_entry_json(item.parked),
+        "discovered": _discovered_work_json(item.discovered),
+    }
+
+
+def _lane_json(state: State, lane: Lane) -> JsonValue:
+    return {
+        "id": lane.id,
+        "name": lane.name,
+        "agent": lane.agent,
+        "model": lane.model,
+        "effort": lane.effort,
+        "item_ids": list(lane.item_ids),
+        "standing_down": lane.standing_down,
+        "status": lane_status(state, lane),
+    }
+
+
+def _attention_json(entry: AttentionEntry) -> JsonValue:
+    return {
+        "text": entry.text,
+        "item": entry.item,
+        "lane": entry.lane,
+        "auto": entry.auto,
+        "kind": entry.kind,
+    }
+
+
+def _observation_json(obs: Observation) -> JsonValue:
+    return {
+        "level": obs.level,
+        "message": obs.message,
+        "item": obs.item,
+        "lane": obs.lane,
+        "ts": obs.ts,
+    }
+
+
+def _merged_entry_json(entry: MergedEntry) -> JsonValue:
+    return {"item": entry.item, "pr": entry.pr, "sha": entry.sha, "ts": entry.ts}
+
+
+def _closed_entry_json(entry: ClosedEntry) -> JsonValue:
+    return {"item": entry.item, "pr": entry.pr, "reason": entry.reason, "ts": entry.ts}
+
+
+def anomaly_json(anomaly: AnomalyRecord | None) -> JsonValue:
+    if anomaly is None:
+        return None
+    return {
+        "ts": anomaly.ts,
+        "type": anomaly.type,
+        "item": anomaly.item,
+        "lane": anomaly.lane,
+        "reason": anomaly.reason,
+    }
+
+
+def full_state_json(state: State) -> dict[str, JsonValue]:
+    """The entire fold output (spec: `status --full`'s "entire state serialized")."""
+    return {
+        "seeded": state.seeded,
+        "title": state.title,
+        "repo": state.repo,
+        "mission": state.mission,
+        "protocols": state.protocols,
+        "config": dict(state.config),
+        "paused": state.paused,
+        "pause_reason": state.pause_reason,
+        "resume_checklist": list(state.resume_checklist),
+        "finished": state.finished,
+        "finish_summary": state.finish_summary,
+        "lanes": {lane_id: _lane_json(state, lane) for lane_id, lane in state.lanes.items()},
+        "items": {item_id: _item_json(item) for item_id, item in state.items.items()},
+        "attention": [_attention_json(a) for a in state.attention],
+        "observations": [_observation_json(o) for o in state.observations],
+        "merged_ledger": [_merged_entry_json(m) for m in state.merged_ledger],
+        "closed_ledger": [_closed_entry_json(c) for c in state.closed_ledger],
+        "lessons": [_observation_json(o) for o in state.lessons],
+        "anomalies": [anomaly_json(a) for a in state.anomalies],
+    }
+
+
+def summarize(state: State) -> dict[str, JsonValue]:
+    """The default `status` / `create` / `finish` report: header + counts, not
+    the full item-by-item state (spec: `status`'s "Default: summary")."""
+    items_by_status: dict[str, int] = {}
+    for item in state.items.values():
+        if item.parked is not None:
+            continue
+        items_by_status[item.status] = items_by_status.get(item.status, 0) + 1
+
+    return {
+        "title": state.title,
+        "repo": state.repo,
+        "paused": state.paused,
+        "pause_reason": state.pause_reason,
+        "finished": state.finished,
+        "lanes": [
+            {"id": lane.id, "name": lane.name, "status": lane_status(state, lane)}
+            for lane in state.lanes.values()
+        ],
+        "items_by_status": cast("dict[str, JsonValue]", items_by_status),
+        "parked_count": len(state.parking_lot()),
+        "attention_count": len(state.attention),
+        "anomaly_count": len(state.anomalies),
+    }

--- a/packages/grind/src/grind/store.py
+++ b/packages/grind/src/grind/store.py
@@ -1,0 +1,132 @@
+"""events.jsonl I/O: the write-path torn-tail repair, append, and read-back.
+
+The write-path repair belongs here, not in `grind.log` (spec "Torn tail":
+"the write path repairs before it appends"; `grind.log`'s docstring calls this
+"a later bead" -- this module is that bead). `grind.log` stays the read-only,
+defense-in-depth half: it tolerates an unrepaired torn tail for a log read
+before any write-path call has touched it (e.g. `status` on a freshly-crashed
+grind), but never writes.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from grind.log import fold_log, parse_event_log
+from grind.model import JsonValue, RawEvent, State
+
+EVENTS_FILENAME = "events.jsonl"
+QUARANTINE_FILENAME = "events.quarantine"
+STATE_FILENAME = "state.json"
+
+
+@dataclass(frozen=True)
+class TornTailRepair:
+    """One write-path repair (spec "Torn tail"): `quarantined` distinguishes a
+    durable-but-unterminated event (repaired in place, `quarantined=False`)
+    from a genuinely unparsable fragment (moved to the quarantine sidecar,
+    `quarantined=True`)."""
+
+    quarantined: bool
+    reason: str
+
+
+def events_path(dir_: Path) -> Path:
+    return dir_ / EVENTS_FILENAME
+
+
+def quarantine_path(dir_: Path) -> Path:
+    return dir_ / QUARANTINE_FILENAME
+
+
+def state_path(dir_: Path) -> Path:
+    return dir_ / STATE_FILENAME
+
+
+def read_raw_log(dir_: Path) -> str:
+    path = events_path(dir_)
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def is_log_nonempty(dir_: Path) -> bool:
+    return read_raw_log(dir_).strip() != ""
+
+
+def repair_torn_tail(dir_: Path) -> TornTailRepair | None:
+    """Repair an unterminated final line before the next append (spec "Torn tail").
+
+    A crash mid-append can leave a truncated final line; simply dropping it at
+    fold time (`grind.log`'s defense-in-depth) doesn't make the log appendable
+    again, since the next append would concatenate onto the fragment. This
+    inspects the log's final byte: a line that still parses as a complete JSON
+    object is a durable transition that only lost its trailing newline, so the
+    repair is appending the missing newline. An unparsable fragment is moved to
+    the append-only `events.quarantine` sidecar (never deleted) and the log
+    truncated back to its last complete line. Returns `None` when the log
+    already ends in a newline (or doesn't exist) -- no repair needed.
+    """
+    path = events_path(dir_)
+    if not path.exists():
+        return None
+    raw = path.read_bytes()
+    if raw == b"" or raw.endswith(b"\n"):
+        return None
+
+    last_newline = raw.rfind(b"\n")
+    head = raw[: last_newline + 1]  # everything through the prior newline, or b"" if none
+    tail = raw[last_newline + 1 :]
+
+    try:
+        parsed: JsonValue = json.loads(tail.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        parsed = None
+
+    if isinstance(parsed, dict):
+        path.write_bytes(raw + b"\n")
+        return TornTailRepair(
+            quarantined=False,
+            reason="torn_tail: final line was a complete event missing its trailing newline",
+        )
+
+    with quarantine_path(dir_).open("ab") as sidecar:
+        sidecar.write(tail if tail.endswith(b"\n") else tail + b"\n")
+    path.write_bytes(head)
+    return TornTailRepair(
+        quarantined=True,
+        reason="torn_tail: final line did not parse as an event and was quarantined",
+    )
+
+
+def append_event(dir_: Path, event: RawEvent) -> TornTailRepair | None:
+    """Repair a torn tail (if any), then append `event` as one JSON line."""
+    dir_.mkdir(parents=True, exist_ok=True)
+    repair = repair_torn_tail(dir_)
+    with events_path(dir_).open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, sort_keys=True))
+        fh.write("\n")
+    return repair
+
+
+def load_events(dir_: Path) -> list[RawEvent]:
+    """The parsed event list, tolerating an unrepaired torn tail (dropped, not raised)."""
+    text = read_raw_log(dir_)
+    if text.strip() == "":
+        return []
+    return parse_event_log(text).events
+
+
+def fold_dir(dir_: Path) -> State:
+    """Refold from zero over the on-disk log (spec: "the fold refolds from zero
+    on every command")."""
+    return fold_log(read_raw_log(dir_))
+
+
+def write_state(dir_: Path, payload: dict[str, JsonValue]) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    with state_path(dir_).open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")

--- a/packages/grind/src/grind/store.py
+++ b/packages/grind/src/grind/store.py
@@ -14,6 +14,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+from grind.jsonio import NonFiniteJsonError, loads
 from grind.log import fold_log, parse_event_log
 from grind.model import JsonValue, RawEvent, State
 
@@ -81,8 +82,8 @@ def repair_torn_tail(dir_: Path) -> TornTailRepair | None:
     tail = raw[last_newline + 1 :]
 
     try:
-        parsed: JsonValue = json.loads(tail.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
+        parsed: JsonValue = loads(tail.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, NonFiniteJsonError):
         parsed = None
 
     if isinstance(parsed, dict):
@@ -106,7 +107,7 @@ def append_event(dir_: Path, event: RawEvent) -> TornTailRepair | None:
     dir_.mkdir(parents=True, exist_ok=True)
     repair = repair_torn_tail(dir_)
     with events_path(dir_).open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(event, sort_keys=True))
+        fh.write(json.dumps(event, sort_keys=True, allow_nan=False))
         fh.write("\n")
     return repair
 
@@ -128,5 +129,5 @@ def fold_dir(dir_: Path) -> State:
 def write_state(dir_: Path, payload: dict[str, JsonValue]) -> None:
     dir_.mkdir(parents=True, exist_ok=True)
     with state_path(dir_).open("w", encoding="utf-8") as fh:
-        json.dump(payload, fh, indent=2, sort_keys=True)
+        json.dump(payload, fh, indent=2, sort_keys=True, allow_nan=False)
         fh.write("\n")

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -1,0 +1,134 @@
+"""The four command bodies: `create`, `log`, `status`, `finish`.
+
+Each takes the grind directory and an injected `now` clock (never a bare
+`datetime.now()` call -- same seam precedent as workcli's `read_file`/`now`),
+and returns a plain `dict[str, JsonValue]` shaped exactly per the spec's CLI
+contract / emit-back envelope. `cli.py` owns argv parsing and stdout/exit-code
+wiring; this module owns behavior only, so it's testable without a process.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+from grind.derive import lane_status
+from grind.envelope import GrindError
+from grind.fold import fold
+from grind.model import AnomalyRecord, JsonValue, RawEvent, State
+from grind.payloads import validate_payload
+from grind.serialize import anomaly_json, full_state_json, summarize
+from grind.store import append_event, fold_dir, is_log_nonempty, load_events, write_state
+
+Clock = Callable[[], datetime]
+
+
+def _iso(when: datetime) -> str:
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _validate_or_raise(event_type: str, payload: RawEvent) -> None:
+    errors = validate_payload(event_type, payload)
+    if errors:
+        raise GrindError(f"invalid payload for {event_type!r}: " + "; ".join(errors))
+
+
+def _entity_delta(before: State, after: State, event: RawEvent) -> JsonValue:
+    """The fold delta of one appended event: the entity's old/new status, or
+    `None` when nothing changed (spec: "entity + old_status/new_status when an
+    item/lane status changed, else null"). `item` takes precedence over `lane`
+    when an event carries both (only `item_enqueued` does, and it's item-scoped)."""
+    item_id = event.get("item")
+    if isinstance(item_id, str):
+        old_item = before.items.get(item_id)
+        new_item = after.items.get(item_id)
+        old_status = old_item.status if old_item is not None else None
+        new_status = new_item.status if new_item is not None else None
+        if old_status == new_status:
+            return None
+        return {"entity": item_id, "old_status": old_status, "new_status": new_status}
+
+    lane_id = event.get("lane")
+    if isinstance(lane_id, str):
+        old_lane = before.lanes.get(lane_id)
+        new_lane = after.lanes.get(lane_id)
+        if old_lane is None or new_lane is None:
+            return None
+        old_lane_status = lane_status(before, old_lane)
+        new_lane_status = lane_status(after, new_lane)
+        if old_lane_status == new_lane_status:
+            return None
+        return {"entity": lane_id, "old_status": old_lane_status, "new_status": new_lane_status}
+
+    return None
+
+
+def _new_anomaly(before: State, after_check: State) -> AnomalyRecord | None:
+    """The single anomaly (if any) the just-appended event produced, isolated
+    by diffing two pure in-memory folds over `existing_events` vs.
+    `existing_events + [event]` -- `fold` is deterministic and never revisits
+    earlier events, so any new tail entries are attributable to this event
+    alone (at most one: every fold handler calls `_anomaly` at most once)."""
+    new_anomalies = after_check.anomalies[len(before.anomalies) :]
+    return new_anomalies[0] if new_anomalies else None
+
+
+def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue]:
+    """`grind create --file seed.json` (spec CLI contract table)."""
+    if is_log_nonempty(dir_):
+        raise GrindError(
+            "refusing to create: events.jsonl already exists and is non-empty; "
+            "creation goes through create only once, never grind log grind_created mid-run"
+        )
+    _validate_or_raise("grind_created", seed)
+
+    event: RawEvent = {"ts": _iso(now()), "type": "grind_created", **seed}
+    append_event(dir_, event)
+    state = fold_dir(dir_)
+    write_state(dir_, full_state_json(state))
+    return {"ok": True, "state_summary": summarize(state)}
+
+
+def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> dict[str, JsonValue]:
+    """`grind log <type> --json '<payload>'` -- returns the emit-back envelope."""
+    _validate_or_raise(event_type, payload)
+
+    existing_events = load_events(dir_)
+    before_state = fold(existing_events)
+    event: RawEvent = {"ts": _iso(now()), "type": event_type, **payload}
+    check_state = fold([*existing_events, event])
+
+    append_event(dir_, event)
+    after_state = fold_dir(dir_)
+    write_state(dir_, full_state_json(after_state))
+
+    anomaly = _new_anomaly(before_state, check_state)
+    return {
+        "ok": True,
+        "applied": anomaly is None,
+        "anomaly": anomaly_json(anomaly),
+        "delta": _entity_delta(before_state, check_state, event),
+        # The conditions engine is a sibling bead (spec §"Emit-back"); this
+        # verb never computes orchestration facts itself.
+        "conditions": [],
+    }
+
+
+def cmd_status(dir_: Path, *, full: bool) -> dict[str, JsonValue]:
+    """`grind status [--full]`."""
+    state = fold_dir(dir_)
+    if full:
+        return {"ok": True, "state": full_state_json(state), "conditions": []}
+    return {"ok": True, "state_summary": summarize(state), "conditions": []}
+
+
+def cmd_finish(dir_: Path, summary: str, *, now: Clock) -> dict[str, JsonValue]:
+    """`grind finish --summary <text>`."""
+    _validate_or_raise("grind_finished", {"summary": summary})
+
+    event: RawEvent = {"ts": _iso(now()), "type": "grind_finished", "summary": summary}
+    append_event(dir_, event)
+    state = fold_dir(dir_)
+    write_state(dir_, full_state_json(state))
+    return {"ok": True, "state_summary": summarize(state)}

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -23,12 +23,27 @@ from grind.store import append_event, fold_dir, is_log_nonempty, load_events, wr
 
 Clock = Callable[[], datetime]
 
+# `ts` and `type` are stamped by the CLI at append time (spec: "ts ... Never
+# supplied by the caller"; `type` is the CLI-selected taxonomy). A payload/seed
+# carrying either would overwrite the CLI-controlled envelope via the `**`
+# spread below -- e.g. an `observation` smuggling `type=grind_finished` would
+# persist and apply a terminal event while the envelope reports success. A
+# caller supplying one is confused, so reject (command error, nothing appended)
+# rather than silently merge-last.
+_RESERVED_ENVELOPE_KEYS = ("ts", "type")
+
 
 def _iso(when: datetime) -> str:
     return when.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _validate_or_raise(event_type: str, payload: RawEvent) -> None:
+    reserved = [key for key in _RESERVED_ENVELOPE_KEYS if key in payload]
+    if reserved:
+        raise GrindError(
+            f"payload for {event_type!r} may not carry CLI-controlled envelope "
+            f"key(s) {', '.join(reserved)}: the CLI stamps ts and type"
+        )
     errors = validate_payload(event_type, payload)
     if errors:
         raise GrindError(f"invalid payload for {event_type!r}: " + "; ".join(errors))

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -19,7 +19,14 @@ from grind.fold import fold
 from grind.model import AnomalyRecord, JsonValue, RawEvent, State
 from grind.payloads import validate_payload
 from grind.serialize import anomaly_json, full_state_json, summarize
-from grind.store import append_event, fold_dir, is_log_nonempty, load_events, write_state
+from grind.store import (
+    TornTailRepair,
+    append_event,
+    fold_dir,
+    is_log_nonempty,
+    load_events,
+    write_state,
+)
 
 Clock = Callable[[], datetime]
 
@@ -89,14 +96,35 @@ def _new_anomaly(before: State, after: State) -> AnomalyRecord | None:
     return new_anomalies[0] if new_anomalies else None
 
 
-def _append_and_persist(dir_: Path, event: RawEvent) -> State:
+def _torn_tail_json(repair: TornTailRepair | None) -> JsonValue:
+    """The write-path torn-tail repair (if any) as an emit-back field (spec
+    "Torn tail": "records a torn_tail anomaly in the command's envelope").
+    `None` when the log was intact. Deliberately distinct from the envelope's
+    `anomaly` field, which is the fold-derived event-level anomaly: a torn-tail
+    repair and an event anomaly can co-occur on one append, and neither may mask
+    the other."""
+    if repair is None:
+        return None
+    return {"quarantined": repair.quarantined, "reason": repair.reason}
+
+
+def _append_and_persist(dir_: Path, event: RawEvent) -> tuple[State, TornTailRepair | None]:
     """The one write-then-refold sequence every appending verb shares: append,
     refold from the persisted log (never from memory -- state.json must
-    reflect what disk actually holds), rewrite state.json."""
-    append_event(dir_, event)
+    reflect what disk actually holds), rewrite state.json.
+
+    `append_event` may repair a torn tail left by a crashed prior writer; once
+    repaired the tail is gone from disk, so the subsequent `fold_dir` cannot see
+    it and the returned `State.anomalies` never carries it. The repair is
+    returned separately for the verb to surface in its envelope -- the only place
+    a caller learns prior log data was quarantined or a newline restored. It is
+    deliberately NOT folded into `state.anomalies`: after repair a
+    delete-and-refold yields a clean log, so persisting a non-reproducible
+    anomaly would break the spec's byte-identical replay invariant."""
+    repair = append_event(dir_, event)
     state = fold_dir(dir_)
     write_state(dir_, full_state_json(state))
-    return state
+    return state, repair
 
 
 def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue]:
@@ -109,7 +137,9 @@ def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue
     _validate_or_raise("grind_created", seed)
 
     event: RawEvent = {"ts": _iso(now()), "type": "grind_created", **seed}
-    state = _append_and_persist(dir_, event)
+    # `create` refuses a non-empty log (above), so a torn tail is unreachable
+    # here -- the repair is always None; no `torn_tail` field to surface.
+    state, _ = _append_and_persist(dir_, event)
     return {"ok": True, "state_summary": summarize(state)}
 
 
@@ -131,13 +161,14 @@ def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> di
 
     before_state = fold(load_events(dir_))
     event: RawEvent = {"ts": _iso(now()), "type": event_type, **payload}
-    after_state = _append_and_persist(dir_, event)
+    after_state, repair = _append_and_persist(dir_, event)
 
     anomaly = _new_anomaly(before_state, after_state)
     return {
         "ok": True,
         "applied": anomaly is None,
         "anomaly": anomaly_json(anomaly),
+        "torn_tail": _torn_tail_json(repair),
         "delta": _entity_delta(before_state, after_state, event),
         # The conditions engine is a sibling bead (spec §"Emit-back"); this
         # verb never computes orchestration facts itself.
@@ -158,5 +189,5 @@ def cmd_finish(dir_: Path, summary: str, *, now: Clock) -> dict[str, JsonValue]:
     _validate_or_raise("grind_finished", {"summary": summary})
 
     event: RawEvent = {"ts": _iso(now()), "type": "grind_finished", "summary": summary}
-    state = _append_and_persist(dir_, event)
-    return {"ok": True, "state_summary": summarize(state)}
+    state, repair = _append_and_persist(dir_, event)
+    return {"ok": True, "state_summary": summarize(state), "torn_tail": _torn_tail_json(repair)}

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -115,6 +115,18 @@ def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue
 
 def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> dict[str, JsonValue]:
     """`grind log <type> --json '<payload>'` -- returns the emit-back envelope."""
+    if event_type == "grind_created":
+        # Creation goes through `create` only (spec CLI contract), and
+        # `cmd_create`'s refusal message explicitly promises `grind log
+        # grind_created` is never allowed. In a fresh dir the fold would
+        # otherwise treat this as the first, valid creation event; reject it as
+        # a command error regardless of directory state (nothing appended). The
+        # reserved-key guard does not cover this -- the event type is the verb
+        # argument, not a payload key.
+        raise GrindError(
+            "refusing to log 'grind_created': creation goes through create "
+            "only, never grind log grind_created"
+        )
     _validate_or_raise(event_type, payload)
 
     before_state = fold(load_events(dir_))

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -64,14 +64,24 @@ def _entity_delta(before: State, after: State, event: RawEvent) -> JsonValue:
     return None
 
 
-def _new_anomaly(before: State, after_check: State) -> AnomalyRecord | None:
+def _new_anomaly(before: State, after: State) -> AnomalyRecord | None:
     """The single anomaly (if any) the just-appended event produced, isolated
-    by diffing two pure in-memory folds over `existing_events` vs.
-    `existing_events + [event]` -- `fold` is deterministic and never revisits
-    earlier events, so any new tail entries are attributable to this event
-    alone (at most one: every fold handler calls `_anomaly` at most once)."""
-    new_anomalies = after_check.anomalies[len(before.anomalies) :]
+    by diffing the pre-append fold against the post-append fold -- `fold` is
+    deterministic and never revisits earlier events, so any new tail entries
+    are attributable to this event alone (at most one: every fold handler
+    calls `_anomaly` at most once)."""
+    new_anomalies = after.anomalies[len(before.anomalies) :]
     return new_anomalies[0] if new_anomalies else None
+
+
+def _append_and_persist(dir_: Path, event: RawEvent) -> State:
+    """The one write-then-refold sequence every appending verb shares: append,
+    refold from the persisted log (never from memory -- state.json must
+    reflect what disk actually holds), rewrite state.json."""
+    append_event(dir_, event)
+    state = fold_dir(dir_)
+    write_state(dir_, full_state_json(state))
+    return state
 
 
 def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue]:
@@ -84,9 +94,7 @@ def cmd_create(dir_: Path, seed: RawEvent, *, now: Clock) -> dict[str, JsonValue
     _validate_or_raise("grind_created", seed)
 
     event: RawEvent = {"ts": _iso(now()), "type": "grind_created", **seed}
-    append_event(dir_, event)
-    state = fold_dir(dir_)
-    write_state(dir_, full_state_json(state))
+    state = _append_and_persist(dir_, event)
     return {"ok": True, "state_summary": summarize(state)}
 
 
@@ -94,21 +102,16 @@ def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> di
     """`grind log <type> --json '<payload>'` -- returns the emit-back envelope."""
     _validate_or_raise(event_type, payload)
 
-    existing_events = load_events(dir_)
-    before_state = fold(existing_events)
+    before_state = fold(load_events(dir_))
     event: RawEvent = {"ts": _iso(now()), "type": event_type, **payload}
-    check_state = fold([*existing_events, event])
+    after_state = _append_and_persist(dir_, event)
 
-    append_event(dir_, event)
-    after_state = fold_dir(dir_)
-    write_state(dir_, full_state_json(after_state))
-
-    anomaly = _new_anomaly(before_state, check_state)
+    anomaly = _new_anomaly(before_state, after_state)
     return {
         "ok": True,
         "applied": anomaly is None,
         "anomaly": anomaly_json(anomaly),
-        "delta": _entity_delta(before_state, check_state, event),
+        "delta": _entity_delta(before_state, after_state, event),
         # The conditions engine is a sibling bead (spec §"Emit-back"); this
         # verb never computes orchestration facts itself.
         "conditions": [],
@@ -128,7 +131,5 @@ def cmd_finish(dir_: Path, summary: str, *, now: Clock) -> dict[str, JsonValue]:
     _validate_or_raise("grind_finished", {"summary": summary})
 
     event: RawEvent = {"ts": _iso(now()), "type": "grind_finished", "summary": summary}
-    append_event(dir_, event)
-    state = fold_dir(dir_)
-    write_state(dir_, full_state_json(state))
+    state = _append_and_persist(dir_, event)
     return {"ok": True, "state_summary": summarize(state)}

--- a/packages/grind/tests/unit/test_cli.py
+++ b/packages/grind/tests/unit/test_cli.py
@@ -116,6 +116,44 @@ def test_log_verb_invalid_json_string_yields_nonzero_exit(tmp_path: Path):
     assert envelope["ok"] is False
 
 
+def test_create_rejects_non_finite_constant_in_seed(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    # A hand-authored seed with a bare `NaN` -- stdlib json.loads would accept
+    # it, then re-emit it into events.jsonl/state.json as non-standard JSON.
+    seed_text = '{"title":"t","repo":"r","mission":{"goal":NaN},"protocols":{},"lanes":[]}'
+
+    exit_code, envelope, _err = _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": seed_text},
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+    assert not (grind_dir / "events.jsonl").exists()
+
+
+def test_log_rejects_non_finite_constant_in_json_payload(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(
+        [
+            "log",
+            "item_started",
+            "--json",
+            '{"item": "wgclw.1", "x": Infinity}',
+            "--dir",
+            str(grind_dir),
+        ]
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+
+
 def test_status_default_and_full(tmp_path: Path):
     grind_dir = tmp_path / "run"
     _run(

--- a/packages/grind/tests/unit/test_cli.py
+++ b/packages/grind/tests/unit/test_cli.py
@@ -1,0 +1,175 @@
+"""`grind.cli.main`: argv parsing, the four verbs end-to-end, and the envelope/
+exit-code contract (spec: "all output is a JSON envelope on stdout ... exit
+code 0 unless the command itself failed")."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from io import StringIO
+from pathlib import Path
+
+from grind.cli import main
+
+_SEED = {
+    "title": "Widget grind",
+    "repo": "acme/widgets",
+    "mission": {"goal": "ship widgets"},
+    "protocols": {},
+    "lanes": [{"id": "lane-a", "queue": [{"id": "wgclw.1", "title": "First item"}]}],
+}
+
+
+def _run(argv: Sequence[str], read_file: dict[str, str] | None = None) -> tuple[int, dict, str]:
+    out, err = StringIO(), StringIO()
+    exit_code = main(
+        list(argv),
+        out=out,
+        err=err,
+        read_file=(lambda p: (read_file or {})[p]) if read_file is not None else None,
+    )
+    return exit_code, json.loads(out.getvalue()), err.getvalue()
+
+
+def test_create_via_file_flag(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    exit_code, envelope, _err = _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert (grind_dir / "events.jsonl").exists()
+    assert (grind_dir / "state.json").exists()
+
+
+def test_create_refusal_yields_nonzero_exit_and_error_envelope(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, err = _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+    assert "error" in envelope
+    assert err == ""
+
+
+def test_log_verb_returns_emit_back_envelope_and_exits_zero(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(
+        [
+            "log",
+            "item_started",
+            "--json",
+            json.dumps({"item": "wgclw.1"}),
+            "--dir",
+            str(grind_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert envelope["applied"] is True
+    assert envelope["delta"]["new_status"] == "in-progress"
+
+
+def test_log_verb_malformed_payload_yields_nonzero_exit(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(
+        ["log", "pr_opened", "--json", json.dumps({"item": "wgclw.1"}), "--dir", str(grind_dir)]
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+
+
+def test_log_verb_invalid_json_string_yields_nonzero_exit(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(
+        ["log", "item_started", "--json", "{not json", "--dir", str(grind_dir)]
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+
+
+def test_status_default_and_full(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(["status", "--dir", str(grind_dir)])
+    assert exit_code == 0
+    assert "state_summary" in envelope
+
+    exit_code, envelope, _err = _run(["status", "--full", "--dir", str(grind_dir)])
+    assert exit_code == 0
+    assert "state" in envelope
+
+
+def test_finish_verb(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(["finish", "--summary", "shipped it", "--dir", str(grind_dir)])
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert envelope["state_summary"]["finished"] is True
+
+
+def test_dir_defaults_to_cwd(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    exit_code, _envelope, _err = _run(
+        ["create", "--file", "seed.json"], read_file={"seed.json": json.dumps(_SEED)}
+    )
+
+    assert exit_code == 0
+    assert (tmp_path / "events.jsonl").exists()
+
+
+def test_unknown_verb_yields_usage_error_not_a_stack_trace():
+    exit_code, envelope, err = _run(["bogus-verb"])
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+    assert err == ""
+
+
+def test_missing_seed_file_yields_error_envelope_not_a_traceback(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    exit_code, envelope, _err = _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={},
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False

--- a/packages/grind/tests/unit/test_jsonio.py
+++ b/packages/grind/tests/unit/test_jsonio.py
@@ -1,0 +1,42 @@
+"""`grind.jsonio.loads`: the strict decoder that refuses non-standard
+non-finite JSON constants (`NaN`, `Infinity`, `-Infinity`) at every boundary."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from grind.jsonio import NonFiniteJsonError, loads
+
+
+def test_loads_accepts_ordinary_json() -> None:
+    assert loads('{"a": 1, "b": [true, null, 2.5], "c": "x"}') == {
+        "a": 1,
+        "b": [True, None, 2.5],
+        "c": "x",
+    }
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_loads_rejects_top_level_non_finite_constant(constant: str) -> None:
+    with pytest.raises(NonFiniteJsonError):
+        loads(constant)
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_loads_rejects_nested_non_finite_constant(constant: str) -> None:
+    with pytest.raises(NonFiniteJsonError):
+        loads('{"mission": {"goal": ' + constant + "}}")
+
+
+def test_non_finite_json_error_is_a_value_error() -> None:
+    # A ValueError subclass so boundary catch sites can group it with the
+    # stdlib `json.JSONDecodeError` (itself a ValueError) as malformed input.
+    assert issubclass(NonFiniteJsonError, ValueError)
+
+
+def test_loads_still_produces_finite_floats_for_valid_numbers() -> None:
+    value = loads('{"n": 1.5}')
+    assert isinstance(value, dict)
+    assert math.isfinite(value["n"])  # type: ignore[arg-type]

--- a/packages/grind/tests/unit/test_log_parsing.py
+++ b/packages/grind/tests/unit/test_log_parsing.py
@@ -50,6 +50,29 @@ def test_a_malformed_line_that_is_not_the_tail_raises() -> None:
         parse_event_log(text)
 
 
+def test_a_non_finite_constant_off_the_tail_is_treated_as_corruption() -> None:
+    # A non-finite constant is non-standard JSON, so a non-tail line carrying
+    # one is corruption -- same disposition as any other malformed non-tail
+    # line, not a silently-accepted value.
+    good = _line(seed_event())
+    text = '{"ts": "t", "type": "item_started", "item": "x", "n": NaN}\n' + good + "\n"
+
+    with pytest.raises(LogCorruptionError):
+        parse_event_log(text)
+
+
+def test_a_non_finite_constant_on_the_final_line_is_dropped_as_torn_tail() -> None:
+    # On the tail, a non-parsing line follows the torn-tail convention: dropped
+    # and flagged, never silently folded in.
+    good = _line(seed_event())
+    text = good + "\n" + '{"ts": "t", "type": "item_started", "item": "x", "n": Infinity}'
+
+    parsed = parse_event_log(text)
+
+    assert parsed.events == [seed_event()]
+    assert parsed.torn_tail is True
+
+
 def test_fold_log_records_a_torn_tail_as_an_attention_raising_observation() -> None:
     good = _line(seed_event())
     torn = '{"ts": "t", "type": "item_start'

--- a/packages/grind/tests/unit/test_payloads.py
+++ b/packages/grind/tests/unit/test_payloads.py
@@ -1,0 +1,220 @@
+"""`payloads.validate_payload` -- the malformed/illegal seam (spec: "malformation
+is caught before the log, illegality is caught after"). These tests only cover
+*shape* validation; transition legality is the fold's job (tested elsewhere)."""
+
+from __future__ import annotations
+
+from grind.payloads import validate_payload
+
+# -- grind_created (also used by `grind create`'s seed validation) ----------
+
+
+def test_grind_created_requires_title_repo_mission_protocols_lanes():
+    errors = validate_payload("grind_created", {})
+    assert any("title" in e for e in errors)
+    assert any("repo" in e for e in errors)
+    assert any("mission" in e for e in errors)
+    assert any("protocols" in e for e in errors)
+    assert any("lanes" in e for e in errors)
+
+
+def test_grind_created_accepts_minimal_valid_seed():
+    errors = validate_payload(
+        "grind_created",
+        {
+            "title": "Widget grind",
+            "repo": "acme/widgets",
+            "mission": {"goal": "ship widgets"},
+            "protocols": {},
+            "lanes": [],
+        },
+    )
+    assert errors == []
+
+
+def test_grind_created_config_must_be_object_when_present():
+    errors = validate_payload(
+        "grind_created",
+        {
+            "title": "t",
+            "repo": "r",
+            "mission": {},
+            "protocols": {},
+            "lanes": [],
+            "config": "not-an-object",
+        },
+    )
+    assert any("config" in e for e in errors)
+
+
+def test_grind_created_validates_lane_and_item_shapes():
+    errors = validate_payload(
+        "grind_created",
+        {
+            "title": "t",
+            "repo": "r",
+            "mission": {},
+            "protocols": {},
+            "lanes": [{"name": "no id"}, {"id": "lane-a", "queue": [{"title": "no id"}]}],
+        },
+    )
+    assert any("lanes[0]" in e for e in errors)
+    assert any("lanes[1].queue[0]" in e for e in errors)
+
+
+# -- item lifecycle -----------------------------------------------------------
+
+
+def test_item_started_requires_item():
+    assert validate_payload("item_started", {}) != []
+    assert validate_payload("item_started", {"item": "wgclw.1"}) == []
+
+
+def test_pr_opened_requires_item_and_int_pr():
+    assert validate_payload("pr_opened", {"item": "wgclw.1"}) != []
+    assert validate_payload("pr_opened", {"item": "wgclw.1", "pr": "not-int"}) != []
+    assert validate_payload("pr_opened", {"item": "wgclw.1", "pr": 42}) == []
+    assert validate_payload("pr_opened", {"item": "wgclw.1", "pr": 42, "url": "https://x"}) == []
+
+
+def test_review_round_requires_item_kind_round_head_sha():
+    payload = {"item": "wgclw.1", "kind": "codex", "round": 1, "head_sha": "abc123"}
+    assert validate_payload("review_round", payload) == []
+    assert validate_payload("review_round", {**payload, "kind": "bogus"}) != []
+    assert validate_payload("review_round", {**payload, "round": "one"}) != []
+
+
+def test_review_verdict_requires_verdict_enum_and_validates_findings():
+    base = {"item": "wgclw.1", "kind": "codex", "round": 1, "head_sha": "abc", "verdict": "clean"}
+    assert validate_payload("review_verdict", base) == []
+    assert validate_payload("review_verdict", {**base, "verdict": "bogus"}) != []
+    good_finding = {"findings": [{"severity": "high", "summary": "x", "disposition": "fixed"}]}
+    assert validate_payload("review_verdict", {**base, **good_finding}) == []
+    bad_finding = {"findings": [{"severity": "high", "summary": "x", "disposition": "bogus"}]}
+    assert validate_payload("review_verdict", {**base, **bad_finding}) != []
+
+
+def test_pr_closed_requires_item_pr_reason_and_valid_next():
+    base = {"item": "wgclw.1", "pr": 1, "reason": "superseded"}
+    assert validate_payload("pr_closed", {**base, "next": "queued"}) == []
+    assert validate_payload("pr_closed", {**base, "next": "parked"}) == []
+    assert validate_payload("pr_closed", {**base, "next": "bogus"}) != []
+    assert validate_payload("pr_closed", base) != []  # next is required
+
+
+def test_item_blocked_requires_item_and_list_of_str_on():
+    assert validate_payload("item_blocked", {"item": "a", "on": ["b", "c"]}) == []
+    assert validate_payload("item_blocked", {"item": "a", "on": "b"}) != []
+    assert validate_payload("item_blocked", {"item": "a"}) != []
+
+
+def test_item_waiting_human_requires_item_and_why():
+    assert validate_payload("item_waiting_human", {"item": "a", "why": "needs a call"}) == []
+    assert validate_payload("item_waiting_human", {"item": "a"}) != []
+
+
+def test_item_resumed_requires_item_and_ruling():
+    assert validate_payload("item_resumed", {"item": "a", "ruling": "proceed"}) == []
+    assert validate_payload("item_resumed", {"item": "a"}) != []
+
+
+def test_item_merged_requires_item_pr_sha():
+    assert validate_payload("item_merged", {"item": "a", "pr": 1, "sha": "deadbeef"}) == []
+    assert validate_payload("item_merged", {"item": "a", "pr": 1}) != []
+
+
+def test_item_done_requires_item():
+    assert validate_payload("item_done", {"item": "a"}) == []
+    assert validate_payload("item_done", {}) != []
+
+
+def test_item_parked_requires_item_kind_note():
+    assert validate_payload("item_parked", {"item": "a", "kind": "deferred", "note": "n"}) == []
+    assert validate_payload("item_parked", {"item": "a", "kind": "bogus", "note": "n"}) != []
+    assert validate_payload("item_parked", {"item": "a", "kind": "deferred"}) != []
+
+
+def test_item_enqueued_requires_item_and_lane():
+    assert validate_payload("item_enqueued", {"item": "a", "lane": "lane-a"}) == []
+    assert validate_payload("item_enqueued", {"item": "a", "lane": "lane-a", "position": 0}) == []
+    assert validate_payload("item_enqueued", {"item": "a", "lane": "lane-a", "position": "x"}) != []
+    assert validate_payload("item_enqueued", {"item": "a"}) != []
+
+
+def test_discovered_work_requires_disposition_specific_fields():
+    parked = {
+        "item": "disc-1",
+        "description": "found a thing",
+        "source": "lane-a",
+        "disposition": "parked",
+        "rationale": "why",
+        "kind": "discovered-work",
+    }
+    assert validate_payload("discovered_work", parked) == []
+    # kind is required when parked
+    assert validate_payload("discovered_work", {**parked, "kind": None}) != []
+
+    enqueued = {
+        "item": "disc-2",
+        "description": "found a thing",
+        "source": "lane-a",
+        "disposition": "enqueued",
+        "rationale": "why",
+        "lane": "lane-a",
+    }
+    assert validate_payload("discovered_work", enqueued) == []
+    without_lane = {k: v for k, v in enqueued.items() if k != "lane"}
+    assert validate_payload("discovered_work", without_lane) != []
+
+
+# -- lane / grind lifecycle / cross-cutting -----------------------------------
+
+
+def test_lane_standing_down_requires_lane():
+    assert validate_payload("lane_standing_down", {"lane": "lane-a"}) == []
+    assert validate_payload("lane_standing_down", {}) != []
+
+
+def test_lane_handover_requires_core_fields():
+    payload = {"lane": "lane-a", "from_agent": "x", "to_agent": "y", "reason": "rotation"}
+    assert validate_payload("lane_handover", payload) == []
+    assert validate_payload("lane_handover", {**payload, "to_model": "sonnet"}) == []
+
+
+def test_grind_paused_requires_reason():
+    assert validate_payload("grind_paused", {"reason": "eod"}) == []
+    assert validate_payload("grind_paused", {"reason": "eod", "resume_checklist": ["a"]}) == []
+    assert validate_payload("grind_paused", {}) != []
+
+
+def test_grind_resumed_has_no_required_fields():
+    assert validate_payload("grind_resumed", {}) == []
+
+
+def test_grind_finished_requires_summary():
+    assert validate_payload("grind_finished", {"summary": "done"}) == []
+    assert validate_payload("grind_finished", {}) != []
+
+
+def test_observation_requires_level_and_message():
+    assert validate_payload("observation", {"level": "INFO", "message": "hi"}) == []
+    assert validate_payload("observation", {"level": "BOGUS", "message": "hi"}) != []
+    assert validate_payload("observation", {"level": "INFO"}) != []
+
+
+def test_attention_raised_requires_text():
+    assert validate_payload("attention_raised", {"text": "look"}) == []
+    assert validate_payload("attention_raised", {}) != []
+
+
+def test_attention_cleared_requires_text_or_item():
+    assert validate_payload("attention_cleared", {"text": "look"}) == []
+    assert validate_payload("attention_cleared", {"item": "a"}) == []
+    assert validate_payload("attention_cleared", {}) != []
+
+
+# -- unknown types: forward-compatibility, no shape validation ---------------
+
+
+def test_unknown_type_has_no_validator_and_is_always_shape_valid():
+    assert validate_payload("some_future_event", {"anything": "goes"}) == []

--- a/packages/grind/tests/unit/test_payloads.py
+++ b/packages/grind/tests/unit/test_payloads.py
@@ -62,6 +62,49 @@ def test_grind_created_validates_lane_and_item_shapes():
     assert any("lanes[1].queue[0]" in e for e in errors)
 
 
+def _seed_with_item(item: dict) -> dict:
+    return {
+        "title": "t",
+        "repo": "r",
+        "mission": {},
+        "protocols": {},
+        "lanes": [{"id": "lane-a", "queue": [{"id": "wgclw.1", **item}]}],
+    }
+
+
+def test_grind_created_validates_seeded_blocker_edges():
+    # A seeded item's optional `on` (blocker edges) must be an array of strings;
+    # the fold silently drops malformed values and folds the item as `queued`
+    # instead of `blocked`, so dependent work could start despite the edge.
+    assert validate_payload("grind_created", _seed_with_item({})) == []
+    assert validate_payload("grind_created", _seed_with_item({"on": []})) == []
+    assert validate_payload("grind_created", _seed_with_item({"on": ["wgclw.2"]})) == []
+    # scalar string instead of an array
+    errors = validate_payload("grind_created", _seed_with_item({"on": "wgclw.2"}))
+    assert any("lanes[0].queue[0].on" in e for e in errors)
+    # array containing non-strings
+    errors = validate_payload("grind_created", _seed_with_item({"on": [42]}))
+    assert any("lanes[0].queue[0].on" in e for e in errors)
+
+
+def test_grind_created_validates_optional_seed_string_fields():
+    # Item title and lane name/agent/model/effort are silently coerced to None
+    # by the fold when malformed -- validate them at the boundary.
+    errors = validate_payload("grind_created", _seed_with_item({"title": 42}))
+    assert any("lanes[0].queue[0].title" in e for e in errors)
+    errors = validate_payload(
+        "grind_created",
+        {
+            "title": "t",
+            "repo": "r",
+            "mission": {},
+            "protocols": {},
+            "lanes": [{"id": "lane-a", "model": 7}],
+        },
+    )
+    assert any("lanes[0].model" in e for e in errors)
+
+
 # -- item lifecycle -----------------------------------------------------------
 
 

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -1,0 +1,105 @@
+"""`grind.serialize`: State -> JsonValue for `state.json` and `status --full`,
+plus the `status` default summary shape."""
+
+from __future__ import annotations
+
+from grind.fold import fold
+from grind.serialize import full_state_json, summarize
+
+from .builders import event, seed_event
+
+
+def test_summarize_reports_header_lane_and_item_counts():
+    events = [seed_event(), event("item_started", item="wgclw.1")]
+    state = fold(events)
+
+    summary = summarize(state)
+
+    assert summary["title"] == "Widget grind"
+    assert summary["repo"] == "acme/widgets"
+    assert summary["paused"] is False
+    assert summary["finished"] is False
+    assert summary["items_by_status"] == {"in-progress": 1, "queued": 1}
+    assert summary["attention_count"] == 0
+    assert summary["anomaly_count"] == 0
+    lanes = summary["lanes"]
+    assert isinstance(lanes, list)
+    assert lanes[0]["id"] == "lane-a"
+    assert lanes[0]["status"] == "in-progress"
+
+
+def test_summarize_counts_attention_and_anomalies():
+    events = [seed_event(), event("item_waiting_human", item="does-not-exist", why="?")]
+    state = fold(events)
+
+    summary = summarize(state)
+
+    assert summary["attention_count"] == 1
+    assert summary["anomaly_count"] == 1
+
+
+def test_full_state_json_round_trips_item_fields():
+    events = [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=42, url="https://example/42"),
+        event(
+            "review_round",
+            item="wgclw.1",
+            kind="codex",
+            round=1,
+            head_sha="deadbeef",
+            detail="looks fine",
+        ),
+    ]
+    state = fold(events)
+
+    full = full_state_json(state)
+
+    assert full["title"] == "Widget grind"
+    items = full["items"]
+    assert isinstance(items, dict)
+    item = items["wgclw.1"]
+    assert isinstance(item, dict)
+    assert item["status"] == "in-review"
+    pr = item["pr"]
+    assert isinstance(pr, dict)
+    assert pr["number"] == 42
+    assert pr["url"] == "https://example/42"
+    review = item["review"]
+    assert isinstance(review, dict)
+    assert review["round"] == 1
+    assert review["head_sha"] == "deadbeef"
+
+
+def test_full_state_json_serializes_ledgers_and_parking_lot():
+    events = [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        event("item_parked", item="wgclw.2", kind="deferred", note="later"),
+    ]
+    state = fold(events)
+
+    full = full_state_json(state)
+
+    merged = full["merged_ledger"]
+    assert isinstance(merged, list)
+    assert merged[0]["item"] == "wgclw.1"
+    items = full["items"]
+    assert isinstance(items, dict)
+    parked_item = items["wgclw.2"]
+    assert isinstance(parked_item, dict)
+    parked = parked_item["parked"]
+    assert isinstance(parked, dict)
+    assert parked["kind"] == "deferred"
+
+
+def test_full_state_json_is_json_serializable():
+    import json
+
+    events = [seed_event()]
+    state = fold(events)
+
+    json.dumps(full_state_json(state))  # raises if any value isn't JSON-safe

--- a/packages/grind/tests/unit/test_store.py
+++ b/packages/grind/tests/unit/test_store.py
@@ -1,0 +1,119 @@
+"""`grind.store`: events.jsonl I/O, the write-path torn-tail repair, and
+refold-from-zero (spec "Torn tail" + "The fold refolds from zero on every
+command"). Read-side torn-tail tolerance itself is `grind.log`'s job (already
+tested); this module is what makes the log appendable again after a crash."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from grind.store import (
+    append_event,
+    events_path,
+    is_log_nonempty,
+    load_events,
+    quarantine_path,
+    read_raw_log,
+    repair_torn_tail,
+)
+
+
+def _write_raw(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_is_log_nonempty_false_for_missing_and_empty_and_whitespace_only(tmp_path: Path):
+    assert is_log_nonempty(tmp_path) is False
+    _write_raw(events_path(tmp_path), "")
+    assert is_log_nonempty(tmp_path) is False
+    _write_raw(events_path(tmp_path), "\n\n")
+    assert is_log_nonempty(tmp_path) is False
+
+
+def test_is_log_nonempty_true_once_an_event_line_exists(tmp_path: Path):
+    _write_raw(events_path(tmp_path), '{"ts":"t","type":"grind_created"}\n')
+    assert is_log_nonempty(tmp_path) is True
+
+
+def test_repair_torn_tail_no_op_when_file_ends_with_newline(tmp_path: Path):
+    _write_raw(events_path(tmp_path), '{"ts":"t","type":"item_started","item":"a"}\n')
+    assert repair_torn_tail(tmp_path) is None
+    assert read_raw_log(tmp_path).endswith("\n")
+
+
+def test_repair_torn_tail_no_op_when_no_log_exists(tmp_path: Path):
+    assert repair_torn_tail(tmp_path) is None
+
+
+def test_repair_torn_tail_appends_missing_newline_for_a_complete_last_line(tmp_path: Path):
+    complete_event = '{"ts":"t","type":"item_started","item":"a"}'
+    _write_raw(events_path(tmp_path), complete_event)  # no trailing newline
+
+    repair = repair_torn_tail(tmp_path)
+
+    assert repair is not None
+    assert repair.quarantined is False
+    assert read_raw_log(tmp_path) == complete_event + "\n"
+    # The event itself survives -- it was a durable transition, only the
+    # newline was lost mid-crash.
+    events = load_events(tmp_path)
+    assert events == [{"ts": "t", "type": "item_started", "item": "a"}]
+
+
+def test_repair_torn_tail_quarantines_an_unparsable_fragment(tmp_path: Path):
+    good_line = '{"ts":"t1","type":"item_started","item":"a"}\n'
+    fragment = '{"ts":"t2","type":"pr_opened","item'  # truncated mid-write
+    _write_raw(events_path(tmp_path), good_line + fragment)
+
+    repair = repair_torn_tail(tmp_path)
+
+    assert repair is not None
+    assert repair.quarantined is True
+    assert read_raw_log(tmp_path) == good_line
+    assert load_events(tmp_path) == [{"ts": "t1", "type": "item_started", "item": "a"}]
+    quarantined = quarantine_path(tmp_path).read_text(encoding="utf-8")
+    assert fragment in quarantined
+
+
+def test_repair_torn_tail_quarantine_sidecar_is_append_only(tmp_path: Path):
+    _write_raw(events_path(tmp_path), "not json at all")
+    repair_torn_tail(tmp_path)
+    _write_raw(events_path(tmp_path), "also not json")
+    repair_torn_tail(tmp_path)
+
+    quarantined_lines = quarantine_path(tmp_path).read_text(encoding="utf-8").splitlines()
+    assert quarantined_lines == ["not json at all", "also not json"]
+
+
+def test_append_event_creates_the_directory_and_the_log(tmp_path: Path):
+    grind_dir = tmp_path / "nested" / "grind"
+    append_event(grind_dir, {"ts": "t", "type": "grind_created"})
+
+    assert load_events(grind_dir) == [{"ts": "t", "type": "grind_created"}]
+
+
+def test_append_event_repairs_a_torn_tail_before_appending(tmp_path: Path):
+    complete_event = '{"ts":"t1","type":"item_started","item":"a"}'
+    _write_raw(events_path(tmp_path), complete_event)  # missing trailing newline
+
+    repair = append_event(tmp_path, {"ts": "t2", "type": "pr_opened", "item": "a", "pr": 1})
+
+    assert repair is not None
+    assert repair.quarantined is False
+    events = load_events(tmp_path)
+    assert events == [
+        {"ts": "t1", "type": "item_started", "item": "a"},
+        {"ts": "t2", "type": "pr_opened", "item": "a", "pr": 1},
+    ]
+
+
+def test_append_event_serializes_json_one_line_per_event(tmp_path: Path):
+    append_event(tmp_path, {"ts": "t1", "type": "grind_created"})
+    append_event(tmp_path, {"ts": "t2", "type": "item_started", "item": "a"})
+
+    lines = read_raw_log(tmp_path).splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["type"] == "grind_created"
+    assert json.loads(lines[1])["type"] == "item_started"

--- a/packages/grind/tests/unit/test_store.py
+++ b/packages/grind/tests/unit/test_store.py
@@ -6,7 +6,10 @@ tested); this module is what makes the log appendable again after a crash."""
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
+
+import pytest
 
 from grind.store import (
     append_event,
@@ -16,6 +19,7 @@ from grind.store import (
     quarantine_path,
     read_raw_log,
     repair_torn_tail,
+    write_state,
 )
 
 
@@ -117,3 +121,28 @@ def test_append_event_serializes_json_one_line_per_event(tmp_path: Path):
     assert len(lines) == 2
     assert json.loads(lines[0])["type"] == "grind_created"
     assert json.loads(lines[1])["type"] == "item_started"
+
+
+def test_append_event_refuses_to_serialize_a_non_finite_float(tmp_path: Path):
+    # Defense in depth: allow_nan=False makes a non-finite value a loud write
+    # failure rather than a non-standard `NaN` literal silently in events.jsonl.
+    with pytest.raises(ValueError):
+        append_event(tmp_path, {"ts": "t", "type": "x", "n": math.nan})
+
+
+def test_write_state_refuses_to_serialize_a_non_finite_float(tmp_path: Path):
+    with pytest.raises(ValueError):
+        write_state(tmp_path, {"metric": math.inf})
+
+
+def test_repair_torn_tail_quarantines_a_final_line_carrying_a_non_finite_constant(tmp_path: Path):
+    good = '{"ts":"t","type":"grind_created"}'
+    # The tail's `NaN` no longer parses as a value -- it is an unparsable
+    # fragment, so the repair quarantines it exactly like any other torn tail.
+    _write_raw(events_path(tmp_path), good + "\n" + '{"ts":"t2","type":"x","n":NaN}')
+
+    repair = repair_torn_tail(tmp_path)
+
+    assert repair is not None
+    assert repair.quarantined is True
+    assert read_raw_log(tmp_path) == good + "\n"

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from grind.envelope import GrindError
-from grind.store import load_events
+from grind.store import events_path, load_events
 from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
 
 _NOW = lambda: datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)  # noqa: E731
@@ -32,6 +32,19 @@ _SEED = {
 def _seeded(tmp_path: Path) -> Path:
     cmd_create(tmp_path, dict(_SEED), now=_NOW)
     return tmp_path
+
+
+def _strip_trailing_newline(dir_: Path) -> None:
+    """Simulate a crash mid-append: the durable final line lost its newline."""
+    path = events_path(dir_)
+    path.write_text(path.read_text(encoding="utf-8").rstrip("\n"), encoding="utf-8")
+
+
+def _append_unparsable_fragment(dir_: Path) -> None:
+    """Simulate a crash mid-append: a truncated final line that won't parse."""
+    path = events_path(dir_)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"ts":"tX","type":"pr_ope')  # truncated mid-write, no newline
 
 
 # -- create -------------------------------------------------------------------
@@ -97,6 +110,46 @@ def test_log_appends_folds_and_returns_emit_back_envelope(tmp_path: Path):
     assert delta["old_status"] == "queued"
     assert delta["new_status"] == "in-progress"
     assert len(load_events(tmp_path)) == 2
+    assert result["torn_tail"] is None  # intact log -> no repair to surface
+
+
+def test_log_surfaces_torn_tail_repair_when_first_writer_after_crash(tmp_path: Path):
+    # A crash left the seed line without its trailing newline; `log` is the
+    # first writer after the crash. append_event repairs the tail, then folds
+    # a clean log -- so state.anomalies can't carry the torn_tail. The repair
+    # rides the envelope's dedicated `torn_tail` field instead (spec "Torn
+    # tail": "records a torn_tail anomaly in the command's envelope").
+    _seeded(tmp_path)
+    _strip_trailing_newline(tmp_path)
+
+    result = cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+
+    torn = result["torn_tail"]
+    assert isinstance(torn, dict)
+    assert torn["quarantined"] is False  # complete line, only the newline was lost
+    assert "torn_tail" in torn["reason"]
+    # The new event still applied normally alongside the repair.
+    assert result["applied"] is True
+    assert result["anomaly"] is None
+    assert len(load_events(tmp_path)) == 2
+
+
+def test_log_torn_tail_and_event_anomaly_do_not_mask_each_other(tmp_path: Path):
+    # Co-occurrence: a quarantined torn-tail fragment AND a well-formed but
+    # illegal new event. The event-level anomaly rides `anomaly`; the repair
+    # rides `torn_tail`. Neither field masks the other.
+    _seeded(tmp_path)
+    _append_unparsable_fragment(tmp_path)
+
+    result = cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
+
+    anomaly = result["anomaly"]
+    assert isinstance(anomaly, dict)
+    assert anomaly["type"] == "item_merged"  # illegal from queued
+    torn = result["torn_tail"]
+    assert isinstance(torn, dict)
+    assert torn["quarantined"] is True  # the fragment didn't parse
+    assert "torn_tail" in torn["reason"]
 
 
 def test_log_rejects_a_malformed_payload_and_appends_nothing(tmp_path: Path):
@@ -222,6 +275,21 @@ def test_finish_appends_grind_finished_and_returns_summary(tmp_path: Path):
     summary = result["state_summary"]
     assert isinstance(summary, dict)
     assert summary["finished"] is True
+    assert result["torn_tail"] is None  # intact log -> no repair to surface
+
+
+def test_finish_surfaces_torn_tail_repair_when_first_writer_after_crash(tmp_path: Path):
+    # `finish` is the first writer after a crash: it must surface the repair
+    # too, not just `log` (spec "Torn tail" applies to the write path uniformly).
+    _seeded(tmp_path)
+    _strip_trailing_newline(tmp_path)
+
+    result = cmd_finish(tmp_path, "shipped it", now=_NOW)
+
+    torn = result["torn_tail"]
+    assert isinstance(torn, dict)
+    assert torn["quarantined"] is False
+    assert "torn_tail" in torn["reason"]
 
 
 def test_finish_rejects_missing_summary(tmp_path: Path):

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -66,6 +66,19 @@ def test_create_rejects_a_malformed_seed_and_writes_nothing(tmp_path: Path):
     assert load_events(tmp_path) == []
 
 
+@pytest.mark.parametrize("reserved_key", ["ts", "type"])
+def test_create_rejects_a_seed_carrying_a_reserved_envelope_key(tmp_path: Path, reserved_key: str):
+    # The CLI stamps `ts` and `type`; a seed supplying either would overwrite
+    # the CLI-controlled envelope via the dict spread. Reject before appending.
+    poisoned = dict(_SEED)
+    poisoned[reserved_key] = "attacker-controlled"
+
+    with pytest.raises(GrindError):
+        cmd_create(tmp_path, poisoned, now=_NOW)
+
+    assert load_events(tmp_path) == []
+
+
 # -- log ------------------------------------------------------------------
 
 
@@ -91,6 +104,21 @@ def test_log_rejects_a_malformed_payload_and_appends_nothing(tmp_path: Path):
 
     with pytest.raises(GrindError):
         cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": "not-an-int"}, now=_NOW)
+
+    assert len(load_events(tmp_path)) == 1  # only the seed event
+
+
+@pytest.mark.parametrize("reserved_key", ["ts", "type"])
+def test_log_rejects_a_payload_carrying_a_reserved_envelope_key(tmp_path: Path, reserved_key: str):
+    # The codex-flagged smuggle: a valid `observation` payload carrying
+    # `type=grind_finished` would, via the dict spread, persist and apply a
+    # grind_finished event -- prematurely terminal -- while reporting success.
+    # Reserved envelope keys are rejected before anything is appended.
+    _seeded(tmp_path)
+    poisoned = {"level": "INFO", "message": "x", reserved_key: "grind_finished"}
+
+    with pytest.raises(GrindError):
+        cmd_log(tmp_path, "observation", poisoned, now=_NOW)
 
     assert len(load_events(tmp_path)) == 1  # only the seed event
 

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -1,0 +1,180 @@
+"""`grind.verbs`: the four command bodies over `grind.store` + `grind.fold`,
+independent of argv/stdout wiring (that's `cli.py`, tested separately)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from grind.envelope import GrindError
+from grind.store import load_events
+from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
+
+_NOW = lambda: datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)  # noqa: E731
+
+_SEED = {
+    "title": "Widget grind",
+    "repo": "acme/widgets",
+    "mission": {"goal": "ship widgets"},
+    "protocols": {},
+    "lanes": [
+        {
+            "id": "lane-a",
+            "name": "Lane A",
+            "queue": [{"id": "wgclw.1", "title": "First item"}],
+        }
+    ],
+}
+
+
+def _seeded(tmp_path: Path) -> Path:
+    cmd_create(tmp_path, dict(_SEED), now=_NOW)
+    return tmp_path
+
+
+# -- create -------------------------------------------------------------------
+
+
+def test_create_writes_first_event_and_returns_state_summary(tmp_path: Path):
+    result = cmd_create(tmp_path, dict(_SEED), now=_NOW)
+
+    assert result["ok"] is True
+    summary = result["state_summary"]
+    assert isinstance(summary, dict)
+    assert summary["title"] == "Widget grind"
+    events = load_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["type"] == "grind_created"
+    assert events[0]["ts"] == "2026-07-19T12:00:00Z"
+
+
+def test_create_refuses_when_events_log_already_nonempty(tmp_path: Path):
+    _seeded(tmp_path)
+
+    with pytest.raises(GrindError):
+        cmd_create(tmp_path, dict(_SEED), now=_NOW)
+
+    assert len(load_events(tmp_path)) == 1  # nothing appended by the refused call
+
+
+def test_create_rejects_a_malformed_seed_and_writes_nothing(tmp_path: Path):
+    with pytest.raises(GrindError):
+        cmd_create(tmp_path, {"title": "missing everything else"}, now=_NOW)
+
+    assert load_events(tmp_path) == []
+
+
+# -- log ------------------------------------------------------------------
+
+
+def test_log_appends_folds_and_returns_emit_back_envelope(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+
+    assert result["ok"] is True
+    assert result["applied"] is True
+    assert result["anomaly"] is None
+    assert result["conditions"] == []
+    delta = result["delta"]
+    assert isinstance(delta, dict)
+    assert delta["entity"] == "wgclw.1"
+    assert delta["old_status"] == "queued"
+    assert delta["new_status"] == "in-progress"
+    assert len(load_events(tmp_path)) == 2
+
+
+def test_log_rejects_a_malformed_payload_and_appends_nothing(tmp_path: Path):
+    _seeded(tmp_path)
+
+    with pytest.raises(GrindError):
+        cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": "not-an-int"}, now=_NOW)
+
+    assert len(load_events(tmp_path)) == 1  # only the seed event
+
+
+def test_log_accepts_a_well_formed_but_illegal_event_as_an_anomaly(tmp_path: Path):
+    _seeded(tmp_path)
+    # item is still `queued`; item_merged is illegal from `queued` per the
+    # transition table -- well-formed shape, illegal transition.
+
+    result = cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
+
+    assert result["ok"] is True
+    assert result["applied"] is False
+    anomaly = result["anomaly"]
+    assert isinstance(anomaly, dict)
+    assert anomaly["type"] == "item_merged"
+    assert anomaly["item"] == "wgclw.1"
+    assert result["delta"] is None
+    assert len(load_events(tmp_path)) == 2  # anomalous events still append
+
+
+def test_log_delta_is_none_when_no_status_changed(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_log(tmp_path, "observation", {"level": "INFO", "message": "fyi"}, now=_NOW)
+
+    assert result["applied"] is True
+    assert result["delta"] is None
+
+
+def test_log_rewrites_state_json_after_append(tmp_path: Path):
+    _seeded(tmp_path)
+
+    cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+
+    import json
+
+    state_json = json.loads((tmp_path / "state.json").read_text(encoding="utf-8"))
+    assert state_json["items"]["wgclw.1"]["status"] == "in-progress"
+
+
+# -- status ---------------------------------------------------------------
+
+
+def test_status_default_returns_summary(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_status(tmp_path, full=False)
+
+    assert result["ok"] is True
+    assert "state_summary" in result
+    assert "state" not in result
+
+
+def test_status_full_returns_entire_state(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_status(tmp_path, full=True)
+
+    assert result["ok"] is True
+    state = result["state"]
+    assert isinstance(state, dict)
+    assert "items" in state
+
+
+# -- finish -----------------------------------------------------------------
+
+
+def test_finish_appends_grind_finished_and_returns_summary(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_finish(tmp_path, "shipped it", now=_NOW)
+
+    assert result["ok"] is True
+    events = load_events(tmp_path)
+    assert events[-1]["type"] == "grind_finished"
+    assert events[-1]["summary"] == "shipped it"
+    summary = result["state_summary"]
+    assert isinstance(summary, dict)
+    assert summary["finished"] is True
+
+
+def test_finish_rejects_missing_summary(tmp_path: Path):
+    _seeded(tmp_path)
+
+    with pytest.raises(GrindError):
+        cmd_finish(tmp_path, "", now=_NOW)

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -123,6 +123,29 @@ def test_log_rejects_a_payload_carrying_a_reserved_envelope_key(tmp_path: Path, 
     assert len(load_events(tmp_path)) == 1  # only the seed event
 
 
+def test_log_rejects_grind_created_in_a_fresh_dir_and_appends_nothing(tmp_path: Path):
+    # Codex-flagged: in a fresh --dir, `grind log grind_created --json <seed>`
+    # would fold as the first, valid creation event -- bypassing the CLI
+    # contract that creation goes through `create` only (spec CLI table:
+    # "creation goes through create, never through grind log grind_created").
+    # The reserved-key guard does not catch this: the event *type* is the verb
+    # argument, not a payload key. Reject it as a command error regardless of
+    # directory state.
+    with pytest.raises(GrindError):
+        cmd_log(tmp_path, "grind_created", dict(_SEED), now=_NOW)
+
+    assert load_events(tmp_path) == []  # nothing appended by the refused call
+
+
+def test_log_rejects_grind_created_mid_run_and_appends_nothing(tmp_path: Path):
+    _seeded(tmp_path)
+
+    with pytest.raises(GrindError):
+        cmd_log(tmp_path, "grind_created", dict(_SEED), now=_NOW)
+
+    assert len(load_events(tmp_path)) == 1  # only the seed event
+
+
 def test_log_accepts_a_well_formed_but_illegal_event_as_an_anomaly(tmp_path: Path):
     _seeded(tmp_path)
     # item is still `queued`; item_merged is illegal from `queued` per the


### PR DESCRIPTION
## Summary
- Adds the `grind` CLI entry point with four verbs over the merged event-sourced fold (PR #355): `create` (seed + first event, refuses a non-empty log), `log` (per-type payload validation at the boundary, append, refold from zero, emit-back envelope), `status` (summary or `--full` state), `finish` (terminal event).
- Event store (`store.py`) with write-path torn-tail repair; `State` → JSON serialization (`serialize.py`) for `state.json` and status output; per-type payload validation (`payloads.py`) derived from the spec's event taxonomy.
- Shared `_append_and_persist` write-then-refold seam; `cmd_log` folds twice (pre-append + persisted-log refold), never from memory for `state.json`.

## Scope
- **In:** the four verbs above, JSON envelopes, exit-code semantics (anomalous events exit 0 — anomalies are data; malformed payloads exit non-zero, nothing appended).
- **Out (sibling beads, deliberate placeholders):** the conditions engine (`conditions` is a hard-coded empty list — wgclw.30.5), dashboard rendering (`grind render` and render side-effects — 30.3), `grind check`/staleness watchdog and `--handoff` (30.6), installer PATH wiring (uv tool install receipts).

## Ground truth
- Spec: `docs/specs/2026-07-19-event-sourced-grind-runtime.md` — "CLI contract — grind" and "Emit-back" sections.
- Fold core (unchanged here): `packages/grind/src/grind/{model,fold,log}.py`.

## Test Plan
- [x] `make ci-grind`: 164 tests pass, 93.97% coverage, mypy --strict clean, pip-audit clean, entry-verify OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yKoGZrxEvPQtgVEMc4VFj