### PR TITLE
fix(9k9.53.7.2.3): a row the sweep takes no longer calls its own merge unproven

### DIFF
--- a/packages/gitclean/AGENTS.md
+++ b/packages/gitclean/AGENTS.md
@@ -66,7 +66,12 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   not zero, clean, or absent. Defaulting an unanswered question to the
   convenient value turns each transient git failure into data loss, so unknowns
   render as a stated unknown on that target's own row. If you add a read, add
-  its `None` path with it.
+  its `None` path with it. The one thing that suppresses such a sentence is
+  another tier having already answered the same question — the tiers are
+  independent reads, so a failed count sits happily beside authoritative merge
+  proof, and printing both leaves a row that calls the merge unproven next to
+  the decision to sweep it. Suppress only the question that was answered: a
+  proven merge says nothing about whether the work was pushed.
 - **A relation the report states is a field, never a sentence.** A worktree, the
   branch it holds and that branch's copy on the server are one thing with two or
   three parts, and a reader deciding about one has to see the others. Those

--- a/packages/gitclean/src/gitclean/classify.py
+++ b/packages/gitclean/src/gitclean/classify.py
@@ -17,7 +17,10 @@ human naming it deletes it.
 ``None`` is a question git declined to answer; it renders as a stated unknown
 on that target's own row instead of resolving to the convenient value. The rule
 is one-directional on purpose: it costs the occasional branch left uncleaned,
-and the alternative costs work.
+and the alternative costs work. Where it stops is the unknown that nothing
+turns on: a question another tier has already answered is not restated as open
+beside that answer, because a row saying both is wrong whichever half a reader
+believes.
 
 One thing here is not judgement: ``Counterpart``. It restates a relation the
 survey already read -- which worktree holds which branch, which branch tracks
@@ -196,15 +199,28 @@ def worktree_pairing(worktree: Worktree, index: PairingIndex) -> tuple[Counterpa
     )
 
 
-def unanswered_probes(branch: Branch, base_ref: str) -> tuple[str, ...]:
+def unanswered_probes(branch: Branch, base_ref: str, *, proven: bool) -> tuple[str, ...]:
     """Reasons naming each count the read layer could not obtain.
 
-    Kept beside the measurements rather than folded into the sweep rule so the
-    audit trail cannot drift from the behaviour: a branch whose merge count
-    never came back carries ``MergeEvidence.NONE``, which is exactly what the
-    first question refuses."""
+    Kept beside the measurements rather than folded into the sweep rule, so
+    each unknown renders on the row of the branch it was missing from while
+    the sweep goes on deciding from the evidence tier.
+
+    The merge sentence is suppressed once something else proved the merge. An
+    unanswered count does not imply ``MergeEvidence.NONE``: the tiers are
+    independent reads -- a pull request is answered by the forge, this count by
+    `rev-list` -- so a branch can carry authoritative proof while that one
+    probe failed, and the row would then call the merge unproven beside the
+    tier that proved it. The unknown that can withhold a deletion is one in the
+    tier authorising it, and this is not that; what is dropped here changed no
+    outcome and contradicted the proof next to it.
+
+    The unpushed sentence is not suppressed on those grounds and must not be. A
+    merge proves these commits reached the base ref; it says nothing about
+    whether this branch's own upstream ever received them, so that unknown
+    stays true beside any proof and stays worth saying."""
     unknown: list[str] = []
-    if branch.unmerged_commits is None:
+    if branch.unmerged_commits is None and not proven:
         unknown.append(f"could not count commits missing from {base_ref}; merge state unproven")
     if branch.upstream is not None and branch.unpushed_commits is None:
         unknown.append(
@@ -412,7 +428,7 @@ def classify_branch(
                 )
             if branch.unpushed_commits:
                 reasons.append(f"{branch.unpushed_commits} commit(s) not on {branch.upstream}")
-    reasons.extend(unanswered_probes(branch, survey_data.base_ref))
+    reasons.extend(unanswered_probes(branch, survey_data.base_ref, proven=proven))
     reasons.extend(branch.probe_failures)
 
     withheld = withheld_reason(

--- a/packages/gitclean/tests/unit/test_classify.py
+++ b/packages/gitclean/tests/unit/test_classify.py
@@ -7,9 +7,17 @@ report is measurement, and measurement is the survey's business."""
 
 from __future__ import annotations
 
+import pytest
 from conftest import iso, make_branch, make_pr, make_survey, make_worktree
 
-from gitclean.classify import classify, classify_branch, classify_worktree, pairing_index, trunk
+from gitclean.classify import (
+    MERGE_PROOF,
+    classify,
+    classify_branch,
+    classify_worktree,
+    pairing_index,
+    trunk,
+)
 from gitclean.model import Counterpart, MergeEvidence, Survey, Target
 
 # A commit no fixture's trunk sits on, for the cases that must not collide with
@@ -159,6 +167,35 @@ def test_an_uncounted_unmerged_total_never_yields_the_sweep() -> None:
     target = _one(branch)
     assert not target.sweepable
     assert any("merge state unproven" in reason for reason in target.reasons)
+
+
+@pytest.mark.parametrize("evidence", sorted(MERGE_PROOF, key=str), ids=lambda e: e.value)
+def test_a_swept_row_never_calls_its_own_merge_unproven(evidence: MergeEvidence) -> None:
+    """The count probe and the tier that proved this merge are independent
+    reads, so a failure of the first says nothing about the second. Printed
+    beside `merge proven by ...` on a row the sweep is taking, the unknown
+    contradicts the decision printed with it, and a reader has no way to tell
+    which half to believe. Asked of every tier because each one reaches this
+    row by its own path."""
+    branch = make_branch(head=ELSEWHERE, merge_evidence=evidence, unmerged_commits=None)
+    target = _one(branch)
+    assert target.sweepable
+    assert not any("merge state unproven" in r for r in target.reasons)
+
+
+def test_a_proven_merge_does_not_silence_the_unpushed_unknown() -> None:
+    """Only the merge sentence is made redundant by merge proof. A merge says
+    these commits reached the base ref and nothing at all about whether this
+    branch's upstream has them, so suppressing both would drop a fact that is
+    still true -- and the row would then read as though the push had been
+    measured."""
+    branch = make_branch(
+        head=ELSEWHERE,
+        merge_evidence=MergeEvidence.PR_MERGED,
+        unmerged_commits=None,
+        unpushed_commits=None,
+    )
+    assert any("nothing proves these commits are pushed" in r for r in _one(branch).reasons)
 
 
 def test_an_uncounted_unpushed_total_is_stated_as_unknown() -> None:


### PR DESCRIPTION
## The contradiction

A branch could be swept on genuine merge proof while its own report row said the merge was unproven. Reproduced in-process before touching anything, over all four proof tiers — a branch with `unmerged_commits=None` and any tier of proof:

```
== pr_merged: sweepable=True withheld=None
   - merge proven by pr_merged
   - could not count commits missing from refs/remotes/origin/main; merge state unproven
```

The row contradicts the decision printed beside it, and a reader has no way to tell which half to believe.

## Why the docstring's premise failed

`unanswered_probes` justified the unconditional sentence by asserting that a branch whose merge count never came back "carries `MergeEvidence.NONE`, which is exactly what the first question refuses." That holds within one tier and not across them. The pull-request tier is answered by the forge and the count comes from `rev-list`; they are independent reads, so a branch can carry `PR_MERGED` — authoritative proof — while the count probe separately failed and left `None`. The same is reachable through `ANCESTOR` (batch ancestry), `PATCH_EQUAL` and `SQUASH_EQUAL`, none of which consults that count. `withheld_reason` never reads `unanswered_probes`, so the sweep proceeded correctly on the proof and only the sentence was wrong. The now-false premise is corrected in the docstring rather than left to mislead the next reader.

## Suppression, not withholding

The other conceivable reading — make the sweep withhold on an unanswered probe — would hold back branches carrying real merge proof because an unrelated `rev-list` failed, costing capability for no safety gain. The unknown that can withhold a deletion is one in the tier that authorises it; an unknown elsewhere changed no outcome. So the fix threads `proven` into `unanswered_probes` and suppresses the merge sentence, exactly as `missing_pr_evidence` already does a few lines above for the same reason.

## What stays unsuppressed

- **The unpushed sentence.** A merge proves these commits reached the base ref and says nothing about whether the branch's own upstream received them, so that unknown stays true beside any proof. A test pins it, so a later reader cannot "simplify" the fix by suppressing both.
- **The age sentence**, on the same grounds.
- **`probe_failures`.** Checked, and it does not produce the same contradiction. In `_resolve_merge` the only proof tier that returns a non-empty failure list is `SQUASH_EQUAL`, and the only entry it can carry there is the patch-id probe failure — `PR_MERGED`, `ANCESTOR` and `PATCH_EQUAL` all return `()`. That sentence says which probe errored and what class of merge it would have caught; it makes no claim about merge state, so beside `merge proven by squash_equal` it explains why the tier is squash rather than patch, and stays.

## Mutations

Both run before claiming anything; the file was restored from a backup copy rather than `git checkout`.

| Mutation | Result |
| --- | --- |
| Suppression removed (`and not proven` dropped) | 4 failures — the new test at every proof tier, full suite otherwise green (510 passed) |
| Unpushed sentence suppressed on proof too | 1 failure — `test_a_proven_merge_does_not_silence_the_unpushed_unknown` |

The new merge-state test is parametrised over `MERGE_PROOF` itself, so a tier added later is covered without anyone remembering to extend the list.

## Gate

`make ci-gitclean` from the worktree root, standalone, exit status read on its own: **0**. 514 passed, coverage 98.13%.

`packages/gitclean/AGENTS.md` gains the one clause its `None` rule now needs: the only thing that suppresses a stated unknown is another tier having answered the same question, and only the question that was answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk