### PR TITLE
fix(9k9.117, 9k9.119): the trunk is named by the remotes a repository has, not by one called origin

### DIFF
--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -27,7 +27,7 @@ does not is what lands in the target's `withheld` field.
 | # | question | answered from |
 |---|---|---|
 | 1 | is the merge proven? | `merge_evidence` is `pr_merged`, `ancestor`, `patch_equal` or `squash_equal` |
-| 2 | is the default branch verified? | `origin/HEAD` or a local `main`/`master` that resolves |
+| 2 | is the default branch verified? | a remote's published HEAD, or a local `main`/`master`, that resolves |
 | 3 | is this the trunk? | the default branch, the ref merges are measured against, and either one's counterpart across the remote boundary — by name *and* by commit |
 | 4 | is the working tree empty? | a measured zero from `git status`; unknown and `prunable` are not zero |
 | 5 | is this a server ref? | server refs are deleted only when named |
@@ -139,10 +139,20 @@ Without `gh` on PATH there is no squash signal at all. That is reported in
   reader deciding what to name is looking at the row, and there "not measured"
   has to read differently from "measured zero".
 
-A repository whose default branch cannot be identified — no published
-`origin/HEAD`, no `main`, no `master` — sweeps nothing at all, because the run
-cannot tell the trunk from cruft. Naming targets still works. Publish it with
-`git remote set-head origin -a`.
+A repository whose default branch cannot be identified — no remote publishing a
+HEAD, no `main`, no `master` — sweeps nothing at all, because the run cannot
+tell the trunk from cruft. Naming targets still works. Publish it with `git
+remote set-head <remote> -a`.
+
+Which remote is asked is the configured list's business, not a name this tool
+spells. `origin` answers alone wherever it is configured, so a fork takes its
+trunk from the repository it was cloned from rather than from `upstream`.
+Elsewhere every configured remote is asked, and one distinct published branch
+name settles it — whether that is one remote speaking or several agreeing.
+Remotes that disagree name no trunk at all: their trunks are allowed to differ,
+and measuring merges against one that is ahead of the real trunk would report
+unmerged work as merged, so the run says which remotes disagreed and sweeps
+nothing.
 
 ## Trades worth knowing
 

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -133,9 +133,83 @@ def _ref_exists(port: CommandPort, cwd: Path | None, ref: str) -> bool | None:
     return False if result.returncode == 1 else None
 
 
-def resolve_default_branch(port: CommandPort, cwd: Path | None) -> tuple[str | None, str | None]:
+def _published_trunk(
+    port: CommandPort, cwd: Path | None, remotes: tuple[str, ...]
+) -> tuple[str, tuple[str, ...], str]:
+    """The branch these remotes publish as their HEAD, the remotes that publish
+    it, and -- when no single name came back -- the clause saying why.
+
+    A published HEAD is a local symbolic ref that `git fetch` or `git remote
+    set-head` wrote, so asking every configured remote costs no network round
+    trip and this loop is as cheap as the single question it grew out of.
+
+    One distinct name is the whole bar, and remotes that agree are worth as much
+    as a remote on its own: what this tier produces is the trunk's *name*, and
+    two servers that both call their trunk `main` are saying the same thing
+    about it. Remotes that disagree are saying nothing that can be acted on --
+    picking one of them would silently decide which repository's history every
+    merge in the report is measured against, and picking the one that is ahead
+    is what makes unmerged work look merged -- so the disagreement is handed
+    back as prose and the tier declines. Declining costs a tier and leaves the
+    local main/master below it to answer; guessing costs commits."""
+    if not remotes:
+        return "", (), "this repository has no configured remote to publish a HEAD"
+    published: dict[str, str] = {}
+    unreadable: list[tuple[str, int]] = []
+    for remote in remotes:
+        result = port.git(["symbolic-ref", "--quiet", f"refs/remotes/{remote}/HEAD"], cwd=cwd)
+        if result.ok:
+            name = _first_line(result.out).removeprefix(f"refs/remotes/{remote}/")
+            if name:
+                published[remote] = name
+        elif result.returncode != 1:
+            # Exit 1 is git saying this remote has published no HEAD, which is
+            # an answer. Anything else is git declining to look, which is not.
+            unreadable.append((remote, result.returncode))
+    names = set(published.values())
+    if len(names) == 1:
+        trunk = next(iter(names))
+        return trunk, tuple(r for r, n in published.items() if n == trunk), ""
+    if len(names) > 1:
+        spelled = ", ".join(f"{r} publishes {n}" for r, n in sorted(published.items()))
+        return "", (), f"the configured remotes disagree about which branch is the trunk: {spelled}"
+    if unreadable:
+        listed = ", ".join(f"{remote} (exit {code})" for remote, code in unreadable)
+        unread_detail = (
+            f"{unreadable[0][0]}'s published HEAD could not be read (exit {unreadable[0][1]})"
+            if len(unreadable) == 1
+            else f"the published HEAD of these remotes could not be read: {listed}"
+        )
+        return "", (), unread_detail
+    if len(remotes) == 1:
+        return "", (), f"{remotes[0]} has published no HEAD"
+    return "", (), f"none of this repository's remotes ({', '.join(remotes)}) has published a HEAD"
+
+
+def _consulted_remotes(remotes: tuple[str, ...] | None) -> tuple[str, ...]:
+    """The remotes whose account of the trunk this repository will accept.
+
+    `origin` alone whenever it is configured, and that is behaviour worth
+    stating rather than defaulting into. In a fork, `origin` and `upstream`
+    legitimately disagree about the trunk, and the repository you are standing
+    in is the one `origin` describes -- so consulting the others there could
+    only replace a right answer with a refusal. Only where there is no `origin`
+    does the rest of the remote list get a say.
+
+    An unreadable remote list is not an empty one, and it is not a licence to
+    ask more widely either: nothing can be enumerated, so this asks `origin` and
+    no further, which is exactly the reach it had before any other remote could
+    be consulted. A transient failure to list remotes therefore costs nothing
+    that was working, and widens nothing on the strength of what nobody read."""
+    return ("origin",) if remotes is None or "origin" in remotes else remotes
+
+
+def resolve_default_branch(
+    port: CommandPort, cwd: Path | None, remotes: tuple[str, ...] | None
+) -> tuple[str | None, str | None, str | None]:
     """The repository's trunk -- the branch that is never a deletion candidate
-    -- and, when nothing answered, the warning that says which tier declined.
+    -- the remote whose published HEAD named it, and, when nothing answered,
+    the warning that says which tier declined.
 
     Discovered, never supplied by the caller. A caller who could name what
     merges are measured against could measure against something the real trunk
@@ -143,13 +217,26 @@ def resolve_default_branch(port: CommandPort, cwd: Path | None) -> tuple[str | N
     sweepable -- so the question is asked of the repository, and only of the
     repository.
 
-    origin's published HEAD first, then a local main/master -- **each verified
+    A remote's published HEAD first, then a local main/master -- **each verified
     to resolve**. Returning the literal `main` when nothing answers used to
     look harmless: every merge probe against a ref that is not there fails, so
     nothing could be proven merged. But protection is assigned by *name*, and
     a repository whose trunk is `trunk` then has no protected branch at all:
     the real trunk is left indistinguishable from cruft, deletable like any
     other branch.
+
+    Which remote is asked is decided from the configured list rather than
+    spelled `origin` in the question. A repository whose remote is called
+    anything else -- and which has no local `main` or `master` either -- used to
+    reach no tier at all, so no trunk resolved, nothing could be proven merged,
+    and the tool was inert in it. See the two helpers above for which remotes
+    get a say and what settles a disagreement between them.
+
+    The remote is handed back so that what merges are measured against can be
+    that same remote's copy of the trunk rather than a second, independent
+    guess. Only a sole publisher is recorded: where several remotes agree, the
+    *name* is settled and which server's copy to measure against is not, and
+    that second question is one the base ref resolves for itself.
 
     The published-HEAD tier is the one most likely to be stale -- a dangling
     `origin/HEAD -> origin/master` is the standard leftover after a
@@ -162,42 +249,73 @@ def resolve_default_branch(port: CommandPort, cwd: Path | None) -> tuple[str | N
     verdict is the same either way -- an unverified name is not a trunk -- but
     the sentence is not, and telling someone their `main` does not exist when
     the probe never answered sends them to fix the wrong thing."""
-    head = port.git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd=cwd)
-    published = _first_line(head.out).removeprefix("refs/remotes/origin/") if head.ok else ""
-    candidates = [(published, f"refs/remotes/origin/{published}")] if published else []
-    candidates += [(name, f"refs/heads/{name}") for name in ("main", "master")]
+    consulted = _consulted_remotes(remotes)
+    published, publishers, declined = _published_trunk(port, cwd, consulted)
+    source = publishers[0] if len(publishers) == 1 else None
+    candidates: list[tuple[str, str, str | None]] = [
+        (published, f"refs/remotes/{remote}/{published}", source) for remote in publishers
+    ]
+    candidates += [(name, f"refs/heads/{name}", None) for name in ("main", "master")]
     unread: list[str] = []
-    for name, ref in candidates:
+    for name, ref, from_remote in candidates:
         state = _ref_exists(port, cwd, ref)
         if state:
-            return name, None
+            return name, from_remote, None
         if state is None:
             unread.append(ref)
 
     if unread:
         detail = f"git would not say whether {' or '.join(unread)} exists, so no tier was ruled out"
-    elif published:
-        detail = (
-            f"origin publishes HEAD as origin/{published}, which no longer exists, and neither "
-            f"main nor master exists"
-        )
-    elif head.ok or head.returncode == 1:
-        detail = "origin has published no HEAD, and neither main nor master exists"
     else:
+        if not published:
+            cause = declined
+        elif len(publishers) == 1:
+            cause = (
+                f"{publishers[0]} publishes HEAD as {publishers[0]}/{published}, which no longer "
+                f"exists"
+            )
+        else:
+            cause = (
+                f"{', '.join(publishers)} agree in publishing HEAD as {published}, and no "
+                f"remote-tracking ref for it exists under any of them"
+            )
+        detail = f"{cause}, and neither main nor master exists"
+    if remotes is None:
         detail = (
-            f"origin's published HEAD could not be read (exit {head.returncode}), and neither "
-            f"main nor master exists"
+            f"this repository's remote list could not be read, so no remote beyond origin could "
+            f"be consulted, and {detail}"
         )
-    return None, (
+
+    # Every remote this prescribes is one git listed. A repository with no
+    # `origin` must not be told to publish origin's HEAD, and a repository whose
+    # remote list went unread has no remote this can name at all -- there the
+    # placeholder says what to do without asserting that any particular remote
+    # is there to do it to.
+    named = None if remotes is None else consulted
+    remedies: list[str] = []
+    if named is not None and len(named) == 1:
+        remedies.append(
+            f"publish {named[0]}'s HEAD (`git remote set-head {named[0]} -a`) and re-run"
+        )
+    elif consulted:
+        remedies.append(
+            "publish the HEAD of whichever remote holds your trunk "
+            "(`git remote set-head <remote> -a`) and re-run"
+        )
+    remedies.append("delete what you want gone by naming it")
+    warning = (
         f"could not determine this repository's default branch: {detail}. Nothing here can be "
-        f"told apart from the trunk, so nothing will be swept; publish origin's HEAD "
-        f"(`git remote set-head origin -a`) and re-run, or delete what you want gone by "
-        f"naming it"
+        f"told apart from the trunk, so nothing will be swept; {', or '.join(remedies)}"
     )
+    return None, None, warning
 
 
 def resolve_base_ref(
-    port: CommandPort, cwd: Path | None, default_branch: str
+    port: CommandPort,
+    cwd: Path | None,
+    default_branch: str,
+    remotes: tuple[str, ...] | None,
+    trunk_remote: str | None,
 ) -> tuple[str, str | None]:
     """What merges are measured against, plus the warning when the preferred
     ref could not be read.
@@ -208,6 +326,16 @@ def resolve_base_ref(
     and merely quiet when the probe errored -- so the second case says so, and
     every merge verdict in the report is then known to have been measured
     against a ref that may be behind.
+
+    Whose copy of the trunk that is comes from ``trunk_remote`` -- the remote
+    whose published HEAD named the default branch -- rather than from a second
+    guess made here. Where the name came from a local `main` or `master`
+    instead, nothing has nominated a remote, so the same one-distinct-answer
+    rule the trunk tier uses applies again: exactly one remote holding a copy of
+    the trunk is an answer, and several is not. Several is left to the local
+    branch, because it is the direction that fails closed -- a base ref *behind*
+    the real trunk under-reports merges, while one *ahead* of it reports
+    unmerged work as merged.
 
     Handed back as a **full ref path**, which is the only spelling that reaches
     the ref this function just proved exists. `origin/main` does not: git tries
@@ -221,17 +349,35 @@ def resolve_base_ref(
     A path beginning `refs/` is matched literally by the first of git's
     rev-parse rules, so no other ref can shadow it however the repository is
     arranged, and it needs no `--` terminator either: a ref path cannot begin
-    with `-`. The warning below keeps the short form, being prose for a reader
+    with `-`. The warnings below keep the short form, being prose for a reader
     rather than a rev for git."""
-    state = _ref_exists(port, cwd, f"refs/remotes/origin/{default_branch}")
-    if state:
-        return f"refs/remotes/origin/{default_branch}", None
-    if state is None:
-        return f"refs/heads/{default_branch}", (
-            f"git would not say whether origin/{default_branch} exists, so merges here are "
+    candidates = (trunk_remote,) if trunk_remote is not None else _consulted_remotes(remotes)
+    local = f"refs/heads/{default_branch}"
+    found: list[str] = []
+    unread: list[str] = []
+    for remote in candidates:
+        state = _ref_exists(port, cwd, f"refs/remotes/{remote}/{default_branch}")
+        if state:
+            found.append(remote)
+        elif state is None:
+            unread.append(remote)
+    if len(found) > 1:
+        listed = ", ".join(f"{remote}/{default_branch}" for remote in found)
+        return local, (
+            f"more than one remote holds a {default_branch} ({listed}) and no published HEAD "
+            f"says which of them this repository's work merges into; measuring against one that "
+            f"is ahead of the real trunk would report unmerged work as merged, so merges here "
+            f"are measured against the local {default_branch}, which may be behind"
+        )
+    if unread:
+        listed = " or ".join(f"{remote}/{default_branch}" for remote in unread)
+        return local, (
+            f"git would not say whether {listed} exists, so merges here are "
             f"measured against the local {default_branch}, which may be behind the remote"
         )
-    return f"refs/heads/{default_branch}", None
+    if found:
+        return f"refs/remotes/{found[0]}/{default_branch}", None
+    return local, None
 
 
 def read_remotes(port: CommandPort, cwd: Path | None) -> tuple[tuple[str, ...] | None, str | None]:
@@ -1427,12 +1573,19 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
         return "not inside a git repository"
     repo_root, common_dir = resolved
 
-    resolved_default, default_branch_warning = resolve_default_branch(port, cwd)
+    # Read before the trunk is resolved rather than beside the other reads
+    # below: which remote's published HEAD gets to name the default branch is
+    # decided from this list, so it has to be in hand first. Its warning joins
+    # the others further down, where there is a list to put it in.
+    remotes, remotes_warning = read_remotes(port, cwd)
+    resolved_default, trunk_remote, default_branch_warning = resolve_default_branch(
+        port, cwd, remotes
+    )
     # The name is still needed downstream to compare against, but it is now
     # known to be a guess -- so it protects nothing it cannot prove, and the
     # flag travels with the survey so the run can report that it is guessing.
     default_branch = resolved_default if resolved_default is not None else "main"
-    base_ref, base_ref_warning = resolve_base_ref(port, cwd, default_branch)
+    base_ref, base_ref_warning = resolve_base_ref(port, cwd, default_branch, remotes, trunk_remote)
 
     head = port.git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd)
     current = _first_line(head.out) if head.ok else None
@@ -1461,7 +1614,6 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
     prs, gh_error, pr_evidence_gap = read_pull_requests(port, cwd)
     if pr_evidence_gap:
         warnings.append(pr_evidence_gap)
-    remotes, remotes_warning = read_remotes(port, cwd)
     if remotes_warning is not None:
         warnings.append(remotes_warning)
     refspecs, refspecs_warning = read_fetch_refspecs(port, cwd)

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -151,7 +151,14 @@ def _published_trunk(
     merge in the report is measured against, and picking the one that is ahead
     is what makes unmerged work look merged -- so the disagreement is handed
     back as prose and the tier declines. Declining costs a tier and leaves the
-    local main/master below it to answer; guessing costs commits."""
+    local main/master below it to answer; guessing costs commits.
+
+    A remote whose HEAD could not be read is one of those disagreements as far
+    as anything here knows, so it declines the tier too -- even when another
+    remote did answer. Accepting the name that came back would be taking
+    agreement from a remote that was never asked: the read that failed is the
+    one that might have contradicted it, and a trunk accepted on partial data is
+    exactly what the disagreement rule above exists to refuse."""
     if not remotes:
         return "", (), "this repository has no configured remote to publish a HEAD"
     published: dict[str, str] = {}
@@ -167,20 +174,32 @@ def _published_trunk(
             # an answer. Anything else is git declining to look, which is not.
             unreadable.append((remote, result.returncode))
     names = set(published.values())
-    if len(names) == 1:
-        trunk = next(iter(names))
-        return trunk, tuple(r for r, n in published.items() if n == trunk), ""
     if len(names) > 1:
         spelled = ", ".join(f"{r} publishes {n}" for r, n in sorted(published.items()))
         return "", (), f"the configured remotes disagree about which branch is the trunk: {spelled}"
     if unreadable:
         listed = ", ".join(f"{remote} (exit {code})" for remote, code in unreadable)
+        if names:
+            # Withheld agreement rather than a missing HEAD, and the two are
+            # worth separate sentences: something did answer here, and what
+            # stopped the tier is that the remote which did not could have
+            # contradicted it.
+            answered = ", ".join(sorted(published))
+            withheld = (
+                f"the published HEAD of {listed} could not be read, and a remote that would "
+                f"not answer could name a trunk other than the {next(iter(names))} that came "
+                f"back from {answered}"
+            )
+            return "", (), withheld
         unread_detail = (
             f"{unreadable[0][0]}'s published HEAD could not be read (exit {unreadable[0][1]})"
             if len(unreadable) == 1
             else f"the published HEAD of these remotes could not be read: {listed}"
         )
         return "", (), unread_detail
+    if len(names) == 1:
+        trunk = next(iter(names))
+        return trunk, tuple(r for r, n in published.items() if n == trunk), ""
     if len(remotes) == 1:
         return "", (), f"{remotes[0]} has published no HEAD"
     return "", (), f"none of this repository's remotes ({', '.join(remotes)}) has published a HEAD"

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -1149,27 +1149,22 @@ def test_two_remotes_fetching_into_one_path_is_refused_rather_than_misattributed
     assert "feat/live" in git(repo, "ls-remote", "--heads", "upstream")
 
 
-@pytest.mark.parametrize(
-    ("remote", "discovered"),
-    [("origin", True), ("team", False), ("team/origin", False)],
-)
-def test_a_trunk_published_only_by_a_remote_not_called_origin_stops_the_sweep(
-    repo: Path, tmp_path: Path, remote: str, discovered: bool
+@pytest.mark.parametrize("remote", ["origin", "team", "team/origin"])
+def test_a_trunk_published_by_the_only_remote_is_found_whatever_it_is_called(
+    repo: Path, tmp_path: Path, remote: str
 ) -> None:
-    """Discovery asks `refs/remotes/origin/HEAD` and then a local main/master,
-    so a trunk published only through a differently-named remote is found by no
-    tier. What matters is which way that fails, and it fails closed twice over:
-    no trunk is verified, and the ref merges would be measured against does not
-    resolve either, so nothing can reach merge proof in the first place. The
-    branch below is genuinely merged -- the setup insists on it -- and is still
-    left alone.
+    """Discovery used to ask `refs/remotes/origin/HEAD` and then a local
+    main/master, so a trunk published only through a differently-named remote
+    was found by no tier: none was verified, the ref merges would be measured
+    against did not resolve either, and the tool was inert in that repository.
+    The branch below is genuinely merged -- the setup insists on it -- and used
+    to be left alone in two of these three rows.
 
-    The remote's name is the only thing varying, and the slash in it changes
-    nothing: `team` and `team/origin` behave identically, because the tier that
-    declines is the one asking for `origin` by name rather than any split of a
-    path. The `origin` row is the control that keeps the other two from passing
-    vacuously -- same shape, same merged branch, and there the sweep does take
-    it."""
+    The remote's name is the only thing varying, and none of it matters now: the
+    question is asked of whichever remotes are configured. The slash in
+    `team/origin` earns its own row because a remote name may contain one, so a
+    path under `refs/remotes/` does not say on its own where the name stops. The
+    `origin` row is the behaviour-preservation control."""
     bare = tmp_path / "server.git"
     SubprocessCommands().git(["init", "-q", "--bare", "-b", "trunk", str(bare)])
     git(repo, "branch", "-m", "main", "trunk")
@@ -1182,8 +1177,8 @@ def test_a_trunk_published_only_by_a_remote_not_called_origin_stops_the_sweep(
     git(repo, "push", "-q", remote, "trunk")
     git(repo, "fetch", "-q", remote)
     git(repo, "remote", "set-head", remote, "-a")
-    # Raises unless feat really is merged: without this the withholding below
-    # could be the ordinary no-merge-proof answer rather than the trunk one.
+    # Raises unless feat really is merged: without this the sweep below could be
+    # passing on the ordinary no-merge-proof answer rather than on the trunk.
     git(repo, "merge-base", "--is-ancestor", "feat", "trunk")
 
     with reachability_guard(repo):
@@ -1191,20 +1186,63 @@ def test_a_trunk_published_only_by_a_remote_not_called_origin_stops_the_sweep(
 
     repo_block = payload["repo"]
     assert isinstance(repo_block, dict)
-    assert repo_block["default_branch_known"] is discovered
+    assert repo_block["default_branch_known"] is True
+    assert repo_block["default_branch"] == "trunk"
+    # And measured against that remote's copy of it, not against a spelling
+    # assembled out of a name no repository is obliged to use.
+    assert repo_block["base_ref"] == f"refs/remotes/{remote}/trunk"
     execution = payload["execution"]
     assert isinstance(execution, dict)
-    swept = {d["target_id"] for d in execution["deletions"] if d["deleted"]}
+    assert {d["target_id"] for d in execution["deletions"] if d["deleted"]} == {"branch:feat"}
+    # The trunk itself is still here: found means protected, not swept.
+    assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/trunk") != ""
 
-    if discovered:
-        assert repo_block["default_branch"] == "trunk"
-        assert swept == {"branch:feat"}
-        return
 
-    # Nothing was taken, and the trunk this repository actually has is still
-    # here under a name no tier recognised.
-    assert swept == set()
+def test_remotes_that_disagree_about_the_trunk_stop_the_sweep(repo: Path, tmp_path: Path) -> None:
+    """The limit that survives consulting the remote list: two servers, two
+    published HEADs, and nothing in the repository saying which one it belongs
+    to. Their trunks are allowed to differ, and measuring merges against one
+    that is ahead of the real trunk reports unmerged work as merged -- so the
+    tier declines rather than picking, and with no local main or master beneath
+    it nothing resolves at all. The branch below is genuinely merged into the
+    trunk this repository does have, and is still left alone."""
+    alpha_bare = tmp_path / "alpha.git"
+    beta_bare = tmp_path / "beta.git"
+    SubprocessCommands().git(["init", "-q", "--bare", "-b", "trunk", str(alpha_bare)])
+    SubprocessCommands().git(["init", "-q", "--bare", "-b", "release", str(beta_bare)])
+    git(repo, "branch", "-m", "main", "trunk")
+    git(repo, "remote", "add", "alpha", str(alpha_bare))
+    git(repo, "remote", "add", "beta", str(beta_bare))
+    git(repo, "push", "-q", "-u", "alpha", "trunk")
+    git(repo, "checkout", "-q", "-b", "release")
+    commit(repo, "release.txt")
+    git(repo, "push", "-q", "-u", "beta", "release")
+    git(repo, "checkout", "-q", "trunk")
+    git(repo, "checkout", "-q", "-b", "feat")
+    commit(repo, "feat.txt")
+    git(repo, "checkout", "-q", "trunk")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge feat", "feat")
+    git(repo, "push", "-q", "alpha", "trunk")
+    for remote in ("alpha", "beta"):
+        git(repo, "fetch", "-q", remote)
+        git(repo, "remote", "set-head", remote, "-a")
+    git(repo, "merge-base", "--is-ancestor", "feat", "trunk")
+
+    with reachability_guard(repo):
+        payload = report(repo, "--cleanup")
+
+    repo_block = payload["repo"]
+    assert isinstance(repo_block, dict)
+    assert repo_block["default_branch_known"] is False
+    execution = payload["execution"]
+    assert isinstance(execution, dict)
+    assert {d["target_id"] for d in execution["deletions"] if d["deleted"]} == set()
     assert find(payload, "branch:feat")["sweepable"] is False
+    warnings = payload["warnings"]
+    assert isinstance(warnings, list)
+    # Named, so a reader can go and settle it rather than being told only that
+    # something was indeterminate.
+    assert any("alpha publishes trunk, beta publishes release" in w for w in warnings)
     for ref in ("refs/heads/trunk", "refs/heads/feat"):
         assert git(repo, "for-each-ref", "--format=%(refname)", ref) != ""
 

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -335,6 +335,30 @@ def test_remotes_that_disagree_about_the_trunk_decline_rather_than_pick_one() ->
     assert "alpha publishes trunk, beta publishes release" in warning
 
 
+def test_a_remote_that_would_not_answer_is_not_taken_for_one_that_agreed() -> None:
+    """One remote publishes a trunk and the read of another's HEAD errors. The
+    name that came back is not evidence on its own: the read that failed is the
+    one that could have contradicted it, so accepting it would be taking
+    agreement from a remote nothing managed to ask. That is the same partial
+    data the disagreement rule refuses, and it declines the same way -- with a
+    sentence of its own, because a HEAD nobody could read is not a HEAD nobody
+    published."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/alpha/HEAD": ok("refs/remotes/alpha/trunk"),
+            "symbolic-ref --quiet refs/remotes/beta/HEAD": fail("fatal: bad ref store", code=128),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    name, remote, warning = resolve_default_branch(port, None, ("alpha", "beta"))
+
+    assert (name, remote) == (None, None)
+    assert warning is not None
+    assert "the published HEAD of beta (exit 128) could not be read" in warning
+    assert "could name a trunk other than the trunk that came back from alpha" in warning
+
+
 def test_a_fork_still_takes_its_trunk_from_origin() -> None:
     """`origin` and `upstream` disagreeing about the trunk is what a fork looks
     like, and the repository you are standing in is the one `origin` describes.

--- a/packages/gitclean/tests/unit/test_survey.py
+++ b/packages/gitclean/tests/unit/test_survey.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from gitclean.model import MergeEvidence, PullRequestOutcome, Survey
 from gitclean.ports import CommandResult, ScriptedCommands, SubprocessCommands, fail, ok
 from gitclean.survey import (
@@ -137,6 +139,15 @@ def make_port(
     pr_view: dict[str, object] | None = None,
 ) -> ScriptedCommands:
     configured_refspecs = refspecs if refspecs is not None else default_refspecs(remotes)
+    configured = tuple(line.strip() for line in remotes.splitlines() if line.strip())
+    # Whose published HEAD names the trunk here. `origin` wherever it is
+    # configured, which is what production consults first; otherwise the first
+    # remote the fixture lists, so a fixture that renamed its remote still
+    # describes a repository whose trunk was found rather than one where every
+    # tier declined. That is the boring case, and a test about a repository that
+    # cannot name its trunk says so by overriding these through `extra`.
+    trunk_remote = "origin" if not configured or "origin" in configured else configured[0]
+    trunk_ref = f"refs/remotes/{trunk_remote}/main"
     table: dict[str, CommandResult] = {
         "rev-parse --show-toplevel": ok("/repo"),
         # Asked of every survey: it is the only thing that says where a
@@ -149,8 +160,8 @@ def make_port(
         # case; a test about a refspec that does something else passes its own.
         "config -z --get-regexp": ok(configured_refspecs),
         "rev-parse --path-format=absolute --git-common-dir": ok("/repo/.git"),
-        "symbolic-ref --quiet refs/remotes/origin/HEAD": ok("refs/remotes/origin/main"),
-        "show-ref --verify --quiet refs/remotes/origin/main": ok(),
+        f"symbolic-ref --quiet refs/remotes/{trunk_remote}/HEAD": ok(trunk_ref),
+        f"show-ref --verify --quiet {trunk_ref}": ok(),
         "rev-parse --abbrev-ref HEAD": ok("main"),
         "worktree list --porcelain": ok(porcelain(worktrees)),
         "status --porcelain=v1": ok(""),
@@ -163,7 +174,7 @@ def make_port(
         # The trunk is probed like any other branch, so its own count is part
         # of the boring case. A test that cares what it says overrides it
         # through `counts`, which is applied after this table.
-        "rev-list --count refs/remotes/origin/main..main": ok("0"),
+        f"rev-list --count {trunk_ref}..main": ok("0"),
         # The merge base's tree, which the squash tier compares against the
         # branch tip's. Deliberately unlike the "treesha" those tests give the
         # tip: the boring branch changed something, so there is a diff to
@@ -171,6 +182,16 @@ def make_port(
         # overriding this to match.
         "rev-parse basesha^{tree}": ok("basetreesha"),
     }
+    if trunk_remote != "origin":
+        # Where there is no `origin` to consult on its own, production asks
+        # every configured remote what it publishes as HEAD. The ones that are
+        # not the trunk's publish none, and git reports that as exit 1 -- an
+        # answer rather than a failed read. Left unscripted where `origin` is
+        # configured, so a run that consulted the others anyway fails naming the
+        # argv instead of passing on a fixture that answered a question the tool
+        # should not have asked.
+        for remote in configured:
+            table.setdefault(f"symbolic-ref --quiet refs/remotes/{remote}/HEAD", fail())
     for spec, value in (counts or {}).items():
         table[f"rev-list --count {spec}"] = ok(value)
     # Every remote some surveyed ref belongs to is asked what it still holds.
@@ -240,7 +261,7 @@ def test_default_branch_comes_from_origins_published_head() -> None:
             "show-ref --verify --quiet refs/remotes/origin/trunk": ok(),
         }
     )
-    assert resolve_default_branch(port, None) == ("trunk", None)
+    assert resolve_default_branch(port, None, ("origin",)) == ("trunk", "origin", None)
 
 
 def test_default_branch_falls_back_to_master_when_main_is_absent() -> None:
@@ -251,7 +272,185 @@ def test_default_branch_falls_back_to_master_when_main_is_absent() -> None:
             "show-ref --verify --quiet refs/heads/master": ok(),
         }
     )
-    assert resolve_default_branch(port, None) == ("master", None)
+    # No remote nominated it, so nothing is handed to the base ref either -- it
+    # works out whose copy of `master` to measure against for itself.
+    assert resolve_default_branch(port, None, ("origin",)) == ("master", None, None)
+
+
+@pytest.mark.parametrize("remote", ["team", "team/origin"])
+def test_a_trunk_published_by_the_only_remote_is_found_whatever_it_is_called(remote: str) -> None:
+    """The defect this pins: discovery used to spell `origin` in the question,
+    so a repository whose remote is called anything else reached the
+    published-HEAD tier for nobody. With no local `main` or `master` either --
+    the shape below -- no trunk resolved at all, nothing could be told apart
+    from the trunk, and the tool was inert in that repository.
+
+    A slash in the remote's name changes nothing, and is worth a row of its own
+    because it is the case where a path cannot be taken apart: `git remote add
+    team/origin <url>` is accepted, and the configured list is the only thing
+    that says where the name stops."""
+    port = ScriptedCommands(
+        git={
+            f"symbolic-ref --quiet refs/remotes/{remote}/HEAD": ok(f"refs/remotes/{remote}/trunk"),
+            f"show-ref --verify --quiet refs/remotes/{remote}/trunk": ok(),
+        }
+    )
+    assert resolve_default_branch(port, None, (remote,)) == ("trunk", remote, None)
+
+
+def test_remotes_that_agree_about_the_trunk_name_it_between_them() -> None:
+    """Several remotes and no `origin`. They say the same thing, so the name is
+    settled -- but which server's copy of it merges are measured against is not,
+    and that question is left to the base ref rather than answered by picking
+    whichever remote was listed first."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/alpha/HEAD": ok("refs/remotes/alpha/trunk"),
+            "symbolic-ref --quiet refs/remotes/beta/HEAD": ok("refs/remotes/beta/trunk"),
+            "show-ref --verify --quiet refs/remotes/alpha/trunk": ok(),
+        }
+    )
+    assert resolve_default_branch(port, None, ("alpha", "beta")) == ("trunk", None, None)
+
+
+def test_remotes_that_disagree_about_the_trunk_decline_rather_than_pick_one() -> None:
+    """Two servers, two answers, and nothing in the repository says which one it
+    belongs to. Picking one would decide silently what every merge in the report
+    is measured against, and picking the one that is ahead of the real trunk
+    reports unmerged work as merged -- so the tier declines, names the
+    disagreement, and lets a local main or master answer if there is one. Here
+    there is not, so nothing is swept at all."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/alpha/HEAD": ok("refs/remotes/alpha/trunk"),
+            "symbolic-ref --quiet refs/remotes/beta/HEAD": ok("refs/remotes/beta/release"),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    name, remote, warning = resolve_default_branch(port, None, ("alpha", "beta"))
+
+    assert (name, remote) == (None, None)
+    assert warning is not None
+    assert "alpha publishes trunk, beta publishes release" in warning
+
+
+def test_a_fork_still_takes_its_trunk_from_origin() -> None:
+    """`origin` and `upstream` disagreeing about the trunk is what a fork looks
+    like, and the repository you are standing in is the one `origin` describes.
+    Consulting the others there could only replace a right answer with a
+    refusal, so `origin` configured is consulted alone -- which the fixture
+    enforces by leaving upstream's HEAD unscripted: asking for it raises."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/origin/HEAD": ok("refs/remotes/origin/trunk"),
+            "show-ref --verify --quiet refs/remotes/origin/trunk": ok(),
+        }
+    )
+    assert resolve_default_branch(port, None, ("origin", "upstream")) == ("trunk", "origin", None)
+
+
+def test_an_unreadable_remote_list_asks_origin_and_widens_to_nobody() -> None:
+    """`None` is "nobody could say", not "there are none" -- and it is not a
+    licence to ask more widely either. Nothing can be enumerated, so the tier
+    keeps exactly the reach it had before any other remote could be consulted,
+    and a transient failure to list remotes costs nothing that was working."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/origin/HEAD": ok("refs/remotes/origin/trunk"),
+            "show-ref --verify --quiet refs/remotes/origin/trunk": ok(),
+        }
+    )
+    assert resolve_default_branch(port, None, None) == ("trunk", "origin", None)
+
+
+def test_a_repository_with_no_remotes_says_so_rather_than_prescribing_one() -> None:
+    """Every remote the warning prescribes has to be one git listed. There is
+    none here, so the remedy that names one is dropped rather than sending a
+    reader to publish the HEAD of a remote that does not exist."""
+    port = ScriptedCommands(git={"show-ref --verify --quiet refs/heads/": fail()})
+
+    name, remote, warning = resolve_default_branch(port, None, ())
+
+    assert (name, remote) == (None, None)
+    assert warning is not None
+    assert "no configured remote to publish a HEAD" in warning
+    assert "set-head" not in warning
+
+
+def test_a_repository_without_an_origin_is_never_told_to_publish_origins_head() -> None:
+    """The remedy used to spell `origin` unconditionally, which in a repository
+    whose remote is called something else is an instruction that cannot be
+    carried out."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/team/HEAD": fail(),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    _, _, warning = resolve_default_branch(port, None, ("team",))
+
+    assert warning is not None
+    assert "`git remote set-head team -a`" in warning
+    assert "origin" not in warning
+
+
+def test_several_remotes_and_no_published_head_between_them_names_none_of_them() -> None:
+    """No remote to prescribe by name, so the remedy carries a placeholder
+    rather than picking one of them for the reader to argue with."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/alpha/HEAD": fail(),
+            "symbolic-ref --quiet refs/remotes/beta/HEAD": fail(),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    _, _, warning = resolve_default_branch(port, None, ("alpha", "beta"))
+
+    assert warning is not None
+    assert "none of this repository's remotes (alpha, beta) has published a HEAD" in warning
+    assert "`git remote set-head <remote> -a`" in warning
+
+
+def test_remotes_agreeing_on_a_head_that_resolves_nowhere_report_all_of_them() -> None:
+    """The dangling-pointer case with more than one pointer. Every remote that
+    published the name is named back, because the reader has to know which
+    `set-head` went stale and there is no way to tell from one of them."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/alpha/HEAD": ok("refs/remotes/alpha/trunk"),
+            "symbolic-ref --quiet refs/remotes/beta/HEAD": ok("refs/remotes/beta/trunk"),
+            "show-ref --verify --quiet refs/remotes/": fail(),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    name, _, warning = resolve_default_branch(port, None, ("alpha", "beta"))
+
+    assert name is None
+    assert warning is not None
+    assert "alpha, beta agree in publishing HEAD as trunk" in warning
+
+
+def test_an_unreadable_remote_list_says_so_rather_than_implying_there_were_none() -> None:
+    """The warning has to survive the reader asking why only `origin` was
+    consulted. Nothing enumerated the remotes, which is a different sentence
+    from this repository having only that one -- and it is why no remote is
+    prescribed by name here."""
+    port = ScriptedCommands(
+        git={
+            "symbolic-ref --quiet refs/remotes/origin/HEAD": fail(),
+            "show-ref --verify --quiet refs/heads/": fail(),
+        }
+    )
+
+    _, _, warning = resolve_default_branch(port, None, None)
+
+    assert warning is not None
+    assert "remote list could not be read" in warning
+    assert "`git remote set-head <remote> -a`" in warning
 
 
 def test_an_unidentifiable_default_branch_is_unknown_not_guessed_as_main() -> None:
@@ -265,8 +464,8 @@ def test_an_unidentifiable_default_branch_is_unknown_not_guessed_as_main() -> No
             "show-ref --verify --quiet refs/heads/": fail(),
         }
     )
-    name, warning = resolve_default_branch(port, None)
-    assert name is None
+    name, remote, warning = resolve_default_branch(port, None, ("origin",))
+    assert (name, remote) == (None, None)
     assert warning is not None and "origin has published no HEAD" in warning
 
 
@@ -286,8 +485,8 @@ def test_a_dangling_origin_head_is_not_a_default_branch() -> None:
             "show-ref --verify --quiet refs/heads/master": fail(),
         }
     )
-    name, warning = resolve_default_branch(port, None)
-    assert name is None
+    name, remote, warning = resolve_default_branch(port, None, ("origin",))
+    assert (name, remote) == (None, None)
     assert warning is not None and "origin/master" in warning
 
 
@@ -301,7 +500,7 @@ def test_a_dangling_origin_head_still_falls_through_to_a_local_trunk() -> None:
             "show-ref --verify --quiet refs/heads/main": ok(),
         }
     )
-    assert resolve_default_branch(port, None) == ("main", None)
+    assert resolve_default_branch(port, None, ("origin",)) == ("main", None, None)
 
 
 def test_a_dangling_origin_head_leaves_the_trunk_unknown_on_the_report() -> None:
@@ -351,6 +550,29 @@ def test_an_unknown_default_branch_is_reported_on_the_survey() -> None:
     assert any("could not determine" in w for w in result.warnings)
 
 
+def test_a_survey_reads_the_remote_list_before_it_resolves_the_trunk() -> None:
+    """The wiring the discovery rule depends on. Which remote's published HEAD
+    may name the trunk comes out of the configured list, so the list has to be
+    in hand first -- and in a repository whose only remote is called something
+    else, a survey that asked `origin` would find no trunk, prove no merge, and
+    report a repository it cannot act in. The fixture scripts no `origin`
+    anything, so asking for one raises rather than quietly answering."""
+    port = make_port(
+        remotes="team\n",
+        refs=[
+            ref_line("refs/heads/main", "main", head="*"),
+            ref_line("refs/remotes/team/feat", "team/feat"),
+        ],
+        counts={"refs/remotes/team/main..team/feat": "0"},
+    )
+
+    result = run(port)
+
+    assert result.default_branch_known is True
+    assert (result.default_branch, result.base_ref) == ("main", "refs/remotes/team/main")
+    assert {b.name: b.merged for b in result.branches}["team/feat"] is True
+
+
 def test_a_ref_probe_that_errors_is_not_read_as_a_missing_trunk() -> None:
     """`show-ref` exits 1 for a ref that is not there and 128 when it could not
     look. Collapsing the two told the reader that neither main nor master
@@ -364,9 +586,9 @@ def test_a_ref_probe_that_errors_is_not_read_as_a_missing_trunk() -> None:
         }
     )
 
-    name, warning = resolve_default_branch(port, None)
+    name, remote, warning = resolve_default_branch(port, None, ("origin",))
 
-    assert name is None
+    assert (name, remote) == (None, None)
     assert warning is not None
     assert "would not say whether refs/heads/main exists" in warning
     assert "neither main nor master exists" not in warning
@@ -383,9 +605,9 @@ def test_an_unreadable_published_head_is_not_reported_as_an_unpublished_one() ->
         }
     )
 
-    name, warning = resolve_default_branch(port, None)
+    name, remote, warning = resolve_default_branch(port, None, ("origin",))
 
-    assert name is None
+    assert (name, remote) == (None, None)
     assert warning is not None and "published HEAD could not be read" in warning
 
 
@@ -396,14 +618,17 @@ def test_base_prefers_the_remote_tracking_tip() -> None:
     the ref this just proved exists: `origin/main` is also a legal *local*
     branch, and git reaches `refs/heads/` before `refs/remotes/`."""
     port = ScriptedCommands(git={"show-ref --verify --quiet refs/remotes/origin/main": ok()})
-    assert resolve_base_ref(port, None, "main") == ("refs/remotes/origin/main", None)
+    assert resolve_base_ref(port, None, "main", ("origin",), "origin") == (
+        "refs/remotes/origin/main",
+        None,
+    )
 
 
 def test_base_falls_back_to_the_local_branch_without_a_remote() -> None:
     """The fallback is a ref path for the same reason: `main` alone would find
     a tag of that name before the branch."""
     port = ScriptedCommands(git={"show-ref --verify --quiet refs/remotes/origin/main": fail()})
-    assert resolve_base_ref(port, None, "main") == ("refs/heads/main", None)
+    assert resolve_base_ref(port, None, "main", ("origin",), "origin") == ("refs/heads/main", None)
 
 
 def test_an_unreadable_remote_tip_falls_back_to_the_local_branch_and_says_so() -> None:
@@ -414,11 +639,65 @@ def test_an_unreadable_remote_tip_falls_back_to_the_local_branch_and_says_so() -
     port = ScriptedCommands(
         git={"show-ref --verify --quiet refs/remotes/origin/main": fail("bad object", code=128)}
     )
-    base, warning = resolve_base_ref(port, None, "main")
+    base, warning = resolve_base_ref(port, None, "main", ("origin",), "origin")
     assert base == "refs/heads/main"
     # The warning is prose for a reader, so it keeps the short spelling the
     # reader would type; only the rev handed to git has to be unambiguous.
     assert warning is not None and "would not say whether origin/main exists" in warning
+
+
+def test_base_measures_against_the_remote_that_named_the_trunk() -> None:
+    """Not a second guess at which remote to ask. The trunk tier has already
+    established whose published HEAD named this branch, and that is the server
+    whose copy the work here merges into -- so the answer travels rather than
+    being re-derived.
+
+    Re-deriving it would cost the answer outright here: `mirror` holds a `main`
+    of its own, so a second pass over the remotes would find two candidates,
+    decline between them, and fall back to a local branch that may be behind.
+    The fixture leaves mirror's ref unscripted, so asking about it raises."""
+    port = ScriptedCommands(git={"show-ref --verify --quiet refs/remotes/team/main": ok()})
+    assert resolve_base_ref(port, None, "main", ("team", "mirror"), "team") == (
+        "refs/remotes/team/main",
+        None,
+    )
+
+
+def test_base_finds_the_only_remote_holding_the_trunk_when_none_nominated_it() -> None:
+    """A trunk named by a local `main` rather than by any published HEAD. No
+    remote has been nominated, so the same one-distinct-answer rule applies
+    again: one remote holds a copy of it, and that is an answer."""
+    port = ScriptedCommands(git={"show-ref --verify --quiet refs/remotes/team/main": ok()})
+    assert resolve_base_ref(port, None, "main", ("team",), None) == (
+        "refs/remotes/team/main",
+        None,
+    )
+
+
+def test_base_declines_when_several_remotes_hold_a_copy_of_the_trunk() -> None:
+    """Nothing here says which server's `main` this repository's work merges
+    into, and the two are allowed to differ. Measuring against one that is ahead
+    of the real trunk would report unmerged work as merged, so the local branch
+    answers instead -- behind is the direction that fails closed."""
+    port = ScriptedCommands(
+        git={
+            "show-ref --verify --quiet refs/remotes/alpha/main": ok(),
+            "show-ref --verify --quiet refs/remotes/beta/main": ok(),
+        }
+    )
+
+    base, warning = resolve_base_ref(port, None, "main", ("alpha", "beta"), None)
+
+    assert base == "refs/heads/main"
+    assert warning is not None and "alpha/main, beta/main" in warning
+
+
+def test_base_asks_origin_alone_when_the_remote_list_could_not_be_read() -> None:
+    """The same reach the trunk tier keeps on an unreadable list: `origin` and
+    no further. The fixture enforces it -- there is no other remote it could
+    ask, because there is no list to ask from."""
+    port = ScriptedCommands(git={"show-ref --verify --quiet refs/remotes/origin/main": ok()})
+    assert resolve_base_ref(port, None, "main", None, None) == ("refs/remotes/origin/main", None)
 
 
 # -- worktree parsing --------------------------------------------------------
@@ -1039,7 +1318,7 @@ def test_a_remote_name_containing_a_slash_is_taken_whole() -> None:
             ref_line("refs/heads/main", "main", head="*"),
             ref_line("refs/remotes/team/origin/feat/x", "team/origin/feat/x"),
         ],
-        counts={"refs/remotes/origin/main..team/origin/feat/x": "0"},
+        counts={"refs/remotes/team/origin/main..team/origin/feat/x": "0"},
     )
 
     surveyed = run(port)


### PR DESCRIPTION
## What was broken

`gitclean` decided two things by spelling the remote name `origin` literally in `packages/gitclean/src/gitclean/survey.py`:

- `resolve_default_branch` asked `git symbolic-ref --quiet refs/remotes/origin/HEAD`, then fell back to a local `main`/`master`.
- `resolve_base_ref` probed `refs/remotes/origin/<default_branch>` as the ref every merge verdict is measured against.

In a repository whose remote is called anything else, the published-HEAD tier fired for nobody. With no local `main` or `master` either, no trunk resolved at all, nothing reached merge proof, and the tool was inert — fail-closed, so a capability limit rather than a safety defect, but a total one: a genuinely merged branch was left alone and the real trunk was protected by nothing.

Closes the sibling item that describes the same root cause — 9k9.117 and 9k9.119 are the same defect filed twice.

## What decides the remote now

The configured remote list is read before the trunk is resolved, and it decides who gets asked.

- **`origin` configured answers alone.** Not laziness — behaviour preservation for the shape that dominates, forks included. In a fork `origin` and `upstream` legitimately disagree about the trunk, and the repository you are standing in is the one `origin` describes; consulting the others there could only replace a right answer with a refusal.
- **Otherwise every configured remote is asked** for its published HEAD (a local symbolic ref, so no network round trip). One distinct branch name settles it — whether that is one remote speaking or several agreeing — and the remote that produced it is recorded.
- **Remotes that disagree name no trunk.** Their trunks are allowed to differ, and measuring merges against one that is ahead of the real trunk is what makes unmerged work look merged. The tier declines, the local `main`/`master` beneath it still gets its turn, and the warning names the disagreement. Declining is what happened in this repository shape anyway, so it is strictly an improvement that fails closed on genuine ambiguity.
- **The base ref uses the remote that named the trunk**, not a second guess. Where a local `main`/`master` named it instead, the same one-distinct-answer rule applies over the remotes that actually hold a copy: one is an answer, several falls back to the local branch — behind is the direction that fails closed.
- **An unreadable remote list is not an empty one.** `read_remotes` returning `None` means "nobody could say", so discovery consults `origin` and widens to nobody: exactly the reach it had before, so a transient failure to list remotes costs nothing that was working and widens nothing on the strength of what nobody read.

Every warning that a repository without an `origin` can now produce was checked: the remedy that unconditionally said `git remote set-head origin -a` now names the remote that is actually there, or carries a `<remote>` placeholder when none can be named — and says the list could not be read when that is why.

## Mutation checks

Each mutation applied alone to `survey.py`, gate re-run, source restored from a backup copy:

| mutation | caught by |
|---|---|
| `_consulted_remotes` returns `("origin",)` always (the original defect) | 13 unit + 3 integration |
| the remote that named the trunk is not handed to the base ref | 6 unit |
| disagreeing published HEADs pick the first instead of declining | 1 unit + 1 integration |
| several remotes holding the trunk take the first instead of declining | 1 unit |
| an unreadable remote list read as an empty one | 8 unit |
| the remedy names `origin` whatever the list says | 2 unit |
| the survey resolves the trunk without the list it just read | 5 unit + 3 integration |

The `origin` row of the parametrised integration test passed under every mutation, which is what makes it the behaviour-preservation control rather than a vacuous pass.

## Tests

`tests/integration/test_real_git.py` — the parametrised test that pinned the limit (`origin` / `team` / `team/origin`) now asserts all three resolve the trunk, sweep the merged branch, and measure against that remote's copy of it. The limit that survives is a new test: two real bare repos publishing different HEADs, no `origin`, nothing swept and the disagreement named.

`tests/unit/test_survey.py` — a remote of any name (including one containing a slash) publishing the trunk; remotes agreeing; remotes disagreeing; a fork still taking its trunk from `origin` (upstream's HEAD left unscripted, so asking for it raises); the `None` remote list; base-ref resolution against the nominating remote, against the only remote holding a copy, and declining between several; and the prose of every warning a repository without an `origin` can reach.

`make ci-gitclean` — exit 0, 472 passed, coverage 98.10%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk