### PR TITLE
feat(9k9.1.8): grind status --handoff re-orientation projection

### DIFF
--- a/packages/grind/src/grind/cli.py
+++ b/packages/grind/src/grind/cli.py
@@ -65,7 +65,20 @@ def _build_parser() -> _RaisingArgumentParser:
     _add_dir_flag(log_parser)
 
     status_parser = subparsers.add_parser("status", help="report the folded state")
-    status_parser.add_argument("--full", action="store_true")
+    # Alternative projections of one fold, so the parser refuses the
+    # combination outright rather than silently picking a winner.
+    status_view = status_parser.add_mutually_exclusive_group()
+    status_view.add_argument(
+        "--full", action="store_const", const="full", dest="view", help="the entire folded state"
+    )
+    status_view.add_argument(
+        "--handoff",
+        action="store_const",
+        const="handoff",
+        dest="view",
+        help="the re-orientation projection a contextless session resumes from",
+    )
+    status_parser.set_defaults(view="summary")
     _add_dir_flag(status_parser)
 
     check_parser = subparsers.add_parser("check", help="staleness probe (exits 1 when stale)")
@@ -131,7 +144,7 @@ def _dispatch(
         return cmd_log(grind_dir, args.type, payload, now=now)
 
     if args.verb == "status":
-        return cmd_status(grind_dir, full=args.full, now=now)
+        return cmd_status(grind_dir, view=args.view, now=now)
 
     if args.verb == "check":
         return cmd_check(grind_dir, args.max_age, now=now)

--- a/packages/grind/src/grind/handoff.py
+++ b/packages/grind/src/grind/handoff.py
@@ -1,0 +1,182 @@
+"""`grind status --handoff` -- the re-orientation projection.
+
+The reader this is shaped for is an agent session with no context: freshly
+started, or just compacted. It needs, in one call and without asking a human,
+what this run is, where it got to, what is stuck and on what, where each lane
+picks up, and which anomalies were accepted-and-flagged along the way. That
+is the whole point -- a session that has to ask is a babysitting intervention.
+
+It replaces the hand-maintained handoff file, so it carries exactly that
+file's anatomy (spec "Compaction handoff"), sourced from the fold:
+
+| handoff key | source |
+|---|---|
+| `mission` | `grind_created.mission` |
+| `pause` | `grind_paused`, while unresumed |
+| `lanes` / `frontier` | seeded lanes + `lane_handover` + derived item statuses |
+| `merged_ledger` / `closed_ledger` | `item_merged` / `pr_closed` |
+| `human_docket` | the attention list (`item_waiting_human.why` lands there) |
+| `protocols` | `grind_created.protocols` |
+| `quirks` / `lessons` | `WARN` / `LESSON` observations |
+
+**It is a projection over already-folded state and nothing more.** No event
+type is introduced, no wall clock is read (the caller's `conditions` ride the
+same envelope, as they do for every other `status` mode), and no orchestration
+policy is expressed: like a condition, every field states what is true and
+carries its evidence. Every key this projection *coins* is held to
+`conditions.IMPERATIVE_VERBS` by test; keys it reuses from `State`'s own
+serialized vocabulary (`pause_reason`, `resume_checklist`, ...) are that
+vocabulary's business, and re-spelling them here to dodge the lock would buy a
+green test with a synonym.
+
+`frontier` is where that seam is easiest to cross and deliberately isn't:
+it reports, per lane, the frontmost item in the lane's own queue order that is
+neither terminal nor parked, and the `basis` on which that position was
+picked. Which lane's frontier to act on next is a priority decision, and
+priority is policy -- it belongs to the layer above this one, which is why no
+field here ranks lanes against each other.
+"""
+
+from __future__ import annotations
+
+from grind.derive import lane_status
+from grind.model import Item, JsonValue, Lane, State
+from grind.serialize import (
+    anomaly_json,
+    attention_json,
+    closed_entry_json,
+    merged_entry_json,
+    observation_json,
+    park_fields,
+    summarize,
+)
+
+# An item at or past these has left the queue; it can't be where a lane picks
+# up. Same two statuses `conditions` calls terminal.
+_TERMINAL_ITEM_STATUSES = {"merged", "done"}
+
+_FRONTIER_FOUND = "frontmost item in the lane's queue order that is neither terminal nor parked"
+_FRONTIER_EMPTY = "every item in the lane's queue order is terminal or parked"
+
+
+def _item_row(item: Item) -> dict[str, JsonValue]:
+    """One item as the handoff reports it: identity, position, and the handles
+    a cold reader needs to pick the work back up (`bead` to cross-reference the
+    tracker, `pr` to find the open change). Narrower than `status --full`'s
+    item -- round history and discovery provenance are audit material, not
+    re-orientation."""
+    return {
+        "id": item.id,
+        "lane": item.lane,
+        "title": item.title,
+        "status": item.status,
+        "bead": item.bead,
+        "pr": {"number": item.pr.number, "url": item.pr.url} if item.pr is not None else None,
+        "blocked_on": list(item.blocked_on),
+        "parked": park_fields(item.parked) if item.parked is not None else None,
+        "review": {
+            "round": item.review.round,
+            "kind": item.review.kind,
+            "verdict": item.review.verdict,
+            "open_threads": item.review.open_threads,
+            "stalemate": item.review.stalemate,
+        },
+    }
+
+
+def _lane_items(state: State, lane: Lane) -> list[Item]:
+    return [state.items[item_id] for item_id in lane.item_ids if item_id in state.items]
+
+
+def _lane_row(state: State, lane: Lane) -> dict[str, JsonValue]:
+    """A lane and the exact position of every item on it -- the roster half of
+    the handoff. `agent`/`model`/`effort` are post-`lane_handover` values, so
+    the roster names who is actually on the lane now, not who was seeded onto
+    it."""
+    return {
+        "id": lane.id,
+        "name": lane.name,
+        "agent": lane.agent,
+        "model": lane.model,
+        "effort": lane.effort,
+        "status": lane_status(state, lane),
+        "standing_down": lane.standing_down,
+        "items": [_item_row(item) for item in _lane_items(state, lane)],
+    }
+
+
+def _frontier_row(state: State, lane: Lane) -> dict[str, JsonValue]:
+    for item in _lane_items(state, lane):
+        if item.parked is None and item.status not in _TERMINAL_ITEM_STATUSES:
+            return {
+                "lane": lane.id,
+                "item": item.id,
+                "title": item.title,
+                "status": item.status,
+                "blocked_on": list(item.blocked_on),
+                "basis": _FRONTIER_FOUND,
+            }
+    return {
+        "lane": lane.id,
+        "item": None,
+        "title": None,
+        "status": None,
+        "blocked_on": [],
+        "basis": _FRONTIER_EMPTY,
+    }
+
+
+def _blocked_row(state: State, item: Item) -> dict[str, JsonValue]:
+    """A stuck item and what it is stuck on, each blocker carrying its own
+    current status -- the evidence that says whether the block is about to
+    clear or is itself stuck. A blocker absent from `items` reports a `null`
+    status rather than being dropped: an edge naming an unknown item is
+    exactly the kind of thing a re-orienting reader must see."""
+    return {
+        "item": item.id,
+        "lane": item.lane,
+        "status": item.status,
+        "note": item.blocked_note,
+        "blocked_on": [
+            {
+                "item": blocker_id,
+                "status": state.items[blocker_id].status if blocker_id in state.items else None,
+            }
+            for blocker_id in item.blocked_on
+        ],
+    }
+
+
+def handoff_json(state: State) -> dict[str, JsonValue]:
+    """The whole projection, in reading order: what this run is, whether it is
+    running, where it got to, what is stuck, what a human owes it, what shipped,
+    and what surprised it."""
+    blocked = [
+        item
+        for item in state.items.values()
+        if item.status == "blocked" or (item.blocked_on and item.parked is None)
+    ]
+    return {
+        "summary": summarize(state),
+        "mission": state.mission,
+        "protocols": state.protocols,
+        "last_event_ts": state.last_event_ts,
+        # Pause state under `State`'s own field names rather than a nested
+        # block of synonyms: one name per fact across the package, and the
+        # imperative-verb lock stays strict on the vocabulary this projection
+        # actually coins.
+        "paused": state.paused,
+        "pause_reason": state.pause_reason,
+        "resume_checklist": list(state.resume_checklist),
+        "finish_summary": state.finish_summary,
+        "lanes": [_lane_row(state, lane) for lane in state.lanes.values()],
+        "frontier": [_frontier_row(state, lane) for lane in state.lanes.values()],
+        "blocked": [_blocked_row(state, item) for item in blocked],
+        "human_docket": [attention_json(entry) for entry in state.attention],
+        "merged_ledger": [merged_entry_json(entry) for entry in state.merged_ledger],
+        "closed_ledger": [closed_entry_json(entry) for entry in state.closed_ledger],
+        "parking_lot": [_item_row(item) for item in state.parking_lot().values()],
+        "quirks": [observation_json(obs) for obs in state.observations if obs.level == "WARN"],
+        "lessons": [observation_json(obs) for obs in state.lessons],
+        "anomalies": [anomaly_json(record) for record in state.anomalies],
+    }

--- a/packages/grind/src/grind/handoff.py
+++ b/packages/grind/src/grind/handoff.py
@@ -12,7 +12,7 @@ file's anatomy (spec "Compaction handoff"), sourced from the fold:
 | handoff key | source |
 |---|---|
 | `mission` | `grind_created.mission` |
-| `pause` | `grind_paused`, while unresumed |
+| `paused` / `pause_reason` / `resume_checklist` | `grind_paused`, while unresumed |
 | `lanes` / `frontier` | seeded lanes + `lane_handover` + derived item statuses |
 | `merged_ledger` / `closed_ledger` | `item_merged` / `pr_closed` |
 | `human_docket` | the attention list (`item_waiting_human.why` lands there) |
@@ -61,16 +61,16 @@ _FRONTIER_EMPTY = "every item in the lane's queue order is terminal or parked"
 
 def _item_row(item: Item) -> dict[str, JsonValue]:
     """One item as the handoff reports it: identity, position, and the handles
-    a cold reader needs to pick the work back up (`bead` to cross-reference the
-    tracker, `pr` to find the open change). Narrower than `status --full`'s
-    item -- round history and discovery provenance are audit material, not
-    re-orientation."""
+    a cold reader needs to pick the work back up (`work_id` to cross-reference
+    the external work tracker, `pr` to find the open change). Narrower than
+    `status --full`'s item -- round history and discovery provenance are audit
+    material, not re-orientation."""
     return {
         "id": item.id,
         "lane": item.lane,
         "title": item.title,
         "status": item.status,
-        "bead": item.bead,
+        "work_id": item.work_id,
         "pr": {"number": item.pr.number, "url": item.pr.url} if item.pr is not None else None,
         "blocked_on": list(item.blocked_on),
         "parked": park_fields(item.parked) if item.parked is not None else None,

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -106,7 +106,9 @@ def _lane_json(state: State, lane: Lane) -> JsonValue:
     }
 
 
-def _attention_json(entry: AttentionEntry) -> JsonValue:
+def attention_json(entry: AttentionEntry) -> JsonValue:
+    """Public like `park_fields`: `state.json` and the handoff projection emit
+    the same attention row, so neither can drift from the other."""
     return {
         "text": entry.text,
         "item": entry.item,
@@ -117,7 +119,7 @@ def _attention_json(entry: AttentionEntry) -> JsonValue:
     }
 
 
-def _observation_json(obs: Observation) -> JsonValue:
+def observation_json(obs: Observation) -> JsonValue:
     return {
         "level": obs.level,
         "message": obs.message,
@@ -127,11 +129,11 @@ def _observation_json(obs: Observation) -> JsonValue:
     }
 
 
-def _merged_entry_json(entry: MergedEntry) -> JsonValue:
+def merged_entry_json(entry: MergedEntry) -> JsonValue:
     return {"item": entry.item, "pr": entry.pr, "sha": entry.sha, "ts": entry.ts}
 
 
-def _closed_entry_json(entry: ClosedEntry) -> JsonValue:
+def closed_entry_json(entry: ClosedEntry) -> JsonValue:
     return {"item": entry.item, "pr": entry.pr, "reason": entry.reason, "ts": entry.ts}
 
 
@@ -164,11 +166,11 @@ def full_state_json(state: State) -> dict[str, JsonValue]:
         "last_event_ts": state.last_event_ts,
         "lanes": {lane_id: _lane_json(state, lane) for lane_id, lane in state.lanes.items()},
         "items": {item_id: _item_json(item) for item_id, item in state.items.items()},
-        "attention": [_attention_json(a) for a in state.attention],
-        "observations": [_observation_json(o) for o in state.observations],
-        "merged_ledger": [_merged_entry_json(m) for m in state.merged_ledger],
-        "closed_ledger": [_closed_entry_json(c) for c in state.closed_ledger],
-        "lessons": [_observation_json(o) for o in state.lessons],
+        "attention": [attention_json(a) for a in state.attention],
+        "observations": [observation_json(o) for o in state.observations],
+        "merged_ledger": [merged_entry_json(m) for m in state.merged_ledger],
+        "closed_ledger": [closed_entry_json(c) for c in state.closed_ledger],
+        "lessons": [observation_json(o) for o in state.lessons],
         "anomalies": [anomaly_json(a) for a in state.anomalies],
         "last_item_ts": cast("JsonValue", dict(state.last_item_ts)),
         "last_lane_ts": cast("JsonValue", dict(state.last_lane_ts)),

--- a/packages/grind/src/grind/verbs.py
+++ b/packages/grind/src/grind/verbs.py
@@ -13,12 +13,13 @@ import re
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 from grind.conditions import conditions, item_unblocked_conditions
 from grind.derive import lane_status
 from grind.envelope import GrindError
 from grind.fold import fold
+from grind.handoff import handoff_json
 from grind.model import DEFAULT_CONFIG, AnomalyRecord, JsonValue, RawEvent, State
 from grind.payloads import validate_payload
 from grind.render import render_dashboard
@@ -35,6 +36,11 @@ from grind.store import (
 )
 
 Clock = Callable[[], datetime]
+
+# The three alternative projections of one fold `grind status` can report
+# (spec CLI contract: "Default: summary + conditions. `--full`: entire state.
+# `--handoff`: the compaction handoff").
+StatusView = Literal["summary", "full", "handoff"]
 
 # `ts` and `type` are stamped by the CLI at append time (spec: "ts ... Never
 # supplied by the caller"; `type` is the CLI-selected taxonomy). A payload/seed
@@ -226,13 +232,19 @@ def cmd_log(dir_: Path, event_type: str, payload: RawEvent, *, now: Clock) -> di
     }
 
 
-def cmd_status(dir_: Path, *, full: bool, now: Clock) -> dict[str, JsonValue]:
-    """`grind status [--full]`. Level conditions only -- `item_unblocked` is a
-    transition condition, never recomputed from state (spec §"Emit-back")."""
+def cmd_status(dir_: Path, *, view: StatusView = "summary", now: Clock) -> dict[str, JsonValue]:
+    """`grind status [--full | --handoff]`. Level conditions only -- `item_unblocked`
+    is a transition condition, never recomputed from state (spec §"Emit-back").
+
+    One `view` rather than a flag per mode: the three are alternative
+    projections of the same fold, and a signature that can express "full and
+    handoff at once" would be describing a state the CLI refuses anyway."""
     state = fold_dir(dir_)
     current_conditions = cast("JsonValue", conditions(state, now()))
-    if full:
+    if view == "full":
         return {"ok": True, "state": full_state_json(state), "conditions": current_conditions}
+    if view == "handoff":
+        return {"ok": True, "handoff": handoff_json(state), "conditions": current_conditions}
     return {"ok": True, "state_summary": summarize(state), "conditions": current_conditions}
 
 

--- a/packages/grind/tests/unit/test_handoff.py
+++ b/packages/grind/tests/unit/test_handoff.py
@@ -92,7 +92,7 @@ def _rich_log() -> list[dict[str, Any]]:
         event("item_started", item="wgclw.4"),
         event("pr_opened", item="wgclw.4", pr=104),
         event("pr_closed", item="wgclw.4", pr=104, reason="superseded", next="parked"),
-        # work discovered mid-run, admitted to lane-a with its tracker id
+        # work discovered mid-run, admitted to lane-a with its work-tracker id
         event(
             "discovered_work",
             item="wgclw.9",
@@ -101,7 +101,7 @@ def _rich_log() -> list[dict[str, Any]]:
             rationale="the schema change needs its own item",
             disposition="enqueued",
             lane="lane-a",
-            bead="acme-9",
+            work_id="acme-9",
         ),
         # roster change, traps, and a pause
         event(
@@ -190,10 +190,10 @@ def test_a_contextless_session_re_orients_from_one_call(tmp_path: Path):
         "wgclw.3": "waiting-human",
         "wgclw.9": "queued",
     }
-    # The tracker handle rides along, so the session can cross-reference the
-    # item without a second source.
-    beads = {item["id"]: item["bead"] for lane in handoff["lanes"] for item in lane["items"]}
-    assert beads["wgclw.9"] == "acme-9"
+    # The work-tracker handle rides along, so the session can cross-reference
+    # the item without a second source.
+    work_ids = {item["id"]: item["work_id"] for lane in handoff["lanes"] for item in lane["items"]}
+    assert work_ids["wgclw.9"] == "acme-9"
 
     # 5. Where does each lane pick up?
     frontier = {row["lane"]: row for row in handoff["frontier"]}
@@ -301,7 +301,11 @@ def test_no_handoff_key_reads_as_an_instruction():
     state = _state()
 
     coined = _keys(handoff_json(state)) - _keys(full_state_json(state))
+    # The exemption is load-bearing in both directions, so pin both: it must
+    # not swallow this projection's own vocabulary, and it must actually
+    # resolve against the real serializer rather than degrading to a no-op.
     assert "frontier" in coined, "the exemption must not swallow the whole key set"
+    assert "resume_checklist" not in coined, "State's own vocabulary must resolve as inherited"
 
     for key in coined:
         for word in re.split(r"[_\s]", key):

--- a/packages/grind/tests/unit/test_handoff.py
+++ b/packages/grind/tests/unit/test_handoff.py
@@ -1,0 +1,463 @@
+"""`grind status --handoff` -- the re-orientation projection.
+
+The headline test is `test_a_contextless_session_re_orients_from_one_call`:
+one `main(["status", "--handoff"])` invocation, and every question a
+post-compaction session would otherwise have to ask a human is answered out
+of that single envelope. The rest pin the pieces it is built from.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from grind.cli import main
+from grind.conditions import IMPERATIVE_VERBS
+from grind.fold import fold
+from grind.handoff import handoff_json
+from grind.model import State
+from grind.serialize import full_state_json
+from tests.unit.builders import event, seed_event
+
+_NOW = datetime(2026, 7, 19, 1, 0, 0, tzinfo=UTC)
+
+_MISSION = {
+    "goal": "ship the widget rewrite",
+    "out_of_scope": ["the billing migration"],
+}
+_PROTOCOLS = {
+    "review": "codex adversarial, two rounds minimum",
+    "merge": "merge-guard clean, no exceptions",
+}
+
+
+def _seed() -> dict[str, Any]:
+    return seed_event(
+        mission=_MISSION,
+        protocols=_PROTOCOLS,
+        lanes=[
+            {
+                "id": "lane-a",
+                "name": "Lane A",
+                "agent": "lieutenant-a",
+                "queue": [
+                    {"id": "wgclw.1", "title": "First item"},
+                    {"id": "wgclw.2", "title": "Second item"},
+                ],
+            },
+            {
+                "id": "lane-b",
+                "name": "Lane B",
+                "agent": "lieutenant-b",
+                "queue": [
+                    {"id": "wgclw.3", "title": "Third item"},
+                    {"id": "wgclw.4", "title": "Fourth item"},
+                ],
+            },
+        ],
+    )
+
+
+def _rich_log() -> list[dict[str, Any]]:
+    """A run that has reached every corner of the handoff's anatomy: something
+    shipped, something stuck on something else, something waiting on a human,
+    a PR closed unmerged into the parking lot, a lane handed over, a quirk and
+    a lesson recorded, a pause standing, and an event that folded anomalously."""
+    return [
+        _seed(),
+        # wgclw.1 -- all the way through to done
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=101, url="https://example.test/pr/101"),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="aaa"),
+        event(
+            "review_verdict", item="wgclw.1", kind="codex", round=1, head_sha="aaa", verdict="clean"
+        ),
+        event("item_merged", item="wgclw.1", pr=101, sha="aaa"),
+        event("item_done", item="wgclw.1"),
+        # wgclw.2 -- stuck on wgclw.3
+        event("item_started", item="wgclw.2"),
+        event("item_blocked", item="wgclw.2", on=["wgclw.3"], note="needs the shared schema"),
+        # wgclw.3 -- open PR, handed to a human
+        event("item_started", item="wgclw.3"),
+        event("pr_opened", item="wgclw.3", pr=103),
+        event("item_waiting_human", item="wgclw.3", why="needs a human ruling on the API break"),
+        # wgclw.4 -- PR closed unmerged, into the parking lot
+        event("item_started", item="wgclw.4"),
+        event("pr_opened", item="wgclw.4", pr=104),
+        event("pr_closed", item="wgclw.4", pr=104, reason="superseded", next="parked"),
+        # work discovered mid-run, admitted to lane-a with its tracker id
+        event(
+            "discovered_work",
+            item="wgclw.9",
+            description="Ninth item",
+            source="lane-a review of wgclw.1",
+            rationale="the schema change needs its own item",
+            disposition="enqueued",
+            lane="lane-a",
+            bead="acme-9",
+        ),
+        # roster change, traps, and a pause
+        event(
+            "lane_handover",
+            lane="lane-a",
+            from_agent="lieutenant-a",
+            to_agent="lieutenant-c",
+            reason="context exhausted",
+            to_model="opus",
+            to_effort="high",
+        ),
+        event("observation", level="WARN", message="the widget test suite needs a clean build dir"),
+        event("observation", level="LESSON", message="open the dashboard once, at creation"),
+        event("observation", level="INFO", message="routine progress note"),
+        event(
+            "grind_paused",
+            reason="waiting on the API ruling",
+            resume_checklist=["confirm the API break with the human"],
+        ),
+        # an event illegal from its item's status -- accepted and flagged
+        event("item_started", item="wgclw.1"),
+    ]
+
+
+def _state() -> State:
+    return fold(_rich_log())
+
+
+def _handoff() -> dict[str, Any]:
+    return handoff_json(_state())
+
+
+def _run(argv: Sequence[str], *, cwd: Path) -> tuple[int, dict[str, Any]]:
+    out, err = StringIO(), StringIO()
+    exit_code = main(list(argv), out=out, err=err, now=lambda: _NOW, cwd=cwd, env={})
+    assert err.getvalue() == ""
+    return exit_code, json.loads(out.getvalue())
+
+
+def _written_grind(tmp_path: Path) -> Path:
+    """The rich log, on disk, exactly as the CLI would have written it."""
+    grind_dir = tmp_path / "run"
+    grind_dir.mkdir()
+    (grind_dir / "events.jsonl").write_text(
+        "".join(json.dumps(evt, sort_keys=True) + "\n" for evt in _rich_log()), encoding="utf-8"
+    )
+    return grind_dir
+
+
+def test_a_contextless_session_re_orients_from_one_call(tmp_path: Path):
+    """The acceptance proof. A session with no context makes exactly one call
+    and answers, from that one envelope alone, every question it would
+    otherwise have had to ask the human."""
+    grind_dir = _written_grind(tmp_path)
+
+    exit_code, envelope = _run(["status", "--handoff", "--dir", str(grind_dir)], cwd=tmp_path)
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    handoff = envelope["handoff"]
+
+    # 1. What is this run, and what is it explicitly not?
+    assert handoff["summary"]["title"] == "Widget grind"
+    assert handoff["summary"]["repo"] == "acme/widgets"
+    assert handoff["mission"]["goal"] == "ship the widget rewrite"
+    assert handoff["mission"]["out_of_scope"] == ["the billing migration"]
+
+    # 2. Under what rules is it operating?
+    assert handoff["protocols"] == _PROTOCOLS
+
+    # 3. Is it even running, and what stands between it and running again?
+    assert handoff["paused"] is True
+    assert handoff["pause_reason"] == "waiting on the API ruling"
+    assert handoff["resume_checklist"] == ["confirm the API break with the human"]
+
+    # 4. Who is on which lane, and where did every item get to?
+    roster = {lane["id"]: lane for lane in handoff["lanes"]}
+    assert roster["lane-a"]["agent"] == "lieutenant-c"  # post-handover, not the seeded agent
+    assert roster["lane-a"]["model"] == "opus"
+    positions = {item["id"]: item["status"] for lane in handoff["lanes"] for item in lane["items"]}
+    # wgclw.4 is absent by design: parking takes an item off its lane's queue,
+    # and the parking lot below is where it is accounted for.
+    assert positions == {
+        "wgclw.1": "done",
+        "wgclw.2": "blocked",
+        "wgclw.3": "waiting-human",
+        "wgclw.9": "queued",
+    }
+    # The tracker handle rides along, so the session can cross-reference the
+    # item without a second source.
+    beads = {item["id"]: item["bead"] for lane in handoff["lanes"] for item in lane["items"]}
+    assert beads["wgclw.9"] == "acme-9"
+
+    # 5. Where does each lane pick up?
+    frontier = {row["lane"]: row for row in handoff["frontier"]}
+    assert frontier["lane-a"]["item"] == "wgclw.2"
+    assert frontier["lane-b"]["item"] == "wgclw.3"
+
+    # 6. What is stuck, and on what?
+    blocked = {row["item"]: row for row in handoff["blocked"]}
+    assert blocked["wgclw.2"]["note"] == "needs the shared schema"
+    assert blocked["wgclw.2"]["blocked_on"] == [{"item": "wgclw.3", "status": "waiting-human"}]
+
+    # 7. What does a human owe this run?
+    docket = [entry["text"] for entry in handoff["human_docket"]]
+    assert "needs a human ruling on the API break" in docket
+
+    # 8. What already shipped, and what died on the vine?
+    assert [entry["item"] for entry in handoff["merged_ledger"]] == ["wgclw.1"]
+    assert [entry["item"] for entry in handoff["closed_ledger"]] == ["wgclw.4"]
+    assert [entry["id"] for entry in handoff["parking_lot"]] == ["wgclw.4"]
+
+    # 9. What traps has this repo already sprung?
+    assert [obs["message"] for obs in handoff["quirks"]] == [
+        "the widget test suite needs a clean build dir"
+    ]
+    assert [obs["message"] for obs in handoff["lessons"]] == [
+        "open the dashboard once, at creation"
+    ]
+
+    # 10. What did the log accept but flag as wrong?
+    assert [record["type"] for record in handoff["anomalies"]] == ["item_started"]
+    assert "illegal from status" in handoff["anomalies"][0]["reason"]
+
+    # ...and the conditions ride the same envelope, as they do for every
+    # other status mode -- still one call.
+    assert isinstance(envelope["conditions"], list)
+
+
+def test_handoff_is_a_projection_of_the_same_fold_the_other_views_report(tmp_path: Path):
+    """No new event type, no separate persistence: `--handoff` reads the same
+    log the other views read and writes nothing."""
+    grind_dir = _written_grind(tmp_path)
+    before = (grind_dir / "events.jsonl").read_bytes()
+
+    _, handoff_envelope = _run(["status", "--handoff", "--dir", str(grind_dir)], cwd=tmp_path)
+    _, full_envelope = _run(["status", "--full", "--dir", str(grind_dir)], cwd=tmp_path)
+
+    assert (grind_dir / "events.jsonl").read_bytes() == before
+    assert not (grind_dir / "state.json").exists()
+    assert handoff_envelope["conditions"] == full_envelope["conditions"]
+    assert handoff_envelope["handoff"]["last_event_ts"] == full_envelope["state"]["last_event_ts"]
+
+
+def test_handoff_and_full_are_mutually_exclusive(tmp_path: Path):
+    grind_dir = _written_grind(tmp_path)
+
+    exit_code, envelope = _run(
+        ["status", "--handoff", "--full", "--dir", str(grind_dir)], cwd=tmp_path
+    )
+
+    assert exit_code != 0
+    assert envelope["ok"] is False
+
+
+def test_default_status_view_is_unchanged_by_the_new_flag(tmp_path: Path):
+    grind_dir = _written_grind(tmp_path)
+
+    _, envelope = _run(["status", "--dir", str(grind_dir)], cwd=tmp_path)
+
+    assert "state_summary" in envelope
+    assert "handoff" not in envelope
+
+
+def test_log_emit_back_envelope_still_carries_no_state(tmp_path: Path):
+    """The handoff is what re-orients a cold session -- deliberately not the
+    `log` envelope, whose keys stay exactly as specified so nobody builds a
+    recovery path on a call that cannot support one."""
+    grind_dir = _written_grind(tmp_path)
+
+    _, envelope = _run(
+        ["log", "grind_resumed", "--json", "{}", "--dir", str(grind_dir)], cwd=tmp_path
+    )
+
+    assert set(envelope) == {"ok", "applied", "anomaly", "torn_tail", "delta", "conditions"}
+
+
+# -- the shaped pieces -------------------------------------------------------
+
+
+def _keys(node: Any) -> set[str]:
+    if isinstance(node, dict):
+        return set(node) | {key for value in node.values() for key in _keys(value)}
+    if isinstance(node, list):
+        return {key for value in node for key in _keys(value)}
+    return set()
+
+
+def test_no_handoff_key_reads_as_an_instruction():
+    """The `conditions.py` seam, applied to this projection's vocabulary: the
+    handoff reports facts, so no key it coins -- at any depth -- may read as an
+    order.
+
+    The exemption is mechanical, not a hand-kept allow-list: a key that already
+    appears in `state.json` is `State`'s vocabulary, governed where it is
+    defined. Only what this projection invents is on trial here."""
+    state = _state()
+
+    coined = _keys(handoff_json(state)) - _keys(full_state_json(state))
+    assert "frontier" in coined, "the exemption must not swallow the whole key set"
+
+    for key in coined:
+        for word in re.split(r"[_\s]", key):
+            assert word not in IMPERATIVE_VERBS, f"handoff key {key!r} reads as an imperative"
+
+
+def test_frontier_is_the_frontmost_non_terminal_unparked_item_with_its_basis():
+    frontier = {row["lane"]: row for row in _handoff()["frontier"]}
+
+    # wgclw.1 is done, so lane-a's queue order moves past it to wgclw.2.
+    assert frontier["lane-a"]["item"] == "wgclw.2"
+    assert frontier["lane-a"]["status"] == "blocked"
+    assert frontier["lane-a"]["blocked_on"] == ["wgclw.3"]
+    assert "queue order" in frontier["lane-a"]["basis"]
+
+
+def test_frontier_reports_a_lane_with_nothing_left_as_such():
+    events = [
+        _seed(),
+        event("item_started", item="wgclw.3"),
+        event("pr_opened", item="wgclw.3", pr=103),
+        event("item_merged", item="wgclw.3", pr=103, sha="ccc"),
+        event("item_done", item="wgclw.3"),
+        event("item_parked", item="wgclw.4", reason="later-wave", note="next wave"),
+    ]
+    frontier = {row["lane"]: row for row in handoff_json(fold(events))["frontier"]}
+
+    assert frontier["lane-b"]["item"] is None
+    assert frontier["lane-b"]["status"] is None
+    assert (
+        frontier["lane-b"]["basis"] == "every item in the lane's queue order is terminal or parked"
+    )
+
+
+def test_frontier_passes_over_a_parked_item_but_stops_on_a_blocked_one():
+    events = [
+        _seed(),
+        event("item_parked", item="wgclw.1", reason="later-wave", note="next wave"),
+        event("item_blocked", item="wgclw.2", on=["wgclw.3"], note="waits on the schema"),
+    ]
+    frontier = {row["lane"]: row for row in handoff_json(fold(events))["frontier"]}
+
+    assert frontier["lane-a"]["item"] == "wgclw.2"
+    assert frontier["lane-a"]["status"] == "blocked"
+
+
+def test_blocked_rows_carry_each_blockers_current_status_as_evidence():
+    blocked = {row["item"]: row for row in _handoff()["blocked"]}
+
+    assert list(blocked) == ["wgclw.2"]
+    assert blocked["wgclw.2"]["lane"] == "lane-a"
+    assert blocked["wgclw.2"]["blocked_on"] == [{"item": "wgclw.3", "status": "waiting-human"}]
+
+
+def test_blocked_row_reports_an_unknown_blocker_as_a_null_status_rather_than_dropping_it():
+    events = [
+        _seed(),
+        event("item_started", item="wgclw.2"),
+        event("item_blocked", item="wgclw.2", on=["wgclw.2", "ghost-item"], note="n"),
+    ]
+    blocked = {row["item"]: row for row in handoff_json(fold(events))["blocked"]}
+
+    assert {"item": "ghost-item", "status": None} in blocked["wgclw.2"]["blocked_on"]
+
+
+def test_quirks_are_warn_observations_only_and_lessons_stay_separate():
+    handoff = _handoff()
+
+    assert [obs["level"] for obs in handoff["quirks"]] == ["WARN"]
+    assert [obs["level"] for obs in handoff["lessons"]] == ["LESSON"]
+
+
+def test_pause_fields_are_inert_on_a_running_grind():
+    handoff = handoff_json(fold([_seed()]))
+
+    assert handoff["paused"] is False
+    assert handoff["pause_reason"] is None
+    assert handoff["resume_checklist"] == []
+
+
+def test_handoff_of_a_never_created_grind_is_shaped_but_empty():
+    """A fold of zero events still yields every key, so a reader never has to
+    branch on presence -- only on emptiness."""
+    handoff = handoff_json(State())
+
+    assert handoff["lanes"] == []
+    assert handoff["frontier"] == []
+    assert handoff["mission"] is None
+    assert handoff["paused"] is False
+
+
+def test_finished_grind_reports_its_closing_summary():
+    events = [_seed(), event("grind_finished", summary="all four items landed")]
+    handoff = handoff_json(fold(events))
+
+    assert handoff["summary"]["finished"] is True
+    assert handoff["finish_summary"] == "all four items landed"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "summary",
+        "mission",
+        "protocols",
+        "last_event_ts",
+        "paused",
+        "pause_reason",
+        "resume_checklist",
+        "finish_summary",
+        "lanes",
+        "frontier",
+        "blocked",
+        "human_docket",
+        "merged_ledger",
+        "closed_ledger",
+        "parking_lot",
+        "quirks",
+        "lessons",
+        "anomalies",
+    ],
+)
+def test_every_handoff_key_is_present_on_every_run(key: str):
+    """Stable, greppable structure: the key set does not depend on what the run
+    happened to do, so a cold reader's expectations never depend on luck."""
+    assert key in _handoff()
+    assert key in handoff_json(State())
+
+
+def test_parking_lot_entries_carry_the_typed_park_axis_and_category():
+    events = [
+        _seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=101),
+        event("item_parked", item="wgclw.1", reason="ci-failure", note="flaky integration suite"),
+    ]
+    parking_lot = handoff_json(fold(events))["parking_lot"]
+
+    assert parking_lot[0]["parked"] == {
+        "reason": "ci-failure",
+        "axis": "failure",
+        "category": "machine",
+        "note": "flaky integration suite",
+    }
+
+
+def test_item_rows_carry_the_pr_handle_and_review_position():
+    events = [
+        _seed(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=101, url="https://example.test/pr/101"),
+        event("review_round", item="wgclw.1", kind="codex", round=2, head_sha="aaa"),
+    ]
+    lane_a = handoff_json(fold(events))["lanes"][0]
+    first_item = lane_a["items"][0]
+
+    assert first_item["pr"] == {"number": 101, "url": "https://example.test/pr/101"}
+    assert first_item["review"]["round"] == 2
+    assert first_item["review"]["kind"] == "codex"

--- a/packages/grind/tests/unit/test_verbs.py
+++ b/packages/grind/tests/unit/test_verbs.py
@@ -173,7 +173,7 @@ def test_status_reports_currently_true_level_conditions_but_never_item_unblocked
     cmd_log(tmp_path, "pr_opened", {"item": "wgclw.1", "pr": 1}, now=_NOW)
     cmd_log(tmp_path, "item_merged", {"item": "wgclw.1", "pr": 1, "sha": "abc"}, now=_NOW)
 
-    result = cmd_status(tmp_path, full=False, now=_NOW)
+    result = cmd_status(tmp_path, now=_NOW)
 
     names = {c["condition"] for c in result["conditions"]}
     assert "item_unblocked" not in names  # transition condition, never from state alone
@@ -308,7 +308,7 @@ def test_log_rewrites_state_json_after_append(tmp_path: Path):
 def test_status_default_returns_summary(tmp_path: Path):
     _seeded(tmp_path)
 
-    result = cmd_status(tmp_path, full=False, now=_NOW)
+    result = cmd_status(tmp_path, now=_NOW)
 
     assert result["ok"] is True
     assert "state_summary" in result
@@ -318,7 +318,7 @@ def test_status_default_returns_summary(tmp_path: Path):
 def test_status_full_returns_entire_state(tmp_path: Path):
     _seeded(tmp_path)
 
-    result = cmd_status(tmp_path, full=True, now=_NOW)
+    result = cmd_status(tmp_path, view="full", now=_NOW)
 
     assert result["ok"] is True
     state = result["state"]


### PR DESCRIPTION
Closes `agents-config-9k9.1.8`. **Stacked on #390** (`fix/9k9.1.9-grind-dir-resolution`) — review the incremental diff here; merge that one first.

## The gap

`handoff` had **zero occurrences** in `packages/grind/src`. The compaction handoff was specced in full (spec §"Compaction handoff", which retires the hand-maintained handoff file) and never built, so a cold or post-compaction session had two options: `status --full`, which dumps the entire fold unshaped, or ask the human. Asking the human is exactly the babysitting intervention this slice exists to remove.

## What `--handoff` reports

A **projection over already-folded state** carrying the spec's §7 anatomy, in the order a cold reader needs it:

| key | answers |
|---|---|
| `summary` | what this run is, and its counts at a glance |
| `mission` / `protocols` | the goal, the explicit out-of-scope, the rules in force |
| `paused` / `pause_reason` / `resume_checklist` | is it even running, and what stands between it and running again |
| `lanes` | the roster (post-`lane_handover` agent/model/effort) and every item's exact position |
| `frontier` | where each lane picks up, and the basis for that position |
| `blocked` | what is stuck, and on what — **each blocker carrying its own current status** as evidence |
| `human_docket` | what a human owes the run (`item_waiting_human.why` lands here) |
| `merged_ledger` / `closed_ledger` / `parking_lot` | what shipped, what died unmerged, what was set aside and why (typed axis/category) |
| `quirks` / `lessons` | `WARN` and `LESSON` observations — traps recorded when context was fresh |
| `anomalies` | what the log accepted and flagged |

## Design choices

**JSON, not text, and no `--json` switch.** The spec's CLI contract is "all output is a JSON envelope on stdout" and every other verb obeys it; a rendered text blob would break the one-envelope invariant that `_RaisingArgumentParser` and the error paths exist to protect. For the LLM consumer the ticket names, JSON is also the better substrate: stable greppable keys, and *the same key set on every run* — a test asserts every top-level key is present both on the rich fixture and on a zero-event fold, so a cold reader never branches on presence, only on emptiness.

**The seam holds — `frontier`, not "next action".** The ticket asks for "the single next thing". The honest fact-shaped version is per-lane: `frontier` reports, for each lane, the frontmost item in that lane's own queue order that is neither terminal nor parked, plus the `basis` on which that position was picked. It deliberately does **not** rank lanes against each other — choosing which lane to act on is a priority decision, priority is policy, and policy lives above this layer (`conditions.py`: "a condition is a fact with evidence, never orchestration policy"). For a single-lane grind, `frontier` is literally the single next thing; for a multi-lane one, ranking them here would have been the seam violation.

**The imperative-verb lock, extended with a mechanical exemption.** `test_no_handoff_key_reads_as_an_instruction` runs every key of the projection, at every depth, against `conditions.IMPERATIVE_VERBS`. Keys that already appear in `full_state_json` are exempt — not by a hand-kept allow-list, but by set subtraction, so the rule is "`State`'s vocabulary is governed where it is defined; only what this projection *coins* is on trial here", and the test asserts the exemption doesn't swallow the key set. This caught a real design mistake mid-implementation: my first draft nested pause state under a coined `pause` key with a `checklist` synonym. The lock flagged `pause`, and the right fix was not a cleverer synonym but to stop coining — the pause facts now carry `State`'s own field names.

**One `view`, not a flag per mode.** `--full` and `--handoff` are alternative projections of one fold, so the parser refuses the combination outright (mutually exclusive group → normal error envelope) and `cmd_status` takes `view: Literal["summary","full","handoff"]` instead of two booleans that could express a state the CLI rejects.

**No new event type, no new persistence, no wall clock of its own.** `--handoff` reads the same log the other views read, writes nothing, and its `conditions` ride the envelope exactly as they do for every other `status` mode — still one call. Four serializers in `serialize.py` were promoted from private to public (`attention_json`, `observation_json`, `merged_entry_json`, `closed_entry_json`) so `state.json` and the handoff emit the same rows instead of two drifting copies — the same reasoning `park_fields` already documents.

**The `log` envelope is untouched**, and `test_log_emit_back_envelope_still_carries_no_state` pins its key set to `{ok, applied, anomaly, torn_tail, delta, conditions}`. A cold session cannot re-orient from its first `log` call, and nothing here invites anyone to build a recovery path on one.

## What the tests prove

`remove_when`: *a contextless session can resume from one call, proven by test.*

`test_a_contextless_session_re_orients_from_one_call` is that proof. A fixture log that has reached every corner of the anatomy — something shipped, something blocked on something else, something waiting on a human, a PR closed unmerged into the parking lot, work discovered mid-run, a lane handed over, a quirk, a lesson, a standing pause, and an event that folded anomalously — is written to disk, and **exactly one** `main(["status", "--handoff"])` call is made. Ten numbered assertion blocks then answer, from that single envelope alone, every question the session would otherwise have had to ask: what this run is and isn't, under what protocols, whether it is running and what would restart it, who is on which lane and where every item got to, where each lane picks up, what is stuck and on what, what a human owes it, what shipped and what died, what traps the repo has already sprung, and what the log accepted but flagged.

Around it: the projection writes nothing and matches `--full`'s fold; `--handoff --full` is refused; the default view is unchanged; the `log` envelope is unchanged; frontier behaviour on an exhausted lane, a parked head, and a blocked head; blocked rows carrying blocker statuses (including a `null` status for an unknown blocker rather than dropping the edge); WARN/LESSON separation; typed park axis/category; the PR handle and review position on item rows; and the empty-fold shape.

## Out of scope, worth a ticket

`grind_created` never reads a `bead` from a seeded queue item — `Item.bead` is only ever populated by `discovered_work`. The spec's seed shape is "queue of items with bead ids", so a seeded item's tracker handle is silently dropped at fold time. It shows up here as a `null` `bead` on every seeded item in the handoff. Not fixed in this PR: it is a fold defect, not a projection one.

## Gate

`make ci-grind` — full gate, passed:

```
Name                      Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------
src/grind/cli.py            113      7     22      4    92%   102, 133, 143, 164, 178, 180, 211
src/grind/conditions.py     138      5     60      6    94%   72->81, 93, 146, 185, 235, 289
src/grind/fold.py           449     12    176      9    97%   ...
src/grind/log.py             41      2     12      2    92%   48, 57
src/grind/payloads.py       225     10     50      6    94%   ...
src/grind/verbs.py          126     11     32      3    89%   87, 122-130, 268
---------------------------------------------------------------------
TOTAL                      1462     47    402     30    96%

10 files skipped due to complete coverage.
Required test coverage of 80.0% reached. Total coverage: 95.65%
============================= 344 passed in 0.33s ==============================
cd packages/grind && uv sync --frozen && uv run pip-audit
Audited 43 packages in 0.84ms
No known vulnerabilities found
uv --project packages/grind run grind --help > /dev/null
```

(`src/grind/handoff.py` is among the files skipped for complete coverage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6xaZYtSkFYPSkYabWFzrh
