### PR TITLE
refactor(9k9.135): index the pairing relation instead of scanning

### DIFF
--- a/packages/gitclean/src/gitclean/classify.py
+++ b/packages/gitclean/src/gitclean/classify.py
@@ -30,6 +30,7 @@ from a reason sentence by splitting on a delimiter those names may contain.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from gitclean.model import (
@@ -80,14 +81,42 @@ def holder_unmeasured(survey_data: Survey) -> bool:
     return not survey_data.worktrees_known or bool(survey_data.dropped_worktrees)
 
 
-def counterpart_worktree(branch: Branch, survey_data: Survey) -> Counterpart:
+@dataclass(frozen=True, slots=True)
+class PairingIndex:
+    """The membership questions ``branch_pairing`` and ``worktree_pairing`` ask
+    repeatedly, answered once per classification instead of once per row.
+
+    Membership is not identity. A local branch and a ref on the server may
+    carry the same short name, so ``local_branch_names`` and
+    ``remote_branch_names`` stay two sets rather than one, each built with the
+    same ``is_remote`` split the scans they replace tested inline -- losing
+    that split here would let a local branch answer for the server's copy of a
+    name it merely happens to share."""
+
+    worktree_paths: frozenset[str]
+    local_branch_names: frozenset[str]
+    remote_branch_names: frozenset[str]
+
+
+def pairing_index(survey_data: Survey) -> PairingIndex:
+    """Built once per classification and threaded down to every row, rather
+    than rescanning ``survey_data.worktrees`` and ``survey_data.branches`` once
+    per branch or worktree."""
+    return PairingIndex(
+        worktree_paths=frozenset(w.path for w in survey_data.worktrees),
+        local_branch_names=frozenset(b.name for b in survey_data.branches if not b.is_remote),
+        remote_branch_names=frozenset(b.name for b in survey_data.branches if b.is_remote),
+    )
+
+
+def counterpart_worktree(branch: Branch, survey_data: Survey, index: PairingIndex) -> Counterpart:
     """The worktree holding this branch, if the survey can say."""
     holder = branch.checked_out_at
     if holder is None:
         return Counterpart(
             relation="worktree", name=None, id=None, known=not holder_unmeasured(survey_data)
         )
-    listed = any(w.path == holder for w in survey_data.worktrees)
+    listed = holder in index.worktree_paths
     return Counterpart(
         relation="worktree",
         name=holder,
@@ -106,7 +135,7 @@ def tracks_a_server_ref(branch: Branch) -> bool:
     return bool(branch.upstream_ref and branch.upstream_ref.startswith("refs/remotes/"))
 
 
-def counterpart_upstream(branch: Branch, survey_data: Survey) -> Counterpart:
+def counterpart_upstream(branch: Branch, index: PairingIndex) -> Counterpart:
     """This branch's copy on the server, as the branch itself records it.
 
     Tracking nothing and tracking another local branch are one answer here, and
@@ -126,7 +155,7 @@ def counterpart_upstream(branch: Branch, survey_data: Survey) -> Counterpart:
     upstream = branch.upstream
     if upstream is None or not tracks_a_server_ref(branch):
         return Counterpart(relation="upstream", name=None, id=None, known=True)
-    listed = any(b.is_remote and b.name == upstream for b in survey_data.branches)
+    listed = upstream in index.remote_branch_names
     return Counterpart(
         relation="upstream",
         name=upstream,
@@ -135,16 +164,18 @@ def counterpart_upstream(branch: Branch, survey_data: Survey) -> Counterpart:
     )
 
 
-def branch_pairing(branch: Branch, survey_data: Survey) -> tuple[Counterpart, ...]:
+def branch_pairing(
+    branch: Branch, survey_data: Survey, index: PairingIndex
+) -> tuple[Counterpart, ...]:
     """Nothing for a server ref. No worktree can hold one and it tracks nothing
     itself, so both relations run the other way -- from the local branch that
     names it as its upstream, which is how it joins that branch's group."""
     if branch.is_remote:
         return ()
-    return (counterpart_worktree(branch, survey_data), counterpart_upstream(branch, survey_data))
+    return (counterpart_worktree(branch, survey_data, index), counterpart_upstream(branch, index))
 
 
-def worktree_pairing(worktree: Worktree, survey_data: Survey) -> tuple[Counterpart, ...]:
+def worktree_pairing(worktree: Worktree, index: PairingIndex) -> tuple[Counterpart, ...]:
     """The branch this worktree has checked out.
 
     Measured either way: the listing states outright whether a branch is
@@ -154,7 +185,7 @@ def worktree_pairing(worktree: Worktree, survey_data: Survey) -> tuple[Counterpa
     different thing from a detached checkout."""
     if worktree.branch is None:
         return (Counterpart(relation="branch", name=None, id=None, known=True),)
-    listed = any(not b.is_remote and b.name == worktree.branch for b in survey_data.branches)
+    listed = worktree.branch in index.local_branch_names
     return (
         Counterpart(
             relation="branch",
@@ -338,6 +369,7 @@ def classify_branch(
     *,
     trunk_names: frozenset[str],
     trunk_commits: frozenset[str],
+    index: PairingIndex,
 ) -> Target:
     reasons: list[str] = []
     kind = TargetKind.REMOTE_BRANCH if branch.is_remote else TargetKind.BRANCH
@@ -398,7 +430,7 @@ def classify_branch(
         id=ident,
         kind=kind,
         name=branch.name,
-        pairing=branch_pairing(branch, survey_data),
+        pairing=branch_pairing(branch, survey_data, index),
         merge_evidence=branch.merge_evidence,
         merge_proven=proven,
         sweepable=withheld is None,
@@ -463,6 +495,7 @@ def classify_worktree(
     *,
     trunk_names: frozenset[str],
     trunk_commits: frozenset[str],
+    index: PairingIndex,
 ) -> Target:
     evidence = commit_proof(worktree.head, survey_data.branches)
     dirt = held_dirt(worktree)
@@ -532,7 +565,7 @@ def classify_worktree(
         id=worktree_id(worktree.path),
         kind=TargetKind.WORKTREE,
         name=worktree.path,
-        pairing=worktree_pairing(worktree, survey_data),
+        pairing=worktree_pairing(worktree, index),
         merge_evidence=evidence,
         merge_proven=evidence in MERGE_PROOF,
         sweepable=withheld is None,
@@ -547,12 +580,17 @@ def classify(survey_data: Survey) -> tuple[Target, ...]:
     then local branches, then remote branches -- the order deletion must
     follow, since a branch cannot be deleted while a worktree holds it."""
     trunk_names, trunk_commits = trunk(survey_data)
+    index = pairing_index(survey_data)
     branch_targets = [
-        classify_branch(b, survey_data, trunk_names=trunk_names, trunk_commits=trunk_commits)
+        classify_branch(
+            b, survey_data, trunk_names=trunk_names, trunk_commits=trunk_commits, index=index
+        )
         for b in survey_data.branches
     ]
     worktree_targets = [
-        classify_worktree(w, survey_data, trunk_names=trunk_names, trunk_commits=trunk_commits)
+        classify_worktree(
+            w, survey_data, trunk_names=trunk_names, trunk_commits=trunk_commits, index=index
+        )
         for w in survey_data.worktrees
     ]
     locals_ = [t for t in branch_targets if t.kind is TargetKind.BRANCH]

--- a/packages/gitclean/tests/unit/test_classify.py
+++ b/packages/gitclean/tests/unit/test_classify.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from conftest import iso, make_branch, make_pr, make_survey, make_worktree
 
-from gitclean.classify import classify, classify_branch, classify_worktree, trunk
+from gitclean.classify import classify, classify_branch, classify_worktree, pairing_index, trunk
 from gitclean.model import Counterpart, MergeEvidence, Survey, Target
 
 # A commit no fixture's trunk sits on, for the cases that must not collide with
@@ -20,13 +20,17 @@ ELSEWHERE = "e" * 40
 def _one(branch, survey: Survey | None = None) -> Target:  # type: ignore[no-untyped-def]
     resolved = survey or make_survey()
     names, commits = trunk(resolved)
-    return classify_branch(branch, resolved, trunk_names=names, trunk_commits=commits)
+    index = pairing_index(resolved)
+    return classify_branch(branch, resolved, trunk_names=names, trunk_commits=commits, index=index)
 
 
 def _wt(worktree, survey: Survey | None = None) -> Target:  # type: ignore[no-untyped-def]
     resolved = survey or make_survey()
     names, commits = trunk(resolved)
-    return classify_worktree(worktree, resolved, trunk_names=names, trunk_commits=commits)
+    index = pairing_index(resolved)
+    return classify_worktree(
+        worktree, resolved, trunk_names=names, trunk_commits=commits, index=index
+    )
 
 
 def _pairing(target: Target) -> dict[str, Counterpart]:
@@ -537,6 +541,19 @@ def test_a_branch_named_like_a_server_ref_does_not_become_one() -> None:
 
     assert _pairing(_one(published))["upstream"].name == "origin/main"
     assert _pairing(_one(local))["upstream"].name is None
+
+
+def test_a_local_branch_sharing_the_upstreams_name_does_not_answer_for_it() -> None:
+    """The remote counterpart is matched among branches marked `is_remote` --
+    a local branch that merely happens to share the upstream's short name must
+    not be mistaken for the copy on the server that name refers to."""
+    tracking = make_branch("feat/thing", head=ELSEWHERE, upstream="origin/main")
+    impostor = make_branch("origin/main", head=ELSEWHERE)
+    survey = make_survey(branches=(tracking, impostor))
+
+    assert _pairing(_one(tracking, survey))["upstream"] == Counterpart(
+        relation="upstream", name="origin/main", id=None, known=True
+    )
 
 
 def test_a_server_ref_carries_no_pairing_of_its_own() -> None:


### PR DESCRIPTION
## What changed

`classify.py`'s pairing relation built each row's counterparts by scanning
`survey_data.worktrees` / `survey_data.branches` in full for every branch or
worktree row: `counterpart_worktree` scanned worktrees per local branch,
`counterpart_upstream` scanned branches per local branch, and
`worktree_pairing` scanned branches per worktree.

`classify()` now builds a `PairingIndex` once per classification -- three
frozensets (`worktree_paths`, `local_branch_names`, `remote_branch_names`) --
and threads it down through `classify_branch`/`classify_worktree` to
`branch_pairing`/`worktree_pairing` and the `counterpart_*` functions, which
now do an O(1) membership test instead of a scan. `local_branch_names` and
`remote_branch_names` are kept as two separate sets, mirroring the `is_remote`
discrimination the scans made inline -- a local branch can legally share a
name with a ref on the server, and collapsing them into one set would let a
local branch answer for the server's copy.

Signature notes: `counterpart_upstream` and `worktree_pairing` no longer take
`survey_data` (they only ever used it for the branch/worktree scan, now
replaced by the index); `counterpart_worktree`, `branch_pairing`,
`classify_branch` and `classify_worktree` gained an `index: PairingIndex`
parameter. None of these are used outside `classify.py` except by
`tests/unit/test_classify.py`'s `_one`/`_wt` helpers, which now build the
index once via the same `pairing_index()` builder `classify()` uses.

**Complexity:** before, `O(branches * (worktrees + branches) + worktrees * branches)`;
after, `O(branches + worktrees)` to build the index plus `O(branches + worktrees)`
membership tests -- linear instead of quadratic in the collection sizes.

## No performance problem was measured

This repository surveys on the order of thirty rows and nothing about it is
slow. This item was filed to get the shape on record, not because a slowdown
was observed. No benchmark was added.

## Verification

- **Suite:** 456 passed before, 457 passed after (one test added, see below).
- **Gate:** `make ci-gitclean`, run standalone from the worktree root, exit 0
  (ruff check, ruff format --check, mypy --strict, pytest --cov at 98.08%,
  pip-audit, `gitclean --help`).
- **Differential check:** captured `gitclean --report --format json` against
  this repository (real state: ~20 worktrees, many branches) before and after
  the change, using `git stash`/`git stash pop` to hold the survey target's
  git state as close to fixed as possible across both captures (roughly a
  minute apart). Across the full ~2,989-line report, the only difference was
  the invoking worktree's own `dirty_file_count` (0 -> 2), fully explained by
  the stash pop reintroducing the two files this change edits -- not by any
  change in judgement. A separate, wider-window capture (taken ~13 minutes
  later, after committing) showed additional diffs, but all of them traced to
  genuine concurrent repository activity from other agents working in this
  repo's worktrees during that window (a new worktree, a newly opened PR,
  pushed commits on unrelated branches) -- not to this change.
- **New test:** `test_a_local_branch_sharing_the_upstreams_name_does_not_answer_for_it`
  in `test_classify.py`. The existing suite had no survey containing both a
  local branch and a remote branch with the same short name, so nothing
  pinned that the new `remote_branch_names` index (built with an `is_remote`
  filter) can't be satisfied by a same-named local branch. Added because this
  is exactly the failure mode the refactor could introduce silently.

## Judgement calls

- Threading the index required changing the internal signatures listed above.
  These are not imported anywhere outside `classify.py` and its own test file,
  so I treated this as within "minimal" rather than a public-shape change.
- `PairingIndex` lives in `classify.py` rather than `model.py`: it's an
  implementation detail of how classification does its lookups, not a domain
  concept the report exposes (unlike `Counterpart`, which is part of the
  `Target` JSON contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk