### PR TITLE
chore(9k9.15.5): sweep L-number law refs and spec-section citations

### DIFF
--- a/packages/installer/src/installer/core/clis.py
+++ b/packages/installer/src/installer/core/clis.py
@@ -59,7 +59,7 @@ def cli_source_digest(package_dir: Path) -> str:
     Inputs: pyproject.toml (required — missing means the registry points at a
     non-package: fail fast), uv.lock (omitted when absent), and src/** minus
     __pycache__/*.pyc. tests/README/AGENTS.md are deliberately excluded — a
-    docs-only change must not force a reinstall (spec §5)."""
+    docs-only change must not force a reinstall."""
     pyproject = package_dir / "pyproject.toml"
     if not pyproject.is_file():
         msg = f"not a deployable CLI package (no pyproject.toml): {package_dir}"
@@ -88,7 +88,7 @@ def cli_source_digest(package_dir: Path) -> str:
 class CliDeployPort(Protocol):
     """Injected subprocess seam for uv-tool deploys. All installed-state
     decisions are PATH-independent (bin_dir/shim_path/tool_list); ``which``
-    serves only the reachability invariant (spec §4)."""
+    serves only the reachability invariant."""
 
     def uv_version(self) -> tuple[int, ...] | None: ...  # pragma: no cover
     def bin_dir(self) -> Path: ...  # pragma: no cover
@@ -233,7 +233,7 @@ class UvCliDeploy:
         result = self._run(["uv", "tool", "dir", "--bin"], _QUERY_TIMEOUT)
         if result.ok and result.output.strip():
             return Path(result.output.strip().splitlines()[0])
-        # uv's documented resolution order, in full (spec §4; item 17).
+        # uv's documented resolution order, in full.
         if env := os.environ.get("UV_TOOL_BIN_DIR"):
             return Path(env)
         if env := os.environ.get("XDG_BIN_HOME"):
@@ -307,8 +307,8 @@ class UvCliDeploy:
     def update_shell(self) -> CommandResult:
         result = self._run(["uv", "tool", "update-shell"], _QUERY_TIMEOUT)
         # uv exits non-zero when the shell config already contains the PATH
-        # entry; that expected steady state counts as success (spec §6 /
-        # item 20 — repeat installs from an un-restarted shell stay green).
+        # entry; that expected steady state counts as success (repeat
+        # installs from an un-restarted shell stay green).
         if not result.ok and "already" in result.output.lower():
             return CommandResult(ok=True, output=result.output)
         return result

--- a/packages/installer/src/installer/core/receipt.py
+++ b/packages/installer/src/installer/core/receipt.py
@@ -36,7 +36,7 @@ class ReceiptEntry:
 
 @dataclass(frozen=True, slots=True)
 class CliReceiptEntry:
-    """One installer-deployed uv tool (spec §7). ``name`` is the registry /
+    """One installer-deployed uv tool. ``name`` is the registry /
     uv tool name; ``digest`` is ``cli_source_digest`` at deploy time."""
 
     name: str

--- a/packages/installer/src/installer/core/receipt_build.py
+++ b/packages/installer/src/installer/core/receipt_build.py
@@ -90,7 +90,7 @@ def merge_clis(
     uninstalled_names: set[str],
     relinquished_names: set[str],
 ) -> tuple[CliReceiptEntry, ...]:
-    """Union merge over registry CLIs and prior entries (spec §7).
+    """Union merge over registry CLIs and prior entries.
 
     Registry CLI -> the new entry when this run deployed it, else the
     retained prior entry (skip/decline/failure keep the old record).
@@ -129,7 +129,7 @@ def merge_receipt(
     by the caller as the already-computed ``merge_clis`` result; ``None``
     preserves the prior value unchanged (the ``_run_project`` path never passes
     it, so a project-local receipt's ``clis`` — none in practice — is
-    untouched; spec §7)."""
+    untouched)."""
     by_path: dict[Path, ReceiptEntry] = {
         e.path: e
         for e in prior.entries

--- a/packages/installer/src/installer/core/receipt_store.py
+++ b/packages/installer/src/installer/core/receipt_store.py
@@ -101,7 +101,7 @@ def _cli_entry_from_json(d: object) -> CliReceiptEntry:
         raise ValueError("cli entry is not an object")  # noqa: TRY003, TRY004  # caught -> CORRUPT
     name, binary, digest = d.get("name"), d.get("binary"), d.get("digest")
     # Non-string fields fail closed -> CORRUPT: a malformed entry must not
-    # drive deploy/prune decisions (spec §7).
+    # drive deploy/prune decisions.
     if not (isinstance(name, str) and isinstance(binary, str) and isinstance(digest, str)):
         raise ValueError(  # noqa: TRY003, TRY004  # caught -> CORRUPT; subclass not justified
             "cli entry name/binary/digest must be strings"

--- a/packages/installer/src/installer/core/run.py
+++ b/packages/installer/src/installer/core/run.py
@@ -357,7 +357,7 @@ class CliDeployOutcome:
     """What the CLI deploy half did. ``deployed`` holds only this run's
     smoked-OK installs (keyed by registry name) — the merge rule retains
     prior entries for everything else. ``any_failed`` drives _run's exit
-    code (spec §6 failure surfacing)."""
+    code."""
 
     deployed: dict[str, CliReceiptEntry]
     counters: dict[str, Counters]
@@ -374,7 +374,7 @@ def deploy_clis(
     dry_run: bool = False,
     auto_yes: bool = False,
 ) -> CliDeployOutcome:
-    """The CLI deploy half (spec §6): registry order, PATH-independent
+    """The CLI deploy half: registry order, PATH-independent
     decision signals, consent on any unproven overwrite, reachability
     invariant per bin dir."""
     deployed: dict[str, CliReceiptEntry] = {}
@@ -440,7 +440,7 @@ def _deploy_one(
     deployed: dict[str, CliReceiptEntry],
     c: Counters,
 ) -> tuple[bool, bool]:
-    """Run the §6 decision table for one CLI.
+    """Run the decision table for one CLI.
 
     Returns (failed, shim_present_at_end); the caller's reachability gate
     keys off the second element instead of re-reading shim_path."""
@@ -448,7 +448,7 @@ def _deploy_one(
     shim = deploy.shim_path(spec.binary)
     env_present = tools is not None and spec.name in tools
     # Provenance: the registered env currently provides the registered
-    # binary. Unproven (tools is None) is never provenance (spec §6).
+    # binary. Unproven (tools is None) is never provenance.
     provenance = tools is not None and spec.binary in tools.get(spec.name, frozenset())
     evidence = shim is not None or env_present or tools is None
 
@@ -518,7 +518,7 @@ def _deploy_one(
                 )
             )
         # Receipt present but provenance mismatch (foreign env/shim) ->
-        # takeover consent (spec §6 provenance precondition / item 19).
+        # takeover consent (provenance precondition).
         return _done(
             *_consented_install(
                 spec,
@@ -538,7 +538,7 @@ def _deploy_one(
 
     if not evidence:
         # Fresh: non-forcing; an already-exists failure re-routes to
-        # takeover consent (spec §6 fresh row / item 18).
+        # takeover consent.
         if dry_run:
             io.info(f"cli:{spec.name}: would install")
             return _done(False, False)
@@ -681,7 +681,7 @@ def _check_reachability(
     auto_yes: bool,
     resolved_dirs: set[Path],
 ) -> bool:
-    """PATH-reachability invariant (spec §6): a property of the bin dir,
+    """PATH-reachability invariant: a property of the bin dir,
     evaluated once per dir per run; update-shell repair memoized. Returns
     False only on a genuine deployment failure."""
     bin_dir = deploy.bin_dir()
@@ -698,7 +698,7 @@ def _check_reachability(
     if bin_dir in resolved_dirs:
         return True
     # Reachability is never evaluated under dry-run: deploy_clis gates this call
-    # with `if not dry_run and shim_present` (Task 6 loop), so dry_run is always
+    # with `if not dry_run and shim_present`, so dry_run is always
     # False here — the literal below routes the no-TTY convention at this consent
     # point (raises ConsentRequiredError iff non-interactive AND not --yes).
     require_consent(io, dry_run=False, auto_yes=auto_yes)
@@ -737,7 +737,7 @@ def prune_clis(
     dry_run: bool = False,
     auto_yes: bool = False,
 ) -> CliPruneOutcome:
-    """Retire prior CLI entries no longer in the registry (spec §7).
+    """Retire prior CLI entries no longer in the registry.
 
     Uninstall authority is bounded by ``registry_names | retired`` — the
     receipt's integrity digest is tamper-evidence, not authentication, so a

--- a/packages/installer/src/installer/core/summary.py
+++ b/packages/installer/src/installer/core/summary.py
@@ -116,7 +116,7 @@ def render_summary(
     order; ``all_tools`` / ``all_plugins`` are the ALL_* universes used to emit
     the '(not detected, skipped)' footers. ``clis`` is the active cli:<name>
     deploy/prune target set. ``any_failed`` is the CLI-deploy stage's
-    record-and-continue failure flag (spec §6/§8): a hard failure (version
+    record-and-continue failure flag: a hard failure (version
     guard, install, smoke) never touches a per-target counter, so it would
     otherwise reach quiet mode's all-zero branch and print a false
     'up to date' line right before the caller returns exit 1. ``verbose``

--- a/packages/installer/tests/unit/test_cli_deploy_wiring.py
+++ b/packages/installer/tests/unit/test_cli_deploy_wiring.py
@@ -1,4 +1,4 @@
-"""End-to-end wiring tests: main() drives the CLI deploy stage (spec §6/§7)."""
+"""End-to-end wiring tests: main() drives the CLI deploy stage."""
 
 from __future__ import annotations
 
@@ -70,8 +70,8 @@ def test_full_install_deploys_both_clis_and_records_receipt(tmp_path: Path) -> N
     Then exit 0, both CLIs deploy, and the receipt carries both clis
     entries.
 
-    Pins spec §6+§7 wiring: stage runs inside the lock, entries thread
-    through record_receipt/merge_receipt (item 11 second half).
+    Pins the receipt-wiring contract: stage runs inside the lock, entries
+    thread through record_receipt/merge_receipt.
     """
     repo = _hermetic_repo(tmp_path)
     bin_dir = tmp_path / "bin"
@@ -107,7 +107,7 @@ def test_deploy_failure_exits_1_after_summary(tmp_path: Path) -> None:
     Then exit 1, and the summary still rendered (Done./up-to-date line in
     transcript AFTER the err).
 
-    Pins spec §6 failure surfacing: exit flag carried out of the lock.
+    Pins the failure-surfacing rule: exit flag carried out of the lock.
     """
     repo = _hermetic_repo(tmp_path)
     # --yes auto-accepts the TOCTOU takeover re-route, so each fresh CLI
@@ -145,7 +145,7 @@ def test_prune_only_drops_retired_cli_through_real_receipt_path(tmp_path: Path) 
     Then the deploy half never fires, the uninstall does, and the rewritten
     receipt no longer carries the entry.
 
-    Pins spec §7 --prune-only convergence / item 10. NOTE: requires a
+    Pins the --prune-only convergence rule. NOTE: requires a
     nonzero RETIRED_CLIS in the test — monkeypatch installer.core.run's
     retired source or pass through a seam; the implementer wires
     prune_clis(retired=frozenset(RETIRED_CLIS)) in cli.py, so monkeypatch
@@ -191,7 +191,7 @@ def test_prune_only_no_tty_without_yes_exits_1(tmp_path: Path) -> None:
     the prune branch, since the existing prune try catches only
     PruneAbortedError.
 
-    Pins spec §10 item 12, prune half (the deploy half is
+    Pins the no-TTY consent rule, prune half (the deploy half is
     test_no_tty_without_yes_at_cli_consent_exits_1 below).
     """
     repo = _hermetic_repo(tmp_path)
@@ -227,7 +227,7 @@ def test_second_noop_run_skips_via_persisted_clis(tmp_path: Path) -> None:
     Then the second run smokes-and-skips (no tool_install) — the clis
     entries persisted through the real path.
 
-    Pins item 11 (second no-op run converges).
+    Pins the second-run convergence rule (no-op on repeat).
     """
     repo = _hermetic_repo(tmp_path)
     home = tmp_path / "home"
@@ -284,7 +284,7 @@ def test_project_run_no_deploys_and_clis_untouched(tmp_path: Path) -> None:
     Then no port method is called (empty queues never pop) and a
     pre-existing project receipt's clis (synthetic) is untouched.
 
-    Pins spec §6 --project exclusion / item 13.
+    Pins the --project exclusion rule.
     """
     repo = _hermetic_repo(tmp_path)
     project = tmp_path / "project"
@@ -310,7 +310,7 @@ def test_corrupt_receipt_deploy_not_persisted(tmp_path: Path) -> None:
     Then the receipt file is left untouched (still corrupt) — the deploy is
     not persisted.
 
-    Pins spec §7 corrupt-receipt consequence / item 14.
+    Pins the corrupt-receipt consequence rule.
     """
     repo = _hermetic_repo(tmp_path)
     home = tmp_path / "home"
@@ -347,7 +347,7 @@ def test_no_tty_without_yes_at_cli_consent_exits_1(tmp_path: Path) -> None:
     When main runs
     Then exit 1 via the ConsentRequiredError convention.
 
-    Pins spec §6 no-TTY / item 12.
+    Pins the no-TTY consent rule.
     """
     repo = _hermetic_repo(tmp_path)
     deploy = ScriptedCliDeploy(

--- a/packages/installer/tests/unit/test_cli_project.py
+++ b/packages/installer/tests/unit/test_cli_project.py
@@ -444,7 +444,7 @@ def test_project_kit_selector_scoped_to_user_errors_pre_resolve(
 
 def test_user_install_byte_identical_through_resolver(tmp_path: Path) -> None:
     """A plain user install (no --project) must stay byte-identical once
-    main()'s resolver pass (S2 Task 9) is wired in ahead of install_pipeline.
+    main()'s resolver pass is wired in ahead of install_pipeline.
 
     An empty CLI profile selection resolves to the "full" profile
     (`include = ["**"]` in profiles.toml), so every staged item matches and
@@ -468,7 +468,7 @@ def test_project_install_persists_profiles_then_bare_rerun_reinstalls(tmp_path: 
     """A successful ``--project p --profiles=beads-kit`` install writes
     <p>/project-config.toml's [install].profiles; a subsequent BARE
     ``--project p`` (no --profiles) then reads that persisted selection
-    (Task 10's read_project_profiles path) and reinstalls beads-kit."""
+    (the read_project_profiles path) and reinstalls beads-kit."""
     repo = _hermetic_repo_with_profiles(tmp_path)
     kit = repo / "src" / "kits" / "beads" / ".beads"
     kit.mkdir(parents=True)

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -61,7 +61,7 @@ def _write_installignore(repo: Path) -> None:
 
 
 def _write_profiles_toml(repo: Path) -> None:
-    """Mirror the real profiles.toml so main()'s resolver pass (S2 Task 9) can
+    """Mirror the real profiles.toml so main()'s resolver pass can
     load it. Only needed by fixtures that stage non-empty tool plans — main()
     skips the resolver entirely on an empty universe, so an all-empty fixture
     (e.g. ``_repo_with_installer_toml``) needs no profiles.toml. Copied from

--- a/packages/installer/tests/unit/test_clis_port.py
+++ b/packages/installer/tests/unit/test_clis_port.py
@@ -1,4 +1,4 @@
-"""Tests for the CliDeployPort fake and real implementation (spec §4)."""
+"""Tests for the CliDeployPort fake and real implementation."""
 
 import subprocess
 from pathlib import Path
@@ -19,7 +19,7 @@ def test_scripted_fake_stable_reads_and_stateful_queues(tmp_path: Path) -> None:
     (shim_path/install/smoke/...) pop per-method queues, and the transcript
     records (method, key-arg) tuples.
 
-    Pins spec §4 fake contract (queue semantics reserved for calls whose
+    Pins the fake contract (queue semantics reserved for calls whose
     sequence matters — ralf plan-review cycle 1 M3).
     """
     bin_dir = tmp_path / "bin"
@@ -52,7 +52,7 @@ def test_scripted_fake_exhaustion_is_loud(tmp_path: Path) -> None:
     When tool_install / shim_path are called
     Then each raises with a message naming the exhausted queue.
 
-    Pins spec §4: exhaustion-error self-diagnosis mirrors ScriptedIO.
+    Pins that exhaustion-error self-diagnosis mirrors ScriptedIO.
     """
     fake = ScriptedCliDeploy()
     with pytest.raises(RuntimeError, match="installs"):
@@ -74,7 +74,7 @@ def test_uv_version_parses_semver(monkeypatch: pytest.MonkeyPatch) -> None:
     When uv_version() runs
     Then it returns (0, 10, 4); an unparseable output returns None.
 
-    Pins spec §4/§6: the MIN_UV_VERSION guard input.
+    Pins the MIN_UV_VERSION guard input.
     """
     port = UvCliDeploy()
     monkeypatch.setattr(
@@ -92,7 +92,7 @@ def test_bin_dir_fallback_chain(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     Then it honors UV_TOOL_BIN_DIR, then XDG_BIN_HOME, then
     XDG_DATA_HOME/../bin, then ~/.local/bin.
 
-    Pins spec §4 / item 17 (full documented uv precedence).
+    Pins the full documented uv precedence.
     """
 
     def _boom(*_a: object, **_k: object) -> _FakeCompleted:
@@ -121,7 +121,7 @@ def test_tool_list_parses_names_and_executables(monkeypatch: pytest.MonkeyPatch)
     Then it returns {tool: frozenset(executables)}; a failed query returns
     None.
 
-    Pins spec §4: the provenance mapping gating promptless heal (item 19).
+    Pins the provenance mapping gating promptless heal.
     """
     out = "workcli v0.1.0\n- work\nprgroom v0.1.0\n- prgroom\n"
     port = UvCliDeploy()
@@ -144,7 +144,7 @@ def test_tool_install_exports_constraints_when_lock_present(
     `uv tool install --constraints <file> <dir>`; force=True adds --force;
     a lock-less package installs unconstrained.
 
-    Pins spec §4 / items 16, 18 (lock-respecting + non-forcing fresh).
+    Pins the lock-respecting + non-forcing-fresh install rules.
     """
     calls: list[list[str]] = []
 
@@ -172,7 +172,7 @@ def test_tool_install_exports_constraints_when_lock_present(
     # --force alone reuses uv's build cache for local path packages (keyed on
     # package metadata/version, not src/** contents); --reinstall forces a
     # rebuild from source so a digest-triggered upgrade can't silently install
-    # a stale cached wheel (agents-config-9k9.14).
+    # a stale cached wheel.
     assert "--reinstall" in calls[0]
 
 
@@ -182,7 +182,7 @@ def test_subprocess_failures_map_to_not_ok(monkeypatch: pytest.MonkeyPatch, tmp_
     When tool_uninstall or smoke runs
     Then CommandResult(ok=False, output=...) is returned, never an exception.
 
-    Pins spec §4/§8: fail loud via the result, no exception leakage.
+    Pins the fail-loud rule: return the result, no exception leakage.
     """
     port = UvCliDeploy()
 
@@ -215,8 +215,8 @@ def test_update_shell_already_configured_counts_as_success(
     from an un-restarted shell stay green); a genuinely different failure
     stays ok=False.
 
-    Pins spec §6 already-configured classification / item 20 (real-impl
-    branch; the stage-level behavior is driven through the fake in Task 9).
+    Pins the already-configured classification (real-impl
+    branch; the stage-level behavior is driven through the fake elsewhere).
     """
     port = UvCliDeploy()
     monkeypatch.setattr(
@@ -241,8 +241,8 @@ def test_bin_dir_uses_uv_tool_dir_when_available(
     When bin_dir() resolves
     Then the printed path wins over every env fallback.
 
-    Pins spec §4: the uv query is the primary source; the env chain is
-    fallback only (success arm of item 17).
+    Pins that the uv query is the primary source; the env chain is
+    fallback only.
     """
     monkeypatch.setenv("UV_TOOL_BIN_DIR", str(tmp_path / "ignored"))
     monkeypatch.setattr(
@@ -260,7 +260,7 @@ def test_tool_install_export_failure_aborts_install(
     Then the failing export result is returned and `uv tool install` never
     runs — a lock-respecting install refuses to proceed unconstrained.
 
-    Pins spec §4 / item 16 export-failure arm.
+    Pins the export-failure arm.
     """
     calls: list[list[str]] = []
 

--- a/packages/installer/tests/unit/test_clis_registry.py
+++ b/packages/installer/tests/unit/test_clis_registry.py
@@ -1,4 +1,4 @@
-"""Tests for the CLI-deploy registry and source digest (spec §3, §5)."""
+"""Tests for the CLI-deploy registry and source digest."""
 
 from pathlib import Path
 
@@ -27,7 +27,7 @@ def test_registry_is_exactly_workcli_and_prgroom() -> None:
     Then it contains exactly workcli->work and prgroom->prgroom, and
     RETIRED_CLIS is empty.
 
-    Pins spec §3: closed registry; pdlc/holding-place/vizsuite must NOT
+    Pins the closed registry; pdlc/holding-place/vizsuite must NOT
     auto-deploy.
     """
     assert [s.name for s in CLI_PACKAGES] == ["workcli", "prgroom"]
@@ -45,7 +45,7 @@ def test_digest_missing_pyproject_raises(tmp_path: Path) -> None:
     When cli_source_digest runs
     Then it raises FileNotFoundError naming the dir.
 
-    Pins spec §5 / item 15: a registry entry at a non-package is a wiring
+    Pins that a registry entry at a non-package is a wiring
     bug — fail fast.
     """
     with pytest.raises(FileNotFoundError):
@@ -58,8 +58,6 @@ def test_digest_missing_lock_omitted_and_later_lock_changes_digest(tmp_path: Pat
     When a uv.lock is added later
     Then the digest changes (lock participates when present, is silently
     omitted when absent).
-
-    Pins spec §5 / item 15.
     """
     pkg = _package(tmp_path)
     before = cli_source_digest(pkg)
@@ -73,7 +71,7 @@ def test_digest_ignores_tests_pycache_and_pyc(tmp_path: Path) -> None:
     When files under tests/**, __pycache__/, or *.pyc change
     Then the digest does not change.
 
-    Pins spec §5 / item 15: docs/tests/build churn is not a reason to
+    Pins that docs/tests/build churn is not a reason to
     reinstall.
     """
     pkg = _package(tmp_path)
@@ -90,7 +88,7 @@ def test_digest_changes_on_src_change(tmp_path: Path) -> None:
     When a file under src/** changes
     Then the digest changes.
 
-    Pins spec §5: src/** is deployable source.
+    Pins that src/** is deployable source.
     """
     pkg = _package(tmp_path)
     before = cli_source_digest(pkg)

--- a/packages/installer/tests/unit/test_deploy_clis.py
+++ b/packages/installer/tests/unit/test_deploy_clis.py
@@ -1,4 +1,4 @@
-"""Tests for the deploy_clis decision engine (spec §6)."""
+"""Tests for the deploy_clis decision engine."""
 
 from pathlib import Path
 
@@ -37,7 +37,7 @@ def test_verify_skip_smokes_and_skips(tmp_path: Path) -> None:
     Then no install fires, the smoke ran against the absolute shim path,
     and the counter is skipped.
 
-    Pins spec §6 verify row / item 1. Shim budget: 1 (decision read only —
+    Pins the verify row. Shim budget: 1 (decision read only —
     no install happened).
     """
     prior = _prior_with_current_digest(tmp_path)
@@ -73,7 +73,7 @@ def test_verify_smoke_failure_heals_with_force(tmp_path: Path) -> None:
     Then a force=True reinstall fires without a consent prompt, then
     re-smokes; the entry is refreshed.
 
-    Pins spec §6 verify row heal-on-fail / item 1. Shim budget: 2 (decision
+    Pins the verify-row heal-on-fail branch. Shim budget: 2 (decision
     + post-install re-read after the successful heal install).
     """
     prior = _prior_with_current_digest(tmp_path)
@@ -110,7 +110,7 @@ def test_heal_missing_shim_reinstalls_without_prompt(tmp_path: Path) -> None:
     Then it reinstalls without a prompt (created counter) — env absent uses
     force=False.
 
-    Pins spec §6 heal row + provenance-absent exception / items 3, 19.
+    Pins the heal row plus the provenance-absent exception.
     Shim budget: 2 (decision None + post-install re-read).
     """
     prior = _prior_with_current_digest(tmp_path)
@@ -146,7 +146,7 @@ def test_fresh_install_no_evidence_no_prompt(tmp_path: Path) -> None:
     Then a force=False install fires with no prompt; created counter; entry
     recorded after smoke.
 
-    Pins spec §6 fresh row / items 2, 18. Shim budget: 2.
+    Pins the fresh row. Shim budget: 2.
     """
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -180,7 +180,7 @@ def test_upgrade_consent_accept_and_decline(tmp_path: Path) -> None:
     Then accept -> force install + updated counter; decline -> skipped and
     no install.
 
-    Pins spec §6 upgrade row / item 4. Shim budgets: accept 2, decline 1.
+    Pins the upgrade row. Shim budgets: accept 2, decline 1.
     """
     pkg = _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -235,7 +235,7 @@ def test_takeover_triggers_all_three_evidence_forms(tmp_path: Path) -> None:
     When deploy_clis runs with declining confirms
     Then each form prompts for takeover and no install fires on decline.
 
-    Pins spec §6 takeover row / item 5. Case (a) leaves the shim present,
+    Pins the takeover row. Case (a) leaves the shim present,
     so the reachability gate runs — which_map keeps it green; cases (b)/(c)
     end shimless, no gate.
     """
@@ -274,7 +274,7 @@ def test_fresh_toctou_already_exists_reroutes_to_takeover(tmp_path: Path) -> Non
     When deploy_clis runs with an accepting confirm
     Then a takeover consent fires and the retry uses force=True.
 
-    Pins spec §6 fresh row TOCTOU re-route / item 18. Shim budget: 2
+    Pins the fresh-row TOCTOU re-route. Shim budget: 2
     (decision None + post-install re-read after the consented force
     install; the FAILED non-forcing install triggers no re-read).
     """
@@ -311,7 +311,7 @@ def test_stale_receipt_foreign_provenance_requires_takeover(tmp_path: Path) -> N
     When deploy_clis runs with a declining confirm
     Then no promptless heal fires — takeover consent, decline skips.
 
-    Pins spec §6 provenance precondition / item 19.
+    Pins the provenance precondition.
     """
     shim = tmp_path / "bin" / "work"
     prior = _prior_with_current_digest(tmp_path)  # creates the package dir itself
@@ -343,7 +343,7 @@ def test_smoke_failure_after_install_fails_run_no_entry(tmp_path: Path) -> None:
     Then any_failed is True, err carries the smoke output, and no deployed
     entry is recorded (next run retries).
 
-    Pins spec §6 failure surfacing / item 7.
+    Pins the failure-surfacing rule.
     """
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -375,7 +375,7 @@ def test_install_ok_but_no_shim_is_failure(tmp_path: Path) -> None:
     When deploy_clis runs
     Then it is a failure (err), not a silent success.
 
-    Pins spec §6 / item 7 (install-ok-but-no-shim).
+    Pins the install-ok-but-no-shim failure rule.
     """
     _pkg(tmp_path)
     deploy = ScriptedCliDeploy(
@@ -405,7 +405,7 @@ def test_one_broken_cli_does_not_block_the_other(tmp_path: Path) -> None:
     When deploy_clis runs
     Then the second still deploys and any_failed is True.
 
-    Pins spec §6/§8: record-and-continue, exit 1 at the end / item 8.
+    Pins the record-and-continue rule: exit 1 at the end.
     CLI1 path: verify (digest equal, provenance ok) -> smoke fail -> heal
     force install FAILS -> hard failure, no consent involved. CLI2: fresh
     success. Shim budgets: CLI1 = 1 (decision; failed install, no re-read),
@@ -449,7 +449,7 @@ def test_dry_run_previews_every_branch_without_subprocess(tmp_path: Path) -> Non
     Then each reports its would-X line and never calls
     tool_install/smoke/update_shell.
 
-    Pins spec §6 dry-run / item 6 (each branch reports would-X).
+    Pins the dry-run rule (each branch reports would-X).
     """
     prior_current = _prior_with_current_digest(tmp_path)
     prior_stale = Receipt(
@@ -495,7 +495,7 @@ def test_uv_version_guard_blocks_all_cli_work(tmp_path: Path) -> None:
     Then one actionable err fires, zero install/uninstall/update_shell
     calls happen, and any_failed is True.
 
-    Pins spec §6 version guard / item 21.
+    Pins the version-guard rule.
     """
     for version in [(0, 9, 0), None]:
         deploy = ScriptedCliDeploy(uv_version=version)
@@ -523,7 +523,7 @@ def test_reachability_which_none_update_shell_consent(tmp_path: Path) -> None:
     Then the run resolves (not failed) with an info notice; decline instead
     -> err + failure.
 
-    Pins spec §6 reachability / item 9. which_map deliberately empty (miss).
+    Pins the reachability rule. which_map deliberately empty (miss).
     """
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -576,7 +576,7 @@ def test_reachability_shadow_is_hard_error(tmp_path: Path) -> None:
     Then err names both paths and the run fails; update_shell is never
     offered (it cannot fix PATH order).
 
-    Pins spec §6 shadowing / item 9.
+    Pins the shadowing rule.
     """
     _pkg(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -615,7 +615,7 @@ def test_reachability_memoized_per_bin_dir(tmp_path: Path) -> None:
     Then update_shell runs exactly once and the second CLI reuses the
     memoized success (no second prompt, no failure).
 
-    Pins spec §6 memoization / item 20.
+    Pins the memoization rule.
     """
     pkg2 = tmp_path / "packages" / "prgroom"
     (pkg2 / "src").mkdir(parents=True)
@@ -654,7 +654,7 @@ def test_reachability_fires_on_steady_state_skip_run(tmp_path: Path) -> None:
     Then the run FAILS — the invariant fires on SKIPPED_IDENTICAL runs,
     not only after a deploy.
 
-    Pins spec §6 steady-state enforcement / item 9.
+    Pins the steady-state enforcement rule.
     """
     prior = _prior_with_current_digest(tmp_path)
     shim = tmp_path / "bin" / "work"
@@ -689,7 +689,7 @@ def test_reachability_no_tty_without_yes_raises(tmp_path: Path) -> None:
     reachability consent point honors the same no-TTY convention as every
     other consent point, never silently returning a failure.
 
-    Pins spec §6 no-TTY / item 12 (reachability side; symmetric with the
+    Pins the no-TTY consent rule (reachability side; symmetric with the
     prune side's test_prune_no_tty_without_yes_raises).
     """
     _pkg(tmp_path)

--- a/packages/installer/tests/unit/test_profiles.py
+++ b/packages/installer/tests/unit/test_profiles.py
@@ -1,8 +1,8 @@
 """Behavioural tests for the profiles manifest + pure scope-routing resolver
-(spec §10 items 1-11; docs/specs/2026-07-06-profiles-scope-routing.md).
+(docs/specs/2026-07-06-profiles-scope-routing.md).
 
-# NOTE: spec §10 item 4 (the DYNAMIC-INCLUDE-ALL-RULES vs DYNAMIC-INCLUDE-RULES
-# template-flattening boundary) is deferred to the orchestrator-wiring slice
+# NOTE: the DYNAMIC-INCLUDE-ALL-RULES vs DYNAMIC-INCLUDE-RULES
+# template-flattening boundary is deferred to the orchestrator-wiring slice
 # (S2/S3) — it concerns `templates.py`/the orchestrator, not this pure
 # resolver, and is intentionally not implemented or tested here.
 """
@@ -479,7 +479,7 @@ def test_load_manifest_string_exclude_errors(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# project_universe — selector-key normalization (spec §3)
+# project_universe — selector-key normalization
 # ---------------------------------------------------------------------------
 
 
@@ -599,7 +599,7 @@ def test_project_universe_unions_refs_across_tool_plans() -> None:
 
 
 def test_project_universe_normalization_pin_against_real_universe(ignore: InstallIgnore) -> None:
-    """spec §10 item 6 normalization pin: `rules/memory-routing` matches the
+    """Normalization pin: `rules/memory-routing` matches the
     staged `rules/memory-routing.md`, and `instructions` matches the tool-root
     instruction templates — both asserted directly via `project_universe`
     keys built from the real repo root."""
@@ -612,7 +612,7 @@ def test_project_universe_normalization_pin_against_real_universe(ignore: Instal
 
 
 # ---------------------------------------------------------------------------
-# resolve() — spec §10 items 2, 3, 5, 6, 8, 9, 10, 11
+# resolve()
 # ---------------------------------------------------------------------------
 
 
@@ -896,7 +896,7 @@ def test_filter_plan_to_scope_carries_over_kept_dir_overrides() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Golden / zero-breakage pin — spec §10 item 1
+# Golden / zero-breakage pin
 # ---------------------------------------------------------------------------
 
 

--- a/packages/installer/tests/unit/test_prune_clis.py
+++ b/packages/installer/tests/unit/test_prune_clis.py
@@ -1,4 +1,4 @@
-"""Tests for the CLI prune half (spec §7, item 10)."""
+"""Tests for the CLI prune half."""
 
 import pytest
 
@@ -23,8 +23,6 @@ def test_retired_allowlisted_cli_uninstalled_with_consent() -> None:
     When prune_clis runs with an accepting confirm
     Then uv tool uninstall fires, pruned counter increments, and the name
     lands in uninstalled_names.
-
-    Pins spec §7 / item 10.
     """
     deploy = ScriptedCliDeploy(uninstalls=[_OK])
     io = ScriptedIO(confirms=[True])
@@ -49,7 +47,7 @@ def test_declined_uninstall_retains_entry() -> None:
     Then no uninstall fires and the name is NOT in uninstalled_names
     (retirement retried next prune).
 
-    Pins spec §7 decline / item 10.
+    Pins the declined-uninstall retention rule.
     """
     deploy = ScriptedCliDeploy()
     outcome = prune_clis(
@@ -73,7 +71,7 @@ def test_foreign_name_never_uninstalled_relinquished_instead() -> None:
     Then NO uninstall fires even under --yes; the name is warned about and
     relinquished.
 
-    Pins spec §7 closed uninstall authority / item 10 (tampered receipt).
+    Pins the closed-registry uninstall authority (tampered receipt).
     """
     deploy = ScriptedCliDeploy()
     io = ScriptedIO()
@@ -97,8 +95,6 @@ def test_uninstall_of_absent_tool_counts_as_success() -> None:
     Given a retired entry whose uv uninstall fails with 'not installed'
     When prune_clis runs (auto_yes)
     Then the outcome treats it as uninstalled (desired state: absent).
-
-    Pins spec §7 / item 10.
     """
     deploy = ScriptedCliDeploy(
         uninstalls=[CommandResult(ok=False, output="`oldtool` is not installed")]
@@ -121,7 +117,7 @@ def test_dry_run_previews_no_uninstall() -> None:
     When prune_clis runs
     Then it reports would-uninstall and calls nothing.
 
-    Pins spec §7 dry-run / item 10.
+    Pins the dry-run uninstall preview.
     """
     deploy = ScriptedCliDeploy()
     io = ScriptedIO()
@@ -147,7 +143,7 @@ def test_prune_no_tty_without_yes_raises() -> None:
     Then ConsentRequiredError raises (the caller maps it to exit 1) — the
     prune side honors the same no-TTY convention as the deploy side.
 
-    Pins spec §7 no-TTY / item 12 (prune side).
+    Pins the no-TTY consent convention (prune side).
     """
     deploy = ScriptedCliDeploy()
     with pytest.raises(ConsentRequiredError):

--- a/packages/installer/tests/unit/test_receipt_clis.py
+++ b/packages/installer/tests/unit/test_receipt_clis.py
@@ -1,4 +1,4 @@
-"""Tests for the additive Receipt.clis field (spec §7, item 11)."""
+"""Tests for the additive Receipt.clis field."""
 
 import json
 from pathlib import Path
@@ -16,7 +16,7 @@ def test_clis_round_trip(tmp_path: Path) -> None:
     When written and re-read
     Then status is OK and the entry survives intact.
 
-    Pins spec §7 / item 11: receipt_store round-trips the field.
+    Pins that receipt_store round-trips the field.
     """
     path = tmp_path / "install-receipt.json"
     write_receipt(path, Receipt(clis=(_ENTRY,)))
@@ -31,8 +31,8 @@ def test_legacy_receipt_without_clis_still_validates(tmp_path: Path) -> None:
     When read by the new code
     Then it reads OK (integrity still validates) with clis == ().
 
-    Pins spec §7: canonical_bytes includes "clis" only when non-empty, so a
-    legacy receipt hashes byte-identically (item 11).
+    Pins that canonical_bytes includes "clis" only when non-empty, so a
+    legacy receipt hashes byte-identically.
     """
     path = tmp_path / "install-receipt.json"
     legacy = Receipt()  # no clis
@@ -50,7 +50,7 @@ def test_empty_clis_hashes_identically_to_absent() -> None:
     When canonical_bytes runs
     Then the bytes are identical (no integrity break for legacy receipts).
 
-    Pins spec §7 omit-when-empty.
+    Pins the omit-when-empty rule.
     """
     assert canonical_bytes(Receipt()) == canonical_bytes(Receipt(clis=()))
     assert compute_integrity(Receipt()) == compute_integrity(Receipt(clis=()))
@@ -64,7 +64,7 @@ def test_malformed_clis_entry_reads_corrupt(tmp_path: Path) -> None:
     Then status is CORRUPT (fail closed — only the clis type validation can
     produce this, since the restamped integrity MATCHES the coerced value).
 
-    Pins spec §7 validation / item 11: the fail-closed type check in
+    Pins that the fail-closed type check in
     _cli_entry_from_json — not a stale integrity — is what rejects the entry.
     """
     path = tmp_path / "install-receipt.json"
@@ -92,7 +92,7 @@ def test_merge_clis_union_rule() -> None:
     Then the merge keeps workcli's prior entry (skip retains), adds
     prgroom's new entry, and drops oldtool.
 
-    Pins spec §7 union merge rule (registry -> new-if-deployed else
+    Pins the union merge rule (registry -> new-if-deployed else
     retained; non-registry -> dropped iff uninstalled).
     """
     merged = merge_clis(
@@ -113,7 +113,7 @@ def test_merge_clis_declined_uninstall_retained_foreign_relinquished() -> None:
     Then the declined one is retained (retried next prune) and the
     relinquished foreign one is dropped without uninstall.
 
-    Pins spec §7 (decline retains; foreign names relinquished — item 10).
+    Pins the decline-retains / foreign-names-relinquished rule.
     """
     merged = merge_clis(
         prior_clis=(_e("oldtool"), _e("ruff")),

--- a/packages/installer/tests/unit/test_summary.py
+++ b/packages/installer/tests/unit/test_summary.py
@@ -372,7 +372,7 @@ def test_cli_targets_render_as_blocks() -> None:
     Then verbose renders a '-- cli:workcli --' block and quiet renders its
     change line (previously cli:* keys were silently dropped).
 
-    Pins spec §6 summary-rendering change.
+    Pins the summary-rendering change for cli: targets.
     """
     counters = {"cli:workcli": Counters(created=1)}
     io = ScriptedIO()
@@ -412,8 +412,7 @@ def test_quiet_cli_failure_with_no_counters_does_not_claim_up_to_date() -> None:
     reach render_summary with empty cli: counters, right before cli.py
     returns exit 1, so the quiet summary must not claim success.
 
-    Pins spec §6 summary-rendering change (Task 12) + failure surfacing
-    (Task 8/9).
+    Pins the summary-rendering change plus the failure-surfacing rule.
     """
     io = ScriptedIO()
     render_summary(

--- a/packages/installer/tests/unit/test_sync_outcomes.py
+++ b/packages/installer/tests/unit/test_sync_outcomes.py
@@ -1,5 +1,5 @@
 """Unit tests for the per-item ``InstallOutcome`` stream threaded through
-``sync_plan`` (Task 8 — outcome plumbing).
+``sync_plan`` (outcome plumbing).
 
 ``Counters.skipped`` conflates a hash-equal skip with a consent-declined
 overwrite; the receipt must tell them apart (a DECLINED item holds the user's

--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -8,9 +8,9 @@ All `Backend` protocol primitives are wired here: `capabilities`, `get`,
 `ready`/`search` parse through the same `parse_items` the `list`/`show`
 adapters use, on the assumption bd emits the same per-item shape for all four
 read commands. No golden fixture captures `bd ready`/`bd search` output
-specifically (decision 14 only captured `show`/`list`/`dep list`/`label
-list`) -- an actual shape difference surfaces as `E_BACKEND_DRIFT` rather than
-a silent misparse, same as any other unrecognized bd shape.
+specifically -- only `show`/`list`/`dep list`/`label list` were golden-
+captured -- an actual shape difference surfaces as `E_BACKEND_DRIFT` rather
+than a silent misparse, same as any other unrecognized bd shape.
 
 `create`'s output shape (a single JSON object, not an array -- see
 `adapters/bd/parse.py::parse_created_id`) was confirmed by reading bd's own
@@ -40,8 +40,8 @@ from workcli.backend import Capabilities, DepOp, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, JsonValue, StepProgress, WorkError, with_progress
 from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
 
-# Decision 9's exact stderr wording (orchestrator ruling, not a golden capture
-# -- `bd dolt` is never run mutating against a real DB in this project): `bd
+# Exact stderr wording per an orchestrator ruling, not a golden capture
+# -- `bd dolt` is never run mutating against a real DB in this project. `bd
 # dolt commit` with nothing pending, and `bd dolt pull` against a dirty
 # working set, are asserted to log these substrings to stderr.
 _NOTHING_TO_COMMIT_STDERR_MARKER = "nothing to commit"
@@ -90,11 +90,11 @@ class BdBackend:
         by_id = {item.id: item for item in items}
         missing = [item_id for item_id in ids if item_id not in by_id]
         if missing:
-            # bd's own quirk (decision 14 golden capture): `bd show a b --json`
+            # bd's own quirk, per golden capture: `bd show a b --json`
             # exits 0 and silently omits any id it couldn't find, logging the
             # miss to stderr instead of failing the call. A partial hit must
-            # not read as full success (decision 10 needs `data.items` to
-            # match the request one-for-one).
+            # not read as full success -- `data.items` must match the
+            # request one-for-one.
             raise WorkError(
                 ErrorCode.NOT_FOUND,
                 f"bd show: no such item(s): {', '.join(missing)}",

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -5,7 +5,7 @@ this module is the single place that turns bd's raw, occasionally
 inconsistent shapes into workcli's normalized `Item`/`DepEdge` model. Any
 shape bd emits that this module cannot map raises `WorkError(BACKEND_DRIFT)`
 -- bd's own model of itself broke, and silently guessing is worse than
-alarming loudly (spec test-plan item 9).
+alarming loudly.
 
 Two known shape inconsistencies this module bridges (found capturing the
 golden fixtures, not documented anywhere in bd's `--help`):
@@ -33,7 +33,7 @@ from workcli.model import DepEdge, Item
 
 _REQUIRED_ITEM_KEYS = ("id", "title", "issue_type", "status", "priority")
 
-# Confirmed against the real bd binary (decision 14 golden capture): a
+# Confirmed against the real bd binary, per golden capture: a
 # not-found `show` logs this exact wording to stderr per missing id, even
 # though the overall process may still exit 0 if other requested ids matched
 # (see BdBackend.batch_get's own missing-id reconciliation for that case).
@@ -74,8 +74,8 @@ def _dep_edge_from_raw(entry: dict[str, JsonValue], self_id: str) -> DepEdge:
     if "dependency_type" in entry:
         # show-shape: full embedded bead + dependency_type; id/status
         # describe the OTHER end of the edge directly. A drifted bd omitting
-        # `id` here must alarm loudly (spec test-plan item 9), not raise a
-        # raw KeyError that surfaces as E_INTERNAL.
+        # `id` here must alarm loudly, not raise a raw KeyError that surfaces
+        # as E_INTERNAL.
         if "id" not in entry:
             raise _drift(
                 "bd dependency edge (show-shape) is missing required key: id",
@@ -134,8 +134,8 @@ def _list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> list[Any]:
 
     An explicit JSON `null` is NOT the same as a missing key: bd emitting
     `null` where the facade's model says the field is an array is itself
-    model drift (spec test-plan item 9) -- it must alarm loudly via
-    `WorkError(BACKEND_DRIFT)`, never silently coerce to `[]` and never
+    model drift -- it must alarm loudly via `WorkError(BACKEND_DRIFT)`,
+    never silently coerce to `[]` and never
     raise a raw `AssertionError`/`TypeError` from an unguarded downstream
     `isinstance`/iteration.
     """
@@ -192,9 +192,8 @@ def _string_list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> lis
     Layers per-element string validation on top of `_list_field` (absent ->
     `[]`, null/non-array -> drift). The normalized contract types this field
     as a `string[]`; a non-string element (a number, an object, ...) is bd
-    model drift, not something to silently coerce with `str()` (spec
-    test-plan item 9) -- the same discipline `parse_labels` applies to the
-    `label list` command.
+    model drift, not something to silently coerce with `str()` -- the same
+    discipline `parse_labels` applies to the `label list` command.
     """
     values = _list_field(raw, key, item_id)
     for value in values:
@@ -219,8 +218,8 @@ def _assert_object_elements(entries: list[Any], *, field: str, item_id: str) -> 
     was previously filtered out silently by an `isinstance(entry, dict)`
     guard at the call site, dropping the edge and continuing with a
     partially-mangled Item. That is bd shape drift, not something to drop and
-    carry on from (spec test-plan item 9) -- same discipline as
-    `parse_items`'/`parse_dep_edges`' own `element_not_an_object` check.
+    carry on from -- same discipline as `parse_items`'/`parse_dep_edges`'
+    own `element_not_an_object` check.
     """
     for entry in entries:
         if not isinstance(entry, dict):
@@ -374,7 +373,7 @@ def parse_labels(stdout: str, *, command: str = "label list") -> list[str]:
 
 
 def map_bd_failure(argv: Sequence[str], result: BdResult) -> WorkError:
-    """Translate a nonzero bd exit into a typed error (decision 4).
+    """Translate a nonzero bd exit into a typed error.
 
     NOT_FOUND, TYPE_WALL, and DEP_CYCLE are mapped here; anything this
     function doesn't recognize is the same alarm class as an unparseable

--- a/packages/workcli/src/workcli/adapters/bd/retry.py
+++ b/packages/workcli/src/workcli/adapters/bd/retry.py
@@ -1,4 +1,4 @@
-"""Bounded backoff around a single bd invocation (locked decision 8).
+"""Bounded backoff around a single bd invocation.
 
 Retryable = a lock-contention stderr pattern, or subprocess `TimeoutExpired`.
 3 attempts total; injectable `sleep(0.5)` then `sleep(1.0)` between them.

--- a/packages/workcli/src/workcli/adapters/bd/runner.py
+++ b/packages/workcli/src/workcli/adapters/bd/runner.py
@@ -4,8 +4,7 @@
 `tests/fakes.ScriptedBdRunner`; `SubprocessBdRunner` is the sole
 implementation that actually shells out to the real `bd` binary. It raises
 `subprocess.TimeoutExpired` on its 60s deadline rather than catching it --
-`adapters/bd/retry.py` is the layer that treats that as retryable
-(decision 8).
+`adapters/bd/retry.py` is the layer that treats that as retryable.
 """
 
 from __future__ import annotations
@@ -29,7 +28,7 @@ class BdRunner(Protocol):
 
 
 class SubprocessBdRunner:
-    """Drives the real bd binary. timeout=60s; TimeoutExpired is retryable (decision 8).
+    """Drives the real bd binary. timeout=60s; TimeoutExpired is retryable.
 
     Raising `subprocess.TimeoutExpired` on deadline is subprocess.run's own
     documented behavior -- this class does not catch it. `adapters/bd/retry.py`

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -4,8 +4,8 @@
 (argv, the bd runner, stdout/stderr, sleep) arrives as an argument, never a
 module global. The `Backend` itself is constructed lazily, inside `main()`,
 only when a verb actually dispatches -- `--protocol-version` short-circuits
-before it and never touches the runner (spec §5: the handshake is cheap and
-side-effect-free).
+before it and never touches the runner: the handshake is cheap and
+side-effect-free.
 """
 
 from __future__ import annotations
@@ -34,8 +34,8 @@ class _EnvelopeArgumentParser(ArgumentParser):
 
     Default argparse behavior on error prints a usage block to stderr and
     exits — that would violate the "stdout is always exactly one JSON
-    envelope" invariant (spec §4). Raising lets `main()` convert the failure
-    into an `E_USAGE` envelope instead.
+    envelope" invariant. Raising lets `main()` convert the failure into an
+    `E_USAGE` envelope instead.
     """
 
     def error(self, message: str) -> NoReturn:
@@ -281,8 +281,8 @@ def _peek_format(argv: list[str] | None) -> str:
     """Best-effort recovery of `--format` when full parsing has already failed.
 
     `parse_args()` can raise (bad flag, unknown verb) before we learn whether
-    `--format human` was requested, yet spec §4 says the human view still
-    renders to stderr alongside the stdout envelope even on usage errors. A
+    `--format human` was requested, yet the human view still renders to
+    stderr alongside the stdout envelope even on usage errors. A
     lenient parser that knows only `--format` and ignores everything else
     recovers the value without re-raising on the very error we're about to
     report; anything it can't make sense of (e.g. an invalid `--format`
@@ -300,8 +300,8 @@ def _peek_format(argv: list[str] | None) -> str:
 def _finish_success(data: JsonValue, out: TextIO, err: TextIO, fmt: str) -> int:
     """Emit the success envelope to `out`; additionally render it to `err` on `--format human`.
 
-    stdout always carries the envelope regardless of `fmt` (spec §4) -- this
-    never replaces `emit_success`, only adds the human view alongside it.
+    stdout always carries the envelope regardless of `fmt` -- this never
+    replaces `emit_success`, only adds the human view alongside it.
     """
     exit_code = emit_success(data, out)
     if fmt == "human":
@@ -359,7 +359,7 @@ def _default_read_file(path: str) -> str:
 
 
 def _default_config_loader(explicit_path: str | None) -> TrackLayerConfig:
-    """The real track-layer config resolution: upward search from cwd (track spec §3)."""
+    """The real track-layer config resolution: upward search from cwd."""
     return load_config(Path.cwd(), explicit_path)
 
 
@@ -402,13 +402,13 @@ def main(
 
     # Resolved once here and attached to the parsed Namespace -- only
     # `deliver` reads it, but every handler keeps the transport's
-    # `(Backend, Namespace) -> JsonValue` signature (plan L12), so this
-    # travels as an `args` attribute rather than an extra handler parameter.
+    # `(Backend, Namespace) -> JsonValue` signature, so this travels as an
+    # `args` attribute rather than an extra handler parameter.
     args.read_file = read_file if read_file is not None else _default_read_file
 
     # Same args-attachment precedent as read_file: resolved once, loaded
     # LAZILY -- only a track-layer surface calls args.load_config(), so
-    # pre-existing verbs never trigger config resolution (track spec §3).
+    # pre-existing verbs never trigger config resolution.
     resolved_config_loader = config_loader if config_loader is not None else _default_config_loader
     args.load_config = lambda: resolved_config_loader(args.config)
 
@@ -439,12 +439,12 @@ def main(
     # Everything from here on -- backend construction, the capability gate,
     # and the handler call -- runs inside one guarded region. An exception
     # anywhere in this region must still yield exactly one envelope on
-    # stdout (spec §4's invariant holds even on internal bugs, §4's
+    # stdout (the invariant holds even on internal bugs; see the
     # `E_INTERNAL` note) rather than escaping with a raw traceback and no
     # envelope at all.
     try:
         # Constructed only now -- never for --protocol-version above -- so the
-        # handshake never touches the runner (spec §5).
+        # handshake never touches the runner.
         backend = _build_backend(runner, sleep)
 
         if missing_capability(args.verb, backend.capabilities, args):

--- a/packages/workcli/src/workcli/config.py
+++ b/packages/workcli/src/workcli/config.py
@@ -1,12 +1,12 @@
-"""Track-layer config: discovery, parsing, validation (track spec §3).
+"""Track-layer config: discovery, parsing, validation.
 
-Loaded lazily -- only when a track-layer surface (a §4 flag, verb, or gate)
-needs it -- so pre-existing verbs never trigger a load. Every failure is the
-single typed `E_NOT_CONFIGURED`, its message naming the specific parse or
-validation problem; `detail.reason` distinguishes "not-found" from "invalid"
-so the create gate can stay fail-safe (spec §3: a broken config fails only
-the track layer, never an existing verb). Parse and validate once here;
-everything inward trusts the frozen dataclass.
+Loaded lazily -- only when a track-layer surface (a flag, verb, or gate) needs
+it -- so pre-existing verbs never trigger a load. Every failure is the single
+typed `E_NOT_CONFIGURED`, its message naming the specific parse or validation
+problem; `detail.reason` distinguishes "not-found" from "invalid" so the
+create gate can stay fail-safe: a broken config fails only the track layer,
+never an existing verb. Parse and validate once here; everything inward
+trusts the frozen dataclass.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ class TrackLayerConfig:
     )  # None: [operating-model] absent/key omitted -> nag check never fires
     groom_state_bead: (
         str | None
-    )  # None: omitted OR "" (not yet minted by the §7 backfill) -> groom gates E_NOT_CONFIGURED
+    )  # None: omitted OR "" (not yet minted by the config backfill) -> groom gates E_NOT_CONFIGURED
     extraction_max_track_backlog: (
         int | None
     )  # None: [extraction.pressure] absent/key omitted -> backlog pressure never fires
@@ -57,7 +57,7 @@ def _not_configured(problem: str, reason: Reason) -> WorkError:
 
 
 def _find_config(start_dir: Path) -> Path | None:
-    """Upward search from `start_dir`, bounded by the enclosing git root (spec §3).
+    """Upward search from `start_dir`, bounded by the enclosing git root.
 
     The git root is located FIRST: with no git root on the walk -- the working
     directory lies outside any repo -- the search finds nothing, even when a

--- a/packages/workcli/src/workcli/lifecycle/__init__.py
+++ b/packages/workcli/src/workcli/lifecycle/__init__.py
@@ -53,7 +53,7 @@ def manifest_snapshot(notes: str) -> Manifest | None:
 
 
 def is_container(item: Item) -> bool:
-    """Declared-state container test -- never child-count (spec §5/invariant 5)."""
+    """Declared-state container test -- never child-count."""
     if _CONTAINER_SHAPE_LABELS & set(item.labels):
         return True
     return item.type in _CONTAINER_TYPES

--- a/packages/workcli/src/workcli/lifecycle/closewalk.py
+++ b/packages/workcli/src/workcli/lifecycle/closewalk.py
@@ -3,8 +3,8 @@
 Close + close-walk + note happen as ONE facade call: a parent whose last open
 child closes is exhausted and closes with it, recursively, so a fully
 delivered tree never strands its containers open. Milestones are the walk
-boundary -- a milestone closes only when its own acceptance criteria are met,
-never on child exhaustion.
+boundary -- a milestone never auto-closes on child exhaustion; closing one is
+always a deliberate, explicit close call.
 """
 
 from __future__ import annotations

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -1,11 +1,11 @@
-"""`work create <noun>` -- noun-templated creation (plan Task 3).
+"""`work create <noun>` -- noun-templated creation.
 
 `create_noun` is the lifecycle layer's public creation mode, dispatched to
 from `verbs/__init__.py`'s `create` router (never called directly by
 `--raw`, which stays the transport primitive in `verbs/write.py`).
-`instantiate_spec_shape` is shared with `promote` (Task 4): it mints the
-design child + blocked placeholder under an existing container and never
-stamps `planned` -- the caller stamps it strictly last (L16).
+`instantiate_spec_shape` is shared with `promote`: it mints the design
+child + blocked placeholder under an existing container and never stamps
+`planned` -- the caller stamps it strictly last.
 """
 
 from __future__ import annotations
@@ -43,8 +43,8 @@ def instantiate_spec_shape(
 ) -> tuple[str, str]:
     """Find-or-create the design child + blocked placeholder under a container.
 
-    Returns (design_child_id, placeholder_id). **Idempotent** (spec §6, L16):
-    a child already carrying `shape-design` / `impl-placeholder` under the
+    Returns (design_child_id, placeholder_id). **Idempotent**: a child
+    already carrying `shape-design` / `impl-placeholder` under the
     container is reused, never duplicated -- so the `reconcile` sweep (or a
     re-run) that replays an interrupted instantiation mints only what a partial
     crash left missing. Does NOT stamp `planned` or touch `creating-spec` -- the
@@ -98,10 +98,11 @@ def finalize_spec_instantiation(
 ) -> tuple[str, str]:
     """Idempotently complete a spec container born under `creating-spec`.
 
-    The single source of the L16 completion tail shared by `create spec`,
-    `promote`, and the `reconcile` sweep -- triplicating it is what let the
-    `promote` crash window drift open. Every step is idempotent, so replaying it
-    over any crash point (or a fully healed container) converges:
+    The single source of the completion tail (stamps `planned` strictly
+    last) shared by `create spec`, `promote`, and the `reconcile` sweep --
+    triplicating it is what let the `promote` crash window drift open.
+    Every step is idempotent, so replaying it over any crash point (or a
+    fully healed container) converges:
 
     1. Ensure the container *shape* (`shape-spec` on, `shape-feat` off). `create
        spec` births the container already `shape-spec`, so this is a no-op there;
@@ -129,8 +130,8 @@ def _validate_usage(args: Namespace, noun: Noun) -> None:
             f"create {noun}: --type is set by the noun; omit it",
         )
     if noun is Noun.MILESTONE and args.track is not None:
-        # Milestone-type beads are track-exempt and carry no track:* label
-        # (track spec §3) -- refuse rather than mint an exemption violation.
+        # Milestone-type beads are track-exempt and carry no track:* label --
+        # refuse rather than mint an exemption violation.
         raise WorkError(
             ErrorCode.USAGE,
             "create milestone: milestones are track-exempt; omit --track",
@@ -174,13 +175,13 @@ def _check_duplicate_title(backend: Backend, title: str) -> None:
 def _resolve_track(
     backend: Backend, args: Namespace, parent: str | None
 ) -> tuple[str | None, list[str]]:
-    """Track resolution for `work create <noun>`: derive, else enforce (track spec §4).
+    """Track resolution for `work create <noun>`: derive, else enforce.
 
     Explicit --track wins; else a tracked parent's derived track is inherited
     (a track-less parent falls through); else enforcement decides. A repo with
-    no resolvable config behaves exactly as before the track layer existed
-    (criterion 17); an INVALID config skips the gate with a warning instead of
-    breaking `create` (spec §3: a broken config fails only the track layer).
+    no resolvable config behaves exactly as before the track layer existed;
+    an INVALID config skips the gate with a warning instead of breaking
+    `create` -- a broken config fails only the track layer.
     """
     try:
         config = args.load_config()
@@ -245,7 +246,7 @@ def _create_spec_container(
     if args.orphan:
         _append_orphan_marker(backend, container_id)
     # The completion tail (mint children, stamp `planned`, drop `creating-spec`
-    # strictly last -- L16) is shared with `promote` and the `reconcile` sweep.
+    # strictly last) is shared with `promote` and the `reconcile` sweep.
     # A crash anywhere before the handle comes off leaves a `shape-spec`
     # container that is NOT `planned` and still carries `creating-spec`: it
     # self-reports into the Planning queue (visible) AND is finished by the sweep
@@ -257,7 +258,7 @@ def _create_spec_container(
 
 
 def create_noun(backend: Backend, args: Namespace) -> JsonValue:
-    """`work create <noun> --title T (--parent ID | --orphan) [...]` (plan L9/L13/L14/L16)."""
+    """`work create <noun> --title T (--parent ID | --orphan) [...]`."""
     noun = Noun(args.noun)
     template = NOUN_TEMPLATES[noun]
 
@@ -265,8 +266,8 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     _check_duplicate_title(backend, args.title)
 
     parent = None if args.orphan else args.parent
-    # Milestones are track-exempt by contract (track spec §3): no requirement
-    # even under enforcement = "required", and never a track:* label.
+    # Milestones are track-exempt by contract: no requirement even under
+    # enforcement = "required", and never a track:* label.
     track: str | None = None
     warnings: list[str] = []
     if noun is not Noun.MILESTONE:
@@ -301,7 +302,7 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def _append_orphan_marker(backend: Backend, item_id: str) -> None:
-    """Append the orphan marker, surfacing `item_id` on failure (discover spec §3.2).
+    """Append the orphan marker, surfacing `item_id` on failure.
 
     The mint (`backend.create`) already returned by the time this runs, so a
     failure here leaves a created-but-unmarked bead. `detail.created_id` lets

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -1,13 +1,13 @@
 """`deliver` -- evidence-gated leaf delivery + design-spec placeholder
-reconciliation (plan Task 5, test-plan items 4, 5, 6).
+reconciliation.
 
 Dispatches on the `shape-design` label (CLI surface table): a design
 child's `deliver` parses the merged spec's `## Continuations` manifest and
-reconciles the sibling placeholder (L7/L8); a leaf's `deliver` verifies
+reconciles the sibling placeholder; a leaf's `deliver` verifies
 bd-observable evidence before recording the `[work] delivered:` marker and
 closing. A container is refused outright -- it completes via close-walk when
 its children close, never through `deliver`. `reconcile_placeholder` is
-exported for reuse by `reconcile` (Task 6) -- it is short-circuit idempotent
+exported for reuse by `reconcile` -- it is short-circuit idempotent
 on the `impl-placeholder` label's absence.
 """
 
@@ -135,8 +135,8 @@ def _deliver_design(backend: Backend, args: Namespace, design_item: Item) -> Jso
         )
 
     # Replay toward the frozen in-band snapshot when one exists; only the first
-    # delivery parses the spec file and records the target (spec §6, L7), so a
-    # post-delivery edit to the file can never alter a committed unit. `manifest:`
+    # delivery parses the spec file and records the target, so a post-delivery
+    # edit to the file can never alter a committed unit. `manifest:`
     # and `spec:` are written together at first delivery, but the appends are
     # gated independently: an old bead carrying only a `spec:` marker (pre-snapshot
     # delivery, interrupted) gets the snapshot added without a duplicate `spec:`.
@@ -156,7 +156,7 @@ def _deliver_design(backend: Backend, args: Namespace, design_item: Item) -> Jso
 
 
 def _leaf_evidence(backend: Backend, args: Namespace) -> str:
-    """Verify + describe the evidence for a leaf `deliver` (plan L8).
+    """Verify + describe the evidence for a leaf `deliver`.
 
     `--pr` is caller-attested (no bd verification); `--items` is verified
     via `batch_get` -- a miss surfaces `E_NOT_FOUND`, translated here to
@@ -221,12 +221,12 @@ def _deliver_leaf(backend: Backend, args: Namespace, item: Item) -> JsonValue:
 
 
 def deliver(backend: Backend, args: Namespace) -> JsonValue:
-    """`work deliver ID [--spec PATH] [--pr REF] [--items ID,ID] [--trivial]` (plan L8)."""
+    """`work deliver ID [--spec PATH] [--pr REF] [--items ID,ID] [--trivial]`."""
     item = backend.get(args.id)
     if DESIGN_CHILD_LABEL in item.labels:
         return _deliver_design(backend, args, item)
     # A container is never delivered directly: it closes via close-walk when its
-    # children close (spec §6/§8). Refuse at dispatch -- before any evidence
+    # children close. Refuse at dispatch -- before any evidence
     # check or leaf mutation -- so `deliver` on a spec/epic/`shape-impl-container`
     # fails loud instead of silently recording a leaf delivery on a container.
     if is_container(item):
@@ -242,9 +242,9 @@ def deliver(backend: Backend, args: Namespace) -> JsonValue:
 
 def _reconcile_single(backend: Backend, placeholder_id: str, manifest: Manifest) -> None:
     # Add the shape + spec-ready labels here; `impl-placeholder` is removed by
-    # the shared completion tail, STRICTLY LAST (C2 -- an add-then-remove-here
+    # the shared completion tail, STRICTLY LAST -- an add-then-remove-here
     # order would, on a crash between the two, strand the placeholder without
-    # its shape label yet already off the sweep's handle).
+    # its shape label yet already off the sweep's handle.
     item = manifest.items[0]
     template = NOUN_TEMPLATES[Noun(item.noun)]
     backend.set_type(placeholder_id, template.bd_type)
@@ -271,13 +271,13 @@ def _reconcile_multi(backend: Backend, placeholder: Item, manifest: Manifest) ->
             )
         )
     # Stamp the placeholder as the impl sub-container so `claim` and the router
-    # treat it as a declared-state container (spec §6 -- keyed on the label, not
-    # child count). Idempotent (label add is set-union), so an interrupted
+    # treat it as a declared-state container -- keyed on the label, not
+    # child count. Idempotent (label add is set-union), so an interrupted
     # expansion replays through the still-present handle and re-stamps
     # harmlessly. Applied BEFORE the shared tail removes `impl-placeholder`
     # last: that handle is the queryable signal `reconcile` enumerates
     # interrupted expansions through, dropped only once every child exists AND
-    # the design child has closed (L10).
+    # the design child has closed.
     backend.label_mutate("add", placeholder.id, [IMPL_CONTAINER_LABEL])
 
 
@@ -304,7 +304,7 @@ def _design_sibling(backend: Backend, placeholder: Item) -> Item | None:
 
 def reconcile_placeholder(backend: Backend, placeholder_id: str, manifest: Manifest) -> None:
     """Idempotently complete one placeholder's delivery against a parsed manifest
-    (spec §6) -- the single completion routine both `deliver` and the `reconcile`
+    -- the single completion routine both `deliver` and the `reconcile`
     sweep call, so every crash point heals to the same final state.
 
     Body, by manifest shape:
@@ -314,7 +314,7 @@ def reconcile_placeholder(backend: Backend, placeholder_id: str, manifest: Manif
     `shape-impl-container` on the placeholder.
 
     Then the shared tail, unconditionally: close the design child, then remove
-    `impl-placeholder` STRICTLY LAST. That ordering (C1/C2, L10) makes the
+    `impl-placeholder` STRICTLY LAST. That ordering makes the
     handle's absence the sole "delivery wholly done" signal -- no body path
     removes it -- so a replay short-circuits on its absence and a crash anywhere
     leaves it present for the sweep.

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -6,11 +6,11 @@ triage record (Scope / Priority / Anchor), then mints the bead through the
 existing `create <noun>` path -- inheriting its noun template, duplicate
 guard, and track gate -- adds the `discovered-from` provenance edge, and
 returns the completion-report manifest row as a structured envelope field.
-The verb enforces *form*; scope correctness stays caller judgment (spec §5).
+The verb enforces *form*; scope correctness stays caller judgment.
 
 Composes over `create_noun` (lifecycle/create.py) and adds no new minting
-logic (spec §4 step 4): noun->type/shape templating, the duplicate-title
-guard, placement validation, and track resolution all execute unchanged.
+logic: noun->type/shape templating, the duplicate-title guard, placement
+validation, and track resolution all execute unchanged.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ def _triage_incomplete(field: str, message: str) -> WorkError:
 
 
 def _require_rationale(value: str | None, field: str, flag: str) -> str:
-    """The rationale-shape rule (spec §3.2): required, non-blank after strip, single-line."""
+    """The rationale-shape rule: required, non-blank after strip, single-line."""
     if value is None:
         raise _triage_incomplete(field, f"{flag} is required")
     stripped = value.strip()
@@ -99,7 +99,7 @@ def _resolve_source(backend: Backend, discovered_from: str | None) -> Item:
 def _validate_anchor(
     backend: Backend, anchor: str, scope: str, source: Item, source_id: str
 ) -> None:
-    """Scope-dependent anchor validity (spec §3.4). Only called when `--anchor` is given."""
+    """Scope-dependent anchor validity. Only called when `--anchor` is given."""
     if scope == "out-of-scope":
         target = backend.get(anchor)
         if not is_container(target):
@@ -194,11 +194,11 @@ def _build_create_namespace(args: Namespace, description: str, priority: str) ->
 def discover(backend: Backend, args: Namespace) -> JsonValue:
     """`work discover --noun N --title T (--anchor ID | --orphan) --discovered-from ID ...`.
 
-    Body mirrors spec §4: validate the triage form and resolve the provenance
-    source before any mint (steps 1-2), render the triage block (step 3),
-    mint via `create_noun` (step 4), add the `discovered-from` edge (step 5),
-    then assemble the envelope (step 6). The dep-write capability gate (step
-    0) is enforced by the `REQUIRED_CAPABILITY` registration in
+    Validates the triage form and resolves the provenance source before any
+    mint (steps 1-2), renders the triage block (step 3), mints via
+    `create_noun` (step 4), adds the `discovered-from` edge (step 5), then
+    assembles the envelope (step 6). The dep-write capability gate (step 0)
+    is enforced by the `REQUIRED_CAPABILITY` registration in
     `verbs/__init__.py`, ahead of this handler ever running.
     """
     _validate_placement_usage(args)

--- a/packages/workcli/src/workcli/lifecycle/manifest.py
+++ b/packages/workcli/src/workcli/lifecycle/manifest.py
@@ -1,7 +1,7 @@
-"""`## Continuations` manifest grammar (plan Task 2, finalizes spec §15).
+"""`## Continuations` manifest grammar.
 
-Pure text parsing -- no `Backend`, no I/O. `deliver` (Task 5) and `reconcile`
-(Task 6) feed this the spec text an injected file-reader already fetched.
+Pure text parsing -- no `Backend`, no I/O. `deliver` and `reconcile` feed
+this the spec text an injected file-reader already fetched.
 """
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ _AC_SEPARATOR = " — AC: "
 @dataclass(frozen=True)
 class ManifestItem:
     noun: str  # a bare Noun value — placement is NOT a manifest field (all items
-    title: str  # mint under the objective/placeholder; §12's cross-parent design-doc
+    title: str  # mint under the objective/placeholder; cross-parent design-doc
     acceptance: str  # annotations like "(under X)" are not part of the facade grammar)
 
 
@@ -135,8 +135,8 @@ def _reject_duplicate_titles(items: tuple[ManifestItem, ...]) -> None:
     `reconcile_placeholder`'s multi-unit path (`deliver.py::_reconcile_multi`)
     matches existing children by title to make the mint idempotent under
     replay -- a manifest with two same-titled items would silently mint only
-    one, destroying conservation of committed work (invariant 1). Caught here
-    at parse time, loudly, rather than as a silent under-mint at delivery.
+    one, destroying conservation of committed work. Caught here at parse
+    time, loudly, rather than as a silent under-mint at delivery.
     """
     seen: set[str] = set()
     for item in items:
@@ -181,7 +181,7 @@ def deserialize_manifest(text: str) -> Manifest:
     another agent can hand-edit -- so a truncated, malformed, or tampered payload
     is *expected* corruption, not an internal bug. It surfaces as a typed
     `E_BACKEND_DRIFT` carrying the offending text, so `reconcile` can report one
-    poisoned placeholder as a single attention finding (L10) instead of a raw
+    poisoned placeholder as a single attention finding instead of a raw
     `JSONDecodeError`/`KeyError` aborting the whole sweep as `E_INTERNAL`.
     Validating the noun here (not just the JSON shape) means a returned
     `Manifest` is fully trustworthy inward -- callers never re-hit `Noun(...)`.

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -16,8 +16,8 @@ class Noun(StrEnum):
 
 
 # Leaf nouns -- everything except the two container nouns (spec/epic). `work
-# discover` restricts to these (discover spec §3.1): a discovery files a work
-# item, not a structural container.
+# discover` restricts to these: a discovery files a work item, not a
+# structural container.
 LEAF_NOUNS: tuple[Noun, ...] = (Noun.SPIKE, Noun.CHORE, Noun.DECISION, Noun.FEAT, Noun.BUGFIX)
 
 
@@ -27,7 +27,7 @@ class NounTemplate:
     shape_label: str  # birth shape label, e.g. "shape-feat"
     is_container: bool  # True for spec/epic
     expects_evidence: bool  # True for feat/bugfix (evidence rule applies)
-    born_planned: bool  # True for spec -- but `planned` is stamped LAST (L16)
+    born_planned: bool  # True for spec -- but `planned` is stamped LAST
 
 
 NOUN_TEMPLATES: dict[Noun, NounTemplate] = {
@@ -78,8 +78,8 @@ IMPL_CONTAINER_LABEL = "shape-impl-container"
 # A spec container mid-instantiation: born with this handle (create spec /
 # promote) and removed STRICTLY LAST, after design child + placeholder exist and
 # `planned` is stamped. Its presence is the queryable signal `reconcile`
-# enumerates interrupted spec instantiations through (L10/L16); its absence means
-# the template is wholly minted. Not a container-shape label -- the container
+# enumerates interrupted spec instantiations through; its absence means the
+# template is wholly minted. Not a container-shape label -- the container
 # already carries `shape-spec` for the claim guard.
 CREATING_SPEC_LABEL = "creating-spec"
 PLANNED_LABEL = "planned"

--- a/packages/workcli/src/workcli/lifecycle/park.py
+++ b/packages/workcli/src/workcli/lifecycle/park.py
@@ -124,10 +124,10 @@ def _unpark(backend: Backend, args: Namespace, verb: str, marker: str) -> JsonVa
 
     Status `open` first (the item re-enters `ready` the instant anything
     lands), the intent marker second, and the `parked` handle off STRICTLY
-    LAST (L16): every crash window leaves the label as the recoverable
-    handle, so a replay re-enters this path -- never the no-op branch -- and
-    the marker is guaranteed durable before the handle drops. The dedup
-    guard keeps the replay from minting a second marker.
+    LAST: every crash window leaves the label as the recoverable handle, so
+    a replay re-enters this path -- never the no-op branch -- and the
+    marker is guaranteed durable before the handle drops. The dedup guard
+    keeps the replay from minting a second marker.
     """
     item = backend.get(args.id)
     if item.status == "closed":

--- a/packages/workcli/src/workcli/lifecycle/reconcile.py
+++ b/packages/workcli/src/workcli/lifecycle/reconcile.py
@@ -1,4 +1,4 @@
-"""`reconcile` -- handle-driven recovery sweep (plan L10).
+"""`reconcile` -- handle-driven recovery sweep.
 
 Candidate sets are enumerated **only** through removable completion handles
 (labels), never inferred from external state such as a design child's status or
@@ -61,7 +61,7 @@ def _sweep_pending_placeholders(backend: Backend, *, dry_run: bool) -> list[Json
     the handle last. A placeholder with no snapshot has no recorded target, so it
     surfaces as an attention finding without auto-repair. A corrupt snapshot is
     one poisoned bead, reported as its own finding rather than aborting recovery
-    of every healthy placeholder (L10) -- the typed drift `manifest_snapshot`
+    of every healthy placeholder -- the typed drift `manifest_snapshot`
     raises is caught per-item here."""
     findings: list[JsonValue] = []
     for candidate in backend.query(QueryFilters(label=IMPL_PLACEHOLDER_LABEL)):
@@ -84,7 +84,7 @@ def _placeholder_reconciled(backend: Backend, design: Item) -> bool:
     """True iff this design child's own placeholder has completed its delivery.
 
     The placeholder is the item `instantiate_spec_shape` minted `blocks`-linked
-    behind the design child (spec §6). Identify it by that structural edge *plus*
+    behind the design child. Identify it by that structural edge *plus*
     a placeholder note marker (`[work] manifest:`, or legacy `[work] spec:`) -- a
     design may carry other `blocks`-dependents for unrelated reasons, and "any
     dependent lacks impl-placeholder" would wrongly close the design on one of
@@ -126,9 +126,9 @@ def _sweep_orphaned_designs(backend: Backend, *, dry_run: bool) -> list[JsonValu
 
 def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> list[JsonValue]:
     """Enumerate `creating-spec` handles; finish each interrupted spec
-    instantiation (`create spec` / `promote` crashed before the handle came off,
-    L16) via the shared `finalize_spec_instantiation` -- the same idempotent tail
-    the write paths run, so a crashed `promote` gets its `shape-feat`->`shape-spec`
+    instantiation (`create spec` / `promote` crashed before the handle came
+    off) via the shared `finalize_spec_instantiation` -- the same idempotent
+    tail the write paths run, so a crashed `promote` gets its `shape-feat`->`shape-spec`
     swap reconstructed, not just create-spec's tail replayed. Each candidate is
     re-`get()`d for its labels first: a container's own design child /
     placeholder can carry a LEAKED `creating-spec` (bd inherited the parent's
@@ -153,7 +153,7 @@ def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> lis
 
 
 def reconcile(backend: Backend, args: Namespace) -> JsonValue:
-    """`work reconcile [--dry-run]` (plan L10). Reads no external state (no spec
+    """`work reconcile [--dry-run]`. Reads no external state (no spec
     file); every candidate is found through a completion handle."""
     dry_run = bool(args.dry_run)
     findings = _sweep_interrupted_delivers(backend, dry_run=dry_run)

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -1,13 +1,12 @@
-"""`claim`/`release`/`plan`/`promote` -- guarded lifecycle transitions (plan Task 4).
+"""`claim`/`release`/`plan`/`promote` -- guarded lifecycle transitions.
 
-Every mutation here reads current state first and no-ops when already applied
-(L7). `claim`'s container guard is declared-state (`is_container`), never
-child-count (L16/§5 invariant 5) -- a childless `epic` is refused exactly
-like a populated one. `promote` mirrors `create spec`'s L16 mint-before-
-`planned` discipline: the two label swaps, then `instantiate_spec_shape`,
-then `planned` stamped strictly last, so an interrupted promote leaves a
-self-reporting, not-yet-planned container in the Planning queue rather than
-a queue-invisible one.
+Every mutation here reads current state first and no-ops when already
+applied. `claim`'s container guard is declared-state (`is_container`), never
+child-count -- a childless `epic` is refused exactly like a populated one.
+`promote` mirrors `create spec`'s mint-before-`planned` discipline: the two
+label swaps, then `instantiate_spec_shape`, then `planned` stamped strictly
+last, so an interrupted promote leaves a self-reporting, not-yet-planned
+container in the Planning queue rather than a queue-invisible one.
 """
 
 from __future__ import annotations
@@ -23,7 +22,7 @@ from workcli.lifecycle.park import PARKED_LABEL
 
 
 def claim(backend: Backend, args: Namespace) -> JsonValue:
-    """`work claim ID` (plan L1: bd's own atomic `--claim`; invariant 3 staleness detection)."""
+    """`work claim ID` -- uses bd's own atomic `--claim`; detects stale claims."""
     item = backend.get(args.id)
     if item.status == "closed":
         raise WorkError(ErrorCode.NOT_CLAIMABLE, f"{args.id}: a closed item cannot be claimed")
@@ -49,7 +48,7 @@ def claim(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def release(backend: Backend, args: Namespace) -> JsonValue:
-    """`work release ID` -- returns a claimed item to `open` (plan L1)."""
+    """`work release ID` -- returns a claimed item to `open`."""
     item = backend.get(args.id)
     if item.status == "in_progress":
         backend.set_status(args.id, "open")
@@ -60,7 +59,7 @@ def release(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def plan(backend: Backend, args: Namespace) -> JsonValue:
-    """`work plan ID (--done | --undo) [--force]` -- Planning-queue membership (§5, L16)."""
+    """`work plan ID (--done | --undo) [--force]` -- Planning-queue membership."""
     if args.done == args.undo:
         raise WorkError(ErrorCode.USAGE, "plan: exactly one of --done or --undo is required")
 
@@ -79,7 +78,7 @@ def plan(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def promote(backend: Backend, args: Namespace) -> JsonValue:
-    """`work promote ID` -- a `shape-feat` leaf becomes a `shape-spec` container (L16)."""
+    """`work promote ID` -- a `shape-feat` leaf becomes a `shape-spec` container."""
     item = backend.get(args.id)
     # `shape-spec` short-circuit FIRST, so a promote rerun is replay-safe: an
     # interrupted promote leaves `[shape-spec, creating-spec]` (shape-feat already
@@ -95,7 +94,7 @@ def promote(backend: Backend, args: Namespace) -> JsonValue:
     # from here on leaves the handle set and the `reconcile` sweep replays the
     # shared completion tail (`finalize_spec_instantiation`: swap shape-feat->
     # shape-spec, mint the template children, stamp `planned`, drop the handle
-    # strictly last, L16). A crash before the handle is added leaves an untouched
+    # strictly last). A crash before the handle is added leaves an untouched
     # `shape-feat` leaf -- promote simply never started.
     backend.label_mutate("add", args.id, [CREATING_SPEC_LABEL])
     finalize_spec_instantiation(backend, args.id, item.title)

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -50,7 +50,7 @@ class DepListing:
 class SyncResult:
     synced: bool
     # "push" | "pull" | "noop" -- "noop" is reserved for server-authoritative
-    # backends (spec §6's declared no-op); the bd adapter never emits it.
+    # backends that declare themselves a no-op; the bd adapter never emits it.
     mode: str
 
 

--- a/packages/workcli/src/workcli/render.py
+++ b/packages/workcli/src/workcli/render.py
@@ -2,7 +2,7 @@
 
 Renders the envelope's `data` (on success) or `error` (on failure) to
 **stderr only** — stdout always carries the JSON envelope regardless of
-`--format` (spec §4); this module never touches stdout and never raises on
+`--format`; this module never touches stdout and never raises on
 malformed input, since a rendering bug must never break the stdout
 invariant it sits beside.
 

--- a/packages/workcli/src/workcli/tracks.py
+++ b/packages/workcli/src/workcli/tracks.py
@@ -1,4 +1,4 @@
-"""Track derivation and vocabulary validation (track spec §4).
+"""Track derivation and vocabulary validation.
 
 Derivation is config-free by design -- a pure function over labels -- so the
 `Item.track` envelope field appears on every read verb regardless of config
@@ -16,7 +16,7 @@ TRACK_PREFIX = "track:"
 
 
 def derive_track(labels: Sequence[str]) -> str | None:
-    """Exactly one `track:*` label -> its name; zero or 2+ -> None (spec §4)."""
+    """Exactly one `track:*` label -> its name; zero or 2+ -> None."""
     names = [label[len(TRACK_PREFIX) :] for label in labels if label.startswith(TRACK_PREFIX)]
     if len(names) == 1:
         return names[0]

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -1,4 +1,4 @@
-"""VERBS registry and the capability gate (decision 11).
+"""VERBS registry and the capability gate.
 
 `VERBS` maps a verb name to its handler: `(Backend, Namespace) -> JsonValue`.
 `REQUIRED_CAPABILITY` maps a verb name to a predicate function over
@@ -61,7 +61,7 @@ def _raw_incompatible_flags(args: Namespace) -> list[str]:
 
 def _create(backend: Backend, args: Namespace) -> JsonValue:
     """Dispatch `work create`: `--raw` (transport primitive) or a NOUN;
-    absent both, refuse naming the two valid modes (spec §2, plan L9/CLI surface).
+    absent both, refuse naming the two valid modes.
 
     `--raw` is transport-only: combining it with a noun or a lifecycle flag it
     cannot honor is rejected as `E_USAGE` rather than proceeding with a
@@ -123,7 +123,7 @@ REQUIRED_CAPABILITY: dict[str, Callable[[Capabilities, Namespace], bool]] = {
     "dep": lambda c, a: a.action == "list" or c.supports_dep_write,
     # discover always mints a typed discovered-from edge (step 5), so it
     # carries the same precondition as `dep add`/`dep remove` -- gated
-    # ahead of the handler exactly like `dep` itself (spec §4 step 0).
+    # ahead of the handler exactly like `dep` itself.
     "discover": lambda c, _a: c.supports_dep_write,
 }
 

--- a/packages/workcli/src/workcli/verbs/groom.py
+++ b/packages/workcli/src/workcli/verbs/groom.py
@@ -1,5 +1,4 @@
-"""`work groom --done` / `work groom --status` -- Backlog Grooming state
-(track spec §4/§6, criteria 14-15).
+"""`work groom --done` / `work groom --status` -- Backlog Grooming state.
 
 Its own module, not `report.py`: `--done` MUTATES state (bd's own
 per-item state, on a note field) unlike the read-only aggregations
@@ -28,7 +27,7 @@ from workcli.envelope import ErrorCode, JsonValue, WorkError
 
 _NOTE_LINE_PATTERN = re.compile(r"^backlog_last_groomed: (.*)$", re.MULTILINE)
 _TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-# backlog_last_groomed is dolt-synced across machines (spec §6): ordinary
+# backlog_last_groomed is dolt-synced across machines: ordinary
 # NTP drift on a fast clock can leave a freshly-written marker slightly in
 # the future, and treating that as invalid would fail a groom that just
 # happened. A marker further in the future than this isn't drift -- it's
@@ -139,7 +138,7 @@ def _status(
     # clamp to 0 rather than reporting a negative days_since, so an honest
     # cross-machine groom never falsely reports breached=True.
     days_since = max((now - parsed).days, 0)
-    breached = nag_days is not None and days_since > nag_days  # strict > (criterion 14)
+    breached = nag_days is not None and days_since > nag_days  # strictly greater-than
     return {
         "backlog_last_groomed": last_groomed,
         "days_since": days_since,

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -22,7 +22,7 @@ def _serialize_item(item: Item) -> dict[str, JsonValue]:
     # `deps` comes out already lean (`{id, type, status}`) with no extra work.
     serialized = cast("dict[str, JsonValue]", dataclasses.asdict(item))
     # Derived in the verb layer, config-free, so every read envelope carries
-    # it regardless of config state (track spec §4; the 1.1 additive field).
+    # it regardless of config state (the 1.1 additive field).
     serialized["track"] = derive_track(item.labels)
     return serialized
 
@@ -32,7 +32,7 @@ def _serialize_items(items: list[Item]) -> JsonValue:
 
 
 def show(backend: Backend, args: Namespace) -> JsonValue:
-    """`work show ID...` — one id -> object, 2+ ids -> `{"items": [...]}` (decision 10)."""
+    """`work show ID...` — one id -> object, 2+ ids -> `{"items": [...]}`."""
     items = backend.batch_get(args.ids)
     if len(items) == 1:
         return _serialize_item(items[0])
@@ -44,7 +44,7 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
 
     `--track` filters on the DERIVED `Item.track` (never raw label presence),
     so filter and envelope field always agree: zero-or-multi-label beads
-    derive to null and match nothing (track spec §4). Validated against the
+    derive to null and match nothing. Validated against the
     vocabulary for parity with `create --track` -- a typo returns
     E_UNKNOWN_TRACK, not a silently-empty result. Ordering matters twice:
     config loads BEFORE the backend query (E_NOT_CONFIGURED must precede any
@@ -84,7 +84,7 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def ready(backend: Backend, args: Namespace) -> JsonValue:
-    """`work ready [--label]` — unbounded by default (spec §3)."""
+    """`work ready [--label]` — unbounded by default."""
     return _serialize_items(backend.ready(args.label))
 
 

--- a/packages/workcli/src/workcli/verbs/relations.py
+++ b/packages/workcli/src/workcli/verbs/relations.py
@@ -17,7 +17,7 @@ _DEFAULT_DEP_TYPE = "blocks"
 
 
 def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) -> None:
-    """Pre-check the `blocks` type wall (spec item 4, decision 5).
+    """Pre-check the `blocks` type wall.
 
     `blocks` requires both items epic, or both non-epic (a milestone counts
     as non-epic). One order-preserving `Backend.batch_get` read pays for
@@ -43,7 +43,7 @@ def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) 
 
 
 def dep(backend: Backend, args: Namespace) -> JsonValue:
-    """`work dep {add,remove,list} ID [TARGET] [--type]` (spec §3).
+    """`work dep {add,remove,list} ID [TARGET] [--type]`.
 
     `dep add A B` = A depends on B. `list` maps bd's own inverted
     `--direction` naming into `{depends_on, dependents}` (the ruling that
@@ -83,7 +83,7 @@ def label(backend: Backend, args: Namespace) -> JsonValue:
     bd's own `label add`/`label remove` accept exactly one label per call
     (orchestrator ruling) -- `add`/`remove` fan a multi-label request out
     into one bd invocation per label, still one envelope. `list` returns
-    the flat `string[]` bd itself emits (spec §4: "labels are always
+    the flat `string[]` bd itself emits ("labels are always
     `string[]`").
     """
     if args.action in ("add", "remove") and not args.labels:

--- a/packages/workcli/src/workcli/verbs/report.py
+++ b/packages/workcli/src/workcli/verbs/report.py
@@ -1,12 +1,11 @@
 """`work lint` + `work graph --json` + `work triggers` -- the repo-wide
 reporting verbs.
 
-All three are defined as aggregations over tracks (track spec §4's
-split-portability rule): one sweep, pure reducers, no single-DB semantics in
-the contract. Advisory in v1: lint always exits 0 (spec §9 defers CI-gating);
-violations live in the envelope, not the exit code. `triggers` (spec §5) is
-likewise advisory-only -- it evaluates extraction pressure/eligibility and
-never edits config or splits anything.
+All three are defined as aggregations over tracks, per the split-portability
+rule: one sweep, pure reducers, no single-DB semantics in the contract.
+Advisory in v1: lint always exits 0; violations live in the envelope, not
+the exit code. `triggers` is likewise advisory-only -- it evaluates
+extraction pressure/eligibility and never edits config or splits anything.
 """
 
 from __future__ import annotations
@@ -29,7 +28,7 @@ def _sweep(backend: Backend) -> list[Item]:
 
 
 def _track_violations(non_milestone: list[Item], config: TrackLayerConfig) -> list[JsonValue]:
-    """Invariant 1: exactly one track:* label per non-closed, non-milestone
+    """Exactly one track:* label per non-closed, non-milestone
     bead, AND its name in the configured vocabulary -- raw label writes can
     mint `track:ghost`, which no gate sees and `list --track` can't query;
     lint is the net that makes that corruption recoverable."""
@@ -72,7 +71,7 @@ def _has_milestone_ancestor(
 def _milestone_orphans(
     backend: Backend, swept: list[Item], by_id: dict[str, Item]
 ) -> list[JsonValue]:
-    """Invariant 2: milestone ancestor, or an explicit exempt label."""
+    """A milestone ancestor is required, or an explicit exempt label."""
     fetched: dict[str, Item] = {}
     return [
         item.id
@@ -84,9 +83,9 @@ def _milestone_orphans(
 
 
 def _milestone_wip(swept: list[Item], config: TrackLayerConfig) -> JsonValue:
-    """Invariant 3: in_progress milestones vs the WIP cap, exempt list excluded.
+    """In_progress milestones vs the WIP cap, exempt list excluded.
     An unset cap ([operating-model] absent) skips the check: breached=False,
-    cap=null -- §6 hardcodes nothing."""
+    cap=null -- nothing is hardcoded."""
     active = [
         item.id
         for item in swept
@@ -104,7 +103,7 @@ def _milestone_wip(swept: list[Item], config: TrackLayerConfig) -> JsonValue:
 
 
 def _lease_report(non_milestone: list[Item]) -> JsonValue:
-    """Invariant 4: every non-milestone lease listed; tracks holding >1 flagged."""
+    """Every non-milestone lease listed; tracks holding >1 flagged."""
     leases = [item for item in non_milestone if item.status == "in_progress"]
     counts: dict[str, int] = {}
     for item in leases:
@@ -118,7 +117,7 @@ def _lease_report(non_milestone: list[Item]) -> JsonValue:
 
 
 def _track_mismatches(non_milestone: list[Item], by_id: dict[str, Item]) -> list[JsonValue]:
-    """Invariant 5: soft warning on parent-child track mismatch below milestone level."""
+    """Soft warning on parent-child track mismatch below milestone level."""
     mismatches: list[JsonValue] = []
     for item in non_milestone:
         if item.parent is None or item.parent not in by_id:
@@ -141,7 +140,7 @@ def _track_mismatches(non_milestone: list[Item], by_id: dict[str, Item]) -> list
 
 
 def lint(backend: Backend, args: Namespace) -> JsonValue:
-    """`work lint` -- five advisory invariants, one sweep (track spec §4)."""
+    """`work lint` -- five advisory invariants, one sweep."""
     config = args.load_config()
     swept = _sweep(backend)
     by_id = {item.id: item for item in swept}
@@ -188,10 +187,10 @@ def _closed_ancestors(backend: Backend, items: list[Item], by_id: dict[str, Item
 
 def graph(backend: Backend, args: Namespace) -> JsonValue:
     """`work graph --json` -- the vizsuite V2 / landscape data contract
-    (track spec §4; schema shipped at workcli/schemas/work-graph.schema.json)."""
+    (schema shipped at workcli/schemas/work-graph.schema.json)."""
     if not args.json_output:
         raise WorkError(ErrorCode.USAGE, "work graph requires --json (the only v1 output)")
-    args.load_config()  # new-verb gate (criterion 17); the payload itself is config-free
+    args.load_config()  # new-verb gate; the payload itself is config-free
     lean = _sweep(backend)
     items = backend.batch_get([item.id for item in lean])  # full detail: deps + children
     by_id = {item.id: item for item in items}
@@ -209,8 +208,9 @@ def graph(backend: Backend, args: Namespace) -> JsonValue:
 
 def _backlog_counts(swept: list[Item], config: TrackLayerConfig) -> dict[str, int]:
     """Every configured track name -> count of non-closed beads whose derived
-    track equals it (spec §4). Beads with zero or 2+ track labels derive to
-    `None` and count toward no track -- lint invariant 1 is the net for those."""
+    track equals it. Beads with zero or 2+ track labels derive to
+    `None` and count toward no track -- lint's track-label check is the net
+    for those."""
     counts = dict.fromkeys(config.names, 0)
     for item in swept:
         track_name = derive_track(item.labels)
@@ -222,7 +222,7 @@ def _backlog_counts(swept: list[Item], config: TrackLayerConfig) -> dict[str, in
 def _cross_track_edge_counts(
     backend: Backend, items: list[Item], by_id: dict[str, Item]
 ) -> dict[str, int]:
-    """Spec §5: for every raw (non-parent-child) dep edge between two
+    """For every raw (non-parent-child) dep edge between two
     non-closed beads whose tracks differ, +1 to each endpoint's track total --
     both directions counted independently via the two endpoints of one edge.
     A dep target outside the sweep (closed, or absent from the batch) is
@@ -266,11 +266,11 @@ def _review_question(config: TrackLayerConfig) -> str:
 
 
 def triggers(backend: Backend, args: Namespace) -> JsonValue:
-    """`work triggers` -- extraction pressure/eligibility per track (track
-    spec §5, criterion 13). Organizing-only tracks appear in `backlog_counts`
-    but never receive an extraction status. An unconfigured eligibility
-    ceiling (`max-cross-track-edges` omitted) can never prove eligibility --
-    a deliberate fail-safe, never a false `pressured-eligible`."""
+    """`work triggers` -- extraction pressure/eligibility per track.
+    Organizing-only tracks appear in `backlog_counts` but never receive an
+    extraction status. An unconfigured eligibility ceiling
+    (`max-cross-track-edges` omitted) can never prove eligibility -- a
+    deliberate fail-safe, never a false `pressured-eligible`."""
     config = args.load_config()
     swept = _sweep(backend)
     items = backend.batch_get([item.id for item in swept])  # full detail: deps

--- a/packages/workcli/src/workcli/verbs/syncing.py
+++ b/packages/workcli/src/workcli/verbs/syncing.py
@@ -15,7 +15,7 @@ from workcli.model import SyncResult
 
 
 def sync(backend: Backend, args: Namespace) -> JsonValue:
-    """`work sync [--pull]` (decision 9): default = commit+push; `--pull` = pull.
+    """`work sync [--pull]`: default = commit+push; `--pull` = pull.
 
     `SERVER_AUTHORITATIVE` backends have nothing to sync -- an honest no-op
     success (`synced: false`, `mode: "noop"`) without ever calling

--- a/packages/workcli/src/workcli/verbs/tracks.py
+++ b/packages/workcli/src/workcli/verbs/tracks.py
@@ -3,7 +3,7 @@
 Its own verb family: `update` stays scalar-replace-only per the contract's
 layering (labels are not `UpdateFields`). The two underlying label operations
 are NOT transactional -- an interruption can leave the bead track-less, which
-lint invariant 1 surfaces (track spec §4: lint-recoverable, not atomic). Raw
+lint's track-derivation check surfaces: lint-recoverable, not atomic. Raw
 `work label add track:<anything>` stays possible and unvalidated by design:
 lint is the net, `track set` is the gate.
 """
@@ -20,9 +20,9 @@ from workcli.tracks import TRACK_PREFIX, derive_track, require_known_track, trac
 def _swap_track_label(
     backend: Backend, current_labels: list[str], item_id: str, new_name: str
 ) -> None:
-    """Remove stale `track:*` labels, then add the target (spec §4 ordering:
+    """Remove stale `track:*` labels, then add the target -- ordering:
     a crash between the two leaves the bead track-less -- lint's case --
-    never double-tracked)."""
+    never double-tracked."""
     target = track_label(new_name)
     stale = [
         label for label in current_labels if label.startswith(TRACK_PREFIX) and label != target
@@ -38,7 +38,7 @@ def _cascade(
 ) -> tuple[int, list[str]]:
     """Relabel descendants on the root's PRE-change track (plus untracked ones);
     skip-and-report everything else -- cross-track parenting is legal and a
-    descendant deliberately on another track is never clobbered (spec §4).
+    descendant deliberately on another track is never clobbered.
     Whole-subtree traversal: a skipped child's own descendants are still
     evaluated by the same one rule."""
     relabeled = 0

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -18,11 +18,11 @@ from workcli.model import CreateFields, UpdateFields
 
 
 def create_raw(backend: Backend, args: Namespace) -> JsonValue:
-    """`work create --raw --title T [...]` — the adapter primitive (spec §2).
+    """`work create --raw --title T [...]` — the adapter primitive.
 
     Public, noun-templated creation belongs to the lifecycle layer (bead
     .9.2); `--raw` gates this transport-layer passthrough so a caller can
-    never reach it by accident (locked decision 7).
+    never reach it by accident.
     """
     if not args.raw:
         raise WorkError(
@@ -45,10 +45,10 @@ def create_raw(backend: Backend, args: Namespace) -> JsonValue:
 def update(backend: Backend, args: Namespace) -> JsonValue:
     """`work update ID [--set-title] [--set-priority] [--set-description]`.
 
-    Replace semantics only (spec §3); status never moves through this verb
+    Replace semantics only; status never moves through this verb
     (lifecycle verbs own claiming/status). `--set-notes` is recognized by
     argparse only so it reaches this named clobber-guard rather than a
-    generic `E_USAGE` (locked decision 6) — notes only ever move through
+    generic `E_USAGE` — notes only ever move through
     `work note`. (Suppressed from `--help`; rationale at its
     `add_argument` site in `cli.py`.)
     """
@@ -69,7 +69,7 @@ def update(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def note(backend: Backend, args: Namespace) -> JsonValue:
-    """`work note ID TEXT` — append-only (spec §3; PDLC `append_audit_note`)."""
+    """`work note ID TEXT` — append-only."""
     backend.append_note(args.id, args.text)
     return None
 

--- a/packages/workcli/tests/unit/test_batch_get_edges.py
+++ b/packages/workcli/tests/unit/test_batch_get_edges.py
@@ -1,4 +1,4 @@
-"""`BdBackend.batch_get` edge cases (plan L5, 38o1v #4).
+"""`BdBackend.batch_get` edge cases.
 
 Empty `ids` -> `[]` with zero bd calls (a new guard -- previously an empty
 request still built and sent a `show --json` argv). Duplicate/extra-record

--- a/packages/workcli/tests/unit/test_close_walk.py
+++ b/packages/workcli/tests/unit/test_close_walk.py
@@ -2,9 +2,10 @@
 
 close + close-walk + note is ONE facade call: a non-milestone parent whose
 last open child closes is exhausted and closes with it, recursively, with a
-`[work] close-walk` note. Milestones are the boundary -- they close only when
-their own acceptance criteria are met, never on child exhaustion. State-based
-against `FakeBackend`, driving the real `close` and `deliver` handlers.
+`[work] close-walk` note. Milestones are the boundary -- they never auto-close
+on child exhaustion; closing one is always a deliberate, explicit close call.
+State-based against `FakeBackend`, driving the real `close` and `deliver`
+handlers.
 """
 
 from __future__ import annotations

--- a/packages/workcli/tests/unit/test_config_loading.py
+++ b/packages/workcli/tests/unit/test_config_loading.py
@@ -1,4 +1,4 @@
-"""Behavioral tests for workcli.config.load_config (track spec §3, criterion 16/17)."""
+"""Behavioral tests for workcli.config.load_config."""
 
 from __future__ import annotations
 
@@ -57,7 +57,7 @@ def test_search_stops_at_git_root(tmp_path: Path) -> None:
 
 
 def test_outside_any_git_repo_is_not_configured(tmp_path: Path) -> None:
-    # No .git anywhere on the walk -> treated as "no config found" (spec §3),
+    # No .git anywhere on the walk -> treated as "no config found",
     # even when a project-config.toml exists in a parent dir. REGRESSION PIN:
     # a naive walk that checks for the config file before establishing a git
     # root adopts that unrelated parent config instead of failing safe --
@@ -167,7 +167,7 @@ def test_non_table_operating_model_is_invalid(tmp_path: Path) -> None:
     assert "[operating-model]" in exc_info.value.message
 
 
-# -- [operating-model].backlog-groom-nag-days / .groom-state-bead (groom state, track spec §4/§6) --
+# -- [operating-model].backlog-groom-nag-days / .groom-state-bead (groom state) --
 
 
 def test_groom_fields_parsed(tmp_path: Path) -> None:
@@ -256,7 +256,7 @@ def test_git_file_marker_counts_as_root(tmp_path: Path) -> None:
     assert load_config(root).names == ("alpha", "beta", "gamma")
 
 
-# -- [extraction.pressure] / [extraction.eligibility] (extraction policy §5) --
+# -- [extraction.pressure] / [extraction.eligibility] (extraction policy) --
 
 
 def test_extraction_tables_absent_yield_safe_defaults(tmp_path: Path) -> None:

--- a/packages/workcli/tests/unit/test_config_seam.py
+++ b/packages/workcli/tests/unit/test_config_seam.py
@@ -1,4 +1,4 @@
-"""The config-loader seam: injected, lazy, --config passthrough (track spec §3)."""
+"""The config-loader seam: injected, lazy, --config passthrough."""
 
 from __future__ import annotations
 

--- a/packages/workcli/tests/unit/test_create_milestone_and_labels.py
+++ b/packages/workcli/tests/unit/test_create_milestone_and_labels.py
@@ -170,7 +170,7 @@ def _required_config() -> TrackLayerConfig:
 
 
 def test_create_milestone_is_track_exempt_under_required_enforcement():  # S2-A1
-    # Track spec §3: milestone-type beads are track-exempt and carry no
+    # Milestone-type beads are track-exempt and carry no
     # track:* label -- even when [tracks].enforcement = "required".
     backend = FakeBackend()
     args = _create_args("milestone", orphan=True)

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -1,8 +1,8 @@
-"""`work create <noun>` -- noun-templated creation (plan Task 3, test-plan items 1-3).
+"""`work create <noun>` -- noun-templated creation.
 
-Duplicate-title guard (L13) fires before any `create` reaches bd; placement
-(L14) requires exactly one of `--parent`/`--orphan`; the spec shape mints its
-design child + placeholder before stamping `planned` LAST (L16). All
+Duplicate-title guard fires before any `create` reaches bd; placement
+requires exactly one of `--parent`/`--orphan`; the spec shape mints its
+design child + placeholder before stamping `planned` LAST. All
 call-log assertions go through `run_cli_with_runner` (conftest.py) since
 `run_cli` discards its runner and exposes no `.calls`.
 """
@@ -423,7 +423,7 @@ def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
         ("label", "add", "x.1", "planned"),
         ("label", "remove", "x.1", "creating-spec"),
     ]
-    # `creating-spec` comes off strictly last, after `planned` (L16).
+    # `creating-spec` comes off strictly last, after `planned`.
     assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")
 
 

--- a/packages/workcli/tests/unit/test_create_raw.py
+++ b/packages/workcli/tests/unit/test_create_raw.py
@@ -1,8 +1,8 @@
-"""`work create --raw` (spec test-plan item 3, locked decisions 6/7).
+"""`work create --raw`.
 
 `create` is the adapter primitive only -- public, noun-templated creation
 belongs to the lifecycle layer (bead .9.2), so a bare `work create` without
-`--raw` must refuse with `E_USAGE` naming that layer (decision 7). With
+`--raw` must refuse with `E_USAGE` naming that layer. With
 `--raw`, exactly one bd invocation reaches the runner even when a `--parent`
 is given -- bd's own `--parent` flag auto-adds the parent edge, so a second
 `dep add` call would double it (established fact from earlier tasks).

--- a/packages/workcli/tests/unit/test_create_track_gate.py
+++ b/packages/workcli/tests/unit/test_create_track_gate.py
@@ -1,4 +1,4 @@
-"""create track gate (track spec §4; criteria 1-5, 9, 17)."""
+"""create track gate."""
 
 from __future__ import annotations
 
@@ -178,7 +178,7 @@ def test_invalid_config_skips_gate_with_warning_never_breaks_create() -> None:
 
 
 def test_raw_milestone_create_bypasses_gate_even_in_required_mode() -> None:
-    # Milestones are track-exempt (track spec §3) and enter via --raw; the
+    # Milestones are track-exempt and enter via --raw; the
     # gate must not touch this path regardless of enforcement. The exploding
     # loader proves --raw never even loads config.
     def explode(_explicit_path: str | None) -> TrackLayerConfig:

--- a/packages/workcli/tests/unit/test_deliver.py
+++ b/packages/workcli/tests/unit/test_deliver.py
@@ -1,9 +1,9 @@
 """`deliver` -- evidence-gated leaf delivery + design-spec placeholder
-reconciliation (plan Task 5, test-plan items 4, 5, 6).
+reconciliation.
 
 DESIGN path dispatches on the `shape-design` label: it locates the sibling
 placeholder under the design child's parent (the container always has
-exactly the two children `instantiate_spec_shape` minted -- L9), records the
+exactly the two children `instantiate_spec_shape` minted), records the
 `[work] spec:` marker on the placeholder, reconciles it against the parsed
 `## Continuations` manifest, then closes the design child. LEAF path
 verifies bd-observable evidence (`--items` existence via `batch_get`,

--- a/packages/workcli/tests/unit/test_dep_type_wall.py
+++ b/packages/workcli/tests/unit/test_dep_type_wall.py
@@ -1,6 +1,6 @@
 """`dep add/remove/list` — type-wall pre-check, positional order, direction mapping.
 
-Spec test-plan item 4 + decision 5: a `blocks` dep between an epic and a
+A `blocks` dep between an epic and a
 non-epic is pre-checked via one `Backend.batch_get([from_id, to_id])` read
 (never a bd `dep` mutation) and raises the named `E_TYPE_WALL` before bd is
 ever asked to add the edge. The wall only applies to `blocks`; any other dep

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -416,7 +416,7 @@ def test_edge_add_failure_surfaces_created_id_for_replay() -> None:
 
 # --- recovery contract: post-create track read fails -> detail.created_id set ---
 # (codex review finding on PR #327: backend.get(new_id) for track derivation is a
-# third post-create step the spec's §3.2 enumeration didn't name; it must carry
+# third post-create step not covered by the original enumeration; it must carry
 # created_id on failure exactly like the edge-add and orphan-marker seams do.)
 
 

--- a/packages/workcli/tests/unit/test_drift_alarm.py
+++ b/packages/workcli/tests/unit/test_drift_alarm.py
@@ -1,4 +1,4 @@
-"""The drift alarm (spec test-plan item 9): whenever bd's actual output shape
+"""The drift alarm: whenever bd's actual output shape
 no longer matches what the parser expects, the facade raises
 `WorkError(BACKEND_DRIFT)` naming exactly what broke -- never a silent
 best-effort guess.
@@ -433,7 +433,7 @@ def test_show_shape_dependency_edge_missing_id_raises_backend_drift():
     # A `dependencies[]` entry carrying `dependency_type` (show-shape) but no
     # `id` for the other end would raise a raw KeyError -> E_INTERNAL from
     # `_dep_edge_from_raw`'s direct indexing. It must alarm as BACKEND_DRIFT
-    # like every other unmappable shape (spec test-plan item 9).
+    # like every other unmappable shape.
     raw_item = {
         "id": "x.1",
         "title": "t",
@@ -478,8 +478,7 @@ def test_parent_child_dependent_missing_id_raises_backend_drift():
     # A `dependents[]` parent-child record (the shape that becomes `children`)
     # carrying `dependency_type` but no `id` for the other end would raise a
     # raw KeyError -> E_INTERNAL from `children`'s direct indexing. It must
-    # alarm as BACKEND_DRIFT like the `dependencies[]` show-shape edge does
-    # (spec test-plan item 9).
+    # alarm as BACKEND_DRIFT like the `dependencies[]` show-shape edge does.
     raw_item = {
         "id": "x.1",
         "title": "t",
@@ -502,7 +501,7 @@ def test_non_object_dependency_entry_raises_backend_drift_not_a_silent_drop():
     # A `dependencies[]` entry that isn't a JSON object (e.g. a bare string)
     # was previously filtered out silently by `isinstance(entry, dict)` and
     # continued with a partially-mangled Item -- that is bd shape drift, not
-    # something to drop and carry on from (spec test-plan item 9).
+    # something to drop and carry on from.
     raw_item = {
         "id": "x.1",
         "title": "t",

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -1,4 +1,4 @@
-"""Envelope invariant matrix (spec test-plan item 1) + handshake tail (item 10).
+"""Envelope invariant matrix + handshake tail.
 
 Every one of the twelve contract verbs, in both a success and a failure
 case, must emit exactly one parseable JSON envelope on stdout carrying
@@ -218,8 +218,8 @@ VERB_CASES: list[VerbCase] = [
             )
         ],
     ),
-    # --- lifecycle verbs (plan Task 7 -- one success + one failure per verb,
-    # over the seven lifecycle verbs from create through reconcile) ---------
+    # --- lifecycle verbs (one success + one failure per verb, over the
+    # seven lifecycle verbs from create through reconcile) ---------
     VerbCase(
         "create_noun",
         ["create", "spec", "--title", "New Objective", "--parent", "P"],

--- a/packages/workcli/tests/unit/test_format_human.py
+++ b/packages/workcli/tests/unit/test_format_human.py
@@ -1,4 +1,4 @@
-"""`--format human` (locked decision 2, spec §4).
+"""`--format human`.
 
 Human rendering is opt-in and goes to **stderr only** — stdout must remain
 byte-identical to the same invocation without the flag, so the "stdout is
@@ -54,7 +54,7 @@ def test_format_json_explicit_never_writes_to_stderr() -> None:
 
 
 def test_format_human_on_a_usage_error_still_renders_to_stderr() -> None:
-    # A parse/usage failure raises before the verb dispatches, but spec §4's
+    # A parse/usage failure raises before the verb dispatches, but the
     # "human view to stderr" invariant still applies: --format human must be
     # recovered from argv even though full parsing never completed.
     out = StringIO()

--- a/packages/workcli/tests/unit/test_groom.py
+++ b/packages/workcli/tests/unit/test_groom.py
@@ -1,5 +1,4 @@
-"""`work groom --done` / `work groom --status` -- Backlog Grooming state
-(track spec §4/§6, criteria 14-15).
+"""`work groom --done` / `work groom --status` -- Backlog Grooming state.
 
 State lives on the designated `[operating-model].groom-state-bead` as a
 parseable note line (`backlog_last_groomed: <iso8601>`) -- the fallback
@@ -280,7 +279,7 @@ def test_done_recovers_from_a_stale_future_skewed_marker() -> None:
 
 
 # -- round-3 Codex finding: clock skew across dolt-synced machines --
-# backlog_last_groomed is synced via dolt (spec §6); a marker written from a
+# backlog_last_groomed is synced via dolt; a marker written from a
 # fast-clocked machine can land slightly in the future. <=24h is ordinary
 # NTP drift and clamps to days_since=0; beyond that is invalid state.
 

--- a/packages/workcli/tests/unit/test_help_exemption.py
+++ b/packages/workcli/tests/unit/test_help_exemption.py
@@ -1,5 +1,5 @@
 """Finding 3: `--help`/`-h` is a documented, pinned exemption from the
-"stdout is always exactly one envelope" invariant (spec §4).
+"stdout is always exactly one envelope" invariant.
 
 argparse's built-in help action prints human-oriented usage text to the
 *real* `sys.stdout` and raises `SystemExit(0)` -- it never routes through

--- a/packages/workcli/tests/unit/test_internal_guard.py
+++ b/packages/workcli/tests/unit/test_internal_guard.py
@@ -5,7 +5,7 @@ gate, and the handler call -- must stay inside one guarded region.
 Before this fix, `_build_backend(runner, sleep)` and `backend.capabilities`
 (via `missing_capability`) ran unguarded in `main()`: an exception raised
 there escaped with a raw traceback and NO envelope on stdout at all,
-violating "stdout is always exactly one envelope" (spec §4). This file pins
+violating "stdout is always exactly one envelope". This file pins
 that any exception raised anywhere in that region still yields exactly one
 `E_INTERNAL` envelope on stdout, a traceback on stderr, and exit code 1.
 """

--- a/packages/workcli/tests/unit/test_item_track_field.py
+++ b/packages/workcli/tests/unit/test_item_track_field.py
@@ -1,4 +1,4 @@
-"""Item.track envelope field on all read verbs (track spec §4, criterion 8)."""
+"""Item.track envelope field on all read verbs."""
 
 from __future__ import annotations
 

--- a/packages/workcli/tests/unit/test_label_verbs.py
+++ b/packages/workcli/tests/unit/test_label_verbs.py
@@ -2,7 +2,7 @@
 
 bd's own `label add`/`label remove` accept only one label per call; the
 facade's `work label add ID a b c` fans that out into three ordered bd
-invocations behind a single envelope (spec §3). `label list` normalizes to
+invocations behind a single envelope. `label list` normalizes to
 the golden `bd label list --json` shape: a flat `string[]`.
 """
 

--- a/packages/workcli/tests/unit/test_list_unbounded.py
+++ b/packages/workcli/tests/unit/test_list_unbounded.py
@@ -1,4 +1,4 @@
-"""`list`/`ready` default to unbounded (spec test-plan item 5).
+"""`list`/`ready` default to unbounded.
 
 bd's own `list`/`ready` default row caps (50/100) are the exact quirk this
 facade exists to kill: the adapter always sends `--limit 0` unless the

--- a/packages/workcli/tests/unit/test_lock_retry.py
+++ b/packages/workcli/tests/unit/test_lock_retry.py
@@ -1,4 +1,4 @@
-"""Lock-contention retry (spec test-plan item 7, locked decision 8).
+"""Lock-contention retry.
 
 Retryable = lock-contention stderr patterns or subprocess `TimeoutExpired`;
 3 attempts total, injectable `sleep(0.5)` then `sleep(1.0)` between them;

--- a/packages/workcli/tests/unit/test_manifest.py
+++ b/packages/workcli/tests/unit/test_manifest.py
@@ -1,4 +1,4 @@
-"""`## Continuations` manifest parser (plan Task 2 / spec §6, §15).
+"""`## Continuations` manifest parser.
 
 `parse_continuations` turns a spec's `## Continuations` section into a typed
 `Manifest`. The grammar is wrap-tolerant (a bullet's title/AC may continue

--- a/packages/workcli/tests/unit/test_note_append_only.py
+++ b/packages/workcli/tests/unit/test_note_append_only.py
@@ -1,11 +1,11 @@
 """`work note` is append-only; `work update` refuses to clobber notes.
 
-Spec test-plan item 6: two `note` calls concatenate via bd's `--append-notes`
+Two `note` calls concatenate via bd's `--append-notes`
 flag, in order; no verb path may ever reach bd's bare replace flag `--notes`.
 `--set-notes` on `update` is recognized by argparse (so it is never swallowed
 as a generic `E_USAGE` unknown-flag error) but the verb handler rejects it
-with the named `E_FIELD_CLOBBER_GUARD` code before any bd call (locked
-decision 6) -- notes only ever move through `work note`. The flag is also
+with the named `E_FIELD_CLOBBER_GUARD` code before any bd call --
+notes only ever move through `work note`. The flag is also
 suppressed from `--help` (rationale at its `add_argument` site in `cli.py`).
 """
 

--- a/packages/workcli/tests/unit/test_nouns.py
+++ b/packages/workcli/tests/unit/test_nouns.py
@@ -1,13 +1,11 @@
-"""Noun taxonomy (plan L9) + the lifecycle marker/container helpers (plan
-`lifecycle/__init__.py`).
+"""Noun taxonomy + the lifecycle marker/container helpers (`lifecycle/__init__.py`).
 
-`NOUN_TEMPLATES` is the single source of truth Task 3+ verbs key off of to
+`NOUN_TEMPLATES` is the single source of truth verbs key off to
 turn a noun into a bd `--type` + birth shape label. `is_container` is a
 declared-state test only -- deep review flagged (MAJOR) an earlier
 child-count-based guard as wrong, since a `claim` on a childless-but-labeled
 container must still be rejected, and a plain item with children but no
-container label/type must not accidentally be treated as one (spec
-§5/invariant 5).
+container label/type must not accidentally be treated as one.
 """
 
 from __future__ import annotations

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -1,4 +1,4 @@
-"""Protocol handshake tests (spec §5, test-plan item 10).
+"""Protocol handshake tests.
 
 `work --protocol-version` is the consumer handshake at adapter init: prgroom
 and PDLC pin a major version and refuse to run against a mismatched facade.

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -1,4 +1,4 @@
-"""State-based recovery contract (spec §6, plan L7/L10).
+"""State-based recovery contract.
 
 These tests assert the *healed final state* of a bead tree after delivery and
 after a recovery sweep -- labels, status, children, notes -- against a
@@ -136,7 +136,7 @@ def test_reconcile_single_closes_design_child_and_swaps_labels_last():
 def test_deliver_design_records_manifest_snapshot_in_band():
     # The frozen target: `deliver` parses the spec once and records the parsed
     # manifest as a `[work] manifest:` note, so every later reconcile replays
-    # toward it without re-reading the (mutable) spec file (spec §6, L7).
+    # toward it without re-reading the (mutable) spec file.
     backend = FakeBackend()
     _spec_tree(backend)
 
@@ -164,7 +164,7 @@ def test_deliver_design_replay_uses_frozen_snapshot_not_the_spec_file():
     assert backend.get("d").status == "closed"
 
 
-# --- reconcile sweep (plan L10: handle-driven, no external-state gate) ---
+# --- reconcile sweep: handle-driven, no external-state gate ---
 
 
 def _snapshot_note(manifest: Manifest) -> str:
@@ -327,7 +327,7 @@ def test_deliver_design_multi_mints_children_under_placeholder_and_closes_design
     child_titles = {backend.get(cid).title for cid in placeholder.children}
     assert child_titles == {"Alpha", "Beta"}
     # The placeholder is now the impl sub-container: stamped so `claim`/the
-    # router treat it as a declared-state container (spec §6), with the
+    # router treat it as a declared-state container, with the
     # completion handle removed strictly last.
     assert IMPL_CONTAINER_LABEL in placeholder.labels
     assert IMPL_PLACEHOLDER_LABEL not in placeholder.labels
@@ -497,7 +497,7 @@ def test_reconcile_dry_run_reports_leaf_and_orphaned_design_without_mutating():
 
 def test_reconcile_flags_a_corrupt_snapshot_without_aborting_the_sweep():
     # One poisoned placeholder must not block recovery of a healthy one: the
-    # typed drift is caught per-item, reported, and the sweep continues (L10).
+    # typed drift is caught per-item, reported, and the sweep continues.
     backend = FakeBackend()
     _spec_tree(backend, design_status="in_progress", placeholder_notes=_snapshot_note(_single()))
     backend.add("c2", type="feature", labels=["shape-spec"])
@@ -562,7 +562,7 @@ def test_reconcile_repairs_pending_placeholder_with_no_design_sibling():
     assert {"id": "p", "kind": "unreconciled_placeholder", "repaired": True} in findings
 
 
-# --- creating-spec recovery (spec §6, plan L16: interrupted spec instantiation) ---
+# --- creating-spec recovery: interrupted spec instantiation ---
 
 
 def _creating_spec_container(backend: FakeBackend, *, with_design=False, with_placeholder=False):
@@ -586,7 +586,7 @@ def _creating_spec_container(backend: FakeBackend, *, with_design=False, with_pl
 def test_instantiate_spec_shape_is_idempotent_when_both_children_exist():
     # A replay (reconcile sweep, or a re-run) over a container whose design child
     # and placeholder already exist must find-or-create: return the existing ids,
-    # mint nothing new -- no duplicate template children (spec §6, L16).
+    # mint nothing new -- no duplicate template children.
     backend = FakeBackend()
     _creating_spec_container(backend, with_design=True, with_placeholder=True)
 

--- a/packages/workcli/tests/unit/test_retry_safety.py
+++ b/packages/workcli/tests/unit/test_retry_safety.py
@@ -1,4 +1,4 @@
-"""Retry-safety fix (plan L4, 38o1v #3): `retry_on_timeout` on `run_with_retry`.
+"""Retry-safety fix: `retry_on_timeout` on `run_with_retry`.
 
 Non-idempotent bd mutations (`create`, `append_note`) must not retry a
 subprocess timeout -- re-running a possibly-completed create/append would

--- a/packages/workcli/tests/unit/test_seam_lifecycle.py
+++ b/packages/workcli/tests/unit/test_seam_lifecycle.py
@@ -1,4 +1,4 @@
-"""The four lifecycle seam primitives (plan L2) + `create`'s new fields (L3).
+"""The four lifecycle seam primitives + `create`'s new fields.
 
 `claim`/`set_status`/`set_type`/`set_acceptance` are thin `BdBackend`
 primitives the lifecycle verb layer (bead .9.2, later tasks) composes into

--- a/packages/workcli/tests/unit/test_show_normalization.py
+++ b/packages/workcli/tests/unit/test_show_normalization.py
@@ -1,4 +1,4 @@
-"""`show` verb normalization (spec test-plan item 2, decision 10).
+"""`show` verb normalization.
 
 A single id must yield an object (never a single-element array), with lean
 dep edges (`{id, type, status}`) and `string[]` labels. Multiple ids must

--- a/packages/workcli/tests/unit/test_sync.py
+++ b/packages/workcli/tests/unit/test_sync.py
@@ -1,4 +1,4 @@
-"""`sync` — ordered dolt commit+push, or `--pull` (spec §3, decision 9).
+"""`sync` — ordered dolt commit+push, or `--pull`.
 
 Default mode is commit-then-push, in that exact order (a dolt commit failing
 with "nothing to commit" is still success -- idempotent sync, still

--- a/packages/workcli/tests/unit/test_track_derivation.py
+++ b/packages/workcli/tests/unit/test_track_derivation.py
@@ -1,4 +1,4 @@
-"""derive_track: the single label->track rule every consumer shares (track spec §4)."""
+"""derive_track: the single label->track rule every consumer shares."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ def test_no_track_label_derives_none() -> None:
 
 
 def test_multiple_track_labels_derive_none() -> None:
-    # Reachable via raw label writes; spec §4 pins null, lint invariant 1 flags it.
+    # Reachable via raw label writes; the rule pins null, lint invariant 1 flags it.
     assert derive_track(["track:installer", "track:prgroom"]) is None
 
 

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -1,9 +1,8 @@
-"""`claim`/`release`/`plan`/`promote` -- guarded lifecycle transitions (plan Task 4,
-test-plan items 8, 9, 10).
+"""`claim`/`release`/`plan`/`promote` -- guarded lifecycle transitions.
 
 `claim`'s container guard is label/type-based (`is_container`), never child-count
-(§5/invariant 5) -- the childless-`epic` test below is the proof. `promote`'s
-mutation order (labels, then `instantiate_spec_shape`, then `planned` last, L16)
+(invariant 5) -- the childless-`epic` test below is the proof. `promote`'s
+mutation order (labels, then `instantiate_spec_shape`, then `planned` last)
 mirrors `create spec`. All call-log assertions go through `run_cli_with_runner`
 (conftest.py) since `run_cli` discards its runner and exposes no `.calls`.
 """
@@ -392,10 +391,10 @@ def test_promote_shape_feat_leaf_mints_spec_shape_in_order_creating_spec_removed
         ("label", "add", "x.1", "planned"),
         ("label", "remove", "x.1", "creating-spec"),
     ]
-    # `creating-spec` comes off strictly last -- after `planned` (L16).
+    # `creating-spec` comes off strictly last -- after `planned`.
     assert runner.calls[-1] == ("label", "remove", "x.1", "creating-spec")
     # No reparent/new-parent call on x.1 itself -- id, parent, and edges
-    # untouched (L16/plan item 10).
+    # untouched.
     assert not any(call[:2] == ("update", "x.1") for call in runner.calls)
 
 

--- a/packages/workcli/tests/unit/test_triggers.py
+++ b/packages/workcli/tests/unit/test_triggers.py
@@ -1,4 +1,4 @@
-"""`work triggers`: extraction pressure/eligibility evaluation (track spec §5, criterion 13)."""
+"""`work triggers`: extraction pressure/eligibility evaluation."""
 
 from __future__ import annotations
 
@@ -167,7 +167,7 @@ def test_unconfigured_ceiling_never_yields_eligible() -> None:
 
 def test_parent_child_edges_not_counted_as_cross_track() -> None:
     # A synthesized parent-child edge must never inflate the cross-track
-    # count -- only raw `item.deps` entries count (spec §5).
+    # count -- only raw `item.deps` entries count.
     config = TrackLayerConfig(
         names=("alpha", "beta"),
         organizing_only=(),


### PR DESCRIPTION
## What

Follow-up to #381 (merged). That PR purged charter/slice/decision jargon from shipped code prose; post-merge review surfaced a second, pervasive class of the same problem: internal planning-doc **provenance citations** still studded throughout the installer and workcli packages.

Swept in this PR:
- **L-number "law" tags** (`L1`..`L16`, `LAST (L16)`, `plan L9/L13/L14/L16`, `(L7)`, etc.) — enumerated "laws" from the old workcli plan doc, meaningless outside it.
- **Spec-section citations** (`spec §4`, `§5`, `track spec §3`, `discover spec §3.2`, `plan Task 2`, `test-plan item 10`, `criterion 13`, `decision 9`, ...).
- **Stray bead IDs** (`38o1v #4`, `agents-config-9k9.14`).

Each was rewritten to state the actual rule/behavior in plain, standalone English, preserving all real semantic content. Prose only — no behavior, name, or logic changes.

## Same sanitization rule as #381

Shipped artifacts must read standalone; provenance belongs in specs, commits, and the tracker, not in code prose. AC-cited test function names and any bare per-criterion tag are retained as traceability.

## Preserved on purpose

References that cite a **resolvable committed file path** are kept intact as real developer pointers — e.g. `docs/specs/2026-07-06-profiles-scope-routing.md §§3,5,6,7,10` in `profiles.py`, and the design-doc citations in `model.py` / `test_model.py` / `test_io_port.py`. Bare `§N` refs that point back to a doc named in the same file were left as anchored references. Test-data tracker IDs (`agents-config-wgclw.9.x`) and fixtures are untouched — they are semantic test inputs, not prose.

## Meaning-drift correction (from #381 codex review)

The close-walk module docstring (and its test) said a milestone "closes only when its own acceptance criteria are met" — implying code-enforced acceptance validation that does not exist. The code performs no such check: only the auto-close walk refuses milestones; an explicit `work close <milestone>` closes unconditionally. Reworded `closewalk.py` and `test_close_walk.py` to say a milestone never auto-closes on child exhaustion and closing one is always a deliberate, explicit call.

## Scope

75 files across `packages/workcli/{src,tests}` and `packages/installer/{src,tests}`.

## Gates (from worktree root, standalone)

- `make ci-workcli` → exit 0 (612 passed; coverage 98.97%)
- `make ci-installer` → exit 0 (947 passed, 1 skipped; coverage 97.79%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ7AFo9nW6JTJ85QEbCtzp