### PR TITLE
feat(workcli): S2 slices A+C — milestone noun, additive --label, close-walk atomicity

### DIFF
--- a/docs/specs/2026-07-22-workcli-completion-s2.md
+++ b/docs/specs/2026-07-22-workcli-completion-s2.md
@@ -1,0 +1,158 @@
+# S2 — workcli Completion: the Pipeline Verb Set
+
+**Date:** 2026-07-22
+**Status:** Child spec of `docs/specs/2026-07-21-harness-rework-way-forward.md` (S2 slice; discharges open verification V2, implements D11 with D10 park semantics)
+**Supersedes where they conflict:** `docs/specs/2026-07-04-work-facade-cli-contract.md` (predates the rework; audited, not inherited)
+
+The harness of tomorrow addresses the tracker exclusively through the `work`
+facade (D11). This spec records the V2 gap audit of workcli's implemented
+verbs against the D11 pipeline set, the decisions closing the gaps, and the
+per-slice acceptance criteria. All logic lands in `packages/workcli/`, never
+in prose.
+
+---
+
+## 1. V2 audit — implemented verbs vs the D11 pipeline set
+
+Audited 2026-07-22 against `packages/workcli/src/workcli/` (verb registry
+`verbs/__init__.py::VERBS`) and the installed CLI's `--help` surface.
+
+| D11 verb | Verdict | Evidence |
+| --- | --- | --- |
+| **mint** | **partial** | `work create <noun>` exists (`lifecycle/create.py`), guarded and track-aware. Three defects: **(a)** no `milestone` noun — the noun set is `spike\|chore\|decision\|feat\|bugfix\|spec\|epic` (`lifecycle/nouns.py::Noun`); **(b)** `create --raw` is transport-only and rejects `--acceptance` (`verbs/__init__.py::_raw_incompatible_flags`) — combined with (a), a milestone with an acceptance section is not expressible via the facade (S1 fell back to `bd create` for `agents-config-9k9` itself; recorded as a note on that bead); **(c)** noun-based create rejects `--label` (`lifecycle/create.py::_validate_usage`: "labels are set by the noun") — labeled creation needs a second `work label add` call, breaking single-call atomicity. |
+| **ready** | **exists** | `verbs/read.py::ready`, capability-gated (`ReadySupport`), used by `claim`'s guard. |
+| **claim** | **exists** | `lifecycle/transitions.py::claim` — refuses closed/container/blocked, idempotent on `in_progress`, delegates to bd's atomic `--claim`. |
+| **park(reason)** | **missing** | No verb. No facade path sets a non-`open` idle status (`release` only walks `in_progress → open`; `update` refuses status by design). No typed-reason vocabulary exists anywhere in the package. |
+| **re-dispatch** | **missing** | No verb. |
+| **abandon** | **missing** | No verb. `release` is the nearest neighbor but refuses non-`in_progress` items and records nothing. |
+| **close-on-merge** | **partial / wrong-semantics** | `verbs/write.py::close` = batch close + optional disposition note — **no close-walk**. `lifecycle/deliver.py` closes a leaf on `--pr` evidence, and its own docstring promises "a container closes via close-walk when its children close" — but no code anywhere implements a walk. A fully delivered tree strands its containers open forever; D11 requires close + close-walk + note as one verb. |
+| **dependency edges** | **exists** | `verbs/relations.py::dep` — add/remove/list, typed, `blocks` type-wall pre-check, capability-gated. |
+| **containment** | **partial (accepted)** | Parent set at mint (`--parent`/`--orphan`, mutually exclusive, enforced); queried via `show`/`list --parent`. Re-parenting is not expressible (`update` has no `--set-parent`; the `Backend` seam has no `set_parent`). The pipeline mints containment and never re-parents mid-flight — reparent is **out of scope** for S2, recorded as a known facade boundary (fall back to `bd update --parent` and count each use as a new gap signal). |
+
+Verbs outside the D11 set (`plan`, `promote`, `deliver`, `reconcile`,
+`discover`, `track`, `lint`, `graph`, `triggers`, `groom`, `sync`) are not
+audited here; they persist unchanged.
+
+## 2. Decisions
+
+**S2-D1 — Park is a status + marker + label, all backend-primitive.**
+`work park` sets bd's built-in `blocked` status (drops the item out of
+`ready`, so `claim` refuses it with no new guard code), adds the `parked`
+label (the cheap queryable handle), and appends a structured note
+`[work] parked <ISO-8601> <code>: <text>`. One facade call, three backend
+primitives, replay-safe in the L7 idempotency style.
+
+**S2-D2 — Typed reason vocabulary (D10).** Fixed codes, category derived:
+machine-actionable = `ci-failure`, `merge-conflict`; human-required =
+`approval-required`, `bot-declined`, `budget-exhausted`. Unknown codes are
+`E_USAGE` naming the vocabulary. The budget numbers themselves (2 CI-fix
+attempts, 1 rebase) are executor policy (S9), not facade logic — the facade
+records the outcome, it never counts attempts.
+
+**S2-D3 — `redispatch` and `abandon` are the un-park verbs; recut is not a
+tracker verb.** Both walk `parked → open` (label off, status `open`, marker
+note appended: `[work] redispatched …` / `[work] abandoned …`). They differ
+only in recorded intent — re-dispatch means the cause is fixed, abandon
+means the PR is closed and the item returns to ready. D10's *recut* is
+abandon at the tracker layer (the fresh implementation is executor behavior),
+so no third verb exists.
+
+**S2-D4 — The machine never acts on a parked item; staleness is visibility
+only.** `work parked` is a read-only report: parked items with code,
+category, parked-at, and a `stale` flag past `--stale-days` (default 7). It
+performs zero writes. Surfacing it at open-new-work interactions is S9
+wiring, not S2.
+
+**S2-D5 — Close-walk is `close`'s default semantics, bounded by milestones.**
+After closing its ids, `work close` walks each parent chain: a parent closes
+iff it is not a milestone, not already closed, and every child is closed;
+each auto-close appends `[work] close-walk: all children closed` and the walk
+recurses upward. Milestones never auto-close — a milestone closes on its own
+acceptance section (charter AC9), not on child exhaustion. `deliver`'s leaf
+close shares the same walk helper, making its docstring true. `reconcile`'s
+internal closes keep their current no-walk behavior (advisory follow-up, not
+an S2 AC).
+
+**S2-D6 — Milestone noun.** `work create milestone` mints bd type
+`milestone` with shape label `shape-milestone` (declared-state container,
+consistent with the shape discipline; `is_container` already catches the
+type as fallback). `--acceptance` flows through like every noun. Not a
+`discover` noun (LEAF_NOUNS unchanged). `create --raw` stays
+transport-minimal and keeps rejecting lifecycle flags — the milestone noun is
+what closes the expressibility gap, not a fatter primitive.
+
+**S2-D7 — `--label` on noun create is additive with a reserved-namespace
+wall.** User labels append after the noun's shape labels. Labels that forge
+lifecycle state are refused as `E_USAGE`: prefix `shape-`, prefix `track:`
+(that's `--track`'s job), and the exact machine labels `planned`,
+`creating-spec`, `impl-placeholder`, `spec-ready`, `parked`.
+
+## 3. Slices and acceptance criteria
+
+Each AC is red-test-convertible against the fake backend; IDs are cited by
+the tests. Edge-case taxonomy (inverse, boundary, dependency failure,
+repeated invocation, idempotency) applied per slice.
+
+### Slice A — mint completeness (audit rows: mint a/b/c)
+
+- **S2-A1** `work create milestone --title T --acceptance X --orphan`
+  succeeds; the created item has bd type `milestone`, label
+  `shape-milestone`, and the acceptance text recorded.
+- **S2-A2** `work create milestone` is refused a second creation with the
+  same title (`E_DUPLICATE_TITLE` — existing rule holds for the new noun).
+- **S2-A3** `work create feat --parent P --label install --title T` succeeds
+  in one call; the item carries both `shape-feat` and `install`.
+- **S2-A4** Reserved labels are refused with `E_USAGE`: `--label shape-x`,
+  `--label track:workcli`, `--label planned` (representatives of the wall in
+  S2-D7); the backend sees zero create calls (refusal precedes mutation).
+- **S2-A5** `work claim <milestone-id>` is refused `E_NOT_CLAIMABLE` as a
+  container (inverse: the new noun does not leak into the claimable set).
+
+### Slice B — park / re-dispatch / abandon / parked (D10)
+
+- **S2-B1** `work park ID --reason ci-failure [--note TEXT]` on an
+  `in_progress` item → status `blocked`, label `parked`, one
+  `[work] parked <ISO> ci-failure: …` note; envelope data reports
+  `{id, status: "parked", reason: "ci-failure", category: "machine"}`.
+- **S2-B2** Every code in the S2-D2 vocabulary maps to its category
+  (machine: ci-failure, merge-conflict; human: approval-required,
+  bot-declined, budget-exhausted); an unknown code is `E_USAGE` naming the
+  vocabulary, with zero backend writes.
+- **S2-B3** Parking a closed item is `E_USAGE`; re-parking an already-parked
+  item is an idempotent no-op (no second marker, no error).
+- **S2-B4** A parked item is not claimable: `work claim` → `E_NOT_CLAIMABLE`
+  (via the existing ready-set guard — parked never re-enters `ready`).
+- **S2-B5** `work redispatch ID` on a parked item → status `open`, `parked`
+  label removed, `[work] redispatched <ISO>` note; on an unparked open item
+  it is an idempotent no-op; on a closed item `E_USAGE`.
+- **S2-B6** `work abandon ID` — same transition and guards as S2-B5 with an
+  `[work] abandoned <ISO>` note (distinct recorded intent).
+- **S2-B7** `work parked` lists exactly the `parked`-labeled items with
+  `{id, title, reason, category, parked_at, stale}`; `stale` is true iff
+  parked_at is older than `--stale-days` (default 7) against the injected
+  clock; the report issues zero backend mutations (fake call log is
+  read-only). An item whose marker is unparseable surfaces with
+  `reason: null` rather than crashing the report (dependency failure).
+
+### Slice C — close-walk atomicity (close-on-merge)
+
+- **S2-C1** Closing the last open child of an epic in one `work close` call
+  also closes the epic and appends `[work] close-walk: all children closed`
+  to it.
+- **S2-C2** The walk recurses: when the auto-closed epic was itself the last
+  open child of a non-milestone grandparent, the grandparent closes too.
+- **S2-C3** The walk stops at milestones: a milestone whose last child
+  closes stays open (boundary from S2-D5).
+- **S2-C4** Closing a child while a sibling remains open leaves the parent
+  open (inverse); a parent already closed is not re-closed (idempotency).
+- **S2-C5** `work deliver ID --pr N` on the last open leaf of a container
+  triggers the identical walk (the deliver docstring's promise becomes
+  code).
+
+## 4. Out of scope
+
+Re-parenting (audit row: containment), reparse/backfill of pre-S2 parked
+states (none exist in the new DB), staleness surfacing at open-new-work
+interactions and attempt-budget counting (S9 executor loop), `reconcile`
+walk-on-close (advisory follow-up), GH-issues/Jira adapters (admitted
+separately per D11).

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -71,7 +71,7 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
         nargs="?",
         choices=[noun.value for noun in Noun],
         metavar="NOUN",
-        help="spike|chore|decision|feat|bugfix|spec|epic -- omit with --raw",
+        help="spike|chore|decision|feat|bugfix|spec|epic|milestone -- omit with --raw",
     )
     create_parser.add_argument("--raw", action="store_true")
     create_parser.add_argument("--title", required=True)

--- a/packages/workcli/src/workcli/lifecycle/__init__.py
+++ b/packages/workcli/src/workcli/lifecycle/__init__.py
@@ -11,7 +11,9 @@ MANIFEST_MARKER = (
 )
 ORPHAN_MARKER = "[work] orphan-by-choice"  # item note (exact)
 
-_CONTAINER_SHAPE_LABELS = frozenset({"shape-spec", "shape-epic", IMPL_CONTAINER_LABEL})
+_CONTAINER_SHAPE_LABELS = frozenset(
+    {"shape-spec", "shape-epic", "shape-milestone", IMPL_CONTAINER_LABEL}
+)
 _CONTAINER_TYPES = frozenset({"epic", "milestone"})  # legacy/unstamped fallback
 
 

--- a/packages/workcli/src/workcli/lifecycle/closewalk.py
+++ b/packages/workcli/src/workcli/lifecycle/closewalk.py
@@ -1,0 +1,42 @@
+"""Close-walk: the containment-closure tail shared by `close` and `deliver`
+(S2-D5; V2 audit row close-on-merge).
+
+D11 requires close + close-walk + note as ONE facade call: a parent whose
+last open child closes is exhausted and closes with it, recursively, so a
+fully delivered tree never strands its containers open. Milestones are the
+walk boundary -- a milestone closes on its own acceptance section (charter
+AC9), never on child exhaustion.
+"""
+
+from __future__ import annotations
+
+from workcli.backend import Backend
+
+CLOSE_WALK_MARKER = "[work] close-walk: all children closed"
+
+
+def close_walk(backend: Backend, ids: list[str]) -> list[str]:
+    """Walk each closed id's parent chain, closing exhausted parents.
+
+    A parent closes iff it is not a milestone, not already closed, and every
+    child is closed; each auto-close appends `CLOSE_WALK_MARKER` and the walk
+    recurses upward. Returns the auto-closed ids in walk order. Closing
+    sibling ids in one call converges: the second sibling's walk meets the
+    already-closed parent and stops without a duplicate note (idempotency,
+    S2-C4).
+    """
+    walked: list[str] = []
+    for start in backend.batch_get(ids):
+        current = start
+        while current.parent is not None:
+            parent = backend.get(current.parent)
+            if parent.type == "milestone" or parent.status == "closed":
+                break
+            children = backend.batch_get(parent.children)
+            if any(child.status != "closed" for child in children):
+                break
+            backend.close([parent.id])
+            backend.append_note(parent.id, CLOSE_WALK_MARKER)
+            walked.append(parent.id)
+            current = parent
+    return walked

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -26,7 +26,16 @@ from workcli.lifecycle.nouns import (
     NounTemplate,
 )
 from workcli.model import CreateFields
-from workcli.tracks import derive_track, require_known_track, track_label
+from workcli.tracks import TRACK_PREFIX, derive_track, require_known_track, track_label
+
+# The reserved-namespace wall for additive `--label` (S2-D7): labels that
+# forge lifecycle state are refused at usage-validation time, before any
+# backend call. `parked` is a string literal until the park verbs (slice
+# S2-B) mint its constant.
+_RESERVED_LABEL_EXACT = frozenset(
+    {PLANNED_LABEL, CREATING_SPEC_LABEL, IMPL_PLACEHOLDER_LABEL, SPEC_READY_LABEL, "parked"}
+)
+_RESERVED_LABEL_PREFIXES = ("shape-", TRACK_PREFIX)
 
 
 def instantiate_spec_shape(
@@ -119,11 +128,18 @@ def _validate_usage(args: Namespace, noun: Noun) -> None:
             ErrorCode.USAGE,
             f"create {noun}: --type is set by the noun; omit it",
         )
-    if args.label:
-        raise WorkError(
-            ErrorCode.USAGE,
-            f"create {noun}: labels are set by the noun; omit --label",
+    for user_label in args.label:
+        # Additive user labels are welcome (single-call atomicity, V2 audit
+        # row mint (c)); lifecycle/track state is not label-forgeable.
+        reserved = user_label in _RESERVED_LABEL_EXACT or user_label.startswith(
+            _RESERVED_LABEL_PREFIXES
         )
+        if reserved:
+            raise WorkError(
+                ErrorCode.USAGE,
+                f"create {noun}: label {user_label!r} is reserved (lifecycle/track "
+                f"state is set by the noun and --track, never --label)",
+            )
     if args.spec is not None and args.trivial:
         raise WorkError(
             ErrorCode.USAGE,
@@ -214,7 +230,8 @@ def _create_spec_container(
             priority=args.priority,
             parent=parent,
             labels=(template.shape_label, CREATING_SPEC_LABEL)
-            + ((track_label(track),) if track is not None else ()),
+            + ((track_label(track),) if track is not None else ())
+            + tuple(args.label),
             acceptance=args.acceptance,
         )
     )
@@ -253,6 +270,7 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
         labels.append(SPEC_READY_LABEL)
     if track is not None:
         labels.append(track_label(track))
+    labels.extend(args.label)
 
     new_id = backend.create(
         CreateFields(

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -128,6 +128,13 @@ def _validate_usage(args: Namespace, noun: Noun) -> None:
             ErrorCode.USAGE,
             f"create {noun}: --type is set by the noun; omit it",
         )
+    if noun is Noun.MILESTONE and args.track is not None:
+        # Milestone-type beads are track-exempt and carry no track:* label
+        # (track spec §3) -- refuse rather than mint an exemption violation.
+        raise WorkError(
+            ErrorCode.USAGE,
+            "create milestone: milestones are track-exempt; omit --track",
+        )
     for user_label in args.label:
         # Additive user labels are welcome (single-call atomicity, V2 audit
         # row mint (c)); lifecycle/track state is not label-forgeable.
@@ -258,7 +265,12 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     _check_duplicate_title(backend, args.title)
 
     parent = None if args.orphan else args.parent
-    track, warnings = _resolve_track(backend, args, parent)
+    # Milestones are track-exempt by contract (track spec §3): no requirement
+    # even under enforcement = "required", and never a track:* label.
+    track: str | None = None
+    warnings: list[str] = []
+    if noun is not Noun.MILESTONE:
+        track, warnings = _resolve_track(backend, args, parent)
 
     if noun is Noun.SPEC:
         return _with_warnings(

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -186,6 +186,20 @@ def _leaf_evidence(backend: Backend, args: Namespace) -> str:
     )
 
 
+def _walked_leaf_result(backend: Backend, item_id: str) -> JsonValue:
+    """Close-walk from a closed leaf, then the leaf's `closed` envelope.
+
+    Same walk as `work close` (S2-D5/S2-C5): delivering the last open leaf
+    of a container closes the container -- this module's long-standing
+    "closes via close-walk" promise, now code.
+    """
+    walked = close_walk(backend, [item_id])
+    result: dict[str, JsonValue] = {"id": item_id, "status": "closed"}
+    if walked:
+        result["walked"] = cast("list[JsonValue]", list(walked))
+    return result
+
+
 def _deliver_leaf(backend: Backend, args: Namespace, item: Item) -> JsonValue:
     if args.spec is not None:
         raise WorkError(
@@ -193,20 +207,17 @@ def _deliver_leaf(backend: Backend, args: Namespace, item: Item) -> JsonValue:
             f"deliver {args.id}: --spec belongs to design delivery; omit for a leaf",
         )
     if item.status == "closed":
-        return _closed(args.id)
+        # Replay path: a crash between the close and the walk leaves a closed
+        # leaf under a possibly-exhausted parent -- the walk must re-run here
+        # (idempotent; no-op when the parent chain is already settled), or the
+        # replay would report success while stranding the containers open.
+        return _walked_leaf_result(backend, args.id)
 
     evidence = _leaf_evidence(backend, args)
     if not has_marker(item.notes, DELIVERED_MARKER):
         backend.append_note(args.id, f"{DELIVERED_MARKER} {evidence}")
     backend.close([args.id])
-    # Same walk as `work close` (S2-D5/S2-C5): delivering the last open leaf
-    # of a container closes the container -- this docstring's long-standing
-    # "closes via close-walk" promise, now code.
-    walked = close_walk(backend, [args.id])
-    result: dict[str, JsonValue] = {"id": args.id, "status": "closed"}
-    if walked:
-        result["walked"] = cast("list[JsonValue]", list(walked))
-    return result
+    return _walked_leaf_result(backend, args.id)
 
 
 def deliver(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -14,6 +14,7 @@ on the `impl-placeholder` label's absence.
 from __future__ import annotations
 
 from argparse import Namespace
+from typing import cast
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
@@ -26,6 +27,7 @@ from workcli.lifecycle import (
     manifest_snapshot,
     spec_path,
 )
+from workcli.lifecycle.closewalk import close_walk
 from workcli.lifecycle.manifest import Manifest, parse_continuations, serialize_manifest
 from workcli.lifecycle.nouns import (
     CREATING_SPEC_LABEL,
@@ -197,7 +199,14 @@ def _deliver_leaf(backend: Backend, args: Namespace, item: Item) -> JsonValue:
     if not has_marker(item.notes, DELIVERED_MARKER):
         backend.append_note(args.id, f"{DELIVERED_MARKER} {evidence}")
     backend.close([args.id])
-    return _closed(args.id)
+    # Same walk as `work close` (S2-D5/S2-C5): delivering the last open leaf
+    # of a container closes the container -- this docstring's long-standing
+    # "closes via close-walk" promise, now code.
+    walked = close_walk(backend, [args.id])
+    result: dict[str, JsonValue] = {"id": args.id, "status": "closed"}
+    if walked:
+        result["walked"] = cast("list[JsonValue]", list(walked))
+    return result
 
 
 def deliver(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -12,6 +12,7 @@ class Noun(StrEnum):
     BUGFIX = "bugfix"
     SPEC = "spec"
     EPIC = "epic"
+    MILESTONE = "milestone"
 
 
 # Leaf nouns -- everything except the two container nouns (spec/epic). `work
@@ -54,6 +55,17 @@ NOUN_TEMPLATES: dict[Noun, NounTemplate] = {
     ),
     Noun.EPIC: NounTemplate(
         "epic", "shape-epic", is_container=True, expects_evidence=False, born_planned=False
+    ),
+    # S2-D6: closes the milestone-with-acceptance expressibility gap (V2 audit
+    # row mint (a)/(b)) -- `--acceptance` flows through like every noun, and
+    # `create --raw` stays transport-minimal. Never a discover noun (a
+    # discovery is not a roadmap anchor), so LEAF_NOUNS is unchanged.
+    Noun.MILESTONE: NounTemplate(
+        "milestone",
+        "shape-milestone",
+        is_container=True,
+        expects_evidence=False,
+        born_planned=False,
     ),
 }
 

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -81,7 +81,7 @@ def _create(backend: Backend, args: Namespace) -> JsonValue:
     raise WorkError(
         ErrorCode.USAGE,
         "create requires --raw (transport primitive) or a noun "
-        "(spike|chore|decision|feat|bugfix|spec|epic)",
+        "(spike|chore|decision|feat|bugfix|spec|epic|milestone)",
     )
 
 

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -9,9 +9,11 @@ envelope.
 from __future__ import annotations
 
 from argparse import Namespace
+from typing import cast
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.closewalk import close_walk
 from workcli.model import CreateFields, UpdateFields
 
 
@@ -73,16 +75,22 @@ def note(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def close(backend: Backend, args: Namespace) -> JsonValue:
-    """`work close IDS... [--disposition TEXT]`.
+    """`work close IDS... [--disposition TEXT]` -- close + close-walk + note,
+    one call (S2-D5).
 
     Batch `bd close` for all ids first, then one `--append-notes` call per
     id carrying the disposition text (orchestrator ruling: `bd close
-    --reason` lands in the wrong field; the disposition is an appended note).
+    --reason` lands in the wrong field; the disposition is an appended note),
+    then the close-walk: exhausted non-milestone parents close with a walk
+    note. `data` stays None when nothing walked (pre-S2 envelope shape).
     """
     backend.close(args.ids)
     if args.disposition is not None:
         for item_id in args.ids:
             backend.append_note(item_id, args.disposition)
+    walked = close_walk(backend, list(args.ids))
+    if walked:
+        return {"walked": cast("list[JsonValue]", list(walked))}
     return None
 
 

--- a/packages/workcli/tests/unit/test_close_walk.py
+++ b/packages/workcli/tests/unit/test_close_walk.py
@@ -1,0 +1,132 @@
+"""Slice S2-C: close-walk atomicity (spec 2026-07-22-workcli-completion-s2 §3).
+
+close + close-walk + note is ONE facade call (S2-D5; V2 audit row
+close-on-merge): a non-milestone parent whose last open child closes is
+exhausted and closes with it, recursively, with a `[work] close-walk` note.
+Milestones are the boundary -- they close on their own acceptance section
+(charter AC9), never on child exhaustion. State-based against `FakeBackend`,
+driving the real `close` and `deliver` handlers.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from tests.conftest import fake_reader
+from tests.fake_backend import FakeBackend
+from workcli.lifecycle import DELIVERED_MARKER
+from workcli.lifecycle.closewalk import CLOSE_WALK_MARKER
+from workcli.lifecycle.deliver import deliver
+from workcli.verbs.write import close
+
+
+def _close(backend: FakeBackend, ids: list[str], disposition: str | None = None):
+    return close(backend, Namespace(ids=ids, disposition=disposition))
+
+
+def test_closing_last_open_child_closes_the_epic_with_a_walk_note():  # S2-C1
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"])
+        .add("c1", parent="E", status="closed")
+        .add("c2", parent="E", status="open")
+    )
+
+    data = _close(backend, ["c2"], disposition="merged PR #7")
+
+    assert backend.get("E").status == "closed"
+    assert CLOSE_WALK_MARKER in backend.note_lines("E")
+    assert "merged PR #7" in backend.note_lines("c2")
+    assert data == {"walked": ["E"]}
+
+
+def test_walk_recurses_through_exhausted_grandparent():  # S2-C2
+    backend = (
+        FakeBackend()
+        .add("G", type="epic", labels=["shape-epic"])
+        .add("E", type="epic", labels=["shape-epic"], parent="G")
+        .add("c1", parent="E", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.get("E").status == "closed"
+    assert backend.get("G").status == "closed"
+    assert CLOSE_WALK_MARKER in backend.note_lines("E")
+    assert CLOSE_WALK_MARKER in backend.note_lines("G")
+    assert data == {"walked": ["E", "G"]}
+
+
+def test_walk_stops_at_milestones():  # S2-C3
+    backend = (
+        FakeBackend()
+        .add("M", type="milestone", labels=["shape-milestone"])
+        .add("c1", parent="M", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.get("M").status == "open"
+    assert backend.note_lines("M") == []
+    assert data is None
+
+
+def test_open_sibling_holds_the_parent_open():  # S2-C4 (inverse)
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"])
+        .add("c1", parent="E", status="open")
+        .add("c2", parent="E", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.get("E").status == "open"
+    assert data is None
+
+
+def test_already_closed_parent_is_not_reclosed_or_renoted():  # S2-C4 (idempotency)
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"], status="closed")
+        .add("c1", parent="E", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.note_lines("E") == []
+    assert data is None
+
+
+def test_sibling_batch_close_walks_the_parent_exactly_once():  # S2-C4 (repeated)
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"])
+        .add("c1", parent="E", status="open")
+        .add("c2", parent="E", status="open")
+    )
+
+    data = _close(backend, ["c1", "c2"])
+
+    assert backend.get("E").status == "closed"
+    assert backend.note_lines("E").count(CLOSE_WALK_MARKER) == 1
+    assert data == {"walked": ["E"]}
+
+
+def test_deliver_leaf_triggers_the_same_walk():  # S2-C5
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"])
+        .add("L", parent="E", status="in_progress", labels=["shape-feat"])
+    )
+    args = Namespace(
+        id="L", spec=None, pr="42", items=None, trivial=False, read_file=fake_reader({})
+    )
+
+    data = deliver(backend, args)
+
+    assert backend.get("L").status == "closed"
+    assert any(line.startswith(DELIVERED_MARKER) for line in backend.note_lines("L"))
+    assert backend.get("E").status == "closed"
+    assert CLOSE_WALK_MARKER in backend.note_lines("E")
+    assert data == {"id": "L", "status": "closed", "walked": ["E"]}

--- a/packages/workcli/tests/unit/test_close_walk.py
+++ b/packages/workcli/tests/unit/test_close_walk.py
@@ -130,3 +130,23 @@ def test_deliver_leaf_triggers_the_same_walk():  # S2-C5
     assert backend.get("E").status == "closed"
     assert CLOSE_WALK_MARKER in backend.note_lines("E")
     assert data == {"id": "L", "status": "closed", "walked": ["E"]}
+
+
+def test_deliver_replay_on_closed_leaf_resumes_the_walk():  # S2-C5 (crash replay)
+    # Crash window: the leaf closed but the walk never ran. The deliver
+    # replay short-circuits the evidence check yet must still settle the
+    # parent chain.
+    backend = (
+        FakeBackend()
+        .add("E", type="epic", labels=["shape-epic"])
+        .add("L", parent="E", status="closed", labels=["shape-feat"])
+    )
+    args = Namespace(
+        id="L", spec=None, pr=None, items=None, trivial=False, read_file=fake_reader({})
+    )
+
+    data = deliver(backend, args)
+
+    assert backend.get("E").status == "closed"
+    assert CLOSE_WALK_MARKER in backend.note_lines("E")
+    assert data == {"id": "L", "status": "closed", "walked": ["E"]}

--- a/packages/workcli/tests/unit/test_create_milestone_and_labels.py
+++ b/packages/workcli/tests/unit/test_create_milestone_and_labels.py
@@ -155,3 +155,44 @@ def test_cli_accepts_the_milestone_noun():  # S2-A1 (wiring)
 
     assert exit_code == 0
     assert envelope["data"] == {"id": "m.1"}
+
+
+def _required_config() -> TrackLayerConfig:
+    return TrackLayerConfig(
+        names=("workcli",),
+        organizing_only=(),
+        enforcement="required",
+        milestone_wip_cap=None,
+        wip_exempt_milestones=(),
+        backlog_groom_nag_days=None,
+        groom_state_bead=None,
+        extraction_max_track_backlog=None,
+    )
+
+
+def test_create_milestone_is_track_exempt_under_required_enforcement():  # S2-A1
+    # Track spec §3: milestone-type beads are track-exempt and carry no
+    # track:* label -- even when [tracks].enforcement = "required".
+    backend = FakeBackend()
+    args = _create_args("milestone", orphan=True)
+    args.load_config = _required_config
+
+    data = create_noun(backend, args)
+
+    assert isinstance(data, dict)
+    item = backend.get(str(data["id"]))
+    assert not any(label.startswith("track:") for label in item.labels)
+
+
+def test_create_milestone_with_explicit_track_is_refused():  # S2-A1 (inverse)
+    backend = FakeBackend()
+    args = _create_args("milestone", orphan=True)
+    args.track = "workcli"
+    args.load_config = _required_config
+
+    with pytest.raises(WorkError) as excinfo:
+        create_noun(backend, args)
+
+    assert excinfo.value.code is ErrorCode.USAGE
+    assert "track-exempt" in excinfo.value.message
+    assert backend.ids() == []

--- a/packages/workcli/tests/unit/test_create_milestone_and_labels.py
+++ b/packages/workcli/tests/unit/test_create_milestone_and_labels.py
@@ -1,0 +1,157 @@
+"""Slice S2-A: mint completeness (spec 2026-07-22-workcli-completion-s2 §3).
+
+The milestone noun closes the milestone-with-acceptance expressibility gap
+(S2-D6; V2 audit rows mint (a)/(b)); additive `--label` behind the
+reserved-namespace wall closes the single-call-atomicity gap (S2-D7; row
+mint (c)). State assertions run against `FakeBackend`; one CLI-level test
+pins the argparse wiring for the new noun.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+
+import pytest
+
+from tests.conftest import run_cli_with_runner
+from tests.fake_backend import FakeBackend
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+from workcli.lifecycle import ORPHAN_MARKER, is_container
+from workcli.lifecycle.create import create_noun
+from workcli.lifecycle.transitions import claim
+
+_OK = BdResult(returncode=0, stdout="", stderr="")
+
+
+def _raise_not_configured() -> TrackLayerConfig:
+    # Track gate as a no-op (criterion 17): these tests are about nouns and
+    # labels, never track resolution.
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
+
+
+def _create_args(
+    noun: str,
+    *,
+    title: str = "T",
+    parent: str | None = None,
+    orphan: bool = False,
+    label: list[str] | None = None,
+    acceptance: str | None = None,
+) -> Namespace:
+    return Namespace(
+        noun=noun,
+        raw=False,
+        title=title,
+        description=None,
+        type=None,
+        priority=None,
+        parent=parent,
+        label=label or [],
+        orphan=orphan,
+        spec=None,
+        trivial=False,
+        acceptance=acceptance,
+        track=None,
+        load_config=_raise_not_configured,
+    )
+
+
+def test_create_milestone_mints_container_with_acceptance():  # S2-A1
+    backend = FakeBackend()
+
+    data = create_noun(backend, _create_args("milestone", orphan=True, acceptance="AC1 ..."))
+
+    assert isinstance(data, dict)
+    item = backend.get(str(data["id"]))
+    assert item.type == "milestone"
+    assert "shape-milestone" in item.labels
+    assert backend.acceptance_of(item.id) == "AC1 ..."
+    assert is_container(item)
+    assert ORPHAN_MARKER in backend.note_lines(item.id)
+
+
+def test_create_milestone_duplicate_title_refused():  # S2-A2
+    backend = FakeBackend().add("m0", title="Roadmap", type="milestone")
+
+    with pytest.raises(WorkError) as excinfo:
+        create_noun(backend, _create_args("milestone", title="Roadmap", orphan=True))
+
+    assert excinfo.value.code is ErrorCode.DUPLICATE_TITLE
+    assert backend.ids() == ["m0"]
+
+
+def test_create_feat_with_user_label_is_one_call():  # S2-A3
+    backend = FakeBackend().add("P", title="Parent", type="epic", labels=["shape-epic"])
+
+    data = create_noun(backend, _create_args("feat", parent="P", label=["install"]))
+
+    assert isinstance(data, dict)
+    item = backend.get(str(data["id"]))
+    # Both labels present at birth -- carried by the single create, never a
+    # follow-up `work label add`.
+    assert "shape-feat" in item.labels
+    assert "install" in item.labels
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    [
+        "shape-x",
+        "track:workcli",
+        "planned",
+        "creating-spec",
+        "impl-placeholder",
+        "spec-ready",
+        "parked",
+    ],
+)
+def test_reserved_labels_refused_before_any_mutation(reserved: str):  # S2-A4
+    backend = FakeBackend().add("P", title="Parent", type="epic", labels=["shape-epic"])
+
+    with pytest.raises(WorkError) as excinfo:
+        create_noun(backend, _create_args("feat", parent="P", label=[reserved]))
+
+    assert excinfo.value.code is ErrorCode.USAGE
+    assert reserved in excinfo.value.message
+    assert backend.ids() == ["P"]
+
+
+def test_claim_milestone_refused_as_container():  # S2-A5
+    backend = FakeBackend().add("m1", type="milestone", labels=["shape-milestone"], status="open")
+
+    with pytest.raises(WorkError) as excinfo:
+        claim(backend, Namespace(id="m1"))
+
+    assert excinfo.value.code is ErrorCode.NOT_CLAIMABLE
+
+
+def test_cli_accepts_the_milestone_noun():  # S2-A1 (wiring)
+    create_result = BdResult(
+        returncode=0,
+        stdout=json.dumps({"id": "m.1", "schema_version": 3, "title": "T"}),
+        stderr="",
+    )
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("search",), BdResult(returncode=0, stdout="[]", stderr="")),
+            ScriptedStep(("create",), create_result),
+            ScriptedStep(("update",), _OK),  # orphan marker append
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["create", "milestone", "--title", "T", "--orphan", "--acceptance", "AC1"],
+        runner,
+        config_loader=lambda _p: _raise_not_configured(),
+    )
+
+    assert exit_code == 0
+    assert envelope["data"] == {"id": "m.1"}

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -173,19 +173,20 @@ def test_create_feat_with_type_flag_is_usage_error_without_any_bd_call():
     assert error["code"] == str(ErrorCode.USAGE)
 
 
-def test_create_feat_with_label_flag_is_usage_error_without_any_bd_call():
-    # The noun owns its labels (lifecycle-semantic queryable handles); a
-    # user-supplied --label is rejected rather than silently dropped, mirroring
-    # the --type rejection.
+def test_create_feat_with_reserved_label_is_usage_error_without_any_bd_call():
+    # Additive --label is welcome (S2-D7, single-call atomicity), but
+    # lifecycle/track state stays noun-owned: a reserved label is rejected
+    # before any bd call. Positive additive-label coverage lives in
+    # test_create_milestone_and_labels.py (S2-A3).
     exit_code, envelope, _ = run_cli(
-        ["create", "feat", "--title", "T", "--parent", "P", "--label", "hot"], steps=[]
+        ["create", "feat", "--title", "T", "--parent", "P", "--label", "shape-hot"], steps=[]
     )
 
     assert exit_code == 1
     error = envelope["error"]
     assert isinstance(error, dict)
     assert error["code"] == str(ErrorCode.USAGE)
-    assert "--label" in error["message"]
+    assert "shape-hot" in error["message"]
 
 
 def test_create_feat_with_spec_evidence_adds_spec_ready_label():

--- a/packages/workcli/tests/unit/test_deliver.py
+++ b/packages/workcli/tests/unit/test_deliver.py
@@ -474,9 +474,13 @@ def test_deliver_leaf_with_no_evidence_flag_is_evidence_error():
     assert runner.calls == [("show", "x.1", "--json")]
 
 
-def test_deliver_leaf_already_closed_is_a_noop_with_no_evidence_check():
+def test_deliver_leaf_already_closed_skips_evidence_but_replays_the_walk():
+    # No evidence check on a closed leaf -- but the close-walk re-runs
+    # (idempotent): a crash between close and walk must not strand exhausted
+    # parents open behind a "successful" replay (S2-D5).
     runner = ScriptedBdRunner(
         steps=[
+            ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
             ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
         ]
     )
@@ -485,7 +489,7 @@ def test_deliver_leaf_already_closed_is_a_noop_with_no_evidence_check():
 
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1", "status": "closed"}
-    assert runner.calls == [("show", "x.1", "--json")]
+    assert runner.calls == [("show", "x.1", "--json"), ("show", "x.1", "--json")]
 
 
 def test_deliver_leaf_interrupted_replay_skips_duplicate_note_and_just_closes():

--- a/packages/workcli/tests/unit/test_deliver.py
+++ b/packages/workcli/tests/unit/test_deliver.py
@@ -413,6 +413,8 @@ def test_deliver_leaf_with_pr_appends_delivered_note_then_closes():
             ),
             ScriptedStep(("update",), _OK),  # delivered note
             ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
         ]
     )
 
@@ -426,6 +428,7 @@ def test_deliver_leaf_with_pr_appends_delivered_note_then_closes():
         ("show", "x.1", "--json"),
         ("update", "x.1", "--append-notes", f"{DELIVERED_MARKER} https://example/pr/1"),
         ("close", "x.1"),
+        ("show", "x.1", "--json"),
     ]
 
 
@@ -500,6 +503,8 @@ def test_deliver_leaf_interrupted_replay_skips_duplicate_note_and_just_closes():
                 ),
             ),
             ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
         ]
     )
 
@@ -512,6 +517,7 @@ def test_deliver_leaf_interrupted_replay_skips_duplicate_note_and_just_closes():
     assert runner.calls == [
         ("show", "x.1", "--json"),
         ("close", "x.1"),
+        ("show", "x.1", "--json"),
     ]
 
 
@@ -547,6 +553,8 @@ def test_deliver_leaf_with_items_present_appends_items_evidence_then_closes():
             ),
             ScriptedStep(("update",), _OK),  # delivered note
             ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
         ]
     )
 
@@ -559,6 +567,7 @@ def test_deliver_leaf_with_items_present_appends_items_evidence_then_closes():
         ("show", "a", "b", "--json"),
         ("update", "x.1", "--append-notes", f"{DELIVERED_MARKER} items:a,b"),
         ("close", "x.1"),
+        ("show", "x.1", "--json"),
     ]
 
 
@@ -570,6 +579,8 @@ def test_deliver_leaf_with_trivial_appends_trivial_evidence_then_closes():
             ),
             ScriptedStep(("update",), _OK),  # delivered note
             ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(("show",), _show_result(_item_raw("x.1", status="closed"))),
         ]
     )
 
@@ -581,6 +592,7 @@ def test_deliver_leaf_with_trivial_appends_trivial_evidence_then_closes():
         ("show", "x.1", "--json"),
         ("update", "x.1", "--append-notes", f"{DELIVERED_MARKER} trivial"),
         ("close", "x.1"),
+        ("show", "x.1", "--json"),
     ]
 
 

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -150,7 +150,11 @@ VERB_CASES: list[VerbCase] = [
     VerbCase(
         "close",
         ["close", "a.1"],
-        [ScriptedStep(("close",), _OK)],
+        [
+            ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(("show",), _show_result(_item_raw("a.1", "T", status="closed"))),
+        ],
         ["close", "bogus"],
         [ScriptedStep(("close",), _NOT_FOUND)],
     ),
@@ -266,6 +270,11 @@ VERB_CASES: list[VerbCase] = [
             ),
             ScriptedStep(("update",), _OK),  # delivered note
             ScriptedStep(("close",), _OK),
+            # close-walk parent probe (S2-D5): parentless -> nothing walked
+            ScriptedStep(
+                ("show",),
+                _show_result(_item_raw("d.1", "T", status="closed", labels=["shape-feat"])),
+            ),
         ],
         ["deliver", "d.2"],  # no --pr/--items/--trivial -> E_EVIDENCE
         [

--- a/packages/workcli/tests/unit/test_nouns.py
+++ b/packages/workcli/tests/unit/test_nouns.py
@@ -69,7 +69,8 @@ def test_is_container_false_for_feature_item_with_children_but_no_container_labe
     assert is_container(item) is False
 
 
-def test_noun_templates_covers_all_seven_nouns_per_the_l9_table():
+def test_noun_templates_covers_all_eight_nouns_per_the_l9_table():
+    # Seven from the L9 table + milestone (S2-D6).
     assert {
         Noun.SPIKE: NounTemplate("task", "shape-spike", False, False, False),
         Noun.CHORE: NounTemplate("chore", "shape-chore", False, False, False),
@@ -78,4 +79,5 @@ def test_noun_templates_covers_all_seven_nouns_per_the_l9_table():
         Noun.BUGFIX: NounTemplate("bug", "shape-bugfix", False, True, False),
         Noun.SPEC: NounTemplate("feature", "shape-spec", True, False, True),
         Noun.EPIC: NounTemplate("epic", "shape-epic", True, False, False),
+        Noun.MILESTONE: NounTemplate("milestone", "shape-milestone", True, False, False),
     } == NOUN_TEMPLATES

--- a/packages/workcli/tests/unit/test_retry_safety.py
+++ b/packages/workcli/tests/unit/test_retry_safety.py
@@ -215,7 +215,6 @@ def test_end_to_end_note_surfaces_timeout_without_retry():
 @pytest.mark.parametrize(
     "argv",
     [
-        ["close", "x.1"],
         ["update", "x.1", "--set-title", "T"],
         ["label", "add", "x.1", "foo"],
     ],
@@ -231,3 +230,37 @@ def test_end_to_end_idempotent_mutations_retry_a_timeout_then_succeed(argv: list
     assert envelope["ok"] is True
     assert sleep_calls == [0.5]
     assert len(runner.calls) == 2
+
+
+def test_end_to_end_close_retries_a_timeout_then_succeeds_and_probes_parents():
+    # close keeps its retry-a-timeout semantics; the close-walk parent probe
+    # (one bd show -- S2-D5) follows the retried success.
+    ok = BdResult(returncode=0, stdout="", stderr="")
+    show_ok = BdResult(
+        returncode=0,
+        stdout=json.dumps(
+            [
+                {
+                    "id": "x.1",
+                    "title": "T",
+                    "issue_type": "task",
+                    "status": "closed",
+                    "priority": 2,
+                    "labels": [],
+                    "parent": None,
+                    "dependencies": [],
+                    "dependents": [],
+                }
+            ]
+        ),
+        stderr="",
+    )
+    runner = _SequencedRunner([_TIMEOUT_STEP, ok, show_ok])
+    sleep_calls, sleep = _recording_sleep()
+
+    exit_code, envelope, _ = _invoke(["close", "x.1"], runner, sleep=sleep)
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    assert sleep_calls == [0.5]
+    assert [call[0] for call in runner.calls] == ["close", "close", "show"]

--- a/packages/workcli/tests/unit/test_write_verbs.py
+++ b/packages/workcli/tests/unit/test_write_verbs.py
@@ -5,10 +5,14 @@ exists at all on this subparser) and requires at least one `--set-*` flag.
 `close --disposition` is one batch `bd close` call followed by one
 `--append-notes` call per id, in that order (orchestrator ruling: `bd close
 --reason` lands in the wrong field; the disposition text is an appended
-note). `reopen` is a single id, single bd call.
+note), then the close-walk's parent probe (one `bd show` of the closed ids
+-- S2-D5; walk *behavior* is state-tested in `test_close_walk.py`).
+`reopen` is a single id, single bd call.
 """
 
 from __future__ import annotations
+
+import json
 
 from tests.conftest import run_cli, run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
@@ -16,6 +20,25 @@ from workcli.adapters.bd.runner import BdResult
 from workcli.envelope import ErrorCode
 
 _OK = BdResult(returncode=0, stdout="", stderr="")
+
+
+def _parentless_show_result(*ids: str) -> BdResult:
+    """A `bd show` result for the walk's parent probe: closed, parentless items."""
+    raw = [
+        {
+            "id": item_id,
+            "title": "T",
+            "issue_type": "task",
+            "status": "closed",
+            "priority": 2,
+            "labels": [],
+            "parent": None,
+            "dependencies": [],
+            "dependents": [],
+        }
+        for item_id in ids
+    ]
+    return BdResult(returncode=0, stdout=json.dumps(raw), stderr="")
 
 
 def test_update_set_title_and_set_priority_sends_one_bd_call_with_both_flags():
@@ -63,6 +86,7 @@ def test_close_with_disposition_closes_then_appends_one_note_per_id_in_order():
             ScriptedStep(("close",), _OK),
             ScriptedStep(("update",), _OK),
             ScriptedStep(("update",), _OK),
+            ScriptedStep(("show",), _parentless_show_result("a.1", "a.2")),
         ]
     )
 
@@ -75,16 +99,24 @@ def test_close_with_disposition_closes_then_appends_one_note_per_id_in_order():
         ("close", "a.1", "a.2"),
         ("update", "a.1", "--append-notes", "done, wontfix elsewhere"),
         ("update", "a.2", "--append-notes", "done, wontfix elsewhere"),
+        ("show", "a.1", "a.2", "--json"),
     ]
 
 
-def test_close_without_disposition_sends_exactly_one_bd_call():
-    runner = ScriptedBdRunner(steps=[ScriptedStep(("close",), _OK)])
+def test_close_without_disposition_sends_close_then_one_parent_probe():
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("close",), _OK),
+            ScriptedStep(("show",), _parentless_show_result("a.1")),
+        ]
+    )
 
-    exit_code, _, _ = run_cli_with_runner(["close", "a.1"], runner)
+    exit_code, envelope, _ = run_cli_with_runner(["close", "a.1"], runner)
 
     assert exit_code == 0
-    assert runner.calls == [("close", "a.1")]
+    # Nothing walked (parentless) -- the envelope keeps its pre-S2 None shape.
+    assert envelope["data"] is None
+    assert runner.calls == [("close", "a.1"), ("show", "a.1", "--json")]
 
 
 def test_close_not_found_maps_to_not_found_envelope():


### PR DESCRIPTION
## Summary

First of two PRs executing **S2 (workcli completion)** of the harness-rework charter (`docs/specs/2026-07-21-harness-rework-way-forward.md`, D11). Ships the **V2 gap audit** as a child spec — `docs/specs/2026-07-22-workcli-completion-s2.md` — with the D11-verb gap table and per-slice red-test-convertible ACs, plus the code closing two of its three slices:

### Slice A — mint completeness (ACs S2-A1..A5)
- `work create milestone`: new noun (bd type `milestone`, `shape-milestone` declared-state container label); `--acceptance` flows through — closes the milestone-with-acceptance expressibility gap recorded on bead `agents-config-9k9` during S1 (audit rows mint (a)/(b)). `create --raw` stays transport-minimal.
- `--label` is now **additive** on noun create behind a reserved-namespace wall (`shape-*`, `track:*`, `planned`, `creating-spec`, `impl-placeholder`, `spec-ready`, `parked`) — single-call atomicity for labeled creation (audit row mint (c)).

### Slice C — close-walk atomicity (ACs S2-C1..C5)
- `work close` and leaf `deliver` now run close + close-walk + note as **one facade call**: an exhausted non-milestone parent (all children closed) closes with a `[work] close-walk: all children closed` note, recursively. Milestones are the walk boundary — they close on their own acceptance section (charter AC9), never on child exhaustion. `deliver`'s long-standing "closes via close-walk" docstring promise is now code.
- Envelope: `close`/`deliver` gain a `walked` field only when the walk closed something; the pre-S2 shapes are otherwise unchanged.

Slice B (park/redispatch/abandon + parked report, D10) follows in the next PR.

Work items: `agents-config-9k9.7.1`, `agents-config-9k9.7.3` under epic `agents-config-9k9.7` (Harness-rework milestone).

## Test plan
- `make ci-workcli` green: 587 passed, 99.11% coverage, lint/format/typecheck/audit clean.
- New: `test_create_milestone_and_labels.py` (S2-A1..A5), `test_close_walk.py` (S2-C1..C5, state-based on FakeBackend).
- Updated for the walk's parent probe / new noun: `test_write_verbs`, `test_deliver`, `test_envelope_invariants`, `test_retry_safety` (dedicated close-retry case), `test_nouns`, `test_create_noun` (reserved-label variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKiFzhzkybP7XgTqiMWR7z