### PR TITLE
fix(9k9.131): the server decides which of its refs still exist, not a cache

### DIFF
--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -1114,11 +1114,17 @@ def _advertised_heads(
     reading the column rather than searching the line is what keeps an
     unrelated `a/feat/x` from answering for `feat/x`.
 
-    `--` matters, and for the same reason it matters there: `remote` is
-    repo-derived, and git accepts a *path* in this position. Given a name that
-    is not a configured remote, a sibling directory of that name that happens
-    to be a repository is opened instead and answers -- well-formed, empty, and
-    about somebody else entirely."""
+    Two separate protections, and it is worth not confusing them. `--` ends
+    option parsing, which is what keeps a branch or remote named like a flag
+    from being read as one. It does *not* stop git accepting a path in the
+    repository position -- nothing does.
+
+    What covers that is where `remote` comes from: the decomposition against
+    the configured remote list, so the only names reaching here are ones git
+    itself listed. It matters because a name that is not a configured remote
+    is not rejected -- a sibling directory of that name that happens to be a
+    repository is opened instead and answers, well-formed, empty, and about
+    somebody else entirely. An empty answer here means every branch is gone."""
     result = port.git(["ls-remote", "--heads", "--", remote], cwd=cwd)
     if not result.ok:
         return None, (

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -1097,6 +1097,93 @@ def _resolve_merge(
     return False, MergeEvidence.NONE, covers_tip, tuple(failures)
 
 
+def _advertised_heads(
+    port: CommandPort, cwd: Path | None, remote: str
+) -> tuple[set[str] | None, str | None]:
+    """Every branch this remote currently advertises, or None and the warning
+    when it would not say.
+
+    Asked because everything under `refs/remotes/` is a local cache that a
+    fetch refreshes and nothing invalidates. On a forge that deletes a branch
+    when its pull request merges -- the common configuration -- that cache
+    routinely names refs the server dropped weeks ago, so offering one as a
+    target sends a reader after something that is not there.
+
+    The refname is the LAST tab-separated field, which is the same comparison
+    the deletion-time probe makes: `ls-remote` prints `<oid>\\t<refname>`, and
+    reading the column rather than searching the line is what keeps an
+    unrelated `a/feat/x` from answering for `feat/x`.
+
+    `--` matters, and for the same reason it matters there: `remote` is
+    repo-derived, and git accepts a *path* in this position. Given a name that
+    is not a configured remote, a sibling directory of that name that happens
+    to be a repository is opened instead and answers -- well-formed, empty, and
+    about somebody else entirely."""
+    result = port.git(["ls-remote", "--heads", "--", remote], cwd=cwd)
+    if not result.ok:
+        return None, (
+            f"could not ask {remote} which branches it still has (exit {result.returncode}); "
+            f"its refs are reported as this repository's remote-tracking refs hold them, which "
+            f"may be out of date -- nothing here says any of them is gone"
+        )
+    return {
+        line.split("\t")[-1].strip() for line in result.stdout.splitlines() if line.strip()
+    }, None
+
+
+def _verify_against_remotes(
+    port: CommandPort, cwd: Path | None, branches: list[Branch]
+) -> tuple[list[Branch], list[NotOffered], list[str]]:
+    """The branches with the phantoms taken out, those phantoms, and the
+    remotes that would not answer.
+
+    A phantom is a remote-tracking ref whose server no longer advertises the
+    branch it names. The deletion path already asks this question before
+    spending anything on such a target; asking it during the survey is what
+    keeps one from being offered as a target at all, so a reader is never shown
+    a branch that is already gone.
+
+    One probe per remote, and only for remotes some candidate ref belongs to.
+    That is why this is a pass over the branches rather than a sweep over the
+    configured remotes: a remote nobody has refs from -- a server that moved,
+    a colleague's fork left in the config -- would otherwise cost a full
+    network timeout to learn nothing about.
+
+    A probe that did not answer leaves its branches exactly as they were. Not
+    knowing what a server holds is not evidence that it holds nothing, and
+    reading it that way would drop every one of that remote's refs out of the
+    report on the strength of a connection that failed."""
+    advertised: dict[str, set[str] | None] = {}
+    kept: list[Branch] = []
+    phantoms: list[NotOffered] = []
+    warnings: list[str] = []
+    for branch in branches:
+        remote = branch.remote
+        if remote is None:
+            # A local branch: no server holds a copy, so there is nobody to ask.
+            kept.append(branch)
+            continue
+        if remote not in advertised:
+            heads, warning = _advertised_heads(port, cwd, remote)
+            advertised[remote] = heads
+            if warning is not None:
+                warnings.append(warning)
+        heads = advertised[remote]
+        if heads is None or f"refs/heads/{branch.ref_name}" in heads:
+            kept.append(branch)
+            continue
+        phantoms.append(
+            NotOffered(
+                name=branch.name,
+                reason=f"{remote} no longer advertises refs/heads/{branch.ref_name}, so there "
+                f"is nothing on the server to delete; what is left is {branch.ref}, the "
+                f"remote-tracking ref a fetch created here, and `git fetch --prune {remote}` "
+                f"is what clears it -- gitclean does not prune refs it did not create",
+            )
+        )
+    return kept, phantoms, warnings
+
+
 def read_branches(
     port: CommandPort,
     cwd: Path | None,
@@ -1285,6 +1372,12 @@ def read_branches(
                 probe_failures=probe_failures,
             )
         )
+    # Last, over the branches this loop built: every server ref here was read
+    # from a cache, and the servers themselves are the only thing that says
+    # which of those refs still exist.
+    branches, phantoms, probe_warnings = _verify_against_remotes(port, cwd, branches)
+    not_offered.extend(phantoms)
+    warnings.extend(probe_warnings)
     if dropped:
         warnings.append(
             f"{dropped} ref row(s) could not be parsed and are missing from this report; "

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -840,9 +840,13 @@ def test_a_server_ref_the_remote_already_dropped_is_never_offered(
     quietly cleaned the cache would test nothing.
 
     Real git, because this is also what proves `ls-remote --heads --` is an
-    argv git accepts: the terminator is what keeps a remote name from being
-    read as a path to some other repository, and a spelling git rejected would
-    fail every probe and report every server ref as still there."""
+    argv git accepts. The terminator is there for option safety -- it stops a
+    remote named like a flag being read as one -- and not for the repository
+    position, which git will fill from a path whatever precedes it; what keeps
+    the probe pointed at a real remote is that the name came from the
+    configured remote list. Either way a spelling git rejected would fail every
+    probe, and a failed probe reports every server ref as still there, so this
+    would pass while measuring nothing."""
     bare = _with_remote(repo, tmp_path)
     _push_only_copy(repo, "feat/vanished")
     git(bare, "update-ref", "-d", "refs/heads/feat/vanished")

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -99,6 +99,22 @@ class Recording(GitOnly):
         return super().git(args, cwd=cwd)
 
 
+def remotes_asked(transcript: list[tuple[str, ...]]) -> list[str]:
+    """Every remote an `ls-remote` in this transcript was pointed at.
+
+    Two questions reach a remote by that command and they are spelled
+    differently: the survey asks one what it still advertises
+    (`ls-remote --heads -- <remote>`), and the deletion asks after a single ref
+    on it (`ls-remote --heads <remote> <ref>`). The remote is the first
+    argument that is not an option in both, which is what this reads -- a fixed
+    position is not something the two spellings share."""
+    return [
+        next(arg for arg in call[call.index("ls-remote") + 1 :] if not arg.startswith("-"))
+        for call in transcript
+        if "ls-remote" in call
+    ]
+
+
 def report(
     repo: Path, *args: str, now: datetime | None = None, port: CommandPort | None = None
 ) -> dict[str, object]:
@@ -807,12 +823,13 @@ def test_a_salvaged_server_ref_restores_by_the_command_the_tool_printed(
     assert git(clone, "cat-file", "-p", f"{only}:feat-gone.txt") == "the only copy"
 
 
-def test_a_server_ref_the_remote_already_dropped_costs_no_bundle(
+def test_a_server_ref_the_remote_already_dropped_is_never_offered(
     repo: Path, tmp_path: Path
 ) -> None:
     """What a forge that deletes a branch when its PR merges leaves behind: a
     tracking ref under refs/remotes naming a branch the server no longer has.
-    That stale ref is the only reason the target is in the plan at all.
+    That stale ref is the only thing that ever made this a target, and the
+    survey asks the server rather than believing it.
 
     The ref is dropped *inside the bare repository*, which is what a forge
     tidying up after a merge does and is the only way to reach this state:
@@ -822,9 +839,10 @@ def test_a_server_ref_the_remote_already_dropped_costs_no_bundle(
     this is about, and the assertion below is there because a setup that
     quietly cleaned the cache would test nothing.
 
-    The salvage list is what matters. Learning the ref is gone from a rejected
-    push means learning it after bundling the branch's entire history for
-    something that was never there to lose."""
+    Real git, because this is also what proves `ls-remote --heads --` is an
+    argv git accepts: the terminator is what keeps a remote name from being
+    read as a path to some other repository, and a spelling git rejected would
+    fail every probe and report every server ref as still there."""
     bare = _with_remote(repo, tmp_path)
     _push_only_copy(repo, "feat/vanished")
     git(bare, "update-ref", "-d", "refs/heads/feat/vanished")
@@ -832,14 +850,20 @@ def test_a_server_ref_the_remote_already_dropped_costs_no_bundle(
 
     payload = report(repo, "--cleanup", "origin/feat/vanished")
 
-    assert payload["_exit"] == EXIT_OK
+    assert payload["_exit"] == EXIT_REFUSED
+    refusal = refusals(payload)[0]
+    assert refusal["code"] == "E_NOT_A_TARGET"
+    assert "no longer advertises refs/heads/feat/vanished" in str(refusal["message"])
+    assert "fetch --prune origin" in str(refusal["message"])
+    assert "remote:origin/feat/vanished" not in [t["id"] for t in payload["targets"]]  # type: ignore[union-attr]
+    # Nothing was spent finding that out, and the tracking ref is still here:
+    # gitclean does not prune what a fetch created.
     execution = payload["execution"]
     assert isinstance(execution, dict)
     assert execution["anomalies"] == []
     assert execution["salvages"] == []
-    deletion = execution["deletions"][0]
-    assert deletion["already_absent"] is True
-    assert deletion["deleted"] is False
+    assert execution["deletions"] == []
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/remotes/origin/feat/vanished")
 
 
 def test_the_salvage_ref_does_not_outlive_the_run(repo: Path, tmp_path: Path) -> None:
@@ -1010,7 +1034,7 @@ def test_a_remote_whose_name_holds_a_slash_is_never_split_at_the_wrong_one(
 
     # Every remote git was given is the configured name, never its first
     # component -- and the decoy was never opened.
-    named = [call[call.index("--heads") + 1] for call in port.transcript if "--heads" in call]
+    named = remotes_asked(port.transcript)
     assert named and set(named) == {"team/origin"}
     assert git(decoy, "for-each-ref", "--format=%(refname)") == ""
 
@@ -1068,7 +1092,7 @@ def test_a_ref_reachable_only_through_a_custom_refspec_belongs_to_who_fetches_it
 
     # Every remote git was handed is the one that fetches the ref, never the
     # one the path happens to spell.
-    named = [call[call.index("--heads") + 1] for call in port.transcript if "--heads" in call]
+    named = remotes_asked(port.transcript)
     assert named and set(named) == {"upstream"}
 
 

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -389,6 +389,51 @@ def test_a_bare_name_only_the_server_wears_is_told_the_spelling_that_reaches_it(
     assert execution["deletions"] == []
 
 
+def _phantom_remote_port() -> ScriptedCommands:
+    """The tracking ref is here and the server has moved on: origin advertises
+    the trunk and nothing else, which is what a forge that deletes a branch
+    when its pull request merges leaves behind."""
+    return make_port(
+        refs=[
+            ref_at("refs/heads/main", "main", "a" * 40, head="*"),
+            ref_at("refs/remotes/origin/feat/x", "origin/feat/x", "f" * 40),
+        ],
+        counts={"refs/remotes/origin/main..origin/feat/x": "0"},
+        ls_remote={"origin": ok(f"{'a' * 40}\trefs/heads/main")},
+    )
+
+
+def test_naming_a_ref_the_server_dropped_says_what_is_actually_the_matter() -> None:
+    """The survey no longer offers it, so the full spelling lands on the
+    exclusion rather than on a deletion -- and the reason is the whole value of
+    the refusal: nothing on the server, a tracking ref a fetch left here, and
+    the prune that clears it."""
+    port = _phantom_remote_port()
+
+    code, payload = invoke(["--cleanup", "origin/feat/x"], port)
+
+    assert code == EXIT_REFUSED
+    refusal = sole_refusal(payload)
+    assert refusal["code"] == "E_NOT_A_TARGET"
+    assert "no longer advertises refs/heads/feat/x" in str(refusal["message"])
+    assert "git fetch --prune origin" in str(refusal["message"])
+    assert not any(call[:2] == ("git", "push") for call in port.transcript)
+
+
+def test_a_bare_name_the_server_no_longer_wears_is_absent_rather_than_quoted() -> None:
+    """The other half of the same change. `E_BARE_NAME_IS_SERVER_REF` exists to
+    quote the spelling that would reach the server's copy, and there is no
+    longer a copy to reach -- so the honest answer is the one the caller asked
+    for: nothing here wears that name."""
+    code, payload = invoke(["--cleanup", "feat/x"], _phantom_remote_port())
+
+    assert code == EXIT_OK
+    assert refusals(payload) == []
+    plan = payload["plan"]
+    assert isinstance(plan, dict)
+    assert [a["selector"] for a in plan["absent"]] == ["feat/x"]
+
+
 def test_a_miss_with_no_refs_read_exits_refused_not_clean() -> None:
     """Exit 0 here would report a branch as gone on the strength of a list that
     failed to load. The caller is entitled to know the difference between "it
@@ -711,8 +756,13 @@ def test_an_unsplittable_server_ref_is_counted_on_the_survey() -> None:
 
 
 def _absent_remote_port() -> ScriptedCommands:
-    """The tracking ref is here and the server's copy is not, which is what a
-    forge that deletes merged branches leaves behind."""
+    """A server that dropped the ref between the survey and the deletion.
+
+    It advertises the branch when the survey asks what it holds -- so the
+    target is offered -- and holds nothing by the time the executor asks after
+    that one ref. That race is what the check before the delete is for, and it
+    is the only route to this outcome now that a ref the survey found missing
+    never becomes a target at all."""
     return make_port(
         refs=[
             ref_at("refs/heads/main", "main", "a" * 40, head="*"),

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -15,6 +15,7 @@ from gitclean.survey import (
     resolve_base_ref,
     resolve_default_branch,
     resolve_repo,
+    split_remote_ref,
     survey,
 )
 
@@ -80,6 +81,45 @@ def default_refspecs(remotes: str) -> str:
     )
 
 
+def advertised_heads(refs: list[str], remotes: str, refspecs: str) -> dict[str, CommandResult]:
+    """What each remote answers `ls-remote --heads` with, derived from the refs
+    the fixture already supplied: a server holding exactly what the local cache
+    holds.
+
+    That is the boring case, and it is what nearly every fixture here means. A
+    survey asks each remote what it still advertises, so a fixture that
+    answered nothing would describe every server ref in it as one the remote
+    dropped -- turning tests about splitting a path, or about proving a merge,
+    into tests about stale tracking refs. A test that is actually about a stale
+    one says so by passing `ls_remote` itself.
+
+    Which remote owns a path, and what the server calls the branch that landed
+    there, come from the production split rather than from the shape of the
+    path. A fixture whose refspec renames on the way in has a server-side name
+    the local path does not spell, and one where two remotes fetch into a
+    single namespace has no owner at all -- so deriving either by hand here
+    would answer differently from the code under test."""
+    configured = tuple(line.strip() for line in remotes.splitlines() if line.strip())
+    specs: dict[str, list[str]] = {}
+    for record in refspecs.split("\0"):
+        if not record:
+            continue
+        key, _, value = record.partition("\n")
+        specs.setdefault(key.removeprefix("remote.").removesuffix(".fetch"), []).append(value)
+    parsed = {remote: tuple(values) for remote, values in specs.items()}
+    heads: dict[str, list[str]] = {}
+    for line in refs:
+        full = line.split(SEP)[0]
+        if not full.startswith("refs/remotes/") or full.endswith("/HEAD"):
+            continue
+        split = split_remote_ref(full, configured, parsed)
+        if isinstance(split, str):
+            continue
+        remote, ref_name = split
+        heads.setdefault(remote, []).append(f"{'a' * 40}\trefs/heads/{ref_name}")
+    return {remote: ok("\n".join(lines)) for remote, lines in heads.items()}
+
+
 def make_port(
     *,
     refs: list[str] | None = None,
@@ -93,8 +133,10 @@ def make_port(
     gh_result: CommandResult | None = None,
     remotes: str = "origin\n",
     refspecs: str | None = None,
+    ls_remote: dict[str, CommandResult] | None = None,
     pr_view: dict[str, object] | None = None,
 ) -> ScriptedCommands:
+    configured_refspecs = refspecs if refspecs is not None else default_refspecs(remotes)
     table: dict[str, CommandResult] = {
         "rev-parse --show-toplevel": ok("/repo"),
         # Asked of every survey: it is the only thing that says where a
@@ -105,9 +147,7 @@ def make_port(
         # says which remote fetched one. Defaulted to what `git remote add`
         # writes for each remote in `remotes`, because that is the boring
         # case; a test about a refspec that does something else passes its own.
-        "config -z --get-regexp": ok(
-            refspecs if refspecs is not None else default_refspecs(remotes)
-        ),
+        "config -z --get-regexp": ok(configured_refspecs),
         "rev-parse --path-format=absolute --git-common-dir": ok("/repo/.git"),
         "symbolic-ref --quiet refs/remotes/origin/HEAD": ok("refs/remotes/origin/main"),
         "show-ref --verify --quiet refs/remotes/origin/main": ok(),
@@ -133,6 +173,14 @@ def make_port(
     }
     for spec, value in (counts or {}).items():
         table[f"rev-list --count {spec}"] = ok(value)
+    # Every remote some surveyed ref belongs to is asked what it still holds.
+    # Keyed per remote and left unscripted for the rest, so a run that probes a
+    # remote nothing was fetched from fails naming the argv rather than on a
+    # default that hides the cost of asking.
+    advertised = advertised_heads(refs or [], remotes, configured_refspecs)
+    advertised.update(ls_remote or {})
+    for remote, answer in advertised.items():
+        table[f"ls-remote --heads -- {remote}"] = answer
     table.update(extra or {})
     gh = gh_result or ok(json.dumps(prs or []))
     answers = {"pr list": gh}
@@ -1428,6 +1476,103 @@ def test_a_failed_batch_ancestry_check_is_warned_not_swallowed() -> None:
     feat = next(b for b in result.branches if b.name == "feat")
     assert feat.merge_evidence is MergeEvidence.PATCH_EQUAL
     assert any("batch ancestry check for local branches" in w for w in result.warnings)
+
+
+# -- what the server still advertises -----------------------------------------
+
+
+def _stale_ref_port(**kwargs: object) -> ScriptedCommands:
+    """One server ref beside the trunk, with what origin answers left open.
+
+    The refs are the same in every test below; what differs is whether origin
+    still has `feat/x`, and whether it answers at all."""
+    return make_port(
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+        ],
+        counts={"refs/remotes/origin/main..origin/feat/x": "0"},
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_a_server_ref_the_remote_still_advertises_stays_a_target() -> None:
+    """The ordinary case, and the one the check must not cost anything: the
+    cache and the server agree, so the branch is surveyed as it always was."""
+    surveyed = run(_stale_ref_port())
+
+    feat = next(b for b in surveyed.branches if b.is_remote)
+    assert (feat.name, feat.remote, feat.ref_name) == ("origin/feat/x", "origin", "feat/x")
+    assert not surveyed.not_offered
+    assert not surveyed.warnings
+
+
+def test_a_server_ref_the_remote_dropped_is_recorded_rather_than_offered() -> None:
+    """What a forge configured to delete a branch when its PR merges leaves
+    behind. `refs/remotes/` is a cache nothing invalidates, so it goes on
+    naming the branch for as long as nobody prunes -- and offering that as a
+    target sends a reader after something that is not there.
+
+    Recorded rather than dropped, because a caller who names it must be told
+    what is actually the matter and what clears it, not that it is already
+    gone."""
+    port = _stale_ref_port(ls_remote={"origin": ok(f"{'a' * 40}\trefs/heads/main")})
+
+    surveyed = run(port)
+
+    assert not [b for b in surveyed.branches if b.is_remote]
+    reason = {n.name: n.reason for n in surveyed.not_offered}["origin/feat/x"]
+    assert "no longer advertises refs/heads/feat/x" in reason
+    assert "git fetch --prune origin" in reason
+    assert "does not prune refs it did not create" in reason
+
+
+def test_a_remote_that_would_not_answer_leaves_its_refs_exactly_as_they_were() -> None:
+    """The invariant the whole check rests on. A probe that errored is a
+    question nobody answered, and reading it as "the server does not have it"
+    would take every one of that remote's refs out of the report on the
+    strength of a connection that failed -- while telling the reader they are
+    gone."""
+    port = _stale_ref_port(ls_remote={"origin": fail("could not read from remote", code=128)})
+
+    surveyed = run(port)
+
+    assert [b.name for b in surveyed.branches if b.is_remote] == ["origin/feat/x"]
+    assert not surveyed.not_offered
+    warning = next(w for w in surveyed.warnings if "origin" in w)
+    assert "could not ask origin which branches it still has" in warning
+    assert "may be out of date" in warning
+
+
+def test_each_remote_is_asked_once_and_a_remote_with_no_refs_here_not_at_all() -> None:
+    """One probe per remote rather than per branch, and only for remotes some
+    surveyed ref actually belongs to.
+
+    The second half is why this runs over the branches instead of over the
+    configured remotes: `abandoned` below is a server that moved or a fork
+    somebody left in the config, and asking it costs a full network timeout to
+    learn nothing. It is left unscripted, so a run that asks fails naming the
+    argv."""
+    port = make_port(
+        remotes="origin\nupstream\nabandoned\n",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/origin/feat/x", "origin/feat/x"),
+            ref_line("refs/remotes/origin/feat/y", "origin/feat/y"),
+            ref_line("refs/remotes/upstream/feat/z", "upstream/feat/z"),
+        ],
+        counts={
+            "refs/remotes/origin/main..origin/feat/x": "0",
+            "refs/remotes/origin/main..origin/feat/y": "0",
+            "refs/remotes/origin/main..upstream/feat/z": "0",
+        },
+    )
+
+    surveyed = run(port)
+
+    assert len([b for b in surveyed.branches if b.is_remote]) == 3
+    probes = [call for call in port.transcript if call[1] == "ls-remote"]
+    assert [call[-1] for call in probes] == ["origin", "upstream"]
 
 
 # -- the merge tiers ---------------------------------------------------------


### PR DESCRIPTION
The last of `9k9.131` — change **2** from the item. #449 shipped the `--after-merge` verb, #450 shipped changes 3 and 4. This closes the item.

## The problem

Everything under `refs/remotes/` is a local cache a fetch refreshes and nothing invalidates. On a forge that deletes a branch when its pull request merges — the configuration on this repository — that cache routinely names refs the server dropped weeks ago, and `gitclean` offered every one of them as a target. A reader was being sent after branches that were already gone. This is the "phantom target" that cost the round trip in the original field report.

## The change

The survey asks. One `ls-remote` per remote, and a ref the server no longer advertises is recorded as `not_offered` instead of becoming a target.

**Nothing is pruned.** The remote-tracking ref stays exactly where it is; `gitclean` does not delete refs it did not create, and the reason it records says `git fetch --prune` is what clears it.

**Only remotes with candidate refs are asked.** That is why this is a pass over the branches rather than a sweep over the configured remotes — a remote nobody has refs from (a server that moved, a colleague's fork left in the config) would otherwise cost a full 60-second timeout to learn nothing.

**A probe that does not answer leaves its branches exactly as they were.** Not knowing what a server holds is not evidence that it holds nothing, and reading it that way would drop every one of a remote's refs out of the report on the strength of a connection that failed. This is the invariant most worth protecting here, and it is what mutation MA below exists to guard.

## Composition with #450

Both fall out without extra machinery, which is the sign the seam is in the right place:

- A **bare name** for a dropped ref now correctly reaches `Absent` — "already gone" has become *true* of it, where before it would have been a false report.
- Naming it **in full** reaches `E_NOT_A_TARGET` carrying the new reason.
- A local branch whose upstream was dropped reports that upstream **named, with a null `id`** — the state the pairing contract already reserved for "a counterpart this report has no row for". `test_classify.py:463` already pinned it, and its docstring already named this exact case: *"a ref the remote has dropped is not there to be one."*

## Latency

This puts a network call on the `--report` path. Worth stating plainly, but it is not a new exposure: `gh pr list` already runs there under the same 60-second port timeout and degrades to a warning the same way. Say the word if you would rather it were bounded separately and I will add it — I left it out because the identical exposure has never needed one.

## Verification

- `make ci` green from this worktree (exit 0 read standalone, not through a pipe). Coverage 99.35%.
- **Three mutations checked by hand:**

| mutation | caught by |
|---|---|
| MA — an unanswered probe reads as "the server does not have it" | the failed-probe test |
| MB — the remote is re-probed once per branch instead of once | the probe-count test |
| MC — phantoms recorded but still offered as targets | 4 tests, incl. the real-git integration test |

- **Run against this repository for real.** It drops exactly the four tracking refs left behind by merged pull requests, and keeps the three branches `origin` still advertises:

```
recorded as gone from the server:  origin/feat/9k9.131-after-merge
                                   origin/fix/9k9.125-broker-reaper
                                   origin/fix/9k9.131-selector-resolution
                                   origin/fix/9k9.134-fetch-refspec
still offered (all three confirmed advertised by origin):
                                   remote:origin/feat/grind-30-7-integration
                                   remote:origin/worktree-prgroom-reviewer-registry-seed
                                   remote:origin/worktree-vaac15-code-review-workflow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zSUyTCy13ju28gaFmkykq