### PR TITLE
fix(installer): force CLI deploys to rebuild from source with --reinstall (agents-config-9k9.14)

### DIFF
--- a/packages/installer/src/installer/core/clis.py
+++ b/packages/installer/src/installer/core/clis.py
@@ -265,7 +265,11 @@ class UvCliDeploy:
     def tool_install(self, package_dir: Path, *, force: bool) -> CommandResult:
         cmd = ["uv", "tool", "install"]
         if force:
-            cmd.append("--force")
+            # --force alone reuses uv's build cache for local path packages,
+            # which keys on package metadata (version), not src/** contents.
+            # --reinstall forces a rebuild from source so a digest-triggered
+            # upgrade can't silently install a stale cached wheel.
+            cmd.extend(["--force", "--reinstall"])
         lock = package_dir / "uv.lock"
         if not lock.is_file():
             cmd.append(str(package_dir))

--- a/packages/installer/tests/unit/test_clis_port.py
+++ b/packages/installer/tests/unit/test_clis_port.py
@@ -169,6 +169,11 @@ def test_tool_install_exports_constraints_when_lock_present(
     assert port.tool_install(lockless, force=True).ok
     assert calls[0][:3] == ["uv", "tool", "install"]
     assert "--force" in calls[0] and "--constraints" not in calls[0]
+    # --force alone reuses uv's build cache for local path packages (keyed on
+    # package metadata/version, not src/** contents); --reinstall forces a
+    # rebuild from source so a digest-triggered upgrade can't silently install
+    # a stale cached wheel (agents-config-9k9.14).
+    assert "--reinstall" in calls[0]
 
 
 def test_subprocess_failures_map_to_not_ok(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `uv tool install --force` does not guarantee a rebuild for local path packages: uv's build cache keys on package metadata (version, unchanged at 0.1.0), not `src/**` contents, so a digest-triggered upgrade reinstalled the stale cached wheel while `_finish_install` stamped the receipt with the new digest — a silent false-green deploy. Observed 2026-07-24: post-S2 workcli merged, installer reported deployed, yet the installed `work` binary still lacked the milestone noun.
- Fix: the force path in `clis.py::tool_install` now passes `--force --reinstall`, so a digest-triggered upgrade always rebuilds from source.
- Test: argv-shape assertion that the force path includes `--reinstall`, beside the existing tool_install argv tests.

Tracker: agents-config-9k9.14.

## Verification

- `make ci-installer` green from the branch worktree: 927 passed, 1 skipped; coverage 97.85% (floor 90%); lint/format/mypy/audit/entry-verify clean.
- HEAVY quality-gate workflow: acceptance, clean-at-floor (0 findings at major floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ7AFo9nW6JTJ85QEbCtzp