### PR TITLE
docs(9k9.137): restate USER-CORE style blocks as discriminating tests

### DIFF
--- a/src/user/.agents/USER-CORE.md.template
+++ b/src/user/.agents/USER-CORE.md.template
@@ -18,10 +18,8 @@ Narrow "when in doubt, do the safe thing" rules (merge authorization, destructiv
 </decisions>
 
 <reporting>
-- While delegated work is outstanding, do not report incremental progress unless otherwise instructed. No partial findings, no per-agent play-by-play, and no answer a later report might revise.
-- When the last one is in, deliver one answer: recommendation first, then only the facts that carry it, then an offer of detail on request.
-- Fold corrections into that answer instead of spending a turn on them.
-- When subagents' "idle" messages appear, if you've already given the report, do not explain "this is just the agent idle notification" - that is obvious.  Do not rehash the report unless there is new information.
+- While delegated work is outstanding, report no partial findings and no per-agent play-by-play — nothing a later report might revise. A one-line status is fine.
+- When the last delegated result is in, deliver one answer: recommendation first, then only the facts that carry it, then an offer of detail on request. Fold corrections into it rather than spending a turn on them.
 </reporting>
 
 <hard-lines>
@@ -37,18 +35,15 @@ Narrow "when in doubt, do the safe thing" rules (merge authorization, destructiv
 - If the repo has a CONTEXT.md glossary, use its terminology.
 </conventions>
 
-<communication-and-doc-style>
-Clarity & Prose Standards
-- **Write for Human Readers:** Avoid hyper-compressed phrasing, telegraphic shorthand, or internal agent jargon. Standardize on plain, precise, professional English.
-- **No Abbreviated Jargon:** Never invent or use unstandardized abbreviations (e.g., `impl`, `cfg`, `req`) unless they are established in the codebase.
-- **Complete Context in Documentation:** When writing specs, skills, architectural docs, or code comments, include full rationale, prerequisites, and explicit context. Do not omit intermediate reasoning steps or assume implicit background knowledge.
+<communication>
+- Write prose for human readers: complete sentences in plain professional English — no telegraphic fragments, no arrow chains, no invented abbreviations (`impl`, `cfg`, `req`) unless the codebase already uses them.
+- Lead with the outcome or recommendation; supporting detail after.
+- Docs and specs state the decision, its rationale, and its prerequisites so a reader who was not present can follow — no reasoning transcripts, no padding.
+- Keep progress narration to a sentence; never mix it into the deliverable.
+</communication>
 
-Formatting & Deliverable Structure
-- **BLUF (Bottom Line Up Front):** Lead directly with the outcome, core finding, or summary sentence before diving into technical details.
-- **Separate Narration from Deliverables:** Keep progress updates brief (1 sentence). Do not mix meta-commentary or self-correction into the final documentation deliverable.
-</communication-and-doc-style>
-
-<code-complexity-and-defensive-limits>
-- **Pragmatism Over Paranoia:** Write clean, minimal, maintainable code. Do not write hyper-defensive code, unnecessary abstraction layers, or speculative validation for unlikely edge cases unless explicitly required.
-- **YAGNI Enforcement:** Handle happy paths and standard error cases first. Do NOT design for theoretical future requirements or extreme, low-probability scenarios.
-</code-complexity-and-defensive-limits>
+<simplicity>
+- Guard only against conditions that can occur. Validate at trust boundaries (user input, network data, parsed files); do not re-validate what the type system or caller contract already guarantees.
+- No speculative abstraction layers, config flags, fallbacks, or compatibility shims for consumers that don't exist. If you cannot name the real trigger for a defensive construct, delete it.
+- Go beyond happy path plus standard error handling only when an observed failure or an explicit requirement demands it.
+</simplicity>

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -1,6 +1,6 @@
 ---
 admission:
-  provides: Standing authorization to delegate to subagents and workflows without being asked each time, the boundary between orchestrator work and delegated work, the pointer to the delegate-selection skill, and a consult gate before spawning a Fable subagent.
+  provides: Standing authorization to delegate to subagents and workflows without being asked each time, the boundary between orchestrator work and delegated work, the pointer to the delegate-selection skill, a consult gate before spawning a Fable subagent, and the no-reply rule for post-report idle notifications.
   cost: Always-on rule loaded into every Claude Code session; biases toward spawning subagents, spending dispatch overhead on work the main loop could have done inline.
   remove_when: The harness stops shipping a built-in prohibition on unrequested delegation, and unaided sessions hold the orchestrator/delegated boundary without being told.
 ---
@@ -39,7 +39,8 @@ when authorized; what stays with you is judgment — framing the task, synthesiz
 results, verifying claims, and accountability for the outcome. Delegate the grunt work 
 aggressively: your context window is the scarcest resource you manage. A delegated 
 claim is not a result until you have verified it. Keep every agent on task, and own 
-what ships.
+what ships. When a subagent's idle notification arrives after your report is delivered, 
+it warrants no reply — do not explain the notification or restate the report.
 </mandate>
 
 <routing>


### PR DESCRIPTION
## What

Rewrites the three blocks added to `USER-CORE.md.template` on 2026-08-04 (reporting, communication/doc style, code complexity) so every bullet is a rule a model can test itself against at write time, rather than a principle that requires self-diagnosis to apply.

- **`<reporting>`** — bans the answer-shaped content that actually leaks early (partial findings, per-agent play-by-play) while permitting a one-line status, dissolving the conflict with the standing "progress summaries for long-running tasks" guidance. The Claude-only subagent-idle-notification rule moves to `src/user/.claude/rules/delegation.md` per placement-by-capability; its admission record's `provides` is updated to match.
- **`<communication>`** (was `<communication-and-doc-style>`) — names the concrete failure forms (telegraphic fragments, arrow chains, invented abbreviations) and replaces the "include full rationale… do not omit intermediate reasoning steps" mandate — which contradicted `<conventions>` state-the-decision-not-history — with decision + rationale + prerequisites, no reasoning transcripts.
- **`<simplicity>`** (was `<code-complexity-and-defensive-limits>`) — anchors YAGNI on trust boundaries so it cannot be read as license to skip validating external input (L1 collision as written), names the concrete artifacts of defensive paranoia, and gives the discriminator: no nameable real trigger, no guard.

Formatting drops the bold Title-Case labels and sub-headers to match the document's terse imperative style.

## Verification

`make content-lint` from the worktree root, exit 0. Shared always-on surface: **994 → 840 tokens**, back at the charter's D17 ~800 sub-budget (was ~24% over). Claude surface: 1614 → 1499 including the delegation-rule addition.

Tracker: `agents-config-9k9.137` (child of the harness-rework milestone, admission record on the item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcPFSUJdENi3EWywZ1dfrQ