### PR TITLE
docs(9k9.126): make the openrouter skill's prose say what the code does

### DIFF
--- a/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/SKILL.md
@@ -42,10 +42,11 @@ is a hard requirement; if it is missing, stop and say so rather than falling
 back to a direct invocation.
 
 **The run is pinned to `--model`.** The subagent may delegate further, and
-every run it starts answers on that same model — the aliases are redirected,
-so a nested dispatch that names `sonnet`, or an agent type that carries its own
-model, still lands there. A request for anything else is refused with an error
-explaining the alternative. Two families are refused outright, pin or no pin:
+every run it starts answers on that same model — the aliases are redirected, so
+a dispatch that names `sonnet`, or an agent type whose own model is one of those
+aliases, still lands there. Anything outside that vocabulary is refused with an
+error explaining the alternative, including an agent type pinned to a specific
+vendor model id and a request that names no model at all. Two families are refused outright, pin or no pin:
 Claude models, which belong in the harness you are already running, and the
 large GPT tiers (`gpt-5.5*`, `gpt-5.6*`, `-mini` variants excepted), which have
 their own transport. Naming one exits `78` before anything starts, and there is

--- a/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
+++ b/src/user/.claude/skills/openrouter-claude-subagent/references/proxy-contract.md
@@ -66,12 +66,11 @@ switch, not a boolean, so there is no way to spell "off" except by unsetting it.
 
 Every completion request leaves one line on stderr naming the method, path,
 model, and decision (`forward`, `deny-pin`, or `deny-denylist`). When a bill
-looks wrong later, that ledger is the record to read — the alternative is
-digging through transcripts, which is how the leak this pin exists to close
-went unnoticed for a day.
+looks wrong later, that ledger is the record to read.
 
-Counting tokens is not a completion: it neither generates nor speaks, so it is
-forwarded ungated and unledgered.
+The gate applies to requests that generate a reply. A request that only
+measures a payload — counting its tokens — is forwarded without being checked
+or logged, since nothing is produced and nothing is billed.
 
 ## Why in-process, on a kernel-assigned port
 


### PR DESCRIPTION
Prose-only follow-up to #441, covering three inaccuracies in that skill's documentation. Two came from a review left pending on #441 and never published, so they were not visible to anyone but their author.

**`SKILL.md` — the redirect's reach was overstated.** It said an agent type "that carries its own model" still lands on the pinned model. True only when the model it carries is one of the standard aliases, which is what the redirect rewrites. An agent type pinned to a specific vendor model id is outside that vocabulary and gets refused; I watched one take a 403 during live validation of #441, so the paragraph promised something the code does not do. Now names the boundary, and mentions the model-less request refused on the same rule.

**`references/proxy-contract.md` — the ledger paragraph rehearsed an incident.** It closed by recounting how a past billing leak went unnoticed. This file ships to other projects, where that story is neither accessible nor actionable, and the instruction it decorated — read the ledger when a bill looks wrong — stands without it. Git keeps the history.

**`references/proxy-contract.md` — the token-counting note was unreadable.** It answered a question the document never raised, used "speaks" for a meaning only its author held, and described the request as "unledgered" two paragraphs after the ledger was introduced. It now states what a reader needs: the gate covers requests that generate a reply, and measuring a payload is not one.

No behaviour changes. `content-lint` and `content-tests` both exit 0, run standalone. The skill's always-on budget moves 1587 → 1616 tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgmAQCWNvJ9A6yeRHiHngy