### PR TITLE
fix(9k9.120): one match is not the only match when the survey lost a row

### DIFF
--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -38,9 +38,11 @@ a branch, its detached HEAD when it does not. A commit no ref proves merged has
 no proof, whether or not a branch names it.
 
 Naming a target deletes it. Nothing is re-derived, no flag is demanded, and the
-reflog is the undo for a local branch. Two things still stop a named deletion:
-the worktree this process is running in, and git itself — a checked-out branch,
-a dirty or locked worktree. Those refusals arrive verbatim, with the transcript.
+reflog is the undo for a local branch. Three things still stop a named deletion:
+the worktree this process is running in; git itself — a checked-out branch, a
+dirty or locked worktree — whose refusals arrive verbatim, with the transcript;
+and a listing that dropped a row it could not parse, which leaves the run unable
+to say the one thing your name matched is the only thing it matches.
 
 A bare name reaches a worktree or a local branch. The copy on a server answers
 to its full `<remote>/<ref>` spelling and to nothing shorter, so the name you

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -18,9 +18,10 @@ narrowed the scope *and* relaxed the proof would be a naming wearing a sweep's
 clothes.
 
 So the refusals left here are few, and each answers something the caller could
-not have answered themselves: a name matching two things, a branch git will
-reject because a worktree still holds it, and the directory this process is
-standing in.
+not have answered themselves: a name matching two things, a name matching one
+thing in a survey that lost a row -- where whether it matched two is exactly
+what went unrecorded -- a branch git will reject because a worktree still holds
+it, and the directory this process is standing in.
 
 None of them stops the rest. A refusal is about the selector it names, so what
 resolved cleanly is still planned and still deleted, and the refusals ride
@@ -156,21 +157,47 @@ def _unsplit_this_could_name(selector: str, survey_data: Survey) -> NotOffered |
     return None
 
 
+def _could_name_a_worktree(selector: str) -> bool:
+    """Whether the worktree listing is one this selector's answer depends on.
+
+    The `worktree:` / `branch:` / `remote:` prefixes are the convention the ids
+    use, and a caller who spelled the kind out has said which listing is the
+    relevant one -- what happened in the other is then none of this selector's
+    business. An absolute path says the same thing without the prefix: git will
+    not create a ref whose short name begins with a slash, so nothing but a
+    worktree can be meant. A bare name says neither, so it depends on both
+    listings: being unable to say which kind was meant is not a reason to trust
+    whichever one happened to answer.
+
+    Written once because two questions turn on it -- whether a miss can mean
+    absence, and whether a match can mean the only match -- and two copies of
+    this would be two places to disagree about what a selector denotes."""
+    return not selector.startswith(("branch:", "remote:"))
+
+
+def _could_name_a_ref(selector: str) -> bool:
+    """The same question about the ref listing, on the same convention: a
+    `worktree:` prefix or an absolute path has said a worktree is meant, and
+    nothing in the ref listing can answer for it."""
+    return not selector.startswith(("worktree:", "/"))
+
+
+_WORKTREE_ROWS_LOST = "{count} worktree block(s) went unparsed"
+_REF_ROWS_LOST = "{count} ref row(s) went unparsed"
+"""What a listing that definitely lost a row says about itself.
+
+One wording each, because the two questions it settles -- whether a miss is
+absence, and whether a match is the only match -- are the same measurement read
+for two purposes, and a reader should not have to work out that they are."""
+
+
 def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str]:
     """Of the listings that could have contained this name, which did not run.
 
-    Keyed on what the selector's own spelling can denote. The `worktree:` /
-    `branch:` / `remote:` prefixes are the convention the ids use, and a caller
-    who spelled out the kind has said which listing is the relevant one -- a
-    failure in the other is then none of this selector's business, and refusing
-    on it would block the commonest cleanup there is, a worktree already
-    removed, over a ref read that had nothing to do with it. An absolute path
-    says the same thing without the prefix: git will not create a ref whose
-    short name begins with a slash, so nothing but a worktree can be meant.
-
-    A bare name could be either -- a branch, or a worktree's basename -- so it
-    needs both. Being unable to say which kind was meant is not a reason to
-    trust whichever one happened to answer.
+    Keyed on what the selector's own spelling can denote, which the two
+    predicates above answer. What that keying buys here is the commonest cleanup
+    there is: a worktree already removed, named after the fact, which a failed
+    ref read that had nothing to do with it must not block.
 
     "Could not answer" covers a listing that did not run, one that ran without
     describing everything it listed, *and* one holding a server ref whose
@@ -187,14 +214,12 @@ def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str
     branch outright. Local refs were read and split fine; a miss there is a
     real miss, and refusing it over a remote ref nobody was talking about
     trades a false absence for a false refusal."""
-    worktree_only = selector.startswith("worktree:") or selector.startswith("/")
-    ref_only = selector.startswith(("branch:", "remote:"))
     unread: list[str] = []
-    if not ref_only:
+    if _could_name_a_worktree(selector):
         if not survey_data.worktrees_known:
             unread.append("no worktree could be listed")
         elif survey_data.dropped_worktrees:
-            unread.append(f"{survey_data.dropped_worktrees} worktree block(s) went unparsed")
+            unread.append(_WORKTREE_ROWS_LOST.format(count=survey_data.dropped_worktrees))
         elif not survey_data.worktrees_framed:
             # Not "a path was truncated" -- nobody can say that. The listing
             # cannot prove it named every path, and a name matching nothing is
@@ -207,11 +232,11 @@ def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str
                 "the worktree listing could not be framed so a path containing a newline stays "
                 "whole, so it cannot show that every worktree it holds was named in full"
             )
-    if not worktree_only:
+    if _could_name_a_ref(selector):
         if not survey_data.branches_known:
             unread.append("no ref could be read")
         elif survey_data.dropped_refs:
-            unread.append(f"{survey_data.dropped_refs} ref row(s) went unparsed")
+            unread.append(_REF_ROWS_LOST.format(count=survey_data.dropped_refs))
         unsplit = _unsplit_this_could_name(selector, survey_data)
         if unsplit is not None:
             unread.append(
@@ -220,6 +245,57 @@ def _lists_that_could_not_answer(selector: str, survey_data: Survey) -> list[str
                 f"exactly the question that went unanswered"
             )
     return unread
+
+
+def _rows_that_may_hide_a_second_match(selector: str, survey_data: Survey) -> list[str]:
+    """Of the listings this selector reaches, the ones that definitely lost a row.
+
+    A match is a claim about one target. Deleting on it is a claim about all of
+    them -- that nothing else here answers to the name -- and only the first of
+    those was measured. A listing that dropped a row is where the two come
+    apart: git handed back something nobody could parse, so what that row named
+    is unknown, and one of the things it may have named is a second target
+    wearing this selector. Removing a worktree has no undo, so the run reports
+    what it measured rather than acting on what it assumed.
+
+    Only a *proven* loss, never an unproven completeness, and that distinction
+    is the whole of this rule. ``worktrees_framed`` says the listing could not
+    show it named every path it holds, which is true of every git too old to
+    offer NUL framing whether or not anything was lost -- so refusing a match on
+    it would refuse every named cleanup on those versions and buy nothing that
+    was measured. It stays where it belongs, withholding the one conclusion it
+    really does undermine: that a miss means absence. ``worktrees_known`` and
+    ``branches_known`` are that same kind of claim about a listing that never
+    ran, and a listing that never ran contributed no match to refuse.
+
+    Scoped by what the selector can denote, for the reason the miss path scopes
+    it: a `branch:` cannot collide with a lost worktree block, and a `worktree:`
+    cannot collide with a lost ref row.
+
+    The ref count has no reachable trigger on any git shipping today. A row is
+    dropped when it comes back with fewer fields than were asked for, and the
+    fields are separated by `\\x1f` and the newline -- both of which
+    `git check-ref-format` bars from a refname, along with every other ASCII
+    control byte, so no refname can split its own row. It is covered because
+    covering it costs one condition, and because that unreachability is a
+    property of the ref format as it stands rather than a guarantee this package
+    is owed. Nobody can produce one; if the format ever admits such a byte, the
+    check is already here.
+
+    What this cannot see, and what no count can: a worktree block truncated at a
+    newline whose remaining text begins with an attribute name, which reads as a
+    perfectly well-formed block. Nothing about it announces itself, so the count
+    stays 0 and this returns nothing. A caller whose match is refused here has
+    learned that a row was definitely lost; a caller whose match is accepted has
+    learned only that no loss announced itself, which is the weaker fact. That
+    gap is permanent for as long as an unframed listing is read at all, and
+    closing it would take framing every listing, not a further count."""
+    lost: list[str] = []
+    if _could_name_a_worktree(selector) and survey_data.dropped_worktrees:
+        lost.append(_WORKTREE_ROWS_LOST.format(count=survey_data.dropped_worktrees))
+    if _could_name_a_ref(selector) and survey_data.dropped_refs:
+        lost.append(_REF_ROWS_LOST.format(count=survey_data.dropped_refs))
+    return lost
 
 
 def resolve_selectors(
@@ -252,6 +328,12 @@ def resolve_selectors(
     Nothing here can distinguish a worktree removed thirty seconds ago from a
     name with a letter wrong -- the repository answers identically -- so
     asserting either one would be a claim the tool cannot support.
+
+    A match is held to the same standard, and for a while it was not. One match
+    is measured; the *only* match is a second claim about every row that was
+    supposed to have been listed, and a survey that dropped one has not made it.
+    So a single match against a listing that lost a row refuses too, rather than
+    deleting on an assertion nobody checked.
     """
     resolved: list[Target] = []
     absent: list[Absent] = []
@@ -324,6 +406,26 @@ def resolve_selectors(
                     message=f"{selector!r} matches more than one target: {ids}",
                     blocked=tuple(matches),
                     remedy="re-run naming the exact `id`",
+                )
+            )
+            continue
+        lost = _rows_that_may_hide_a_second_match(selector, survey_data)
+        if lost:
+            # The same claim the miss path makes, so it keeps the same code: the
+            # survey did not describe everything it listed, and what follows
+            # from a name here is not what it would be from a complete one.
+            # There the unrecorded row may be the thing the caller named; here
+            # it may be a second one, and choosing between two things when only
+            # one of them was recorded is not a choice this run gets to make.
+            refused.append(
+                Refusal(
+                    code="E_SURVEY_INCOMPLETE",
+                    message=f"{selector!r} matches {matches[0].id}, and this run cannot say that "
+                    f"is the only thing it matches: {' and '.join(lost)}, and nothing records "
+                    f"what they named -- one of them may be a second target wearing that name",
+                    blocked=(matches[0],),
+                    remedy="fix what stopped the listing (the warnings say what it was) and "
+                    "re-run; nothing under this name was deleted",
                 )
             )
             continue

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -421,8 +421,9 @@ def resolve_selectors(
                 Refusal(
                     code="E_SURVEY_INCOMPLETE",
                     message=f"{selector!r} matches {matches[0].id}, and this run cannot say that "
-                    f"is the only thing it matches: {' and '.join(lost)}, and nothing records "
-                    f"what they named -- one of them may be a second target wearing that name",
+                    f"is the only thing it matches: {' and '.join(lost)}. Nothing records what "
+                    f"those unparsed rows named, so one of them may be a second target wearing "
+                    f"that name",
                     blocked=(matches[0],),
                     remedy="fix what stopped the listing (the warnings say what it was) and "
                     "re-run; nothing under this name was deleted",

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -348,6 +348,86 @@ def test_a_dropped_worktree_block_is_the_same_hole_on_the_other_listing() -> Non
     assert "2 worktree block(s) went unparsed" in refusal.message
 
 
+def test_a_dropped_block_stops_a_match_meaning_the_only_match() -> None:
+    """One match is measured; the only match is a further claim about every row
+    the listing was supposed to have described, and a block nobody could parse
+    is a row that went unrecorded. It may have been a second worktree wearing
+    this name, and removing the wrong one has no undo."""
+    survey = make_survey(worktrees_known=True, dropped_worktrees=1)
+    targets = (target("worktree:/repo/wt", kind=TargetKind.WORKTREE),)
+
+    result = plan_for(targets, survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert [t.id for t in refusal.blocked] == ["worktree:/repo/wt"]
+    assert "1 worktree block(s) went unparsed" in refusal.message
+
+
+def test_a_dropped_block_does_not_stop_a_branch_that_matches() -> None:
+    """The counts are read per listing on the match path exactly as they are on
+    the miss path. A `branch:` names a local ref, and no worktree block -- lost
+    or listed -- can be a second thing wearing that name."""
+    survey = make_survey(dropped_worktrees=1)
+    targets = (target("branch:feat/x"),)
+
+    result = plan_for(targets, survey=survey, selectors=["branch:feat/x"])
+
+    assert result.refused == ()
+    assert [t.name for t in result.targets] == ["feat/x"]
+
+
+def test_a_dropped_ref_row_stops_a_branch_match_the_same_way() -> None:
+    """The other listing, and the one no git shipping today can trigger: the
+    fields are separated by `\\x1f` and the newline, and `git check-ref-format`
+    bars both from a refname. Covered because the rule is about a row that went
+    unrecorded rather than about which listing lost it, and because that
+    unreachability is a fact about the ref format as it stands."""
+    survey = make_survey(dropped_refs=1)
+    targets = (target("branch:feat/x"),)
+
+    result = plan_for(targets, survey=survey, selectors=["branch:feat/x"])
+
+    assert result.targets == ()
+    [refusal] = result.refused
+    assert refusal.code == "E_SURVEY_INCOMPLETE"
+    assert "1 ref row(s) went unparsed" in refusal.message
+
+
+def test_an_unframed_listing_does_not_stop_a_match() -> None:
+    """The trigger is a proven loss, not an unproven completeness, and these are
+    different claims. `worktrees_framed` is false on every git too old to offer
+    NUL framing, whether or not a path was truncated -- refusing a match on it
+    would refuse every named cleanup on those versions in exchange for nothing
+    anybody measured. It keeps withholding the conclusion it does undermine, on
+    the miss path, and leaves a match alone."""
+    survey = make_survey(worktrees_framed=False, dropped_worktrees=0)
+    targets = (target("worktree:/repo/wt", kind=TargetKind.WORKTREE),)
+
+    result = plan_for(targets, survey=survey, selectors=["worktree:/repo/wt"])
+
+    assert result.refused == ()
+    assert [t.name for t in result.targets] == ["/repo/wt"]
+
+
+def test_a_match_refused_over_a_dropped_block_does_not_spend_the_other_names() -> None:
+    """A refusal is about the selector it names. The caller asked for two
+    things, one of them cannot be answered for, and the other is still theirs to
+    have -- an unrelated name paying for it is the round trip this run exists
+    not to cost."""
+    survey = make_survey(dropped_worktrees=1)
+    targets = (
+        target("worktree:/repo/wt", kind=TargetKind.WORKTREE),
+        target("branch:feat/x"),
+    )
+
+    result = plan_for(targets, survey=survey, selectors=["worktree:/repo/wt", "branch:feat/x"])
+
+    assert [r.code for r in result.refused] == ["E_SURVEY_INCOMPLETE"]
+    assert [t.name for t in result.targets] == ["feat/x"]
+
+
 def test_a_dropped_ref_row_does_not_block_naming_a_worktree() -> None:
     """The counts are read per listing, like the flags beside them. A ref row
     nobody could parse says nothing about the worktree listing."""


### PR DESCRIPTION
## What was asserted without measurement

`resolve_selectors` in `packages/gitclean/src/gitclean/plan.py` took a selector that
resolved to exactly one recorded target and deleted it. That is two claims, not one:
that this target matches the name, which the survey measured, and that nothing else
here does, which nobody asked. Where the survey recorded that a row came back
unparsed, the second claim was false as a matter of record — git handed back
something whose contents nobody could read, so what it named is unknown, and one of
the things it may have named is a second target wearing the same selector. Removing
a worktree has no undo.

The miss path already consults the survey's completeness through
`_lists_that_could_not_answer`. This extends the same idea to the match path.

## The trigger, and why it is proven loss rather than unproven completeness

A single match refuses only when `dropped_worktrees` or `dropped_refs` is nonzero on
a listing the selector reaches. Those counters mean git handed back a row that could
not be parsed: **something was definitely lost**.

`worktrees_framed`, `worktrees_known` and `branches_known` are deliberately not
triggers. They say a listing could not be *proven* complete, which is a different
claim — `worktrees_framed` is false on every git too old to offer NUL framing whether
or not anything was actually lost, so refusing a match on it would refuse every named
cleanup on those versions and buy nothing anybody measured. They stay miss-only,
withholding the one conclusion they really do undermine: that a miss means absence.

Scoping is per listing, on the same `worktree:` / `branch:` / `remote:` / bare-path
keying the miss path uses. That keying is now written once, in
`_could_name_a_worktree` and `_could_name_a_ref`, so the two paths cannot come to
disagree about what a selector denotes; the miss path's behaviour is unchanged by the
extraction. The refusal reuses `E_SURVEY_INCOMPLETE` — the same claim under the same
code — with a message that fits the match case, since the miss-path wording does not.

`dropped_refs` is covered and has no reachable trigger on any git shipping today: the
ref row's fields are separated by `\x1f` and the newline, and `git check-ref-format`
bars both from a refname along with every other ASCII control byte, so no refname can
split its own row. It is covered because covering it costs one condition and because
that unreachability is a property of today's ref format rather than a guarantee this
package is owed. The docstring says exactly that, so nobody later reads the check as
evidence somebody produced the case.

## Blast radius

Newly refused: a run that names a target, resolves it to exactly one match, **and**
sits on a survey whose corresponding listing dropped at least one row. In practice
that is the unframed worktree listing on git older than 2.36 where a path containing
a newline announced its own truncation. Nothing else changes — a match against a
clean survey resolves and deletes as before, an unframed-but-lossless listing does
not refuse a match, and sweeps are untouched. A refusal still spends only its own
selector: other names in the same invocation still resolve and are still deleted.

## The gap this cannot see

A worktree block truncated at a newline whose remaining text begins with an attribute
name reads as a well-formed block (`survey.py` `_parse_worktrees`, and
`WorktreeListing.can_place`). It announces nothing and increments no counter, so no
counter-based check reaches it — this one included. That gap is permanent for as long
as an unframed listing is read at all; closing it takes framing every listing, not a
further count. It is recorded in the new helper's docstring for the same reason it is
here: a reader who concludes "a lost row can no longer surprise me" would be worse off
than one who knows the boundary.

## Verification

`make ci-gitclean` run standalone from the worktree root: **exit 0**, 461 passed,
`plan.py` at 99% (lint, format-check, mypy --strict, pytest --cov, pip-audit,
entry-verify).

Mutations, each applied to the shipped code and reverted from a backup copy:

| mutation | tests that caught it |
| --- | --- |
| widen the trigger to include `worktrees_framed` | 3 — `test_an_unframed_listing_does_not_stop_a_match`, plus the two pre-existing `test_cli.py` tests `test_a_worktree_that_does_match_is_unaffected_by_the_unframed_listing` and `test_naming_the_truncated_path_gets_gits_refusal_rather_than_a_phantom_removal` |
| drop the per-listing kind scoping | 2 — `test_a_dropped_block_does_not_stop_a_branch_that_matches`, `test_a_match_refused_over_a_dropped_block_does_not_spend_the_other_names` |
| remove the refusal entirely | 3 — `test_a_dropped_block_stops_a_match_meaning_the_only_match`, `test_a_dropped_ref_row_stops_a_branch_match_the_same_way`, `test_a_match_refused_over_a_dropped_block_does_not_spend_the_other_names` |

The non-regression test `test_a_worktree_that_does_match_is_unaffected_by_the_unframed_listing`
needed **no edit** and stays green; it is one of the tests that catches the widened
trigger, which is the check that the trigger condition is the right one.

`README.md` gains the third stop on a named deletion, since it previously enumerated
two and that list is now untruthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk
