### PR TITLE
feat(grind): dashboard render projection over the folded state (wgclw.30.3)

### DIFF
--- a/packages/grind/pyproject.toml
+++ b/packages/grind/pyproject.toml
@@ -61,6 +61,10 @@ select = [
 # NonFiniteJsonError's message names the exact rejected constant -- a
 # self-contained boundary-failure reason, same rationale as the modules above.
 "src/grind/jsonio.py" = ["TRY003"]
+# The dashboard's inline CSS/JS are data (a static template string), not
+# Python code to wrap -- their line lengths follow CSS/JS convention, not
+# this project's line-length rule.
+"src/grind/render.py" = ["E501"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -22,7 +22,7 @@ from typing import NoReturn, TextIO
 from grind.envelope import GrindError
 from grind.jsonio import NonFiniteJsonError, loads
 from grind.model import JsonValue
-from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_status
+from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_render, cmd_status
 
 
 class _RaisingArgumentParser(ArgumentParser):
@@ -57,6 +57,8 @@ def _build_parser() -> _RaisingArgumentParser:
     check_parser = subparsers.add_parser("check", help="staleness probe (exits 1 when stale)")
     check_parser.add_argument("--max-age", default=None, dest="max_age", metavar="DUR")
     check_parser.add_argument("--dir", default=".", metavar="DIR")
+    render_parser = subparsers.add_parser("render", help="refold and re-render dashboard.html only")
+    render_parser.add_argument("--dir", default=".", metavar="DIR")
 
     finish_parser = subparsers.add_parser("finish", help="append grind_finished and final-fold")
     finish_parser.add_argument("--summary", required=True, metavar="TEXT")
@@ -105,11 +107,13 @@ def _dispatch(
 
     if args.verb == "check":
         return cmd_check(grind_dir, args.max_age, now=now)
+    if args.verb == "render":
+        return cmd_render(grind_dir)
 
     if args.verb == "finish":
         return cmd_finish(grind_dir, args.summary, now=now)
 
-    raise GrindError("no verb given; choose one of: create, log, status, check, finish")
+    raise GrindError("no verb given; choose one of: create, log, status, render, check, finish")
 
 
 def _default_now() -> datetime:

--- a/packages/grind/src/grind/derive.py
+++ b/packages/grind/src/grind/derive.py
@@ -43,5 +43,10 @@ def lane_status(state: State, lane: Lane) -> LaneStatus:
 
     # `done` items don't count toward "most advanced ACTIVE state" once the
     # lane still has work left -- otherwise one finished item would flash a
-    # `done` lane while its siblings haven't even started.
-    return max(in_flight, key=lambda item: _RANK[item.status]).status
+    # `done` lane while its siblings haven't even started. `_RANK.get(...,
+    # 0)` degrades an item status outside the closed vocabulary to "no
+    # forward progress" rather than raising: the dashboard renderer spec
+    # requires unknown status values to degrade gracefully, never break the
+    # board, and `ItemStatus` closes the vocabulary only at the type level
+    # -- it is not re-checked at this runtime boundary.
+    return max(in_flight, key=lambda item: _RANK.get(item.status, 0)).status

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -623,6 +623,12 @@ def fold(events: Sequence[Mapping[str, JsonValue]]) -> State:
     state = State()
     for index, raw in enumerate(events):
         evt: RawEvent = dict(raw)
+        # Recorded for every event this loop walks, applied or anomalous --
+        # the renderer's `last_generated` timestamp (dashboard renderer spec)
+        # tracks the log, not any one event's fate.
+        ts = _str(evt, "ts")
+        if ts is not None:
+            state.last_event_ts = ts
         etype = _str(evt, "type")
         if etype == "grind_created" and index != 0:
             # Legal only as the log's first event -- a later creation (even after

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -625,10 +625,9 @@ def fold(events: Sequence[Mapping[str, JsonValue]]) -> State:
         evt: RawEvent = dict(raw)
         # Recorded for every event this loop walks, applied or anomalous --
         # the renderer's `last_generated` timestamp (dashboard renderer spec)
-        # tracks the log, not any one event's fate.
-        ts = _str(evt, "ts")
-        if ts is not None:
-            state.last_event_ts = ts
+        # tracks the log, not any one event's fate. A ts-less tail event
+        # clears the field: no timestamp beats a stale one on the board.
+        state.last_event_ts = _str(evt, "ts")
         etype = _str(evt, "type")
         if etype == "grind_created" and index != 0:
             # Legal only as the log's first event -- a later creation (even after

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -175,6 +175,11 @@ class State:
     resume_checklist: tuple[str, ...] = ()
     finished: bool = False
     finish_summary: str | None = None
+    # The `ts` carried by the last event `fold` walked, whatever its outcome
+    # (applied or anomalous) -- the dashboard renderer's "as fresh as its log,
+    # never fresher" timestamp derives from this, never a wall clock (renderer
+    # spec, "Contract": "the `ts` of the last folded event").
+    last_event_ts: str | None = None
 
     lanes: dict[str, Lane] = field(default_factory=dict)
     items: dict[str, Item] = field(default_factory=dict)

--- a/packages/grind/src/grind/render.py
+++ b/packages/grind/src/grind/render.py
@@ -1,0 +1,705 @@
+"""`State -> dashboard.html`: a pure, deterministic projection.
+
+`render_dashboard` never touches the wall clock or the filesystem -- it is a
+straight `State -> str` function (renderer spec: "a pure function of folded
+state. Same state, same bytes."). All interactivity (lane collapse, the
+auto-refresh toggle, review-detail tooltips) is client-side JS baked into the
+static template below; the only per-render input is the JSON payload spliced
+into the inlined `<script id="grind-dashboard">` block, with every `<` escaped as
+`\\u003c` per the serialization contract (renderer spec, "Contract") so a
+work-item title containing literal HTML can never break out of the block.
+
+The renderer only lays out typed fields already computed by the fold --
+review counts, item/lane status, parking kind -- it never re-derives domain
+facts from prose (renderer spec, "Input"). Two fields the reference prototype
+(`docs/prototypes/grind-dashboard/variation-a.html`) shows but `State` has no
+typed home for are deliberately dropped here rather than invented:
+
+- Per-finding detail (severity/summary/disposition list). `review_verdict`'s
+  payload carries `findings[]`, but the fold (`grind.fold._h_review_verdict`)
+  only derives `open_threads`/`wont_fix_count` from it and does not retain
+  the list on `ItemReview` -- there is nothing to project. The required
+  review affordances (round badge hidden at done, stalemate pill, full-label
+  open-threads pill with a `detail` tooltip, wont-fix count) do not need it.
+- Per-item free-text notes and a `waiting-human` "why" box. `Item` carries no
+  generic `note` field, and item-level "why" text is not stored on the item
+  as an attention entry it (`fold._h_item_waiting_human` folds it into
+  `state.attention`) -- the attention banner already surfaces it, so an
+  item-level echo would be domain re-derivation, not layout. `blocked_note`
+  *is* a typed field and is rendered.
+"""
+
+from __future__ import annotations
+
+import json
+
+from grind.derive import lane_status
+from grind.model import (
+    AttentionEntry,
+    Item,
+    ItemReview,
+    JsonValue,
+    Lane,
+    Observation,
+    PrRef,
+    State,
+)
+
+
+def _pr_json(pr: PrRef | None) -> JsonValue:
+    if pr is None:
+        return None
+    return {"number": pr.number, "url": pr.url}
+
+
+def _review_json(review: ItemReview) -> JsonValue:
+    # `round is None` means no review round has ever landed on this item --
+    # the fold's default `ItemReview()`, not "round zero". Rendering it would
+    # fabricate a badge for work that was never reviewed.
+    if review.round is None:
+        return None
+    return {
+        "round": review.round,
+        "kind": review.kind,
+        "detail": review.detail,
+        "stalemate": review.stalemate,
+        "open_threads": review.open_threads,
+        "wont_fix_count": review.wont_fix_count,
+    }
+
+
+def _item_json(item: Item) -> JsonValue:
+    return {
+        "id": item.id,
+        "title": item.title,
+        "status": item.status,
+        "pr": _pr_json(item.pr),
+        "review": _review_json(item.review),
+        "blocked_on": list(item.blocked_on),
+        "blocked_note": item.blocked_note,
+    }
+
+
+def _lane_json(state: State, lane: Lane) -> JsonValue:
+    queue = [state.items[item_id] for item_id in lane.item_ids if item_id in state.items]
+    return {
+        "id": lane.id,
+        "name": lane.name,
+        "agent": lane.agent,
+        "model": lane.model,
+        "effort": lane.effort,
+        "status": lane_status(state, lane),
+        "queue": [_item_json(item) for item in queue],
+    }
+
+
+def _attention_json(entry: AttentionEntry) -> JsonValue:
+    return {"text": entry.text, "item": entry.item}
+
+
+def _observation_json(obs: Observation) -> JsonValue:
+    return {"ts": obs.ts, "level": obs.level, "message": obs.message, "item": obs.item}
+
+
+def _lesson_json(obs: Observation) -> JsonValue:
+    return {"ts": obs.ts, "message": obs.message, "item": obs.item}
+
+
+def _parking_json(item_id: str, item: Item) -> JsonValue:
+    parked = item.parked
+    kind = parked.kind if parked is not None else None
+    note = parked.note if parked is not None else None
+    return {"id": item_id, "title": item.title, "kind": kind, "note": note}
+
+
+def _dashboard_state_json(state: State) -> dict[str, JsonValue]:
+    return {
+        "title": state.title,
+        "repo": state.repo,
+        "mission": state.mission,
+        "last_generated": state.last_event_ts,
+        "pause": {
+            "paused": state.paused,
+            "reason": state.pause_reason,
+            "resume_checklist": list(state.resume_checklist),
+        },
+        "attention": [_attention_json(a) for a in state.attention],
+        "lanes": [_lane_json(state, lane) for lane in state.lanes.values()],
+        "parking_lot": [_parking_json(i, item) for i, item in state.parking_lot().items()],
+        "observations": [_observation_json(o) for o in state.observations],
+        "lessons": [_lesson_json(o) for o in state.lessons],
+    }
+
+
+def _inline_state_json(payload: dict[str, JsonValue]) -> str:
+    """The serialization contract: a real JSON serializer, every `<` escaped
+    as `\\u003c` -- a raw splice of a work-item title carrying `</script>`
+    would close the block early and execute (renderer spec, "Contract")."""
+    text = json.dumps(payload, sort_keys=True, allow_nan=False)
+    return text.replace("<", "\\u003c")
+
+
+def render_dashboard(state: State) -> str:
+    """The self-contained `dashboard.html` for `state` -- deterministic:
+    same `State`, same bytes (no wall-clock reads anywhere in this path)."""
+    state_json = _inline_state_json(_dashboard_state_json(state))
+    return _PAGE_TEMPLATE.replace("__GRIND_STATE_JSON__", state_json)
+
+
+_STYLE = """
+:root {
+  --bg: #eef0f4; --panel: #ffffff; --panel-2: #f4f6f9; --border: #d3d9e1;
+  --text: #171c24; --text-dim: #4d5766; --accent: #2f5fd6; --red: #c62828;
+  --lane-w: 340px; --lane-w-collapsed: 170px;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 12.5px; line-height: 1.45; padding: 14px 18px 24px;
+}
+a { color: var(--accent); }
+a:focus-visible, button:focus-visible, input:focus-visible + span {
+  outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px;
+}
+.st-queued        { --c: #6e7681; --cbg: rgba(110,118,129,0.13); }
+.st-in-progress   { --c: #2f5fd6; --cbg: rgba(47,95,214,0.12); }
+.st-pr-open       { --c: #7c3aed; --cbg: rgba(124,58,237,0.12); }
+.st-in-review     { --c: #9a6c00; --cbg: rgba(154,108,0,0.13); }
+.st-merged        { --c: #1e8e3e; --cbg: rgba(30,142,62,0.12); }
+.st-done          { --c: #0f7b3f; --cbg: rgba(15,123,63,0.18); }
+.st-blocked       { --c: #c62828; --cbg: rgba(198,40,40,0.12); }
+.st-waiting-human { --c: #b45309; --cbg: rgba(180,83,9,0.13); }
+.st-standing-down { --c: #64748b; --cbg: rgba(100,116,139,0.16); }
+.st-unknown       { --c: #8a94a3; --cbg: rgba(138,148,163,0.14); }
+.icon { vertical-align: -2px; }
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; flex-wrap: wrap; margin-bottom: 12px;
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  padding: 10px 14px;
+}
+.brand { display: flex; align-items: baseline; gap: 10px; min-width: 0; }
+.topbar .mission {
+  flex-basis: 100%; margin: 2px 0 0; color: var(--text-dim); font-size: 12px;
+  line-height: 1.45; max-width: 1000px;
+}
+.topbar .mission.hidden { display: none; }
+.brand .sigil {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-weight: 700; font-size: 11px; letter-spacing: 1px;
+  background: #171c24; color: #fff; border-radius: 4px; padding: 3px 7px;
+}
+h1 {
+  font-size: 17px; margin: 0; font-weight: 650; letter-spacing: 0.1px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.topmeta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.repo-chip, .gen-chip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px; color: var(--text-dim);
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px; padding: 3px 7px;
+}
+.refresh-control {
+  display: flex; align-items: center; gap: 7px;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px;
+}
+.refresh-control label { display: flex; align-items: center; gap: 6px; cursor: pointer; }
+#refresh-status { font-variant-numeric: tabular-nums; min-width: 74px; color: var(--text-dim); }
+#pause-banner, #attention-banner {
+  display: none; border-radius: 8px; padding: 10px 14px; margin-bottom: 12px; border-left-width: 5px;
+}
+#pause-banner.show, #attention-banner.show { display: block; }
+#pause-banner { background: #fff7e6; border: 1px solid #d9a514; color: #6b4e00; }
+#attention-banner { background: #fdeaea; border: 1px solid var(--red); color: #7a1a1a; }
+#pause-banner h2, #attention-banner h2 {
+  margin: 0 0 6px; font-size: 12px; letter-spacing: 1px; text-transform: uppercase;
+}
+#pause-banner h2 { color: #8a6500; }
+#attention-banner h2 { color: var(--red); }
+#pause-banner ol, #attention-banner ul { margin: 0; padding-left: 20px; }
+#pause-banner li, #attention-banner li { margin-bottom: 4px; }
+.attn-item-chip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px;
+  background: #fff; border: 1px solid rgba(198,40,40,0.4); border-radius: 3px;
+  padding: 0 5px; margin-left: 5px;
+}
+.board { display: flex; gap: 10px; overflow-x: auto; align-items: stretch; padding-bottom: 10px; margin-bottom: 14px; }
+.lane {
+  flex: 0 0 var(--lane-w); min-width: var(--lane-w);
+  background: var(--panel); border: 1px solid var(--border); border-top: 3px solid var(--c, var(--border));
+  border-radius: 8px; display: flex; flex-direction: column;
+}
+.lane.collapsed { flex-basis: var(--lane-w-collapsed); min-width: var(--lane-w-collapsed); background: var(--panel-2); }
+.lane-head { display: flex; align-items: center; gap: 7px; padding: 9px 10px 7px; }
+.lane-head .lane-icon { color: var(--c); flex: none; display: inline-flex; }
+.lane-titles { min-width: 0; flex: 1 1 auto; }
+.lane-titles h2 {
+  margin: 0; font-size: 13px; font-weight: 650; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.lane-sub { color: var(--text-dim); font-size: 10.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lane.collapsed .lane-sub { display: none; }
+.lane.collapsed .lane-head .pill { display: none; }
+.lane-toggle {
+  flex: none; border: 1px solid var(--border); background: var(--panel); color: var(--text-dim);
+  border-radius: 5px; width: 22px; height: 22px; cursor: pointer; font-size: 13px; padding: 0;
+}
+.lane-toggle:hover { background: var(--panel-2); color: var(--text); }
+.lane-body { padding: 2px 10px 10px; display: flex; flex-direction: column; gap: 8px; }
+.queue-empty { color: var(--text-dim); font-size: 11.5px; font-style: italic; padding: 4px 2px; }
+.pill {
+  display: inline-flex; align-items: center; gap: 4px; padding: 1px 7px; border-radius: 999px;
+  font-size: 10.5px; font-weight: 600; background: var(--cbg); color: var(--c); white-space: nowrap;
+}
+.pill-round { background: rgba(47,95,214,0.10); color: var(--accent); font-variant-numeric: tabular-nums; }
+.pill-round.is-stalemate { background: rgba(198,40,40,0.12); color: var(--red); }
+.pill-stalemate { background: var(--red); color: #fff; text-transform: uppercase; letter-spacing: 0.6px; font-size: 9.5px; }
+.pill-threads { background: rgba(154,108,0,0.12); color: #9a6c00; cursor: help; border-bottom: 1px dotted #9a6c00; }
+.pill-wontfix { background: rgba(110,118,129,0.14); color: #525c69; }
+.chip {
+  display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px; padding: 1px 6px; border-radius: 4px; border: 1px solid var(--border);
+  background: var(--panel-2); color: var(--text-dim);
+}
+.chip-blocker { border-color: rgba(198,40,40,0.45); color: var(--red); background: rgba(198,40,40,0.07); }
+.kind {
+  font-family: inherit; font-size: 10px; font-weight: 700; letter-spacing: 0.4px;
+  text-transform: uppercase; border-radius: 3px; padding: 2px 6px;
+}
+.kind-discovered-work { background: rgba(15,118,110,0.13); color: #0f766e; }
+.kind-human-gated     { background: rgba(190,18,60,0.11); color: #be123c; }
+.kind-later-wave      { background: rgba(67,56,202,0.11); color: #4338ca; }
+.kind-deferred        { background: rgba(82,82,82,0.13);  color: #525252; }
+.kind-unknown         { background: rgba(138,148,163,0.15); color: #6e7681; }
+.item { border: 1px solid var(--border); border-left: 3px solid var(--c); border-radius: 6px; padding: 7px 9px; background: #fff; }
+.item-top { display: flex; align-items: center; gap: 6px; margin-bottom: 3px; }
+.item-top .icon { color: var(--c); flex: none; }
+.item-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10.5px;
+  color: var(--text-dim); flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.pr-link { font-size: 11px; text-decoration: none; font-variant-numeric: tabular-nums; flex: none; }
+.pr-link:hover { text-decoration: underline; }
+.pr-plain { color: var(--text-dim); font-size: 11px; }
+.item-title { font-weight: 600; font-size: 12px; margin-bottom: 5px; overflow-wrap: break-word; }
+.item-badges { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.item-note { color: var(--text-dim); font-size: 11px; margin-top: 5px; }
+.item-blockers { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px; align-items: center; font-size: 10.5px; color: var(--text-dim); }
+.item-slim { display: flex; align-items: center; gap: 5px; padding: 4px 2px; border-bottom: 1px dashed var(--border); }
+.item-slim:last-child { border-bottom: none; }
+.item-slim .icon { color: var(--c); flex: none; }
+.item-slim .item-id { flex: none; max-width: 62px; }
+.item-slim .t { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; }
+.item-slim .pr-link, .item-slim .pr-plain { font-size: 10.5px; }
+.dock { display: flex; gap: 10px; flex-wrap: wrap; }
+.dock-panel { flex: 1 1 300px; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; }
+.dock-panel h2 {
+  margin: 0 0 8px; font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+  color: var(--text-dim); display: flex; align-items: center; gap: 7px;
+}
+.count-tag {
+  font-size: 10px; font-weight: 700; background: var(--panel-2); border: 1px solid var(--border);
+  color: var(--text-dim); padding: 0 7px; border-radius: 999px;
+}
+.obs-list, .parking-list, .lesson-list { list-style: none; margin: 0; padding: 0; }
+.obs-list { max-height: 170px; overflow-y: auto; }
+.obs-list li {
+  display: flex; gap: 7px; align-items: baseline; padding: 3px 0; border-bottom: 1px dashed rgba(0,0,0,0.06); font-size: 11px;
+}
+.obs-list li:last-child { border-bottom: none; }
+.obs-list .ts {
+  flex: none; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 9.5px; color: #8a94a3;
+}
+.lvl { flex: none; font-size: 9px; font-weight: 800; letter-spacing: 0.5px; border-radius: 3px; padding: 1px 5px; }
+.lvl-INFO { background: rgba(47,95,214,0.11); color: var(--accent); }
+.lvl-WARN { background: rgba(154,108,0,0.13); color: #9a6c00; }
+.lvl-ERROR { background: rgba(198,40,40,0.13); color: var(--red); }
+.lvl-LESSON { background: rgba(15,118,110,0.13); color: #0f766e; }
+.parking-list li {
+  display: flex; gap: 8px; align-items: baseline; padding: 6px 8px; border: 1px solid var(--border);
+  border-radius: 6px; margin-bottom: 6px; background: #fff;
+}
+.parking-list .pt { flex: 1 1 auto; min-width: 0; }
+.parking-list .pt .pid {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; color: var(--text-dim); margin-right: 6px;
+}
+.parking-list .pn { display: block; color: var(--text-dim); font-size: 10.5px; margin-top: 2px; }
+.lesson-list li {
+  padding: 6px 8px; border-left: 3px solid #0f766e; background: rgba(15,118,110,0.06);
+  border-radius: 0 6px 6px 0; margin-bottom: 6px; font-size: 11.5px;
+}
+.lesson-list .lts {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 9.5px; color: #8a94a3; margin-right: 6px;
+}
+.lesson-list .litem {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; color: #0f766e;
+}
+"""
+
+_SCRIPT = """
+"use strict";
+
+var STATE = __GRIND_STATE_JSON__;
+
+var KNOWN_STATUSES = [
+  "queued", "in-progress", "pr-open", "in-review", "merged",
+  "done", "blocked", "waiting-human", "standing-down"
+];
+function statusCls(status) {
+  var k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? "st-" + k : "st-unknown";
+}
+var ICONS = {
+  "queued": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/>',
+  "in-progress": '<circle cx="8" cy="8" r="5.5" fill="none" stroke="currentColor" stroke-width="2"/>' +
+    '<path d="M8 2.5A5.5 5.5 0 0 1 8 13.5Z" fill="currentColor"/>',
+  "pr-open": '<circle cx="5" cy="4.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/>' +
+    '<circle cx="5" cy="11.5" r="2" fill="none" stroke="currentColor" stroke-width="1.8"/>' +
+    '<circle cx="11" cy="8" r="2" fill="currentColor"/>' +
+    '<path d="M5 6.5v3M6.8 8h2.2" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "in-review": '<path d="M1.8 8C4 4.8 12 4.8 14.2 8 12 11.2 4 11.2 1.8 8Z" fill="none" ' +
+    'stroke="currentColor" stroke-width="1.8"/><circle cx="8" cy="8" r="1.9" fill="currentColor"/>',
+  "merged": '<circle cx="5" cy="4" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/>' +
+    '<circle cx="5" cy="12" r="1.9" fill="none" stroke="currentColor" stroke-width="1.7"/>' +
+    '<circle cx="11.5" cy="12" r="1.9" fill="currentColor"/>' +
+    '<path d="M5 6v4M5 9.5c0 1.6 2 1 4 1.4" fill="none" stroke="currentColor" stroke-width="1.6"/>',
+  "done": '<circle cx="8" cy="8" r="6.4" fill="currentColor"/>' +
+    '<path d="M5.1 8.3l2 2 3.8-4.2" fill="none" stroke="#ffffff" stroke-width="1.9" ' +
+    'stroke-linecap="round" stroke-linejoin="round"/>',
+  "blocked": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/>' +
+    '<path d="M4.2 11.8 11.8 4.2" stroke="currentColor" stroke-width="2"/>',
+  "waiting-human": '<circle cx="8" cy="5" r="2.5" fill="currentColor"/>' +
+    '<path d="M3.2 13.4c.4-2.8 2.4-4.2 4.8-4.2s4.4 1.4 4.8 4.2" fill="none" ' +
+    'stroke="currentColor" stroke-width="2" stroke-linecap="round"/>',
+  "standing-down": '<path d="M4.5 14V2.6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>' +
+    '<path d="M4.5 3.2h7.6l-2.2 2.9 2.2 2.9H4.5Z" fill="currentColor"/>',
+  "unknown": '<circle cx="8" cy="8" r="5.8" fill="none" stroke="currentColor" stroke-width="2"/>' +
+    '<path d="M6.4 6.3c.3-1.1 1-1.7 1.7-1.7 1 0 1.7.6 1.7 1.5 0 1.3-1.7 1.5-1.7 2.8" fill="none" ' +
+    'stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>' +
+    '<circle cx="8.1" cy="11.5" r="1" fill="currentColor"/>'
+};
+function iconName(status) {
+  var k = String(status || "").toLowerCase();
+  return KNOWN_STATUSES.indexOf(k) >= 0 ? k : "unknown";
+}
+function iconSvg(status, size) {
+  var s = size || 14;
+  return '<svg class="icon" width="' + s + '" height="' + s + '" viewBox="0 0 16 16" ' +
+    'aria-hidden="true" focusable="false">' + (ICONS[iconName(status)] || ICONS.unknown) + '</svg>';
+}
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+  });
+}
+function text(s) { return s === null || s === undefined ? "" : String(s); }
+
+function safeHref(url) {
+  try {
+    var scheme = new URL(url, "https://github.com").protocol;
+    return (scheme === "https:" || scheme === "http:") ? url : null;
+  } catch (e) { return null; }
+}
+// Explicit `pr.url` wins (scheme-checked); else derive from the repo slug;
+// else no link at all -- plain-text number (renderer spec, "Contract").
+function prUrl(pr, repo) {
+  if (!pr) return null;
+  if (typeof pr.url === "string" && pr.url.trim() !== "") {
+    var safe = safeHref(pr.url.trim());
+    if (safe) return safe;
+  }
+  if (repo) return "https://github.com/" + repo + "/pull/" + pr.number;
+  return null;
+}
+function prLink(pr, repo) {
+  if (!pr || pr.number === null || pr.number === undefined) return "";
+  var url = prUrl(pr, repo);
+  var label = "#" + escapeHtml(pr.number);
+  return url
+    ? '<a class="pr-link" href="' + escapeHtml(url) + '" target="_blank" rel="noopener">' + label + '</a>'
+    : '<span class="pr-plain">' + label + '</span>';
+}
+
+// Round badge hides at `done` (a high round count survives as a LESSON, not
+// a badge on finished work); open-threads reads as a full label with the
+// review detail as its tooltip; wont-fix rides its own pill.
+function reviewBits(review, itemStatus) {
+  if (!review) return "";
+  var out = "";
+  var stale = !!review.stalemate;
+  if (String(itemStatus).toLowerCase() !== "done") {
+    out += '<span class="pill pill-round' + (stale ? " is-stalemate" : "") + '">' +
+      escapeHtml(review.kind || "review") + " \\u00b7 round " + (Number(review.round) || 0) + "</span>";
+  }
+  if (stale) out += '<span class="pill pill-stalemate">stalemate</span>';
+  var n = Number(review.open_threads) || 0;
+  if (n > 0) {
+    var label = n === 1 ? "1 open thread" : n + " open threads";
+    var tip = review.detail ? ' title="' + escapeHtml(review.detail) + '"' : "";
+    out += '<span class="pill pill-threads"' + tip + ">" + label + "</span>";
+  }
+  var wf = Number(review.wont_fix_count) || 0;
+  if (wf > 0) out += '<span class="pill pill-wontfix">' + wf + (wf === 1 ? " wont-fix" : " wont-fix items") + "</span>";
+  return out;
+}
+
+var KNOWN_KINDS = ["discovered-work", "human-gated", "later-wave", "deferred"];
+function kindChip(kind) {
+  var k = String(kind || "").toLowerCase();
+  var cls = KNOWN_KINDS.indexOf(k) >= 0 ? "kind-" + k : "kind-unknown";
+  return '<span class="kind ' + cls + '">' + escapeHtml(kind || "unknown") + "</span>";
+}
+
+// Mission is a typed JsonValue, not guaranteed to be a plain string --
+// render whatever shape it is without parsing its prose.
+function missionText(m) {
+  if (typeof m === "string") return m;
+  if (m && typeof m === "object") {
+    if (typeof m.goal === "string") {
+      var oos = typeof m.out_of_scope === "string" ? " Out of scope: " + m.out_of_scope : "";
+      return m.goal + oos;
+    }
+    try { return JSON.stringify(m); } catch (e) { return ""; }
+  }
+  return "";
+}
+
+// ---- per-lane collapse, persisted; a `done` lane auto-collapses by default ----
+var LS_COLLAPSE = "grind.dashboard.collapsed.v1";
+var collapsePrefs = {};
+try { collapsePrefs = JSON.parse(localStorage.getItem(LS_COLLAPSE) || "{}") || {}; }
+catch (e) { collapsePrefs = {}; }
+function isCollapsed(lane) {
+  if (Object.prototype.hasOwnProperty.call(collapsePrefs, lane.id)) return !!collapsePrefs[lane.id];
+  return String(lane.status).toLowerCase() === "done";
+}
+function toggleLane(id) {
+  var lane = (STATE.lanes || []).find(function (l) { return l.id === id; });
+  if (!lane) return;
+  collapsePrefs[id] = !isCollapsed(lane);
+  try { localStorage.setItem(LS_COLLAPSE, JSON.stringify(collapsePrefs)); } catch (e) { /* no-op */ }
+  renderBoard();
+}
+
+function renderItemExpanded(q) {
+  var cls = statusCls(q.status);
+  var html = '<article class="item ' + cls + '">' +
+    '<div class="item-top">' + iconSvg(q.status) +
+    '<span class="item-id">' + escapeHtml(q.id) + "</span>" + prLink(q.pr, STATE.repo) + "</div>" +
+    '<div class="item-title">' + escapeHtml(text(q.title) || q.id) + "</div>" +
+    '<div class="item-badges"><span class="pill ' + cls + '">' + escapeHtml(q.status) + "</span>" +
+    reviewBits(q.review, q.status) + "</div>";
+  if (q.blocked_note) html += '<div class="item-note">' + escapeHtml(q.blocked_note) + "</div>";
+  if (q.blocked_on && q.blocked_on.length) {
+    html += '<div class="item-blockers">blocked on ' +
+      q.blocked_on.map(function (b) {
+        return '<span class="chip chip-blocker">' + escapeHtml(b) + "</span>";
+      }).join(" ") + "</div>";
+  }
+  return html + "</article>";
+}
+
+// Collapsed anatomy: status icon + work-item id + title + PR# only.
+function renderItemSlim(q) {
+  return '<div class="item-slim ' + statusCls(q.status) + '">' + iconSvg(q.status, 12) +
+    '<span class="item-id">' + escapeHtml(q.id) + "</span>" +
+    '<span class="t" title="' + escapeHtml(text(q.title) || q.id) + '">' +
+    escapeHtml(text(q.title) || q.id) + "</span>" + prLink(q.pr, STATE.repo) + "</div>";
+}
+
+function renderBoard() {
+  var board = document.getElementById("board");
+  board.innerHTML = "";
+  (STATE.lanes || []).forEach(function (lane) {
+    var collapsed = isCollapsed(lane);
+    var cls = statusCls(lane.status);
+    var sec = document.createElement("section");
+    sec.className = "lane " + cls + (collapsed ? " collapsed" : "");
+    sec.setAttribute("aria-label", text(lane.name) || lane.id);
+    var bodyId = "lane-body-" + lane.id;
+    var items = lane.queue || [];
+    var body = items.length
+      ? items.map(function (q) { return collapsed ? renderItemSlim(q) : renderItemExpanded(q); }).join("")
+      : '<div class="queue-empty">queue empty</div>';
+    sec.innerHTML =
+      '<header class="lane-head">' +
+      '<span class="lane-icon">' + iconSvg(lane.status, 16) + "</span>" +
+      '<div class="lane-titles"><h2>' + escapeHtml(text(lane.name) || lane.id) + "</h2>" +
+      '<div class="lane-sub">' + escapeHtml(text(lane.agent)) + " \\u00b7 " +
+      escapeHtml(text(lane.model)) + " \\u00b7 " + escapeHtml(text(lane.effort)) + " effort</div></div>" +
+      '<span class="pill ' + cls + '">' + escapeHtml(lane.status) + "</span>" +
+      '<button type="button" class="lane-toggle" aria-expanded="' + (collapsed ? "false" : "true") + '" ' +
+      'aria-controls="' + bodyId + '" title="' + (collapsed ? "Expand " : "Collapse ") +
+      escapeHtml(text(lane.name) || lane.id) + '" data-lane="' + escapeHtml(lane.id) + '">' +
+      (collapsed ? "\\u00bb" : "\\u00ab") + "</button>" +
+      "</header>" +
+      '<div class="lane-body" id="' + bodyId + '">' + body + "</div>";
+    board.appendChild(sec);
+  });
+  board.querySelectorAll(".lane-toggle").forEach(function (btn) {
+    btn.addEventListener("click", function () { toggleLane(btn.getAttribute("data-lane")); });
+  });
+}
+
+function renderDock() {
+  var obs = (STATE.observations || []).slice().reverse();
+  document.getElementById("obs-count").textContent = obs.length;
+  document.getElementById("obs-list").innerHTML = obs.map(function (o) {
+    return "<li><span class='ts'>" + escapeHtml(text(o.ts).replace("T", " ")) + "</span>" +
+      '<span class="lvl lvl-' + escapeHtml(o.level || "INFO") + '">' + escapeHtml(o.level || "INFO") + "</span>" +
+      "<span>" + escapeHtml(o.message) +
+      (o.item ? ' <span class="chip">' + escapeHtml(o.item) + "</span>" : "") + "</span></li>";
+  }).join("");
+
+  var parked = STATE.parking_lot || [];
+  document.getElementById("park-count").textContent = parked.length;
+  document.getElementById("parking-list").innerHTML = parked.map(function (p) {
+    return "<li>" + kindChip(p.kind) +
+      '<span class="pt"><span class="pid">' + escapeHtml(p.id) + "</span>" + escapeHtml(text(p.title) || p.id) +
+      (p.note ? '<span class="pn">' + escapeHtml(p.note) + "</span>" : "") + "</span></li>";
+  }).join("");
+
+  var lessons = STATE.lessons || [];
+  document.getElementById("lesson-count").textContent = lessons.length;
+  document.getElementById("lesson-list").innerHTML = lessons.map(function (l) {
+    return "<li><span class='lts'>" + escapeHtml(text(l.ts)) + "</span>" +
+      (l.item ? '<span class="litem">' + escapeHtml(l.item) + "</span> " : "") +
+      escapeHtml(l.message) + "</li>";
+  }).join("");
+}
+
+function render() {
+  document.title = (STATE.title || "Grind") + " \\u2014 Control Room";
+  document.getElementById("title").textContent = STATE.title || "Grind";
+  document.getElementById("repo").textContent = STATE.repo || "no repo slug";
+  document.getElementById("last-generated").textContent = "log @ " + (STATE.last_generated || "\\u2014");
+
+  var missionEl = document.getElementById("mission");
+  var mission = missionText(STATE.mission);
+  if (mission) { missionEl.textContent = mission; missionEl.classList.remove("hidden"); }
+  else { missionEl.classList.add("hidden"); }
+
+  var pause = STATE.pause;
+  var pb = document.getElementById("pause-banner");
+  if (pause && pause.paused) {
+    pb.classList.add("show");
+    document.getElementById("pause-reason").textContent = pause.reason || "";
+    document.getElementById("pause-checklist").innerHTML =
+      (pause.resume_checklist || []).map(function (c) { return "<li>" + escapeHtml(c) + "</li>"; }).join("");
+  } else { pb.classList.remove("show"); }
+
+  var attn = STATE.attention || [];
+  var ab = document.getElementById("attention-banner");
+  var al = document.getElementById("attention-list");
+  if (attn.length) {
+    ab.classList.add("show");
+    al.innerHTML = attn.map(function (a) {
+      return "<li>" + escapeHtml(a.text) +
+        (a.item ? '<span class="attn-item-chip">' + escapeHtml(a.item) + "</span>" : "") + "</li>";
+    }).join("");
+  } else { ab.classList.remove("show"); al.innerHTML = ""; }
+
+  renderBoard();
+  renderDock();
+}
+
+render();
+
+// ---- auto-refresh: 15s, visible toggle, persisted ----
+var REFRESH_SECONDS = 15;
+var LS_REFRESH = "grind.dashboard.autorefresh.v1";
+var toggle = document.getElementById("refresh-toggle");
+var statusEl = document.getElementById("refresh-status");
+var countdown = REFRESH_SECONDS, tickTimer = null;
+function updateStatusText() { statusEl.textContent = toggle.checked ? ("on \\u2014 " + countdown + "s") : "off"; }
+function startTicking() {
+  if (tickTimer) clearInterval(tickTimer);
+  countdown = REFRESH_SECONDS;
+  updateStatusText();
+  tickTimer = setInterval(function () {
+    countdown -= 1;
+    if (countdown <= 0) { location.reload(); return; }
+    updateStatusText();
+  }, 1000);
+}
+function stopTicking() {
+  if (tickTimer) clearInterval(tickTimer);
+  tickTimer = null;
+  updateStatusText();
+}
+var savedRefresh = null;
+try { savedRefresh = localStorage.getItem(LS_REFRESH); } catch (e) { savedRefresh = null; }
+toggle.checked = savedRefresh === null ? true : savedRefresh === "true";
+toggle.addEventListener("change", function () {
+  try { localStorage.setItem(LS_REFRESH, toggle.checked ? "true" : "false"); } catch (e) { /* no-op */ }
+  if (toggle.checked) startTicking(); else stopTicking();
+});
+if (toggle.checked) startTicking(); else stopTicking();
+"""
+
+_PAGE_TEMPLATE = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Grind — Control Room</title>
+<style>{_STYLE}</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="brand">
+    <span class="sigil">GRIND</span>
+    <h1 id="title">Grind</h1>
+  </div>
+  <div class="topmeta">
+    <span class="repo-chip" id="repo"></span>
+    <span class="gen-chip" id="last-generated"
+      title="Timestamp of the last folded event -- the board is as fresh as its log, never fresher."></span>
+    <div class="refresh-control">
+      <label><input type="checkbox" id="refresh-toggle"><span>auto-refresh</span></label>
+      <span id="refresh-status">off</span>
+    </div>
+  </div>
+  <p class="mission hidden" id="mission"></p>
+</header>
+
+<div id="pause-banner" role="status">
+  <h2>⏸ Grind paused</h2>
+  <p class="reason" id="pause-reason"></p>
+  <ol id="pause-checklist"></ol>
+</div>
+
+<div id="attention-banner" role="alert">
+  <h2>⚠ Attention — needs the human</h2>
+  <ul id="attention-list"></ul>
+</div>
+
+<main class="board" id="board" aria-label="Lanes"></main>
+
+<div class="dock">
+  <section class="dock-panel" aria-label="Observations">
+    <h2>Observations <span class="count-tag" id="obs-count">0</span></h2>
+    <ul class="obs-list" id="obs-list"></ul>
+  </section>
+  <section class="dock-panel" aria-label="Parking lot">
+    <h2>Parking lot <span class="count-tag" id="park-count">0</span></h2>
+    <ul class="parking-list" id="parking-list"></ul>
+  </section>
+  <section class="dock-panel" aria-label="Lessons learned">
+    <h2>Lessons learned <span class="count-tag" id="lesson-count">0</span></h2>
+    <ul class="lesson-list" id="lesson-list"></ul>
+  </section>
+</div>
+
+<script id="grind-dashboard">
+// SERIALIZATION CONTRACT: every less-than sign in the STATE literal below is
+// escaped as \\u003c before splicing, exactly as `grind render` emits it --
+// a raw splice of a work-item title carrying `</script>` would close this
+// block early and execute.
+{_SCRIPT}
+</script>
+
+</body>
+</html>
+"""

--- a/packages/grind/src/grind/render.py
+++ b/packages/grind/src/grind/render.py
@@ -396,8 +396,11 @@ function text(s) { return s === null || s === undefined ? "" : String(s); }
 
 function safeHref(url) {
   try {
-    var scheme = new URL(url, "https://github.com").protocol;
-    return (scheme === "https:" || scheme === "http:") ? url : null;
+    // Return the RESOLVED href, not the input: a relative override like
+    // "/org/repo/pull/7" passes the scheme check via the GitHub base but
+    // would otherwise resolve against this file:// page when clicked.
+    var resolved = new URL(url, "https://github.com");
+    return (resolved.protocol === "https:" || resolved.protocol === "http:") ? resolved.href : null;
   } catch (e) { return null; }
 }
 // Explicit `pr.url` wins (scheme-checked); else derive from the repo slug;

--- a/packages/grind/src/grind/render.py
+++ b/packages/grind/src/grind/render.py
@@ -516,7 +516,7 @@ function renderBoard() {
     var sec = document.createElement("section");
     sec.className = "lane " + cls + (collapsed ? " collapsed" : "");
     sec.setAttribute("aria-label", text(lane.name) || lane.id);
-    var bodyId = "lane-body-" + lane.id;
+    var bodyId = "lane-body-" + escapeHtml(lane.id);
     var items = lane.queue || [];
     var body = items.length
       ? items.map(function (q) { return collapsed ? renderItemSlim(q) : renderItemExpanded(q); }).join("")
@@ -695,8 +695,8 @@ _PAGE_TEMPLATE = f"""<!DOCTYPE html>
 <script id="grind-dashboard">
 // SERIALIZATION CONTRACT: every less-than sign in the STATE literal below is
 // escaped as \\u003c before splicing, exactly as `grind render` emits it --
-// a raw splice of a work-item title carrying `</script>` would close this
-// block early and execute.
+// a raw splice of a work-item title carrying `\\u003c/script>` would close
+// this block early and execute (the `<` is escaped here for the same reason).
 {_SCRIPT}
 </script>
 

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -141,6 +141,7 @@ def full_state_json(state: State) -> dict[str, JsonValue]:
         "resume_checklist": list(state.resume_checklist),
         "finished": state.finished,
         "finish_summary": state.finish_summary,
+        "last_event_ts": state.last_event_ts,
         "lanes": {lane_id: _lane_json(state, lane) for lane_id, lane in state.lanes.items()},
         "items": {item_id: _item_json(item) for item_id, item in state.items.items()},
         "attention": [_attention_json(a) for a in state.attention],

--- a/packages/grind/src/grind/store.py
+++ b/packages/grind/src/grind/store.py
@@ -21,6 +21,7 @@ from grind.model import JsonValue, RawEvent, State
 EVENTS_FILENAME = "events.jsonl"
 QUARANTINE_FILENAME = "events.quarantine"
 STATE_FILENAME = "state.json"
+DASHBOARD_FILENAME = "dashboard.html"
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,10 @@ def quarantine_path(dir_: Path) -> Path:
 
 def state_path(dir_: Path) -> Path:
     return dir_ / STATE_FILENAME
+
+
+def dashboard_path(dir_: Path) -> Path:
+    return dir_ / DASHBOARD_FILENAME
 
 
 def read_raw_log(dir_: Path) -> str:
@@ -131,3 +136,8 @@ def write_state(dir_: Path, payload: dict[str, JsonValue]) -> None:
     with state_path(dir_).open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=2, sort_keys=True, allow_nan=False)
         fh.write("\n")
+
+
+def write_dashboard(dir_: Path, html: str) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    dashboard_path(dir_).write_text(html, encoding="utf-8")

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -19,13 +19,16 @@ from grind.envelope import GrindError
 from grind.fold import fold
 from grind.model import DEFAULT_CONFIG, AnomalyRecord, JsonValue, RawEvent, State
 from grind.payloads import validate_payload
+from grind.render import render_dashboard
 from grind.serialize import anomaly_json, full_state_json, summarize
 from grind.store import (
     TornTailRepair,
     append_event,
+    dashboard_path,
     fold_dir,
     is_log_nonempty,
     load_events,
+    write_dashboard,
     write_state,
 )
 
@@ -159,6 +162,7 @@ def _append_and_persist(dir_: Path, event: RawEvent) -> tuple[State, TornTailRep
     repair = append_event(dir_, event)
     state = fold_dir(dir_)
     write_state(dir_, full_state_json(state))
+    write_dashboard(dir_, render_dashboard(state))
     return state, repair
 
 
@@ -252,6 +256,14 @@ def cmd_check(dir_: Path, max_age: str | None, *, now: Clock) -> dict[str, JsonV
         "paused": state.paused,
         "finished": state.finished,
     }
+
+
+def cmd_render(dir_: Path) -> dict[str, JsonValue]:
+    """`grind render` (spec CLI contract table): refolds and re-renders
+    `dashboard.html` only -- no event is appended, `state.json` is untouched."""
+    state = fold_dir(dir_)
+    write_dashboard(dir_, render_dashboard(state))
+    return {"ok": True, "path": str(dashboard_path(dir_))}
 
 
 def cmd_finish(dir_: Path, summary: str, *, now: Clock) -> dict[str, JsonValue]:

--- a/packages/grind/tests/unit/test_cli.py
+++ b/packages/grind/tests/unit/test_cli.py
@@ -220,6 +220,21 @@ def test_check_verb_empty_log_yields_error_envelope_and_nonzero_exit(tmp_path: P
     assert envelope["ok"] is False
 
 
+def test_render_verb(tmp_path: Path):
+    grind_dir = tmp_path / "run"
+    _run(
+        ["create", "--file", "seed.json", "--dir", str(grind_dir)],
+        read_file={"seed.json": json.dumps(_SEED)},
+    )
+
+    exit_code, envelope, _err = _run(["render", "--dir", str(grind_dir)])
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert envelope["path"] == str(grind_dir / "dashboard.html")
+    assert (grind_dir / "dashboard.html").exists()
+
+
 def test_finish_verb(tmp_path: Path):
     grind_dir = tmp_path / "run"
     _run(

--- a/packages/grind/tests/unit/test_fold_grind_lifecycle.py
+++ b/packages/grind/tests/unit/test_fold_grind_lifecycle.py
@@ -70,3 +70,18 @@ def test_second_grind_finished_is_also_rejected() -> None:
 
     assert state.finish_summary == "done"
     assert len(state.anomalies) == 1
+
+
+def test_ts_less_tail_event_clears_last_event_ts() -> None:
+    # A JSON-valid tail event with no usable ts must clear the freshness
+    # field: the board shows no timestamp rather than the previous event's,
+    # which would misdate a state that includes the newer tail event.
+    events = [
+        seed_event(),
+        event("observation", level="INFO", message="stamped"),
+        {"type": "observation", "level": "INFO", "message": "no ts at all"},
+    ]
+
+    state = fold(events)
+
+    assert state.last_event_ts is None

--- a/packages/grind/tests/unit/test_render.py
+++ b/packages/grind/tests/unit/test_render.py
@@ -1,0 +1,128 @@
+"""`grind.render`: `State -> dashboard.html` -- PR-link derivation order,
+unknown-status degradation, empty-state edges, and the pure-function
+(determinism) guarantee. The CI smoke test over a rich fixture lives in
+`test_render_dashboard_smoke.py`."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from grind.fold import fold
+from grind.model import Item, ItemStatus, Lane, PrRef, State
+from grind.render import render_dashboard
+
+from .builders import event, seed_event
+
+
+def _state_with_item(item: Item) -> State:
+    """A minimally-seeded `State` with `item` filed under one lane -- the
+    renderer only projects items reachable via `lane.item_ids` (mirroring the
+    fold), so a bare `state.items[...]` assignment with no lane membership
+    would silently never appear on the board."""
+    state = State(seeded=True, title="t", repo="acme/widgets")
+    state.lanes["lane-a"] = Lane(id="lane-a", name="Lane A", item_ids=[item.id])
+    state.items[item.id] = item
+    return state
+
+
+def _state_json_blob(html: str) -> str:
+    """The literal JSON payload text between `var STATE = ` and the next
+    statement -- the exact substring the serialization contract governs."""
+    start = html.index("var STATE = ") + len("var STATE = ")
+    end = html.index(";\n\nvar KNOWN_STATUSES", start)
+    return html[start:end]
+
+
+# -- determinism ---------------------------------------------------------
+
+
+def test_render_is_a_pure_function_of_state():
+    events = [seed_event(), event("item_started", item="wgclw.1")]
+
+    html_a = render_dashboard(fold(events))
+    html_b = render_dashboard(fold(events))
+
+    assert html_a == html_b
+
+
+# -- PR-link derivation order ---------------------------------------------
+
+
+def _item_with_pr(pr: PrRef | None) -> Item:
+    return Item(id="wgclw.1", lane="lane-a", title="Item", status="pr-open", pr=pr)
+
+
+def test_pr_link_prefers_explicit_url_over_repo_derivation():
+    item = _item_with_pr(PrRef(number=7, url="https://example.com/pr/7"))
+    html = render_dashboard(_state_with_item(item))
+
+    blob = _state_json_blob(html)
+    assert '"url": "https://example.com/pr/7"' in blob
+    assert '"number": 7' in blob
+
+
+def test_pr_link_falls_back_to_repo_slug_when_no_explicit_url():
+    item = _item_with_pr(PrRef(number=9, url=None))
+    html = render_dashboard(_state_with_item(item))
+
+    blob = _state_json_blob(html)
+    assert '"url": null' in blob
+    assert '"number": 9' in blob
+    # The renderer emits the raw PR fields; repo-slug derivation is a
+    # client-side concern (`prUrl` in the inlined script) -- assert the
+    # function that performs it ships in the page.
+    assert "function prUrl(pr, repo)" in html
+    assert 'repo) return "https://github.com/" + repo + "/pull/" + pr.number;' in html
+
+
+def test_pr_absent_when_item_has_no_pr():
+    item = _item_with_pr(None)
+    html = render_dashboard(_state_with_item(item))
+
+    blob = _state_json_blob(html)
+    assert '"pr": null' in blob
+
+
+# -- unknown-status degradation --------------------------------------------
+
+
+def test_unknown_item_status_passes_through_without_raising():
+    item = Item(
+        id="wgclw.1",
+        lane="lane-a",
+        title="Weird",
+        status=cast("ItemStatus", "totally-unrecognized"),
+    )
+    state = _state_with_item(item)
+
+    html = render_dashboard(state)  # must not raise
+
+    blob = _state_json_blob(html)
+    assert "totally-unrecognized" in blob
+    # The client-side fallback path exists so an unrecognized value still
+    # renders neutrally rather than breaking the board.
+    assert "st-unknown" in html
+    assert "ICONS.unknown" in html
+
+
+# -- empty-state edges ------------------------------------------------------
+
+
+def test_renders_with_no_lanes_no_attention_no_lessons():
+    state = State(seeded=True, title="Empty grind", repo="acme/widgets")
+
+    html = render_dashboard(state)
+
+    blob = _state_json_blob(html)
+    assert '"lanes": []' in blob
+    assert '"attention": []' in blob
+    assert '"lessons": []' in blob
+    assert '"parking_lot": []' in blob
+
+
+def test_review_omitted_when_item_has_never_been_reviewed():
+    item = Item(id="wgclw.1", lane="lane-a", title="Fresh", status="queued")
+    html = render_dashboard(_state_with_item(item))
+
+    blob = _state_json_blob(html)
+    assert '"review": null' in blob

--- a/packages/grind/tests/unit/test_render_dashboard_smoke.py
+++ b/packages/grind/tests/unit/test_render_dashboard_smoke.py
@@ -1,0 +1,262 @@
+"""CI smoke test for `grind render` (renderer spec, "Testing"): a State built
+from a rich event log exercising every status, every parking kind, an active
+review, a stalemate, and a paused grind -- the same scenario shape as
+`docs/prototypes/grind-dashboard/fixture-state.json`, adapted into a real
+folded `State` rather than a hand-authored display blob (the renderer's only
+legal input, per its contract, is `State`; it never reads `events.jsonl` or a
+display-shaped fixture directly).
+
+Asserts (per spec): byte-stable output across two folds of the same log, no
+unescaped `<` inside the inlined state block, and every status icon / kind
+chip / required panel is present -- string/DOM-level, not a screenshot.
+"""
+
+from __future__ import annotations
+
+from grind.fold import fold
+from grind.model import JsonValue, RawEvent
+from grind.render import render_dashboard
+
+_SCRIPT_PROBE_TITLE = 'Serializer probe: "</script>" must render as inert text, never execute'
+_LONG_TITLE = "A very long work-item title that keeps going " * 4  # >100 chars, exercises overflow
+
+_SEED: RawEvent = {
+    "title": "Discipline-Layer Grind — smoke",
+    "repo": "acme/widgets",
+    "mission": {"goal": "Ship the grind dashboard", "out_of_scope": "Nothing else this round"},
+    "protocols": {},
+    "lanes": [
+        {
+            "id": "lane-flow",
+            "name": "Lane One — mainline flow",
+            "agent": "lt-one",
+            "model": "opus",
+            "effort": "high",
+            "queue": [
+                {"id": "item-queued", "title": "Queued item"},
+                {"id": "item-inprogress", "title": "In progress item"},
+                {"id": "item-pr-open", "title": "PR open item"},
+                {"id": "item-in-review", "title": "In review item"},
+                {"id": "item-merged", "title": "Merged item"},
+                {"id": "item-done", "title": "Done item"},
+            ],
+        },
+        {
+            "id": "lane-blockers",
+            "name": "Lane Two — blockers & human gates",
+            "agent": "lt-two",
+            "model": "sonnet",
+            "effort": "medium",
+            "queue": [
+                {"id": "item-blocked", "title": "Blocked item", "on": ["item-queued"]},
+                {"id": "item-waiting", "title": "Waiting on human item"},
+                {"id": "item-stalemate", "title": "Stalemate item"},
+            ],
+        },
+        {
+            "id": "lane-parking-source",
+            "name": "Lane Three — parking source",
+            "agent": "lt-three",
+            "queue": [
+                {"id": "park-discovered", "title": "Discovered work candidate"},
+                {"id": "park-human", "title": "Human-gated candidate"},
+                {"id": "park-later", "title": "Later-wave candidate"},
+                {"id": "park-deferred", "title": "Deferred candidate"},
+            ],
+        },
+        {"id": "lane-standing-down", "name": "Lane Four — standing down", "agent": "lt-four"},
+        {"id": "lane-idle", "name": "Lane Five — idle", "agent": "lt-five"},
+        {
+            "id": "lane-edges",
+            "name": "Lane Six — edge-case titles",
+            "agent": "lt-six",
+            "queue": [
+                {"id": "item-long-title", "title": _LONG_TITLE},
+                {"id": "item-script-probe", "title": _SCRIPT_PROBE_TITLE},
+            ],
+        },
+    ],
+}
+
+
+def _events() -> list[RawEvent]:
+    def e(evt_type: str, **fields: JsonValue) -> RawEvent:
+        return {"ts": "2026-07-19T00:00:00Z", "type": evt_type, **fields}
+
+    return [
+        {"ts": "2026-07-19T00:00:00Z", "type": "grind_created", **_SEED},
+        e("item_started", item="item-inprogress"),
+        e("item_started", item="item-pr-open"),
+        e("pr_opened", item="item-pr-open", pr=101),
+        e("item_started", item="item-in-review"),
+        e("pr_opened", item="item-in-review", pr=102),
+        e(
+            "review_verdict",
+            item="item-in-review",
+            kind="codex",
+            round=2,
+            head_sha="abc123",
+            verdict="findings",
+            detail="round 2: one deferred, one wont-fix",
+            findings=[
+                {"severity": "medium", "summary": "needs a follow-up", "disposition": "deferred"},
+                {"severity": "low", "summary": "tolerated by design", "disposition": "wont-fix"},
+            ],
+        ),
+        e("item_started", item="item-merged"),
+        e("pr_opened", item="item-merged", pr=103),
+        e("item_merged", item="item-merged", pr=103, sha="deadbeef"),
+        e("item_started", item="item-done"),
+        e("pr_opened", item="item-done", pr=104),
+        e("item_merged", item="item-done", pr=104, sha="cafebabe"),
+        e("item_done", item="item-done"),
+        e("item_blocked", item="item-blocked", on=["item-queued"], note="waiting on item-queued"),
+        e("item_started", item="item-waiting"),
+        e("item_waiting_human", item="item-waiting", why="need a merge ruling"),
+        e("item_started", item="item-stalemate"),
+        e("pr_opened", item="item-stalemate", pr=105),
+        e(
+            "review_verdict",
+            item="item-stalemate",
+            kind="codex",
+            round=4,
+            head_sha="xyz789",
+            verdict="stalemate",
+            detail="round 4 re-raised on an unchanged head",
+        ),
+        e("lane_standing_down", lane="lane-standing-down"),
+        e(
+            "item_parked",
+            item="park-discovered",
+            kind="discovered-work",
+            note="surfaced during review",
+        ),
+        e("item_parked", item="park-human", kind="human-gated", note="needs a human"),
+        e("item_parked", item="park-later", kind="later-wave", note="wave 2"),
+        e("item_parked", item="park-deferred", kind="deferred", note="revisit later"),
+        e(
+            "grind_paused",
+            reason="Human decision needed before lanes resume",
+            resume_checklist=["Pick a call", "grind log grind_resumed"],
+        ),
+        e("observation", level="INFO", message="informational note", item="item-inprogress"),
+        e("observation", level="WARN", message="staleness warning", lane="lane-idle"),
+        e("observation", level="ERROR", message="synthetic anomaly for the smoke test"),
+        e("observation", level="LESSON", message="a lesson worth keeping", item="item-done"),
+        e("attention_raised", text="General ops note not tied to any item"),
+    ]
+
+
+_ALL_ITEM_STATUSES = (
+    "queued",
+    "in-progress",
+    "pr-open",
+    "in-review",
+    "merged",
+    "done",
+    "blocked",
+    "waiting-human",
+)
+_ALL_PARK_KINDS = ("discovered-work", "human-gated", "later-wave", "deferred")
+
+
+def _state_json_blob(html: str) -> str:
+    start = html.index("var STATE = ") + len("var STATE = ")
+    end = html.index(";\n\nvar KNOWN_STATUSES", start)
+    return html[start:end]
+
+
+def test_fixture_state_is_a_valid_rich_scenario():
+    """Sanity-check the fixture itself before trusting the renderer
+    assertions below: every status/kind this test claims to cover must
+    actually be present in the folded state, and folding must not have
+    silently anomalied any of the crafted events."""
+    state = fold(_events())
+
+    assert state.anomalies == []
+    statuses = {item.status for item in state.items.values()}
+    assert statuses == set(_ALL_ITEM_STATUSES)
+    assert state.lanes["lane-standing-down"].standing_down is True
+    parked_kinds = {item.parked.kind for item in state.parking_lot().values() if item.parked}
+    assert parked_kinds == set(_ALL_PARK_KINDS)
+    assert state.items["item-stalemate"].review.stalemate is True
+    assert state.paused is True
+
+
+def test_render_is_byte_stable_across_two_folds_of_the_same_log():
+    events = _events()
+
+    html_a = render_dashboard(fold(events))
+    html_b = render_dashboard(fold(events))
+
+    assert html_a == html_b
+
+
+def test_state_block_has_no_unescaped_angle_bracket():
+    html = render_dashboard(fold(_events()))
+    blob = _state_json_blob(html)
+
+    assert "<" not in blob
+    # The escape actually landed on the probe title, proving the round trip
+    # (not merely that the title was absent from the payload). Only `<` is
+    # escaped per the contract; the trailing `>` is untouched and harmless.
+    assert "\\u003c/script>" in blob
+    assert "</script>" not in blob
+
+
+def test_renders_every_status_icon_and_kind_chip():
+    html = render_dashboard(fold(_events()))
+    blob = _state_json_blob(html)
+
+    for status in (*_ALL_ITEM_STATUSES, "standing-down"):
+        assert f'"{status}"' in blob, f"status {status!r} missing from the state payload"
+        assert f".st-{status}" in html, f"no status palette entry for {status!r}"
+        assert f'"{status}":' in html, f"no ICONS entry for {status!r}"
+
+    for kind in _ALL_PARK_KINDS:
+        assert f'"{kind}"' in blob, f"parking kind {kind!r} missing from the state payload"
+        assert f".kind-{kind}" in html, f"no kind-chip CSS entry for {kind!r}"
+
+
+def test_renders_required_panels_and_no_merged_or_closed_panels():
+    html = render_dashboard(fold(_events()))
+
+    assert 'id="board"' in html
+    assert 'id="obs-list"' in html and "Observations" in html
+    assert 'id="parking-list"' in html and "Parking lot" in html
+    assert 'id="lesson-list"' in html and "Lessons learned" in html
+    assert 'id="attention-banner"' in html
+    assert 'id="pause-banner"' in html
+    assert 'id="mission"' in html
+
+    # The event log is the ledger now -- no Merged/Closed panels (renderer
+    # spec, UX #6).
+    assert "merged_ledger" not in html
+    assert "closed_ledger" not in html
+    assert "Merged</h2>" not in html
+    assert "Closed</h2>" not in html
+
+
+def test_review_pill_data_present_for_open_threads_wontfix_and_stalemate():
+    html = render_dashboard(fold(_events()))
+    blob = _state_json_blob(html)
+
+    assert '"open_threads": 1' in blob
+    assert '"wont_fix_count": 1' in blob
+    assert '"stalemate": true' in blob
+
+
+def test_pause_and_mission_data_present():
+    html = render_dashboard(fold(_events()))
+    blob = _state_json_blob(html)
+
+    assert '"paused": true' in blob
+    assert "Human decision needed before lanes resume" in blob
+    assert "Ship the grind dashboard" in blob
+
+
+def test_at_least_six_lanes_present():
+    html = render_dashboard(fold(_events()))
+    blob = _state_json_blob(html)
+
+    assert blob.count('"agent":') >= 6

--- a/packages/grind/tests/unit/test_render_dashboard_smoke.py
+++ b/packages/grind/tests/unit/test_render_dashboard_smoke.py
@@ -260,3 +260,41 @@ def test_at_least_six_lanes_present():
     blob = _state_json_blob(html)
 
     assert blob.count('"agent":') >= 6
+
+
+def test_script_elements_survive_html_parsing_intact():
+    # HTML terminates a <script> element at the FIRST literal "</script"
+    # sequence, even inside a JS // comment -- parse the page the way a
+    # browser does and assert the dashboard script still carries both the
+    # state payload and the renderer code past every inline comment.
+    from html.parser import HTMLParser
+
+    html = render_dashboard(fold(_events()))
+
+    class _ScriptCollector(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__(convert_charrefs=True)
+            self._in_script = False
+            self.scripts: list[str] = []
+
+        def handle_starttag(self, tag: str, attrs: object) -> None:  # noqa: ARG002 -- HTMLParser API
+            if tag == "script":
+                self._in_script = True
+                self.scripts.append("")
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag == "script":
+                self._in_script = False
+
+        def handle_data(self, data: str) -> None:
+            if self._in_script:
+                self.scripts[-1] += data
+
+    parser = _ScriptCollector()
+    parser.feed(html)
+
+    dashboard = [s for s in parser.scripts if "grind" in s or "STATE" in s]
+    assert dashboard, "dashboard script parsed as empty -- early </script> termination"
+    content = max(dashboard, key=len)
+    assert "var STATE" in content or "STATE =" in content
+    assert "function renderBoard" in content  # renderer code is INSIDE the script element

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -1,4 +1,4 @@
-"""`grind.verbs`: the four command bodies over `grind.store` + `grind.fold`,
+"""`grind.verbs`: the five command bodies over `grind.store` + `grind.fold`,
 independent of argv/stdout wiring (that's `cli.py`, tested separately)."""
 
 from __future__ import annotations
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from grind.envelope import GrindError
-from grind.store import events_path, load_events
-from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_status
+from grind.store import dashboard_path, events_path, load_events
+from grind.verbs import cmd_check, cmd_create, cmd_finish, cmd_log, cmd_render, cmd_status
 
 _NOW = lambda: datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)  # noqa: E731
 
@@ -370,3 +370,64 @@ def test_finish_rejects_missing_summary(tmp_path: Path):
 
     with pytest.raises(GrindError):
         cmd_finish(tmp_path, "", now=_NOW)
+
+
+# -- dashboard rendering (create/log/finish re-render; render refolds only) ----
+
+
+def test_create_writes_dashboard_html(tmp_path: Path):
+    _seeded(tmp_path)
+
+    html = dashboard_path(tmp_path).read_text(encoding="utf-8")
+    assert "Widget grind" in html
+    assert "<!DOCTYPE html>" in html
+
+
+def test_log_re_renders_dashboard_html_after_append(tmp_path: Path):
+    _seeded(tmp_path)
+    before = dashboard_path(tmp_path).read_text(encoding="utf-8")
+
+    cmd_log(tmp_path, "item_started", {"item": "wgclw.1"}, now=_NOW)
+
+    after = dashboard_path(tmp_path).read_text(encoding="utf-8")
+    assert after != before  # the item's status changed, so the board changed
+    assert '"in-progress"' in after
+
+
+def test_finish_re_renders_dashboard_html(tmp_path: Path):
+    _seeded(tmp_path)
+
+    cmd_finish(tmp_path, "shipped it", now=_NOW)
+
+    html = dashboard_path(tmp_path).read_text(encoding="utf-8")
+    assert "Widget grind" in html
+
+
+def test_render_writes_dashboard_html_and_returns_its_path(tmp_path: Path):
+    _seeded(tmp_path)
+    dashboard_path(tmp_path).unlink()  # prove `render` (not `create`) produced it
+
+    result = cmd_render(tmp_path)
+
+    assert result == {"ok": True, "path": str(dashboard_path(tmp_path))}
+    assert dashboard_path(tmp_path).exists()
+
+
+def test_render_does_not_append_an_event_or_touch_state_json(tmp_path: Path):
+    _seeded(tmp_path)
+    events_before = load_events(tmp_path)
+    state_before = (tmp_path / "state.json").read_text(encoding="utf-8")
+
+    cmd_render(tmp_path)
+
+    assert load_events(tmp_path) == events_before
+    assert (tmp_path / "state.json").read_text(encoding="utf-8") == state_before
+
+
+def test_render_reflects_the_current_log_on_an_unseeded_directory(tmp_path: Path):
+    # `render` refolds from whatever is on disk -- an empty/unseeded dir still
+    # renders a (mostly empty) board rather than raising.
+    result = cmd_render(tmp_path)
+
+    assert result["ok"] is True
+    assert dashboard_path(tmp_path).exists()


### PR DESCRIPTION
## Summary
- Implements bead agents-config-wgclw.30.3: `render_dashboard(state) -> str`, a pure State→HTML projection producing the self-contained Control Room dashboard (light theme, mission line in header) per docs/specs/2026-07-19-grind-dashboard-renderer.md and the settled UX §1–9 in that spec; visual reference is docs/prototypes/grind-dashboard/variation-a.html.
- New `grind render [--dir]` verb (refold + rewrite dashboard.html only), and create/log/finish now re-render the dashboard on every write per the CLI contract table.
- All 9 UX requirements are in: per-lane collapse with localStorage persistence and auto-collapsed done lanes, slim collapsed anatomy at 50% width, all 9 status icons + neutral unknown fallback, parking-kind chips, lessons panel, no Merged/Closed panels, full open-threads pill with tooltip, round badge hidden at done, Control Room design with mission header.

## Scope
- In: render.py (new), verbs.py/cli.py (render verb + re-render wiring), store.py (dashboard path/write), model.py/fold.py/serialize.py (additive `State.last_event_ts` — the spec's `last_generated` is the ts of the last folded event, which State didn't previously carry), derive.py (one-line unknown-status guard), pyproject.toml (per-file E501 ignore for template data), 4 test files.
- Out: per-finding review detail rows (see notes), item free-text notes, any Merged/Closed panel.

## Notes for reviewers
- **Renderer is a pure function of State** — no wall clock; `last_generated` comes from `State.last_event_ts`. Byte-stability across refolds is test-pinned.
- **Serialization contract:** the state payload is spliced into an inline `<script>` block with every `<` escaped; a `</script>`-bearing probe title is exercised in the smoke test.
- **Per-finding severity/summary rows from the prototype are intentionally absent:** the fold consumes `review_verdict.findings[]` only into `open_threads`/`wont_fix_count`; State retains no raw findings list, and none of the settled UX §1–9 require it. Flagging it as missing would be flagging the spec's own data model — the required review affordances (round badge, stalemate pill, open-threads pill, wont-fix count) are all present.
- **derive.py's `_RANK.get(item.status, 0)`** implements the renderer spec's "unknown status values degrade, never break the board" — previously an unknown status would KeyError the whole render.
- **`state.mission` display** tolerates string / {goal, out_of_scope} object / anything else (JSON-stringified) — a display transform, not domain parsing.
- Ground truth: docs/specs/2026-07-19-grind-dashboard-renderer.md (UX §1–9, serialization contract) and the runtime spec's CLI contract table.

## Test Plan
- [x] test_render.py: PR-link derivation order, unknown-status pass-through, empty-state edges, never-reviewed omission, determinism
- [x] test_render_dashboard_smoke.py: rich fold-built State (all 9 statuses, 4 parking kinds, review with open threads + wont-fix, stalemate, paused, 6 lanes, escaping probe); byte-stability; CSS hooks; panel presence/absence
- [x] test_verbs.py/test_cli.py: dashboard writes on create/log/finish; render verb end-to-end
- [x] `make ci-grind` green post-rebase onto main (includes #365/#366): ruff, format, mypy --strict, 228 passed, 94.67% coverage, render.py at 100%, pip-audit, entry-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yKoGZrxEvPQtgVEMc4VFj