### PR TITLE
feat(workcli): parked_stale block on ready/claim — protocol 1.4 (9k9.1.6)

### DIFF
--- a/docs/specs/2026-07-04-work-facade-cli-contract.md
+++ b/docs/specs/2026-07-04-work-facade-cli-contract.md
@@ -89,8 +89,8 @@ only their envelope/error-code vocabulary above).
 JSON envelope on stdout, always, exit code mirrors `ok`:
 
 ```json
-{"protocol": "1.3", "ok": true, "data": { ... }, "error": null}
-{"protocol": "1.3", "ok": false, "data": null,
+{"protocol": "1.4", "ok": true, "data": { ... }, "error": null}
+{"protocol": "1.4", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y", "dep_type": "blocks"}}}
 ```
@@ -104,6 +104,12 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
   (contract pinned by the 2026-07-15 track-partition design, §4). `create`
   responses MAY carry an optional `warnings: [string]` array (advisory-mode
   track gate).
+- `ready` and `claim` success envelopes carry a read-only `parked_stale` array
+  — the parked items past the default staleness threshold plus any whose age
+  is unreadable, each `{id, title, reason, category, parked_at}` — always
+  present, empty when nothing qualifies, and never bypassable: a verb whose
+  parked read fails errors rather than reporting without it (contract pinned
+  by the 2026-07-25 executor-seam S9 Tier 1 spec, S9T1-D10).
 - Human-readable output is opt-in (`--format human`), for direct human use only:
   it renders the human view to **stderr** while stdout still carries the JSON
   envelope, so the "stdout, always" invariant above holds and consumers MUST
@@ -135,7 +141,7 @@ JSON envelope on stdout, always, exit code mirrors `ok`:
 - Every envelope carries `protocol` (semver `MAJOR.MINOR`). Additive fields bump
   MINOR; any breaking change to envelope or `data` shapes bumps MAJOR.
 - `work --protocol-version` returns a standard success envelope on stdout
-  (`ok: true`, `data: {"protocol": "1.3"}`, exit 0) — no exception to the
+  (`ok: true`, `data: {"protocol": "1.4"}`, exit 0) — no exception to the
   "stdout is always a JSON envelope" invariant (§4). It is the consumer
   handshake at adapter init (prgroom/PDLC pin a major and refuse a mismatch at
   startup rather than mis-parsing mid-run).

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.3"
+PROTOCOL_VERSION = "1.4"

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -25,6 +25,7 @@ from workcli.adapters.bd.runner import BdRunner, SubprocessBdRunner
 from workcli.config import TrackLayerConfig, load_config
 from workcli.envelope import ErrorCode, JsonValue, WorkError, emit_failure, emit_success
 from workcli.lifecycle.nouns import LEAF_NOUNS, Noun
+from workcli.lifecycle.park import DEFAULT_STALE_DAYS
 from workcli.render import render_human
 from workcli.verbs import VERBS, missing_capability
 
@@ -225,7 +226,9 @@ def _add_report_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser
     parked_parser = subparsers.add_parser(
         "parked", help="read-only parked-item staleness report (reports, never acts)"
     )
-    parked_parser.add_argument("--stale-days", type=int, default=7, dest="stale_days")
+    parked_parser.add_argument(
+        "--stale-days", type=int, default=DEFAULT_STALE_DAYS, dest="stale_days"
+    )
 
     groom_parser = subparsers.add_parser(
         "groom", help="Backlog Grooming state: --done records completion, --status reports nag"

--- a/packages/workcli/src/workcli/lifecycle/park.py
+++ b/packages/workcli/src/workcli/lifecycle/park.py
@@ -8,21 +8,32 @@ timestamped `[work] parked` marker note carrying the reason. The two human
 verbs walk it back to `open` with distinct recorded intent -- recut is
 abandon at the tracker layer. `parked` is a read-only staleness report; the
 machine NEVER acts on a parked item of its own accord.
+
+`parked_stale` is the second, narrower surface over the same reads: the block
+`ready` and `claim` carry so that pulling new work always shows the stuck
+work first (S9T1-D10). Both surfaces read; neither writes.
 """
 
 from __future__ import annotations
 
 from argparse import Namespace
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
-from workcli.model import QueryFilters
+from workcli.model import Item, QueryFilters
 
 PARKED_LABEL = "parked"
 PARKED_MARKER = "[work] parked"  # full: "[work] parked <ISO-8601> <code>: <text>"
 REDISPATCHED_MARKER = "[work] redispatched"  # full: "[work] redispatched <ISO-8601>"
 ABANDONED_MARKER = "[work] abandoned"  # full: "[work] abandoned <ISO-8601>"
+
+# S2-D4's threshold, and the ONE definition of it: `work parked --stale-days`
+# defaults to it, and the `parked_stale` block rides it with no flag of its
+# own -- tuning stays on the report, so the surfacing every `ready`/`claim`
+# carries cannot be quietly widened per call site.
+DEFAULT_STALE_DAYS = 7
 
 # The typed-reason vocabulary: code -> category. Machine-actionable
 # reasons arrive here only after the executor's bounded budget is spent;
@@ -57,6 +68,46 @@ def _last_park_record(notes: str) -> tuple[str | None, str | None]:
         return None, None
     parked_at, code = parts
     return parked_at, code if code in REASONS else None
+
+
+@dataclass(frozen=True)
+class _Stint:
+    """The last park stint as it can actually be read off an item's notes.
+
+    `parked_at is None` is the load-bearing case: it means the age is
+    *unknowable* -- no marker, a malformed head, or a timestamp that isn't
+    ISO-8601 -- which the two surfaces treat oppositely. `stale` is
+    PROVABLY-older-than-threshold and stays false when the age is unknowable
+    (S2-B7); the `parked_stale` block adds the unknowable ones back.
+    """
+
+    parked_at: str | None
+    reason: str | None
+    stale: bool
+
+
+def _read_stint(notes: str, now: datetime, threshold: timedelta) -> _Stint:
+    parked_at, reason = _last_park_record(notes)
+    stale = False
+    if parked_at is not None:
+        try:
+            stale = now - datetime.fromisoformat(parked_at) > threshold
+        except (ValueError, TypeError):
+            # Not an ISO timestamp (or naive where aware is expected):
+            # degrade the field, never the report.
+            parked_at = None
+    return _Stint(parked_at=parked_at, reason=reason, stale=stale)
+
+
+def _stint_row(item: Item, stint: _Stint) -> dict[str, JsonValue]:
+    """The fields both surfaces share; `parked` appends its own `stale` flag."""
+    return {
+        "id": item.id,
+        "title": item.title,
+        "reason": stint.reason,
+        "category": REASONS.get(stint.reason) if stint.reason is not None else None,
+        "parked_at": stint.parked_at,
+    }
 
 
 def park(backend: Backend, args: Namespace) -> JsonValue:
@@ -153,35 +204,60 @@ def abandon(backend: Backend, args: Namespace) -> JsonValue:
     return _unpark(backend, args, "abandon", ABANDONED_MARKER)
 
 
+def _read_parked_items(backend: Backend) -> list[Item]:
+    """The two-read join both surfaces share: the parked set, notes included.
+
+    Query results are lean (no notes fidelity guarantee), so the parked set is
+    re-read via one `batch_get` -- the same re-get seam `reconcile` uses on
+    its candidates. Reads only; a caller of either surface issues no write on
+    account of it (S9T1-P2).
+    """
+    lean = backend.query(QueryFilters(label=PARKED_LABEL))
+    return backend.batch_get([entry.id for entry in lean])
+
+
 def parked(backend: Backend, args: Namespace) -> JsonValue:
     """`work parked [--stale-days N]` -- the read-only staleness report.
 
-    Reports, never acts: reads only. Query results are lean (no
-    notes fidelity guarantee), so the parked set is re-read via one
-    `batch_get` -- the same re-get seam `reconcile` uses on its candidates.
+    Reports, never acts: reads only.
     """
-    lean = backend.query(QueryFilters(label=PARKED_LABEL))
     threshold = timedelta(days=args.stale_days)
     now = args.now()
     rows: list[JsonValue] = []
-    for item in backend.batch_get([entry.id for entry in lean]):
-        parked_at, reason = _last_park_record(item.notes)
-        stale = False
-        if parked_at is not None:
-            try:
-                stale = now - datetime.fromisoformat(parked_at) > threshold
-            except (ValueError, TypeError):
-                # Not an ISO timestamp (or naive where aware is expected):
-                # degrade the field, never the report.
-                parked_at = None
-        rows.append(
-            {
-                "id": item.id,
-                "title": item.title,
-                "reason": reason,
-                "category": REASONS.get(reason) if reason is not None else None,
-                "parked_at": parked_at,
-                "stale": stale,
-            }
-        )
+    for item in _read_parked_items(backend):
+        stint = _read_stint(item.notes, now, threshold)
+        rows.append({**_stint_row(item, stint), "stale": stint.stale})
     return {"items": rows, "stale_days": args.stale_days}
+
+
+def parked_stale(backend: Backend, now: datetime, *, verb: str) -> list[JsonValue]:
+    """The `parked_stale` block `ready` and `claim` carry (S9T1-D10).
+
+    Membership is *proven-stale OR unknown-age*: an item past
+    `DEFAULT_STALE_DAYS`, plus every item whose park marker cannot be read at
+    all. That is deliberately wider than `work parked`'s `stale` flag, which
+    stays false when the age is unprovable (S2-B7) -- here a corrupted marker
+    must never be the thing that exempts an item from being surfaced.
+
+    Fail-closed: a failed read raises rather than returning a short block, so
+    no `ready`/`claim` success envelope can ever carry a silently
+    under-reported surfacing. The underlying error's code and detail survive
+    (a caller's retry logic keys on them); only the message gains the stage,
+    so the envelope says which of the verb's two reads went down.
+    """
+    threshold = timedelta(days=DEFAULT_STALE_DAYS)
+    try:
+        items = _read_parked_items(backend)
+    except WorkError as read_error:
+        raise WorkError(
+            read_error.code,
+            f"{verb}: cannot read the parked-work surfacing ({read_error.message}); "
+            f"the block is mandatory, so {verb} fails rather than reporting without it",
+            {**read_error.detail, "stage": "parked_stale"},
+        ) from read_error
+    rows: list[JsonValue] = []
+    for item in items:
+        stint = _read_stint(item.notes, now, threshold)
+        if stint.stale or stint.parked_at is None:
+            rows.append(_stint_row(item, stint))
+    return rows

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -18,16 +18,28 @@ from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
 from workcli.lifecycle.create import finalize_spec_instantiation
 from workcli.lifecycle.nouns import CREATING_SPEC_LABEL, PLANNED_LABEL
-from workcli.lifecycle.park import PARKED_LABEL
+from workcli.lifecycle.park import PARKED_LABEL, parked_stale
+
+
+def _claimed(item_id: str, block: list[JsonValue]) -> JsonValue:
+    return {"id": item_id, "status": "in_progress", "parked_stale": block}
 
 
 def claim(backend: Backend, args: Namespace) -> JsonValue:
-    """`work claim ID` -- uses bd's own atomic `--claim`; detects stale claims."""
+    """`work claim ID` -- uses bd's own atomic `--claim`; detects stale claims.
+
+    Every SUCCESS carries the read-only `parked_stale` block: taking new work
+    is exactly the interaction that must show the stuck work first. A refusal
+    carries no block -- nothing was handed out to price. On the claiming
+    path the block is read STRICTLY BEFORE `backend.claim`, so a failed
+    surfacing leaves the backend untouched: an error envelope can never hide
+    an item this very call already took.
+    """
     item = backend.get(args.id)
     if item.status == "closed":
         raise WorkError(ErrorCode.NOT_CLAIMABLE, f"{args.id}: a closed item cannot be claimed")
     if item.status == "in_progress":
-        return {"id": args.id, "status": "in_progress"}
+        return _claimed(args.id, parked_stale(backend, args.now(), verb="claim"))
     if is_container(item):
         raise WorkError(ErrorCode.NOT_CLAIMABLE, f"{args.id}: container; planned, not claimed")
     if PARKED_LABEL in item.labels:
@@ -43,8 +55,9 @@ def claim(backend: Backend, args: Namespace) -> JsonValue:
     if args.id not in ready_ids:
         raise WorkError(ErrorCode.NOT_CLAIMABLE, f"{args.id}: blocked by an open dependency")
 
+    block = parked_stale(backend, args.now(), verb="claim")
     backend.claim(args.id)
-    return {"id": args.id, "status": "in_progress"}
+    return _claimed(args.id, block)
 
 
 def release(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -13,6 +13,7 @@ from typing import cast
 
 from workcli.backend import Backend
 from workcli.envelope import JsonValue
+from workcli.lifecycle.park import parked_stale
 from workcli.model import Item, QueryFilters
 from workcli.tracks import derive_track, require_known_track
 
@@ -84,8 +85,19 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def ready(backend: Backend, args: Namespace) -> JsonValue:
-    """`work ready [--label]` — unbounded by default."""
-    return _serialize_items(backend.ready(args.label))
+    """`work ready [--label]` — unbounded by default, plus the `parked_stale` block.
+
+    The block is always present — an empty list when nothing qualifies,
+    because "no stale parked work" is a reported fact, not a missing field.
+    It rides the default threshold and takes no flag of its own; tuning stays
+    on `work parked --stale-days`. The parked read runs FIRST, matching the
+    order the composed `{parked, ready}` surface reads in — and it is
+    fail-closed, so a `ready` list is never handed out beside a surfacing
+    that quietly failed.
+    """
+    block = parked_stale(backend, args.now(), verb="ready")
+    items = backend.ready(args.label)
+    return {"items": [_serialize_item(item) for item in items], "parked_stale": block}
 
 
 def search(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -274,3 +274,47 @@ class FakeBackend:
 
     def sync(self, pull: bool) -> SyncResult:
         return SyncResult(synced=True, mode="pull" if pull else "push")
+
+
+class ReadOnlyFakeBackend(FakeBackend):
+    """Raises on every mutator: the proof surface for a reads-only claim.
+
+    `work parked` and the `parked_stale` block both promise zero writes. A
+    call-log assertion proves what bd was *asked*; this proves the verb layer
+    cannot write at all -- any mutator reached is a loud failure rather than a
+    line someone has to notice in a log.
+    """
+
+    def _refuse(self, *_args: object, **_kwargs: object) -> None:
+        raise AssertionError("this surface must never mutate the backend")
+
+    def create(self, fields: CreateFields) -> str:
+        self._refuse(fields)
+        raise AssertionError  # unreachable; keeps the signature's return type honest
+
+    def set_fields(self, item_id: str, fields: UpdateFields) -> None:
+        self._refuse(item_id, fields)
+
+    def claim(self, item_id: str) -> None:
+        self._refuse(item_id)
+
+    def set_status(self, item_id: str, status: str) -> None:
+        self._refuse(item_id, status)
+
+    def set_type(self, item_id: str, item_type: str) -> None:
+        self._refuse(item_id, item_type)
+
+    def set_acceptance(self, item_id: str, text: str) -> None:
+        self._refuse(item_id, text)
+
+    def append_note(self, item_id: str, text: str) -> None:
+        self._refuse(item_id, text)
+
+    def close(self, ids: Sequence[str]) -> None:
+        self._refuse(ids)
+
+    def reopen(self, item_id: str) -> None:
+        self._refuse(item_id)
+
+    def label_mutate(self, op: str, item_id: str, labels: Sequence[str]) -> None:
+        self._refuse(op, item_id, labels)

--- a/packages/workcli/tests/integration/test_verbs_happy.py
+++ b/packages/workcli/tests/integration/test_verbs_happy.py
@@ -43,6 +43,9 @@ def test_ready_lists_unblocked(read_only_driver):
     env = read_only_driver(["ready"])
     assert env["ok"] is True
     assert isinstance(env["data"]["items"], list)
+    # The parked_stale block rides every ready envelope; nothing in the
+    # read-only corpus is parked, so it is present and empty (never absent).
+    assert env["data"]["parked_stale"] == []
 
 
 def test_search_finds_seeded(read_only_driver):

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -175,9 +175,10 @@ VERB_CASES: list[VerbCase] = [
     VerbCase(
         "ready",
         ["ready"],
-        [ScriptedStep(("ready",), _EMPTY_ARRAY)],
+        # the parked_stale block's read precedes `ready`'s own listing
+        [ScriptedStep(("list",), _EMPTY_ARRAY), ScriptedStep(("ready",), _EMPTY_ARRAY)],
         ["ready"],
-        [ScriptedStep(("ready",), _GARBAGE)],
+        [ScriptedStep(("list",), _EMPTY_ARRAY), ScriptedStep(("ready",), _GARBAGE)],
     ),
     VerbCase(
         "dep",
@@ -246,6 +247,7 @@ VERB_CASES: list[VerbCase] = [
         [
             ScriptedStep(("show",), _show_result(_item_raw("c.1", "T", status="open"))),
             ScriptedStep(("ready",), _list_result(_item_raw("c.1", "T", status="open"))),
+            ScriptedStep(("list",), _EMPTY_ARRAY),  # parked_stale, before the claim
             ScriptedStep(("update",), _OK),
         ],
         ["claim", "c.2"],

--- a/packages/workcli/tests/unit/test_item_track_field.py
+++ b/packages/workcli/tests/unit/test_item_track_field.py
@@ -53,16 +53,19 @@ def test_show_zero_or_multi_track_labels_carry_null() -> None:
 
 
 @pytest.mark.parametrize(
-    ("argv", "prefix"),
+    ("argv", "leading_prefixes", "prefix"),
     [
-        (["list"], ("list",)),
-        (["ready"], ("ready",)),
-        (["search", "T"], ("search",)),
+        (["list"], (), ("list",)),
+        # `ready` reads the parking lot first (the parked_stale block), so its
+        # own listing is the SECOND bd call.
+        (["ready"], (("list",),), ("ready",)),
+        (["search", "T"], (), ("search",)),
     ],
 )
 def test_every_list_shaped_read_verb_carries_track(
-    argv: list[str], prefix: tuple[str, ...]
+    argv: list[str], leading_prefixes: tuple[tuple[str, ...], ...], prefix: tuple[str, ...]
 ) -> None:
+    empty = BdResult(returncode=0, stdout="[]", stderr="")
     step = ScriptedStep(
         prefix,
         BdResult(
@@ -71,7 +74,8 @@ def test_every_list_shaped_read_verb_carries_track(
             stderr="",
         ),
     )
-    exit_code, envelope, _ = run_cli(argv, [step])
+    steps = [ScriptedStep(leading, empty) for leading in leading_prefixes] + [step]
+    exit_code, envelope, _ = run_cli(argv, steps)
     assert exit_code == 0
     data = envelope["data"]
     assert isinstance(data, dict)

--- a/packages/workcli/tests/unit/test_list_unbounded.py
+++ b/packages/workcli/tests/unit/test_list_unbounded.py
@@ -14,6 +14,8 @@ from tests.conftest import run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.adapters.bd.runner import BdResult
 
+_EMPTY = BdResult(returncode=0, stdout="[]", stderr="")
+
 
 def _bare_items(count: int, *, prefix: str = "x") -> list[dict[str, object]]:
     return [
@@ -103,10 +105,11 @@ def test_list_status_label_parent_type_filters_map_to_bd_flags():
 def test_ready_defaults_to_unbounded_and_every_row_surfaces():
     runner = ScriptedBdRunner(
         steps=[
+            ScriptedStep(("list",), _EMPTY),  # parked_stale, read first
             ScriptedStep(
                 ("ready",),
                 BdResult(returncode=0, stdout=json.dumps(_bare_items(120)), stderr=""),
-            )
+            ),
         ]
     )
 
@@ -116,15 +119,26 @@ def test_ready_defaults_to_unbounded_and_every_row_surfaces():
     data = envelope["data"]
     assert isinstance(data, dict)
     assert len(data["items"]) == 120
-    assert runner.calls == [("ready", "--json", "--limit", "0")]
+    assert runner.calls == [
+        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("ready", "--json", "--limit", "0"),
+    ]
 
 
 def test_ready_label_flag_passes_through():
     runner = ScriptedBdRunner(
-        steps=[ScriptedStep(("ready",), BdResult(returncode=0, stdout="[]", stderr=""))]
+        steps=[
+            ScriptedStep(("list",), _EMPTY),
+            ScriptedStep(("ready",), _EMPTY),
+        ]
     )
 
     exit_code, _, _ = run_cli_with_runner(["ready", "--label", "tech-debt"], runner)
 
     assert exit_code == 0
-    assert runner.calls == [("ready", "--json", "--label", "tech-debt", "--limit", "0")]
+    # `--label` reaches `bd ready` only; the parked read is never re-scoped by
+    # it -- the surfacing is the whole parking lot regardless of the filter.
+    assert runner.calls == [
+        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("ready", "--json", "--label", "tech-debt", "--limit", "0"),
+    ]

--- a/packages/workcli/tests/unit/test_park.py
+++ b/packages/workcli/tests/unit/test_park.py
@@ -3,21 +3,23 @@
 Parked = status `blocked` + `parked` label + a timestamped typed marker, one
 facade call; the un-park verbs walk back to `open` with distinct recorded
 intent; `parked` is a read-only staleness report -- the machine never acts
-on a parked item. State-based on `FakeBackend`; `_ReadOnlyFakeBackend` proves
+on a parked item. State-based on `FakeBackend`; `ReadOnlyFakeBackend` proves
 the report's zero-writes contract by raising on every mutator.
+
+The `parked_stale` block over the same reads has its own file
+(`test_parked_stale_block.py`).
 """
 
 from __future__ import annotations
 
 import tomllib
 from argparse import Namespace
-from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from tests.fake_backend import FakeBackend
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
 from workcli.envelope import ErrorCode, WorkError
 from workcli.lifecycle.park import (
     ABANDONED_MARKER,
@@ -31,7 +33,6 @@ from workcli.lifecycle.park import (
     redispatch,
 )
 from workcli.lifecycle.transitions import claim
-from workcli.model import CreateFields, UpdateFields
 
 _NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC)
 _ISO = _NOW.isoformat()
@@ -59,44 +60,6 @@ def _parked_item(backend: FakeBackend, item_id: str, *, parked_at: str, reason: 
         labels=[PARKED_LABEL],
         notes=f"{PARKED_MARKER} {parked_at} {reason}: CI red",
     )
-
-
-class _ReadOnlyFakeBackend(FakeBackend):
-    """Raises on every mutator: the `parked` report reports, never acts."""
-
-    def _refuse(self, *_args: object, **_kwargs: object) -> None:
-        raise AssertionError("parked report must never mutate the backend")
-
-    def create(self, fields: CreateFields) -> str:
-        self._refuse(fields)
-        raise AssertionError  # unreachable; keeps the signature's return type honest
-
-    def set_fields(self, item_id: str, fields: UpdateFields) -> None:
-        self._refuse(item_id, fields)
-
-    def claim(self, item_id: str) -> None:
-        self._refuse(item_id)
-
-    def set_status(self, item_id: str, status: str) -> None:
-        self._refuse(item_id, status)
-
-    def set_type(self, item_id: str, item_type: str) -> None:
-        self._refuse(item_id, item_type)
-
-    def set_acceptance(self, item_id: str, text: str) -> None:
-        self._refuse(item_id, text)
-
-    def append_note(self, item_id: str, text: str) -> None:
-        self._refuse(item_id, text)
-
-    def close(self, ids: Sequence[str]) -> None:
-        self._refuse(ids)
-
-    def reopen(self, item_id: str) -> None:
-        self._refuse(item_id)
-
-    def label_mutate(self, op: str, item_id: str, labels: Sequence[str]) -> None:
-        self._refuse(op, item_id, labels)
 
 
 def test_park_sets_blocked_plus_label_plus_typed_marker():  # S2-B1
@@ -149,7 +112,7 @@ def test_vocabulary_matches_the_shared_park_reason_contract():
 
 
 def test_park_unknown_reason_is_usage_error_before_any_backend_call():  # S2-B2 (inverse)
-    backend = _ReadOnlyFakeBackend()  # any touch -- even a read's mutation -- would raise
+    backend = ReadOnlyFakeBackend()  # any touch -- even a read's mutation -- would raise
 
     with pytest.raises(WorkError) as excinfo:
         park(backend, _park_args("w1", "vibes"))
@@ -249,7 +212,7 @@ def test_abandon_records_its_own_distinct_intent():  # S2-B6
 
 
 def test_parked_report_lists_reason_category_staleness_read_only():  # S2-B7
-    backend = _ReadOnlyFakeBackend()
+    backend = ReadOnlyFakeBackend()
     _parked_item(
         backend,
         "old",
@@ -290,7 +253,7 @@ def test_parked_report_lists_reason_category_staleness_read_only():  # S2-B7
 
 
 def test_parked_report_degrades_an_unparseable_marker_to_nulls():  # S2-B7 (dep failure)
-    backend = _ReadOnlyFakeBackend()
+    backend = ReadOnlyFakeBackend()
     backend.add("w1", status="blocked", labels=[PARKED_LABEL], notes="hand-written note")
 
     data = parked(backend, _parked_args())

--- a/packages/workcli/tests/unit/test_parked_stale_block.py
+++ b/packages/workcli/tests/unit/test_parked_stale_block.py
@@ -1,0 +1,422 @@
+"""The `parked_stale` block on `ready` and `claim` (S9T1-P1..P6).
+
+D10's rule is that *any* open-new-work interaction shows the stuck work
+first. `executor next` is the composed surface; this block is the layer that
+makes the rule hold for every caller who never touches the executor -- so it
+is always present, computed by reads alone, and fail-closed: a `ready` or
+`claim` that cannot compute it errors rather than handing out work beside a
+surfacing that quietly failed.
+
+Membership is deliberately WIDER than `work parked`'s `stale` flag:
+proven-stale OR unknown-age. A corrupted marker makes an item's age
+unprovable, and unprovable must never read as "not stale yet".
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tests.conftest import run_cli_with_runner
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.park import DEFAULT_STALE_DAYS, PARKED_LABEL, PARKED_MARKER, parked
+from workcli.lifecycle.transitions import claim
+from workcli.model import Item, QueryFilters
+from workcli.verbs.read import ready
+
+_NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC)
+_STALE_AT = (_NOW - timedelta(days=30)).isoformat()
+_FRESH_AT = (_NOW - timedelta(days=1)).isoformat()
+
+
+def _ready_args(label: str | None = None) -> Namespace:
+    return Namespace(label=label, now=lambda: _NOW)
+
+
+def _claim_args(item_id: str) -> Namespace:
+    return Namespace(id=item_id, now=lambda: _NOW)
+
+
+def _parked_args(stale_days: int = DEFAULT_STALE_DAYS) -> Namespace:
+    return Namespace(stale_days=stale_days, now=lambda: _NOW)
+
+
+def _park(
+    backend: FakeBackend,
+    item_id: str,
+    *,
+    parked_at: str,
+    reason: str = "ci-failure",
+    title: str = "T",
+) -> FakeBackend:
+    return backend.add(
+        item_id,
+        title=title,
+        status="blocked",
+        labels=[PARKED_LABEL],
+        notes=f"{PARKED_MARKER} {parked_at} {reason}: CI red",
+    )
+
+
+def _block(data: JsonValue) -> list[JsonValue]:
+    assert isinstance(data, dict)
+    block = data["parked_stale"]
+    assert isinstance(block, list)
+    return block
+
+
+# --- S9T1-P1: the block is present, shaped, and always emitted -------------
+
+
+def test_ready_carries_the_stale_parked_items_with_their_five_fields():  # S9T1-P1
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "stuck", parked_at=_STALE_AT, reason="approval-required", title="Old thing")
+    backend.add("w1", status="open")
+
+    data = ready(backend, _ready_args())
+
+    assert _block(data) == [
+        {
+            "id": "stuck",
+            "title": "Old thing",
+            "reason": "approval-required",
+            "category": "human",
+            "parked_at": _STALE_AT,
+        }
+    ]
+    # The block rides ALONGSIDE the ready list; it never filters it.
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    assert [item["id"] for item in items if isinstance(item, dict)] == ["w1"]
+
+
+def test_claim_carries_the_same_block_on_the_item_it_hands_out():  # S9T1-P1
+    backend = FakeBackend().add("w1", status="open")
+    _park(backend, "stuck", parked_at=_STALE_AT)
+
+    data = claim(backend, _claim_args("w1"))
+
+    assert data == {
+        "id": "w1",
+        "status": "in_progress",
+        "parked_stale": [
+            {
+                "id": "stuck",
+                "title": "T",
+                "reason": "ci-failure",
+                "category": "machine",
+                "parked_at": _STALE_AT,
+            }
+        ],
+    }
+
+
+def test_the_block_is_present_and_empty_when_nothing_qualifies():  # S9T1-P1 (empty boundary)
+    # The absence of stale parked work is a REPORTED FACT, not a missing key:
+    # a consumer must never have to tell "none" from "the field wasn't computed".
+    backend = FakeBackend().add("w1", status="open")
+
+    assert _block(ready(backend, _ready_args())) == []
+    assert _block(claim(backend, _claim_args("w1"))) == []
+
+
+def test_claim_on_an_already_claimed_item_still_carries_the_block():  # S9T1-P1
+    # The idempotent no-op is a SUCCESS envelope, so it owes the surfacing too.
+    backend = FakeBackend().add("w1", status="in_progress")
+    _park(backend, "stuck", parked_at=_STALE_AT)
+
+    assert len(_block(claim(backend, _claim_args("w1")))) == 1
+
+
+def test_ready_and_claim_take_no_stale_days_flag():  # S9T1-P1 (D10: no new flags)
+    # Tuning lives on `work parked --stale-days`; the block rides S2-D4's
+    # default so the surfacing cannot be widened per call site.
+    for argv in (["ready", "--stale-days", "90"], ["claim", "w1", "--stale-days", "90"]):
+        exit_code, envelope, _ = run_cli_with_runner(argv, ScriptedBdRunner(steps=[]))
+        error = envelope["error"]
+        assert exit_code == 1
+        assert isinstance(error, dict)
+        assert error["code"] == str(ErrorCode.USAGE)
+
+
+# --- S9T1-P2: reads only ---------------------------------------------------
+
+
+def test_ready_computes_the_block_without_a_single_mutation():  # S9T1-P2
+    # ReadOnlyFakeBackend raises on every mutator: not "no writes were
+    # logged", but "no write was reachable at all".
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "stuck", parked_at=_STALE_AT)
+
+    assert len(_block(ready(backend, _ready_args()))) == 1
+
+
+def test_ready_bd_call_log_is_two_reads_and_nothing_else():  # S9T1-P2
+    empty = BdResult(returncode=0, stdout="[]", stderr="")
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("list",), empty), ScriptedStep(("ready",), empty)]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["ready"], runner)
+
+    assert exit_code == 0
+    assert envelope["data"] == {"items": [], "parked_stale": []}
+    assert runner.calls == [
+        ("list", "--json", "--label", PARKED_LABEL, "--limit", "0"),
+        ("ready", "--json", "--limit", "0"),
+    ]
+
+
+def test_claims_write_set_is_unchanged_by_the_block():  # S9T1-P2
+    # Pre-block, `claim` issued exactly one mutation: bd's atomic `--claim`.
+    # The block joins two reads onto that; the write set must not move.
+    empty = BdResult(returncode=0, stdout="[]", stderr="")
+    item = BdResult(
+        returncode=0,
+        stdout=json.dumps(
+            [
+                {
+                    "id": "w1",
+                    "title": "T",
+                    "issue_type": "task",
+                    "status": "open",
+                    "priority": 2,
+                    "labels": [],
+                    "parent": None,
+                    "dependencies": [],
+                    "dependents": [],
+                }
+            ]
+        ),
+        stderr="",
+    )
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("show",), item),
+            ScriptedStep(("ready",), item),
+            ScriptedStep(("list",), empty),
+            ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr="")),
+        ]
+    )
+
+    exit_code, _, _ = run_cli_with_runner(["claim", "w1"], runner)
+
+    assert exit_code == 0
+    mutations = [call for call in runner.calls if call[0] not in {"show", "list", "ready"}]
+    assert mutations == [("update", "w1", "--claim")]
+
+
+# --- S9T1-P3: the block is the threshold surfacing, not a second report ----
+
+
+def test_a_recently_parked_item_is_reported_by_parked_but_not_by_the_block():  # S9T1-P3
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "fresh", parked_at=_FRESH_AT)
+
+    report = parked(backend, _parked_args())
+
+    assert isinstance(report, dict)
+    items = report["items"]
+    assert isinstance(items, list)
+    assert [item["id"] for item in items if isinstance(item, dict)] == ["fresh"]
+    assert _block(ready(backend, _ready_args())) == []
+
+
+@pytest.mark.parametrize(
+    ("age", "in_block"),
+    [
+        (timedelta(days=DEFAULT_STALE_DAYS), False),
+        (timedelta(days=DEFAULT_STALE_DAYS, seconds=1), True),
+    ],
+)
+def test_the_threshold_boundary_is_strictly_older_than(age, in_block):  # S9T1-P3 (boundary)
+    # Exactly at the threshold is NOT stale -- the block and `work parked`'s
+    # `stale` flag agree on the boundary; they differ only on unknown age.
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "edge", parked_at=(_NOW - age).isoformat())
+
+    assert bool(_block(ready(backend, _ready_args()))) is in_block
+
+
+# --- S9T1-P4: fail-closed on a failed parked read -------------------------
+
+
+class _ParkedReadDown(ReadOnlyFakeBackend):
+    """The parking-lot query is down; everything else works."""
+
+    def query(self, filters: QueryFilters) -> list[Item]:
+        raise WorkError(ErrorCode.BACKEND_DRIFT, f"bd list: unparseable output ({filters.label})")
+
+
+def test_ready_fails_typed_rather_than_reporting_without_the_block():  # S9T1-P4
+    backend = _ParkedReadDown().add("w1", status="open")
+
+    with pytest.raises(WorkError) as excinfo:
+        ready(backend, _ready_args())
+
+    # The transport code survives (a caller's retry logic keys on it); the
+    # message names which of the verb's reads went down.
+    assert excinfo.value.code is ErrorCode.BACKEND_DRIFT
+    assert excinfo.value.detail["stage"] == "parked_stale"
+    assert "ready" in excinfo.value.message
+
+
+def test_claim_fails_typed_and_the_item_stays_unclaimed():  # S9T1-P4 (fail-closed)
+    # ReadOnlyFakeBackend refuses `claim` outright, so reaching the mutation
+    # would surface as an AssertionError rather than this WorkError.
+    backend = _ParkedReadDown().add("w1", status="open")
+
+    with pytest.raises(WorkError) as excinfo:
+        claim(backend, _claim_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.BACKEND_DRIFT
+    assert excinfo.value.detail["stage"] == "parked_stale"
+    assert backend.get("w1").status == "open"
+
+
+def test_claim_leaves_the_bd_mutation_log_empty_when_the_parked_read_fails():  # S9T1-P4
+    # An error envelope must never hide an item this very call already took.
+    item = BdResult(
+        returncode=0,
+        stdout=json.dumps(
+            [
+                {
+                    "id": "w1",
+                    "title": "T",
+                    "issue_type": "task",
+                    "status": "open",
+                    "priority": 2,
+                    "labels": [],
+                    "parent": None,
+                    "dependencies": [],
+                    "dependents": [],
+                }
+            ]
+        ),
+        stderr="",
+    )
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("show",), item),
+            ScriptedStep(("ready",), item),
+            ScriptedStep(("list",), BdResult(returncode=0, stdout="not json", stderr="")),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["claim", "w1"], runner)
+
+    error = envelope["error"]
+    assert exit_code == 1
+    assert isinstance(error, dict)
+    assert isinstance(error["detail"], dict)
+    assert error["detail"]["stage"] == "parked_stale"
+    assert not any(call[0] == "update" for call in runner.calls)
+
+
+def test_ready_never_issues_its_own_listing_once_the_parked_read_fails():  # S9T1-P4
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("list",), BdResult(returncode=0, stdout="not json", stderr=""))]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["ready"], runner)
+
+    assert exit_code == 1
+    assert envelope["data"] is None
+    assert runner.calls == [("list", "--json", "--label", PARKED_LABEL, "--limit", "0")]
+
+
+# --- S9T1-P5: an unreadable marker surfaces, it does not exempt ------------
+
+
+def test_an_unparseable_marker_surfaces_with_null_reason_and_null_parked_at():  # S9T1-P5
+    backend = ReadOnlyFakeBackend()
+    backend.add("corrupt", status="blocked", labels=[PARKED_LABEL], notes="hand-written note")
+
+    assert _block(ready(backend, _ready_args())) == [
+        {
+            "id": "corrupt",
+            "title": "T",
+            "reason": None,
+            "category": None,
+            "parked_at": None,
+        }
+    ]
+
+
+def test_an_unreadable_timestamp_surfaces_too_though_parked_calls_it_not_stale():  # S9T1-P5
+    # The deliberate divergence from S2-B7: `work parked` reports stale=false
+    # when the age is unprovable; the block reports the item anyway. Unprovable
+    # age must never be the reason an item escapes the surfacing.
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "corrupt", parked_at="yesterday-ish")
+
+    report = parked(backend, _parked_args())
+
+    assert isinstance(report, dict)
+    items = report["items"]
+    assert isinstance(items, list)
+    row = items[0]
+    assert isinstance(row, dict)
+    assert row["stale"] is False
+    assert row["parked_at"] is None
+
+    assert [
+        entry["id"] for entry in _block(ready(backend, _ready_args())) if isinstance(entry, dict)
+    ] == ["corrupt"]
+
+
+def test_a_marker_head_of_the_wrong_shape_surfaces_rather_than_being_exempted():  # S9T1-P5
+    # The other malformed-marker shape: a well-formed prefix whose head does
+    # not split into exactly (timestamp, code). Both fields degrade to null,
+    # and the item is still in the block -- there is no shape of corruption
+    # that buys an item its way out of the surfacing.
+    backend = ReadOnlyFakeBackend()
+    backend.add(
+        "corrupt",
+        status="blocked",
+        labels=[PARKED_LABEL],
+        notes=f"{PARKED_MARKER} {_STALE_AT} ci-failure oops: CI red",
+    )
+
+    assert _block(ready(backend, _ready_args())) == [
+        {
+            "id": "corrupt",
+            "title": "T",
+            "reason": None,
+            "category": None,
+            "parked_at": None,
+        }
+    ]
+
+
+def test_a_corrupt_marker_does_not_crash_the_verb_it_rides_on():  # S9T1-P5
+    backend = FakeBackend().add("w1", status="open")
+    backend.add("corrupt", status="blocked", labels=[PARKED_LABEL], notes="")
+
+    data = claim(backend, _claim_args("w1"))
+
+    assert isinstance(data, dict)
+    assert data["status"] == "in_progress"
+    assert len(_block(data)) == 1
+
+
+# --- S9T1-P6: idempotent read ---------------------------------------------
+
+
+def test_two_consecutive_ready_calls_return_identical_blocks_and_mutate_nothing():  # S9T1-P6
+    backend = ReadOnlyFakeBackend()
+    _park(backend, "stuck", parked_at=_STALE_AT)
+    _park(backend, "corrupt", parked_at="not-a-date")
+
+    first = ready(backend, _ready_args())
+    second = ready(backend, _ready_args())
+
+    assert first == second
+    assert len(_block(first)) == 2

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -60,4 +60,4 @@ def test_protocol_wire_value_is_pinned() -> None:
     # The serialization boundary pins the literal wire value; every other
     # test references PROTOCOL_VERSION. Bumping the protocol means updating
     # this one assertion deliberately.
-    assert PROTOCOL_VERSION == "1.3"
+    assert PROTOCOL_VERSION == "1.4"

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -63,6 +63,7 @@ def test_claim_on_open_unblocked_leaf_sends_claim_and_returns_in_progress():
         steps=[
             ScriptedStep(("show",), _show_result(_item_raw("x.1", status="open"))),
             ScriptedStep(("ready",), _ready_result(_item_raw("x.1", status="open"))),
+            ScriptedStep(("list",), _ready_result()),  # parked_stale: nothing parked
             ScriptedStep(("update",), _OK),
         ]
     )
@@ -70,10 +71,13 @@ def test_claim_on_open_unblocked_leaf_sends_claim_and_returns_in_progress():
     exit_code, envelope, _ = run_cli_with_runner(["claim", "x.1"], runner)
 
     assert exit_code == 0
-    assert envelope["data"] == {"id": "x.1", "status": "in_progress"}
+    assert envelope["data"] == {"id": "x.1", "status": "in_progress", "parked_stale": []}
+    # The parked read sits BETWEEN the guards and the claim -- the mutation is
+    # strictly last, so a failed surfacing leaves the item unclaimed (S9T1-P4).
     assert runner.calls == [
         ("show", "x.1", "--json"),
         ("ready", "--json", "--limit", "0"),
+        ("list", "--json", "--label", "parked", "--limit", "0"),
         ("update", "x.1", "--claim"),
     ]
 
@@ -145,14 +149,19 @@ def test_claim_on_already_in_progress_is_a_noop_with_no_claim_call():
     runner = ScriptedBdRunner(
         steps=[
             ScriptedStep(("show",), _show_result(_item_raw("x.1", status="in_progress"))),
+            ScriptedStep(("list",), _ready_result()),  # parked_stale: still a success envelope
         ]
     )
 
     exit_code, envelope, _ = run_cli_with_runner(["claim", "x.1"], runner)
 
     assert exit_code == 0
-    assert envelope["data"] == {"id": "x.1", "status": "in_progress"}
-    assert runner.calls == [("show", "x.1", "--json")]
+    assert envelope["data"] == {"id": "x.1", "status": "in_progress", "parked_stale": []}
+    assert runner.calls == [
+        ("show", "x.1", "--json"),
+        ("list", "--json", "--label", "parked", "--limit", "0"),
+    ]
+    assert not any(call[:1] == ("update",) for call in runner.calls)
 
 
 def test_claim_on_closed_item_is_not_claimable():


### PR DESCRIPTION
Slice P of S9 Tier 1 — the workcli half of `agents-config-9k9.1.6`. Binding contract: `docs/specs/2026-07-25-executor-seam-s9-tier1.md`, decision **S9T1-D10**.

`work ready` and `work claim` success envelopes now carry a read-only `parked_stale` array. That is the layer that makes D10's *"any open-new-work interaction shows the stuck work first"* hold for every caller who never touches the executor — `executor next` (Slice N) is the composed surface over the same reads and is **not** in this PR.

## Shape

Each row is `{id, title, reason, category, parked_at}`. The block is **always present** — an empty list when nothing qualifies, because the absence of stale parked work is a reported fact, not a missing field.

Three properties govern it:

1. **Reads only.** The block joins `bd list --label parked` with one `batch_get` and counts nothing, so `S2-D2` ("the facade records outcomes and never counts attempts") is intact.
2. **Fail closed, twice over.** A failed parked read raises rather than returning a short block, so no success envelope can carry a silently under-reported surfacing. On `claim` the read runs **strictly before** bd's atomic `--claim`, so a failure leaves the mutation log empty — an error envelope never hides an item the call already took. And membership is *proven-stale **or** unknown-age*, deliberately wider than `work parked`'s `stale` flag, which stays false when age is unprovable (`S2-B7`): a corrupted marker must never be the thing that exempts an item from being surfaced.
3. **No new flags.** `ready` and `claim` gain none. The block rides `S2-D4`'s 7-day default, now the single `DEFAULT_STALE_DAYS` constant that `work parked --stale-days` also defaults to; tuning stays on `work parked`.

The typed error preserves the underlying transport code and detail (a caller's retry logic keys on them) and adds `detail.stage = "parked_stale"` plus a message naming which of the verb's two reads went down.

## Protocol bump: 1.3 → 1.4 (MINOR)

The facade contract's §5 rule is explicit: *"Additive fields bump MINOR; any breaking change to envelope or `data` shapes bumps MAJOR."* `parked_stale` is an additive field on two existing success `data` shapes — no field removed, none re-typed — so MINOR is the rule's answer, not a judgment call. It matches the 1.0→1.1 (`track` field) and 1.2→1.3 (`discover` + new error code) precedents, both of which also updated the literals in `docs/specs/2026-07-04-work-facade-cli-contract.md`; this PR does the same and adds a bullet documenting the block. No consumer outside `packages/workcli/` reads a `ready`/`claim` envelope today (checked across `prgroom`, `pdlc`, `grind`, `installer`), and the handshake pins MAJOR, so nothing needs to move in lockstep.

## Acceptance criteria discharged

All in `packages/workcli/tests/unit/test_parked_stale_block.py` unless noted.

| AC | How it is tested |
| --- | --- |
| **S9T1-P1** | The block on `ready` and on `claim` with all five fields; present-and-empty on both when nothing qualifies; present on `claim`'s idempotent already-`in_progress` success too (it is still a success envelope); `--stale-days` on either verb is `E_USAGE` (the no-new-flags half of D10). |
| **S9T1-P2** | `ready` computes the block against `ReadOnlyFakeBackend`, which *raises* on every mutator — not "no writes logged" but "no write reachable". Plus two bd call-log assertions: `ready`'s log is exactly two reads, and `claim`'s non-read calls are exactly `("update", "w1", "--claim")` — its pre-block write set, unmoved. |
| **S9T1-P3** | A recently-parked item appears in `work parked` and not in the block. Parametrized boundary: exactly at the threshold is **not** in the block, one second past it is. |
| **S9T1-P4** | With the parked query down, `ready` and `claim` raise typed (code and `detail.stage` asserted) and the item stays `open`; at CLI level, a failed parked read leaves `runner.calls` with no `update` at all, and `ready` never issues its own listing. |
| **S9T1-P5** | Both malformed-marker shapes surface with null reason and null `parked_at` — an unreadable prefix, and a well-formed prefix whose head does not split into (timestamp, code). One test asserts the divergence directly: for the same item, `work parked` reports `stale: false` while the block reports it anyway. One asserts the host verb does not crash. |
| **S9T1-P6** | Two consecutive `ready` calls against an unchanged backend and a held clock return identical envelopes, against the mutation-refusing fake. |

## Verification

`make ci` — **exit 0**, run standalone (not piped) from the root of this worktree, `.claude/worktrees/9k9-1-6-parked-stale`. Full membership: `ci-installer ci-prgroom ci-workcli ci-vizsuite ci-grind lint-actions spec-lint`. workcli: 641 passed, branch coverage 99.17%, `park.py` at zero statement misses.

Also ran `make itest-workcli` — **exit 0**, 36 passed in 113s — the real-bd integration suite (not a merge gate; pre-push discipline). It exercises the new `bd list --label parked` read on the live `ready` and `claim` paths, and carries one added value-level assertion that the block is present-and-empty against the read-only corpus.

## Not in scope

`packages/grind/` (Slice B) and `packages/executor/` (Slices A/C/N) are untouched — separate branches, in flight in parallel. `agents-config-9k9.1.6` stays **open** until Slice N lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVH6V9Fa8umDS1zEL8Kdfc