### PR TITLE
feat(grind): grind check — external staleness watchdog (wgclw.30.6)

### DIFF
--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -22,7 +22,7 @@ from typing import NoReturn, TextIO
 from grind.envelope import GrindError
 from grind.jsonio import NonFiniteJsonError, loads
 from grind.model import JsonValue
-from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
+from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_status
 
 
 class _RaisingArgumentParser(ArgumentParser):
@@ -53,6 +53,10 @@ def _build_parser() -> _RaisingArgumentParser:
     status_parser = subparsers.add_parser("status", help="report the folded state")
     status_parser.add_argument("--full", action="store_true")
     status_parser.add_argument("--dir", default=".", metavar="DIR")
+
+    check_parser = subparsers.add_parser("check", help="staleness probe (exits 1 when stale)")
+    check_parser.add_argument("--max-age", default=None, dest="max_age", metavar="DUR")
+    check_parser.add_argument("--dir", default=".", metavar="DIR")
 
     finish_parser = subparsers.add_parser("finish", help="append grind_finished and final-fold")
     finish_parser.add_argument("--summary", required=True, metavar="TEXT")
@@ -99,10 +103,13 @@ def _dispatch(
     if args.verb == "status":
         return cmd_status(grind_dir, full=args.full)
 
+    if args.verb == "check":
+        return cmd_check(grind_dir, args.max_age, now=now)
+
     if args.verb == "finish":
         return cmd_finish(grind_dir, args.summary, now=now)
 
-    raise GrindError("no verb given; choose one of: create, log, status, finish")
+    raise GrindError("no verb given; choose one of: create, log, status, check, finish")
 
 
 def _default_now() -> datetime:
@@ -144,6 +151,11 @@ def main(
 
     json.dump(data, out, allow_nan=False)
     out.write("\n")
+    # `grind check`'s exit code carries the staleness verdict itself (spec CLI
+    # contract: "exit 1 when stale"), distinct from every other verb where exit
+    # code only ever signals a command error (an `ok: true` envelope is always 0).
+    if args.verb == "check" and isinstance(data, dict) and data.get("stale") is True:
+        return 1
     return 0
 
 

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -1,4 +1,4 @@
-"""The four command bodies: `create`, `log`, `status`, `finish`.
+"""The five command bodies: `create`, `log`, `status`, `check`, `finish`.
 
 Each takes the grind directory and an injected `now` clock (never a bare
 `datetime.now()` call -- same seam precedent as workcli's `read_file`/`now`),
@@ -9,14 +9,15 @@ wiring; this module owns behavior only, so it's testable without a process.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from grind.derive import lane_status
 from grind.envelope import GrindError
 from grind.fold import fold
-from grind.model import AnomalyRecord, JsonValue, RawEvent, State
+from grind.model import DEFAULT_CONFIG, AnomalyRecord, JsonValue, RawEvent, State
 from grind.payloads import validate_payload
 from grind.serialize import anomaly_json, full_state_json, summarize
 from grind.store import (
@@ -42,6 +43,40 @@ _RESERVED_ENVELOPE_KEYS = ("ts", "type")
 
 def _iso(when: datetime) -> str:
     return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_ts(ts: str) -> datetime:
+    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+
+
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 3600}
+_DURATION_RE = re.compile(r"^(\d+)([smh])$")
+
+
+def _parse_duration(text: str) -> float:
+    """`<int><unit>` where unit is `s`/`m`/`h` (spec examples: "45m", "30m", "1h")."""
+    match = _DURATION_RE.match(text)
+    if match is None:
+        raise GrindError(
+            f"invalid duration {text!r}: expected <int><unit> with unit s, m, or h (e.g. 30m)"
+        )
+    amount, unit = match.groups()
+    return float(amount) * _DURATION_UNITS[unit]
+
+
+def _default_max_age_seconds(config: dict[str, JsonValue]) -> float:
+    """No dedicated grind-level threshold exists in `config` -- `grind check` probes
+    whole-grind liveness, not a single item or lane. Default to the stricter (lower)
+    of the two entity-level thresholds so the watchdog fires promptly; this also
+    matches the spec's own example invocation, `grind check --max-age 30m`, which is
+    `stale_lane_after`'s default."""
+    item_after = config.get("stale_item_after", DEFAULT_CONFIG["stale_item_after"])
+    lane_after = config.get("stale_lane_after", DEFAULT_CONFIG["stale_lane_after"])
+    if not isinstance(item_after, str) or not isinstance(lane_after, str):
+        raise GrindError(
+            "config stale_item_after/stale_lane_after must be duration strings (e.g. 30m)"
+        )
+    return min(_parse_duration(item_after), _parse_duration(lane_after))
 
 
 def _validate_or_raise(event_type: str, payload: RawEvent) -> None:
@@ -182,6 +217,41 @@ def cmd_status(dir_: Path, *, full: bool) -> dict[str, JsonValue]:
     if full:
         return {"ok": True, "state": full_state_json(state), "conditions": []}
     return {"ok": True, "state_summary": summarize(state), "conditions": []}
+
+
+def cmd_check(dir_: Path, max_age: str | None, *, now: Clock) -> dict[str, JsonValue]:
+    """`grind check [--max-age <dur>]` (spec "Staleness watchdog"): the external
+    probe a fully-quiet grind can't self-report. Folds the log first -- `paused`
+    and `finished` are always fold-derived, never read off the raw final line, so
+    a trailing anomalous event can't hide either state. A paused or finished grind
+    reports `stale: false` and exits 0 regardless of the last event's age; an
+    unfinished, unpaused grind is stale once that age exceeds `max_age` (or, absent
+    `--max-age`, the config's own stale thresholds)."""
+    events = load_events(dir_)
+    if not events:
+        raise GrindError(
+            "cannot check staleness: no events in log (grind not yet created via `grind create`)"
+        )
+
+    state = fold(events)
+    last_ts = events[-1].get("ts")
+    if not isinstance(last_ts, str):
+        raise GrindError("cannot check staleness: last logged event has no ts")
+
+    age_s = (now() - _parse_ts(last_ts)).total_seconds()
+    max_age_s = (
+        _parse_duration(max_age) if max_age is not None else _default_max_age_seconds(state.config)
+    )
+    stale = not state.paused and not state.finished and age_s > max_age_s
+
+    return {
+        "ok": True,
+        "last_event_ts": last_ts,
+        "age_s": age_s,
+        "stale": stale,
+        "paused": state.paused,
+        "finished": state.finished,
+    }
 
 
 def cmd_finish(dir_: Path, summary: str, *, now: Clock) -> dict[str, JsonValue]:

--- a/packages/grind/tests/unit/test_cli.py
+++ b/packages/grind/tests/unit/test_cli.py
@@ -5,7 +5,8 @@ code 0 unless the command itself failed")."""
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 
@@ -19,13 +20,20 @@ _SEED = {
     "lanes": [{"id": "lane-a", "queue": [{"id": "wgclw.1", "title": "First item"}]}],
 }
 
+_NOW = lambda: datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)  # noqa: E731
 
-def _run(argv: Sequence[str], read_file: dict[str, str] | None = None) -> tuple[int, dict, str]:
+
+def _run(
+    argv: Sequence[str],
+    read_file: dict[str, str] | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> tuple[int, dict, str]:
     out, err = StringIO(), StringIO()
     exit_code = main(
         list(argv),
         out=out,
         err=err,
+        now=now,
         read_file=(lambda p: (read_file or {})[p]) if read_file is not None else None,
     )
     return exit_code, json.loads(out.getvalue()), err.getvalue()
@@ -168,6 +176,48 @@ def test_status_default_and_full(tmp_path: Path):
     exit_code, envelope, _err = _run(["status", "--full", "--dir", str(grind_dir)])
     assert exit_code == 0
     assert "state" in envelope
+
+
+def test_check_verb_exits_zero_when_fresh(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+        now=_NOW,
+    )
+
+    exit_code, envelope, _err = _run(["check", "--dir", str(grind_dir)], now=_NOW)
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert envelope["stale"] is False
+
+
+def test_check_verb_exits_one_when_stale(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+        now=_NOW,
+    )
+
+    exit_code, envelope, _err = _run(
+        ["check", "--max-age", "10m", "--dir", str(grind_dir)],
+        now=lambda: datetime(2026, 7, 19, 13, 0, 0, tzinfo=UTC),
+    )
+
+    assert exit_code == 1
+    assert envelope["ok"] is True  # a stale grind is still a successful probe
+    assert envelope["stale"] is True
+
+
+def test_check_verb_empty_log_yields_error_envelope_and_nonzero_exit(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+
+    exit_code, envelope, _err = _run(["check", "--dir", str(grind_dir)])
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
 
 
 def test_finish_verb(tmp_path: Path):

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -3,14 +3,14 @@ independent of argv/stdout wiring (that's `cli.py`, tested separately)."""
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
 from grind.envelope import GrindError
 from grind.store import events_path, load_events
-from grind.verbs import cmd_create, cmd_finish, cmd_log, cmd_status
+from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_status
 
 _NOW = lambda: datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)  # noqa: E731
 
@@ -258,6 +258,79 @@ def test_status_full_returns_entire_state(tmp_path: Path):
     state = result["state"]
     assert isinstance(state, dict)
     assert "items" in state
+
+
+# -- check -------------------------------------------------------------------
+
+
+def _at(hours_after_seed: float):
+    when = datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC) + timedelta(hours=hours_after_seed)
+    return lambda: when
+
+
+def test_check_fresh_log_is_not_stale(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_check(tmp_path, None, now=_NOW)
+
+    assert result["ok"] is True
+    assert result["stale"] is False
+    assert result["paused"] is False
+    assert result["finished"] is False
+    assert result["age_s"] == 0.0
+    assert result["last_event_ts"] == "2026-07-19T12:00:00Z"
+
+
+def test_check_old_last_event_is_stale_under_default_max_age(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_check(tmp_path, None, now=_at(1))  # 1h later; default is 30m
+
+    assert result["stale"] is True
+
+
+def test_check_respects_explicit_max_age(tmp_path: Path):
+    _seeded(tmp_path)
+
+    stale = cmd_check(tmp_path, "10m", now=_at(1))
+    not_stale = cmd_check(tmp_path, "2h", now=_at(1))
+
+    assert stale["stale"] is True
+    assert not_stale["stale"] is False
+
+
+def test_check_rejects_malformed_max_age(tmp_path: Path):
+    _seeded(tmp_path)
+
+    with pytest.raises(GrindError):
+        cmd_check(tmp_path, "soon", now=_NOW)
+
+
+def test_check_paused_grind_is_never_stale_regardless_of_age(tmp_path: Path):
+    _seeded(tmp_path)
+    cmd_log(tmp_path, "grind_paused", {"reason": "waiting on human"}, now=_NOW)
+
+    result = cmd_check(tmp_path, "10m", now=_at(1))
+
+    assert result["paused"] is True
+    assert result["finished"] is False
+    assert result["stale"] is False
+
+
+def test_check_finished_grind_is_never_stale_regardless_of_age(tmp_path: Path):
+    _seeded(tmp_path)
+    cmd_finish(tmp_path, "shipped it", now=_NOW)
+
+    result = cmd_check(tmp_path, "10m", now=_at(1))
+
+    assert result["finished"] is True
+    assert result["paused"] is False
+    assert result["stale"] is False
+
+
+def test_check_empty_log_raises(tmp_path: Path):
+    with pytest.raises(GrindError):
+        cmd_check(tmp_path, None, now=_NOW)
 
 
 # -- finish -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds the `grind check` verb (bead agents-config-wgclw.30.6 of the event-sourced grind runtime spec, docs/specs/2026-07-19-event-sourced-grind-runtime.md): an external staleness watchdog that reports `stale: true` and **exits 1** when the log's last event is older than `--max-age` — unless the grind is paused or finished, which always report `stale: false` per spec.
- `cmd_check(dir_, max_age, *, now)` in `verbs.py`: folds the log for `paused`/`finished` (never reads the raw tail), computes age from the last event's `ts` against an injected `now` (purity preserved), raises a command error on an empty/missing log.
- Default `--max-age` is the stricter of the two config thresholds (`min(stale_item_after, stale_lane_after)` = 30m), matching the spec's example invocation `grind check --max-age 30m`. New `_parse_duration` supports `s/m/h`.
- `grind finish` already existed and satisfies this bead's finish half; this PR adds tests pinning finished-grind behavior but does not modify `cmd_finish`.

## Scope
- In: `packages/grind/src/grind/{cli.py,verbs.py}`, `packages/grind/tests/unit/{test_cli.py,test_verbs.py}`.
- Out: `grind render` (bead 30.3, separate PR), conditions engine (bead 30.5, separate PR), fold internals.

## Notes for reviewers
- `grind check` is the ONE verb where a successful (`ok: true`) envelope can still exit non-zero — `stale: true` maps to exit 1 by spec ("exit 1 when stale"). The cli.py comment calls this out; it is intentional, not an error-handling gap.
- Paused/finished grinds still report the real `age_s` (diagnostic), only the `stale` flag is suppressed.
- Ground truth: the runtime spec's CLI contract table (`grind check` row) and its watchdog section.

## Test Plan
- [x] 10 new tests (staleness boundaries both sides of max-age, override, malformed duration, paused/finished exemptions, empty-log error, CLI exit codes 0/1/error)
- [x] `make ci-grind` green: ruff, format, mypy --strict, 201 passed, 94.31% coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yKoGZrxEvPQtgVEMc4VFj