### PR TITLE
feat(skills): S5 Slice A — admit grilling + to-spec, regularize grill-with-docs (agents-config-9k9.15.2)

### DIFF
--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -60,7 +60,9 @@ Skills built from scratch in-repo do not appear here. This table tracks only OSS
 | `using-git-worktrees` | `oss-snapshots/superpowers/using-git-worktrees/` | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-23 | accept-periodic-resync |
 | `writing-plans` | `oss-snapshots/superpowers/writing-plans/` | `obra/superpowers @ f2cbfbe` (v5.1.0) | 2026-05-23 | accept-periodic-resync |
 | `improve-codebase-architecture` | `oss-snapshots/pocock/skills/skills/engineering/improve-codebase-architecture/` (pristine upstream; local extensions in deployed copy) | `mattpocock/skills @ e74f0061` | 2026-05-23 | rewrite-and-divorce (project-extended fork) |
-| `grill-with-docs` | `oss-snapshots/pocock/skills/skills/engineering/grill-with-docs/` | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
+| `grill-with-docs` | `oss-snapshots/pocock/skills/skills/engineering/grill-with-docs/` | `mattpocock/skills @ e74f0061` | 2026-05-23 | local-fork |
+| `grilling` | `oss-snapshots/pocock/skills/skills/productivity/grilling/` | `mattpocock/skills @ e74f0061` | 2026-07-24 | local-fork |
+| `to-spec` | `oss-snapshots/pocock/skills/skills/engineering/to-spec/` | `mattpocock/skills @ e74f0061` | 2026-07-24 | local-fork |
 | `caveman` | repo-owned (upstream removed the skill; detached 2026-07-24) | `mattpocock/skills @ e74f0061` (historical origin) | 2026-05-23 | rewrite-and-divorce |
 | `prototype` | `oss-snapshots/pocock/skills/skills/engineering/prototype/` | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |
 | `writing-unit-tests` | `oss-snapshots/pocock/skills/skills/engineering/tdd/` (amalgamated deltas only) | `mattpocock/skills @ e74f0061` | 2026-05-23 | accept-periodic-resync |

--- a/src/user/.agents/skills/grill-with-docs/SKILL.md
+++ b/src/user/.agents/skills/grill-with-docs/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: grill-with-docs
 description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+admission:
+  prevents: An existing plan advancing to implementation while it still contradicts the project's glossary, ADRs, and code — the drift surfaces late as rework and human intervention.
+  cost: Adds a standalone deep session that cross-checks every claim against CONTEXT.md/ADR docs and holds the plan until its acceptance criteria are enumerated.
+  remove_when: The readiness gate can mechanically detect glossary/ADR contradictions and prove enumerated red-test-convertible acceptance criteria without this session having run.
 ---
 
 <!--
 Source: oss-snapshots/pocock/skills/skills/engineering/grill-with-docs/
 Upstream: https://github.com/mattpocock/skills @ e74f0061bb67222181640effa98c675bdb2fdaa7
 Last sync: 2026-05-23
-Drift policy: accept-periodic-resync
+Drift policy: local-fork — grafted, do not re-sync
 Note: promoted from byte-identical local copy at <repo>/.claude/skills/grill-with-docs/.
 -->
 
@@ -22,11 +26,6 @@ If a question can be answered by exploring the codebase, explore the codebase in
 </what-to-do>
 
 <supporting-info>
-
-Note: the brainstorming skill adopts this skill's glossary discipline inline
-(challenge terms, sharpen language, update `CONTEXT.md`) whenever a `CONTEXT.md`
-or `CONTEXT-MAP.md` exists at brainstorm time. grill-with-docs remains the
-standalone deep session for stress-testing an existing plan.
 
 ## Domain awareness
 
@@ -97,5 +96,19 @@ Only offer to create an ADR when all three are true:
 3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
 
 If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](./ADR-FORMAT.md).
+
+## Exit criterion
+
+A deep session against the docs does not end at glossary agreement. It ends only when the plan's **acceptance criteria are enumerated with stable IDs**, each one stated so it is directly expressible as a *failing test* (red-test-convertible: a concrete observable — false today, true when the work is done — that a reader can check against the code and the docs).
+
+For every acceptance criterion, apply the edge-case taxonomy — surface and resolve, or explicitly rule out with a reason, each of:
+
+- **Inverse case** — the negative/failure path, not just the happy path.
+- **Empty / boundary input** — zero, empty, min, max, first, last.
+- **Dependency failure** — an upstream tool, file, service, or precondition is absent or errors.
+- **Repeated / concurrent invocation** — run twice, run in parallel, interleaved.
+- **Idempotency** — a second identical run changes nothing beyond the first.
+
+Cross-check each criterion against `CONTEXT.md` and the ADRs as you go: an AC that contradicts the recorded glossary or a documented decision is not done — resolve the contradiction (update the docs or revise the AC) before the session ends. If any AC lacks an ID, cannot be phrased as a failing test, or has an unaddressed taxonomy row, keep grilling until it can.
 
 </supporting-info>

--- a/src/user/.agents/skills/grilling/SKILL.md
+++ b/src/user/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: grilling
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+admission:
+  prevents: Implementation starting from a goals-only idea whose decisions and edge cases were never resolved, forcing rework and human babysitting downstream.
+  cost: Front-loads a one-question-at-a-time interview and a terminal acceptance-criteria enumeration before any building begins.
+  remove_when: The readiness gate can mechanically prove a plan enumerates red-test-convertible acceptance criteria without this interview having run.
+---
+
+<!--
+Source: oss-snapshots/pocock/skills/skills/productivity/grilling/
+Upstream: https://github.com/mattpocock/skills
+Drift policy: local-fork — grafted, do not re-sync
+-->
+
+Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+
+Do not act on it until I confirm we have reached a shared understanding.
+
+## Exit criterion
+
+The grilling session does not end until the plan's **acceptance criteria are enumerated with stable IDs**, and each one is stated so it is directly expressible as a *failing test* (red-test-convertible: a concrete observable that is false today and true when the work is done).
+
+For every acceptance criterion, apply the edge-case taxonomy — surface and resolve, or explicitly rule out with a reason, each of:
+
+- **Inverse case** — the negative/failure path, not just the happy path.
+- **Empty / boundary input** — zero, empty, min, max, first, last.
+- **Dependency failure** — an upstream tool, file, service, or precondition is absent or errors.
+- **Repeated / concurrent invocation** — run twice, run in parallel, interleaved.
+- **Idempotency** — a second identical run changes nothing beyond the first.
+
+If any AC lacks an ID, cannot be phrased as a failing test, or has an unaddressed taxonomy row, the session is not done — keep grilling until it is.

--- a/src/user/.agents/skills/to-spec/SKILL.md
+++ b/src/user/.agents/skills/to-spec/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: to-spec
+description: Turn the current conversation into a spec — no interview, just synthesis of what you've already discussed. Invoke when the user asks to turn the conversation into a spec.
+admission:
+  prevents: A resolved conversation evaporating into a goals-only or verbally-agreed plan that an implementer cannot execute without re-litigating decisions and edge cases.
+  cost: Adds a synthesis pass that writes a dated spec whose output contract requires enumerated acceptance criteria and an ordered, AC-cited slice list before it is done.
+  remove_when: The pipeline can mechanically emit an implementable spec with red-test-convertible acceptance criteria and sliced work from the conversation without this authoring step.
+---
+
+<!--
+Source: oss-snapshots/pocock/skills/skills/engineering/to-spec/
+Upstream: https://github.com/mattpocock/skills
+Drift policy: local-fork — grafted, do not re-sync
+-->
+
+This skill takes the current conversation context and codebase understanding and produces a spec (you may know this document as a PRD). Do NOT interview the user — just synthesize what you already know.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the spec, and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better — the ideal number is one.
+
+Check with the user that these seams match their expectations.
+
+3. Write the spec using the template below and save it as a dated file (`YYYY-MM-DD-<slug>.md`) in the project's spec home. Publishing work items to the issue tracker is a separate step and out of scope here.
+
+<spec-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each in the format: `As an <actor>, I want a <feature>, so that <benefit>`. Cover all aspects of the feature.
+
+## Implementation Decisions
+
+The modules built/modified, their interfaces, technical clarifications, architectural decisions, schema changes, API contracts, specific interactions. Do NOT include file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose (state machine, reducer, schema, type shape), inline the decision-rich bits and note it came from a prototype.
+
+## Testing Decisions
+
+What makes a good test (only external behavior, not implementation details), which modules will be tested, and prior art for the tests.
+
+## Acceptance Criteria
+
+A numbered list of acceptance criteria, each with a **stable ID** (`<ID>` matches `[A-Z0-9]+-[A-Z]\d+` or `AC\d+`, e.g. `AC1`, `FOO-A1`). Each criterion MUST be **red-test-convertible**: stated as a concrete observable that is false today and true when the work is done, so it maps to one failing test.
+
+For every criterion, apply the edge-case taxonomy — resolve or explicitly rule out each of: **inverse case** (failure path), **empty/boundary input** (zero, empty, min, max), **dependency failure** (an upstream tool/file/service absent or erroring), **repeated/concurrent invocation**, and **idempotency** (a second identical run changes nothing).
+
+## Ordered Slice List
+
+An ordered list of slices. Each slice is the **smallest independently mergeable** unit of work and **cites the acceptance-criterion IDs it satisfies**. Order so each slice's dependencies land before it.
+
+**Size tripwire:** if the spec exceeds **400 lines** or **8 slices**, split it into a parent spec plus child specs (one child per coherent slice group), each child carrying its own Acceptance Criteria and Ordered Slice List.
+
+## Out of Scope
+
+The things that are out of scope for this spec.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</spec-template>


### PR DESCRIPTION
## Summary

Implements Slice A (S5-A1..S5-A5) of `docs/specs/2026-07-24-spec-contract-s5.md`.

- **NEW `grilling`** — promoted from the pocock mirror (interview core kept intact), with provenance header (`local-fork`), an `admission:` record, and the D18 exit-criterion graft: the session doesn't end until the plan's ACs are enumerated with IDs, red-test-convertible, edge-case taxonomy applied.
- **NEW `to-spec`** — adapted per S5-D3: no Claude-specific frontmatter (user-invoked intent lives in the description); the embedded template's output contract now requires an Acceptance Criteria section + ordered AC-cited slice list with the D2 size tripwire; publish-to-tracker step removed (to-tickets' seat).
- **`grill-with-docs`** — admission record, `local-fork` drift policy, exit-criterion graft, brainstorming cross-ref deleted.
- Registry rows updated; all rows verified to resolve to existing skill dirs.

These are the first three deployed artifacts to carry real admission records (S5-D7).

Tracker: agents-config-9k9.15.2.

## Verification

- `admission.classify()` → COMPLETE for all three; bodies 456/1238/850 tokens (≤ 2k cap); `disable-model-invocation` absent from to-spec; zero `brainstorming` refs left in grill-with-docs.
- HEAVY quality-gate workflow (3 finders / 2 refuters, fidelity-vs-spec probes): acceptance, clean-at-floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ7AFo9nW6JTJ85QEbCtzp