### PR TITLE
feat(9k9.1.12): choosing-a-delegate — one door for who does delegated work

### DIFF
--- a/src/plugins/codex/.claude/skills/delegating-to-codex/SKILL.md
+++ b/src/plugins/codex/.claude/skills/delegating-to-codex/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: delegating-to-codex
-description: Use when work is actually being handed to Codex — "use codex", "have codex review this", "get a second opinion from codex", "rescue this with codex" — when another skill or brief calls for a Codex pass, or when picking the model for a Codex run you are about to dispatch. Not for questions about Codex or its model tiers when nothing is being dispatched, not for Codex CLI setup or auth, and not for OpenRouter models, a nested claude harness, or Gemini CLI.
+description: Use when a run is being launched on Codex and the model tier still has to be chosen — the user named Codex, or another skill sent a dispatch here. Not for deciding whether to leave Claude in the first place, not for questions about Codex when nothing is being dispatched, not for Codex CLI setup or auth, and not for OpenRouter or Gemini CLI.
 admission:
   provides: The task-profile-to-model mapping for a Codex run — the one routing decision the Codex plugin declines to make, since its own runtime leaves the model unset unless the caller names one.
-  cost: 115 always-on tokens for this description line, measured; the body's 409 are paid only when a Codex dispatch is actually in hand. Replaces a 470-token always-on rule, so the surface it loads into drops by 355. The model table needs a refresh whenever OpenAI reprices, renames, or retires a tier.
+  cost: 68 always-on tokens for this description line, measured; the body's 409 are paid only when a Codex dispatch is actually in hand. The model table needs a refresh whenever OpenAI reprices, renames, or retires a tier.
   remove_when: The Codex plugin's runtime selects a model by task profile itself, so a caller that names nothing still gets the right tier.
 ---
 

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -1,6 +1,6 @@
 ---
 admission:
-  provides: Standing authorization to delegate to subagents and workflows without being asked each time, the boundary between orchestrator work and delegated work, the model/effort floor, and a consult gate before spawning a Fable subagent.
+  provides: Standing authorization to delegate to subagents and workflows without being asked each time, the boundary between orchestrator work and delegated work, the pointer to the delegate-selection skill, and a consult gate before spawning a Fable subagent.
   cost: Always-on rule loaded into every Claude Code session; biases toward spawning subagents, spending dispatch overhead on work the main loop could have done inline.
   remove_when: The harness stops shipping a built-in prohibition on unrequested delegation, and unaided sessions hold the orchestrator/delegated boundary without being told.
 ---
@@ -48,7 +48,7 @@ what ships.
   skill. The user not naming a vendor is not a reason to stay native.
 - Match model to the job: cheap tiers for mechanical work, top tiers for judgment.
 - When your own judgment is strained, a dispatch upward is legitimate: consult an
-  advisor agent on a stronger model or higher effort than your own.
+  advisor agent on a stronger model than your own.
 - **Never spawn a subagent with Fable as the model without first consulting the user.**
 </routing>
 

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -43,13 +43,10 @@ what ships.
 </mandate>
 
 <routing>
-- The native Agent tool and Workflow are the default substrate. Alternatives exist —
-  other vendors, cheaper models, other harnesses — and each states when to use it in
-  its own skill or rule description. Read those before choosing.
-- Match model and effort to the job — cheap tiers for mechanical work, top tiers for
-  judgment. Sonnet and Opus: prefer `high` or `xhigh` effort for anything requiring
-  any amount of reasoning or judgment; reserve `low`/`medium` for genuinely
-  mechanical stages.
+- The native Agent tool and Workflow are the default substrate. Before delegating to
+  anything else — another vendor, another harness — read the `choosing-a-delegate`
+  skill. The user not naming a vendor is not a reason to stay native.
+- Match model to the job: cheap tiers for mechanical work, top tiers for judgment.
 - When your own judgment is strained, a dispatch upward is legitimate: consult an
   advisor agent on a stronger model or higher effort than your own.
 - **Never spawn a subagent with Fable as the model without first consulting the user.**
@@ -57,6 +54,5 @@ what ships.
 
 <instructions-to-subagents>
 A subagent inherits none of your intent, and a vague dispatch returns noise you have to
-redo yourself. Read the `instructing-subagents` skill before you dispatch: it holds what
-a brief must carry, what it must never prescribe, and how the agent reports back.
+redo yourself. Read the `instructing-subagents` skill before you dispatch.
 </instructions-to-subagents>

--- a/src/user/.claude/skills/choosing-a-delegate/SKILL.md
+++ b/src/user/.claude/skills/choosing-a-delegate/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: choosing-a-delegate
+description: Use when handing work to anyone but yourself — a second opinion, an independent review, an adversarial critique, or any task you are about to delegate. Apply whenever you think "find someone to look at this", "get another perspective", "poke holes in it", or "have someone check this before I commit", and whenever a judgement must be independent of whoever produced the work. Not for writing the brief once the delegate is known, and not for vendor CLI setup.
+admission:
+  provides: The decision of who does delegated work, and standing permission to reach another vendor for it unasked. An orchestrator that is not told this treats a foreign-model dispatch as something the user must request by name, and answers "get me a second opinion" with a larger model from the same vendor as the work under review.
+  cost: One description line always-on; the body only when a dispatch is actually in hand. The vendor pointers need revisiting whenever a delegation route is added or retired.
+  remove_when: Sessions that were never given this reach cross-vendor on their own judgement when independence is what the task needs.
+---
+
+<!--
+Source: authored 2026-08-02.
+-->
+
+# Choosing a Delegate
+
+Independence comes from a different **vendor**, not a bigger model from the same one.
+Two models trained by one lab share the blind spot that let the defect through in the
+first place; the second pass agrees with the first and returns clean. A stronger
+same-vendor model buys depth, which is a different thing and not a substitute.
+
+## Reaching another vendor is your call
+
+**The user's silence about vendors is not a prohibition.** "Find someone to poke holes
+in this" is a request for independence, not a request for a Claude subagent — and
+waiting to be told "use codex" before considering a foreign model is not caution, it is
+a wrong answer delivered politely.
+
+You do not need permission to *choose the delegate*. You need permission for what the
+delegate may **do** — writing files, reaching the network, spending real money against
+the user's account. Those are the gates. Who reads the code is your judgement.
+
+## Does this need another vendor?
+
+| The work | Delegate |
+|---|---|
+| Judging work a model produced — review, critique, "poke holes", adversarial pass | **Another vendor.** The thing being tested is whether a *different* set of blind spots sees it. |
+| A second attempt at something that failed once — diagnosis, a stuck bug, a rescue | **Another vendor.** A retry on the same lineage tends to repeat the reasoning that failed. |
+| Independent verification of a claim before you act on it | **Another vendor**, when the claim came from a model. |
+| Producing work — implementing, refactoring, writing, researching | Native. Vendor diversity buys nothing here; pick on capability and cost. |
+| Anything needing the harness's own tools — worktree isolation, file edits under your permission mode | Native. Foreign routes have their own sandboxes and cannot borrow yours. |
+
+When the answer is native, the Agent tool is the substrate and `model` is the whole
+capability lever on it — the Agent tool accepts no effort parameter, so do not write a
+dispatch or a brief that assumes one.
+
+## Where to go
+
+Each route carries its own current model table. **Open it and read the table; never
+infer a model identifier from a skill name, a file name, or memory** — names outlive the
+model generations they were named for, and a plausible-looking identifier that no longer
+exists fails at dispatch or silently routes somewhere you did not intend.
+
+| Route | Reach it through |
+|---|---|
+| OpenAI models, via that vendor's own runtime | The Codex delegation skill — **present only when the Codex plugin is installed**. Check your skill list; if it is absent, that route does not exist in this session. |
+| Everything else — other vendors, cheaper tiers, a specific named model | The OpenRouter subagent skill, which runs this same harness against another vendor's weights. |
+| A stronger or higher-effort perspective on Claude | The Agent tool. Legitimate when your own judgement is strained, but it is depth, not independence. |
+
+If the route you want is absent, say so and offer the one that is present. Do not
+substitute a same-vendor delegate and describe it as a second opinion.
+
+## Two things that bite
+
+**A Codex rescue dispatch defaults to write-capable.** Its sandbox permits edits unless
+the request explicitly asks for review, diagnosis, or research without changes. When you
+want a critique and not a patch, say so in the request text — the default is not the one
+you want for a second opinion.
+
+**A review round's transports are already decided.** When a review contract declares a
+transport per lens, that declaration is the vendor-diversity plan for the round. This
+skill governs dispatch where nothing has declared one; it does not override a round that
+has.
+
+## Then write the brief
+
+Choosing the delegate is not the same as briefing it, and a foreign model inherits even
+less of your intent than a native subagent does.
+
+REQUIRED SUB-SKILL: Use `instructing-subagents` once you know who is doing the work.

--- a/src/user/.claude/skills/choosing-a-delegate/SKILL.md
+++ b/src/user/.claude/skills/choosing-a-delegate/SKILL.md
@@ -41,7 +41,8 @@ the user's account. Those are the gates. Who reads the code is your judgement.
 
 When the answer is native, the Agent tool is the substrate and `model` is the whole
 capability lever on it — the Agent tool accepts no effort parameter, so do not write a
-dispatch or a brief that assumes one.
+dispatch or a brief that assumes one. Effort exists on Workflow `agent()` calls and in
+an agent definition's own front matter; if you need that lever, those are where it is.
 
 ## Where to go
 
@@ -54,7 +55,7 @@ exists fails at dispatch or silently routes somewhere you did not intend.
 |---|---|
 | OpenAI models, via that vendor's own runtime | The Codex delegation skill — **present only when the Codex plugin is installed**. Check your skill list; if it is absent, that route does not exist in this session. |
 | Everything else — other vendors, cheaper tiers, a specific named model | The OpenRouter subagent skill, which runs this same harness against another vendor's weights. |
-| A stronger or higher-effort perspective on Claude | The Agent tool. Legitimate when your own judgement is strained, but it is depth, not independence. |
+| A stronger perspective on Claude | The Agent tool, on a stronger model. Legitimate when your own judgement is strained, but it is depth, not independence. |
 
 If the route you want is absent, say so and offer the one that is present. Do not
 substitute a same-vendor delegate and describe it as a second opinion.

--- a/src/user/.claude/skills/choosing-a-delegate/evals/trigger-eval.json
+++ b/src/user/.claude/skills/choosing-a-delegate/evals/trigger-eval.json
@@ -1,0 +1,17 @@
+[
+  {"query": "i just wrote this cache layer, find someone to poke holes in it", "should_trigger": true},
+  {"query": "get me a second opinion on this before i commit", "should_trigger": true},
+  {"query": "i want an independent review of this design, not just you agreeing with yourself", "should_trigger": true},
+  {"query": "can you have someone else check my migration plan, i've been staring at it too long", "should_trigger": true},
+  {"query": "this diagnosis has failed twice now, get a fresh pair of eyes on it", "should_trigger": true},
+  {"query": "before i open the PR i want an adversarial pass over the auth changes", "should_trigger": true},
+  {"query": "spin up a kimi subagent to summarize the error handling across src/", "should_trigger": false},
+  {"query": "can you delegate this refactor to a cheap model through openrouter", "should_trigger": false},
+  {"query": "use codex to look at layer.py", "should_trigger": false},
+  {"query": "run this past gpt-5.6-terra and tell me what it says", "should_trigger": false},
+  {"query": "what models does openrouter support and what do they cost", "should_trigger": false},
+  {"query": "codex keeps failing to log in, how do i fix the auth", "should_trigger": false},
+  {"query": "write the brief for the subagent thats going to fix this flaky test", "should_trigger": false},
+  {"query": "review this PR for me", "should_trigger": false},
+  {"query": "add a docstring to CacheLayer.get", "should_trigger": false}
+]

--- a/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openrouter-claude-subagent
-description: Use when launching a run on an OpenRouter-hosted model — the route is settled and what is needed now is the launch command, the tool grant, the model identifier and its price. Apply when the user names OpenRouter or a model it hosts (Kimi, GLM, Gemini, GPT), or when another skill sends a dispatch here. Not for deciding whether to leave Claude in the first place, and not for Codex or Gemini CLI.
+description: Use when launching a run on an OpenRouter-hosted model, or when working out which one fits a task and what it costs. Apply when the user names OpenRouter or a model it hosts (Kimi, GLM, Gemini, GPT), when another skill sends a dispatch here, or when a model's price, context window, or effort support needs looking up rather than recalling. Not for deciding whether to leave Claude in the first place, and not for Codex or Gemini CLI.
 admission:
   provides: A nested Claude Code harness whose model traffic is repointed at a non-Anthropic model, plus the stream repair that makes the reply actually arrive — so a task runs on another vendor's weights while keeping this harness's tool loop, permission system, and file editing.
   cost: A local proxy process for the life of each nested run, and an OpenRouter API key the user must supply and pay against. Node must be installed, and the model routing table needs a refresh whenever OpenRouter reprices or retires a model.

--- a/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: openrouter-claude-subagent
-description: Use when delegating work to an OpenRouter-hosted model (Kimi, GLM, Gemini Flash, GPT-5.6 variants, etc.) while still running it through the Claude Code CLI as the agent harness — spinning up a subagent on a different or cheaper model, routing a task through OpenRouter, launching a nested claude instance against an OpenRouter key, or when the user says "use openrouter", "route this to <model>", "delegate to a cheap model", "spin up a kimi/glm/gemini-flash subagent", "run this through OpenRouter", or asks which OpenRouter model fits a task and what it costs. Not for delegating to Codex, Gemini CLI, or any harness other than a nested claude process.
+description: Use when launching a run on an OpenRouter-hosted model — the route is settled and what is needed now is the launch command, the tool grant, the model identifier and its price. Apply when the user names OpenRouter or a model it hosts (Kimi, GLM, Gemini, GPT), or when another skill sends a dispatch here. Not for deciding whether to leave Claude in the first place, and not for Codex or Gemini CLI.
 admission:
-  prevents: Every review lens and every delegated opinion running on one vendor's models, so the whole panel shares that vendor's blind spots and agrees on a defect none of its models can see. Without a way to run the same harness against another vendor's model, "a second opinion" is the same opinion twice.
+  provides: A nested Claude Code harness whose model traffic is repointed at a non-Anthropic model, plus the stream repair that makes the reply actually arrive — so a task runs on another vendor's weights while keeping this harness's tool loop, permission system, and file editing.
   cost: A local proxy process for the life of each nested run, and an OpenRouter API key the user must supply and pay against. Node must be installed, and the model routing table needs a refresh whenever OpenRouter reprices or retires a model.
   remove_when: The review tooling can address models from more than one vendor natively, so a caller can name a non-Anthropic model without a nested harness and a repair proxy in between.
 ---


### PR DESCRIPTION
## The failure this fixes

An orchestrator in a project with no repo-specific instructions was asked to *"find someone to poke holes in my architecture."* It answered with a **larger Claude model** — the same vendor as the work under review — and rejected both cross-vendor routes:

> both are gated on the user naming an external vendor ("use codex", "route to X") … routing to a specific external vendor unasked would be **presumptuous** per those skills' own trigger scoping.

It did not fail to *find* the skills. It read them and concluded it was **not permitted** to use them unprompted. The brand-word descriptions don't merely fail to attract the right dispatch — they repel it. And it understood the trade it was making, justifying the bigger model as *"a real change in reasoning depth rather than another pass of the same model re-agreeing with itself."* It grasped the independence problem and had no sanctioned route to it.

**Capability present. Permission withheld.**

## How that was established

Four baseline scenarios run *inside this repo* all passed — and two of them cited this repo's `AGENTS.md` and project memories by name, neither of which deploys anywhere. On that evidence the skill looked like ballast.

Re-run from a scratch git repo with **no `AGENTS.md`, no `CLAUDE.md`, no memories**, retaining everything that actually deploys (global instruction file, delegation rule, full skill catalog, plugins), the same model on the same task **inverted its decision and failed**. The in-repo passes were borrowed context.

A control confirms the diagnosis is the trigger and not the content: the same bare session, asked explicitly for *"a model that is NOT a Claude model,"* found every mechanism, read `gpt-5.6-terra` out of the real table, and volunteered that this was *"a read directly from the file, not a guess."*

## What ships

**`choosing-a-delegate`** (new, 995 tokens) owns one decision: does independence require a different *vendor*, and is reaching for one your call. It carries **no substrate mechanics and no model tables** — the control run proved those are read correctly from the vendor skills once opened, so restating them is duplication the admission bar declines.

**Both vendor skills narrow** to launch mechanics, so one door fires and routes instead of two competing for one trigger.

**The delegation rule** loses the line that caused the split (*"each states when to use it in its own description"*) and its effort guidance — which prescribed a lever that does not exist: **the Agent tool accepts no `effort` parameter**. That now lives in the skill, paid only at dispatch.

## Verification

| Check | Result |
|---|---|
| `make ci` | **exit 0** |
| `content-lint` / `content-tests` | exit 0 standalone, 8 suites |
| Skill body | **995** / 2000 cap |
| Delegation rule | 850 → **781** — under the ~800 sub-budget it was breaching |
| Always-on surface | 1127 → **1080** (−47) |

GREEN test: identical prompt, identical bare project, skill staged project-locally. Routed to Codex on `gpt-5.6-sol`, read the id from the table rather than inferring it, caught the Codex write-capable default and called the review-only framing *"load-bearing,"* confirmed the plugin was present before choosing it, and stopped at the decision naming `instructing-subagents` as next.

## Scope honesty

The earlier shaping also approved **decompose-or-decline**, the **nesting constraint / decision ladder**, and **monitoring doctrine**. No baseline was run against any of them, so there is no evidence an unaided agent fails at them — and this round disproved a plausible-looking gap four times. They are unevidenced, not abandoned; each needs its own bare-project baseline first.

Also folds in the openrouter admission record's `prevents` → `provides` correction, and absorbs the bare-dispatch question as a routing row rather than a separate skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLWYUEiyb1Esmq13K5tPrs
