### PR TITLE
fix(9k9.169): create routes noun and priority through the validators discover already uses

### DIFF
--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -24,7 +24,7 @@ from workcli.adapters.bd.backend import BdBackend
 from workcli.adapters.bd.runner import BdRunner, SubprocessBdRunner
 from workcli.config import TrackLayerConfig, load_config
 from workcli.envelope import ErrorCode, JsonValue, WorkError, emit_failure, emit_success
-from workcli.lifecycle.nouns import LEAF_NOUNS, Noun
+from workcli.lifecycle.nouns import LEAF_NOUNS
 from workcli.lifecycle.park import DEFAULT_STALE_DAYS
 from workcli.render import render_human
 from workcli.verbs import VERBS, missing_capability
@@ -70,9 +70,16 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
     create_parser.add_argument(
         "noun",
         nargs="?",
-        choices=[noun.value for noun in Noun],
         metavar="NOUN",
-        help="spike|chore|decision|feat|bugfix|spec|epic|milestone -- omit with --raw",
+        # No `choices=` here: an invalid NOUN is validated inside the
+        # create_noun handler instead of by argparse, alongside --priority, so
+        # a caller who gets both wrong learns both from one invocation rather
+        # than argparse raising on whichever it parses first -- same
+        # precedent as `discover`'s --noun.
+        help=(
+            "spike|chore|decision|feat|bugfix|spec|epic|milestone "
+            "('bug' accepted as an alias for bugfix) -- omit with --raw"
+        ),
     )
     create_parser.add_argument("--raw", action="store_true")
     create_parser.add_argument("--title", required=True)

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -24,7 +24,7 @@ from workcli.adapters.bd.backend import BdBackend
 from workcli.adapters.bd.runner import BdRunner, SubprocessBdRunner
 from workcli.config import TrackLayerConfig, load_config
 from workcli.envelope import ErrorCode, JsonValue, WorkError, emit_failure, emit_success
-from workcli.lifecycle.nouns import LEAF_NOUNS
+from workcli.lifecycle.nouns import LEAF_NOUNS, Noun
 from workcli.lifecycle.park import DEFAULT_STALE_DAYS
 from workcli.render import render_human
 from workcli.verbs import VERBS, missing_capability
@@ -77,7 +77,7 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
         # than argparse raising on whichever it parses first -- same
         # precedent as `discover`'s --noun.
         help=(
-            "spike|chore|decision|feat|bugfix|spec|epic|milestone "
+            f"{'|'.join(noun.value for noun in Noun)} "
             "('bug' accepted as an alias for bugfix) -- omit with --raw"
         ),
     )

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -26,6 +26,7 @@ from workcli.lifecycle.nouns import (
     NounTemplate,
 )
 from workcli.lifecycle.park import PARKED_LABEL
+from workcli.lifecycle.validate import combine_errors, validate_noun, validate_priority
 from workcli.model import CreateFields
 from workcli.tracks import TRACK_PREFIX, derive_track, require_known_track, track_label
 
@@ -121,6 +122,38 @@ def finalize_spec_instantiation(
     backend.label_mutate("add", container_id, [PLANNED_LABEL])
     backend.label_mutate("remove", container_id, [CREATING_SPEC_LABEL])
     return design_child_id, placeholder_id
+
+
+def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str | None]:
+    """Validate the NOUN positional and --priority together, in one pass.
+
+    Same two-pass shape as `discover`'s validator, over the same shared
+    `validate.validate_noun`/`validate.validate_priority` primitives: both
+    validators run before either is allowed to raise, so a caller with both
+    fields wrong learns about both from one invocation. Unlike `discover`,
+    `create` accepts every noun (not just leaf nouns) and --priority stays
+    optional -- omitted, it passes through as `None` unchanged, exactly as
+    before this validator existed.
+    """
+    noun_result: Noun | WorkError
+    try:
+        noun_result = validate_noun(args.noun)
+    except WorkError as noun_error:
+        noun_result = noun_error
+
+    priority_result: str | None | WorkError
+    try:
+        priority_result = None if args.priority is None else validate_priority(args.priority)
+    except WorkError as priority_error:
+        priority_result = priority_error
+
+    if isinstance(noun_result, WorkError) and isinstance(priority_result, WorkError):
+        raise combine_errors([noun_result, priority_result])
+    if isinstance(noun_result, WorkError):
+        raise noun_result
+    if isinstance(priority_result, WorkError):
+        raise priority_result
+    return noun_result, priority_result
 
 
 def _validate_usage(args: Namespace, noun: Noun) -> None:
@@ -258,8 +291,19 @@ def _create_spec_container(
 
 
 def create_noun(backend: Backend, args: Namespace) -> JsonValue:
-    """`work create <noun> --title T (--parent ID | --orphan) [...]`."""
-    noun = Noun(args.noun)
+    """`work create <noun> --title T (--parent ID | --orphan) [...]`.
+
+    NOUN and --priority are validated together, before any backend call --
+    same precedence discover's aggregate holds, and the same reason: a caller
+    who gets both wrong learns about both from one invocation, and an invalid
+    NOUN never reaches bd. `args.priority` is reassigned to the validated,
+    canonicalized value so every downstream read (here and in
+    `_create_spec_container`) sees the same notation `discover` would have
+    produced for the same input, without threading a second parameter through
+    both call sites.
+    """
+    noun, priority = _validate_noun_and_priority(args)
+    args.priority = priority
     template = NOUN_TEMPLATES[noun]
 
     _validate_usage(args, noun)

--- a/packages/workcli/src/workcli/lifecycle/discover.py
+++ b/packages/workcli/src/workcli/lifecycle/discover.py
@@ -15,7 +15,6 @@ validation, and track resolution all execute unchanged.
 
 from __future__ import annotations
 
-import re
 from argparse import Namespace
 from typing import cast
 
@@ -23,13 +22,13 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
 from workcli.lifecycle.create import create_noun
-from workcli.lifecycle.nouns import LEAF_NOUNS, Noun, resolve_noun
+from workcli.lifecycle.nouns import LEAF_NOUNS, Noun
+from workcli.lifecycle.validate import combine_errors, validate_noun
+from workcli.lifecycle.validate import validate_priority as _validate_priority_format
 from workcli.model import Item
 from workcli.tracks import derive_track
 
 _HATCHES = ("externally-blocked", "blast-radius", "own-cycle")
-_PRIORITY_RE = re.compile(r"^P[0-4]$")
-_BARE_PRIORITY_RE = re.compile(r"^[0-4]$")
 _DISCOVERED_FROM_TYPE = "discovered-from"
 _ORPHAN_ANCHOR_DISPLAY = "none: escalated"
 
@@ -75,68 +74,19 @@ def _parse_scope(value: str | None) -> tuple[str, str | None]:
     )
 
 
-def _normalize_priority(value: str) -> str:
-    """A bare digit ('2') normalizes to the canonical 'P2' notation.
-
-    Nothing else about the value is ambiguous -- only the notation was ever
-    rejected -- so anything not matching the bare-digit shape passes through
-    unchanged for `_PRIORITY_RE` to accept or reject as before.
-    """
-    if _BARE_PRIORITY_RE.match(value):
-        return f"P{value}"
-    return value
-
-
 def _validate_priority(value: str | None) -> str:
+    """discover's own required-ness over the shared notation rule
+    (`validate.validate_priority`): missing is triage-semantic, and so is a
+    malformed value -- both `E_TRIAGE_INCOMPLETE`, unlike `create`'s plain
+    `E_USAGE` framing over the same shared validator.
+    """
     if value is None:
         raise _triage_incomplete("priority", "--priority is required")
-    normalized = _normalize_priority(value)
-    if not _PRIORITY_RE.match(normalized):
-        raise _triage_incomplete("priority", f"priority must be one of P0-P4, got {value!r}")
-    return normalized
+    return _validate_priority_format(value, code=ErrorCode.TRIAGE_INCOMPLETE)
 
 
 def _validate_noun(value: str) -> Noun:
-    noun = resolve_noun(value)
-    if noun is not None and noun in LEAF_NOUNS:
-        return noun
-    raise WorkError(
-        ErrorCode.USAGE,
-        f"invalid choice: {value!r} (choose from {', '.join(n.value for n in LEAF_NOUNS)})",
-        detail={"field": "noun"},
-    )
-
-
-def _combined_error(errors: list[WorkError]) -> WorkError:
-    """Fold 2+ independent field failures into one well-formed error.
-
-    `message` and `detail.errors` preserve every folded failure's own
-    message and code verbatim. The top-level `code` is `E_TRIAGE_INCOMPLETE`
-    if any folded failure is triage-semantic, `E_USAGE` only when every
-    folded failure is pure arg-shape -- so a caller grepping the top level
-    for a triage rejection still finds one when an unrelated arg-shape
-    mistake co-occurs in the same call.
-    """
-    detail: dict[str, JsonValue] = {
-        "errors": cast(
-            "list[JsonValue]",
-            [
-                {
-                    "code": str(error.code),
-                    "field": error.detail.get("field"),
-                    "message": error.message,
-                }
-                for error in errors
-            ],
-        )
-    }
-    message = "; ".join(f"{error.detail.get('field', '?')}: {error.message}" for error in errors)
-    code = (
-        ErrorCode.TRIAGE_INCOMPLETE
-        if any(error.code is ErrorCode.TRIAGE_INCOMPLETE for error in errors)
-        else ErrorCode.USAGE
-    )
-    return WorkError(code, message, detail)
+    return validate_noun(value, LEAF_NOUNS)
 
 
 def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:
@@ -145,7 +95,7 @@ def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:
     Both validators run before either is allowed to raise, so a caller with
     both fields wrong learns about both from one invocation. A single-field
     failure still raises that field's own error unchanged; two failures fold
-    into one via `_combined_error`.
+    into one via `validate.combine_errors`.
     """
     noun_result: Noun | WorkError
     try:
@@ -160,7 +110,7 @@ def _validate_noun_and_priority(args: Namespace) -> tuple[Noun, str]:
         priority_result = priority_error
 
     if isinstance(noun_result, WorkError) and isinstance(priority_result, WorkError):
-        raise _combined_error([noun_result, priority_result])
+        raise combine_errors([noun_result, priority_result])
     if isinstance(noun_result, WorkError):
         raise noun_result
     if isinstance(priority_result, WorkError):

--- a/packages/workcli/src/workcli/lifecycle/validate.py
+++ b/packages/workcli/src/workcli/lifecycle/validate.py
@@ -1,0 +1,97 @@
+"""Shared field validation for `create` and `discover` -- noun aliases,
+priority notation, and folding independent field failures into one envelope.
+
+Both lifecycle verbs mint through the same noun vocabulary (`resolve_noun`)
+and accept the same priority notations; this module is their single shared
+implementation so the two verbs cannot drift apart on either rule. `create`
+and `discover` each own their own required/optional and error-code framing
+around these primitives -- that framing differs by verb (a missing priority
+is `E_TRIAGE_INCOMPLETE` for `discover`, simply omitted for `create`), so it
+stays in each verb's own module.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from typing import cast
+
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.nouns import Noun, resolve_noun
+
+_PRIORITY_RE = re.compile(r"^P[0-4]$")
+_BARE_PRIORITY_RE = re.compile(r"^[0-4]$")
+
+
+def validate_noun(value: str, choices: Sequence[Noun] = tuple(Noun)) -> Noun:
+    """Resolve `value` to a `Noun` in `choices`, accepting aliases too.
+
+    Raises `E_USAGE` (field `"noun"`) naming `choices` when `value` is
+    neither a canonical noun value, a known alias, nor in `choices` --
+    the single validator behind both `create <noun>` (all nouns) and
+    `discover --noun` (`LEAF_NOUNS` only).
+    """
+    noun = resolve_noun(value)
+    if noun is not None and noun in choices:
+        return noun
+    raise WorkError(
+        ErrorCode.USAGE,
+        f"invalid choice: {value!r} (choose from {', '.join(n.value for n in choices)})",
+        detail={"field": "noun"},
+    )
+
+
+def normalize_priority(value: str) -> str:
+    """A bare digit ('2') normalizes to the canonical 'P2' notation.
+
+    Nothing else about the value is ambiguous -- only the notation was ever
+    rejected -- so anything not matching the bare-digit shape passes through
+    unchanged for `validate_priority` to accept or reject as before.
+    """
+    if _BARE_PRIORITY_RE.match(value):
+        return f"P{value}"
+    return value
+
+
+def validate_priority(value: str, *, code: ErrorCode = ErrorCode.USAGE) -> str:
+    """Normalize then validate P0-P4; raises `code` (field `"priority"`) on failure.
+
+    `code` lets each call site pick its own error-code framing (`discover`
+    raises `E_TRIAGE_INCOMPLETE` for a malformed priority; `create` raises
+    plain `E_USAGE`) over the one shared notation rule.
+    """
+    normalized = normalize_priority(value)
+    if not _PRIORITY_RE.match(normalized):
+        raise WorkError(
+            code, f"priority must be one of P0-P4, got {value!r}", {"field": "priority"}
+        )
+    return normalized
+
+
+def combine_errors(errors: Sequence[WorkError]) -> WorkError:
+    """Fold 2+ independent field failures into one well-formed error.
+
+    `message` and `detail.errors` preserve every folded failure's own
+    message and code verbatim. The top-level `code` is the first non-`E_USAGE`
+    code among the folded failures, else `E_USAGE` -- so a caller grepping the
+    top level for a semantic rejection (e.g. `E_TRIAGE_INCOMPLETE`) still
+    finds one when an unrelated arg-shape mistake co-occurs in the same call.
+    """
+    detail: dict[str, JsonValue] = {
+        "errors": cast(
+            "list[JsonValue]",
+            [
+                {
+                    "code": str(error.code),
+                    "field": error.detail.get("field"),
+                    "message": error.message,
+                }
+                for error in errors
+            ],
+        )
+    }
+    message = "; ".join(f"{error.detail.get('field', '?')}: {error.message}" for error in errors)
+    code = next(
+        (error.code for error in errors if error.code is not ErrorCode.USAGE), ErrorCode.USAGE
+    )
+    return WorkError(code, message, detail)

--- a/packages/workcli/tests/unit/test_create_noun_synonyms.py
+++ b/packages/workcli/tests/unit/test_create_noun_synonyms.py
@@ -1,0 +1,285 @@
+"""`work create <noun>` accepts the same noun aliases and priority notations
+`work discover --noun` already does -- 9k9.169, the residual of 9k9.99 for
+the `create` surface.
+
+`create`'s NOUN positional used to be an argparse `choices=` list built
+straight off the `Noun` enum, which bypassed `resolve_noun` (and its
+`NOUN_ALIASES`) entirely and rejected before the handler -- and hence before
+`discover`-style combined-error reporting -- ever ran. These tests pin: the
+alias resolves to the identical mint discover's does, the bare-priority-digit
+form normalizes the same way, an invalid NOUN is rejected by the handler (not
+argparse) with zero backend calls, and an invalid NOUN + an invalid --priority
+together fold into one envelope.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from argparse import Namespace
+
+import pytest
+
+from tests.conftest import run_cli_with_runner
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, WorkError
+from workcli.lifecycle.create import create_noun
+
+
+def _not_found_config_loader(_explicit_path: str | None = None) -> TrackLayerConfig:
+    # Byte-identical to pre-track-layer behavior: NOT_CONFIGURED/"not-found"
+    # makes the track gate a no-op, same convention as test_create_noun.py.
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured: no project-config.toml",
+        detail={"reason": "not-found"},
+    )
+
+
+def _search_result(*raw_items: dict[str, object]) -> BdResult:
+    return BdResult(returncode=0, stdout=json.dumps(list(raw_items)), stderr="")
+
+
+def _create_result(new_id: str) -> BdResult:
+    return BdResult(
+        returncode=0,
+        stdout=json.dumps({"id": new_id, "schema_version": 3, "title": "T"}),
+        stderr="",
+    )
+
+
+def _create_args(
+    *,
+    noun: str = "chore",
+    priority: str | None = None,
+    parent: str | None = "P",
+) -> Namespace:
+    return Namespace(
+        noun=noun,
+        raw=False,
+        title="T",
+        description=None,
+        type=None,
+        priority=priority,
+        parent=parent,
+        label=[],
+        orphan=parent is None,
+        spec=None,
+        trivial=False,
+        acceptance=None,
+        track=None,
+        load_config=_not_found_config_loader,
+    )
+
+
+# --- AC1: 'bug' mints the identical item 'bugfix' would ---
+
+
+def test_create_bug_alias_sends_the_identical_bd_call_as_bugfix() -> None:
+    runner_alias = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("search",), _search_result()),
+            ScriptedStep(("create",), _create_result("x.1")),
+        ]
+    )
+    runner_canon = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("search",), _search_result()),
+            ScriptedStep(("create",), _create_result("x.1")),
+        ]
+    )
+
+    exit_alias, envelope_alias, _ = run_cli_with_runner(
+        ["create", "bug", "--title", "T", "--parent", "P"],
+        runner_alias,
+        config_loader=_not_found_config_loader,
+    )
+    exit_canon, envelope_canon, _ = run_cli_with_runner(
+        ["create", "bugfix", "--title", "T", "--parent", "P"],
+        runner_canon,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_alias == 0 and exit_canon == 0
+    assert envelope_alias["data"] == envelope_canon["data"]
+    assert runner_alias.calls == runner_canon.calls
+    assert runner_canon.calls == [
+        ("search", "T", "--json"),
+        (
+            "create",
+            "--json",
+            "--title",
+            "T",
+            "--type",
+            "bug",
+            "--parent",
+            "P",
+            "--no-inherit-labels",
+            "--labels",
+            "shape-bugfix",
+        ),
+    ]
+
+
+def test_create_bug_alias_and_canonical_form_produce_byte_identical_items() -> None:
+    backend_alias = FakeBackend()
+    backend_canon = FakeBackend()
+
+    data_alias = create_noun(backend_alias, _create_args(noun="bug"))
+    data_canon = create_noun(backend_canon, _create_args(noun="bugfix"))
+
+    assert isinstance(data_alias, dict)
+    assert isinstance(data_canon, dict)
+    item_alias = backend_alias.get(str(data_alias["id"]))
+    item_canon = backend_canon.get(str(data_canon["id"]))
+
+    assert dataclasses.replace(item_alias, id="") == dataclasses.replace(item_canon, id="")
+
+
+# --- AC2: bare-digit --priority accepted on the same terms discover accepts it ---
+
+
+def test_create_bare_priority_digit_normalizes_to_canonical_p_notation() -> None:
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("search",), _search_result()),
+            ScriptedStep(("create",), _create_result("x.1")),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["create", "chore", "--title", "T", "--parent", "P", "--priority", "2"],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 0
+    assert envelope["data"] == {"id": "x.1"}
+    assert runner.calls == [
+        ("search", "T", "--json"),
+        (
+            "create",
+            "--json",
+            "--title",
+            "T",
+            "--type",
+            "chore",
+            "--priority",
+            "P2",
+            "--parent",
+            "P",
+            "--no-inherit-labels",
+            "--labels",
+            "shape-chore",
+        ),
+    ]
+
+
+def test_create_priority_omitted_still_creates_without_a_priority_flag() -> None:
+    """Regression guard: --priority stays optional for `create` -- unlike
+    `discover`, which requires it. Every noun that worked before this change
+    (no --priority at all) must keep working."""
+    backend = FakeBackend()
+
+    data = create_noun(backend, _create_args(priority=None))
+
+    assert isinstance(data, dict)
+    assert backend.get(str(data["id"])).priority == "P2"  # FakeBackend's create() default
+
+
+def test_create_invalid_priority_alone_raises_its_own_usage_error() -> None:
+    """A valid noun with a malformed --priority still raises that field's own
+    (non-combined) error unchanged -- mirrors discover's
+    `test_priority_only_failure_still_returns_triage_incomplete_alone`, but
+    `create` has no triage concept, so the code stays plain `E_USAGE`."""
+    backend = ReadOnlyFakeBackend()
+
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(priority="P9"))
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert exc_info.value.message == "priority must be one of P0-P4, got 'P9'"
+    assert exc_info.value.detail == {"field": "priority"}
+
+
+# --- AC4: an invalid NOUN is rejected by the handler, not argparse, with zero backend calls ---
+
+
+def test_invalid_noun_rejected_by_handler_not_argparse_with_zero_backend_calls() -> None:
+    runner = ScriptedBdRunner(steps=[])
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["create", "widget", "--title", "T", "--parent", "P"],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.USAGE)
+    # argparse's own choices-rejection message is prefixed "argument NOUN: ";
+    # the handler's own message (validate.validate_noun) carries no such
+    # prefix -- this is the mechanical proof the rejection moved surfaces.
+    assert error["message"] == (
+        "invalid choice: 'widget' (choose from spike, chore, decision, feat, "
+        "bugfix, spec, epic, milestone)"
+    )
+    assert error["detail"] == {"field": "noun"}
+    assert runner.calls == []
+
+
+def test_invalid_noun_alone_touches_no_backend_mutation() -> None:
+    """Handler-level mirror of the CLI proof above, using `ReadOnlyFakeBackend`
+    (raises on every mutator) -- same proof shape as
+    `test_discover.test_unknown_noun_alone_touches_no_backend_mutation`."""
+    backend = ReadOnlyFakeBackend()
+
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(noun="widget"))
+
+    assert exc_info.value.code is ErrorCode.USAGE
+
+
+# --- AC3: an invalid NOUN and an invalid --priority together, one envelope ---
+
+
+def test_invalid_noun_and_invalid_priority_together_reported_in_one_envelope() -> None:
+    runner = ScriptedBdRunner(steps=[])
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["create", "widget", "--title", "T", "--parent", "P", "--priority", "P9"],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    # Neither folded failure is triage-semantic in create's context (create has
+    # no triage concept) -- the top-level code stays E_USAGE, unlike discover's
+    # equivalent aggregate, which surfaces E_TRIAGE_INCOMPLETE.
+    assert error["code"] == str(ErrorCode.USAGE)
+    errors = error["detail"]["errors"]
+    assert isinstance(errors, list)
+    fields = {entry["field"] for entry in errors}
+    assert fields == {"noun", "priority"}
+    codes_by_field = {entry["field"]: entry["code"] for entry in errors}
+    assert codes_by_field == {"noun": str(ErrorCode.USAGE), "priority": str(ErrorCode.USAGE)}
+    assert runner.calls == []
+
+
+def test_invalid_noun_and_invalid_priority_together_touches_no_backend_mutation() -> None:
+    backend = ReadOnlyFakeBackend()
+
+    with pytest.raises(WorkError) as exc_info:
+        create_noun(backend, _create_args(noun="widget", priority="P9"))
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    errors = exc_info.value.detail["errors"]
+    assert isinstance(errors, list)
+    fields = {entry["field"] for entry in errors}  # type: ignore[union-attr]
+    assert fields == {"noun", "priority"}


### PR DESCRIPTION
Closes `agents-config-9k9.169`. This is the residual of `agents-config-9k9.99`, which shipped
the same three fixes for `discover` only and was closed today.

## What was wrong

`work create` and `work discover` disagreed about their own vocabulary. `work discover --noun bug`
resolved the synonym happily; `work create bug` was rejected outright — and rejected by argparse,
because the NOUN positional was built with a `choices=` list derived straight off the noun enum,
bypassing the alias resolver entirely.

Rejecting there has a second cost beyond the synonym. Because argparse fires before the handler,
create could not participate in the combined-error reporting `discover` already had: a caller who
got both the noun *and* the priority wrong still paid two round-trips. `--priority` was likewise
passed through unnormalized, so the bare-integer form discover accepts was refused here.

An agent that learned `bug` works from one verb had no way to discover the other verb was stricter,
and the error it got back never mentioned that the synonym exists elsewhere.

## The fix

The noun and priority validation `discover.py` already carried is now a shared module, and both
verbs route through it. **Each rule still has exactly one implementation** — alias resolution stays
where it was, and the priority normalizer now lives in one place instead of being private to
discover.

That is slightly more than the routing change the item described, and deliberately so: the item's
own point is that two verbs disagreeing about one vocabulary is the defect, and leaving discover's
copy private would have set up the next divergence. Discover's behaviour is unchanged, and the
evidence is that **its entire existing test file passes unmodified** — not one line edited to
accommodate the extraction.

Create keeps the differences that are real rather than accidental: it accepts all eight nouns where
discover is leaf-only, and `--priority` stays optional where discover requires it.

## Verification

`make ci-workcli` run standalone from the worktree root, exit status read on its own: **exit 0**.
`ruff check` clean, `ruff format --check` clean, `mypy --strict` clean across 33 files, 674 passed
at 99.20% coverage against a 90% floor.

Probed live against the real CLI, with no item minted (both calls fail before any backend write):

```
$ work create bug --title zzz --priority nonsense --orphan --track workcli
E_USAGE: priority must be one of P0-P4, got 'nonsense'      # the NOUN got through
$ work create widget --title zzz --priority nonsense --orphan --track workcli
E_USAGE: noun: invalid choice: 'widget' (choose from ...); priority: must be one of P0-P4
         detail.errors: [ {field: noun, ...}, {field: priority, ...} ]   # one envelope, both faults
```

Zero-backend-call is proven two ways rather than inferred: at CLI level by asserting the subprocess
runner recorded no calls, and at handler level against a read-only fake that raises on every mutator.

Discoverability survives the loss of the argparse `choices` list — `work create --help` still
enumerates all eight nouns and now names the alias too:

```
NOUN    spike|chore|decision|feat|bugfix|spec|epic|milestone
        ('bug' accepted as an alias for bugfix) -- omit with --raw
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1