### PR TITLE
fix(9k9.131): a bare name means something local, and one bad name no longer spends the rest

### DIFF
--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -42,6 +42,18 @@ reflog is the undo for a local branch. Two things still stop a named deletion:
 the worktree this process is running in, and git itself — a checked-out branch,
 a dirty or locked worktree. Those refusals arrive verbatim, with the transcript.
 
+A bare name reaches a worktree or a local branch. The copy on a server answers
+to its full `<remote>/<ref>` spelling and to nothing shorter, so the name you
+just merged is never ambiguous between the two — and a bare name that only a
+server ref wears is refused with the full spelling to use, rather than reported
+as already gone about a ref that is sitting right there.
+
+Each refusal stops only the name it is about. Whatever else was named and
+resolved cleanly is deleted, every refusal lands in `plan.refused` with its own
+code and remedy, and the run exits 1 for having raised any — so one mistyped
+name costs a correction rather than a whole re-run. **Exit 1 therefore does not
+mean nothing happened**: read `execution.deletions` for what did.
+
 ## How a merge gets proven
 
 `git branch --merged` is wrong in both directions under a squash-merge
@@ -170,7 +182,7 @@ because the argument parser claims `-m` as a flag first: select it by its
 | code | meaning |
 |---|---|
 | 0 | clean |
-| 1 | refused (see `refusal.code` and `refusal.remedy`) |
+| 1 | something was refused (`plan.refused[]`, or `refusal` for a whole-run one) — other named targets may still have been deleted |
 | 2 | unusable (not a repository, bad arguments) |
 | 3 | acted, but something surprised us (see `execution.anomalies`) |
 

--- a/packages/gitclean/src/gitclean/cli.py
+++ b/packages/gitclean/src/gitclean/cli.py
@@ -55,6 +55,9 @@ a pairing by splitting a name or a reason sentence.
 
 naming a target deletes it. Nothing is re-derived, no flag is demanded, and git's
 own refusals -- a checked-out branch, a dirty or locked worktree -- stand as they are.
+a bare name reaches a worktree or a local branch only; the copy on a server answers to
+its full `<remote>/<ref>` spelling and to nothing shorter, so the name you merged is
+never ambiguous between the two.
 
 a name that matches nothing is not an error, once nothing-matched actually means gone.
 It lands in `plan.absent` with a note and the other named targets are still deleted. A
@@ -64,9 +67,15 @@ reported as work done: `deleted` stays false, because only a true there means th
 acted.
 
 it refuses instead where nothing-matched proves nothing -- when no ref could be read at
-all, and when the name is a ref this tool does not offer as a target, such as the
-server's copy of the trunk. Both of those look identical to an absent name and neither
-one is, so saying "already gone" about them would be a false report.
+all, when the name is a ref this tool does not offer as a target such as the server's
+copy of the trunk, and when the only thing wearing the name is a server ref, which the
+refusal then spells out in full for you. All of those look identical to an absent name
+and none of them is, so saying "already gone" about them would be a false report.
+
+one refusal does not stop the others. Whatever resolved cleanly is still deleted, each
+refusal is reported in `plan.refused` with its own code and remedy, and the run exits 1
+for having raised any -- so a single mistyped name no longer costs a whole re-run. An
+unverified deletion still outranks it and exits 3.
 
 what --after-merge takes:
   the local branch a pull request was opened from, and the worktree holding it -- each
@@ -298,6 +307,15 @@ def _render_human(payload: dict[str, object], out: TextIO) -> None:
     # that as FAIL would teach the reader to distrust a clean preview.
     dry = isinstance(plan, dict) and bool(plan.get("dry_run"))
     if isinstance(plan, dict):
+        # Ahead of the deletions rather than after them. A caller who named
+        # five things and reads four `ok` lines has been shown a successful
+        # run; the thing that makes it not one has to arrive before they stop
+        # reading.
+        for entry in plan.get("refused") or []:
+            if isinstance(entry, dict):
+                print("", file=out)
+                print(f"REFUSED ({entry.get('code')}): {entry.get('message')}", file=out)
+                print(f"  remedy: {entry.get('remedy')}", file=out)
         skipped = plan.get("skipped")
         if isinstance(skipped, list) and skipped:
             print("", file=out)
@@ -414,7 +432,7 @@ def main(
     _emit(
         _envelope(
             mode,
-            ok=execution.ok,
+            ok=execution.ok and not outcome.refused,
             survey_data=surveyed,
             targets=targets,
             plan=outcome,
@@ -423,7 +441,13 @@ def main(
         args.format,
         stream,
     )
-    return EXIT_OK if execution.ok else EXIT_ANOMALY
+    # An anomaly outranks a refusal. A refusal is the tool declining to act and
+    # leaving the repository as it found it; an anomaly is a deletion that ran
+    # and could not be confirmed afterwards, which is the one outcome a reader
+    # must not have hidden behind the milder code.
+    if not execution.ok:
+        return EXIT_ANOMALY
+    return EXIT_REFUSED if outcome.refused else EXIT_OK
 
 
 def entry() -> None:

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -742,7 +742,15 @@ class Plan:
 
     Distinct from ``skipped``, which is the sweep declining to take something
     nobody asked for by name. Both are omissions; only this one contradicts an
-    instruction."""
+    instruction.
+
+    Ordered as: everything raised while resolving names, in the order those
+    names were given, then the two checks made of the selection as a whole once
+    it is known -- the worktree the run is standing in, and branches a worktree
+    still holds. Not one flat selector order, because the second of those pair
+    is a single refusal covering however many branches were occupied, so it has
+    no one position among the selectors to take. Map a refusal back to what you
+    typed through ``blocked`` and the names in its message, never by index."""
 
     def as_json(self) -> dict[str, object]:
         return {

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -427,8 +427,8 @@ class NotOffered:
     copy of the trunk. This one does not -- ``name`` is the whole path under
     `refs/remotes/`, and where the remote's name stops inside it is the
     unanswered question. So this is the only entry whose *other* spellings are
-    unknown, which is what makes it able to collide with a selector that
-    matched something else."""
+    unknown, which is why a name that matches nothing cannot be called absent
+    while one of these is on the books."""
 
     def as_json(self) -> dict[str, object]:
         return {"name": self.name, "reason": self.reason, "unsplit": self.unsplit}
@@ -731,6 +731,18 @@ class Plan:
     absent: tuple[Absent, ...] = field(default_factory=tuple)
     """Names that resolved to nothing. A plan holding only these is a plan to
     do nothing, which is a valid plan and not an error."""
+    refused: tuple[Refusal, ...] = field(default_factory=tuple)
+    """Names this run would not act on, each with the reason and the remedy.
+
+    A plan carrying these is still a plan: the targets beside them resolved
+    cleanly and are deleted. What the refusals change is the verdict on the
+    run as a whole -- `ok` is false and the exit code says something was
+    refused -- because a caller who named five things and had four deleted has
+    not had their command carried out, however much of it worked.
+
+    Distinct from ``skipped``, which is the sweep declining to take something
+    nobody asked for by name. Both are omissions; only this one contradicts an
+    instruction."""
 
     def as_json(self) -> dict[str, object]:
         return {
@@ -739,6 +751,7 @@ class Plan:
             "dry_run": self.dry_run,
             "skipped": [s.as_json() for s in self.skipped],
             "absent": [a.as_json() for a in self.absent],
+            "refused": [r.as_json() for r in self.refused],
         }
 
 
@@ -749,8 +762,9 @@ class Refusal:
     Refusals are few and narrow, because a named target is an authorisation
     rather than a proposal. What is left answers something the caller could not
     have answered themselves -- a name matching two things, a deletion git
-    itself will reject. ``blocked`` lists the targets so they can be dropped
-    from the selection rather than argued with.
+    itself will reject. ``blocked`` lists the targets the refusal is about,
+    which a per-selector refusal has already dropped from the plan: it is there
+    to be read, not to be acted on before re-running.
 
     A name matching *nothing* is not among them. It asks for a state that
     already holds, which is a job already done rather than a job refused; see

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -22,20 +22,27 @@ not have answered themselves: a name matching two things, a branch git will
 reject because a worktree still holds it, and the directory this process is
 standing in.
 
-A name matching *nothing* used to be one of them, and was wrong. The caller
-asked for that thing to be gone; it is gone. Refusing there reports a completed
-job as a failure -- and because a selector refusal aborts the whole plan, one
-name that had already been dealt with stopped every other deletion the caller
-asked for.
+None of them stops the rest. A refusal is about the selector it names, so what
+resolved cleanly is still planned and still deleted, and the refusals ride
+along beside it -- the run reports both and exits non-zero. Aborting the whole
+selection over one bad name was the older behaviour and it was the worse one:
+a name that had already been dealt with stopped every other deletion the caller
+asked for, and the only way out was to re-run with the offender removed, which
+is a round trip spent teaching the tool something it had already worked out.
 
-What replaced it is narrower than "a miss is fine", because a miss has three
-causes and only one of them is absence. The list can also be empty because the
-ref read failed, or missing a name because this tool does not offer that ref as
-a target -- and in both the branch is sitting right there. Those two refuse,
-and the refusal codes say which, because the alternative is telling somebody
-their branch is gone while it is not. Concluding absence from a list that was
-never able to answer is the same mistake as reading an unanswered probe as a
-clean working tree.
+A name matching *nothing* is not a refusal at all. The caller asked for that
+thing to be gone; it is gone, and reporting a finished job as a failure is what
+sends somebody back to raw git.
+
+That is narrower than "a miss is fine", though, because a miss has four causes
+and only one of them is absence. The list can also be empty because the ref
+read failed, or missing a name because this tool does not offer that ref as a
+target, or missing it because the only thing wearing that name is a copy on a
+server -- which a bare name deliberately no longer reaches. In all three the
+branch is sitting right there. Those refuse, and the codes say which, because
+the alternative is telling somebody their branch is gone while it is not.
+Concluding absence from a list that was never able to answer is the same
+mistake as reading an unanswered probe as a clean working tree.
 """
 
 from __future__ import annotations
@@ -58,17 +65,40 @@ from gitclean.model import (
 def _selector_candidates(target: Target) -> set[str]:
     """Every string a caller may reasonably use to name this target.
 
-    The bare-branch alias for a server ref is the name the *remote* knows it
-    by, carried down from the survey. Recovering it here by dropping everything
-    before the first slash would put `origin/feat/x` in this set for a ref on a
-    remote called `team/origin` -- a spelling that names nothing, offered to a
-    caller as though it named their branch."""
+    A server ref answers to its full `<remote>/<ref>` spelling and its
+    `remote:` id, and to nothing shorter. The bare name a remote knows a branch
+    by is, in any ordinary repository, the very string the local branch goes by
+    -- so accepting it here made the commonest cleanup there is, deleting the
+    branch whose work just merged, ambiguous between a local ref and a copy on
+    a server that this tool declines to delete unnamed anyway. Requiring the
+    full spelling contradicts nothing the tool offers: a bare name only ever
+    reached a server ref where no local branch shared it, and where one did,
+    the run refused rather than choosing."""
     names = {target.id, target.name}
     if target.kind is TargetKind.WORKTREE:
         names.add(Path(target.name).name)
-    if target.kind is TargetKind.REMOTE_BRANCH and target.ref_name:
-        names.add(target.ref_name)
     return names
+
+
+def _bare_server_refs(selector: str, targets: tuple[Target, ...]) -> list[Target]:
+    """Every server ref this selector names in each way except the one that counts.
+
+    Consulted only once nothing matched, and it is what keeps that miss from
+    being read as absence. The refs are right there; what is absent is a local
+    target wearing the name. "Already gone" would be false about the only
+    things that bear it, and staying silent would leave a caller believing a
+    deletion they asked for had happened.
+
+    All of them rather than the first, because a fork with `origin` and
+    `upstream` carries the same branch name twice as a matter of course, and
+    telling that caller about one copy would name half of what is there --
+    which reads as the whole of it.
+
+    Not asked of a selector that has already said it means something else: a
+    `branch:` names a local ref, and `worktree:` or a path names a worktree."""
+    if selector.startswith(("branch:", "worktree:", "/")):
+        return []
+    return [t for t in targets if t.kind is TargetKind.REMOTE_BRANCH and t.ref_name == selector]
 
 
 def _not_offered(selector: str, survey_data: Survey) -> NotOffered | None:
@@ -86,8 +116,15 @@ def _not_offered(selector: str, survey_data: Survey) -> NotOffered | None:
 
 
 def _unsplit_this_could_name(selector: str, survey_data: Survey) -> NotOffered | None:
-    """A ref whose remote and branch name could not be told apart, and which
-    this selector might have been naming.
+    """A ref whose remote and branch name could not be told apart, and whose
+    branch name this selector may be.
+
+    Not a rival for the selection -- a bare name does not reach a server ref at
+    all now, so nothing here competes for a match. It is the unsplittable twin
+    of the case above: where the split succeeded, a bare name that hits only a
+    server ref can be told exactly what to spell instead, and where it failed
+    the spelling to suggest is the unanswered question. So the run reports the
+    doubt rather than an absence it cannot support.
 
     The doubt is per-selector, and that is decidable rather than a guess. A
     remote-tracking ref is `refs/remotes/<remote>/<branch>`, and the two halves
@@ -136,14 +173,15 @@ def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str
     trust whichever one happened to answer.
 
     "Could not answer" covers a listing that did not run, one that ran without
-    describing everything it listed, *and* one that described a ref under a
-    spelling this selector cannot be compared against. A row nobody could
-    parse is a thing whose existence went unrecorded, which is the same hole as
-    never having looked -- and so is a server ref recorded only as
-    `<remote>/<ref>` because the two halves could not be told apart. The tool
-    offers the bare name a remote knows a branch by as a way to select it, and
-    for those refs that name is precisely what could not be recovered, so it
-    matches nothing here while the branch may be alive on the server.
+    describing everything it listed, *and* one holding a server ref whose
+    branch name went unrecovered. A row nobody could parse is a thing whose
+    existence went unrecorded, which is the same hole as never having looked --
+    and so is a ref recorded only as `<remote>/<ref>` because the two halves
+    could not be told apart. A bare name would not have selected that ref in
+    any case, but where the split succeeds the caller is told the full spelling
+    to use instead, and here that spelling is exactly what nobody could work
+    out. Absence is the one answer that stays unavailable, since the branch may
+    be alive on the server under the name they gave.
 
     That last one is asked of every selector but `branch:`, which says a local
     branch outright. Local refs were read and split fine; a miss there is a
@@ -178,27 +216,35 @@ def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str
         if unsplit is not None:
             unread.append(
                 f"the server ref recorded as {unsplit.name} could not be split into a remote and "
-                f"a branch name, and one of the ways it may split is the name you gave"
+                f"a branch name, so whether the server holds a branch called {selector!r} is "
+                f"exactly the question that went unanswered"
             )
     return unread
 
 
 def resolve_selectors(
     selectors: list[str], targets: tuple[Target, ...], survey_data: Survey
-) -> tuple[list[Target], list[Absent], Refusal | None]:
+) -> tuple[list[Target], list[Absent], list[Refusal]]:
     """Map caller-supplied names onto targets.
+
+    Every selector is resolved on its own, and one that cannot be resolved
+    takes only itself out of the run. What it produces is a refusal in the
+    returned list rather than a stop: the caller named several things, and the
+    ones that resolved are still theirs to have.
 
     A miss is recorded and the remaining selectors are still resolved. But a
     miss only *means* absence when the survey was in a position to see the
-    thing, and there are two ways it was not -- both of which reach here
+    thing, and there are three ways it was not -- all of which reach here
     looking exactly like a name that matches nothing:
 
     - the listing that would have held it failed, so it is missing from a list
       that is empty for that reason rather than because the repository is
     - the name is a ref this tool deliberately does not offer as a target
+    - the only thing wearing the name is a copy on a server, which a bare name
+      does not select
 
-    In neither case is "there is nothing to delete" a fact anybody measured,
-    and saying it would leave a caller believing a deletion happened. Both
+    In none of them is "there is nothing to delete" a fact anybody measured,
+    and saying it would leave a caller believing a deletion happened. All three
     refuse instead, which is what the tool does whenever the honest answer is
     that it cannot say.
 
@@ -209,36 +255,51 @@ def resolve_selectors(
     """
     resolved: list[Target] = []
     absent: list[Absent] = []
+    refused: list[Refusal] = []
     for selector in selectors:
         matches = [t for t in targets if selector in _selector_candidates(t)]
         if not matches:
             excluded = _not_offered(selector, survey_data)
             if excluded is not None:
-                return (
-                    [],
-                    [],
+                refused.append(
                     Refusal(
                         code="E_NOT_A_TARGET",
                         message=f"{excluded.name} exists but is not something gitclean "
                         f"deletes: {excluded.reason}",
                         remedy="use git directly if that is genuinely what you want; "
                         "nothing in this run touched it",
-                    ),
+                    )
                 )
+                continue
+            servers = _bare_server_refs(selector, targets)
+            if servers:
+                spellings = ", ".join(t.name for t in servers)
+                refused.append(
+                    Refusal(
+                        code="E_BARE_NAME_IS_SERVER_REF",
+                        message=f"nothing local matches {selector!r}: no worktree, and no branch "
+                        f"in this repository. What carries that name here is {spellings} -- a "
+                        f"copy on a server, which a bare name does not select",
+                        blocked=tuple(servers),
+                        remedy=f"if a server's copy is what you meant, re-run naming it in full "
+                        f"({spellings}) -- a server keeps no reflog, so its refs go only when "
+                        f"spelled out; if you meant a local branch, it is already gone",
+                    )
+                )
+                continue
             unread = _lists_that_could_not_answer(selector, survey_data)
             if unread:
-                return (
-                    [],
-                    [],
+                refused.append(
                     Refusal(
                         code="E_SURVEY_INCOMPLETE",
                         message=f"nothing matched {selector!r}, and nothing follows from that "
-                        f"here: {' and '.join(unread)}, so what would have matched was never "
-                        f"listed -- it may be sitting right there",
+                        f"here: {' and '.join(unread)}. So this run cannot tell you that name "
+                        f"is gone -- what wears it may be sitting right there",
                         remedy="fix what stopped the listing (the warnings say what it was) "
-                        "and re-run; nothing was deleted",
-                    ),
+                        "and re-run; nothing under this name was deleted",
+                    )
                 )
+                continue
             absent.append(
                 Absent(
                     selector=selector,
@@ -250,40 +311,18 @@ def resolve_selectors(
             continue
         if len(matches) > 1:
             ids = ", ".join(t.id for t in matches)
-            return (
-                [],
-                [],
+            refused.append(
                 Refusal(
                     code="E_AMBIGUOUS_TARGET",
                     message=f"{selector!r} matches more than one target: {ids}",
                     blocked=tuple(matches),
                     remedy="re-run naming the exact `id`",
-                ),
+                )
             )
-        # Matching something is not the same as matching everything that could
-        # have matched. A ref whose remote and branch name could not be told
-        # apart never became a target, so it cannot appear above -- and one of
-        # the ways it may split is this very name. Had the split succeeded, the
-        # count here would have been two and this would already be refused, so
-        # taking the single match would let a probe that failed decide what
-        # gets deleted. That is the one thing an unanswered probe must never do.
-        rival = _unsplit_this_could_name(selector, survey_data)
-        if rival is not None:
-            return (
-                [],
-                [],
-                Refusal(
-                    code="E_AMBIGUOUS_TARGET",
-                    message=f"{selector!r} matches {matches[0].id}, and may also be the server "
-                    f"ref recorded as {rival.name}, which could not be split into a remote and "
-                    f"a branch name: {rival.reason}",
-                    blocked=tuple(matches),
-                    remedy="re-run naming the exact `id`, which says which of the two you mean",
-                ),
-            )
+            continue
         if matches[0] not in resolved:
             resolved.append(matches[0])
-    return resolved, absent, None
+    return resolved, absent, refused
 
 
 _ORDER = {TargetKind.WORKTREE: 0, TargetKind.BRANCH: 1, TargetKind.REMOTE_BRANCH: 2}
@@ -494,38 +533,51 @@ def build_plan(
     selectors: list[str],
     dry_run: bool,
     salvage_dir: str | None,
-) -> Plan | Refusal:
+) -> Plan:
+    """Always a plan, never a refusal for the run as a whole.
+
+    Nothing a caller can put on a command line makes the *other* things they
+    named undeletable, so there is no longer a way for this to answer with a
+    stop. Each objection belongs to the target it is about, travels in
+    ``Plan.refused``, and the run exits non-zero for having raised any."""
     absent: list[Absent] = []
+    refused: list[Refusal] = []
     if selectors:
-        chosen, absent, refusal = resolve_selectors(selectors, targets, survey_data)
-        if refusal is not None:
-            return refusal
+        chosen, absent, refused = resolve_selectors(selectors, targets, survey_data)
         invoking = _invoking_worktree(chosen, survey_data)
         if invoking:
-            return Refusal(
-                code="E_INVOKING_WORKTREE",
-                message=f"this run is executing inside {survey_data.repo_root}, so removing "
-                f"it would delete the process's own working directory",
-                blocked=tuple(invoking),
-                remedy="run gitclean from another worktree, or from the main checkout, "
-                "and name this one from there",
+            chosen = [t for t in chosen if t not in invoking]
+            refused.append(
+                Refusal(
+                    code="E_INVOKING_WORKTREE",
+                    message=f"this run is executing inside {survey_data.repo_root}, so removing "
+                    f"it would delete the process's own working directory",
+                    blocked=tuple(invoking),
+                    remedy="run gitclean from another worktree, or from the main checkout, "
+                    "and name this one from there",
+                )
             )
     else:
         chosen = [t for t in targets if t.sweepable]
 
     occupancy = _occupancy_blockers(chosen, survey_data)
+    chosen, skipped = _skip_occupied(chosen, occupancy)
     if occupancy and selectors:
         # Named explicitly: the caller believes this is deletable and git is
         # about to disagree, so say so rather than silently doing less than
-        # they asked for.
+        # they asked for. Reported as a refusal rather than the sweep's quiet
+        # `Skipped` row, and in place of it -- one omission, said once, in the
+        # register the caller's own naming earned.
         detail = "; ".join(f"{t.name} is checked out at {path}" for t, path in occupancy)
-        return Refusal(
-            code="E_BRANCH_IN_USE",
-            message=f"git will not delete a branch a worktree still holds: {detail}",
-            blocked=tuple(t for t, _ in occupancy),
-            remedy="add the holding worktree to the same cleanup so it is removed first",
+        refused.append(
+            Refusal(
+                code="E_BRANCH_IN_USE",
+                message=f"git will not delete a branch a worktree still holds: {detail}",
+                blocked=tuple(t for t, _ in occupancy),
+                remedy="add the holding worktree to the same cleanup so it is removed first",
+            )
         )
-    chosen, skipped = _skip_occupied(chosen, occupancy)
+        skipped = []
 
     return Plan(
         targets=_ordered(chosen),
@@ -539,4 +591,5 @@ def build_plan(
         dry_run=dry_run,
         skipped=tuple(skipped),
         absent=tuple(absent),
+        refused=tuple(refused),
     )

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -273,16 +273,23 @@ def resolve_selectors(
                 continue
             servers = _bare_server_refs(selector, targets)
             if servers:
-                spellings = ", ".join(t.name for t in servers)
+                listed = ", ".join(t.name for t in servers)
+                # Joined with `or` for the remedy, where the comma-joined list
+                # would be actively misleading: a remedy that reads as something
+                # to paste puts `origin/x, upstream/x` on the command line as a
+                # single argv, comma and all, which names nothing at all. It is
+                # a choice besides -- two remotes carrying the name is not two
+                # copies the caller meant.
+                choice = " or ".join(t.name for t in servers)
                 refused.append(
                     Refusal(
                         code="E_BARE_NAME_IS_SERVER_REF",
                         message=f"nothing local matches {selector!r}: no worktree, and no branch "
-                        f"in this repository. What carries that name here is {spellings} -- a "
+                        f"in this repository. What carries that name here is {listed} -- a "
                         f"copy on a server, which a bare name does not select",
                         blocked=tuple(servers),
-                        remedy=f"if a server's copy is what you meant, re-run naming it in full "
-                        f"({spellings}) -- a server keeps no reflog, so its refs go only when "
+                        remedy=f"if a server's copy is what you meant, re-run naming that one in "
+                        f"full: {choice}. A server keeps no reflog, so its refs go only when "
                         f"spelled out; if you meant a local branch, it is already gone",
                     )
                 )

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -124,6 +124,21 @@ def find(payload: dict[str, object], target_id: str) -> dict[str, object]:
     return match
 
 
+def refusals(payload: dict[str, object]) -> list[dict[str, object]]:
+    """The objections a cleanup raised, each about one name the caller gave.
+
+    Read out of the plan rather than out of the envelope's `refusal` field.
+    That field is the run having nothing to act on at all, and a cleanup no
+    longer produces one: the names that resolved cleanly are still deleted, so
+    there is always a plan."""
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    entries = plan["refused"]
+    assert isinstance(entries, list)
+    assert all(isinstance(entry, dict) for entry in entries), entries
+    return entries
+
+
 def anomaly_lines(payload: dict[str, object]) -> str:
     execution = payload["execution"]
     assert isinstance(execution, dict)
@@ -252,9 +267,7 @@ def test_naming_the_branch_you_are_standing_on_does_not_delete_it(repo: Path) ->
         payload = report(repo, "--cleanup", "feat/parked")
 
     assert payload["_exit"] == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
-    assert refusal["code"] == "E_BRANCH_IN_USE"
+    assert [r["code"] for r in refusals(payload)] == ["E_BRANCH_IN_USE"]
     assert git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "feat/parked"
     assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feat/parked") != ""
 
@@ -477,10 +490,38 @@ def test_the_worktree_the_run_executes_in_is_never_deleted(repo: Path) -> None:
     assert swept["_exit"] == EXIT_OK
     assert "executing in" in str(find(swept, f"worktree:{work}")["withheld"])
     assert named["_exit"] == EXIT_REFUSED
-    refusal = named["refusal"]
-    assert isinstance(refusal, dict)
-    assert refusal["code"] == "E_INVOKING_WORKTREE"
-    assert str(work) in str(refusal["message"])
+    refused = refusals(named)
+    assert [r["code"] for r in refused] == ["E_INVOKING_WORKTREE"]
+    assert str(work) in str(refused[0]["message"])
+
+
+def test_a_refusal_beside_a_merged_branch_still_leaves_the_branch_deleted(repo: Path) -> None:
+    """Partial execution, asked of git rather than of the run's own report.
+
+    Two names in one command: `feat/done`, provably merged, and the worktree
+    the process is executing in, which can never go while it is standing there.
+    Aborting the selection over the second used to spend the first as well, and
+    the caller's remedy was to re-run with the offender removed -- a round trip
+    over a name the tool had already worked out it could not act on.
+
+    Both halves have to be true at once, and each is what stops the other being
+    read wrong: a caller who sees only exit 1 must not conclude the deletion
+    did not happen, and one who sees only the deletion must not conclude the
+    command was carried out. So the branch is looked for in git afterwards,
+    not in the envelope that has an interest in the answer."""
+    git(repo, "checkout", "-q", "-b", "feat/done")
+    commit(repo, "done.txt")
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge feat/done", "feat/done")
+
+    with reachability_guard(repo):
+        payload = report(repo, "--cleanup", "feat/done", f"worktree:{repo}")
+
+    assert payload["_exit"] == EXIT_REFUSED, anomaly_lines(payload)
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feat/done") == ""
+    assert repo.exists()
+    assert str(repo) in git(repo, "worktree", "list", "--porcelain")
+    assert [r["code"] for r in refusals(payload)] == ["E_INVOKING_WORKTREE"]
 
 
 def test_a_worktree_that_goes_dirty_after_the_survey_is_left_alone(repo: Path) -> None:

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -45,6 +45,33 @@ def invoke_human(argv: list[str], port: ScriptedCommands) -> tuple[int, str]:
     return code, buffer.getvalue()
 
 
+def refusals(payload: dict[str, object]) -> list[dict[str, object]]:
+    """The objections a cleanup raised, each about one name the caller gave.
+
+    Read out of the plan rather than out of the envelope's `refusal` field.
+    That field is the run as a whole having nothing to act on -- a survey that
+    failed, or an --after-merge whose authorising fact could not be read -- and
+    a cleanup no longer produces one: whatever resolved cleanly is still
+    deleted, so there is always a plan."""
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    entries = plan["refused"]
+    assert isinstance(entries, list)
+    assert all(isinstance(entry, dict) for entry in entries), entries
+    return entries
+
+
+def sole_refusal(payload: dict[str, object]) -> dict[str, object]:
+    """The one refusal a run raised, insisting there is exactly one.
+
+    A test that reached for `[0]` would pass just as happily on a run that
+    refused the names beside it too, which is the failure most of these are
+    here to catch."""
+    refused = refusals(payload)
+    assert len(refused) == 1, refused
+    return refused[0]
+
+
 def merged_branch_port(
     *, pr_view: dict[str, object] | None = None, has_gh: bool = True
 ) -> ScriptedCommands:
@@ -249,10 +276,9 @@ def test_naming_the_invoking_worktree_exits_one_with_its_path() -> None:
     port = merged_branch_port()
     code, payload = invoke(["--cleanup", "worktree:/repo"], port)
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
+    refusal = sole_refusal(payload)
     assert refusal["code"] == "E_INVOKING_WORKTREE"
-    assert "/repo" in refusal["message"]
+    assert "/repo" in str(refusal["message"])
     assert refusal["remedy"]
 
 
@@ -336,6 +362,33 @@ def test_an_explicit_salvage_dir_is_honoured() -> None:
     assert plan["salvage_dir"] == "/var/salvage/keep"
 
 
+def test_a_bare_name_only_the_server_wears_is_told_the_spelling_that_reaches_it() -> None:
+    """Nothing local answers to `feat/x`, and origin's copy answers to it in
+    every way except the one that selects a server ref. Calling that absence
+    would be false about the only thing in the repository bearing the name, and
+    it is the answer a caller acts on by moving on -- so the run says what is
+    actually there and quotes the spelling that would delete it.
+
+    Nothing goes in the meantime, deliberately. The server keeps no reflog, so
+    the second command is the authorisation, and printing the remedy is not the
+    same as taking it."""
+    port = _remote_port()
+
+    code, payload = invoke(["--cleanup", "feat/x"], port)
+
+    assert code == EXIT_REFUSED
+    refusal = sole_refusal(payload)
+    assert refusal["code"] == "E_BARE_NAME_IS_SERVER_REF"
+    assert "origin/feat/x" in str(refusal["message"])
+    # The full `<remote>/<ref>` spelling, which is the only one that would
+    # reach it -- a remedy that echoed the bare name back is the wall.
+    assert "origin/feat/x" in str(refusal["remedy"])
+    assert not any(call[:2] == ("git", "push") for call in port.transcript)
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["deletions"] == []
+
+
 def test_a_miss_with_no_refs_read_exits_refused_not_clean() -> None:
     """Exit 0 here would report a branch as gone on the strength of a list that
     failed to load. The caller is entitled to know the difference between "it
@@ -345,9 +398,7 @@ def test_a_miss_with_no_refs_read_exits_refused_not_clean() -> None:
     code, payload = invoke(["--cleanup", "done"], port)
 
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
-    assert refusal["code"] == "E_SURVEY_INCOMPLETE"
+    assert sole_refusal(payload)["code"] == "E_SURVEY_INCOMPLETE"
     assert not any(call[:3] == ("git", "branch", "-D") for call in port.transcript)
 
 
@@ -365,8 +416,7 @@ def test_naming_the_servers_copy_of_the_trunk_exits_refused() -> None:
     code, payload = invoke(["--cleanup", "origin/main"], port)
 
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
+    refusal = sole_refusal(payload)
     assert refusal["code"] == "E_NOT_A_TARGET"
     assert refusal["remedy"]
 
@@ -396,28 +446,59 @@ def _colliding_names_port(*, remote_list: str | None = "origin\n") -> ScriptedCo
     return port
 
 
-def test_a_name_reaching_two_refs_is_refused_whether_or_not_the_split_answered() -> None:
+def test_a_failed_split_cannot_change_what_a_bare_name_selects() -> None:
     """The defect this pins ran the wrong way round: the probe that FAILED made
-    the tool more willing to delete.
+    the tool more willing to delete. Read the remote list and origin's copy of
+    `feat/x` became a target whose bare alias was `feat/x`, so the name reached
+    two things and the run refused. Fail that read and the same ref never
+    became a target at all, the name reached one thing, and the local branch
+    went. Same repository, same command, and the only difference was a question
+    git declined to answer.
 
-    Read the remote list and origin's copy of `feat/x` is a target whose bare
-    alias is `feat/x`, so the name reaches two things and is refused. Fail that
-    read and the same ref never becomes a target, the name reaches one thing,
-    and the local branch goes. Same repository, same command, and the only
-    difference is a question git declined to answer."""
-    answered = _colliding_names_port()
-    code, payload = invoke(["--cleanup", "feat/x"], answered)
-    assert code == EXIT_REFUSED
-    assert payload["refusal"]["code"] == "E_AMBIGUOUS_TARGET"  # type: ignore[index]
+    A bare name no longer reaches a server ref under any splitting, so the
+    answer to that question is not consulted when this selection is made. Both
+    runs resolve `feat/x` to the local branch, both delete it, and neither goes
+    anywhere near the copy on the server -- which is the same invariant the
+    refusal used to enforce, held by construction instead. That is the stronger
+    way to hold it: there is no longer a path along which the unanswered
+    question could widen anything, so nothing has to notice that it went
+    unanswered."""
+    outcomes: list[tuple[int, list[object]]] = []
+    for port in (_colliding_names_port(), _colliding_names_port(remote_list=None)):
+        code, payload = invoke(["--cleanup", "feat/x"], port)
+        execution = payload["execution"]
+        assert isinstance(execution, dict)
+        outcomes.append((code, [d["target_id"] for d in execution["deletions"] if d["deleted"]]))
+        # The ref the split question was about: no route to it was taken, so
+        # there is nothing for either answer to have widened.
+        assert not any(call[:2] == ("git", "push") for call in port.transcript)
 
-    unanswered = _colliding_names_port(remote_list=None)
-    code, payload = invoke(["--cleanup", "feat/x"], unanswered)
+    assert outcomes[0] == outcomes[1]
+    assert outcomes[0] == (EXIT_OK, ["branch:feat/x"])
 
-    assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
-    assert refusal["code"] == "E_AMBIGUOUS_TARGET"
-    assert not any(call[:3] == ("git", "branch", "-D") for call in unanswered.transcript)
+
+def test_a_bare_name_deletes_the_local_branch_and_leaves_the_servers_copy() -> None:
+    """The command this whole rule exists for: the branch whose work just
+    merged, named the way everybody names it, in a repository where origin
+    still holds a copy under the same name. That is the commonest cleanup
+    there is, and it used to answer E_AMBIGUOUS_TARGET -- the tool declining to
+    choose between a local ref and a copy on a server that it will not delete
+    unnamed anyway, which made the ambiguity one it had already resolved.
+
+    Both halves are asserted, because dropping the server ref from the
+    selection is only right if it is also left alone: the run deletes the local
+    branch and issues nothing at all towards the remote."""
+    port = _colliding_names_port()
+
+    code, payload = invoke(["--cleanup", "feat/x"], port)
+
+    assert code == EXIT_OK
+    assert refusals(payload) == []
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert [d["target_id"] for d in execution["deletions"] if d["deleted"]] == ["branch:feat/x"]
+    assert ("git", "branch", "-D", "--", "feat/x") in port.transcript
+    assert not any(call[:2] == ("git", "push") for call in port.transcript)
 
 
 def test_the_id_remedy_deletes_the_branch_the_caller_meant() -> None:
@@ -476,8 +557,7 @@ def test_a_miss_against_an_unframed_worktree_listing_exits_refused() -> None:
     code, payload = invoke(["--cleanup", "/repo/we\nbare"], port)
 
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
+    refusal = sole_refusal(payload)
     assert refusal["code"] == "E_SURVEY_INCOMPLETE"
     assert "newline" in str(refusal["message"])
     repo = payload["repo"]
@@ -575,10 +655,16 @@ def _unsplittable_remote_port() -> ScriptedCommands:
 
 
 def test_naming_an_unsplittable_server_ref_by_its_short_name_exits_refused() -> None:
-    """The bare name a remote knows a branch by is a spelling this tool offers
-    for selecting one -- and for a ref it could not split, that name is exactly
-    what it failed to recover. So the selector matches nothing, while the
-    branch may be alive on the server.
+    """A bare name does not select a server ref, so this one is not competing
+    for the match. What it is doing is making the miss unreadable.
+
+    Where a server ref splits, a bare name that hits nothing local can be told
+    the full `<remote>/<ref>` spelling that would reach it, and that sentence is
+    the whole remedy. Here the spelling to quote is precisely what could not be
+    recovered: `feat/x` may be the branch name inside the ref recorded as
+    `origin/feat/x`, and nothing in this repository can say. So the run cannot
+    offer the remedy, and it cannot say the name is already gone either, since
+    the branch may be alive on the server under exactly the name given.
 
     A miss means absence only where the survey was in a position to see the
     thing under the name being used. Here it was not, and the same rule that
@@ -589,26 +675,27 @@ def test_naming_an_unsplittable_server_ref_by_its_short_name_exits_refused() -> 
     code, payload = invoke(["--cleanup", "feat/x"], port)
 
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
+    refusal = sole_refusal(payload)
     assert refusal["code"] == "E_SURVEY_INCOMPLETE"
+    # The ref that went unspelled, and the measurement that stopped it -- the
+    # two things the sentence is for, whatever wording carries them.
+    assert "origin/feat/x" in str(refusal["message"])
     assert "could not be split" in str(refusal["message"])
     assert not any(call[:2] == ("git", "push") for call in port.transcript)
 
 
 def test_the_full_spelling_of_an_unsplittable_server_ref_still_refuses_by_name() -> None:
-    """The other door to the same target, unmoved. It is recorded in
-    `not_offered` under the full spelling git gave, so this path answers with
-    the measurement that stopped the split rather than with the survey's
-    general incompleteness -- a better sentence, and the reason both doors are
-    checked rather than one."""
+    """The spelling that does select a server ref, aimed at one this tool never
+    offered. It is recorded in `not_offered` under the full spelling git gave,
+    so this path answers with the measurement that stopped the split rather
+    than with the survey's general incompleteness -- a better sentence, and the
+    reason both spellings are checked rather than one."""
     port = _unsplittable_remote_port()
 
     code, payload = invoke(["--cleanup", "origin/feat/x"], port)
 
     assert code == EXIT_REFUSED
-    refusal = payload["refusal"]
-    assert isinstance(refusal, dict)
+    refusal = sole_refusal(payload)
     assert refusal["code"] == "E_NOT_A_TARGET"
     assert "remote list could not be read" in str(refusal["message"])
 
@@ -657,6 +744,88 @@ def test_an_absent_name_does_not_take_the_names_beside_it_down() -> None:
     assert isinstance(execution, dict)
     assert [d["name"] for d in execution["deletions"]] == ["done"]
     assert execution["deletions"][0]["deleted"] is True
+
+
+def test_a_refused_name_does_not_take_the_names_beside_it_down() -> None:
+    """The change this is all for. `worktree:/repo` is the directory the
+    process is executing in and can never be removed by the run standing in it;
+    `done` is provably merged and was asked for in the same breath. Aborting
+    the selection over the first spent the second too, and the caller's only
+    way out was to re-run with the offender removed -- a round trip spent
+    teaching the tool something it had already worked out.
+
+    The deletion is asserted twice over, in the port's transcript and in the
+    run's own account of itself. The transcript is what git was really asked;
+    the report is what a caller reads, and a run that did the work while
+    reporting nothing would be as unusable as one that skipped it."""
+    port = merged_branch_port()
+
+    code, payload = invoke(["--cleanup", "done", "worktree:/repo"], port)
+
+    assert code == EXIT_REFUSED
+    assert payload["ok"] is False
+    assert ("git", "branch", "-D", "--", "done") in port.transcript
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert [d["name"] for d in execution["deletions"] if d["deleted"]] == ["done"]
+    assert sole_refusal(payload)["code"] == "E_INVOKING_WORKTREE"
+
+
+def test_a_refusal_about_one_name_does_not_fill_the_run_wide_refusal_field() -> None:
+    """`refusal` at the top of the envelope means the run had nothing to act
+    on at all -- a survey that failed, or an --after-merge that could not
+    establish the merge authorising it. An objection to one of several names is
+    a different fact, and populating both fields would tell a reader checking
+    either one that the whole command was declined.
+
+    So a reader still on the old field sees a null. That is the honest answer
+    to the question that field asks, and it is the reason the two are not
+    interchangeable."""
+    code, payload = invoke(["--cleanup", "done", "worktree:/repo"], merged_branch_port())
+
+    assert code == EXIT_REFUSED
+    assert payload["refusal"] is None
+    assert [r["code"] for r in refusals(payload)] == ["E_INVOKING_WORKTREE"]
+
+
+def test_an_anomaly_outranks_a_refusal_in_the_exit_code() -> None:
+    """A refusal is the tool declining to act and leaving the repository as it
+    found it. An anomaly is a deletion that ran and could not be confirmed
+    afterwards, which is the one outcome somebody has to go and look at. A run
+    that raised both must not report the milder of the two: exit 1 is what a
+    caller scripts "fix the name and re-run" against, and doing that here would
+    walk straight past an unverified deletion."""
+    port = make_port(
+        refs=[
+            ref_at("refs/heads/main", "main", "a" * 40, head="*"),
+            ref_at("refs/heads/done", "done", "d" * 40),
+        ],
+        counts={"refs/remotes/origin/main..done": "0"},
+        extra={
+            "branch -D -- done": ok(),
+            # git reported the deletion and the ref is still there afterwards.
+            "for-each-ref --format=%(refname) refs/heads/done": ok("refs/heads/done"),
+        },
+    )
+
+    code, payload = invoke(["--cleanup", "done", "worktree:/repo"], port)
+
+    assert code == EXIT_ANOMALY
+    assert sole_refusal(payload)["code"] == "E_INVOKING_WORKTREE"
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert execution["anomalies"]
+
+
+def test_a_cleanup_that_refused_nothing_says_so_with_an_empty_list() -> None:
+    """The field is always present, so a caller reads its length rather than
+    testing whether the key is there -- and a run that refused nothing has to
+    be distinguishable from one whose refusals were never published."""
+    code, payload = invoke(["--cleanup", "done"], merged_branch_port())
+
+    assert code == EXIT_OK
+    assert payload["ok"] is True
+    assert refusals(payload) == []
 
 
 def test_a_server_ref_already_gone_exits_clean_rather_than_anomalous() -> None:
@@ -758,6 +927,22 @@ def test_human_refusal_names_the_code_and_the_remedy() -> None:
     _, text = invoke_human(["--cleanup", "worktree:/repo"], merged_branch_port())
     assert "REFUSED (E_INVOKING_WORKTREE)" in text
     assert "remedy:" in text
+
+
+def test_human_output_prints_a_refusal_above_the_deletions_it_travelled_with() -> None:
+    """A caller who named two things and reads one `ok` line has been shown a
+    successful run, and the thing that makes it not one has to arrive before
+    they stop reading. So the refusal and its remedy are printed ahead of the
+    deletion rather than after it, where a reader who got what they came for
+    would never reach them."""
+    code, text = invoke_human(["--cleanup", "done", "worktree:/repo"], merged_branch_port())
+
+    assert code == EXIT_REFUSED
+    assert "REFUSED (E_INVOKING_WORKTREE)" in text
+    assert "  remedy:" in text
+    assert "  ok   done" in text
+    assert text.index("REFUSED (E_INVOKING_WORKTREE)") < text.index("  ok   done")
+    assert text.index("  remedy:") < text.index("  ok   done")
 
 
 def test_human_output_names_a_skipped_target() -> None:

--- a/packages/gitclean/tests/unit/test_json_contract.py
+++ b/packages/gitclean/tests/unit/test_json_contract.py
@@ -200,6 +200,7 @@ PLAN = {
     "dry_run": bool,
     "skipped": [dict],
     "absent": [dict],
+    "refused": [dict],
 }
 
 EXECUTION = {
@@ -371,10 +372,26 @@ def test_a_plan_holds_exactly_its_published_fields() -> None:
         dry_run=True,
         skipped=(Skipped(target_id="branch:feat/thing", name="feat/thing", reason="held"),),
         absent=(Absent(selector="feat/gone", note="nothing matched"),),
+        # A plan carries its refusals rather than replacing itself with one, so
+        # they are part of the published shape and not a separate envelope key
+        # a consumer reads instead of this object.
+        refused=(
+            Refusal(
+                code="E_BRANCH_IN_USE",
+                message="a worktree still holds it",
+                blocked=(_target(),),
+                remedy="add the holding worktree to the same cleanup",
+            ),
+        ),
     )
     payload = full.as_json()
     assert_shape(payload, PLAN, "plan")
-    for key, spec in (("targets", TARGET), ("skipped", SKIPPED), ("absent", ABSENT)):
+    for key, spec in (
+        ("targets", TARGET),
+        ("skipped", SKIPPED),
+        ("absent", ABSENT),
+        ("refused", REFUSAL),
+    ):
         rows = payload[key]
         assert isinstance(rows, list)
         assert_shape(rows[0], spec, f"plan.{key}[0]")

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -61,7 +61,10 @@ def plan_for(
     *,
     survey=None,  # type: ignore[no-untyped-def]
     selectors: list[str] | None = None,
-) -> Plan | Refusal:
+) -> Plan:
+    # Always a plan. An objection belongs to the selector it is about and rides
+    # in `Plan.refused`, so there is no longer a return value that stands in
+    # for the whole run having stopped.
     return build_plan(
         targets,
         survey if survey is not None else make_survey(),
@@ -145,10 +148,29 @@ def test_naming_the_invoking_worktree_is_refused_with_its_path() -> None:
 
     result = plan_for(targets, selectors=["worktree:/repo"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_INVOKING_WORKTREE"
-    assert "/repo" in result.message
-    assert [t.name for t in result.blocked] == ["/repo"]
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_INVOKING_WORKTREE"
+    assert "/repo" in refusal.message
+    assert [t.name for t in refusal.blocked] == ["/repo"]
+
+
+def test_the_invoking_worktree_is_refused_without_stopping_the_one_beside_it() -> None:
+    """The objection is about one directory: this process is standing in it.
+    It says nothing about another worktree the same command named, which is
+    somewhere else entirely and still goes -- and an agent cleaning up several
+    trees at once is precisely the caller who names the one it is running in
+    by accident."""
+    here = target("worktree:/repo", kind=TargetKind.WORKTREE, sweepable=False)
+    elsewhere = target("worktree:/repo/wt", kind=TargetKind.WORKTREE, sweepable=False)
+
+    result = plan_for((here, elsewhere), selectors=["worktree:/repo", "worktree:/repo/wt"])
+
+    assert [t.id for t in result.targets] == ["worktree:/repo/wt"]
+    [refusal] = result.refused
+    assert refusal.code == "E_INVOKING_WORKTREE"
+    assert "/repo" in refusal.message
+    assert [t.id for t in refusal.blocked] == ["worktree:/repo"]
 
 
 def test_a_named_deletion_still_works_without_a_known_trunk() -> None:
@@ -166,9 +188,13 @@ def test_a_named_deletion_still_works_without_a_known_trunk() -> None:
 
 
 def test_another_worktree_is_not_mistaken_for_the_invoking_one() -> None:
+    """A worktree *under* the invoking one is still a different directory. The
+    comparison is between whole paths, and a prefix test would refuse every
+    tree a repository keeps beside its checkout."""
     targets = (target("worktree:/repo/wt", kind=TargetKind.WORKTREE, sweepable=False),)
     result = plan_for(targets, selectors=["worktree:/repo/wt"])
-    assert isinstance(result, Plan)
+    assert [t.id for t in result.targets] == ["worktree:/repo/wt"]
+    assert result.refused == ()
 
 
 # -- selector resolution -----------------------------------------------------
@@ -208,6 +234,45 @@ def test_one_absent_name_does_not_abort_the_names_beside_it() -> None:
     assert [a.selector for a in result.absent] == ["gone-already"]
 
 
+def test_a_refused_name_takes_only_itself_out_of_the_run() -> None:
+    """The whole cost of the old whole-run refusal. One name this tool would
+    not act on stopped every other deletion asked for in the same breath, and
+    the only way forward was to re-run with the offender removed -- a round
+    trip spent teaching the tool something it had already worked out.
+
+    A refusal is about the selector it names. What resolved beside it is still
+    the caller's to have, and the run reports both."""
+    survey = make_survey(
+        not_offered=(NotOffered(name="origin/main", reason="the server's copy of the trunk"),)
+    )
+    targets = (target("branch:x"), target("branch:y"))
+
+    result = plan_for(targets, survey=survey, selectors=["x", "origin/main", "y"])
+
+    assert [t.id for t in result.targets] == ["branch:x", "branch:y"]
+    assert [r.code for r in result.refused] == ["E_NOT_A_TARGET"]
+
+
+def test_refusals_arrive_in_the_order_their_selectors_were_given() -> None:
+    """Reading order is the only order a caller can map back onto what they
+    typed. A list assembled in some order of the tool's own -- by code, or by
+    whichever target happened to be surveyed first -- leaves somebody who named
+    six things pairing refusals to selectors by hand.
+
+    Asserted both ways round, because a single ordering is also what a fixed
+    order of codes would produce."""
+    survey = make_survey(
+        not_offered=(NotOffered(name="origin/main", reason="the server's copy of the trunk"),)
+    )
+    targets = (target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False),)
+
+    result = plan_for(targets, survey=survey, selectors=["origin/main", "feat/x"])
+    assert [r.code for r in result.refused] == ["E_NOT_A_TARGET", "E_BARE_NAME_IS_SERVER_REF"]
+
+    swapped = plan_for(targets, survey=survey, selectors=["feat/x", "origin/main"])
+    assert [r.code for r in swapped.refused] == ["E_BARE_NAME_IS_SERVER_REF", "E_NOT_A_TARGET"]
+
+
 def test_a_miss_is_not_absence_when_no_ref_could_be_read() -> None:
     """`branches` is empty here because `for-each-ref` failed, not because the
     repository has none -- and the list alone cannot tell those apart. Calling
@@ -217,10 +282,11 @@ def test_a_miss_is_not_absence_when_no_ref_could_be_read() -> None:
 
     result = plan_for((), survey=survey, selectors=["feat/x"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "feat/x" in result.message
-    assert result.remedy
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "feat/x" in refusal.message
+    assert refusal.remedy
 
 
 def test_a_worktree_miss_is_not_absence_when_no_worktree_could_be_listed() -> None:
@@ -231,9 +297,10 @@ def test_a_worktree_miss_is_not_absence_when_no_worktree_could_be_listed() -> No
 
     result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "no worktree could be listed" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "no worktree could be listed" in refusal.message
 
 
 def test_a_failed_ref_read_does_not_block_naming_an_absent_worktree() -> None:
@@ -258,9 +325,10 @@ def test_a_listing_that_ran_but_dropped_a_row_has_not_answered() -> None:
 
     result = plan_for((), survey=survey, selectors=["branch:feat/x"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "1 ref row(s) went unparsed" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "1 ref row(s) went unparsed" in refusal.message
 
 
 def test_a_dropped_worktree_block_is_the_same_hole_on_the_other_listing() -> None:
@@ -268,9 +336,10 @@ def test_a_dropped_worktree_block_is_the_same_hole_on_the_other_listing() -> Non
 
     result = plan_for((), survey=survey, selectors=["worktree:/repo/wt"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "2 worktree block(s) went unparsed" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "2 worktree block(s) went unparsed" in refusal.message
 
 
 def test_a_dropped_ref_row_does_not_block_naming_a_worktree() -> None:
@@ -303,9 +372,10 @@ def test_a_bare_name_needs_both_listings_because_it_could_be_either() -> None:
 
     result = plan_for((), survey=survey, selectors=["ambiguous"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "no ref could be read" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "no ref could be read" in refusal.message
 
 
 _UNSPLIT = NotOffered(
@@ -322,39 +392,60 @@ to, and nothing here can say which."""
 
 def test_a_ref_that_could_not_be_split_stops_a_miss_meaning_absence() -> None:
     """A server ref recorded only as `<remote>/<ref>`, because telling the two
-    halves apart is what failed. Every other spelling of it -- including the
-    bare one this tool offers for selecting a server ref -- matches nothing,
-    and nothing is what a name that was never there matches too.
+    halves apart is what failed. `feat/x` is one of the two ways
+    `origin/feat/x` may split, so it is a name this ref may answer to, and the
+    ref is sitting right there.
 
-    `feat/x` is one of the two ways `origin/feat/x` may split, so it is a name
-    this ref may answer to."""
+    Had the split succeeded, this same miss would still refuse -- a bare name
+    does not select a server ref -- but it would refuse by quoting the full
+    spelling to use instead. Here that spelling is exactly what nobody could
+    work out, so the refusal reports the unanswered question rather than a
+    remedy it cannot name. Either way the one answer that stays unavailable is
+    absence."""
     survey = make_survey(unsplit_refs=1, not_offered=(_UNSPLIT,))
 
     result = plan_for((target("branch:x"),), survey=survey, selectors=["feat/x"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_SURVEY_INCOMPLETE"
-    assert "could not be split" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "could not be split" in refusal.message
 
 
-def test_a_match_does_not_settle_a_name_a_ref_nobody_split_may_also_answer_to() -> None:
-    """The failed probe used to *widen* what a run would delete, which is the
-    one thing an unanswered probe must never do.
+def test_a_failed_split_cannot_change_what_a_bare_name_deletes() -> None:
+    """An unanswered probe must never *widen* what a run deletes, and that is
+    now true by construction rather than by a refusal.
 
-    With the remote list read, `refs/remotes/origin/feat/x` becomes a target
-    whose bare alias is `feat/x`, so `feat/x` matches two things and is refused
-    as ambiguous. With the read failed, that ref never becomes a target at all
-    -- so the same name matches exactly one thing and the local branch is
-    deleted. The count of matches is not evidence while something that could
-    have joined it went unnamed."""
-    survey = make_survey(unsplit_refs=1, not_offered=(_UNSPLIT,))
+    It used to be enforced the hard way. With the remote list read,
+    `refs/remotes/origin/feat/x` became a target whose bare alias was `feat/x`,
+    so the name matched two things and was refused as ambiguous; with the read
+    failed, that ref never became a target and the same name matched exactly
+    one. The number of things a name meant therefore moved with a probe that
+    had measured nothing about the repository, and refusing was how that was
+    kept from turning into a deletion.
 
-    result = plan_for((target("branch:feat/x"),), survey=survey, selectors=["feat/x"])
+    A bare name no longer reaches a server ref under either reading, so the ref
+    never joins the match and the local branch is the only thing `feat/x` can
+    mean. The two fixtures below agree, which is precisely the property the
+    refusal was buying -- and nothing is lost with it, because the server's copy
+    is still unreachable without its full spelling either way."""
+    both_read = plan_for(
+        (
+            target("branch:feat/x"),
+            target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH),
+        ),
+        selectors=["feat/x"],
+    )
+    assert [t.id for t in both_read.targets] == ["branch:feat/x"]
+    assert both_read.refused == ()
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_AMBIGUOUS_TARGET"
-    assert "origin/feat/x" in result.message
-    assert "id" in result.remedy
+    split_failed = plan_for(
+        (target("branch:feat/x"),),
+        survey=make_survey(unsplit_refs=1, not_offered=(_UNSPLIT,)),
+        selectors=["feat/x"],
+    )
+    assert [t.id for t in split_failed.targets] == ["branch:feat/x"]
+    assert split_failed.refused == ()
 
 
 def test_the_exact_id_still_resolves_past_a_ref_nobody_split() -> None:
@@ -417,10 +508,11 @@ def test_a_ref_this_tool_declines_to_offer_is_not_reported_as_gone() -> None:
 
     result = plan_for((target("branch:x"),), survey=survey, selectors=["origin/main"])
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_NOT_A_TARGET"
-    assert "origin/main" in result.message
-    assert "the server's copy of the trunk" in result.message
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_NOT_A_TARGET"
+    assert "origin/main" in refusal.message
+    assert "the server's copy of the trunk" in refusal.message
 
 
 def test_the_local_trunk_is_not_confused_with_the_servers_copy_of_it() -> None:
@@ -437,17 +529,139 @@ def test_the_local_trunk_is_not_confused_with_the_servers_copy_of_it() -> None:
     assert [t.name for t in result.targets] == ["main"]
 
 
-def test_ambiguous_bare_name_is_refused_with_the_candidates() -> None:
-    """`feat/x` names both the local branch and origin's copy. Guessing which
-    one the caller meant is how the wrong ref gets deleted."""
+# -- a bare name is local; a server ref is spelled out -----------------------
+
+
+def test_a_bare_name_takes_the_local_branch_and_not_the_servers_copy_of_it() -> None:
+    """The commonest cleanup there is: the branch whose work just merged, named
+    the way a person says it. In any ordinary repository the server's copy
+    wears that same bare name, so offering the spelling to both made the
+    routine case ambiguous -- naming the branch that had just been merged was
+    answered with a refusal and a demand for an `id`.
+
+    Nothing about the server's copy is decided here. It is neither deleted nor
+    an obstacle: it goes only when it is spelled out in full, and that rule is
+    what makes the bare name unambiguous again."""
+    targets = (
+        target("branch:docs/thing"),
+        target("remote:origin/docs/thing", kind=TargetKind.REMOTE_BRANCH),
+    )
+
+    result = plan_for(targets, selectors=["docs/thing"])
+
+    assert [t.id for t in result.targets] == ["branch:docs/thing"]
+    assert result.refused == ()
+    # No server ref entered the plan, so there is nothing here that a bundle
+    # would be the only undo for.
+    assert result.salvage_dir is None
+
+
+def test_a_bare_name_only_a_server_ref_wears_is_refused_rather_than_called_gone() -> None:
+    """Nothing local answers to it, and ordinarily that is a job already done.
+    Not here: the thing the caller named is on the server under exactly that
+    name, so "already gone" would be false about the only ref that bears it,
+    and a caller told that believes a deletion happened.
+
+    The refusal is also what keeps the server's copy safe. It is the one
+    deletion with no reflog behind it, so it goes only when it is named in
+    full, and the remedy quotes the spelling that would do it."""
+    server = target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False)
+
+    result = plan_for((server, target("branch:other")), selectors=["feat/x"])
+
+    assert result.targets == ()
+    assert result.absent == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_BARE_NAME_IS_SERVER_REF"
+    assert [t.id for t in refusal.blocked] == ["remote:origin/feat/x"]
+    assert "origin/feat/x" in refusal.remedy
+
+
+def test_every_server_copy_of_a_bare_name_is_named_not_just_the_first() -> None:
+    """A fork carries the same branch name on two remotes as a matter of
+    course, and a caller working in one has no reason to be thinking about the
+    other. Naming one copy would describe half of what is there, and a reader
+    handed half reads it as the whole -- so they delete the one they were told
+    about and leave a ref they meant to be rid of, believing it gone."""
+    survey = make_survey(remotes=("origin", "upstream"))
+    targets = (
+        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False),
+        target("remote:upstream/feat/x", kind=TargetKind.REMOTE_BRANCH, remote="upstream"),
+    )
+
+    result = plan_for(targets, survey=survey, selectors=["feat/x"])
+
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_BARE_NAME_IS_SERVER_REF"
+    assert [t.id for t in refusal.blocked] == [
+        "remote:origin/feat/x",
+        "remote:upstream/feat/x",
+    ]
+    assert "upstream/feat/x" in refusal.remedy
+
+
+def test_the_full_name_still_selects_the_servers_copy_past_a_local_branch() -> None:
+    """The remedy has to reach the ref or the refusal above is a dead end --
+    and it has to reach it in a repository where the local branch of that name
+    is still present, which is the only shape the refusal ever appears in."""
     targets = (
         target("branch:feat/x"),
-        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH),
+        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False),
     )
-    result = plan_for(targets, selectors=["feat/x"])
-    assert isinstance(result, Refusal)
-    assert result.code == "E_AMBIGUOUS_TARGET"
-    assert len(result.blocked) == 2
+
+    result = plan_for(targets, selectors=["origin/feat/x"])
+
+    assert [t.id for t in result.targets] == ["remote:origin/feat/x"]
+    assert result.refused == ()
+
+
+def test_the_id_still_selects_the_servers_copy_too() -> None:
+    """The other spelling that names one ref and no other. `--report` prints
+    this one on every row, so it is what an agent copies out of the report."""
+    targets = (
+        target("branch:feat/x"),
+        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False),
+    )
+
+    result = plan_for(targets, selectors=["remote:origin/feat/x"])
+
+    assert [t.id for t in result.targets] == ["remote:origin/feat/x"]
+    assert result.refused == ()
+
+
+def test_a_branch_selector_is_not_diverted_to_a_server_ref_of_that_bare_name() -> None:
+    """`branch:` says a local ref outright. The server's copy is not something
+    that selector could have meant however it is spelled, so the miss is a
+    plain miss -- and the caller is told the job is done rather than handed a
+    refusal about a ref they were not talking about."""
+    server = target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False)
+
+    result = plan_for((server,), selectors=["branch:feat/x"])
+
+    assert result.refused == ()
+    assert [a.selector for a in result.absent] == ["branch:feat/x"]
+
+
+def test_ambiguous_bare_name_is_refused_with_the_candidates() -> None:
+    """A worktree answers to its basename and a branch to its name, and neither
+    of those is derived from the other -- so `feat` can still mean two things
+    at once, and nothing but the caller knows which. Guessing is how the wrong
+    one gets deleted, so the refusal names both and asks for an `id`.
+
+    A local branch beside the server's copy of it is no longer this case, and
+    it was much the commoner one: a bare name does not reach a server ref, so
+    that pair does not collide any more. What is left is a collision between
+    the two listings."""
+    targets = (
+        target("branch:feat"),
+        target("worktree:/repo/wt/feat", kind=TargetKind.WORKTREE),
+    )
+    result = plan_for(targets, selectors=["feat"])
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_AMBIGUOUS_TARGET"
+    assert {t.id for t in refusal.blocked} == {"branch:feat", "worktree:/repo/wt/feat"}
 
 
 def test_exact_id_disambiguates() -> None:
@@ -460,11 +674,17 @@ def test_exact_id_disambiguates() -> None:
     assert [t.id for t in result.targets] == ["branch:feat/x"]
 
 
-def test_a_server_refs_bare_alias_is_the_name_the_remote_knows() -> None:
-    """The convenience spelling for `team/origin/feat/x` is `feat/x`, because
-    that is what the server calls the branch. Dropping everything before the
-    first slash offers `origin/feat/x` instead -- a name nothing in the
-    repository has, handed to a caller as though it were theirs."""
+def test_the_bare_name_a_server_ref_answers_to_is_the_one_the_remote_knows() -> None:
+    """A bare name no longer *selects* a server ref, but it is still matched
+    against one to tell a caller the ref is there -- and which name it is
+    matched against is the same question it always was. The remote knows
+    `team/origin/feat/x` as `feat/x`, so that is the name the refusal answers
+    to and the full spelling is what its remedy quotes.
+
+    Dropping everything before the first slash would answer to `origin/feat/x`
+    instead: a name nothing in this repository has. Reporting that one as
+    already gone is a claim about a ref that does not exist, and it would arrive
+    while the ref the caller was reaching for sat untouched."""
     targets = (
         target(
             "remote:team/origin/feat/x",
@@ -473,10 +693,13 @@ def test_a_server_refs_bare_alias_is_the_name_the_remote_knows() -> None:
         ),
     )
 
-    assert isinstance(plan_for(targets, selectors=["feat/x"]), Plan)
+    [refusal] = plan_for(targets, selectors=["feat/x"]).refused
+    assert refusal.code == "E_BARE_NAME_IS_SERVER_REF"
+    assert "team/origin/feat/x" in refusal.remedy
+
     result = plan_for(targets, selectors=["origin/feat/x"])
-    assert isinstance(result, Plan)
     assert result.targets == ()
+    assert result.refused == ()
     assert [a.selector for a in result.absent] == ["origin/feat/x"]
 
 
@@ -496,29 +719,35 @@ def test_repeated_selector_is_not_planned_twice() -> None:
 
 def test_resolve_selectors_returns_targets_in_request_order() -> None:
     targets = (target("branch:a"), target("branch:b"))
-    resolved, absent, refusal = resolve_selectors(["b", "a"], targets, make_survey())
-    assert refusal is None
+    resolved, absent, refusals = resolve_selectors(["b", "a"], targets, make_survey())
+    assert refusals == []
     assert absent == []
     assert [t.name for t in resolved] == ["b", "a"]
 
 
-def test_ambiguity_still_refuses_and_carries_nothing_forward() -> None:
+def test_ambiguity_refuses_that_name_and_nothing_else() -> None:
     """A miss is a job done; ambiguity is a question. Two real things match and
-    picking one destroys the other, so this is the refusal that stays -- and it
-    resolves no selector beside it, because the caller is about to re-issue the
-    whole command with a precise name."""
+    picking one destroys the other, so this is the refusal that stays.
+
+    What it no longer does is take the rest of the command with it. The
+    question is about one name -- the others were unambiguous, and the caller
+    is going to re-issue only the offending one with an `id`. Discarding their
+    resolved targets meant the re-run had to repeat every name that had already
+    worked, and a caller who edits that line under time pressure is the one who
+    drops a name they meant to keep."""
     targets = (
-        target("branch:feat/x"),
-        target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH),
+        target("branch:feat"),
+        target("worktree:/repo/wt/feat", kind=TargetKind.WORKTREE),
         target("branch:other"),
     )
-    resolved, absent, refusal = resolve_selectors(
-        ["other", "feat/x", "nope"], targets, make_survey()
+    resolved, absent, refusals = resolve_selectors(
+        ["other", "feat", "nope"], targets, make_survey()
     )
-    assert refusal is not None
-    assert refusal.code == "E_AMBIGUOUS_TARGET"
-    assert resolved == []
-    assert absent == []
+    assert [r.code for r in refusals] == ["E_AMBIGUOUS_TARGET"]
+    assert [t.id for t in resolved] == ["branch:other"]
+    # And the selector after the ambiguous one was still resolved, rather than
+    # never reached: resolution does not stop at the first objection.
+    assert [a.selector for a in absent] == ["nope"]
 
 
 # -- worktree occupancy ------------------------------------------------------
@@ -530,10 +759,34 @@ def _occupied_survey():  # type: ignore[no-untyped-def]
 
 def test_named_occupied_branch_is_refused() -> None:
     """Not a safety judgement -- git is about to reject this outright, and
-    saying so names the worktree that has to go first."""
+    saying so names the worktree that has to go first.
+
+    Refused rather than carrying the sweep's quiet `Skipped` row, and in place
+    of it: the caller named this one, so the omission is said once, in the
+    register their naming earned."""
     result = plan_for((target("branch:held"),), survey=_occupied_survey(), selectors=["held"])
-    assert isinstance(result, Refusal)
-    assert result.code == "E_BRANCH_IN_USE"
+    assert result.targets == ()
+    assert result.skipped == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_BRANCH_IN_USE"
+
+
+def test_an_occupied_branch_named_is_refused_beside_a_target_that_still_goes() -> None:
+    """The objection is git's, and it is about one branch. Every other name in
+    the same command resolved to something git will delete without complaint,
+    and holding those back would make one occupied worktree a reason to do
+    none of the work asked for."""
+    result = plan_for(
+        (target("branch:held"), target("branch:free")),
+        survey=_occupied_survey(),
+        selectors=["held", "free"],
+    )
+
+    assert [t.id for t in result.targets] == ["branch:free"]
+    assert result.skipped == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_BRANCH_IN_USE"
+    assert [t.id for t in refusal.blocked] == ["branch:held"]
 
 
 def test_the_occupancy_check_reads_the_local_branch_not_a_server_ref_of_that_name() -> None:
@@ -557,9 +810,10 @@ def test_the_occupancy_check_reads_the_local_branch_not_a_server_ref_of_that_nam
         (target("branch:origin/held"),), survey=survey, selectors=["branch:origin/held"]
     )
 
-    assert isinstance(result, Refusal)
-    assert result.code == "E_BRANCH_IN_USE"
-    assert "/repo/wt" in result.message
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_BRANCH_IN_USE"
+    assert "/repo/wt" in refusal.message
 
 
 def test_automatic_sweep_skips_an_occupied_branch_instead_of_refusing() -> None:
@@ -575,6 +829,19 @@ def test_a_skipped_target_is_reported_never_silently_dropped() -> None:
     assert isinstance(result, Plan)
     assert [s.name for s in result.skipped] == ["held"]
     assert "/repo/wt" in result.skipped[0].reason
+
+
+def test_a_bare_sweep_still_skips_an_occupied_branch_rather_than_refusing_it() -> None:
+    """The line between the two modes, and it is the one thing splitting the
+    refusal out per selector must not blur. Nobody named this branch, so no
+    instruction was contradicted -- an unattended sweep that turned an occupied
+    branch into a refusal would exit non-zero, and report a run as failed, on a
+    repository where everything it was actually asked to do was done."""
+    result = plan_for((target("branch:held"), target("branch:free")), survey=_occupied_survey())
+
+    assert [t.id for t in result.targets] == ["branch:free"]
+    assert [s.target_id for s in result.skipped] == ["branch:held"]
+    assert result.refused == ()
 
 
 def test_occupancy_resolves_when_the_worktree_is_also_being_removed() -> None:

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -253,11 +253,17 @@ def test_a_refused_name_takes_only_itself_out_of_the_run() -> None:
     assert [r.code for r in result.refused] == ["E_NOT_A_TARGET"]
 
 
-def test_refusals_arrive_in_the_order_their_selectors_were_given() -> None:
-    """Reading order is the only order a caller can map back onto what they
-    typed. A list assembled in some order of the tool's own -- by code, or by
-    whichever target happened to be surveyed first -- leaves somebody who named
-    six things pairing refusals to selectors by hand.
+def test_refusals_raised_while_resolving_keep_the_order_their_selectors_had() -> None:
+    """Reading order is the order a caller can map back onto what they typed,
+    so a list assembled by code, or by whichever target happened to be surveyed
+    first, leaves somebody who named six things pairing refusals up by hand.
+
+    Scoped to resolution deliberately. The two checks made of the selection as
+    a whole -- the invoking worktree, and branches a worktree still holds --
+    are appended after these, and the second is one refusal covering however
+    many branches were occupied, so it has no single position among the
+    selectors to hold. Claiming one flat selector order would be claiming
+    something the shape of that refusal cannot deliver; `Plan.refused` says so.
 
     Asserted both ways round, because a single ordering is also what a fixed
     order of codes would produce."""
@@ -582,7 +588,14 @@ def test_every_server_copy_of_a_bare_name_is_named_not_just_the_first() -> None:
     course, and a caller working in one has no reason to be thinking about the
     other. Naming one copy would describe half of what is there, and a reader
     handed half reads it as the whole -- so they delete the one they were told
-    about and leave a ref they meant to be rid of, believing it gone."""
+    about and leave a ref they meant to be rid of, believing it gone.
+
+    The remedy offers them as a choice and not as a list to paste. A remedy is
+    read as something to type back, and `origin/feat/x, upstream/feat/x` typed
+    back is one argument with a comma in it, which names nothing -- so a caller
+    following the advice exactly would be told their own remedy matched
+    nothing. Two remotes carrying a name is also not two copies anybody meant
+    to be rid of."""
     survey = make_survey(remotes=("origin", "upstream"))
     targets = (
         target("remote:origin/feat/x", kind=TargetKind.REMOTE_BRANCH, sweepable=False),
@@ -598,7 +611,11 @@ def test_every_server_copy_of_a_bare_name_is_named_not_just_the_first() -> None:
         "remote:origin/feat/x",
         "remote:upstream/feat/x",
     ]
-    assert "upstream/feat/x" in refusal.remedy
+    assert "origin/feat/x or upstream/feat/x" in refusal.remedy
+    assert "origin/feat/x, upstream/feat/x" not in refusal.remedy
+    # The message is a statement of what is there, so it stays a list; only the
+    # remedy is read as something to type back.
+    assert "origin/feat/x, upstream/feat/x" in refusal.message
 
 
 def test_the_full_name_still_selects_the_servers_copy_past_a_local_branch() -> None:

--- a/src/user/.claude/commands/clean-up-git.md
+++ b/src/user/.claude/commands/clean-up-git.md
@@ -150,19 +150,24 @@ Then `gitclean --cleanup --dry-run` with exactly those names, show the plan, and
 `gitclean --cleanup` with the same names. **MUST NOT** re-run a refused command
 unchanged: every refusal carries a `remedy` saying what would let it proceed.
 
-Both of those carry `plan.skipped` — targets the run selected and then dropped.
-Report every one. This is the first step that has them: a report builds no plan,
-so nothing in step 3 could have shown them, and a sweep that quietly did less
-than asked reads as success.
+Both of those carry `plan.skipped` — targets the run selected and then dropped —
+and `plan.refused`, names it would not act on at all. Report every one of both.
+This is the first step that has them: a report builds no plan, so nothing in
+step 3 could have shown them, and a run that quietly did less than asked reads
+as success.
 
 **A remedy is advice to the user, not authority for you.** Some of them widen
 the selection — the refusal for a branch a worktree still holds is remedied by
 adding that worktree to the cleanup, and taking that step yourself would delete
 a directory nobody named. Where a remedy would add a target the user did not
-name, relay it and stop. Otherwise follow it, or drop the blocked target and
-clean the rest.
+name, relay it and stop. Otherwise follow it. Clearing the rest of the selection
+is never the remedy: a refusal takes only its own name out of the run, so
+everything else named was deleted on the first call.
 
 **Exit 0 is a claim, not a result.** State what was deleted and what was
-verified. Exit 3 means it acted and something surprised it: read
+verified. **Exit 1 does not mean nothing happened** — report the deletions that
+did land alongside each `plan.refused` entry, or the next reader will believe
+the repository is as they left it. Exit 3 means it acted and something
+surprised it: read
 `execution.anomalies`, which carry the failing argv, the exit code and both
 streams. Diagnose from those; do not re-run to see what happens.


### PR DESCRIPTION
PR B of two for `9k9.131` (the gitclean cleanup-friction item). PR A was #449, which shipped the `--after-merge` verb. This one is changes **3** and **4** from the item; change **2** follows in its own PR.

Both changes are in how `--cleanup` reads the names it is given, and they land together because both live in `resolve_selectors` — change 3 *deletes* the machinery change 4 would otherwise have had to restructure.

## Change 3 — a bare name selects something local

A bare name used to reach a server ref through the ref's bare alias. That made the commonest cleanup there is — delete the branch whose work just merged — ambiguous between the local branch and the copy on the server, and the run refused rather than choosing. This is the exact failure the item was filed from:

```
REFUSED (E_AMBIGUOUS_TARGET): 'docs/9k9.129-codex-home-idiom' matches more than one target:
  branch:docs/9k9.129-codex-home-idiom, remote:origin/docs/9k9.129-codex-home-idiom
```

A server ref now answers to its full `<remote>/<ref>` spelling and its `remote:` id, and to nothing shorter — which is what the tool already claimed, since it declines to delete a server ref that was not named.

A bare name that **only** a server ref wears is refused with `E_BARE_NAME_IS_SERVER_REF`, carrying the spelling that would reach it. Reporting it absent would be a false report about a ref that is sitting right there. Every matching copy is named, not just the first: a fork with `origin` and `upstream` carries the same branch name twice as a matter of course.

**A hazard settled by construction.** A remote list git could not read used to make the tool *more* willing to delete — the unreadable ref never became a target, so it never became a rival for the name, and the local branch went. It cannot be a rival under either outcome now, so the failed probe changes nothing. Two tests that previously pinned this via a refusal now pin it as an equivalence.

## Change 4 — one refusal costs one name

Each objection belongs to the name it is about, travels in `plan.refused` with its own code and remedy, and the targets beside it are still deleted.

- `build_plan` returns a `Plan` and never a `Refusal`.
- The run-wide `refusal` field keeps what it always meant — a run with no authority at all: a failed survey, or an `--after-merge` whose merge could not be established. It is `null` for a `--cleanup` with per-name refusals, deliberately, so a reader checking the old field is not told the whole command was declined.
- All four paths that can object route there, including `E_INVOKING_WORKTREE` and `E_BRANCH_IN_USE`. Applying it to only some of them would leave a two-tier rule a reader has to memorise; this way the contract is one sentence.
- A named occupied branch appears in `plan.refused` and **not** in `plan.skipped` — said once, in the register the caller's own naming earned. A bare sweep is unchanged and still uses `plan.skipped`.
- **Exit 1 now means something was refused, not that nothing happened.** An unverified deletion still outranks it at exit 3.

## Docs

The README and the `/clean-up-git` command both told a reader that exit 1 meant the repository was as they left it. Both now say what to report instead. The `post-merge-cleanup` skill needed no change — it already works in full spellings, and the new refusal carries its own remedy at the point of use.

## Verification

- `make ci` green from this worktree (exit 0 read standalone, not through a pipe).
- 449 tests, gitclean coverage 97.94%.
- **Seven mutations checked by hand.** Reverting each half of the change, and each of the four paths that reach `plan.refused`, fails a test that names the behaviour it removed:

| mutation | caught by |
|---|---|
| bare name matches a server ref again | 9 tests |
| a resolve refusal carries nothing forward | 2 tests |
| naming the invoking worktree aborts the selection | 5 tests |
| a named occupied branch is both refused and skipped | 2 tests |
| only the first server copy is named | 1 test |
| a refusal hides an unverified deletion behind exit 1 | 1 test |
| `ok` stays true though the run refused | 1 test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zSUyTCy13ju28gaFmkykq