### PR TITLE
fix(9k9.53.7.5): terminate argv in the squash merge-evidence tier

### DIFF
--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -130,17 +130,17 @@ synthesising the equivalent single commit with `git commit-tree` and asking
 gc` collects it. Suppressing it in report mode would make `--report` and
 `--cleanup` disagree about what is merged, which is worse than a stray blob.
 
-**A branch whose name begins with `-` is deleted correctly, but proven merged
-only some of the way.** `git branch` will not create such a ref, but `git
-update-ref` will and a remote can push one. Every deletion terminates its argv,
-so git reads the name as a name — a `-m` branch that ancestry or patch-id
-proves merged is swept, and one named outright is deleted and its server copy
-bundled. The squash tier is the gap: it asks `merge-base` and `rev-parse` for
-the branch without a terminator, git rejects the name as a switch, and the
-probe gives up. A squash-merged `-m` therefore reads as unproven and stays in
-the report — the safe direction, and the wrong answer. Naming one on the
-command line is a separate matter, because the argument parser claims `-m` as a
-flag first: select it by its `id`, `gitclean --cleanup branch:-m`.
+**A branch whose name begins with `-` is deleted correctly, and proven merged
+by every tier, including squash.** `git branch` will not create such a ref,
+but `git update-ref` will and a remote can push one. Every deletion terminates
+its argv, so git reads the name as a name. Merge evidence does the same, with
+one adjustment: `merge-base` accepts a `--` terminator, but `rev-parse` does
+not — it echoes one back as a literal output line instead of consuming it — so
+the squash tier's tree lookup instead names the branch by its full ref path,
+which never begins with `-`. A squash-merged `-m` is proven and swept the same
+as any other name. Naming one on the command line is a separate matter,
+because the argument parser claims `-m` as a flag first: select it by its
+`id`, `gitclean --cleanup branch:-m`.
 
 ## Exit codes
 

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -415,11 +415,25 @@ def _squash_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str)
     up with what a squash merge actually produced.
 
     `commit-tree` writes a loose object. It is unreachable and gc collects it;
-    nothing in the repo's refs is touched."""
-    base = port.git(["merge-base", base_ref, name], cwd=cwd)
+    nothing in the repo's refs is touched.
+
+    A name beginning with `-` -- `refs/heads/-m` is a legal ref that
+    `update-ref` or a remote push can create -- is otherwise read by git as a
+    switch. `--` genuinely terminates `merge-base`'s option parsing, so it is
+    applied unconditionally, matching every other probe in this module.
+    `rev-parse` has no terminator that survives here: both `--` and
+    `--end-of-options` are echoed back as a literal output line rather than
+    consumed, so the tree lookup instead names the branch by its full ref path
+    when the short name would otherwise be misread -- a path never begins with
+    `-`. That substitution is conditional, not unconditional like the one
+    above: a remote-tracking branch's short name always carries its remote
+    first (`origin/feat`, never bare `feat`) and already resolves correctly,
+    while `refs/heads/` would be the wrong prefix for it."""
+    base = port.git(["merge-base", base_ref, "--", name], cwd=cwd)
     if not base.ok or not base.out:
         return False
-    tree = port.git(["rev-parse", f"{name}^{{tree}}"], cwd=cwd)
+    ref = f"refs/heads/{name}" if name.startswith("-") else name
+    tree = port.git(["rev-parse", f"{ref}^{{tree}}"], cwd=cwd)
     if not tree.ok or not tree.out:
         return False
     synthetic = port.git(

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -682,6 +682,48 @@ def test_a_branch_named_like_an_option_is_swept_not_misread(repo: Path) -> None:
     assert "-m" in [d["name"] for d in payload["execution"]["deletions"]]  # type: ignore[index]
 
 
+def test_a_squash_merged_branch_named_like_an_option_is_proven(repo: Path) -> None:
+    """The one case the test above does not cover: an ancestor or patch-id
+    merge never reaches the squash tier at all, and that tier's own `git`
+    calls used to lose the argv terminator that protects every other probe
+    here. Two commits are used deliberately, as in
+    `test_a_real_squash_merge_is_detected` -- with one, patch-id equivalence
+    would settle it before the squash tier ran, and this would prove nothing
+    about its argv."""
+    git(repo, "checkout", "-q", "-b", "feat/opt-squash")
+    first = commit(repo, "one.txt")
+    second = commit(repo, "two.txt")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "--squash", "feat/opt-squash")
+    git(repo, "commit", "-q", "-m", "squashed feat/opt-squash")
+    head = git(repo, "rev-parse", "refs/heads/feat/opt-squash")
+    git(repo, "branch", "-D", "feat/opt-squash")
+    git(repo, "update-ref", "refs/heads/-m", head)
+
+    assert "-m" not in git(repo, "branch", "--merged", "main")
+
+    with reachability_guard(repo) as guard:
+        surveyed = report(repo, "--report")
+        payload = report(repo, "--cleanup")
+        # A squash rewrites the work into one new commit on main, so these two
+        # are stranded by design -- that is what the sweep exists to remove.
+        guard.expect_unreachable(first, second)
+
+    branches = surveyed["repo"]
+    assert isinstance(branches, dict)
+    dashed = next(b for b in branches["branches"] if b["name"] == "-m")
+    assert dashed["merge_evidence"] == "squash_equal"
+
+    listed = find(surveyed, "branch:-m")
+    assert listed["name"] == "-m"
+    assert listed["merge_proven"] is True
+    assert listed["sweepable"] is True
+
+    assert payload["_exit"] == EXIT_OK
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/-m") == ""
+    assert "-m" in [d["name"] for d in payload["execution"]["deletions"]]  # type: ignore[index]
+
+
 def test_a_branch_named_like_an_option_is_selectable_by_id(repo: Path) -> None:
     """Naming it directly cannot go through the bare name -- argparse claims
     `-m` as a flag before gitclean sees it. The `id` form is the way in, which

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -207,7 +207,7 @@ def test_a_dangling_origin_head_leaves_the_trunk_unknown_on_the_report() -> None
             "show-ref --verify --quiet refs/heads/main": fail(),
             "show-ref --verify --quiet refs/heads/master": fail(),
             "cherry origin/main -- trunk": fail(),
-            "merge-base origin/main trunk": fail(),
+            "merge-base origin/main -- trunk": fail(),
         },
     )
 
@@ -231,8 +231,8 @@ def test_an_unknown_default_branch_is_reported_on_the_survey() -> None:
             "show-ref --verify --quiet refs/remotes/origin/main": fail(),
             "cherry main -- trunk": fail(),
             "cherry main -- feature": fail(),
-            "merge-base main trunk": fail(),
-            "merge-base main feature": fail(),
+            "merge-base main -- trunk": fail(),
+            "merge-base main -- feature": fail(),
         },
     )
 
@@ -677,7 +677,7 @@ def test_a_merged_pr_that_predates_the_tip_does_not_prove_the_branch_merged() ->
         extra={
             "merge-base --is-ancestor": fail("not an ancestor"),
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("+ synthsha"),
@@ -717,7 +717,7 @@ def test_a_pr_with_no_head_sha_never_covers_a_tip() -> None:
         prs=[_pr("MERGED", oid="")],
         extra={
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("+ synthsha"),
@@ -740,7 +740,7 @@ def test_the_squash_tier_still_answers_when_a_pr_verdict_is_declined() -> None:
         extra={
             "merge-base --is-ancestor": fail("not an ancestor"),
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("- synthsha"),
@@ -784,7 +784,7 @@ def test_a_discard_decision_does_not_reach_commits_made_after_it() -> None:
         extra={
             "merge-base --is-ancestor": fail("not an ancestor"),
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("+ synthsha"),
@@ -806,7 +806,7 @@ def test_squash_merges_are_caught_by_replaying_the_tree_as_one_commit() -> None:
     port = _tier_port(
         **{
             "cherry origin/main -- feat": ok("+ aaa\n+ bbb"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("- synthsha"),
@@ -816,11 +816,39 @@ def test_squash_merges_are_caught_by_replaying_the_tree_as_one_commit() -> None:
     assert feat.merged and feat.merge_evidence is MergeEvidence.SQUASH_EQUAL
 
 
+def test_the_squash_probe_terminates_argv_for_a_branch_named_like_an_option() -> None:
+    """`refs/heads/-m` is a legal ref that `update-ref` or a remote push can
+    create, and it reaches this tier the same way `feat` does above: ancestry
+    and patch-id both miss. `merge-base` accepts `--`, so the branch name is
+    terminated the same way as every other probe; `rev-parse` does not accept
+    a terminator here, so the tree lookup instead resolves through the
+    branch's full ref path, which never begins with `-`. Scripting only the
+    corrected argv means a regression -- the bare name reappearing in either
+    call -- fails with `ScriptedCommands has no answer for`, not a wrong
+    verdict."""
+    port = make_port(
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/heads/-m", "-m"),
+        ],
+        counts={"origin/main..-m": "2"},
+        extra={
+            "cherry origin/main -- -m": ok("+ aaa\n+ bbb"),
+            "merge-base origin/main -- -m": ok("basesha"),
+            "rev-parse refs/heads/-m^{tree}": ok("treesha"),
+            "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
+            "cherry origin/main synthsha": ok("- synthsha"),
+        },
+    )
+    branch = next(b for b in run(port).branches if b.name == "-m")
+    assert branch.merged and branch.merge_evidence is MergeEvidence.SQUASH_EQUAL
+
+
 def test_a_genuinely_unmerged_branch_proves_nothing() -> None:
     port = _tier_port(
         **{
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("+ synthsha"),
@@ -832,14 +860,14 @@ def test_a_genuinely_unmerged_branch_proves_nothing() -> None:
 
 def test_squash_probe_gives_up_cleanly_when_git_will_not_answer() -> None:
     for broken in (
-        {"merge-base origin/main feat": fail("no merge base")},
+        {"merge-base origin/main -- feat": fail("no merge base")},
         {"rev-parse feat^{tree}": fail("bad object")},
         {"commit-tree": fail("cannot write")},
     ):
         port = _tier_port(
             **{
                 "cherry origin/main -- feat": ok("+ aaa"),
-                "merge-base origin/main feat": ok("basesha"),
+                "merge-base origin/main -- feat": ok("basesha"),
                 "rev-parse feat^{tree}": ok("treesha"),
                 "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
                 "cherry origin/main synthsha": ok("+ x"),
@@ -856,7 +884,7 @@ def test_an_empty_cherry_result_does_not_count_as_merged() -> None:
     port = _tier_port(
         **{
             "cherry origin/main -- feat": ok(""),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok(""),
@@ -972,7 +1000,7 @@ def test_a_failing_rev_list_is_unknown_and_never_proves_a_merge() -> None:
     port = _tier_port(
         **{
             "cherry origin/main -- feat": ok("+ aaa"),
-            "merge-base origin/main feat": ok("basesha"),
+            "merge-base origin/main -- feat": ok("basesha"),
             "rev-parse feat^{tree}": ok("treesha"),
             "commit-tree treesha -p basesha -m gitclean-probe": ok("synthsha"),
             "cherry origin/main synthsha": ok("+ synthsha"),


### PR DESCRIPTION
## Summary

The squash merge-evidence tier in `gitclean` called `git merge-base` and `git rev-parse` with a repo-derived branch name and no argv terminator. `git branch` will not create a branch name beginning with `-`, but `git update-ref` and a remote push both will, and without a terminator git reads that name as an option -- the probe gives up and the branch reads as unproven merged, even when a squash merge genuinely covers it. That is the safe direction (nothing gets swept it shouldn't), but the wrong answer (a legitimately merged branch never clears the sweep).

- `git merge-base` accepts a `--` terminator directly, so it is applied unconditionally in that call, matching every other probe in this module.
- `git rev-parse` does **not** treat `--` (or `--end-of-options`) as a real terminator here -- verified empirically against a real git binary, both are echoed back as a literal output line rather than consumed, so the name is still misread. The tree lookup (`<name>^{tree}`) instead resolves through the branch's full ref path (`refs/heads/<name>`) when the short name would otherwise be misread, since a full path never begins with `-`. This substitution is applied only when needed: a remote-tracking branch's short name always carries its remote prefix first (`origin/feat`, never bare `feat`) and already resolves correctly without it, so applying the prefix unconditionally would have broken every remote branch's squash tier instead.

## Changes

- `packages/gitclean/src/gitclean/survey.py` -- the two call sites in `_squash_equal`, plus a docstring explaining why each is handled differently.
- `packages/gitclean/tests/unit/test_survey.py` -- updated ~13 pre-existing scripted `merge-base` argv keys to include the now-unconditional `--`, plus a new unit test pinning the exact corrected argv for a `-m`-named branch reaching the squash tier.
- `packages/gitclean/tests/integration/test_real_git.py` -- a new integration test against a real repository: a branch named `-m`, genuinely squash-merged (two commits, so patch-id equivalence can't settle it first), proving the squash tier now proves the merge and sweeps it.
- `packages/gitclean/README.md` -- updated the paragraph that documented this as a known gap; kept the separate, still-true note about the command-line argument parser claiming `-m` as a flag.

## Test plan

- [x] `make ci-gitclean` run standalone (not piped), exit code 0
- [x] 244 tests passed, 96.82% total coverage (90% branch floor required)
- [x] `ruff check`, `ruff format --check`, `mypy --strict`, `pip-audit`, `gitclean --help` all pass
- [x] Verified `git rev-parse --` / `--end-of-options` behavior against a real git binary in a throwaway repo before choosing the full-ref-path fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)