### PR TITLE
chore(9k9.1.19): rename grind's bead field to work_id

### DIFF
--- a/docs/specs/2026-07-19-event-sourced-grind-runtime.md
+++ b/docs/specs/2026-07-19-event-sourced-grind-runtime.md
@@ -37,7 +37,7 @@ First-class entities (present in the schema):
   `grind_created` … `grind_finished` bound its lifetime.
 - **Lane** — a conflict-partitioned, ordered queue of items owned by one
   lieutenant. An *ownership* grouping, nothing more.
-- **Item** — **the** atomic unit of the FSM. Maps 1:1 to a work-tracker bead,
+- **Item** — **the** atomic unit of the FSM. Maps 1:1 to a work-tracker item,
   typically ships as one PR, and is the only entity carrying the nine-status
   lifecycle. Every typed event that is not grind- or lane-scoped references
   exactly one item.
@@ -125,7 +125,7 @@ things now *are*.
 
 | Type | Payload | Effect |
 |------|---------|--------|
-| `grind_created` | `title`, `repo` (owner/name), `mission` (goal + explicit out-of-scope), `protocols` (structured block: review protocol choice, merge-policy resolution, watcher conventions, session grants), `config` (thresholds, below), `lanes[]` (id, name, agent, model+effort the lieutenant runs at, queue of items with bead ids, titles, blocker edges) | Seeds the entire board. Legal only as the log's **first** event; any subsequent `grind_created` folds as an anomaly (accept-and-flag), leaving the board unchanged. The mission/protocols block is what makes `status --handoff` self-contained (§7 replacement). |
+| `grind_created` | `title`, `repo` (owner/name), `mission` (goal + explicit out-of-scope), `protocols` (structured block: review protocol choice, merge-policy resolution, watcher conventions, session grants), `config` (thresholds, below), `lanes[]` (id, name, agent, model+effort the lieutenant runs at, queue of items with work ids, titles, blocker edges) | Seeds the entire board. Legal only as the log's **first** event; any subsequent `grind_created` folds as an anomaly (accept-and-flag), leaving the board unchanged. The mission/protocols block is what makes `status --handoff` self-contained (§7 replacement). |
 | `grind_paused` | `reason`, `resume_checklist[]` | Board banner; handoff carries pause state |
 | `grind_resumed` | — | Clears pause |
 | `grind_finished` | `summary` | Terminal. Fold rejects (anomaly) further mutating events. |
@@ -162,7 +162,7 @@ below)
 | `item_done` | `item` | `merged → done` (post-merge leg complete); clears any attention/round badge for the item |
 | `item_parked` | `item`, `reason` (see the park vocabulary below), `note` | Removes from active queue into the parking lot |
 | `item_enqueued` | `item`, `lane`, `position?` | Parking lot's one exit: `parked → queued` in the named lane. Also legalizes mid-grind queue additions. |
-| `discovered_work` | `item` (durable id), `description`, `source` (lane/PR that surfaced it), `bead?`, `disposition` (parked \| enqueued), `reason?` (when parked), `lane?` (when enqueued), `rationale` | Creates a new item carrying its triage rationale, keyed by the required `item` id: the bead id when one exists, else a ROOT-assigned run-unique slug (`disc-<n>`, next free ordinal). `bead?` is optional metadata, carried only when it differs from `item`. `enqueued` is sugar for discover + `item_enqueued` in one event. |
+| `discovered_work` | `item` (durable id), `description`, `source` (lane/PR that surfaced it), `work_id?`, `disposition` (parked \| enqueued), `reason?` (when parked), `lane?` (when enqueued), `rationale` | Creates a new item carrying its triage rationale, keyed by the required `item` id: the work-tracker id when one exists, else a ROOT-assigned run-unique slug (`disc-<n>`, next free ordinal). `work_id?` is optional metadata, carried only when it differs from `item`. `enqueued` is sugar for discover + `item_enqueued` in one event. |
 
 **Cross-cutting**
 

--- a/packages/grind/src/grind/derive.py
+++ b/packages/grind/src/grind/derive.py
@@ -2,7 +2,7 @@
 
 Lane status is "otherwise fully derived from item statuses" (spec): all done
 -> `done`; any in flight -> the most advanced active state. Unlike
-`conditions(State, now)` (a sibling bead's time-dependent facts), lane status
+`conditions(State, now)` (a sibling work item's time-dependent facts), lane status
 needs no wall clock and is safe to compute inline wherever `State` is read.
 """
 

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -630,12 +630,13 @@ def _h_discovered_work(state: State, evt: RawEvent) -> None:
         return
     disposition = _str(evt, "disposition")
     description = _str(evt, "description")
-    # `bead?` is "optional metadata, carried only when it differs from `item`"
-    # (spec) -- a caller-supplied bead equal to the item id is redundant, so
-    # it's normalized away rather than stored twice under two names.
-    bead = _str(evt, "bead")
-    if bead == item_id:
-        bead = None
+    # `work_id?` is "optional metadata, carried only when it differs from
+    # `item`" (spec) -- a caller-supplied work id equal to the item id is
+    # redundant, so it's normalized away rather than stored twice under two
+    # names.
+    work_id = _str(evt, "work_id")
+    if work_id == item_id:
+        work_id = None
     # The item "carries its triage rationale" (spec) plus its source -- state is
     # the renderer's only input, so both dispositions must preserve this
     # provenance or a later projection can't explain the work's origin.
@@ -652,7 +653,7 @@ def _h_discovered_work(state: State, evt: RawEvent) -> None:
         if reason is not None and PARK_REASONS[reason][0] != "scheduling":
             _anomaly(state, evt, f"discovered_work park reason {reason!r} is not a scheduling one")
             reason = None
-        item = Item(id=item_id, lane=None, title=description, status="queued", bead=bead)
+        item = Item(id=item_id, lane=None, title=description, status="queued", work_id=work_id)
         item.parked = ParkingEntry(reason=reason, note=rationale)
         item.discovered = provenance
         state.items[item_id] = item
@@ -660,7 +661,7 @@ def _h_discovered_work(state: State, evt: RawEvent) -> None:
         lane = _resolve_lane(state, evt)
         if lane is None:
             return
-        item = Item(id=item_id, lane=lane.id, title=description, status="queued", bead=bead)
+        item = Item(id=item_id, lane=lane.id, title=description, status="queued", work_id=work_id)
         item.discovered = provenance
         state.items[item_id] = item
         lane.item_ids.append(item_id)

--- a/packages/grind/src/grind/log.py
+++ b/packages/grind/src/grind/log.py
@@ -3,7 +3,7 @@
 This module only *reads*. The write-path repair described in the spec's
 "Torn tail" section (moving an unparsable fragment to `events.quarantine`,
 appending the missing newline to a complete-but-unterminated line) belongs to
-the CLI's append path (a later bead) -- this module is the defense-in-depth
+the CLI's append path (a later work item) -- this module is the defense-in-depth
 half: it tolerates a torn tail when reading a log no repair has touched yet
 (e.g. `status` on a freshly-crashed grind), per spec: "the fold still
 tolerates a non-parsing last line (drops it, reports the torn_tail anomaly)".

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -143,7 +143,11 @@ class Item:
     lane: str | None
     title: str | None
     status: ItemStatus
-    bead: str | None = None
+    # The item's id in the external work tracker, when it differs from `id`.
+    # Named for the `work` facade, never for a tracker backend: the backend is
+    # quarantined behind that facade, so its nouns must not be frozen into
+    # grind's persisted event schema or its `state.json` projection.
+    work_id: str | None = None
     blocked_on: tuple[str, ...] = ()
     blocked_note: str | None = None
     pr: PrRef | None = None

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -313,7 +313,7 @@ def _validate_discovered_work(payload: RawEvent) -> list[str]:
     _require_str(errors, payload, "description")
     _require_str(errors, payload, "source")
     _require_str(errors, payload, "rationale")
-    _optional_str(errors, payload, "bead")
+    _optional_str(errors, payload, "work_id")
     disposition = payload.get("disposition")
     if disposition not in _WORK_DISPOSITIONS:
         errors.append("disposition must be one of parked|enqueued")

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -80,7 +80,7 @@ def _item_json(item: Item) -> JsonValue:
         "lane": item.lane,
         "title": item.title,
         "status": item.status,
-        "bead": item.bead,
+        "work_id": item.work_id,
         "blocked_on": list(item.blocked_on),
         "blocked_note": item.blocked_note,
         "pr": _pr_ref_json(item.pr),

--- a/packages/grind/src/grind/store.py
+++ b/packages/grind/src/grind/store.py
@@ -2,10 +2,10 @@
 
 The write-path repair belongs here, not in `grind.log` (spec "Torn tail":
 "the write path repairs before it appends"; `grind.log`'s docstring calls this
-"a later bead" -- this module is that bead). `grind.log` stays the read-only,
-defense-in-depth half: it tolerates an unrepaired torn tail for a log read
-before any write-path call has touched it (e.g. `status` on a freshly-crashed
-grind), but never writes.
+"a later work item" -- this module is that work item). `grind.log` stays the
+read-only, defense-in-depth half: it tolerates an unrepaired torn tail for a
+log read before any write-path call has touched it (e.g. `status` on a
+freshly-crashed grind), but never writes.
 """
 
 from __future__ import annotations

--- a/packages/grind/tests/unit/test_fold_parking.py
+++ b/packages/grind/tests/unit/test_fold_parking.py
@@ -240,15 +240,15 @@ def test_discovered_work_enqueued_preserves_source_and_rationale() -> None:
     assert item.discovered.rationale == "blocks the milestone"
 
 
-def test_discovered_work_bead_is_normalized_away_when_equal_to_item_id() -> None:
-    # spec: bead? is "optional metadata, carried only when it differs from item".
+def test_discovered_work_work_id_is_normalized_away_when_equal_to_item_id() -> None:
+    # spec: work_id? is "optional metadata, carried only when it differs from item".
     events = [
         seed_event(),
         event(
             "discovered_work",
             item="disc-1",
-            bead="disc-1",
-            description="dup bead id",
+            work_id="disc-1",
+            description="dup work id",
             source="lane-a",
             disposition="enqueued",
             lane="lane-a",
@@ -258,17 +258,40 @@ def test_discovered_work_bead_is_normalized_away_when_equal_to_item_id() -> None
 
     state = fold(events)
 
-    assert state.items["disc-1"].bead is None
+    assert state.items["disc-1"].work_id is None
 
 
-def test_discovered_work_keeps_bead_when_it_differs_from_item_id() -> None:
+def test_discovered_work_keeps_work_id_when_it_differs_from_item_id() -> None:
+    events = [
+        seed_event(),
+        event(
+            "discovered_work",
+            item="disc-1",
+            work_id="wgclw.99",
+            description="real work id",
+            source="lane-a",
+            disposition="enqueued",
+            lane="lane-a",
+            rationale="r",
+        ),
+    ]
+
+    state = fold(events)
+
+    assert state.items["disc-1"].work_id == "wgclw.99"
+
+
+def test_discovered_work_does_not_accept_the_tracker_backends_noun() -> None:
+    # Name lock (D11): the tracker backend is quarantined behind the `work`
+    # facade, so its noun must not be a key grind's event schema honours. A
+    # payload carrying `bead` leaves `work_id` unset rather than reviving it.
     events = [
         seed_event(),
         event(
             "discovered_work",
             item="disc-1",
             bead="wgclw.99",
-            description="real bead id",
+            description="backend noun",
             source="lane-a",
             disposition="enqueued",
             lane="lane-a",
@@ -278,7 +301,7 @@ def test_discovered_work_keeps_bead_when_it_differs_from_item_id() -> None:
 
     state = fold(events)
 
-    assert state.items["disc-1"].bead == "wgclw.99"
+    assert state.items["disc-1"].work_id is None
 
 
 def test_discovered_work_parked_creates_a_new_parked_item() -> None:

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -72,6 +72,34 @@ def test_full_state_json_round_trips_item_fields():
     assert review["head_sha"] == "deadbeef"
 
 
+def test_item_projection_publishes_work_id_and_never_the_backends_noun():
+    # Name lock (D11): `state.json` is grind's public JSON, so the tracker
+    # backend's noun must not appear as a key any consumer could come to
+    # depend on. The tracker id rides as `work_id` or not at all.
+    events = [
+        seed_event(),
+        event(
+            "discovered_work",
+            item="disc-1",
+            work_id="wgclw.99",
+            description="found in review",
+            source="lane-a",
+            disposition="enqueued",
+            lane="lane-a",
+            rationale="r",
+        ),
+    ]
+    state = fold(events)
+
+    items = full_state_json(state)["items"]
+    assert isinstance(items, dict)
+    for item in items.values():
+        assert isinstance(item, dict)
+        assert "work_id" in item
+        assert "bead" not in item
+    assert items["disc-1"]["work_id"] == "wgclw.99"
+
+
 def test_full_state_json_serializes_ledgers_and_parking_lot():
     events = [
         seed_event(),


### PR DESCRIPTION
Tracker: `agents-config-9k9.1.19`

## Why

Not a coupling defect — a **vocabulary** defect. grind does not execute `bd`; there are zero subprocess calls of any kind in `packages/grind/src`. But `bead` is the issue-tracker *backend's* noun, and **D11** quarantines that backend behind the `work` facade. The noun had leaked into two places that outlive any one backend:

- the **persisted event schema** — `bead` was a validated payload key on `discovered_work`, so it was written into `events.jsonl`
- the **public JSON** — `bead` was a key in the `state.json` item projection

A GH-issues backend would have inherited a field called `bead`, or required a schema migration. That is exactly the drift the facade exists to prevent. Name chosen to match the facade (`work`) and the charter's own phrasing ("work item IDs").

## Sites renamed (grind's own field / key / output)

| File | Change |
|---|---|
| `packages/grind/src/grind/model.py:146` | `Item.bead` → `Item.work_id`, plus a comment recording why the name tracks the facade and not a backend |
| `packages/grind/src/grind/payloads.py:316` | validated `discovered_work` payload key `bead` → `work_id` |
| `packages/grind/src/grind/serialize.py:83` | `state.json` item projection key `"bead"` → `"work_id"` |
| `packages/grind/src/grind/fold.py:633-638` | the spec-quoting comment, the read, and the equals-item-id normalization |
| `packages/grind/src/grind/fold.py:655,663` | both `Item(...)` constructions (parked + enqueued dispositions) |
| `docs/specs/2026-07-19-event-sourced-grind-runtime.md:40` | Item definition: "Maps 1:1 to a work-tracker bead" → "work-tracker item" |
| `docs/specs/…:128` | `grind_created` row: "queue of items with bead ids" → "work ids" |
| `docs/specs/…:165` | `discovered_work` row: `bead?` → `work_id?`, "the bead id when one exists" → "the work-tracker id when one exists", and the optional-metadata gloss |
| `packages/grind/tests/unit/test_fold_parking.py` | both normalization tests renamed and re-keyed |
| `packages/grind/src/grind/derive.py:5` | docstring: "a sibling bead's time-dependent facts" → "a sibling work item's …" |
| `packages/grind/src/grind/log.py:6` | docstring: "the CLI's append path (a later bead)" → "(a later work item)" |
| `packages/grind/src/grind/store.py:5` | docstring: "calls this 'a later bead' — this module is that bead" → "'a later work item' — this module is that work item" |

After this, **`packages/grind/src` contains zero occurrences of the backend's noun.**

## The three module docstrings — reworded

These three said "bead" meaning *a tracker work item*, not grind's field. They were initially left alone on that reading, then reworded on instruction: D11's point is that the runtime's source should not name the tracker backend **at all**, in code or in comments, and these were the last three occurrences in `packages/grind/src`.

- `derive.py:5` — "a sibling bead's time-dependent facts" → "a sibling work item's time-dependent facts"
- `log.py:6` — "the CLI's append path (a later bead)" → "(a later work item)"
- `store.py:5` — "…calls this 'a later bead' — this module is that bead" → "'a later work item' — this module is that work item"

`store.py` quotes `log.py`'s docstring verbatim, so both were changed together to keep the quotation matching; verified after the edit. Rewording only — same meaning, same length ballpark, one paragraph rewrapped in `store.py` to the file's existing ~78-col style, no restructuring.

### Staleness spotted and deliberately left

`log.py:6` and `store.py:3-5` both describe the CLI append path as *future* work ("a later work item", "belongs to the CLI's append path"), but that path exists now — `store.py` itself is it, and `cli.py`/`verbs.py` ship the append verbs. Likewise `derive.py:5` frames `conditions(State, now)` as a sibling's future scope when `conditions.py` is present in the package. That is real rot, but fixing it here would muddy a rename diff, so the staleness is left as-is for separate tracking.

## Deliberately left alone

- The spec's tracker-item prose: the `**Bead:**` header (line 3), "per bead wgclw.28.4" (421), and the Delivery / Continuations sections' delivery-plan bead IDs `.30.1`–`.30.7` (471, 478, 488, 491). Legitimate prose about this project's own process.
- `packages/grind/AGENTS.md` — owned by `agents-config-9k9.1.10`. Not touched. Checked for fallout: its five "bead" uses (19, 79, 84, 197, 199) are all tracker-ticket prose and it never documents the field, so this rename makes **nothing** in it newly wrong.
- The `grind_created` seed handler's failure to read the field at all — that is `agents-config-9k9.1.17`, edged behind this item. The seed queue entries still carry no work id; not added here.
- `packages/workcli`'s `groom_state_bead` and `packages/vizsuite`'s `from_bead`/`to_bead`. Out of this item's scope, and **escalated separately** — both are D11 violations in worse positions than grind's was: `groom_state_bead` sits in the facade's *generic* layer (`config.py`, `verbs/groom.py`) with a `groom-state-bead` TOML key in the user-facing config contract, and vizsuite's rides a `ProposedEdge` next to a `TrackerPort` abstraction.

## No migration needed — verified, not assumed

- `find . -name events.jsonl` (excluding `.git`) → **zero** results. No persisted log exists anywhere in the repo.
- Repo-wide grep for the `bead` key across `*.py`/`*.md`/`*.json`/`*.jsonl` → no test fixture and no seed builder carried it; `tests/unit/builders.py`'s `seed_event()` queue entries have only `id` and `title`.

So this is a **clean break**: no dual-read compatibility shim, no accepting both keys.

## Regression pin (this item's `remove_when`)

Two new name-lock tests, so the backend noun cannot creep back silently:

- `test_serialize.py::test_item_projection_publishes_work_id_and_never_the_backends_noun` — asserts every item in `state.json` has `work_id` and **no** `bead` key.
- `test_fold_parking.py::test_discovered_work_does_not_accept_the_tracker_backends_noun` — a payload carrying `bead` leaves `work_id` unset rather than reviving the old key. (Payload validation tolerates unknown keys by design, so this pins the *read* side.)

## Gate output

`make ci` (full repo gate) — green.

```
Required test coverage of 80.0% reached. Total coverage: 95.24%
============================= 311 passed in 0.66s ==============================
cd packages/grind && uv sync --frozen && uv run pip-audit
Audited 43 packages in 0.98ms
No known vulnerabilities found
uv --project packages/grind run grind --help > /dev/null
uv --project packages/installer run actionlint
uv --project packages/installer run python -m installer.spec_lint_cli .
```

`make ci-grind` and `make spec-lint` were also run individually and are clean. Coverage went up, not down; no threshold was touched.

Re-run after the docstring rewording commit — `make ci-grind` green (311 passed, coverage 95.24%, pip-audit clean, entry-verify clean) and `make spec-lint` exit 0.

Note: `graphify update .` was not run — this repo's history ships graph refreshes as standalone `graphify update` commits rather than bundling the regenerated `graphify-out/` into feature PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6xaZYtSkFYPSkYabWFzrh

