### PR TITLE
feat(9k9.131): a merged pull request is an authority, so an agent can clean up after itself

### DIFF
--- a/packages/gitclean/src/gitclean/cli.py
+++ b/packages/gitclean/src/gitclean/cli.py
@@ -3,8 +3,9 @@
 Cleanup re-surveys before it acts. The report the caller read may be minutes
 old; a branch can gain commits or a worktree can go dirty in that window, and
 acting on the stale classification is precisely the failure this tool exists
-to prevent. So --cleanup runs the full survey and classification again, and
-plans against what is true now.
+to prevent. So every mode that acts -- --cleanup and --after-merge alike --
+runs the full survey and classification again, and plans against what is true
+now.
 """
 
 from __future__ import annotations
@@ -20,8 +21,9 @@ from gitclean import get_version
 from gitclean.classify import classify
 from gitclean.execute import ExecutionReport, Executor, default_salvage_dir
 from gitclean.model import MergeEvidence, Plan, Refusal, Survey, Target
-from gitclean.plan import build_plan
+from gitclean.plan import build_after_merge_plan, build_plan
 from gitclean.ports import CommandPort, SubprocessCommands
+from gitclean.survey import read_pull_request
 from gitclean.survey import survey as run_survey
 
 EXIT_OK = 0
@@ -33,6 +35,7 @@ _EPILOG = """\
 modes:
   --report                 survey only; emits the full measured state as JSON
   --cleanup [NAME ...]     sweep what is provably merged, or delete exactly the named targets
+  --after-merge PR         sweep what one merged pull request produced
 
 what a bare --cleanup takes:
   a target whose merge_evidence is pr_merged, ancestor, patch_equal or squash_equal,
@@ -65,11 +68,21 @@ all, and when the name is a ref this tool does not offer as a target, such as th
 server's copy of the trunk. Both of those look identical to an absent name and neither
 one is, so saying "already gone" about them would be a false report.
 
+what --after-merge takes:
+  the local branch a pull request was opened from, and the worktree holding it -- each
+  only where it clears the same checks a bare sweep applies. It is a sweep with a
+  narrower scope, not a list of names: what authorises it is the mechanical fact that
+  the pull request merged, so gh has to answer, and a pull request that closed without
+  merging is refused rather than treated as a decision about the branch's commits. The
+  branch's copy on the server is reported and never deleted; naming it stays the only
+  way that happens. Nothing left to clean up exits 0 with an empty plan.
+
 examples:
   gitclean --report --format human
   gitclean --cleanup --dry-run
   gitclean --cleanup feat/old-thing worktree:/path/to/wt
   gitclean --cleanup origin/feat/old-thing
+  gitclean --after-merge 438 --dry-run
 """
 
 
@@ -90,6 +103,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="NAME",
         help="delete the safe subset, or exactly the named worktrees/branches",
     )
+    mode.add_argument(
+        "--after-merge",
+        metavar="PR",
+        help="sweep the branch and worktree one merged pull request produced",
+    )
 
     parser.add_argument(
         "--dry-run", action="store_true", help="resolve and report the plan without executing it"
@@ -103,6 +121,24 @@ def build_parser() -> argparse.ArgumentParser:
         "--format", choices=("json", "human"), default="json", help="output format (default json)"
     )
     return parser
+
+
+def _pull_request_number(parser: argparse.ArgumentParser, given: str) -> str:
+    """The pull request number as the caller spelled it, or a usage error.
+
+    Checked rather than converted, and handed on as the same string. `gh pr
+    view` also accepts a URL and a branch name in that position, and either
+    would resolve *some* pull request -- which is not the same as the one the
+    caller named, and would authorise a deletion against a branch nobody asked
+    about. Round-tripping through ``int`` would answer that, and would also
+    quietly rewrite the spelling gh is asked for; this keeps the argv exact.
+
+    A usage error rather than a refusal, because nothing has been measured yet.
+    The command as typed cannot be carried out at all, which is what exit 2
+    means everywhere else in this CLI."""
+    if not given.isdigit():
+        parser.error(f"--after-merge takes a pull request number, not {given!r}")
+    return given
 
 
 def _envelope(
@@ -319,10 +355,18 @@ def main(
 ) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    # Before the survey: a command line that cannot be carried out is not worth
+    # reading a repository for, and exit 2 must not arrive after a minute of git.
+    number = None if args.after_merge is None else _pull_request_number(parser, args.after_merge)
     stream = out if out is not None else sys.stdout
     runner: CommandPort = port if port is not None else SubprocessCommands()
     moment = now if now is not None else datetime.now(UTC)
-    mode = "report" if args.report else "cleanup"
+    if args.report:
+        mode = "report"
+    elif number is not None:
+        mode = "after-merge"
+    else:
+        mode = "cleanup"
 
     surveyed = run_survey(runner, cwd=cwd)
     if isinstance(surveyed, str):
@@ -339,14 +383,25 @@ def main(
         )
         return EXIT_OK
 
-    salvage_dir = args.salvage_dir or default_salvage_dir(surveyed, moment)
-    outcome = build_plan(
-        targets,
-        surveyed,
-        selectors=list(args.cleanup or []),
-        dry_run=args.dry_run,
-        salvage_dir=salvage_dir,
-    )
+    if number is not None:
+        outcome = build_after_merge_plan(
+            targets,
+            surveyed,
+            # Read here rather than before the survey: the survey is what says
+            # this is a repository at all, and asking a forge about a pull
+            # request in a directory that is not one answers the wrong question.
+            pull_request=read_pull_request(runner, cwd, number),
+            dry_run=args.dry_run,
+        )
+    else:
+        salvage_dir = args.salvage_dir or default_salvage_dir(surveyed, moment)
+        outcome = build_plan(
+            targets,
+            surveyed,
+            selectors=list(args.cleanup or []),
+            dry_run=args.dry_run,
+            salvage_dir=salvage_dir,
+        )
     if isinstance(outcome, Refusal):
         _emit(
             _envelope(mode, ok=False, survey_data=surveyed, targets=targets, refusal=outcome),

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -91,6 +91,48 @@ class PullRequest:
 
 
 @dataclass(frozen=True, slots=True)
+class PullRequestOutcome:
+    """What one pull request decided, read because a caller named it.
+
+    ``PullRequest`` above is a row in an index built from one bulk read and
+    keyed by the branch a PR was opened from. It travels *to* a branch, as
+    evidence to be laid beside everything else measured about it, and a gh that
+    could not answer costs it a tier and nothing more.
+
+    This is the other direction, and it carries a different weight. A caller
+    naming a pull request is asking this tool to act because that pull request
+    merged, so the read is not evidence about a target -- it is the whole
+    authorisation, and a read that did not answer leaves nothing to act on.
+
+    It carries the head ref because nothing else here does: the bulk index
+    spends that string as its key, and the head ref is precisely what one pull
+    request says about which branch is finished with.
+
+    Deliberately absent from the envelope. What the report publishes is what a
+    run measured about the repository; this is the fact that authorised the run,
+    and it reaches a reader through the refusal that quotes it or not at all.
+    """
+
+    number: int
+    state: str
+    """OPEN | MERGED | CLOSED, verbatim from gh."""
+    head_ref: str
+    """The branch the pull request was opened from, as the server names it.
+
+    A local branch of that name is what a merged pull request finishes with. It
+    is not a promise that such a branch is still here, nor that what is here is
+    what the pull request merged -- both of those are measured elsewhere, and
+    neither is inferred from this string."""
+    merged_at: str | None
+    """When it merged, or None when nothing merged it.
+
+    Read alongside ``state`` because the two are one fact stated twice, and a
+    fact stated twice is established only when both statements agree. A payload
+    that says MERGED and dates nothing is gh saying something this cannot read,
+    which is not the same as a merge."""
+
+
+@dataclass(frozen=True, slots=True)
 class Worktree:
     path: str
     branch: str | None

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -115,7 +115,13 @@ class PullRequestOutcome:
 
     number: int
     state: str
-    """OPEN | MERGED | CLOSED, verbatim from gh."""
+    """OPEN | MERGED | CLOSED, upper-cased on the way in.
+
+    Case-folded rather than kept verbatim because the comparison that decides
+    whether anything is deleted is made against MERGED, and one that depended
+    on how a payload happened to spell a word is one gh could change
+    underneath this. Empty when gh named no state at all -- which is not a
+    state, and reaches the caller as a refusal like any other."""
     head_ref: str
     """The branch the pull request was opened from, as the server names it.
 

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -7,6 +7,16 @@ up arguing with the person using it. git's own refusals still stand where
 nothing overrides them, and they carry better information than a re-derivation
 would -- git knows what its working tree holds right now.
 
+Between those two sits a merged pull request, and it is a sweep rather than a
+naming. Nothing about it is authorised by somebody's judgement that a branch is
+finished with: what authorises it is the mechanical fact that the pull request
+merged, which a caller cannot assert and gh has to answer. So every check a
+bare sweep applies is applied here too, unchanged -- the scope is narrowed to
+the targets one pull request produced, and nothing else about the sweep moves.
+That is the whole of the difference, and it is deliberate: a mode that both
+narrowed the scope *and* relaxed the proof would be a naming wearing a sweep's
+clothes.
+
 So the refusals left here are few, and each answers something the caller could
 not have answered themselves: a name matching two things, a branch git will
 reject because a worktree still holds it, and the directory this process is
@@ -36,6 +46,7 @@ from gitclean.model import (
     Absent,
     NotOffered,
     Plan,
+    PullRequestOutcome,
     Refusal,
     Skipped,
     Survey,
@@ -309,6 +320,173 @@ def _occupancy_blockers(chosen: list[Target], survey_data: Survey) -> list[tuple
     return blockers
 
 
+def _skip_occupied(
+    chosen: list[Target], occupancy: list[tuple[Target, str]]
+) -> tuple[list[Target], list[Skipped]]:
+    """Drop the branches git will refuse because a worktree still holds them,
+    and say which.
+
+    What a sweep does about occupancy, wherever the sweep got its candidates
+    from: one occupied branch must not block cleaning everything else that is
+    provably merged, so it is skipped rather than refused -- and the ``Skipped``
+    row carries the omission, because a clean-looking run that quietly did less
+    than the caller assumes reads as "everything was cleaned".
+
+    One function rather than one per sweeping mode. Two copies of this would be
+    two places to disagree about whether an occupied branch stops a run."""
+    blocked = {t.id for t, _ in occupancy}
+    return (
+        [t for t in chosen if t.id not in blocked],
+        [
+            Skipped(
+                target_id=t.id,
+                name=t.name,
+                reason=f"checked out at {path}; remove that worktree to make it deletable",
+            )
+            for t, path in occupancy
+        ],
+    )
+
+
+def _pull_request_scope(head_ref: str, targets: tuple[Target, ...]) -> list[Target]:
+    """Everything one pull request produced that this report has a row for: the
+    branch it was opened from, the worktree holding that branch, and the copy of
+    that branch on the server.
+
+    The counterparts are reached by following ``pairing``, which is the relation
+    the survey measured, and never by taking a path or a ref apart. Both of
+    those are strings whose halves cannot be recovered by looking for a
+    delimiter -- a worktree path may contain anything at all, and a remote's own
+    name may contain the slash in `<remote>/<ref>` -- so a scope built by
+    splitting would silently take in a neighbour's worktree, or miss the one it
+    was aiming at. Following the id is what publishing the id is for.
+
+    The server copy is gathered so that it can be *reported*. It is part of what
+    the pull request produced, and a scope that simply left it out would let a
+    caller read a clean run as the branch being gone everywhere, which is the
+    one place this mode could quietly mislead."""
+    branch = next((t for t in targets if t.kind is TargetKind.BRANCH and t.name == head_ref), None)
+    if branch is None:
+        return []
+    by_id = {t.id: t for t in targets}
+    scope = [by_id[c.id] for c in branch.pairing if c.id is not None]
+    scope.append(branch)
+    return scope
+
+
+def build_after_merge_plan(
+    targets: tuple[Target, ...],
+    survey_data: Survey,
+    *,
+    pull_request: PullRequestOutcome | str,
+    dry_run: bool,
+) -> Plan | Refusal:
+    """A sweep narrowed to what one merged pull request produced.
+
+    The refusals here are all about the authorising fact, because that fact is
+    the only thing this mode has that a bare sweep does not. It cannot be
+    asserted by the caller and it cannot be inferred from the repository: a
+    merged pull request is something gh answers for, so a gh that did not answer
+    means this run has no authority at all -- not a degraded one -- and a pull
+    request that closed without merging is not an authority either. Closing one
+    says somebody stopped wanting the change; it never says its commits exist
+    anywhere else, and they do not.
+
+    Past that point nothing is taken on the pull request's word. A merged pull
+    request describes the commit its head pointed at, not whatever the branch of
+    that name holds now, so what the sweep takes is decided by the same six
+    questions classification asks of everything else. A branch in scope that
+    fails one of them is reported with the measurement that stopped it and left
+    exactly where it is.
+
+    ``salvage_dir`` has no parameter here, and that is a property of the mode
+    rather than an omission: salvage is retained only where no reflog exists,
+    which is the server, and no server ref can enter this plan."""
+    if isinstance(pull_request, str):
+        return Refusal(
+            code="E_PR_UNREADABLE",
+            message=f"this run deletes only what a merged pull request produced, and whether "
+            f"one merged could not be established: {pull_request}",
+            remedy="fix what stopped the pull-request read and re-run, or name what you want "
+            "gone to --cleanup, which asks nothing of gh; nothing here was touched",
+        )
+    if pull_request.state != "MERGED":
+        return Refusal(
+            code="E_PR_NOT_MERGED",
+            message=f"pull request #{pull_request.number} is {pull_request.state}, not merged: "
+            f"the one thing authorising this mode to delete is that the change landed, and a "
+            f"pull request that closed without merging says somebody stopped wanting it rather "
+            f"than that its commits exist anywhere else",
+            remedy=f"nothing was deleted; if you want {pull_request.head_ref} gone regardless, "
+            f"name it to --cleanup -- that authorisation is yours to give, and this mode "
+            f"deliberately will not infer it",
+        )
+    if pull_request.merged_at is None:
+        return Refusal(
+            code="E_PR_UNREADABLE",
+            message=f"gh reports pull request #{pull_request.number} as MERGED and recorded no "
+            f"time at which it merged, so the two things it says about that decision do not "
+            f"agree; a merge this cannot read is not one it acts on",
+            remedy="check what gh reports for that pull request and re-run, or name what you "
+            "want gone to --cleanup; nothing here was touched",
+        )
+
+    scope = _pull_request_scope(pull_request.head_ref, targets)
+    if not scope:
+        # A job already done is a success. The branch a merged pull request
+        # finishes with is routinely deleted by the forge, by whatever removed
+        # the worktree, or by the agent that ran this a moment ago -- and being
+        # told a completed job failed is what sends a caller to raw git.
+        return Plan(
+            targets=(),
+            salvage_dir=None,
+            dry_run=dry_run,
+            absent=(
+                Absent(
+                    selector=pull_request.head_ref,
+                    note=f"pull request #{pull_request.number} merged, and nothing it produced "
+                    f"is still here: no local branch named {pull_request.head_ref!r}, and so no "
+                    f"worktree holding one. The cleanup was already done",
+                ),
+            ),
+        )
+
+    chosen: list[Target] = []
+    skipped: list[Skipped] = []
+    for candidate in scope:
+        if candidate.kind is TargetKind.REMOTE_BRANCH:
+            # Whatever its state, and not by way of the sweep rule that would
+            # have caught it anyway: a merged pull request is an authority over
+            # this repository's copy of the work, and deleting the server's copy
+            # is irreversible for everyone fetching it.
+            skipped.append(
+                Skipped(
+                    target_id=candidate.id,
+                    name=candidate.name,
+                    reason=f"the copy on the server, which a merged pull request does not "
+                    f"authorise deleting: the server keeps no reflog, so it goes only when it "
+                    f"is named -- `gitclean --cleanup {candidate.name}` bundles it first",
+                )
+            )
+        elif candidate.withheld is not None:
+            # `sweepable` asked in the spelling that carries the answer: the two
+            # are the same question, and only one of them can be reported.
+            skipped.append(
+                Skipped(target_id=candidate.id, name=candidate.name, reason=candidate.withheld)
+            )
+        else:
+            chosen.append(candidate)
+
+    chosen, occupied = _skip_occupied(chosen, _occupancy_blockers(chosen, survey_data))
+    skipped.extend(occupied)
+    return Plan(
+        targets=_ordered(chosen),
+        salvage_dir=None,
+        dry_run=dry_run,
+        skipped=tuple(skipped),
+    )
+
+
 def build_plan(
     targets: tuple[Target, ...],
     survey_data: Survey,
@@ -347,21 +525,7 @@ def build_plan(
             blocked=tuple(t for t, _ in occupancy),
             remedy="add the holding worktree to the same cleanup so it is removed first",
         )
-    skipped: list[Skipped] = []
-    if occupancy:
-        # Swept automatically: one occupied branch must not block cleaning
-        # everything else that is provably merged. Skip it; `skipped` carries
-        # the omission so a clean-looking run never hides what it left behind.
-        blocked_ids = {t.id for t, _ in occupancy}
-        chosen = [t for t in chosen if t.id not in blocked_ids]
-        skipped.extend(
-            Skipped(
-                target_id=t.id,
-                name=t.name,
-                reason=f"checked out at {path}; remove that worktree to make it deletable",
-            )
-            for t, path in occupancy
-        )
+    chosen, skipped = _skip_occupied(chosen, occupancy)
 
     return Plan(
         targets=_ordered(chosen),

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -707,7 +707,13 @@ def read_pull_request(port: CommandPort, cwd: Path | None, number: str) -> PullR
         return f"gh pr view {number} returned unparseable JSON ({exc})"
     if not isinstance(payload, dict):
         return f"gh pr view {number} returned a payload that describes no pull request"
-    head = str(payload.get("headRefName", ""))
+    # Emptiness is decided before the value becomes a string, not after. JSON
+    # null reaches here as None, and `str(None)` is the five-character word
+    # "None" -- which is not empty, so a check made afterwards passes it, and a
+    # field gh declined to answer becomes a branch name. Nothing then refuses,
+    # and the scope narrows to a branch literally called None.
+    raw_head = payload.get("headRefName")
+    head = str(raw_head) if raw_head else ""
     if not head:
         return f"gh did not say which branch pull request #{number} was opened from"
     try:
@@ -716,10 +722,11 @@ def read_pull_request(port: CommandPort, cwd: Path | None, number: str) -> PullR
         # A pull request number that is not a number is gh telling us something
         # this does not understand about the very thing being asked after.
         return f"gh answered for pull request #{number} with a number this could not read"
+    raw_state = payload.get("state")
     merged_at = payload.get("mergedAt")
     return PullRequestOutcome(
         number=resolved,
-        state=str(payload.get("state", "")).upper(),
+        state=str(raw_state).upper() if raw_state else "",
         head_ref=head,
         merged_at=str(merged_at) if merged_at else None,
     )

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -20,7 +20,15 @@ import json
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from gitclean.model import Branch, MergeEvidence, NotOffered, PullRequest, Survey, Worktree
+from gitclean.model import (
+    Branch,
+    MergeEvidence,
+    NotOffered,
+    PullRequest,
+    PullRequestOutcome,
+    Survey,
+    Worktree,
+)
 from gitclean.ports import CommandPort, CommandResult
 
 _SEP = "\x1f"
@@ -61,6 +69,12 @@ _REF_FORMAT = _SEP.join(
 )
 _REF_FIELDS = 8
 _PR_LIMIT = 500
+_PR_VIEW_FIELDS = "number,state,headRefName,mergedAt"
+"""What one pull request has to say for itself before it authorises anything.
+
+``mergedAt`` is asked for alongside ``state`` deliberately: they are one fact
+stated twice, and requiring both to agree is what keeps a payload this cannot
+read from being taken for a merge."""
 
 
 def _first_line(result_out: str) -> str:
@@ -657,6 +671,58 @@ def read_pull_requests(
             f"were left out; a branch of theirs is judged on git evidence alone"
         )
     return index, None, "; ".join(gaps) if gaps else None
+
+
+def read_pull_request(port: CommandPort, cwd: Path | None, number: str) -> PullRequestOutcome | str:
+    """One pull request, asked for by number -- or the measurement that stopped
+    the read.
+
+    Every failure here is a sentence rather than an empty result, which is what
+    separates this from the bulk read above. That one gathers evidence to lay
+    beside branches nobody named: a gh that is absent or failing costs it a
+    tier, the run continues, and each row says squash merges were invisible to
+    it. Here the pull request is the authorisation itself. A read that did not
+    answer leaves nothing to act on, so the only honest outcomes are the fact or
+    the reason it is missing -- and a caller who is told which can fix it.
+
+    ``number`` travels as the caller spelled it. It goes straight into an argv,
+    and round-tripping it through ``int`` would change the string gh is asked
+    for -- gh accepts a URL and a branch name there too, so the spelling that
+    reaches it is worth keeping exact.
+
+    The payload is read the way the bulk list is read: nothing is assumed about
+    the shape gh returns, because an entry described in terms this does not
+    understand is a fact nobody established, and the one thing it must not
+    become is a merge.
+    """
+    if not port.has_gh():
+        return f"gh is not on PATH, so nothing could say whether pull request #{number} merged"
+    result = port.gh(["pr", "view", number, "--json", _PR_VIEW_FIELDS], cwd=cwd)
+    if not result.ok:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        return f"gh pr view {number} failed ({detail})"
+    try:
+        payload = json.loads(result.stdout or "null")
+    except json.JSONDecodeError as exc:
+        return f"gh pr view {number} returned unparseable JSON ({exc})"
+    if not isinstance(payload, dict):
+        return f"gh pr view {number} returned a payload that describes no pull request"
+    head = str(payload.get("headRefName", ""))
+    if not head:
+        return f"gh did not say which branch pull request #{number} was opened from"
+    try:
+        resolved = int(payload.get("number", 0))
+    except (TypeError, ValueError):
+        # A pull request number that is not a number is gh telling us something
+        # this does not understand about the very thing being asked after.
+        return f"gh answered for pull request #{number} with a number this could not read"
+    merged_at = payload.get("mergedAt")
+    return PullRequestOutcome(
+        number=resolved,
+        state=str(payload.get("state", "")).upper(),
+        head_ref=head,
+        merged_at=str(merged_at) if merged_at else None,
+    )
 
 
 def _merged_set(

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -1772,3 +1772,170 @@ def test_the_port_reports_a_real_failure_with_its_transcript(repo: Path) -> None
 
     assert not result.ok
     assert "$ git cat-file -e does-not-exist" in result.transcript()[0]
+
+
+class WithPullRequest(Recording):
+    """The real port, git untouched, answering for exactly one pull request.
+
+    A tmp repository has no forge behind it, so the authorising fact has to come
+    from somewhere -- and the thing under test is what gitclean does with that
+    fact against a real repository, not whether it can parse gh. Everything git
+    is asked still goes to git."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        super().__init__()
+        self._payload = payload
+
+    def has_gh(self) -> bool:
+        return True
+
+    def gh(
+        self,
+        args: Sequence[str],
+        *,
+        cwd: Path | None = None,  # noqa: ARG002 - the port's signature; gh needs no cwd here
+    ) -> CommandResult:
+        # The bulk index answers empty on purpose. Merge evidence then comes
+        # from git alone, so what these tests exercise is the mode acting on
+        # the pull request it was handed rather than on a PR-state tier that
+        # happened to agree with it.
+        if list(args[:2]) == ["pr", "list"]:
+            body = "[]"
+        elif list(args[:2]) == ["pr", "view"]:
+            body = json.dumps(self._payload)
+        else:  # pragma: no cover - a call no test intends
+            raise AssertionError(f"unexpected gh call: {args}")
+        return CommandResult(argv=("gh", *args), returncode=0, stdout=body, stderr="")
+
+
+def _merge_a_branch(repo: Path, name: str) -> str:
+    """A branch carrying one commit that is now an ancestor of the trunk.
+
+    A bare `git branch` off the tip is NOT this: gitclean withholds a branch
+    sitting exactly on the trunk, because nothing on disk distinguishes that
+    from the trunk itself, and a fixture built that way tests the withhold
+    rather than the sweep."""
+    git(repo, "checkout", "-q", "-b", name)
+    head = commit(repo, f"{name}.txt", f"work on {name}\n")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "--no-ff", "-m", f"merge {name}", name)
+    return head
+
+
+def _merged_payload(head_ref: str, number: int = 438) -> dict[str, object]:
+    return {
+        "number": number,
+        "state": "MERGED",
+        "headRefName": head_ref,
+        "mergedAt": "2026-08-01T09:30:00Z",
+    }
+
+
+def test_after_merge_removes_the_worktree_and_branch_one_pull_request_produced(
+    repo: Path, tmp_path: Path
+) -> None:
+    """The whole point of the mode, against a real repository: an agent that
+    merged its own pull request reaches the end state in one call, having named
+    nothing, and every other branch is still there afterwards."""
+    _merge_a_branch(repo, "shipped")
+    wt = tmp_path / "wt-shipped"
+    git(repo, "worktree", "add", "-q", str(wt), "shipped")
+    git(repo, "branch", "someone-elses-work")
+
+    port = WithPullRequest(_merged_payload("shipped"))
+    with reachability_guard(repo):
+        payload = report(repo, "--after-merge", "438", port=port)
+
+    assert payload["_exit"] == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert {d["name"] for d in execution["deletions"]} == {str(wt), "shipped"}
+    assert all(d["deleted"] and d["verified"] for d in execution["deletions"])
+
+    remaining = git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    assert "shipped" not in remaining.split()
+    assert "someone-elses-work" in remaining.split()
+    assert not wt.exists()
+
+
+def test_after_merge_never_deletes_the_worktree_the_run_is_standing_in(
+    repo: Path, tmp_path: Path
+) -> None:
+    """The likeliest way to invoke this mode is from inside the worktree it is
+    about -- an agent merges its own pull request and cleans up where it stands.
+    Removing that directory pulls the working directory out from under the
+    process, so the sweep withholds it, and the branch it holds is withheld
+    beside it because git would refuse that too. Nothing is deleted and both
+    reasons are reported."""
+    _merge_a_branch(repo, "shipped")
+    wt = tmp_path / "wt-shipped"
+    git(repo, "worktree", "add", "-q", str(wt), "shipped")
+
+    port = WithPullRequest(_merged_payload("shipped"))
+    with reachability_guard(repo):
+        # cwd is the worktree itself, which is what makes it the invoking one.
+        payload = report(wt, "--after-merge", "438", port=port)
+
+    assert payload["_exit"] == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["deletions"] == []
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    reasons = {s["target_id"]: str(s["reason"]) for s in plan["skipped"]}
+    assert set(reasons) == {f"worktree:{wt}", "branch:shipped"}
+    # Each withheld for its own measured reason, not incidentally.
+    assert "the run is executing in" in reasons[f"worktree:{wt}"]
+    assert str(wt) in reasons["branch:shipped"]
+    assert wt.exists()
+    assert "shipped" in git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads").split()
+
+
+def test_after_merge_leaves_a_branch_carrying_work_the_pull_request_did_not_merge(
+    repo: Path,
+) -> None:
+    """A merged pull request describes the commit its head pointed at, not
+    whatever the branch of that name holds now. Someone pushing one more commit
+    after the merge is ordinary, and that commit exists nowhere else."""
+    git(repo, "checkout", "-q", "-b", "shipped")
+    commit(repo, "shipped.txt", "merged work\n")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "shipped")
+    git(repo, "checkout", "-q", "shipped")
+    stranded = commit(repo, "after.txt", "landed after the merge\n")
+    git(repo, "checkout", "-q", "main")
+
+    port = WithPullRequest(_merged_payload("shipped"))
+    with reachability_guard(repo):
+        payload = report(repo, "--after-merge", "438", port=port)
+
+    assert payload["_exit"] == EXIT_OK
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["deletions"] == []
+    assert stranded in git(repo, "rev-list", "--all").split()
+    assert "shipped" in git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads").split()
+
+
+def test_a_pull_request_that_closed_unmerged_deletes_nothing_in_a_real_repository(
+    repo: Path,
+) -> None:
+    """The refusal that protects the only copy of abandoned work."""
+    git(repo, "checkout", "-q", "-b", "abandoned")
+    only = commit(repo, "abandoned.txt", "the only copy\n")
+    git(repo, "checkout", "-q", "main")
+
+    payload = {
+        "number": 438,
+        "state": "CLOSED",
+        "headRefName": "abandoned",
+        "mergedAt": None,
+    }
+    with reachability_guard(repo):
+        envelope = report(repo, "--after-merge", "438", port=WithPullRequest(payload))
+
+    assert envelope["_exit"] == EXIT_REFUSED
+    refusal = envelope["refusal"]
+    assert isinstance(refusal, dict)
+    assert refusal["code"] == "E_PR_NOT_MERGED"
+    assert only in git(repo, "rev-list", "--all").split()

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -45,8 +45,14 @@ def invoke_human(argv: list[str], port: ScriptedCommands) -> tuple[int, str]:
     return code, buffer.getvalue()
 
 
-def merged_branch_port() -> ScriptedCommands:
-    """A repo with one provably-merged branch and nothing else interesting."""
+def merged_branch_port(
+    *, pr_view: dict[str, object] | None = None, has_gh: bool = True
+) -> ScriptedCommands:
+    """A repo with one provably-merged branch and nothing else interesting.
+
+    `pr_view` stays unset unless a test is about a pull request, so a run that
+    reaches for one nobody set up fails naming the argv rather than on a
+    default that quietly authorises something."""
     return make_port(
         refs=[
             ref_at("refs/heads/main", "main", "a" * 40, head="*"),
@@ -57,6 +63,8 @@ def merged_branch_port() -> ScriptedCommands:
             "branch -D -- done": ok(),
             "for-each-ref --format=%(refname) refs/heads/done": ok(""),
         },
+        pr_view=pr_view,
+        has_gh=has_gh,
     )
 
 
@@ -773,3 +781,86 @@ def test_human_output_warns_when_gh_is_unavailable() -> None:
     port = make_port(refs=[ref_line("refs/heads/main", "main", head="*")], has_gh=False)
     _, text = invoke_human(["--report"], port)
     assert "WARN:" in text
+
+
+# -- --after-merge -----------------------------------------------------------
+
+
+_MERGED_DONE: dict[str, object] = {
+    "number": 438,
+    "state": "MERGED",
+    "headRefName": "done",
+    "mergedAt": "2026-08-01T09:30:00Z",
+}
+
+
+def after_merge_port(**pr: object) -> ScriptedCommands:
+    """The merged-branch repository, plus an answer for one pull request."""
+    payload = dict(_MERGED_DONE)
+    payload.update(pr)
+    return merged_branch_port(pr_view=payload)
+
+
+def test_after_merge_sweeps_the_branch_the_pull_request_finished_with() -> None:
+    """The round trip this mode removes: an agent that merged its own pull
+    request cleans up after itself in one call, and nothing else moves."""
+    code, payload = invoke(["--after-merge", "438"], after_merge_port())
+
+    assert code == EXIT_OK
+    assert payload["mode"] == "after-merge"
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert [d["name"] for d in execution["deletions"]] == ["done"]
+
+
+def test_a_pull_request_that_did_not_merge_refuses_and_deletes_nothing() -> None:
+    code, payload = invoke(["--after-merge", "438"], after_merge_port(state="CLOSED"))
+
+    assert code == EXIT_REFUSED
+    refusal = payload["refusal"]
+    assert isinstance(refusal, dict)
+    assert refusal["code"] == "E_PR_NOT_MERGED"
+    assert payload.get("execution") is None
+
+
+def test_after_merge_without_gh_refuses_rather_than_falling_back_to_a_sweep() -> None:
+    """No forge, no authorising fact. Falling back to a bare sweep here would
+    take every provably-merged branch in the repository on the strength of a
+    command that asked about one."""
+    code, payload = invoke(["--after-merge", "438"], merged_branch_port(has_gh=False))
+
+    assert code == EXIT_REFUSED
+    refusal = payload["refusal"]
+    assert isinstance(refusal, dict)
+    assert refusal["code"] == "E_PR_UNREADABLE"
+
+
+def test_a_pull_request_number_that_is_not_a_number_is_a_usage_error() -> None:
+    """Exit 2 before anything is read: `gh pr view` also accepts a URL and a
+    branch name there, so a spelling that is not a number could resolve some
+    other pull request and authorise a deletion nobody asked for."""
+    with pytest.raises(SystemExit) as exit_info:
+        invoke(["--after-merge", "feat/x"], merged_branch_port())
+
+    assert exit_info.value.code == EXIT_USAGE
+
+
+def test_after_merge_and_cleanup_cannot_be_asked_for_together() -> None:
+    """One authorises by proof and the other by naming. A command line claiming
+    both has not said which rule applies to the targets."""
+    with pytest.raises(SystemExit) as exit_info:
+        invoke(["--after-merge", "438", "--cleanup", "done"], merged_branch_port())
+
+    assert exit_info.value.code == EXIT_USAGE
+
+
+def test_after_merge_dry_run_changes_nothing() -> None:
+    code, payload = invoke(["--after-merge", "438", "--dry-run"], after_merge_port())
+
+    assert code == EXIT_OK
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    assert plan["dry_run"] is True
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert all(d["deleted"] is False for d in execution["deletions"])

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 from conftest import make_branch, make_survey
 
-from gitclean.model import MergeEvidence, NotOffered, Plan, Refusal, Target, TargetKind
-from gitclean.plan import build_plan, resolve_selectors
+from gitclean.model import (
+    Counterpart,
+    MergeEvidence,
+    NotOffered,
+    Plan,
+    PullRequestOutcome,
+    Refusal,
+    Target,
+    TargetKind,
+)
+from gitclean.plan import build_after_merge_plan, build_plan, resolve_selectors
 
 
 def target(
@@ -15,6 +24,7 @@ def target(
     name: str | None = None,
     sweepable: bool = True,
     remote: str = "origin",
+    pairing: tuple[Counterpart, ...] = (),
 ) -> Target:
     resolved = name if name is not None else ident.split(":", 1)[1]
     # The remote a server ref lives on, which only the survey can recover. Most
@@ -33,7 +43,17 @@ def target(
         last_activity=None,
         remote=remote if on_remote else None,
         ref_name=resolved.removeprefix(f"{remote}/") if on_remote else None,
+        pairing=pairing,
     )
+
+
+def counterpart(relation: str, of: Target) -> Counterpart:
+    """The relation a classified row carries, built from the row it points at.
+
+    Taking the target rather than two strings is what stops a fixture
+    describing a report that cannot exist: a counterpart naming a row carries
+    that row's own id and name, and the two cannot drift apart here."""
+    return Counterpart(relation=relation, name=of.name, id=of.id, known=True)
 
 
 def plan_for(
@@ -579,3 +599,201 @@ def test_plan_orders_worktrees_then_local_then_remote() -> None:
     result = plan_for(targets, selectors=["remote:origin/z", "branch:b", "worktree:/repo/w"])
     assert isinstance(result, Plan)
     assert [t.kind.value for t in result.targets] == ["worktree", "branch", "remote_branch"]
+
+
+# -- after a merged pull request ---------------------------------------------
+
+
+def _merged(number: int = 438, head_ref: str = "feat/shipped") -> PullRequestOutcome:
+    return PullRequestOutcome(
+        number=number, state="MERGED", head_ref=head_ref, merged_at="2026-08-01T00:00:00Z"
+    )
+
+
+def after_merge(
+    targets: tuple[Target, ...],
+    *,
+    pull_request: PullRequestOutcome | str | None = None,
+    survey=None,  # type: ignore[no-untyped-def]
+) -> Plan | Refusal:
+    return build_after_merge_plan(
+        targets,
+        survey if survey is not None else make_survey(),
+        pull_request=pull_request if pull_request is not None else _merged(),
+        dry_run=False,
+    )
+
+
+def _shipped_pair() -> tuple[Target, Target]:
+    """A merged branch and the worktree holding it, pointing at each other.
+
+    Built as a pair because that is how the survey reports them: the scope is
+    reached by following the relation, so a fixture whose rows do not name each
+    other is testing a report that never occurs."""
+    worktree = target(
+        "worktree:/repo/wt-shipped", kind=TargetKind.WORKTREE, name="/repo/wt-shipped"
+    )
+    branch = target("branch:feat/shipped", pairing=(counterpart("worktree", worktree),))
+    return branch, worktree
+
+
+def test_a_merged_pull_request_sweeps_its_branch_and_the_worktree_holding_it() -> None:
+    """The round trip this mode exists to remove. Nothing is named and nothing
+    is skipped: the scope is what the pull request produced, and both rows
+    cleared the same checks a bare sweep applies."""
+    branch, worktree = _shipped_pair()
+
+    result = after_merge((branch, worktree, target("branch:someone-elses-work")))
+
+    assert isinstance(result, Plan)
+    assert [t.name for t in result.targets] == ["/repo/wt-shipped", "feat/shipped"]
+    assert result.skipped == ()
+
+
+def test_nothing_a_different_pull_request_produced_enters_the_scope() -> None:
+    """The whole reason a bare sweep was not an option. An agent cleaning up
+    after itself must take its own two rows and leave every other branch in the
+    repository exactly where it is, however provably merged they are."""
+    branch, worktree = _shipped_pair()
+    others = (
+        target("branch:someone-elses-work"),
+        target("worktree:/repo/wt-theirs", kind=TargetKind.WORKTREE, name="/repo/wt-theirs"),
+    )
+
+    result = after_merge((branch, worktree, *others))
+
+    assert isinstance(result, Plan)
+    assert {t.name for t in result.targets} == {"/repo/wt-shipped", "feat/shipped"}
+
+
+def test_a_pull_request_that_closed_without_merging_is_not_a_deletion_authority() -> None:
+    """Closing a pull request says somebody stopped wanting the change. It
+    never says the commits landed anywhere else, and they did not."""
+    branch, worktree = _shipped_pair()
+    closed = PullRequestOutcome(number=438, state="CLOSED", head_ref="feat/shipped", merged_at=None)
+
+    result = after_merge((branch, worktree), pull_request=closed)
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_PR_NOT_MERGED"
+    assert "CLOSED" in result.message
+
+
+def test_an_open_pull_request_is_not_a_deletion_authority_either() -> None:
+    """The failure that would hurt most: deleting the branch of a pull request
+    still under review takes the only copy of work nobody has merged."""
+    branch, worktree = _shipped_pair()
+    still_open = PullRequestOutcome(
+        number=438, state="OPEN", head_ref="feat/shipped", merged_at=None
+    )
+
+    result = after_merge((branch, worktree), pull_request=still_open)
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_PR_NOT_MERGED"
+
+
+def test_a_pull_request_read_that_did_not_answer_authorises_nothing() -> None:
+    """The authorising fact is the only thing this mode has that a sweep does
+    not, so a read that failed leaves it with no authority at all -- not a
+    degraded one that falls back to sweeping."""
+    branch, worktree = _shipped_pair()
+
+    result = after_merge((branch, worktree), pull_request="gh is not on PATH")
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_PR_UNREADABLE"
+    assert "gh is not on PATH" in result.message
+
+
+def test_a_merge_stated_without_a_time_is_not_one_this_acts_on() -> None:
+    """State and merge time are one fact stated twice, and a fact stated twice
+    is established only when both statements agree."""
+    branch, worktree = _shipped_pair()
+    undated = PullRequestOutcome(
+        number=438, state="MERGED", head_ref="feat/shipped", merged_at=None
+    )
+
+    result = after_merge((branch, worktree), pull_request=undated)
+
+    assert isinstance(result, Refusal)
+    assert result.code == "E_PR_UNREADABLE"
+
+
+def test_the_servers_copy_is_reported_and_never_swept() -> None:
+    """A merged pull request authorises deleting this repository's copy of the
+    work. The server keeps no reflog, so its copy still goes only when named --
+    and the row saying so is what stops a clean run reading as gone everywhere."""
+    server = target("remote:origin/feat/shipped", kind=TargetKind.REMOTE_BRANCH)
+    worktree = target(
+        "worktree:/repo/wt-shipped", kind=TargetKind.WORKTREE, name="/repo/wt-shipped"
+    )
+    branch = target(
+        "branch:feat/shipped",
+        pairing=(counterpart("worktree", worktree), counterpart("upstream", server)),
+    )
+
+    result = after_merge((branch, worktree, server))
+
+    assert isinstance(result, Plan)
+    assert "remote:origin/feat/shipped" not in [t.id for t in result.targets]
+    reported = {s.target_id: s.reason for s in result.skipped}
+    assert "the copy on the server" in reported["remote:origin/feat/shipped"]
+
+
+def test_a_branch_the_sweep_would_withhold_is_left_exactly_where_it_is() -> None:
+    """The pull request describes the commit its head pointed at, not whatever
+    the branch of that name holds now. So the six questions are still asked, and
+    a branch that fails one is reported with the measurement that stopped it."""
+    worktree = target(
+        "worktree:/repo/wt-shipped", kind=TargetKind.WORKTREE, name="/repo/wt-shipped"
+    )
+    branch = target(
+        "branch:feat/shipped", sweepable=False, pairing=(counterpart("worktree", worktree),)
+    )
+
+    result = after_merge((branch, worktree))
+
+    assert isinstance(result, Plan)
+    assert [t.name for t in result.targets] == ["/repo/wt-shipped"]
+    reported = {s.target_id: s.reason for s in result.skipped}
+    assert reported["branch:feat/shipped"] == branch.withheld
+
+
+def test_an_occupied_branch_is_skipped_rather_than_stopping_the_run() -> None:
+    """What a sweep does about occupancy, and this is a sweep. git refuses to
+    delete a branch a worktree still holds, so the branch is skipped with the
+    holder named and everything else in scope still goes."""
+    held = target("branch:held", pairing=())
+    survey = make_survey(branches=(make_branch("held", checked_out_at="/repo/elsewhere"),))
+
+    result = after_merge((held,), pull_request=_merged(head_ref="held"), survey=survey)
+
+    assert isinstance(result, Plan)
+    assert result.targets == ()
+    assert [s.target_id for s in result.skipped] == ["branch:held"]
+    assert "/repo/elsewhere" in result.skipped[0].reason
+
+
+def test_a_pull_request_whose_branch_is_already_gone_is_a_completed_job() -> None:
+    """Routine rather than exceptional: the forge deletes the branch on merge,
+    or the agent ran this a moment ago. Reporting a finished job as a failure is
+    what sends a caller back to raw git."""
+    result = after_merge((target("branch:something-else"),))
+
+    assert isinstance(result, Plan)
+    assert result.targets == ()
+    assert result.skipped == ()
+    assert [a.selector for a in result.absent] == ["feat/shipped"]
+
+
+def test_a_pull_request_plan_never_carries_a_salvage_directory() -> None:
+    """Salvage is retained only where no reflog exists, which is the server --
+    and no server ref can enter this plan. A directory here would be a bundle
+    nothing writes and a route nobody takes."""
+    branch, worktree = _shipped_pair()
+
+    result = after_merge((branch, worktree))
+
+    assert isinstance(result, Plan)
+    assert result.salvage_dir is None

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -777,6 +777,30 @@ def test_a_pull_request_with_no_head_ref_names_no_branch_to_act_on() -> None:
     assert "which branch" in outcome
 
 
+def test_a_null_head_ref_is_absence_rather_than_a_branch_called_none() -> None:
+    """JSON null arrives as None, and `str(None)` is the five-character word
+    "None" -- not empty, so an emptiness check made after the conversion passes
+    it. A field gh declined to answer would then become the scope, and the
+    sweep would narrow to a branch literally called None."""
+    port = pr_view(number=7, state="MERGED", headRefName=None, mergedAt="2026-08-01T09:30:00Z")
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "did not say which branch" in outcome
+
+
+def test_a_null_state_is_no_state_rather_than_the_word_none() -> None:
+    """Same conversion, same trap, and here it reaches a caller as the sentence
+    explaining why nothing was deleted."""
+    port = pr_view(number=7, state=None, headRefName="feat/x", mergedAt=None)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert not isinstance(outcome, str)
+    assert outcome.state == ""
+
+
 def test_a_pull_request_number_gh_states_as_something_else_is_not_read_past() -> None:
     """`int()` on whatever gh put there would raise out of the read and take
     the run with it -- and the number is what every sentence downstream names,

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from gitclean.model import MergeEvidence, Survey
+from gitclean.model import MergeEvidence, PullRequestOutcome, Survey
 from gitclean.ports import CommandResult, ScriptedCommands, SubprocessCommands, fail, ok
 from gitclean.survey import (
     _count_dirt,
+    read_pull_request,
     read_pull_requests,
     read_worktrees,
     resolve_base_ref,
@@ -79,6 +80,7 @@ def make_port(
     has_gh: bool = True,
     gh_result: CommandResult | None = None,
     remotes: str = "origin\n",
+    pr_view: dict[str, object] | None = None,
 ) -> ScriptedCommands:
     table: dict[str, CommandResult] = {
         "rev-parse --show-toplevel": ok("/repo"),
@@ -113,7 +115,12 @@ def make_port(
         table[f"rev-list --count {spec}"] = ok(value)
     table.update(extra or {})
     gh = gh_result or ok(json.dumps(prs or []))
-    return ScriptedCommands(git=table, gh={"pr list": gh}, has_gh=has_gh)
+    answers = {"pr list": gh}
+    if pr_view is not None:
+        # Left unscripted unless a test asks for one, so that a run reaching for
+        # a pull request nobody set up fails loudly rather than on a default.
+        answers["pr view"] = ok(json.dumps(pr_view))
+    return ScriptedCommands(git=table, gh=answers, has_gh=has_gh)
 
 
 def run(port: ScriptedCommands, **kwargs: object) -> Survey:
@@ -653,6 +660,146 @@ def test_a_pr_list_below_the_cap_warns_about_nothing() -> None:
     port = ScriptedCommands(gh={"pr list": ok(payload)}, has_gh=True)
 
     assert read_pull_requests(port, None)[2] is None
+
+
+# -- one pull request, read because a caller named it -------------------------
+
+
+def pr_view(**fields: object) -> ScriptedCommands:
+    """A port whose only answer is `gh pr view`, carrying the fields given.
+
+    Spelled as gh spells them, because that is the payload this parse has to
+    survive -- rewriting them into the model's own names here would test the
+    builder rather than the read."""
+    return ScriptedCommands(gh={"pr view": ok(json.dumps(fields))}, has_gh=True)
+
+
+MERGED_PR: dict[str, object] = {
+    "number": 7,
+    "state": "MERGED",
+    "headRefName": "feat/x",
+    "mergedAt": "2026-08-01T09:30:00Z",
+}
+
+
+def test_a_pull_request_read_by_number_carries_the_branch_it_was_opened_from() -> None:
+    """The head ref is the whole of what one pull request says about which
+    branch is finished with, and the bulk read spends that string as its index
+    key -- so this is the only place it survives as a value."""
+    port = pr_view(**MERGED_PR)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, PullRequestOutcome)
+    assert (outcome.number, outcome.state, outcome.head_ref) == (7, "MERGED", "feat/x")
+    assert outcome.merged_at == "2026-08-01T09:30:00Z"
+
+
+def test_the_pull_request_number_reaches_gh_exactly_as_the_caller_spelled_it() -> None:
+    """`gh pr view` accepts a URL and a branch name in that position too, so a
+    round trip through int() would change what is asked for. The argv is
+    asserted rather than the result, because a run that resolved some *other*
+    pull request would return an outcome that looks perfectly well-formed."""
+    port = pr_view(**MERGED_PR)
+
+    read_pull_request(port, None, "0007")
+
+    assert (
+        "gh",
+        "pr",
+        "view",
+        "0007",
+        "--json",
+        "number,state,headRefName,mergedAt",
+    ) in port.transcript
+
+
+def test_without_gh_nothing_says_whether_the_pull_request_merged() -> None:
+    """The bulk read degrades here and carries on, because a missing tier still
+    leaves the git evidence. This read is the authorisation itself, so there is
+    nothing left to carry on with -- and the sentence has to say so."""
+    outcome = read_pull_request(ScriptedCommands(has_gh=False), None, "7")
+
+    assert isinstance(outcome, str)
+    assert "gh is not on PATH" in outcome
+    assert "#7" in outcome
+
+
+def test_a_failing_gh_pr_view_is_reported_with_what_gh_said() -> None:
+    port = ScriptedCommands(gh={"pr view": fail("could not resolve to a PullRequest")}, has_gh=True)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "could not resolve to a PullRequest" in outcome
+
+
+def test_a_gh_failure_with_nothing_on_stderr_still_says_what_happened() -> None:
+    """An empty stderr is not an empty answer. Reporting the exit code is what
+    keeps the refusal from reading as though gh said nothing at all."""
+    port = ScriptedCommands(gh={"pr view": fail("", code=4)}, has_gh=True)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "exit 4" in outcome
+
+
+def test_unparseable_gh_pr_view_json_authorises_nothing() -> None:
+    port = ScriptedCommands(gh={"pr view": ok("{{{not json")}, has_gh=True)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "unparseable" in outcome
+
+
+def test_a_payload_that_is_not_a_pull_request_object_authorises_nothing() -> None:
+    """gh answering with a list, or with null, is gh describing something this
+    did not ask about. Reading a merge out of it would be inventing one."""
+    port = ScriptedCommands(gh={"pr view": ok("[]")}, has_gh=True)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "describes no pull request" in outcome
+
+
+def test_a_pull_request_with_no_head_ref_names_no_branch_to_act_on() -> None:
+    """The head ref is the scope. Without it there is nothing this run could
+    narrow itself to, and an empty string would match no branch while looking
+    exactly like a repository that had already been cleaned."""
+    port = pr_view(number=7, state="MERGED", headRefName="", mergedAt="2026-08-01T09:30:00Z")
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "which branch" in outcome
+
+
+def test_a_pull_request_number_gh_states_as_something_else_is_not_read_past() -> None:
+    """`int()` on whatever gh put there would raise out of the read and take
+    the run with it -- and the number is what every sentence downstream names,
+    so a guess in its place is a report about a pull request nobody opened."""
+    port = pr_view(
+        number="not-a-number", state="MERGED", headRefName="feat/x", mergedAt="2026-08-01T09:30:00Z"
+    )
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, str)
+    assert "could not read" in outcome
+
+
+def test_a_pull_request_that_never_merged_carries_no_merge_time() -> None:
+    """gh states `mergedAt` as null there, and null is not a timestamp: the
+    field says nothing merged rather than saying nothing."""
+    port = pr_view(number=7, state="CLOSED", headRefName="feat/x", mergedAt=None)
+
+    outcome = read_pull_request(port, None, "7")
+
+    assert isinstance(outcome, PullRequestOutcome)
+    assert (outcome.state, outcome.merged_at) == ("CLOSED", None)
 
 
 # -- ref classification ------------------------------------------------------

--- a/src/user/.agents/skills/post-merge-cleanup/SKILL.md
+++ b/src/user/.agents/skills/post-merge-cleanup/SKILL.md
@@ -35,8 +35,8 @@ one pull request's branch and worktree without asking. It is not a naming and
 skips nothing: it applies the same proof and the same checks a bare sweep does,
 scoped to what that pull request produced, and reports whatever it will not
 take. What authorises it is that the pull request merged — a fact the forge
-answers, not one you judged. The server's copy is **not** in its scope; that
-still waits to be named.
+answers, not one you judged. It reports the server's copy and **never deletes
+it**; that one still waits to be named.
 
 Reach for it. It is easy not to — it is a CLI on PATH, not a git subcommand, so
 nothing in a git session suggests it exists. If it is not installed, say so

--- a/src/user/.agents/skills/post-merge-cleanup/SKILL.md
+++ b/src/user/.agents/skills/post-merge-cleanup/SKILL.md
@@ -30,6 +30,14 @@ there has no reflog, so `gitclean` removes it only when it is named. The end
 state above therefore needs a further call naming that ref — after the user has
 agreed to it, never bundled into the sweep on their behalf.
 
+After a pull request **you** merged, `gitclean --after-merge <pr>` takes that
+one pull request's branch and worktree without asking. It is not a naming and
+skips nothing: it applies the same proof and the same checks a bare sweep does,
+scoped to what that pull request produced, and reports whatever it will not
+take. What authorises it is that the pull request merged — a fact the forge
+answers, not one you judged. The server's copy is **not** in its scope; that
+still waits to be named.
+
 Reach for it. It is easy not to — it is a CLI on PATH, not a git subcommand, so
 nothing in a git session suggests it exists. If it is not installed, say so
 rather than substituting `git branch --merged`: under a squash merge that answer
@@ -46,4 +54,5 @@ deletion on the strength of a survey that never happened.
 So: survey everything you mention, relay each withheld target **with the reason
 given**, and say plainly when something was not measured. Naming a target to
 `gitclean` skips the checks a bare sweep applies, which makes it the user's
-decision to make and never yours to make for them.
+decision to make and never yours to make for them — the one exception being the
+pull request you merged, where nothing is skipped and nothing was judged.


### PR DESCRIPTION
First of two PRs for `agents-config-9k9.131`. This one adds the `--after-merge` verb and narrows the skill rule. The selector and batch fixes (bare names not selecting server refs, partial-batch handling, survey-time remote verification) follow in PR B.

## The gap

`gitclean` had two modes and needed three.

- A bare `--cleanup` proves every candidate and sweeps **all** of them.
- Naming a target deletes exactly it and **re-derives nothing** — a name is the caller's authorisation.

There was no mode that *proves one named thing*. So an agent that just merged its own PR had no legal move: naming its own worktree and branch would be skipping the checks its rules forbid, and a bare sweep would have taken nineteen other targets belonging to other work. It had to stop and ask a human, on the most routine action in the delivery cycle.

## The verb

```
gitclean --after-merge 438
```

A **sweep with a narrower scope, not a naming.** Every check a bare sweep applies is applied unchanged; only the scope moves. A mode that narrowed the scope *and* relaxed the proof would be a naming wearing a sweep's clothes.

What authorises it is mechanical — the pull request merged — rather than an agent's judgement that a branch looks finished with.

**Refusals**, all about that authorising fact, since it is the only thing this mode has that a sweep does not:

| Code | When |
|---|---|
| `E_PR_UNREADABLE` | gh absent, or the read failed, or the payload is unparseable. No forge, no authority — *not* a degraded one that falls back to sweeping. |
| `E_PR_NOT_MERGED` | The PR closed without merging. Closing says somebody stopped wanting the change; it never says its commits exist anywhere else. |
| `E_PR_UNREADABLE` | gh reports `MERGED` and dates nothing. State and merge time are one fact stated twice, and a fact stated twice is established only when both agree. |

Past that point **nothing is taken on the pull request's word.** A merge describes the commit its head pointed at, not whatever the branch of that name holds now — so the same six questions are asked, and a branch that fails one is reported with the measurement that stopped it and left where it is.

The **server's copy is gathered into the scope so it can be reported, and never deleted.** It keeps no reflog, so it still goes only when named. Leaving it out entirely would let a clean run read as "gone everywhere", which is the one place this mode could quietly mislead.

A non-numeric PR argument is a **usage error before the survey runs** — `gh pr view` also accepts a URL and a branch name there, and either would resolve *some* pull request, which is not the one the caller named.

## The rule change

The `post-merge-cleanup` skill's rule was:

> Naming a target to `gitclean` skips the checks a bare sweep applies, which makes it the user's decision to make and never yours to make for them.

That rule is load-bearing *because naming skips the checks*. `--after-merge` skips nothing, so the exception is exactly as wide as the fact that justifies it — the PR you merged, and nothing else.

**The `/clean-up-git` command is deliberately unchanged.** Its `MUST NOT name a target the user did not name` governs an interactive flow where the user is present and ratifying each entry; `--after-merge` has no business there, and loosening it would widen an agent's authority in the one place a human is already standing.

## Evidence

`make ci` green (exit 0) from this worktree. 415 tests; `plan.py` and `model.py` at full coverage, package total 98%.

**Mutation-checked.** Two mutations — treating any PR as an authority, and letting the server's copy into the sweep — are each caught, by five tests spanning the plan layer, the CLI layer, and real git:

- `test_a_pull_request_that_closed_without_merging_is_not_a_deletion_authority`
- `test_an_open_pull_request_is_not_a_deletion_authority_either`
- `test_the_servers_copy_is_reported_and_never_swept`
- `test_a_pull_request_that_did_not_merge_refuses_and_deletes_nothing`
- `test_a_pull_request_that_closed_unmerged_deletes_nothing_in_a_real_repository`

Real-git coverage includes the case most likely to be hit in practice: **running `--after-merge` from inside the worktree it is about.** The sweep withholds that directory (removing it would pull the working directory out from under the process) and withholds the branch beside it, deletes nothing, and reports both reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zSUyTCy13ju28gaFmkykq