### PR TITLE
chore(9k9.63): de-rot the always-on instruction surfaces + add a staging hard-line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,24 +4,26 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Purpose
 
-This is a versioned collection of agents, skills, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
+A versioned collection of agents, skills, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
 
 ## Harness Rework (active — read this first)
 
-The harness this repo shipped through mid-2026 obstructed its own mission and is being rebuilt. Until the rework milestone closes (charter AC9), orient new work against these sources, in this order:
+The harness is being rebuilt. Until the rework milestone closes (charter AC9), orient new work against these sources, in this order:
 
 1. `docs/specs/2026-07-21-harness-rework-way-forward.md` — the canonical charter: all decisions (D1–D20), acceptance criteria (AC1–AC9), the ordered slice plan (S0–S10), and the zero-based user AGENTS.md draft (Appendix A). If you read only one file, read this one.
-2. `work show agents-config-9k9` — where "where are we right now" lives: the milestone bead carries the charter pointer, records facade gaps in its notes, and its children are the live status of what's minted, in-flight, and done. The charter deliberately tracks no progress.
-3. `SAVEPOINTS/2026-07-20-harness-findings-handoff.md` — the findings that motivated the charter: why the old harness failed and the evidence behind the decisions. Read when a decision seems underjustified.
-4. `docs/specs/2026-07-22-workcli-completion-s2.md` — the S2 child spec: the current state of the `work` facade, and the worked example of the per-slice pattern (child spec → per-slice ACs → implement).
+2. `work show agents-config-9k9` — where "where are we right now" lives: the milestone carries the charter pointer, records facade gaps in its notes, and its children are the live status of what is minted, in flight, and done. The charter deliberately tracks no progress.
+3. `SAVEPOINTS/2026-07-20-harness-findings-handoff.md` — the evidence behind the charter's decisions. Read when a decision seems underjustified.
+4. `docs/specs/2026-07-22-workcli-completion-s2.md` — the S2 child spec, and the worked example of the per-slice pattern (child spec → per-slice ACs → implement).
 
 Standing implications while the rework runs:
 
 - Where any deployed rule, skill, or doc (including this file) contradicts the charter, the charter wins — and flag the contradiction explicitly so it gets fixed.
 - Address the tracker through the `work` facade (D11). Fall back to `bd` only when the facade cannot express the operation, and record each fallback as a facade gap in a note on `agents-config-9k9`.
-- New harness work enters only as a child of the milestone, carrying an admission record: the failure it prevents, what it costs, and what observation would remove it (D16/D20).
-- Any proposal to add a rule/skill/command/agent to `src/`, or to lift one out of `archive/`, runs through the `admit-request` skill (`.claude/skills/admit-request/`) — a project-scoped gate, not a deployed asset. Its default verdict is DECLINE; there is no grandfathering.
-- **`src/` is admitted content only; `archive/` is not live.** The installer's admission gate drops any rule/skill/command/agent without a complete `admission:` record. What it admits, it sanitizes: the `admission:`/`claims:` front matter and the provenance comment are repo-side bookkeeping and are stripped from the deployed bytes, so write them for this repo's reader, not the downstream agent's. Every record-less artifact now sits under `archive/src/user/**`. Nothing under `archive/` describes current behaviour — do not follow it, cite it as a contract, or invoke a skill found there. If a workflow you need exists only in `archive/`, that is the signal to escalate, not to reinstate it by hand.
+- New harness work enters only as a child of the milestone, carrying an admission record: what it prevents or provides, what it costs, and what observation would remove it (D16/D20).
+- Any proposal to add a rule/skill/command/agent to `src/`, or to lift one out of `archive/`, runs through the `admit-request` skill — a project-scoped gate, not a deployed asset. Its default verdict is DECLINE; there is no grandfathering.
+- **`archive/` is not live.** Nothing under it describes current behaviour — do not follow it, cite it as a contract, or invoke a skill found there. If a workflow you need exists only in `archive/`, that is the signal to escalate, not to reinstate it by hand.
+- **The admission gate decides what deploys, not the folder.** The installer drops any rule/skill/command/agent whose front matter lacks a complete `admission:` record, wherever it sits — `src/plugins/*/` currently ships four rules with no record, so they deploy nothing. What the gate admits, it sanitizes: the `admission:`/`claims:` front matter and the provenance comment are repo-side bookkeeping, stripped from the deployed bytes. Write them for this repo's reader, not the downstream agent's.
+- **Presence in `src/` is not evidence of deployment.** Before telling a user or a subagent that a skill, rule, or command is available, list the tool's own config directory and confirm it landed.
 
 ### How work ships here
 
@@ -29,8 +31,9 @@ This is the whole delivery contract:
 
 1. Enter the work in the tracker via `work` verbs, as a child of `agents-config-9k9`, with an admission record.
 2. Implement on a worktree branch; never commit to the default branch.
-3. Verify mechanically before claiming anything: `make ci` for `packages/**`; for prose-only changes, state what you checked and how.
-4. Open a PR, address review to quiescence, then merge only under `project-config.toml`'s `[merge-policy]` — absent that section, an explicit human instruction.
+3. Verify mechanically before claiming anything. For `packages/**` that is `make ci` — read the `ci` target in the `Makefile` for its current membership, and note that a single package's gate is not the whole-repo gate. For prose-only changes, state what you checked and how.
+4. Open a PR and address review to quiescence.
+5. **Merge only on an explicit human instruction.** `project-config.toml` declares `merge-authorization = "rule-based"`, but no implementation of that policy is deployed and the repository ruleset requires an approving review that no configured reviewer submits — see `agents-config-9k9.23`. Read those sections as inert, never as authorization.
 
 ## Vision & Mission
 
@@ -40,97 +43,71 @@ This is the whole delivery contract:
 
 **Prime directive** — *Get the human out of the agent-babysitting job.* When prioritizing work or resolving trade-offs in this repo, the tiebreaker question is: does this reduce human interventions per merged PR? Prefer the option that moves human time upstream (specs, judgment) or into thin verification gates; reject work that adds polish without reducing interventions.
 
-**Mission** — Ship a portable discipline layer (agents, skills, commands, formulas, plugins) that makes that operating ratio achievable on any major AI coding assistant. The mechanism rests on five load-bearing commitments:
+**Mission** — Ship a portable discipline layer that makes that operating ratio achievable on any major AI coding assistant. The mechanism rests on five load-bearing commitments:
 
 1. **Frontload human creativity & judgment** via rigorous brainstorming and a spec-readiness gate
 2. **Make AI good at saying "no, not ready"** — bounce under-specified work back BEFORE implementation, with structured feedback on what is missing
-3. **Substitute adversarial cross-model review** for human review wherever quality permits (RALF, foreign-CLI configs, codex adversarial review)
-4. **Guardrail every completion claim with mechanical evidence** (completion gate, verify-checklist)
-5. **Persist context** (work tickets, memories, formulas) so work survives compaction, agent handoff, and overnight runs
+3. **Substitute adversarial cross-model review** for human review wherever quality permits
+4. **Guardrail every completion claim with mechanical evidence**
+5. **Persist context** (work items, memories) so work survives compaction, agent handoff, and overnight runs
+
+Commitments 3 and 4 have no deployed implementation right now; the charter's slice plan owns what replaces them. Do not go looking for the retired one.
 
 ### Design principles for this repo
 
 - **Code over Prose** — anything code can do better than agents, we move out of prose and into code helpers
 - **Python/Go/Node over Bash** — thin shell script wrappers are fine; any logic that needs testing goes in Python, Go, or Node
-- **Consolidate over conflict** — where plugins' assets overlap, merge the best-of-breed into the canonical source; avoid competing instructions
+- **Consolidate over conflict** — where assets overlap, merge the best-of-breed into the canonical source; avoid competing instructions
 - **The `work` facade is the tracker interface** — address the tracker through `work` verbs (charter D11); the harness never speaks `bd`. Fall back to `bd` only for operations the facade can't express, and record each fallback as a facade gap (note on `agents-config-9k9`)
 - **Flag confusing context** — if instructions, rules, or skills in this repo are conflicting or unclear, say so explicitly; cleaning up agent context is a first-class priority
 - **Apply backpressure** — if a requested change doesn't clearly align with "cleaning house" or "advancing the vision", push back and ask how it fits before proceeding
 
 ## Project Architecture
 
-It's simple: this project hosts "agent configuration" (and tools, helpers, etc.) under `src/` that are installed into the user space (e.g. `~/.claude/`, et. al) using the install script.  The installer will expand content into the target agents' config files, e.g. since only claude supports rules, the rules are expanded into codex's AGENTS.md file.  THUS whenever we're discussing making a change to a skill, an agent, a command, a rule, etc., your FIRST AND ONLY PLACE TO MAKE CHANGES is under the `src/**` folders' contents unless explicitly told otherwise.
+This project hosts agent configuration under `src/`, which the install script deploys into user space (`~/.claude/`, `~/.codex/`, `~/.gemini/`, `~/.config/opencode/`). **When changing a skill, agent, command, rule, or any other configuration artifact, `src/` is your first and only place to make changes** unless explicitly told otherwise.
 
 **Implications:**
 
-- **Always edit source, never deployed artifacts** — when the user asks to change a skill, agent, command, rule, or any other configuration artifact, edit the source file under `src/` (e.g., `src/user/.agents/skills/`, `src/user/.claude/rules/`). Files under `~/.claude/`, `~/.codex/`, `~/.gemini/`, etc. are deploy outputs and will be overwritten on the next installer run. If you catch yourself editing a path outside `src/`, stop and find the source equivalent.
-- **No file-path citations in specs or prose** — Remember that the files that get written into the user space get used in OTHER projects.  Thus our assets CANNOT reference project-internal resources.  `AGENTS.md.template` and all shared templates are flattened into per-tool assembled files at install time via `DYNAMIC-INCLUDE`. File-path citations (`AGENTS.md > <section>`) are dead-ends after assembly. Always reference shared content by concept or block name (e.g., "the shared decision rules", "the `<decisions>` block") so cross-references survive flattening.
+- **Always edit source, never deployed artifacts** — files under `~/.claude/`, `~/.codex/`, `~/.gemini/` and `~/.config/opencode/` are deploy outputs and are overwritten on the next installer run. If you catch yourself editing a path outside `src/`, stop and find the source equivalent.
+- **No file-path citations in deployed prose** — deployed assets get used in OTHER projects, so they cannot reference this project's resources. Shared templates are flattened into per-tool assembled files at install time via `DYNAMIC-INCLUDE`, which makes a file-path citation a dead end after assembly. Reference shared content by concept or block name (e.g. "the shared decision rules", "the `<decisions>` block") so cross-references survive flattening.
 - **NEVER run `scripts/install.sh` or `scripts/install.py` automatically** — only the user runs the installer, and only when they explicitly say so
-- **Placement by capability-dependency, not asset type** — a new skill/agent/rule goes in the shared tree `src/user/.agents/` only if it works on every supported tool; anything that depends on tool-specific capabilities (e.g. Claude subagent orchestration, the Skill tool, AskUserQuestion, hooks) goes in that tool's tree (e.g. `src/user/.claude/skills/`)
+- **Placement by capability-dependency, not asset type** — an artifact goes in the shared tree `src/user/.agents/` only if it works on every supported tool; anything depending on tool-specific capabilities (Claude subagent orchestration, the Skill tool, AskUserQuestion, hooks) goes in that tool's tree
 
 ## Repository Structure (current, not target state)
 
-- `scripts/` - Installation and maintenance scripts
-  - `install.sh` - Thin exec stub; delegates to the uv-managed Python installer (`packages/installer`) via `uv run`
-  - `install.py` - Python entry point (`from installer.cli import main`); also invocable as `uv run python -m installer`
-- `archive/` - Retired content, mirroring the live tree's shape (`archive/src/user/**`, `archive/docs/**`). **Historical only — never a behavioural contract.** Read it to recover an idea; do not follow it, cite it, or copy a path back into `src/` without an admission record
-- `docs/guide/` - **User guide** for people *using* the deployed assets: how to install, configure a project, and run the opinionated agentic SDLC (`index`, `getting-started`, `configuration`, `sdlc-workflow`, `reference`)
-- `docs/plans/` - Design documents for features in development
-- `docs/specs/` - Design specifications (point-in-time proposals; date-prefixed filenames; status varies from draft through implemented)
-- `docs/primers/` - Knowledge base of specific subjects to augment what you already know, or can get through your tools, about key primitives in this architecture (skills, agents, rules, commands, bead formulas, etc.)
-- `docs/architecture/` - **High-level design (HLD) artifacts** for major subsystems: C4 diagrams (Context / Container / Component / Deployment), sequence diagrams, state machines, data-flow / persistence views. Grouped per subsystem in its own subfolder (e.g. `docs/architecture/pdlc-orchestrator/`). **Evergreen reference material** — amended in place as systems evolve; filenames are undated and describe content (e.g. `c4-l1-context.md`, `state-machine.md`). Distinct from `docs/specs/` (dated point-in-time proposals) and `docs/primers/` (prose explainers for the discipline layer itself). Each subfolder has an `index.md` orientation file referenced from its source design spec(s)
-- `src/user/.agents/` - **Shared content** (copied into all detected tools)
-  - `agents/` - Role-based agent definitions (frontmatter + instructions)
-  - `skills/` - Methodology guides, some with supporting code/scripts
-  - `rules/` - Tool-agnostic workflow rules; same-name collisions append-merge
-  - `AGENTS.md.template` - Zero-based shared laws, decision matrix, hard lines, and conventions (D17)
-  - `AGENT-PERSONA.md.template` - Agent persona/personality template
-  - `USER-PERSONA.md.template` - User persona template
-- `src/user/.claude/` - **Claude-specific** content (copies to `~/.claude/`)
-  - `commands/` - Slash command definitions (`.md`)
-  - `skills/` - Claude-only skills (skills that depend on Claude-specific capabilities); cross-tool skills are sourced from `src/user/.agents/skills/`
-  - `rules/` - Claude-specific rules (rules that only apply to Claude contexts); general rules are sourced from `src/user/.agents/rules/`
-  - `workflows/` - Claude `Workflow` scripts. **Not admission-gated** — these deploy without a record (`agents-config-9k9.21`)
-  - `AGENTS.md.template` - Claude instruction file (refs shared + Claude extensions)
-  - `CLAUDE.md.template` - Points to AGENTS.md
-  - `CLAUDE-EXTENSIONS.md.template` - Stub header (content moved to `rules/`)
-  - `settings.json.template` - Permission presets, hooks, and experimental features
-- `src/user/.codex/` - **Codex-specific** content (copies to `~/.codex/`)
-  - `AGENTS.md.template` - Codex instruction file (refs shared + Codex extensions)
-  - `CODEX-EXTENSIONS.md.template` - Codex-specific sections (placeholder)
-- `src/user/.gemini/` - **Gemini-specific** content (copies to `~/.gemini/`)
-  - `GEMINI.md.template` - Gemini instruction file (refs shared + Gemini extensions)
-  - `GEMINI-EXTENSIONS.md.template` - Gemini-specific sections (placeholder)
-- `src/user/.opencode/` - **OpenCode-specific** content (flattens to `~/.config/opencode/`)
-  - `AGENTS.md.template` - Flat instruction skeleton with dynamic-include markers
-  - `OPENCODE-EXTENSIONS.md.template` - OpenCode-specific notes and conventions
-  - `opencode.jsonc.template` - Settings (model, permissions, skills paths)
-- `src/plugins/` - **Optional plugin content** (auto-detected and installed by the Python installer via a directory scan of `src/plugins/`; a plugin's rules deploy only when its tool is detected)
-  - `beads/` - beads plugin: ships two rules — `beads.md` (bd CLI gotchas) and `discovered-work.md` (sibling-test placement). Gets a specialized adapter that also routes `~/.beads/`. The bd instruction surface is slated for deletion from agent reach once the `work` cutover completes (charter D11)
-  - `graphify/` - graphify plugin: the graphify discipline rule (shared)
-  - `codex/` - codex plugin: the Codex routing rule (Claude-only)
-- `packages/` - **Real Python packages** (standalone uv projects, each with its own `pyproject.toml`; not part of the installed config surface)
-  - `installer/` - the installer engine that `scripts/install.sh` execs; CI-gated (`make ci-installer`)
-  - `prgroom/` - deterministic PR-grooming CLI; CI-gated (`make ci-prgroom`). Per charter D13 it is **carved, not finished** (slice S8): retain the `gh`/`git` clients, config, error taxonomy, and escalation typing; delete reply/poll/wait/snapshot/legacy-export and the in-package fix-dispatch machinery; add a thin verdict harvester and merge-eligibility evaluation. The `wait-for-pr-comments`, `reply-and-resolve-pr-threads`, and `monitor-pr` skills are slated for deletion (AC5) but remain deployed until S8 lands. **Installed onto PATH by the installer** (`uv tool install`, receipt-tracked, pruned on retirement)
-  - `workcli/` - the `work` facade CLI: quarantines the issue-tracker backend (bd) behind a stable JSON-envelope contract, verbs over an injected `Backend` seam; CI-gated (`make ci-workcli`). Driven by the S2 completion spec (`docs/specs/2026-07-22-workcli-completion-s2.md`), which supersedes the 2026-07-04 work-facade contract spec where they conflict. The D11 pipeline verb set is implemented (S2 closed): mint incl. the milestone noun, ready/claim, park/redispatch/abandon with typed reasons, close with close-walk atomicity, dependency edges, containment; re-parenting is a recorded facade boundary. **Installed onto PATH by the installer** (`uv tool install`, receipt-tracked, pruned on retirement)
-  - `grind/` - the event-sourced grind runtime: event schema + FSM fold plus the `grind` CLI (`create`/`log`/`status`/`check`/`render`/`finish`) that D14 nominates as the pipeline executor loop; CI-gated (`make ci-grind`). **Installed onto PATH by the installer** (`uv tool install`, receipt-tracked, pruned on retirement)
-  - `pdlc/` - PDLC Orchestrator: the deterministic FSM engine intended to drive Objectives through the lifecycle. Early — happy-path tracer bullet only; not yet CI-gated
-  - `holding-place/` - Idea pipeline + the Promote contract into the PDLC Orchestrator. Early; not yet CI-gated
-- `project-config.toml` - part of the target architecture, contains key project-level configuration for how skills, agents, rules, etc. should behave for things like validation, agent delegation, etc.
+- `scripts/` — installer entry points and maintenance scripts. `install.sh` is a thin exec stub delegating to the uv-managed Python installer in `packages/installer`; `install.py` is the Python entry point. See `scripts/AGENTS.md`.
+- `src/` — **the deployed surface.** Everything installed into user space is authored here.
+  - `src/user/.agents/` — shared content, staged into every active tool: `skills/`, `rules/`, and `USER-CORE.md.template` (the zero-based laws, decision matrix, hard lines, and conventions, D17). See `src/user/.agents/AGENTS.md` for the install model and the name-collision rules.
+  - `src/user/.claude/` — Claude-only: `skills/`, `rules/`, `hooks/`, `AGENTS.md.template`, `CLAUDE.md.template`, `settings.json.template`
+  - `src/user/.codex/`, `src/user/.gemini/`, `src/user/.opencode/` — per-tool instruction templates; OpenCode additionally carries `opencode.jsonc.template` and gets a flat, dynamically-built instruction file rather than `@` includes
+  - `src/plugins/` — optional plugin content, auto-detected by a directory scan (`beads/`, `codex/`, `graphify/`). A plugin's content deploys only when its tool is detected **and** the artifact clears the admission gate.
+  - Each rules directory carries its own `AGENTS.md` stating what currently lives there; read it rather than inferring from the folder's contents.
+- `archive/` — retired content mirroring the live tree's shape (`archive/src/user/**`, `archive/docs/**`). **Historical only — never a behavioural contract.** Read it to recover an idea; do not copy a path back into `src/` without an admission record.
+- `docs/`
+  - `guide/` — user guide for people *running* the deployed assets: install, configure a project, run the agentic SDLC
+  - `specs/` — dated point-in-time design proposals; status varies from draft through implemented
+  - `architecture/` — evergreen HLD artifacts (C4 levels, sequence diagrams, state machines, data-flow views), grouped per subsystem with an `index.md` orientation file. Amended in place; filenames are undated and describe content.
+  - `primers/` — explainers for the key primitives of this architecture (skills, agents, rules, commands, formulas)
+  - `plans/`, `adr/`, `reference/`, `prototypes/`, `beads/` — supporting material
+- `packages/` — standalone uv projects; **not** part of the installed config surface.
+  - `installer/` — the installer engine that `scripts/install.sh` execs
+  - `workcli/` — the `work` facade CLI: quarantines the issue-tracker backend behind a stable JSON-envelope contract. Driven by `docs/specs/2026-07-22-workcli-completion-s2.md`, which supersedes the 2026-07-04 work-facade contract spec where they conflict.
+  - `grind/` — the event-sourced grind runtime: event schema, FSM fold, and the `grind` CLI that D14 nominates as the pipeline executor loop
+  - `prgroom/` — PR-grooming CLI. Per charter D13 it is **carved, not finished** (slice S8).
+  - `pdlc/`, `holding-place/`, `vizsuite/`, `contracts/` — earlier-stage packages
+  - `workcli`, `prgroom` and `grind` are the only packages installed onto PATH (`uv tool install`, receipt-tracked, pruned on retirement), landing as the `work`, `prgroom` and `grind` commands; `installer/core/clis.py` holds that list. Most packages carry their own `AGENTS.md` with a scoped workflow — read it before changing that package.
+- `project-config.toml` — project-level configuration for how skills, agents, and rules behave. Its merge sections are inert; see the delivery contract above.
 
 Other notes:
 
-- Most of the repo (config content under `src/`) is documentation and templates with no build step — changes there just follow existing formatting conventions per file type.
-- **Exception — the packages under `packages/` are real Python code with mandatory quality gates.** `make ci` (the whole-repo gate CI enforces) runs `ci-installer` + `ci-prgroom` + `ci-workcli` + `lint-actions`. Before pushing a change under `packages/installer/` run `make ci-installer`; under `packages/prgroom/` run `make ci-prgroom`; under `packages/workcli/` run `make ci-workcli`. Each gate runs lint, format-check, typecheck, coverage, audit, and entry-verify. See the package's own `AGENTS.md` for its scoped workflow. (`packages/pdlc/` and `packages/holding-place/` are early and not yet wired into `make ci`.)
-
+- Content under `src/` is documentation and templates with no build step — changes there follow existing formatting conventions per file type.
+- **Exception — `packages/` is real Python code with mandatory quality gates.** `make ci` is the whole-repo gate CI enforces; each gated package also has its own `ci-<package>` target running lint, format-check, typecheck, coverage, audit, and entry-verify. Read the `Makefile` for which packages are currently in `ci` — not every package under `packages/` is wired in.
 
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a graphify knowledge graph at `graphify-out/`, tracked in git.
 
-Rules:
-- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
-- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
-
+- **Check its freshness before trusting it.** Compare the mtime of `graphify-out/graph.json` against the files you care about; a stale graph and a current one are indistinguishable at the point of use. The refresh, and the branch conflict it runs into, are owned by `agents-config-9k9.65`.
+- `graphify-out/GRAPH_REPORT.md` carries god nodes and community structure, useful for orienting in an unfamiliar subsystem.
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files.
+- Regenerating the graph is not a side task: the deployed graphify rule forbids committing `graphify-out/` from a worktree onto a feature branch, which collides with this repo's "never commit to the default branch". Do not resolve that on your own — it is the open question on `agents-config-9k9.65`.

--- a/src/user/.agents/USER-CORE.md.template
+++ b/src/user/.agents/USER-CORE.md.template
@@ -19,6 +19,7 @@ Narrow "when in doubt, do the safe thing" rules (merge authorization, destructiv
 
 <hard-lines>
 - No hard resets, force pushes, amends, or `git clean -fd` without explicit approval.
+- Stage by explicit path. `git add -A`, `git add .` and `commit -a` sweep in untracked artifacts and other agents' in-flight files; read `git status` first and name what you are committing.
 - Creating a PR is not authorization to merge. Absent an explicit instruction or a configured rule-based policy, do not merge.
 - Before deleting or overwriting work you didn't create, look at it; surface contradictions instead of proceeding.
 </hard-lines>


### PR DESCRIPTION
Closes work item `agents-config-9k9.63`.

Two always-on surfaces load on every session and neither was doing its job: the root `AGENTS.md` asserted things the tree contradicts, and the shared instruction template had no constraint at the git staging layer.

## 1. Root `AGENTS.md` — verified against the tree

Every claim was inventoried, checked, and either corrected or cut. What was false:

| Claim | Reality |
|---|---|
| `make ci` runs installer + prgroom + workcli + lint-actions | `Makefile:21` also runs `ci-vizsuite`, `ci-grind`, `spec-lint` |
| `wait-for-pr-comments`, `reply-and-resolve-pr-threads`, `monitor-pr` "remain deployed until S8 lands" | None deployed, none in `src/` |
| `packages/` inventory | omitted `contracts/` and `vizsuite/` |
| `src/user/.agents/AGENTS.md.template`, `AGENT-PERSONA`, `USER-PERSONA`, `agents/` | none exist; the real file is `USER-CORE.md.template` |
| four `*-EXTENSIONS.md.template` files, `src/user/.claude/workflows/` | do not exist |
| "Every record-less artifact now sits under `archive/src/user/**`" | the four rules under `src/plugins/*/` carry no record and deploy nothing |
| `graphify-out/wiki/index.md` as preferred entry point | does not exist |

Also corrected during self-review, before commit: "each package with its own `pyproject.toml`" (`contracts/` has none) and "installer … installed onto PATH" (only `workcli`, `prgroom`, `grind` are in `CLI_PACKAGES`).

Structural changes beyond fact-fixing:

- **Merge authorization is now stated as explicit human instruction only.** `project-config.toml`'s `[merge-policy]` is marked inert, pointing at `9k9.23` — which records empirically that the main-protector ruleset requires an APPROVING review that Codex never submits, so the declared rule-based policy cannot pass by construction.
- Per-package descriptive detail delegated to each package's own `AGENTS.md`; `make ci` membership delegated to the `Makefile`. Authorities that cannot drift from themselves.
- Added: presence in `src/` is not evidence of deployment — verify against the tool's config directory before telling anyone a skill is available.
- Net −22 lines, and the remaining claim surface is materially smaller.

## 2. Staging hard-line

```
- Stage by explicit path. `git add -A`, `git add .` and `commit -a` sweep in
  untracked artifacts and other agents' in-flight files; read `git status`
  first and name what you are committing.
```

`<hard-lines>` covered resets, force-push, amend and `git clean -fd` but nothing at the staging layer, while `Bash(git add:*)` is blanket-allowlisted — so `git add -A` never prompts and `git commit` does, i.e. the prompt arrives after the debris is staged.

Placed in `<hard-lines>` because the decision matrix explicitly defers to hard lines on destructive git. Always-on surface measures **465 tokens** against its 10k cap.

**Admission outcomes recorded:** `archive/src/user/.agents/rules/worktrees.md` and `archive/src/user/.claude/rules/worktree-safety.md` were evaluated for admission and **DECLINED** — both fail the always-on test's *unconditional* check (they apply only while using worktrees) and the paragraph-sized sub-budget. Reopens if their content is re-proposed as an invoked skill.

## Verification

- `make spec-lint` — exit 0
- Every path, directory, Makefile target and package named in the new file enumerated against the working tree
- Universal-quantifier sweep (`every|all|only|never|always|each`) run over the rewritten file; two overclaims found and fixed before commit
- Two path-scoped commits, one per concern — no `git add -A`

## Follow-ups filed, not done here

- `agents-config-9k9.64` — reinstate the autonomous-merge authorization once the gate is executable (blocked on `9k9.23` + `9k9.28`)
- `agents-config-9k9.65` — refresh the stale tracked `graphify-out/`, and resolve the rule conflict that blocks it

## Known, deliberately out of scope

`src/user/.agents/skills/AGENTS.md` (the shared skills provenance registry) still lists `verify-checklist`, `wait-for-pr-comments` and `reply-and-resolve-pr-threads` as live rows. Same defect class, different file and review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRbvTspQ3teKePpDC6hJXs