### PR TITLE
docs(9k9.129): name the codex plugin path CODEX_PLUGIN_ROOT, not CODEX_HOME

### DIFF
--- a/archive/src/user/.agents/skills/ralf-implement/subagent-foreign-cycle.md
+++ b/archive/src/user/.agents/skills/ralf-implement/subagent-foreign-cycle.md
@@ -44,8 +44,8 @@ Agent tool (subagent_type: provided by orchestrator, mode: "auto"):
 
     Codex invocation:
     ```bash
-    CODEX_HOME="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"
-    node "$CODEX_HOME/scripts/codex-companion.mjs" task --model gpt-5.6-terra < .ralf/{session_id}/prompt-{agent_lower}-{timestamp}.md > .ralf/{session_id}/{agent_lower}-review-{timestamp}.md 2>.ralf/{session_id}/{agent_lower}-errors-{timestamp}.log
+    CODEX_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}"
+    node "$CODEX_PLUGIN_ROOT/scripts/codex-companion.mjs" task --model gpt-5.6-terra < .ralf/{session_id}/prompt-{agent_lower}-{timestamp}.md > .ralf/{session_id}/{agent_lower}-review-{timestamp}.md 2>.ralf/{session_id}/{agent_lower}-errors-{timestamp}.log
     ```
 
     Gemini invocation:

--- a/docs/specs/2026-07-03-agent-ruling-merge-judge.md
+++ b/docs/specs/2026-07-03-agent-ruling-merge-judge.md
@@ -266,7 +266,7 @@ pre-judge gates, then the backend, then collapses:
    piping the bespoke merge-worthiness prompt on stdin:
 
    ```bash
-   node "$CODEX_HOME/scripts/codex-companion.mjs" task \
+   node "$CODEX_PLUGIN_ROOT/scripts/codex-companion.mjs" task \
      --json -m "<judge-model>" --effort "<judge-effort>" < merge_judge_prompt.md
    ```
 

--- a/docs/specs/2026-07-24-review-contracts-s6.md
+++ b/docs/specs/2026-07-24-review-contracts-s6.md
@@ -26,7 +26,7 @@ requirements, not lore.
 
 | Artifact | State | Facts |
 | --- | --- | --- |
-| Cross-model reviewer | working, unpackaged | The local codex CLI is the live foreign reviewer (GitHub codex auto-reviews are off since 2026-07-24 — request-only). Invoked `node "$CODEX_HOME/scripts/codex-companion.mjs" task --model gpt-5.6-terra --json < prompt.md`, `CODEX_HOME=${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}`, read-only sandbox, run in background (minutes). Proven prompt shape and exact-JSON completion contract exist as tribal practice, in no deployed asset. |
+| Cross-model reviewer | working, unpackaged | The local codex CLI is the live foreign reviewer (GitHub codex auto-reviews are off since 2026-07-24 — request-only). Invoked `node "$CODEX_PLUGIN_ROOT/scripts/codex-companion.mjs" task --model gpt-5.6-terra --json < prompt.md`, `CODEX_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/openai-codex/plugins/codex}`, read-only sandbox, run in background (minutes). Proven prompt shape and exact-JSON completion contract exist as tribal practice, in no deployed asset. |
 | Verdict artifact schema | nowhere | No schema, no file convention, no notion of "a complete round" keyed to a head SHA. The S5 loop carried the shape in-context only. |
 | Class-specific review contracts | nowhere | No typed-code / spec / skill-prose split; no reviewer prompt asset. Reviewers were prompted ad hoc. |
 | AC-attack round (D3) | nowhere | No pre-implementation attack asset. The S5 spec-contract slice explicitly deferred this to S6. |


### PR DESCRIPTION
Renames the variable in three surviving copies of a retired codex invocation recipe. `agents-config-9k9.129`.

## Why

`CODEX_HOME` is the codex binary's own home directory — the root from which it reads `auth.json` and `config.toml`. These three sites use that name to mean "path to the plugin, so I can find `codex-companion.mjs`". An agent that transcribes the recipe and adds `export`, which is the correct instinct for passing a variable to a child process, redirects the credential lookup into the plugin directory. That directory has no `auth.json`, so codex issues its request with no `Authorization` header and the server answers `401 Missing bearer or basic authentication in header`.

That outage has happened twice — 2026-07-25 and 2026-08-02 — and cost two multi-day investigations. Root cause is recorded on `agents-config-9k9.123`; the July diagnosis of credential expiry recorded on `agents-config-9k9.58` has been corrected there.

Nothing deployed teaches this idiom. The codex plugin's own runtime skill uses `CLAUDE_PLUGIN_ROOT` and never mentions `CODEX_HOME`, and `delegating-to-codex` defers to the plugin's contract rather than prescribing an invocation. The recipe propagates only by transcription from these copies.

## Why correct inert text

All three forms assign without exporting, so as written they cannot cause the failure. They are corrected anyway because the defect is the **name**, not the export. A variable meaning "plugin root" must not be called `CODEX_HOME`, or the next reader exports it for entirely sound reasons and loses the credential again. Renaming removes the trap permanently; leaving the name and warning about it does not.

No caveat is added at any site — each now reads correctly standalone, which is the point.

## Verification

`make ci` run standalone from the worktree root: **exit 0**. `spec-lint` is in that gate and covers both changed files under `docs/specs/`. A repository-wide grep confirms no `CODEX_HOME` remains anywhere in the tree.

## Deliberately out of scope

- `~/.claude/rules-backup/codex-routing.md.backup-20260801-095406` — a dated historical snapshot outside this repository. Editing a backup defeats what a backup is for.
- `~/.claude/panel/state/dispatch.sh` — the one artifact that actually carries `export`. Agent-generated panel scratch, regenerated per run, sourced from nothing here.
- `docs/specs/2026-07-03-agent-ruling-merge-judge.md:275` still refers to `codex-routing` as "the already-sanctioned programmatic runtime path". That rule is retired. Flagged rather than fixed, to keep this change to the one thing it claims to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgmAQCWNvJ9A6yeRHiHngy
