### PR TITLE
feat(grind): count fix attempts in the fold (S9 Tier 1, Slice B)

### DIFF
--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -240,9 +240,15 @@ must pass before push.
   attempt, so a count past its budget keeps climbing and the condition keeps
   reporting the larger number; refusing, parking, and spending the budget
   belong to the decision layer. Two consequences worth not re-litigating:
-  - *An attempt is gated on the PR ref, not on status* — the same key and the
-    same post-`pr_closed` permissiveness as a failure-axis park, for the same
-    reason: an attempt is a statement about fixing a PR that has not merged.
+  - *An attempt is gated on an **open** PR, keyed on the ref and not on
+    status.* Status cannot answer it — `in-progress` is reachable both with an
+    open PR (via `item_resumed`) and with a closed one (via `pr_closed`) — so
+    `pr_closed` marks `PrRef.closed` and the gate reads that. This is where the
+    attempt rule and the failure-axis park rule deliberately diverge despite
+    reading the same field: a park states that this item's PR did not merge,
+    which stays true after the PR closes, while an attempt claims to be fixing
+    one that is still open. Hence the ref survives a close for the park's sake
+    and is marked closed for the attempt's.
   - *The ledger's lifetime is one PR cycle.* `pr_closed` clears it (a new PR
     must not inherit spent budget) and `item_enqueued` clears it (leaving the
     parking lot deliberately grants a fresh window). No other event does —

--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -259,7 +259,12 @@ must pass before push.
   source state and a second exit from the lot. The optional `closure` payload
   instead adds the closed-ledger entry and drops the PR ref (with the review
   history belonging to it) as the item re-enters play; without it the ref
-  survives, which is what makes a plain re-enqueue resume the same PR.
+  survives, which is what makes a plain re-enqueue resume the same PR. The
+  closure must name the PR the item actually holds — the boundary can only
+  check that the number is an integer, so a mistyped one would record a
+  closure for a PR this item never had *and* discard the live ref the park
+  rule and the attempt gate read. A mismatch is accept-and-flag: the closure
+  does not apply, the enqueue still does.
 
 ## Tests
 

--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -264,7 +264,12 @@ must pass before push.
   check that the number is an integer, so a mistyped one would record a
   closure for a PR this item never had *and* discard the live ref the park
   rule and the attempt gate read. A mismatch is accept-and-flag: the closure
-  does not apply, the enqueue still does.
+  does not apply, the enqueue still does. Note what "an integer" has to mean
+  here: `bool` is an `int` subclass and `True == 1`, so a replayed `"pr": true`
+  would satisfy both the type check and the match against PR 1. Every `pr`
+  field in the fold therefore goes through `_int`, which excludes bools — the
+  same exclusion `payloads._is_int` makes at the boundary that replayed events
+  never cross.
 
 ## Tests
 

--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -240,8 +240,10 @@ must pass before push.
   attempt, so a count past its budget keeps climbing and the condition keeps
   reporting the larger number; refusing, parking, and spending the budget
   belong to the decision layer. Two consequences worth not re-litigating:
-  - *An attempt is gated on an **open** PR, keyed on the ref and not on
-    status.* Status cannot answer it — `in-progress` is reachable both with an
+  - *An attempt is gated on an **open, identifiable** PR, keyed on the ref and
+    not on status.* A ref whose number did not survive the log names no cycle
+    anything can act on, so it does not pass — the same predicate the closure
+    guard requires. Status cannot answer it — `in-progress` is reachable both with an
     open PR (via `item_resumed`) and with a closed one (via `pr_closed`) — so
     `pr_closed` marks `PrRef.closed` and the gate reads that. This is where the
     attempt rule and the failure-axis park rule deliberately diverge despite

--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -234,10 +234,12 @@ must pass before push.
   per-kind count onto `Item.attempts`; `ci_fix_budget`/`rebase_budget` are
   `config` numbers the `attempt_budget_spent` condition compares those counts
   against — the same caller-seeded-threshold shape as `stalemate_risk_round`,
-  and the same tolerance for garbage config. Nothing here refuses an attempt,
-  so a count past its budget keeps climbing and the condition keeps reporting
-  the larger number; refusing, parking, and spending the budget belong to the
-  decision layer. Two consequences worth not re-litigating:
+  and the same tolerance for garbage config, with one difference: a budget of
+  `0` is honored (the caller spends nothing on that kind) where a stalemate
+  window of `0` rounds is meaningless and falls back. Nothing here refuses an
+  attempt, so a count past its budget keeps climbing and the condition keeps
+  reporting the larger number; refusing, parking, and spending the budget
+  belong to the decision layer. Two consequences worth not re-litigating:
   - *An attempt is gated on the PR ref, not on status* — the same key and the
     same post-`pr_closed` permissiveness as a failure-axis park, for the same
     reason: an attempt is a statement about fixing a PR that has not merged.

--- a/packages/grind/AGENTS.md
+++ b/packages/grind/AGENTS.md
@@ -230,6 +230,29 @@ must pass before push.
   `pr_closed` leaves the ref behind, so a re-queued item still passes — the
   check is deliberately permissive there rather than risking a false rejection.
 
+- **The attempt ledger counts and never caps.** `fix_attempted` folds a
+  per-kind count onto `Item.attempts`; `ci_fix_budget`/`rebase_budget` are
+  `config` numbers the `attempt_budget_spent` condition compares those counts
+  against — the same caller-seeded-threshold shape as `stalemate_risk_round`,
+  and the same tolerance for garbage config. Nothing here refuses an attempt,
+  so a count past its budget keeps climbing and the condition keeps reporting
+  the larger number; refusing, parking, and spending the budget belong to the
+  decision layer. Two consequences worth not re-litigating:
+  - *An attempt is gated on the PR ref, not on status* — the same key and the
+    same post-`pr_closed` permissiveness as a failure-axis park, for the same
+    reason: an attempt is a statement about fixing a PR that has not merged.
+  - *The ledger's lifetime is one PR cycle.* `pr_closed` clears it (a new PR
+    must not inherit spent budget) and `item_enqueued` clears it (leaving the
+    parking lot deliberately grants a fresh window). No other event does —
+    parking itself does not, so the count survives to be read at the park.
+- **`item_enqueued.closure` records an abandoned PR on the lot's one exit.**
+  Abandonment ends a PR cycle from inside the parking lot, and the alternative
+  — letting `pr_closed` fire on a parked item — would give that event a new
+  source state and a second exit from the lot. The optional `closure` payload
+  instead adds the closed-ledger entry and drops the PR ref (with the review
+  history belonging to it) as the item re-enters play; without it the ref
+  survives, which is what makes a plain re-enqueue resume the same PR.
+
 ## Tests
 
 - Behavioural, not tautological — each test pins a coded transition-table

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -81,14 +81,23 @@ def _duration(value: JsonValue, default_seconds: int) -> timedelta:
     return timedelta(seconds=default_seconds)
 
 
-def _positive_int_threshold(value: JsonValue, default: int) -> int:
+def _int_threshold(value: JsonValue, default: int, *, minimum: int) -> int:
     """A caller-seeded count threshold, falling back to `default` when the
-    config value is missing or not a usable count -- thresholds are advisory
+    config value is missing or below `minimum` -- thresholds are advisory
     config, never validated payload (the tolerance `_duration` gives the
-    staleness timers)."""
+    staleness timers).
+
+    `minimum` differs by threshold because zero means different things to each.
+    A stalemate window of zero rounds is meaningless, so it falls back; an
+    attempt budget of zero is a caller saying "spend nothing on this kind", and
+    silently restoring the default there would hand the decision layer attempts
+    its caller forbade.
+    """
     # bool is an int subtype: `true` would otherwise read as threshold 1
     return (
-        value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else default
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+        else default
     )
 
 
@@ -218,7 +227,7 @@ def _blocked_chains(state: State) -> list[Condition]:
 
 
 def _review_stalemate_risk(state: State) -> list[Condition]:
-    n = _positive_int_threshold(state.config.get("stalemate_risk_round"), 3)
+    n = _int_threshold(state.config.get("stalemate_risk_round"), 3, minimum=1)
     out: list[Condition] = []
     for item in state.items.values():
         # round_history survives the review cycle (it is fold history, never
@@ -267,7 +276,7 @@ def _attempt_budget_spent(state: State) -> list[Condition]:
         if item.parked is not None or item.status in _TERMINAL_ITEM_STATUSES:
             continue
         for kind, (config_key, default) in ATTEMPT_BUDGETS.items():
-            budget = _positive_int_threshold(state.config.get(config_key), default)
+            budget = _int_threshold(state.config.get(config_key), default, minimum=0)
             attempts = item.attempts.get(kind, 0)
             if attempts < budget:
                 continue

--- a/packages/grind/src/grind/conditions.py
+++ b/packages/grind/src/grind/conditions.py
@@ -21,7 +21,7 @@ from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from grind.derive import lane_status
-from grind.model import Item, JsonValue, State
+from grind.model import ATTEMPT_BUDGETS, Item, JsonValue, State
 
 Condition = dict[str, JsonValue]
 
@@ -81,7 +81,11 @@ def _duration(value: JsonValue, default_seconds: int) -> timedelta:
     return timedelta(seconds=default_seconds)
 
 
-def _round_threshold(value: JsonValue, default: int) -> int:
+def _positive_int_threshold(value: JsonValue, default: int) -> int:
+    """A caller-seeded count threshold, falling back to `default` when the
+    config value is missing or not a usable count -- thresholds are advisory
+    config, never validated payload (the tolerance `_duration` gives the
+    staleness timers)."""
     # bool is an int subtype: `true` would otherwise read as threshold 1
     return (
         value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else default
@@ -214,7 +218,7 @@ def _blocked_chains(state: State) -> list[Condition]:
 
 
 def _review_stalemate_risk(state: State) -> list[Condition]:
-    n = _round_threshold(state.config.get("stalemate_risk_round"), 3)
+    n = _positive_int_threshold(state.config.get("stalemate_risk_round"), 3)
     out: list[Condition] = []
     for item in state.items.values():
         # round_history survives the review cycle (it is fold history, never
@@ -245,6 +249,40 @@ def _review_stalemate_risk(state: State) -> list[Condition]:
     return out
 
 
+def _attempt_budget_spent(state: State) -> list[Condition]:
+    """Per item and kind: the fix attempts already spent have reached the
+    configured budget.
+
+    A fact with its evidence, and nothing beyond it. The counts come from the
+    fold, the budget is a number the caller seeded into `config` (the
+    `stalemate_risk_round` precedent), and both ride the condition so the
+    decision layer never keeps a counter of its own. Refusing the next attempt
+    is that layer's call: this fires while the count keeps climbing.
+
+    Parked and terminal items are excluded -- a parked item is already out of
+    play and its exit grants a fresh window, and finished work spends nothing.
+    """
+    out: list[Condition] = []
+    for item in state.items.values():
+        if item.parked is not None or item.status in _TERMINAL_ITEM_STATUSES:
+            continue
+        for kind, (config_key, default) in ATTEMPT_BUDGETS.items():
+            budget = _positive_int_threshold(state.config.get(config_key), default)
+            attempts = item.attempts.get(kind, 0)
+            if attempts < budget:
+                continue
+            out.append(
+                {
+                    "condition": "attempt_budget_spent",
+                    "item": item.id,
+                    "kind": kind,
+                    "attempts": attempts,
+                    "budget": budget,
+                }
+            )
+    return out
+
+
 def conditions(state: State, now: datetime) -> list[Condition]:
     """Every currently-true level condition (spec table, all rows but
     `item_unblocked`). Returned by both the `grind log` emit-back envelope and
@@ -261,6 +299,7 @@ def conditions(state: State, now: datetime) -> list[Condition]:
         *_attention_pending(state, now),
         *_blocked_chains(state),
         *_review_stalemate_risk(state),
+        *_attempt_budget_spent(state),
     ]
 
 

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 
 from grind.model import (
+    ATTEMPT_BUDGETS,
     PARK_REASONS,
     AnomalyRecord,
     AttentionEntry,
@@ -30,6 +31,7 @@ from grind.model import (
     PrRef,
     RawEvent,
     State,
+    new_attempt_ledger,
 )
 
 # The pre-charter park vocabulary, which lived on a field named `kind`. Three
@@ -90,9 +92,10 @@ def _typed_park_reason(state: State, evt: RawEvent) -> ParkReason | None:
     return reason
 
 
-# Statuses `merged`/`done` resolve any blocker edge pointing at that item
-# (spec: "an edge resolves only when its target reaches merged/done").
-_TERMINAL_RESOLVING = {"merged", "done"}
+# The two terminal item statuses. An item that reached either resolves any
+# blocker edge pointing at it (spec: "an edge resolves only when its target
+# reaches merged/done"), and has no work left to attempt.
+_TERMINAL_ITEM_STATUSES = {"merged", "done"}
 
 Handler = Callable[[State, RawEvent], None]
 
@@ -281,7 +284,7 @@ def _unresolved_edges(state: State, item: Item) -> tuple[str, ...]:
         target
         for target in item.blocked_on
         if (target_item := state.items.get(target)) is None
-        or target_item.status not in _TERMINAL_RESOLVING
+        or target_item.status not in _TERMINAL_ITEM_STATUSES
     )
 
 
@@ -463,8 +466,10 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
         )
     )
     # the review cycle ends with its PR: a later pr_opened starts a fresh
-    # cycle that must not inherit the closed PR's stalemate history
+    # cycle that must not inherit the closed PR's stalemate history, nor the
+    # fix budget spent on it -- the attempt ledger's lifetime is one PR cycle
     item.round_history = ()
+    item.attempts = new_attempt_ledger()
     if next_status == "parked":
         # `pr_closed.reason` is a free-text closure note, not the typed park
         # vocabulary -- the two share a field name and not a contract. When it
@@ -474,6 +479,36 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
         _park_item(state, item, reason=_park_reason(evt), note=reason)
     else:
         item.status = next_status  # type: ignore[assignment]  # validated above
+
+
+@_handler("fix_attempted")
+def _h_fix_attempted(state: State, evt: RawEvent) -> None:
+    """Count one fix attempt against the item's ledger, and only ever count it.
+
+    Whether the budget is spent is a condition's report and whether to refuse
+    the next attempt is the decision layer's call; this handler never caps, so
+    the count past the budget keeps climbing and stays an honest record of what
+    was attempted.
+
+    An attempt exists only inside a PR cycle, so the PR ref gates it -- the
+    same key, and the same permissiveness after `pr_closed` leaves the ref
+    behind, as the failure-axis park rule below.
+    """
+    item = _active_item(state, evt)
+    if item is None:
+        return
+    if item.status in _TERMINAL_ITEM_STATUSES:
+        _anomaly(state, evt, f"fix_attempted illegal from status {item.status!r}")
+        return
+    if item.pr is None:
+        _anomaly(state, evt, "fix_attempted on an item with no PR")
+        return
+    kind = _str(evt, "kind")
+    # Membership narrows the `str` to the key type, as it does for park reasons.
+    if kind is None or kind not in ATTEMPT_BUDGETS:
+        _anomaly(state, evt, f"unrecognized attempt kind {kind!r}")
+        return
+    item.attempts[kind] = item.attempts.get(kind, 0) + 1
 
 
 # Statuses from which recording/replacing blocker edges is legal. A currently
@@ -617,6 +652,36 @@ def _h_item_parked(state: State, evt: RawEvent) -> None:
     _park_item(state, item, reason=reason, note=_str(evt, "note"))
 
 
+def _record_closure(state: State, item: Item, evt: RawEvent) -> None:
+    """`item_enqueued.closure` -- the abandoned PR whose cycle this exit ends.
+
+    The parking lot keeps its single exit: an abandoned item re-enters play
+    exactly as any other does, and the closure only adds what abandonment
+    means on top of that -- the ledger entry recording which PR closed and why,
+    and dropping the PR ref (with the review history belonging to it) so the
+    next cycle starts clean. `pr_closed` gains no new source state from this.
+
+    Structural garbage is tolerated as everywhere else in the fold: the
+    boundary rejects a closure that cannot name an integer PR, so a
+    hand-edited log reaching here records the entry with a null `pr` rather
+    than losing the closure.
+    """
+    closure = evt.get("closure")
+    if not isinstance(closure, dict):
+        return
+    pr = closure.get("pr")
+    state.closed_ledger.append(
+        ClosedEntry(
+            item=item.id,
+            pr=pr if isinstance(pr, int) else None,
+            reason=_str(closure, "reason"),
+            ts=_str(evt, "ts"),
+        )
+    )
+    item.pr = None
+    item.round_history = ()
+
+
 @_handler("item_enqueued")
 def _h_item_enqueued(state: State, evt: RawEvent) -> None:
     item_id = _str(evt, "item")
@@ -629,6 +694,10 @@ def _h_item_enqueued(state: State, evt: RawEvent) -> None:
         return
     item.parked = None
     item.lane = lane.id
+    # Leaving the parking lot deliberately grants a fresh fix budget: whatever
+    # was spent belonged to the cycle that ended in the park.
+    item.attempts = new_attempt_ledger()
+    _record_closure(state, item, evt)
     # Queued is the baseline; blocked is derived, never asserted -- an item
     # re-entering play with unresolved blocker edges surfaces as blocked.
     item.status = "queued"

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -470,6 +470,10 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
     # fix budget spent on it -- the attempt ledger's lifetime is one PR cycle
     item.round_history = ()
     item.attempts = new_attempt_ledger()
+    # The ref stays for the failure-axis park rule; marking it closed is what
+    # keeps "has a PR ref" from being read as "has an open PR".
+    if item.pr is not None:
+        item.pr.closed = True
     if next_status == "parked":
         # `pr_closed.reason` is a free-text closure note, not the typed park
         # vocabulary -- the two share a field name and not a contract. When it
@@ -490,9 +494,12 @@ def _h_fix_attempted(state: State, evt: RawEvent) -> None:
     the count past the budget keeps climbing and stays an honest record of what
     was attempted.
 
-    An attempt exists only inside a PR cycle, so the PR ref gates it -- the
-    same key, and the same permissiveness after `pr_closed` leaves the ref
-    behind, as the failure-axis park rule below.
+    An attempt exists only inside a PR cycle, so an OPEN PR gates it. Keyed on
+    the ref like the failure-axis park rule below -- status cannot answer this,
+    since `in-progress` is reachable both with an open PR (via resume) and with
+    a closed one (via `pr_closed`) -- but, unlike that rule, a closed ref does
+    not pass: a park describes a PR that already failed to merge, while an
+    attempt claims to be fixing one that is still open.
     """
     item = _active_item(state, evt)
     if item is None:
@@ -500,8 +507,8 @@ def _h_fix_attempted(state: State, evt: RawEvent) -> None:
     if item.status in _TERMINAL_ITEM_STATUSES:
         _anomaly(state, evt, f"fix_attempted illegal from status {item.status!r}")
         return
-    if item.pr is None:
-        _anomaly(state, evt, "fix_attempted on an item with no PR")
+    if item.pr is None or item.pr.closed:
+        _anomaly(state, evt, "fix_attempted on an item with no open PR")
         return
     kind = _str(evt, "kind")
     # Membership narrows the `str` to the key type, as it does for park reasons.

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -599,6 +599,11 @@ def _h_item_merged(state: State, evt: RawEvent) -> None:
         return
     pr = evt.get("pr")
     item.status = "merged"
+    # A merge ends the PR's life as surely as a close does -- `closed` records
+    # "no longer open", and both transitions that reach it must say so or the
+    # retained ref reports a merged PR as still open.
+    if item.pr is not None:
+        item.pr.closed = True
     state.merged_ledger.append(
         MergedEntry(
             item=item.id,

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -115,6 +115,20 @@ def _str(evt: RawEvent, key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _int(evt: RawEvent, key: str) -> int | None:
+    """`_str`'s sibling, and the bool exclusion is the whole point of it.
+
+    `bool` is an `int` subclass in Python, so a JSON `true` otherwise passes as
+    a PR number -- and compares equal to PR 1, which is enough to satisfy a
+    check that the number matches the one the item holds. The boundary
+    validator already excludes it; a hand-edited or historical log reaches this
+    fold without ever passing that boundary, and every `pr` field here feeds
+    either a ledger entry or the ref two rules read.
+    """
+    value = evt.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
 def _work_id(payload: RawEvent, item_id: str) -> str | None:
     """The item's external tracker handle, or None when it has no distinct one.
 
@@ -343,8 +357,7 @@ def _h_pr_opened(state: State, evt: RawEvent) -> None:
     if item.status not in ("in-progress", "waiting-human"):
         _anomaly(state, evt, f"pr_opened illegal from status {item.status!r}")
         return
-    pr = evt.get("pr")
-    item.pr = PrRef(number=pr if isinstance(pr, int) else None, url=_str(evt, "url"))
+    item.pr = PrRef(number=_int(evt, "pr"), url=_str(evt, "url"))
     item.status = "pr-open"
 
 
@@ -458,12 +471,9 @@ def _h_pr_closed(state: State, evt: RawEvent) -> None:
     if next_status != "parked" and next_status not in _PR_CLOSED_NEXT:
         _anomaly(state, evt, f"pr_closed has invalid next {next_status!r}")
         return
-    pr = evt.get("pr")
     reason = _str(evt, "reason")
     state.closed_ledger.append(
-        ClosedEntry(
-            item=item.id, pr=pr if isinstance(pr, int) else None, reason=reason, ts=_str(evt, "ts")
-        )
+        ClosedEntry(item=item.id, pr=_int(evt, "pr"), reason=reason, ts=_str(evt, "ts"))
     )
     # the review cycle ends with its PR: a later pr_opened starts a fresh
     # cycle that must not inherit the closed PR's stalemate history, nor the
@@ -597,7 +607,6 @@ def _h_item_merged(state: State, evt: RawEvent) -> None:
     if item.status not in _MERGEABLE:
         _anomaly(state, evt, f"item_merged illegal from status {item.status!r}")
         return
-    pr = evt.get("pr")
     item.status = "merged"
     # A merge ends the PR's life as surely as a close does -- `closed` records
     # "no longer open", and both transitions that reach it must say so or the
@@ -607,7 +616,7 @@ def _h_item_merged(state: State, evt: RawEvent) -> None:
     state.merged_ledger.append(
         MergedEntry(
             item=item.id,
-            pr=pr if isinstance(pr, int) else None,
+            pr=_int(evt, "pr"),
             sha=_str(evt, "sha"),
             ts=_str(evt, "ts"),
         )
@@ -685,10 +694,10 @@ def _record_closure(state: State, item: Item, evt: RawEvent) -> None:
     closure = evt.get("closure")
     if not isinstance(closure, dict):
         return
-    pr = closure.get("pr")
-    if item.pr is None or not isinstance(pr, int) or item.pr.number != pr:
-        held = item.pr.number if item.pr is not None else None
-        _anomaly(state, evt, f"closure names PR {pr!r}, but the item holds {held!r}")
+    pr = _int(closure, "pr")
+    held = item.pr.number if item.pr is not None else None
+    if pr is None or held != pr:
+        _anomaly(state, evt, f"closure names PR {closure.get('pr')!r}, but the item holds {held!r}")
         return
     state.closed_ledger.append(
         ClosedEntry(item=item.id, pr=pr, reason=_str(closure, "reason"), ts=_str(evt, "ts"))

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -504,8 +504,12 @@ def _h_fix_attempted(state: State, evt: RawEvent) -> None:
     the count past the budget keeps climbing and stays an honest record of what
     was attempted.
 
-    An attempt exists only inside a PR cycle, so an OPEN PR gates it. Keyed on
-    the ref like the failure-axis park rule below -- status cannot answer this,
+    An attempt exists only inside a PR cycle, so an open PR with a number of
+    its own gates it -- a ref whose number did not survive the log names no
+    cycle anything can act on, and an attempt charged against it spends a
+    budget nobody can attribute. That is the predicate `_record_closure` also
+    requires. Keyed on the ref like the failure-axis park rule below -- status
+    cannot answer this,
     since `in-progress` is reachable both with an open PR (via resume) and with
     a closed one (via `pr_closed`) -- but, unlike that rule, a closed ref does
     not pass: a park describes a PR that already failed to merge, while an
@@ -517,7 +521,7 @@ def _h_fix_attempted(state: State, evt: RawEvent) -> None:
     if item.status in _TERMINAL_ITEM_STATUSES:
         _anomaly(state, evt, f"fix_attempted illegal from status {item.status!r}")
         return
-    if item.pr is None or item.pr.closed:
+    if item.pr is None or item.pr.number is None or item.pr.closed:
         _anomaly(state, evt, "fix_attempted on an item with no open PR")
         return
     kind = _str(evt, "kind")

--- a/packages/grind/src/grind/fold.py
+++ b/packages/grind/src/grind/fold.py
@@ -668,22 +668,25 @@ def _record_closure(state: State, item: Item, evt: RawEvent) -> None:
     and dropping the PR ref (with the review history belonging to it) so the
     next cycle starts clean. `pr_closed` gains no new source state from this.
 
-    Structural garbage is tolerated as everywhere else in the fold: the
-    boundary rejects a closure that cannot name an integer PR, so a
-    hand-edited log reaching here records the entry with a null `pr` rather
-    than losing the closure.
+    The PR named must be the one the item actually holds. The boundary can
+    only check that `--pr` is an integer, so a mistyped number arrives
+    well-formed and would otherwise write a closure record for a PR this item
+    never had *and* discard the live ref two other rules read (the failure-axis
+    park, and the attempt gate). Accept-and-flag applies as it does to a
+    failure-axis park on an item with no PR: the mismatch is recorded, the
+    closure is not applied, and the enqueue itself still proceeds -- losing the
+    item's exit from the parking lot would be a second harm.
     """
     closure = evt.get("closure")
     if not isinstance(closure, dict):
         return
     pr = closure.get("pr")
+    if item.pr is None or not isinstance(pr, int) or item.pr.number != pr:
+        held = item.pr.number if item.pr is not None else None
+        _anomaly(state, evt, f"closure names PR {pr!r}, but the item holds {held!r}")
+        return
     state.closed_ledger.append(
-        ClosedEntry(
-            item=item.id,
-            pr=pr if isinstance(pr, int) else None,
-            reason=_str(closure, "reason"),
-            ts=_str(evt, "ts"),
-        )
+        ClosedEntry(item=item.id, pr=pr, reason=_str(closure, "reason"), ts=_str(evt, "ts"))
     )
     item.pr = None
     item.round_history = ()

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -108,6 +108,14 @@ AttentionKind = Literal["waiting-human"]
 class PrRef:
     number: int | None = None
     url: str | None = None
+    # Whether this reference is to a PR that has since closed. `pr_closed`
+    # deliberately leaves the ref behind so a re-queued item can still carry a
+    # failure-axis park describing the PR that did not merge -- which makes
+    # "the item has a PR ref" and "the item has an OPEN PR" two different
+    # questions. Both have callers, so the fold records the answer rather than
+    # letting each of them guess from status (`in-progress` is reachable both
+    # with an open PR, via resume, and with a closed one).
+    closed: bool = False
 
 
 @dataclass

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -108,13 +108,14 @@ AttentionKind = Literal["waiting-human"]
 class PrRef:
     number: int | None = None
     url: str | None = None
-    # Whether this reference is to a PR that has since closed. `pr_closed`
-    # deliberately leaves the ref behind so a re-queued item can still carry a
-    # failure-axis park describing the PR that did not merge -- which makes
-    # "the item has a PR ref" and "the item has an OPEN PR" two different
-    # questions. Both have callers, so the fold records the answer rather than
-    # letting each of them guess from status (`in-progress` is reachable both
-    # with an open PR, via resume, and with a closed one).
+    # Whether this reference points at a PR that is no longer open -- set by
+    # both transitions that end a PR's life, `pr_closed` and `item_merged`.
+    # `pr_closed` deliberately leaves the ref behind so a re-queued item can
+    # still carry a failure-axis park describing the PR that did not merge,
+    # which makes "the item has a PR ref" and "the item has an OPEN PR" two
+    # different questions. Both have callers, so the fold records the answer
+    # rather than letting each of them guess from status (`in-progress` is
+    # reachable both with an open PR, via resume, and with a closed one).
     closed: bool = False
 
 

--- a/packages/grind/src/grind/model.py
+++ b/packages/grind/src/grind/model.py
@@ -75,6 +75,28 @@ PARK_REASONS: dict[ParkReason, tuple[ParkAxis, ParkCategory]] = {
     "deferred": ("scheduling", "human"),
 }
 
+# The kinds of fix attempt an item can spend inside one PR cycle, each with the
+# `config` key holding its budget and that budget's initial value. One table, so
+# the boundary, the fold and the condition cannot disagree about the vocabulary,
+# and a default cannot drift from the key it belongs to.
+#
+# Counts are facts the fold records; a budget is a caller-seeded number a
+# condition compares them against, exactly as `stalemate_risk_round` works.
+# Refusing the next attempt is the decision layer's call -- this package counts
+# and never caps.
+AttemptKind = Literal["ci-fix", "rebase"]
+ATTEMPT_BUDGETS: dict[AttemptKind, tuple[str, int]] = {
+    "ci-fix": ("ci_fix_budget", 2),
+    "rebase": ("rebase_budget", 1),
+}
+
+
+def new_attempt_ledger() -> dict[AttemptKind, int]:
+    """A zeroed per-kind ledger: every kind present, so a consumer reads a
+    count rather than an absence, and clearing one is a single call."""
+    return dict.fromkeys(ATTEMPT_BUDGETS, 0)
+
+
 ObservationLevel = Literal["INFO", "WARN", "ERROR", "LESSON"]
 # The one auto-attention cause `item_resumed` is specified to clear. Other
 # auto-raised entries (anomaly, ERROR observation) carry `kind=None` so resume
@@ -154,6 +176,12 @@ class Item:
     review: ItemReview = field(default_factory=ItemReview)
     parked: ParkingEntry | None = None
     discovered: DiscoveredWork | None = None
+    # Fix attempts spent per kind. A count, never a cap: the fold records what
+    # was attempted and a condition compares it against the configured budget.
+    # Its lifetime is one PR cycle -- `pr_closed` clears it (a new PR must not
+    # inherit spent budget) and `item_enqueued` clears it (leaving the parking
+    # lot grants a fresh window); no other event touches it.
+    attempts: dict[AttemptKind, int] = field(default_factory=new_attempt_ledger)
     # (round, head_sha, ts) per distinct round, last-event-wins within a
     # round -- the raw material `conditions()` needs for
     # `review_stalemate_risk`'s "dumb arithmetic" (spec: "the last N distinct
@@ -226,6 +254,10 @@ DEFAULT_CONFIG: dict[str, JsonValue] = {
     "stale_item_after": "45m",
     "stale_lane_after": "30m",
     "stalemate_risk_round": 3,
+    # `ci_fix_budget` and `rebase_budget`, straight from the table that owns
+    # both names and both numbers. A caller seeding `config` overrides them;
+    # nothing in this package enforces either.
+    **dict(ATTEMPT_BUDGETS.values()),
 }
 
 

--- a/packages/grind/src/grind/payloads.py
+++ b/packages/grind/src/grind/payloads.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from grind.model import PARK_REASONS, RawEvent
+from grind.model import ATTEMPT_BUDGETS, PARK_REASONS, RawEvent
 
 Validator = Callable[[RawEvent], list[str]]
 
@@ -30,6 +30,10 @@ _PARK_REASONS_HELP = "|".join(PARK_REASONS)
 # the accepted set here is what keeps the axis honest at the boundary.
 _SCHEDULING_REASONS: set[str] = {r for r, (axis, _) in PARK_REASONS.items() if axis == "scheduling"}
 _SCHEDULING_REASONS_HELP = "|".join(r for r in PARK_REASONS if r in _SCHEDULING_REASONS)
+# Same single-source rule as the park vocabulary: the attempt kinds and their
+# error text both derive from `grind.model.ATTEMPT_BUDGETS`.
+_ATTEMPT_KINDS: set[str] = set(ATTEMPT_BUDGETS)
+_ATTEMPT_KINDS_HELP = "|".join(ATTEMPT_BUDGETS)
 _PR_CLOSED_NEXT = {"in-progress", "queued", "parked"}
 _OBSERVATION_LEVELS = {"INFO", "WARN", "ERROR", "LESSON"}
 _WORK_DISPOSITIONS = {"parked", "enqueued"}
@@ -319,12 +323,37 @@ def _validate_item_parked(payload: RawEvent) -> list[str]:
     return errors
 
 
+def _validate_fix_attempted(payload: RawEvent) -> list[str]:
+    errors: list[str] = []
+    _require_str(errors, payload, "item")
+    _require(
+        errors,
+        _is_enum(payload, "kind", _ATTEMPT_KINDS),
+        f"kind must be one of {_ATTEMPT_KINDS_HELP}",
+    )
+    _optional_str(errors, payload, "note")
+    return errors
+
+
 def _validate_item_enqueued(payload: RawEvent) -> list[str]:
     errors: list[str] = []
     _require_str(errors, payload, "item")
     _require_str(errors, payload, "lane")
     if "position" in payload:
         _require(errors, _is_int(payload, "position"), "position must be an integer when present")
+    # `closure` records the abandoned PR whose cycle this exit ends. It is the
+    # only place a PR number reaches this event, so a closure that cannot name
+    # one is malformed rather than merely incomplete -- the ledger entry it
+    # produces would be a closure record of nothing.
+    if "closure" in payload:
+        closure = payload["closure"]
+        if not isinstance(closure, dict):
+            errors.append("closure must be an object when present")
+        else:
+            _require(
+                errors, _is_int(closure, "pr"), "closure.pr is required and must be an integer"
+            )
+            _optional_nested_str(errors, closure, "reason", "closure")
     return errors
 
 
@@ -398,6 +427,7 @@ _VALIDATORS: dict[str, Validator] = {
     "item_merged": _validate_item_merged,
     "item_done": _validate_item_done,
     "item_parked": _validate_item_parked,
+    "fix_attempted": _validate_fix_attempted,
     "item_enqueued": _validate_item_enqueued,
     "discovered_work": _validate_discovered_work,
     "observation": _validate_observation,

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -30,7 +30,7 @@ from grind.model import (
 def _pr_ref_json(pr: PrRef | None) -> JsonValue:
     if pr is None:
         return None
-    return {"number": pr.number, "url": pr.url}
+    return {"number": pr.number, "url": pr.url, "closed": pr.closed}
 
 
 def _item_review_json(review: ItemReview) -> JsonValue:

--- a/packages/grind/src/grind/serialize.py
+++ b/packages/grind/src/grind/serialize.py
@@ -85,6 +85,9 @@ def _item_json(item: Item) -> JsonValue:
         "blocked_note": item.blocked_note,
         "pr": _pr_ref_json(item.pr),
         "review": _item_review_json(item.review),
+        # The per-kind fix-attempt counts, every kind present. The decision
+        # layer reads its attempt evidence here rather than counting for itself.
+        "attempts": cast("JsonValue", dict(item.attempts)),
         "parked": _parking_entry_json(item.parked),
         "discovered": _discovered_work_json(item.discovered),
         "round_history": [

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -304,6 +304,96 @@ def test_review_stalemate_risk_ignores_late_earlier_round_duplicate() -> None:
     assert "review_stalemate_risk" not in _names(result)
 
 
+# -- attempt_budget_spent -------------------------------------------------------
+
+
+def _attempt(kind: str = "ci-fix") -> dict[str, object]:
+    return event("fix_attempted", item="wgclw.1", kind=kind)
+
+
+_NOW = datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC)
+
+
+def test_attempt_budget_spent_fires_at_the_budget_and_not_one_below() -> None:
+    # Boundary: the default ci-fix budget is 2, so one attempt is not spent and
+    # the second is. The condition carries the evidence -- kind and both
+    # numbers -- so the decision layer never keeps a counter of its own.
+    prefix = [*_to_pr_open(), _attempt()]
+
+    under = conditions(fold(prefix), _NOW)
+    at_budget = conditions(fold([*prefix, _attempt()]), _NOW)
+
+    assert "attempt_budget_spent" not in _names(under)
+    spent = _by_name(at_budget, "attempt_budget_spent")
+    assert spent == [
+        {
+            "condition": "attempt_budget_spent",
+            "item": "wgclw.1",
+            "kind": "ci-fix",
+            "attempts": 2,
+            "budget": 2,
+        }
+    ]
+
+
+def test_attempt_budget_spent_keeps_firing_past_the_budget() -> None:
+    # grind counts and never caps, so an attempt past the budget raises the
+    # reported count rather than changing the fact being reported.
+    state = fold([*_to_pr_open(), _attempt(), _attempt(), _attempt()])
+
+    spent = _by_name(conditions(state, _NOW), "attempt_budget_spent")
+
+    assert [c["attempts"] for c in spent] == [3]
+
+
+def test_attempt_budget_spent_is_per_kind() -> None:
+    # One rebase spends the default rebase budget of 1; one ci-fix does not
+    # spend the ci-fix budget of 2.
+    state = fold([*_to_pr_open(), _attempt("ci-fix"), _attempt("rebase")])
+
+    spent = _by_name(conditions(state, _NOW), "attempt_budget_spent")
+
+    assert [(c["kind"], c["attempts"], c["budget"]) for c in spent] == [("rebase", 1, 1)]
+
+
+def test_attempt_budget_spent_honors_a_caller_seeded_budget() -> None:
+    # The `stalemate_risk_round` precedent: the number is config the caller
+    # seeds, not a constant this package owns.
+    seed = _two_item_lane_seed()
+    seed["config"] = {"ci_fix_budget": 3}
+    events = [seed, event("item_started", item="wgclw.1"), event("pr_opened", item="wgclw.1", pr=1)]
+
+    at_two = conditions(fold([*events, _attempt(), _attempt()]), _NOW)
+    at_three = conditions(fold([*events, _attempt(), _attempt(), _attempt()]), _NOW)
+
+    assert "attempt_budget_spent" not in _names(at_two)
+    assert _by_name(at_three, "attempt_budget_spent")[0]["budget"] == 3
+
+
+def test_attempt_budget_spent_absent_for_parked_and_terminal_items() -> None:
+    # A parked item is out of play and its exit grants a fresh window; a merged
+    # one has nothing left to attempt. Neither is a live budget fact.
+    parked = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            _attempt(),
+            event("item_parked", item="wgclw.1", reason="ci-failure", note="budget spent"),
+        ]
+    )
+    terminal = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            _attempt(),
+            event("item_merged", item="wgclw.1", pr=1, sha="abc"),
+        ]
+    )
+
+    assert "attempt_budget_spent" not in _names(conditions(parked, _NOW))
+    assert "attempt_budget_spent" not in _names(conditions(terminal, _NOW))
+
+
 # -- item_unblocked (transition) ------------------------------------------------
 
 
@@ -464,7 +554,12 @@ def test_condition_names_are_never_imperative() -> None:
     ]
     state = fold(events)
     result = conditions(state, datetime(2026, 7, 19, 0, 5, 0, tzinfo=UTC))
-    all_names = _names(result) | {"item_unblocked"}  # transition condition, named statically
+    # The fixture covers no condition it does not happen to fire, so a name it
+    # cannot reach joins the set explicitly or the lock silently skips it.
+    all_names = _names(result) | {
+        "item_unblocked",  # transition condition, never fired by a level fold
+        "attempt_budget_spent",  # needs a spent budget this fixture never spends
+    }
 
     for name in all_names:
         first_word = re.split(r"[_\s]", name)[0]

--- a/packages/grind/tests/unit/test_conditions.py
+++ b/packages/grind/tests/unit/test_conditions.py
@@ -370,6 +370,25 @@ def test_attempt_budget_spent_honors_a_caller_seeded_budget() -> None:
     assert _by_name(at_three, "attempt_budget_spent")[0]["budget"] == 3
 
 
+def test_a_zero_budget_is_honored_and_spent_before_the_first_attempt() -> None:
+    # Zero is a caller saying "spend nothing on this kind", not garbage config:
+    # restoring the default here would hand the decision layer two attempts its
+    # caller forbade. Negative and boolean values stay garbage and fall back.
+    seed = _two_item_lane_seed()
+    seed["config"] = {"ci_fix_budget": 0}
+    events = [seed, event("item_started", item="wgclw.1"), event("pr_opened", item="wgclw.1", pr=1)]
+
+    spent = _by_name(conditions(fold(events), _NOW), "attempt_budget_spent")
+
+    assert [(c["kind"], c["attempts"], c["budget"]) for c in spent] == [("ci-fix", 0, 0)]
+
+    for garbage in (-1, True, "2", None):
+        seed = _two_item_lane_seed()
+        seed["config"] = {"ci_fix_budget": garbage}
+        state = fold([seed, event("item_started", item="wgclw.1")])
+        assert "attempt_budget_spent" not in _names(conditions(state, _NOW)), garbage
+
+
 def test_attempt_budget_spent_absent_for_parked_and_terminal_items() -> None:
     # A parked item is out of play and its exit grants a fresh window; a merged
     # one has nothing left to attempt. Neither is a live budget fact.

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -129,31 +129,31 @@ def test_fix_attempted_with_an_unrecognized_kind_flags_rather_than_miscounting()
 
 
 def test_pr_closed_resets_the_attempt_ledger() -> None:
-    state = fold(
-        [
-            *_to_pr_open(),
-            _attempt(),
-            _attempt("rebase"),
-            event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
-        ]
+    # A new PR must not inherit the spent budget of the one that closed.
+    spent = [*_to_pr_open(), _attempt(), _attempt("rebase")]
+    assert fold(spent).items["wgclw.1"].attempts == {"ci-fix": 1, "rebase": 1}
+
+    closed = fold(
+        [*spent, event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress")]
     )
 
-    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+    assert closed.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
 
 
 def test_item_enqueued_resets_the_attempt_ledger() -> None:
-    # Leaving the parking lot deliberately grants a fresh window.
-    state = fold(
-        [
-            *_to_pr_open(),
-            _attempt(),
-            _attempt(),
-            event("item_parked", item="wgclw.1", reason="ci-failure", note="budget spent"),
-            event("item_enqueued", item="wgclw.1", lane="lane-a"),
-        ]
-    )
+    # Leaving the parking lot deliberately grants a fresh window. The park
+    # itself does not clear the ledger -- the counts survive to be read there.
+    parked = [
+        *_to_pr_open(),
+        _attempt(),
+        _attempt(),
+        event("item_parked", item="wgclw.1", reason="ci-failure", note="budget spent"),
+    ]
+    assert fold(parked).items["wgclw.1"].attempts["ci-fix"] == 2
 
-    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+    enqueued = fold([*parked, event("item_enqueued", item="wgclw.1", lane="lane-a")])
+
+    assert enqueued.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
 
 
 def test_events_inside_the_pr_cycle_leave_the_ledger_unchanged() -> None:

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -111,6 +111,28 @@ def test_fix_attempted_needs_a_pr_and_reads_the_ref_not_the_status() -> None:
     assert blocked_with_pr.anomalies == []
 
 
+def test_fix_attempted_needs_an_identifiable_pr_not_merely_a_ref() -> None:
+    # A replayed `pr_opened` whose number did not survive leaves a ref with no
+    # number. It names no cycle anything can act on, so charging an attempt
+    # against it would spend a budget nobody can attribute -- and would fire
+    # attempt_budget_spent for a PR that cannot be found. Same predicate the
+    # closure guard requires.
+    state = fold(
+        [
+            seed_event(),
+            event("item_started", item="wgclw.1"),
+            event("pr_opened", item="wgclw.1", pr="not-a-number"),
+            _attempt(),
+        ]
+    )
+
+    item = state.items["wgclw.1"]
+    assert item.pr is not None
+    assert item.pr.number is None
+    assert item.attempts["ci-fix"] == 0
+    assert any(a.type == "fix_attempted" and "no open PR" in a.reason for a in state.anomalies)
+
+
 def test_fix_attempted_after_the_pr_closes_flags_until_a_new_pr_opens() -> None:
     # `pr_closed` leaves the ref behind for the failure-park rule, so "has a PR
     # ref" is not "has an open PR": an attempt in the gap has nothing to fix,

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -269,6 +269,46 @@ def test_a_closure_is_optional_and_the_pr_survives_an_exit_without_one() -> None
     assert state.closed_ledger == []
 
 
+def test_a_closure_naming_another_pr_is_flagged_and_not_applied() -> None:
+    # `--pr` is only shape-checked at the boundary, so a mistyped number
+    # arrives well-formed. Applying it would write a closure record for a PR
+    # this item never had and throw away the live ref the park rule and the
+    # attempt gate both read -- while the enqueue itself must still happen.
+    state = fold(
+        [
+            *_parked_with_history(),
+            event("item_enqueued", item="wgclw.1", lane="lane-a", closure={"pr": 9}),
+        ]
+    )
+
+    item = state.items["wgclw.1"]
+    assert state.closed_ledger == []
+    assert item.pr is not None
+    assert item.pr.number == 7
+    assert any(
+        a.type == "item_enqueued" and "closure names PR 9" in a.reason for a in state.anomalies
+    )
+    # the exit from the parking lot proceeds regardless
+    assert item.parked is None
+    assert item.status == "queued"
+
+
+def test_a_closure_on_an_item_holding_no_pr_is_flagged_and_not_applied() -> None:
+    state = fold(
+        [
+            seed_event(),
+            event("item_parked", item="wgclw.1", reason="later-wave", note="not yet"),
+            event("item_enqueued", item="wgclw.1", lane="lane-a", closure={"pr": 7}),
+        ]
+    )
+
+    assert state.closed_ledger == []
+    assert state.items["wgclw.1"].parked is None
+    assert any(
+        a.type == "item_enqueued" and "the item holds None" in a.reason for a in state.anomalies
+    )
+
+
 def test_a_closure_reason_is_optional() -> None:
     state = fold(
         [

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -1,0 +1,242 @@
+"""`fix_attempted` -- the attempt ledger the fold counts and never caps -- and
+`item_enqueued.closure`, the abandoned PR recorded on the parking lot's exit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from grind.fold import fold
+from tests.unit.builders import event, seed_event
+
+
+def _to_pr_open() -> list[dict[str, Any]]:
+    return [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=7),
+    ]
+
+
+def _attempt(kind: str = "ci-fix", item: str = "wgclw.1") -> dict[str, Any]:
+    return event("fix_attempted", item=item, kind=kind)
+
+
+# -- counting (S9T1-B2) --------------------------------------------------------
+
+
+def test_two_ci_fix_attempts_fold_to_two_and_a_third_folds_to_three() -> None:
+    # grind counts, it never caps: the third attempt is past the default budget
+    # of 2 and is still recorded, because refusing it is the decision layer's
+    # call and the ledger's job is to stay an honest record of what happened.
+    prefix = [*_to_pr_open(), _attempt(), _attempt()]
+
+    two = fold(prefix)
+    three = fold([*prefix, _attempt()])
+
+    assert two.items["wgclw.1"].attempts["ci-fix"] == 2
+    assert three.items["wgclw.1"].attempts["ci-fix"] == 3
+    assert three.anomalies == []
+
+
+def test_attempt_counts_are_kept_per_kind() -> None:
+    state = fold([*_to_pr_open(), _attempt("ci-fix"), _attempt("rebase"), _attempt("ci-fix")])
+
+    assert state.items["wgclw.1"].attempts == {"ci-fix": 2, "rebase": 1}
+
+
+def test_an_untouched_item_carries_a_zeroed_ledger_rather_than_an_empty_one() -> None:
+    # Every kind present at zero: a consumer reads a count, never an absence.
+    state = fold([seed_event()])
+
+    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+
+
+def test_default_config_carries_the_initial_attempt_budgets() -> None:
+    # S9T1-B4: the budgets are caller-tunable config, seeded with D10's initial
+    # values. Nothing in this package enforces either number.
+    state = fold([seed_event()])
+
+    assert state.config["ci_fix_budget"] == 2
+    assert state.config["rebase_budget"] == 1
+
+
+# -- the anomaly edges (S9T1-B1) -----------------------------------------------
+
+
+def test_fix_attempted_on_a_parked_item_flags_and_leaves_the_ledger_alone() -> None:
+    state = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            event("item_parked", item="wgclw.1", reason="ci-failure", note="budget spent"),
+            _attempt(),
+        ]
+    )
+
+    assert state.items["wgclw.1"].attempts["ci-fix"] == 1
+    assert any(a.type == "fix_attempted" and "parked" in a.reason for a in state.anomalies)
+
+
+def test_fix_attempted_on_a_terminal_item_flags_and_leaves_the_ledger_alone() -> None:
+    state = fold(
+        [*_to_pr_open(), event("item_merged", item="wgclw.1", pr=7, sha="abc"), _attempt()]
+    )
+
+    assert state.items["wgclw.1"].attempts["ci-fix"] == 0
+    assert any(
+        a.type == "fix_attempted" and "illegal from status 'merged'" in a.reason
+        for a in state.anomalies
+    )
+
+
+def test_fix_attempted_on_an_absent_item_flags() -> None:
+    state = fold([*_to_pr_open(), _attempt(item="does-not-exist")])
+
+    assert any(a.type == "fix_attempted" and "unknown item" in a.reason for a in state.anomalies)
+
+
+def test_fix_attempted_needs_a_pr_and_reads_the_ref_not_the_status() -> None:
+    # An attempt exists only inside a PR cycle, so the check mirrors the
+    # failure-park rule exactly: keyed on the PR ref, which `blocked` legally
+    # holds, never on status.
+    no_pr = fold([seed_event(), event("item_started", item="wgclw.1"), _attempt()])
+
+    assert no_pr.items["wgclw.1"].attempts["ci-fix"] == 0
+    assert any(a.type == "fix_attempted" and "no PR" in a.reason for a in no_pr.anomalies)
+
+    blocked_with_pr = fold(
+        [*_to_pr_open(), event("item_blocked", item="wgclw.1", on=["wgclw.2"]), _attempt()]
+    )
+
+    assert blocked_with_pr.items["wgclw.1"].attempts["ci-fix"] == 1
+    assert blocked_with_pr.anomalies == []
+
+
+def test_fix_attempted_with_an_unrecognized_kind_flags_rather_than_miscounting() -> None:
+    # The boundary rejects an unknown kind as a command error appending
+    # nothing; a hand-edited or replayed log that carries one anyway must not
+    # land it in a ledger slot nobody reads.
+    state = fold([*_to_pr_open(), _attempt("lint-fix")])
+
+    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+    assert any(
+        a.type == "fix_attempted" and "unrecognized attempt kind" in a.reason
+        for a in state.anomalies
+    )
+
+
+# -- ledger lifetime is one PR cycle (S9T1-B3) ---------------------------------
+
+
+def test_pr_closed_resets_the_attempt_ledger() -> None:
+    state = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            _attempt("rebase"),
+            event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
+        ]
+    )
+
+    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+
+
+def test_item_enqueued_resets_the_attempt_ledger() -> None:
+    # Leaving the parking lot deliberately grants a fresh window.
+    state = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            _attempt(),
+            event("item_parked", item="wgclw.1", reason="ci-failure", note="budget spent"),
+            event("item_enqueued", item="wgclw.1", lane="lane-a"),
+        ]
+    )
+
+    assert state.items["wgclw.1"].attempts == {"ci-fix": 0, "rebase": 0}
+
+
+def test_events_inside_the_pr_cycle_leave_the_ledger_unchanged() -> None:
+    # Representatives for "no other event resets it": a review round mid-cycle,
+    # and the pr_opened that starts the next one.
+    after_review = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        ]
+    )
+
+    assert after_review.items["wgclw.1"].attempts["ci-fix"] == 1
+
+    # pr_closed leaves the PR ref behind, so the attempt after it is accepted
+    # and counts from the cleared ledger; the next pr_opened does not clear it.
+    reopened = fold(
+        [
+            *_to_pr_open(),
+            _attempt(),
+            event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
+            _attempt(),
+            event("pr_opened", item="wgclw.1", pr=8),
+        ]
+    )
+
+    assert reopened.items["wgclw.1"].attempts["ci-fix"] == 1
+
+
+# -- item_enqueued.closure (S9T1-B7) -------------------------------------------
+
+
+def _parked_with_history() -> list[dict[str, Any]]:
+    return [
+        *_to_pr_open(),
+        event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="a1"),
+        event("item_parked", item="wgclw.1", reason="bot-declined", note="reviewer said no"),
+    ]
+
+
+def test_a_closure_records_the_closed_ledger_entry_and_drops_the_pr() -> None:
+    state = fold(
+        [
+            *_parked_with_history(),
+            event(
+                "item_enqueued",
+                item="wgclw.1",
+                lane="lane-a",
+                closure={"pr": 7, "reason": "abandoned"},
+            ),
+        ]
+    )
+
+    item = state.items["wgclw.1"]
+    assert item.pr is None
+    # the review cycle ended with its PR, so the next one starts clean
+    assert item.round_history == ()
+    assert [(c.item, c.pr, c.reason) for c in state.closed_ledger] == [("wgclw.1", 7, "abandoned")]
+    # the park exit itself proceeds unchanged
+    assert item.parked is None
+    assert item.status == "queued"
+    assert "wgclw.1" in state.lanes["lane-a"].item_ids
+    assert state.anomalies == []
+
+
+def test_a_closure_is_optional_and_the_pr_survives_an_exit_without_one() -> None:
+    # Redispatch resumes the same PR, so a plain enqueue must not drop the ref.
+    state = fold([*_parked_with_history(), event("item_enqueued", item="wgclw.1", lane="lane-a")])
+
+    item = state.items["wgclw.1"]
+    assert item.pr is not None
+    assert item.pr.number == 7
+    assert state.closed_ledger == []
+
+
+def test_a_closure_reason_is_optional() -> None:
+    state = fold(
+        [
+            *_parked_with_history(),
+            event("item_enqueued", item="wgclw.1", lane="lane-a", closure={"pr": 7}),
+        ]
+    )
+
+    assert state.closed_ledger[0].reason is None
+    assert state.items["wgclw.1"].pr is None

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -293,6 +293,29 @@ def test_a_closure_naming_another_pr_is_flagged_and_not_applied() -> None:
     assert item.status == "queued"
 
 
+def test_a_boolean_closure_pr_does_not_pass_for_pr_one() -> None:
+    # `bool` is an `int` subclass and `True == 1`, so a hand-edited `"pr": true`
+    # would otherwise satisfy both the type check and the match against PR 1 --
+    # writing `pr: true` into the ledger and discarding the live ref.
+    state = fold(
+        [
+            seed_event(),
+            event("item_started", item="wgclw.1"),
+            event("pr_opened", item="wgclw.1", pr=1),
+            event("item_parked", item="wgclw.1", reason="bot-declined", note="no"),
+            event("item_enqueued", item="wgclw.1", lane="lane-a", closure={"pr": True}),
+        ]
+    )
+
+    item = state.items["wgclw.1"]
+    assert state.closed_ledger == []
+    assert item.pr is not None
+    assert item.pr.number == 1
+    assert any(
+        a.type == "item_enqueued" and "closure names PR True" in a.reason for a in state.anomalies
+    )
+
+
 def test_a_closure_on_an_item_holding_no_pr_is_flagged_and_not_applied() -> None:
     state = fold(
         [

--- a/packages/grind/tests/unit/test_fold_attempts.py
+++ b/packages/grind/tests/unit/test_fold_attempts.py
@@ -96,13 +96,12 @@ def test_fix_attempted_on_an_absent_item_flags() -> None:
 
 
 def test_fix_attempted_needs_a_pr_and_reads_the_ref_not_the_status() -> None:
-    # An attempt exists only inside a PR cycle, so the check mirrors the
-    # failure-park rule exactly: keyed on the PR ref, which `blocked` legally
-    # holds, never on status.
+    # An attempt exists only inside a PR cycle. Keyed on the PR ref rather than
+    # on status, because `blocked` legally holds an open PR.
     no_pr = fold([seed_event(), event("item_started", item="wgclw.1"), _attempt()])
 
     assert no_pr.items["wgclw.1"].attempts["ci-fix"] == 0
-    assert any(a.type == "fix_attempted" and "no PR" in a.reason for a in no_pr.anomalies)
+    assert any(a.type == "fix_attempted" and "no open PR" in a.reason for a in no_pr.anomalies)
 
     blocked_with_pr = fold(
         [*_to_pr_open(), event("item_blocked", item="wgclw.1", on=["wgclw.2"]), _attempt()]
@@ -110,6 +109,45 @@ def test_fix_attempted_needs_a_pr_and_reads_the_ref_not_the_status() -> None:
 
     assert blocked_with_pr.items["wgclw.1"].attempts["ci-fix"] == 1
     assert blocked_with_pr.anomalies == []
+
+
+def test_fix_attempted_after_the_pr_closes_flags_until_a_new_pr_opens() -> None:
+    # `pr_closed` leaves the ref behind for the failure-park rule, so "has a PR
+    # ref" is not "has an open PR": an attempt in the gap has nothing to fix,
+    # and charging the fresh ledger there would spend the next cycle's budget
+    # before that cycle exists.
+    closed = [
+        *_to_pr_open(),
+        event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
+    ]
+    in_the_gap = fold([*closed, _attempt()])
+
+    assert in_the_gap.items["wgclw.1"].attempts["ci-fix"] == 0
+    assert any(a.type == "fix_attempted" and "no open PR" in a.reason for a in in_the_gap.anomalies)
+
+    # ... and the next PR restores it: pr_opened builds a fresh, open ref.
+    recut = fold([*closed, event("pr_opened", item="wgclw.1", pr=8), _attempt()])
+
+    assert recut.items["wgclw.1"].attempts["ci-fix"] == 1
+    assert recut.anomalies == []
+
+
+def test_a_failure_axis_park_still_accepts_the_closed_ref_the_attempt_gate_refuses() -> None:
+    # The two rules read the same field and answer different questions: a park
+    # states that this item's PR did not merge, which stays true after it
+    # closes. Tightening the attempt gate must not tighten this one.
+    state = fold(
+        [
+            *_to_pr_open(),
+            event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
+            event("item_parked", item="wgclw.1", reason="ci-failure", note="never went green"),
+        ]
+    )
+
+    parked = state.items["wgclw.1"].parked
+    assert parked is not None
+    assert parked.reason == "ci-failure"
+    assert state.anomalies == []
 
 
 def test_fix_attempted_with_an_unrecognized_kind_flags_rather_than_miscounting() -> None:
@@ -169,15 +207,16 @@ def test_events_inside_the_pr_cycle_leave_the_ledger_unchanged() -> None:
 
     assert after_review.items["wgclw.1"].attempts["ci-fix"] == 1
 
-    # pr_closed leaves the PR ref behind, so the attempt after it is accepted
-    # and counts from the cleared ledger; the next pr_opened does not clear it.
+    # pr_opened starts the next cycle but does not itself clear the ledger, so
+    # an attempt charged under the new PR is the only thing in it.
     reopened = fold(
         [
             *_to_pr_open(),
             _attempt(),
             event("pr_closed", item="wgclw.1", pr=7, reason="superseded", next="in-progress"),
-            _attempt(),
             event("pr_opened", item="wgclw.1", pr=8),
+            _attempt(),
+            event("review_round", item="wgclw.1", kind="codex", round=1, head_sha="b1"),
         ]
     )
 

--- a/packages/grind/tests/unit/test_fold_item_core_lifecycle.py
+++ b/packages/grind/tests/unit/test_fold_item_core_lifecycle.py
@@ -78,3 +78,34 @@ def test_unknown_event_type_is_tolerated_as_an_anomaly() -> None:
     assert state.items["wgclw.1"].status == "queued"
     assert len(state.anomalies) == 1
     assert "unknown event type" in state.anomalies[0].reason
+
+
+def test_a_boolean_pr_number_is_read_as_no_number_at_all() -> None:
+    # `bool` is an `int` subclass, so a hand-edited or historical log carrying
+    # `"pr": true` would otherwise store `True` as a PR number and put it in
+    # both ledgers. The boundary validator rejects it; the fold, which nothing
+    # replayed passes through that boundary, reads it as unavailable instead.
+    state = fold(
+        [
+            seed_event(),
+            event("item_started", item="wgclw.1"),
+            event("pr_opened", item="wgclw.1", pr=True),
+            event("item_merged", item="wgclw.1", pr=True, sha="abc"),
+        ]
+    )
+
+    item = state.items["wgclw.1"]
+    assert item.pr is not None
+    assert item.pr.number is None
+    assert state.merged_ledger[0].pr is None
+
+    closed = fold(
+        [
+            seed_event(),
+            event("item_started", item="wgclw.1"),
+            event("pr_opened", item="wgclw.1", pr=4),
+            event("pr_closed", item="wgclw.1", pr=True, reason="superseded", next="queued"),
+        ]
+    )
+
+    assert closed.closed_ledger[0].pr is None

--- a/packages/grind/tests/unit/test_payloads.py
+++ b/packages/grind/tests/unit/test_payloads.py
@@ -222,6 +222,27 @@ def test_item_enqueued_requires_item_and_lane():
     assert validate_payload("item_enqueued", {"item": "a"}) != []
 
 
+def test_item_enqueued_closure_requires_an_integer_pr():
+    # A closure records which PR was abandoned; one that cannot name a PR would
+    # produce a ledger entry about nothing, so it is a command error here
+    # rather than a half-recorded closure in the log.
+    base = {"item": "a", "lane": "lane-a"}
+    assert validate_payload("item_enqueued", {**base, "closure": {"pr": 7}}) == []
+    assert validate_payload("item_enqueued", {**base, "closure": {"pr": 7, "reason": "r"}}) == []
+    assert validate_payload("item_enqueued", {**base, "closure": {"reason": "r"}}) != []
+    assert validate_payload("item_enqueued", {**base, "closure": {"pr": "7"}}) != []
+    assert validate_payload("item_enqueued", {**base, "closure": {"pr": 7, "reason": 7}}) != []
+    assert validate_payload("item_enqueued", {**base, "closure": "abandoned"}) != []
+
+
+def test_fix_attempted_requires_item_and_a_known_kind():
+    assert validate_payload("fix_attempted", {"item": "a", "kind": "ci-fix"}) == []
+    assert validate_payload("fix_attempted", {"item": "a", "kind": "rebase", "note": "n"}) == []
+    assert validate_payload("fix_attempted", {"item": "a", "kind": "lint-fix"}) != []
+    assert validate_payload("fix_attempted", {"item": "a"}) != []
+    assert validate_payload("fix_attempted", {"kind": "ci-fix"}) != []
+
+
 def test_discovered_work_requires_disposition_specific_fields():
     parked = {
         "item": "disc-1",

--- a/packages/grind/tests/unit/test_replay_determinism.py
+++ b/packages/grind/tests/unit/test_replay_determinism.py
@@ -29,9 +29,20 @@ _EVENTS = [
         verdict="findings",
         findings=[{"severity": "low", "summary": "nit", "disposition": "wont-fix"}],
     ),
+    event("fix_attempted", item="wgclw.1", kind="ci-fix", note="rerun the flaky job"),
+    event("fix_attempted", item="wgclw.1", kind="rebase"),
     event("item_merged", item="wgclw.1", pr=7, sha="a1"),
     event("item_done", item="wgclw.1"),
+    event("item_started", item="wgclw.2"),
+    event("pr_opened", item="wgclw.2", pr=8),
     event("item_blocked", item="wgclw.2", on=["does-not-exist"]),
+    event("item_parked", item="wgclw.2", reason="ci-failure", note="budget spent"),
+    event(
+        "item_enqueued",
+        item="wgclw.2",
+        lane="lane-a",
+        closure={"pr": 8, "reason": "abandoned, starting over"},
+    ),
     event("observation", level="WARN", message="watch this repo's flaky CI"),
 ]
 

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -196,6 +196,30 @@ def test_full_state_serializes_round_history():
     ]
 
 
+def test_full_state_reports_whether_a_retained_pr_ref_is_closed():
+    # The ref outlives its PR (the failure-park rule needs it), so the snapshot
+    # has to say which of the two questions -- "has a ref" and "has an open PR"
+    # -- a consumer is getting an answer to.
+    open_pr = [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+    ]
+    closed = [
+        *open_pr,
+        event("pr_closed", item="wgclw.1", pr=1, reason="superseded", next="in-progress"),
+    ]
+
+    def pr_of(events):
+        items = full_state_json(fold(events))["items"]
+        assert isinstance(items, dict)
+        return items["wgclw.1"]["pr"]
+
+    assert pr_of(open_pr)["closed"] is False
+    assert pr_of(closed)["closed"] is True
+    assert pr_of(closed)["number"] == 1
+
+
 def test_full_state_serializes_the_attempt_ledger():
     # The decision layer reads its attempt evidence off this surface rather
     # than counting for itself, so every kind is present with its count.

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -196,6 +196,23 @@ def test_full_state_serializes_round_history():
     ]
 
 
+def test_full_state_serializes_the_attempt_ledger():
+    # The decision layer reads its attempt evidence off this surface rather
+    # than counting for itself, so every kind is present with its count.
+    events = [
+        seed_event(),
+        event("item_started", item="wgclw.1"),
+        event("pr_opened", item="wgclw.1", pr=1),
+        event("fix_attempted", item="wgclw.1", kind="ci-fix"),
+    ]
+    state = fold(events)
+
+    items = full_state_json(state)["items"]
+    assert isinstance(items, dict)
+    assert items["wgclw.1"]["attempts"] == {"ci-fix": 1, "rebase": 0}
+    assert items["wgclw.2"]["attempts"] == {"ci-fix": 0, "rebase": 0}
+
+
 def test_full_state_serializes_staleness_ts_maps():
     events = [seed_event(), event("item_started", item="wgclw.1")]
     state = fold(events)

--- a/packages/grind/tests/unit/test_serialize.py
+++ b/packages/grind/tests/unit/test_serialize.py
@@ -215,9 +215,14 @@ def test_full_state_reports_whether_a_retained_pr_ref_is_closed():
         assert isinstance(items, dict)
         return items["wgclw.1"]["pr"]
 
+    merged = [*open_pr, event("item_merged", item="wgclw.1", pr=1, sha="abc")]
+
     assert pr_of(open_pr)["closed"] is False
     assert pr_of(closed)["closed"] is True
     assert pr_of(closed)["number"] == 1
+    # a merge ends the PR's life too -- reporting it as open would tell a
+    # consumer that finished work still has something to fix
+    assert pr_of(merged)["closed"] is True
 
 
 def test_full_state_serializes_the_attempt_ledger():


### PR DESCRIPTION
Slice B of `docs/specs/2026-07-25-executor-seam-s9-tier1.md` — the grind half of `agents-config-9k9.1.3`. Discharges **S9T1-B1 … S9T1-B7** under decisions **S9T1-D2** (counts are facts, budgets are config, enforcement is policy) and **S9T1-D4** (the ledger's lifetime is one PR cycle).

**grind counts and never caps.** Nothing here refuses, parks, or blocks on a budget: the fold records what was attempted, a condition reports when the configured budget is reached, and enforcement lands in Slice C (`packages/executor/`). `9k9.1.3` stays open until then — its admission requires enforcement, not just counting.

## What lands

| AC | Change | Test |
| --- | --- | --- |
| B1 | `fix_attempted {item, kind, note?}`, `kind` ∈ `ci-fix`\|`rebase`. Unknown kind → command error appending nothing (validator). Parked / terminal / absent item, or one holding no open PR → accept-and-flag anomaly, ledger unchanged. The PR gate keys on `item.pr`, mirroring the failure-axis park rule (status is the wrong key: `blocked` legally holds an open PR). | `test_payloads.py::test_fix_attempted_requires_item_and_a_known_kind`; `test_fold_attempts.py` — the four anomaly-edge tests plus `..._needs_a_pr_and_reads_the_ref_not_the_status` |
| B2 | `Item.attempts` folds per-kind counts; two `ci-fix` fold to 2, a third to 3 (past the default budget, still recorded). | `test_two_ci_fix_attempts_fold_to_two_and_a_third_folds_to_three`, `test_attempt_counts_are_kept_per_kind` |
| B3 | `pr_closed` resets the ledger; `item_enqueued` resets it; nothing else does (`pr_opened` and `review_round` as representatives). | `test_pr_closed_resets_the_attempt_ledger`, `test_item_enqueued_resets_the_attempt_ledger`, `test_events_inside_the_pr_cycle_leave_the_ledger_unchanged` |
| B4 | `DEFAULT_CONFIG` gains `ci_fix_budget: 2` / `rebase_budget: 1`; a caller-seeded override is honored. | `test_default_config_carries_the_initial_attempt_budgets`, `test_attempt_budget_spent_honors_a_caller_seeded_budget` |
| B5 | New condition `attempt_budget_spent`, per kind, firing iff count ≥ budget, carrying `{item, kind, attempts, budget}` as evidence. Fires at `count == budget`, not at `budget − 1`; absent for parked and terminal items. Its name is added **explicitly** to the `IMPERATIVE_VERBS` lock's covered-name set — the fixture fires no attempt, so it would otherwise be skipped silently. | five tests under `# -- attempt_budget_spent` in `test_conditions.py`, plus the amended `test_condition_names_are_never_imperative` |
| B6 | `attempts` joins the serialized item in `status --full`; the replay-determinism log now carries `fix_attempted` and a closure-bearing `item_enqueued`, and the suite stays green over it. | `test_full_state_serializes_the_attempt_ledger`; `test_replay_determinism.py`'s `_EVENTS` (verified to fold with zero anomalies) |
| B7 | `item_enqueued` accepts optional `closure {pr, reason?}`: records the closed-ledger entry, clears the item's PR ref, park exit otherwise unchanged. Absent closure leaves the ref (redispatch resumes the same PR). A closure without an integer `pr` is a command error appending nothing. | three closure tests in `test_fold_attempts.py`; `test_item_enqueued_closure_requires_an_integer_pr` |

## Judgment calls worth a reviewer's eye

- **A closure clears `round_history` alongside the PR ref.** Not named in B7, but `pr_closed` already clears it for the documented reason "a new PR must not inherit an old stalemate", and a closure *is* a PR cycle ending — leaving it would let a later `pr_opened` accumulate rounds onto the abandoned PR's history.
- **`closure.reason` is optional**, because S9T1-D12 spells the executor verb as `abandon <id> --pr <n> [--reason <text>]`. Only the integer `pr` is required.
- **Budget parsing reuses the `stalemate_risk_round` helper** (`_round_threshold`, renamed `_positive_int_threshold` now that a second caller shares it) — the precedent B4 cites. A non-positive or non-int budget falls back to the default, exactly as the stalemate threshold does.
- **`ATTEMPT_BUDGETS` in `model.py` is the one table** carrying kind → (config key, default); `DEFAULT_CONFIG` splats it, the boundary derives its enum and error text from it, and the condition reads its defaults from it — the same single-source rule `PARK_REASONS` follows.
- `_TERMINAL_RESOLVING` is renamed `_TERMINAL_ITEM_STATUSES` (one prior call site) — it now also answers "is there work left to attempt", which its old name did not describe.

## Verification

`make ci` run standalone from the worktree root `/Users/scott/src/projects/agents-config/.claude/worktrees/9k9-1-3-attempts` — **exit 0**. Full membership: `ci-installer ci-prgroom ci-workcli ci-vizsuite ci-grind lint-actions spec-lint`. grind: 376 passed, coverage 95.87%. Also smoke-tested end to end through the real CLI (`grind log fix_attempted` rejects an unknown kind with nothing appended; two attempts surface `attempt_budget_spent` on both the `log` emit-back envelope and `status`).

Out of scope by the spec's own §4: renderer surfacing of the ledger (display-only), and any enforcement (Slice C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVH6V9Fa8umDS1zEL8Kdfc