### PR TITLE
chore(9k9.55): refresh the openrouter model routing table

### DIFF
--- a/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
@@ -100,11 +100,15 @@ bucket table already encodes.
 Use the user's level if they named one. `max` only on an explicit request —
 it is the most expensive tier.
 
-Whether the level reaches the target model depends on that model honoring
-OpenRouter's normalized `reasoning.effort` parameter. The routing table and
-the registry both record this per model; trust the recorded value rather than
-re-verifying at dispatch. Where it is unconfirmed, pass `--effort` anyway and
-treat model *choice* as the reliable capability lever.
+Not every model accepts every level. `references/model-routing.md` lists the
+levels each one takes — pick from that list, since two of the listed models
+accept no level at all and others are missing the middle of the range. Trust
+the recorded value rather than re-verifying at dispatch.
+
+Whether `--effort` actually reaches the model as that level is unverified: it
+travels through an Anthropic-compatible skin that speaks thinking budgets, not
+`reasoning.effort`. Pass it regardless — it costs nothing — and treat model
+*choice* as the reliable capability lever.
 
 ## Example
 

--- a/src/user/.claude/skills/openrouter-claude-subagent/references/model-routing.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/references/model-routing.md
@@ -1,22 +1,46 @@
 # OpenRouter Model Routing Table
 
-Prices are $/M tokens on OpenRouter, captured 2026-07-18. **Verify current
-pricing at `openrouter.ai/<model-id>` before routing anything cost-sensitive**
-— OpenRouter repricing and model churn happen without notice, and this table
-will drift.
+Captured **2026-07-25** from `https://openrouter.ai/api/v1/models`, OpenRouter's
+public catalog endpoint. That endpoint is authoritative for price, context
+length, max output, and which reasoning-effort levels a model accepts, and it
+is machine-readable — refresh this table from it rather than reading ten model
+pages by hand. Re-verify there before routing anything cost-sensitive:
+OpenRouter reprices and retires models without notice, and this table is a
+snapshot that starts decaying immediately.
 
-| Model ID (`--model` value) | Input $/M | Output $/M | Context | Effort param? | Best for |
+Prices are $/M tokens. Rows are sorted by input price.
+
+| Model ID (`--model` value) | Input $/M | Output $/M | Context | Effort levels accepted | Best for |
 |---|---|---|---|---|---|
-| `google/gemini-3.1-flash-lite` | $0.25 | $1.50 | 1M | confirmed | Cheapest tier — high-volume triage, extraction, formatting |
-| `z-ai/glm-5.2` | $0.30 | $0.94 | 1.05M / 131K out | confirmed (reasoning model) | Very cheap long-horizon agentic coding |
-| `moonshotai/kimi-k2.6` | $0.66 | $3.41 | 262k | confirmed | Cheapest Kimi tier, general/mechanical |
-| `moonshotai/kimi-k2.7-code` | $0.72 | $3.50 | 262k | confirmed | Code-tuned mid-tier, strong cost/perf for implementation |
-| `google/gemini-3.5-flash` | $1.50 | $9.00 | 1M | confirmed | Near-Pro coding/reasoning at flash latency |
-| `openai/gpt-5.6-luna` | $1.00 | $6.00 | 1.05M | confirmed | Cheap high-volume classification / lightweight agentic |
-| `openai/gpt-5.6-terra` | $2.50 | $15.00 | 1.05M | confirmed | Balanced everyday coding/agentic — standard implementation |
-| `moonshotai/kimi-k3` | $3.00 | $15.00 | 1.05M | confirmed (via `reasoning`) | Frontier-tier agentic coding, large repos |
-| `anthropic/claude-opus-4.8` | $5.00 | $25.00 | 1M | confirmed (native thinking) | Frontier architecture/judgment |
-| `openai/gpt-5.6-sol` | $5.00 | $30.00 | 1.05M | confirmed | Flagship complex reasoning/coding, cross-subsystem work |
+| `google/gemini-3.1-flash-lite` | $0.25 | $1.50 | 1M / 64K out | `minimal` `low` `medium` `high` | Cheapest tier — high-volume triage, extraction, formatting |
+| `moonshotai/kimi-k2.6` | $0.65 | $2.72 | 262K | **none** — reasoning on/off only | Cheapest Kimi tier, general/mechanical |
+| `z-ai/glm-5.2` | $0.76 | $2.39 | 1M / 131K out | `high` `xhigh` **only** | Long-horizon agentic coding; cheapest output in its price band |
+| `moonshotai/kimi-k2.7-code` | $0.78 | $3.50 | 262K | **none** — reasoning always on | Code-tuned mid-tier, strong cost/perf for implementation |
+| `openai/gpt-5.6-luna` | $1.00 | $6.00 | 1.05M / 128K out | `none` `low` `medium` `high` `xhigh` `max` | Cheap high-volume classification / lightweight agentic |
+| `google/gemini-3.5-flash` | $1.50 | $9.00 | 1M / 64K out | `minimal` `low` `medium` `high` | Near-Pro coding/reasoning at flash latency |
+| `openai/gpt-5.6-terra` | $2.50 | $15.00 | 1.05M / 128K out | `none` `low` `medium` `high` `xhigh` `max` | Balanced everyday coding/agentic — standard implementation |
+| `moonshotai/kimi-k3` | $3.00 | $15.00 | 1M | `low` `high` `max` — no `medium`, no `xhigh` | Frontier-tier agentic coding, large repos |
+| `anthropic/claude-opus-4.8` | $5.00 | $25.00 | 1M / 128K out | `low` `medium` `high` `xhigh` `max` | Frontier architecture/judgment |
+| `openai/gpt-5.6-sol` | $5.00 | $30.00 | 1.05M / 128K out | `none` `low` `medium` `high` `xhigh` `max` | Flagship complex reasoning/coding, cross-subsystem work |
+
+## Reading the effort column
+
+The column lists the discrete levels each model accepts on OpenRouter's
+normalized `reasoning.effort` parameter. Two consequences worth internalizing
+before dispatch:
+
+- **Not every level exists on every model.** `glm-5.2` accepts only `high` and
+  `xhigh`, so there is no cheap low-effort run on it. `kimi-k3` has no
+  `medium` and no `xhigh` — a task that wants "high or xhigh" gets `high` or
+  `max`, nothing between. Both Kimi mid-tier models accept no level at all;
+  reasoning is simply on.
+- **The mapping from the CLI to that parameter is unverified.** The Claude
+  Code CLI's `--effort` flag travels through OpenRouter's Anthropic-compatible
+  skin, which speaks the Messages API's thinking budget rather than
+  `reasoning.effort` directly. What this table records is what the *model*
+  accepts, not proof that a given `--effort` value arrives as that level. Where
+  the effort lever matters to an outcome, treat model choice as the reliable
+  control and the effort level as a hint.
 
 ## Selection by task bucket
 
@@ -26,27 +50,23 @@ will drift.
 | Standard implementation | `moonshotai/kimi-k2.7-code` | `google/gemini-3.1-flash-lite` or `z-ai/glm-5.2` | `openai/gpt-5.6-terra` or `moonshotai/kimi-k3` |
 | Architecture / judgment-heavy | `moonshotai/kimi-k3` | `openai/gpt-5.6-terra` | `openai/gpt-5.6-sol` or `anthropic/claude-opus-4.8` |
 
-`z-ai/glm-5.2` is a good universal fallback when the task is agentic
-(multi-step, tool-using) but still cost-sensitive — cheaper than the Kimi
-code tier at a similar context window, with confirmed reasoning support.
+`z-ai/glm-5.2` is the cheapest output in its price band and holds a 1M context,
+which keeps it useful for long-horizon agentic work. It is no longer the
+all-purpose cheap fallback it once was: its input price now sits within two
+cents of the Kimi code tier, and accepting only `high`/`xhigh` means it cannot
+be run cheaply on mechanical work. For that, step down to
+`google/gemini-3.1-flash-lite`.
 
 ## Anthropic-compatibility mechanics
 
 `https://openrouter.ai/api` exposes an Anthropic Messages API–compatible
 endpoint (OpenRouter's "Anthropic Skin"), which is what lets
-`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` route a stock Claude Code
-process through it. Compatibility is not complete, though: responses that end
-on a reasoning block break the client, which is why this skill routes through
-the local repair proxy rather than pointing at OpenRouter directly (see
-`proxy-contract.md`). Model IDs are OpenRouter's normal
-`vendor/model-slug` form — no extra prefixing needed beyond what's in this
-table. OpenRouter also normalizes a `reasoning.effort` parameter
-(`none`/`minimal`/`low`/`medium`/`high`/`xhigh`, internally mapped to a
-token-budget ratio of `max_tokens`) across providers that support it, but not
-every provider honors it — some silently drop reasoning tokens.
-
-Sources checked 2026-07-18: OpenRouter's Claude Code integration cookbook,
-each model's own OpenRouter page, and the OpenRouter reasoning-tokens guide.
+`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` route a stock Claude Code process
+through it. Compatibility is not complete: responses that end on a reasoning
+block break the client, which is why this skill routes through the local repair
+proxy rather than pointing at OpenRouter directly (see `proxy-contract.md`).
+Model IDs are OpenRouter's normal `vendor/model-slug` form — no extra prefixing
+beyond what is in this table.
 
 ## Supplemental registry
 
@@ -66,13 +86,18 @@ object keyed by model ID:
     "input_per_m": 0.00,
     "output_per_m": 0.00,
     "context": "...",
-    "effort_param": "confirmed | not confirmed | unknown",
+    "supported_efforts": ["low", "high"],
     "best_for": "...",
     "added": "YYYY-MM-DD",
-    "source": "user-reported | researched: <url>"
+    "source": "user-reported | catalog | researched: <url>"
   }
 }
 ```
+
+An entry written before 2026-07-25 may carry `effort_param` instead, whose
+`confirmed` value means only that the model reasons — not which levels it
+takes. Treat that as levels-unknown and re-read it from the catalog when it
+matters.
 
 ## Unknown Model Workflow
 
@@ -82,14 +107,13 @@ above nor the supplemental registry.
 1. Tell the user plainly: this skill has no pricing, context, or effort data
    on that model.
 2. Ask them to choose — **(a)** proceed with it as specified, accepting that
-   cost and capability are unverified, or **(b)** research it now (its
-   OpenRouter model page: pricing, context window, whether it honors
-   `reasoning.effort`).
-3. If they choose research, gather it and present what you found *and from
-   where* for confirmation before using it. Don't silently trust a single
-   scraped page for something that drives both cost and tool-grant risk. Ask
-   the user for any field you couldn't find — if the model page doesn't say
-   whether it honors `reasoning.effort`, ask rather than assuming.
+   cost and capability are unverified, or **(b)** look it up now in the catalog
+   endpoint, which carries `pricing`, `context_length`, `top_provider`, and
+   `reasoning.supported_efforts` for every listed model.
+3. Present what you found *and from where* for confirmation before using it.
+   If the model is absent from the catalog entirely, say so — that means
+   OpenRouter does not serve it, and no amount of further searching will
+   change the dispatch outcome.
 4. Once confirmed, ask whether to persist it for future invocations. If yes,
    create `~/.config/agents-config/` if absent and write or update the entry
    using the schema above.


### PR DESCRIPTION
Deferred out of #401. Re-captured from `https://openrouter.ai/api/v1/models` — OpenRouter's public catalog endpoint, authoritative for price, context length, max output, and supported reasoning efforts. It is machine-readable and unauthenticated, so the next refresh is one request rather than ten model pages read by eye; the table now says so.

**No model was retired.** All ten still resolve.

## Prices — 3 of 10 moved

| Model | Was | Now | Δ |
|---|---|---|---|
| `z-ai/glm-5.2` | $0.30 / $0.94 | **$0.76 / $2.39** | +153% / +154% |
| `moonshotai/kimi-k2.6` | $0.66 / $3.41 | **$0.65 / $2.72** | −2% / −20% |
| `moonshotai/kimi-k2.7-code` | $0.72 / $3.50 | **$0.78** / $3.50 | +8% input |

Confirmed unchanged **by row, not by omission**: `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gpt-5.6-luna`, `gpt-5.6-terra`, `kimi-k3`, `claude-opus-4.8`, `gpt-5.6-sol`.

## The effort column was wrong, not stale

It read `confirmed` for all ten rows. The catalog reports discrete supported levels, and they differ materially:

- **`kimi-k2.6` and `kimi-k2.7-code` accept no effort level at all** — reasoning is on/off. Two rows claimed a capability that does not exist.
- **`glm-5.2` accepts only `high` and `xhigh`.** There is no cheap low-effort run on it, which undercuts its former billing as the all-purpose cost-sensitive fallback.
- **`kimi-k3` accepts `low`/`high`/`max`** — no `medium`, and no `xhigh`. Step 3's rubric routes architecture work to "`high` or `xhigh`", so it was pointing at a level this model does not have.
- The Gemini pair top out at `high`; the GPT-5.6 family takes the full range.

The column now lists actual levels. `SKILL.md` Step 3 sends the reader to that list instead of assuming a level exists.

**One honest caveat added rather than papered over:** whether `--effort` reaches the model *as* `reasoning.effort` is unverified. It crosses OpenRouter's Anthropic-compatible skin, which speaks the Messages API thinking budget. What this table records is what the model accepts, not proof of what arrives. The doc now says exactly that.

## Also

- Context lengths normalized — `1,048,576` was written both `1M` and `1.05M` in the same table. Max output added per row.
- Registry schema's `effort_param` → `supported_efforts`, with a back-compat note that a pre-2026-07-25 `confirmed` means only "it reasons", levels unknown.
- Unknown Model Workflow now points at the catalog endpoint, and says that absence from the catalog means OpenRouter does not serve the model — no amount of further searching changes the dispatch outcome.
- Bucket picks need no structural change at the new prices. The `glm-5.2` note did.

## Verification

- Skill body **1,413 / 2,000** tokens via the installer's own `sanitize_text` + `approx_tokens` — 587 of headroom retained.
- `make spec-lint` clean.
- No live model call was needed; the catalog endpoint requires no key and costs nothing.

Closes `agents-config-9k9.55`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BK4UXfEaUr7pAmtAGsNSr