### PR TITLE
chore(9k9.53.7.6): remove dead tar/archive path from gitclean ports

### DIFF
--- a/packages/gitclean/src/gitclean/ports.py
+++ b/packages/gitclean/src/gitclean/ports.py
@@ -67,51 +67,6 @@ class CommandPort(Protocol):
 
     def write_text(self, path: Path, content: str) -> None: ...  # pragma: no cover
 
-    def create_archive(self, source: Path, dest: Path) -> CommandResult: ...  # pragma: no cover
-
-    def list_archive(self, path: Path) -> CommandResult: ...  # pragma: no cover
-
-
-def is_inside(inner: Path, outer: Path) -> bool:
-    try:
-        inner.resolve().relative_to(outer.resolve())
-    except (ValueError, OSError):
-        return False
-    return True
-
-
-def _self_exclusion(source: Path, dest: Path) -> list[str]:
-    """Keep tar from archiving its own output directory.
-
-    A caller is free to point --salvage-dir inside the very worktree being
-    salvaged. The directory is created before tar runs, so without this it is
-    captured as an empty directory in the archive of the tree it is saving."""
-    if not is_inside(dest.parent, source):
-        return []
-    relative = dest.parent.resolve().relative_to(source.resolve())
-    # A salvage directory one level down is excluded whole; one that *is* the
-    # worktree root cannot be, so only the archive file itself is skipped.
-    if str(relative) == ".":
-        return [f"--exclude=./{dest.name}"]
-    return [f"--exclude=./{relative}"]
-
-
-def _staging_path(source: Path, dest: Path) -> Path | None:
-    """Where to write the archive so tar never writes into what it is reading.
-
-    None when the destination already sits outside the source and tar can
-    write straight to it.
-
-    Excluding the output from the archive's *contents* is not enough: the
-    directory still changes while tar walks it, and GNU tar exits 1 on
-    `file changed as we read it`. BSD tar -- what ships on macOS -- says
-    nothing, so this is invisible until the suite runs on Linux. Staging
-    beside the source directory removes the race rather than tolerating it,
-    and stays on the same filesystem so the move into place is a rename."""
-    if not is_inside(dest.parent, source):
-        return None
-    return source.parent / f".{dest.name}.gitclean-partial"
-
 
 class SubprocessCommands:
     """Real ``CommandPort``: git and gh via subprocess, plus the filesystem
@@ -159,46 +114,6 @@ class SubprocessCommands:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
-    def create_archive(self, source: Path, dest: Path) -> CommandResult:
-        """Archive a whole directory, symlinks kept AS symlinks.
-
-        tar rather than a file-by-file copy for three reasons that each cost
-        work when got wrong: `shutil.copy2` follows symlinks by default, so an
-        untracked link to ~/.ssh/id_rsa would copy the key's bytes into the
-        salvage directory; it crashes outright on a dangling link; and a copy
-        driven by `git ls-files` cannot see ignored files, which is where a
-        .env lives. `.git` is excluded because it is reconstructible and, in
-        the main worktree, would drag in the whole object store."""
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        excludes = ["--exclude=./.git", *_self_exclusion(source, dest)]
-        staged = _staging_path(source, dest)
-        written = staged if staged is not None else dest
-
-        result = self._run(["tar", "-czf", str(written), "-C", str(source), *excludes, "."], None)
-
-        if staged is None:
-            return result
-        if not result.ok:
-            staged.unlink(missing_ok=True)
-            return result
-        try:
-            shutil.move(str(staged), str(dest))
-        except OSError as exc:
-            # The archive exists but not where the caller will look for it, so
-            # this is a failed salvage: the deletion it would authorise must
-            # not proceed.
-            staged.unlink(missing_ok=True)
-            return CommandResult(
-                argv=result.argv,
-                returncode=1,
-                stdout=result.stdout,
-                stderr=f"could not move the archive into {dest.parent}: {exc}",
-            )
-        return result
-
-    def list_archive(self, path: Path) -> CommandResult:
-        return self._run(["tar", "-tzf", str(path)], None)
-
 
 class ScriptedCommands:
     """Test fake. Answers are keyed by the argv prefix that identifies the
@@ -217,20 +132,12 @@ class ScriptedCommands:
         gh: dict[str, CommandResult | list[CommandResult]] | None = None,
         has_gh: bool = True,
         files: dict[str, str] | None = None,
-        archive_create: CommandResult | None = None,
-        archive_list: CommandResult | None = None,
     ) -> None:
         self._git = dict(git or {})
         self._gh = dict(gh or {})
         self._has_gh = has_gh
         self.files: dict[str, str] = dict(files or {})
         self.transcript: list[tuple[str, ...]] = []
-        # Same discipline as the command tables: an unscripted archive call
-        # raises rather than defaulting, because a salvage that silently
-        # "succeeded" in a test is the failure this fake exists to catch.
-        self._archive_create = archive_create
-        self._archive_list = archive_list
-        self.archives: list[tuple[str, str]] = []
 
     @staticmethod
     def _match(
@@ -286,19 +193,6 @@ class ScriptedCommands:
 
     def write_text(self, path: Path, content: str) -> None:
         self.files[str(path)] = content
-
-    def create_archive(self, source: Path, dest: Path) -> CommandResult:
-        self.transcript.append(("tar", "-czf", str(dest), "-C", str(source)))
-        self.archives.append((str(source), str(dest)))
-        if self._archive_create is None:
-            raise AssertionError(f"ScriptedCommands has no archive answer for: {source} -> {dest}")
-        return self._archive_create
-
-    def list_archive(self, path: Path) -> CommandResult:
-        self.transcript.append(("tar", "-tzf", str(path)))
-        if self._archive_list is None:
-            raise AssertionError(f"ScriptedCommands has no archive listing for: {path}")
-        return self._archive_list
 
 
 def ok(stdout: str = "", *, stderr: str = "") -> CommandResult:

--- a/packages/gitclean/tests/unit/test_ports.py
+++ b/packages/gitclean/tests/unit/test_ports.py
@@ -15,9 +15,7 @@ from gitclean.ports import (
     CommandResult,
     ScriptedCommands,
     SubprocessCommands,
-    _staging_path,
     fail,
-    is_inside,
     ok,
 )
 
@@ -109,120 +107,6 @@ def test_write_text_creates_missing_parents(tmp_path: Path) -> None:
     assert target.read_text() == "x"
 
 
-# -- archiving ---------------------------------------------------------------
-
-
-def test_an_archive_round_trips_a_real_directory(tmp_path: Path) -> None:
-    port = SubprocessCommands()
-    source = tmp_path / "tree"
-    (source / "sub").mkdir(parents=True)
-    (source / "sub" / "a.txt").write_text("payload")
-    dest = tmp_path / "salvage" / "deep" / "tree.tar.gz"
-
-    assert port.create_archive(source, dest).ok
-    listing = port.list_archive(dest)
-    assert listing.ok
-    assert "./sub/a.txt" in listing.stdout
-
-    restored = tmp_path / "restored"
-    restored.mkdir()
-    subprocess.run(["tar", "-xzf", str(dest), "-C", str(restored)], check=True)  # noqa: S603, S607
-    assert (restored / "sub" / "a.txt").read_text() == "payload"
-
-
-def test_an_archive_keeps_a_symlink_as_a_symlink(tmp_path: Path) -> None:
-    """`shutil.copy2` follows links, so an untracked link to ~/.ssh/id_rsa
-    would copy the key's bytes into the salvage directory -- and it raises
-    outright on a dangling one."""
-    port = SubprocessCommands()
-    source = tmp_path / "tree"
-    source.mkdir()
-    secret = tmp_path / "secret.txt"
-    secret.write_text("private key")
-    (source / "link").symlink_to(secret)
-    (source / "dangling").symlink_to(tmp_path / "not-there")
-
-    dest = tmp_path / "tree.tar.gz"
-    assert port.create_archive(source, dest).ok
-
-    restored = tmp_path / "restored"
-    restored.mkdir()
-    subprocess.run(["tar", "-xzf", str(dest), "-C", str(restored)], check=True)  # noqa: S603, S607
-    # Still a link, still pointing where it pointed: the secret's bytes were
-    # never copied into the salvage, and the dangling link did not raise.
-    assert (restored / "link").is_symlink()
-    assert (restored / "link").readlink() == secret
-    assert (restored / "dangling").is_symlink()
-
-
-def test_an_archive_captures_ignored_files_and_excludes_dot_git(tmp_path: Path) -> None:
-    port = SubprocessCommands()
-    source = tmp_path / "tree"
-    (source / ".git").mkdir(parents=True)
-    (source / ".git" / "config").write_text("[core]")
-    (source / ".env").write_text("TOKEN=hunter2")
-    (source / ".gitignore").write_text(".env\n")
-
-    dest = tmp_path / "tree.tar.gz"
-    assert port.create_archive(source, dest).ok
-    listing = port.list_archive(dest).stdout
-    assert "./.env" in listing
-    assert ".git/config" not in listing
-
-
-def test_listing_a_missing_archive_is_a_result_not_an_exception(tmp_path: Path) -> None:
-    assert not SubprocessCommands().list_archive(tmp_path / "absent.tar.gz").ok
-
-
-def test_an_archive_does_not_capture_itself(tmp_path: Path) -> None:
-    """--salvage-dir may legitimately point inside the worktree being salvaged.
-    GNU tar warns about archiving its own output; BSD tar, which is what ships
-    on macOS, does not."""
-    port = SubprocessCommands()
-    source = tmp_path / "tree"
-    source.mkdir()
-    (source / "a.txt").write_text("payload")
-
-    nested = port.create_archive(source, source / "salvage" / "tree.tar.gz")
-    assert nested.ok
-    listing = port.list_archive(source / "salvage" / "tree.tar.gz").stdout
-    assert "./a.txt" in listing
-    assert "salvage" not in listing
-
-
-def test_an_archive_written_into_the_root_it_archives_skips_only_itself(tmp_path: Path) -> None:
-    port = SubprocessCommands()
-    source = tmp_path / "tree"
-    source.mkdir()
-    (source / "a.txt").write_text("payload")
-
-    assert port.create_archive(source, source / "tree.tar.gz").ok
-    listing = port.list_archive(source / "tree.tar.gz").stdout
-    assert "./a.txt" in listing
-    assert "./tree.tar.gz" not in listing
-
-
-def test_tar_never_writes_into_the_directory_it_is_reading(tmp_path: Path) -> None:
-    """Excluding the output from the archive's contents is not enough. The
-    directory still changes while tar walks it, and GNU tar exits 1 on
-    `file changed as we read it` -- while BSD tar, which is what ships on
-    macOS, says nothing at all. So the difference is invisible until the suite
-    runs on Linux, and the fix has to be checked as a property rather than as
-    an exit code: wherever the caller asks for the archive, tar writes it
-    somewhere outside the tree it is archiving."""
-    source = tmp_path / "tree"
-    source.mkdir()
-
-    at_root = _staging_path(source, source / "tree.tar.gz")
-    nested = _staging_path(source, source / "salvage" / "tree.tar.gz")
-    outside = _staging_path(source, tmp_path / "elsewhere" / "tree.tar.gz")
-
-    assert at_root is not None and not is_inside(at_root, source)
-    assert nested is not None and not is_inside(nested, source)
-    # Already outside, so there is nothing to stage around.
-    assert outside is None
-
-
 # -- the fake ----------------------------------------------------------------
 
 
@@ -266,16 +150,6 @@ def test_the_fake_models_written_files_in_memory() -> None:
     port = ScriptedCommands()
     port.write_text(Path("/salvage/keep"), "x")
     assert port.files["/salvage/keep"] == "x"
-
-
-def test_an_unscripted_archive_call_fails_loudly() -> None:
-    """Same discipline as the command tables: a salvage that silently
-    'succeeded' in a test is exactly what this fake exists to catch."""
-    port = ScriptedCommands()
-    with pytest.raises(AssertionError, match="archive answer"):
-        port.create_archive(Path("/repo/wt"), Path("/salvage/wt.tar.gz"))
-    with pytest.raises(AssertionError, match="archive listing"):
-        ScriptedCommands().list_archive(Path("/salvage/wt.tar.gz"))
 
 
 def test_the_longest_matching_key_wins_so_a_shorter_one_cannot_absorb_it() -> None:


### PR DESCRIPTION
## Summary

Removes the tar/archive path in `packages/gitclean/src/gitclean/ports.py` that has had no production caller since worktree salvage moved to `git bundle` (see the live salvage mechanism in `execute.py`). Deletion only; no behavior change to any live code path.

## Deadness evidence

Grepped the entire worktree (not just `packages/gitclean/`) for callers outside test files:

- **`create_archive`** / **`list_archive`** (Protocol method + `SubprocessCommands` + `ScriptedCommands` implementations): the only call sites anywhere in the tree, outside `ports.py` itself, were in `tests/unit/test_ports.py`. Confirmed `execute.py`'s live salvage path (`_salvage_remote_branch`) uses `CommandPort.git()` (`git bundle create`) and `write_text()` only — it never calls either archive method.
- **`is_inside`**: only called from `_self_exclusion` and `_staging_path`, both of which exist solely to serve `create_archive`. No other production call site.
- **`_self_exclusion`**: only called from `create_archive`.
- **`_staging_path`**: only called from `create_archive`.

All five are unreachable once `create_archive`/`list_archive` are removed — the whole chain terminates in functions nothing calls.

README.md and `packages/gitclean/AGENTS.md` were checked for archive/tar salvage descriptions — neither mentions "archive" or "tar" at all (the bundle-salvage mechanism they describe lives entirely in `execute.py` and is untouched by this PR). No doc corrections were needed.

## What changed

- Deleted `create_archive`, `list_archive`, `is_inside`, `_self_exclusion`, and `_staging_path` from `ports.py`, along with the `create_archive`/`list_archive` implementations on both `SubprocessCommands` and the `ScriptedCommands` test double (and the `archive_create`/`archive_list`/`archives` constructor plumbing that only existed to feed them).
- Removed the 8 tests in `tests/unit/test_ports.py` that existed solely to exercise this path (7 in the `-- archiving --` section plus `test_an_unscripted_archive_call_fails_loudly`).

## Coverage

| | branch coverage | tests |
|---|---|---|
| before | 96.82% | 242 passed |
| after | 97.41% | 234 passed |

Coverage went **up**, not down — the deleted code was where `ports.py`'s only partial-coverage lines lived (`182-183, 186-191, 295, 301`); `ports.py` now reports complete coverage. Floor is 90%, both before and after clear it comfortably.

`make ci-gitclean` exit code: **0** (ruff check, ruff format --check, mypy --strict, pytest --cov, pip-audit, entry-verify all green).

## Not touched

- `survey.py`, `execute.py`, and the integration topology matrix — out of scope per the brief (a parallel PR is changing `execute.py`'s bundle-salvage verification).
- The bundle-salvage mechanism itself (`_salvage_remote_branch` in `execute.py`) — this is a live, different mechanism for server refs with no reflog, and is unaffected by this deletion.
- No renames or refactors beyond the deletions — the task was deletion-only.

## Test plan

- [x] `make ci-gitclean` run standalone from the worktree root, exit code captured on its own line: `0`
- [x] Grepped entire worktree (not just `packages/gitclean/`) for every candidate symbol before deleting
- [x] Confirmed no dangling references to any deleted symbol remain anywhere in `packages/gitclean/`