### PR TITLE
fix(9k9.134): a ref belongs to the remote that fetches it, not the one the path spells

### DIFF
--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -248,38 +248,151 @@ def read_remotes(port: CommandPort, cwd: Path | None) -> tuple[tuple[str, ...] |
     return tuple(line.strip() for line in result.stdout.splitlines() if line.strip()), None
 
 
-def split_remote_ref(full: str, remotes: tuple[str, ...] | None) -> tuple[str, str] | str:
-    """(remote, branch name) for a ref under `refs/remotes/`, or the
-    measurement that stopped the split.
+def read_fetch_refspecs(
+    port: CommandPort, cwd: Path | None
+) -> tuple[dict[str, tuple[str, ...]] | None, str | None]:
+    """Every configured `remote.<name>.fetch`, keyed by remote.
 
-    The remote's name is matched against the ones git says are configured
-    rather than taken to be everything before the first slash. Both failure
-    modes are real and neither is guessable: a path no configured remote
-    accounts for -- a tracking ref left behind by `git remote remove` -- and a
-    path two of them could account for, which is what having both `team` and
-    `team/origin` produces. A caller who wants either gone can still use git;
-    what this must not do is pick one and issue a deletion against it."""
+    This is what actually says which remote a path under `refs/remotes/`
+    belongs to. The name in that path is a destination a refspec chose, not a
+    remote naming itself: `git config remote.upstream.fetch
+    '+refs/heads/*:refs/remotes/origin/*'` is legal, and puts upstream's
+    branches under `refs/remotes/origin/` while a remote genuinely called
+    `origin` sits beside them owning none of them.
+
+    None rather than an empty mapping when the read failed, for the same
+    reason `read_remotes` draws that line: "no remote configures a fetch
+    refspec" and "nobody could say" are different answers, and only the second
+    one is a hole in the survey. Exit 1 is the first of those -- `--get-regexp`
+    spends it on "nothing matched" -- so only a worse code is a failure.
+
+    `-z` because a config value may hold a newline; git writes one back for
+    `\\n` in a value and would then split a single refspec across what a
+    line-framed read calls two records. Each `-z` record is `key\\nvalue`, and
+    a key holds no newline, so the first one in a record is the boundary."""
+    result = port.git(["config", "-z", "--get-regexp", r"^remote\..*\.fetch$"], cwd=cwd)
+    if not result.ok and result.returncode > 1:
+        return None, (
+            f"could not read this repository's fetch refspecs (exit {result.returncode}); "
+            f"nothing says which remote a ref under refs/remotes/ was fetched by, so none of "
+            f"them is offered for deletion"
+        )
+    specs: dict[str, list[str]] = {}
+    for record in result.stdout.split("\0"):
+        if not record:
+            continue
+        key, _, value = record.partition("\n")
+        remote = key.removeprefix("remote.").removesuffix(".fetch")
+        specs.setdefault(remote, []).append(value)
+    return {remote: tuple(values) for remote, values in specs.items()}, None
+
+
+def _refspec_destination_match(destination: str, full: str) -> str | None:
+    """What `*` stood for when this destination matched, or None for no match.
+
+    An exact destination matches exactly and captures the empty string, which
+    is why the answer is a string-or-None rather than a truthy one: a literal
+    refspec that matched returns `""`, and that is a match."""
+    prefix, star, suffix = destination.partition("*")
+    if not star:
+        return "" if full == destination else None
+    if not full.startswith(prefix) or not full.endswith(suffix):
+        return None
+    if len(full) < len(prefix) + len(suffix):
+        return None
+    return full[len(prefix) : len(full) - len(suffix)] if suffix else full[len(prefix) :]
+
+
+def _fetch_sources(refspec: str, full: str) -> str | None:
+    """The ref on the server that this refspec would fetch into `full`.
+
+    A negative refspec (`^refs/heads/wip/*`) is skipped rather than
+    interpreted. It narrows what a remote fetches, so honouring it could only
+    ever remove a remote from the candidates -- and every caller here treats
+    two candidates as a refusal. Ignoring one can therefore turn a correct
+    single answer into a stated refusal, and can never turn it into a
+    deletion issued against the wrong remote, which is the direction that
+    matters."""
+    spec = refspec.removeprefix("+")
+    if spec.startswith("^"):
+        return None
+    source, colon, destination = spec.partition(":")
+    if not colon:
+        return None
+    capture = _refspec_destination_match(destination, full)
+    if capture is None:
+        return None
+    return source.replace("*", capture, 1) if "*" in source else source
+
+
+def split_remote_ref(
+    full: str,
+    remotes: tuple[str, ...] | None,
+    refspecs: dict[str, tuple[str, ...]] | None,
+) -> tuple[str, str] | str:
+    """(remote, branch name on that remote) for a ref under `refs/remotes/`,
+    or the measurement that stopped the split.
+
+    Ownership is decided by asking which remote's fetch refspec puts a ref at
+    this path, not by matching configured remote names against the path
+    itself. The path is a destination some refspec chose; the remote whose
+    name it happens to spell need not be the one that fetches it, and probing
+    that remote reports a branch alive on the server as already gone.
+
+    The branch name comes back out of the refspec's source side for the same
+    reason: `+refs/heads/*:refs/remotes/origin/mirror/*` makes `mirror/` part
+    of the local path and no part of what the server calls the branch, so the
+    tail of the tracking path is the wrong string to hand `git push --delete`.
+
+    Every failure mode here is real and none is guessable: a path no refspec
+    accounts for, a path two remotes both fetch into, a remote configured with
+    no fetch refspec at all, and a refspec that maps something other than a
+    branch. A caller who wants any of them gone can still use git; what this
+    must not do is pick one and issue a deletion against it."""
     rest = full.removeprefix("refs/remotes/")
     if remotes is None:
         return (
             f"the configured remote list could not be read, so which part of {full} names a "
             f"remote and which part names the branch on it is unknown"
         )
-    matches = [r for r in remotes if rest.startswith(f"{r}/")]
-    if len(matches) == 1:
-        remote = matches[0]
-        return remote, rest[len(remote) + 1 :]
-    if not matches:
+    if refspecs is None:
         return (
-            f"no configured remote accounts for {full}, so nothing says which part of it names "
-            f"a remote; a tracking ref outliving its remote looks exactly like this"
+            f"this repository's fetch refspecs could not be read, so nothing says which remote "
+            f"{full} was fetched by"
         )
-    named = ", ".join(sorted(matches))
-    return (
-        f"{full} could be a branch on any of these configured remotes: {named} -- the ref path "
-        f"does not say which, and a deletion issued against the wrong one is a deletion on a "
-        f"repository nobody asked about"
-    )
+    owners: dict[str, set[str]] = {}
+    for remote in remotes:
+        for refspec in refspecs.get(remote, ()):
+            source = _fetch_sources(refspec, full)
+            if source is not None:
+                owners.setdefault(remote, set()).add(source)
+    if not owners:
+        return (
+            f"no configured remote accounts for {full}: no remote's fetch refspec puts a ref "
+            f"at that path, which is what a tracking ref outliving its remote -- or a remote "
+            f"configured with no fetch refspec -- looks like"
+        )
+    if len(owners) > 1:
+        named = ", ".join(sorted(owners))
+        return (
+            f"{full} is fetched into that path by more than one configured remote: {named} -- "
+            f"nothing says which one holds it, and a deletion issued against the wrong one is "
+            f"a deletion on a repository nobody asked about"
+        )
+    remote, sources = next(iter(owners.items()))
+    if len(sources) > 1:
+        spelled = ", ".join(sorted(sources))
+        return (
+            f"{remote} fetches {rest} through refspecs that disagree about what it is called "
+            f"there: {spelled} -- a deletion has to name one of them and nothing says which"
+        )
+    source = next(iter(sources))
+    if not source.startswith("refs/heads/"):
+        return (
+            f"{full} is fetched from {source}, which is not a branch on {remote}; deleting it "
+            f"is not something `git push --delete` expresses"
+        )
+    return remote, source.removeprefix("refs/heads/")
 
 
 _WORKTREE_ATTRIBUTES = frozenset(
@@ -920,6 +1033,7 @@ def read_branches(
     prs: dict[str, PullRequest],
     worktree_by_branch: dict[str, str],
     remotes: tuple[str, ...] | None,
+    refspecs: dict[str, tuple[str, ...]] | None,
 ) -> tuple[list[Branch], list[str], bool, list[NotOffered], int, int]:
     """The branches, the warnings, whether the ref read answered at all, the
     refs deliberately left out of the first list, and two counts of what this
@@ -994,10 +1108,10 @@ def read_branches(
 
         if is_remote:
             # The whole of the decomposition, and it is done from the full path
-            # against the configured remote list. Nothing here reads the short
-            # form: it is what git would let you *type*, which is a different
-            # question from where the remote's name ends.
-            split = split_remote_ref(full, remotes)
+            # against the refspecs that put refs there. Nothing here reads the
+            # short form: it is what git would let you *type*, which is a
+            # different question from which remote fetched this.
+            split = split_remote_ref(full, remotes, refspecs)
             if isinstance(split, str):
                 # Unsplittable, so nothing can be issued against it -- but it
                 # is sitting right there, and a caller who names it must not be
@@ -1178,6 +1292,9 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
     remotes, remotes_warning = read_remotes(port, cwd)
     if remotes_warning is not None:
         warnings.append(remotes_warning)
+    refspecs, refspecs_warning = read_fetch_refspecs(port, cwd)
+    if refspecs_warning is not None:
+        warnings.append(refspecs_warning)
     read = read_branches(
         port,
         cwd,
@@ -1186,6 +1303,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         prs=prs,
         worktree_by_branch=worktree_by_branch,
         remotes=remotes,
+        refspecs=refspecs,
     )
     branches, branch_warnings, branches_known, not_offered, dropped_refs, unsplit_refs = read
     warnings.extend(branch_warnings)

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -974,6 +974,112 @@ def test_a_remote_whose_name_holds_a_slash_is_never_split_at_the_wrong_one(
     assert git(decoy, "for-each-ref", "--format=%(refname)") == ""
 
 
+def test_a_ref_reachable_only_through_a_custom_refspec_belongs_to_who_fetches_it(
+    repo: Path, tmp_path: Path
+) -> None:
+    """A fetch refspec chooses where refs land, and it may choose a path that
+    spells another remote's name. `+refs/heads/*:refs/remotes/origin/*` on a
+    remote called `upstream` is legal, and puts upstream's branches under
+    `refs/remotes/origin/` while nothing called `origin` is involved at all.
+
+    Matching configured names against the path answers `origin` here, which is
+    a remote this repository does not have. What the path cannot say, the
+    refspec can, so the refspec is what is asked."""
+    bare = tmp_path / "upstream.git"
+    SubprocessCommands().git(["init", "-q", "--bare", "-b", "main", str(bare)])
+    git(repo, "remote", "add", "upstream", str(bare))
+    git(repo, "config", "remote.upstream.fetch", "+refs/heads/*:refs/remotes/origin/*")
+    git(repo, "push", "-q", "upstream", "main")
+    git(repo, "checkout", "-q", "-b", "feat/live")
+    only = commit(repo, "feat-live.txt", "the only copy\n")
+    git(repo, "push", "-q", "upstream", "feat/live")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "fetch", "-q", "upstream")
+
+    surveyed = report(repo)
+    branches = surveyed["repo"]
+    assert isinstance(branches, dict)
+    feat = next(b for b in branches["branches"] if b["name"] == "origin/feat/live")
+    assert feat["remote"] == "upstream"
+    assert feat["ref_name"] == "feat/live"
+
+    port = Recording()
+    with reachability_guard(bare) as guard:
+        out = StringIO()
+        code = main(
+            ["--cleanup", "remote:origin/feat/live"],
+            port=port,
+            cwd=repo,
+            now=datetime.now(UTC),
+            out=out,
+        )
+        payload = json.loads(out.getvalue())
+        guard.proven_by_bundle(Path(str(payload["execution"]["salvages"][0]["path"])))
+
+    assert code == EXIT_OK
+    deletion = payload["execution"]["deletions"][0]
+    # The defect's signature: `already_absent` on a branch the server holds,
+    # settled by asking a remote that never had it.
+    assert deletion["already_absent"] is False
+    assert deletion["deleted"] is True
+    assert "feat/live" not in git(repo, "ls-remote", "--heads", "upstream")
+    assert only not in git(bare, "rev-list", "--all").split()
+
+    # Every remote git was handed is the one that fetches the ref, never the
+    # one the path happens to spell.
+    named = [call[call.index("--heads") + 1] for call in port.transcript if "--heads" in call]
+    assert named and set(named) == {"upstream"}
+
+
+def test_two_remotes_fetching_into_one_path_is_refused_rather_than_misattributed(
+    repo: Path, tmp_path: Path
+) -> None:
+    """The configuration the defect was reported against: `origin` present and
+    fetching normally, `upstream` configured to fetch into the same namespace,
+    and the branch live only on upstream. Nothing can say which of them holds a
+    given ref there.
+
+    The old answer was the worst available one -- attribute it to `origin`,
+    find nothing, and report a live branch as already gone while prescribing a
+    prune that would drop its tracking ref. A refusal costs a round trip; that
+    answer costs the ref."""
+    origin_bare = tmp_path / "origin.git"
+    upstream_bare = tmp_path / "upstream.git"
+    for path in (origin_bare, upstream_bare):
+        SubprocessCommands().git(["init", "-q", "--bare", "-b", "main", str(path)])
+    git(repo, "remote", "add", "origin", str(origin_bare))
+    git(repo, "remote", "add", "upstream", str(upstream_bare))
+    git(repo, "config", "remote.upstream.fetch", "+refs/heads/*:refs/remotes/origin/*")
+    git(repo, "push", "-q", "-u", "origin", "main")
+    git(repo, "checkout", "-q", "-b", "feat/live")
+    only = commit(repo, "feat-live.txt", "the only copy\n")
+    git(repo, "push", "-q", "upstream", "feat/live")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "fetch", "-q", "upstream")
+
+    surveyed = report(repo)
+    branches = surveyed["repo"]
+    assert isinstance(branches, dict)
+    assert "origin/feat/live" not in [b["name"] for b in branches["branches"]]
+    excluded = {n["name"]: str(n["reason"]) for n in branches["not_offered"]}
+    assert "origin, upstream" in excluded["origin/feat/live"]
+
+    out = StringIO()
+    code = main(
+        ["--cleanup", "origin/feat/live"],
+        port=Recording(),
+        cwd=repo,
+        now=datetime.now(UTC),
+        out=out,
+    )
+
+    # Loud, and the branch is still there -- not a clean exit reporting a
+    # deletion nobody could have performed.
+    assert code == EXIT_REFUSED
+    assert only in git(upstream_bare, "rev-list", "--all").split()
+    assert "feat/live" in git(repo, "ls-remote", "--heads", "upstream")
+
+
 @pytest.mark.parametrize(
     ("remote", "discovered"),
     [("origin", True), ("team", False), ("team/origin", False)],

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -67,6 +67,18 @@ def ref_line(
     return SEP.join([full, short, "a" * 40, committed, upstream_ref, upstream, track, head])
 
 
+def default_refspecs(remotes: str) -> str:
+    """What `git remote add` writes for each of these remotes, NUL-framed.
+
+    Every remote fetching into the path that spells its own name is the case
+    that made a name match look like a parse for as long as it did."""
+    return "".join(
+        f"remote.{name}.fetch\n+refs/heads/*:refs/remotes/{name}/*\0"
+        for name in (line.strip() for line in remotes.splitlines())
+        if name
+    )
+
+
 def make_port(
     *,
     refs: list[str] | None = None,
@@ -79,6 +91,7 @@ def make_port(
     has_gh: bool = True,
     gh_result: CommandResult | None = None,
     remotes: str = "origin\n",
+    refspecs: str | None = None,
 ) -> ScriptedCommands:
     table: dict[str, CommandResult] = {
         "rev-parse --show-toplevel": ok("/repo"),
@@ -86,6 +99,13 @@ def make_port(
         # remote's name stops inside a path under refs/remotes/, so the boring
         # case has to answer it too.
         "remote": ok(remotes),
+        # And the refspecs that put refs under refs/remotes/, which is what
+        # says which remote fetched one. Defaulted to what `git remote add`
+        # writes for each remote in `remotes`, because that is the boring
+        # case; a test about a refspec that does something else passes its own.
+        "config -z --get-regexp": ok(
+            refspecs if refspecs is not None else default_refspecs(remotes)
+        ),
         "rev-parse --path-format=absolute --git-common-dir": ok("/repo/.git"),
         "symbolic-ref --quiet refs/remotes/origin/HEAD": ok("refs/remotes/origin/main"),
         "show-ref --verify --quiet refs/remotes/origin/main": ok(),
@@ -900,6 +920,250 @@ def test_a_ref_two_remotes_could_own_is_reported_rather_than_guessed() -> None:
     assert not [b for b in surveyed.branches if b.is_remote]
     reason = {n.name: n.reason for n in surveyed.not_offered}["team/origin/x"]
     assert "team, team/origin" in reason
+
+
+def test_a_remote_fetching_into_another_remotes_path_owns_what_it_fetched() -> None:
+    """The name in a `refs/remotes/` path is a destination some refspec chose,
+    not a remote naming itself. With upstream configured to fetch into
+    `refs/remotes/origin/`, the branch there is upstream's -- and probing the
+    remote actually called `origin` reports a branch alive on the server as
+    already gone, then prescribes a prune that would discard its tracking ref."""
+    port = make_port(
+        remotes="origin\nupstream\n",
+        refspecs=(
+            "remote.origin.fetch\n+refs/heads/*:refs/remotes/origin-mirror/*\0"
+            "remote.upstream.fetch\n+refs/heads/*:refs/remotes/origin/*\0"
+        ),
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/live", "origin/feat/live"),
+        ],
+        counts={"refs/remotes/origin/main..origin/feat/live": "0"},
+    )
+
+    surveyed = run(port)
+
+    live = {b.name: b for b in surveyed.branches if b.is_remote}["origin/feat/live"]
+    assert (live.remote, live.ref_name) == ("upstream", "feat/live")
+
+
+def test_a_refspec_that_renames_on_the_way_in_reports_the_servers_own_name() -> None:
+    """`+refs/heads/*:refs/remotes/origin/mirror/*` makes `mirror/` part of the
+    local path and no part of what the server calls the branch. The tail of the
+    tracking path is therefore the wrong string to hand `git push --delete`;
+    the refspec's source side is the right one."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="remote.origin.fetch\n+refs/heads/*:refs/remotes/origin/mirror/*\0",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/mirror/feat/x", "origin/mirror/feat/x"),
+        ],
+        counts={"refs/remotes/origin/main..origin/mirror/feat/x": "0"},
+    )
+
+    surveyed = run(port)
+
+    mirrored = {b.name: b for b in surveyed.branches if b.is_remote}["origin/mirror/feat/x"]
+    assert (mirrored.remote, mirrored.ref_name) == ("origin", "feat/x")
+
+
+def test_a_remote_configured_with_no_fetch_refspec_accounts_for_nothing() -> None:
+    """Git's own answer to which tracking refs a remote owns is its fetch
+    refspec, so a remote without one owns none of them. Failing closed here
+    costs a report line; guessing costs a deletion issued somewhere nobody
+    asked about."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    assert (
+        "no configured remote accounts"
+        in {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
+    )
+
+
+def test_two_remotes_fetching_into_one_path_is_reported_rather_than_guessed() -> None:
+    """Nothing forbids two remotes writing into the same namespace, and the
+    path cannot say which of them last put a ref there."""
+    port = make_port(
+        remotes="origin\nupstream\n",
+        refspecs=(
+            "remote.origin.fetch\n+refs/heads/*:refs/remotes/origin/*\0"
+            "remote.upstream.fetch\n+refs/heads/*:refs/remotes/origin/*\0"
+        ),
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    reason = {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
+    assert "origin, upstream" in reason
+
+
+def test_a_refspec_fetching_something_other_than_a_branch_is_not_offered() -> None:
+    """`git push --delete` names a branch. A ref that arrived from somewhere
+    else in the server's namespace has no such name, and inventing one from
+    the local path is how a deletion lands on the wrong kind of ref."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="remote.origin.fetch\n+refs/tags/*:refs/remotes/origin/tags/*\0",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/tags/v1", "origin/tags/v1"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    assert (
+        "is not a branch on origin"
+        in {n.name: n.reason for n in surveyed.not_offered}["origin/tags/v1"]
+    )
+
+
+def test_a_refspec_naming_one_branch_rather_than_globbing_still_accounts_for_it() -> None:
+    """A refspec is not required to glob. `refs/heads/release:refs/remotes/
+    origin/release` fetches exactly one branch, and the ref it puts there
+    belongs to that remote as much as any other."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="remote.origin.fetch\n+refs/heads/release:refs/remotes/origin/release\0",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/release", "origin/release"),
+        ],
+        counts={"refs/remotes/origin/main..origin/release": "0"},
+    )
+
+    surveyed = run(port)
+
+    released = {b.name: b for b in surveyed.branches if b.is_remote}["origin/release"]
+    assert (released.remote, released.ref_name) == ("origin", "release")
+
+
+def test_a_negative_refspec_is_skipped_rather_than_read_as_a_destination() -> None:
+    """`^refs/heads/wip/*` has no destination side at all, so reading it as one
+    would attribute nothing and lose the remote that does own the ref. Skipping
+    it can only ever widen the candidates, and two candidates is a refusal --
+    never a deletion issued somewhere nobody asked about."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs=(
+            "remote.origin.fetch\n+refs/heads/*:refs/remotes/origin/*\0"
+            "remote.origin.fetch\n^refs/heads/wip/*\0"
+        ),
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+        counts={"refs/remotes/origin/main..origin/feat/x": "0"},
+    )
+
+    surveyed = run(port)
+
+    feat = {b.name: b for b in surveyed.branches if b.is_remote}["origin/feat/x"]
+    assert (feat.remote, feat.ref_name) == ("origin", "feat/x")
+
+
+def test_one_remotes_refspecs_disagreeing_about_a_name_is_reported_not_picked() -> None:
+    """Two refspecs on the same remote may both cover a path and disagree about
+    what the server calls what lands there. The remote is not in doubt; the
+    branch name is, and that is the string `git push --delete` is handed."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs=(
+            "remote.origin.fetch\n+refs/heads/*:refs/remotes/origin/*\0"
+            "remote.origin.fetch\n+refs/heads/team/*:refs/remotes/origin/*\0"
+        ),
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    reason = {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
+    assert "refs/heads/feat/x, refs/heads/team/feat/x" in reason
+
+
+def test_a_refspec_with_no_destination_puts_nothing_anywhere() -> None:
+    """A one-sided refspec fetches into FETCH_HEAD and writes no tracking ref,
+    so it accounts for nothing under refs/remotes/."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="remote.origin.fetch\n+refs/heads/*\0",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    assert (
+        "no configured remote accounts"
+        in {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
+    )
+
+
+def test_a_ref_too_short_for_its_destination_pattern_is_not_a_match() -> None:
+    """`refs/remotes/origin/*/x` needs something on both sides of what `*`
+    stands for. A path that satisfies the prefix and the suffix by overlapping
+    them has nothing left in between, and reading one anyway is how a captured
+    name comes back inside out."""
+    port = make_port(
+        remotes="origin\n",
+        refspecs="remote.origin.fetch\n+refs/heads/*:refs/remotes/origin/*/x\0",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/x", "origin/x"),
+        ],
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    assert (
+        "no configured remote accounts"
+        in {n.name: n.reason for n in surveyed.not_offered}["origin/x"]
+    )
+
+
+def test_an_unreadable_refspec_list_leaves_every_server_ref_unoffered() -> None:
+    """The question that decides which remote holds a ref is one probe like any
+    other, and an unanswered probe authorises nothing. Exit 1 is not that
+    failure -- `--get-regexp` spends it on "nothing matched", which is an
+    answer."""
+    port = make_port(
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+        extra={"config -z --get-regexp": fail("fatal: bad config line 3", code=128)},
+    )
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    assert any("fetch refspecs" in w for w in surveyed.all_warnings())
+    assert "could not be read" in {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
 
 
 def test_an_unreadable_remote_list_leaves_every_server_ref_unoffered() -> None:


### PR DESCRIPTION
Closes the false-absence defect in gitclean's remote attribution (`agents-config-9k9.134`).

## The defect

`split_remote_ref` decided which remote owned a `refs/remotes/<...>` ref by matching configured remote **names** against the path. It never read `remote.<name>.fetch`.

A custom fetch refspec is legal and not rare. With `upstream` configured as `+refs/heads/*:refs/remotes/origin/*`, upstream's branches land under `refs/remotes/origin/` — and gitclean probed the unrelated remote actually named `origin`.

Reproduced against real git: with `feat/live` present only on `upstream`, `gitclean --cleanup origin/feat/live` printed

```
gone origin/feat/live -- origin does not advertise refs/heads/feat/live, so there is nothing there to delete
```

and exited 0, while `git ls-remote --heads upstream feat/live` still returned the live ref.

Nothing was deleted, so this is a false absence rather than data loss. The prescribed remedy — `git fetch --prune origin` — is the dangerous part: it would drop the tracking ref for a branch that is alive.

## The fix

Ownership now comes from the refspecs, which is the question git itself answers with:

- `read_fetch_refspecs` reads every `remote.<name>.fetch`, NUL-framed (a config value may hold a newline) and spending exit 1 on "nothing matched" rather than on failure.
- `split_remote_ref` asks which remote's refspec puts a ref at this path.
- The branch name comes out of the refspec's **source** side. `+refs/heads/*:refs/remotes/origin/mirror/*` makes `mirror/` part of the local path and no part of what the server calls the branch, so the tail of the tracking path is the wrong string to hand `git push --delete`.

Four ways this can fail to resolve, each reported rather than guessed:

| Situation | Answer |
|---|---|
| No refspec accounts for the path | not offered, with the measurement |
| Two remotes fetch into the path | refused, both named |
| One remote's refspecs disagree about the server-side name | refused, both spellings named |
| Refspec maps something other than a branch | not offered |

A remote configured with **no** fetch refspec owns nothing. That is git's own semantics, and it fails closed.

Negative refspecs (`^refs/heads/wip/*`) are skipped rather than interpreted — honouring one could only ever *remove* a remote from the candidates, and two candidates is already a refusal. Ignoring one can turn a correct answer into a stated refusal; it can never turn one into a deletion issued against the wrong remote.

## Evidence

`make ci` green (exit 0), run from this worktree.

The new tests were mutation-checked: with the attribution reverted to name matching, **both real-git reproductions and five of six new unit cases fail**. The sixth pins the unreadable-refspec path, which that mutation does not touch.

- `tests/integration/test_real_git.py` — attribution through a custom refspec (deletion goes to `upstream`, `already_absent` is `False`), and the reported two-remote configuration now refusing loudly instead of misattributing.
- `tests/unit/test_survey.py` — ten cases across attribution, renaming refspecs, literal refspecs, negative refspecs, one-sided refspecs, no refspec, ambiguity in both directions, and an unreadable refspec list.

Package coverage on `survey.py` is 98%; every branch added here is exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zSUyTCy13ju28gaFmkykq