### PR TITLE
fix(9k9.126): pin an OpenRouter run to the model it was launched with

### DIFF
--- a/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
@@ -41,6 +41,16 @@ credentials, so ask the user where to find the key rather than guessing. Node
 is a hard requirement; if it is missing, stop and say so rather than falling
 back to a direct invocation.
 
+**The run is pinned to `--model`.** The subagent may delegate further, and
+every run it starts answers on that same model — the aliases are redirected,
+so a nested dispatch that names `sonnet`, or an agent type that carries its own
+model, still lands there. A request for anything else is refused with an error
+explaining the alternative. Two families are refused outright, pin or no pin:
+Claude models, which belong in the harness you are already running, and the
+large GPT tiers (`gpt-5.5*`, `gpt-5.6*`, `-mini` variants excepted), which have
+their own transport. Naming one exits `78` before anything starts, and there is
+no rerouting around it — if that transport is down, the task waits.
+
 `references/proxy-contract.md` covers what the proxy repairs, why the tool
 grant is limited to what you pass, and what to re-verify when the Claude Code
 CLI changes.

--- a/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
@@ -44,11 +44,14 @@ The launcher pins the run to the one model you named, three ways:
   `..._SONNET_MODEL`, `..._HAIKU_MODEL`, `..._FABLE_MODEL` — are set to
   `--model`. Delegation still works; it just cannot leave the model you paid
   for. This is the part that keeps subagents useful rather than banning them.
-- **Pin.** The proxy refuses any completion request naming a different model
-  with an HTTP 403 carrying an Anthropic-shaped error body, and dials nothing
-  upstream. The message says what to do instead — carry on unaided, or delegate
-  with the model field left out — because an API error is the only channel back
-  to whatever asked.
+- **Pin.** On a completion request the rule is exact match or nothing: any
+  other model gets an HTTP 403 carrying an Anthropic-shaped error body, and
+  nothing is dialed upstream. A request naming *no* model is refused on the
+  same rule — it has not switched models, but it has handed the choice to
+  whatever is upstream, which loses the same control by a quieter route. The
+  message says what to do instead — carry on unaided, or delegate with the
+  model field left out — because an API error is the only channel back to
+  whatever asked.
 - **Denylist.** Claude models and the large GPT tiers are refused outright,
   pin or no pin: they are served properly elsewhere, so arriving here means
   something misrouted. The `-mini` GPT variants are exempt. The launcher exits

--- a/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
@@ -29,6 +29,47 @@ tools granted via `--allowedTools`.
 Practical consequence: **the subagent can use only the tools you list.** There
 is no deferred pool to fall back on. List everything the task needs.
 
+## The model pin
+
+A nested run can start runs of its own, and each of those picks its own model
+— named outright, taken from an agent type's definition, or taken from a
+built-in default. Every one of them bills the same OpenRouter account and
+answers in the launching run's name. Left alone, that is how a cheap run on one
+vendor's model quietly becomes an expensive run on another's, with the point of
+view you launched it for replaced along the way.
+
+The launcher pins the run to the one model you named, three ways:
+
+- **Redirect.** All four model aliases — `ANTHROPIC_DEFAULT_OPUS_MODEL`,
+  `..._SONNET_MODEL`, `..._HAIKU_MODEL`, `..._FABLE_MODEL` — are set to
+  `--model`. Delegation still works; it just cannot leave the model you paid
+  for. This is the part that keeps subagents useful rather than banning them.
+- **Pin.** The proxy refuses any completion request naming a different model
+  with an HTTP 403 carrying an Anthropic-shaped error body, and dials nothing
+  upstream. The message says what to do instead — carry on unaided, or delegate
+  with the model field left out — because an API error is the only channel back
+  to whatever asked.
+- **Denylist.** Claude models and the large GPT tiers are refused outright,
+  pin or no pin: they are served properly elsewhere, so arriving here means
+  something misrouted. The `-mini` GPT variants are exempt. The launcher exits
+  `78` before binding a listener when `--model` names one; the proxy refuses
+  them too, so neither layer depends on the other.
+
+Alias redirection also covers the background chores the harness runs on the
+cheap alias, which would otherwise bill the model you named. `run.js` switches
+those off with `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`. Note the semantics:
+**any non-empty value enables the setting, `"0"` included.** It reads as a
+switch, not a boolean, so there is no way to spell "off" except by unsetting it.
+
+Every completion request leaves one line on stderr naming the method, path,
+model, and decision (`forward`, `deny-pin`, or `deny-denylist`). When a bill
+looks wrong later, that ledger is the record to read — the alternative is
+digging through transcripts, which is how the leak this pin exists to close
+went unnoticed for a day.
+
+Counting tokens is not a completion: it neither generates nor speaks, so it is
+forwarded ungated and unledgered.
+
 ## Why in-process, on a kernel-assigned port
 
 The proxy runs inside the launcher process, listening on `port: 0`. Two
@@ -43,13 +84,16 @@ properties follow, both load-bearing:
 
 ## What the launcher owns
 
-When debugging a run, note that `run.js` sets these four in the child
+When debugging a run, note that `run.js` sets all of these in the child
 environment and a caller cannot override them: `ANTHROPIC_BASE_URL` (the
 proxy), `ANTHROPIC_AUTH_TOKEN` (from `$OPENROUTER_API_KEY`), `ANTHROPIC_API_KEY`
 (forced empty — present and empty, since an inherited real key would take
-precedence and quietly bill Anthropic), and `CLAUDE_CONFIG_DIR`
+precedence and quietly bill Anthropic), `CLAUDE_CONFIG_DIR`
 (`~/.claude_openrouter`, so the nested process neither collides with nor
-inherits the parent session's `~/.claude`).
+inherits the parent session's `~/.claude`), the four
+`ANTHROPIC_DEFAULT_*_MODEL` aliases and
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` (both above). An alias redirect
+inherited from the parent environment is overwritten, not honoured.
 
 `CLAUDE_CONFIG_DIR_OPENROUTER` is the one supported override, for pointing the
 nested session's config elsewhere.

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy.js
@@ -160,6 +160,124 @@ function stripDeferredTools(body) {
   return body;
 }
 
+// ─── Model gate ────────────────────────────────────────────────────
+
+// A nested run can start further runs of its own, and each one picks its own
+// model. Every one of those bills this proxy's account and answers in this
+// run's name, so a run that silently switches models spends money nobody
+// approved and swaps out the point of view it was launched to provide.
+//
+// Two independent checks close that. The pin refuses any model but the one
+// this run was launched with. The denylist refuses a small set of models
+// outright, whatever the pin says, because they are served properly by other
+// transports and have no business arriving here at all.
+
+/** Model families this transport never carries, matched as slug prefixes.
+ *  Claude models run natively in the harness that launches these runs, and the
+ *  large GPT tiers have their own vendor transport; reaching either one from
+ *  here means something upstream misrouted. A literal list is the point — it
+ *  needs revisiting when the model roster moves, and a clever pattern would
+ *  hide that. */
+const DENIED_MODEL_PREFIXES = ["claude", "gpt-5.5", "gpt-5.6"];
+
+/** Prefixes above whose `-mini` variants stay reachable: they are cheap enough
+ *  to be worth having, and are not what the denial is protecting against.
+ *  `claude` is absent on purpose — no Claude model belongs on this transport. */
+const MINI_EXEMPT_PREFIXES = ["gpt-5.5", "gpt-5.6"];
+
+/** Reduce a routing id to its bare model slug. Ids arrive as `vendor/slug`,
+ *  sometimes with an OpenRouter `:variant` suffix, and the vendor prefix must
+ *  not be a way to walk past the denylist. */
+function modelSlug(model) {
+  if (typeof model !== "string") return "";
+  const slug = model.trim().toLowerCase().split("/").pop();
+  return slug.split(":")[0];
+}
+
+/** True when this model is refused outright, pin or no pin. */
+function isDeniedModel(model) {
+  const slug = modelSlug(model);
+  if (!slug) return false;
+  const matched = DENIED_MODEL_PREFIXES.find((p) => slug.startsWith(p));
+  if (!matched) return false;
+  if (!MINI_EXEMPT_PREFIXES.includes(matched)) return true;
+  return !slug.split("-").includes("mini");
+}
+
+/** The gate applies to completion requests only — those are the requests that
+ *  generate, bill, and speak in this run's voice. Counting tokens does none of
+ *  the three, so it is measured and forwarded like any other metadata call. */
+function isCompletionPath(pathname) {
+  return pathname.replace(/^\/api\//, "/").replace(/\/+$/, "") === "/v1/messages";
+}
+
+/** Advisory carried by a refusal. It is the only channel back to whatever
+ *  asked for the wrong model — the caller sees an API error and nothing else —
+ *  so it has to say what to do instead, not just what went wrong. */
+function pinAdvice(requested, pinned) {
+  return (
+    `This run is pinned to ${pinned}, and the request asked for ${requested}. ` +
+    "Every model reached from inside this run bills the same account and answers in this " +
+    "run's name, so switching models spends against a budget nobody approved and replaces " +
+    "the point of view this run exists to provide. Either carry on in your own context, or " +
+    `delegate with the model field left out — the work then runs on ${pinned} and the point ` +
+    "of view survives. If an agent type names a model of its own that does not resolve to " +
+    `${pinned}, its requests are refused the same way.`
+  );
+}
+
+function deniedAdvice(requested, pinned) {
+  return (
+    `${requested} is not reachable over this transport, by design and not by accident: Claude ` +
+    "models run natively in the harness that launched this run, and the large GPT tiers run " +
+    "through their own vendor transport. Nothing here can route to it. " +
+    (pinned ? `This run is pinned to ${pinned}. ` : "") +
+    "Carry on in your own context, or delegate with the model field left out so the work runs " +
+    "on the same model this run does."
+  );
+}
+
+/** Adjudicate one completion request.
+ *  @param {*} model The `model` field as it appeared in the body; `undefined`
+ *    when the body carried none, which is not a model switch and not refused.
+ *  @param {string|null} pinnedModel The model this run was launched with.
+ *  @returns {{decision: "forward"|"deny-pin"|"deny-denylist", message?: string}} */
+function screenModel(model, pinnedModel) {
+  if (isDeniedModel(model)) {
+    return { decision: "deny-denylist", message: deniedAdvice(String(model), pinnedModel) };
+  }
+  if (!pinnedModel) return { decision: "forward" };
+  if (model === undefined || model === null) return { decision: "forward" };
+  // Exact match, deliberately: anything else is a switch, and a near-miss that
+  // fails loudly costs one recoverable error while a near-miss that passes
+  // costs money quietly.
+  if (model === pinnedModel) return { decision: "forward" };
+  return { decision: "deny-pin", message: pinAdvice(describeModel(model), pinnedModel) };
+}
+
+/** Render a model field for the ledger and for advisory text, distinguishing
+ *  "the body named no model" from "the body named an empty one" — the second
+ *  is a refusal and the first is not. */
+function describeModel(model) {
+  if (model === undefined || model === null) return "none";
+  if (model === "") return "(empty)";
+  return String(model);
+}
+
+/** Anthropic-shaped refusal. The client renders the message verbatim as an API
+ *  error, which is what carries the advisory back to the caller. */
+function refuse(clientRes, message) {
+  const body = JSON.stringify({
+    type: "error",
+    error: { type: "permission_error", message },
+  });
+  clientRes.writeHead(403, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  clientRes.end(body);
+}
+
 // ─── SSE stream processor ──────────────────────────────────────────
 
 /**
@@ -364,7 +482,7 @@ function createSSEFixer(res, log = defaultLog) {
 
 // ─── HTTP proxy ────────────────────────────────────────────────────
 
-function proxyRequest(clientReq, clientRes, log) {
+function proxyRequest(clientReq, clientRes, log, pinnedModel = null) {
   // The request target must not be able to choose the upstream host. In
   // absolute-form (RFC 9112 §3.2.2) `new URL(target, base)` ignores the base
   // entirely, so `GET http://elsewhere/x` would send this request — carrying
@@ -413,13 +531,12 @@ function proxyRequest(clientReq, clientRes, log) {
   const wantSSE = isStreamingRequest(clientReq.headers);
   const proto = targetUrl.protocol === "https:" ? https : http;
 
-  const proxyReq = proto.request({
-    hostname: targetUrl.hostname,
-    port: targetUrl.port || (targetUrl.protocol === "https:" ? 443 : 80),
-    path: targetUrl.pathname + targetUrl.search,
-    method: clientReq.method,
-    headers,
-  }, (proxyRes) => {
+  // Nothing is dialed until the body has been read and adjudicated. A refused
+  // request must not open an upstream connection at all: the whole point of
+  // the gate is that a disallowed model costs nothing.
+  let proxyReq = null;
+
+  function handleUpstreamResponse(proxyRes) {
     const sse = isSSEResponse(proxyRes.headers);
     const resHeaders = { ...proxyRes.headers };
 
@@ -477,12 +594,43 @@ function proxyRequest(clientReq, clientRes, log) {
       if (!clientRes.headersSent) clientRes.writeHead(502, { "Content-Type": "text/plain" });
       clientRes.end("Bad Gateway: upstream response error");
     });
-  });
+  }
+
+  /** Open the upstream connection and send the adjudicated body. */
+  function dialUpstream(body) {
+    proxyReq = proto.request({
+      hostname: targetUrl.hostname,
+      port: targetUrl.port || (targetUrl.protocol === "https:" ? 443 : 80),
+      path: targetUrl.pathname + targetUrl.search,
+      method: clientReq.method,
+      headers,
+    }, handleUpstreamResponse);
+
+    proxyReq.on("error", (err) => {
+      log(`upstream request error: ${err.message}`);
+      if (!clientRes.headersSent) clientRes.writeHead(502, { "Content-Type": "text/plain" });
+      clientRes.end(`Bad Gateway: ${err.message}`);
+    });
+
+    // Streaming responses need a far longer idle deadline than request/response
+    // traffic, but not an unlimited one: `wantSSE` comes from a client-supplied
+    // Accept header, so disabling the timeout outright would let any local
+    // sender park upstream connections and file descriptors indefinitely.
+    proxyReq.setTimeout(wantSSE ? SSE_IDLE_TIMEOUT_MS : 60000, () => {
+      log("upstream request timeout");
+      proxyReq.destroy();
+    });
+
+    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
+    proxyReq.write(body);
+    proxyReq.end();
+  }
 
   // Buffer the request body so mixed-content user messages can be split
-  // before forwarding (see splitMixedMessages). Buffering is why the size is
-  // capped: without a ceiling any local sender could exhaust memory and take
-  // the launcher down with the proxy.
+  // before forwarding (see splitMixedMessages), and so the model it names can
+  // be read before anything is dialed. Buffering is why the size is capped:
+  // without a ceiling any local sender could exhaust memory and take the
+  // launcher down with the proxy.
   const chunks = [];
   let bodyBytes = 0;
   let bodyTooLarge = false;
@@ -493,7 +641,6 @@ function proxyRequest(clientReq, clientRes, log) {
       bodyTooLarge = true;
       log(`refused: request body exceeds ${MAX_REQUEST_BODY_BYTES} bytes`);
       chunks.length = 0;
-      proxyReq.destroy();
       if (!clientRes.headersSent) {
         clientRes.writeHead(413, { "Content-Type": "text/plain" });
         clientRes.end("Payload Too Large");
@@ -506,37 +653,40 @@ function proxyRequest(clientReq, clientRes, log) {
     if (bodyTooLarge) return;
     const raw = Buffer.concat(chunks).toString();
     let body = raw;
+    // `undefined` here means the body named no model at all, which is not a
+    // model switch — a non-JSON body leaves it that way too.
+    let model;
     try {
       const obj = JSON.parse(raw);
+      model = obj.model;
       if (obj.messages || obj.tools) {
         if (obj.messages) splitMixedMessages(obj.messages);
         if (!isAnthropicModel(obj.model)) stripDeferredTools(obj);
         body = JSON.stringify(obj);
       }
     } catch { /* pass non-JSON bodies through unmodified */ }
-    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
-    proxyReq.write(body);
-    proxyReq.end();
+
+    if (isCompletionPath(targetUrl.pathname)) {
+      const verdict = screenModel(model, pinnedModel);
+      // One line, one write: this ledger is the record a later billing
+      // question gets read against, and an interleaved half-line is no record.
+      log(
+        `model-ledger ${clientReq.method} ${targetUrl.pathname} ` +
+        `model=${describeModel(model)} decision=${verdict.decision}`
+      );
+      if (verdict.decision !== "forward") {
+        clientReq.resume();
+        refuse(clientRes, verdict.message);
+        return;
+      }
+    }
+
+    dialUpstream(body);
   });
 
   clientReq.on("error", (err) => {
     log(`client request error: ${err.message}`);
-    proxyReq.destroy();
-  });
-
-  proxyReq.on("error", (err) => {
-    log(`upstream request error: ${err.message}`);
-    if (!clientRes.headersSent) clientRes.writeHead(502, { "Content-Type": "text/plain" });
-    clientRes.end(`Bad Gateway: ${err.message}`);
-  });
-
-  // Streaming responses need a far longer idle deadline than request/response
-  // traffic, but not an unlimited one: `wantSSE` comes from a client-supplied
-  // Accept header, so disabling the timeout outright would let any local
-  // sender park upstream connections and file descriptors indefinitely.
-  proxyReq.setTimeout(wantSSE ? SSE_IDLE_TIMEOUT_MS : 60000, () => {
-    log("upstream request timeout");
-    proxyReq.destroy();
+    if (proxyReq) proxyReq.destroy();
   });
 }
 
@@ -552,16 +702,19 @@ function proxyRequest(clientReq, clientRes, log) {
  *   random port and checking it first is a TOCTOU race.
  * @param {string} [opts.host] Interface to bind. Loopback only by default.
  * @param {(msg: string) => void} [opts.log] Log sink; defaults to stderr.
+ * @param {string|null} [opts.pinnedModel] The one model completion requests
+ *   may name. Left unset the pin is off and only the denylist applies, which
+ *   is the right shape for a proxy started outside a launched run.
  * @returns {Promise<{ port: number, close: () => Promise<void> }>}
  */
-function start({ port = 0, host = "127.0.0.1", log = defaultLog } = {}) {
+function start({ port = 0, host = "127.0.0.1", log = defaultLog, pinnedModel = null } = {}) {
   // The parse guard in proxyRequest covers the one throw we know about. This
   // covers the ones we don't: because the proxy shares a process with the
   // launcher, an unhandled throw here would kill the running claude child
   // too. A failed request must never be able to end the session.
   const server = http.createServer((req, res) => {
     try {
-      proxyRequest(req, res, log);
+      proxyRequest(req, res, log, pinnedModel);
     } catch (err) {
       log(`request handler error: ${err.message}`);
       if (!res.headersSent) res.writeHead(500, { "Content-Type": "text/plain" });
@@ -588,7 +741,14 @@ function start({ port = 0, host = "127.0.0.1", log = defaultLog } = {}) {
 
 module.exports = {
   start,
+  // The launcher refuses a denied model before it binds a listener, so it
+  // shares this proxy's list rather than keeping a second one in step.
+  isDeniedModel,
   // Exported for tests.
+  screenModel,
+  isCompletionPath,
+  modelSlug,
+  describeModel,
   createSSEFixer,
   splitMixedMessages,
   stripDeferredTools,

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy.js
@@ -215,8 +215,11 @@ function isCompletionPath(pathname) {
  *  asked for the wrong model — the caller sees an API error and nothing else —
  *  so it has to say what to do instead, not just what went wrong. */
 function pinAdvice(requested, pinned) {
+  const asked = requested === "none"
+    ? "the request named no model at all"
+    : `the request asked for ${requested}`;
   return (
-    `This run is pinned to ${pinned}, and the request asked for ${requested}. ` +
+    `This run is pinned to ${pinned}, and ${asked}. ` +
     "Every model reached from inside this run bills the same account and answers in this " +
     "run's name, so switching models spends against a budget nobody approved and replaces " +
     "the point of view this run exists to provide. Either carry on in your own context, or " +
@@ -239,7 +242,7 @@ function deniedAdvice(requested, pinned) {
 
 /** Adjudicate one completion request.
  *  @param {*} model The `model` field as it appeared in the body; `undefined`
- *    when the body carried none, which is not a model switch and not refused.
+ *    when the body carried none, or when the body did not parse as JSON.
  *  @param {string|null} pinnedModel The model this run was launched with.
  *  @returns {{decision: "forward"|"deny-pin"|"deny-denylist", message?: string}} */
 function screenModel(model, pinnedModel) {
@@ -247,21 +250,27 @@ function screenModel(model, pinnedModel) {
     return { decision: "deny-denylist", message: deniedAdvice(String(model), pinnedModel) };
   }
   if (!pinnedModel) return { decision: "forward" };
-  if (model === undefined || model === null) return { decision: "forward" };
-  // Exact match, deliberately: anything else is a switch, and a near-miss that
-  // fails loudly costs one recoverable error while a near-miss that passes
-  // costs money quietly.
+  // Exact match or nothing. A near-miss that fails loudly costs one
+  // recoverable error; a near-miss that passes costs money quietly. A body
+  // naming no model at all is refused on the same rule and for the same
+  // reason: it has not switched models, but it has handed the choice of model
+  // to whatever is upstream, which is the same loss of control by a quieter
+  // route. No real client sends one — every completion observed under a live
+  // run named its model.
   if (model === pinnedModel) return { decision: "forward" };
   return { decision: "deny-pin", message: pinAdvice(describeModel(model), pinnedModel) };
 }
 
 /** Render a model field for the ledger and for advisory text, distinguishing
- *  "the body named no model" from "the body named an empty one" — the second
- *  is a refusal and the first is not. */
+ *  "the body named no model" from "the body named an empty one". */
 function describeModel(model) {
   if (model === undefined || model === null) return "none";
   if (model === "") return "(empty)";
-  return String(model);
+  // A model id is a routing token, not prose. Flattening whitespace stops a
+  // value carrying a newline from forging a second ledger line, and the length
+  // cap stops one from burying the real lines; the ledger is only evidence for
+  // as long as one request means exactly one line.
+  return String(model).replace(/\s+/g, " ").slice(0, 120);
 }
 
 /** Anthropic-shaped refusal. The client renders the message verbatim as an API
@@ -649,7 +658,20 @@ function proxyRequest(clientReq, clientRes, log, pinnedModel = null) {
     }
     chunks.push(chunk);
   });
+  // The guard in `start` wraps the synchronous call only, and this runs later
+  // on the event loop: an unhandled throw here reaches nothing and takes the
+  // process down, which strands the `claude` child sharing it.
   clientReq.on("end", () => {
+    try {
+      adjudicateAndForward();
+    } catch (err) {
+      log(`request adjudication error: ${err.message}`);
+      if (!clientRes.headersSent) clientRes.writeHead(500, { "Content-Type": "text/plain" });
+      clientRes.end("Internal proxy error");
+    }
+  });
+
+  function adjudicateAndForward() {
     if (bodyTooLarge) return;
     const raw = Buffer.concat(chunks).toString();
     let body = raw;
@@ -682,7 +704,7 @@ function proxyRequest(clientReq, clientRes, log, pinnedModel = null) {
     }
 
     dialUpstream(body);
-  });
+  }
 
   clientReq.on("error", (err) => {
     log(`client request error: ${err.message}`);

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy_test.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy_test.js
@@ -902,9 +902,26 @@ test("screenModel fails closed on a present-but-empty model", () => {
   assert.equal(screenModel("", "moonshotai/kimi-k3").decision, "deny-pin");
 });
 
-test("screenModel lets a body that names no model through", () => {
-  assert.equal(screenModel(undefined, "moonshotai/kimi-k3").decision, "forward");
-  assert.equal(screenModel(null, "moonshotai/kimi-k3").decision, "forward");
+// Naming no model is not a switch, but it hands the choice of model to
+// whatever is upstream — the same loss of control, arriving quietly. Under a
+// pin the rule is exact match or nothing.
+test("screenModel refuses a body that names no model rather than letting upstream choose", () => {
+  assert.equal(screenModel(undefined, "moonshotai/kimi-k3").decision, "deny-pin");
+  assert.equal(screenModel(null, "moonshotai/kimi-k3").decision, "deny-pin");
+});
+
+test("the refusal for a model-less body says so, rather than reporting a model called none", () => {
+  assert.match(screenModel(undefined, "moonshotai/kimi-k3").message, /named no model at all/);
+});
+
+test("with no pin configured a model-less body is still forwarded", () => {
+  assert.equal(screenModel(undefined, null).decision, "forward");
+});
+
+test("a model id cannot forge a second ledger line with a newline", () => {
+  const forged = describeModel("a\nmodel-ledger POST /x model=y decision=forward");
+  assert.doesNotMatch(forged, /\n/, "one request must stay one line");
+  assert.ok(describeModel("x".repeat(500)).length <= 120, "nor may it bury the real lines");
 });
 
 test("the denylist refuses a model even when it is the pinned one", () => {
@@ -1061,16 +1078,30 @@ test("a completion naming an empty model is refused rather than forwarded", asyn
   }
 });
 
-test("a completion naming no model at all is forwarded, and the ledger says so", async () => {
+test("a completion naming no model at all is refused, and the ledger records it", async () => {
   const logs = [];
   const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
-  const sent = rawSend(proxy.port, "POST", "/v1/messages", JSON.stringify({ messages: [] }));
-  sent.response.catch(() => {});
   try {
-    const line = await waitForLog(logs, /^model-ledger/);
-    assert.match(line, /model=none decision=forward$/);
+    const { response } = rawSend(proxy.port, "POST", "/v1/messages", JSON.stringify({ messages: [] }));
+    const raw = await response;
+    assert.match(raw, /^HTTP\/1\.1 403\b/);
+    assert.match(await waitForLog(logs, /^model-ledger/), /model=none decision=deny-pin$/);
+    assert.deepEqual(
+      logs.filter((line) => line.startsWith("upstream")), [],
+      "handing the model choice upstream is exactly what must not be dialed",
+    );
   } finally {
-    sent.abort();
+    await proxy.close();
+  }
+});
+
+test("a completion body that is not JSON at all is refused under a pin", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(proxy.port, "POST", "/v1/messages", "not json");
+    assert.match(await response, /^HTTP\/1\.1 403\b/);
+  } finally {
     await proxy.close();
   }
 });

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy_test.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/proxy_test.js
@@ -817,3 +817,279 @@ test("only Anthropic-vendor model ids keep the deferred-tool protocol", () => {
   assert.equal(isAnthropicModel("google/gemini-3.1-flash-lite"), false);
   assert.equal(isAnthropicModel(undefined), false, "a body with no model must not be treated as Anthropic");
 });
+
+// ─── Model gate: which model a request is allowed to name ──────────
+//
+// A nested run can start further runs, each choosing its own model, and every
+// one of them bills this proxy's account and answers in the launching run's
+// name. The denylist refuses a few families outright; the pin refuses anything
+// but the model the run was launched with. Both are enforced here because the
+// proxy is the only place the traffic has to pass through — the client's tool
+// grant does not reach the spawn path at all.
+
+const {
+  isDeniedModel,
+  isCompletionPath,
+  screenModel,
+  describeModel,
+} = require("./proxy.js");
+
+test("denies Claude models with or without a vendor prefix, in any case", () => {
+  assert.equal(isDeniedModel("anthropic/claude-opus-5"), true);
+  assert.equal(isDeniedModel("claude-sonnet-5"), true);
+  assert.equal(isDeniedModel("Anthropic/Claude-Opus-5"), true, "case must not be a way around it");
+});
+
+test("denies the large GPT tiers this transport does not carry", () => {
+  assert.equal(isDeniedModel("openai/gpt-5.6-sol"), true);
+  assert.equal(isDeniedModel("openai/gpt-5.5-turbo"), true);
+  assert.equal(isDeniedModel("gpt-5.6"), true);
+});
+
+test("exempts the -mini GPT variants, which are cheap and not what the denial guards", () => {
+  assert.equal(isDeniedModel("openai/gpt-5.6-mini"), false);
+  assert.equal(isDeniedModel("openai/gpt-5.5-mini-high"), false);
+  assert.equal(isDeniedModel("gpt-5.6-minimal"), true, "the exemption is the segment `mini`, not the letters");
+});
+
+test("no -mini spelling exempts a Claude model, which never belongs on this transport", () => {
+  assert.equal(isDeniedModel("anthropic/claude-mini"), true);
+});
+
+test("an OpenRouter :variant suffix is not a way around the denylist", () => {
+  assert.equal(isDeniedModel("anthropic/claude-opus-5:beta"), true);
+  assert.equal(isDeniedModel("openai/gpt-5.6-sol:nitro"), true);
+});
+
+test("leaves the models this transport exists to reach alone", () => {
+  assert.equal(isDeniedModel("moonshotai/kimi-k3"), false);
+  assert.equal(isDeniedModel("google/gemini-3.5-flash"), false);
+  assert.equal(isDeniedModel("z-ai/glm-5.2"), false);
+});
+
+test("treats an absent or non-string model as nothing to deny", () => {
+  assert.equal(isDeniedModel(undefined), false);
+  assert.equal(isDeniedModel(""), false);
+  assert.equal(isDeniedModel(42), false);
+});
+
+test("the gate applies to completions, not to counting tokens", () => {
+  assert.equal(isCompletionPath("/v1/messages"), true);
+  assert.equal(isCompletionPath("/api/v1/messages"), true, "the upstream rewrite must not shake the gate off");
+  assert.equal(isCompletionPath("/api/v1/messages/"), true, "a trailing slash is the same endpoint");
+  assert.equal(isCompletionPath("/api/v1/messages/count_tokens"), false);
+  assert.equal(isCompletionPath("/api/v1/models"), false);
+});
+
+test("screenModel forwards the model the run was launched with", () => {
+  assert.deepEqual(screenModel("moonshotai/kimi-k3", "moonshotai/kimi-k3"), { decision: "forward" });
+});
+
+test("screenModel refuses any other model and names both in the advice", () => {
+  const verdict = screenModel("anthropic-free/other", "moonshotai/kimi-k3");
+  assert.equal(verdict.decision, "deny-pin");
+  assert.match(verdict.message, /moonshotai\/kimi-k3/);
+  assert.match(verdict.message, /anthropic-free\/other/);
+});
+
+test("the refusal advises what to do instead, not only what went wrong", () => {
+  const verdict = screenModel("some/other", "moonshotai/kimi-k3");
+  assert.match(verdict.message, /your own context/i, "carrying on unaided must be offered");
+  assert.match(verdict.message, /model field left out/i, "so must the delegation that still works");
+});
+
+test("screenModel fails closed on a present-but-empty model", () => {
+  assert.equal(screenModel("", "moonshotai/kimi-k3").decision, "deny-pin");
+});
+
+test("screenModel lets a body that names no model through", () => {
+  assert.equal(screenModel(undefined, "moonshotai/kimi-k3").decision, "forward");
+  assert.equal(screenModel(null, "moonshotai/kimi-k3").decision, "forward");
+});
+
+test("the denylist refuses a model even when it is the pinned one", () => {
+  const verdict = screenModel("anthropic/claude-opus-5", "anthropic/claude-opus-5");
+  assert.equal(verdict.decision, "deny-denylist", "the pin must not be able to authorize a denied model");
+});
+
+test("with no pin configured the denylist still applies and nothing else does", () => {
+  assert.equal(screenModel("moonshotai/kimi-k3", null).decision, "forward");
+  assert.equal(screenModel("anything/at-all", null).decision, "forward");
+  assert.equal(screenModel("anthropic/claude-opus-5", null).decision, "deny-denylist");
+});
+
+test("describeModel separates a body that named no model from one that named an empty one", () => {
+  assert.equal(describeModel(undefined), "none");
+  assert.equal(describeModel(""), "(empty)");
+  assert.equal(describeModel("vendor/m"), "vendor/m");
+});
+
+// ─── Model gate over a real socket ─────────────────────────────────
+//
+// The pure tests above fix the decision; these fix what a client actually
+// receives, since the advisory only steers anything if it survives the wire as
+// an error the caller can read.
+
+/** Send one raw request and hand back both the socket and the response.
+ *  Callers expecting a refusal await `response`. Callers testing a request
+ *  that gets *forwarded* call `abort()` instead and assert on the log: the
+ *  real upstream is not reachable from a test sandbox, and waiting for it to
+ *  give up costs a minute per test. */
+function rawSend(port, method, urlPath, body) {
+  const payload = body === null ? "" : body;
+  const request =
+    `${method} ${urlPath} HTTP/1.1\r\n` +
+    "Host: 127.0.0.1\r\n" +
+    "Content-Type: application/json\r\n" +
+    "Connection: close\r\n" +
+    `Content-Length: ${Buffer.byteLength(payload)}\r\n\r\n` +
+    payload;
+
+  let socket;
+  const response = new Promise((resolve, reject) => {
+    socket = net.createConnection(port, "127.0.0.1", () => socket.write(request));
+    let data = "";
+    socket.setTimeout(5000, () => {
+      socket.destroy();
+      reject(new Error("socket timed out waiting for a response"));
+    });
+    socket.on("data", (chunk) => { data += chunk.toString(); });
+    socket.on("end", () => resolve(data));
+    socket.on("error", reject);
+  });
+  return { response, abort: () => socket.destroy() };
+}
+
+/** Resolve once `logs` contains a matching line, or reject at the deadline. */
+async function waitForLog(logs, pattern, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const hit = logs.find((line) => pattern.test(line));
+    if (hit) return hit;
+    if (Date.now() > deadline) throw new Error(`no log line matched ${pattern} in ${JSON.stringify(logs)}`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+const PINNED = "moonshotai/kimi-k3";
+
+test("a completion naming another model is refused with a readable Anthropic error", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(
+      proxy.port, "POST", "/v1/messages",
+      JSON.stringify({ model: "some/other-model", messages: [] }),
+    );
+    const raw = await response;
+
+    assert.match(raw, /^HTTP\/1\.1 403\b/, "a model switch is a refusal, not a bad request");
+    const body = JSON.parse(raw.slice(raw.indexOf("\r\n\r\n") + 4));
+    assert.equal(body.type, "error", "the client only renders Anthropic-shaped errors");
+    assert.equal(body.error.type, "permission_error");
+    assert.match(body.error.message, new RegExp(PINNED), "the advice has to name the model that would work");
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a refused completion never opens a connection to the upstream", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(
+      proxy.port, "POST", "/v1/messages",
+      JSON.stringify({ model: "some/other-model", messages: [] }),
+    );
+    await response;
+    assert.deepEqual(
+      logs.filter((line) => line.startsWith("upstream")), [],
+      "a refusal that still dials upstream is a refusal that still costs money",
+    );
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("every completion request leaves one ledger line naming the model and the decision", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(
+      proxy.port, "POST", "/v1/messages",
+      JSON.stringify({ model: "some/other-model", messages: [] }),
+    );
+    await response;
+
+    const ledger = logs.filter((line) => line.startsWith("model-ledger"));
+    assert.equal(ledger.length, 1, "one request, one line — a ledger that double-counts is not a ledger");
+    assert.match(ledger[0], /^model-ledger POST \/api\/v1\/messages model=some\/other-model decision=deny-pin$/);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a denied model is refused even when the run is pinned to it", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: "anthropic/claude-opus-5", log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(
+      proxy.port, "POST", "/v1/messages",
+      JSON.stringify({ model: "anthropic/claude-opus-5", messages: [] }),
+    );
+    const raw = await response;
+    assert.match(raw, /^HTTP\/1\.1 403\b/);
+    await waitForLog(logs, /decision=deny-denylist/);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a completion naming an empty model is refused rather than forwarded", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  try {
+    const { response } = rawSend(
+      proxy.port, "POST", "/v1/messages",
+      JSON.stringify({ model: "", messages: [] }),
+    );
+    const raw = await response;
+    assert.match(raw, /^HTTP\/1\.1 403\b/);
+    await waitForLog(logs, /model=\(empty\) decision=deny-pin/);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test("a completion naming no model at all is forwarded, and the ledger says so", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  const sent = rawSend(proxy.port, "POST", "/v1/messages", JSON.stringify({ messages: [] }));
+  sent.response.catch(() => {});
+  try {
+    const line = await waitForLog(logs, /^model-ledger/);
+    assert.match(line, /model=none decision=forward$/);
+  } finally {
+    sent.abort();
+    await proxy.close();
+  }
+});
+
+test("counting tokens is not a completion and is neither gated nor ledgered", async () => {
+  const logs = [];
+  const proxy = await start({ port: 0, pinnedModel: PINNED, log: (m) => logs.push(m) });
+  const sent = rawSend(
+    proxy.port, "POST", "/v1/messages/count_tokens",
+    JSON.stringify({ model: "some/other-model", messages: [] }),
+  );
+  sent.response.catch(() => {});
+  try {
+    // Give the request the same head start the ledger tests get, then assert
+    // the absence — the gate declining to act is the whole claim.
+    await new Promise((r) => setTimeout(r, 200));
+    assert.deepEqual(logs.filter((line) => line.startsWith("model-ledger")), []);
+  } finally {
+    sent.abort();
+    await proxy.close();
+  }
+});

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/run.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/run.js
@@ -47,11 +47,29 @@ const REQUIRED_FLAGS = [
   ["--allowedTools", "--allowed-tools"],
 ];
 
+/** Argv with the prompt's value dropped.
+ *
+ *  Every other argument is written by whoever launched the run. The prompt
+ *  carries task text, which routinely comes from the material being worked on,
+ *  so a prompt beginning `--effort` would otherwise read as that flag being
+ *  present — and the checks below exist precisely because a missing one fails
+ *  silently rather than loudly. */
+function configArgv(argv) {
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    out.push(argv[i]);
+    if (argv[i] === "-p" || argv[i] === "--print") i++;
+  }
+  return out;
+}
+
 /** Check argv for the required flags, accepting both `--flag v` and `--flag=v`.
  *  @returns {string|null} a message naming every missing flag, or null if none. */
 function validateArgv(argv) {
   const present = new Set(
-    argv.filter((arg) => arg.startsWith("--")).map((arg) => arg.split("=", 1)[0])
+    configArgv(argv)
+      .filter((arg) => arg.startsWith("--"))
+      .map((arg) => arg.split("=", 1)[0])
   );
   const missing = REQUIRED_FLAGS.filter(
     (spellings) => !spellings.some((flag) => present.has(flag))
@@ -74,11 +92,12 @@ function validateArgv(argv) {
  *
  *  @returns {{model: string}|{error: string}} */
 function resolveModel(argv) {
+  const args = configArgv(argv);
   const values = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     if (arg === "--model") {
-      const next = argv[i + 1];
+      const next = args[i + 1];
       // A model id never starts with a dash, so the next token being a flag
       // means this one was left without a value.
       values.push(next === undefined || next.startsWith("-") ? "" : next);

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/run.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/run.js
@@ -35,7 +35,8 @@ const EXIT_CONFIG_ERROR = 78;
  *  - `--allowedTools`: the proxy strips the deferred-tool declaration for
  *    non-Anthropic models, so this list is the entire tool grant.
  *  - `--model`: without it the redirect points at whatever default the client
- *    picks, which the OpenRouter account may not serve at all.
+ *    picks, which the OpenRouter account may not serve at all. It is also the
+ *    model the whole run is pinned to — see resolveModel and buildChildEnv.
  *  - `--effort`: the harness otherwise picks a reasoning level the task never
  *    asked for, at a cost nobody chose.
  */
@@ -64,16 +65,61 @@ function validateArgv(argv) {
   );
 }
 
+/** Read the single model id this run is pinned to out of argv.
+ *
+ *  Every model the run reaches bills one account, so the launcher has to know
+ *  which one was asked for before it starts anything. Two values for the same
+ *  flag is refused rather than guessed at: which one the child would honour is
+ *  the client's business, and a wrong guess pins the wrong model.
+ *
+ *  @returns {{model: string}|{error: string}} */
+function resolveModel(argv) {
+  const values = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--model") {
+      const next = argv[i + 1];
+      // A model id never starts with a dash, so the next token being a flag
+      // means this one was left without a value.
+      values.push(next === undefined || next.startsWith("-") ? "" : next);
+    } else if (arg.startsWith("--model=")) {
+      values.push(arg.slice("--model=".length));
+    }
+  }
+
+  const distinct = [...new Set(values.map((v) => v.trim()))];
+  if (distinct.length > 1) {
+    return {
+      error:
+        "--model was given more than one value (" +
+        distinct.map((v) => v || "<empty>").join(", ") +
+        "). This launcher pins the run to one model and cannot choose between them.",
+    };
+  }
+  const model = distinct[0] || "";
+  if (!model) {
+    return {
+      error:
+        "--model was given no value. This launcher pins the run to the model " +
+        "you name, so the name cannot be empty.",
+    };
+  }
+  return { model };
+}
+
 /** Build the child environment. The launcher owns every variable that decides
- *  WHERE the traffic goes, so a caller cannot half-configure the redirect and
- *  silently bill the wrong account. */
-function buildChildEnv(parentEnv, proxyUrl) {
+ *  WHERE the traffic goes and WHICH model answers, so a caller cannot
+ *  half-configure the redirect and silently bill the wrong account. */
+function buildChildEnv(parentEnv, proxyUrl, model) {
   const apiKey = parentEnv.OPENROUTER_API_KEY;
   if (!apiKey) {
     throw new Error(
       "OPENROUTER_API_KEY is not set. This launcher does not create or store " +
       "credentials — export the key, or ask where to find it."
     );
+  }
+  if (!model) {
+    throw new Error("buildChildEnv requires the model this run is pinned to.");
   }
   return {
     ...parentEnv,
@@ -87,6 +133,21 @@ function buildChildEnv(parentEnv, proxyUrl) {
     // Empty, not absent: an inherited real Anthropic key takes precedence over
     // ANTHROPIC_AUTH_TOKEN, and the call would quietly go to Anthropic.
     ANTHROPIC_API_KEY: "",
+    // Every model alias resolves to the one model this run was launched with.
+    // A nested run can start further runs, and each of those picks a model of
+    // its own from this alias vocabulary — by name, from an agent type's
+    // definition, or from a built-in default. Pointing all four at the named
+    // model means those runs still happen, still on the model the caller chose
+    // and paid for, and still speaking with this run's voice.
+    ANTHROPIC_DEFAULT_OPUS_MODEL: model,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: model,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: model,
+    ANTHROPIC_DEFAULT_FABLE_MODEL: model,
+    // The background chores — conversation titles and the like — ride the
+    // cheap alias, which now points at a model that may be neither cheap nor
+    // free. Nothing about this run needs them. Any non-empty value switches
+    // them off, "0" included; the variable reads as a switch, not a boolean.
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
   };
 }
 
@@ -106,12 +167,29 @@ async function main(argv) {
     return EXIT_CONFIG_ERROR;
   }
 
-  const { port, close } = await proxy.start({ port: 0 });
+  const resolved = resolveModel(argv);
+  if (resolved.error) {
+    process.stderr.write(`[run] ${resolved.error}\n`);
+    return EXIT_CONFIG_ERROR;
+  }
+  const model = resolved.model;
+
+  if (proxy.isDeniedModel(model)) {
+    process.stderr.write(
+      `[run] ${model} is not reachable over this transport, by design and not by ` +
+      "accident: Claude models run natively in the harness that launched this run, " +
+      "and the large GPT tiers run through their own vendor transport. Dispatch " +
+      "through the transport that serves it, or name a model from another vendor.\n"
+    );
+    return EXIT_CONFIG_ERROR;
+  }
+
+  const { port, close } = await proxy.start({ port: 0, pinnedModel: model });
   const proxyUrl = `http://127.0.0.1:${port}`;
 
   let env;
   try {
-    env = buildChildEnv(process.env, proxyUrl);
+    env = buildChildEnv(process.env, proxyUrl, model);
   } catch (err) {
     process.stderr.write(`[run] ${err.message}\n`);
     await close();
@@ -163,6 +241,7 @@ if (require.main === module) {
 module.exports = {
   main,
   validateArgv,
+  resolveModel,
   buildChildEnv,
   resolveExitCode,
   EXIT_CONFIG_ERROR,

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/run_test.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/run_test.js
@@ -96,23 +96,23 @@ test("main() rejects an incomplete invocation with EXIT_CONFIG_ERROR", async () 
 test("buildChildEnv throws mentioning OPENROUTER_API_KEY when absent", () => {
   const parentEnv = { HOME: "/home/u" };
   assert.throws(
-    () => buildChildEnv(parentEnv, "http://127.0.0.1:1"),
+    () => buildChildEnv(parentEnv, "http://127.0.0.1:1", "vendor/model"),
     /OPENROUTER_API_KEY/
   );
 });
 
 test("buildChildEnv sets ANTHROPIC_BASE_URL to the passed proxy URL", () => {
-  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:9999");
+  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:9999", "vendor/model");
   assert.equal(env.ANTHROPIC_BASE_URL, "http://127.0.0.1:9999");
 });
 
 test("buildChildEnv sets ANTHROPIC_AUTH_TOKEN to the OpenRouter key", () => {
-  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1");
+  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1", "vendor/model");
   assert.equal(env.ANTHROPIC_AUTH_TOKEN, "sk-or-1");
 });
 
 test("buildChildEnv sets ANTHROPIC_API_KEY to present-and-empty, not absent", () => {
-  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1");
+  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1", "vendor/model");
   assert.ok("ANTHROPIC_API_KEY" in env, "ANTHROPIC_API_KEY must be present");
   assert.equal(env.ANTHROPIC_API_KEY, "");
 });
@@ -122,14 +122,15 @@ test("buildChildEnv overrides an inherited real ANTHROPIC_API_KEY to empty", () 
     OPENROUTER_API_KEY: "sk-or-1",
     ANTHROPIC_API_KEY: "sk-ant-real-and-billable",
   };
-  const env = buildChildEnv(parentEnv, "http://127.0.0.1:1");
+  const env = buildChildEnv(parentEnv, "http://127.0.0.1:1", "vendor/model");
   assert.equal(env.ANTHROPIC_API_KEY, "");
 });
 
 test("buildChildEnv defaults CLAUDE_CONFIG_DIR to <HOME>/.claude_openrouter", () => {
   const env = buildChildEnv(
     { OPENROUTER_API_KEY: "sk-or-1", HOME: "/home/u" },
-    "http://127.0.0.1:1"
+    "http://127.0.0.1:1",
+    "vendor/model"
   );
   assert.equal(env.CLAUDE_CONFIG_DIR, path.join("/home/u", ".claude_openrouter"));
 });
@@ -141,7 +142,8 @@ test("buildChildEnv honors CLAUDE_CONFIG_DIR_OPENROUTER override", () => {
       HOME: "/home/u",
       CLAUDE_CONFIG_DIR_OPENROUTER: "/custom/dir",
     },
-    "http://127.0.0.1:1"
+    "http://127.0.0.1:1",
+    "vendor/model"
   );
   assert.equal(env.CLAUDE_CONFIG_DIR, "/custom/dir");
 });
@@ -149,7 +151,8 @@ test("buildChildEnv honors CLAUDE_CONFIG_DIR_OPENROUTER override", () => {
 test("buildChildEnv passes through unrelated parent env vars", () => {
   const env = buildChildEnv(
     { OPENROUTER_API_KEY: "sk-or-1", PATH: "/usr/bin:/bin" },
-    "http://127.0.0.1:1"
+    "http://127.0.0.1:1",
+    "vendor/model"
   );
   assert.equal(env.PATH, "/usr/bin:/bin");
 });
@@ -157,7 +160,7 @@ test("buildChildEnv passes through unrelated parent env vars", () => {
 test("buildChildEnv does not mutate the passed-in parentEnv object", () => {
   const parentEnv = { OPENROUTER_API_KEY: "sk-or-1", HOME: "/home/u" };
   const snapshot = { ...parentEnv };
-  buildChildEnv(parentEnv, "http://127.0.0.1:1");
+  buildChildEnv(parentEnv, "http://127.0.0.1:1", "vendor/model");
   assert.deepEqual(parentEnv, snapshot);
 });
 
@@ -272,4 +275,140 @@ test("no proxy listener survives after main()'s not-on-PATH failure path", (t) =
   // via spawnSync's bounded wait. Asserting anything further here would be
   // vacuous.
   t.skip("not observable from outside the child process; see the preceding PATH test");
+});
+
+// ─── resolveModel ──────────────────────────────────────────────────
+//
+// The run is pinned to one model, so the launcher has to know which one
+// before it starts anything. Everything here is about refusing to guess.
+
+const { resolveModel } = require("./run.js");
+
+test("resolveModel reads the model from the --flag value form", () => {
+  assert.deepEqual(resolveModel(VALID_ARGV), { model: "vendor/model" });
+});
+
+test("resolveModel reads the model from the --flag=value form", () => {
+  assert.deepEqual(resolveModel(["--model=vendor/other", "-p", "task"]), { model: "vendor/other" });
+});
+
+test("resolveModel refuses --model with no value rather than pinning the next flag", () => {
+  const result = resolveModel(["--model", "--effort", "low"]);
+  assert.match(result.error, /--model was given no value/);
+});
+
+test("resolveModel refuses an empty --model=", () => {
+  assert.match(resolveModel(["--model=", "-p", "task"]).error, /--model was given no value/);
+});
+
+test("resolveModel refuses a whitespace-only model name", () => {
+  assert.match(resolveModel(["--model", "   ", "-p", "task"]).error, /--model was given no value/);
+});
+
+test("resolveModel accepts the same model named twice", () => {
+  assert.deepEqual(
+    resolveModel(["--model", "vendor/model", "--model", "vendor/model"]),
+    { model: "vendor/model" },
+  );
+});
+
+// A prompt is task text from somewhere else, and argv is flat, so a prompt
+// that happens to start with `--model` is indistinguishable from a second
+// flag. Refusing is the safe read of that: pinning the wrong model is how the
+// spend leaks in the first place.
+test("resolveModel refuses two different models instead of choosing one", () => {
+  const result = resolveModel(["--model", "vendor/model", "-p", "--model", "anthropic/claude-opus-5"]);
+  assert.match(result.error, /more than one value/);
+  assert.match(result.error, /vendor\/model/);
+});
+
+// ─── buildChildEnv: the model pin ──────────────────────────────────
+
+test("buildChildEnv points every model alias at the model the run was launched with", () => {
+  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1", "moonshotai/kimi-k3");
+  assert.equal(env.ANTHROPIC_DEFAULT_OPUS_MODEL, "moonshotai/kimi-k3");
+  assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, "moonshotai/kimi-k3");
+  assert.equal(env.ANTHROPIC_DEFAULT_HAIKU_MODEL, "moonshotai/kimi-k3");
+  assert.equal(env.ANTHROPIC_DEFAULT_FABLE_MODEL, "moonshotai/kimi-k3");
+});
+
+test("buildChildEnv overrides alias redirects inherited from the parent", () => {
+  const env = buildChildEnv(
+    {
+      OPENROUTER_API_KEY: "sk-or-1",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-5",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-5",
+    },
+    "http://127.0.0.1:1",
+    "moonshotai/kimi-k3",
+  );
+  assert.equal(env.ANTHROPIC_DEFAULT_SONNET_MODEL, "moonshotai/kimi-k3");
+  assert.equal(env.ANTHROPIC_DEFAULT_OPUS_MODEL, "moonshotai/kimi-k3");
+});
+
+test("buildChildEnv switches off the background traffic the cheap alias would bill", () => {
+  const env = buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1", "vendor/model");
+  assert.equal(env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, "1");
+});
+
+test("buildChildEnv refuses to build an environment with no model to pin", () => {
+  assert.throws(
+    () => buildChildEnv({ OPENROUTER_API_KEY: "sk-or-1" }, "http://127.0.0.1:1", ""),
+    /model this run is pinned to/,
+  );
+});
+
+// ─── main(): refusals that cost nothing ────────────────────────────
+//
+// A bad invocation must not bind a listener. `proxy.start` is stubbed to
+// throw rather than to record, so a regression that reaches it fails the test
+// loudly instead of leaking a live socket into the rest of the suite.
+
+/** Run `main(argv)` with the proxy rigged to explode if it is ever started. */
+async function mainWithoutProxy(argv) {
+  const realStart = proxy.start;
+  proxy.start = async () => {
+    throw new Error("proxy.start was reached: this invocation should have been refused first");
+  };
+  try {
+    return await main(argv);
+  } finally {
+    proxy.start = realStart;
+  }
+}
+
+test("main() refuses an empty --model before the proxy binds anything", async () => {
+  const code = await mainWithoutProxy([
+    "--model=", "--effort", "low", "--permission-mode", "dontAsk",
+    "--allowedTools", "Read", "-p", "task",
+  ]);
+  assert.equal(code, EXIT_CONFIG_ERROR);
+});
+
+test("main() refuses a denied model before the proxy binds anything", async () => {
+  const code = await mainWithoutProxy([
+    "--model", "anthropic/claude-opus-5", "--effort", "low", "--permission-mode", "dontAsk",
+    "--allowedTools", "Read", "-p", "task",
+  ]);
+  assert.equal(code, EXIT_CONFIG_ERROR);
+});
+
+test("main() refuses a denied model named without its vendor prefix too", async () => {
+  const code = await mainWithoutProxy([
+    "--model", "gpt-5.6-sol", "--effort", "low", "--permission-mode", "dontAsk",
+    "--allowedTools", "Read", "-p", "task",
+  ]);
+  assert.equal(code, EXIT_CONFIG_ERROR);
+});
+
+test("main() still accepts the -mini tiers the denylist exempts", async () => {
+  // Reaching proxy.start is the pass condition here — the stub throwing is
+  // proof the model cleared both refusals, and it costs no listener.
+  await assert.rejects(
+    mainWithoutProxy([
+      "--model", "openai/gpt-5.6-mini", "--effort", "low", "--permission-mode", "dontAsk",
+      "--allowedTools", "Read", "-p", "task",
+    ]),
+    /proxy\.start was reached/,
+  );
 });

--- a/src/user/.claude/skills/openrouter-claude-subagent/scripts/run_test.js
+++ b/src/user/.claude/skills/openrouter-claude-subagent/scripts/run_test.js
@@ -312,12 +312,11 @@ test("resolveModel accepts the same model named twice", () => {
   );
 });
 
-// A prompt is task text from somewhere else, and argv is flat, so a prompt
-// that happens to start with `--model` is indistinguishable from a second
-// flag. Refusing is the safe read of that: pinning the wrong model is how the
-// spend leaks in the first place.
+// Which of two `--model` flags the nested client would honour is its business,
+// not this launcher's, and a wrong guess pins the wrong model — which is how
+// the spend leaks in the first place.
 test("resolveModel refuses two different models instead of choosing one", () => {
-  const result = resolveModel(["--model", "vendor/model", "-p", "--model", "anthropic/claude-opus-5"]);
+  const result = resolveModel(["--model", "vendor/model", "--model=anthropic/claude-opus-5"]);
   assert.match(result.error, /more than one value/);
   assert.match(result.error, /vendor\/model/);
 });
@@ -411,4 +410,42 @@ test("main() still accepts the -mini tiers the denylist exempts", async () => {
     ]),
     /proxy\.start was reached/,
   );
+});
+
+// ─── The prompt is not a source of flags ───────────────────────────
+//
+// Prompt text routinely comes from the material being worked on, so a prompt
+// that opens with a flag name must not be able to answer for that flag. The
+// required-flag check is the launcher's guard against arguments that fail
+// silently; satisfying it with borrowed text would disarm it.
+
+test("a prompt that is exactly a flag name does not answer for that flag", () => {
+  const message = validateArgv([
+    "--model", "vendor/model",
+    "--permission-mode", "dontAsk",
+    "--allowedTools", "Read",
+    "-p", "--effort",
+  ]);
+  assert.match(message, /missing required flag\(s\): --effort\./);
+});
+
+test("nor does a prompt in the --flag=value shape, under either prompt spelling", () => {
+  const message = validateArgv([
+    "--model", "vendor/model",
+    "--permission-mode", "dontAsk",
+    "--allowedTools", "Read",
+    "--print", "--effort=high",
+  ]);
+  assert.match(message, /missing required flag\(s\): --effort\./);
+});
+
+test("a prompt cannot smuggle in a model of its own", () => {
+  assert.deepEqual(
+    resolveModel(["--model", "vendor/model", "-p", "--model=evil/model"]),
+    { model: "vendor/model" },
+  );
+});
+
+test("a legitimate prompt that merely mentions a flag still validates", () => {
+  assert.equal(validateArgv([...VALID_ARGV.slice(0, -1), "explain the --effort flag"]), null);
 });


### PR DESCRIPTION
## What was broken

A nested `claude` run launched over the OpenRouter transport could start further runs on any model it liked. Every one billed the same OpenRouter account and answered in the launching run's name. On 2026-08-02 that cost more than every named model on the run combined, and silently replaced the point of view the run existed to provide.

Tool grants cannot contain it: the spawn path is reachable regardless of `--allowedTools`. The proxy is the only chokepoint the traffic must pass through.

## What changed

Three layers, each independently sufficient for the case it covers:

- **Redirect (primary).** The launcher points all four `ANTHROPIC_DEFAULT_*_MODEL` aliases at `--model`, so a nested dispatch that names an alias — outright, from an agent type's front matter, or from a built-in default — still lands on the model the caller chose. Delegation keeps working; it just cannot leave the model that was paid for. `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` switches off the background chores that ride the cheap alias, since that alias now costs money.
- **Pin (backstop).** The proxy refuses any completion naming a different model with an Anthropic-shaped 403 and dials nothing upstream. The body says what to do instead, because an API error is the only channel back to the caller.
- **Denylist (independent tripwire).** Claude models and the large GPT tiers (`-mini` excepted) are refused outright, pin or no pin. The launcher exits 78 before binding a listener; the proxy refuses them even when they equal the pin.

Plus a per-request stderr ledger: method, path, model, decision. The next billing question reads a log instead of transcripts.

Adjudicating before dialing meant deferring the upstream request until the body is buffered. The response handling moved into a named function with its body unchanged.

## Verification

- `make ci` — exit 0, run standalone from this worktree.
- `content-tests` — 8 suites pass; proxy_test.js 65 pass / 1 pre-existing skip, run_test.js 42 pass / 1 pre-existing skip. 35 tests added.
- **Live end-to-end** against the real launcher and OpenRouter, pinned to `google/gemini-3.1-flash-lite`, verified against nested transcript ground truth:
  - a spawn explicitly asking for `sonnet` ran on `google/gemini-3.1-flash-lite`;
  - a model-omitted spawn ran on it too;
  - an agent type pinning the alias `opus` ran on it too;
  - an agent type pinning a raw non-alias model id was refused, and the advisory reached the parent's context verbatim — the parent quoted it back in full.

## Resolved reading

The `-mini` exemption applies to the GPT prefixes only; `claude*` is denied unconditionally. That is the more restrictive reading, and it matches the decision that Claude models run natively rather than over this transport.

## Accepted consequence

The denylist removes OpenRouter as a substitution target for Claude and large-GPT lenses. If their own transport is down, those runs hard-stop rather than rerouting.

Closes agents-config-9k9.126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgmAQCWNvJ9A6yeRHiHngy