### PR TITLE
fix(9k9.53.7.2.4): the argv rule holds wherever git is asked, not only where it is told

### DIFF
--- a/packages/gitclean/src/gitclean/execute.py
+++ b/packages/gitclean/src/gitclean/execute.py
@@ -37,7 +37,7 @@ from datetime import datetime
 from pathlib import Path
 
 from gitclean.model import Anomaly, Deletion, Plan, SalvageRecord, Survey, Target, TargetKind
-from gitclean.ports import CommandPort
+from gitclean.ports import CommandPort, git_argv
 from gitclean.survey import list_worktrees
 
 SALVAGE_PREFIX = "gitclean-salvage"
@@ -64,36 +64,6 @@ class ExecutionReport:
     @property
     def ok(self) -> bool:
         return not self.anomalies
-
-
-def git_argv(*command: str, name: str | None = None) -> list[str]:
-    """The only place a name out of the repository is put into a git argv.
-
-    A repo-derived name can be spelled exactly like an option. `refs/heads/-m`
-    is a legal ref -- `git branch` will not create one, but `update-ref` will
-    and a remote can push one -- and `git branch -D -m` is a rename, not a
-    deletion. Two spellings survive that, and which one applies is a property
-    of the name rather than of the caller, so it is decided here:
-
-    - a full `refs/...` path, which no git command parses as an option, and
-    - the `--` terminator, for names that have to stay short.
-
-    Both exist because `bundle create` hands its arguments to rev-list, where
-    `--` introduces a pathspec: terminating there yields `Refusing to create
-    empty bundle` rather than protection. `branch -D` is the mirror image --
-    it rejects a full ref path and takes only the short name -- so neither
-    spelling covers every call site and neither can be the single rule.
-
-    Passing through one constructor is what makes that impossible to forget: a
-    new call site has nowhere else to put the name. Commands carrying no
-    repo-derived name come through here too, so the rule is "every git call in
-    this module", which a test can check -- rather than "every git call that a
-    reader judged to carry a name", which is the judgement that missed two."""
-    if name is None:
-        return list(command)
-    if name.startswith("refs/"):
-        return [*command, name]
-    return [*command, "--", name]
 
 
 def slug(name: str) -> str:

--- a/packages/gitclean/src/gitclean/ports.py
+++ b/packages/gitclean/src/gitclean/ports.py
@@ -5,6 +5,12 @@ returns data. That is what makes the classification rules testable without a
 fixture repo, and it is why ``ScriptedCommands`` fails loudly on an unscripted
 call -- a silent default would let a test pass while the real tool asks git a
 question nobody predicted.
+
+It is also where an argument is spelled for git. The two constructors below
+are the only places a name the repository chose gets the spelling that keeps
+git from reading it as an option, and they live here rather than beside either
+caller because both the read stage and the write stage need them and neither
+may import the other.
 """
 
 from __future__ import annotations
@@ -19,6 +25,65 @@ from pathlib import Path
 from typing import Protocol, runtime_checkable
 
 _DEFAULT_TIMEOUT = 60
+
+
+def git_argv(*command: str, name: str | None = None) -> list[str]:
+    """The only place a name out of the repository is put into a git argv.
+
+    A repo-derived name can be spelled exactly like an option. `refs/heads/-m`
+    is a legal ref -- `git branch` will not create one, but `update-ref` will
+    and a remote can push one -- and `git branch -D -m` is a rename, not a
+    deletion. Two spellings survive that, and which one applies is a property
+    of the name rather than of the caller, so it is decided here:
+
+    - a full `refs/...` path, which no git command parses as an option, and
+    - the `--` terminator, for names that have to stay short.
+
+    Both exist because `bundle create` hands its arguments to rev-list, where
+    `--` introduces a pathspec: terminating there yields `Refusing to create
+    empty bundle` rather than protection. `branch -D` is the mirror image --
+    it rejects a full ref path and takes only the short name -- so neither
+    spelling covers every call site and neither can be the single rule. The
+    same split is why only a name in the last position can be terminated at
+    all: `--` protects everything after it and nothing before, so a name
+    followed by another argument goes in as a full ref path or not at all.
+
+    What neither spelling does is bound where git will look. `--` ends option
+    parsing; it does not stop git accepting a path in the repository position,
+    and nothing in an argv does. Only where the name came from covers that.
+
+    Passing through one constructor is what makes the option case impossible to
+    forget: a new call site has nowhere else to put the name. Commands carrying
+    no repo-derived name come through here too, so the rule is "every git call
+    in this package", which a test can check -- rather than "every git call
+    that a reader judged to carry a name", which is the judgement that missed
+    two."""
+    if name is None:
+        return list(command)
+    if name.startswith("refs/"):
+        return [*command, name]
+    return [*command, "--", name]
+
+
+def git_rev(name: str) -> str:
+    """A repo-derived branch name spelled for a rev expression it is only part
+    of -- `<rev>^{tree}`, `<a>..<b>` -- where neither argv spelling is offered.
+
+    A composed rev occupies one argument with no room to terminate anything
+    inside it, and the commands that take one spend `--` on a pathspec anyway.
+    `rev-parse` will not even consume a terminator: both `--` and
+    `--end-of-options` come back from it as a literal line of output rather
+    than being read as one. So the protection left is the other spelling,
+    applied within the expression -- a full ref path, which cannot begin with
+    `-`.
+
+    Applied only when the short name would otherwise be misread, because
+    `refs/heads/` is the wrong prefix for half of what reaches here. A
+    remote-tracking branch's short name always leads with its remote --
+    `origin/feat`, never a bare `feat` -- so it already resolves to the ref it
+    names, while prefixing it would ask for a local branch that is usually not
+    there and occasionally is somebody else's."""
+    return f"refs/heads/{name}" if name.startswith("-") else name
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -12,6 +12,12 @@ reader can see *why* a deletion was called safe.
 The tiers are ordered by cost. Batch reads (`for-each-ref`, `branch --merged`,
 one `gh pr list`) answer most branches; the per-branch probes run only on the
 residue nothing cheaper could resolve.
+
+Every git call here is assembled by the shared argv constructor, and a name the
+repository chose reaches git only through it or through the rev spelling beside
+it. A probe added without one is the failure mode: the terminator is not a
+habit to apply call site by call site, and the sites that forget it are the ones
+nobody can type by hand.
 """
 
 from __future__ import annotations
@@ -29,7 +35,7 @@ from gitclean.model import (
     Survey,
     Worktree,
 )
-from gitclean.ports import CommandPort, CommandResult
+from gitclean.ports import CommandPort, CommandResult, git_argv, git_rev
 
 _SEP = "\x1f"
 # The FULL refname leads deliberately, and everything the survey *records*
@@ -105,14 +111,14 @@ def _whole_path(stdout: str) -> str:
 
 def resolve_repo(port: CommandPort, cwd: Path | None) -> tuple[str, str] | None:
     """Return (repo_root, git_common_dir), or None when cwd is not a repo."""
-    root = port.git(["rev-parse", "--show-toplevel"], cwd=cwd)
+    root = port.git(git_argv("rev-parse", "--show-toplevel"), cwd=cwd)
     if not root.ok:
         return None
-    common = port.git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=cwd)
+    common = port.git(git_argv("rev-parse", "--path-format=absolute", "--git-common-dir"), cwd=cwd)
     if not common.ok:
         # --path-format landed in git 2.31; older git still answers the plain
         # form, relative to the repo root.
-        common = port.git(["rev-parse", "--git-common-dir"], cwd=cwd)
+        common = port.git(git_argv("rev-parse", "--git-common-dir"), cwd=cwd)
         if not common.ok:
             return None
         resolved = Path(_whole_path(root.stdout)) / _whole_path(common.stdout)
@@ -127,7 +133,7 @@ def _ref_exists(port: CommandPort, cwd: Path | None, ref: str) -> bool | None:
     when it could not look -- an unreadable ref store, a repository it will not
     open. Reading both as "not there" is how the report comes to state that the
     trunk no longer exists when nothing ever checked."""
-    result = port.git(["show-ref", "--verify", "--quiet", ref], cwd=cwd)
+    result = port.git(git_argv("show-ref", "--verify", "--quiet", name=ref), cwd=cwd)
     if result.ok:
         return True
     return False if result.returncode == 1 else None
@@ -164,7 +170,9 @@ def _published_trunk(
     published: dict[str, str] = {}
     unreadable: list[tuple[str, int]] = []
     for remote in remotes:
-        result = port.git(["symbolic-ref", "--quiet", f"refs/remotes/{remote}/HEAD"], cwd=cwd)
+        result = port.git(
+            git_argv("symbolic-ref", "--quiet", name=f"refs/remotes/{remote}/HEAD"), cwd=cwd
+        )
         if result.ok:
             name = _first_line(result.out).removeprefix(f"refs/remotes/{remote}/")
             if name:
@@ -417,7 +425,7 @@ def read_remotes(port: CommandPort, cwd: Path | None) -> tuple[tuple[str, ...] |
     in this module: git refuses to create a remote whose name holds a newline,
     and refuses to read a config key containing one, so no name it prints can
     span two lines."""
-    result = port.git(["remote"], cwd=cwd)
+    result = port.git(git_argv("remote"), cwd=cwd)
     if not result.ok:
         return None, (
             f"could not read this repository's remote list (exit {result.returncode}); no ref "
@@ -449,7 +457,7 @@ def read_fetch_refspecs(
     `\\n` in a value and would then split a single refspec across what a
     line-framed read calls two records. Each `-z` record is `key\\nvalue`, and
     a key holds no newline, so the first one in a record is the boundary."""
-    result = port.git(["config", "-z", "--get-regexp", r"^remote\..*\.fetch$"], cwd=cwd)
+    result = port.git(git_argv("config", "-z", "--get-regexp", r"^remote\..*\.fetch$"), cwd=cwd)
     if not result.ok and result.returncode > 1:
         return None, (
             f"could not read this repository's fetch refspecs (exit {result.returncode}); "
@@ -713,11 +721,11 @@ def list_worktrees(port: CommandPort, cwd: Path | None) -> WorktreeListing:
     it recorded every path. That costs nothing where `-z` answers, and where it
     does not it withholds one conclusion: that something absent from this
     listing is absent from the repository."""
-    framed = port.git(["worktree", "list", "--porcelain", "-z"], cwd=cwd)
+    framed = port.git(git_argv("worktree", "list", "--porcelain", "-z"), cwd=cwd)
     if framed.ok:
         blocks, dropped = _parse_worktrees(framed.stdout.split("\0"), framed=True)
         return WorktreeListing(tuple(blocks), (), dropped, framed)
-    plain = port.git(["worktree", "list", "--porcelain"], cwd=cwd)
+    plain = port.git(git_argv("worktree", "list", "--porcelain"), cwd=cwd)
     if not plain.ok:
         return WorktreeListing((), (), 0, plain, framed=False)
     blocks, dropped = _parse_worktrees(plain.stdout.splitlines(), framed=False)
@@ -836,7 +844,8 @@ def _count_dirt(port: CommandPort, path: Path) -> tuple[int, int, int] | None:
     to ``=all``. Measured on a 2.5 GB checkout the pair costs ~0.15s against
     ~0.02s, and returns 47,620 ignored files where the old pair returned 90."""
     status = port.git(
-        ["status", "--porcelain=v1", "--untracked-files=all", "--ignored=traditional"], cwd=path
+        git_argv("status", "--porcelain=v1", "--untracked-files=all", "--ignored=traditional"),
+        cwd=path,
     )
     if not status.ok:
         return None
@@ -1015,11 +1024,16 @@ def _merged_set(
 ) -> tuple[set[str], str | None]:
     """Branches the batch ancestry check calls merged, plus a warning when it
     would not run. An empty set only costs the cheap tier -- the per-branch
-    probes still answer -- so failure here degrades speed, not safety."""
-    args = ["branch", "--merged", base_ref, "--format=%(refname:short)"]
-    if remote:
-        args.insert(1, "-r")
-    result = port.git(args, cwd=cwd)
+    probes still answer -- so failure here degrades speed, not safety.
+
+    ``base_ref`` is the one repo-derived name here and it goes in as a plain
+    argument: it arrives as a full ref path, which is the spelling that needs no
+    terminator, and it could not have taken one anyway with a format argument
+    behind it."""
+    remote_only = ("-r",) if remote else ()
+    result = port.git(
+        git_argv("branch", *remote_only, "--merged", base_ref, "--format=%(refname:short)"), cwd=cwd
+    )
     if not result.ok:
         scope = "remote" if remote else "local"
         return set(), (
@@ -1035,8 +1049,14 @@ def _count_revs(port: CommandPort, cwd: Path | None, spec: str) -> int | None:
     None is load-bearing. Returning 0 for a failed count reads downstream as
     "nothing ahead of base", which resolves to ANCESTOR, which is proof of a
     merge -- so a transient failure would authorise deleting the branch it
-    failed on."""
-    result = port.git(["rev-list", "--count", spec], cwd=cwd)
+    failed on.
+
+    The range is one argument with two revs inside it, so it goes in whole
+    rather than as a terminated name -- `rev-list` spends `--` on a pathspec,
+    and counting commits that touched a path is not this question. What keeps
+    it from being read as an option is the spelling of the rev it opens with,
+    which the callers settle before composing it."""
+    result = port.git(git_argv("rev-list", "--count", spec), cwd=cwd)
     if not result.ok:
         return None
     try:
@@ -1063,7 +1083,10 @@ def _unpushed_count(
     ``name`` is what a reader is told and ``spec`` is what git is asked. They
     are the same string in every ordinary repository and come apart in the one
     that made this distinction necessary, so the two roles are separate
-    parameters rather than one value used for both."""
+    parameters rather than one value used for both. ``upstream`` splits the same
+    way: the sentences below spell it as a reader knows it, and the range below
+    those opens with it, which is the position an option-shaped name would be
+    read from -- so that one copy is spelled by the rev constructor."""
     if not upstream:
         return None, None
     if not track:
@@ -1073,7 +1096,7 @@ def _unpushed_count(
         )
     if ">" not in track:
         return 0, None
-    count = _count_revs(port, cwd, f"{upstream}..{spec}")
+    count = _count_revs(port, cwd, f"{git_rev(upstream)}..{spec}")
     if count is None:
         return None, (
             f"could not count the commits on {name} missing from {upstream}; "
@@ -1088,10 +1111,11 @@ def _patch_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str) 
     probe errored: `git cherry` has no exit code meaning "no", so a non-zero
     exit is always a question that went unanswered rather than an answer of
     not-equivalent."""
-    # `--` because the branch name is repo-derived: `refs/heads/-m` is a
-    # perfectly legal ref that plumbing and remotes can both create, and
-    # without the terminator `git cherry` reads it as a switch and errors.
-    result = port.git(["cherry", base_ref, "--", name], cwd=cwd)
+    # The branch name is repo-derived, so it reaches git through the argv
+    # constructor: `refs/heads/-m` is a perfectly legal ref that plumbing and
+    # remotes can both create, and unterminated `git cherry` reads it as a
+    # switch and errors.
+    result = port.git(git_argv("cherry", base_ref, name=name), cwd=cwd)
     if not result.ok:
         return None
     lines = [line for line in result.stdout.splitlines() if line.strip()]
@@ -1118,28 +1142,23 @@ def _squash_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str)
 
     A name beginning with `-` -- `refs/heads/-m` is a legal ref that
     `update-ref` or a remote push can create -- is otherwise read by git as a
-    switch. `--` genuinely terminates `merge-base`'s option parsing, so it is
-    applied unconditionally, matching every other probe in this module.
-    `rev-parse` has no terminator that survives here: both `--` and
-    `--end-of-options` are echoed back as a literal output line rather than
-    consumed, so the tree lookup instead names the branch by its full ref path
-    when the short name would otherwise be misread -- a path never begins with
-    `-`. That substitution is conditional, not unconditional like the one
-    above: a remote-tracking branch's short name always carries its remote
-    first (`origin/feat`, never bare `feat`) and already resolves correctly,
-    while `refs/heads/` would be the wrong prefix for it."""
-    base = port.git(["merge-base", base_ref, "--", name], cwd=cwd)
+    switch, and this tier is where both spellings that survive that are needed
+    at once. `merge-base` takes the name as an argument of its own, so the argv
+    constructor terminates it. The tree lookup composes the name into a rev
+    expression instead, where nothing can be terminated, so it goes through the
+    rev constructor beside it -- and both decisions live there rather than
+    here."""
+    base = port.git(git_argv("merge-base", base_ref, name=name), cwd=cwd)
     if base.returncode == 1:
         # git's own answer, not a failed read: these histories share no commit,
         # so there is no base to replay the tree onto and no squash to find.
         return False
     if not base.ok or not base.out:
         return None
-    ref = f"refs/heads/{name}" if name.startswith("-") else name
-    tree = port.git(["rev-parse", f"{ref}^{{tree}}"], cwd=cwd)
+    tree = port.git(git_argv("rev-parse", f"{git_rev(name)}^{{tree}}"), cwd=cwd)
     if not tree.ok or not tree.out:
         return None
-    base_tree = port.git(["rev-parse", f"{_first_line(base.out)}^{{tree}}"], cwd=cwd)
+    base_tree = port.git(git_argv("rev-parse", f"{_first_line(base.out)}^{{tree}}"), cwd=cwd)
     if not base_tree.ok or not base_tree.out:
         return None
     if _first_line(base_tree.out) == _first_line(tree.out):
@@ -1152,12 +1171,19 @@ def _squash_equal(port: CommandPort, cwd: Path | None, base_ref: str, name: str)
         # commits are the only copy of the work they hold.
         return False
     synthetic = port.git(
-        ["commit-tree", _first_line(tree.out), "-p", _first_line(base.out), "-m", "gitclean-probe"],
+        git_argv(
+            "commit-tree",
+            _first_line(tree.out),
+            "-p",
+            _first_line(base.out),
+            "-m",
+            "gitclean-probe",
+        ),
         cwd=cwd,
     )
     if not synthetic.ok or not synthetic.out:
         return None
-    cherry = port.git(["cherry", base_ref, _first_line(synthetic.out)], cwd=cwd)
+    cherry = port.git(git_argv("cherry", base_ref, _first_line(synthetic.out)), cwd=cwd)
     if not cherry.ok:
         return None
     lines = [line for line in cherry.stdout.splitlines() if line.strip()]
@@ -1188,7 +1214,7 @@ def _pr_covers_tip(port: CommandPort, cwd: Path | None, pr: PullRequest, head: s
         return None
     if pr.head_oid == head:
         return True
-    result = port.git(["merge-base", "--is-ancestor", head, pr.head_oid], cwd=cwd)
+    result = port.git(git_argv("merge-base", "--is-ancestor", head, pr.head_oid), cwd=cwd)
     if result.ok:
         return True
     return False if result.returncode == 1 else None
@@ -1279,10 +1305,10 @@ def _advertised_heads(
     reading the column rather than searching the line is what keeps an
     unrelated `a/feat/x` from answering for `feat/x`.
 
-    Two separate protections, and it is worth not confusing them. `--` ends
-    option parsing, which is what keeps a branch or remote named like a flag
-    from being read as one. It does *not* stop git accepting a path in the
-    repository position -- nothing does.
+    Two separate protections, and it is worth not confusing them. The
+    terminator the argv constructor applies ends option parsing, which is what
+    keeps a branch or remote named like a flag from being read as one. It does
+    *not* stop git accepting a path in the repository position -- nothing does.
 
     What covers that is where `remote` comes from: the decomposition against
     the configured remote list, so the only names reaching here are ones git
@@ -1290,7 +1316,7 @@ def _advertised_heads(
     is not rejected -- a sibling directory of that name that happens to be a
     repository is opened instead and answers, well-formed, empty, and about
     somebody else entirely. An empty answer here means every branch is gone."""
-    result = port.git(["ls-remote", "--heads", "--", remote], cwd=cwd)
+    result = port.git(git_argv("ls-remote", "--heads", name=remote), cwd=cwd)
     if not result.ok:
         return None, (
             f"could not ask {remote} which branches it still has (exit {result.returncode}); "
@@ -1382,7 +1408,7 @@ def read_branches(
     travel because both leave a spelling a caller might use matching nothing,
     and a miss that means nothing must never settle as absence."""
     result = port.git(
-        ["for-each-ref", f"--format={_REF_FORMAT}", "refs/heads", "refs/remotes"], cwd=cwd
+        git_argv("for-each-ref", f"--format={_REF_FORMAT}", "refs/heads", "refs/remotes"), cwd=cwd
     )
     if not result.ok:
         return (
@@ -1576,12 +1602,16 @@ def _worktree_activity(
     created ten seconds ago at a two-year-old tag reports a two-year-old
     timestamp. Nothing judges on it, which is why the discrepancy is tolerable
     -- it is a fact for a reader, and no rule reads it. If anything ever does,
-    this is the wrong measurement for it."""
+    this is the wrong measurement for it.
+
+    The head is an object id git printed, and it goes in as a plain argument: an
+    object id cannot begin with `-`, and `show` spends `--` on a pathspec, so a
+    terminator here would ask for a date filtered by a path of that name."""
     if worktree.branch:
         return activity_by_branch.get(worktree.branch)
     if worktree.prunable or not worktree.head:
         return None
-    result = port.git(["show", "-s", "--format=%cI", worktree.head], cwd=cwd)
+    result = port.git(git_argv("show", "-s", "--format=%cI", worktree.head), cwd=cwd)
     return _first_line(result.out) if result.ok else None
 
 
@@ -1606,7 +1636,7 @@ def survey(port: CommandPort, *, cwd: Path | None = None) -> Survey | str:
     default_branch = resolved_default if resolved_default is not None else "main"
     base_ref, base_ref_warning = resolve_base_ref(port, cwd, default_branch, remotes, trunk_remote)
 
-    head = port.git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd)
+    head = port.git(git_argv("rev-parse", "--abbrev-ref", "HEAD"), cwd=cwd)
     current = _first_line(head.out) if head.ok else None
     if current == "HEAD":
         current = None

--- a/packages/gitclean/tests/unit/test_execute.py
+++ b/packages/gitclean/tests/unit/test_execute.py
@@ -6,15 +6,12 @@ successes, which is why every deletion re-asks."""
 
 from __future__ import annotations
 
-import ast
 from datetime import UTC, datetime
-from pathlib import Path
 
 from conftest import make_branch, make_survey, make_worktree
 from test_survey import porcelain
 
-from gitclean import execute
-from gitclean.execute import SALVAGE_PREFIX, Executor, default_salvage_dir, git_argv, slug
+from gitclean.execute import SALVAGE_PREFIX, Executor, default_salvage_dir, slug
 from gitclean.model import MergeEvidence, Plan, Target, TargetKind
 from gitclean.ports import CommandResult, ScriptedCommands, fail, ok
 
@@ -856,48 +853,6 @@ def test_an_unrelated_branch_still_deletes_when_a_worktree_fails() -> None:
 
 
 # -- helpers -----------------------------------------------------------------
-
-
-def test_every_git_call_is_assembled_by_the_one_argv_constructor() -> None:
-    """The terminator used to be a habit applied call site by call site, and
-    the two sites that forgot it were the two nobody could type by hand: a
-    bundle of a ref named `-m`, and a survival probe for one. Neither shows up
-    in review as a missing argument -- it looks exactly like the sites that
-    were right.
-
-    So the property is asserted over the module rather than over one call: a
-    site that builds its own argument list is the failure, whatever that list
-    happens to contain today."""
-    tree = ast.parse(Path(execute.__file__).read_text(encoding="utf-8"))
-    unrouted = [
-        ast.unparse(node)
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and ast.unparse(node.func).endswith("_port.git")
-        and not (
-            node.args
-            and isinstance(node.args[0], ast.Call)
-            and ast.unparse(node.args[0].func) == "git_argv"
-        )
-    ]
-    assert unrouted == []
-
-
-def test_the_constructor_terminates_a_name_git_would_read_as_an_option() -> None:
-    assert git_argv("branch", "-D", name="-m") == ["branch", "-D", "--", "-m"]
-
-
-def test_the_constructor_leaves_a_full_ref_path_unterminated() -> None:
-    """`bundle create` hands its arguments to rev-list, where `--` introduces a
-    pathspec: terminating there produces `Refusing to create empty bundle`
-    rather than protection. A `refs/...` path needs no terminator -- no git
-    command reads one as an option."""
-    assert git_argv("bundle", "create", "/salvage/x.bundle", name="refs/heads/-m") == [
-        "bundle",
-        "create",
-        "/salvage/x.bundle",
-        "refs/heads/-m",
-    ]
 
 
 def test_slug_is_filesystem_safe_and_readable() -> None:

--- a/packages/gitclean/tests/unit/test_ports.py
+++ b/packages/gitclean/tests/unit/test_ports.py
@@ -2,22 +2,109 @@
 
 The real port's job is to turn every way a command can go wrong into a
 CommandResult rather than an exception, because the layers above it report
-anomalies and must never be interrupted by one."""
+anomalies and must never be interrupted by one.
+
+The argv constructors are tested here for the same reason they live here: the
+rule they carry is about everything this package hands to git, not about one of
+the modules that does the handing."""
 
 from __future__ import annotations
 
+import ast
 import subprocess
 from pathlib import Path
 
 import pytest
 
+import gitclean
 from gitclean.ports import (
     CommandResult,
     ScriptedCommands,
     SubprocessCommands,
     fail,
+    git_argv,
+    git_rev,
     ok,
 )
+
+# -- the argv constructors ---------------------------------------------------
+
+
+def test_every_git_call_in_the_package_is_assembled_by_the_one_argv_constructor() -> None:
+    """The terminator used to be a habit applied call site by call site, and
+    the sites that forgot it were the ones nobody could type by hand: a bundle
+    of a ref named `-m`, and a survival probe for one. Neither shows up in
+    review as a missing argument -- it looks exactly like the sites that were
+    right.
+
+    So the property is asserted over every module in the package, not over one
+    call and not over one file. Checking only the module the known defects
+    happened to land in is the same judgement that missed them: the next probe
+    goes wherever the next question is asked, and a file nobody remembered to
+    add here would be covered by nothing at all."""
+    package = Path(gitclean.__file__).parent
+    unrouted: list[str] = []
+    asking: set[str] = set()
+    for module in sorted(package.glob("*.py")):
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and ast.unparse(node.func).endswith(".git")):
+                continue
+            asking.add(module.name)
+            if not (
+                node.args
+                and isinstance(node.args[0], ast.Call)
+                and ast.unparse(node.args[0].func) == "git_argv"
+            ):
+                unrouted.append(f"{module.name}: {ast.unparse(node)}")
+
+    assert unrouted == []
+    # Not vacuous. A glob that matched nothing, or a module renamed out from
+    # under this, leaves an empty list to compare and passes on having looked
+    # at no code -- so the two files that do ask git are named.
+    assert {"survey.py", "execute.py"} <= asking
+
+
+def test_the_constructor_terminates_a_name_git_would_read_as_an_option() -> None:
+    assert git_argv("branch", "-D", name="-m") == ["branch", "-D", "--", "-m"]
+
+
+def test_the_constructor_leaves_a_full_ref_path_unterminated() -> None:
+    """`bundle create` hands its arguments to rev-list, where `--` introduces a
+    pathspec: terminating there produces `Refusing to create empty bundle`
+    rather than protection. A `refs/...` path needs no terminator -- no git
+    command reads one as an option."""
+    assert git_argv("bundle", "create", "/salvage/x.bundle", name="refs/heads/-m") == [
+        "bundle",
+        "create",
+        "/salvage/x.bundle",
+        "refs/heads/-m",
+    ]
+
+
+def test_a_command_carrying_no_name_comes_through_unchanged() -> None:
+    """Which is what makes the rule checkable: every git call goes through the
+    constructor, so a new one has nowhere else to put a name."""
+    assert git_argv("worktree", "list", "--porcelain", "-z") == [
+        "worktree",
+        "list",
+        "--porcelain",
+        "-z",
+    ]
+
+
+def test_a_rev_spelling_names_an_option_shaped_branch_by_its_full_path() -> None:
+    """A rev expression has no argument of its own to terminate, so the name
+    inside it is spelled as a path instead."""
+    assert f"{git_rev('-m')}^{{tree}}" == "refs/heads/-m^{tree}"
+
+
+def test_a_rev_spelling_leaves_a_name_git_reads_correctly_alone() -> None:
+    """`refs/heads/` is the wrong prefix for a remote-tracking branch, and its
+    short name leads with its remote, so it is already unambiguous."""
+    assert git_rev("origin/feat") == "origin/feat"
+    assert git_rev("feat") == "feat"
+
 
 # -- CommandResult -----------------------------------------------------------
 


### PR DESCRIPTION
## What was open

`gitclean` holds a rule that every repository-derived name reaching git is spelled by one argv constructor, so a branch named like an option cannot be read as a switch. The test enforcing it, `test_every_git_call_is_assembled_by_the_one_argv_constructor`, parsed `execute.py` and nothing else. `survey.py` — the read stage, and the file where the next probe will be added — issued 19 git calls with argument lists it assembled itself.

Three of those carried a repo-derived name and spelled it correctly by hand. That is worth being precise about: **no capability was broken.** `test_a_squash_merged_branch_named_like_an_option_is_proven` already proves a squash-merged `-m` today, and it passes on `main`. What was missing is the guard over the file, so the next probe added there would have been protected by nothing.

## What changed

**The constructor moved to the seam.** `git_argv` lived in `execute.py`, which imports from `survey.py` — so `survey.py` could not import it back. It now lives in `ports.py`, the module that hands argv to the process and imports nothing else in the package.

**A companion constructor, `git_rev`, for the case `git_argv` cannot express.** A name composed into a rev expression (`<rev>^{tree}`, `<a>..<b>`) has no argument of its own to terminate, and `rev-parse` does not consume `--` or `--end-of-options` at all — it echoes them back as output. The surviving protection is the full ref path, applied inside the expression, and only when the short name would otherwise be misread. This is the decision `_squash_equal` was already making inline; it now has a name and a docstring.

**Converted — all 19 `port.git` calls in `survey.py`.** Four carried a repo-derived name:

| call | before | after |
|---|---|---|
| `_patch_equal` | `["cherry", base_ref, "--", name]` | `git_argv("cherry", base_ref, name=name)` |
| `_squash_equal` | `["merge-base", base_ref, "--", name]` | `git_argv("merge-base", base_ref, name=name)` |
| `_squash_equal` | `f"refs/heads/{name}" if name.startswith("-") else name` | `git_rev(name)` |
| `_unpushed_count` | `f"{upstream}..{spec}"` | `f"{git_rev(upstream)}..{spec}"` |

The first three are the sites the task named; each produces a byte-identical argv. The fourth was found on the way: `%(upstream:short)` opens that range, which is the position an option-shaped name is read from, and it had no protection. The spelling is unchanged for every name that does not begin with `-`, so nothing moves in an ordinary repository.

The other 15 calls were rewritten to `git_argv(...)` with no name, which is what makes the rule checkable — a new call site has nowhere else to put one.

**Deliberately left as plain arguments,** with the reason stated at each site: `rev-list --count <range>`, `show -s --format=%cI <oid>`, `commit-tree`, `cherry <base> <oid>`, `merge-base --is-ancestor <oid> <oid>`, and `base_ref` in `branch --merged`. Two reasons, both load-bearing. Those commands spend `--` on a pathspec, so terminating there would ask a different question rather than protect anything — and object ids cannot begin with `-`, while `base_ref` arrives from `resolve_base_ref` as a full ref path, which is already the protected spelling. `base_ref` also sits mid-argv, where a terminator would cover the wrong arguments.

The two `port.gh` calls are untouched: the only name they carry is the PR number the caller typed.

**The guard was widened** and moved to `tests/unit/test_ports.py`, beside the constructor. It now walks every `*.py` in the package rather than one named file, so a module added later is covered without anyone remembering to extend the test, and it reports the offending module name with the call. It also asserts that `survey.py` and `execute.py` were both seen asking git — a glob that stops matching would otherwise leave an empty list to compare and pass on having read no code.

**No exemptions.** Every git call routes, so no exemption mechanism was added; an unused registry is the kind of machinery this package's own rules reject.

## Evidence

**The mutation, both directions.** Dropping the terminator from `_patch_equal` (`["cherry", base_ref, name]`):

- before this change — `pytest -k every_git_call` **passes** (exit 0). The gap.
- after this change — **fails** (exit 1), reporting ``survey.py: port.git(['cherry', base_ref, name], cwd=cwd)``.

Restored in both cases.

**Differential report.** `gitclean --report` over `agents-config`, run twice seconds apart against the same tree: once with `origin/main`'s package extracted to a scratch directory, once with this branch. **Byte-identical JSON** — 63 targets, 38 branches, 25 worktrees, and a merge-evidence distribution of `ancestor: 26, squash_equal: 8, patch_equal: 2, pr_merged: 2, none: 25`, so the converted probes were exercised rather than skipped. An earlier attempt that stashed the change instead showed one diff — my own worktree's dirt count, since stashing cleaned it — which is what prompted running both captures against identical tree state.

**Suite.** 509 passed before, 512 after. The collected node ids differ by exactly six lines: the three constructor tests moved from `test_execute.py` to `test_ports.py` (one renamed to say it reads the package), plus three new ones covering the no-name path and both `git_rev` branches. Nothing was lost.

**Gate.** `make ci-gitclean` from the worktree root, run standalone: **exit 0**, 512 passed, 98.13% coverage.

## Found, not fixed

`_unpushed_count` measures against `%(upstream:short)`. That is the same shadowing exposure `resolve_base_ref` argues at length about for the base ref — git resolves `refs/heads/` before `refs/remotes/`, so a local branch named `origin/feat` would answer for the server's ref — and the full `%(upstream)` refname is already read in the same loop. Changing which ref that probe reads would change merge verdicts, which this PR is committed to not doing, so it is left alone and reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk
