### PR TITLE
fix(9k9.1.17): grind_created seed handler reads each queued item's work_id

### DIFF
--- a/docs/specs/2026-07-19-event-sourced-grind-runtime.md
+++ b/docs/specs/2026-07-19-event-sourced-grind-runtime.md
@@ -125,7 +125,7 @@ things now *are*.
 
 | Type | Payload | Effect |
 |------|---------|--------|
-| `grind_created` | `title`, `repo` (owner/name), `mission` (goal + explicit out-of-scope), `protocols` (structured block: review protocol choice, merge-policy resolution, watcher conventions, session grants), `config` (thresholds, below), `lanes[]` (id, name, agent, model+effort the lieutenant runs at, queue of items with work ids, titles, blocker edges) | Seeds the entire board. Legal only as the log's **first** event; any subsequent `grind_created` folds as an anomaly (accept-and-flag), leaving the board unchanged. The mission/protocols block is what makes `status --handoff` self-contained (§7 replacement). |
+| `grind_created` | `title`, `repo` (owner/name), `mission` (goal + explicit out-of-scope), `protocols` (structured block: review protocol choice, merge-policy resolution, watcher conventions, session grants), `config` (thresholds, below), `lanes[]` (id, name, agent, model+effort the lieutenant runs at, queue of items with ids, titles, blocker edges, `work_id?`) | Seeds the entire board. A seeded item's `id` is its work-tracker id when one exists, so `work_id?` is optional metadata carried only when it differs from `id` — identical semantics to `discovered_work`'s. Legal only as the log's **first** event; any subsequent `grind_created` folds as an anomaly (accept-and-flag), leaving the board unchanged. The mission/protocols block is what makes `status --handoff` self-contained (§7 replacement). |
 | `grind_paused` | `reason`, `resume_checklist[]` | Board banner; handoff carries pause state |
 | `grind_resumed` | — | Clears pause |
 | `grind_finished` | `summary` | Terminal. Fold rejects (anomaly) further mutating events. |

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -172,11 +172,23 @@ def _h_grind_created(state: State, evt: RawEvent) -> None:
             on = item_payload.get("on")
             blocked_on = tuple(o for o in on if isinstance(o, str)) if isinstance(on, list) else ()
             status: ItemStatus = "blocked" if blocked_on else "queued"
+            # The seed queue carries "items with work ids" (spec), and an item
+            # id is itself "the work-tracker id when one exists" (spec) -- so a
+            # seeded work id equal to the item id is the redundant case, and is
+            # normalized away exactly as `discovered_work` does. `work_id` then
+            # means one thing for every producer: the tracker handle when it
+            # differs from `id`. Skipping this would make two items with
+            # identical facts project differently in `state.json` depending on
+            # which event created them.
+            work_id = _str(item_payload, "work_id")
+            if work_id == item_id:
+                work_id = None
             item = Item(
                 id=item_id,
                 lane=lane_id,
                 title=_str(item_payload, "title"),
                 status=status,
+                work_id=work_id,
                 blocked_on=blocked_on,
             )
             state.items[item_id] = item

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -112,6 +112,22 @@ def _str(evt: RawEvent, key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _work_id(payload: RawEvent, item_id: str) -> str | None:
+    """The item's external tracker handle, or None when it has no distinct one.
+
+    Both producers (`grind_created` seed queues, `discovered_work`) route through
+    here so `work_id` carries one meaning in state: present means a handle that
+    differs from `id`. An id equal to `item_id` is the redundant case, and `""`
+    is not a handle -- the boundary rejects both, and this mirrors it so a
+    hand-edited or historical log cannot falsify the invariant a consumer reads
+    as "non-None means the handle differs from `id`".
+    """
+    work_id = _str(payload, "work_id")
+    if not work_id or work_id == item_id:
+        return None
+    return work_id
+
+
 def _anomaly(state: State, evt: RawEvent, reason: str) -> None:
     etype = _str(evt, "type") or "<missing type>"
     item_id = _str(evt, "item")
@@ -174,15 +190,8 @@ def _h_grind_created(state: State, evt: RawEvent) -> None:
             status: ItemStatus = "blocked" if blocked_on else "queued"
             # The seed queue carries "items with work ids" (spec), and an item
             # id is itself "the work-tracker id when one exists" (spec) -- so a
-            # seeded work id equal to the item id is the redundant case, and is
-            # normalized away exactly as `discovered_work` does. `work_id` then
-            # means one thing for every producer: the tracker handle when it
-            # differs from `id`. Skipping this would make two items with
-            # identical facts project differently in `state.json` depending on
-            # which event created them.
-            work_id = _str(item_payload, "work_id")
-            if work_id == item_id:
-                work_id = None
+            # seeded work id equal to the item id is the redundant case.
+            work_id = _work_id(item_payload, item_id)
             item = Item(
                 id=item_id,
                 lane=lane_id,
@@ -646,9 +655,7 @@ def _h_discovered_work(state: State, evt: RawEvent) -> None:
     # `item`" (spec) -- a caller-supplied work id equal to the item id is
     # redundant, so it's normalized away rather than stored twice under two
     # names.
-    work_id = _str(evt, "work_id")
-    if work_id == item_id:
-        work_id = None
+    work_id = _work_id(evt, item_id)
     # The item "carries its triage rationale" (spec) plus its source -- state is
     # the renderer's only input, so both dispositions must preserve this
     # provenance or a later projection can't explain the work's origin.

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -124,6 +124,7 @@ def _validate_grind_created(payload: RawEvent) -> list[str]:
                 errors.append(f"{item_prefix} must be an object with a non-empty string id")
                 continue
             _optional_nested_str(errors, item, "title", item_prefix)
+            _optional_nested_str(errors, item, "work_id", item_prefix)
             _optional_nested_list_of_str(errors, item, "on", item_prefix)
     return errors
 

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -81,6 +81,26 @@ def _optional_nested_str(errors: list[str], container: RawEvent, key: str, prefi
         )
 
 
+# An identifier a consumer resolves against an external system carries a
+# presence invariant -- absent means "no distinct handle", present means "this
+# handle" -- so `""` must not pass as present. Free text (`title`, `description`)
+# has no such invariant and keeps the permissive variants above.
+def _optional_nonempty_str(errors: list[str], payload: RawEvent, key: str) -> None:
+    if key in payload and payload[key] is not None:
+        _require(errors, _is_str(payload, key), f"{key} must be a non-empty string when present")
+
+
+def _optional_nested_nonempty_str(
+    errors: list[str], container: RawEvent, key: str, prefix: str
+) -> None:
+    if container.get(key) is not None:
+        _require(
+            errors,
+            _is_str(container, key),
+            f"{prefix}.{key} must be a non-empty string when present",
+        )
+
+
 def _optional_nested_list_of_str(
     errors: list[str], container: RawEvent, key: str, prefix: str
 ) -> None:
@@ -124,7 +144,7 @@ def _validate_grind_created(payload: RawEvent) -> list[str]:
                 errors.append(f"{item_prefix} must be an object with a non-empty string id")
                 continue
             _optional_nested_str(errors, item, "title", item_prefix)
-            _optional_nested_str(errors, item, "work_id", item_prefix)
+            _optional_nested_nonempty_str(errors, item, "work_id", item_prefix)
             _optional_nested_list_of_str(errors, item, "on", item_prefix)
     return errors
 
@@ -314,7 +334,7 @@ def _validate_discovered_work(payload: RawEvent) -> list[str]:
     _require_str(errors, payload, "description")
     _require_str(errors, payload, "source")
     _require_str(errors, payload, "rationale")
-    _optional_str(errors, payload, "work_id")
+    _optional_nonempty_str(errors, payload, "work_id")
     disposition = payload.get("disposition")
     if disposition not in _WORK_DISPOSITIONS:
         errors.append("disposition must be one of parked|enqueued")

--- a/packages/grind/tests/unit/test_fold_grind_created.py
+++ b/packages/grind/tests/unit/test_fold_grind_created.py
@@ -67,6 +67,37 @@ def test_seeded_blocker_edges_fold_item_as_blocked_not_queued() -> None:
     assert state.items["wgclw.3"].blocked_on == ("wgclw.1",)
 
 
+def test_seeded_item_folds_with_its_work_id() -> None:
+    event = _seed_event()
+    lanes = event["lanes"]
+    assert isinstance(lanes, list)
+    lanes[0]["queue"].append({"id": "disc-1", "title": "Slug-keyed item", "work_id": "wgclw.9"})
+
+    state = fold([event])
+
+    assert state.items["disc-1"].work_id == "wgclw.9"
+
+
+def test_seeded_item_without_a_work_id_folds_to_none() -> None:
+    state = fold([_seed_event()])
+
+    assert state.items["wgclw.1"].work_id is None
+
+
+def test_seeded_work_id_equal_to_the_item_id_is_normalized_away() -> None:
+    # `work_id` carries the tracker handle only when it differs from `id`, the
+    # same normalization `discovered_work` applies -- a seeded work id equal to
+    # the item id is redundant, not a second name to store.
+    event = _seed_event()
+    lanes = event["lanes"]
+    assert isinstance(lanes, list)
+    lanes[0]["queue"][0]["work_id"] = "wgclw.1"
+
+    state = fold([event])
+
+    assert state.items["wgclw.1"].work_id is None
+
+
 def test_second_grind_created_is_an_anomaly_leaving_board_unchanged() -> None:
     first = _seed_event()
     second = _seed_event(title="Different title")

--- a/packages/grind/tests/unit/test_fold_grind_created.py
+++ b/packages/grind/tests/unit/test_fold_grind_created.py
@@ -98,6 +98,20 @@ def test_seeded_work_id_equal_to_the_item_id_is_normalized_away() -> None:
     assert state.items["wgclw.1"].work_id is None
 
 
+def test_seeded_empty_work_id_folds_to_none() -> None:
+    # The boundary rejects `""`; the fold mirrors it -- as it mirrors the
+    # park-reason axis and the observation levels -- so a hand-edited or
+    # historical log cannot leave a present-but-unusable handle in state.
+    event = _seed_event()
+    lanes = event["lanes"]
+    assert isinstance(lanes, list)
+    lanes[0]["queue"][0]["work_id"] = ""
+
+    state = fold([event])
+
+    assert state.items["wgclw.1"].work_id is None
+
+
 def test_seeded_item_does_not_accept_the_tracker_backends_noun() -> None:
     # Name lock (D11): the tracker backend is quarantined behind the `work`
     # facade, so its noun must not be a key grind's seed schema honours. A queue

--- a/packages/grind/tests/unit/test_fold_grind_created.py
+++ b/packages/grind/tests/unit/test_fold_grind_created.py
@@ -98,6 +98,25 @@ def test_seeded_work_id_equal_to_the_item_id_is_normalized_away() -> None:
     assert state.items["wgclw.1"].work_id is None
 
 
+def test_seeded_item_does_not_accept_the_tracker_backends_noun() -> None:
+    # Name lock (D11): the tracker backend is quarantined behind the `work`
+    # facade, so its noun must not be a key grind's seed schema honours. A queue
+    # item carrying `bead` leaves `work_id` unset rather than reviving it.
+    #
+    # The noun is spelled here deliberately -- pinning an absence requires naming
+    # what is absent. The seed handler reads a tracker field, so it carries the
+    # same hazard `discovered_work` does: a careless rename re-adding the old key
+    # as a fallback, silently, into the persisted schema.
+    event = _seed_event()
+    lanes = event["lanes"]
+    assert isinstance(lanes, list)
+    lanes[0]["queue"].append({"id": "disc-1", "title": "Backend noun", "bead": "wgclw.9"})
+
+    state = fold([event])
+
+    assert state.items["disc-1"].work_id is None
+
+
 def test_second_grind_created_is_an_anomaly_leaving_board_unchanged() -> None:
     first = _seed_event()
     second = _seed_event(title="Different title")

--- a/packages/grind/tests/unit/test_fold_parking.py
+++ b/packages/grind/tests/unit/test_fold_parking.py
@@ -281,6 +281,29 @@ def test_discovered_work_keeps_work_id_when_it_differs_from_item_id() -> None:
     assert state.items["disc-1"].work_id == "wgclw.99"
 
 
+def test_discovered_work_empty_work_id_folds_to_none() -> None:
+    # `""` is not a handle. The boundary rejects it on this event as well as on
+    # seed queues, and the fold mirrors that so no log can leave a
+    # present-but-unusable value under a field whose presence is the signal.
+    events = [
+        seed_event(),
+        event(
+            "discovered_work",
+            item="disc-1",
+            work_id="",
+            description="empty work id",
+            source="lane-a",
+            disposition="enqueued",
+            lane="lane-a",
+            rationale="r",
+        ),
+    ]
+
+    state = fold(events)
+
+    assert state.items["disc-1"].work_id is None
+
+
 def test_discovered_work_does_not_accept_the_tracker_backends_noun() -> None:
     # Name lock (D11): the tracker backend is quarantined behind the `work`
     # facade, so its noun must not be a key grind's event schema honours. A

--- a/packages/grind/tests/unit/test_payloads.py
+++ b/packages/grind/tests/unit/test_payloads.py
@@ -108,6 +108,28 @@ def test_grind_created_validates_optional_seed_string_fields():
     assert any("lanes[0].model" in e for e in errors)
 
 
+def test_work_id_must_be_non_empty_when_present_on_both_producers():
+    # `work_id` is an identifier a consumer resolves against an external system:
+    # absent means "no distinct handle", present means "this handle". `""` reads
+    # as present while resolving to nothing, so it is rejected at the boundary on
+    # every event carrying the field -- the seed queue and `discovered_work`
+    # alike, or the invariant holds for one producer and not the other.
+    errors = validate_payload("grind_created", _seed_with_item({"work_id": ""}))
+    assert any("lanes[0].queue[0].work_id" in e and "non-empty" in e for e in errors)
+
+    discovered = {
+        "item": "disc-1",
+        "description": "d",
+        "source": "lane-a",
+        "rationale": "r",
+        "disposition": "enqueued",
+        "lane": "lane-a",
+    }
+    assert validate_payload("discovered_work", {**discovered, "work_id": "wgclw.9"}) == []
+    errors = validate_payload("discovered_work", {**discovered, "work_id": ""})
+    assert any("work_id" in e and "non-empty" in e for e in errors)
+
+
 # -- item lifecycle -----------------------------------------------------------
 
 

--- a/packages/grind/tests/unit/test_payloads.py
+++ b/packages/grind/tests/unit/test_payloads.py
@@ -92,6 +92,9 @@ def test_grind_created_validates_optional_seed_string_fields():
     # by the fold when malformed -- validate them at the boundary.
     errors = validate_payload("grind_created", _seed_with_item({"title": 42}))
     assert any("lanes[0].queue[0].title" in e for e in errors)
+    assert validate_payload("grind_created", _seed_with_item({"work_id": "wgclw.9"})) == []
+    errors = validate_payload("grind_created", _seed_with_item({"work_id": 42}))
+    assert any("lanes[0].queue[0].work_id" in e for e in errors)
     errors = validate_payload(
         "grind_created",
         {


### PR DESCRIPTION
## What changed

`agents-config-9k9.1.17`. `_h_grind_created` in `packages/grind/src/grind/fold.py` looped each lane's `queue` reading only `id`, `on`, and `title`, then constructed `Item(...)` with no value for `work_id` — so every seeded item's tracker handle was silently dropped at fold time and surfaced as a null `work_id` in `state.json` and `status --handoff`.

- `fold.py` — the seed loop now reads `work_id` off each queue item and passes it to `Item(...)`.
- `payloads.py` — `_validate_grind_created` validates `work_id` as an optional string on queue items, alongside `title`.
- `docs/specs/2026-07-19-event-sourced-grind-runtime.md` — the `grind_created` row named the field only obliquely ("queue of items with work ids") and was silent on its optionality. It now names `work_id?` and states the semantics.

## Why the `work_id == item_id -> None` normalisation applies here too

Applied, on the spec's own item-id convention rather than on symmetry with `discovered_work` for its own sake:

- The glossary: an **Item** "maps 1:1 to a work-tracker item".
- The `discovered_work` row: the item is "keyed by the required `item` id: **the work-tracker id when one exists**, else a ROOT-assigned run-unique slug (`disc-<n>`)".

So an item's `id` already *is* its work id in the ordinary case; a distinct `work_id` only carries information when the id is a slug instead. That is exactly why the same row calls `work_id?` "optional metadata, carried only when it differs from `item`" — a rule about the field's meaning, not about one event that produces it. `Item.work_id` is one field with one documented meaning ("the item's id in the external work tracker, when it differs from `id`"), so honouring a redundant seeded value would make two items with identical facts project differently in `state.json` depending on which event created them, and would break any consumer that reads `work_id is not None` as "the tracker handle differs from the id" — for seeded items only.

Note for `9k9.1.4`: the Tier-1 join key `work_id or id` is unchanged in behaviour by this fix, but now rests on intent rather than on the defect.

## Scope check: `serialize.py` / `handoff.py`

Confirmed **no change needed**. `serialize.py:83` and `handoff.py:73` both emit `item.work_id` unconditionally, with no per-event branching, so the corrected fold flows through both projections as-is. `test_serialize.py` already asserts `work_id` is present on every serialized item.

## Mechanical evidence

`make ci-grind` on `53ccaa2` — lint, format-check, typecheck, coverage, audit, entry-verify:

```
============================= 353 passed in 0.41s ==============================
Required test coverage of 80.0% reached. Total coverage: 95.69%
No known vulnerabilities found
uv --project packages/grind run grind --help > /dev/null
```

GitHub CI keyed to that SHA: `CI [53ccaa2]: completed/success`.

Pins: a seeded item carrying a `work_id` folds with it on `Item`; a seeded item without one folds to `None`; a seeded `work_id` equal to the item id normalises to `None`; `""` is rejected at the boundary and folds to `None`, on **both** producers; the validator rejects a non-string with a `lanes[0].queue[0].work_id` path; and a name-lock pins that the quarantined backend noun is not honoured as a seed payload key.

## Review round 2 — empty `work_id` (Codex P2, `53ccaa2`)

Codex found that `""` passed `_optional_nested_str` (which guards on `is not None`, then `isinstance`) and survived `_str`, so `work_id` could be present-but-unusable — falsifying the very invariant this PR establishes, since the `work_id == item_id` normalisation cannot catch it (`id` is validated non-empty). Correct, and fixed.

The fix intentionally goes wider than the flag: `_validate_discovered_work` used `_optional_str`, with the identical guard, so **`discovered_work` accepted `work_id: ""` too**. That hole is pre-existing and invisible in this diff, but it is the same hole in the same invariant on the producer whose semantics justify this change — closing only the seed path would leave the invariant false while the new tests claimed it held.

- `payloads.py` — added `_optional_nonempty_str` / `_optional_nested_nonempty_str` (the package had no optional-non-empty variant), used for `work_id` on both events.
- `fold.py` — both producers route through one `_work_id(payload, item_id)` helper.

**Why the fold mirrors the boundary instead of trusting it** — the package's existing convention, not belt-and-braces by preference: the fold already re-checks `discovered_work`'s park-reason axis after the boundary narrows it ("so a hand-edited or historical log cannot replay discovered work … as a machine-caused failure") and re-checks `observation.level` against an `_OBSERVATION_LEVELS` set duplicated in both modules. `_str` is deliberately unchanged — coercing `""` there would alter every string field in the package. `title` keeps the permissive helper; no presence invariant rides on it.

## D11 vocabulary

The standing form of the check is `git grep -in bead -- packages/grind/src/`, which is **zero on this branch**. The full-package grep is not zero, by design:

- `packages/grind/AGENTS.md` (5 hits) — owned by `9k9.1.10`, being rewritten in parallel; untouched here.
- `tests/unit/test_fold_parking.py`, `tests/unit/test_serialize.py`, and now `tests/unit/test_fold_grind_created.py` — deliberate name-lock guards asserting the backend noun is *not* honoured as a payload key and *not* emitted in `state.json`. Pinning an absence requires naming what is absent; deleting these to clean up a grep would trade real regression protection for command output.

This PR adds the third of those: the seed path reads a tracker field as of this change, so it carries the same hazard `discovered_work` does — a careless rename re-adding the old key as a fallback, silently, into the persisted schema. A seed queue item carrying the old key folds with `work_id is None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6xaZYtSkFYPSkYabWFzrh

