### PR TITLE
fix(9k9.103): a job already done is a success, not an error

### DIFF
--- a/packages/gitclean/AGENTS.md
+++ b/packages/gitclean/AGENTS.md
@@ -90,10 +90,14 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   same discipline as `None` never authorising a deletion, applied to the other
   end: before reporting that a named thing is already gone, check that the look
   was capable of finding it. Three ways it is not, and all three arrive looking
-  identical to a name that matches nothing — the ref read failed so *every*
-  branch is missing; the name is a ref deliberately kept out of the target list,
-  which is why `Survey.not_offered` records those rather than dropping them; or
-  the remote is not advertising a ref it still holds. The first two refuse. The
+  identical to a name that matches nothing — the listing that would have held it
+  failed, which is what `branches_known` and `worktrees_known` are for; the name
+  is a ref deliberately kept out of the target list, which is why
+  `Survey.not_offered` records those rather than dropping them; or the remote is
+  not advertising a ref it still holds. The first two refuse, and the first is
+  asked *per selector kind*: a `worktree:` name is answered by the worktree
+  listing alone, so a failed ref read must not block it, and a bare name needs
+  both because it could have been either. The
   third cannot be distinguished by any question `ls-remote` can ask, so the row
   states what was measured — the remote does not advertise it — instead of the
   conclusion, and the cost lands as a deletion not made rather than as a lie.

--- a/packages/gitclean/AGENTS.md
+++ b/packages/gitclean/AGENTS.md
@@ -19,10 +19,10 @@ It runs, in order: `ruff check`, `ruff format --check`, `mypy --strict src`,
 hand-pick a subset — the linter and the formatter are orthogonal. Faster inner
 loop: `make test-gitclean`.
 
-This package is **not** in the installer's `CLI_PACKAGES` registry and nothing
-installs it onto PATH — being inside `make ci` does not deploy a package. Run it
-from a checkout. Do not add it to that registry without an explicit decision to
-ship it.
+This package **is** in the installer's `CLI_PACKAGES` registry and installs onto
+PATH as `gitclean`. Being inside `make ci` is not what earns that — `vizsuite`
+is gated and stays off — so a change here reaches a deployed tool, and the
+`clean-up-git` skill drives it.
 
 ## Architecture
 
@@ -75,6 +75,17 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   safety underneath the caller, and do not add a flag for them to pass. git's
   own refusals still stand, and they carry better information than a
   re-derivation would.
+- **A job already done is a success.** When the state the caller asked for
+  already holds, that is neither a refusal nor an anomaly: a name matching
+  nothing lands in `Plan.absent`, and a server ref the remote no longer has
+  becomes a `Deletion` with `already_absent`. Both exit 0. The cost of getting
+  this wrong is not cosmetic — a caller told a finished job failed retries,
+  hand-rolls raw git, or escalates, and every one of those is worse than the
+  no-op it should have been handed. Two rules keep it honest: `deleted` stays
+  false, because only a true there is evidence the tool acted; and the state is
+  measured before anything is spent on reaching it, which is why the server is
+  asked about a ref *before* its history is bundled rather than after the push
+  is rejected.
 - **With one exception, and know why it is there.** git's refusals cover
   uncommitted content; they say nothing about a commit made inside a worktree
   on no branch. That tree is clean, git removes it happily, and the record it

--- a/packages/gitclean/AGENTS.md
+++ b/packages/gitclean/AGENTS.md
@@ -86,6 +86,19 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   measured before anything is spent on reaching it, which is why the server is
   asked about a ref *before* its history is bundled rather than after the push
   is rejected.
+- **Absence is a measurement, and "I did not find it" is not one.** This is the
+  same discipline as `None` never authorising a deletion, applied to the other
+  end: before reporting that a named thing is already gone, check that the look
+  was capable of finding it. Three ways it is not, and all three arrive looking
+  identical to a name that matches nothing — the ref read failed so *every*
+  branch is missing; the name is a ref deliberately kept out of the target list,
+  which is why `Survey.not_offered` records those rather than dropping them; or
+  the remote is not advertising a ref it still holds. The first two refuse. The
+  third cannot be distinguished by any question `ls-remote` can ask, so the row
+  states what was measured — the remote does not advertise it — instead of the
+  conclusion, and the cost lands as a deletion not made rather than as a lie.
+  Adding an exclusion to `read_branches` without adding its `NotOffered` record
+  reintroduces this defect silently.
 - **With one exception, and know why it is there.** git's refusals cover
   uncommitted content; they say nothing about a commit made inside a worktree
   on no branch. That tree is clean, git removes it happily, and the record it

--- a/packages/gitclean/src/gitclean/cli.py
+++ b/packages/gitclean/src/gitclean/cli.py
@@ -44,11 +44,17 @@ what a bare --cleanup takes:
 naming a target deletes it. Nothing is re-derived, no flag is demanded, and git's
 own refusals -- a checked-out branch, a dirty or locked worktree -- stand as they are.
 
-a name that matches nothing is not an error. The state you asked for already holds, so
-it lands in `plan.absent` with a note and the other named targets are still deleted.
-A server ref the remote no longer has settles the same way, as `already_absent`, without
-writing a salvage bundle for something that is not there to lose. Neither is reported as
-work done: `deleted` stays false, because only a true there means the tool acted.
+a name that matches nothing is not an error, once nothing-matched actually means gone.
+It lands in `plan.absent` with a note and the other named targets are still deleted. A
+server ref the remote no longer advertises settles the same way, as `already_absent`,
+without writing a salvage bundle for something that is not there to lose. Neither is
+reported as work done: `deleted` stays false, because only a true there means the tool
+acted.
+
+it refuses instead where nothing-matched proves nothing -- when no ref could be read at
+all, and when the name is a ref this tool does not offer as a target, such as the
+server's copy of the trunk. Both of those look identical to an absent name and neither
+one is, so saying "already gone" about them would be a false report.
 
 examples:
   gitclean --report --format human

--- a/packages/gitclean/src/gitclean/cli.py
+++ b/packages/gitclean/src/gitclean/cli.py
@@ -44,6 +44,12 @@ what a bare --cleanup takes:
 naming a target deletes it. Nothing is re-derived, no flag is demanded, and git's
 own refusals -- a checked-out branch, a dirty or locked worktree -- stand as they are.
 
+a name that matches nothing is not an error. The state you asked for already holds, so
+it lands in `plan.absent` with a note and the other named targets are still deleted.
+A server ref the remote no longer has settles the same way, as `already_absent`, without
+writing a salvage bundle for something that is not there to lose. Neither is reported as
+work done: `deleted` stays false, because only a true there means the tool acted.
+
 examples:
   gitclean --report --format human
   gitclean --cleanup --dry-run
@@ -143,6 +149,17 @@ def _planned_ids(payload: dict[str, object]) -> frozenset[str]:
     )
 
 
+def _deletion_mark(entry: dict[str, object], *, dry: bool) -> str:
+    """`gone` outranks `plan`: a target that is already absent is a settled
+    fact rather than something a later run would still get to, and a preview
+    saying `plan` for it would be promising work that does not exist."""
+    if entry.get("already_absent"):
+        return "gone"
+    if dry:
+        return "plan"
+    return "ok  " if entry.get("verified") else "FAIL"
+
+
 def _render_human(payload: dict[str, object], out: TextIO) -> None:
     repo = payload.get("repo")
     if isinstance(repo, dict):
@@ -207,6 +224,16 @@ def _render_human(payload: dict[str, object], out: TextIO) -> None:
             for entry in skipped:
                 if isinstance(entry, dict):
                     print(f"  SKIPPED {entry.get('name')} -- {entry.get('reason')}", file=out)
+        # Printed rather than passed over in silence. The run did what was
+        # asked, so it is not a failure -- but a name that matched nothing is
+        # also how a typo looks, and the reader is the only one who can tell
+        # the two apart.
+        absent = plan.get("absent")
+        if isinstance(absent, list) and absent:
+            print("", file=out)
+            for entry in absent:
+                if isinstance(entry, dict):
+                    print(f"  ABSENT  {entry.get('selector')} -- {entry.get('note')}", file=out)
 
     execution = payload.get("execution")
     if isinstance(execution, dict):
@@ -215,7 +242,7 @@ def _render_human(payload: dict[str, object], out: TextIO) -> None:
         if isinstance(deletions, list):
             for entry in deletions:
                 if isinstance(entry, dict):
-                    mark = "plan" if dry else ("ok  " if entry.get("verified") else "FAIL")
+                    mark = _deletion_mark(entry, dry=dry)
                     print(f"  {mark} {entry.get('name')} -- {entry.get('detail')}", file=out)
         if execution.get("salvage_dir"):
             print(f"  salvage: {execution.get('salvage_dir')}", file=out)

--- a/packages/gitclean/src/gitclean/execute.py
+++ b/packages/gitclean/src/gitclean/execute.py
@@ -477,7 +477,16 @@ class Executor:
         A probe that does not answer returns ``None`` and the normal route
         runs. Not knowing whether the ref is there is not evidence that it is
         not, and the ordinary route already copes with a server that will not
-        talk."""
+        talk.
+
+        What the row claims is what was measured -- that the remote does not
+        advertise the ref -- rather than the conclusion drawn from it. The two
+        come apart: a server configured with `uploadpack.hideRefs` holds refs
+        it does not advertise, so an empty answer is very good evidence of
+        absence and not proof of it. Stating the measurement keeps the row true
+        on such a server, where the cost is a deletion this run declines to
+        make; the tracking ref survives, the next report shows the target
+        again, and naming it after a fetch still works."""
         remote, _, ref = target.name.partition("/")
         if not ref:
             # Unparseable, and _delete_remote_branch is where that is reported.
@@ -491,9 +500,9 @@ class Executor:
             name=target.name,
             deleted=False,
             verified=True,
-            detail=f"{ref} is already gone from {remote}; nothing to delete. The tracking "
-            f"ref refs/remotes/{target.name} is stale -- `git fetch --prune {remote}` "
-            f"clears it",
+            detail=f"{remote} does not advertise refs/heads/{ref}, so there is nothing there "
+            f"to delete. The tracking ref refs/remotes/{target.name} is what put this in "
+            f"the plan -- `git fetch --prune {remote}` clears it",
             already_absent=True,
         )
 

--- a/packages/gitclean/src/gitclean/execute.py
+++ b/packages/gitclean/src/gitclean/execute.py
@@ -8,7 +8,11 @@ git's configured expiry, and a worktree is removed by git itself, which refuses
 while the tree holds anything uncommitted. Where salvage does run, it precedes
 the deletion, and what earns the deletion is a restore rather than an
 inspection: the bundle is cloned into an empty directory and the commit about
-to be deleted has to come back out of it. `git bundle verify` is the weaker
+to be deleted has to come back out of it. It is also spent only on a ref the
+server still has -- that question is asked before the bundle is written rather
+than discovered from a rejected push afterwards, so a branch the forge deleted
+when its PR merged settles as a no-op instead of as an anomaly with an archive
+of the whole history behind it. `git bundle verify` is the weaker
 question -- it asks whether the archive applies to the repository holding every
 object already, and answers yes for bundles that clone back empty and for
 bundles that will not clone at all. A salvage that does not restore is reported
@@ -436,6 +440,63 @@ class Executor:
             detail="local ref deleted",
         )
 
+    def _remote_ref_present(
+        self, remote: str, ref_path: str
+    ) -> tuple[bool | None, tuple[str, ...]]:
+        """Does the server still hold this ref? ``None`` when it would not say.
+
+        `ls-remote` takes a pattern and matches it on path-component
+        boundaries, so an unrelated `a/feat/x` answers a question asked about
+        `feat/x`. The refname column settles it -- the same exact comparison
+        the local path makes."""
+        probe = self._port.git(
+            git_argv("ls-remote", "--heads", remote, name=ref_path), cwd=self._cwd
+        )
+        if not probe.ok:
+            return None, probe.transcript()
+        present = any(
+            line.split("\t")[-1].strip() == ref_path for line in probe.stdout.splitlines()
+        )
+        return present, probe.transcript()
+
+    def _remote_already_gone(self, target: Target) -> Deletion | None:
+        """Ask the server before spending anything on the ref.
+
+        Everything known about a remote branch here was read from
+        `refs/remotes/<remote>/<ref>` -- a local cache a fetch refreshes and
+        nothing invalidates. On a forge that deletes a branch when its PR
+        merges, which is the common configuration, that cache routinely names
+        refs the server dropped weeks ago. So "the server no longer has it" is
+        the ordinary path for this kind of target, not a corner case.
+
+        Discovered afterwards, that arrives as a rejected push: an anomaly, a
+        nonzero exit, and a bundle of the branch's whole history written first
+        for a ref that was never there to lose. Discovered first, it costs one
+        `ls-remote` and settles the target having spent nothing.
+
+        A probe that does not answer returns ``None`` and the normal route
+        runs. Not knowing whether the ref is there is not evidence that it is
+        not, and the ordinary route already copes with a server that will not
+        talk."""
+        remote, _, ref = target.name.partition("/")
+        if not ref:
+            # Unparseable, and _delete_remote_branch is where that is reported.
+            return None
+        present, _ = self._remote_ref_present(remote, f"refs/heads/{ref}")
+        if present is not False:
+            return None
+        return Deletion(
+            target_id=target.id,
+            kind=target.kind,
+            name=target.name,
+            deleted=False,
+            verified=True,
+            detail=f"{ref} is already gone from {remote}; nothing to delete. The tracking "
+            f"ref refs/remotes/{target.name} is stale -- `git fetch --prune {remote}` "
+            f"clears it",
+            already_absent=True,
+        )
+
     def _delete_remote_branch(self, target: Target) -> Deletion:
         """Delete the server's ref, but only if the server still holds what we
         judged.
@@ -480,29 +541,21 @@ class Executor:
                 removal.transcript(),
             )
             return _failed(target, "push --delete failed")
-        ref_path = f"refs/heads/{ref}"
-        probe = self._port.git(
-            git_argv("ls-remote", "--heads", remote, name=ref_path), cwd=self._cwd
-        )
-        if not probe.ok:
+        present, transcript = self._remote_ref_present(remote, f"refs/heads/{ref}")
+        if present is None:
             self._record(
                 "verify",
                 target.id,
                 f"could not confirm {ref} is gone from {remote}; the delete reported success",
-                probe.transcript(),
+                transcript,
             )
             return _failed(target, "deletion unverified")
-        # `ls-remote` takes a pattern, and it matches on path-component
-        # boundaries: an unrelated `a/feat/x` on the same server answers a
-        # question asked about `feat/x`. Reading that as survival turns a
-        # deletion git performed into a reported failure, so the refname column
-        # settles it -- the same exact comparison the local path makes.
-        if any(line.split("\t")[-1].strip() == ref_path for line in probe.stdout.splitlines()):
+        if present:
             self._record(
                 "verify",
                 target.id,
                 f"{ref} still exists on {remote} after `git push --delete` reported success",
-                probe.transcript(),
+                transcript,
             )
             return _failed(target, "remote ref survived deletion")
         # No `remote prune` here. It drops every tracking ref under
@@ -556,6 +609,16 @@ class Executor:
             # is the only thing that is bundled first.
             salvage_first = target.kind is TargetKind.REMOTE_BRANCH
 
+            if salvage_first:
+                # Asked ahead of the dry-run branch as well. A preview that
+                # promises to delete a ref the server does not have is the same
+                # false report, in the mode whose whole job is to be trusted
+                # before the real one runs.
+                settled = self._remote_already_gone(target)
+                if settled is not None:
+                    deletions.append(settled)
+                    continue
+
             if plan.dry_run:
                 deletions.append(
                     Deletion(
@@ -586,7 +649,11 @@ class Executor:
 
             if target.kind is TargetKind.WORKTREE:
                 outcome = self._delete_worktree(target)
-                if not outcome.deleted:
+                # What blocks a branch is its worktree still being on disk.
+                # `deleted` alone answers a narrower question -- whether this
+                # run did the removing -- and a tree that was already gone
+                # holds nothing.
+                if not outcome.deleted and not outcome.already_absent:
                     self._strand(target, stranded)
                 deletions.append(outcome)
             elif target.kind is TargetKind.BRANCH:

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -357,8 +357,23 @@ class Deletion:
     kind: TargetKind
     name: str
     deleted: bool
+    """Whether **this run** performed the deletion. Not whether the thing is
+    gone: a target that was already absent is gone and this is False, because
+    only a True here is evidence the tool did something."""
     verified: bool
     detail: str
+    already_absent: bool = False
+    """The end state was reached before this run started.
+
+    Deleting is not a state change the caller wanted for its own sake -- they
+    wanted the thing gone, and it is. Reporting that as a failure teaches a
+    caller to retry, to reach for raw git, or to escalate, all of which are
+    worse than the no-op they should have been told about.
+
+    It stays a separate field rather than folding into ``deleted`` because the
+    two carry different evidence. ``deleted`` says the tool acted; this says it
+    found no work. A run of nothing but these did nothing at all, which a
+    reader should be able to see at a glance."""
 
     def as_json(self) -> dict[str, object]:
         return {
@@ -368,6 +383,7 @@ class Deletion:
             "deleted": self.deleted,
             "verified": self.verified,
             "detail": self.detail,
+            "already_absent": self.already_absent,
         }
 
 
@@ -391,6 +407,27 @@ class Skipped:
 
 
 @dataclass(frozen=True, slots=True)
+class Absent:
+    """A name the caller gave that matches nothing in the repository.
+
+    This is not a refusal, because the caller asked for a state -- that thing,
+    gone -- and the repository is already in it. It is also not silence: the
+    tool genuinely cannot tell a target somebody removed a moment ago from a
+    name they mistyped, since both match nothing, so it reports what it looked
+    for and lets the reader recognise their own typo.
+
+    Carrying the selector rather than a target is not an omission. There is no
+    target to carry, and inventing an id for something that was never surveyed
+    would put a row in the output that no other field could speak about."""
+
+    selector: str
+    note: str
+
+    def as_json(self) -> dict[str, object]:
+        return {"selector": self.selector, "note": self.note}
+
+
+@dataclass(frozen=True, slots=True)
 class Plan:
     """A resolved intention to delete, ordered so dependants go first."""
 
@@ -398,6 +435,9 @@ class Plan:
     salvage_dir: str | None
     dry_run: bool
     skipped: tuple[Skipped, ...] = field(default_factory=tuple)
+    absent: tuple[Absent, ...] = field(default_factory=tuple)
+    """Names that resolved to nothing. A plan holding only these is a plan to
+    do nothing, which is a valid plan and not an error."""
 
     def as_json(self) -> dict[str, object]:
         return {
@@ -405,6 +445,7 @@ class Plan:
             "salvage_dir": self.salvage_dir,
             "dry_run": self.dry_run,
             "skipped": [s.as_json() for s in self.skipped],
+            "absent": [a.as_json() for a in self.absent],
         }
 
 
@@ -414,9 +455,13 @@ class Refusal:
 
     Refusals are few and narrow, because a named target is an authorisation
     rather than a proposal. What is left answers something the caller could not
-    have answered themselves -- a name matching nothing, a name matching two
-    things, a deletion git itself will reject. ``blocked`` lists the targets so
-    they can be dropped from the selection rather than argued with."""
+    have answered themselves -- a name matching two things, a deletion git
+    itself will reject. ``blocked`` lists the targets so they can be dropped
+    from the selection rather than argued with.
+
+    A name matching *nothing* is not among them. It asks for a state that
+    already holds, which is a job already done rather than a job refused; see
+    ``Absent``."""
 
     code: str
     message: str

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -294,6 +294,13 @@ class Survey:
     every worktree row: with no refs read, nothing *could* have proved the
     commit a worktree holds merged, and the row has to say that rather than
     report an absence of proof as though the question had been asked."""
+    worktrees_known: bool = True
+    """False when `worktree list` itself failed.
+
+    ``worktrees`` is then empty, and so is the list for a repository whose only
+    working tree could not be described. The distinction matters to exactly one
+    caller: naming a worktree that is not in the list means it is gone only if
+    the list could have held it."""
     not_offered: tuple[NotOffered, ...] = ()
     """Refs that exist and are deliberately absent from ``branches``.
 
@@ -323,6 +330,7 @@ class Survey:
             "worktrees": [w.as_json() for w in self.worktrees],
             "branches": [b.as_json() for b in self.branches],
             "branches_known": self.branches_known,
+            "worktrees_known": self.worktrees_known,
             "not_offered": [n.as_json() for n in self.not_offered],
         }
 

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -361,6 +361,12 @@ class Deletion:
     gone: a target that was already absent is gone and this is False, because
     only a True here is evidence the tool did something."""
     verified: bool
+    """The end state was confirmed by asking git, rather than inferred from an
+    exit code. It does **not** mean a deletion happened -- an already-absent
+    target is verified too, because the server was asked and answered.
+
+    So this is the wrong field to count a cleanup's work by; ``deleted`` is the
+    one that says the tool acted. The pair is only ever read together."""
     detail: str
     already_absent: bool = False
     """The end state was reached before this run started.

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -301,6 +301,17 @@ class Survey:
     working tree could not be described. The distinction matters to exactly one
     caller: naming a worktree that is not in the list means it is gone only if
     the list could have held it."""
+    dropped_refs: int = 0
+    """Ref rows `for-each-ref` produced that could not be parsed.
+
+    Distinct from ``branches_known``, which says the command ran. A listing can
+    run and still not describe everything it listed, and the difference is
+    invisible downstream: a dropped row is a ref whose existence went
+    unrecorded, so "nothing matched that name" and "that name is not in this
+    repository" stop being the same statement."""
+    dropped_worktrees: int = 0
+    """Worktree blocks the listing produced that could not be parsed. Same
+    distinction as ``dropped_refs``, on the other listing."""
     not_offered: tuple[NotOffered, ...] = ()
     """Refs that exist and are deliberately absent from ``branches``.
 
@@ -331,6 +342,8 @@ class Survey:
             "branches": [b.as_json() for b in self.branches],
             "branches_known": self.branches_known,
             "worktrees_known": self.worktrees_known,
+            "dropped_refs": self.dropped_refs,
+            "dropped_worktrees": self.dropped_worktrees,
             "not_offered": [n.as_json() for n in self.not_offered],
         }
 

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -239,6 +239,24 @@ class Target:
 
 
 @dataclass(frozen=True, slots=True)
+class NotOffered:
+    """A ref the survey read and deliberately did not turn into a target.
+
+    Recorded rather than merely skipped, because "absent from the target list"
+    and "absent from the repository" are different facts and only one of them
+    authorises telling a caller there is nothing to delete. Without this the
+    two are indistinguishable downstream, and naming a ref gitclean does not
+    offer would be answered "it is already gone" about a ref that is right
+    there."""
+
+    name: str
+    reason: str
+
+    def as_json(self) -> dict[str, object]:
+        return {"name": self.name, "reason": self.reason}
+
+
+@dataclass(frozen=True, slots=True)
 class Survey:
     """Everything read from git and gh in one pass, before any judgement."""
 
@@ -276,6 +294,12 @@ class Survey:
     every worktree row: with no refs read, nothing *could* have proved the
     commit a worktree holds merged, and the row has to say that rather than
     report an absence of proof as though the question had been asked."""
+    not_offered: tuple[NotOffered, ...] = ()
+    """Refs that exist and are deliberately absent from ``branches``.
+
+    Recorded where the decision is made rather than re-derived later: a second
+    place working out which names those were is a second place to get it
+    wrong, and the two would drift the first time an exclusion changed."""
     warnings: tuple[str, ...] = ()
     """Every probe that did not answer, in reader-facing prose.
 
@@ -299,6 +323,7 @@ class Survey:
             "worktrees": [w.as_json() for w in self.worktrees],
             "branches": [b.as_json() for b in self.branches],
             "branches_known": self.branches_known,
+            "not_offered": [n.as_json() for n in self.not_offered],
         }
 
     def all_warnings(self) -> tuple[str, ...]:

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -12,18 +12,36 @@ not have answered themselves: a name matching two things, a branch git will
 reject because a worktree still holds it, and the directory this process is
 standing in.
 
-A name matching *nothing* used to be a fourth, and was wrong. The caller asked
-for that thing to be gone; it is gone. Refusing there reports a completed job
-as a failure -- and because a selector refusal aborts the whole plan, one name
-that had already been dealt with stopped every other deletion the caller asked
-for.
+A name matching *nothing* used to be one of them, and was wrong. The caller
+asked for that thing to be gone; it is gone. Refusing there reports a completed
+job as a failure -- and because a selector refusal aborts the whole plan, one
+name that had already been dealt with stopped every other deletion the caller
+asked for.
+
+What replaced it is narrower than "a miss is fine", because a miss has three
+causes and only one of them is absence. The list can also be empty because the
+ref read failed, or missing a name because this tool does not offer that ref as
+a target -- and in both the branch is sitting right there. Those two refuse,
+and the refusal codes say which, because the alternative is telling somebody
+their branch is gone while it is not. Concluding absence from a list that was
+never able to answer is the same mistake as reading an unanswered probe as a
+clean working tree.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from gitclean.model import Absent, Plan, Refusal, Skipped, Survey, Target, TargetKind
+from gitclean.model import (
+    Absent,
+    NotOffered,
+    Plan,
+    Refusal,
+    Skipped,
+    Survey,
+    Target,
+    TargetKind,
+)
 
 
 def _selector_candidates(target: Target) -> set[str]:
@@ -36,25 +54,75 @@ def _selector_candidates(target: Target) -> set[str]:
     return names
 
 
+def _not_offered(selector: str, survey_data: Survey) -> NotOffered | None:
+    """A ref that exists and that gitclean deliberately does not target.
+
+    Matched on the full `<remote>/<ref>` spelling only. A bare-short fallback
+    looks helpful and is a trap: `main` would match the recorded `origin/main`
+    and refuse to delete the *local* trunk, a different ref that is a perfectly
+    legal thing to name. This is only ever consulted once nothing matched, so
+    the narrow comparison costs nothing real."""
+    return next(
+        (e for e in survey_data.not_offered if selector in {e.name, f"remote:{e.name}"}),
+        None,
+    )
+
+
 def resolve_selectors(
-    selectors: list[str], targets: tuple[Target, ...]
+    selectors: list[str], targets: tuple[Target, ...], survey_data: Survey
 ) -> tuple[list[Target], list[Absent], Refusal | None]:
     """Map caller-supplied names onto targets.
 
-    A miss is recorded and the remaining selectors are still resolved; only
-    ambiguity refuses, because there the tool would have to guess which of two
-    real things to destroy.
+    A miss is recorded and the remaining selectors are still resolved. But a
+    miss only *means* absence when the survey was in a position to see the
+    thing, and there are two ways it was not -- both of which reach here
+    looking exactly like a name that matches nothing:
 
-    The note deliberately states both readings. Nothing here can distinguish a
-    worktree removed thirty seconds ago from a name with a letter wrong -- the
-    repository answers identically -- so asserting either one would be a claim
-    the tool cannot support.
+    - the ref read failed, so every branch is missing from a list that is
+      empty for that reason rather than because the repository is
+    - the name is a ref this tool deliberately does not offer as a target
+
+    In neither case is "there is nothing to delete" a fact anybody measured,
+    and saying it would leave a caller believing a deletion happened. Both
+    refuse instead, which is what the tool does whenever the honest answer is
+    that it cannot say.
+
+    Where the survey *did* answer, the note states both remaining readings.
+    Nothing here can distinguish a worktree removed thirty seconds ago from a
+    name with a letter wrong -- the repository answers identically -- so
+    asserting either one would be a claim the tool cannot support.
     """
     resolved: list[Target] = []
     absent: list[Absent] = []
     for selector in selectors:
         matches = [t for t in targets if selector in _selector_candidates(t)]
         if not matches:
+            excluded = _not_offered(selector, survey_data)
+            if excluded is not None:
+                return (
+                    [],
+                    [],
+                    Refusal(
+                        code="E_NOT_A_TARGET",
+                        message=f"{excluded.name} exists but is not something gitclean "
+                        f"deletes: {excluded.reason}",
+                        remedy="use git directly if that is genuinely what you want; "
+                        "nothing in this run touched it",
+                    ),
+                )
+            if not survey_data.branches_known:
+                return (
+                    [],
+                    [],
+                    Refusal(
+                        code="E_SURVEY_INCOMPLETE",
+                        message=f"no ref could be read in this repository, so nothing matched "
+                        f"{selector!r} and nothing can be concluded from that -- the branch "
+                        f"may be sitting right there",
+                        remedy="fix what stopped `git for-each-ref` (the warnings say what "
+                        "it was) and re-run; nothing was deleted",
+                    ),
+                )
             absent.append(
                 Absent(
                     selector=selector,
@@ -126,7 +194,7 @@ def build_plan(
 ) -> Plan | Refusal:
     absent: list[Absent] = []
     if selectors:
-        chosen, absent, refusal = resolve_selectors(selectors, targets)
+        chosen, absent, refusal = resolve_selectors(selectors, targets, survey_data)
         if refusal is not None:
             return refusal
         invoking = _invoking_worktree(chosen, survey_data)

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -68,6 +68,28 @@ def _not_offered(selector: str, survey_data: Survey) -> NotOffered | None:
     )
 
 
+def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str]:
+    """Of the listings that could have contained this name, which did not run.
+
+    Keyed on the selector's own prefix, which is the same `worktree:`/`branch:`
+    /`remote:` convention the ids use. A caller who spelled out the kind has
+    told us which listing is the relevant one, and a failure in the other is
+    then genuinely none of this selector's business -- refusing on it would
+    block the commonest cleanup there is, a worktree already removed, over a
+    ref read that had nothing to do with it.
+
+    A bare name could be either, so it needs both. Being unable to say which
+    kind was meant is not a reason to trust one of them."""
+    worktree_only = selector.startswith("worktree:")
+    ref_only = selector.startswith(("branch:", "remote:"))
+    unread: list[str] = []
+    if not ref_only and not survey_data.worktrees_known:
+        unread.append("no worktree could be listed")
+    if not worktree_only and not survey_data.branches_known:
+        unread.append("no ref could be read")
+    return unread
+
+
 def resolve_selectors(
     selectors: list[str], targets: tuple[Target, ...], survey_data: Survey
 ) -> tuple[list[Target], list[Absent], Refusal | None]:
@@ -78,8 +100,8 @@ def resolve_selectors(
     thing, and there are two ways it was not -- both of which reach here
     looking exactly like a name that matches nothing:
 
-    - the ref read failed, so every branch is missing from a list that is
-      empty for that reason rather than because the repository is
+    - the listing that would have held it failed, so it is missing from a list
+      that is empty for that reason rather than because the repository is
     - the name is a ref this tool deliberately does not offer as a target
 
     In neither case is "there is nothing to delete" a fact anybody measured,
@@ -110,17 +132,18 @@ def resolve_selectors(
                         "nothing in this run touched it",
                     ),
                 )
-            if not survey_data.branches_known:
+            unread = _lists_that_could_not_answer(selector, survey_data)
+            if unread:
                 return (
                     [],
                     [],
                     Refusal(
                         code="E_SURVEY_INCOMPLETE",
-                        message=f"no ref could be read in this repository, so nothing matched "
-                        f"{selector!r} and nothing can be concluded from that -- the branch "
-                        f"may be sitting right there",
-                        remedy="fix what stopped `git for-each-ref` (the warnings say what "
-                        "it was) and re-run; nothing was deleted",
+                        message=f"nothing matched {selector!r}, and nothing follows from that "
+                        f"here: {' and '.join(unread)}, so what would have matched was never "
+                        f"listed -- it may be sitting right there",
+                        remedy="fix what stopped the listing (the warnings say what it was) "
+                        "and re-run; nothing was deleted",
                     ),
                 )
             absent.append(

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -8,16 +8,22 @@ nothing overrides them, and they carry better information than a re-derivation
 would -- git knows what its working tree holds right now.
 
 So the refusals left here are few, and each answers something the caller could
-not have answered themselves: a name matching nothing, a name matching two
-things, a branch git will reject because a worktree still holds it, and the
-directory this process is standing in.
+not have answered themselves: a name matching two things, a branch git will
+reject because a worktree still holds it, and the directory this process is
+standing in.
+
+A name matching *nothing* used to be a fourth, and was wrong. The caller asked
+for that thing to be gone; it is gone. Refusing there reports a completed job
+as a failure -- and because a selector refusal aborts the whole plan, one name
+that had already been dealt with stopped every other deletion the caller asked
+for.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from gitclean.model import Plan, Refusal, Skipped, Survey, Target, TargetKind
+from gitclean.model import Absent, Plan, Refusal, Skipped, Survey, Target, TargetKind
 
 
 def _selector_candidates(target: Target) -> set[str]:
@@ -32,28 +38,47 @@ def _selector_candidates(target: Target) -> set[str]:
 
 def resolve_selectors(
     selectors: list[str], targets: tuple[Target, ...]
-) -> tuple[list[Target], Refusal | None]:
-    """Map caller-supplied names onto targets, refusing on miss or ambiguity."""
+) -> tuple[list[Target], list[Absent], Refusal | None]:
+    """Map caller-supplied names onto targets.
+
+    A miss is recorded and the remaining selectors are still resolved; only
+    ambiguity refuses, because there the tool would have to guess which of two
+    real things to destroy.
+
+    The note deliberately states both readings. Nothing here can distinguish a
+    worktree removed thirty seconds ago from a name with a letter wrong -- the
+    repository answers identically -- so asserting either one would be a claim
+    the tool cannot support.
+    """
     resolved: list[Target] = []
+    absent: list[Absent] = []
     for selector in selectors:
         matches = [t for t in targets if selector in _selector_candidates(t)]
         if not matches:
-            return [], Refusal(
-                code="E_UNKNOWN_TARGET",
-                message=f"no worktree or branch matches {selector!r}",
-                remedy="run `gitclean --report` and select by the `id` field",
+            absent.append(
+                Absent(
+                    selector=selector,
+                    note=f"no worktree or branch matches {selector!r}, so there is nothing "
+                    f"to delete -- it was already gone before this run, or the name is "
+                    f"wrong. `gitclean --report` lists every `id` that exists",
+                )
             )
+            continue
         if len(matches) > 1:
             ids = ", ".join(t.id for t in matches)
-            return [], Refusal(
-                code="E_AMBIGUOUS_TARGET",
-                message=f"{selector!r} matches more than one target: {ids}",
-                blocked=tuple(matches),
-                remedy="re-run naming the exact `id`",
+            return (
+                [],
+                [],
+                Refusal(
+                    code="E_AMBIGUOUS_TARGET",
+                    message=f"{selector!r} matches more than one target: {ids}",
+                    blocked=tuple(matches),
+                    remedy="re-run naming the exact `id`",
+                ),
             )
         if matches[0] not in resolved:
             resolved.append(matches[0])
-    return resolved, None
+    return resolved, absent, None
 
 
 _ORDER = {TargetKind.WORKTREE: 0, TargetKind.BRANCH: 1, TargetKind.REMOTE_BRANCH: 2}
@@ -99,8 +124,9 @@ def build_plan(
     dry_run: bool,
     salvage_dir: str | None,
 ) -> Plan | Refusal:
+    absent: list[Absent] = []
     if selectors:
-        chosen, refusal = resolve_selectors(selectors, targets)
+        chosen, absent, refusal = resolve_selectors(selectors, targets)
         if refusal is not None:
             return refusal
         invoking = _invoking_worktree(chosen, survey_data)
@@ -155,4 +181,5 @@ def build_plan(
         ),
         dry_run=dry_run,
         skipped=tuple(skipped),
+        absent=tuple(absent),
     )

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -71,22 +71,36 @@ def _not_offered(selector: str, survey_data: Survey) -> NotOffered | None:
 def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str]:
     """Of the listings that could have contained this name, which did not run.
 
-    Keyed on the selector's own prefix, which is the same `worktree:`/`branch:`
-    /`remote:` convention the ids use. A caller who spelled out the kind has
-    told us which listing is the relevant one, and a failure in the other is
-    then genuinely none of this selector's business -- refusing on it would
-    block the commonest cleanup there is, a worktree already removed, over a
-    ref read that had nothing to do with it.
+    Keyed on what the selector's own spelling can denote. The `worktree:` /
+    `branch:` / `remote:` prefixes are the convention the ids use, and a caller
+    who spelled out the kind has said which listing is the relevant one -- a
+    failure in the other is then none of this selector's business, and refusing
+    on it would block the commonest cleanup there is, a worktree already
+    removed, over a ref read that had nothing to do with it. An absolute path
+    says the same thing without the prefix: git will not create a ref whose
+    short name begins with a slash, so nothing but a worktree can be meant.
 
-    A bare name could be either, so it needs both. Being unable to say which
-    kind was meant is not a reason to trust one of them."""
-    worktree_only = selector.startswith("worktree:")
+    A bare name could be either -- a branch, or a worktree's basename -- so it
+    needs both. Being unable to say which kind was meant is not a reason to
+    trust whichever one happened to answer.
+
+    "Could not answer" covers a listing that did not run *and* one that ran
+    without describing everything it listed. A row nobody could parse is a
+    thing whose existence went unrecorded, which is the same hole as never
+    having looked."""
+    worktree_only = selector.startswith("worktree:") or selector.startswith("/")
     ref_only = selector.startswith(("branch:", "remote:"))
     unread: list[str] = []
-    if not ref_only and not survey_data.worktrees_known:
-        unread.append("no worktree could be listed")
-    if not worktree_only and not survey_data.branches_known:
-        unread.append("no ref could be read")
+    if not ref_only:
+        if not survey_data.worktrees_known:
+            unread.append("no worktree could be listed")
+        elif survey_data.dropped_worktrees:
+            unread.append(f"{survey_data.dropped_worktrees} worktree block(s) went unparsed")
+    if not worktree_only:
+        if not survey_data.branches_known:
+            unread.append("no ref could be read")
+        elif survey_data.dropped_refs:
+            unread.append(f"{survey_data.dropped_refs} ref row(s) went unparsed")
     return unread
 
 

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -168,13 +168,17 @@ def resolve_base_ref(
     return default_branch, None
 
 
-def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree], list[str]]:
+def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree], list[str], bool]:
     """Parse `worktree list --porcelain` and stat each tree for dirt.
 
-    Returns the worktrees plus any parse warnings."""
+    Returns the worktrees, any parse warnings, and whether the listing answered
+    at all. The last is not derivable from an empty list -- a repository with
+    only its main working tree produces one entry, but a listing that failed
+    produces none, and "no worktree is there" is a conclusion only one of those
+    supports."""
     result = port.git(["worktree", "list", "--porcelain"], cwd=cwd)
     if not result.ok:
-        return [], [f"could not list worktrees (exit {result.returncode})"]
+        return [], [f"could not list worktrees (exit {result.returncode})"], False
 
     blocks: list[dict[str, str]] = []
     current: dict[str, str] = {}
@@ -242,7 +246,7 @@ def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree],
                 last_activity=None,
             )
         )
-    return worktrees, warnings
+    return worktrees, warnings, True
 
 
 def _count_dirt(port: CommandPort, path: Path) -> tuple[int, int, int] | None:
@@ -809,7 +813,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         )
     )
 
-    worktrees, warnings = read_worktrees(port, cwd)
+    worktrees, warnings, worktrees_known = read_worktrees(port, cwd)
     if base_ref_warning is not None:
         warnings.append(base_ref_warning)
     if current_warning is not None:
@@ -853,6 +857,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         worktrees=tuple(worktrees),
         branches=tuple(branches),
         branches_known=branches_known,
+        worktrees_known=worktrees_known,
         not_offered=tuple(not_offered),
         warnings=tuple(warnings),
     )

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -168,7 +168,9 @@ def resolve_base_ref(
     return default_branch, None
 
 
-def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree], list[str], bool]:
+def read_worktrees(
+    port: CommandPort, cwd: Path | None
+) -> tuple[list[Worktree], list[str], bool, int]:
     """Parse `worktree list --porcelain` and stat each tree for dirt.
 
     Returns the worktrees, any parse warnings, and whether the listing answered
@@ -178,7 +180,7 @@ def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree],
     supports."""
     result = port.git(["worktree", "list", "--porcelain"], cwd=cwd)
     if not result.ok:
-        return [], [f"could not list worktrees (exit {result.returncode})"], False
+        return [], [f"could not list worktrees (exit {result.returncode})"], False, 0
 
     blocks: list[dict[str, str]] = []
     current: dict[str, str] = {}
@@ -196,10 +198,15 @@ def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree],
 
     worktrees: list[Worktree] = []
     warnings: list[str] = []
+    dropped_blocks = 0
     for index, block in enumerate(blocks):
         path = block.get("worktree", "")
         if not path:
+            # Counted as well as warned: a block nobody could read is a
+            # worktree whose existence went unrecorded, which a later
+            # "nothing matched" must not be allowed to call absence.
             warnings.append(f"worktree block {index} had no path; skipped")
+            dropped_blocks += 1
             continue
         branch_ref = block.get("branch")
         branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
@@ -246,7 +253,7 @@ def read_worktrees(port: CommandPort, cwd: Path | None) -> tuple[list[Worktree],
                 last_activity=None,
             )
         )
-    return worktrees, warnings, True
+    return worktrees, warnings, True, dropped_blocks
 
 
 def _count_dirt(port: CommandPort, path: Path) -> tuple[int, int, int] | None:
@@ -634,7 +641,7 @@ def read_branches(
     default_branch: str,
     prs: dict[str, PullRequest],
     worktree_by_branch: dict[str, str],
-) -> tuple[list[Branch], list[str], bool, list[NotOffered]]:
+) -> tuple[list[Branch], list[str], bool, list[NotOffered], int]:
     """The branches, the warnings, whether the ref read answered at all, and
     the refs deliberately left out of the first list.
 
@@ -657,6 +664,7 @@ def read_branches(
             ],
             False,
             [],
+            0,
         )
 
     local_merged, local_warning = _merged_set(port, cwd, base_ref, remote=False)
@@ -665,16 +673,22 @@ def read_branches(
 
     branches: list[Branch] = []
     not_offered: list[NotOffered] = []
+    dropped = 0
     for line in result.stdout.splitlines():
         if not line.strip():
             continue
         fields = line.split(_SEP)
         if len(fields) < _REF_FIELDS:
+            # Counted, not swallowed. A row nobody could parse is a ref whose
+            # existence went unrecorded, and a later "nothing matched that
+            # name" cannot tell that apart from the ref not being there.
+            dropped += 1
             continue
         full, name, head, committed, upstream, track, head_marker = (
             f.strip() for f in fields[:_REF_FIELDS]
         )
         if not name or not full:
+            dropped += 1
             continue
 
         is_remote = full.startswith("refs/remotes/")
@@ -759,7 +773,12 @@ def read_branches(
                 probe_failures=probe_failures,
             )
         )
-    return branches, warnings, True, not_offered
+    if dropped:
+        warnings.append(
+            f"{dropped} ref row(s) could not be parsed and are missing from this report; "
+            f"a name that matches nothing may be one of them"
+        )
+    return branches, warnings, True, not_offered, dropped
 
 
 def _worktree_activity(
@@ -813,7 +832,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         )
     )
 
-    worktrees, warnings, worktrees_known = read_worktrees(port, cwd)
+    worktrees, warnings, worktrees_known, dropped_worktrees = read_worktrees(port, cwd)
     if base_ref_warning is not None:
         warnings.append(base_ref_warning)
     if current_warning is not None:
@@ -823,7 +842,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
     prs, gh_error, pr_evidence_gap = read_pull_requests(port, cwd)
     if pr_evidence_gap:
         warnings.append(pr_evidence_gap)
-    branches, branch_warnings, branches_known, not_offered = read_branches(
+    branches, branch_warnings, branches_known, not_offered, dropped_refs = read_branches(
         port,
         cwd,
         base_ref=base_ref,
@@ -858,6 +877,8 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         branches=tuple(branches),
         branches_known=branches_known,
         worktrees_known=worktrees_known,
+        dropped_refs=dropped_refs,
+        dropped_worktrees=dropped_worktrees,
         not_offered=tuple(not_offered),
         warnings=tuple(warnings),
     )

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -20,7 +20,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 
-from gitclean.model import Branch, MergeEvidence, PullRequest, Survey, Worktree
+from gitclean.model import Branch, MergeEvidence, NotOffered, PullRequest, Survey, Worktree
 from gitclean.ports import CommandPort
 
 _SEP = "\x1f"
@@ -630,12 +630,17 @@ def read_branches(
     default_branch: str,
     prs: dict[str, PullRequest],
     worktree_by_branch: dict[str, str],
-) -> tuple[list[Branch], list[str], bool]:
-    """The branches, the warnings, and whether the ref read answered at all.
+) -> tuple[list[Branch], list[str], bool, list[NotOffered]]:
+    """The branches, the warnings, whether the ref read answered at all, and
+    the refs deliberately left out of the first list.
 
-    The last one is not derivable from an empty branch list, and a worktree row
+    The third is not derivable from an empty branch list, and a worktree row
     needs it: with no refs read there was nothing a commit could have been
-    proven merged against."""
+    proven merged against.
+
+    The fourth exists because "not a target" and "not in the repository" are
+    different facts that a bare absence from ``branches`` cannot tell apart --
+    and only one of them lets a caller be told there is nothing to delete."""
     result = port.git(
         ["for-each-ref", f"--format={_REF_FORMAT}", "refs/heads", "refs/remotes"], cwd=cwd
     )
@@ -647,6 +652,7 @@ def read_branches(
                 f"no branch was surveyed, so this report describes worktrees only"
             ],
             False,
+            [],
         )
 
     local_merged, local_warning = _merged_set(port, cwd, base_ref, remote=False)
@@ -654,6 +660,7 @@ def read_branches(
     warnings = [w for w in (local_warning, remote_warning) if w]
 
     branches: list[Branch] = []
+    not_offered: list[NotOffered] = []
     for line in result.stdout.splitlines():
         if not line.strip():
             continue
@@ -669,11 +676,28 @@ def read_branches(
         is_remote = full.startswith("refs/remotes/")
         if is_remote and full.endswith("/HEAD"):
             # The remote's symbolic HEAD is a pointer, not a branch.
+            not_offered.append(
+                NotOffered(
+                    # Recorded from the full path rather than `name`: git
+                    # shortens refs/remotes/origin/HEAD to a bare `origin`,
+                    # which is not a spelling anybody would type at this tool.
+                    name=full.removeprefix("refs/remotes/"),
+                    reason="the remote's symbolic HEAD, which points at a branch rather than "
+                    "being one; delete the branch it names instead",
+                )
+            )
             continue
         remote = name.split("/", 1)[0] if is_remote and "/" in name else None
         short = name.split("/", 1)[1] if is_remote and remote else name
 
         if is_remote and short == default_branch:
+            not_offered.append(
+                NotOffered(
+                    name=name,
+                    reason=f"the server's copy of the trunk ({default_branch}); gitclean does "
+                    f"not offer it for deletion, and git will do it if you truly mean to",
+                )
+            )
             continue
 
         is_default = not is_remote and name == default_branch
@@ -731,7 +755,7 @@ def read_branches(
                 probe_failures=probe_failures,
             )
         )
-    return branches, warnings, True
+    return branches, warnings, True, not_offered
 
 
 def _worktree_activity(
@@ -795,7 +819,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
     prs, gh_error, pr_evidence_gap = read_pull_requests(port, cwd)
     if pr_evidence_gap:
         warnings.append(pr_evidence_gap)
-    branches, branch_warnings, branches_known = read_branches(
+    branches, branch_warnings, branches_known, not_offered = read_branches(
         port,
         cwd,
         base_ref=base_ref,
@@ -829,5 +853,6 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         worktrees=tuple(worktrees),
         branches=tuple(branches),
         branches_known=branches_known,
+        not_offered=tuple(not_offered),
         warnings=tuple(warnings),
     )

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -786,10 +786,51 @@ def test_a_squash_merged_branch_named_like_an_option_is_proven(repo: Path) -> No
     assert "-m" in [d["name"] for d in payload["execution"]["deletions"]]  # type: ignore[index]
 
 
+def test_a_name_nothing_matches_is_clean_and_does_not_stop_the_rest(repo: Path) -> None:
+    """Both halves matter. Exit 0 because the state the caller asked for holds,
+    and `feat/done` actually gone because the absent name did not take the
+    command down with it -- a selector refusal was plan-level, so one name
+    already dealt with aborted every deletion beside it."""
+    _merged_branch_beside(repo, "feat/done")
+
+    with reachability_guard(repo):
+        payload = report(repo, "--cleanup", "feat/done", "feat/never-existed")
+
+    assert payload["_exit"] == EXIT_OK
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feat/done") == ""
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    assert [a["selector"] for a in plan["absent"]] == ["feat/never-existed"]
+
+
+def test_the_post_merge_sequence_an_agent_performs_cleans_up(repo: Path, tmp_path: Path) -> None:
+    """The scenario this behaviour exists for, end to end.
+
+    Leaving the worktree before cleaning it is the *correct* order -- git will
+    not delete a branch a worktree still holds, and whatever owns that tree
+    usually removes it on the way out. Doing it right is what made the worktree
+    name match nothing, and the refusal that produced was plan-level: the
+    branch survived, and the run said it failed."""
+    work = tmp_path / "wt"
+    git(repo, "worktree", "add", "-q", "-b", "feat/shipped", str(work))
+    commit(work, "shipped.txt")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge feat/shipped", "feat/shipped")
+    git(repo, "worktree", "remove", str(work))
+
+    with reachability_guard(repo):
+        payload = report(repo, "--cleanup", f"worktree:{work}", "feat/shipped")
+
+    assert payload["_exit"] == EXIT_OK
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feat/shipped") == ""
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    assert [a["selector"] for a in plan["absent"]] == [f"worktree:{work}"]
+
+
 def test_a_branch_named_like_an_option_is_selectable_by_id(repo: Path) -> None:
     """Naming it directly cannot go through the bare name -- argparse claims
     `-m` as a flag before gitclean sees it. The `id` form is the way in, which
-    is what the unknown-target refusal already tells the reader to use."""
+    is what a name matching nothing points the reader back to."""
     head = git(repo, "rev-parse", "HEAD")
     git(repo, "update-ref", "refs/heads/-m", head)
 

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -527,6 +527,41 @@ def test_a_salvaged_server_ref_restores_by_the_command_the_tool_printed(
     assert git(clone, "cat-file", "-p", f"{only}:feat-gone.txt") == "the only copy"
 
 
+def test_a_server_ref_the_remote_already_dropped_costs_no_bundle(
+    repo: Path, tmp_path: Path
+) -> None:
+    """What a forge that deletes a branch when its PR merges leaves behind: a
+    tracking ref under refs/remotes naming a branch the server no longer has.
+    That stale ref is the only reason the target is in the plan at all.
+
+    The ref is dropped *inside the bare repository*, which is what a forge
+    tidying up after a merge does and is the only way to reach this state:
+    `push --delete` from the clone updates the tracking ref on the way out, so
+    the clone would know. Deleting it server-side leaves
+    `refs/remotes/origin/feat/vanished` behind untouched, which is the input
+    this is about, and the assertion below is there because a setup that
+    quietly cleaned the cache would test nothing.
+
+    The salvage list is what matters. Learning the ref is gone from a rejected
+    push means learning it after bundling the branch's entire history for
+    something that was never there to lose."""
+    bare = _with_remote(repo, tmp_path)
+    _push_only_copy(repo, "feat/vanished")
+    git(bare, "update-ref", "-d", "refs/heads/feat/vanished")
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/feat/vanished")
+
+    payload = report(repo, "--cleanup", "origin/feat/vanished")
+
+    assert payload["_exit"] == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["anomalies"] == []
+    assert execution["salvages"] == []
+    deletion = execution["deletions"][0]
+    assert deletion["already_absent"] is True
+    assert deletion["deleted"] is False
+
+
 def test_the_salvage_ref_does_not_outlive_the_run(repo: Path, tmp_path: Path) -> None:
     """Bundling needs a ref under refs/heads to bundle, and one left behind
     would surface in the next report as a branch nobody created."""

--- a/packages/gitclean/tests/unit/conftest.py
+++ b/packages/gitclean/tests/unit/conftest.py
@@ -147,6 +147,7 @@ def make_survey(
     gh_error: str | None = None,
     pr_evidence_gap: str | None = None,
     branches_known: bool = True,
+    worktrees_known: bool = True,
     not_offered: tuple[NotOffered, ...] = (),
     warnings: tuple[str, ...] = (),
 ) -> Survey:
@@ -163,6 +164,7 @@ def make_survey(
         worktrees=worktrees,
         branches=branches,
         branches_known=branches_known,
+        worktrees_known=worktrees_known,
         not_offered=not_offered,
         warnings=warnings,
     )

--- a/packages/gitclean/tests/unit/conftest.py
+++ b/packages/gitclean/tests/unit/conftest.py
@@ -19,7 +19,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from gitclean.model import Branch, MergeEvidence, PullRequest, Survey, Worktree
+from gitclean.model import Branch, MergeEvidence, NotOffered, PullRequest, Survey, Worktree
 
 NOW = datetime(2026, 7, 25, 12, 0, 0, tzinfo=UTC)
 
@@ -147,6 +147,7 @@ def make_survey(
     gh_error: str | None = None,
     pr_evidence_gap: str | None = None,
     branches_known: bool = True,
+    not_offered: tuple[NotOffered, ...] = (),
     warnings: tuple[str, ...] = (),
 ) -> Survey:
     return Survey(
@@ -162,6 +163,7 @@ def make_survey(
         worktrees=worktrees,
         branches=branches,
         branches_known=branches_known,
+        not_offered=not_offered,
         warnings=warnings,
     )
 

--- a/packages/gitclean/tests/unit/conftest.py
+++ b/packages/gitclean/tests/unit/conftest.py
@@ -148,6 +148,8 @@ def make_survey(
     pr_evidence_gap: str | None = None,
     branches_known: bool = True,
     worktrees_known: bool = True,
+    dropped_refs: int = 0,
+    dropped_worktrees: int = 0,
     not_offered: tuple[NotOffered, ...] = (),
     warnings: tuple[str, ...] = (),
 ) -> Survey:
@@ -165,6 +167,8 @@ def make_survey(
         branches=branches,
         branches_known=branches_known,
         worktrees_known=worktrees_known,
+        dropped_refs=dropped_refs,
+        dropped_worktrees=dropped_worktrees,
         not_offered=not_offered,
         warnings=warnings,
     )

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -328,6 +328,41 @@ def test_an_explicit_salvage_dir_is_honoured() -> None:
     assert plan["salvage_dir"] == "/var/salvage/keep"
 
 
+def test_a_miss_with_no_refs_read_exits_refused_not_clean() -> None:
+    """Exit 0 here would report a branch as gone on the strength of a list that
+    failed to load. The caller is entitled to know the difference between "it
+    is not there" and "I could not look"."""
+    port = make_port(extra={"for-each-ref": fail("fatal: bad object"), "branch -D -- done": ok()})
+
+    code, payload = invoke(["--cleanup", "done"], port)
+
+    assert code == EXIT_REFUSED
+    refusal = payload["refusal"]
+    assert isinstance(refusal, dict)
+    assert refusal["code"] == "E_SURVEY_INCOMPLETE"
+    assert not any(call[:3] == ("git", "branch", "-D") for call in port.transcript)
+
+
+def test_naming_the_servers_copy_of_the_trunk_exits_refused() -> None:
+    """It is on the server and gitclean keeps it out of the target list, so a
+    miss says nothing about whether it exists. Exit 0 with `already gone` would
+    be a false report about a ref sitting right there."""
+    port = make_port(
+        refs=[
+            ref_at("refs/heads/main", "main", "a" * 40, head="*"),
+            ref_at("refs/remotes/origin/main", "origin/main", "a" * 40),
+        ]
+    )
+
+    code, payload = invoke(["--cleanup", "origin/main"], port)
+
+    assert code == EXIT_REFUSED
+    refusal = payload["refusal"]
+    assert isinstance(refusal, dict)
+    assert refusal["code"] == "E_NOT_A_TARGET"
+    assert refusal["remedy"]
+
+
 def _absent_remote_port() -> ScriptedCommands:
     """The tracking ref is here and the server's copy is not, which is what a
     forge that deletes merged branches leaves behind."""

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -296,6 +296,10 @@ def _remote_port() -> ScriptedCommands:
             ref_at("refs/remotes/origin/feat/x", "origin/feat/x", "f" * 40),
         ],
         counts={"origin/main..origin/feat/x": "0"},
+        # The server still has it. Every route to deleting a server ref asks
+        # that first, dry runs included, so a fixture that left it unscripted
+        # would only ever exercise the already-gone path.
+        extra={"ls-remote": ok(f"{'f' * 40}\trefs/heads/feat/x")},
     )
 
 
@@ -324,7 +328,75 @@ def test_an_explicit_salvage_dir_is_honoured() -> None:
     assert plan["salvage_dir"] == "/var/salvage/keep"
 
 
+def _absent_remote_port() -> ScriptedCommands:
+    """The tracking ref is here and the server's copy is not, which is what a
+    forge that deletes merged branches leaves behind."""
+    return make_port(
+        refs=[
+            ref_at("refs/heads/main", "main", "a" * 40, head="*"),
+            ref_at("refs/remotes/origin/feat/x", "origin/feat/x", "f" * 40),
+        ],
+        counts={"origin/main..origin/feat/x": "0"},
+        extra={"ls-remote": ok("")},
+    )
+
+
+def test_naming_something_already_gone_is_a_clean_exit() -> None:
+    """Exit 1 here is the failure that matters: an agent that correctly leaves
+    a worktree before cleaning it up, then names it, is told the run refused
+    and reaches for raw git or escalates over a job already done."""
+    code, payload = invoke(["--cleanup", "not-a-thing"], merged_branch_port())
+    assert code == EXIT_OK
+    assert payload["refusal"] is None
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    assert [a["selector"] for a in plan["absent"]] == ["not-a-thing"]
+
+
+def test_an_absent_name_does_not_take_the_names_beside_it_down() -> None:
+    """A selector refusal is plan-level, so before this the one name that had
+    already been dealt with aborted every other deletion in the command."""
+    code, payload = invoke(["--cleanup", "done", "not-a-thing"], merged_branch_port())
+    assert code == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert [d["name"] for d in execution["deletions"]] == ["done"]
+    assert execution["deletions"][0]["deleted"] is True
+
+
+def test_a_server_ref_already_gone_exits_clean_rather_than_anomalous() -> None:
+    """Exit 3 says something is wrong and needs reading. Spending it on the
+    ordinary outcome of a forge that tidies up after itself teaches a reader to
+    skip the code that was supposed to stop them."""
+    code, payload = invoke(["--cleanup", "origin/feat/x"], _absent_remote_port())
+    assert code == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["anomalies"] == []
+    assert execution["deletions"][0]["already_absent"] is True
+
+
 # -- human rendering ---------------------------------------------------------
+
+
+def test_human_output_names_what_it_could_not_find() -> None:
+    """Not an error, and not silence either. A name matching nothing is also
+    exactly what a typo looks like from in here, and the reader is the only one
+    who can tell the two apart -- so the name goes on the page for them."""
+    code, text = invoke_human(["--cleanup", "not-a-thing"], merged_branch_port())
+    assert code == EXIT_OK
+    assert "ABSENT" in text
+    assert "not-a-thing" in text
+
+
+def test_human_output_does_not_mark_an_already_gone_ref_as_deleted() -> None:
+    """`ok` is the mark for a deletion this run performed and verified. Reusing
+    it here would put a cleanup that did nothing and one that did the work on
+    the same line."""
+    code, text = invoke_human(["--cleanup", "origin/feat/x"], _absent_remote_port())
+    assert code == EXIT_OK
+    assert "gone origin/feat/x" in text
+    assert "ok   origin/feat/x" not in text
 
 
 def test_human_report_marks_the_sweepable_rows_and_shows_the_evidence() -> None:

--- a/packages/gitclean/tests/unit/test_execute.py
+++ b/packages/gitclean/tests/unit/test_execute.py
@@ -57,12 +57,24 @@ def test_dry_run_issues_no_commands() -> None:
 
 
 def test_dry_run_announces_the_salvage_step_for_a_server_ref() -> None:
-    port = ScriptedCommands()
+    port = ScriptedCommands(git={"ls-remote": ok(f"{REMOTE_HEAD}\trefs/heads/wip")})
     report = run(
         port,
         plan(target(TargetKind.REMOTE_BRANCH, "origin/wip"), dry_run=True),
     )
     assert "after salvage" in report.deletions[0].detail
+
+
+def test_a_dry_run_does_not_promise_to_delete_a_ref_the_server_lost() -> None:
+    """The preview exists to be believed before the real run, so it asks the
+    same question the real run does. Announcing `would delete` for a ref that
+    is not there sends a caller to a cleanup with nothing in it."""
+    port = ScriptedCommands(git={"ls-remote": ok("")})
+    report = run(port, plan(target(TargetKind.REMOTE_BRANCH, "origin/wip"), dry_run=True))
+
+    assert report.ok
+    assert report.deletions[0].already_absent
+    assert "would delete" not in report.deletions[0].detail
 
 
 def test_dry_run_announces_no_salvage_for_a_local_branch() -> None:
@@ -343,14 +355,20 @@ def _salvage_calls(bundle: str) -> dict[str, CommandResult]:
 def _remote_port(**overrides: object) -> ScriptedCommands:
     """Every server deletion is bundled first, so every one of these scripts
     the bundle. A test that omitted it would be exercising the salvage-failure
-    path while claiming to be about the push."""
-    table: dict[str, CommandResult] = {
+    path while claiming to be about the push.
+
+    `ls-remote` is asked twice with two different answers, and that is a fact
+    about the domain rather than about call order: the deletion in between is
+    what changes what the server has. One answer for both would make a liar of
+    one of them -- say `ok("")` throughout and the run finds the ref already
+    gone and never pushes at all."""
+    table: dict[str, CommandResult | list[CommandResult]] = {
         **_salvage_calls(FEAT_BUNDLE),
         "push --force-with-lease": ok(),
-        "ls-remote": ok(""),
+        "ls-remote": [ok(f"{REMOTE_HEAD}\trefs/heads/feat/x"), ok("")],
     }
     table.update(overrides)  # type: ignore[arg-type]
-    return ScriptedCommands(git=table)  # type: ignore[arg-type]
+    return ScriptedCommands(git=table)
 
 
 def test_remote_deletion_is_confirmed_against_the_server() -> None:
@@ -437,7 +455,14 @@ def test_a_sibling_ref_on_the_server_is_not_read_as_the_target_surviving() -> No
     unrelated `a/feat/x` answers a question about `feat/x`. Reading that as the
     target having survived turns a deletion git performed into a reported
     failure, and the exit code says the run went wrong."""
-    port = _remote_port(**{"ls-remote": ok("dbfd823\trefs/heads/a/feat/x")})
+    port = _remote_port(
+        **{
+            "ls-remote": [
+                ok(f"{REMOTE_HEAD}\trefs/heads/feat/x"),
+                ok("dbfd823\trefs/heads/a/feat/x"),
+            ]
+        }
+    )
     report = run(port, plan(target(TargetKind.REMOTE_BRANCH, "origin/feat/x")), _remote_survey())
     assert report.ok
     assert report.deletions[0].verified
@@ -468,13 +493,14 @@ WIP_BUNDLE = f"/salvage/{slug(REMOTE)}.bundle"
 
 
 def _remote_salvage_port(**overrides: object) -> ScriptedCommands:
-    table: dict[str, CommandResult] = {
+    table: dict[str, CommandResult | list[CommandResult]] = {
         **_salvage_calls(WIP_BUNDLE),
         "push --force-with-lease": ok(),
-        "ls-remote": ok(""),
+        # Present, then gone. See _remote_port for why one answer will not do.
+        "ls-remote": [ok(f"{REMOTE_HEAD}\trefs/heads/wip"), ok("")],
     }
     table.update(overrides)  # type: ignore[arg-type]
-    return ScriptedCommands(git=table)  # type: ignore[arg-type]
+    return ScriptedCommands(git=table)
 
 
 def test_a_server_ref_is_bundled_before_it_is_deleted() -> None:
@@ -490,6 +516,55 @@ def test_a_server_ref_is_bundled_before_it_is_deleted() -> None:
     # calls verified.
     assert verbs.index("clone") < verbs.index("push")
     assert report.salvages[0].verified
+
+
+def test_a_server_ref_the_forge_already_deleted_costs_nothing() -> None:
+    """A forge that drops the branch when its PR merges is the common setup,
+    and the stale tracking ref it leaves behind is the only reason this target
+    is in the plan at all. Found from the rejected push instead, the same fact
+    costs an archive of the whole history, written for a ref that was never
+    there to lose, and lands as an anomaly over a job already finished."""
+    port = _remote_salvage_port(**{"ls-remote": ok("")})
+    report = run(port, plan(target(TargetKind.REMOTE_BRANCH, REMOTE)), _remote_survey(REMOTE))
+
+    assert report.ok
+    assert report.deletions[0].already_absent
+    assert report.salvages == ()
+    # One read-only question and nothing else: no scratch branch, no bundle,
+    # no clone, no push.
+    assert [call[1] for call in port.transcript] == ["ls-remote"]
+
+
+def test_an_already_absent_ref_is_not_evidence_the_run_did_something() -> None:
+    """`deleted` is the field that says the tool acted, and a caller counting
+    what a cleanup achieved must not be handed work it never did."""
+    port = _remote_salvage_port(**{"ls-remote": ok("")})
+    report = run(port, plan(target(TargetKind.REMOTE_BRANCH, REMOTE)), _remote_survey(REMOTE))
+
+    assert not report.deletions[0].deleted
+    assert report.deletions[0].verified
+
+
+def test_an_already_absent_ref_says_which_stale_ref_conjured_it() -> None:
+    """The target exists because refs/remotes still names it, so the row that
+    reports nothing to do should say where the phantom came from -- otherwise
+    the next report shows it again and reads as a cleanup that did not work."""
+    port = _remote_salvage_port(**{"ls-remote": ok("")})
+    report = run(port, plan(target(TargetKind.REMOTE_BRANCH, REMOTE)), _remote_survey(REMOTE))
+
+    assert "fetch --prune origin" in report.deletions[0].detail
+
+
+def test_a_probe_that_will_not_answer_never_claims_the_ref_is_gone() -> None:
+    """Not knowing whether the server still has it is not evidence that it
+    does not. The ordinary route runs, which is the one keeping a lease in
+    front of the delete -- and being wrong this way costs a bundle, while being
+    wrong the other way skips a deletion the caller asked for."""
+    port = _remote_salvage_port(**{"ls-remote": fail("could not read from remote")})
+    report = run(port, plan(target(TargetKind.REMOTE_BRANCH, REMOTE)), _remote_survey(REMOTE))
+
+    assert not any(d.already_absent for d in report.deletions)
+    assert "push" in [call[1] for call in port.transcript]
 
 
 def test_a_local_branch_is_not_bundled() -> None:
@@ -519,6 +594,9 @@ def test_the_bundle_is_taken_from_a_branch_this_run_makes_and_removes() -> None:
 
     scratch = f"{SALVAGE_PREFIX}/{slug(REMOTE)}"
     assert port.transcript == [
+        # The server is asked first, and nothing above is spent until it says
+        # the ref is there to lose.
+        ("git", "ls-remote", "--heads", "origin", "refs/heads/wip"),
         ("git", "branch", "--no-track", scratch, f"refs/remotes/{REMOTE}"),
         ("git", "rev-parse", "--verify", f"refs/heads/{scratch}"),
         ("git", "bundle", "create", WIP_BUNDLE, f"refs/heads/{scratch}"),
@@ -614,14 +692,20 @@ def test_an_unreadable_scratch_tip_aborts_before_anything_is_bundled() -> None:
 
 
 def test_missing_salvage_directory_aborts_rather_than_deleting_unprotected() -> None:
-    port = ScriptedCommands()
+    """The assertion is that nothing was *changed*, which is narrower than the
+    `transcript == []` it replaces and is the claim the test was always about.
+    One read-only question now precedes the abort: whether the server still has
+    the ref. It has to, and in that order -- a ref the server no longer holds
+    needs no bundle, so refusing it for want of somewhere to put one would be
+    an error raised about a job that does not exist."""
+    port = ScriptedCommands(git={"ls-remote": ok(f"{REMOTE_HEAD}\trefs/heads/wip")})
     report = run(
         port,
         plan(target(TargetKind.REMOTE_BRANCH, REMOTE), salvage_dir=None),
         _remote_survey(REMOTE),
     )
     assert not report.ok
-    assert port.transcript == []
+    assert [call[1] for call in port.transcript] == ["ls-remote"]
 
 
 # -- cascade -----------------------------------------------------------------

--- a/packages/gitclean/tests/unit/test_execute.py
+++ b/packages/gitclean/tests/unit/test_execute.py
@@ -372,10 +372,15 @@ def _remote_port(**overrides: object) -> ScriptedCommands:
 
 
 def test_remote_deletion_is_confirmed_against_the_server() -> None:
+    """`deleted` is asserted alongside `verified` because a target that was
+    already absent satisfies `ok` and `verified` too. Without this line the
+    test passes on a fixture whose server never had the ref, which is a
+    different code path than the one it is named for."""
     port = _remote_port()
     report = run(port, plan(target(TargetKind.REMOTE_BRANCH, "origin/feat/x")), _remote_survey())
     assert report.ok
     assert report.deletions[0].verified
+    assert report.deletions[0].deleted
 
 
 def test_the_remote_delete_is_leased_to_the_commit_that_was_judged() -> None:

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from conftest import make_branch, make_survey
 
-from gitclean.model import MergeEvidence, Plan, Refusal, Target, TargetKind
+from gitclean.model import MergeEvidence, NotOffered, Plan, Refusal, Target, TargetKind
 from gitclean.plan import build_plan, resolve_selectors
 
 
@@ -181,6 +181,51 @@ def test_one_absent_name_does_not_abort_the_names_beside_it() -> None:
     assert [a.selector for a in result.absent] == ["gone-already"]
 
 
+def test_a_miss_is_not_absence_when_no_ref_could_be_read() -> None:
+    """`branches` is empty here because `for-each-ref` failed, not because the
+    repository has none -- and the list alone cannot tell those apart. Calling
+    it absence would tell a caller their branch is gone while it sits
+    untouched, which is the one thing this tool must never say."""
+    survey = make_survey(branches_known=False)
+
+    result = plan_for((), survey=survey, selectors=["feat/x"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_SURVEY_INCOMPLETE"
+    assert "feat/x" in result.message
+    assert result.remedy
+
+
+def test_a_ref_this_tool_declines_to_offer_is_not_reported_as_gone() -> None:
+    """The server's copy of the trunk exists and is deliberately kept out of
+    the target list. "Nothing matched" is therefore true and "it is already
+    gone" is false, and only the second is a thing to tell somebody."""
+    survey = make_survey(
+        not_offered=(NotOffered(name="origin/main", reason="the server's copy of the trunk"),)
+    )
+
+    result = plan_for((target("branch:x"),), survey=survey, selectors=["origin/main"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_NOT_A_TARGET"
+    assert "origin/main" in result.message
+    assert "the server's copy of the trunk" in result.message
+
+
+def test_the_local_trunk_is_not_confused_with_the_servers_copy_of_it() -> None:
+    """A short-name fallback in the not-offered lookup would match `main`
+    against the recorded `origin/main` and refuse to delete a different ref
+    that is a legal thing to name."""
+    survey = make_survey(
+        not_offered=(NotOffered(name="origin/main", reason="the server's copy of the trunk"),)
+    )
+
+    result = plan_for((target("branch:main", sweepable=False),), survey=survey, selectors=["main"])
+
+    assert isinstance(result, Plan)
+    assert [t.name for t in result.targets] == ["main"]
+
+
 def test_ambiguous_bare_name_is_refused_with_the_candidates() -> None:
     """`feat/x` names both the local branch and origin's copy. Guessing which
     one the caller meant is how the wrong ref gets deleted."""
@@ -220,7 +265,7 @@ def test_repeated_selector_is_not_planned_twice() -> None:
 
 def test_resolve_selectors_returns_targets_in_request_order() -> None:
     targets = (target("branch:a"), target("branch:b"))
-    resolved, absent, refusal = resolve_selectors(["b", "a"], targets)
+    resolved, absent, refusal = resolve_selectors(["b", "a"], targets, make_survey())
     assert refusal is None
     assert absent == []
     assert [t.name for t in resolved] == ["b", "a"]
@@ -236,7 +281,9 @@ def test_ambiguity_still_refuses_and_carries_nothing_forward() -> None:
         target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH),
         target("branch:other"),
     )
-    resolved, absent, refusal = resolve_selectors(["other", "feat/x", "nope"], targets)
+    resolved, absent, refusal = resolve_selectors(
+        ["other", "feat/x", "nope"], targets, make_survey()
+    )
     assert refusal is not None
     assert refusal.code == "E_AMBIGUOUS_TARGET"
     assert resolved == []

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -147,10 +147,38 @@ def test_another_worktree_is_not_mistaken_for_the_invoking_one() -> None:
 # -- selector resolution -----------------------------------------------------
 
 
-def test_unknown_selector_is_refused() -> None:
+def test_a_selector_matching_nothing_is_a_job_already_done() -> None:
+    """The caller asked for that thing to be gone. It is gone. Refusing there
+    reports a completed job as a failure, and an agent told it failed retries,
+    reaches for raw git, or escalates -- all worse than the no-op it should
+    have been handed."""
     result = plan_for((target("branch:x"),), selectors=["nope"])
-    assert isinstance(result, Refusal)
-    assert result.code == "E_UNKNOWN_TARGET"
+    assert isinstance(result, Plan)
+    assert result.targets == ()
+    assert [a.selector for a in result.absent] == ["nope"]
+
+
+def test_a_selector_matching_nothing_states_both_readings() -> None:
+    """Nothing here can tell a branch deleted a minute ago from a name with a
+    letter wrong -- the repository answers identically -- so the note commits
+    to neither and points at the list that would settle it."""
+    result = plan_for((target("branch:x"),), selectors=["nope"])
+    assert isinstance(result, Plan)
+    note = result.absent[0].note
+    assert "already gone" in note
+    assert "the name is wrong" in note
+    assert "--report" in note
+
+
+def test_one_absent_name_does_not_abort_the_names_beside_it() -> None:
+    """This is the whole cost of the old refusal. Selector refusals are
+    plan-level, so a single name that had already been dealt with stopped every
+    other deletion the caller asked for in the same breath."""
+    targets = (target("branch:x"), target("branch:y"))
+    result = plan_for(targets, selectors=["x", "gone-already", "y"])
+    assert isinstance(result, Plan)
+    assert [t.id for t in result.targets] == ["branch:x", "branch:y"]
+    assert [a.selector for a in result.absent] == ["gone-already"]
 
 
 def test_ambiguous_bare_name_is_refused_with_the_candidates() -> None:
@@ -192,9 +220,27 @@ def test_repeated_selector_is_not_planned_twice() -> None:
 
 def test_resolve_selectors_returns_targets_in_request_order() -> None:
     targets = (target("branch:a"), target("branch:b"))
-    resolved, refusal = resolve_selectors(["b", "a"], targets)
+    resolved, absent, refusal = resolve_selectors(["b", "a"], targets)
     assert refusal is None
+    assert absent == []
     assert [t.name for t in resolved] == ["b", "a"]
+
+
+def test_ambiguity_still_refuses_and_carries_nothing_forward() -> None:
+    """A miss is a job done; ambiguity is a question. Two real things match and
+    picking one destroys the other, so this is the refusal that stays -- and it
+    resolves no selector beside it, because the caller is about to re-issue the
+    whole command with a precise name."""
+    targets = (
+        target("branch:feat/x"),
+        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH),
+        target("branch:other"),
+    )
+    resolved, absent, refusal = resolve_selectors(["other", "feat/x", "nope"], targets)
+    assert refusal is not None
+    assert refusal.code == "E_AMBIGUOUS_TARGET"
+    assert resolved == []
+    assert absent == []
 
 
 # -- worktree occupancy ------------------------------------------------------

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -222,6 +222,53 @@ def test_a_failed_ref_read_does_not_block_naming_an_absent_worktree() -> None:
     assert [a.selector for a in result.absent] == ["worktree:/repo/wt"]
 
 
+def test_a_listing_that_ran_but_dropped_a_row_has_not_answered() -> None:
+    """`branches_known` says the command exited 0, which is a smaller claim
+    than describing everything it listed. A row nobody could parse is a ref
+    whose existence went unrecorded, and that is the same hole as never having
+    looked -- so it must not turn into "already gone"."""
+    survey = make_survey(branches_known=True, dropped_refs=1)
+
+    result = plan_for((), survey=survey, selectors=["branch:feat/x"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_SURVEY_INCOMPLETE"
+    assert "1 ref row(s) went unparsed" in result.message
+
+
+def test_a_dropped_worktree_block_is_the_same_hole_on_the_other_listing() -> None:
+    survey = make_survey(worktrees_known=True, dropped_worktrees=2)
+
+    result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_SURVEY_INCOMPLETE"
+    assert "2 worktree block(s) went unparsed" in result.message
+
+
+def test_a_dropped_ref_row_does_not_block_naming_a_worktree() -> None:
+    """The counts are read per listing, like the flags beside them. A ref row
+    nobody could parse says nothing about the worktree listing."""
+    survey = make_survey(dropped_refs=1)
+
+    result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert isinstance(result, Plan)
+    assert [a.selector for a in result.absent] == ["worktree:/repo/wt"]
+
+
+def test_an_absolute_path_is_a_worktree_without_needing_the_prefix() -> None:
+    """git will not create a ref whose short name begins with a slash, so an
+    absolute path can only mean a worktree -- and the worktree listing is the
+    only one that has to have answered for it."""
+    survey = make_survey(branches_known=False, worktrees_known=True)
+
+    result = plan_for((), survey=survey, selectors=["/repo/wt"])
+
+    assert isinstance(result, Plan)
+    assert [a.selector for a in result.absent] == ["/repo/wt"]
+
+
 def test_a_bare_name_needs_both_listings_because_it_could_be_either() -> None:
     """Being unable to say which kind was meant is not a reason to trust
     whichever one happened to answer."""

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -196,6 +196,44 @@ def test_a_miss_is_not_absence_when_no_ref_could_be_read() -> None:
     assert result.remedy
 
 
+def test_a_worktree_miss_is_not_absence_when_no_worktree_could_be_listed() -> None:
+    """The same defect as the ref read, on the other listing. `worktrees` is
+    empty because `worktree list` failed, and a repository whose trees could
+    not be described has not been shown to lack the one that was named."""
+    survey = make_survey(worktrees_known=False)
+
+    result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_SURVEY_INCOMPLETE"
+    assert "no worktree could be listed" in result.message
+
+
+def test_a_failed_ref_read_does_not_block_naming_an_absent_worktree() -> None:
+    """The commonest cleanup there is -- a worktree already removed, named
+    after the fact -- and the worktree listing answered. Refusing it over a ref
+    read that has nothing to do with this selector would take the tool's whole
+    reason for accepting an absent name and give it back."""
+    survey = make_survey(branches_known=False, worktrees_known=True)
+
+    result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert isinstance(result, Plan)
+    assert [a.selector for a in result.absent] == ["worktree:/repo/wt"]
+
+
+def test_a_bare_name_needs_both_listings_because_it_could_be_either() -> None:
+    """Being unable to say which kind was meant is not a reason to trust
+    whichever one happened to answer."""
+    survey = make_survey(branches_known=False, worktrees_known=True)
+
+    result = plan_for((), survey=survey, selectors=["ambiguous"])
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_SURVEY_INCOMPLETE"
+    assert "no ref could be read" in result.message
+
+
 def test_a_ref_this_tool_declines_to_offer_is_not_reported_as_gone() -> None:
     """The server's copy of the trunk exists and is deliberately kept out of
     the target list. "Nothing matched" is therefore true and "it is already

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -326,7 +326,7 @@ def test_worktree_porcelain_blocks_are_parsed() -> None:
             "status --porcelain=v1": ok(""),
         }
     )
-    worktrees, warnings = read_worktrees(port, None)
+    worktrees, warnings, _known = read_worktrees(port, None)
     assert [w.path for w in worktrees] == ["/repo", "/repo/wt", "/repo/gone"]
     assert worktrees[0].is_main and worktrees[0].branch == "main"
     assert worktrees[1].locked
@@ -343,7 +343,7 @@ def test_a_worktree_block_without_a_path_is_warned_not_dropped_silently() -> Non
             "status --porcelain=v1": ok(""),
         }
     )
-    worktrees, warnings = read_worktrees(port, None)
+    worktrees, warnings, _known = read_worktrees(port, None)
     assert worktrees == []
     assert warnings and "no path" in warnings[0]
 
@@ -355,7 +355,7 @@ def test_modified_untracked_and_ignored_files_are_counted_separately() -> None:
             "status --porcelain=v1": ok(" M a.txt\nA  b.txt\n?? c.txt\n?? d.txt\n!! .env\n"),
         }
     )
-    worktrees, _ = read_worktrees(port, None)
+    worktrees, _, _known = read_worktrees(port, None)
     assert worktrees[0].dirty_file_count == 2
     assert worktrees[0].untracked_file_count == 2
     assert worktrees[0].ignored_file_count == 1
@@ -373,7 +373,7 @@ def test_ignored_files_are_counted_but_do_not_make_a_worktree_dirty() -> None:
             "status --porcelain=v1": ok("!! .venv/\n!! __pycache__/\n!! .env\n"),
         }
     )
-    worktrees, _ = read_worktrees(port, None)
+    worktrees, _, _known = read_worktrees(port, None)
     assert worktrees[0].ignored_file_count == 3
     assert worktrees[0].dirty is False
 
@@ -435,7 +435,7 @@ def test_a_worktree_git_cannot_stat_is_unknown_not_clean() -> None:
             "status --porcelain=v1": fail("no such directory"),
         }
     )
-    worktrees, warnings = read_worktrees(port, None)
+    worktrees, warnings, _known = read_worktrees(port, None)
     assert worktrees[0].dirty is None
     assert worktrees[0].dirty_file_count is None
     assert worktrees[0].untracked_file_count is None
@@ -457,7 +457,7 @@ def test_a_prunable_worktree_is_unknown_dirt_not_clean() -> None:
             ),
         }
     )
-    worktrees, warnings = read_worktrees(port, None)
+    worktrees, warnings, _known = read_worktrees(port, None)
     assert worktrees[0].dirty is None
     assert worktrees[0].dirty_file_count is None
     assert worktrees[0].untracked_file_count is None
@@ -470,7 +470,7 @@ def test_a_prunable_worktree_is_unknown_dirt_not_clean() -> None:
 
 def test_unlistable_worktrees_are_reported() -> None:
     port = ScriptedCommands(git={"worktree list --porcelain": fail("boom")})
-    worktrees, warnings = read_worktrees(port, None)
+    worktrees, warnings, _known = read_worktrees(port, None)
     assert worktrees == []
     assert warnings
 
@@ -629,6 +629,23 @@ def test_origins_symbolic_head_is_not_offered_as_a_branch() -> None:
     )
     names = [b.name for b in run(port).branches]
     assert "origin" not in names
+
+
+def test_a_failed_worktree_listing_is_recorded_as_unread_not_as_empty() -> None:
+    """A repository with only its main working tree lists one entry; a listing
+    that failed lists none. Both arrive as an empty tuple, and only one of them
+    supports concluding that a named worktree is gone."""
+    port = make_port(extra={"worktree list --porcelain": fail("fatal: bad config")})
+
+    surveyed = run(port)
+
+    assert surveyed.worktrees == ()
+    assert surveyed.worktrees_known is False
+
+
+def test_a_worktree_listing_that_answered_says_so() -> None:
+    port = make_port()
+    assert run(port).worktrees_known is True
 
 
 def test_a_ref_left_out_of_the_targets_is_recorded_rather_than_dropped() -> None:

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -631,6 +631,30 @@ def test_origins_symbolic_head_is_not_offered_as_a_branch() -> None:
     assert "origin" not in names
 
 
+def test_a_ref_left_out_of_the_targets_is_recorded_rather_than_dropped() -> None:
+    """Skipping it silently makes "not a target" and "not in the repository"
+    the same fact downstream, and only one of them lets a caller be told there
+    is nothing to delete.
+
+    The symbolic HEAD is recorded under a spelling somebody might actually
+    type. git shortens the ref to a bare `origin`, which nobody would."""
+    port = make_port(
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/HEAD", "origin"),
+            ref_line("refs/remotes/origin/main", "origin/main"),
+        ]
+    )
+
+    surveyed = run(port)
+
+    recorded = {n.name: n.reason for n in surveyed.not_offered}
+    assert set(recorded) == {"origin/HEAD", "origin/main"}
+    assert "symbolic HEAD" in recorded["origin/HEAD"]
+    assert "trunk" in recorded["origin/main"]
+    assert "origin/main" not in [b.name for b in surveyed.branches]
+
+
 def test_remote_refs_are_identified_by_prefix_not_by_a_slash() -> None:
     port = make_port(
         refs=[

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -326,7 +326,7 @@ def test_worktree_porcelain_blocks_are_parsed() -> None:
             "status --porcelain=v1": ok(""),
         }
     )
-    worktrees, warnings, _known = read_worktrees(port, None)
+    worktrees, warnings, _known, _dropped = read_worktrees(port, None)
     assert [w.path for w in worktrees] == ["/repo", "/repo/wt", "/repo/gone"]
     assert worktrees[0].is_main and worktrees[0].branch == "main"
     assert worktrees[1].locked
@@ -343,7 +343,7 @@ def test_a_worktree_block_without_a_path_is_warned_not_dropped_silently() -> Non
             "status --porcelain=v1": ok(""),
         }
     )
-    worktrees, warnings, _known = read_worktrees(port, None)
+    worktrees, warnings, _known, _dropped = read_worktrees(port, None)
     assert worktrees == []
     assert warnings and "no path" in warnings[0]
 
@@ -355,7 +355,7 @@ def test_modified_untracked_and_ignored_files_are_counted_separately() -> None:
             "status --porcelain=v1": ok(" M a.txt\nA  b.txt\n?? c.txt\n?? d.txt\n!! .env\n"),
         }
     )
-    worktrees, _, _known = read_worktrees(port, None)
+    worktrees, _, _known, _dropped = read_worktrees(port, None)
     assert worktrees[0].dirty_file_count == 2
     assert worktrees[0].untracked_file_count == 2
     assert worktrees[0].ignored_file_count == 1
@@ -373,7 +373,7 @@ def test_ignored_files_are_counted_but_do_not_make_a_worktree_dirty() -> None:
             "status --porcelain=v1": ok("!! .venv/\n!! __pycache__/\n!! .env\n"),
         }
     )
-    worktrees, _, _known = read_worktrees(port, None)
+    worktrees, _, _known, _dropped = read_worktrees(port, None)
     assert worktrees[0].ignored_file_count == 3
     assert worktrees[0].dirty is False
 
@@ -435,7 +435,7 @@ def test_a_worktree_git_cannot_stat_is_unknown_not_clean() -> None:
             "status --porcelain=v1": fail("no such directory"),
         }
     )
-    worktrees, warnings, _known = read_worktrees(port, None)
+    worktrees, warnings, _known, _dropped = read_worktrees(port, None)
     assert worktrees[0].dirty is None
     assert worktrees[0].dirty_file_count is None
     assert worktrees[0].untracked_file_count is None
@@ -457,7 +457,7 @@ def test_a_prunable_worktree_is_unknown_dirt_not_clean() -> None:
             ),
         }
     )
-    worktrees, warnings, _known = read_worktrees(port, None)
+    worktrees, warnings, _known, _dropped = read_worktrees(port, None)
     assert worktrees[0].dirty is None
     assert worktrees[0].dirty_file_count is None
     assert worktrees[0].untracked_file_count is None
@@ -470,7 +470,7 @@ def test_a_prunable_worktree_is_unknown_dirt_not_clean() -> None:
 
 def test_unlistable_worktrees_are_reported() -> None:
     port = ScriptedCommands(git={"worktree list --porcelain": fail("boom")})
-    worktrees, warnings, _known = read_worktrees(port, None)
+    worktrees, warnings, _known, _dropped = read_worktrees(port, None)
     assert worktrees == []
     assert warnings
 
@@ -645,7 +645,32 @@ def test_a_failed_worktree_listing_is_recorded_as_unread_not_as_empty() -> None:
 
 def test_a_worktree_listing_that_answered_says_so() -> None:
     port = make_port()
-    assert run(port).worktrees_known is True
+    surveyed = run(port)
+    assert surveyed.worktrees_known is True
+    assert surveyed.dropped_worktrees == 0
+
+
+def test_a_dropped_worktree_block_is_counted_not_just_warned() -> None:
+    """The warning is prose for a reader. The count is what stops a later
+    "nothing matched that name" being read as absence."""
+    port = make_port(worktrees="worktree /repo\nHEAD abc\n\nHEAD deadbeef\nbranch refs/heads/x\n")
+
+    surveyed = run(port)
+
+    assert surveyed.worktrees_known is True
+    assert surveyed.dropped_worktrees == 1
+
+
+def test_an_unparseable_ref_row_is_counted_and_warned_rather_than_vanishing() -> None:
+    """These rows used to be dropped in silence, so a ref could go unrecorded
+    with nothing anywhere saying a row had been lost."""
+    port = make_port(refs=[ref_line("refs/heads/main", "main", head="*"), "truncated\x1frow"])
+
+    surveyed = run(port)
+
+    assert surveyed.branches_known is True
+    assert surveyed.dropped_refs == 1
+    assert any("could not be parsed" in w for w in surveyed.all_warnings())
 
 
 def test_a_ref_left_out_of_the_targets_is_recorded_rather_than_dropped() -> None:


### PR DESCRIPTION
## The missing concept

`gitclean` knew three outcomes — success (0), refusal (1), and acted-but-surprised (3). **Idempotence was none of them.** When the state the caller asked for already held, the tool reported a problem.

**A. A name matching nothing was a refusal.** Selector refusals are plan-level, so one already-handled name aborted *every other deletion in the same command*. The failing sequence is the correct one: an agent leaves a worktree before cleaning it up — which it must, since git will not delete a branch a worktree holds — and the name then matches nothing.

Verified against the deployed binary on an identical scratch repo:

```
OLD:  REFUSED (E_UNKNOWN_TARGET)   exit 1   →  feat/done SURVIVED
NEW:  ok feat/done -- local ref deleted     exit 0
      ABSENT feat/never-existed -- ...
```

The old run refused *and skipped the deletion the caller was entitled to*.

**B. A server ref the forge already deleted was an anomaly at exit 3** — found from a rejected push, *after* bundling the branch's whole history for a ref that was never there to lose. On a forge that deletes merged branches, that is the ordinary path. The server is now asked first: one read-only command, no scratch branch, no bundle, no push.

## Absence has to be measured

Four rounds of cross-model review (`gpt-5.6-sol`) found ten defects, and every one was the same mistake: **concluding "already gone" from a look that was never capable of finding the thing.** That is the inverse of the rule this package already holds everywhere — an unanswered probe is `None`, and `None` concludes nothing. It was applied to deletions and not to absence.

What that cost, and what fixed it:

- **A failed ref read read as proof of absence.** `branches` is empty *because the read failed*, and every named branch was reported already gone — strictly worse than the exit 1 it replaced. Now refuses (`E_SURVEY_INCOMPLETE`).
- **The worktree listing had no completeness flag at all.** Same defect, other list. Now `worktrees_known`.
- **A listing that *ran* is not a listing that *answered*.** Both parsers skip rows they cannot read and returned "known" anyway; the ref-row drops were entirely silent. Now counted, warned, and treated as a hole.
- **Deliberately-excluded refs were reported as gone.** The remote symbolic HEAD and the server's copy of the trunk are real refs kept out of the target list. Now recorded in `Survey.not_offered`; naming one refuses (`E_NOT_A_TARGET`).
- **The completeness question is per listing, not per run.** It keys on the selector's own `worktree:`/`branch:`/`remote:` prefix — an absolute path counts, since no ref short name may begin with `/`. A bare name needs both listings, because not knowing which kind was meant is no reason to trust whichever answered.
- **A short-name collision** in the not-offered lookup would have made `main` match `origin/main` and refuse to delete the *local* trunk.

## What keeps it honest

- **`deleted` stays false.** Only a true there is evidence the tool acted; the renderer marks these `gone`, never `ok`. `verified` now says so on the field, because it is true for an already-absent target too.
- **Exit 3 keeps meaning something is actually wrong.**
- **A probe that will not answer takes the ordinary route.** Not knowing is not evidence.
- **Ambiguity still refuses.** A miss is a job done; two real things matching is a question, and picking one destroys the other.
- **The dry run asks the same question the real run does**, so a preview cannot promise a deletion that does not exist.

## Deliberately not fixed here

- **`uploadpack.hideRefs`** — a server can hold refs it does not advertise, and no question `ls-remote` can ask separates that from absence. Guessing *present* costs a full-history bundle on the common path; guessing *absent* costs a skipped deletion on an exotic server, self-correcting next run. The row states the measurement rather than the conclusion, and the limit is documented. Reasoning recorded on the work item.
- **Name-parsing defects** (`refname:short` ambiguity, slash-containing remote names, newline-containing worktree paths) — all pre-existing, all confirmed against real git, filed with repros. This change makes their symptom quieter, which is said plainly on the item.

## Verification

`make ci` — **exit 0**, run standalone from the worktree root and read on its own line, after every commit. 314 tests, 98% branch coverage, `mypy --strict` clean.

Both instances proven against real git. The remote one is mutation-checked: with the pre-probe disabled it fails `assert 3 == 0`, reproducing the original defect against git itself rather than a hand-written transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gTTteYkaeVJucKh8AM6x2