### PR TITLE
fix(9k9.168): the integration suite brings its own track config

### DIFF
--- a/packages/workcli/tests/integration/conftest.py
+++ b/packages/workcli/tests/integration/conftest.py
@@ -3,6 +3,12 @@
 Every install is a throwaway .beads under pytest tmp_path, bound to bd via
 BEADS_DIR so bd's upward .beads discovery can never reach the repo's real DB.
 The suite skips wholesale when bd is not on PATH.
+
+Two separate bindings keep an install isolated, and they isolate different
+things. BEADS_DIR binds the bd SUBPROCESS to this install's database. The
+`--config` path `driver_for` puts on every call binds the IN-PROCESS track
+layer to this suite's own config -- see `_write_track_config` for why the
+second one is not redundant.
 """
 
 from __future__ import annotations
@@ -17,10 +23,23 @@ from pathlib import Path
 
 import pytest
 
-from workcli.adapters.bd.runner import SubprocessBdRunner
+from workcli.adapters.bd.runner import BdRunner, SubprocessBdRunner
 from workcli.cli import main
 
 _SEED_PREFIX = "itest"
+
+# The one track name this suite may create under. It is the fixture's OWN
+# vocabulary, not the ambient repository's -- `_write_track_config` explains
+# the distinction and why it matters. Tests name it explicitly on every
+# `work create <noun>`; import it rather than spelling the string again.
+ITEST_TRACK = "itest-track"
+
+_TRACK_CONFIG = f"""\
+# Written per-install by the integration conftest. Owned by this suite.
+[tracks]
+names = ["{ITEST_TRACK}"]
+enforcement = "required"
+"""
 
 
 def resolve_bd() -> str:
@@ -85,17 +104,55 @@ def _bd_init(bd_binary: str, install: Path) -> None:
     _run_bd(bd_binary, install, "init", "--prefix", _SEED_PREFIX)
 
 
-def _make_driver(bd_binary: str, install: Path) -> Callable[[Sequence[str]], dict]:
+def _write_track_config(install: Path) -> Path:
+    """Write this install's OWN project-config.toml and return its path.
+
+    WHERE THIS SUITE'S TRACK COMES FROM: this file, named explicitly as
+    `--config` on every `work` call, and never the ambient repository's
+    project-config.toml. The distinction is load-bearing. The track layer
+    resolves its config by walking UP from `Path.cwd()`, and this suite drives
+    production `main()` IN-PROCESS -- so that walk starts at pytest's own
+    working directory, inside this repository, however completely bd itself is
+    bound to an off-repo install by BEADS_DIR. Left alone the suite silently
+    adopts the repository's own [tracks] table: its track names and its
+    enforcement setting would decide what these tests are allowed to create,
+    and editing that table would turn this suite red. `--config` overrides the
+    upward search outright, which closes it.
+
+    Enforcement is pinned to "required" deliberately. The create gate must be
+    LIVE here, so every `work create <noun>` in this suite has to name its
+    track exactly as a real caller does; relaxing it to "advisory" would let
+    the suite pass without ever exercising the gate.
+    """
+    config_path = install / "project-config.toml"
+    config_path.write_text(_TRACK_CONFIG, encoding="utf-8")
+    return config_path
+
+
+def driver_for(runner: BdRunner, install: Path) -> Callable[[Sequence[str]], dict]:
     """Return a callable that drives the PRODUCTION main() against this install
-    and returns the parsed stdout envelope."""
-    runner = SubprocessBdRunner(bd_binary=bd_binary, cwd=str(install), env=_bd_env(install))
+    and returns the parsed stdout envelope.
+
+    Every call carries this install's own `--config`, so no `work` invocation
+    in this suite can reach the ambient repository's track configuration.
+    Public because the crash-recovery tests wrap the real runner in a
+    fault-injecting one and need the same binding on their own calls.
+    """
+    config_path = _write_track_config(install)
 
     def drive(argv: Sequence[str]) -> dict:
         out, err = io.StringIO(), io.StringIO()
-        main(list(argv), runner=runner, out=out, err=err)
+        main(["--config", str(config_path), *argv], runner=runner, out=out, err=err)
         return json.loads(out.getvalue())
 
     return drive
+
+
+def _make_driver(bd_binary: str, install: Path) -> Callable[[Sequence[str]], dict]:
+    return driver_for(
+        SubprocessBdRunner(bd_binary=bd_binary, cwd=str(install), env=_bd_env(install)),
+        install,
+    )
 
 
 @pytest.fixture

--- a/packages/workcli/tests/integration/test_crash_recovery.py
+++ b/packages/workcli/tests/integration/test_crash_recovery.py
@@ -6,29 +6,24 @@ E_BACKEND_DRIFT with detail.reason == "invalid_json"."""
 
 from __future__ import annotations
 
-import io
-import json
 from collections.abc import Sequence
 
-from tests.integration.conftest import _bd_env
+from tests.integration.conftest import ITEST_TRACK, _bd_env, driver_for
 from tests.integration.fault_runner import Fault, FaultInjectingBdRunner
 from workcli.adapters.bd.runner import SubprocessBdRunner
-from workcli.cli import main
 
-
-def _drive(runner, argv: Sequence[str]) -> dict:
-    out, err = io.StringIO(), io.StringIO()
-    main(list(argv), runner=runner, out=out, err=err)
-    return json.loads(out.getvalue())
+# These tests wrap the real runner in a fault-injecting one, so they build their
+# drivers by hand rather than taking the `driver` fixture. `driver_for` is the
+# same factory the fixture uses, which is what keeps their `work` calls bound to
+# the install's own project-config.toml instead of the ambient repository's.
 
 
 def test_malformed_json_on_read_is_invalid_json_drift(fresh_install, bd_binary):
     real = SubprocessBdRunner(
         bd_binary=bd_binary, cwd=str(fresh_install), env=_bd_env(fresh_install)
     )
-    created = _drive(
-        real, ["create", "--raw", "--title", "cr-item", "--type", "task", "--priority", "2"]
-    )
+    drive = driver_for(real, fresh_install)
+    created = drive(["create", "--raw", "--title", "cr-item", "--type", "task", "--priority", "2"])
     item_id = created["data"]["id"]
 
     # Fault the `show --json` read with garbage stdout, exit 0.
@@ -37,7 +32,7 @@ def test_malformed_json_on_read_is_invalid_json_drift(fresh_install, bd_binary):
         fail_when=lambda _n, argv: "show" in argv and "--json" in argv,
         fault=Fault.MALFORMED_JSON,
     )
-    env = _drive(faulted, ["show", item_id])
+    env = driver_for(faulted, fresh_install)(["show", item_id])
     assert env["ok"] is False
     assert env["error"]["code"] == "E_BACKEND_DRIFT"
     assert env["error"]["detail"]["reason"] == "invalid_json"
@@ -50,16 +45,28 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
     real = SubprocessBdRunner(
         bd_binary=bd_binary, cwd=str(fresh_install), env=_bd_env(fresh_install)
     )
+    drive = driver_for(real, fresh_install)
 
     # --- Arrange: promote a shape-feat leaf → a shape-spec container. That mints
     # a design child (shape-design) + an impl-placeholder sibling under it
     # (transitions.py::promote → finalize_spec_instantiation). `create` requires
-    # exactly one of --parent/--orphan; this leaf is standalone → --orphan.
-    leaf = _drive(real, ["create", "feat", "--title", "cr-spec", "--priority", "2", "--orphan"])[
-        "data"
-    ]["id"]
-    _drive(real, ["promote", leaf])
-    design_child, placeholder = _design_and_placeholder(real, leaf)
+    # exactly one of --parent/--orphan; this leaf is standalone → --orphan, which
+    # leaves no parent to inherit a track from, so it names one itself.
+    leaf = drive(
+        [
+            "create",
+            "feat",
+            "--title",
+            "cr-spec",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
+    drive(["promote", leaf])
+    design_child, placeholder = _design_and_placeholder(drive, leaf)
 
     # A `## Continuations` single-item manifest. GRAMMAR (manifest.py, verified):
     # `- <noun>: <title> — AC: <acceptance>` — note the em-dash separator " — AC: ".
@@ -77,7 +84,9 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
         return argv[:1] == ["update"] and "--type" in argv
 
     faulted = FaultInjectingBdRunner(real, fail_when=fail_on_set_type, fault=Fault.NONZERO_EXIT)
-    crashed = _drive(faulted, ["deliver", design_child, "--spec", str(spec_file)])
+    crashed = driver_for(faulted, fresh_install)(
+        ["deliver", design_child, "--spec", str(spec_file)]
+    )
     assert crashed["ok"] is False  # the injected fault aborted deliver
 
     # Partial state is real: the placeholder still carries the impl-placeholder
@@ -85,13 +94,13 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
     # in-band manifest snapshot the appends recorded before the fault is present
     # — that snapshot is what `reconcile` replays off, so its persistence proves
     # the fault landed after the appends and before the shape mutation.
-    mid = _drive(real, ["show", placeholder])["data"]
+    mid = drive(["show", placeholder])["data"]
     assert "impl-placeholder" in mid["labels"]
     assert "shape-feat" not in mid["labels"]
     assert "[work] manifest:" in mid["notes"]
 
     # --- Heal: reconcile replays reconcile_placeholder off the recorded snapshot.
-    swept = _drive(real, ["reconcile"])
+    swept = drive(["reconcile"])
     assert swept["ok"] is True
 
     # Assert the full correct heal: the impl-placeholder recovery handle is
@@ -99,21 +108,21 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
     # (delivery complete), spec-ready is stamped, and the placeholder keeps
     # its manifest-noun shape — the instantiation sweep must never re-finalize
     # it into a planned shape-spec container (wgclw.9.8).
-    healed = _drive(real, ["show", placeholder])["data"]
+    healed = drive(["show", placeholder])["data"]
     assert "impl-placeholder" not in healed["labels"]  # handle removed strictly last
     assert "spec-ready" in healed["labels"]
     assert "shape-feat" in healed["labels"]  # manifest-noun shape survives the sweep
     assert "creating-spec" not in healed["labels"]
     assert "planned" not in healed["labels"]
-    assert _drive(real, ["show", design_child])["data"]["status"] == "closed"
+    assert drive(["show", design_child])["data"]["status"] == "closed"
 
 
-def _design_and_placeholder(runner, container_id: str) -> tuple[str, str]:
+def _design_and_placeholder(drive, container_id: str) -> tuple[str, str]:
     """Return (design_child_id, placeholder_id): the container's two children."""
-    children = _drive(runner, ["show", container_id])["data"]["children"]  # single-id show
+    children = drive(["show", container_id])["data"]["children"]  # single-id show
     design_child = placeholder = None
     for child_id in children:
-        labels = _drive(runner, ["show", child_id])["data"]["labels"]
+        labels = drive(["show", child_id])["data"]["labels"]
         if "shape-design" in labels:
             design_child = child_id
         else:

--- a/packages/workcli/tests/integration/test_error_paths.py
+++ b/packages/workcli/tests/integration/test_error_paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from tests.integration.conftest import _bd_env
+from tests.integration.conftest import ITEST_TRACK, _bd_env
 from workcli.adapters.bd.runner import SubprocessBdRunner
 
 
@@ -21,9 +21,19 @@ def test_bad_flag_is_usage_error(driver):
 
 
 def test_deliver_without_evidence_is_refused(driver):
-    item_id = driver(["create", "feat", "--title", "ep-noevidence", "--priority", "2", "--orphan"])[
-        "data"
-    ]["id"]
+    item_id = driver(
+        [
+            "create",
+            "feat",
+            "--title",
+            "ep-noevidence",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
     driver(["claim", item_id])
     env = driver(["deliver", item_id])  # no --pr/--items/--trivial
     assert env["ok"] is False
@@ -32,12 +42,32 @@ def test_deliver_without_evidence_is_refused(driver):
 
 def test_type_wall_verb_envelope(driver):
     # (a) The verb-layer pre-check raises E_TYPE_WALL before bd is called.
-    epic = driver(["create", "epic", "--title", "ep-epic", "--priority", "2", "--orphan"])["data"][
-        "id"
-    ]
-    task = driver(["create", "feat", "--title", "ep-task", "--priority", "2", "--orphan"])["data"][
-        "id"
-    ]
+    epic = driver(
+        [
+            "create",
+            "epic",
+            "--title",
+            "ep-epic",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
+    task = driver(
+        [
+            "create",
+            "feat",
+            "--title",
+            "ep-task",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
     env = driver(["dep", "add", epic, task, "--type", "blocks"])
     assert env["ok"] is False
     assert env["error"]["code"] == "E_TYPE_WALL"

--- a/packages/workcli/tests/integration/test_lifecycle.py
+++ b/packages/workcli/tests/integration/test_lifecycle.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
+from tests.integration.conftest import ITEST_TRACK
+
 
 def test_create_claim_deliver_trivial_then_reconcile_noop(driver):
     # `create feat` mints a shape-feat leaf (not a container); claimable once ready.
     # `--orphan` is required alongside `--parent` (create.py: exactly one of the two).
-    item_id = driver(["create", "feat", "--title", "lc-leaf", "--priority", "2", "--orphan"])[
-        "data"
-    ]["id"]
+    # `--track` is required too: these are orphans, so there is no tracked parent
+    # to inherit from and the fixture config enforces the track gate.
+    item_id = driver(
+        [
+            "create",
+            "feat",
+            "--title",
+            "lc-leaf",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
     assert driver(["claim", item_id])["ok"] is True
     # A leaf delivery with trivial evidence closes it.
     delivered = driver(["deliver", item_id, "--trivial"])
@@ -25,9 +39,19 @@ def test_plan_add_then_done(driver):
     # no separate "add to queue" step distinct from --done. An epic IS a container
     # (nouns.py: is_container=True), so --done needs no --force (plan's guard:
     # `not is_container(item) and not args.force`).
-    item_id = driver(["create", "epic", "--title", "lc-epic", "--priority", "2", "--orphan"])[
-        "data"
-    ]["id"]
+    item_id = driver(
+        [
+            "create",
+            "epic",
+            "--title",
+            "lc-epic",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
     added = driver(["plan", item_id, "--done"])
     assert added["ok"] is True
     assert added["data"]["planned"] is True
@@ -42,9 +66,19 @@ def test_plan_add_then_done(driver):
 def test_promote_leaf_to_spec_container(driver):
     # promote requires a shape-feat leaf (transitions.py::promote); `create feat`
     # provides exactly that. Result: the leaf becomes a shape-spec container.
-    leaf = driver(["create", "feat", "--title", "lc-promote", "--priority", "2", "--orphan"])[
-        "data"
-    ]["id"]
+    leaf = driver(
+        [
+            "create",
+            "feat",
+            "--title",
+            "lc-promote",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )["data"]["id"]
     promoted = driver(["promote", leaf])
     assert promoted["ok"] is True
     assert promoted["data"]["promoted"] == "spec"

--- a/packages/workcli/tests/integration/test_nouns.py
+++ b/packages/workcli/tests/integration/test_nouns.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+from tests.integration.conftest import ITEST_TRACK
+
 # (noun, expected bd type, expected shape label) — verified against
 # lifecycle/nouns.py NOUN_TEMPLATES (bd_type, shape_label). Exact contract.
 NOUN_EXPECTATIONS = [
@@ -19,12 +21,25 @@ NOUN_EXPECTATIONS = [
 
 @pytest.mark.parametrize("noun,bd_type,shape_label", NOUN_EXPECTATIONS)
 def test_create_noun_stamps_type_and_shape_label(driver, noun, bd_type, shape_label):
-    created = driver(["create", noun, "--title", f"noun-{noun}", "--priority", "2", "--orphan"])
+    created = driver(
+        [
+            "create",
+            noun,
+            "--title",
+            f"noun-{noun}",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )
     assert created["ok"] is True, created
     item_id = created["data"]["id"]  # create → {"id": ...}
     shown = driver(["show", item_id])["data"]  # single-id show → item directly
     assert shown["type"] == bd_type  # Item field is `type`, not `issue_type`
     assert shape_label in shown["labels"]
+    assert f"track:{ITEST_TRACK}" in shown["labels"]  # --track lands as the track label
 
 
 def test_create_spec_children_carry_exactly_their_own_labels(driver):
@@ -34,9 +49,25 @@ def test_create_spec_children_carry_exactly_their_own_labels(driver):
     # and `shape-spec` (wgclw.9.8). The adapter opts out per create; this pins
     # the EXACT label set against a live bd so any new inheritance surprise
     # fails loudly here, not in a reconcile sweep.
-    created = driver(["create", "spec", "--title", "exact-labels", "--priority", "2", "--orphan"])
+    created = driver(
+        [
+            "create",
+            "spec",
+            "--title",
+            "exact-labels",
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+        ]
+    )
     assert created["ok"] is True, created
     design = driver(["show", created["data"]["design_child"]])["data"]
     placeholder = driver(["show", created["data"]["placeholder"]])["data"]
-    assert set(design["labels"]) == {"shape-design"}
-    assert set(placeholder["labels"]) == {"impl-placeholder"}
+    # The container's track propagates to both children (create.py:
+    # instantiate_spec_shape stamps track_label on each), so the exact sets are
+    # the child's own label plus that track — and nothing inherited.
+    track = f"track:{ITEST_TRACK}"
+    assert set(design["labels"]) == {"shape-design", track}
+    assert set(placeholder["labels"]) == {"impl-placeholder", track}


### PR DESCRIPTION
Closes `agents-config-9k9.168`.

## What was wrong

`packages/workcli`'s real-bd integration suite has been **14 of 36 red** since track
enforcement turned on. Nothing caught it: `pyproject.toml` pins `testpaths` to
`tests/unit`, and the `Makefile` deliberately keeps `itest-workcli` out of both
`ci-workcli` and `ci` (it needs the bd toolchain and runs ~2 minutes serial). So
`make ci-workcli` has been green at 99% coverage this whole time with this suite fully
broken — and the package's own `AGENTS.md` names this suite as mandatory pre-push
discipline, a duty it could not discharge for anyone.

One cause, two presentations: every `work create <noun>` in the suite named no track and
is `--orphan`, so under `enforcement = "required"` each was refused and wrote nothing.
Eight tests failed on the envelope assertion; six subscripted `["data"]` on the failed
envelope and surfaced a frame later as `TypeError`.

## The part that wasn't obvious

The failing envelope listed **this repository's** ten configured tracks — even though the
fixture binds bd to a throwaway off-repo install via `BEADS_DIR`. That isolation was never
as complete as it looked: the track layer resolves configuration by walking up from
`Path.cwd()`, and this suite drives production `main()` **in-process**, so the walk started
at pytest's own directory inside the repo and adopted the repo's `[tracks]` table.
`BEADS_DIR` binds the bd *subprocess*; it never bound an in-process TOML read.

That is a hermeticity defect in the fixture, not in production — a real `work` run is a
subprocess whose cwd genuinely is the project directory, so upward search is the intended
resolution. The suite's off-repo **safety** guarantee was never breached: the leak is a
read-only TOML read, and every bd call still goes through the injected runner. No separate
defect filed.

## The fix

Each throwaway install now writes its own `project-config.toml`, and the driver names it
as `--config` on every call, which overrides the upward search outright. The fixture config
declares a single track and **pins `enforcement = "required"` on purpose** — dropping to
`advisory` would have turned the suite green by retiring the very gate that broke it.
`test_crash_recovery.py`'s local driver, which called `main()` with no config binding at
all, now shares the same seam structurally rather than by per-call-site discipline.

Confined to `tests/integration/` — `project-config.toml` and `packages/workcli/src/` are
byte-identical to `main`.

## Verification

Both gates run standalone from the worktree root, exit status read on its own:

| Gate | Exit | Summary |
| --- | --- | --- |
| `make itest-workcli` (before) | 2 | `14 failed, 22 passed` |
| `make itest-workcli` (after) | **0** | `36 passed` |
| `make ci-workcli` | **0** | `665 passed`, 99.19% coverage |

Nothing was skipped, xfailed, deleted or narrowed to reach green: the set of test functions
hashes identical to `main` (30 functions, 36 node ids — one is parametrized 7 ways). Two
assertions were **added** — that the track label lands on a created noun, and that it
propagates to both spec children.

Proven independent of where it runs: `test_nouns.py` passes with cwd `/private/tmp`, outside
any repository. A direct probe confirms the gate is genuinely live inside the fixture
(a create with no `--track` is still refused) and that the ambient vocabulary is gone
(`--track workcli`, a real repo track, is now rejected as unknown).

## Two things deliberately left alone

- **Nothing gates this suite**, so it can go red again silently — which is exactly how it
  stayed red. Wiring it in is a real trade-off (bd toolchain, ~2 min serial) and a
  separate decision, not this PR's.
- **Runtime roughly doubled** (55s → 118s) on an unchanged test count. One small TOML write
  and parse per create does not obviously account for that; ambient machine load is at
  least as plausible. Flagged rather than diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1