### PR TITLE
fix(9k9.146): a read verb declares what it cannot see, instead of reporting it empty

### DIFF
--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.4"
+PROTOCOL_VERSION = "1.5"

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -287,16 +287,30 @@ def parse_item(raw: dict[str, JsonValue], *, unknown: frozenset[str] = frozenset
     _assert_object_elements(dependencies, field="dependencies", item_id=item_id)
     _assert_object_elements(dependents, field="dependents", item_id=item_id)
 
-    deps = [
-        _dep_edge_from_raw(entry, item_id)
-        for entry in dependencies
-        if _dep_type(entry, item_id) != "parent-child"
-    ]
-    children = [
-        _dep_edge_from_raw(entry, item_id).id
-        for entry in dependents
-        if _dep_type(entry, item_id) == "parent-child"
-    ]
+    # A declared-unknown relationship is emptied here, not merely dropped by the
+    # verb layer. `bd list`/`ready` DO carry dependency rows, but with no status
+    # on the far end -- an edge that cannot say whether it still blocks. Keeping
+    # those on the Item would leave partial data for any in-package caller that
+    # reads `Item.deps` without consulting `unknown_relations`, which is the same
+    # half-truth one layer below the envelope.
+    deps = (
+        []
+        if "deps" in unknown
+        else [
+            _dep_edge_from_raw(entry, item_id)
+            for entry in dependencies
+            if _dep_type(entry, item_id) != "parent-child"
+        ]
+    )
+    children = (
+        []
+        if "children" in unknown
+        else [
+            _dep_edge_from_raw(entry, item_id).id
+            for entry in dependents
+            if _dep_type(entry, item_id) == "parent-child"
+        ]
+    )
 
     return Item(
         id=item_id,
@@ -305,16 +319,17 @@ def parse_item(raw: dict[str, JsonValue], *, unknown: frozenset[str] = frozenset
         status=_string_field(raw, "status", item_id),
         priority=f"P{priority_raw}",
         labels=_string_list_field(raw, "labels", item_id),
-        parent=str(raw["parent"]) if raw.get("parent") is not None else None,
+        parent=(None if "parent" in unknown or raw.get("parent") is None else str(raw["parent"])),
         deps=deps,
         children=children,
         description=_string_field(raw, "description", item_id, default=""),
         notes=_string_field(raw, "notes", item_id, default=""),
         created=str(raw["created_at"]) if raw.get("created_at") is not None else None,
         updated=str(raw["updated_at"]) if raw.get("updated_at") is not None else None,
-        # An unanswerable relationship keeps its empty value here and travels
-        # declared: the verb layer drops the field rather than publishing the
-        # empty as an answer.
+        # An unanswerable relationship is empty here AND travels declared, so
+        # neither layer can mistake it for an answer: in-package callers reading
+        # the Item see nothing to misread, and the verb layer drops the field
+        # rather than publishing the empty as a result.
         unknown_relations=unknown,
     )
 

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -16,9 +16,11 @@ golden fixtures, not documented anywhere in bd's `--help`):
   entries are raw edge rows (`issue_id`, `depends_on_id`, `type`) with no
   `status` for the other end at all.
 - `bd show` exposes no `children` key; children are recovered by filtering
-  `dependents[]` down to `dependency_type == "parent-child"`. `bd list`
-  exposes no `dependents` key at all, so query()-sourced Items always have
-  `children == []`.
+  `dependents[]` down to `dependency_type == "parent-child"`.
+
+Which reads can see which relationship is therefore not uniform, and
+`_UNKNOWN_RELATIONS` below is where that asymmetry is declared rather than
+absorbed.
 """
 
 from __future__ import annotations
@@ -32,6 +34,32 @@ from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.model import DepEdge, Item
 
 _REQUIRED_ITEM_KEYS = ("id", "title", "issue_type", "status", "priority")
+
+# Which relationships each bd read simply cannot answer, captured from bd
+# 1.0.3 against an isolated scratch install:
+#
+#   command   parent   dependencies       dependents
+#   show      yes      yes (full beads)   yes
+#   list      yes      yes (edge rows)    never emitted
+#   ready     yes      yes (edge rows)    never emitted
+#   search    never    never              never
+#
+# Children come from `dependents[]`, so only `show` can report them. `list`
+# and `ready` do carry edges, but as raw rows with no status for the far end,
+# and an edge without it cannot answer the one question deps are for -- so
+# they report no deps rather than edges that look complete and are not.
+#
+# Keyed on the command rather than sniffed from the payload because bd omits
+# any key whose value is empty: a missing `dependents` means "this item has no
+# children" under `show` and "this command never says" under the other three,
+# and no amount of looking at one payload tells those apart. Reading it as the
+# first is how `list` came to report every epic as childless.
+_UNKNOWN_RELATIONS: dict[str, frozenset[str]] = {
+    "show": frozenset(),
+    "list": frozenset({"children", "deps"}),
+    "ready": frozenset({"children", "deps"}),
+    "search": frozenset({"parent", "deps", "children"}),
+}
 
 # Confirmed against the real bd binary, per golden capture: a
 # not-found `show` logs this exact wording to stderr per missing id, even
@@ -234,7 +262,7 @@ def _assert_object_elements(entries: list[Any], *, field: str, item_id: str) -> 
             )
 
 
-def parse_item(raw: dict[str, JsonValue]) -> Item:
+def parse_item(raw: dict[str, JsonValue], *, unknown: frozenset[str] = frozenset()) -> Item:
     missing = [key for key in _REQUIRED_ITEM_KEYS if key not in raw]
     if missing:
         raise _drift(
@@ -284,11 +312,16 @@ def parse_item(raw: dict[str, JsonValue]) -> Item:
         notes=_string_field(raw, "notes", item_id, default=""),
         created=str(raw["created_at"]) if raw.get("created_at") is not None else None,
         updated=str(raw["updated_at"]) if raw.get("updated_at") is not None else None,
+        # An unanswerable relationship keeps its empty value here and travels
+        # declared: the verb layer drops the field rather than publishing the
+        # empty as an answer.
+        unknown_relations=unknown,
     )
 
 
 def parse_items(stdout: str, *, command: str = "show") -> list[Item]:
     raw_items = _load_json_array(stdout, command=command)
+    unknown = _UNKNOWN_RELATIONS[command]
     items = []
     for raw in raw_items:
         if not isinstance(raw, dict):
@@ -296,7 +329,7 @@ def parse_items(stdout: str, *, command: str = "show") -> list[Item]:
                 f"bd {command} array element is not a JSON object",
                 {"reason": "element_not_an_object", "raw_type": type(raw).__name__},
             )
-        items.append(parse_item(raw))
+        items.append(parse_item(raw, unknown=unknown))
     return items
 
 

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+# The three fields describing an item's place in the tree. Not every backend
+# read reports all three -- see `Item.unknown_relations`.
+RELATIONSHIP_FIELDS = ("parent", "deps", "children")
+
 
 @dataclass(frozen=True)
 class DepEdge:
@@ -32,6 +36,13 @@ class Item:
     notes: str
     created: str | None  # ISO strings as bd emits them; no datetime parsing in v1
     updated: str | None
+    # Which of `RELATIONSHIP_FIELDS` the source read could not express. The
+    # fields themselves hold their empty value when named here, and the verb
+    # layer drops them from the envelope rather than publishing an empty
+    # stand-in for an answer the backend never gave: `[]` is indistinguishable
+    # from a true "no children", so a verb that cannot see children must say
+    # so rather than imply there are none.
+    unknown_relations: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -22,6 +22,17 @@ def _serialize_item(item: Item) -> dict[str, JsonValue]:
     # `dataclasses.asdict` recurses into the nested `DepEdge` list too, so
     # `deps` comes out already lean (`{id, type, status}`) with no extra work.
     serialized = cast("dict[str, JsonValue]", dataclasses.asdict(item))
+    # A relationship the source read could not express is dropped rather than
+    # published as `null`/`[]`, and named in `unknown_relations` instead --
+    # sorted, and present on every read item so "this verb does not report
+    # children" is legible without knowing which verb produced the item. The
+    # empty stand-in is the thing being removed: a consumer could not tell it
+    # from a true answer, so `search` reported every item as an unparented
+    # leaf and `list` reported every epic as childless.
+    unknown = sorted(item.unknown_relations)
+    for field in unknown:
+        del serialized[field]
+    serialized["unknown_relations"] = cast("list[JsonValue]", unknown)
     # Derived in the verb layer, config-free, so every read envelope carries
     # it regardless of config state (the 1.1 additive field).
     serialized["track"] = derive_track(item.labels)

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -8,11 +8,16 @@ bead state directly, so a test builds a partially-delivered tree, runs the
 recovery, and asserts the final state.
 
 Fidelity choices that matter for recovery correctness:
-- `query()`/`ready()`/`search()` return *lean* Items (`children == []`,
-  `deps == []`), mirroring bd `list`, which carries no children/dependents key
-  (adapters/bd/parse.py). `reconcile` re-`get()`s every candidate precisely
-  because of this; the fake preserves that seam, so a regression that trusts a
-  query result's children is caught rather than masked.
+- `query()`/`ready()`/`search()` report only what the bd command behind each
+  can express, and name the rest in `unknown_relations` (the table in
+  adapters/bd/parse.py, captured from bd 1.0.3). `list`/`ready` carry a parent
+  and raw dependency edge rows but no dependents key at all, so children are
+  unknown and every edge's far-end status is unavailable without a second
+  fetch; `search` carries none of the three. `reconcile` re-`get()`s every
+  candidate precisely because of this, and the fake preserves that seam so a
+  regression that trusts a query result's children is caught rather than
+  masked. A fake that answered any of these from its own complete state would
+  hide exactly the class of defect this seam exists to catch.
 - `Item` is frozen and carries no `acceptance` field, so `get()` rebuilds a
   fresh snapshot per read, and acceptance -- which bd stores but the normalized
   Item drops -- is exposed for assertions via `acceptance_of()`.
@@ -38,6 +43,10 @@ from workcli.model import (
     SyncResult,
     UpdateFields,
 )
+
+# What each read cannot express, mirroring the parser's own per-command table.
+_QUERY_UNKNOWN = frozenset({"children", "deps"})
+_SEARCH_UNKNOWN = frozenset({"parent", "deps", "children"})
 
 
 @dataclass
@@ -115,7 +124,13 @@ class FakeBackend:
     def _children_of(self, item_id: str) -> list[str]:
         return [rec.id for rec in self._items.values() if rec.parent == item_id]
 
-    def _snapshot(self, rec: _Rec, *, lean: bool) -> Item:
+    def _snapshot(self, rec: _Rec, *, unknown: frozenset[str] = frozenset()) -> Item:
+        """One item as the named read would report it, unknowns emptied.
+
+        An unknown field holds its empty value here, exactly as the parser
+        leaves it -- the point is that the emptiness is declared, so nothing
+        downstream can read it as an answer.
+        """
         return Item(
             id=rec.id,
             title=rec.title,
@@ -123,13 +138,14 @@ class FakeBackend:
             status=rec.status,
             priority=rec.priority,
             labels=list(rec.labels),
-            parent=rec.parent,
-            deps=[] if lean else list(rec.deps),
-            children=[] if lean else self._children_of(rec.id),
+            parent=None if "parent" in unknown else rec.parent,
+            deps=[] if "deps" in unknown else list(rec.deps),
+            children=[] if "children" in unknown else self._children_of(rec.id),
             description=rec.description,
             notes=rec.notes,
             created=None,
             updated=None,
+            unknown_relations=unknown,
         )
 
     # -- Backend protocol --
@@ -141,7 +157,7 @@ class FakeBackend:
         )
 
     def get(self, item_id: str) -> Item:
-        return self._snapshot(self._require(item_id), lean=False)
+        return self._snapshot(self._require(item_id))
 
     def batch_get(self, ids: Sequence[str]) -> list[Item]:
         return [self.get(item_id) for item_id in ids]
@@ -217,14 +233,14 @@ class FakeBackend:
                 continue
             if filters.type is not None and rec.type != filters.type:
                 continue
-            out.append(self._snapshot(rec, lean=True))
+            out.append(self._snapshot(rec, unknown=_QUERY_UNKNOWN))
         if filters.limit is not None:
             out = out[: filters.limit]
         return out
 
     def ready(self, label: str | None) -> list[Item]:
         return [
-            self._snapshot(rec, lean=True)
+            self._snapshot(rec, unknown=_QUERY_UNKNOWN)
             for rec in self._items.values()
             if rec.status == "open" and (label is None or label in rec.labels)
         ]
@@ -269,7 +285,9 @@ class FakeBackend:
 
     def search(self, query: str) -> list[Item]:
         return [
-            self._snapshot(rec, lean=True) for rec in self._items.values() if query in rec.title
+            self._snapshot(rec, unknown=_SEARCH_UNKNOWN)
+            for rec in self._items.values()
+            if query in rec.title
         ]
 
     def sync(self, pull: bool) -> SyncResult:

--- a/packages/workcli/tests/fixtures/bd_list_shape.json
+++ b/packages/workcli/tests/fixtures/bd_list_shape.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "shp-23p.2",
+    "title": "rich item shape",
+    "description": "a real description",
+    "notes": "a note line",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T22:00:44Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T22:00:45Z",
+    "labels": [
+      "shape-bugfix",
+      "track:workcli"
+    ],
+    "dependencies": [
+      {
+        "issue_id": "shp-23p.2",
+        "depends_on_id": "shp-23p",
+        "type": "parent-child",
+        "created_at": "2026-08-07T18:00:43Z",
+        "created_by": "Scott Hamilton",
+        "metadata": "{}"
+      }
+    ],
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0,
+    "parent": "shp-23p"
+  },
+  {
+    "id": "shp-bdp",
+    "title": "shape blocker task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:40Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:40Z",
+    "dependency_count": 0,
+    "dependent_count": 1,
+    "comment_count": 0
+  },
+  {
+    "id": "shp-23p.1",
+    "title": "shape child task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:39Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:39Z",
+    "dependencies": [
+      {
+        "issue_id": "shp-23p.1",
+        "depends_on_id": "shp-23p",
+        "type": "parent-child",
+        "created_at": "2026-08-07T17:59:39Z",
+        "created_by": "Scott Hamilton",
+        "metadata": "{}"
+      },
+      {
+        "issue_id": "shp-23p.1",
+        "depends_on_id": "shp-bdp",
+        "type": "blocks",
+        "created_at": "2026-08-07T17:59:40Z",
+        "created_by": "Scott Hamilton",
+        "metadata": "{}"
+      }
+    ],
+    "dependency_count": 1,
+    "dependent_count": 0,
+    "comment_count": 0,
+    "parent": "shp-23p"
+  },
+  {
+    "id": "shp-23p",
+    "title": "shape parent epic",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "epic",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:38Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:38Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_ready_shape.json
+++ b/packages/workcli/tests/fixtures/bd_ready_shape.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "shp-23p.2",
+    "title": "rich item shape",
+    "description": "a real description",
+    "notes": "a note line",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T22:00:44Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T22:00:45Z",
+    "labels": [
+      "shape-bugfix",
+      "track:workcli"
+    ],
+    "dependencies": [
+      {
+        "issue_id": "shp-23p.2",
+        "depends_on_id": "shp-23p",
+        "type": "parent-child",
+        "created_at": "2026-08-07T18:00:43Z",
+        "created_by": "Scott Hamilton",
+        "metadata": "{}"
+      }
+    ],
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0,
+    "parent": "shp-23p"
+  },
+  {
+    "id": "shp-bdp",
+    "title": "shape blocker task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:40Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:40Z",
+    "dependency_count": 0,
+    "dependent_count": 1,
+    "comment_count": 0
+  },
+  {
+    "id": "shp-23p",
+    "title": "shape parent epic",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "epic",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:38Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:38Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_search_shape.json
+++ b/packages/workcli/tests/fixtures/bd_search_shape.json
@@ -1,0 +1,64 @@
+[
+  {
+    "id": "shp-23p.2",
+    "title": "rich item shape",
+    "description": "a real description",
+    "notes": "a note line",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T22:00:44Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T22:00:45Z",
+    "labels": [
+      "shape-bugfix",
+      "track:workcli"
+    ],
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  },
+  {
+    "id": "shp-bdp",
+    "title": "shape blocker task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:40Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:40Z",
+    "dependency_count": 0,
+    "dependent_count": 1,
+    "comment_count": 0
+  },
+  {
+    "id": "shp-23p.1",
+    "title": "shape child task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:39Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:39Z",
+    "dependency_count": 1,
+    "dependent_count": 0,
+    "comment_count": 0
+  },
+  {
+    "id": "shp-23p",
+    "title": "shape parent epic",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "epic",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:38Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:38Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_show_shape.json
+++ b/packages/workcli/tests/fixtures/bd_show_shape.json
@@ -1,0 +1,143 @@
+[
+  {
+    "id": "shp-23p",
+    "title": "shape parent epic",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "epic",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:38Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:38Z",
+    "dependents": [
+      {
+        "id": "shp-23p.1",
+        "title": "shape child task",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T21:59:39Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T21:59:39Z",
+        "dependency_type": "parent-child"
+      },
+      {
+        "id": "shp-23p.2",
+        "title": "rich item shape",
+        "description": "a real description",
+        "notes": "a note line",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T22:00:44Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T22:00:45Z",
+        "labels": [
+          "shape-bugfix",
+          "track:workcli"
+        ],
+        "dependency_type": "parent-child"
+      }
+    ],
+    "epic_total_children": 2,
+    "epic_closed_children": 0,
+    "epic_closeable": false
+  },
+  {
+    "id": "shp-23p.1",
+    "title": "shape child task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:39Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:39Z",
+    "dependencies": [
+      {
+        "id": "shp-23p",
+        "title": "shape parent epic",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "epic",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T21:59:38Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T21:59:38Z",
+        "dependency_type": "parent-child"
+      },
+      {
+        "id": "shp-bdp",
+        "title": "shape blocker task",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T21:59:40Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T21:59:40Z",
+        "dependency_type": "blocks"
+      }
+    ],
+    "parent": "shp-23p"
+  },
+  {
+    "id": "shp-23p.2",
+    "title": "rich item shape",
+    "description": "a real description",
+    "notes": "a note line",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T22:00:44Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T22:00:45Z",
+    "labels": [
+      "shape-bugfix",
+      "track:workcli"
+    ],
+    "dependencies": [
+      {
+        "id": "shp-23p",
+        "title": "shape parent epic",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "epic",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T21:59:38Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T21:59:38Z",
+        "dependency_type": "parent-child"
+      }
+    ],
+    "parent": "shp-23p"
+  },
+  {
+    "id": "shp-bdp",
+    "title": "shape blocker task",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-07T21:59:40Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-07T21:59:40Z",
+    "dependents": [
+      {
+        "id": "shp-23p.1",
+        "title": "shape child task",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scotthamilton77@gmail.com",
+        "created_at": "2026-08-07T21:59:39Z",
+        "created_by": "Scott Hamilton",
+        "updated_at": "2026-08-07T21:59:39Z",
+        "dependency_type": "blocks"
+      }
+    ]
+  }
+]

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -60,4 +60,10 @@ def test_protocol_wire_value_is_pinned() -> None:
     # The serialization boundary pins the literal wire value; every other
     # test references PROTOCOL_VERSION. Bumping the protocol means updating
     # this one assertion deliberately.
-    assert PROTOCOL_VERSION == "1.4"
+    #
+    # 1.5 adds `unknown_relations` to every read item and stops emitting the
+    # relationship fields it names. The removals keep the major: the fields
+    # they drop were never populated on those reads, so no consumer can have
+    # been reading a true value out of one, and the major is what every
+    # consumer handshake pins on.
+    assert PROTOCOL_VERSION == "1.5"

--- a/packages/workcli/tests/unit/test_read_relationship_contract.py
+++ b/packages/workcli/tests/unit/test_read_relationship_contract.py
@@ -29,6 +29,7 @@ import pytest
 from tests.conftest import run_cli
 from tests.fake_backend import FakeBackend
 from tests.fakes import ScriptedStep
+from workcli.adapters.bd.parse import parse_items
 from workcli.adapters.bd.runner import BdResult
 from workcli.envelope import JsonValue
 from workcli.model import RELATIONSHIP_FIELDS
@@ -253,3 +254,23 @@ def test_the_in_memory_backend_holds_the_same_contract_as_bd(verb: str) -> None:
     reported = _one(reads[verb](), "c-1")
 
     _assert_agrees_with_show(reported, shown, verb=verb)
+
+
+@pytest.mark.parametrize("command", ["show", "search", "list", "ready"])
+def test_a_parsed_item_never_holds_a_relationship_it_declares_unknown(command: str) -> None:
+    # The envelope drops a declared field, but `Item` is also read directly
+    # inside this package. `bd list`/`ready` DO emit dependency rows -- with no
+    # status on the far end -- so a parser that only declared, without emptying,
+    # left half-truth edges on the dataclass for any in-package caller that never
+    # consults `unknown_relations`. Pin both halves at the parse boundary.
+    items = parse_items(_payload(f"bd_{command}_shape.json"), command=command)
+    assert items, f"bd_{command}_shape.json carries no items"
+
+    empty_for = {"parent": None, "deps": [], "children": []}
+    for item in items:
+        for field in RELATIONSHIP_FIELDS:
+            if field in item.unknown_relations:
+                assert getattr(item, field) == empty_for[field], (
+                    f"{command} declares {field!r} unknown for {item.id} "
+                    f"but the Item still carries {getattr(item, field)!r}"
+                )

--- a/packages/workcli/tests/unit/test_read_relationship_contract.py
+++ b/packages/workcli/tests/unit/test_read_relationship_contract.py
@@ -1,0 +1,255 @@
+"""One relationship contract, held by every read verb.
+
+`show` is the only bd read whose payload carries all three of parent, deps and
+children. `list`/`ready` carry a parent and raw dependency edge rows but no
+dependents key at all; `search` carries none of the three. The contract under
+test is what the facade does about that: a relationship the source read cannot
+express is absent from the item and named in `unknown_relations`, so a
+consumer reads "not reported" where it used to read a confident `null`/`[]`
+that happened to be false.
+
+The bd payloads driving these tests are golden captures from an isolated
+scratch install (bd 1.0.3, off-repo temp dir, never this repository's
+tracker): a four-item tree where `shp-23p` is an epic with two children,
+`shp-23p.1` is a child that is also blocked by `shp-bdp`, and `shp-23p.2` is a
+child carrying labels, a description and notes. Capturing both sides of the
+comparison from the real binary is the point -- a hand-written payload would
+only prove the facade agrees with whatever this file imagines bd emits.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fake_backend import FakeBackend
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.envelope import JsonValue
+from workcli.model import RELATIONSHIP_FIELDS
+from workcli.verbs.read import list_, ready, search, show
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+_TREE_IDS = ("shp-23p", "shp-23p.1", "shp-23p.2", "shp-bdp")
+_PARENT_ID = "shp-23p"  # the epic bd reports two parent-child dependents for
+
+
+def _payload(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _ok(stdout: str) -> BdResult:
+    return BdResult(returncode=0, stdout=stdout, stderr="")
+
+
+_SHOW_STEPS = [ScriptedStep(("show",), _ok(_payload("bd_show_shape.json")))]
+_SEARCH_STEPS = [ScriptedStep(("search",), _ok(_payload("bd_search_shape.json")))]
+_LIST_STEPS = [ScriptedStep(("list",), _ok(_payload("bd_list_shape.json")))]
+# `ready` reads the parked set first (one `bd list --label parked`); no seeded
+# item carries the label, so the empty reply short-circuits the re-read.
+_READY_STEPS = [
+    ScriptedStep(("list",), _ok("[]")),
+    ScriptedStep(("ready",), _ok(_payload("bd_ready_shape.json"))),
+]
+
+_LIST_SHAPED_READS = (
+    ("search", ["search", "shape"], _SEARCH_STEPS),
+    ("list", ["list"], _LIST_STEPS),
+    ("ready", ["ready"], _READY_STEPS),
+)
+
+
+def _items_by_id(argv: list[str], steps: list[ScriptedStep]) -> dict[str, dict[str, JsonValue]]:
+    exit_code, envelope, _ = run_cli(argv, steps)
+
+    assert exit_code == 0, envelope
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    rows = data["items"]
+    assert isinstance(rows, list)
+    by_id: dict[str, dict[str, JsonValue]] = {}
+    for row in rows:
+        assert isinstance(row, dict)
+        by_id[str(row["id"])] = row
+    return by_id
+
+
+def _shown() -> dict[str, dict[str, JsonValue]]:
+    return _items_by_id(["show", *_TREE_IDS], _SHOW_STEPS)
+
+
+def _assert_agrees_with_show(
+    reported: dict[str, JsonValue], truth: dict[str, JsonValue], *, verb: str
+) -> None:
+    """The whole contract, applied identically to whichever verb reported it.
+
+    Every relationship field is either present and equal to what `show` says,
+    or absent and declared unknown. There is no third case -- and it is the
+    third case, a field present but silently unpopulated, that this pins out
+    of existence.
+    """
+    declared = reported["unknown_relations"]
+    assert isinstance(declared, list)
+    assert declared == sorted(declared), f"{verb}: unknown_relations is unordered: {declared!r}"
+    assert set(declared) <= set(RELATIONSHIP_FIELDS), (
+        f"{verb}: unknown_relations names a field outside the relationship set: {declared!r}"
+    )
+    for field in RELATIONSHIP_FIELDS:
+        if field in declared:
+            assert field not in reported, (
+                f"{verb}: {field} is declared unknown yet still reported as "
+                f"{reported[field]!r} -- an undeclared value is exactly what a "
+                "consumer cannot distinguish from truth"
+            )
+            continue
+        assert field in reported, f"{verb}: {field} is neither reported nor declared unknown"
+        assert reported[field] == truth[field], (
+            f"{verb}: reports {field}={reported[field]!r} for {reported['id']!r} "
+            f"while show reports {truth[field]!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("verb", "argv", "steps"), _LIST_SHAPED_READS, ids=[read[0] for read in _LIST_SHAPED_READS]
+)
+def test_every_read_verb_agrees_with_show_about_the_same_item(
+    verb: str, argv: list[str], steps: list[ScriptedStep]
+) -> None:
+    truth = _shown()
+
+    reported = _items_by_id(argv, steps)
+
+    assert reported, f"{verb}: the golden payload reported no items at all"
+    for item_id, item in reported.items():
+        _assert_agrees_with_show(item, truth[item_id], verb=verb)
+
+
+def test_show_still_reports_all_three_relationships() -> None:
+    # The surface that was already telling the truth; the contract must cost it
+    # nothing. `shp-23p` is the epic, so this also pins that a real child set
+    # still arrives as a child set.
+    parent = _shown()[_PARENT_ID]
+
+    assert parent["unknown_relations"] == []
+    assert parent["children"] == ["shp-23p.1", "shp-23p.2"]
+    assert parent["parent"] is None
+    assert parent["deps"] == []
+
+
+@pytest.mark.parametrize(
+    ("argv", "steps"),
+    [(argv, steps) for _, argv, steps in _LIST_SHAPED_READS],
+    ids=[read[0] for read in _LIST_SHAPED_READS],
+)
+def test_no_read_verb_reports_an_empty_child_set_for_an_item_that_has_children(
+    argv: list[str], steps: list[ScriptedStep]
+) -> None:
+    # The defect in one assertion: `shp-23p` has two children, and every one of
+    # these reads used to answer `children: []` for it.
+    item = _items_by_id(argv, steps)[_PARENT_ID]
+
+    assert "children" not in item
+    assert "children" in item["unknown_relations"]
+
+
+def test_the_three_list_shaped_reads_declare_exactly_what_their_payloads_lack() -> None:
+    # The per-verb pin behind the shared invariant: one verb quietly widening
+    # or narrowing what it claims to know fails here even if it stays
+    # self-consistent.
+    declared = {
+        verb: _items_by_id(argv, steps)[_PARENT_ID]["unknown_relations"]
+        for verb, argv, steps in _LIST_SHAPED_READS
+    }
+
+    assert declared == {
+        "search": ["children", "deps", "parent"],
+        "list": ["children", "deps"],
+        "ready": ["children", "deps"],
+    }
+
+
+def test_the_captured_bd_payloads_still_lack_the_keys_the_contract_assumes() -> None:
+    """The removal condition, made mechanical.
+
+    Every field declared unknown is declared unknown because bd's payload has
+    no key for it. If a later bd starts emitting one, this fails -- and the
+    right response is to report the field rather than to relax the assertion.
+    """
+    search_items = json.loads(_payload("bd_search_shape.json"))
+    list_items = json.loads(_payload("bd_list_shape.json"))
+    ready_items = json.loads(_payload("bd_ready_shape.json"))
+    show_items = json.loads(_payload("bd_show_shape.json"))
+
+    for item in search_items:
+        assert {"parent", "dependencies", "dependents"} & set(item) == set()
+    for item in (*list_items, *ready_items):
+        # No dependents key at all -- children are unrecoverable here.
+        assert "dependents" not in item
+        # Edges arrive as raw rows: a far-end id and a type, never its status.
+        for edge in item.get("dependencies", []):
+            assert "status" not in edge
+        # Parent, by contrast, is right there -- which is why these two report
+        # it and `search` does not.
+        assert "parent" in item or item["id"] not in {"shp-23p.1", "shp-23p.2"}
+    assert any("dependents" in item for item in show_items)
+    assert all("status" in edge for item in show_items for edge in item.get("dependencies", []))
+
+
+# -- the same contract at the verb layer, over the in-memory Backend ----------
+
+
+def _tree() -> FakeBackend:
+    backend = FakeBackend()
+    backend.add("p-1", title="the container")
+    backend.add("c-1", title="the child", parent="p-1")
+    return backend
+
+
+def _read_args(**overrides: object) -> Namespace:
+    base: dict[str, object] = {
+        "status": None,
+        "label": None,
+        "parent": None,
+        "type": None,
+        "limit": None,
+        "track": None,
+        "stale_days": 14,
+        "now": lambda: datetime(2026, 8, 7, 12, 0, tzinfo=UTC),
+        "load_config": lambda: None,
+    }
+    return Namespace(**{**base, **overrides})
+
+
+def _one(data: JsonValue, item_id: str) -> dict[str, JsonValue]:
+    assert isinstance(data, dict)
+    rows = data["items"]
+    assert isinstance(rows, list)
+    for row in rows:
+        assert isinstance(row, dict)
+        if row["id"] == item_id:
+            return row
+    raise AssertionError(f"{item_id} missing from {rows!r}")
+
+
+@pytest.mark.parametrize("verb", ["search", "list", "ready"])
+def test_the_in_memory_backend_holds_the_same_contract_as_bd(verb: str) -> None:
+    # The fake models each read's payload, not its own complete state, so a
+    # verb-level regression that trusts a search result's parent fails here
+    # without a real bd anywhere near it.
+    backend = _tree()
+    shown = show(backend, _read_args(ids=["c-1"]))
+    assert isinstance(shown, dict)
+    reads = {
+        "search": lambda: search(backend, _read_args(query="child")),
+        "list": lambda: list_(backend, _read_args()),
+        "ready": lambda: ready(backend, _read_args(label=None)),
+    }
+
+    reported = _one(reads[verb](), "c-1")
+
+    _assert_agrees_with_show(reported, shown, verb=verb)


### PR DESCRIPTION
Closes `agents-config-9k9.146`. `agents-config-9k9.44` was closed as its duplicate, and its
broader wording — *every* list-shaped verb either reports the true parent or omits the field —
is the scope this PR satisfies.

## What was wrong

`work search` returned `parent: null` and `children: []` for items that demonstrably had both.
`work list` and `work ready` returned `children: []` for **every** item in the tracker. Same
session, same item, two different answers:

```
$ work search 'S6'   -> agents-config-9k9.17: parent null, children []
$ work show  9k9.17  -> parent agents-config-9k9, 13 children
```

The cause is that one shared item shape was serialized from four different backend payloads that
carry different keys. The backend omits any key whose value is empty — so a missing `dependents`
means *"no children"* under `show` and *"never reported"* under the other three, and **no payload
can tell those apart.** Reading it as the first is how `list` came to report every epic as childless.

## The contract

A read verb reports a relationship only when its payload can express it. What it cannot express is
**absent from the item** and **named in a new `unknown_relations` array** that every read item
carries — empty when everything is known.

| verb | `unknown_relations` | reports |
|---|---|---|
| `show` | `[]` | parent, deps, children — unchanged |
| `list` / `ready` | `["children","deps"]` | parent |
| `search` | `["children","deps","parent"]` | none |

Merely omitting the keys would have left absence just as ambiguous as emptiness was — a consumer
holding an item would have to know which verb produced it. The array is what makes *"this verb does
not report children"* legible from the item alone.

The declaration is keyed on the backend command in one table, not sniffed from the payload,
precisely because the payload cannot distinguish absent from empty.

`deps` is declared unknown on `list`/`ready` for a reason the original item didn't know: those
dependency rows carry **no status for the far end**. An edge that cannot answer *"is this still
blocking"* is the same half-truth, so it isn't shipped looking complete.

## What was rejected, and what it cost

- **Enrich each result with a per-item read.** Measured against the real tracker: ~215ms per id —
  6.9s for 30 ids, 26.1s for 120. Search's own default limit is 50, so a full search would pay ~11s.
  Disqualified.
- **Enrich from one whole-database index read.** Constant ~0.79s today. Rejected: it scales with the
  tracker rather than with the answer, and would double `list` and triple `search` latency
  permanently to populate fields most callers never read. A caller who needs relationships pays for
  one `work show`, explicitly, when they need it.
- **Keep the empty values and merely annotate them.** Non-breaking, and it leaves a value a consumer
  can still mistake for truth — which is the defect.

## Protocol 1.4 → 1.5, and why MINOR

Formally, dropping keys is a MAJOR change under the contract spec's own rule, and this is a
deliberate judgement against the letter of it:

- The dropped fields were **never populated with a true value** on those verbs. No consumer can ever
  have read a real relationship out of one.
- The written contract promises *"item + typed dep edges + children"* for **`show` only**. Their
  presence on the other three was an accident of a shared dataclass, never a promise.
- `executor` pins the tracker's major version and hard-refuses a mismatch. A 2.0 bump would break a
  working package, in a coordinated release, to protect a field nobody consumes.

If you'd rather have 2.0, it's one constant plus one assertion here and `executor`'s pin.

## Verification

Every gate run standalone from the worktree root, exit status read on its own:

| Gate | Exit | Result |
|---|---|---|
| `make ci-workcli` | **0** | 689 passed, 99.20% coverage |
| `make itest-workcli` | **0** | 36 passed (real bd) |
| `make ci` (whole repo) | **0** | all packages green, `executor` included |

Probed live against the real tracker on this build:

```
SEARCH  unknown_relations=['children','deps','parent']   parent: ABSENT
LIST    unknown_relations=['children','deps']            parent: agents-config-9k9
SHOW    unknown_relations=[]                             parent: agents-config-9k9, 13 children
```

**The corrected fake would have caught the original defect** — demonstrated before the production
fix landed. The old fake preserved the *true* parent on search while emptying deps and children,
which is exactly why no verb-level test could ever see the bug.

Golden fixtures were captured from a real backend in an isolated off-repo scratch install, so both
sides of every comparison come from the real binary. One test pins the premise itself: if a later
backend starts emitting the missing keys, it fails — the removal condition, made mechanical.

**No consumer breaks.** `list` still carries `parent`, which is the one field any code outside this
package actually reads off a list-shaped result. `executor` is the only package that shells out to
these verbs and passes rows through untouched by design. The deployed asset tree has zero references
to them.

## Two follow-ups, filed rather than folded in

- `work search` silently truncates at 50 — it sends no limit, and the backend's default is 50. That's
  the same silent-truncation quirk the facade deliberately killed for `list` and `ready`, and a
  second way search reports a false picture.
- The 2026-07-04 contract spec still quotes the old protocol version in its examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1