### PR TITLE
fix(9k9.53.7.8): an empty synthesised diff is not proof of a squash merge

### DIFF
--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -55,7 +55,7 @@ recorded on the branch:
 | `pr_merged` | gh reports a merged PR whose head contains this tip. The only signal that survives a squash merge intact. | yes |
 | `ancestor` | reachable from the base tip. | yes |
 | `patch_equal` | every commit's patch-id is already in base (rebase, cherry-pick). | yes |
-| `squash_equal` | the branch's tree, replayed as one commit on the merge base, has a patch-id in base. | yes |
+| `squash_equal` | the branch's tree, replayed as one commit on the merge base, has a patch-id in base. Silent when the branch ends on the tree it started from — see below. | yes |
 | `pr_closed_unmerged` | a human closed the PR without merging. | **no** — reported only |
 | `none` | nothing proved a merge. Not the same as "not merged": see `repo.gh_error`, and the row's own `reasons` for a tier that errored rather than answering. | no |
 
@@ -63,6 +63,15 @@ A closed PR says someone stopped wanting the change. It says nothing about
 whether the commits exist anywhere else, and they do not — they are still only
 on that branch. It is the most useful line in the row for a person deciding
 what to name, and it authorises nothing.
+
+**A branch that ends on the tree it began from proves nothing here, by
+construction.** Work added and then taken off again leaves the tip's tree equal
+to the merge base's, so the commit this tier synthesises would carry an empty
+diff — and every empty diff has the same patch-id as every other. Base need
+only have picked up one empty commit since the fork, which is what a build
+retrigger leaves, for `git cherry` to call that a match. So the tier stops
+before it asks. The cost is a no-op branch nobody sweeps; the alternative is
+deleting a branch whose commits are the only copy of the work they hold.
 
 Without `gh` on PATH there is no squash signal at all. That is reported in
 `repo.gh_error`, never swallowed.

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -467,8 +467,10 @@ def _patch_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str) 
 
 def _squash_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str) -> bool | None:
     """True when the branch's whole tree, replayed as ONE commit on the merge
-    base, has a patch-id already in base. None when one of the four steps
-    errored, since a chain that stopped part-way proves nothing either way.
+    base, has a patch-id already in base. False when there is nothing to replay
+    because the branch ends on the tree it began from. None when one of the
+    steps errored, since a chain that stopped part-way proves nothing either
+    way.
 
     This is the squash-merge case, and nothing cheaper detects it: the squashed
     commit on base shares no patch-id with any individual branch commit, and
@@ -502,6 +504,18 @@ def _squash_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str)
     tree = port.git(["rev-parse", f"{ref}^{{tree}}"], cwd=cwd)
     if not tree.ok or not tree.out:
         return None
+    base_tree = port.git(["rev-parse", f"{_first_line(base.out)}^{{tree}}"], cwd=cwd)
+    if not base_tree.ok or not base_tree.out:
+        return None
+    if _first_line(base_tree.out) == _first_line(tree.out):
+        # The branch ends on the tree it started from -- work added and taken
+        # off again -- so the commit synthesised below carries an empty diff,
+        # and every empty diff has the same patch id as every other. `cherry`
+        # would match it against any empty commit base picked up after the
+        # fork, and a build retrigger leaves exactly one of those. The tier
+        # would then report a squash nobody performed, against a branch whose
+        # commits are the only copy of the work they hold.
+        return False
     synthetic = port.git(
         ["commit-tree", _first_line(tree.out), "-p", _first_line(base.out), "-m", "gitclean-probe"],
         cwd=cwd,

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -1184,14 +1184,6 @@ def _main_worktree_seen_from_a_linked_one(repo: Path) -> Topology:
         pytest.param(
             _branch_whose_work_was_backed_out,
             id="branch-whose-work-was-backed-out-on-itself",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="a branch whose tip tree is its merge base's tree makes the squash "
-                "probe synthesise a commit with an empty diff, and an empty diff shares its "
-                "patch id with every other empty diff -- so any empty commit base picked up "
-                "after the fork reads as proof, and a bare sweep deletes the only copy of "
-                "the work the branch backed out",
-            ),
         ),
         pytest.param(_unmerged_with_remote, id="unmerged-branch-with-remote-copy"),
         pytest.param(_detached_orphan_worktree, id="detached-worktree-holding-an-orphan-commit"),

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -74,6 +74,12 @@ def make_port(
         # of the boring case. A test that cares what it says overrides it
         # through `counts`, which is applied after this table.
         "rev-list --count origin/main..main": ok("0"),
+        # The merge base's tree, which the squash tier compares against the
+        # branch tip's. Deliberately unlike the "treesha" those tests give the
+        # tip: the boring branch changed something, so there is a diff to
+        # replay. A test about a branch that ends where it started says so by
+        # overriding this to match.
+        "rev-parse basesha^{tree}": ok("basetreesha"),
     }
     for spec, value in (counts or {}).items():
         table[f"rev-list --count {spec}"] = ok(value)
@@ -640,6 +646,7 @@ def test_remote_refs_are_identified_by_prefix_not_by_a_slash() -> None:
             "cherry origin/main -- team/feat": ok("+ abc"),
             "cherry origin/main -- origin/feat": ok("+ abc"),
             "merge-base origin/main": ok("base1"),
+            "rev-parse base1^{tree}": ok("basetree1"),
             "rev-parse team/feat^{tree}": ok("tree1"),
             "rev-parse origin/feat^{tree}": ok("tree2"),
             "commit-tree": ok("synth"),
@@ -885,6 +892,32 @@ def test_squash_merges_are_caught_by_replaying_the_tree_as_one_commit() -> None:
     )
     feat = next(b for b in run(port).branches if b.name == "feat")
     assert feat.merged and feat.merge_evidence is MergeEvidence.SQUASH_EQUAL
+
+
+def test_a_branch_ending_on_the_tree_it_started_from_proves_nothing() -> None:
+    """Work added and taken off again leaves the tip tree equal to the merge
+    base's, so the synthesised commit's diff is empty -- and every empty diff
+    carries the same patch id. `cherry` is scripted here to answer as it does
+    against a base holding one empty commit, which one build retrigger leaves:
+    it says the patch is already upstream. It is not, and neither is the work,
+    which lives only on the commits this branch holds. The tier has to stop
+    before asking a question whose answer it cannot use."""
+    port = _tier_port(
+        **{
+            "cherry origin/main -- feat": ok("+ aaa\n+ bbb"),
+            "merge-base origin/main -- feat": ok("basesha"),
+            "rev-parse feat^{tree}": ok("sametree"),
+            "rev-parse basesha^{tree}": ok("sametree"),
+            "cherry origin/main synthsha": ok("- synthsha"),
+        }
+    )
+    feat = next(b for b in run(port).branches if b.name == "feat")
+
+    assert not feat.merged
+    assert feat.merge_evidence is MergeEvidence.NONE
+    assert not any(call[1] == "commit-tree" for call in port.transcript), (
+        "no commit should be synthesised once the diff is known to be empty"
+    )
 
 
 def test_the_squash_probe_terminates_argv_for_a_branch_named_like_an_option() -> None:


### PR DESCRIPTION
Closes the last data-loss path found by the bare-sweep topology matrix, and the last blocker on re-admitting gitclean to PATH.

## The defect

The squash tier replays a branch's whole tree as one commit on the merge base, then asks `git cherry` whether that commit's patch is already upstream. When the branch's tip tree **equals its merge base's tree** — work added and then backed out on the same branch — the synthesised commit carries an empty diff. Every empty diff has the same patch-id as every other. So the moment base has picked up any empty commit since the fork, `cherry` answers "already in base", and the tier reports `squash_equal` for a branch that was never merged at all.

An empty commit on the trunk is what a build retrigger leaves behind, so this is an ordinary repository state rather than an exotic one.

## Reproduction, before and after

Built against a real repository, not inferred.

**Control** — branch adds a file, removes it on the same branch, main has no empty commit:

```
evidence: none          # left alone, correctly
```

**Add one `git commit --allow-empty` to main**, then re-run against the unfixed code:

```
evidence: squash_equal
deletions: [('feat/backed-out', True, True)]   # deleted, verified, exit 0, no salvage
refs containing the commit holding the file: ''   # reachable from nothing
```

**With this change**, same repository:

```
evidence: none
deletions: []
withheld: no merge proof for this commit (evidence: none)
```

## The fix

The tier reads the merge base's tree and stops before synthesising anything when the two trees match. Nothing was replayed, so nothing is proven — `merge_evidence` stays `none`, which is the truthful answer.

The cost is a genuinely no-op branch that nobody sweeps. The alternative is deleting a branch whose commits are the only copy of the work they hold.

## Why this one mattered

A named target is the caller's authorisation and is never re-adjudicated. A **bare sweep** has no per-target authorisation — the user authorised a policy, not a target — so merge-proof discipline is precisely what is owed there. This was a false merge proof on that path, and a false report in its own right.

## Verification

- The bare-sweep topology matrix already carried this shape as a **strict xfail**; that marker is removed and the row now passes for real.
- **Mutation-checked both ways.** With the guard removed, the new unit test fails *and* the matrix row fails through the reachability oracle, which names the stranded commit in its assertion.
- `make ci-gitclean` standalone from the worktree root: exit 0, 281 passed, 97.94% branch.
- Whole-repo `make ci` standalone: exit 0.
- The shared port builder now answers the merge-base tree read by default with a value deliberately unlike the tip's, so the boring case remains a branch that changed something and a test about one that did not says so by overriding it.
