### PR TITLE
fix(9k9.53.7.2.4): a named deletion is carried out and reported, not re-adjudicated

### DIFF
--- a/packages/gitclean/AGENTS.md
+++ b/packages/gitclean/AGENTS.md
@@ -119,25 +119,24 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   conclusion, and the cost lands as a deletion not made rather than as a lie.
   Adding an exclusion to `read_branches` without adding its `NotOffered` record
   reintroduces this defect silently.
-- **With one exception, and know why it is there.** git's refusals cover
+- **No exception to that, and an obligation in its place.** git's refusals cover
   uncommitted content; they say nothing about a commit made inside a worktree
   on no branch. That tree is clean, git removes it happily, and the record it
   deletes is what held the commit — the per-worktree reflog dies with it, so
-  there is no undo. Before removing a worktree the executor asks git whether
-  any ref contains that commit and declines when none does. **It asks about
-  the commit the tree holds now, re-read as the deletion happens, not the one
-  the survey recorded.** Every other guard on that path is git's own and is
-  taken at that moment; this one is ours, so it is taken then too. A commit
-  made in the tree after the survey ran is held by the record about to be
-  deleted and by nothing else, while the commit it replaced sits on a branch
-  and answers "contained" — so asking about the surveyed commit is not a
-  weaker check, it is the wrong one, and it clears in the exact case it exists
-  to refuse. This is the one
-  place a named target is refused on reachability grounds, and it is not a
-  precedent for re-deriving anything else: it exists because "the reflog is
-  the undo" — the argument that retired salvage everywhere else — is simply
-  false here. Do not generalise it, and do not remove it without replacing
-  the guarantee.
+  there is no undo. That is a cost the caller is owed a report of, not a
+  deletion this tool declines: the removal proceeds, and the row for that
+  worktree names the commit and the command that keeps it before git collects
+  the object. **The probe asks about the commit the tree holds now, re-read as
+  the deletion happens, not the one the survey recorded.** A commit made in the
+  tree after the survey ran is held by the record about to be deleted and by
+  nothing else, while the commit it replaced sits on a branch and answers
+  "contained" — so a disclosure built from the surveyed commit is not a smaller
+  one, it is about the wrong commit, and it reports nothing at risk in the
+  exact case where something is. A probe that would not answer is disclosed as
+  unknown rather than resolved either way, for the same reason `None` never
+  authorises anything here. Removing a refusal is not licence to go quiet:
+  saying what a deletion cost blocks nothing, and it is the whole of what
+  survives here.
 - **Never add a merge check that relies on ancestry alone.** `git branch
   --merged` is wrong in both directions under squash merges. New evidence goes
   in as a tier in `_resolve_merge` with its own `MergeEvidence` member, so the
@@ -152,7 +151,12 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   salvage that does not restore is an anomaly carrying the transcript, is
   recorded as no salvage, and leaves the target alone. Unbundling is not a
   substitute — it reports success on exactly the bundle that will not clone.
-- **Verify every deletion by re-asking git.** Exit codes are claims.
+- **A deletion git performed is reported as done; a server ref is asked twice.**
+  For a branch or a worktree, the command that made the deletion is the report,
+  and re-asking afterwards only creates a way to call a deletion that happened
+  one that did not. The server is where an exit code answers a different
+  question than the one asked — `push --delete` can exit 0 against a ref the
+  remote kept — so that one is queried again.
 - **Anomalies carry `CommandResult.transcript()`.** An agent reading the output
   must be able to remediate without re-running anything. Never summarise a
   failure into prose that drops the argv.
@@ -194,10 +198,12 @@ ports.py  →  survey.py  →  classify.py  →  plan.py  →  execute.py  →  
   cherry-picked onto the trunk -- so a bare sweep that strands anything else
   fails a test written before the shape existed. Remotes are guarded with no
   allowance at all, because a bare sweep never reaches a server. What that
-  leaves unmeasured is the deletion a caller *names*: the executor's check that
-  some ref contains a worktree's commit is only reachable that way, since a
-  commit no ref holds carries no merge proof and the sweep withholds it long
-  before the executor is asked. Removing that check passes the entire generated
-  corpus and fails exactly one enumerated test. Both suites stay: the matrix
-  names the shapes worth stating outright, and the draw finds the ones nobody
-  would have.
+  leaves unmeasured is the deletion a caller *names*: the executor's probe for
+  whether some ref contains a worktree's commit is only reachable that way,
+  since a commit no ref holds carries no merge proof and the sweep withholds it
+  long before the executor is asked. That is also why the one test whose block
+  deliberately strands a commit is a named deletion, and why it declares that
+  commit to the guard by name -- the generated corpus would pass with the
+  disclosure gone, and the enumerated test is what fails. Both suites stay: the
+  matrix names the shapes worth stating outright, and the draw finds the ones
+  nobody would have.

--- a/packages/gitclean/README.md
+++ b/packages/gitclean/README.md
@@ -99,17 +99,18 @@ Without `gh` on PATH there is no squash signal at all. That is reported in
   survey read it. Overriding them would mean re-implementing every one of those
   checks in Python. A person who has read git's complaint and still wants the
   tree gone runs one `git worktree remove --force` themselves.
-- **A removal that would strand a commit is declined.** git's refusals cover
+- **A removal that strands a commit says so.** git's refusals cover
   *uncommitted* content and know nothing about a commit made inside a worktree
   on no branch: that tree is clean, so git removes it without complaint, and
   the administrative record it deletes is the only thing holding that commit —
   the per-worktree reflog goes with it. So before removing a worktree the tool
   asks git whether any ref contains the commit that tree holds *now* — re-read
-  as the deletion happens, not taken from the survey — and declines when none
-  does, naming the commit and how to keep it. A commit made in that tree since
-  the survey ran is exactly the one at risk, and the surveyed commit it
-  replaced would have answered for it. Naming a target authorises deleting a
-  checkout; it should not quietly spend a commit.
+  as the deletion happens, not taken from the survey, because a commit made in
+  that tree since is exactly the one at risk and the surveyed commit it
+  replaced would have answered for it. The removal proceeds either way, and
+  where no ref holds it the row for that worktree names the commit and the one
+  command that keeps it before git collects the object. Naming a target
+  authorises deleting a checkout; what it costs is reported, not adjudicated.
 - **Salvage is kept only where there is no reflog** — a ref on the server. It
   becomes a `git bundle` before the delete, and what earns the delete is a
   restore, not an inspection: the bundle is cloned into an empty directory and
@@ -127,8 +128,12 @@ Without `gh` on PATH there is no squash signal at all. That is reported in
   your local `refs/remotes` cache. The delete carries `--force-with-lease`, so
   if the server moved since your last fetch it is rejected rather than taking
   commits nobody surveyed.
-- **Every deletion is verified by re-asking git.** A zero exit code is a claim,
-  not a fact. A ref that survives becomes an anomaly, not a success line.
+- **A deletion git made is reported as made, and a server ref is asked about
+  twice.** For a branch or a worktree, git's own account of what it just did is
+  the outcome — a second opinion could only turn a deletion that happened into
+  a row saying it had not. On a server that reasoning does not hold: `git push
+  --delete` can exit 0 against a ref the remote kept, so that ref is queried
+  again and a survivor becomes an anomaly rather than a success line.
 - **Anomalies carry the transcript** — argv, exit code, both streams — so a
   reader can remediate without re-running anything.
 - **Omissions are named.** A target the sweep selected and then dropped is
@@ -196,7 +201,7 @@ because the argument parser claims `-m` as a flag first: select it by its
 | 0 | clean |
 | 1 | something was refused (`plan.refused[]`, or `refusal` for a whole-run one) — other named targets may still have been deleted |
 | 2 | unusable (not a repository, bad arguments) |
-| 3 | acted, but something surprised us (see `execution.anomalies`) |
+| 3 | a deletion was attempted and did not complete (see `execution.anomalies`) |
 
 ## Scope
 

--- a/packages/gitclean/src/gitclean/cli.py
+++ b/packages/gitclean/src/gitclean/cli.py
@@ -74,8 +74,8 @@ and none of them is, so saying "already gone" about them would be a false report
 
 one refusal does not stop the others. Whatever resolved cleanly is still deleted, each
 refusal is reported in `plan.refused` with its own code and remedy, and the run exits 1
-for having raised any -- so a single mistyped name no longer costs a whole re-run. An
-unverified deletion still outranks it and exits 3.
+for having raised any -- so a single mistyped name no longer costs a whole re-run. A
+deletion that was attempted and did not complete still outranks it and exits 3.
 
 what --after-merge takes:
   the local branch a pull request was opened from, and the worktree holding it -- each
@@ -442,9 +442,9 @@ def main(
         stream,
     )
     # An anomaly outranks a refusal. A refusal is the tool declining to act and
-    # leaving the repository as it found it; an anomaly is a deletion that ran
-    # and could not be confirmed afterwards, which is the one outcome a reader
-    # must not have hidden behind the milder code.
+    # leaving the repository as it found it; an anomaly is a deletion this run
+    # attempted and did not complete, which is the one outcome a reader must
+    # not have hidden behind the milder code.
     if not execution.ok:
         return EXIT_ANOMALY
     return EXIT_REFUSED if outcome.refused else EXIT_OK

--- a/packages/gitclean/src/gitclean/execute.py
+++ b/packages/gitclean/src/gitclean/execute.py
@@ -18,10 +18,14 @@ object already, and answers yes for bundles that clone back empty and for
 bundles that will not clone at all. A salvage that does not restore is reported
 as an anomaly, recorded as no salvage, and aborts its deletion.
 
-**Every deletion is verified by re-asking git.** A zero exit code is a claim,
-not a fact -- `git push --delete` in particular can exit 0 against a ref the
-server kept. So the ref is queried again afterwards, and a survivor becomes an
-anomaly rather than a line in the success list.
+**A deletion git performed is reported as done.** git's own account of a
+deletion it just made is the answer, and re-asking afterwards is a second
+opinion this tool has no standing to hold: a probe that errors would turn a
+removal that happened into a row saying it did not. The server is the one place
+that reasoning does not reach, because there the exit code answers a different
+question than the one that matters -- `git push --delete` can exit 0 against a
+ref the remote kept -- so that ref alone is queried again, and a survivor
+becomes an anomaly rather than a line in the success list.
 
 **Anomalies carry the transcript.** Whoever reads this output must be able to
 remediate without re-running anything, so the argv, exit code, and both
@@ -38,7 +42,6 @@ from pathlib import Path
 
 from gitclean.model import Anomaly, Deletion, Plan, SalvageRecord, Survey, Target, TargetKind
 from gitclean.ports import CommandPort, git_argv
-from gitclean.survey import list_worktrees
 
 SALVAGE_PREFIX = "gitclean-salvage"
 """Where the scratch branch a bundle is taken from lives. Namespaced so the
@@ -247,24 +250,22 @@ class Executor:
     def _head_now(self, target: Target, surveyed: str) -> str:
         """What the worktree holds at this moment, not when the survey read it.
 
-        Every other guard on this path is git's own, taken as the deletion
-        happens, because that is the only moment that describes the disk. This
-        one is ours, so it is taken then too. A commit made in that tree after
-        the survey ran is held by the record about to be deleted and by nothing
-        else -- while the commit it replaced, the one the survey recorded, is
-        sitting safely on some branch and answers the containment question
-        yes. Asking about the stale commit is therefore not a smaller check,
-        it is the wrong check, and it clears exactly when it should refuse.
+        This decides which commit the removal discloses, and the survey is the
+        wrong source for it. A commit made in that tree after the survey ran is
+        held by the record about to be deleted and by nothing else, while the
+        commit it replaced -- the one the survey recorded -- is sitting on some
+        branch and answers the containment question yes. Reading the stale
+        commit would therefore report nothing at risk in exactly the case where
+        something is.
 
-        If git will not say, the surveyed commit is the better of the two
-        remaining answers: stale evidence still refuses far more often than no
-        evidence does."""
+        If git will not say what the tree holds now, the surveyed commit is the
+        only other answer available, and it still names work the removal is
+        about to put out of reach."""
         live = self._port.git(git_argv("rev-parse", "HEAD"), cwd=Path(target.name))
         return live.out if live.ok and live.out else surveyed
 
-    def _commit_only_this_worktree_holds(self, target: Target) -> tuple[str, tuple[str, ...]]:
-        """The commit that removing this worktree would strand, or "", with the
-        transcript of whatever git said when asked.
+    def _commit_only_this_worktree_holds(self, target: Target) -> tuple[str, bool | None]:
+        """The commit this worktree holds, and whether any ref contains it.
 
         git's refusals are the safety story for a named worktree, and they have
         exactly one gap: they know about *uncommitted* content and nothing
@@ -274,25 +275,26 @@ class Executor:
         deleted is what held HEAD, and the per-worktree reflog dies in the same
         step. No ref, no reflog, no undo.
 
-        So the question git cannot answer is asked of git directly: does any
-        ref contain this commit? Not "does it look abandoned", not "is the
-        tree clean" -- reachability, which is the thing that actually decides
-        whether deleting is recoverable. A worktree on a branch answers yes
-        through that branch and is unaffected.
+        That is a cost the caller is owed a report of, not a deletion this tool
+        gets to decline: naming the tree is the authorisation. So the question
+        git cannot answer for itself is asked of git directly -- does any ref
+        contain this commit? -- and the answer is disclosed rather than acted
+        on. A worktree on a branch answers yes through that branch and costs
+        nothing.
 
-        A probe that does not answer is treated as a stranding. The cost of
-        being wrong that way is a worktree someone removes by hand; the cost
-        of being wrong the other way is the commit."""
+        ``None`` is a probe that would not answer, and it stays distinct from
+        ``False``: saying no ref contains a commit is a measurement, and a
+        failed probe never made it."""
         surveyed = next((w for w in self._survey.worktrees if w.path == target.name), None)
         if surveyed is None:
-            return "", ()
+            return "", True
         head = self._head_now(target, surveyed.head)
         if not head:
-            return "", ()
+            return "", True
         refs = self._port.git(
             git_argv("for-each-ref", "--count=1", f"--contains={head}"), cwd=self._cwd
         )
-        return ("", refs.transcript()) if refs.ok and refs.out else (head, refs.transcript())
+        return (head, bool(refs.out)) if refs.ok else (head, None)
 
     def _delete_worktree(self, target: Target) -> Deletion:
         """Remove the worktree and let git's own interlocks stand.
@@ -311,20 +313,10 @@ class Executor:
         Ignored files do not trigger the refusal, so removing a finished
         worktree full of caches is unaffected.
 
-        There is one thing git's refusals do not cover, and it is added below
-        rather than assumed away."""
-        stranded, probe = self._commit_only_this_worktree_holds(target)
-        if stranded:
-            self._record(
-                "delete",
-                target.id,
-                f"removing {target.name} would strand commit {stranded[:8]}, which no ref "
-                f"contains; nothing was deleted. Keep it with "
-                f"`git branch <name> {stranded[:8]}` and re-run, or discard it deliberately "
-                f"with `git worktree remove --force {target.name}`",
-                probe,
-            )
-            return _failed(target, f"would strand commit {stranded[:8]}")
+        There is one thing git's refusals do not cover -- a commit the tree
+        holds on no branch -- and the removal proceeds anyway, carrying what it
+        cost on its own row."""
+        held, contained = self._commit_only_this_worktree_holds(target)
         removal = self._port.git(git_argv("worktree", "remove", name=target.name), cwd=self._cwd)
         if not removal.ok:
             self._record(
@@ -339,77 +331,27 @@ class Executor:
         # every worktree whose directory has gone missing, and those were never
         # planned targets: the executor acts on what the plan named, and
         # nothing else. `worktree remove` takes this one's record with it.
-        # The same framed read the survey uses, because the comparison here is
-        # against a whole path: a listing split on newlines answers "not there"
-        # for a worktree whose path contains one, which is the removal
-        # reporting itself successful by failing to spell what it looked for.
-        listing = list_worktrees(self._port, self._cwd)
-        if not listing.ok or listing.dropped or not listing.can_place(target.name):
-            # Absence of the worktree in output that was never produced -- or
-            # that lost a record on the way, or that cannot show it named this
-            # path in full -- is not evidence of anything. Unverified is its own
-            # outcome, distinct from verified-gone.
-            #
-            # `can_place` rather than the listing's framing outright: the path
-            # in question is known here, and one with no newline in it cannot be
-            # the truncated record. Refusing to confirm every removal on a git
-            # without `-z` would turn each of them into an anomaly and buy
-            # nothing.
-            self._record(
-                "verify",
-                target.id,
-                f"could not confirm {target.name} is gone; the removal reported success",
-                listing.result.transcript(),
-            )
-            return _failed(target, "deletion unverified")
-        if listing.holds(target.name):
-            self._record(
-                "verify",
-                target.id,
-                f"worktree {target.name} still appears in `git worktree list` after removal",
-                listing.result.transcript(),
-            )
-            return _failed(target, "still present after removal")
         return Deletion(
             target_id=target.id,
             kind=target.kind,
             name=target.name,
             deleted=True,
             verified=True,
-            detail="worktree removed",
+            detail=_removal_detail(held, contained),
         )
 
     def _delete_branch(self, target: Target) -> Deletion:
+        """`branch -D`, and what it says about itself is the outcome.
+
+        The commits stay in the reflog for git's configured expiry, so the one
+        thing a second opinion could add here is a way to report a deletion
+        that happened as one that did not."""
         removal = self._port.git(git_argv("branch", "-D", name=target.name), cwd=self._cwd)
         if not removal.ok:
             self._record(
                 "delete", target.id, f"could not delete branch {target.name}", removal.transcript()
             )
             return _failed(target, "delete command failed")
-        # `show-ref --verify` cannot answer this: it exits nonzero both when the
-        # ref is absent and when the command itself failed, so "gone" and
-        # "broken" are the same signal. `for-each-ref` exits 0 either way and
-        # answers in stdout, which separates them.
-        ref = f"refs/heads/{target.name}"
-        probe = self._port.git(
-            git_argv("for-each-ref", "--format=%(refname)", name=ref), cwd=self._cwd
-        )
-        if not probe.ok:
-            self._record(
-                "verify",
-                target.id,
-                f"could not confirm {ref} is gone; the delete reported success",
-                probe.transcript(),
-            )
-            return _failed(target, "deletion unverified")
-        if any(line.strip() == ref for line in probe.stdout.splitlines()):
-            self._record(
-                "verify",
-                target.id,
-                f"{ref} still resolves after `git branch -D`",
-                probe.transcript(),
-            )
-            return _failed(target, "ref survived deletion")
         return Deletion(
             target_id=target.id,
             kind=target.kind,
@@ -669,6 +611,32 @@ class Executor:
             anomalies=tuple(self._anomalies),
             salvage_dir=plan.salvage_dir,
         )
+
+
+def _removal_detail(held: str, contained: bool | None) -> str:
+    """What removing this worktree cost, said on the row it happened on.
+
+    Removing a refusal is not licence to go quiet. The record that held a
+    detached HEAD is gone, and with it the per-worktree reflog, so the commit
+    is now reachable from nothing -- it survives only until git collects it,
+    and the caller has to be told which commit and what one command keeps it.
+    The report is the whole obligation here: it blocks nothing, and the
+    deletion it describes already happened.
+
+    An unanswered probe reads as its own sentence rather than as either
+    answer. "No ref contains this" is a measurement, and a probe that failed
+    did not make it."""
+    if not held or contained:
+        return "worktree removed"
+    if contained is None:
+        return (
+            f"worktree removed; whether any ref contains {held[:8]}, the commit it held, "
+            f"could not be read, so whether the removal put that commit out of reach is unknown"
+        )
+    return (
+        f"worktree removed; it held commit {held[:8]}, which no ref contains, so nothing "
+        f"reaches it now -- keep it with `git branch <name> {held[:8]}` before git collects it"
+    )
 
 
 def _failed(target: Target, detail: str) -> Deletion:

--- a/packages/gitclean/src/gitclean/execute.py
+++ b/packages/gitclean/src/gitclean/execute.py
@@ -287,10 +287,10 @@ class Executor:
         failed probe never made it."""
         surveyed = next((w for w in self._survey.worktrees if w.path == target.name), None)
         if surveyed is None:
-            return "", True
+            return "", None
         head = self._head_now(target, surveyed.head)
         if not head:
-            return "", True
+            return "", None
         refs = self._port.git(
             git_argv("for-each-ref", "--count=1", f"--contains={head}"), cwd=self._cwd
         )

--- a/packages/gitclean/src/gitclean/model.py
+++ b/packages/gitclean/src/gitclean/model.py
@@ -648,9 +648,14 @@ class Deletion:
     gone: a target that was already absent is gone and this is False, because
     only a True here is evidence the tool did something."""
     verified: bool
-    """The end state was confirmed by asking git, rather than inferred from an
-    exit code. It does **not** mean a deletion happened -- an already-absent
-    target is verified too, because the server was asked and answered.
+    """The end state rests on git having said so, rather than on a guess.
+
+    For a local branch or a worktree that is git's report of the deletion it
+    just performed; for a ref on a server it is a second read of the remote,
+    because there a zero exit answers a different question than the one asked
+    and the ref can outlive it. It does **not** mean a deletion happened -- an
+    already-absent target is verified too, because the server was asked and
+    answered.
 
     So this is the wrong field to count a cleanup's work by; ``deleted`` is the
     one that says the tool acted. The pair is only ever read together."""

--- a/packages/gitclean/src/gitclean/plan.py
+++ b/packages/gitclean/src/gitclean/plan.py
@@ -667,27 +667,15 @@ def build_plan(
                     "and name this one from there",
                 )
             )
+        # Occupancy is not asked about here. git will not delete a branch a
+        # worktree still holds, and it says so in a message that names the
+        # worktree and describes the disk as it is at that moment. Working the
+        # objection out again in advance only substitutes an older answer for
+        # git's, and takes the deletion out of the caller's hands to do it.
+        skipped: list[Skipped] = []
     else:
         chosen = [t for t in targets if t.sweepable]
-
-    occupancy = _occupancy_blockers(chosen, survey_data)
-    chosen, skipped = _skip_occupied(chosen, occupancy)
-    if occupancy and selectors:
-        # Named explicitly: the caller believes this is deletable and git is
-        # about to disagree, so say so rather than silently doing less than
-        # they asked for. Reported as a refusal rather than the sweep's quiet
-        # `Skipped` row, and in place of it -- one omission, said once, in the
-        # register the caller's own naming earned.
-        detail = "; ".join(f"{t.name} is checked out at {path}" for t, path in occupancy)
-        refused.append(
-            Refusal(
-                code="E_BRANCH_IN_USE",
-                message=f"git will not delete a branch a worktree still holds: {detail}",
-                blocked=tuple(t for t, _ in occupancy),
-                remedy="add the holding worktree to the same cleanup so it is removed first",
-            )
-        )
-        skipped = []
+        chosen, skipped = _skip_occupied(chosen, _occupancy_blockers(chosen, survey_data))
 
     return Plan(
         targets=_ordered(chosen),

--- a/packages/gitclean/src/gitclean/survey.py
+++ b/packages/gitclean/src/gitclean/survey.py
@@ -598,10 +598,11 @@ way, as a block dropped rather than one recorded wrongly."""
 class WorktreeListing:
     """git's own account of the worktrees, framed so a path survives it whole.
 
-    Kept as one type because two callers need the same listing and the framing
-    rule must not be written twice: the survey builds targets from it, and the
-    executor re-asks it to confirm a removal. A rule about how to read git's
-    output that exists in two places is a rule that will disagree with itself."""
+    The blocks travel with the evidence about how well they were read -- what
+    was dropped, and whether the framing that makes a path whole was available
+    at all -- because the survey's conclusions about absence rest on both, and
+    a caller handed the blocks alone would have no way to tell a listing that
+    named everything from one that could not."""
 
     blocks: tuple[dict[str, str], ...]
     warnings: tuple[str, ...]
@@ -622,26 +623,6 @@ class WorktreeListing:
     @property
     def ok(self) -> bool:
         return self.result.ok
-
-    def holds(self, path: str) -> bool:
-        return any(block.get("worktree") == path for block in self.blocks)
-
-    def can_place(self, path: str) -> bool:
-        """Whether *this* path's absence from the listing means anything.
-
-        A truncation only ever shortens a path at a newline, and it only
-        corrupts the block it happens inside -- records are grouped by the empty
-        record between them, so a fragment lands among its own worktree's
-        attributes and nowhere else. A path with no newline in it therefore
-        cannot be the truncated one, and no other worktree's truncation can hide
-        it, so a framed listing and an unframed one answer alike about it.
-
-        This is narrower than the rule the survey applies to a *selector*, and
-        deliberately: there the string came from a caller and may be a shorter
-        name -- a basename, say -- for a path whose newline is further up, so a
-        selector with no newline in it proves nothing. Here the whole path is in
-        hand."""
-        return self.framed or "\n" not in path
 
 
 def _parse_worktrees(records: list[str], *, framed: bool) -> tuple[list[dict[str, str]], int]:

--- a/packages/gitclean/tests/integration/test_real_git.py
+++ b/packages/gitclean/tests/integration/test_real_git.py
@@ -272,18 +272,22 @@ def test_the_trunk_is_never_swept_although_it_is_provably_merged(
     assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/main") != ""
 
 
-def test_naming_the_branch_you_are_standing_on_does_not_delete_it(repo: Path) -> None:
+def test_naming_the_branch_you_are_standing_on_gets_gits_own_refusal(repo: Path) -> None:
     """Naming a target is an authorisation, so nothing here re-derives whether
-    it is wise. What stops this is that git will not delete a branch a worktree
-    holds -- and saying so up front names the worktree that has to go first."""
+    it is wise. git will not delete a branch a worktree holds, and its message
+    -- read off the disk as the deletion is attempted, and naming the worktree
+    -- is what the caller gets, with the argv that produced it."""
     git(repo, "checkout", "-q", "-b", "feat/parked")
     commit(repo, "parked.txt")
 
     with reachability_guard(repo):
         payload = report(repo, "--cleanup", "feat/parked")
 
-    assert payload["_exit"] == EXIT_REFUSED
-    assert [r["code"] for r in refusals(payload)] == ["E_BRANCH_IN_USE"]
+    assert payload["_exit"] == EXIT_ANOMALY
+    assert refusals(payload) == []
+    said = anomaly_lines(payload)
+    assert "cannot delete branch" in said
+    assert str(repo) in said
     assert git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "feat/parked"
     assert git(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feat/parked") != ""
 
@@ -450,36 +454,61 @@ def test_a_worktree_holding_uncommitted_work_survives_a_bare_sweep(repo: Path) -
     assert "1 untracked file(s)" in str(target["withheld"])
 
 
-def test_naming_a_detached_worktree_will_not_strand_the_commit_it_holds(repo: Path) -> None:
-    """The gap in "git's own refusals are enough".
+def test_naming_a_detached_worktree_removes_it_and_says_what_that_cost(repo: Path) -> None:
+    """The gap in "git's own refusals are enough", and what is done about it.
 
     They cover uncommitted content. They say nothing about a commit made
     inside the worktree on no branch: that tree is clean, git removes it
     without complaint, and the record it deletes is the only thing that held
-    HEAD -- the per-worktree reflog goes with it. No ref, no reflog, no undo.
+    HEAD -- the per-worktree reflog goes with it. No ref, no reflog.
 
-    Naming a target is an authorisation to delete a checkout, and it was
-    silently spending a commit. The run declines and says which commit and
-    how to keep it, which is the difference between authorising and being
-    told afterwards."""
+    Naming a target is an authorisation to delete a checkout, and the caller
+    owns what that spends. So the removal happens, and the row for it names the
+    commit that is now reachable from nothing and the one command that keeps
+    it. The guard is told about that commit by name, because a run that strands
+    one silently is what it exists to catch."""
     work = repo.parent / "wt-orphan"
     git(repo, "worktree", "add", "-q", "--detach", str(work))
     only = commit(work, "only.txt", "the only copy\n")
 
-    with reachability_guard(repo):
+    with reachability_guard(repo) as exemptions:
+        exemptions.expect_unreachable(only)
         payload = report(repo, "--cleanup", f"worktree:{work}")
 
-    assert payload["_exit"] == EXIT_ANOMALY
-    assert work.exists()
+    assert payload["_exit"] == EXIT_OK, anomaly_lines(payload)
+    assert not work.exists()
     assert git(repo, "for-each-ref", "--count=1", f"--contains={only}") == ""
-    said = str(payload["execution"]["anomalies"])  # type: ignore[index]
-    assert only[:8] in said and "git branch" in said
+    deletion = payload["execution"]["deletions"][0]  # type: ignore[index]
+    assert (deletion["deleted"], deletion["verified"]) == (True, True)
+    assert only[:8] in str(deletion["detail"])
+    assert "git branch" in str(deletion["detail"])
 
 
-def test_naming_a_worktree_whose_commit_a_branch_holds_still_removes_it(repo: Path) -> None:
-    """The refusal is about reachability, not about being detached. A commit
-    some branch contains survives the removal, so the removal proceeds --
-    otherwise the check would block the ordinary case it exists to permit."""
+def test_a_bare_sweep_will_not_touch_a_worktree_holding_an_orphan_commit(repo: Path) -> None:
+    """The same repository, with nobody naming anything. The narrowing above is
+    the named path's alone: a commit no ref contains carries no merge proof, so
+    the sweep withholds the tree long before any of this is reached, and the
+    commit is still there afterwards with the guard given no exemption to
+    excuse it."""
+    work = repo.parent / "wt-orphan-swept"
+    git(repo, "worktree", "add", "-q", "--detach", str(work))
+    only = commit(work, "only.txt", "the only copy\n")
+
+    with reachability_guard(repo):
+        payload = report(repo, "--cleanup")
+
+    assert payload["_exit"] == EXIT_OK
+    assert work.exists()
+    assert git(repo, "rev-parse", "--verify", f"{only}^{{commit}}") == only
+    assert find(payload, f"worktree:{work}")["sweepable"] is False
+
+
+def test_naming_a_worktree_whose_commit_a_branch_holds_costs_nothing(repo: Path) -> None:
+    """The disclosure is about reachability, not about being detached. A commit
+    some branch contains survives the removal, so the row for it says only that
+    the worktree was removed -- otherwise every ordinary cleanup would carry a
+    warning about work that is in no danger, and the one that matters would
+    read as more of the same."""
     work = _worktree(repo, "wt-kept", "feat/kept")
     commit(work, "kept.txt")
 
@@ -488,6 +517,7 @@ def test_naming_a_worktree_whose_commit_a_branch_holds_still_removes_it(repo: Pa
 
     assert payload["_exit"] == EXIT_OK
     assert not work.exists()
+    assert payload["execution"]["deletions"][0]["detail"] == "worktree removed"  # type: ignore[index]
 
 
 def test_the_worktree_the_run_executes_in_is_never_deleted(repo: Path) -> None:

--- a/packages/gitclean/tests/unit/test_cli.py
+++ b/packages/gitclean/tests/unit/test_cli.py
@@ -283,8 +283,8 @@ def test_naming_the_invoking_worktree_exits_one_with_its_path() -> None:
 
 
 def test_an_anomaly_exits_three_with_the_transcript() -> None:
-    """Acted, but git surprised us. A caller must be able to tell this from a
-    clean run without parsing prose."""
+    """The run set out to delete something and git would not. A caller must be
+    able to tell that from a clean run without parsing prose."""
     port = make_port(
         refs=[
             ref_at("refs/heads/main", "main", "a" * 40, head="*"),
@@ -292,8 +292,9 @@ def test_an_anomaly_exits_three_with_the_transcript() -> None:
         ],
         counts={"refs/remotes/origin/main..done": "0"},
         extra={
-            "branch -D -- done": ok(),
-            "for-each-ref --format=%(refname) refs/heads/done": ok("refs/heads/done"),
+            "branch -D -- done": fail(
+                "error: cannot delete branch 'done' used by worktree at '/repo/wt'", code=1
+            )
         },
     )
     code, payload = invoke(["--cleanup"], port)
@@ -620,18 +621,6 @@ def test_a_worktree_that_does_match_is_unaffected_by_the_unframed_listing() -> N
     port._git["worktree remove -- /repo/plain"] = ok()
     port._git["rev-parse HEAD"] = ok(_PLAIN_HEAD)
     port._git["for-each-ref --count=1 --contains"] = ok("refs/heads/plain")
-    # The survey reads the listing, then the verifier reads it again after the
-    # removal -- so the second answer is the one without it. The truncated
-    # record stays: nothing removed that one, and its presence is what proves
-    # the confirmation is not riding on a listing that got tidier.
-    port._git["worktree list --porcelain"] = [
-        port._git["worktree list --porcelain"],
-        ok(
-            _UNFRAMED_LISTING.replace(
-                f"worktree /repo/plain\nHEAD {_PLAIN_HEAD}\nbranch refs/heads/plain\n\n", ""
-            )
-        ),
-    ]
 
     code, payload = invoke(["--cleanup", "worktree:/repo/plain"], port)
 
@@ -840,11 +829,11 @@ def test_a_refusal_about_one_name_does_not_fill_the_run_wide_refusal_field() -> 
 
 def test_an_anomaly_outranks_a_refusal_in_the_exit_code() -> None:
     """A refusal is the tool declining to act and leaving the repository as it
-    found it. An anomaly is a deletion that ran and could not be confirmed
-    afterwards, which is the one outcome somebody has to go and look at. A run
-    that raised both must not report the milder of the two: exit 1 is what a
-    caller scripts "fix the name and re-run" against, and doing that here would
-    walk straight past an unverified deletion."""
+    found it. An anomaly is a deletion this run went out and attempted and did
+    not complete, which is the one outcome somebody has to go and look at. A
+    run that raised both must not report the milder of the two: exit 1 is what
+    a caller scripts "fix the name and re-run" against, and doing that here
+    would walk straight past the deletion that did not happen."""
     port = make_port(
         refs=[
             ref_at("refs/heads/main", "main", "a" * 40, head="*"),
@@ -852,9 +841,10 @@ def test_an_anomaly_outranks_a_refusal_in_the_exit_code() -> None:
         ],
         counts={"refs/remotes/origin/main..done": "0"},
         extra={
-            "branch -D -- done": ok(),
-            # git reported the deletion and the ref is still there afterwards.
-            "for-each-ref --format=%(refname) refs/heads/done": ok("refs/heads/done"),
+            # git would not make this deletion, and said why.
+            "branch -D -- done": fail(
+                "error: cannot delete branch 'done' used by worktree at '/repo/wt'", code=1
+            )
         },
     )
 
@@ -964,8 +954,9 @@ def test_human_output_names_a_failed_deletion() -> None:
         ],
         counts={"refs/remotes/origin/main..done": "0"},
         extra={
-            "branch -D -- done": ok(),
-            "for-each-ref --format=%(refname) refs/heads/done": ok("refs/heads/done"),
+            "branch -D -- done": fail(
+                "error: cannot delete branch 'done' used by worktree at '/repo/wt'", code=1
+            )
         },
     )
     _, text = invoke_human(["--cleanup"], port)

--- a/packages/gitclean/tests/unit/test_execute.py
+++ b/packages/gitclean/tests/unit/test_execute.py
@@ -1,8 +1,9 @@
-"""Tests for salvage, deletion, and verification.
+"""Tests for salvage, deletion, and what a deletion reports.
 
-The interesting cases are the ones where git reports success and the thing is
-still there. A tool that trusts exit codes cannot tell those from real
-successes, which is why every deletion re-asks."""
+The interesting cases are the ones where git and this tool could disagree
+about what happened. For anything git deletes here, git's own account is the
+report; the exception is a ref on a server, which a zero exit does not settle,
+so those tests are about the second read of the remote."""
 
 from __future__ import annotations
 
@@ -93,37 +94,23 @@ def test_dry_run_announces_no_salvage_for_a_local_branch() -> None:
 # -- local branch ------------------------------------------------------------
 
 
-def test_branch_deletion_is_verified_by_re_asking_git() -> None:
-    port = ScriptedCommands(
-        git={
-            "branch -D -- feat/x": ok(),
-            "for-each-ref --format=%(refname) refs/heads/feat/x": ok(""),
-        }
-    )
+def test_a_branch_delete_git_performed_is_reported_as_done() -> None:
+    """One question, and its answer is the outcome. The scripted port raises on
+    anything it was not given, so a run that asked a second question about the
+    ref would fail here rather than pass quietly."""
+    port = ScriptedCommands(git={"branch -D -- feat/x": ok()})
     report = run(port, plan(target(TargetKind.BRANCH, "feat/x")))
     assert report.ok
+    assert report.deletions[0].deleted
     assert report.deletions[0].verified
+    assert report.deletions[0].detail == "local ref deleted"
 
 
-def test_a_ref_surviving_a_successful_delete_is_an_anomaly() -> None:
-    """`git branch -D` exited 0 and the ref is still there. Reporting success
-    here is how cleanup silently does nothing."""
-    port = ScriptedCommands(
-        git={
-            "branch -D -- feat/x": ok(),
-            "for-each-ref --format=%(refname) refs/heads/feat/x": ok("refs/heads/feat/x"),
-        }
-    )
-    report = run(port, plan(target(TargetKind.BRANCH, "feat/x")))
-    assert not report.ok
-    assert report.anomalies[0].stage == "verify"
-    assert not report.deletions[0].deleted
-
-
-def test_a_broken_ref_probe_is_unverified_not_deleted() -> None:
-    """`show-ref --verify` cannot express this: it exits nonzero both when the
-    ref is absent and when the command failed, so a fatal error read as a
-    successful deletion. `for-each-ref` exits 0 and answers in stdout."""
+def test_a_ref_probe_that_would_not_answer_costs_the_deletion_nothing() -> None:
+    """The case that earned the removal of the second question. It ran after a
+    successful `branch -D`, and a git that would not answer it turned a
+    deletion that had happened into a row saying it had not -- which sends a
+    caller to re-run, or to raw git, over work already done."""
     port = ScriptedCommands(
         git={
             "branch -D -- feat/x": ok(),
@@ -131,10 +118,25 @@ def test_a_broken_ref_probe_is_unverified_not_deleted() -> None:
         }
     )
     report = run(port, plan(target(TargetKind.BRANCH, "feat/x")))
-    assert not report.ok
-    assert not report.deletions[0].deleted
-    assert report.deletions[0].detail == "deletion unverified"
-    assert "bad repository" in "\n".join(report.anomalies[0].transcript)
+    assert report.ok
+    assert report.deletions[0].deleted
+    assert report.deletions[0].detail == "local ref deleted"
+
+
+def test_a_ref_that_would_still_resolve_is_not_re_adjudicated() -> None:
+    """What taking git at its word costs, stated rather than left to be found.
+    The ref list would still show this branch, and nobody asks it: `branch -D`
+    said what it did and that is the report."""
+    port = ScriptedCommands(
+        git={
+            "branch -D -- feat/x": ok(),
+            "for-each-ref --format=%(refname) refs/heads/feat/x": ok("refs/heads/feat/x"),
+        }
+    )
+    report = run(port, plan(target(TargetKind.BRANCH, "feat/x")))
+    assert report.ok
+    assert report.deletions[0].deleted
+    assert not any("for-each-ref" in call for call in port.transcript)
 
 
 def test_a_failed_delete_carries_the_command_transcript() -> None:
@@ -153,19 +155,29 @@ def test_a_failed_delete_carries_the_command_transcript() -> None:
 # -- worktree ----------------------------------------------------------------
 
 
-def test_worktree_removal_is_verified_against_the_listing() -> None:
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": ok(porcelain("worktree /repo\nHEAD abc\n")),
-        }
-    )
+def test_a_worktree_removal_git_performed_is_reported_as_done() -> None:
+    """`worktree remove` reporting success is the outcome, and the port raises
+    on any question this does not script -- so a run that went back to the
+    worktree listing afterwards would fail here."""
+    port = ScriptedCommands(git={"worktree remove -- /repo/wt": ok()})
     report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
     assert report.ok
+    assert report.deletions[0].deleted
     assert report.deletions[0].verified
+    assert report.deletions[0].detail == "worktree removed"
 
 
-def test_worktree_still_listed_after_removal_is_an_anomaly() -> None:
+def test_a_removal_is_not_re_checked_against_a_listing() -> None:
+    """The listing is not consulted after a removal git said it performed, and
+    that settles four cases at once rather than one per listing defect.
+
+    Each of them was a way for the confirmation to fail to confirm something
+    that had happened: a listing that would not run, one that lost a record to
+    a truncation, one whose framing could not spell the path being looked for,
+    and one that answered with the worktree still in it. Three reported a
+    removal that happened as one that had not. The fourth is the case the
+    check existed for, and the price of losing it is stated here rather than
+    hidden: git said the tree is gone, and the report says so."""
     port = ScriptedCommands(
         git={
             "worktree remove -- /repo/wt": ok(),
@@ -173,86 +185,24 @@ def test_worktree_still_listed_after_removal_is_an_anomaly() -> None:
         }
     )
     report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
-    assert not report.ok
-    assert report.anomalies[0].stage == "verify"
-
-
-def test_a_worktree_whose_path_holds_a_newline_is_verified_against_the_whole_path() -> None:
-    """The removal reported success and the worktree is still listed, which is
-    the case this verification exists for. Split the listing on newlines and
-    the path being looked for spans two lines, so the survivor matches nothing
-    and the run reports the deletion verified -- git's own output disproving
-    the claim, unread."""
-    path = "/repo/we\nird"
-    port = ScriptedCommands(
-        git={
-            f"worktree remove -- {path}": ok(),
-            "worktree list --porcelain": ok(
-                porcelain("worktree /repo\n\n") + f"worktree {path}\0\0"
-            ),
-        }
-    )
-    report = run(port, plan(target(TargetKind.WORKTREE, path)))
-
-    assert not report.ok
-    assert report.anomalies[0].stage == "verify"
-    assert not report.deletions[0].deleted
-
-
-def test_a_worktree_listing_that_lost_a_record_cannot_verify_a_removal() -> None:
-    """On a git with no NUL framing, a block whose keys say a path was cut
-    short is dropped -- so the worktree just removed may be exactly the one
-    missing from the listing. Absence from a listing that lost something is not
-    evidence, the same way absence from one that never ran is not."""
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain -z": fail("error: unknown switch `z'", code=129),
-            "worktree list --porcelain": ok("worktree /repo\n\nworktree /repo/we\nird\n"),
-        }
-    )
-    report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
-
-    assert not report.ok
-    assert report.deletions[0].detail == "deletion unverified"
-
-
-def test_an_unframed_listing_cannot_confirm_a_newline_path_is_gone() -> None:
-    """`worktree remove` reported success, and the listing that would show a
-    survivor cannot spell this path. Absence from it is not evidence, the same
-    way absence from a listing that lost a record is not."""
-    path = "/repo/we\nbare"
-    port = ScriptedCommands(
-        git={
-            f"worktree remove -- {path}": ok(),
-            "worktree list --porcelain -z": fail("error: unknown switch `z'", code=129),
-            "worktree list --porcelain": ok("worktree /repo\n"),
-        }
-    )
-    report = run(port, plan(target(TargetKind.WORKTREE, path)))
-
-    assert not report.ok
-    assert report.deletions[0].detail == "deletion unverified"
-
-
-def test_an_unframed_listing_still_confirms_an_ordinary_path_is_gone() -> None:
-    """The narrowing that keeps the rule affordable. A truncation shortens a
-    path at a newline and corrupts only the block it falls inside -- records are
-    grouped by the empty record between them -- so a path with no newline in it
-    cannot be the truncated one and cannot be hidden by another's truncation.
-    Refusing to confirm every removal on a git without `-z` would make an
-    anomaly of each one and buy nothing."""
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain -z": fail("error: unknown switch `z'", code=129),
-            "worktree list --porcelain": ok("worktree /repo\n\nworktree /repo/we\nbare\n"),
-        }
-    )
-    report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
 
     assert report.ok
-    assert report.deletions[0].verified is True
+    assert report.deletions[0].deleted
+    assert not any("list" in call for call in port.transcript)
+
+
+def test_a_worktree_path_holding_a_newline_reaches_git_whole() -> None:
+    """A path may contain a newline, and every hazard that creates is about
+    reading it back out of git's output. The removal itself takes the path as
+    one argument, so it is handed over whole."""
+    path = "/repo/we\nird"
+    port = ScriptedCommands(git={f"worktree remove -- {path}": ok()})
+    report = run(port, plan(target(TargetKind.WORKTREE, path)))
+
+    assert report.ok
+    assert report.deletions[0].deleted
+    removal = next(call for call in port.transcript if call[:3] == ("git", "worktree", "remove"))
+    assert removal[-1] == path
 
 
 def test_a_worktree_is_never_removed_with_force() -> None:
@@ -261,12 +211,7 @@ def test_a_worktree_is_never_removed_with_force() -> None:
     and overriding them means re-implementing in Python what git has just read
     off the disk. Naming a target authorises the deletion; it does not make
     this process a better judge of that directory than git is."""
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": ok(porcelain("worktree /repo\n")),
-        }
-    )
+    port = ScriptedCommands(git={"worktree remove -- /repo/wt": ok()})
     run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
 
     removal = next(call for call in port.transcript if call[:3] == ("git", "worktree", "remove"))
@@ -305,51 +250,25 @@ def test_removing_a_worktree_prunes_nothing() -> None:
     """`worktree prune` destroys the administrative records of worktrees this
     run never planned to touch -- outside the plan, unsalvaged, and absent from
     `skipped`. The executor acts on planned targets only."""
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": ok(porcelain("worktree /repo\n")),
-        }
-    )
+    port = ScriptedCommands(git={"worktree remove -- /repo/wt": ok()})
     report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
     assert report.ok
     assert not any("prune" in call for call in port.transcript)
 
 
-def test_an_unlistable_worktree_check_is_unverified_not_removed() -> None:
-    """Absence from output that was never produced is not evidence. Empty
-    stdout on a failed command previously read as 'gone'."""
-    port = ScriptedCommands(
-        git={
-            "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": fail("fatal: not a git repository"),
-        }
-    )
-    report = run(port, plan(target(TargetKind.WORKTREE, "/repo/wt")))
-    assert not report.ok
-    assert not report.deletions[0].deleted
-    assert report.deletions[0].detail == "deletion unverified"
-
-
-def test_a_reachability_probe_that_will_not_answer_declines_the_removal() -> None:
-    """The one place a named target is refused on reachability grounds, and the
-    refusal has to hold when the probe itself fails.
-
-    git's interlocks cover uncommitted content and say nothing about a commit
-    made in this tree on no branch: the tree is clean, git removes it happily,
-    and the per-worktree reflog that held the commit dies with the record. So
-    an unanswered probe is read as a stranding. Being wrong that way costs a
-    worktree someone removes by hand; being wrong the other way costs the
-    commit.
-
-    The removal is scripted to succeed, so nothing but the guard stops it."""
+def test_removing_a_worktree_that_holds_an_orphan_commit_says_what_it_cost() -> None:
+    """git's interlocks cover uncommitted content and say nothing about a
+    commit made in this tree on no branch: the tree is clean, git removes it
+    happily, and the per-worktree reflog that held the commit goes with the
+    record. Naming the tree authorises that, so the removal proceeds -- and
+    what the caller is owed afterwards is the commit and the command that
+    keeps it, on the row for the tree that held it."""
     head = "a" * 40
     port = ScriptedCommands(
         git={
             "rev-parse HEAD": ok(head),
-            f"for-each-ref --count=1 --contains={head}": fail("fatal: bad object"),
+            f"for-each-ref --count=1 --contains={head}": ok(""),
             "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": ok(porcelain("worktree /repo\n")),
         }
     )
     report = run(
@@ -358,25 +277,50 @@ def test_a_reachability_probe_that_will_not_answer_declines_the_removal() -> Non
         make_survey(worktrees=(make_worktree("/repo/wt", head=head, branch=None),)),
     )
 
-    assert not report.ok
-    assert not report.deletions[0].deleted
-    assert head[:8] in report.deletions[0].detail
-    assert report.anomalies[0].stage == "delete"
-    assert "would strand" in report.anomalies[0].message
-    # The refusal is a claim about what git said, so it travels with what git
-    # said. A reader cannot re-derive the probe from the prose.
-    assert "for-each-ref" in "\n".join(report.anomalies[0].transcript)
-    assert not any(call[:3] == ("git", "worktree", "remove") for call in port.transcript)
+    assert report.ok
+    assert report.deletions[0].deleted
+    detail = report.deletions[0].detail
+    assert head[:8] in detail
+    assert "no ref contains" in detail
+    assert f"git branch <name> {head[:8]}" in detail
 
 
-def test_a_commit_made_since_the_survey_is_not_stranded_by_the_removal() -> None:
+def test_a_reachability_probe_that_will_not_answer_is_disclosed_not_decided() -> None:
+    """A probe that failed made no measurement, so the row says that rather
+    than choosing one of the two answers it might have given. Reporting "no ref
+    contains it" would be a claim nobody checked; reporting nothing at all
+    would hide a commit that may have just gone out of reach."""
+    head = "a" * 40
+    port = ScriptedCommands(
+        git={
+            "rev-parse HEAD": ok(head),
+            f"for-each-ref --count=1 --contains={head}": fail("fatal: bad object"),
+            "worktree remove -- /repo/wt": ok(),
+        }
+    )
+    report = run(
+        port,
+        plan(target(TargetKind.WORKTREE, "/repo/wt")),
+        make_survey(worktrees=(make_worktree("/repo/wt", head=head, branch=None),)),
+    )
+
+    assert report.ok
+    assert report.deletions[0].deleted
+    detail = report.deletions[0].detail
+    assert head[:8] in detail
+    assert "could not be read" in detail
+    assert "unknown" in detail
+
+
+def test_the_commit_disclosed_is_the_one_the_tree_holds_now() -> None:
     """The survey is a snapshot; the deletion happens after it. An agent
     committing in that tree in between leaves the recorded commit sitting on a
     branch -- where it answers "contained" -- and the new one held only by the
     record this call is about to delete.
 
-    So asking about the surveyed commit is not a weaker check, it is the wrong
-    one: it clears in exactly the case it exists to refuse."""
+    So a disclosure built from the surveyed commit is not a smaller one, it is
+    about the wrong commit: it reports nothing at risk in exactly the case
+    where something is."""
     surveyed, made_since = "a" * 40, "b" * 40
     port = ScriptedCommands(
         git={
@@ -384,7 +328,6 @@ def test_a_commit_made_since_the_survey_is_not_stranded_by_the_removal() -> None
             f"for-each-ref --count=1 --contains={surveyed}": ok("refs/heads/keeps-it"),
             f"for-each-ref --count=1 --contains={made_since}": ok(""),
             "worktree remove -- /repo/wt": ok(),
-            "worktree list --porcelain": ok(porcelain("worktree /repo\n")),
         }
     )
     report = run(
@@ -393,9 +336,9 @@ def test_a_commit_made_since_the_survey_is_not_stranded_by_the_removal() -> None
         make_survey(worktrees=(make_worktree("/repo/wt", head=surveyed, branch=None),)),
     )
 
-    assert not report.ok
+    assert report.ok
     assert made_since[:8] in report.deletions[0].detail
-    assert not any(call[:3] == ("git", "worktree", "remove") for call in port.transcript)
+    assert surveyed[:8] not in report.deletions[0].detail
 
 
 # -- remote branch -----------------------------------------------------------

--- a/packages/gitclean/tests/unit/test_json_contract.py
+++ b/packages/gitclean/tests/unit/test_json_contract.py
@@ -377,10 +377,10 @@ def test_a_plan_holds_exactly_its_published_fields() -> None:
         # a consumer reads instead of this object.
         refused=(
             Refusal(
-                code="E_BRANCH_IN_USE",
-                message="a worktree still holds it",
+                code="E_INVOKING_WORKTREE",
+                message="this run is executing inside it",
                 blocked=(_target(),),
-                remedy="add the holding worktree to the same cleanup",
+                remedy="run gitclean from another worktree and name this one from there",
             ),
         ),
     )

--- a/packages/gitclean/tests/unit/test_plan.py
+++ b/packages/gitclean/tests/unit/test_plan.py
@@ -854,36 +854,30 @@ def _occupied_survey():  # type: ignore[no-untyped-def]
     return make_survey(branches=(make_branch("held", checked_out_at="/repo/wt"),))
 
 
-def test_named_occupied_branch_is_refused() -> None:
-    """Not a safety judgement -- git is about to reject this outright, and
-    saying so names the worktree that has to go first.
-
-    Refused rather than carrying the sweep's quiet `Skipped` row, and in place
-    of it: the caller named this one, so the omission is said once, in the
-    register their naming earned."""
+def test_a_named_occupied_branch_is_planned_and_left_to_git() -> None:
+    """Naming it is the authorisation. git will not delete a branch a worktree
+    still holds, and its refusal is taken at the moment of the deletion and
+    names the worktree in its own words -- so the plan carries the target
+    rather than an objection worked out from a survey taken earlier."""
     result = plan_for((target("branch:held"),), survey=_occupied_survey(), selectors=["held"])
-    assert result.targets == ()
+    assert [t.id for t in result.targets] == ["branch:held"]
     assert result.skipped == ()
-    [refusal] = result.refused
-    assert refusal.code == "E_BRANCH_IN_USE"
+    assert result.refused == ()
 
 
-def test_an_occupied_branch_named_is_refused_beside_a_target_that_still_goes() -> None:
-    """The objection is git's, and it is about one branch. Every other name in
-    the same command resolved to something git will delete without complaint,
-    and holding those back would make one occupied worktree a reason to do
-    none of the work asked for."""
+def test_a_named_occupied_branch_does_not_hold_up_the_rest_of_the_command() -> None:
+    """Whatever git makes of the occupied one, the other names in the same
+    command were resolved and are planned. One branch a worktree holds is not a
+    reason to do none of the work asked for."""
     result = plan_for(
         (target("branch:held"), target("branch:free")),
         survey=_occupied_survey(),
         selectors=["held", "free"],
     )
 
-    assert [t.id for t in result.targets] == ["branch:free"]
+    assert sorted(t.id for t in result.targets) == ["branch:free", "branch:held"]
     assert result.skipped == ()
-    [refusal] = result.refused
-    assert refusal.code == "E_BRANCH_IN_USE"
-    assert [t.id for t in refusal.blocked] == ["branch:held"]
+    assert result.refused == ()
 
 
 def test_the_occupancy_check_reads_the_local_branch_not_a_server_ref_of_that_name() -> None:
@@ -891,7 +885,9 @@ def test_the_occupancy_check_reads_the_local_branch_not_a_server_ref_of_that_nam
     a server one, and the two collide: a local branch `origin/held` and origin's
     copy of `held` are both `origin/held`. A search that only compares names
     can answer with the server ref, whose `checked_out_at` is always None,
-    and the branch its worktree still holds then reads as free.
+    and the branch its worktree still holds then reads as free -- so the sweep
+    takes a branch git is about to refuse, and reports the refusal as a
+    surprise rather than as the omission it planned.
 
     Which one an unfiltered search finds today is decided by git listing
     refs/heads before refs/remotes. That is not a rule this depends on, and
@@ -903,14 +899,11 @@ def test_the_occupancy_check_reads_the_local_branch_not_a_server_ref_of_that_nam
         )
     )
 
-    result = plan_for(
-        (target("branch:origin/held"),), survey=survey, selectors=["branch:origin/held"]
-    )
+    result = plan_for((target("branch:origin/held"),), survey=survey)
 
     assert result.targets == ()
-    [refusal] = result.refused
-    assert refusal.code == "E_BRANCH_IN_USE"
-    assert "/repo/wt" in refusal.message
+    assert [s.target_id for s in result.skipped] == ["branch:origin/held"]
+    assert "/repo/wt" in result.skipped[0].reason
 
 
 def test_automatic_sweep_skips_an_occupied_branch_instead_of_refusing() -> None:


### PR DESCRIPTION
**This PR removes safety guards, deliberately.** The repository owner decided it
after being shown what each one prevents. It is not a cleanup that happens to
narrow behaviour — narrowing the behaviour is the point.

The contract being restored: naming a target on the command line is the
authorisation. The tool carries the deletion out and reports the outcome, and
does not weigh again whether the caller should have asked. A deletion git
performed successfully is never reported as a failure.

## What was removed, and what each one prevented

**`E_BRANCH_IN_USE` (`plan.py`).** Refused a named branch that a worktree still
had checked out, before attempting anything. It prevented a caller from seeing a
git error, by working the objection out from an earlier survey instead. Removed:
the branch is planned, `git branch -D` is attempted, and git's own refusal comes
back as an anomaly with the transcript — a message that describes the disk at
that moment and names the holding worktree.

**The stranded-commit decline (`execute.py`).** Refused to remove a named
worktree holding a commit no ref contains. It prevented an unrecoverable
loss: the administrative record being deleted is what held HEAD, the
per-worktree reflog dies with it, and the object survives only until git
collects it. Removed — see disclosure below for what stands in its place.

**Post-delete re-verification (`execute.py`).** After `git branch -D` or `git
worktree remove` reported success, the code re-asked git and reported the target
as not deleted when that probe errored or disagreed. It prevented believing a
`branch -D` that exited 0 against a ref still present. Removed on both local
paths: git already said what it did.

The server ref keeps its second read. That is not the same construct — `git push
--delete` can exit 0 against a ref the remote kept, so there the exit code
answers a different question than the one asked, and the probe is what
establishes the outcome rather than second-guessing it.

## What survives: disclosure

Removing a refusal is not licence to go quiet. The probe that detects a stranded
commit stays, and the answer now drives a report instead of a decline. Where
removing a named worktree strands a commit, that worktree's own row reads:

> worktree removed; it held commit `abc12345`, which no ref contains, so nothing
> reaches it now — keep it with `git branch <name> abc12345` before git collects it

It blocks nothing, exits 0, and is on the target's row rather than in a refusal.
A probe that would not answer is disclosed as unknown rather than resolved
either way: "no ref contains this" is a measurement, and a failed probe never
made one.

## Why the bare sweep boundary holds

Unchanged, and it has to be: the sweep is unattended, nobody authorised anything
target by target, and that is where the tool's judgement legitimately lives. It
still takes only what it can prove is merged, and still skips an occupied branch
rather than refusing it. A worktree holding an orphan commit is never reached by
this code at all on that path — a commit no ref contains carries no merge proof,
so the sweep withholds the tree long before the executor is asked. That is now
pinned by a test.

`tests/integration/test_generated_topologies.py` — the seeded draw that holds
every generated repository to stranding nothing under a bare sweep — is
untouched in this diff and green.

## Verification

- `make ci-gitclean` run standalone from the worktree root: **exit 0**, 515
  passed, coverage 98.11%.
- Mutation checks, each run against the full suite:
  - restoring `E_BRANCH_IN_USE` → 3 tests fail
  - restoring the stranded-commit decline → 4 tests fail
  - removing the disclosure → 4 tests fail
  - restoring the branch post-delete probe → 3 tests fail
  - restoring the worktree post-removal probe → 8 tests fail
  - leaking the named-path rule into the sweep (dropping its occupancy skip) → 4
    sweep tests fail
- The one test that now genuinely strands a commit declares it to
  `reachability_guard` with `expect_unreachable` naming that commit. The guard
  is unweakened, and it also fails a stale exemption, so the declaration cannot
  be over-broad.

## Docs

`packages/gitclean/AGENTS.md` recorded the stranded-commit guard as a deliberate
exception to the not-re-adjudicated rule. That exception no longer exists; the
rule now states the disclosure obligation that replaced it. The package README
and the `verified` field's contract are corrected the same way.

**Not in this diff, and it needs a follow-up:** two deployed assets under `src/`
still describe the removed behaviour —
`src/user/.claude/commands/clean-up-git.md` says the tool refuses a branch a
worktree holds, and `src/user/.agents/skills/post-merge-cleanup/SKILL.md` says
every deletion is verified by re-asking git. Both are now false. They are left
alone here because they sit on a different gate than `make ci-gitclean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1gMn9F4tZERZcBfbo1Fk
