### PR TITLE
feat(9k9.149): project capability front matter per tool; raise the user-invoked body cap

### DIFF
--- a/.claude/skills/admit-request/SKILL.md
+++ b/.claude/skills/admit-request/SKILL.md
@@ -114,20 +114,41 @@ Two surfaces, and an artifact is priced on the one it actually loads into.
 
 **A skill's body is not always-on.** Until something invokes it, a skill costs
 its description line in the catalog and nothing else. So body size is a
-question of whether the body earns its 2k *at the moment of use*, and
+question of whether the body earns its cap *at the moment of use*, and
 description sprawl is the always-on concern — a vague description is worse than
 a long body, because it is paid every session and buys mis-invocation.
 
 Mechanical caps the installer enforces at deploy:
 
 - always-on surface (instruction file + all rules): **10k tokens**
-- each skill body, after front matter: **2k tokens**
+- each **model-invoked** skill body, after front matter: **2k tokens**
+- each **user-invoked** skill body: **5k tokens**
+
+A skill is user-invoked when its front matter carries
+`disable-model-invocation: true`. That keeps its description out of the model's
+catalog entirely, so it costs zero always-on tokens and its body is reached
+only when the user names it — a cost asked for, at a moment chosen for it. A
+model-invoked body is loaded on the model's own judgement, mid-task, against
+whatever the context is already carrying, which is what the tighter number
+prices. The flag is carried in the shared tree and projected per tool by the
+installer, so it is not a reason to move a skill into `src/user/.claude/`.
+
+**The raised ceiling is relief, not permission.** Progressive disclosure applies
+to every skill regardless of which cap measures it. Where a body exceeds 2k the
+first question is always what belongs in `references/`; the ceiling is what
+catches the residue after that split, not a substitute for making it. A body
+that fits 4,900 tokens only because nothing was ever moved out has failed the
+intent while passing the gate — mark it `ADMIT-WITH-CHANGES` and name the split.
 
 Measure; do not estimate. `wc -c` divided by four is the same approximation the
-installer uses. A skill over the cap is `ADMIT-WITH-CHANGES` at best: delegate
+installer uses. A skill over its cap is `ADMIT-WITH-CHANGES` at best: delegate
 the excess to code, or split it.
 
 **Headroom is not an argument.** The budget is a ceiling, not a target to fill.
+
+Choosing the invocation mode is a catalog-design decision, not a budget one:
+every model-invoked description is one more entry the agent must disambiguate
+before the user types anything. Do not set the flag to buy the looser cap.
 
 Known gap: the installer does not currently count skill/command/agent
 descriptions in the always-on surface, so that cost is on you to police.
@@ -139,6 +160,13 @@ By capability-dependency, never by asset type:
 - works on every supported tool → `src/user/.agents/`
 - needs a tool-specific capability (subagent orchestration, the Skill tool,
   interactive question UI, hooks) → that tool's tree, e.g. `src/user/.claude/`
+
+Capability-dependency is about the artifact's *procedure*, not its front matter.
+The installer projects capability keys per target tool — `allowed-tools`,
+`argument-hint` and `disable-model-invocation` deploy to Claude and are dropped
+for the tools that do not define them — so carrying one of those keys is not by
+itself a reason to leave the shared tree. A skill whose steps only work under
+one tool still belongs in that tool's tree.
 
 Then: does it belong in the **deployed** surface at all? Deployed artifacts run
 in other people's projects. An artifact whose subject is this repo — its

--- a/.claude/skills/admit-request/SKILL.md
+++ b/.claude/skills/admit-request/SKILL.md
@@ -125,13 +125,29 @@ Mechanical caps the installer enforces at deploy:
 - each **user-invoked** skill body: **5k tokens**
 
 A skill is user-invoked when its front matter carries
-`disable-model-invocation: true`. That keeps its description out of the model's
-catalog entirely, so it costs zero always-on tokens and its body is reached
-only when the user names it — a cost asked for, at a moment chosen for it. A
-model-invoked body is loaded on the model's own judgement, mid-task, against
-whatever the context is already carrying, which is what the tighter number
-prices. The flag is carried in the shared tree and projected per tool by the
-installer, so it is not a reason to move a skill into `src/user/.claude/`.
+`disable-model-invocation: true`. On a host that honours the flag, that keeps
+its description out of the model's catalog entirely, so it costs zero always-on
+tokens and its body is reached only when the user names it — a cost asked for,
+at a moment chosen for it. A model-invoked body is loaded on the model's own
+judgement, mid-task, against whatever the context is already carrying, which is
+what the tighter number prices.
+
+**Only Claude honours the flag today.** The installer drops it for Codex, Gemini
+and OpenCode, which have no equivalent to translate onto — so on those three the
+skill stays model-invocable and its description does load into their catalog.
+The cap is keyed on the artifact's authored flag and applied uniformly anyway,
+because a per-tool cap would make this verdict depend on which tools are
+installed on the machine you are running it from. Two consequences to hold:
+
+- The 5k number is Claude-shaped. A 4,900-token body is a model-invoked body on
+  three of four tools, against a 2k intent. That is the price of a uniform cap,
+  and it is another reason the ceiling is relief rather than permission.
+- Carrying the flag is not by itself a reason to leave the shared tree, since it
+  is projected out cleanly. But dropping a key removes the bytes, not the gap: a
+  skill whose worth claim *depends* on never firing unprompted is still
+  model-invocable wherever the flag is unsupported, and belongs in
+  `src/user/.claude/` where the claim holds. Check 5 decides this; check 4 only
+  tells you which number to measure against.
 
 **The raised ceiling is relief, not permission.** Progressive disclosure applies
 to every skill regardless of which cap measures it. Where a body exceeds 2k the

--- a/docs/specs/2026-07-24-spec-contract-s5.md
+++ b/docs/specs/2026-07-24-spec-contract-s5.md
@@ -3,6 +3,7 @@
 **Date:** 2026-07-24
 **Status:** Child spec of `docs/specs/2026-07-21-harness-rework-way-forward.md` (S5 slice; implements D1/D2/D18, discharges AC4 and the `writing-plans` clause of AC5)
 **Tracker:** `agents-config-9k9.15`
+**Amended:** 2026-08-07 — S5-D3's portability clause is reversed; see §5.
 
 The readiness gate needs an authoring path that cannot emit a goals-only
 spec. S5 installs that path: admit the two grilling skills and `to-spec`
@@ -66,6 +67,11 @@ The user-invoked-only intent is expressed portably in the description
 ("invoke when the user asks to turn the conversation into a spec"); if a
 Claude-side invocation hard-stop proves necessary later, that is a
 Claude-tree override admitted separately.
+
+> **Reversed 2026-08-07 — see §5.** The portability clause above no longer
+> holds: the shared tree carries the flag and the installer projects it per
+> tool. The rest of S5-D3 (the output-contract replacement, the dropped
+> tracker-publish step) stands.
 
 **S5-D4 — Drift policy flips to local-fork at graft time.** All three
 skills keep their provenance headers but change `Drift policy:` to
@@ -178,3 +184,46 @@ sweeping admission records onto the rest of the deployed catalog (AC3
 closure), deletion of `wait-for-pr-comments` / `reply-and-resolve-pr-threads`
 / `monitor-pr` (S8, per D13/AC5), and any redesign of the grill skills'
 interview mechanics beyond the exit-criterion graft.
+
+## 5. Amendment 2026-08-07 — S5-D3's portability clause is reversed
+
+**What changes.** A shared-tree skill may now carry
+`disable-model-invocation: true`. S5-D3's ruling that the flag is a
+Claude-specific capability field which shared content must not carry, with the
+user-invoked intent expressed in description prose instead, no longer holds.
+S5-A3's corresponding clause — "the frontmatter carries no Claude-specific
+field" — is retired with it; it recorded a check that was correct when the
+slice shipped and would now fail a conforming artifact.
+
+**Why.** S5-D3 was right that the key is Claude-specific and wrong that the
+only remedy is to omit it, because at the time the installer had no way to make
+one source file deploy differently per tool. It now does: the admission gate
+projects capability front matter per target tool, so Claude receives the key
+and Codex, Gemini and OpenCode receive the artifact without it. The placement
+rule S5-D3 invoked is unchanged — placement follows what an artifact's
+*procedure* depends on, and front matter is no longer evidence of that.
+
+Two things made the reversal worth making rather than merely possible. The flag
+is measurably load-bearing: a deployed skill carrying it is absent from a
+Claude session's skills catalog while every other deployed skill is present, so
+it does not merely suppress auto-firing — it removes the description from the
+agent's context, which the intent expressed as description prose bought none
+of. And the invocation axis is now a design rule the charter admits (D18),
+which the incoming skill wave applies as its default; expressing it in prose
+per skill scales worse the more skills carry it.
+
+**What replaces it.** The installer holds one table of capability keys and the
+tools whose loaders define them; the gate drops, per tool, the keys that tool
+does not define. The projection is removal rather than translation, since no
+other supported tool exposes a per-artifact invocation control to translate
+onto. The same flag additionally selects which body cap measures the skill —
+5,000 tokens user-invoked, 2,000 model-invoked — read from the source front
+matter before projection, so one artifact is measured against one cap on every
+tool. The raised ceiling is relief for a body already split into `references/`,
+not permission to skip the split.
+
+**Prerequisite.** The behaviour is in `packages/installer`
+(`core/capabilities.py`, `core/sanitize.py`, `core/surface_budget.py`,
+`core/deploy_gate.py`) and gated by `make ci`. The `admit-request` gate
+document states the same rule. Tracked as `agents-config-9k9.149`, which also
+subsumes the per-tool half of `agents-config-9k9.68`.

--- a/packages/installer/src/installer/content_lint_cli.py
+++ b/packages/installer/src/installer/content_lint_cli.py
@@ -18,7 +18,11 @@ from installer.core.content_lint import ContentLintResult, lint_content
 from installer.core.io_port import TerminalIO
 from installer.core.merge.base import CollisionError
 from installer.core.merge.registry import UnknownMergeKeyError
-from installer.core.surface_budget import ALWAYS_ON_TOKEN_CAP, SKILL_BODY_TOKEN_CAP
+from installer.core.surface_budget import (
+    ALWAYS_ON_TOKEN_CAP,
+    SKILL_BODY_TOKEN_CAP,
+    USER_INVOKED_SKILL_BODY_TOKEN_CAP,
+)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -50,9 +54,18 @@ def _report_budgets(result: ContentLintResult) -> None:
     # because it is the only thing distinguishing two entries whose origin the
     # staging plan never recorded: those are keyed per tool and so share a
     # printed location.
-    sys.stdout.write(f"content-lint: admitted skill bodies (cap {SKILL_BODY_TOKEN_CAP} tokens)\n")
+    #
+    # Each line also carries its own cap rather than inheriting the header's:
+    # with a looser ceiling for user-invoked skills, one header number would say
+    # nothing about the headroom on the lines it does not apply to.
+    sys.stdout.write(
+        f"content-lint: admitted skill bodies (cap {SKILL_BODY_TOKEN_CAP} tokens, "
+        f"{USER_INVOKED_SKILL_BODY_TOKEN_CAP} when user-invoked)\n"
+    )
     for body in result.skills:
-        sys.stdout.write(f"  {body.tokens:>6} tokens  {body.where}  [{', '.join(body.tools)}]\n")
+        sys.stdout.write(
+            f"  {body.tokens:>6} / {body.cap:<5} tokens  {body.where}  [{', '.join(body.tools)}]\n"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/packages/installer/src/installer/core/capabilities.py
+++ b/packages/installer/src/installer/core/capabilities.py
@@ -1,0 +1,76 @@
+"""Capability front matter: which tool's loader defines which key.
+
+Some front-matter keys describe the artifact (``name``, ``description``) and
+mean the same thing everywhere. Others name a capability of the *runtime that
+loads it*: Claude Code reads ``disable-model-invocation`` to keep a skill out
+of the model's catalog, ``allowed-tools`` to bound what an invoked artifact may
+call, and ``argument-hint`` to describe its ``/name`` invocation. No other
+supported tool defines any of the three.
+
+Shared content stages into every tool, so without a projection step an author
+faces a false choice: carry the key and ship inert lines into Codex, Gemini and
+OpenCode, or drop it and lose the capability on the one tool that has it. The
+projection removes the choice — the shared tree carries the key, and each tool
+receives what is correct for it.
+
+**The projection is to drop the key**, for every tool that does not define it.
+Not to translate it: none of Codex, Gemini or OpenCode exposes a per-artifact
+invocation control, a per-artifact tool allowlist, or an argument hint, so
+there is no target to translate onto and inventing one would assert a
+capability that is not there. Not to keep it inert either, on the sanitizer's
+own reasoning — bytes with no runtime purpose downstream load into the reader's
+context for nothing, and a loader that validates its front matter strictly
+would reject the artifact rather than ignore the key. The same conclusion is
+already reached one namespace over, where the Gemini adapter strips Claude-only
+keys from agent front matter.
+
+Support is declared per key rather than per tool. A tool acquiring one of these
+capabilities is then a one-name edit, and a key nothing supports is visible as
+an empty set rather than as an absence from four lists.
+
+``disable-model-invocation`` carries a second consequence beyond projection: it
+is what decides which body cap measures the artifact (see ``surface_budget``).
+That reading is deliberately taken from the *source* front matter, before
+projection, so one artifact is measured against one cap on every tool.
+"""
+
+from __future__ import annotations
+
+from installer.core.frontmatter import split_frontmatter
+
+#: The key by which an artifact declares itself user-invoked only: the runtime
+#: keeps it out of the model's catalog, so it is reached only when the user
+#: names it.
+USER_INVOKED_KEY = "disable-model-invocation"
+
+#: Capability key → the tool names whose loader defines it. A key absent from a
+#: tool's set is removed from that tool's deployed bytes. Tools are named by
+#: ``Tool.value``, the same string the adapters carry as ``name``; a name here
+#: that is not a known tool is a defect a test catches, because a typo would
+#: silently strip the key from the tool that does support it.
+CAPABILITY_SUPPORT: dict[str, frozenset[str]] = {
+    USER_INVOKED_KEY: frozenset({"claude"}),
+    "allowed-tools": frozenset({"claude"}),
+    "argument-hint": frozenset({"claude"}),
+}
+
+
+def unsupported_keys(tool: str) -> frozenset[str]:
+    """The capability keys ``tool``'s loader does not define.
+
+    An unknown tool name yields every key, which is the safe direction: a tool
+    added to the registry without an entry here ships no inert capability keys,
+    where the opposite default would ship all of them.
+    """
+    return frozenset(key for key, tools in CAPABILITY_SUPPORT.items() if tool not in tools)
+
+
+def is_user_invoked(text: str) -> bool:
+    """True when ``text``'s front matter sets ``disable-model-invocation: true``.
+
+    Compared against ``True`` rather than truthiness, so an explicit ``false``
+    and a stray string both read as model-invoked — the stricter cap is the one
+    to fall back to.
+    """
+    mapping, _body = split_frontmatter(text)
+    return mapping is not None and mapping.get(USER_INVOKED_KEY) is True

--- a/packages/installer/src/installer/core/content_lint.py
+++ b/packages/installer/src/installer/core/content_lint.py
@@ -250,11 +250,13 @@ class SkillBody:
     ``where`` is the source file when the plan records one and the destination
     otherwise. ``tools`` names every tool the body was measured for: a shared
     skill stages into every plan, so ungrouped it reports the same number four
-    times.
+    times. ``cap`` is the ceiling that measured it — a property of the source
+    front matter, so every tool in ``tools`` agrees on it.
     """
 
     where: str
     tokens: int
+    cap: int
     tools: tuple[str, ...]
 
 
@@ -448,16 +450,20 @@ def _group_skill_bodies(
 
     ``tokens`` is part of the key rather than an attribute of the group because a
     per-tool transform can change one source's deployed weight, and one file
-    reporting two different numbers is precisely the thing worth seeing.
+    reporting two different numbers is precisely the thing worth seeing. The cap
+    is not: it is decided by the source front matter, which every tool staging
+    that artifact read, so the first measure in a group speaks for all of them.
     """
-    grouped: dict[tuple[str, int], tuple[str, list[str]]] = {}
+    grouped: dict[tuple[str, int], tuple[str, int, list[str]]] = {}
     for measure in measures:
         identity, where = _identity(measure.label, sources.get(measure.label))
-        _where, tools = grouped.setdefault((identity, measure.tokens), (where, []))
+        _where, _cap, tools = grouped.setdefault(
+            (identity, measure.tokens), (where, measure.cap, [])
+        )
         tools.append(measure.label.partition(":")[0])
     return [
-        SkillBody(where=where, tokens=tokens, tools=tuple(sorted(set(tools))))
-        for (_identity_key, tokens), (where, tools) in sorted(grouped.items())
+        SkillBody(where=where, tokens=tokens, cap=cap, tools=tuple(sorted(set(tools))))
+        for (_identity_key, tokens), (where, cap, tools) in sorted(grouped.items())
     ]
 
 

--- a/packages/installer/src/installer/core/deploy_gate.py
+++ b/packages/installer/src/installer/core/deploy_gate.py
@@ -6,13 +6,15 @@ is assembled and before any write. It:
 1. **partitions** every gated artifact (rules/skills/commands/agents) by its
    admission record — dropping the record-less (the zero-base mechanism),
    collecting the malformed as violations, keeping the complete;
-2. **sanitizes** each admitted artifact — the ``admission``/``claims`` front
-   matter and any provenance comment are deploy-time inputs, so they are
-   stripped from the bytes that ship (see ``sanitize``);
-3. measures the **surface budget** over the *sanitized admitted* content — the
-   always-on surface per tool and each admitted skill body. Measuring after
-   sanitization is the point: the budget weighs what a reader actually loads,
-   not the governance metadata that enforces the budget;
+2. **rewrites** each admitted artifact's front matter — the
+   ``admission``/``claims`` blocks and any provenance comment are deploy-time
+   inputs, so they are stripped from the bytes that ship, and capability keys
+   the target tool's loader does not define are projected out (see
+   ``sanitize`` and ``capabilities``);
+3. measures the **surface budget** over the *rewritten admitted* content — the
+   always-on surface per tool and each admitted skill body. Measuring after the
+   rewrite is the point: the budget weighs what a reader actually loads, not
+   the governance metadata that enforces the budget;
 4. runs the **conflict audit** over the admitted artifacts' claims.
 
 Any violation makes ``GateResult.ok`` false; the caller reports each and aborts
@@ -38,10 +40,12 @@ from installer.core.admission import (
     is_gated,
     record_source_text,
 )
+from installer.core.capabilities import is_user_invoked
 from installer.core.conflict_audit import conflict_violations
 from installer.core.frontmatter import split_frontmatter
-from installer.core.sanitize import sanitize_text
+from installer.core.sanitize import project_capabilities, sanitize_text
 from installer.core.surface_budget import (
+    SkillBodySource,
     SkillMeasure,
     SurfaceMeasure,
     always_on_violations,
@@ -129,7 +133,7 @@ def run_admission_gate(plans: dict[Tool, StagingPlan]) -> GateResult:
     skipped: list[str] = []
     violations: list[str] = []
     claims_by_artifact: list[tuple[str, dict[str, str]]] = []
-    skill_bodies: list[tuple[str, str]] = []
+    skill_bodies: list[SkillBodySource] = []
 
     for tool, plan in plans.items():
         kept: dict[Path, StagedItem] = {}
@@ -152,10 +156,22 @@ def run_admission_gate(plans: dict[Tool, StagingPlan]) -> GateResult:
                 continue
 
             # Admitted: ship the artifact without its deploy-time governance
-            # metadata. A file item carries its own bytes; a directory item is
-            # opaque, so the rewritten entry file rides the dir_overrides side
-            # channel the sync already overlays on top of the source tree.
-            sanitized = sanitize_text(text) if text is not None else None
+            # metadata and without capability keys this tool cannot read. A file
+            # item carries its own bytes; a directory item is opaque, so the
+            # rewritten entry file rides the dir_overrides side channel the sync
+            # already overlays on top of the source tree.
+            #
+            # The invocation mode is read from the SOURCE front matter, before
+            # the projection removes the key for a tool that does not define it.
+            # Reading it after would make one artifact's cap depend on which
+            # tool is being staged, so the same repo would pass on a Claude-only
+            # machine and fail wherever a second tool is detected.
+            user_invoked = is_user_invoked(text) if text is not None else False
+            sanitized = (
+                project_capabilities(sanitize_text(text), tool=tool.value)
+                if text is not None
+                else None
+            )
             if sanitized is not None:
                 if item.content is not None:
                     item = replace(item, content=sanitized.encode("utf-8"))
@@ -165,7 +181,13 @@ def run_admission_gate(plans: dict[Tool, StagingPlan]) -> GateResult:
 
             claims_by_artifact.append((label, verdict.claims))
             if item.namespace == "skills":
-                skill_bodies.append((label, _skill_body(sanitized or "")))
+                skill_bodies.append(
+                    SkillBodySource(
+                        label=label,
+                        body=_skill_body(sanitized or ""),
+                        user_invoked=user_invoked,
+                    )
+                )
 
         # Drop override bytes for any item the gate removed, then lay each
         # admitted dir's sanitized entry file over what survives.

--- a/packages/installer/src/installer/core/sanitize.py
+++ b/packages/installer/src/installer/core/sanitize.py
@@ -1,23 +1,27 @@
-"""Deploy-time sanitization of repo-side governance metadata.
+"""Deploy-time rewriting of front matter the deployed artifact has no use for.
 
-An artifact's ``admission`` and ``claims`` front-matter blocks, and the
-provenance comment naming its upstream snapshot, exist for the *installer*.
-Both are consumed before any byte is written — ``admission`` by the admission
-bar, ``claims`` by the conflict audit — and neither means anything to the
-agent that later loads the deployed file. Shipping them anyway costs twice:
-the bytes load into the reader's context for no runtime purpose, and for a
-rule they are charged against the very always-on budget the record exists to
-police. The provenance comment is worse than useless downstream — it cites
-repo-internal snapshot paths that do not exist in a user's home.
+Two removals, both applied by the admission gate to the bytes it admits.
 
-So the gate rewrites what it admits: governance keys out of the front matter,
-a leading provenance comment out of the body, everything else byte-identical.
+**Governance metadata, everywhere.** An artifact's ``admission`` and ``claims``
+front-matter blocks, and the provenance comment naming its upstream snapshot,
+exist for the *installer*. Both are consumed before any byte is written —
+``admission`` by the admission bar, ``claims`` by the conflict audit — and
+neither means anything to the agent that later loads the deployed file.
+Shipping them anyway costs twice: the bytes load into the reader's context for
+no runtime purpose, and for a rule they are charged against the very always-on
+budget the record exists to police. The provenance comment is worse than
+useless downstream — it cites repo-internal snapshot paths that do not exist in
+a user's home.
 
-The front-matter edit is deliberately **line-based** rather than a YAML
-round-trip. Re-dumping through ``yaml.safe_dump`` would reflow quoting, key
-order, and long ``description`` strings across every deployed artifact — a
-large diff to delete two keys. Dropping the keys' lines preserves the rest
-exactly.
+**Capability keys, per target tool.** A key naming a capability of the runtime
+that loads the artifact is meaningful only to the tools that define it; see
+``capabilities`` for the table and for why the projection drops rather than
+translates.
+
+Both edits are deliberately **line-based** rather than a YAML round-trip.
+Re-dumping through ``yaml.safe_dump`` would reflow quoting, key order, and long
+``description`` strings across every deployed artifact — a large diff to delete
+a couple of keys. Dropping the keys' lines preserves the rest exactly.
 
 A provenance comment is recognized narrowly: an HTML comment standing before
 any prose, carrying a ``Source:`` or ``Upstream:`` line. An arbitrary leading
@@ -28,6 +32,7 @@ from __future__ import annotations
 
 import re
 
+from installer.core.capabilities import unsupported_keys
 from installer.core.frontmatter import split_frontmatter
 
 _FENCE = "---"
@@ -68,8 +73,8 @@ def _line_ending(text: str) -> str:
     return "\r\n" if first.endswith("\r\n") else "\n"
 
 
-def _drop_governance_keys(lines: list[str]) -> list[str]:
-    """``lines`` with every ``GOVERNANCE_KEYS`` block removed.
+def _drop_keys(lines: list[str], keys: frozenset[str]) -> list[str]:
+    """``lines`` with every top-level ``keys`` block removed.
 
     A dropped key swallows everything up to the next top-level key — its
     indented block and any blank lines inside it. Since a block's contents are
@@ -81,7 +86,7 @@ def _drop_governance_keys(lines: list[str]) -> list[str]:
     for line in lines:
         match = _TOP_LEVEL_KEY.match(line)
         if match is not None:
-            dropping = match.group(1) in GOVERNANCE_KEYS
+            dropping = match.group(1) in keys
         if not dropping:
             out.append(line)
     return out
@@ -114,12 +119,24 @@ def _strip_provenance(body: str) -> str:
     return body
 
 
-def sanitize_text(text: str) -> str:
-    """``text`` with governance front matter and a provenance comment removed.
+def _reassemble(text: str, kept: list[str], body: str) -> str:
+    """``kept`` front-matter lines and ``body`` re-fenced as ``text`` was.
 
-    When the front matter holds nothing but governance keys, the fence goes
-    too — an empty ``---\\n---`` block is noise, not metadata.
+    When nothing survives in the front matter the fence goes too — an empty
+    ``---\\n---`` block is noise, not metadata.
+
+    The fences are re-emitted with the artifact's own line ending: the retained
+    lines keep theirs (``keepends``), so hardcoding ``\\n`` would mix endings in
+    a CRLF-authored artifact and break the byte-preservation contract.
     """
+    if not any(line.strip() for line in kept):
+        return body.lstrip("\r\n")
+    newline = _line_ending(text)
+    return f"{_FENCE}{newline}{''.join(kept)}{_FENCE}{newline}{body}"
+
+
+def sanitize_text(text: str) -> str:
+    """``text`` with governance front matter and a provenance comment removed."""
     mapping, _body = split_frontmatter(text)
     if mapping is None:
         return _strip_provenance(text)
@@ -128,15 +145,24 @@ def sanitize_text(text: str) -> str:
     if fm_lines is None:  # pragma: no cover - split_frontmatter already agreed
         return _strip_provenance(text)
 
-    kept = _drop_governance_keys(fm_lines)
-    body = _strip_provenance(body)
-    if not any(line.strip() for line in kept):
-        return body.lstrip("\r\n")
-    # Re-emit the fences with the artifact's own line ending: the retained
-    # lines keep theirs (``keepends``), so hardcoding ``\n`` would mix endings
-    # in a CRLF-authored artifact and break the byte-preservation contract.
-    newline = _line_ending(text)
-    return f"{_FENCE}{newline}{''.join(kept)}{_FENCE}{newline}{body}"
+    return _reassemble(text, _drop_keys(fm_lines, GOVERNANCE_KEYS), _strip_provenance(body))
+
+
+def project_capabilities(text: str, *, tool: str) -> str:
+    """``text`` with every capability key ``tool``'s loader does not define gone.
+
+    Front matter only — the body is a property of the artifact, not of the
+    runtime loading it, so nothing below the fence is projected.
+    """
+    mapping, _body = split_frontmatter(text)
+    if mapping is None:
+        return text
+
+    fm_lines, body = _split_raw(text)
+    if fm_lines is None:  # pragma: no cover - split_frontmatter already agreed
+        return text
+
+    return _reassemble(text, _drop_keys(fm_lines, unsupported_keys(tool)), body)
 
 
 def sanitize_bytes(data: bytes) -> bytes:

--- a/packages/installer/src/installer/core/surface_budget.py
+++ b/packages/installer/src/installer/core/surface_budget.py
@@ -6,7 +6,15 @@ write:
 - the **always-on surface** for a tool — the deployed instruction file plus
   every admitted always-on rule — is capped at ``ALWAYS_ON_TOKEN_CAP``;
 - each admitted **skill body** (the SKILL.md content after its front matter,
-  the on-invoke payload) is capped at ``SKILL_BODY_TOKEN_CAP``.
+  the on-invoke payload) is capped at ``SKILL_BODY_TOKEN_CAP``, or at
+  ``USER_INVOKED_SKILL_BODY_TOKEN_CAP`` when the skill is user-invoked.
+
+A model-invoked skill's body is loaded on the model's own judgement, mid-task,
+against whatever else the context is already carrying. A user-invoked one is
+reached only when the user names it, so the cost is asked for and lands at a
+moment chosen for it. That difference is what the second cap prices, and it is
+all it prices: the looser number is relief for a body that has already been
+split down, never permission to leave it whole.
 
 Token count is the ``bytes / 4`` approximation (ceil): no tokenizer dependency
 is added. The cap carries >20x margin at the zero-base (~418 tokens vs
@@ -24,9 +32,14 @@ surface weighs.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 ALWAYS_ON_TOKEN_CAP = 10_000
 SKILL_BODY_TOKEN_CAP = 2_000
+USER_INVOKED_SKILL_BODY_TOKEN_CAP = 5_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,11 +57,31 @@ class SurfaceMeasure:
 
 
 @dataclass(frozen=True, slots=True)
+class SkillBodySource:
+    """One admitted skill body on its way to the scale.
+
+    ``user_invoked`` is read from the artifact's source front matter, so it is
+    a property of the skill rather than of any one deploy target: a tool whose
+    loader cannot honour the flag still measures the body against the cap the
+    author chose.
+    """
+
+    label: str
+    body: str
+    user_invoked: bool
+
+
+@dataclass(frozen=True, slots=True)
 class SkillMeasure:
-    """One admitted skill body's weight, measured after sanitization."""
+    """One admitted skill body's weight, measured after sanitization.
+
+    ``cap`` travels with the measurement because with two caps in play the
+    number alone no longer says whether a body has headroom.
+    """
 
     label: str
     tokens: int
+    cap: int
 
 
 def approx_tokens(data: bytes | str) -> int:
@@ -73,11 +106,22 @@ def measure_always_on(
     return SurfaceMeasure(tool=tool, tokens=total, rules=len(rules))
 
 
-def measure_skill_bodies(bodies: list[tuple[str, str]]) -> list[SkillMeasure]:
-    """Weigh each admitted skill body. ``bodies`` is ``(label, body_text)``
-    per admitted skill; ``body_text`` is the SKILL.md content with front matter
-    already stripped."""
-    return [SkillMeasure(label=label, tokens=approx_tokens(body)) for label, body in bodies]
+def skill_body_cap(*, user_invoked: bool) -> int:
+    """The cap one skill body is measured against."""
+    return USER_INVOKED_SKILL_BODY_TOKEN_CAP if user_invoked else SKILL_BODY_TOKEN_CAP
+
+
+def measure_skill_bodies(bodies: Sequence[SkillBodySource]) -> list[SkillMeasure]:
+    """Weigh each admitted skill body against the cap its invocation mode picks.
+    ``body`` is the SKILL.md content with front matter already stripped."""
+    return [
+        SkillMeasure(
+            label=source.label,
+            tokens=approx_tokens(source.body),
+            cap=skill_body_cap(user_invoked=source.user_invoked),
+        )
+        for source in bodies
+    ]
 
 
 def always_on_violations(*, tool: str, instruction: bytes | None, rules: list[bytes]) -> list[str]:
@@ -92,12 +136,11 @@ def always_on_violations(*, tool: str, instruction: bytes | None, rules: list[by
     return []
 
 
-def skill_body_violations(bodies: list[tuple[str, str]]) -> list[str]:
-    """Violation messages for admitted skill bodies over the per-skill cap.
-    Returns one message per over-cap skill."""
+def skill_body_violations(bodies: Sequence[SkillBodySource]) -> list[str]:
+    """Violation messages for admitted skill bodies over the cap that applies to
+    them. Returns one message per over-cap skill."""
     return [
-        f"{m.label}: skill body is {m.tokens} tokens, over the "
-        f"{SKILL_BODY_TOKEN_CAP}-token cap — delegate to code"
+        f"{m.label}: skill body is {m.tokens} tokens, over the {m.cap}-token cap — delegate to code"
         for m in measure_skill_bodies(bodies)
-        if m.tokens > SKILL_BODY_TOKEN_CAP
+        if m.tokens > m.cap
     ]

--- a/packages/installer/tests/unit/test_capabilities.py
+++ b/packages/installer/tests/unit/test_capabilities.py
@@ -1,0 +1,53 @@
+"""The capability front-matter table and its reader.
+
+Pins two coded decisions: which tools are declared to define which capability
+key, and that the user-invoked reading is strict about what counts as the flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from installer.core.capabilities import (
+    CAPABILITY_SUPPORT,
+    USER_INVOKED_KEY,
+    is_user_invoked,
+    unsupported_keys,
+)
+from installer.tools.registry import known_tools
+
+
+def test_every_declared_supporter_is_a_known_tool() -> None:
+    """A misspelled tool name would strip the key from the tool that does support
+    it, silently and everywhere — the table's one failure mode with no symptom."""
+    declared = {tool for tools in CAPABILITY_SUPPORT.values() for tool in tools}
+    assert declared <= {tool.value for tool in known_tools()}
+
+
+def test_claude_defines_every_capability_key() -> None:
+    assert unsupported_keys("claude") == frozenset()
+
+
+@pytest.mark.parametrize("tool", ["codex", "gemini", "opencode"])
+def test_the_other_tools_define_none_of_them(tool: str) -> None:
+    """The projection target for a tool with no equivalent capability is to drop
+    the key, so every key is unsupported for all three."""
+    assert unsupported_keys(tool) == frozenset(CAPABILITY_SUPPORT)
+
+
+def test_an_unregistered_tool_name_drops_everything() -> None:
+    """A tool added to the registry without an entry here ships no inert keys.
+    The opposite default would ship all of them."""
+    assert unsupported_keys("some-future-tool") == frozenset(CAPABILITY_SUPPORT)
+
+
+def test_the_flag_is_read_only_as_a_true_boolean() -> None:
+    assert is_user_invoked(f"---\n{USER_INVOKED_KEY}: true\n---\nbody\n")
+    assert not is_user_invoked(f"---\n{USER_INVOKED_KEY}: false\n---\nbody\n")
+    assert not is_user_invoked(f"---\n{USER_INVOKED_KEY}: yes-please\n---\nbody\n")
+
+
+def test_absent_or_missing_front_matter_reads_as_model_invoked() -> None:
+    """The stricter cap is the one to fall back to when nothing says otherwise."""
+    assert not is_user_invoked("---\nname: a\n---\nbody\n")
+    assert not is_user_invoked("# no front matter\n")

--- a/packages/installer/tests/unit/test_content_lint.py
+++ b/packages/installer/tests/unit/test_content_lint.py
@@ -205,12 +205,19 @@ def test_the_trend_report_folds_a_shared_body_but_not_two_bodies_at_one_destinat
     same — under-counting the surface silently, on the run nobody is reading
     closely."""
     from installer.core.content_lint import SkillBody, _group_skill_bodies
-    from installer.core.surface_budget import SkillMeasure
+    from installer.core.surface_budget import SKILL_BODY_TOKEN_CAP, SkillMeasure
 
     shared = Path("src/user/.agents/skills/foo")
-    measures = [SkillMeasure(label=f"{t}:skills/foo", tokens=100) for t in ("claude", "codex")]
+    measures = [
+        SkillMeasure(label=f"{t}:skills/foo", tokens=100, cap=SKILL_BODY_TOKEN_CAP)
+        for t in ("claude", "codex")
+    ]
     folded = _group_skill_bodies(measures, sources={m.label: shared for m in measures})
-    assert folded == [SkillBody(where=str(shared), tokens=100, tools=("claude", "codex"))]
+    assert folded == [
+        SkillBody(
+            where=str(shared), tokens=100, cap=SKILL_BODY_TOKEN_CAP, tools=("claude", "codex")
+        )
+    ]
 
     distinct = _group_skill_bodies(
         measures,
@@ -227,13 +234,13 @@ def test_one_source_measuring_two_weights_reports_both() -> None:
     the source alone would report one of the two numbers and hide the other, which
     is the trend instrument lying about the surface it exists to watch."""
     from installer.core.content_lint import _group_skill_bodies
-    from installer.core.surface_budget import SkillMeasure
+    from installer.core.surface_budget import SKILL_BODY_TOKEN_CAP, SkillMeasure
 
     shared = Path("src/user/.agents/skills/foo")
     bodies = _group_skill_bodies(
         [
-            SkillMeasure(label="claude:skills/foo", tokens=100),
-            SkillMeasure(label="gemini:skills/foo", tokens=80),
+            SkillMeasure(label="claude:skills/foo", tokens=100, cap=SKILL_BODY_TOKEN_CAP),
+            SkillMeasure(label="gemini:skills/foo", tokens=80, cap=SKILL_BODY_TOKEN_CAP),
         ],
         sources={"claude:skills/foo": shared, "gemini:skills/foo": shared},
     )

--- a/packages/installer/tests/unit/test_content_lint_cli.py
+++ b/packages/installer/tests/unit/test_content_lint_cli.py
@@ -13,7 +13,11 @@ import pytest
 
 from installer.content_lint_cli import main
 from installer.core.merge.base import CollisionError
-from installer.core.surface_budget import ALWAYS_ON_TOKEN_CAP, SKILL_BODY_TOKEN_CAP
+from installer.core.surface_budget import (
+    ALWAYS_ON_TOKEN_CAP,
+    SKILL_BODY_TOKEN_CAP,
+    USER_INVOKED_SKILL_BODY_TOKEN_CAP,
+)
 
 _RECORD = "---\nadmission:\n  prevents: p\n  cost: c\n  remove_when: r\n---\n"
 
@@ -35,8 +39,25 @@ def test_clean_tree_exits_zero_and_prints_both_budgets(
 
     out = capsys.readouterr().out
     assert f"cap {ALWAYS_ON_TOKEN_CAP} tokens" in out
+    # Both ceilings on the header, and the one that applied on the body's own
+    # line: with two caps in play a lone number says nothing about headroom.
     assert f"cap {SKILL_BODY_TOKEN_CAP} tokens" in out
+    assert f"{USER_INVOKED_SKILL_BODY_TOKEN_CAP} when user-invoked" in out
+    assert f"/ {SKILL_BODY_TOKEN_CAP}" in out
     assert "skills/tidy" in out
+
+
+def test_a_user_invoked_skill_reports_against_the_raised_ceiling(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A body between the two caps deploys, and the trend line says which ceiling
+    let it through."""
+    body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
+    flagged = _RECORD.replace("---\n", "---\ndisable-model-invocation: true\n", 1)
+    repo = _repo(tmp_path, skill=flagged + body)
+
+    assert main([str(repo)]) == 0
+    assert f"/ {USER_INVOKED_SKILL_BODY_TOKEN_CAP}" in capsys.readouterr().out
 
 
 def test_over_cap_body_exits_one_and_names_the_skill_on_stderr(

--- a/packages/installer/tests/unit/test_deploy_gate.py
+++ b/packages/installer/tests/unit/test_deploy_gate.py
@@ -9,15 +9,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from installer.core.deploy_gate import item_label, run_admission_gate
+import pytest
+
+from installer.core.deploy_gate import GateResult, item_label, run_admission_gate
 from installer.core.model import FileKind, Provenance, StagedItem, StagingPlan, Tool
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_INVOKED_SKILL_BODY_TOKEN_CAP,
     approx_tokens,
 )
 
 _COMPLETE = b"---\nadmission:\n  prevents: p\n  cost: c\n  remove_when: r\n---\nbody\n"
+_RECORD = "admission:\n  prevents: p\n  cost: c\n  remove_when: r\n"
 
 
 def _rule(name: str, content: bytes) -> StagedItem:
@@ -287,6 +291,107 @@ def test_admitted_skill_bodies_are_measured_after_sanitization() -> None:
     assert [(m.label, m.tokens) for m in result.skills] == [
         ("claude:skills/tidy", approx_tokens("body\n"))
     ]
+
+
+def _shared_skill(tmp_path: Path, name: str, text: str) -> StagedItem:
+    """A skill directory staged out of the shared tree, as every tool receives it."""
+    skill = tmp_path / "skills" / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(text, encoding="utf-8")
+    return StagedItem(
+        source_path=skill,
+        dest_relpath=Path("skills") / name,
+        kind=FileKind.DIR,
+        namespace="skills",
+        provenance=Provenance(kind="tool", name="shared"),
+        content=None,
+    )
+
+
+def _deployed_entry(result: GateResult, tool: Tool, name: str) -> bytes:
+    return result.plans[tool].dir_overrides[Path("skills") / name][Path("SKILL.md")]
+
+
+@pytest.mark.parametrize("tool", list(Tool))
+def test_a_shared_flagged_skill_stages_into_every_tool_with_its_projection(
+    tmp_path: Path, tool: Tool
+) -> None:
+    """One shared skill, four deploy targets: Claude keeps the capability keys it
+    defines, and the three tools that define none of them receive the artifact
+    without them rather than with three inert lines."""
+    item = _shared_skill(
+        tmp_path,
+        "handoff",
+        "---\nname: handoff\nargument-hint: [focus]\n"
+        "disable-model-invocation: true\nallowed-tools: Write\n"
+        f"{_RECORD}---\nbody\n",
+    )
+    result = run_admission_gate({tool: _plan(_instruction(b"laws"), item, tool=tool)})
+
+    assert result.ok, result.violations
+    entry = _deployed_entry(result, tool, "handoff")
+    if tool is Tool.CLAUDE:
+        assert entry == (
+            b"---\nname: handoff\nargument-hint: [focus]\n"
+            b"disable-model-invocation: true\nallowed-tools: Write\n---\nbody\n"
+        )
+    else:
+        assert entry == b"---\nname: handoff\n---\nbody\n"
+
+
+def test_a_flagged_body_over_the_raised_ceiling_fails(tmp_path: Path) -> None:
+    body = "x" * (USER_INVOKED_SKILL_BODY_TOKEN_CAP * 4 + 4)
+    item = _shared_skill(
+        tmp_path,
+        "huge",
+        f"---\nname: huge\ndisable-model-invocation: true\n{_RECORD}---\n{body}",
+    )
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert not result.ok
+    assert any(
+        f"{USER_INVOKED_SKILL_BODY_TOKEN_CAP}-token cap" in v and "skills/huge" in v
+        for v in result.violations
+    )
+
+
+def test_a_flagged_body_between_the_two_caps_passes(tmp_path: Path) -> None:
+    body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
+    item = _shared_skill(
+        tmp_path,
+        "roomy",
+        f"---\nname: roomy\ndisable-model-invocation: true\n{_RECORD}---\n{body}",
+    )
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert result.ok, result.violations
+    assert [m.cap for m in result.skills] == [USER_INVOKED_SKILL_BODY_TOKEN_CAP]
+
+
+def test_an_unflagged_body_over_the_standard_cap_still_fails(tmp_path: Path) -> None:
+    body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
+    item = _shared_skill(tmp_path, "bloated", f"---\nname: bloated\n{_RECORD}---\n{body}")
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert not result.ok
+    assert any(f"{SKILL_BODY_TOKEN_CAP}-token cap" in v for v in result.violations)
+
+
+@pytest.mark.parametrize("tool", list(Tool))
+def test_the_cap_is_the_artifact_s_and_not_the_tool_s(tmp_path: Path, tool: Tool) -> None:
+    """The flag is read from the source front matter, before the projection strips
+    it for a tool that cannot honour it. Reading it after would make one repo pass
+    on a Claude-only machine and fail wherever a second tool is detected."""
+    body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
+    item = _shared_skill(
+        tmp_path,
+        "roomy",
+        f"---\nname: roomy\ndisable-model-invocation: true\n{_RECORD}---\n{body}",
+    )
+    result = run_admission_gate({tool: _plan(_instruction(b"laws"), item, tool=tool)})
+
+    assert result.ok, result.violations
+    assert [m.cap for m in result.skills] == [USER_INVOKED_SKILL_BODY_TOKEN_CAP]
 
 
 def test_item_label_is_the_join_key_the_gate_reports_under() -> None:

--- a/packages/installer/tests/unit/test_sanitize.py
+++ b/packages/installer/tests/unit/test_sanitize.py
@@ -1,15 +1,19 @@
-"""Deploy-time sanitization of governance metadata.
+"""Deploy-time rewriting of front matter, both removals.
 
-Pins the two removals (governance front-matter keys, provenance comment) and,
-just as importantly, what must survive them: every other front-matter key,
-byte for byte, and any comment that is content rather than bookkeeping.
+Pins the tool-independent sanitization (governance front-matter keys,
+provenance comment) and the per-tool capability projection, and — just as
+importantly — what must survive each: every other front-matter key, byte for
+byte, and any comment that is content rather than bookkeeping.
 """
 
 from __future__ import annotations
 
-from installer.core.sanitize import sanitize_bytes, sanitize_text
+import pytest
+
+from installer.core.sanitize import project_capabilities, sanitize_bytes, sanitize_text
 
 _RECORD = "admission:\n  prevents: p\n  cost: c\n  remove_when: r\n"
+_FLAGGED = "---\nname: handoff\ndisable-model-invocation: true\n---\nbody\n"
 
 
 def test_admission_block_is_removed() -> None:
@@ -120,3 +124,64 @@ def test_crlf_artifact_keeps_crlf_endings() -> None:
 def test_crlf_artifact_with_only_governance_keys_drops_the_fence() -> None:
     text = "---\r\n" + _RECORD.replace("\n", "\r\n") + "---\r\n\r\nbody\r\n"
     assert sanitize_text(text) == "body\r\n"
+
+
+def test_claude_keeps_the_capability_key() -> None:
+    assert project_capabilities(_FLAGGED, tool="claude") == _FLAGGED
+
+
+@pytest.mark.parametrize("tool", ["codex", "gemini", "opencode"])
+def test_a_tool_without_the_capability_loses_the_key(tool: str) -> None:
+    assert project_capabilities(_FLAGGED, tool=tool) == "---\nname: handoff\n---\nbody\n"
+
+
+@pytest.mark.parametrize("tool", ["codex", "gemini", "opencode"])
+def test_every_claude_only_capability_key_is_projected_out(tool: str) -> None:
+    text = (
+        "---\nname: handoff\nargument-hint: [focus]\n"
+        "disable-model-invocation: true\nallowed-tools: Write Bash(git status *)\n"
+        "description: d\n---\nbody\n"
+    )
+    projected = project_capabilities(text, tool=tool)
+    assert projected == "---\nname: handoff\ndescription: d\n---\nbody\n"
+
+
+def test_surviving_keys_are_byte_identical_through_the_projection() -> None:
+    description = 'description: "Use when: X, Y; or Z — see the notes"'
+    text = f"---\nname: a\n{description}\ndisable-model-invocation: true\n---\nbody\n"
+    assert project_capabilities(text, tool="gemini") == f"---\nname: a\n{description}\n---\nbody\n"
+
+
+def test_the_projection_does_not_touch_the_body() -> None:
+    """A capability is a property of the loading runtime; the body is not. A
+    leading comment that survives sanitization must survive this too."""
+    text = "---\ndisable-model-invocation: true\nname: a\n---\n<!-- TODO: rewrite -->\nbody\n"
+    assert (
+        project_capabilities(text, tool="codex")
+        == "---\nname: a\n---\n<!-- TODO: rewrite -->\nbody\n"
+    )
+
+
+def test_front_matter_of_nothing_but_capability_keys_drops_the_fence() -> None:
+    assert (
+        project_capabilities("---\nallowed-tools: Write\n---\n\nbody\n", tool="codex") == "body\n"
+    )
+
+
+def test_text_without_front_matter_passes_through_the_projection() -> None:
+    assert project_capabilities("# heading\n\nbody\n", tool="codex") == "# heading\n\nbody\n"
+
+
+def test_unparseable_front_matter_is_not_projected() -> None:
+    text = "---\n: : :\n---\ndisable-model-invocation: true\n"
+    assert project_capabilities(text, tool="codex") == text
+
+
+def test_projecting_twice_is_a_no_op() -> None:
+    once = project_capabilities(_FLAGGED, tool="opencode")
+    assert project_capabilities(once, tool="opencode") == once
+
+
+def test_projection_keeps_crlf_endings() -> None:
+    text = "---\r\nname: a\r\ndisable-model-invocation: true\r\n---\r\nbody\r\n"
+    assert project_capabilities(text, tool="gemini") == "---\r\nname: a\r\n---\r\nbody\r\n"

--- a/packages/installer/tests/unit/test_surface_budget.py
+++ b/packages/installer/tests/unit/test_surface_budget.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_INVOKED_SKILL_BODY_TOKEN_CAP,
+    SkillBodySource,
     always_on_violations,
     approx_tokens,
     measure_always_on,
     measure_skill_bodies,
     skill_body_violations,
 )
+
+
+def _body(label: str, tokens: int, *, user_invoked: bool = False) -> SkillBodySource:
+    return SkillBodySource(label=label, body="x" * (tokens * 4), user_invoked=user_invoked)
 
 
 def test_approx_tokens_is_ceil_of_bytes_over_four() -> None:
@@ -47,15 +53,48 @@ def test_no_instruction_file_counts_only_rules() -> None:
 
 
 def test_skill_body_over_cap_is_named() -> None:
-    over = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
-    ok = "y" * (SKILL_BODY_TOKEN_CAP * 4)
-    violations = skill_body_violations([("claude:skills/big", over), ("claude:skills/ok", ok)])
+    violations = skill_body_violations(
+        [
+            _body("claude:skills/big", SKILL_BODY_TOKEN_CAP + 1),
+            _body("claude:skills/ok", SKILL_BODY_TOKEN_CAP),
+        ]
+    )
     assert len(violations) == 1
     assert "claude:skills/big" in violations[0]
+    assert f"{SKILL_BODY_TOKEN_CAP}-token cap" in violations[0]
 
 
 def test_no_skills_no_violations() -> None:
     assert skill_body_violations([]) == []
+
+
+def test_a_user_invoked_body_is_measured_against_the_looser_cap() -> None:
+    """Both sides of the raised boundary: at 5,000 it passes, one token over it
+    fails, and the message names the cap it was measured against."""
+    assert skill_body_violations([_body("c:skills/w", 5_000, user_invoked=True)]) == []
+    violations = skill_body_violations([_body("c:skills/w", 5_001, user_invoked=True)])
+    assert len(violations) == 1
+    assert f"{USER_INVOKED_SKILL_BODY_TOKEN_CAP}-token cap" in violations[0]
+
+
+def test_a_body_between_the_two_caps_passes_only_when_user_invoked() -> None:
+    """The whole point of the second number: 2,971 tokens is a violation for a
+    model-invoked skill and fine for a user-invoked one."""
+    between = 2_971
+    assert skill_body_violations([_body("c:skills/w", between, user_invoked=True)]) == []
+    assert len(skill_body_violations([_body("c:skills/w", between)])) == 1
+
+
+def test_the_measurement_carries_the_cap_that_applies_to_it() -> None:
+    """With two caps the token count alone no longer says whether a body has
+    headroom, so the trend report needs the ceiling beside the number."""
+    measures = measure_skill_bodies(
+        [_body("c:skills/m", 10), _body("c:skills/u", 10, user_invoked=True)]
+    )
+    assert [(m.label, m.cap) for m in measures] == [
+        ("c:skills/m", SKILL_BODY_TOKEN_CAP),
+        ("c:skills/u", USER_INVOKED_SKILL_BODY_TOKEN_CAP),
+    ]
 
 
 def test_measurement_carries_the_rule_count_beside_the_token_total() -> None:
@@ -78,7 +117,12 @@ def test_the_violation_verdict_is_the_measurement_it_reports() -> None:
 def test_skill_bodies_are_measured_whether_or_not_they_breach() -> None:
     """Every admitted body is weighed, not only the over-cap ones — an under-cap
     body that has doubled is the signal the trend report exists to show."""
-    measures = measure_skill_bodies([("claude:skills/small", "y" * 8), ("claude:skills/big", "x")])
+    measures = measure_skill_bodies(
+        [
+            SkillBodySource(label="claude:skills/small", body="y" * 8, user_invoked=False),
+            SkillBodySource(label="claude:skills/big", body="x", user_invoked=False),
+        ]
+    )
     assert [(m.label, m.tokens) for m in measures] == [
         ("claude:skills/small", 2),
         ("claude:skills/big", 1),

--- a/src/user/.agents/skills/AGENTS.md
+++ b/src/user/.agents/skills/AGENTS.md
@@ -70,7 +70,9 @@ Update this table whenever a skill is added, replaced, retired, or amalgamated f
 
 `Upstream` and `Path in upstream` together fetch the exact reference bytes. `Last sync` is a different fact — when the deployed copy was last reconciled against upstream — so it can legitimately predate the pinned commit, and does for two rows here.
 
-`handoff` is the standing exception to the placement rule: it carries Claude-only front matter but sits in the shared tree, so it stages into Codex, Gemini and OpenCode where those keys do nothing. Deliberate and temporary — `agents-config-9k9.68` resolves it, either with per-tool exemption support or by moving the skill back.
+Claude-only front matter is no longer a reason to leave the shared tree. The installer projects capability keys per target tool at deploy: `disable-model-invocation`, `allowed-tools` and `argument-hint` are kept for Claude and dropped for Codex, Gemini and OpenCode, which have no equivalent to translate onto. `handoff` was the standing exception to the placement rule and is now the ordinary case.
+
+Placement still turns on capability-dependency, but of the skill's *procedure* rather than its front matter. A skill whose steps require a Claude-only mechanism belongs in the Claude tree. So does one whose admission record depends on behaviour the other tools cannot reproduce — dropping a key removes the bytes, not the gap, so a skill that must not fire unprompted is still model-invocable wherever the flag is unsupported.
 
 ## Common pitfall — extracted helpers must be wired in
 

--- a/src/user/.agents/skills/handoff/SKILL.md
+++ b/src/user/.agents/skills/handoff/SKILL.md
@@ -13,7 +13,7 @@ admission:
 <!--
 Source: skills/productivity/handoff/ (pristine upstream); promoted project-extended fork
 Upstream: https://github.com/mattpocock/skills @ ed37663cc5fbef691ddfecd080dff42f7e7e350d
-Local extensions: Claude-specific frontmatter (disable-model-invocation, allowed-tools), !-command working-tree snapshot prelude, 8-section required document structure, redaction constraints
+Local extensions: allowed-tools, !-command working-tree snapshot prelude, 8-section required document structure, redaction constraints. Upstream already carries argument-hint and disable-model-invocation; they are not ours.
 Last sync: 2026-05-23
 Drift policy: rewrite-and-divorce (project-extended, Claude-specific; do not re-sync from upstream)
 Placement: shared tree. The Claude-only front matter (disable-model-invocation, allowed-tools, argument-hint) is dropped per tool at deploy, so Codex/Gemini/OpenCode receive neither the keys nor the capability. The !-command prelude still ships everywhere and is inert outside Claude.

--- a/src/user/.agents/skills/handoff/SKILL.md
+++ b/src/user/.agents/skills/handoff/SKILL.md
@@ -16,7 +16,7 @@ Upstream: https://github.com/mattpocock/skills @ ed37663cc5fbef691ddfecd080dff42
 Local extensions: Claude-specific frontmatter (disable-model-invocation, allowed-tools), !-command working-tree snapshot prelude, 8-section required document structure, redaction constraints
 Last sync: 2026-05-23
 Drift policy: rewrite-and-divorce (project-extended, Claude-specific; do not re-sync from upstream)
-Placement: Claude-dependent (!-command syntax, disable-model-invocation/allowed-tools) but staged from the shared tree, so it also lands in Codex/Gemini/OpenCode where those keys do nothing. Deliberate and temporary — agents-config-9k9.68 resolves it with per-tool exemption support or by moving this back under src/user/.claude/skills/.
+Placement: shared tree. The Claude-only front matter (disable-model-invocation, allowed-tools, argument-hint) is dropped per tool at deploy, so Codex/Gemini/OpenCode receive neither the keys nor the capability. The !-command prelude still ships everywhere and is inert outside Claude.
 -->
 
 ## Working-tree snapshot


### PR DESCRIPTION
First of ten PRs admitting the ADMIT-QUEUE wave. **This one lands first** — seven downstream admissions are written against the behaviour it ships.

## What changes

The installer now projects capability front matter per target tool. `disable-model-invocation`, `allowed-tools` and `argument-hint` are kept for Claude and dropped for Codex, Gemini and OpenCode, none of which exposes a per-artifact invocation control, tool allowlist, or argument hint to translate onto.

The skill-body token cap becomes conditional: 2,000 for a model-invoked skill, 5,000 for one carrying `disable-model-invocation: true`. `content-lint` now prints `tokens / cap` per skill, so which ceiling applied is visible rather than inferred.

## Why the raised ceiling is defensible

A user-invoked skill costs zero always-on tokens. Verified rather than assumed: `handoff` carries the flag and is absent from a Claude session's skills catalog while every other deployed skill is present. The flag does not merely suppress auto-firing — it removes the description from the agent's context. So the body is paid only on invocation, and measuring it against a looser ceiling is honest.

The ceiling is relief, not permission. `admit-request` check 4 says so explicitly: progressive disclosure applies to every skill regardless of which cap measures it, and a body that fits 4,900 only because nothing was split into `references/` has failed the intent while passing the gate.

## Two things worth reviewing closely

**The failure this fixes was silent, not loud.** Staging never rejected the unrecognised keys — the sanitizer dropped only `admission` and `claims` — so `handoff` had been shipping three inert lines into three tools all along.

**The cap is a property of the artifact, not the tool.** The flag is read from the source front matter before projection removes it, so a flagged skill is measured against 5,000 even on Gemini, which cannot honour the flag. The alternative — capping per tool's ability to honour it — makes the gate's verdict depend on which tools are installed on the machine running it, and since `content-lint` stages every tool unconditionally it would fail every flagged skill over 2,000 and buy nothing. The honest cost: on the three tools that drop the flag, the skill *is* model-invoked there. The 5,000 is a Claude-shaped number applied uniformly.

## Records amended

`docs/specs/2026-07-24-spec-contract-s5.md` gains a dated §5 recording that S5-D3 is reversed. That decision held the flag out of the shared tree as a Claude-specific capability field; projection is what replaces it. The skills `AGENTS.md` placement rule is rewritten to match, and states the remaining bound: dropping a key removes the bytes, not the capability gap, so a skill whose admission record depends on the flag being honoured still belongs in the Claude tree.

## Evidence

`make ci` exits 0, run standalone from the worktree root. Coverage 97.81% against a 90% floor. Projection verified end-to-end against the real tree — staging `src/` for all four tools and reading the deployed bytes — not only against fixtures. Boundary tests on both sides of both caps, and the projection test is parametrized over the tool enum so a fifth tool adds a case without anyone remembering to.

## Not in scope

`agents-config-9k9.68`'s `exemption:` hatch. This discharges that item's per-tool half; the hatch needs an explicit decline on the record, which its own notes already argue for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne