### PR TITLE
feat(vizsuite): round-3 UI — sonar overlay zoom/pan + constellation label cap

### DIFF
--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -642,6 +642,9 @@ body {
   position: absolute;
   top: 0.5rem;
   right: 0.75rem;
+  /* Ride above the full-size sonar zoom viewport (tree-order paints it
+     later); same precedent as .viz-constellation-reset. */
+  z-index: 2;
 }
 /* ---- Round-3: the overlay-hosted sonar owns its own zoom/pan
    (views/sonar.js wires d3.zoom on .viz-sonar-viewport with a
@@ -671,8 +674,10 @@ body {
   cursor: grab;
 }
 /* Inside the zoomable viewport the stage is transform-positioned by the
-   zoom handler (translate + scale from the top-left origin); the base
-   centered-margin rule below still serves any non-zoom fallback mount. */
+   zoom handler (translate + scale from the top-left origin). The stage is
+   always built inside this viewport, so this rule always applies; if d3 is
+   somehow absent (wireSonarZoom's guard), an oversized stage clips at the
+   viewport edge — accepted, since d3 is vendored inline. */
 .viz-sonar-viewport .viz-sonar-stage {
   position: absolute;
   left: 0;

--- a/packages/vizsuite/src/vizsuite/templates/static/scene.css
+++ b/packages/vizsuite/src/vizsuite/templates/static/scene.css
@@ -643,6 +643,43 @@ body {
   top: 0.5rem;
   right: 0.75rem;
 }
+/* ---- Round-3: the overlay-hosted sonar owns its own zoom/pan
+   (views/sonar.js wires d3.zoom on .viz-sonar-viewport with a
+   fit-to-content baseline). The mount chain fills the overlay so the
+   viewport has real space to fit into — previously the stage shrink-
+   wrapped at natural size in the overlay's flex center and dense
+   neighborhoods rendered tiny with no zoom affordance. Scoped to the
+   overlay so the drawer-mount [hidden] contract above is untouched. ---- */
+.viz-blast-overlay .viz-drill-sonar-mount {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+.viz-sonar {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.viz-sonar-viewport {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  touch-action: none;
+  cursor: grab;
+}
+/* Inside the zoomable viewport the stage is transform-positioned by the
+   zoom handler (translate + scale from the top-left origin); the base
+   centered-margin rule below still serves any non-zoom fallback mount. */
+.viz-sonar-viewport .viz-sonar-stage {
+  position: absolute;
+  left: 0;
+  top: 0;
+  margin: 0;
+  transform-origin: 0 0;
+}
 .viz-sonar-unavailable {
   padding: 0.5rem 0.6rem;
   border: 1px dashed var(--viz-border-strong);
@@ -913,7 +950,11 @@ body {
   position: absolute;
   transform: translate(-50%, -100%);
   padding: 0 2px;
-  font-size: 8px;
+  /* Round-3 label cap: the zoom handler (views/constellation.js) sets
+     --viz-constellation-label-fs to min(8px, cap / k) so the rendered size
+     never exceeds the cap however far in the user zooms; the 8px fallback
+     is the base size (must match LABEL_BASE_PX there). */
+  font-size: var(--viz-constellation-label-fs, 8px);
   line-height: 1.1;
   text-align: center;
   white-space: nowrap;

--- a/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/constellation.js
@@ -114,6 +114,17 @@
   // transition and the rAF node/label/edge tween (createResetTween below) so
   // both animate over the same window — the ONLY place this duration lives. ----
   var RESET_TRANSITION_MS = 400;
+
+  // ---- Label on-screen size cap (round-3): labels live inside the zoomed
+  // stage, so their rendered size is base-font x zoom scale — unbounded
+  // growth turned dense clusters into overlapping mush when zoomed in. The
+  // zoom handler counter-scales the label layer through one CSS custom
+  // property (--viz-constellation-label-fs), so labels keep growing and
+  // shrinking with zoom until the cap, then hold a constant on-screen size.
+  // Base must match .viz-constellation-node-label's fallback in scene.css;
+  // the cap is the legend font size (12px) plus one point. ----
+  var LABEL_BASE_PX = 8;
+  var LABEL_MAX_ONSCREEN_PX = 13;
   // Double-click un-pin window (ms): a node click's activation (dir focus /
   // file drill) is deferred by this window and cancelled when the un-pin
   // dblclick lands, so the un-pin gesture never also opens the drill (whose
@@ -1374,6 +1385,13 @@
           zoomTransform = event.transform;
           visual.style.transform =
             "translate(" + zoomTransform.x + "px," + zoomTransform.y + "px) scale(" + zoomTransform.k + ")";
+          // Round-3 label cap: counter-scale the label font so its on-screen
+          // size is min(LABEL_BASE_PX x k, LABEL_MAX_ONSCREEN_PX) — node
+          // geometry keeps scaling untouched.
+          visual.style.setProperty(
+            "--viz-constellation-label-fs",
+            Math.min(LABEL_BASE_PX, LABEL_MAX_ONSCREEN_PX / zoomTransform.k) + "px"
+          );
           // A wheel-zoom or background pan is a competing gesture: drop any
           // node's still-pending deferred activation so a stale focus/drill
           // never fires mid-gesture.

--- a/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
@@ -228,10 +228,14 @@
         if (event.type === "dblclick") {
           return false;
         }
-        // A drag starting on a ring node belongs to the node's own
-        // click-vs-drag activation (recenter), never the background pan.
+        // A drag starting on an actionable ring node belongs to the node's
+        // own click-vs-drag activation (recenter), never the background pan.
+        // The center node has no activation wired, so it stays pannable.
+        // The ctrl/button tail preserves d3-zoom's documented default filter.
         var target = event.target;
-        return !(target && target.closest && target.closest(".viz-sonar-node"));
+        var onActionableNode =
+          target && target.closest && target.closest(".viz-sonar-node:not(.viz-sonar-node--center)");
+        return (!event.ctrlKey || event.type === "wheel") && !event.button && !onActionableNode;
       })
       .on("zoom", function (event) {
         stage.style.transform =

--- a/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
+++ b/packages/vizsuite/src/vizsuite/templates/static/views/sonar.js
@@ -189,6 +189,58 @@
     });
 
     container.appendChild(stage);
+    return { stage: stage, size: size };
+  }
+
+  // ---- Round-3: the overlay-hosted sonar owns its own zoom/pan. The ring
+  // stage previously rendered at its natural pixel size, shrink-wrapped in
+  // the overlay's flex center — a dense neighborhood rendered tiny with no
+  // zoom affordance at all. Mirrors the constellation's transform contract
+  // (scaleExtent [0.3, 6], wheel zoom, background drag pans, double-click
+  // zoom disabled): the zoom drives the stage's CSS transform only, never
+  // ring geometry. ----
+  function computeSonarFitTransform(viewport, stageSize) {
+    var rect = viewport.getBoundingClientRect();
+    var width = rect.width || viewport.clientWidth || stageSize;
+    var height = rect.height || viewport.clientHeight || stageSize;
+    var fitScale = Math.min(width / stageSize, height / stageSize);
+    var scale = Math.max(0.3, Math.min(6, fitScale));
+    return d3.zoomIdentity
+      .translate(width / 2, height / 2)
+      .scale(scale)
+      .translate(-stageSize / 2, -stageSize / 2);
+  }
+
+  function wireSonarZoom(viewport, stage, stageSize) {
+    // Feature guard: the sonar renders (un-zoomable, at natural size) even
+    // if the d3 bundle is somehow absent — same degrade-don't-crash stance
+    // as the pointer-capture guards elsewhere.
+    if (typeof d3 === "undefined" || !d3.zoom) {
+      return;
+    }
+    var zoomBehavior = d3
+      .zoom()
+      .scaleExtent([0.3, 6])
+      .filter(function (event) {
+        if (event.type === "wheel") {
+          return true;
+        }
+        if (event.type === "dblclick") {
+          return false;
+        }
+        // A drag starting on a ring node belongs to the node's own
+        // click-vs-drag activation (recenter), never the background pan.
+        var target = event.target;
+        return !(target && target.closest && target.closest(".viz-sonar-node"));
+      })
+      .on("zoom", function (event) {
+        stage.style.transform =
+          "translate(" + event.transform.x + "px," + event.transform.y + "px) scale(" + event.transform.k + ")";
+      });
+    d3.select(viewport).call(zoomBehavior).on("dblclick.zoom", null);
+    // Fit-to-content baseline: the whole ring set starts visible, however
+    // large the neighborhood — never a manual zoom-out to find it.
+    d3.select(viewport).call(zoomBehavior.transform, computeSonarFitTransform(viewport, stageSize));
   }
 
   window.vizSonar = {
@@ -226,7 +278,13 @@
           renderEmptyNeighborhood(inner, path);
           return;
         }
-        renderRings(inner, groups, path, mount);
+        // Round-3: rings render inside a dedicated zoomable viewport (the
+        // message states above stay in plain flow — nothing to zoom).
+        var viewport = document.createElement("div");
+        viewport.setAttribute("class", "viz-sonar-viewport");
+        inner.appendChild(viewport);
+        var rendered = renderRings(viewport, groups, path, mount);
+        wireSonarZoom(viewport, rendered.stage, rendered.size);
       }
 
       mount(centerPath);

--- a/packages/vizsuite/tests/unit/test_templates_html.py
+++ b/packages/vizsuite/tests/unit/test_templates_html.py
@@ -494,6 +494,27 @@ def test_render_inlines_blast_radius_overlay_and_empty_state_hooks():
     assert ".viz-blast-overlay {" in html
 
 
+def test_render_inlines_round3_sonar_zoom_and_label_cap_hooks():
+    # Round-3 feedback: (1) the blast-radius sonar owns its own zoom/pan
+    # with a fit-to-content initial transform — the overlay previously
+    # rendered the ring stage tiny with no zoom affordance at all, so its
+    # usability could not even be judged; (2) constellation node labels are
+    # capped in on-screen size — they used to scale with the zoom transform
+    # without bound, so zooming in grew text indefinitely and dense clusters
+    # became unreadable overlapping mush.
+    html = render_html(_scene(FileNode(path="src/app.py", checksum="aaa")))
+
+    # Sonar zoom: a dedicated viewport wraps the ring stage and carries the
+    # d3.zoom behavior; the initial transform fits the stage to the viewport.
+    assert "viz-sonar-viewport" in html
+    assert "function computeSonarFitTransform" in html
+    # Label cap: the zoom handler counter-scales the label layer through one
+    # CSS custom property, so on-screen size = min(base, cap / k) while
+    # geometry keeps scaling untouched.
+    assert "--viz-constellation-label-fs" in html
+    assert "LABEL_MAX_ONSCREEN_PX" in html
+
+
 def test_hostile_strings_in_paths_and_fact_notes_render_inert():
     # Item 7 (complete): hostile strings in *paths* (a repeat of the slice-1
     # embedding case, now exercised alongside the new channel) and in a


### PR DESCRIPTION
## Summary
- **R3-1 — blast-radius sonar zoom/pan**: the overlay-hosted sonar now wraps its ring stage in a `.viz-sonar-viewport` with d3.zoom wired (scaleExtent [0.3, 6], wheel zoom, background pan, dblclick disabled) and a fit-to-content initial transform (`computeSonarFitTransform`), so dense neighborhoods open fully visible instead of shrink-wrapped tiny. Drags starting on actionable ring nodes are excluded from pan so click-to-recenter survives; the center node (no activation) stays pannable. Zoom drives the stage's CSS transform only — ring geometry untouched, layout determinism preserved.
- **R3-2 — constellation label on-screen size cap**: the zoom handler sets `--viz-constellation-label-fs = min(8px, 13px/k)` on the stage; `scene.css` consumes it with an 8px fallback. Labels render byte-identical to pre-round-3 up to k≈1.6, then pin at 13px on-screen (legend font 12px + 1, per spec). Geometry untouched.
- **Review fixes** (kimi-k3 UI review): `.viz-blast-overlay-close` gets `z-index: 2` (was occluded by the new full-size zoom viewport — clicks landed on the pan surface); the sonar zoom filter restores d3-zoom's default `(!ctrlKey || wheel) && !button` tail.

## Scope
- In scope: `packages/vizsuite/src/vizsuite/templates/static/` (`views/sonar.js`, `views/constellation.js`, `scene.css`) + one new string-presence test in `tests/unit/test_templates_html.py`.
- Out of scope (deliberate, do not flag): consolidating the near-duplicate fit-transform/zoom-filter logic between `sonar.js` and `constellation.js` — deferred per rule-of-three until a third zoomable view exists (flagged informational by the quality gate); resize re-fit of the open overlay (short-lived modal).

## Ground truth
- The constellation's zoom contract in `constellation.js` (`computeBaseTransform`, `zoomFilter`) is the precedent the sonar mirrors.
- Reset animation and drag reheat in `constellation.js` are intentionally rAF-tween/1-hop — established in PR #361; not touched here.

## Test Plan
- [x] `make ci-vizsuite` — 435 passed, 100% coverage, pip-audit clean
- [x] Browser-verified in Chrome: overlay fit scale 1.497 with a 442-node neighborhood fully visible; wheel zoom + pan work; label measures exactly 13.00px on-screen at k=3.6 and natural 8px at k=0.9; console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1RgjFBiPgTWWyz5ZaGh8J