### PR TITLE
fix(9k9.99): work discover takes the argument shape the caller already has

### DIFF
--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -175,8 +175,15 @@ def _add_discover_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParse
     discover_parser.add_argument(
         "--noun",
         required=True,
-        choices=[noun.value for noun in LEAF_NOUNS],
-        help="spike|chore|decision|feat|bugfix -- leaf nouns only, a discovery is not a container",
+        metavar="NOUN",
+        # No `choices=` here: an invalid --noun is validated inside the
+        # discover() handler instead of by argparse, alongside --priority, so
+        # a caller who gets both wrong learns both from one invocation
+        # rather than argparse raising on whichever it parses first.
+        help=(
+            f"{'|'.join(noun.value for noun in LEAF_NOUNS)} -- leaf nouns only "
+            "('bug' accepted as an alias for bugfix); a discovery is not a container"
+        ),
     )
     discover_parser.add_argument("--title", required=True)
     discover_parser.add_argument("--description")

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -113,8 +113,9 @@ def _combined_error(errors: list[WorkError]) -> WorkError:
     `message` and `detail.errors` preserve every folded failure's own
     message and code verbatim. The top-level `code` is `E_TRIAGE_INCOMPLETE`
     if any folded failure is triage-semantic, `E_USAGE` only when every
-    folded failure is pure arg-shape -- keeping the top level greppable for
-    a triage rejection, per the discover spec's design decision 6.
+    folded failure is pure arg-shape -- so a caller grepping the top level
+    for a triage rejection still finds one when an unrelated arg-shape
+    mistake co-occurs in the same call.
     """
     detail: dict[str, JsonValue] = {
         "errors": cast(

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -306,9 +306,14 @@ def discover(backend: Backend, args: Namespace) -> JsonValue:
     is enforced by the `REQUIRED_CAPABILITY` registration in
     `verbs/__init__.py`, ahead of this handler ever running.
     """
-    noun, priority = _validate_noun_and_priority(args)
+    # Precedence restored to match the pre-aggregate order: placement-usage
+    # (pure arg-shape) before scope (semantic), before the noun/priority
+    # aggregate (semantic/mixed) -- introducing the aggregate must not change
+    # when placement or scope fire relative to it; it only bundles noun in
+    # alongside priority's own original slot.
     _validate_placement_usage(args)
     scope, hatch = _parse_scope(args.scope)
+    noun, priority = _validate_noun_and_priority(args)
     scope_why = _require_rationale(args.scope_why, "scope_why", "--scope-why")
     priority_why = _require_rationale(args.priority_why, "priority_why", "--priority-why")
     if args.orphan:

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -115,6 +115,16 @@ def _combined_error(errors: list[WorkError]) -> WorkError:
     single-field failure used to report is lost -- the caller just learns
     about every bad field from one invocation instead of one round-trip per
     field.
+
+    The top-level `code` is `E_TRIAGE_INCOMPLETE` if any folded failure is
+    triage-semantic, `E_USAGE` only when every folded failure is pure
+    arg-shape. Per the discover spec's own design decision 6, the separate
+    `E_TRIAGE_INCOMPLETE` code exists so a consumer can grep the top level
+    for "triage rejected" -- collapsing to `E_USAGE` whenever a second,
+    unrelated arg-shape mistake happens to co-occur would make that signal
+    *quieter* exactly when the caller made an additional mistake, which is
+    backwards. `detail.errors` still carries every individual error's own
+    code either way, so nothing is lost by this choice.
     """
     detail: dict[str, JsonValue] = {
         "errors": cast(
@@ -130,7 +140,12 @@ def _combined_error(errors: list[WorkError]) -> WorkError:
         )
     }
     message = "; ".join(f"{error.detail.get('field', '?')}: {error.message}" for error in errors)
-    return WorkError(ErrorCode.USAGE, message, detail)
+    code = (
+        ErrorCode.TRIAGE_INCOMPLETE
+        if any(error.code is ErrorCode.TRIAGE_INCOMPLETE for error in errors)
+        else ErrorCode.USAGE
+    )
+    return WorkError(code, message, detail)
 
 
 def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -110,21 +110,11 @@ def _validate_noun(value: str) -> Noun:
 def _combined_error(errors: list[WorkError]) -> WorkError:
     """Fold 2+ independent field failures into one well-formed error.
 
-    Each field's own message (still naming its valid choices/vocabulary) is
-    preserved verbatim in both `message` and `detail.errors`, so nothing a
-    single-field failure used to report is lost -- the caller just learns
-    about every bad field from one invocation instead of one round-trip per
-    field.
-
-    The top-level `code` is `E_TRIAGE_INCOMPLETE` if any folded failure is
-    triage-semantic, `E_USAGE` only when every folded failure is pure
-    arg-shape. Per the discover spec's own design decision 6, the separate
-    `E_TRIAGE_INCOMPLETE` code exists so a consumer can grep the top level
-    for "triage rejected" -- collapsing to `E_USAGE` whenever a second,
-    unrelated arg-shape mistake happens to co-occur would make that signal
-    *quieter* exactly when the caller made an additional mistake, which is
-    backwards. `detail.errors` still carries every individual error's own
-    code either way, so nothing is lost by this choice.
+    `message` and `detail.errors` preserve every folded failure's own
+    message and code verbatim. The top-level `code` is `E_TRIAGE_INCOMPLETE`
+    if any folded failure is triage-semantic, `E_USAGE` only when every
+    folded failure is pure arg-shape -- keeping the top level greppable for
+    a triage rejection, per the discover spec's design decision 6.
     """
     detail: dict[str, JsonValue] = {
         "errors": cast(
@@ -151,13 +141,10 @@ def _combined_error(errors: list[WorkError]) -> WorkError:
 def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:
     """Validate --noun and --priority together, in one pass.
 
-    Both were previously validated by mechanisms that each raised on the
-    first failure -- argparse's own `choices=` for --noun (which never even
-    reached this module) and this module's own `_validate_priority` -- so a
-    caller who got both wrong learned about only one per invocation. Neither
-    check raises until both have run; a single-field failure still raises
-    that field's own error unchanged (preserving the existing contract), and
-    only a two-field failure changes shape, via `_combined_error`.
+    Both validators run before either is allowed to raise, so a caller with
+    both fields wrong learns about both from one invocation. A single-field
+    failure still raises that field's own error unchanged; two failures fold
+    into one via `_combined_error`.
     """
     noun_result: Noun | WorkError
     try:
@@ -306,11 +293,9 @@ def discover(backend: Backend, args: Namespace) -> JsonValue:
     is enforced by the `REQUIRED_CAPABILITY` registration in
     `verbs/__init__.py`, ahead of this handler ever running.
     """
-    # Precedence restored to match the pre-aggregate order: placement-usage
-    # (pure arg-shape) before scope (semantic), before the noun/priority
-    # aggregate (semantic/mixed) -- introducing the aggregate must not change
-    # when placement or scope fire relative to it; it only bundles noun in
-    # alongside priority's own original slot.
+    # Placement (pure arg-shape) is validated before scope (semantic),
+    # before the noun/priority aggregate -- keep this order: the aggregate
+    # must never fire ahead of placement or scope.
     _validate_placement_usage(args)
     scope, hatch = _parse_scope(args.scope)
     noun, priority = _validate_noun_and_priority(args)

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -23,11 +23,13 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
 from workcli.lifecycle.create import create_noun
+from workcli.lifecycle.nouns import LEAF_NOUNS, Noun, resolve_noun
 from workcli.model import Item
 from workcli.tracks import derive_track
 
 _HATCHES = ("externally-blocked", "blast-radius", "own-cycle")
 _PRIORITY_RE = re.compile(r"^P[0-4]$")
+_BARE_PRIORITY_RE = re.compile(r"^[0-4]$")
 _DISCOVERED_FROM_TYPE = "discovered-from"
 _ORPHAN_ANCHOR_DISPLAY = "none: escalated"
 
@@ -73,12 +75,94 @@ def _parse_scope(value: str | None) -> tuple[str, str | None]:
     )
 
 
+def _normalize_priority(value: str) -> str:
+    """A bare digit ('2') normalizes to the canonical 'P2' notation.
+
+    Nothing else about the value is ambiguous -- only the notation was ever
+    rejected -- so anything not matching the bare-digit shape passes through
+    unchanged for `_PRIORITY_RE` to accept or reject as before.
+    """
+    if _BARE_PRIORITY_RE.match(value):
+        return f"P{value}"
+    return value
+
+
 def _validate_priority(value: str | None) -> str:
     if value is None:
         raise _triage_incomplete("priority", "--priority is required")
-    if not _PRIORITY_RE.match(value):
+    normalized = _normalize_priority(value)
+    if not _PRIORITY_RE.match(normalized):
         raise _triage_incomplete("priority", f"priority must be one of P0-P4, got {value!r}")
-    return value
+    return normalized
+
+
+def _validate_noun(value: str) -> Noun:
+    noun = resolve_noun(value)
+    if noun is not None and noun in LEAF_NOUNS:
+        return noun
+    raise WorkError(
+        ErrorCode.USAGE,
+        f"invalid choice: {value!r} (choose from {', '.join(n.value for n in LEAF_NOUNS)})",
+        detail={"field": "noun"},
+    )
+
+
+def _combined_error(errors: list[WorkError]) -> WorkError:
+    """Fold 2+ independent field failures into one well-formed error.
+
+    Each field's own message (still naming its valid choices/vocabulary) is
+    preserved verbatim in both `message` and `detail.errors`, so nothing a
+    single-field failure used to report is lost -- the caller just learns
+    about every bad field from one invocation instead of one round-trip per
+    field.
+    """
+    detail: dict[str, JsonValue] = {
+        "errors": cast(
+            "list[JsonValue]",
+            [
+                {
+                    "code": str(error.code),
+                    "field": error.detail.get("field"),
+                    "message": error.message,
+                }
+                for error in errors
+            ],
+        )
+    }
+    message = "; ".join(f"{error.detail.get('field', '?')}: {error.message}" for error in errors)
+    return WorkError(ErrorCode.USAGE, message, detail)
+
+
+def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:
+    """Validate --noun and --priority together, in one pass.
+
+    Both were previously validated by mechanisms that each raised on the
+    first failure -- argparse's own `choices=` for --noun (which never even
+    reached this module) and this module's own `_validate_priority` -- so a
+    caller who got both wrong learned about only one per invocation. Neither
+    check raises until both have run; a single-field failure still raises
+    that field's own error unchanged (preserving the existing contract), and
+    only a two-field failure changes shape, via `_combined_error`.
+    """
+    noun_result: Noun | WorkError
+    try:
+        noun_result = _validate_noun(args.noun)
+    except WorkError as noun_error:
+        noun_result = noun_error
+
+    priority_result: str | WorkError
+    try:
+        priority_result = _validate_priority(args.priority)
+    except WorkError as priority_error:
+        priority_result = priority_error
+
+    if isinstance(noun_result, WorkError) and isinstance(priority_result, WorkError):
+        raise _combined_error([noun_result, priority_result])
+    if isinstance(noun_result, WorkError):
+        raise noun_result
+    if isinstance(priority_result, WorkError):
+        raise priority_result
+    return noun_result, priority_result
 
 
 def _resolve_source(backend: Backend, discovered_from: str | None) -> Item:
@@ -143,6 +227,7 @@ def _render_description(
     scope: str,
     hatch: str | None,
     scope_why: str,
+    priority: str,
     priority_why: str,
     placement_why: str,
 ) -> str:
@@ -155,7 +240,10 @@ def _render_description(
         [
             "## Triage",
             f"- {scope_line}",
-            f"- Priority: {args.priority} — {priority_why}",
+            # `priority` (validated/normalized), never args.priority (raw) --
+            # an alternative-notation caller ('2') and a canonical-notation
+            # caller ('P2') must render byte-identical stored records.
+            f"- Priority: {priority} — {priority_why}",
             f"- Anchor: {anchor_display} — {placement_why}",
         ]
     )
@@ -172,9 +260,11 @@ def _derive_lands_in(scope: str, anchor: str | None, orphan: bool) -> str:
     return str(anchor)
 
 
-def _build_create_namespace(args: Namespace, description: str, priority: str) -> Namespace:
+def _build_create_namespace(
+    args: Namespace, description: str, priority: str, noun: Noun
+) -> Namespace:
     return Namespace(
-        noun=args.noun,
+        noun=noun.value,
         raw=False,
         title=args.title,
         description=description,
@@ -201,9 +291,9 @@ def discover(backend: Backend, args: Namespace) -> JsonValue:
     is enforced by the `REQUIRED_CAPABILITY` registration in
     `verbs/__init__.py`, ahead of this handler ever running.
     """
+    noun, priority = _validate_noun_and_priority(args)
     _validate_placement_usage(args)
     scope, hatch = _parse_scope(args.scope)
-    priority = _validate_priority(args.priority)
     scope_why = _require_rationale(args.scope_why, "scope_why", "--scope-why")
     priority_why = _require_rationale(args.priority_why, "priority_why", "--priority-why")
     if args.orphan:
@@ -218,11 +308,13 @@ def discover(backend: Backend, args: Namespace) -> JsonValue:
     if not args.orphan:
         _validate_anchor(backend, args.anchor, scope, source, args.discovered_from)
 
-    description = _render_description(args, scope, hatch, scope_why, priority_why, placement_why)
+    description = _render_description(
+        args, scope, hatch, scope_why, priority, priority_why, placement_why
+    )
 
     created = cast(
         "dict[str, JsonValue]",
-        create_noun(backend, _build_create_namespace(args, description, priority)),
+        create_noun(backend, _build_create_namespace(args, description, priority, noun)),
     )
     new_id = cast("str", created["id"])
 

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -20,12 +20,10 @@ class Noun(StrEnum):
 # structural container.
 LEAF_NOUNS: tuple[Noun, ...] = (Noun.SPIKE, Noun.CHORE, Noun.DECISION, Noun.FEAT, Noun.BUGFIX)
 
-# First-guess synonyms accepted in place of a canonical noun value. 'bug'
-# names the thing discovered; 'bugfix' (the canonical noun) names the
-# remedy -- every other noun already names the thing, so 'bug' is the one
-# people reach for and get wrong. Resolving it here, once, keeps every
-# consumer's stored value byte-identical to the canonical noun regardless of
-# which spelling the caller used.
+# Synonyms accepted in place of a canonical noun value. 'bug' names the
+# thing discovered; 'bugfix' (the canonical noun) names the remedy.
+# Resolved here, once, so every consumer's stored value is byte-identical
+# to the canonical noun regardless of which spelling the caller used.
 NOUN_ALIASES: dict[str, Noun] = {"bug": Noun.BUGFIX}
 
 

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -20,6 +20,30 @@ class Noun(StrEnum):
 # structural container.
 LEAF_NOUNS: tuple[Noun, ...] = (Noun.SPIKE, Noun.CHORE, Noun.DECISION, Noun.FEAT, Noun.BUGFIX)
 
+# First-guess synonyms accepted in place of a canonical noun value. 'bug'
+# names the thing discovered; 'bugfix' (the canonical noun) names the
+# remedy -- every other noun already names the thing, so 'bug' is the one
+# people reach for and get wrong. Resolving it here, once, keeps every
+# consumer's stored value byte-identical to the canonical noun regardless of
+# which spelling the caller used.
+NOUN_ALIASES: dict[str, Noun] = {"bug": Noun.BUGFIX}
+
+
+def resolve_noun(value: str) -> Noun | None:
+    """Resolve `value` to its canonical `Noun`, accepting `NOUN_ALIASES` too.
+
+    Returns `None` when `value` is neither a canonical noun value nor a
+    known alias -- callers turn that into a typed usage error naming the
+    valid choices.
+    """
+    alias = NOUN_ALIASES.get(value)
+    if alias is not None:
+        return alias
+    try:
+        return Noun(value)
+    except ValueError:
+        return None
+
 
 @dataclass(frozen=True)
 class NounTemplate:

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -318,3 +318,6 @@ class ReadOnlyFakeBackend(FakeBackend):
 
     def label_mutate(self, op: str, item_id: str, labels: Sequence[str]) -> None:
         self._refuse(op, item_id, labels)
+
+    def dep_mutate(self, op: DepOp, from_id: str, to_id: str, dep_type: str) -> None:
+        self._refuse(op, from_id, to_id, dep_type)

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -314,6 +314,34 @@ def test_manifest_row_out_of_scope_and_remaining_work_false() -> None:
     assert data["remaining_work"] is False
 
 
+def test_success_payload_matches_the_complete_data_shape_exactly() -> None:
+    """The whole `data` payload for a successful discover, not a subset --
+    catches a field dropped, renamed, or added that a narrower assertion
+    would miss."""
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args()
+
+    data = discover(backend, args)
+
+    assert isinstance(data, dict)
+    new_id = data["item"]["id"]  # type: ignore[index]
+    assert isinstance(new_id, str)
+    assert data == {
+        "item": {"id": new_id, "title": "New discovery", "track": None},
+        "edges": {"parent": "epic-1", "discovered_from": "src-1"},
+        "triage": {"scope": "out-of-scope", "priority": "P2", "anchor": "epic-1"},
+        "manifest_row": {
+            "item": "New discovery",
+            "scope": "out-of-scope",
+            "lands_in": "epic-1",
+            "tracked_item": new_id,
+            "priority_why": "P2 — reason",
+        },
+        "remaining_work": False,
+        "warnings": [],
+    }
+
+
 def test_manifest_row_in_scope_deferred_lands_in_parent_and_remaining_work_true() -> None:
     backend = _backend_with_epic_anchor()
     args = _args(
@@ -493,18 +521,20 @@ def test_noun_alias_bug_resolves_to_canonical_bugfix_template() -> None:
     assert "shape-bugfix" in backend.labels(new_id)
 
 
-def test_bare_priority_normalizes_to_canonical_p_notation() -> None:
+@pytest.mark.parametrize("digit", ["0", "1", "2", "3", "4"])
+def test_bare_priority_normalizes_to_canonical_p_notation(digit: str) -> None:
     backend = _backend_with_epic_anchor()
-    args = _out_of_scope_args(priority="2")
+    args = _out_of_scope_args(priority=digit)
+    expected = f"P{digit}"
 
     data = discover(backend, args)
 
     assert isinstance(data, dict)
-    assert data["triage"]["priority"] == "P2"  # type: ignore[index]
+    assert data["triage"]["priority"] == expected  # type: ignore[index]
     new_id = data["item"]["id"]  # type: ignore[index]
     assert isinstance(new_id, str)
-    assert backend.get(new_id).priority == "P2"
-    assert "- Priority: P2 — reason" in backend.get(new_id).description
+    assert backend.get(new_id).priority == expected
+    assert f"- Priority: {expected} — reason" in backend.get(new_id).description
 
 
 def test_alias_and_canonical_forms_produce_byte_identical_stored_records() -> None:
@@ -553,9 +583,8 @@ def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() 
     """Neither 'widget' (not a noun or a known alias) nor 'P9' (out of
     P0-P4, even after bare-digit normalization) is individually acceptable;
     both are named from this single invocation. The top-level code is
-    `E_TRIAGE_INCOMPLETE` (per discover spec design decision 6: a greppable
-    triage-rejection signal), even though the noun failure alone is
-    `E_USAGE`.
+    `E_TRIAGE_INCOMPLETE`, so a caller grepping for a triage rejection
+    still finds one, even though the noun failure alone is `E_USAGE`.
     """
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(noun="widget", priority="P9")
@@ -676,6 +705,34 @@ def test_scope_precedes_the_noun_priority_aggregate_for_a_bad_noun() -> None:
 
     assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
     assert exc_info.value.detail["field"] == "scope"
+
+
+def test_placement_usage_both_shape_precedes_the_noun_priority_aggregate() -> None:
+    """The 'both' placement shape (--anchor and --orphan together) must also
+    fire before the noun/priority aggregate -- the existing placement
+    precedence tests above only cover the 'neither' shape.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(orphan=True, escalation_why="none fits", priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert "anchor" in exc_info.value.message and "orphan" in exc_info.value.message
+
+
+def test_placement_usage_both_shape_precedes_the_noun_priority_aggregate_for_a_bad_noun() -> None:
+    """Same 'both' placement shape proof as above, exercising the noun side
+    of the aggregate."""
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(orphan=True, escalation_why="none fits", noun="widget")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert "anchor" in exc_info.value.message and "orphan" in exc_info.value.message
 
 
 def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -595,6 +595,37 @@ def test_priority_only_failure_still_returns_triage_incomplete_alone() -> None:
     assert exc_info.value.detail["field"] == "priority"
 
 
+def test_placement_usage_precedes_the_noun_priority_aggregate() -> None:
+    """Placement (pure arg-shape, E_USAGE) must still fire before the
+    noun/priority aggregate, exactly as it fired before --priority alone --
+    the aggregate must not move a pure well-formedness check behind it.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _args(anchor=None, orphan=False, priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert "anchor" in exc_info.value.message and "orphan" in exc_info.value.message
+
+
+def test_scope_precedes_the_noun_priority_aggregate() -> None:
+    """The exact session reported: bad --scope with bad --priority together
+    must still surface the scope rejection, not the priority one -- scope
+    fired before priority before the aggregate existed, and introducing the
+    aggregate must not change that relative order.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(scope="sideways", priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
+    assert exc_info.value.detail["field"] == "scope"
+
+
 def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
     """Same double-failure, driven through the CLI exactly as the friction was
     observed -- top-level code is `E_TRIAGE_INCOMPLETE` (see the unit-level

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -547,7 +547,13 @@ def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() 
 
     Neither 'widget' (not a noun or a known alias) nor 'P9' (out of P0-P4,
     even after bare-digit normalization) is individually acceptable, and
-    both must be named from this single invocation.
+    both must be named from this single invocation. The top-level code is
+    `E_TRIAGE_INCOMPLETE`, not `E_USAGE`: --priority is a triage-semantic
+    failure, and per the discover spec's design decision 6 that must stay
+    greppable at the top level even when an unrelated arg-shape mistake
+    (the bad --noun) co-occurs in the same call -- collapsing to `E_USAGE`
+    would make the triage signal disappear exactly when the caller made an
+    additional mistake.
     """
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(noun="widget", priority="P9")
@@ -555,18 +561,44 @@ def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() 
     with pytest.raises(WorkError) as exc_info:
         discover(backend, args)
 
-    assert exc_info.value.code is ErrorCode.USAGE
+    assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
     assert "widget" in exc_info.value.message
     assert "P0" in exc_info.value.message and "P4" in exc_info.value.message
     errors = exc_info.value.detail["errors"]
     assert isinstance(errors, list)
     fields = {entry["field"] for entry in errors}  # type: ignore[union-attr]
     assert fields == {"noun", "priority"}
+    # Every individual field's own code still survives in detail.errors,
+    # even though the top-level code is the folded one above.
+    codes_by_field = {entry["field"]: entry["code"] for entry in errors}  # type: ignore[union-attr]
+    assert codes_by_field == {
+        "noun": str(ErrorCode.USAGE),
+        "priority": str(ErrorCode.TRIAGE_INCOMPLETE),
+    }
     assert backend.ids() == ["epic-1", "src-1"]
 
 
+def test_priority_only_failure_still_returns_triage_incomplete_alone() -> None:
+    """Pins that the single-field code path is untouched by the combined-error
+    fix: a triage-semantic failure alone must keep returning exactly the
+    `E_TRIAGE_INCOMPLETE` it always did (see
+    `test_invalid_priority_names_field_and_accepted_range`, unedited) -- this
+    is the invariant the top-level-code fix above exists to protect.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
+    assert exc_info.value.detail["field"] == "priority"
+
+
 def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
-    """Same double-failure, driven through the CLI exactly as the friction was observed."""
+    """Same double-failure, driven through the CLI exactly as the friction was
+    observed -- top-level code is `E_TRIAGE_INCOMPLETE` (see the unit-level
+    test's docstring above for why)."""
     exit_code, envelope, _ = run_cli(
         [
             "discover",
@@ -595,7 +627,7 @@ def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
     assert exit_code == 1
     error = envelope["error"]
     assert isinstance(error, dict)
-    assert error["code"] == str(ErrorCode.USAGE)
+    assert error["code"] == str(ErrorCode.TRIAGE_INCOMPLETE)
     detail = error["detail"]
     assert isinstance(detail, dict)
     errors = detail["errors"]

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -475,6 +475,204 @@ def test_container_noun_is_usage_error_via_cli(noun: str) -> None:
     assert envelope["error"]["code"] == str(ErrorCode.USAGE)  # type: ignore[index]
 
 
+# --- 9k9.99: accepted argument-shape aliases (--noun 'bug', bare --priority) ---
+# and single-pass reporting when both --noun and --priority are malformed.
+
+
+def test_noun_alias_bug_resolves_to_canonical_bugfix_template() -> None:
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(noun="bug")
+
+    data = discover(backend, args)
+
+    assert isinstance(data, dict)
+    new_id = data["item"]["id"]  # type: ignore[index]
+    assert isinstance(new_id, str)
+    assert backend.get(new_id).type == "bug"
+    assert "shape-bugfix" in backend.labels(new_id)
+
+
+def test_bare_priority_normalizes_to_canonical_p_notation() -> None:
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(priority="2")
+
+    data = discover(backend, args)
+
+    assert isinstance(data, dict)
+    assert data["triage"]["priority"] == "P2"  # type: ignore[index]
+    new_id = data["item"]["id"]  # type: ignore[index]
+    assert isinstance(new_id, str)
+    assert backend.get(new_id).priority == "P2"
+    assert "- Priority: P2 — reason" in backend.get(new_id).description
+
+
+def test_alias_and_canonical_forms_produce_byte_identical_stored_records() -> None:
+    backend_alias = _backend_with_epic_anchor()
+    backend_canon = _backend_with_epic_anchor()
+
+    data_alias = discover(backend_alias, _out_of_scope_args(noun="bug", priority="2"))
+    data_canon = discover(backend_canon, _out_of_scope_args(noun="bugfix", priority="P2"))
+
+    assert isinstance(data_alias, dict)
+    assert isinstance(data_canon, dict)
+    id_alias = data_alias["item"]["id"]  # type: ignore[index]
+    id_canon = data_canon["item"]["id"]  # type: ignore[index]
+    assert isinstance(id_alias, str)
+    assert isinstance(id_canon, str)
+    item_alias = backend_alias.get(id_alias)
+    item_canon = backend_canon.get(id_canon)
+
+    assert item_alias.type == item_canon.type
+    assert item_alias.priority == item_canon.priority
+    assert item_alias.description == item_canon.description
+    assert set(backend_alias.labels(id_alias)) == set(backend_canon.labels(id_canon))
+
+
+def test_unknown_noun_alone_raises_single_field_usage_error() -> None:
+    """A single bad --noun still raises its own (non-combined) error unchanged."""
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(noun="widget")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert exc_info.value.detail["field"] == "noun"
+    assert "widget" in exc_info.value.message
+    assert backend.ids() == ["epic-1", "src-1"]
+
+
+def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() -> None:
+    """The observed friction: two rejections used to cost two round-trips.
+
+    Neither 'widget' (not a noun or a known alias) nor 'P9' (out of P0-P4,
+    even after bare-digit normalization) is individually acceptable, and
+    both must be named from this single invocation.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(noun="widget", priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert "widget" in exc_info.value.message
+    assert "P0" in exc_info.value.message and "P4" in exc_info.value.message
+    errors = exc_info.value.detail["errors"]
+    assert isinstance(errors, list)
+    fields = {entry["field"] for entry in errors}  # type: ignore[union-attr]
+    assert fields == {"noun", "priority"}
+    assert backend.ids() == ["epic-1", "src-1"]
+
+
+def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
+    """Same double-failure, driven through the CLI exactly as the friction was observed."""
+    exit_code, envelope, _ = run_cli(
+        [
+            "discover",
+            "--noun",
+            "widget",
+            "--title",
+            "T",
+            "--anchor",
+            "epic-1",
+            "--anchor-why",
+            "x",
+            "--discovered-from",
+            "src-1",
+            "--scope",
+            "out-of-scope",
+            "--scope-why",
+            "x",
+            "--priority",
+            "P9",
+            "--priority-why",
+            "x",
+        ],
+        steps=[],
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.USAGE)
+    detail = error["detail"]
+    assert isinstance(detail, dict)
+    errors = detail["errors"]
+    assert isinstance(errors, list)
+    fields = {entry["field"] for entry in errors}  # type: ignore[union-attr]
+    assert fields == {"noun", "priority"}
+
+
+def test_previously_rejected_shapes_now_succeed_via_cli() -> None:
+    """The exact observed session: --noun bug and --priority 2 together succeed."""
+
+    def _show_result(item_id: str, issue_type: str) -> BdResult:
+        return BdResult(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "id": item_id,
+                        "title": "t",
+                        "issue_type": issue_type,
+                        "status": "open",
+                        "priority": 2,
+                        "labels": [],
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("show", "src-1", "--json"), _show_result("src-1", "task")),
+            ScriptedStep(("show", "epic-1", "--json"), _show_result("epic-1", "epic")),
+            ScriptedStep(("search",), BdResult(returncode=0, stdout=json.dumps([]), stderr="")),
+            ScriptedStep(
+                ("create",),
+                BdResult(returncode=0, stdout=json.dumps({"id": "new-1"}), stderr=""),
+            ),
+            ScriptedStep(("dep", "add"), BdResult(returncode=0, stdout="", stderr="")),
+            ScriptedStep(("show", "new-1", "--json"), _show_result("new-1", "bug")),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        [
+            "discover",
+            "--noun",
+            "bug",
+            "--title",
+            "New discovery",
+            "--anchor",
+            "epic-1",
+            "--anchor-why",
+            "best fit",
+            "--discovered-from",
+            "src-1",
+            "--scope",
+            "out-of-scope",
+            "--scope-why",
+            "found it",
+            "--priority",
+            "2",
+            "--priority-why",
+            "hurts overnight",
+        ],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 0
+    assert envelope["ok"] is True
+    create_index = next(i for i, call in enumerate(runner.calls) if call[0] == "create")
+    create_call = runner.calls[create_index]
+    assert "--type" in create_call and "bug" in create_call
+    assert "--priority" in create_call and "P2" in create_call
+
+
 # --- AC12: every invocation emits exactly one parseable envelope ---
 
 

--- a/packages/workcli/tests/unit/test_discover.py
+++ b/packages/workcli/tests/unit/test_discover.py
@@ -11,6 +11,7 @@ matching `test_dep_type_wall.py`/`test_capabilities.py`.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from argparse import Namespace
 from io import StringIO
@@ -18,7 +19,7 @@ from io import StringIO
 import pytest
 
 from tests.conftest import run_cli, run_cli_with_runner
-from tests.fake_backend import FakeBackend
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli import cli as cli_module
 from workcli.adapters.bd.runner import BdResult
@@ -441,10 +442,10 @@ def test_post_create_track_read_failure_surfaces_created_id_for_replay() -> None
     assert exc_info.value.detail["created_id"] not in ("epic-1", "src-1")
 
 
-# --- AC11: --noun spec/epic -> E_USAGE (leaf nouns only, argparse choices) ---
+# --- AC11: --noun outside the leaf set -> E_USAGE (leaf nouns only) ---
 
 
-@pytest.mark.parametrize("noun", ["spec", "epic"])
+@pytest.mark.parametrize("noun", ["spec", "epic", "milestone"])
 def test_container_noun_is_usage_error_via_cli(noun: str) -> None:
     exit_code, envelope, _ = run_cli(
         [
@@ -475,8 +476,8 @@ def test_container_noun_is_usage_error_via_cli(noun: str) -> None:
     assert envelope["error"]["code"] == str(ErrorCode.USAGE)  # type: ignore[index]
 
 
-# --- 9k9.99: accepted argument-shape aliases (--noun 'bug', bare --priority) ---
-# and single-pass reporting when both --noun and --priority are malformed.
+# --- accepted argument-shape aliases (--noun 'bug', bare --priority), and
+# single-pass reporting when both --noun and --priority are malformed. ---
 
 
 def test_noun_alias_bug_resolves_to_canonical_bugfix_template() -> None:
@@ -522,14 +523,18 @@ def test_alias_and_canonical_forms_produce_byte_identical_stored_records() -> No
     item_alias = backend_alias.get(id_alias)
     item_canon = backend_canon.get(id_canon)
 
-    assert item_alias.type == item_canon.type
-    assert item_alias.priority == item_canon.priority
-    assert item_alias.description == item_canon.description
-    assert set(backend_alias.labels(id_alias)) == set(backend_canon.labels(id_canon))
+    # Byte-identical field for field -- title, type, status, priority,
+    # labels, parent, description, notes, children, and dep edges -- except
+    # each backend's own assigned id.
+    assert dataclasses.replace(item_alias, id="") == dataclasses.replace(item_canon, id="")
+    # The discovered-from provenance edge, named explicitly.
+    assert item_alias.deps == item_canon.deps
 
 
 def test_unknown_noun_alone_raises_single_field_usage_error() -> None:
-    """A single bad --noun still raises its own (non-combined) error unchanged."""
+    """A single bad --noun still raises its own (non-combined) error unchanged:
+    the exact code, message, and detail, not just a fragment of any of them --
+    AC5 pins full error identity, not "close enough"."""
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(noun="widget")
 
@@ -537,23 +542,20 @@ def test_unknown_noun_alone_raises_single_field_usage_error() -> None:
         discover(backend, args)
 
     assert exc_info.value.code is ErrorCode.USAGE
-    assert exc_info.value.detail["field"] == "noun"
-    assert "widget" in exc_info.value.message
+    assert exc_info.value.message == (
+        "invalid choice: 'widget' (choose from spike, chore, decision, feat, bugfix)"
+    )
+    assert exc_info.value.detail == {"field": "noun"}
     assert backend.ids() == ["epic-1", "src-1"]
 
 
 def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() -> None:
-    """The observed friction: two rejections used to cost two round-trips.
-
-    Neither 'widget' (not a noun or a known alias) nor 'P9' (out of P0-P4,
-    even after bare-digit normalization) is individually acceptable, and
-    both must be named from this single invocation. The top-level code is
-    `E_TRIAGE_INCOMPLETE`, not `E_USAGE`: --priority is a triage-semantic
-    failure, and per the discover spec's design decision 6 that must stay
-    greppable at the top level even when an unrelated arg-shape mistake
-    (the bad --noun) co-occurs in the same call -- collapsing to `E_USAGE`
-    would make the triage signal disappear exactly when the caller made an
-    additional mistake.
+    """Neither 'widget' (not a noun or a known alias) nor 'P9' (out of
+    P0-P4, even after bare-digit normalization) is individually acceptable;
+    both are named from this single invocation. The top-level code is
+    `E_TRIAGE_INCOMPLETE` (per discover spec design decision 6: a greppable
+    triage-rejection signal), even though the noun failure alone is
+    `E_USAGE`.
     """
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(noun="widget", priority="P9")
@@ -578,12 +580,35 @@ def test_malformed_noun_and_priority_together_are_both_reported_from_one_call() 
     assert backend.ids() == ["epic-1", "src-1"]
 
 
+def test_unknown_noun_alone_touches_no_backend_mutation() -> None:
+    """`ReadOnlyFakeBackend` raises on every mutator, so a malformed --noun
+    reaching `create_noun` fails loudly here. The backend is left empty --
+    noun validation runs before any read too, so nothing needs seeding.
+    """
+    backend = ReadOnlyFakeBackend()
+    args = _out_of_scope_args(noun="widget")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+
+
+def test_malformed_noun_and_priority_together_touches_no_backend_mutation() -> None:
+    """Same mechanical proof as above, for the combined-failure path."""
+    backend = ReadOnlyFakeBackend()
+    args = _out_of_scope_args(noun="widget", priority="P9")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
+
+
 def test_priority_only_failure_still_returns_triage_incomplete_alone() -> None:
-    """Pins that the single-field code path is untouched by the combined-error
-    fix: a triage-semantic failure alone must keep returning exactly the
-    `E_TRIAGE_INCOMPLETE` it always did (see
-    `test_invalid_priority_names_field_and_accepted_range`, unedited) -- this
-    is the invariant the top-level-code fix above exists to protect.
+    """A triage-semantic failure alone returns `E_TRIAGE_INCOMPLETE` with its
+    own field and message -- matches
+    `test_invalid_priority_names_field_and_accepted_range` field for field.
     """
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(priority="P9")
@@ -592,13 +617,14 @@ def test_priority_only_failure_still_returns_triage_incomplete_alone() -> None:
         discover(backend, args)
 
     assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
-    assert exc_info.value.detail["field"] == "priority"
+    assert exc_info.value.message == "priority must be one of P0-P4, got 'P9'"
+    assert exc_info.value.detail == {"field": "priority"}
 
 
 def test_placement_usage_precedes_the_noun_priority_aggregate() -> None:
-    """Placement (pure arg-shape, E_USAGE) must still fire before the
-    noun/priority aggregate, exactly as it fired before --priority alone --
-    the aggregate must not move a pure well-formedness check behind it.
+    """Placement (pure arg-shape, `E_USAGE`) fires before the noun/priority
+    aggregate: the aggregate must never move a pure well-formedness check
+    behind it.
     """
     backend = _backend_with_epic_anchor()
     args = _args(anchor=None, orphan=False, priority="P9")
@@ -611,10 +637,8 @@ def test_placement_usage_precedes_the_noun_priority_aggregate() -> None:
 
 
 def test_scope_precedes_the_noun_priority_aggregate() -> None:
-    """The exact session reported: bad --scope with bad --priority together
-    must still surface the scope rejection, not the priority one -- scope
-    fired before priority before the aggregate existed, and introducing the
-    aggregate must not change that relative order.
+    """Bad --scope with bad --priority together surfaces the scope
+    rejection, not the priority one: scope fires before the aggregate.
     """
     backend = _backend_with_epic_anchor()
     args = _out_of_scope_args(scope="sideways", priority="P9")
@@ -626,10 +650,38 @@ def test_scope_precedes_the_noun_priority_aggregate() -> None:
     assert exc_info.value.detail["field"] == "scope"
 
 
+def test_placement_usage_precedes_the_noun_priority_aggregate_for_a_bad_noun() -> None:
+    """Same precedence proof as the bad-priority case above, exercising the
+    noun side of the aggregate instead: the whole aggregate sits behind
+    placement and scope, not just --priority's side of it.
+    """
+    backend = _backend_with_epic_anchor()
+    args = _args(anchor=None, orphan=False, noun="widget")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert "anchor" in exc_info.value.message and "orphan" in exc_info.value.message
+
+
+def test_scope_precedes_the_noun_priority_aggregate_for_a_bad_noun() -> None:
+    """Same precedence proof as the bad-priority case above, but exercising
+    the noun side of the aggregate."""
+    backend = _backend_with_epic_anchor()
+    args = _out_of_scope_args(scope="sideways", noun="widget")
+
+    with pytest.raises(WorkError) as exc_info:
+        discover(backend, args)
+
+    assert exc_info.value.code is ErrorCode.TRIAGE_INCOMPLETE
+    assert exc_info.value.detail["field"] == "scope"
+
+
 def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
-    """Same double-failure, driven through the CLI exactly as the friction was
-    observed -- top-level code is `E_TRIAGE_INCOMPLETE` (see the unit-level
-    test's docstring above for why)."""
+    """Same double-failure, driven through the CLI -- top-level code is
+    `E_TRIAGE_INCOMPLETE` (see the unit-level test's docstring above for
+    why)."""
     exit_code, envelope, _ = run_cli(
         [
             "discover",
@@ -668,7 +720,7 @@ def test_malformed_noun_and_priority_together_via_cli_one_envelope() -> None:
 
 
 def test_previously_rejected_shapes_now_succeed_via_cli() -> None:
-    """The exact observed session: --noun bug and --priority 2 together succeed."""
+    """--noun bug and --priority 2 together succeed, driven through the CLI."""
 
     def _show_result(item_id: str, issue_type: str) -> BdResult:
         return BdResult(

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -330,6 +330,44 @@ VERB_CASES: list[VerbCase] = [
         ["reconcile"],
         [ScriptedStep(("list",), _GARBAGE)],  # unparseable bd list output -> E_BACKEND_DRIFT
     ),
+    VerbCase(
+        "discover",
+        [
+            "discover",
+            "--noun",
+            "feat",
+            "--title",
+            "New discovery",
+            "--anchor",
+            "epic-1",
+            "--anchor-why",
+            "best fit",
+            "--discovered-from",
+            "src-1",
+            "--scope",
+            "out-of-scope",
+            "--scope-why",
+            "found it",
+            "--priority",
+            "P2",
+            "--priority-why",
+            "hurts overnight",
+        ],
+        [
+            ScriptedStep(("show", "src-1", "--json"), _show_result(_item_raw("src-1", "T"))),
+            ScriptedStep(
+                ("show", "epic-1", "--json"),
+                _show_result(_item_raw("epic-1", "T", labels=["shape-epic"])),
+            ),
+            ScriptedStep(("search",), _search_result()),
+            ScriptedStep(("create",), _lifecycle_create_result("new-1")),
+            ScriptedStep(("dep", "add"), _OK),
+            ScriptedStep(("show", "new-1", "--json"), _show_result(_item_raw("new-1", "T"))),
+        ],
+        ["discover", "--noun", "feat", "--title", "T"],  # missing triage fields -> no bd call
+        [],
+        config_loader=_not_found_config_loader,
+    ),
 ]
 
 TYPED_ERROR_CODES = {str(code) for code in ErrorCode}


### PR DESCRIPTION
`work discover` rejected three plausible first guesses in a row during one session, each a separate round-trip. The values were unambiguous every time; only the notation was refused.

## What changed

- `--noun bug` is accepted as `bugfix`. Every other leaf noun names the thing discovered; `bugfix` names the remedy, which is why it is the one people guess wrong.
- `--priority 2` normalises to `P2`. Nothing else in the tracker makes `2` ambiguous here.
- A malformed noun and a malformed priority are now reported **together**, from one invocation. Previously `--noun` was validated by argparse before the handler ran at all, so a bad noun always masked whatever else was wrong.

Canonical storage is unchanged: a record created through an alias is byte-identical to one created canonically, pinned by a test.

## Two things found while implementing, not in the original report

**`_render_description` interpolated the raw priority, not the normalised one.** Left alone, `--priority 2` and `--priority P2` would have produced *different stored descriptions* — quietly defeating the whole point of normalising. Caught by the byte-identical criterion.

**The combined error swallowed the triage signal.** First cut set the aggregate code to `E_USAGE`, so:

```
--priority P9 alone                  ->  E_TRIAGE_INCOMPLETE
--noun widget --priority P9 together ->  E_USAGE
```

A consumer greps the top-level code for `E_TRIAGE_INCOMPLETE` to detect a triage rejection — that is the entire reason the separate code exists (spec decision 6). Under the first cut, a triage refusal became invisible at the top level *because the caller made an additional mistake*. The aggregate now carries `E_TRIAGE_INCOMPLETE` whenever any folded error is triage-semantic; `detail.errors` keeps every per-field code either way.

## Deliberately not done

- `work create <noun>` keeps its argparse `choices=`. The admission record costs this at "an alias table and one normalising call-site"; a second call site is unevidenced scope.
- `create --priority` / `update --set-priority` are raw passthrough and bd already accepts a bare digit — there is no friction there to fix.
- Scope/rationale/anchor validation stays first-failure. Only noun and priority were evidenced.

No new error code, no envelope shape change, protocol stays 1.4.

## Verification

`make ci-workcli` exit 0 and `make ci` exit 0, each run standalone and never piped. 649 tests, 99.19% coverage. All 648 pre-existing tests pass with no edits beyond the two assertions that had pinned the wrong aggregate code.

The new tests were proven test-worthy by reverting only the source change and confirming they fail against the pre-fix code, then reapplying.

Live end-to-end against the real tracker: the previously-rejected shapes succeeded on the first attempt, creating an item that was closed immediately with its disposition recorded. The combined-failure path was exercised live and created nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gTTteYkaeVJucKh8AM6x2