### PR TITLE
chore(tracks): record the minted groom-state bead

### DIFF
--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -181,9 +181,9 @@ def _validate(raw: dict[str, object], path: Path) -> TrackLayerConfig:
         raise _not_configured(
             f"[operating-model].groom-state-bead must be a string in {path}", "invalid"
         )
-    # Empty string ("" -- this repo's own project-config.toml ships it as a
-    # placeholder until the §7 backfill migration mints the bead) means
-    # "not yet configured", same as an omitted key -- not an error.
+    # Empty string means "not yet configured", same as an omitted key -- not an
+    # error. A repo may ship "" as a placeholder until its groom-state bead is
+    # minted.
     groom_state_bead = groom_state_bead_raw if groom_state_bead_raw else None
 
     extraction = raw.get("extraction")

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -195,9 +195,9 @@ def test_groom_fields_omitted_are_none(tmp_path: Path) -> None:
 
 
 def test_groom_state_bead_empty_string_is_none(tmp_path: Path) -> None:
-    # This repo's own project-config.toml ships groom-state-bead = "" until
-    # the backfill migration mints the bead (spec §7) -- empty string means
-    # "not yet configured", not an error.
+    # A repo may ship groom-state-bead = "" as a placeholder until its
+    # groom-state bead is minted -- empty string means "not yet configured",
+    # not an error.
     root = _repo(
         tmp_path,
         config_text='[tracks]\nnames = ["alpha"]\n[operating-model]\ngroom-state-bead = ""\n',

--- a/project-config.toml
+++ b/project-config.toml
@@ -126,7 +126,7 @@ enforcement = "advisory"   # flip to "required" is agents-config-63nm3
 milestone-wip-cap = 2
 wip-exempt-milestones = ["agents-config-uxns2"]  # PORT — bead id, never display name
 backlog-groom-nag-days = 7
-groom-state-bead = ""   # minted by the backfill migration (spec §7)
+groom-state-bead = "agents-config-zohw0"   # minted by the track backfill migration
 
 [extraction.pressure]
 max-track-backlog = 100


### PR DESCRIPTION
## Summary

Phase 2 of the track backfill migration (`docs/plans/2026-07-19-track-backfill-migration.md`, Task 8) minted the Backlog Grooming state bead in the live tracker: **agents-config-zohw0** (track `ops-meta`, label `lint-exempt:no-milestone`, verified live via `GROOM_STATE_OK`).

This PR records the pointer and cleans up after it:

- `project-config.toml`: `[operating-model].groom-state-bead = "agents-config-zohw0"` (was the `""` placeholder)
- `packages/workcli`: two comments claimed this repo still ships the empty placeholder — now stale; rewritten to state the general contract only (empty string means not-yet-configured)

## Verification

- `make ci-workcli` exit 0 (comment-only change under the package)
- `test_config_loading.py`: 31 passed
- TOML parses; `work groom --status` consumer contract verified against the live bead

Tracked work: agents-config-jpn0s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QJ2LSZRC6NUD4oC64zcVb