### PR TITLE
fix(9k9.127): relock vizsuite's gitpython off the advisory-flagged 3.1.55

### DIFF
--- a/packages/vizsuite/uv.lock
+++ b/packages/vizsuite/uv.lock
@@ -307,14 +307,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.55"
+version = "3.1.57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
+    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What broke

`make ci` exits 2 at `audit-vizsuite` on `main` (a70e1afb) — no branch caused it. `pip-audit` queries advisory data live, so the same commit went green-to-red when two GitPython advisories published:

| advisory | severity | what | fixed in |
|---|---|---|---|
| GHSA-3f7w-8rr8-f37f | high | unguarded git-option forwarding in `IndexFile.checkout()` / `TagReference.create()` → arbitrary file overwrite/read | 3.1.57 |
| GHSA-p538-c434-8v24 | medium | unguarded `Commit.count()` forwards `--output=<path>`, which truncates the target to 0 bytes | 3.1.56 |

Only vizsuite is affected — `audit-installer`, `audit-prgroom`, `audit-workcli`, `audit-grind`, `audit-gitclean` and `audit-executor` each exit 0 on their own.

## What pulled the vulnerable version in

`gitpython` is not a direct dependency and is not named anywhere in `pyproject.toml`. `vizsuite` → `pydriller >=2.5` (resolved 2.10) → `gitpython`, **with no version specifier** — `importlib.metadata.requires('pydriller')` returns a bare `'gitpython'`. So 3.1.55 was the lock file's choice, not a constraint pydriller imposed, and moving it is a relock rather than a version fight.

## The change

`uv lock --upgrade-package gitpython` in `packages/vizsuite`: 3.1.55 → 3.1.57. Three lines, `gitpython` only, no other package moved. No source change, no behaviour change, and vizsuite stays off PATH as it is today.

## Why 3.1.57 is safe for pydriller — verified, not assumed

Both fixes add `check_unsafe_options` guards, so the real risk is a caller that was relying on the now-rejected pass-through. pydriller is not such a caller:

- The `.count()` in pydriller's tree is `HistoryComplexity.count()` — its own metric class, not `Commit.count()`.
- Its checkout calls are `repo.git.checkout('-f', ...)` — the raw command wrapper, not the guarded `IndexFile.checkout()`.
- Its `iter_commits` site was already guarded by an earlier advisory fix that landed before 3.1.55, so it is unchanged here.

3.1.57 also carries a non-security change worth naming: *"Use standard prefixes for parsed patch diffs."* Patch parsing is on the churn adapter's path (`SubprocessGitRunner.churn_for_commits` reads `modified.new_path` / `old_path` / `added_lines` / `deleted_lines`). That path is covered by integration tests that build real git repositories and assert real line counts through real pydriller — not mocks — including the unreachable-from-HEAD case. Those tests pass.

## Evidence

- `make audit-vizsuite` → exit 0, "No known vulnerabilities found"
- `make ci` from the worktree root → exit 0 (run standalone, exit status read directly, not through a pipeline)
- vizsuite suite: 435 passed, **100%** coverage against its 90% floor

## Not done

No advisory was suppressed, ignored, or version-pinned around. If a future advisory has no fixed release, that is an escalation, not a workaround.

Tracked as `agents-config-9k9.127` (child of the harness-rework milestone) with an admission record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kBzoWLKKctWqU56u4SqwB