### PR TITLE
fix(9k9.122): the review panel fails over, and stops when it runs out of transports

### DIFF
--- a/src/user/.agents/skills/review-verdict/SKILL.md
+++ b/src/user/.agents/skills/review-verdict/SKILL.md
@@ -24,10 +24,11 @@ All fields are required.
 | `head_sha` | 40-hex | Reviewed head commit. The verdict is valid only for this commit. |
 | `claim_id` | non-blank string | The completion claim this round adjudicates. |
 | `retained_categories` | array of strings | Categories carried forward from earlier rounds. May be empty, but must be present — an empty array asserts "nothing retained". |
-| `lenses` | array, ≥ 1 | One entry per lens the artifact class declares, green ones included, each recording what actually ran it. |
+| `lenses` | array | One entry per lens the artifact class declares, green ones included, each recording what actually ran it. At least one, unless the round halted first. |
 | `prior_dispositions` | array | What happened to each earlier mechanical finding. May be empty on round 1. |
-| `verdict` | `"clean"` or `"findings"` | Round-level result. |
-| `findings` | array | Findings raised this round. Must be empty when `verdict` is `"clean"` and non-empty when it is `"findings"`. |
+| `verdict` | `"clean"`, `"findings"`, or `"halted"` | Round-level result. |
+| `findings` | array | Findings raised this round. Must be empty when `verdict` is `"clean"` and non-empty when it is `"findings"`. Unconstrained on a halted round. |
+| `halt` | object | Present exactly when `verdict` is `"halted"`. |
 
 ### Lens entry
 
@@ -35,7 +36,8 @@ All fields are required.
 {"lens": "correctness", "verdict": "findings", "vendor": "openai",
  "transport": "openrouter", "model": "openai/gpt-5.6-sol",
  "substitution": {"declared_transport": "codex", "declared_model": "gpt-5.6-terra",
-                  "reason": "codex credential expired; provider returned 401"}}
+                  "reason": "codex credential expired, lens failed over to openrouter",
+                  "transport_error": "401 Missing bearer authentication"}}
 ```
 
 `vendor`, `transport` and `model` record what **actually** produced the report, never what the
@@ -47,6 +49,10 @@ coverage.
 `substitution` appears only when the lens ran on something other than its declared entry, and its
 `reason` is mandatory and non-blank. Recording it is the round's own job: nothing downstream can
 reconstruct a swap the round did not write down.
+
+`transport_error` carries what the declared route returned when the swap was forced rather than
+chosen — verbatim, because a policy that stops a run on one particular provider error has only this
+string to recognise it by.
 
 **Vendor diversity is derived, never stored.** Count the distinct `vendor` values across `lenses`;
 one means the panel collapsed onto a single vendor and its blind spots now correlate. That is an
@@ -80,6 +86,20 @@ the demotion is silent.
 `disposition` is `fixed`, `rebutted`, or `advisory-deferred`. `evidence` is required and non-blank
 for `rebutted` — a rebuttal without evidence is just a disagreement.
 
+### Halt
+
+```json
+{"failures": [{"lens": "security", "transport": "openrouter", "error": "402 Insufficient credits"},
+              {"lens": "security", "transport": "codex", "error": "401 Missing bearer auth"}],
+ "abandoned_lenses": ["test-adequacy", "documentation-quality"]}
+```
+
+A halted round ran out of transports: a dispatch died on its route and the failover to the other
+route died too. It is never clean and never complete, and `verdict` says so outright rather than
+leaving it inferred from a missing lens entry — a silent check guarding the merge gate is one
+nobody notices passing. Its findings are real and still not a verdict on the change: most of it was
+never opened.
+
 ## Where a verdict is posted
 
 Outside the reviewed branch, never as a file in the diff:
@@ -96,7 +116,8 @@ Both media are posted by the App and keyed to a SHA. Two rules follow:
 
 ## When a round is complete
 
-Hand-verify all five against the pull request:
+A `halted` verdict is incomplete by construction. For every other verdict, hand-verify all five
+against the pull request:
 
 1. **Base sync** — the declared `base_sha` equals the diff's actual base (the merge base of the
    branch and its target). A mismatch means the reviewer looked at an unsynced checkout, and the
@@ -111,8 +132,9 @@ Hand-verify all five against the pull request:
 5. **Ledger coverage** — `prior_dispositions` accounts for every `mechanical` finding from every
    prior round's posted verdict.
 
-**Terminal-clean** = a complete round with zero `mechanical` findings. Advisory findings never
-block; they go to the backlog.
+**Terminal-clean** = a complete round whose `verdict` is `clean`, carrying zero `mechanical`
+findings. Advisory findings never block; they go to the backlog. A halted round is never
+terminal-clean, however few findings it holds.
 
 Completeness and diversity are separate questions. A round every lens reported on is complete even
 if all of them ran on one vendor — report the collapse alongside the verdict rather than treating

--- a/src/user/.agents/skills/review-verdict/validate_verdict_test.py
+++ b/src/user/.agents/skills/review-verdict/validate_verdict_test.py
@@ -77,6 +77,34 @@ def mechanical_finding() -> dict[str, Any]:
     }
 
 
+def halt_failure(**overrides: Any) -> dict[str, Any]:
+    entry = {
+        "lens": "correctness",
+        "transport": "openrouter",
+        "error": "402 Insufficient credits",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def halt_object(**overrides: Any) -> dict[str, Any]:
+    entry = {
+        "failures": [halt_failure()],
+        "abandoned_lenses": [],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def halted_verdict() -> dict[str, Any]:
+    doc = valid_verdict()
+    doc["verdict"] = "halted"
+    doc["lenses"] = []
+    doc["findings"] = []
+    doc["halt"] = halt_object()
+    return doc
+
+
 def is_valid(document: Any) -> bool:
     return validator.validate_document(document)["valid"] is True
 
@@ -224,6 +252,109 @@ class TestInternalConsistency:
         assert all(f["type"] == "advisory" for f in doc["findings"])
 
 
+class TestHaltedVerdict:
+    """A round that loses every transport for a lens stops rather than reading as clean."""
+
+    def test_halted_with_empty_lenses_validates(self):
+        """A well-formed halt validates even when the round died on its first dispatch."""
+        assert is_valid(halted_verdict())
+
+    def test_halted_with_reported_lenses_validates(self):
+        """A halt after some lenses already reported is equally valid."""
+        doc = halted_verdict()
+        doc["lenses"] = [lens_entry()]
+        assert is_valid(doc)
+
+    def test_halted_without_halt_object_is_invalid(self):
+        """verdict "halted" without the halt object it requires is invalid."""
+        doc = halted_verdict()
+        del doc["halt"]
+        assert not is_valid(doc)
+
+    def test_halt_on_clean_verdict_is_invalid(self):
+        """halt is rejected outside a halted verdict — here, clean."""
+        doc = valid_verdict()
+        doc["halt"] = halt_object()
+        assert not is_valid(doc)
+
+    def test_halt_on_findings_verdict_is_invalid(self):
+        """halt is rejected outside a halted verdict — here, findings."""
+        doc = valid_verdict()
+        doc["verdict"] = "findings"
+        doc["findings"] = [mechanical_finding()]
+        doc["halt"] = halt_object()
+        assert not is_valid(doc)
+
+    def test_findings_verdict_with_empty_lenses_is_invalid(self):
+        """The halted relaxation on lens coverage must not leak into "findings"."""
+        doc = valid_verdict()
+        doc["verdict"] = "findings"
+        doc["findings"] = [mechanical_finding()]
+        doc["lenses"] = []
+        assert not is_valid(doc)
+
+    def test_halt_failures_empty_is_invalid(self):
+        """A halt with no recorded failure is not a halt."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[])
+        assert not is_valid(doc)
+
+    @pytest.mark.parametrize("field", ["lens", "transport", "error"])
+    def test_halt_failure_missing_field_is_invalid(self, field):
+        """Every failure entry names what failed, on what transport, and why."""
+        failure = halt_failure()
+        del failure[field]
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[failure])
+        assert not is_valid(doc)
+
+    @pytest.mark.parametrize("field", ["lens", "transport", "error"])
+    @pytest.mark.parametrize("blank", ["", "   \t\n"])
+    def test_halt_failure_blank_field_is_invalid(self, field, blank):
+        """Whitespace is not a declaration on a failure entry either."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[halt_failure(**{field: blank})])
+        assert not is_valid(doc)
+
+    def test_halt_carries_unknown_key_is_rejected(self):
+        """halt is closed to unknown fields, same as every other envelope object."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(note="extra")
+        assert not is_valid(doc)
+
+    def test_halt_failure_carries_unknown_key_is_rejected(self):
+        """A failure entry is closed to unknown fields too."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[halt_failure(note="extra")])
+        assert not is_valid(doc)
+
+    def test_halted_verdict_may_carry_findings_lenses_reported_before_it_stopped(self):
+        """A halted round keeps whatever findings its lenses reported before the stop."""
+        doc = halted_verdict()
+        doc["findings"] = [mechanical_finding()]
+        assert is_valid(doc)
+
+    def test_halted_verdict_may_carry_no_findings(self):
+        """Equally, a halted round with nothing gathered yet is valid."""
+        doc = halted_verdict()
+        doc["findings"] = []
+        assert is_valid(doc)
+
+    def test_duplicate_lens_rejected_on_halted_verdict(self):
+        """The duplicate-lens check runs regardless of which verdict value it's checking."""
+        doc = halted_verdict()
+        doc["lenses"] = [lens_entry("correctness"), lens_entry("correctness", transport="codex")]
+        assert not is_valid(doc)
+        assert "duplicate-lens" in codes(doc)
+
+    def test_duplicate_finding_id_rejected_on_halted_verdict(self):
+        """Likewise duplicate-finding-id — the check is not verdict-specific."""
+        doc = halted_verdict()
+        doc["findings"] = [mechanical_finding(), mechanical_finding()]
+        assert not is_valid(doc)
+        assert "duplicate-finding-id" in codes(doc)
+
+
 class TestNoPlanningJargon:
     """S6-A5: the shipped artifacts read standalone."""
 
@@ -345,6 +476,31 @@ class TestWhatActuallyRanTheLens:
         doc = valid_verdict()
         doc["lenses"] = [lens_entry(substitution={"reason": "  "})]
         assert not is_valid(doc)
+
+    def test_substitution_transport_error_validates(self):
+        """The verbatim error the declared route returned is recorded on the substitution."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(substitution={
+            "declared_transport": "codex",
+            "reason": "codex credential expired; 401 from the provider",
+            "transport_error": "401 Missing bearer authentication",
+        })]
+        assert is_valid(doc)
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_substitution_transport_error_is_rejected(self, value):
+        """Whitespace is not a verbatim error either."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(
+            substitution={"reason": "codex credential expired", "transport_error": value}
+        )]
+        assert not is_valid(doc)
+
+    def test_substitution_without_transport_error_still_validates(self):
+        """transport_error is optional — a swap forced by nothing in particular has none to record."""
+        doc = valid_verdict()
+        doc["lenses"] = [lens_entry(substitution={"reason": "operator chose a faster route"})]
+        assert is_valid(doc)
 
     def test_one_vendor_across_the_panel_still_validates(self):
         """Collapse is an observation the reader derives, never a schema error that stalls a round."""

--- a/src/user/.agents/skills/review-verdict/validate_verdict_test.py
+++ b/src/user/.agents/skills/review-verdict/validate_verdict_test.py
@@ -87,9 +87,14 @@ def halt_failure(**overrides: Any) -> dict[str, Any]:
     return entry
 
 
+def halt_failures() -> list[dict[str, Any]]:
+    """The floor for a halt: one lens's declared route died, then its failover died too."""
+    return [halt_failure(), halt_failure(transport="codex", error="503 Service Unavailable")]
+
+
 def halt_object(**overrides: Any) -> dict[str, Any]:
     entry = {
-        "failures": [halt_failure()],
+        "failures": halt_failures(),
         "abandoned_lenses": [],
     }
     entry.update(overrides)
@@ -299,22 +304,53 @@ class TestHaltedVerdict:
         doc["halt"] = halt_object(failures=[])
         assert not is_valid(doc)
 
+    def test_halt_failures_single_well_formed_entry_is_invalid(self):
+        """A halt can never be caused by one dead transport — the declared route and the
+        failover it fell over to both have to die. A lone, otherwise-valid entry is still not a
+        halt."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[halt_failure()])
+        assert not is_valid(doc)
+
+    def test_halt_failures_two_entries_validates(self):
+        """The floor: declared route died, failover died too. Exactly two entries validates."""
+        doc = halted_verdict()
+        assert len(doc["halt"]["failures"]) == 2
+        assert is_valid(doc)
+
+    def test_halt_failures_more_than_two_entries_validates(self):
+        """Parallel dispatches can exhaust their routes together, producing more than two."""
+        doc = halted_verdict()
+        doc["halt"] = halt_object(failures=[
+            halt_failure(lens="correctness", transport="openrouter"),
+            halt_failure(lens="correctness", transport="codex"),
+            halt_failure(lens="security", transport="openrouter"),
+        ])
+        assert is_valid(doc)
+
     @pytest.mark.parametrize("field", ["lens", "transport", "error"])
     def test_halt_failure_missing_field_is_invalid(self, field):
-        """Every failure entry names what failed, on what transport, and why."""
-        failure = halt_failure()
-        del failure[field]
+        """Every failure entry names what failed, on what transport, and why — checked against
+        an otherwise well-formed two-entry array so the two-failure floor isn't what fails it."""
+        bad = halt_failure()
+        del bad[field]
         doc = halted_verdict()
-        doc["halt"] = halt_object(failures=[failure])
+        doc["halt"] = halt_object(failures=[bad, halt_failure(transport="codex")])
         assert not is_valid(doc)
+        doc["halt"] = halt_object(failures=[halt_failure(), halt_failure(transport="codex")])
+        assert is_valid(doc)
 
     @pytest.mark.parametrize("field", ["lens", "transport", "error"])
     @pytest.mark.parametrize("blank", ["", "   \t\n"])
     def test_halt_failure_blank_field_is_invalid(self, field, blank):
-        """Whitespace is not a declaration on a failure entry either."""
+        """Whitespace is not a declaration on a failure entry either — same isolation as above."""
         doc = halted_verdict()
-        doc["halt"] = halt_object(failures=[halt_failure(**{field: blank})])
+        doc["halt"] = halt_object(
+            failures=[halt_failure(**{field: blank}), halt_failure(transport="codex")]
+        )
         assert not is_valid(doc)
+        doc["halt"] = halt_object(failures=[halt_failure(), halt_failure(transport="codex")])
+        assert is_valid(doc)
 
     def test_halt_carries_unknown_key_is_rejected(self):
         """halt is closed to unknown fields, same as every other envelope object."""
@@ -323,10 +359,15 @@ class TestHaltedVerdict:
         assert not is_valid(doc)
 
     def test_halt_failure_carries_unknown_key_is_rejected(self):
-        """A failure entry is closed to unknown fields too."""
+        """A failure entry is closed to unknown fields too — checked against an otherwise
+        well-formed two-entry array."""
         doc = halted_verdict()
-        doc["halt"] = halt_object(failures=[halt_failure(note="extra")])
+        doc["halt"] = halt_object(
+            failures=[halt_failure(note="extra"), halt_failure(transport="codex")]
+        )
         assert not is_valid(doc)
+        doc["halt"] = halt_object(failures=[halt_failure(), halt_failure(transport="codex")])
+        assert is_valid(doc)
 
     def test_halted_verdict_may_carry_findings_lenses_reported_before_it_stopped(self):
         """A halted round keeps whatever findings its lenses reported before the stop."""

--- a/src/user/.agents/skills/review-verdict/verdict.schema.json
+++ b/src/user/.agents/skills/review-verdict/verdict.schema.json
@@ -128,7 +128,7 @@
       "properties": {
         "failures": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 2,
           "items": {
             "type": "object",
             "additionalProperties": false,
@@ -139,7 +139,7 @@
               "error": {"type": "string", "pattern": "\\S"}
             }
           },
-          "description": "Every transport that failed, in the order the round hit them, each with the verbatim error it returned. A policy that halts on a particular provider error reads this."
+          "description": "Every transport failure the round hit and did not recover from, in order, each with the verbatim error it returned. At least two, because the halting condition is a lens whose declared route died and whose failover died as well; more when parallel dispatches exhausted their routes together. A failure a successful failover recovered from belongs on that lens's substitution, not here. A policy that halts on a particular provider error reads this."
         },
         "abandoned_lenses": {
           "type": "array",

--- a/src/user/.agents/skills/review-verdict/verdict.schema.json
+++ b/src/user/.agents/skills/review-verdict/verdict.schema.json
@@ -53,7 +53,7 @@
     },
     "lenses": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -83,7 +83,12 @@
             "properties": {
               "declared_transport": {"type": "string", "pattern": "\\S"},
               "declared_model": {"type": "string", "pattern": "\\S"},
-              "reason": {"type": "string", "pattern": "\\S"}
+              "reason": {"type": "string", "pattern": "\\S"},
+              "transport_error": {
+                "type": "string",
+                "pattern": "\\S",
+                "description": "The verbatim error the declared route returned, when the swap was forced by that route failing rather than chosen. Verbatim because a paraphrase cannot be matched against."
+              }
             },
             "description": "Present only when this lens ran on something other than what its registry entry declared; names what was declared and why the substitute was used."
           }
@@ -115,7 +120,35 @@
       },
       "description": "One entry per mechanical finding from every prior round's posted verdict."
     },
-    "verdict": {"enum": ["clean", "findings"]},
+    "verdict": {"enum": ["clean", "findings", "halted"]},
+    "halt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["failures", "abandoned_lenses"],
+      "properties": {
+        "failures": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["lens", "transport", "error"],
+            "properties": {
+              "lens": {"type": "string", "pattern": "\\S"},
+              "transport": {"type": "string", "pattern": "\\S"},
+              "error": {"type": "string", "pattern": "\\S"}
+            }
+          },
+          "description": "Every transport that failed, in the order the round hit them, each with the verbatim error it returned. A policy that halts on a particular provider error reads this."
+        },
+        "abandoned_lenses": {
+          "type": "array",
+          "items": {"type": "string", "pattern": "\\S"},
+          "description": "Lenses the class declares that were never dispatched because the round stopped. Empty only when the round stopped on its last lens."
+        }
+      },
+      "description": "Present exactly when the verdict is halted: why the round stopped and what it never looked at."
+    },
     "findings": {
       "type": "array",
       "items": {
@@ -158,6 +191,15 @@
     {
       "if": {"properties": {"verdict": {"const": "clean"}}, "required": ["verdict"]},
       "then": {"properties": {"findings": {"maxItems": 0}}}
+    },
+    {
+      "if": {"properties": {"verdict": {"const": "halted"}}, "required": ["verdict"]},
+      "then": {"required": ["halt"]},
+      "else": {"not": {"required": ["halt"]}}
+    },
+    {
+      "if": {"properties": {"verdict": {"enum": ["clean", "findings"]}}, "required": ["verdict"]},
+      "then": {"properties": {"lenses": {"minItems": 1}}}
     }
   ]
 }

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -31,8 +31,8 @@ lens, and the named skill supplies the depth.
 
 Each panel mixes model tiers — hard-reasoning lenses on frontier models, mechanical walks on
 mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
-`transport` is that diversity claim, not a routing guarantee: when it is down the lens runs on
-whatever is up, and the verdict records what actually ran it (`harvest.md`).
+`transport` is that diversity claim, not a routing guarantee: when it is down the lens fails over to
+the other transport, and the verdict records what actually ran it (`harvest.md`).
 
 Most lenses re-read the whole artifact every round. A lens marked `diff` reviews only the change
 since the head it last judged, and only when it returned green that round; anything judging
@@ -105,11 +105,15 @@ gets one entry per lens the class declares, green ones included, so coverage is 
 artifact and never inferred from an empty findings list. Each entry records the vendor, transport
 and model that *actually* produced the report, never the route `contracts.json` declared for it.
 `findings` is the union across lenses; `prior_dispositions` is the ledger from `round.json`.
-Terminal-clean means a complete round with zero mechanical findings across every lens.
+Terminal-clean means a complete round that came out `clean`, with zero mechanical findings across
+every lens; a halted round is neither.
 
-A lens whose reviewer errored, timed out, or returned output no tolerant read can parse may be
-re-dispatched inside the same round, on a substitute route when its own is down; its single entry
-then carries the substitution and the reason. Still without a report, it has no entry and the
-round is incomplete — fail closed. `harvest.md` holds the rest: how tolerantly to read a report,
-what to do with a mechanical finding carrying no evidence, and the vendor-collapse count to make
-before the verdict is written.
+A dispatch that returns no report is two different problems. A dead route — provider, auth, credit,
+connection — fails the lens over to the transport it was not declared on, and its single entry
+carries the substitution with that route's verbatim error; a failover that dies too halts the run,
+abandoning every remaining dispatch for a `halted` verdict naming both dead routes and everything
+they cost the round. A live route returning unusable output may instead be re-dispatched, and
+without a report the lens has no entry and the round is incomplete — fail closed. Every failover is
+reported to the operator, not merely recorded in the verdict. `harvest.md` holds the rest: how to
+tell those two failures apart, how tolerantly to read a report, what to do with a mechanical
+finding carrying no evidence, and the vendor-collapse count to make before the verdict is written.

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -111,8 +111,8 @@ every lens; a halted round is neither.
 A dispatch that returns no report is two different problems. A dead route — provider, auth, credit,
 connection — fails the lens over to the transport it was not declared on, and its single entry
 carries the substitution with that route's verbatim error; a failover that dies too halts the run,
-abandoning every remaining dispatch for a `halted` verdict naming both dead routes and everything
-they cost the round. A live route returning unusable output may instead be re-dispatched, and
+abandoning every remaining dispatch for a `halted` verdict naming the routes that ran out and
+everything they cost the round. A live route returning unusable output may instead be re-dispatched, and
 without a report the lens has no entry and the round is incomplete — fail closed. Every failover is
 reported to the operator, not merely recorded in the verdict. `harvest.md` holds the rest: how to
 tell those two failures apart, how tolerantly to read a report, what to do with a mechanical

--- a/src/user/.claude/skills/review-panel/harvest.md
+++ b/src/user/.claude/skills/review-panel/harvest.md
@@ -47,8 +47,10 @@ If the failover also dies on a transport error — any error, any code, either v
 over. Abandon every dispatch not yet made. Do not retry, do not drop to a lesser model, and do not
 quietly finish the round with the lenses that happened to work.
 
-Write the verdict with `verdict: "halted"`, a `halt` block naming both dead routes and their
-verbatim errors, and every undispatched lens in `abandoned_lenses`.
+Write the verdict with `verdict: "halted"`, a `halt` block carrying every transport failure the
+round did not recover from — at minimum the declared route and the failover behind it, more when
+parallel dispatches ran out together — and every undispatched lens in `abandoned_lenses`. A failure
+some lens did recover from by failing over belongs on that lens's `substitution`, not here.
 
 Stopping forfeits the budget already spent. Continuing forfeits that too, and buys a document that
 reads like a review of a change most of the panel never opened.

--- a/src/user/.claude/skills/review-panel/harvest.md
+++ b/src/user/.claude/skills/review-panel/harvest.md
@@ -14,21 +14,66 @@ exceptional one, and neither transport is the more reliable one — both have be
 other worked.
 
 What you may not do is run the lens and say nothing. Whenever a lens runs on something other than
-its declared entry, its verdict entry carries `substitution` with the declared transport or model
-and the reason. A round that lost diversity silently is indistinguishable from one that kept it.
+its declared entry, its verdict entry carries `substitution` with the declared transport or model,
+the reason, and — when the swap was forced rather than chosen — the dead route's error verbatim in
+`transport_error`. A round that lost diversity silently is indistinguishable from one that kept it.
 
-## Re-dispatching a lens that could not run
+## A dispatch that came back with no report
 
-A lens that errors, times out, or returns output no tolerant read can parse **may be re-dispatched
-inside the same round** — on the same route, or on a substitute model or transport. The round is
-not restarted and the other lenses are not re-run.
+Two failures look alike from outside and are handled oppositely, so tell them apart first.
 
-The lens ends with exactly one entry, describing the attempt that produced the report it carries,
-with `substitution` filled in if that attempt was not the declared route. Two entries for one lens
-is a validation error, not a fuller record: it double-counts coverage.
+**The route died.** What came back describes the *transport*, not the review: an HTTP status, an
+authentication or credit error, a refused connection, a dead broker or session — or nothing at all.
+The reviewer never ran. Judge this on the body rather than the exit status: a dead route shows up
+as an exit 1 carrying a short provider error, and equally as an exit 0 carrying nothing.
 
-If re-dispatch also fails, the lens has **no** entry and the round is incomplete. That is the
-contract working. Fail closed — never write a `clean` entry for a lens that never reported.
+**The reviewer failed.** A body came back that is the model's own output, and it does not survive
+the tolerance ladder below — or the reviewer stalled mid-reasoning. The route worked; what came
+over it is unusable.
+
+### The route died: fail over, once
+
+Fail the lens over to the transport it was **not** declared on — Codex for a lens declared on
+OpenRouter, OpenRouter for a lens declared on Codex — on the same prompt, unchanged. This is not a
+judgement call, and not a retry on the same route: that route has just told you it is down.
+
+The lens ends with exactly one entry, for the attempt that produced the report, carrying the
+`substitution` record above. Two entries for one lens is a validation error, not a fuller record:
+it double-counts coverage.
+
+### Both routes died: stop the run
+
+If the failover also dies on a transport error — any error, any code, either vendor — the round is
+over. Abandon every dispatch not yet made. Do not retry, do not drop to a lesser model, and do not
+quietly finish the round with the lenses that happened to work.
+
+Write the verdict with `verdict: "halted"`, a `halt` block naming both dead routes and their
+verbatim errors, and every undispatched lens in `abandoned_lenses`.
+
+Stopping forfeits the budget already spent. Continuing forfeits that too, and buys a document that
+reads like a review of a change most of the panel never opened.
+
+### The reviewer failed: re-dispatch, then fail closed
+
+A lens whose reviewer returned unusable output **may be re-dispatched** inside the same round, on
+the same route or another. The round is not restarted and the other lenses are not re-run. If the
+re-dispatch fails too, the lens has **no** entry and the round is incomplete. That is the contract
+working. Fail closed — never write a `clean` entry for a lens that never reported.
+
+## Say a failover out loud
+
+A substitution written into the verdict has been recorded, not reported. The verdict goes to a
+check run; the operator reads your summary. So every failover appears in what you tell them, and it
+appears even when the round comes out clean — a clean round that quietly lost a transport is the
+case most likely to go unmentioned.
+
+Per failover, name four things: the lens, the route that died, the route it ran on instead, and the
+error **verbatim**. Verbatim matters more than it looks. "OpenRouter was unavailable" and "402
+Insufficient credits" ask different things of whoever is reading, and only one of them can be acted
+on.
+
+A halted run leads with this, ahead of any finding. What the operator needs first is which
+transports died and what they said.
 
 ## Reading a lens report
 


### PR DESCRIPTION
Closes `agents-config-9k9.122`.

The panel is the merge gate, and it dispatched every lens over a single route while treating a dead route as a per-lens accident. When OpenRouter began returning `402 Insufficient credits` mid-flight, four lens runs across three rounds died on it. What saved those rounds was the assembler failing closed on a missing lens report — correct behaviour, but a silent check, and a silent check guarding the merge gate is one nobody notices passing. It also did nothing to stop the wasted dispatch of every sibling lens.

## What changed

**A dispatch that returns no report is two different problems**, and `harvest.md` now separates them on the body rather than the exit status — a dead route shows up as an exit 1 with a short provider error and equally as an exit 0 with nothing at all.

- **The route died** → mandatory failover to the transport the lens was *not* declared on, same prompt, unchanged. Not a judgement call and not a retry on the route that just said it was down.
- **Both routes died** → the run stops. Every remaining dispatch is abandoned, and the verdict is `halted`.
- **The reviewer failed** (live route, unusable output) → the existing may-re-dispatch path, still fail-closed to incomplete.

**`halted` is a verdict value, not a derivation.** The envelope gains `verdict: "halted"` plus a required `halt` block carrying every dead route with its verbatim error and the lenses nobody read. A halted round is never clean, never complete, and never terminal-clean however few findings it holds. `lenses` may be empty on a halted round only — the relaxation does not leak into `clean` or `findings`.

**Every failover is reported, not merely recorded.** The verdict goes to a check run; the operator reads the agent's summary. So a failover is named out loud — lens, dead route, substitute route, and the error *verbatim* — including when the round comes out clean, which is the case most likely to go unmentioned. `substitution.transport_error` carries that string in the artifact, verbatim because a policy that later wants to halt on one particular provider error has only that string to recognise it by. That policy is not written here; this buys the option.

## One deviation from the bead as filed

It says "failover to Codex". Implemented as **failover to the other transport**. The transports are already declared symmetric, a Codex lens dies on an expired credential exactly as an OpenRouter one dies on 402, and "fail over to Codex" is meaningless for a lens already on Codex. In the case the bead describes, the other transport *is* Codex, so requirement 1 holds as written.

## Verification

- `make content-tests` — exit 0, 8 suites. The verdict suite is 55 → 81 tests.
- `make content-lint` — exit 0. Both gates run standalone with exit statuses captured separately, never through a pipeline.
- **Mutation-checked**, since a passing test is not a biting test. Removing the `halted`⇒`halt` coupling turns the suite red (3 failures); removing the `clean`/`findings`⇒non-empty-`lenses` clause turns it red (2 failures). Restored: 81 pass.

## Worth a reviewer's attention

- `review-verdict`'s body is at **1990 of its 2000-token cap**. It got there honestly — the rationale for stopping now lives in the panel's operator prose and the field-level detail in the schema's own `description` fields — but the next edit to that file will have to buy its space.
- `schema_version` stays `"2"`. The change is additive and every previously-valid verdict is still valid; bumping the `const` would invalidate existing posted verdicts for no reader's benefit, and there is exactly one reader.
- The failover arm is currently unavailable for unrelated reasons (`9k9.123`, Codex 401). The hard stop is the point, and a failover onto a dead target reaches it rather than proceeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhBE3tfdkrZUaGNqzPy8Sc