### PR TITLE
feat(9k9.17.7): record what actually ran each review lens

### DIFF
--- a/src/user/.agents/skills/review-verdict/SKILL.md
+++ b/src/user/.agents/skills/review-verdict/SKILL.md
@@ -17,17 +17,41 @@ All fields are required.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `schema_version` | `"1"` | Version of this contract. |
+| `schema_version` | `"2"` | Version of this contract. |
 | `artifact_class` | string | What kind of change was reviewed; selects the lens set the round must cover. |
 | `round` | integer ≥ 1 | Which review round this is for the claim. |
 | `base_sha` | 40-hex | Commit the reviewed diff was taken against. |
 | `head_sha` | 40-hex | Reviewed head commit. The verdict is valid only for this commit. |
 | `claim_id` | non-blank string | The completion claim this round adjudicates. |
 | `retained_categories` | array of strings | Categories carried forward from earlier rounds. May be empty, but must be present — an empty array asserts "nothing retained". |
-| `lenses` | array, ≥ 1 | One entry per lens the artifact class declares: `{"lens": …, "verdict": "clean"\|"findings"}`. Report green lenses too. |
+| `lenses` | array, ≥ 1 | One entry per lens the artifact class declares, green ones included, each recording what actually ran it. |
 | `prior_dispositions` | array | What happened to each earlier mechanical finding. May be empty on round 1. |
 | `verdict` | `"clean"` or `"findings"` | Round-level result. |
 | `findings` | array | Findings raised this round. Must be empty when `verdict` is `"clean"` and non-empty when it is `"findings"`. |
+
+### Lens entry
+
+```json
+{"lens": "correctness", "verdict": "findings", "vendor": "openai",
+ "transport": "openrouter", "model": "openai/gpt-5.6-sol",
+ "substitution": {"declared_transport": "codex", "declared_model": "gpt-5.6-terra",
+                  "reason": "codex credential expired; provider returned 401"}}
+```
+
+`vendor`, `transport` and `model` record what **actually** produced the report, never what the
+lens registry declared for it. A lens reports exactly once: a lens re-dispatched after a failure
+carries one entry describing the attempt that produced the report it holds, and a second entry for
+the same lens is rejected (`duplicate-lens`) because two attempts reported as two lenses inflate
+coverage.
+
+`substitution` appears only when the lens ran on something other than its declared entry, and its
+`reason` is mandatory and non-blank. Recording it is the round's own job: nothing downstream can
+reconstruct a swap the round did not write down.
+
+**Vendor diversity is derived, never stored.** Count the distinct `vendor` values across `lenses`;
+one means the panel collapsed onto a single vendor and its blind spots now correlate. That is an
+observation a reader makes from the artifact, not a validation error — a collapsed round is a
+real round, and stalling it would trade a weaker review for no review.
 
 ### Finding
 
@@ -40,6 +64,11 @@ All fields are required.
 `id` is unique within the artifact. `type` is `mechanical` (blocks) or `advisory` (never blocks;
 routes to the backlog). `evidence` is mandatory and non-blank for `mechanical` findings —
 omitted, empty, and whitespace-only all fail validation. It is optional for `advisory`.
+
+`downgraded_from: "mechanical"` marks an advisory the harvester demoted because the lens called it
+mechanical and supplied no evidence. Only an advisory may carry it. The marker exists so the
+demotion stays countable: a lens producing many of them is unreliable, and that is invisible if
+the demotion is silent.
 
 ### Prior disposition
 
@@ -77,12 +106,17 @@ Hand-verify all five against the pull request:
 3. **Live and authentic** — the verdict is schema-valid, App-posted, and its `head_sha` equals the
    current head.
 4. **Lens coverage** — `lenses` covers the full lens set the artifact class declares, green lenses
-   included. Coverage is read off the artifact; silence never counts as a clean lens.
+   included, each carrying what ran it. Coverage is read off the artifact; silence never counts as
+   a clean lens, and a lens that died and was never re-dispatched leaves the round incomplete.
 5. **Ledger coverage** — `prior_dispositions` accounts for every `mechanical` finding from every
    prior round's posted verdict.
 
 **Terminal-clean** = a complete round with zero `mechanical` findings. Advisory findings never
 block; they go to the backlog.
+
+Completeness and diversity are separate questions. A round every lens reported on is complete even
+if all of them ran on one vendor — report the collapse alongside the verdict rather than treating
+it as a defect in the round.
 
 The schema checks the shape of a single artifact. The five conditions above are cross-artifact —
 they compare the verdict against the pull request and against earlier verdicts — so today a person
@@ -98,6 +132,7 @@ uv run validate_verdict.py path/to/verdict.json
 ```
 
 Stdout is JSON: `{"valid": true}` or `{"valid": false, "errors": [{"code", "path", "message"}, …]}`.
-Error codes are `unreadable`, `invalid-json`, `schema`, and `duplicate-finding-id`. Exit status is
+Error codes are `unreadable`, `invalid-json`, `schema`, `duplicate-finding-id`, and
+`duplicate-lens`. Exit status is
 0 when valid, 1 when invalid, 2 when the file cannot be read or parsed. Output is deterministic:
 the same input always produces byte-identical output.

--- a/src/user/.agents/skills/review-verdict/validate_verdict.py
+++ b/src/user/.agents/skills/review-verdict/validate_verdict.py
@@ -80,9 +80,35 @@ def _duplicate_id_errors(document: Any) -> list[dict[str, str]]:
     return errors
 
 
+def _duplicate_lens_errors(document: Any) -> list[dict[str, str]]:
+    """One entry per lens, always. A re-dispatched lens reports once, not once per attempt."""
+    if not isinstance(document, dict):
+        return []
+    lenses = document.get("lenses")
+    if not isinstance(lenses, list):
+        return []
+    seen: set[str] = set()
+    errors: list[dict[str, str]] = []
+    for index, entry in enumerate(lenses):
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("lens")
+        if not isinstance(name, str):
+            continue
+        if name in seen:
+            errors.append({
+                "code": "duplicate-lens",
+                "path": f"/lenses/{index}/lens",
+                "message": f"lens {name!r} reports more than once; a lens has exactly one entry",
+            })
+        seen.add(name)
+    return errors
+
+
 def validate_document(document: Any) -> dict[str, Any]:
     """Validate an already-parsed document. Deterministic for identical input."""
-    errors = _schema_errors(document) + _duplicate_id_errors(document)
+    errors = (_schema_errors(document) + _duplicate_id_errors(document)
+              + _duplicate_lens_errors(document))
     if not errors:
         return {"valid": True}
     errors.sort(key=lambda err: (err["path"], err["code"], err["message"]))

--- a/src/user/.agents/skills/review-verdict/validate_verdict_test.py
+++ b/src/user/.agents/skills/review-verdict/validate_verdict_test.py
@@ -38,16 +38,28 @@ SHA_A = "a" * 40
 SHA_B = "b" * 40
 
 
+def lens_entry(name: str = "correctness", **overrides: Any) -> dict[str, Any]:
+    entry = {
+        "lens": name,
+        "verdict": "clean",
+        "vendor": "anthropic",
+        "transport": "openrouter",
+        "model": "anthropic/claude-opus-5",
+    }
+    entry.update(overrides)
+    return entry
+
+
 def valid_verdict() -> dict[str, Any]:
     return {
-        "schema_version": "1",
+        "schema_version": "2",
         "artifact_class": "python-package",
         "round": 1,
         "base_sha": SHA_A,
         "head_sha": SHA_B,
         "claim_id": "claim-1",
         "retained_categories": [],
-        "lenses": [{"lens": "correctness", "verdict": "clean"}],
+        "lenses": [lens_entry()],
         "prior_dispositions": [],
         "verdict": "clean",
         "findings": [],
@@ -286,6 +298,100 @@ class TestValidatorBehaviour:
             )
             assert proc.returncode == expected, proc.stderr
             assert json.loads(proc.stdout)["valid"] is (expected == 0)
+
+
+class TestWhatActuallyRanTheLens:
+    """A lens entry records what ran it, so a later reader is not left with the invoker's memory."""
+
+    def test_version_one_envelope_is_rejected(self):
+        """The lens entry gained required fields, so a v1 verdict is not a v2 verdict."""
+        doc = valid_verdict()
+        doc["schema_version"] = "1"
+        assert not is_valid(doc)
+
+    @pytest.mark.parametrize("field", ["vendor", "transport", "model"])
+    def test_lens_entry_without_run_record_is_rejected(self, field):
+        """Omitting what ran the lens is not a way to avoid declaring it."""
+        entry = lens_entry()
+        del entry[field]
+        doc = valid_verdict()
+        doc["lenses"] = [entry]
+        assert not is_valid(doc)
+
+    @pytest.mark.parametrize("field", ["vendor", "transport", "model"])
+    def test_blank_run_record_is_rejected(self, field):
+        """Whitespace is not a declaration; the blank-string escape is closed on every field."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(**{field: "   "})]
+        assert not is_valid(doc)
+
+    def test_substitution_records_what_was_declared_and_why(self):
+        """A lens re-dispatched onto a substitute stays inside the round, with the swap on record."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(
+            transport="openrouter", model="openai/gpt-5.6-sol", vendor="openai",
+            substitution={"declared_transport": "codex", "declared_model": "gpt-5.6-terra",
+                          "reason": "codex credential expired; 401 from the provider"},
+        )]
+        assert is_valid(doc)
+
+    def test_substitution_without_a_reason_is_rejected(self):
+        """An unexplained swap is the thing this field exists to stop."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(substitution={"declared_transport": "codex"})]
+        assert not is_valid(doc)
+
+    def test_blank_substitution_reason_is_rejected(self):
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(substitution={"reason": "  "})]
+        assert not is_valid(doc)
+
+    def test_one_vendor_across_the_panel_still_validates(self):
+        """Collapse is an observation the reader derives, never a schema error that stalls a round."""
+        doc = valid_verdict()
+        doc["lenses"] = [
+            lens_entry("correctness", vendor="openai", model="openai/gpt-5.6-sol"),
+            lens_entry("security", vendor="openai", model="openai/gpt-5.6-terra"),
+        ]
+        assert is_valid(doc)
+
+    def test_a_lens_reporting_twice_is_rejected(self):
+        """Re-dispatch produces one entry. Two attempts reported as two lenses inflates coverage."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry("correctness"), lens_entry("correctness", transport="codex")]
+        assert not is_valid(doc)
+        assert "duplicate-lens" in codes(doc)
+
+    def test_distinct_lenses_are_not_duplicates(self):
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry("correctness"), lens_entry("security")]
+        assert is_valid(doc)
+
+
+class TestUnevidencedMechanicalDowngrade:
+    """The harvester demotes a mechanical finding with no evidence; the demotion stays visible."""
+
+    def test_downgraded_advisory_validates(self):
+        doc = valid_verdict()
+        doc["verdict"] = "findings"
+        doc["findings"] = [{"id": "f1", "lens": "correctness", "type": "advisory",
+                            "ac": "A1", "claim": "the reader mishandles an empty file",
+                            "downgraded_from": "mechanical"}]
+        assert is_valid(doc)
+
+    def test_downgraded_marker_on_a_mechanical_finding_is_rejected(self):
+        """A finding cannot claim it was demoted and still block."""
+        doc = valid_verdict()
+        doc["verdict"] = "findings"
+        doc["findings"] = [{**mechanical_finding(), "downgraded_from": "mechanical"}]
+        assert not is_valid(doc)
+
+    def test_downgraded_marker_is_a_closed_value(self):
+        doc = valid_verdict()
+        doc["verdict"] = "findings"
+        doc["findings"] = [{"id": "f1", "lens": "correctness", "type": "advisory",
+                            "ac": "A1", "claim": "c", "downgraded_from": "advisory"}]
+        assert not is_valid(doc)
 
 
 if __name__ == "__main__":

--- a/src/user/.agents/skills/review-verdict/verdict.schema.json
+++ b/src/user/.agents/skills/review-verdict/verdict.schema.json
@@ -20,7 +20,7 @@
   ],
   "properties": {
     "schema_version": {
-      "const": "1"
+      "const": "2"
     },
     "artifact_class": {
       "type": "string",
@@ -57,13 +57,39 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["lens", "verdict"],
+        "required": ["lens", "verdict", "vendor", "transport", "model"],
         "properties": {
           "lens": {"type": "string", "pattern": "\\S"},
-          "verdict": {"enum": ["clean", "findings"]}
+          "verdict": {"enum": ["clean", "findings"]},
+          "vendor": {
+            "type": "string",
+            "pattern": "\\S",
+            "description": "Vendor of the model that produced this report. The count of distinct vendors across the lenses is the round's diversity; one distinct vendor means it collapsed."
+          },
+          "transport": {
+            "type": "string",
+            "pattern": "\\S",
+            "description": "Route the prompt actually went out on — not the route the lens registry declared for it."
+          },
+          "model": {
+            "type": "string",
+            "pattern": "\\S",
+            "description": "Model that actually produced this report."
+          },
+          "substitution": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reason"],
+            "properties": {
+              "declared_transport": {"type": "string", "pattern": "\\S"},
+              "declared_model": {"type": "string", "pattern": "\\S"},
+              "reason": {"type": "string", "pattern": "\\S"}
+            },
+            "description": "Present only when this lens ran on something other than what its registry entry declared; names what was declared and why the substitute was used."
+          }
         }
       },
-      "description": "Every lens the artifact class declares, reported individually, green ones included."
+      "description": "Every lens the artifact class declares, reported individually, green ones included, each recording what actually ran it."
     },
     "prior_dispositions": {
       "type": "array",
@@ -102,7 +128,11 @@
           "type": {"enum": ["mechanical", "advisory"]},
           "ac": {"type": "string", "pattern": "\\S"},
           "claim": {"type": "string", "pattern": "\\S"},
-          "evidence": {"type": "string"}
+          "evidence": {"type": "string"},
+          "downgraded_from": {
+            "const": "mechanical",
+            "description": "Present only on an advisory the harvester demoted because the lens marked it mechanical and supplied no evidence."
+          }
         },
         "allOf": [
           {
@@ -111,6 +141,10 @@
               "required": ["evidence"],
               "properties": {"evidence": {"type": "string", "pattern": "\\S"}}
             }
+          },
+          {
+            "if": {"required": ["downgraded_from"]},
+            "then": {"properties": {"type": {"const": "advisory"}}}
           }
         ]
       }

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -30,7 +30,9 @@ carry a `skill` field naming a skill the reviewer must apply; the mandate then o
 lens, and the named skill supplies the depth.
 
 Each panel mixes model tiers — hard-reasoning lenses on frontier models, mechanical walks on
-mid-tier — and spans two vendors, because blind spots correlate inside a vendor.
+mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
+`transport` is that diversity claim, not a routing guarantee: when it is down the lens runs on
+whatever is up, and the verdict records what actually ran it (`harvest.md`).
 
 Most lenses re-read the whole artifact every round. A lens marked `diff` reviews only the change
 since the head it last judged, and only when it returned green that round; anything judging
@@ -100,11 +102,14 @@ text does either.
 
 Collect one report per lens, then build the envelope the review-verdict skill defines: `lenses`
 gets one entry per lens the class declares, green ones included, so coverage is read off the
-artifact and never inferred from an empty findings list. A lens whose reviewer errored or returned
-unparseable output has no entry, and the round is incomplete — fail closed.
+artifact and never inferred from an empty findings list. Each entry records the vendor, transport
+and model that *actually* produced the report, never the route `contracts.json` declared for it.
 `findings` is the union across lenses; `prior_dispositions` is the ledger from `round.json`.
 Terminal-clean means a complete round with zero mechanical findings across every lens.
 
-Non-codex lenses run through the `openrouter-claude-subagent` skill. When that transport is
-unavailable, run every lens serially through the codex command-line tool instead, and note in the
-round that the panel lost its vendor diversity.
+A lens whose reviewer errored, timed out, or returned output no tolerant read can parse may be
+re-dispatched inside the same round, on a substitute route when its own is down; its single entry
+then carries the substitution and the reason. Still without a report, it has no entry and the
+round is incomplete — fail closed. `harvest.md` holds the rest: how tolerantly to read a report,
+what to do with a mechanical finding carrying no evidence, and the vendor-collapse count to make
+before the verdict is written.

--- a/src/user/.claude/skills/review-panel/emit_prompts_test.py
+++ b/src/user/.claude/skills/review-panel/emit_prompts_test.py
@@ -101,14 +101,21 @@ def prompts(out_dir: Path) -> dict[str, str]:
 
 def verdict_round1(repo: Repo) -> dict:
     return {
-        "schema_version": "1", "artifact_class": "typed-code", "round": 1,
+        "schema_version": "2", "artifact_class": "typed-code", "round": 1,
         "base_sha": repo.base, "head_sha": repo.head, "claim_id": "claim-7",
         "retained_categories": [], "prior_dispositions": [], "verdict": "findings",
         "lenses": [
-            {"lens": "correctness", "verdict": "findings"},
-            {"lens": "security", "verdict": "findings"},
-            {"lens": "test-adequacy", "verdict": "clean"},
-            {"lens": "simplification-efficiency", "verdict": "clean"},
+            {"lens": "correctness", "verdict": "findings", "vendor": "openai",
+             "transport": "codex", "model": "gpt-5.6-terra"},
+            {"lens": "security", "verdict": "findings", "vendor": "anthropic",
+             "transport": "openrouter", "model": "anthropic/claude-opus-5"},
+            {"lens": "test-adequacy", "verdict": "clean", "vendor": "openai",
+             "transport": "codex", "model": "gpt-5.6-terra"},
+            {"lens": "simplification-efficiency", "verdict": "clean", "vendor": "moonshotai",
+             "transport": "openrouter", "model": "moonshotai/kimi-k3",
+             "substitution": {"declared_transport": "openrouter",
+                              "declared_model": "anthropic/claude-opus-5",
+                              "reason": "declared model timed out; re-dispatched in-round"}},
         ],
         "findings": [
             {"id": "f1", "lens": "correctness", "type": "mechanical", "ac": "C1",

--- a/src/user/.claude/skills/review-panel/harvest.md
+++ b/src/user/.claude/skills/review-panel/harvest.md
@@ -1,0 +1,66 @@
+# Harvesting a round
+
+What to do between dispatching the lenses and writing the verdict. Every rule here exists because
+a round hit the case and the invoker had to improvise; an improvised rule is one nobody can audit
+afterwards.
+
+## Transport is symmetric
+
+The `transport` in `contracts.json` is a claim about vendor diversity, not about today's
+credentials. **Any lens may run on any transport that is actually up.** An `openrouter` lens runs
+through the codex command-line tool when OpenRouter is down; a `codex` lens runs through the
+`openrouter-claude-subagent` skill when the codex credential has expired. Neither direction is the
+exceptional one, and neither transport is the more reliable one — both have been down while the
+other worked.
+
+What you may not do is run the lens and say nothing. Whenever a lens runs on something other than
+its declared entry, its verdict entry carries `substitution` with the declared transport or model
+and the reason. A round that lost diversity silently is indistinguishable from one that kept it.
+
+## Re-dispatching a lens that could not run
+
+A lens that errors, times out, or returns output no tolerant read can parse **may be re-dispatched
+inside the same round** — on the same route, or on a substitute model or transport. The round is
+not restarted and the other lenses are not re-run.
+
+The lens ends with exactly one entry, describing the attempt that produced the report it carries,
+with `substitution` filled in if that attempt was not the declared route. Two entries for one lens
+is a validation error, not a fuller record: it double-counts coverage.
+
+If re-dispatch also fails, the lens has **no** entry and the round is incomplete. That is the
+contract working. Fail closed — never write a `clean` entry for a lens that never reported.
+
+## Reading a lens report
+
+Models violate an exact-output contract in predictable, harmless ways. Read each report through
+this ladder, in order, and stop at the first step that yields an object:
+
+1. The whole body parses as JSON.
+2. The body is a single fenced code block; strip the fence and parse what is inside.
+3. Decode from the first `{` in the body and ignore any trailing text — this recovers a report
+   behind a prose preamble.
+
+Anything else is **unparseable**: the lens has no entry and the round is incomplete unless you
+re-dispatch it. Tolerance stops here on purpose. Reconstructing a report by hand from prose makes
+the harvester the reviewer, and nothing downstream can tell the difference.
+
+## A mechanical finding with no evidence
+
+A lens sometimes marks a finding `mechanical` and supplies no evidence. The verdict schema rejects
+that finding, so the harvester must resolve it rather than pass it through.
+
+**Downgrade it to `advisory` and set `downgraded_from: "mechanical"`.** Do not drop it, and do not
+discard the whole lens report over it — the claim may still be worth reading, and the other
+findings in that report are unaffected.
+
+This is deliberately the permissive branch, and it is worth knowing why: an unevidenced mechanical
+finding cannot be acted on anyway, since there is nothing to reproduce. The marker keeps the
+demotion countable, so a lens that produces them repeatedly is visible as unreliable rather than
+quietly generating backlog.
+
+## Before writing the verdict
+
+Count the distinct `vendor` values across the lens entries. One means the panel collapsed onto a
+single vendor, and blind spots correlate inside a vendor — say so wherever the verdict is
+reported. It does not make the round incomplete; it makes the round weaker in a way the next
+reader deserves to know without asking anyone.


### PR DESCRIPTION
The review contract is sound where it speaks. This closes three places it was silent, each observed across five real review rounds on PRs #402 and #403, and each of which cost a judgement call the round artifact had nowhere to record.

| Silence | What happened |
| --- | --- |
| **Declared transport unavailable** | `contracts.json` names a transport per lens as a vendor-diversity claim. The codex lane was 401 all session; the skill documented the fallback in one direction only (openrouter down → use codex), and the inverse is what occurred. |
| **Exact-JSON contract not honoured across vendors** | Two of five lenses violated it in round 1, two ways — one wrapped the object in a markdown fence, another emitted a prose preamble. Both recoverable by a tolerant read; under a literal reading both were unparseable, which fail-closed turns into a stalled round. |
| **A lens can die, with no stated recovery** | Two lenses died (one 900s timeout, one empty return). Coverage correctly read the round incomplete — the rule working. Re-dispatching each on a substitute was an unrecorded judgement, and the artifact had no field to say a lens ran on something other than its declared route. |

## One change, not three exceptions

**The round records what actually ran, not what was declared.**

- **Verdict schema `1` → `2`.** Each lens entry requires `vendor`, `transport` and `model` — describing the run that produced the report — plus an optional `substitution` object whose `reason` is mandatory.
- **Vendor collapse is derived, never stored.** Count distinct `vendor` values across the entries. Deliberately not a stored flag (one can disagree with the rows it summarises — the same enumeration/count defect `agents-config-9k9.17.9` documents in prose artifacts) and deliberately not a validation error (failing a collapsed round trades a weaker review for no review). A test pins that a single-vendor panel still validates.
- **Re-dispatch is permitted inside the round**, on the same or a substitute route, and the lens ends with exactly **one** entry. The new `duplicate-lens` validator check is load-bearing *because* of that: without it a harvester could report the failed attempt and the substitute as two lenses and inflate coverage.
- **`harvest.md`** (new sibling) specifies the parse-tolerance ladder — whole body parses, strip a single fence, decode from the first brace ignoring trailing text — and stops there on purpose. Reconstructing a report by hand makes the harvester the reviewer, and nothing downstream can tell the difference.
- **A mechanical finding with no evidence** is downgraded to advisory and marked `downgraded_from: "mechanical"` (schema permits the marker only on an advisory). This is the permissive branch and is labelled as such: the claim cannot be acted on without evidence anyway, and the marker keeps the demotion countable so an unreliable lens stays visible instead of quietly generating backlog.

## On the version bump

The lens entry gained required fields, so a v1 verdict is not a v2 verdict. Redefining v1 in place would have been drift. The bump is cheap: zero persisted verdicts exist (the one hand-assembled for #402 lived in `/tmp`) and there is one consumer.

## Scope

**ac-attack is not in this change.** Its `attack-record.schema.json` carries the identical `{lens, report}` shape, and its SKILL.md carries the matching prose workaround telling the operator to state a substitution by hand. Same fix, but 245 checker tests with lens fixtures to migrate — it ships as the second PR of the pair rather than doubling this one. Filed and linked to this item.

## Verification

- `make ci` run standalone from the worktree root: **exit 0**.
- Verdict suite 31 → 55 tests; emitter suite 31, green.
- **Mutation-checked.** Three reverts, each turning the corresponding tests red: dropping the required run-record fields (3 red), removing the `duplicate-lens` check (1 red), opening `downgraded_from` to any string (1 red). Restored byte-identical from backup afterwards.
- Skill bodies under the 2000-token deploy cap: review-panel 1724, review-verdict 1659.

Tracker: `agents-config-9k9.17.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvnvN6L9debk6gkBS2kQ5w