### PR TITLE
docs(wait-for-pr-comments): reconcile the >= vs > same-second boundary between the two re-review poll helpers

### DIFF
--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -567,6 +567,21 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    reviewing and later posted a review or clean-pass — step 3's added
    eyes-reaction detection is what fixes that.
 
+   **Same-second boundary reconciliation (agents-config-m5tkg):** steps 3 and
+   4 compare the SAME `<rereview_since_timestamp>` value with opposite
+   operators — step 3's start-detection is `>=`, step 4's staleness bound
+   (`--since-timestamp`'s `submitted_at > SINCE` filter) is strict `>`. This
+   is deliberate, not a bug: step 3 asks "has anything happened since the
+   ask" (missing a same-second start is the failure to avoid, so `>=`), step
+   4 asks "is this completion trustworthy as a response to the current ask,
+   not a stale leftover from before it" (false-accepting a stale signal is
+   the failure to avoid, so strict `>`). Narrow, fail-closed consequence: a
+   start signal AND a completion signal both landing in the exact same
+   second as the captured timestamp reads "started" (step 3) then "stale,
+   reject" (step 4) — one extra silent-ask round, never an unsafe merge. Do
+   not "fix" this into a single shared operator; see the reconciled rationale
+   in both scripts' own headers.
+
 5. **If** a new review arrives, return to **Phase 3 (round +1)**.
 
 **Hard cap**: when round >= 6 AND Phase 6 detects a new review, do **one

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -579,8 +579,8 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    start signal AND a completion signal both landing in the exact same
    second as the captured timestamp reads "started" (step 3) then "stale,
    reject" (step 4) — one extra silent-ask round, never an unsafe merge. Do
-   not "fix" this into a single shared operator; see the reconciled rationale
-   in both scripts' own headers.
+   not "fix" this into a single shared operator; both scripts' own headers
+   carry a short pointer back to this section, not a restatement.
 
 5. **If** a new review arrives, return to **Phase 3 (round +1)**.
 

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -572,10 +572,11 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    operators — step 3's start-detection is `>=`, step 4's staleness bound
    (`--since-timestamp`'s `submitted_at > SINCE` filter) is strict `>`. This
    is deliberate, not a bug: step 3 asks "has anything happened since the
-   ask" (missing a same-second start is the failure to avoid, so `>=`), step
-   4 asks "is this completion trustworthy as a response to the current ask,
-   not a stale leftover from before it" (false-accepting a stale signal is
-   the failure to avoid, so strict `>`). Narrow, fail-closed consequence: a
+   ask" (missing a same-second start is the failure to avoid, so `>=`,
+   liveness-favoring), step 4 asks "is this completion trustworthy as a
+   response to the current ask, not a stale leftover from before it"
+   (false-accepting a stale signal is the failure to avoid, so strict `>`,
+   soundness-favoring). Narrow, fail-closed consequence: a
    start signal AND a completion signal both landing in the exact same
    second as the captured timestamp reads "started" (step 3) then "stale,
    reject" (step 4) — one extra silent-ask round, never an unsafe merge. Do

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -567,7 +567,7 @@ the helper's default (1) per spec decision, not a per-repo config knob.
    reviewing and later posted a review or clean-pass — step 3's added
    eyes-reaction detection is what fixes that.
 
-   **Same-second boundary reconciliation (agents-config-m5tkg):** steps 3 and
+   **Same-second boundary reconciliation:** steps 3 and
    4 compare the SAME `<rereview_since_timestamp>` value with opposite
    operators — step 3's start-detection is `>=`, step 4's staleness bound
    (`--since-timestamp`'s `submitted_at > SINCE` filter) is strict `>`. This

--- a/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
+++ b/src/user/.agents/skills/wait-for-pr-comments/SKILL.md
@@ -439,10 +439,13 @@ the helper's default (1) per spec decision, not a per-repo config knob.
 
 1. **Capture** `<rereview_since_timestamp> = $(date -u +%Y-%m-%dT%H:%M:%SZ)`
    **before** issuing the re-review request in step 2. The downstream `--after`
-   (step 3) and `--since-timestamp` (step 4) filters require the bot signal to be
-   strictly later than this value, so capturing it first bounds the prior round
-   without excluding a fast Codex response that lands while `request-rereview.sh`
-   is still returning (or in the same API-timestamp second). Capturing it after
+   (step 3) and `--since-timestamp` (step 4) filters both bound the prior round
+   against this value, but not with the same operator — step 3's start-detection
+   is `>=` (inclusive of a same-second signal), step 4's staleness bound is
+   strict `>` (exclusive); see "Same-second boundary reconciliation" below for
+   why. Capturing the timestamp before dispatch, not after, is what lets step 3
+   recognize a fast Codex response that lands while `request-rereview.sh` is
+   still returning, or in the same API-timestamp second — capturing it after
    the dispatch would discard that valid `+1` or marker comment as stale and
    count the ask as a timeout.
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -206,8 +206,8 @@ for ((i = 1; i <= POLL_COUNT; i++)); do
         # RECONCILED, deliberately, against poll-copilot-review.sh's strict >
         # staleness bound on this same $AFTER/$SINCE value: this is a
         # detection question (liveness-favoring), that is a trust question
-        # (soundness-favoring) — full reasoning in wait-for-pr-comments/
-        # SKILL.md Phase 6, "Same-second boundary reconciliation".
+        # (soundness-favoring) — full reasoning in this skill's "Same-second
+        # boundary reconciliation" block (Phase 6).
         eyes_ts=$(printf '%s' "$reactions" | jq -r \
             --arg after "$AFTER" \
             "[.[] | select(.content == \"eyes\" and (.user.login | ${BOT_LOGIN_FILTER}) and .created_at >= \$after)] | .[0].created_at // empty")

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -203,24 +203,11 @@ for ((i = 1; i <= POLL_COUNT; i++)); do
         # here would silently drop a same-second eyes reaction and count a
         # started Codex review as a silent ask.
         #
-        # RECONCILED against poll-copilot-review.sh's staleness bound: that
-        # script compares the SAME $AFTER/$SINCE value against a COMPLETION
-        # signal using strict >, the opposite
-        # operator. This is not disagreement between the two files — they
-        # answer different questions on the same timestamp. This check asks
-        # "has ANYTHING happened since the ask" (a detection question: a
-        # missed same-second response is the failure to avoid, so >= is
-        # liveness-favoring). poll-copilot-review.sh's completion check asks
-        # "is THIS signal trustworthy as a response to the CURRENT ask, not a
-        # stale leftover from before it" (a soundness question: a
-        # false-accepted stale signal is the failure to avoid, so > is
-        # soundness-favoring). Narrow, fail-closed consequence of the
-        # divergence: if a start signal AND a completion signal both land in
-        # the exact same second as $AFTER/$SINCE, this check correctly reads
-        # "started" while poll-copilot-review.sh correctly rejects that same-
-        # second completion as unproven-fresh and times out — one extra
-        # silent-ask round, never an unsafe merge. Keep the asymmetry; do not
-        # "fix" it into a single shared operator.
+        # RECONCILED, deliberately, against poll-copilot-review.sh's strict >
+        # staleness bound on this same $AFTER/$SINCE value: this is a
+        # detection question (liveness-favoring), that is a trust question
+        # (soundness-favoring) — full reasoning in wait-for-pr-comments/
+        # SKILL.md Phase 6, "Same-second boundary reconciliation".
         eyes_ts=$(printf '%s' "$reactions" | jq -r \
             --arg after "$AFTER" \
             "[.[] | select(.content == \"eyes\" and (.user.login | ${BOT_LOGIN_FILTER}) and .created_at >= \$after)] | .[0].created_at // empty")

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -202,6 +202,25 @@ for ((i = 1; i <= POLL_COUNT; i++)); do
         # not excluded — see that step's own stated contract. A strict >
         # here would silently drop a same-second eyes reaction and count a
         # started Codex review as a silent ask.
+        #
+        # RECONCILED against poll-copilot-review.sh's staleness bound
+        # (agents-config-m5tkg): that script compares the SAME $AFTER/$SINCE
+        # value against a COMPLETION signal using strict >, the opposite
+        # operator. This is not disagreement between the two files — they
+        # answer different questions on the same timestamp. This check asks
+        # "has ANYTHING happened since the ask" (a detection question: a
+        # missed same-second response is the failure to avoid, so >= is
+        # liveness-favoring). poll-copilot-review.sh's completion check asks
+        # "is THIS signal trustworthy as a response to the CURRENT ask, not a
+        # stale leftover from before it" (a soundness question: a
+        # false-accepted stale signal is the failure to avoid, so > is
+        # soundness-favoring). Narrow, fail-closed consequence of the
+        # divergence: if a start signal AND a completion signal both land in
+        # the exact same second as $AFTER/$SINCE, this check correctly reads
+        # "started" while poll-copilot-review.sh correctly rejects that same-
+        # second completion as unproven-fresh and times out — one extra
+        # silent-ask round, never an unsafe merge. Keep the asymmetry; do not
+        # "fix" it into a single shared operator.
         eyes_ts=$(printf '%s' "$reactions" | jq -r \
             --arg after "$AFTER" \
             "[.[] | select(.content == \"eyes\" and (.user.login | ${BOT_LOGIN_FILTER}) and .created_at >= \$after)] | .[0].created_at // empty")

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start.sh
@@ -203,9 +203,9 @@ for ((i = 1; i <= POLL_COUNT; i++)); do
         # here would silently drop a same-second eyes reaction and count a
         # started Codex review as a silent ask.
         #
-        # RECONCILED against poll-copilot-review.sh's staleness bound
-        # (agents-config-m5tkg): that script compares the SAME $AFTER/$SINCE
-        # value against a COMPLETION signal using strict >, the opposite
+        # RECONCILED against poll-copilot-review.sh's staleness bound: that
+        # script compares the SAME $AFTER/$SINCE value against a COMPLETION
+        # signal using strict >, the opposite
         # operator. This is not disagreement between the two files — they
         # answer different questions on the same timestamp. This check asks
         # "has ANYTHING happened since the ask" (a detection question: a

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
@@ -333,20 +333,15 @@ rc_eyes_same_second=$?
 assert "an eyes reaction in the SAME second as --after is accepted (exit 0)" "[ \$rc_eyes_same_second -eq 0 ]"
 assert "same-second eyes reaction still reports signal eyes_reaction" "printf '%s' '$out' | jq -e '.signal == \"eyes_reaction\"' >/dev/null"
 
-# ── agents-config-m5tkg: cross-file reconciliation of this script's >= bound
-# against poll-copilot-review.sh's strict > staleness bound. Both compare
-# against the SAME $AFTER/$SINCE timestamp captured once, before the ask is
-# dispatched -- but this script's >= answers "has ANYTHING happened since the
-# ask" (a detection question, where missing a genuine same-second response is
-# the failure to avoid), while poll-copilot-review.sh's > answers "is THIS
-# completion signal trustworthy as a response to the CURRENT ask, not a stale
-# leftover from before it" (a soundness question, where false-accepting an old
-# signal is the failure to avoid). Different questions on the same value, not
-# a shared boundary that must agree -- the divergence is deliberate, not an
-# oversight, and this assertion locks that the rationale is actually written
-# down where a reader of either file would find it, not just decided once and
-# forgotten.
-assert "documents the reconciled >= vs > divergence with poll-copilot-review.sh (agents-config-m5tkg)" \
-  "grep -qi 'poll-copilot-review.sh' '$SCRIPT' && grep -qi 'm5tkg' '$SCRIPT'"
+# Cross-file reconciliation: this script's >= start-detection bound and
+# poll-copilot-review.sh's strict > staleness bound compare the SAME
+# $AFTER/$SINCE timestamp with opposite operators, deliberately (different
+# questions on the same value, not a shared boundary that must agree — see
+# the rationale above). Assert on the STABLE token (the sibling filename),
+# not comment prose, so a future rewording of the rationale doesn't red this
+# suite for no functional reason — it fails only if the cross-reference is
+# stripped outright.
+assert "cross-references poll-copilot-review.sh's staleness bound" \
+  "grep -qi 'poll-copilot-review.sh' '$SCRIPT'"
 
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
@@ -333,4 +333,20 @@ rc_eyes_same_second=$?
 assert "an eyes reaction in the SAME second as --after is accepted (exit 0)" "[ \$rc_eyes_same_second -eq 0 ]"
 assert "same-second eyes reaction still reports signal eyes_reaction" "printf '%s' '$out' | jq -e '.signal == \"eyes_reaction\"' >/dev/null"
 
+# ── agents-config-m5tkg: cross-file reconciliation of this script's >= bound
+# against poll-copilot-review.sh's strict > staleness bound. Both compare
+# against the SAME $AFTER/$SINCE timestamp captured once, before the ask is
+# dispatched -- but this script's >= answers "has ANYTHING happened since the
+# ask" (a detection question, where missing a genuine same-second response is
+# the failure to avoid), while poll-copilot-review.sh's > answers "is THIS
+# completion signal trustworthy as a response to the CURRENT ask, not a stale
+# leftover from before it" (a soundness question, where false-accepting an old
+# signal is the failure to avoid). Different questions on the same value, not
+# a shared boundary that must agree -- the divergence is deliberate, not an
+# oversight, and this assertion locks that the rationale is actually written
+# down where a reader of either file would find it, not just decided once and
+# forgotten.
+assert "documents the reconciled >= vs > divergence with poll-copilot-review.sh (agents-config-m5tkg)" \
+  "grep -qi 'poll-copilot-review.sh' '$SCRIPT' && grep -qi 'm5tkg' '$SCRIPT'"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh
@@ -333,14 +333,8 @@ rc_eyes_same_second=$?
 assert "an eyes reaction in the SAME second as --after is accepted (exit 0)" "[ \$rc_eyes_same_second -eq 0 ]"
 assert "same-second eyes reaction still reports signal eyes_reaction" "printf '%s' '$out' | jq -e '.signal == \"eyes_reaction\"' >/dev/null"
 
-# Cross-file reconciliation: this script's >= start-detection bound and
-# poll-copilot-review.sh's strict > staleness bound compare the SAME
-# $AFTER/$SINCE timestamp with opposite operators, deliberately (different
-# questions on the same value, not a shared boundary that must agree — see
-# the rationale above). Assert on the STABLE token (the sibling filename),
-# not comment prose, so a future rewording of the rationale doesn't red this
-# suite for no functional reason — it fails only if the cross-reference is
-# stripped outright.
+# Stable-token guard (not prose) that the deliberate reconciliation pointer
+# to poll-copilot-review.sh's staleness bound isn't silently stripped.
 assert "cross-references poll-copilot-review.sh's staleness bound" \
   "grep -qi 'poll-copilot-review.sh' '$SCRIPT'"
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -394,7 +394,26 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
         echo "Warning: reviews API failed (attempt ${i})" >&2; sleep 30; continue;
     }
 
-    # If --since-timestamp was provided, reject reviews that predate it (stale cache guard)
+    # If --since-timestamp was provided, reject reviews that predate it (stale cache guard).
+    #
+    # RECONCILED against poll-copilot-rereview-start.sh's start-detection
+    # bound (agents-config-m5tkg): that script compares this SAME $SINCE
+    # value (passed there as --after, captured once in Phase 6 step 1 before
+    # the re-review ask is dispatched) against a START signal using >=, the
+    # opposite operator. This is not disagreement between the two files —
+    # they answer different questions on the same timestamp. This check asks
+    # "is THIS signal trustworthy as a response to the CURRENT ask, not a
+    # stale leftover from before it" (a soundness question: a false-accepted
+    # stale signal is the failure to avoid, so strict > is soundness-
+    # favoring). poll-copilot-rereview-start.sh's start check asks "has
+    # ANYTHING happened since the ask" (a detection question: a missed same-
+    # second response is the failure to avoid, so >= is liveness-favoring).
+    # Narrow, fail-closed consequence of the divergence: if a start signal
+    # AND a completion signal both land in the exact same second as
+    # $AFTER/$SINCE, the start check correctly reads "started" while this
+    # check correctly rejects that same-second completion as unproven-fresh
+    # and times out — one extra silent-ask round, never an unsafe merge.
+    # Keep the asymmetry; do not "fix" it into a single shared operator.
     if [[ -n "$SINCE" ]]; then
         fresh_reviews=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at > $since)]')
         stale_count=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at <= $since)] | length')

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -396,24 +396,12 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
 
     # If --since-timestamp was provided, reject reviews that predate it (stale cache guard).
     #
-    # RECONCILED against poll-copilot-rereview-start.sh's start-detection
-    # bound: that script compares this SAME $SINCE value (passed there as
-    # --after, captured once in Phase 6 step 1 before
-    # the re-review ask is dispatched) against a START signal using >=, the
-    # opposite operator. This is not disagreement between the two files —
-    # they answer different questions on the same timestamp. This check asks
-    # "is THIS signal trustworthy as a response to the CURRENT ask, not a
-    # stale leftover from before it" (a soundness question: a false-accepted
-    # stale signal is the failure to avoid, so strict > is soundness-
-    # favoring). poll-copilot-rereview-start.sh's start check asks "has
-    # ANYTHING happened since the ask" (a detection question: a missed same-
-    # second response is the failure to avoid, so >= is liveness-favoring).
-    # Narrow, fail-closed consequence of the divergence: if a start signal
-    # AND a completion signal both land in the exact same second as
-    # $AFTER/$SINCE, the start check correctly reads "started" while this
-    # check correctly rejects that same-second completion as unproven-fresh
-    # and times out — one extra silent-ask round, never an unsafe merge.
-    # Keep the asymmetry; do not "fix" it into a single shared operator.
+    # RECONCILED, deliberately, against poll-copilot-rereview-start.sh's >=
+    # start-detection bound on this same $SINCE value (passed there as
+    # --after): this is a trust question (soundness-favoring), that is a
+    # detection question (liveness-favoring) — full reasoning in
+    # wait-for-pr-comments/SKILL.md Phase 6, "Same-second boundary
+    # reconciliation".
     if [[ -n "$SINCE" ]]; then
         fresh_reviews=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at > $since)]')
         stale_count=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at <= $since)] | length')

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -397,8 +397,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     # If --since-timestamp was provided, reject reviews that predate it (stale cache guard).
     #
     # RECONCILED against poll-copilot-rereview-start.sh's start-detection
-    # bound (agents-config-m5tkg): that script compares this SAME $SINCE
-    # value (passed there as --after, captured once in Phase 6 step 1 before
+    # bound: that script compares this SAME $SINCE value (passed there as
+    # --after, captured once in Phase 6 step 1 before
     # the re-review ask is dispatched) against a START signal using >=, the
     # opposite operator. This is not disagreement between the two files —
     # they answer different questions on the same timestamp. This check asks

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review.sh
@@ -399,9 +399,8 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     # RECONCILED, deliberately, against poll-copilot-rereview-start.sh's >=
     # start-detection bound on this same $SINCE value (passed there as
     # --after): this is a trust question (soundness-favoring), that is a
-    # detection question (liveness-favoring) — full reasoning in
-    # wait-for-pr-comments/SKILL.md Phase 6, "Same-second boundary
-    # reconciliation".
+    # detection question (liveness-favoring) — full reasoning in this
+    # skill's "Same-second boundary reconciliation" block (Phase 6).
     if [[ -n "$SINCE" ]]; then
         fresh_reviews=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at > $since)]')
         stale_count=$(printf '%s' "$reviews" | jq --arg since "$SINCE" '[.[] | select(.submitted_at <= $since)] | length')

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -615,4 +615,20 @@ out_mixed=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" 
 rc_mixed=$?
 assert "mixed Copilot+Codex --bot-reviewers does not exit 2 (comment-triggered identity present)" "[ \$rc_mixed -ne 2 ]"
 
+# ── agents-config-m5tkg: cross-file reconciliation of this script's strict >
+# staleness bound against poll-copilot-rereview-start.sh's >= start-detection
+# bound. Both compare against the SAME $AFTER/$SINCE timestamp captured once,
+# before the ask is dispatched -- but this script's > answers "is THIS
+# completion signal trustworthy as a response to the CURRENT ask, not a stale
+# leftover from before it" (a soundness question, where false-accepting an old
+# signal is the failure to avoid), while poll-copilot-rereview-start.sh's >=
+# answers "has ANYTHING happened since the ask" (a detection question, where
+# missing a genuine same-second response is the failure to avoid). Different
+# questions on the same value, not a shared boundary that must agree -- the
+# divergence is deliberate, not an oversight, and this assertion locks that
+# the rationale is actually written down where a reader of either file would
+# find it, not just decided once and forgotten.
+assert "documents the reconciled > vs >= divergence with poll-copilot-rereview-start.sh (agents-config-m5tkg)" \
+  "grep -qi 'poll-copilot-rereview-start.sh' '$SCRIPT' && grep -qi 'm5tkg' '$SCRIPT'"
+
 exit $FAIL

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -615,14 +615,9 @@ out_mixed=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" 
 rc_mixed=$?
 assert "mixed Copilot+Codex --bot-reviewers does not exit 2 (comment-triggered identity present)" "[ \$rc_mixed -ne 2 ]"
 
-# Cross-file reconciliation: this script's strict > staleness bound and
-# poll-copilot-rereview-start.sh's >= start-detection bound compare the SAME
-# $AFTER/$SINCE timestamp with opposite operators, deliberately (different
-# questions on the same value, not a shared boundary that must agree — see
-# the rationale above). Assert on the STABLE token (the sibling filename),
-# not comment prose, so a future rewording of the rationale doesn't red this
-# suite for no functional reason — it fails only if the cross-reference is
-# stripped outright.
+# Stable-token guard (not prose) that the deliberate reconciliation pointer
+# to poll-copilot-rereview-start.sh's start-detection bound isn't silently
+# stripped.
 assert "cross-references poll-copilot-rereview-start.sh's start-detection bound" \
   "grep -qi 'poll-copilot-rereview-start.sh' '$SCRIPT'"
 

--- a/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
+++ b/src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh
@@ -615,20 +615,15 @@ out_mixed=$(env PATH="$STUB_DIR:$PATH" FIXTURE_EVENTS="$FIXTURE_EVENTS_STARTED" 
 rc_mixed=$?
 assert "mixed Copilot+Codex --bot-reviewers does not exit 2 (comment-triggered identity present)" "[ \$rc_mixed -ne 2 ]"
 
-# ── agents-config-m5tkg: cross-file reconciliation of this script's strict >
-# staleness bound against poll-copilot-rereview-start.sh's >= start-detection
-# bound. Both compare against the SAME $AFTER/$SINCE timestamp captured once,
-# before the ask is dispatched -- but this script's > answers "is THIS
-# completion signal trustworthy as a response to the CURRENT ask, not a stale
-# leftover from before it" (a soundness question, where false-accepting an old
-# signal is the failure to avoid), while poll-copilot-rereview-start.sh's >=
-# answers "has ANYTHING happened since the ask" (a detection question, where
-# missing a genuine same-second response is the failure to avoid). Different
-# questions on the same value, not a shared boundary that must agree -- the
-# divergence is deliberate, not an oversight, and this assertion locks that
-# the rationale is actually written down where a reader of either file would
-# find it, not just decided once and forgotten.
-assert "documents the reconciled > vs >= divergence with poll-copilot-rereview-start.sh (agents-config-m5tkg)" \
-  "grep -qi 'poll-copilot-rereview-start.sh' '$SCRIPT' && grep -qi 'm5tkg' '$SCRIPT'"
+# Cross-file reconciliation: this script's strict > staleness bound and
+# poll-copilot-rereview-start.sh's >= start-detection bound compare the SAME
+# $AFTER/$SINCE timestamp with opposite operators, deliberately (different
+# questions on the same value, not a shared boundary that must agree — see
+# the rationale above). Assert on the STABLE token (the sibling filename),
+# not comment prose, so a future rewording of the rationale doesn't red this
+# suite for no functional reason — it fails only if the cross-reference is
+# stripped outright.
+assert "cross-references poll-copilot-rereview-start.sh's start-detection bound" \
+  "grep -qi 'poll-copilot-rereview-start.sh' '$SCRIPT'"
 
 exit $FAIL


### PR DESCRIPTION
## Summary
- `poll-copilot-rereview-start.sh`'s start-detection bound (`>=`) and `poll-copilot-review.sh`'s staleness bound (strict `>`) compare the SAME `<rereview_since_timestamp>`/`--since-timestamp` value with opposite operators. Individually each was already correctly reasoned and tested, but neither cross-referenced the other, so the divergence looked like an unresolved disagreement rather than a deliberate decision.
- Decision: **keep the asymmetry** -- no functional/behavioral change, both operators are unchanged. Traced both bounds: they answer genuinely different questions on the same shared timestamp. Start-detection asks "has anything happened since the ask" (missing a same-second start is the failure to avoid, so `>=`, liveness-favoring). Staleness asks "is this completion trustworthy as a response to the CURRENT ask, not a stale leftover from before it" (false-accepting an old signal is the failure to avoid, so strict `>`, soundness-favoring). The narrow failure mode this produces -- a start signal and a completion signal both landing in the exact same second reads "started" then "stale, reject" -- costs at most one extra silent-ask retry round and never an unsafe merge, matching both scripts' own existing fail-closed design. Also near-unreachable in live conditions given Codex's observed multi-second-to-minutes real latency.
- Cross-referenced the reconciled rationale with `wait-for-pr-comments/SKILL.md` Phase 6 as the single canonical home (both bounds already appear there side by side); both scripts carry a short one-sentence pointer instead of a restatement, avoiding a 5-way duplicated-prose maintenance hazard.
- Added one regression assertion per test file on the stable sibling-filename token (not comment prose, which would be brittle to rewording) confirming the cross-reference is actually present.

## Scope
- In scope: `poll-copilot-rereview-start.sh`, `poll-copilot-review.sh`, their test suites, and `wait-for-pr-comments/SKILL.md` Phase 6 only. No functional/operator changes anywhere.
- Out of scope, deliberately: `request-rereview.sh` and its test suite are currently owned by a different in-flight change in this repo (a sibling bead's producer/consumer fix) -- this PR does not touch either.
- Ground truth: `src/user/.agents/skills/wait-for-pr-comments/{poll-copilot-rereview-start.sh,poll-copilot-review.sh,SKILL.md}` and their test suites.

## Test Plan
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-rereview-start_test.sh` -- 51/51 assertions pass, exit 0
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/poll-copilot-review_test.sh` -- 77/77 assertions pass, exit 0
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/request-rereview_test.sh` -- 79/79 assertions pass, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/compute-rereview-polling_test.sh` -- 0 failures, exit 0 (unaffected sibling)
- [x] `bash src/user/.agents/skills/wait-for-pr-comments/skill_a_frontmatter_test.sh` -- 0 failures, exit 0 (unaffected sibling)

Bead: agents-config-m5tkg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuMvZwLNRmUPRJWfDNCm3q