### PR TITLE
feat(grind): conditions engine — emit-back envelope + condition vocabulary (wgclw.30.5)

### DIFF
--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -101,7 +101,7 @@ def _dispatch(
         return cmd_log(grind_dir, args.type, payload, now=now)
 
     if args.verb == "status":
-        return cmd_status(grind_dir, full=args.full)
+        return cmd_status(grind_dir, full=args.full, now=now)
 
     if args.verb == "check":
         return cmd_check(grind_dir, args.max_age, now=now)

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -66,7 +66,12 @@ def _duration(value: JsonValue, default_seconds: int) -> timedelta:
         match = _DURATION_RE.match(value)
         if match is not None:
             amount, unit = match.groups()
-            return timedelta(seconds=int(amount) * _UNIT_SECONDS[unit])
+            try:
+                return timedelta(seconds=int(amount) * _UNIT_SECONDS[unit])
+            except OverflowError:
+                # an absurdly large threshold is unparsable config too, not
+                # an internal error to surface on every log/status call
+                return timedelta(seconds=default_seconds)
     return timedelta(seconds=default_seconds)
 
 

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -33,6 +33,11 @@ _TERMINAL_ITEM_STATUSES = {"merged", "done"}
 # what makes a chain of blocked items worth flagging as `blocked_chain`.
 _CHAIN_BLOCKING_STATUSES = {"blocked", "waiting-human"}
 
+# Statuses with a live PR/review cycle -- the only place a review stalemate
+# can exist. round_history is fold history and survives the cycle, so
+# `review_stalemate_risk` must not read it once the item moves on.
+_ACTIVE_REVIEW_STATUSES = {"pr-open", "in-review", "waiting-human", "blocked"}
+
 _DURATION_RE = re.compile(r"^(\d+)([smhd])$")
 _UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 
@@ -76,7 +81,10 @@ def _duration(value: JsonValue, default_seconds: int) -> timedelta:
 
 
 def _round_threshold(value: JsonValue, default: int) -> int:
-    return value if isinstance(value, int) and value > 0 else default
+    # bool is an int subtype: `true` would otherwise read as threshold 1
+    return (
+        value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else default
+    )
 
 
 def _parse_ts(value: str | None) -> datetime | None:
@@ -203,6 +211,11 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
     n = _round_threshold(state.config.get("stalemate_risk_round"), 3)
     out: list[Condition] = []
     for item in state.items.values():
+        # round_history survives the review cycle (it is fold history, never
+        # cleared), so gate on a live review state: a done/merged item, or one
+        # whose PR closed and re-queued, is not a stalemate however it got there
+        if item.status not in _ACTIVE_REVIEW_STATUSES:
+            continue
         history = item.round_history
         if len(history) < n:
             continue

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -1,0 +1,251 @@
+"""`conditions(state, now)` -- pure level-condition facts recomputed from
+`State`, plus `item_unblocked_conditions(before, after)`, the one transition
+condition derived from a fold delta.
+
+HARD SEAM: a condition is a fact with evidence, never orchestration policy --
+its name states what is true and its fields carry the evidence, never an
+instruction ("nudge the lane", "escalate the review"). `IMPERATIVE_VERBS` is
+the convention lock a test asserts every condition name against; growing the
+vocabulary means adding a name here, never a verb.
+
+Conditions are never part of the fold and never persisted in `state.json`
+(spec: "not part of the fold ... a separate pure function"). `now` always
+arrives as an explicit argument -- no bare `datetime.now()` call in this
+module, same seam precedent as `verbs.Clock`.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+from grind.derive import lane_status
+from grind.model import Item, JsonValue, State
+
+Condition = dict[str, JsonValue]
+
+# Terminal per `stale_item`'s table row ("item not terminal/parked") -- an
+# item that reached its endpoint is not "going quiet", it's finished.
+_TERMINAL_ITEM_STATUSES = {"merged", "done"}
+
+# A blocker this advanced or further is itself stuck, not merely pending --
+# what makes a chain of blocked items worth flagging as `blocked_chain`.
+_CHAIN_BLOCKING_STATUSES = {"blocked", "waiting-human"}
+
+_DURATION_RE = re.compile(r"^(\d+)([smhd])$")
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+IMPERATIVE_VERBS = {
+    "nudge",
+    "escalate",
+    "notify",
+    "alert",
+    "retry",
+    "resume",
+    "pause",
+    "abort",
+    "cancel",
+    "block",
+    "unblock",
+    "merge",
+    "close",
+    "reopen",
+    "assign",
+    "reassign",
+    "fix",
+    "resolve",
+}
+
+
+def _duration(value: JsonValue, default_seconds: int) -> timedelta:
+    """Parse a `config` threshold like `"45m"`; an unparsable/missing value
+    falls back to `default_seconds` rather than raising -- thresholds are
+    advisory config, not validated payload."""
+    if isinstance(value, str):
+        match = _DURATION_RE.match(value)
+        if match is not None:
+            amount, unit = match.groups()
+            return timedelta(seconds=int(amount) * _UNIT_SECONDS[unit])
+    return timedelta(seconds=default_seconds)
+
+
+def _round_threshold(value: JsonValue, default: int) -> int:
+    return value if isinstance(value, int) and value > 0 else default
+
+
+def _parse_ts(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+
+
+def _age_seconds(ts: str | None, now: datetime) -> float | None:
+    parsed = _parse_ts(ts)
+    if parsed is None:
+        return None
+    return (now - parsed).total_seconds()
+
+
+def _lane_and_grind_complete(state: State) -> list[Condition]:
+    out: list[Condition] = []
+    complete_count = 0
+    for lane in state.lanes.values():
+        if lane_status(state, lane) == "done":
+            out.append({"condition": "lane_complete", "lane": lane.id})
+            complete_count += 1
+    if state.lanes and complete_count == len(state.lanes):
+        out.append({"condition": "grind_complete"})
+    return out
+
+
+def _stale_items(state: State, now: datetime) -> list[Condition]:
+    threshold = _duration(state.config.get("stale_item_after"), 45 * 60)
+    out: list[Condition] = []
+    for item in state.items.values():
+        if item.parked is not None or item.status in _TERMINAL_ITEM_STATUSES:
+            continue
+        last_ts = state.last_item_ts.get(item.id)
+        age = _age_seconds(last_ts, now)
+        if age is None or age <= threshold.total_seconds():
+            continue
+        out.append(
+            {"condition": "stale_item", "item": item.id, "age_seconds": age, "since": last_ts}
+        )
+    return out
+
+
+def _stale_lanes(state: State, now: datetime) -> list[Condition]:
+    threshold = _duration(state.config.get("stale_lane_after"), 30 * 60)
+    out: list[Condition] = []
+    for lane in state.lanes.values():
+        candidates = [ts for ts in (state.last_lane_ts.get(lane.id),) if ts is not None]
+        candidates.extend(
+            ts for item_id in lane.item_ids if (ts := state.last_item_ts.get(item_id)) is not None
+        )
+        if not candidates:
+            continue
+        # Fixed-format "YYYY-MM-DDTHH:MM:SSZ" timestamps sort lexicographically
+        # in chronological order, so max() finds the latest reference cheaply.
+        latest = max(candidates)
+        age = _age_seconds(latest, now)
+        if age is None or age <= threshold.total_seconds():
+            continue
+        out.append(
+            {"condition": "stale_lane", "lane": lane.id, "age_seconds": age, "since": latest}
+        )
+    return out
+
+
+def _attention_pending(state: State, now: datetime) -> list[Condition]:
+    if not state.attention:
+        return []
+    timestamps = [a.ts for a in state.attention if a.ts is not None]
+    oldest_ts = min(timestamps) if timestamps else None
+    return [
+        {
+            "condition": "attention_pending",
+            "count": len(state.attention),
+            "since": oldest_ts,
+            "oldest_age_seconds": _age_seconds(oldest_ts, now),
+        }
+    ]
+
+
+def _blocked_chain(item: Item, state: State) -> list[str]:
+    """The ordered chain of ids starting at `item`, following blocker edges
+    while each next target is itself stuck (blocked/waiting-human/parked).
+    `visited` guards a malformed cyclic edge set from looping forever."""
+    chain = [item.id]
+    visited = {item.id}
+    current = item
+    while True:
+        next_target: Item | None = None
+        for target_id in current.blocked_on:
+            if target_id in visited:
+                continue
+            target = state.items.get(target_id)
+            if target is not None and (
+                target.status in _CHAIN_BLOCKING_STATUSES or target.parked is not None
+            ):
+                next_target = target
+                break
+        if next_target is None:
+            return chain
+        chain.append(next_target.id)
+        visited.add(next_target.id)
+        current = next_target
+
+
+def _blocked_chains(state: State) -> list[Condition]:
+    out: list[Condition] = []
+    for item in state.items.values():
+        if item.status != "blocked":
+            continue
+        chain = _blocked_chain(item, state)
+        if len(chain) > 1:
+            out.append(
+                {
+                    "condition": "blocked_chain",
+                    "item": item.id,
+                    "chain": cast("list[JsonValue]", chain),
+                }
+            )
+    return out
+
+
+def _review_stalemate_risk(state: State) -> list[Condition]:
+    n = _round_threshold(state.config.get("stalemate_risk_round"), 3)
+    out: list[Condition] = []
+    for item in state.items.values():
+        history = item.round_history
+        if len(history) < n:
+            continue
+        window = history[-n:]
+        shas = {sha for _, sha in window}
+        if len(shas) != 1:
+            continue
+        head_sha = next(iter(shas))
+        if head_sha is None:
+            continue
+        out.append(
+            {
+                "condition": "review_stalemate_risk",
+                "item": item.id,
+                "round": window[-1][0],
+                "head_sha": head_sha,
+            }
+        )
+    return out
+
+
+def conditions(state: State, now: datetime) -> list[Condition]:
+    """Every currently-true level condition (spec table, all rows but
+    `item_unblocked`). Returned by both the `grind log` emit-back envelope and
+    `grind status`, so a level condition is never missed by not watching the
+    right call."""
+    return [
+        *_lane_and_grind_complete(state),
+        *_stale_items(state, now),
+        *_stale_lanes(state, now),
+        *_attention_pending(state, now),
+        *_blocked_chains(state),
+        *_review_stalemate_risk(state),
+    ]
+
+
+def item_unblocked_conditions(before: State, after: State) -> list[Condition]:
+    """The transition condition: every item that was `blocked` before this
+    append and isn't after it -- i.e. its final blocker edge just resolved.
+    Derived from the delta between two folds, never recomputed from `after`
+    alone (spec: immediately after the unblock the state is indistinguishable
+    from an item queued with no edges, so this must ride the delta to reach
+    ROOT exactly once)."""
+    out: list[Condition] = []
+    for item_id, after_item in after.items.items():
+        before_item = before.items.get(item_id)
+        if before_item is None:
+            continue
+        if before_item.status == "blocked" and after_item.status != "blocked":
+            out.append({"condition": "item_unblocked", "item": item_id})
+    return out

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -91,7 +91,12 @@ def _round_threshold(value: JsonValue, default: int) -> int:
 def _parse_ts(value: str | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError:
+        # the fold accepts structural garbage, so a recorded ts may be non-ISO;
+        # an unreadable timestamp is unavailable evidence, never a crash
+        return None
 
 
 def _age_seconds(ts: str | None, now: datetime) -> float | None:
@@ -213,9 +218,10 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
     out: list[Condition] = []
     for item in state.items.values():
         # round_history survives the review cycle (it is fold history, never
-        # cleared), so gate on a live review state: a done/merged item, or one
-        # whose PR closed and re-queued, is not a stalemate however it got there
-        if item.status not in _ACTIVE_REVIEW_STATUSES:
+        # cleared), so gate on a live review state: a done/merged item, one
+        # whose PR closed and re-queued, or a parked item (parking preserves
+        # status), is not a stalemate however it got there
+        if item.status not in _ACTIVE_REVIEW_STATUSES or item.parked is not None:
             continue
         history = item.round_history
         if len(history) < n:
@@ -244,10 +250,14 @@ def conditions(state: State, now: datetime) -> list[Condition]:
     `item_unblocked`). Returned by both the `grind log` emit-back envelope and
     `grind status`, so a level condition is never missed by not watching the
     right call."""
+    # staleness measures work going quiet unexpectedly; a paused or finished
+    # grind is quiet on purpose (`grind check` applies the same exemption)
+    stale: list[Condition] = []
+    if not state.paused and not state.finished:
+        stale = [*_stale_items(state, now), *_stale_lanes(state, now)]
     return [
         *_lane_and_grind_complete(state),
-        *_stale_items(state, now),
-        *_stale_lanes(state, now),
+        *stale,
         *_attention_pending(state, now),
         *_blocked_chains(state),
         *_review_stalemate_risk(state),

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -220,7 +220,7 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
         if len(history) < n:
             continue
         window = history[-n:]
-        shas = {sha for _, sha in window}
+        shas = {sha for _, sha, _ in window}
         if len(shas) != 1:
             continue
         head_sha = next(iter(shas))
@@ -232,6 +232,7 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
                 "item": item.id,
                 "round": window[-1][0],
                 "head_sha": head_sha,
+                "since": window[0][2],
             }
         )
     return out

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -73,9 +73,10 @@ def _duration(value: JsonValue, default_seconds: int) -> timedelta:
             amount, unit = match.groups()
             try:
                 return timedelta(seconds=int(amount) * _UNIT_SECONDS[unit])
-            except OverflowError:
-                # an absurdly large threshold is unparsable config too, not
-                # an internal error to surface on every log/status call
+            except (OverflowError, ValueError):
+                # an absurdly large threshold is unparsable config too, not an
+                # internal error to surface on every log/status call. ValueError:
+                # past ~4300 digits int() itself refuses before timedelta can
                 return timedelta(seconds=default_seconds)
     return timedelta(seconds=default_seconds)
 

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -236,7 +236,18 @@ def conditions(state: State, now: datetime) -> list[Condition]:
 
 def item_unblocked_conditions(before: State, after: State) -> list[Condition]:
     """The transition condition: every item that was `blocked` before this
-    append and isn't after it -- i.e. its final blocker edge just resolved.
+    append and the fold returned to `queued` after it -- i.e. its final blocker
+    edge just resolved (spec: "when every edge resolves, the fold returns the
+    item to queued and fires the item_unblocked condition").
+
+    Gated on the `queued` landing, never on any departure from `blocked`. The
+    fold's derived-blocked invariant makes `blocked -> queued` reachable only via
+    edge resolution (`_recompute_blocked`/`_cascade_unblock`, both gated on no
+    unresolved edges), so `queued` is the concrete signal that the edges cleared.
+    A `blocked` item that departs to `waiting-human` (parked or human-gated) keeps
+    its unresolved `blocked_on` edges and is not startable -- that departure is
+    not an unblock and must not fire this condition.
+
     Derived from the delta between two folds, never recomputed from `after`
     alone (spec: immediately after the unblock the state is indistinguishable
     from an item queued with no edges, so this must ride the delta to reach
@@ -246,6 +257,6 @@ def item_unblocked_conditions(before: State, after: State) -> list[Condition]:
         before_item = before.items.get(item_id)
         if before_item is None:
             continue
-        if before_item.status == "blocked" and after_item.status != "blocked":
+        if before_item.status == "blocked" and after_item.status == "queued":
             out.append({"condition": "item_unblocked", "item": item_id})
     return out

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -289,13 +289,23 @@ def _record_round(item: Item, round_: int | None, head_sha: str | None) -> None:
     """Append/replace this round's authoritative head_sha, last-event-wins
     within a round (spec `review_stalemate_risk`: "the LATEST event logged for
     that round"). A round history is thus always distinct rounds in order --
-    exactly what the condition's "last N distinct round values" window needs."""
+    exactly what the condition's "last N distinct round values" window needs.
+
+    Last-event-wins applies to any distinct round, not just the final entry: a
+    late event for an earlier round updates that round's record in place
+    (preserving its position in the ordering) rather than appending a duplicate
+    that would inflate the distinct-round count `_review_stalemate_risk` reads."""
     if round_ is None:
         return
-    if item.round_history and item.round_history[-1][0] == round_:
-        item.round_history = (*item.round_history[:-1], (round_, head_sha))
-    else:
-        item.round_history = (*item.round_history, (round_, head_sha))
+    for i, (existing_round, _) in enumerate(item.round_history):
+        if existing_round == round_:
+            item.round_history = (
+                *item.round_history[:i],
+                (round_, head_sha),
+                *item.round_history[i + 1 :],
+            )
+            return
+    item.round_history = (*item.round_history, (round_, head_sha))
 
 
 @_handler("review_round")

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -285,7 +285,7 @@ def _h_pr_opened(state: State, evt: RawEvent) -> None:
 _REVIEWABLE = {"pr-open", "in-review", "waiting-human"}
 
 
-def _record_round(item: Item, round_: int | None, head_sha: str | None) -> None:
+def _record_round(item: Item, round_: int | None, head_sha: str | None, ts: str | None) -> None:
     """Append/replace this round's authoritative head_sha, last-event-wins
     within a round (spec `review_stalemate_risk`: "the LATEST event logged for
     that round"). A round history is thus always distinct rounds in order --
@@ -297,15 +297,15 @@ def _record_round(item: Item, round_: int | None, head_sha: str | None) -> None:
     that would inflate the distinct-round count `_review_stalemate_risk` reads."""
     if round_ is None:
         return
-    for i, (existing_round, _) in enumerate(item.round_history):
+    for i, (existing_round, _, _) in enumerate(item.round_history):
         if existing_round == round_:
             item.round_history = (
                 *item.round_history[:i],
-                (round_, head_sha),
+                (round_, head_sha, ts),
                 *item.round_history[i + 1 :],
             )
             return
-    item.round_history = (*item.round_history, (round_, head_sha))
+    item.round_history = (*item.round_history, (round_, head_sha, ts))
 
 
 @_handler("review_round")
@@ -323,7 +323,7 @@ def _h_review_round(state: State, evt: RawEvent) -> None:
     item.review.head_sha = _str(evt, "head_sha")
     item.review.detail = _str(evt, "detail")
     item.status = "in-review"
-    _record_round(item, new_round, item.review.head_sha)
+    _record_round(item, new_round, item.review.head_sha, _str(evt, "ts"))
 
 
 _OPEN_DISPOSITIONS = {"deferred", "escalated"}
@@ -374,7 +374,7 @@ def _h_review_verdict(state: State, evt: RawEvent) -> None:
     item.review.wont_fix_count = wont_fix_count
     item.review.stalemate = item.review.verdict == "stalemate"
     item.status = "in-review"
-    _record_round(item, new_round, item.review.head_sha)
+    _record_round(item, new_round, item.review.head_sha, _str(evt, "ts"))
 
 
 _PR_CLOSED_NEXT: set[ItemStatus] = {"in-progress", "queued"}
@@ -399,6 +399,9 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
             item=item.id, pr=pr if isinstance(pr, int) else None, reason=reason, ts=_str(evt, "ts")
         )
     )
+    # the review cycle ends with its PR: a later pr_opened starts a fresh
+    # cycle that must not inherit the closed PR's stalemate history
+    item.round_history = ()
     if next_status == "parked":
         _park_item(state, item, kind=None, note=reason)
     else:

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -78,10 +78,13 @@ def _anomaly(state: State, evt: RawEvent, reason: str) -> None:
         AnomalyRecord(ts=_str(evt, "ts"), type=etype, item=item_id, lane=lane_id, reason=reason)
     )
     message = f"anomaly: {etype} on {item_id or lane_id or 'grind'}: {reason}"
+    ts = _str(evt, "ts")
     state.observations.append(
-        Observation(level="ERROR", message=message, item=item_id, lane=lane_id, ts=_str(evt, "ts"))
+        Observation(level="ERROR", message=message, item=item_id, lane=lane_id, ts=ts)
     )
-    state.attention.append(AttentionEntry(text=message, item=item_id, lane=lane_id, auto=True))
+    state.attention.append(
+        AttentionEntry(text=message, item=item_id, lane=lane_id, auto=True, ts=ts)
+    )
 
 
 @_handler("grind_created")
@@ -282,6 +285,19 @@ def _h_pr_opened(state: State, evt: RawEvent) -> None:
 _REVIEWABLE = {"pr-open", "in-review", "waiting-human"}
 
 
+def _record_round(item: Item, round_: int | None, head_sha: str | None) -> None:
+    """Append/replace this round's authoritative head_sha, last-event-wins
+    within a round (spec `review_stalemate_risk`: "the LATEST event logged for
+    that round"). A round history is thus always distinct rounds in order --
+    exactly what the condition's "last N distinct round values" window needs."""
+    if round_ is None:
+        return
+    if item.round_history and item.round_history[-1][0] == round_:
+        item.round_history = (*item.round_history[:-1], (round_, head_sha))
+    else:
+        item.round_history = (*item.round_history, (round_, head_sha))
+
+
 @_handler("review_round")
 def _h_review_round(state: State, evt: RawEvent) -> None:
     item = _active_item(state, evt)
@@ -291,11 +307,13 @@ def _h_review_round(state: State, evt: RawEvent) -> None:
         _anomaly(state, evt, f"review_round illegal from status {item.status!r}")
         return
     round_ = evt.get("round")
-    item.review.round = round_ if isinstance(round_, int) else item.review.round
+    new_round = round_ if isinstance(round_, int) else item.review.round
+    item.review.round = new_round
     item.review.kind = _str(evt, "kind")
     item.review.head_sha = _str(evt, "head_sha")
     item.review.detail = _str(evt, "detail")
     item.status = "in-review"
+    _record_round(item, new_round, item.review.head_sha)
 
 
 _OPEN_DISPOSITIONS = {"deferred", "escalated"}
@@ -346,6 +364,7 @@ def _h_review_verdict(state: State, evt: RawEvent) -> None:
     item.review.wont_fix_count = wont_fix_count
     item.review.stalemate = item.review.verdict == "stalemate"
     item.status = "in-review"
+    _record_round(item, new_round, item.review.head_sha)
 
 
 _PR_CLOSED_NEXT: set[ItemStatus] = {"in-progress", "queued"}
@@ -417,6 +436,7 @@ def _h_item_waiting_human(state: State, evt: RawEvent) -> None:
             item=item.id,
             auto=True,
             kind="waiting-human",
+            ts=_str(evt, "ts"),
         )
     )
 
@@ -588,7 +608,9 @@ def _h_observation(state: State, evt: RawEvent) -> None:
     )
     state.observations.append(obs)
     if level == "ERROR":
-        state.attention.append(AttentionEntry(text=message, item=item_id, lane=lane_id, auto=True))
+        state.attention.append(
+            AttentionEntry(text=message, item=item_id, lane=lane_id, auto=True, ts=_str(evt, "ts"))
+        )
     elif level == "LESSON":
         state.lessons.append(obs)
 
@@ -599,7 +621,7 @@ def _h_attention_raised(state: State, evt: RawEvent) -> None:
     if text is None:
         _anomaly(state, evt, "attention_raised has no text")
         return
-    state.attention.append(AttentionEntry(text=text, item=_str(evt, "item")))
+    state.attention.append(AttentionEntry(text=text, item=_str(evt, "item"), ts=_str(evt, "ts")))
 
 
 @_handler("attention_cleared")
@@ -644,4 +666,27 @@ def fold(events: Sequence[Mapping[str, JsonValue]]) -> State:
             _anomaly(state, evt, f"unknown event type {etype!r}")
             continue
         handler(state, evt)
+        _record_last_referenced(state, etype, evt)
     return state
+
+
+def _record_last_referenced(state: State, etype: str, evt: RawEvent) -> None:
+    """Stamp `last_item_ts`/`last_lane_ts` for whatever this event just touched --
+    raw facts copied from the event, not a computation, so this stays inside
+    `fold`'s purity contract (spec: `conditions(State, now)` is the only place
+    a clock enters). `grind_created` seeds every lane and item it creates."""
+    ts = _str(evt, "ts")
+    if ts is None:
+        return
+    if etype == "grind_created":
+        for created_item_id in state.items:
+            state.last_item_ts[created_item_id] = ts
+        for created_lane_id in state.lanes:
+            state.last_lane_ts[created_lane_id] = ts
+        return
+    referenced_item_id = _str(evt, "item")
+    if referenced_item_id is not None and referenced_item_id in state.items:
+        state.last_item_ts[referenced_item_id] = ts
+    referenced_lane_id = _str(evt, "lane")
+    if referenced_lane_id is not None and referenced_lane_id in state.lanes:
+        state.last_lane_ts[referenced_lane_id] = ts

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -94,12 +94,15 @@ class Item:
     review: ItemReview = field(default_factory=ItemReview)
     parked: ParkingEntry | None = None
     discovered: DiscoveredWork | None = None
-    # (round, head_sha) per distinct round, last-event-wins within a round --
-    # the raw material `conditions()` needs for `review_stalemate_risk`'s
-    # "dumb arithmetic" (spec: "the last N distinct round values ... all carry
-    # the SAME head_sha"). Recorded by the fold (a fact copied from events),
-    # never itself a computed condition.
-    round_history: tuple[tuple[int, str | None], ...] = ()
+    # (round, head_sha, ts) per distinct round, last-event-wins within a
+    # round -- the raw material `conditions()` needs for
+    # `review_stalemate_risk`'s "dumb arithmetic" (spec: "the last N distinct
+    # round values ... all carry the SAME head_sha"), with each round's
+    # authoritative event ts so the fired condition can report the window's
+    # start (`since`). Recorded by the fold (facts copied from events), never
+    # itself a computed condition; cleared by `pr_closed` -- the history
+    # belongs to one PR cycle, a new PR must not inherit an old stalemate.
+    round_history: tuple[tuple[int, str | None, str | None], ...] = ()
 
 
 @dataclass

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -94,6 +94,12 @@ class Item:
     review: ItemReview = field(default_factory=ItemReview)
     parked: ParkingEntry | None = None
     discovered: DiscoveredWork | None = None
+    # (round, head_sha) per distinct round, last-event-wins within a round --
+    # the raw material `conditions()` needs for `review_stalemate_risk`'s
+    # "dumb arithmetic" (spec: "the last N distinct round values ... all carry
+    # the SAME head_sha"). Recorded by the fold (a fact copied from events),
+    # never itself a computed condition.
+    round_history: tuple[tuple[int, str | None], ...] = ()
 
 
 @dataclass
@@ -114,6 +120,7 @@ class AttentionEntry:
     lane: str | None = None
     auto: bool = False  # raised by the fold itself (anomaly/waiting-human), not ROOT
     kind: AttentionKind | None = None  # what raised it, when resume must clear only its own
+    ts: str | None = None  # the raising event's ts -- needed for attention_pending's "oldest age"
 
 
 @dataclass
@@ -184,6 +191,15 @@ class State:
     closed_ledger: list[ClosedEntry] = field(default_factory=list)
     lessons: list[Observation] = field(default_factory=list)
     anomalies: list[AnomalyRecord] = field(default_factory=list)
+
+    # Last event ts that referenced each item/lane -- raw facts the fold copies
+    # forward from events (never computed from a clock), the material
+    # `conditions(State, now)` needs for `stale_item`/`stale_lane`. Keyed by
+    # item id / lane id; absent key means "never referenced after creation"
+    # (can't happen for anything the fold created, since `grind_created` and
+    # `discovered_work` both stamp an initial entry).
+    last_item_ts: dict[str, str] = field(default_factory=dict)
+    last_lane_ts: dict[str, str] = field(default_factory=dict)
 
     def parking_lot(self) -> dict[str, Item]:
         """Items currently parked -- derived, not separately stored, so it can't drift."""

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -94,6 +94,7 @@ def _attention_json(entry: AttentionEntry) -> JsonValue:
         "lane": entry.lane,
         "auto": entry.auto,
         "kind": entry.kind,
+        "ts": entry.ts,
     }
 
 

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -71,6 +71,9 @@ def _item_json(item: Item) -> JsonValue:
         "review": _item_review_json(item.review),
         "parked": _parking_entry_json(item.parked),
         "discovered": _discovered_work_json(item.discovered),
+        "round_history": [
+            {"round": r, "head_sha": sha, "ts": ts} for r, sha, ts in item.round_history
+        ],
     }
 
 

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -153,6 +153,8 @@ def full_state_json(state: State) -> dict[str, JsonValue]:
         "closed_ledger": [_closed_entry_json(c) for c in state.closed_ledger],
         "lessons": [_observation_json(o) for o in state.lessons],
         "anomalies": [anomaly_json(a) for a in state.anomalies],
+        "last_item_ts": cast("JsonValue", dict(state.last_item_ts)),
+        "last_lane_ts": cast("JsonValue", dict(state.last_lane_ts)),
     }
 
 

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -13,7 +13,9 @@ import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
+from grind.conditions import conditions, item_unblocked_conditions
 from grind.derive import lane_status
 from grind.envelope import GrindError
 from grind.fold import fold
@@ -195,28 +197,39 @@ def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> di
     _validate_or_raise(event_type, payload)
 
     before_state = fold(load_events(dir_))
-    event: RawEvent = {"ts": _iso(now()), "type": event_type, **payload}
+    now_dt = now()
+    event: RawEvent = {"ts": _iso(now_dt), "type": event_type, **payload}
     after_state, repair = _append_and_persist(dir_, event)
 
     anomaly = _new_anomaly(before_state, after_state)
+    # Transition condition first (this append's own delta), then the
+    # currently-true level conditions (spec §"Emit-back") -- both classes
+    # ride the same envelope, never a second round-trip.
+    envelope_conditions = cast(
+        "JsonValue",
+        [
+            *item_unblocked_conditions(before_state, after_state),
+            *conditions(after_state, now_dt),
+        ],
+    )
     return {
         "ok": True,
         "applied": anomaly is None,
         "anomaly": anomaly_json(anomaly),
         "torn_tail": _torn_tail_json(repair),
         "delta": _entity_delta(before_state, after_state, event),
-        # The conditions engine is a sibling bead (spec §"Emit-back"); this
-        # verb never computes orchestration facts itself.
-        "conditions": [],
+        "conditions": envelope_conditions,
     }
 
 
-def cmd_status(dir_: Path, *, full: bool) -> dict[str, JsonValue]:
-    """`grind status [--full]`."""
+def cmd_status(dir_: Path, *, full: bool, now: Clock) -> dict[str, JsonValue]:
+    """`grind status [--full]`. Level conditions only -- `item_unblocked` is a
+    transition condition, never recomputed from state (spec §"Emit-back")."""
     state = fold_dir(dir_)
+    current_conditions = cast("JsonValue", conditions(state, now()))
     if full:
-        return {"ok": True, "state": full_state_json(state), "conditions": []}
-    return {"ok": True, "state_summary": summarize(state), "conditions": []}
+        return {"ok": True, "state": full_state_json(state), "conditions": current_conditions}
+    return {"ok": True, "state_summary": summarize(state), "conditions": current_conditions}
 
 
 def cmd_check(dir_: Path, max_age: str | None, *, now: Clock) -> dict[str, JsonValue]:

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -466,6 +466,7 @@ def test_condition_names_are_never_imperative() -> None:
         first_word = re.split(r"[_\s]", name)[0]
         assert first_word not in IMPERATIVE_VERBS, f"{name!r} reads as an imperative"
 
+
 def test_duration_threshold_overflow_falls_back_to_default() -> None:
     # A regex-valid but astronomically large threshold overflows timedelta;
     # advisory config falls back to the default instead of erroring the verb.

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -471,6 +471,20 @@ def test_condition_names_are_never_imperative() -> None:
         assert first_word not in IMPERATIVE_VERBS, f"{name!r} reads as an imperative"
 
 
+def test_duration_threshold_over_int_digit_limit_falls_back_to_default() -> None:
+    # past ~4300 digits int() raises ValueError before timedelta's OverflowError;
+    # both are advisory-config noise, never an internal error
+    events = [
+        *_to_pr_open(),
+    ]
+    state = fold(events)
+    state.config = {"stale_item_after": "9" * 5000 + "d"}
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 51, 0, tzinfo=UTC))
+
+    assert "stale_item" in _names(result)
+
+
 def test_duration_threshold_overflow_falls_back_to_default() -> None:
     # A regex-valid but astronomically large threshold overflows timedelta;
     # advisory config falls back to the default instead of erroring the verb.

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -352,6 +352,71 @@ def test_item_unblocked_not_recomputed_from_state_alone() -> None:
     assert item_unblocked_conditions(after, after) == []
 
 
+def _blocked_pair_seed() -> dict[str, object]:
+    """A two-item lane where `wgclw.2` is blocked on the unfinished `wgclw.1`."""
+    return {
+        "ts": _T0,
+        "type": "grind_created",
+        "title": "t",
+        "repo": "r",
+        "mission": {},
+        "protocols": {},
+        "config": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "blocker"},
+                    {"id": "wgclw.2", "title": "blocked", "on": ["wgclw.1"]},
+                ],
+            }
+        ],
+    }
+
+
+def test_item_unblocked_absent_when_blocked_item_goes_waiting_human() -> None:
+    # A blocked item can legally fold to waiting-human (parked for a human)
+    # without its blocker edge resolving -- its blocked_on stays unresolved and
+    # it is not startable, so this departure must NOT fire item_unblocked.
+    prefix = [_blocked_pair_seed()]
+    before = fold(prefix)
+    assert before.items["wgclw.2"].status == "blocked"
+    after = fold([*prefix, event("item_waiting_human", item="wgclw.2", why="need a human")])
+    assert after.items["wgclw.2"].status == "waiting-human"
+    assert after.items["wgclw.2"].blocked_on == ("wgclw.1",)
+
+    assert item_unblocked_conditions(before, after) == []
+
+
+def test_item_unblocked_absent_when_blocked_item_is_parked() -> None:
+    # Parking a blocked item leaves its status blocked and its edges unresolved;
+    # it never becomes startable, so no item_unblocked fires.
+    prefix = [_blocked_pair_seed()]
+    before = fold(prefix)
+    after = fold([*prefix, event("item_parked", item="wgclw.2", note="later wave")])
+    assert after.items["wgclw.2"].parked is not None
+    assert after.items["wgclw.2"].blocked_on == ("wgclw.1",)
+
+    assert item_unblocked_conditions(before, after) == []
+
+
+def test_item_unblocked_fires_when_final_edge_resolves_to_queued() -> None:
+    # The genuine case: the blocker reaches merged, the fold returns the item to
+    # queued, and item_unblocked fires exactly once.
+    prefix = [
+        _blocked_pair_seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+    ]
+    before = fold(prefix)
+    after = fold([*prefix, event("item_merged", item="wgclw.1", pr=1, sha="abc")])
+    assert after.items["wgclw.2"].status == "queued"
+
+    assert item_unblocked_conditions(before, after) == [
+        {"condition": "item_unblocked", "item": "wgclw.2"}
+    ]
+
+
 # -- HARD SEAM ------------------------------------------------------------------
 
 

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -568,3 +568,52 @@ def test_stalemate_risk_carries_window_start_as_since() -> None:
     )
 
     assert risk[0]["since"] == "2026-07-19T00:05:00Z"
+
+
+def test_stalemate_risk_excluded_for_parked_item() -> None:
+    # parking preserves the item's status (e.g. waiting-human) and its
+    # round_history; a parked item is out of the active queue, not stalled
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a1"),
+        event("item_waiting_human", item="wgclw.1", why="stalemate"),
+        event("item_parked", item="wgclw.1", kind="deferred"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
+def test_staleness_suppressed_while_paused_or_finished() -> None:
+    # a paused or finished grind is quiet on purpose -- same exemption
+    # `grind check` applies; staleness measures unexpected silence only
+    base = [
+        _two_item_lane_seed(),
+        event("item_started", item="wgclw.1"),
+    ]
+    late = datetime(2026, 7, 19, 6, 0, 0, tzinfo=UTC)
+
+    running = fold(base)
+    assert "stale_item" in _names(conditions(running, late))
+
+    paused = fold([*base, event("grind_paused", reason="lunch")])
+    names = _names(conditions(paused, late))
+    assert "stale_item" not in names and "stale_lane" not in names
+
+
+def test_malformed_recorded_ts_is_unavailable_not_a_crash() -> None:
+    # the fold accepts structural garbage: a non-ISO ts can be recorded as an
+    # item's last reference; conditions() must skip it, never raise
+    events = [
+        _two_item_lane_seed(),
+        {"ts": "not-a-timestamp", "type": "item_started", "item": "wgclw.1"},
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 6, 0, 0, tzinfo=UTC))
+
+    assert all(c["item"] != "wgclw.1" for c in _by_name(result, "stale_item"))

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -481,3 +481,35 @@ def test_duration_threshold_overflow_falls_back_to_default() -> None:
     # default stale_item_after is 45m; at +51m past the last event the item is
     # stale under the fallback, proving the overflowing value was ignored
     assert "stale_item" in _names(result)
+
+
+def test_review_stalemate_risk_not_fired_for_completed_item() -> None:
+    # round_history survives merge/done, but a finished item has no live
+    # review cycle to be stalled -- the risk must not follow it around.
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a1"),
+        event("item_merged", item="wgclw.1", sha="m1"),
+        event("item_done", item="wgclw.1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
+def test_boolean_stalemate_threshold_falls_back_to_default() -> None:
+    # bool is an int subtype; `true` must not read as a threshold of 1
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+    ]
+    state = fold(events)
+    state.config = {"stalemate_risk_round": True}
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -243,6 +243,7 @@ def test_review_stalemate_risk_fires_after_n_distinct_rounds_same_sha() -> None:
         "item": "wgclw.1",
         "round": 3,
         "head_sha": "a1",
+        "since": "2026-07-19T00:05:00Z",
     }
 
 
@@ -293,7 +294,10 @@ def test_review_stalemate_risk_ignores_late_earlier_round_duplicate() -> None:
     ]
     state = fold(events)
 
-    assert state.items["wgclw.1"].round_history == ((1, "a1"), (2, "a1"))
+    assert state.items["wgclw.1"].round_history == (
+        (1, "a1", "2026-07-19T00:05:00Z"),
+        (2, "a1", "2026-07-19T00:05:00Z"),
+    )
 
     result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
 
@@ -513,3 +517,40 @@ def test_boolean_stalemate_threshold_falls_back_to_default() -> None:
     result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
 
     assert "review_stalemate_risk" not in _names(result)
+
+
+def test_stalemate_history_resets_when_pr_closes() -> None:
+    # pr_closed ends the review cycle: a fresh pr_opened must not inherit the
+    # closed PR's rounds and fire a stalemate before any new round occurs.
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a1"),
+        event("pr_closed", item="wgclw.1", pr=1, next="queued", reason="superseded"),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=2),
+    ]
+    state = fold(events)
+
+    assert state.items["wgclw.1"].round_history == ()
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
+def test_stalemate_risk_carries_window_start_as_since() -> None:
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a1"),
+    ]
+    state = fold(events)
+
+    risk = _by_name(
+        conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC)), "review_stalemate_risk"
+    )
+
+    assert risk[0]["since"] == "2026-07-19T00:05:00Z"

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -1,0 +1,375 @@
+"""`conditions(state, now)` -- the level-condition engine, and the transition
+condition `item_unblocked` derived from a fold delta."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+
+from grind.conditions import IMPERATIVE_VERBS, conditions, item_unblocked_conditions
+from grind.fold import fold
+from tests.unit.builders import event, seed_event
+
+_T0 = "2026-07-19T00:00:00Z"
+
+
+def _names(items: list[dict[str, object]]) -> set[str]:
+    return {c["condition"] for c in items}  # type: ignore[misc]
+
+
+def _by_name(items: list[dict[str, object]], name: str) -> list[dict[str, object]]:
+    return [c for c in items if c["condition"] == name]
+
+
+# -- lane_complete / grind_complete ------------------------------------------
+
+
+def _two_item_lane_seed() -> dict[str, object]:
+    return {
+        "ts": _T0,
+        "type": "grind_created",
+        "title": "Widget grind",
+        "repo": "acme/widgets",
+        "mission": {},
+        "protocols": {},
+        "config": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "name": "Lane A",
+                "queue": [{"id": "wgclw.1", "title": "First"}],
+            }
+        ],
+    }
+
+
+def test_lane_complete_fires_when_last_item_in_lane_reaches_done() -> None:
+    events = [
+        _two_item_lane_seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        event("item_done", item="wgclw.1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    lane_conditions = _by_name(result, "lane_complete")
+    assert len(lane_conditions) == 1
+    assert lane_conditions[0]["lane"] == "lane-a"
+
+
+def test_grind_complete_fires_only_when_every_lane_is_complete() -> None:
+    events = [
+        _two_item_lane_seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        event("item_done", item="wgclw.1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "grind_complete" in _names(result)
+
+
+def test_grind_complete_absent_while_any_lane_incomplete() -> None:
+    state = fold([seed_event()])  # two lanes' worth of queued items, untouched
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "grind_complete" not in _names(result)
+    assert "lane_complete" not in _names(result)
+
+
+# -- stale_item / stale_lane --------------------------------------------------
+
+
+def test_stale_item_fires_past_threshold_and_not_before() -> None:
+    seed = _two_item_lane_seed()
+    seed["config"] = {"stale_item_after": "45m"}
+    state = fold([seed])
+
+    just_under = conditions(state, datetime(2026, 7, 19, 0, 44, 59, tzinfo=UTC))
+    just_over = conditions(state, datetime(2026, 7, 19, 0, 45, 1, tzinfo=UTC))
+
+    assert "stale_item" not in _names(just_under)
+    stale = _by_name(just_over, "stale_item")
+    assert len(stale) == 1
+    assert stale[0]["item"] == "wgclw.1"
+
+
+def test_stale_item_excludes_terminal_and_parked_items() -> None:
+    seed = _two_item_lane_seed()
+    seed["config"] = {"stale_item_after": "45m"}
+    events = [
+        seed,
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        event("item_done", item="wgclw.1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 20, 0, 0, 0, tzinfo=UTC))
+
+    assert "stale_item" not in _names(result)
+
+
+def test_stale_lane_considers_events_on_items_currently_assigned() -> None:
+    seed = _two_item_lane_seed()
+    seed["config"] = {"stale_lane_after": "30m"}
+    events = [
+        seed,
+        event("item_started", item="wgclw.1", ts="2026-07-19T00:20:00Z"),
+    ]
+    state = fold(events)
+
+    # 25 min after the last item reference: under threshold.
+    under = conditions(state, datetime(2026, 7, 19, 0, 45, 0, tzinfo=UTC))
+    # 31 min after: over threshold.
+    over = conditions(state, datetime(2026, 7, 19, 0, 51, 0, tzinfo=UTC))
+
+    assert "stale_lane" not in _names(under)
+    stale = _by_name(over, "stale_lane")
+    assert len(stale) == 1
+    assert stale[0]["lane"] == "lane-a"
+
+
+# -- attention_pending ---------------------------------------------------------
+
+
+def test_attention_pending_fires_with_count_and_oldest_age() -> None:
+    events = [
+        _two_item_lane_seed(),
+        event(
+            "item_waiting_human",
+            item="wgclw.1",
+            why="need a human decision",
+            ts="2026-07-19T00:10:00Z",
+        ),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 20, 0, tzinfo=UTC))
+
+    pending = _by_name(result, "attention_pending")
+    assert len(pending) == 1
+    assert pending[0]["count"] == 1
+    assert pending[0]["oldest_age_seconds"] == 600
+
+
+def test_attention_pending_absent_when_no_attention() -> None:
+    state = fold([_two_item_lane_seed()])
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "attention_pending" not in _names(result)
+
+
+# -- blocked_chain --------------------------------------------------------------
+
+
+def test_blocked_chain_reports_ordered_item_list() -> None:
+    seed = {
+        "ts": _T0,
+        "type": "grind_created",
+        "title": "t",
+        "repo": "r",
+        "mission": {},
+        "protocols": {},
+        "config": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "root"},
+                    {"id": "wgclw.2", "title": "mid", "on": ["wgclw.3"]},
+                    {"id": "wgclw.3", "title": "leaf", "on": ["wgclw.4"]},
+                    {"id": "wgclw.4", "title": "unresolved leaf blocker"},
+                ],
+            }
+        ],
+    }
+    events = [seed, event("item_blocked", item="wgclw.1", on=["wgclw.2"])]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    chains = _by_name(result, "blocked_chain")
+    assert any(
+        c["item"] == "wgclw.1" and c["chain"] == ["wgclw.1", "wgclw.2", "wgclw.3"] for c in chains
+    )
+
+
+def test_blocked_chain_absent_when_blocker_is_not_itself_blocked() -> None:
+    seed = _two_item_lane_seed()
+    seed["lanes"][0]["queue"].append({"id": "wgclw.2", "title": "Second"})  # type: ignore[index]
+    state = fold([seed, event("item_blocked", item="wgclw.1", on=["wgclw.2"])])
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "blocked_chain" not in _names(result)
+
+
+# -- review_stalemate_risk -----------------------------------------------------
+
+
+def _to_pr_open() -> list[dict[str, object]]:
+    return [
+        _two_item_lane_seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+    ]
+
+
+def test_review_stalemate_risk_fires_after_n_distinct_rounds_same_sha() -> None:
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    risk = _by_name(result, "review_stalemate_risk")
+    assert len(risk) == 1
+    assert risk[0] == {
+        "condition": "review_stalemate_risk",
+        "item": "wgclw.1",
+        "round": 3,
+        "head_sha": "a1",
+    }
+
+
+def test_review_stalemate_risk_resets_on_changed_head_sha() -> None:
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="b2"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="b2"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
+def test_review_stalemate_risk_not_fired_before_n_distinct_rounds() -> None:
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+    ]
+    state = fold(events)
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
+# -- item_unblocked (transition) ------------------------------------------------
+
+
+def test_item_unblocked_fires_once_on_the_resolving_append() -> None:
+    seed = {
+        "ts": _T0,
+        "type": "grind_created",
+        "title": "t",
+        "repo": "r",
+        "mission": {},
+        "protocols": {},
+        "config": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "blocker"},
+                    {"id": "wgclw.2", "title": "blocked", "on": ["wgclw.1"]},
+                ],
+            }
+        ],
+    }
+    prefix = [
+        seed,
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+    ]
+    before = fold(prefix)
+    merged_event = event("item_merged", item="wgclw.1", pr=1, sha="abc")
+    after = fold([*prefix, merged_event])
+
+    result = item_unblocked_conditions(before, after)
+
+    assert result == [{"condition": "item_unblocked", "item": "wgclw.2"}]
+
+
+def test_item_unblocked_absent_when_nothing_resolves() -> None:
+    prefix = [_two_item_lane_seed(), event("item_started", item="wgclw.1")]
+    before = fold(prefix)
+    after = fold([*prefix, event("pr_opened", item="wgclw.1", pr=1)])
+
+    result = item_unblocked_conditions(before, after)
+
+    assert result == []
+
+
+def test_item_unblocked_not_recomputed_from_state_alone() -> None:
+    # Immediately after the unblock, and on every later fold, the resulting
+    # state is indistinguishable from an item queued with no edges -- so a
+    # second call comparing the *same* after-state to itself must be silent.
+    seed = {
+        "ts": _T0,
+        "type": "grind_created",
+        "title": "t",
+        "repo": "r",
+        "mission": {},
+        "protocols": {},
+        "config": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "blocker"},
+                    {"id": "wgclw.2", "title": "blocked", "on": ["wgclw.1"]},
+                ],
+            }
+        ],
+    }
+    prefix = [
+        seed,
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+    ]
+    after = fold(prefix)
+
+    assert item_unblocked_conditions(after, after) == []
+
+
+# -- HARD SEAM ------------------------------------------------------------------
+
+
+def test_condition_names_are_never_imperative() -> None:
+    """Facts, not orchestration policy (spec HARD SEAM): a condition name never
+    reads as a command like "nudge" or "escalate"."""
+    seed = _two_item_lane_seed()
+    events = [
+        seed,
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        event("item_done", item="wgclw.1"),
+    ]
+    state = fold(events)
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+    all_names = _names(result) | {"item_unblocked"}  # transition condition, named statically
+
+    for name in all_names:
+        first_word = re.split(r"[_\s]", name)[0]
+        assert first_word not in IMPERATIVE_VERBS, f"{name!r} reads as an imperative"

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -465,3 +465,18 @@ def test_condition_names_are_never_imperative() -> None:
     for name in all_names:
         first_word = re.split(r"[_\s]", name)[0]
         assert first_word not in IMPERATIVE_VERBS, f"{name!r} reads as an imperative"
+
+def test_duration_threshold_overflow_falls_back_to_default() -> None:
+    # A regex-valid but astronomically large threshold overflows timedelta;
+    # advisory config falls back to the default instead of erroring the verb.
+    events = [
+        *_to_pr_open(),
+    ]
+    state = fold(events)
+    state.config = {"stale_item_after": "999999999999999999999d"}
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 51, 0, tzinfo=UTC))
+
+    # default stale_item_after is 45m; at +51m past the last event the item is
+    # stale under the fallback, proving the overflowing value was ignored
+    assert "stale_item" in _names(result)

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -273,6 +273,33 @@ def test_review_stalemate_risk_not_fired_before_n_distinct_rounds() -> None:
     assert "review_stalemate_risk" not in _names(result)
 
 
+def test_review_stalemate_risk_ignores_late_earlier_round_duplicate() -> None:
+    # Two distinct rounds on the same SHA, then a valid late verdict for the
+    # earlier round: last-event-wins must update round 1 in place, not append a
+    # third entry that fakes a three-distinct-round stalemate.
+    events = [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a1"),
+        event(
+            "review_verdict",
+            item="wgclw.1",
+            kind="codex",
+            round=1,
+            head_sha="a1",
+            verdict="clean",
+            findings=[],
+        ),
+    ]
+    state = fold(events)
+
+    assert state.items["wgclw.1"].round_history == ((1, "a1"), (2, "a1"))
+
+    result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
+
+    assert "review_stalemate_risk" not in _names(result)
+
+
 # -- item_unblocked (transition) ------------------------------------------------
 
 

--- a/packages/grind/tests/unit/test_fold_review.py
+++ b/packages/grind/tests/unit/test_fold_review.py
@@ -155,3 +155,20 @@ def test_review_round_illegal_before_pr_opened() -> None:
     assert state.items["wgclw.1"].status == "queued"
     assert len(state.anomalies) == 1
     assert state.anomalies[0].type == "review_round"
+
+
+def test_record_round_updates_non_adjacent_earlier_round_in_place() -> None:
+    # A late event for round 1 (arriving after round 3) overwrites round 1's
+    # record where it sits -- last-event-wins per distinct round, ordering
+    # preserved -- instead of appending a duplicate.
+    events = [
+        *_TO_PR_OPEN,
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="a2"),
+        event("review_round", item="wgclw.1", kind="codex", round=3, head_sha="a3"),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="z9"),
+    ]
+
+    state = fold(events)
+
+    assert state.items["wgclw.1"].round_history == ((1, "z9"), (2, "a2"), (3, "a3"))

--- a/packages/grind/tests/unit/test_fold_review.py
+++ b/packages/grind/tests/unit/test_fold_review.py
@@ -171,4 +171,8 @@ def test_record_round_updates_non_adjacent_earlier_round_in_place() -> None:
 
     state = fold(events)
 
-    assert state.items["wgclw.1"].round_history == ((1, "z9"), (2, "a2"), (3, "a3"))
+    assert state.items["wgclw.1"].round_history == (
+        (1, "z9", "2026-07-19T00:05:00Z"),
+        (2, "a2", "2026-07-19T00:05:00Z"),
+        (3, "a3", "2026-07-19T00:05:00Z"),
+    )

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -163,3 +163,27 @@ def test_full_state_serializes_round_history():
     assert items["wgclw.1"]["round_history"] == [
         {"round": 1, "head_sha": "a1", "ts": "2026-07-19T00:05:00Z"}
     ]
+
+
+def test_full_state_serializes_staleness_ts_maps():
+    events = [seed_event(), event("item_started", item="wgclw.1")]
+    state = fold(events)
+
+    payload = full_state_json(state)
+
+    assert payload["last_item_ts"]["wgclw.1"] == "2026-07-19T00:05:00Z"
+    assert "last_lane_ts" in payload
+
+
+def test_full_state_json_is_a_faithful_materialization_of_state():
+    # Reflection lock: every State field must appear in the snapshot (spec:
+    # "entire state serialized"). A new fold fact that skips the serializer
+    # fails here at the moment it is added, not in a later review round.
+    import dataclasses
+
+    from grind.model import State
+
+    payload = full_state_json(fold([seed_event()]))
+
+    missing = [f.name for f in dataclasses.fields(State) if f.name not in payload]
+    assert missing == []

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -131,3 +131,17 @@ def test_full_state_json_is_json_serializable():
     state = fold(events)
 
     json.dumps(full_state_json(state))  # raises if any value isn't JSON-safe
+
+
+def test_full_state_serializes_attention_ts():
+    events = [
+        seed_event(),
+        event("attention_raised", text="look here"),
+    ]
+    state = fold(events)
+
+    payload = full_state_json(state)
+
+    attention = payload["attention"]
+    assert isinstance(attention, list)
+    assert attention[0]["ts"] == "2026-07-19T00:05:00Z"

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -145,3 +145,21 @@ def test_full_state_serializes_attention_ts():
     attention = payload["attention"]
     assert isinstance(attention, list)
     assert attention[0]["ts"] == "2026-07-19T00:05:00Z"
+
+
+def test_full_state_serializes_round_history():
+    events = [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+    ]
+    state = fold(events)
+
+    payload = full_state_json(state)
+
+    items = payload["items"]
+    assert isinstance(items, dict)
+    assert items["wgclw.1"]["round_history"] == [
+        {"round": 1, "head_sha": "a1", "ts": "2026-07-19T00:05:00Z"}
+    ]

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -113,6 +113,72 @@ def test_log_appends_folds_and_returns_emit_back_envelope(tmp_path: Path):
     assert result["torn_tail"] is None  # intact log -> no repair to surface
 
 
+def test_log_envelope_carries_item_unblocked_on_the_resolving_append(tmp_path: Path):
+    seed = {
+        "title": "Widget grind",
+        "repo": "acme/widgets",
+        "mission": {},
+        "protocols": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "blocker"},
+                    {"id": "wgclw.2", "title": "blocked", "on": ["wgclw.1"]},
+                ],
+            }
+        ],
+    }
+    cmd_create(tmp_path, seed, now=_NOW)
+    cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+    cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": 1}, now=_NOW)
+
+    result = cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
+
+    assert {"condition": "item_unblocked", "item": "wgclw.2"} in result["conditions"]
+
+
+def test_log_envelope_carries_currently_true_level_conditions(tmp_path: Path):
+    _seeded(tmp_path)
+
+    result = cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+    result = cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": 1}, now=_NOW)
+    result = cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
+    result = cmd_log(tmp_path, "item_done", {"item": "wgclw.1"}, now=_NOW)
+
+    assert {"condition": "lane_complete", "lane": "lane-a"} in result["conditions"]
+    assert {"condition": "grind_complete"} in result["conditions"]
+
+
+def test_status_reports_currently_true_level_conditions_but_never_item_unblocked(
+    tmp_path: Path,
+) -> None:
+    seed = {
+        "title": "Widget grind",
+        "repo": "acme/widgets",
+        "mission": {},
+        "protocols": {},
+        "lanes": [
+            {
+                "id": "lane-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "blocker"},
+                    {"id": "wgclw.2", "title": "blocked", "on": ["wgclw.1"]},
+                ],
+            }
+        ],
+    }
+    cmd_create(tmp_path, seed, now=_NOW)
+    cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+    cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": 1}, now=_NOW)
+    cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
+
+    result = cmd_status(tmp_path, full=False, now=_NOW)
+
+    names = {c["condition"] for c in result["conditions"]}
+    assert "item_unblocked" not in names  # transition condition, never from state alone
+
+
 def test_log_surfaces_torn_tail_repair_when_first_writer_after_crash(tmp_path: Path):
     # A crash left the seed line without its trailing newline; `log` is the
     # first writer after the crash. append_event repairs the tail, then folds
@@ -242,7 +308,7 @@ def test_log_rewrites_state_json_after_append(tmp_path: Path):
 def test_status_default_returns_summary(tmp_path: Path):
     _seeded(tmp_path)
 
-    result = cmd_status(tmp_path, full=False)
+    result = cmd_status(tmp_path, full=False, now=_NOW)
 
     assert result["ok"] is True
     assert "state_summary" in result
@@ -252,7 +318,7 @@ def test_status_default_returns_summary(tmp_path: Path):
 def test_status_full_returns_entire_state(tmp_path: Path):
     _seeded(tmp_path)
 
-    result = cmd_status(tmp_path, full=True)
+    result = cmd_status(tmp_path, full=True, now=_NOW)
 
     assert result["ok"] is True
     state = result["state"]


### PR DESCRIPTION
## Summary
- Implements bead agents-config-wgclw.30.5 of the event-sourced grind runtime spec (docs/specs/2026-07-19-event-sourced-grind-runtime.md, emit-back section): a pure conditions engine computing the spec's condition vocabulary outside the fold, keeping `fold` time-independent.
- New `packages/grind/src/grind/conditions.py`: `conditions(state, now)` computes all 7 LEVEL conditions (lane_complete, grind_complete, stale_item, stale_lane, attention_pending, blocked_chain, review_stalemate_risk) from State + an explicit injected `now`; `item_unblocked_conditions(before, after)` computes the TRANSITION condition from a fold delta — provably never from state alone (test-pinned).
- Wired into `cmd_log` (transition + level conditions in the envelope) and `cmd_status` (level only; `cli.py` now injects the wall clock into status too).
- Minimal fold/model extensions carrying the facts conditions need, with no clock in the fold: `State.last_item_ts`/`last_lane_ts` stamps, `AttentionEntry.ts`, `Item.round_history` (per-round last-event-wins head_sha window feeding review_stalemate_risk).
- HARD SEAM: condition names are declarative facts, never imperatives — locked by a test checking every fired name's first word against an imperative-verb set.

## Scope
- In: conditions.py (new), fold.py/model.py (fact-carrying extensions), verbs.py/cli.py (envelope wiring), test_conditions.py (new, 17 tests), test_verbs.py (wiring checks).
- Out: dashboard rendering of conditions (bead 30.3), the `grind check` watchdog (merged, PR #366), any imperative recommendation layer.

## Notes for reviewers
- Evidence field shapes beyond the spec's one worked example (review_stalemate_risk) are additive facts chosen here: `age_seconds`/`since` for staleness, `count`/`oldest_age_seconds` for attention_pending, ordered `chain` for blocked_chain. The spec table names the conditions but not every evidence key; this is deliberate refinement, not drift.
- `stale_lane` is implemented literally per the spec table, which (unlike `stale_item`) has no terminal-status exemption — a fully-done lane can fire `stale_lane`. Known spec seam, flagged for a follow-up decision; please don't treat the literal implementation as a bug.
- `item_unblocked` fires one condition entry per unblocked item on a cascade, consistent with the other list-shaped conditions.
- Ground truth: the runtime spec's emit-back/condition-vocabulary section and `conditions.py`'s module docstring.

## Test Plan
- [x] 17 new condition tests (threshold boundaries via varying `now`, stalemate reset behavior, chain ordering, HARD-SEAM name lock, transition-not-from-state proofs) + envelope wiring tests
- [x] `make ci-grind` green post-rebase onto main (includes PRs #365/#366): ruff, format, mypy --strict, 226 passed, 94.00% coverage, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yKoGZrxEvPQtgVEMc4VFj