### PR TITLE
fix(9k9.61, 9k9.1.21): a re-park repairs the marker a partial park never wrote

### DIFF
--- a/packages/workcli/src/workcli/lifecycle/park.py
+++ b/packages/workcli/src/workcli/lifecycle/park.py
@@ -47,6 +47,21 @@ REASONS: dict[str, str] = {
     "budget-exhausted": "human",
 }
 
+# What a repaired marker says about itself. A repair can only ever record the
+# repairing call's instant and reason -- the failed park's are unrecoverable --
+# so the marker admits it, in the free text where no reader parses.
+REPAIR_TEXT = "marker repaired on re-park; this timestamp and reason are the repairing call's"
+
+
+def _park_marker(now: datetime, reason: str, text: str) -> str:
+    """The one park-marker format: `[work] parked <ISO-8601> <code>: <text>`.
+
+    Everything before the first `": "` is the head `_last_park_record` parses
+    and must stay exactly two whitespace-separated tokens; `text` is free
+    prose no reader interprets.
+    """
+    return f"{PARKED_MARKER} {now.isoformat()} {reason}: {text}"
+
 
 def _last_park_record(notes: str) -> tuple[str | None, str | None]:
     """(parked_at, reason) from the LAST `[work] parked` marker, or Nones.
@@ -117,7 +132,9 @@ def park(backend: Backend, args: Namespace) -> JsonValue:
     Mutation order is graceful-degradation order: status `blocked` FIRST
     (kills claimability the instant anything lands), then the `parked`
     handle, then the marker note -- a crash mid-park leaves an item that is
-    at worst un-ready, never a claimable "parked" item.
+    at worst un-ready, never a claimable "parked" item. That order also makes
+    the marker the only thing a partial park can be missing, and re-parking
+    such an item repairs it.
     """
     if args.reason not in REASONS:
         raise WorkError(
@@ -128,20 +145,29 @@ def park(backend: Backend, args: Namespace) -> JsonValue:
     if item.status == "closed":
         raise WorkError(ErrorCode.USAGE, f"park {args.id}: cannot park a closed item")
     if PARKED_LABEL in item.labels:
-        # Idempotent replay: report the existing stint, mint nothing.
+        # Idempotent replay: report the existing stint, mint nothing -- unless
+        # there is no readable stint to report. The three primitives make a
+        # park that failed after the label a parked item with nothing
+        # recorded, and the label short-circuits every later park, so this
+        # branch is the only one that can ever repair it; reporting the
+        # incoming reason over an item that stores none would disguise the
+        # damage instead. Mint the marker the failed park owed, then report it.
         _, existing = _last_park_record(item.notes)
-        reason = existing if existing is not None else args.reason
+        if existing is None:
+            text = f"{REPAIR_TEXT}; {args.note}" if args.note else REPAIR_TEXT
+            backend.append_note(args.id, _park_marker(args.now(), args.reason, text))
+            existing = args.reason
         return {
             "id": args.id,
             "status": "parked",
-            "reason": reason,
-            "category": REASONS[reason],
+            "reason": existing,
+            "category": REASONS[existing],
         }
 
     backend.set_status(args.id, "blocked")
     backend.label_mutate("add", args.id, [PARKED_LABEL])
     text = args.note if args.note is not None else ""
-    backend.append_note(args.id, f"{PARKED_MARKER} {args.now().isoformat()} {args.reason}: {text}")
+    backend.append_note(args.id, _park_marker(args.now(), args.reason, text))
     return {
         "id": args.id,
         "status": "parked",

--- a/packages/workcli/tests/unit/test_park.py
+++ b/packages/workcli/tests/unit/test_park.py
@@ -27,12 +27,14 @@ from workcli.lifecycle.park import (
     PARKED_MARKER,
     REASONS,
     REDISPATCHED_MARKER,
+    REPAIR_TEXT,
     abandon,
     park,
     parked,
     redispatch,
 )
 from workcli.lifecycle.transitions import claim
+from workcli.verbs.read import ready
 
 _NOW = datetime(2026, 7, 22, 12, 0, 0, tzinfo=UTC)
 _ISO = _NOW.isoformat()
@@ -147,6 +149,60 @@ def test_repark_is_an_idempotent_noop_reporting_the_existing_stint():  # S2-B3
     }
 
 
+def test_repark_repairs_the_marker_a_failed_park_never_wrote():  # S2-B3 (partial park)
+    """A park that lost its note append is repaired by the next park call.
+
+    The three primitives land status-first, so the label is on with nothing
+    recorded -- and the label short-circuits every later park, making this
+    the only call that can ever mint the missing marker. The repaired
+    marker's head is the repairing call's instant and reason (the failed
+    park's are unrecoverable), which its free text says outright.
+    """
+    backend = FakeBackend().add("w1", status="blocked", labels=[PARKED_LABEL])
+
+    data = park(backend, _park_args("w1", "ci-failure", note="flaky job"))
+
+    # One marker, in the normal format: the caveat leads, the call's note follows.
+    assert backend.note_lines("w1") == [
+        f"{PARKED_MARKER} {_ISO} ci-failure: {REPAIR_TEXT}; flaky job"
+    ]
+    assert data == {"id": "w1", "status": "parked", "reason": "ci-failure", "category": "machine"}
+
+
+def test_a_repaired_stint_reads_back_as_a_real_one_on_every_surface():  # S2-B3 (partial park)
+    """The point of the repair: the item stops reporting nulls forever.
+
+    Before it, a marker-less parked item shows null reason and null
+    parked-at in `work parked` and sits in the `parked_stale` block on every
+    `ready` and `claim` -- the unknown-age arm, which no amount of waiting
+    clears.
+    """
+    backend = FakeBackend().add("w1", status="blocked", labels=[PARKED_LABEL])
+    backend.add("w2", status="open")
+
+    park(backend, _park_args("w1", "approval-required"))
+
+    assert parked(backend, _parked_args()) == {
+        "items": [
+            {
+                "id": "w1",
+                "title": "T",
+                "reason": "approval-required",
+                "category": "human",
+                "parked_at": _ISO,
+                "stale": False,
+            }
+        ],
+        "stale_days": 7,
+    }
+    for data in (
+        ready(backend, Namespace(label=None, now=lambda: _NOW)),
+        claim(backend, _id_args("w2")),
+    ):
+        assert isinstance(data, dict)
+        assert data["parked_stale"] == []
+
+
 def test_parked_item_is_not_claimable():  # S2-B4
     backend = FakeBackend().add("w1", status="in_progress")
     park(backend, _park_args("w1", "approval-required"))
@@ -209,6 +265,31 @@ def test_abandon_records_its_own_distinct_intent():  # S2-B6
     assert PARKED_LABEL not in item.labels
     assert f"{ABANDONED_MARKER} {_ISO}" in backend.note_lines("w1")
     assert data == {"id": "w1", "status": "open"}
+
+
+def test_abandon_twice_is_an_idempotent_no_op_that_writes_nothing():  # S2-B6 (idempotency)
+    """A lost response makes the executor re-issue `abandon`; the replay is a no-op.
+
+    `abandon` reaches that contract only through the branch it shares with
+    `redispatch`, whose no-op is pinned separately -- so a guard inserted
+    ahead of the shared path would break the retry with the suite green.
+    The replay runs on a backend that raises on every mutator, which turns
+    "returns before any write" into a proof rather than a state comparison.
+    """
+    backend = FakeBackend()
+    _parked_item(backend, "w1", parked_at=_ISO, reason="budget-exhausted")
+
+    first = abandon(backend, _id_args("w1"))
+    settled = backend.get("w1")
+    replay_backend = ReadOnlyFakeBackend().add(
+        "w1", status=settled.status, labels=settled.labels, notes=settled.notes
+    )
+
+    second = abandon(replay_backend, _id_args("w1"))
+
+    assert first == second == {"id": "w1", "status": "open"}
+    lines = replay_backend.note_lines("w1")
+    assert sum(1 for line in lines if line.startswith(ABANDONED_MARKER)) == 1
 
 
 def test_parked_report_lists_reason_category_staleness_read_only():  # S2-B7


### PR DESCRIPTION
Closes `agents-config-9k9.61` and `agents-config-9k9.1.21`.

## What was wrong

Parking an item performs three writes in order: status, label, then the marker note. If the
last one fails, the item is left carrying the parked label with no marker — and it stays that
way forever. Every later `work park` call sees the label, short-circuits, reads the marker
only to fill its own reply, and repairs nothing.

The consequences compound quietly:

- `work parked` reports `reason: null` and `parked_at: null` for that item.
- Because the staleness check admits a null `parked_at` through its *unknown-age* arm, the item
  sits permanently in the stale block that both `ready` and `claim` carry. No amount of waiting
  clears it.
- Worst of the three: the reply envelope fell back to the *incoming* call's reason, so a re-park
  cheerfully reported `reason: ci-failure` while the item stored no reason at all. The failure
  was disguised rather than surfaced.

Separately, `work abandon`'s idempotency was real but unpinned — no test anywhere called it
twice, and its correctness rode entirely on a sibling verb's test.

## The fix

The replay branch now mints the missing marker when the stint has no readable reason, then
reports it. The trigger is exactly the condition under which the old code was about to claim a
reason nothing stored, so **the envelope is now truthful by construction** rather than by case
analysis — the only path that reports the incoming reason is the one that has just written it.

Marker construction moved into a single helper used by both the normal path and the repair, so
the repaired marker cannot drift from the real format.

**One judgement call worth surfacing.** The original park's instant and reason are unrecoverable
— nothing stored them, which *is* the bug. The repaired marker therefore carries the *repairing*
call's timestamp and reason, and **says so in its own free text**. Writing them silently was the
option to avoid: it resets the staleness clock invisibly, so an item stuck three weeks reads as
parked seconds ago and no reader can tell. The caveat lives in the free-text tail, after the
separator, so the repaired marker stays byte-compatible with a normal one for every parser while
being explicit to a human.

The repair deliberately does **not** fire on a marker with a readable reason but a corrupt
timestamp: no code path produces one, and repairing it would overwrite a readable record on the
strength of a hand-edit. That item keeps its pre-existing behaviour, which is separately pinned.

## Verification

`make ci-workcli` run standalone from the worktree root, exit status read on its own: **exit 0**.
668 passed, 99.19% coverage against a 90% floor.

Both repair tests **failed before the change** and were staged honestly to prove it — the helper
extraction landed first as a pure refactor, so the pre-fix run exercised the real old logic rather
than dying on an import error. Pre-fix: `2 failed, 24 passed`.

The zero-writes claim on `abandon` is a proof rather than an inference: the replay runs against a
read-only fake that raises on every mutator, so the test shows the verb returns *before* reaching
one, not merely that state was unchanged.

The test file is **purely additive** — `git diff` reports zero removed lines, so no existing park,
redispatch or abandon test was edited to accommodate the new behaviour.

`make itest-workcli` was not run: it is excluded from `ci-workcli`, and it is red on `main` for
unrelated reasons that #470 fixes. This change touches no backend JSON parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1