### PR TITLE
fix(9k9.147, 9k9.166): dep add refuses what it cannot justify, and update learns to move

### DIFF
--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.5"
+PROTOCOL_VERSION = "1.6"

--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -187,6 +187,13 @@ class BdBackend:
             argv += ["--priority", fields.priority]
         if fields.description is not None:
             argv += ["--description", fields.description]
+        if fields.parent is not None:
+            # bd's own reparent, verified against bd 1.0.3 to REPLACE: after
+            # `update C --parent B`, C's only parent-child edge is to B, the
+            # edge to the old parent is gone from both ends' `dep list`, and
+            # the `parent` scalar agrees. One call, so no window exists in
+            # which the item carries two parents.
+            argv += ["--parent", fields.parent]
 
         self._update_and_check(argv)
 

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -67,6 +67,14 @@ _UNKNOWN_RELATIONS: dict[str, frozenset[str]] = {
 # (see BdBackend.batch_get's own missing-id reconciliation for that case).
 _NOT_FOUND_STDERR_MARKER = "no issue found matching"
 
+# bd's OTHER not-found wording, captured live from `bd update ID --parent
+# <missing>` (exit 1, stderr "Error getting parent X: not found: issue X").
+# The reparent path never emits the marker above, so without this one a
+# typo'd `--set-parent` -- the likeliest mistake anyone makes with that flag
+# -- reports E_BACKEND_DRIFT ("bd's model of itself broke") instead of the
+# plain missing-item answer it is.
+_NOT_FOUND_ALT_STDERR_MARKER = "not found: issue"
+
 # Confirmed by reading bd's own Go source at the installed binary's commit:
 # internal/storage/issueops/dependencies.go emits "epics can only block
 # other epics, not tasks" / "tasks can only block other tasks, not epics"
@@ -431,7 +439,7 @@ def map_bd_failure(argv: Sequence[str], result: BdResult) -> WorkError:
     bd instance should never actually surface these to this function -- but
     a pre-check race (a stale read) is still a bd failure, not a crash.
     """
-    if _NOT_FOUND_STDERR_MARKER in result.stderr:
+    if _NOT_FOUND_STDERR_MARKER in result.stderr or _NOT_FOUND_ALT_STDERR_MARKER in result.stderr:
         return WorkError(
             ErrorCode.NOT_FOUND,
             "bd reported no matching issue",

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -95,12 +95,17 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
     create_parser.add_argument("--track", metavar="NAME")
 
     update_parser = subparsers.add_parser(
-        "update", help="update title/priority/description (replace semantics only)"
+        "update", help="update title/priority/description/parent (replace semantics only)"
     )
     update_parser.add_argument("id", metavar="ID")
     update_parser.add_argument("--set-title")
     update_parser.add_argument("--set-priority")
     update_parser.add_argument("--set-description")
+    update_parser.add_argument(
+        "--set-parent",
+        metavar="ID",
+        help="move this item under a new parent, replacing the old one (the move operation)",
+    )
     # Recognized only so it reaches the named E_FIELD_CLOBBER_GUARD instead
     # of a generic E_USAGE unknown-flag error -- notes are append-only.
     # help=SUPPRESS hides it from --help entirely: it's a tripwire, not an

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -17,7 +17,13 @@ RELATIONSHIP_FIELDS = ("parent", "deps", "children")
 @dataclass(frozen=True)
 class DepEdge:
     id: str
-    type: str  # "blocks" | "related-to" | "parent-child" | "discovered-from" | ...
+    # An open `str`, deliberately, and NOT the closed set `dep add` enforces
+    # (`verbs/relations.py::DEP_TYPES`, bd's own documented vocabulary). bd
+    # validates no type at all and stores whatever it is handed, so edges
+    # carrying an unsanctioned type already exist; a read that could not
+    # express one would misreport the very edges the write-side check now
+    # exists to stop being made. Closed on write, open on read.
+    type: str
     status: str  # status of the item at the other end
 
 
@@ -82,6 +88,11 @@ class UpdateFields:  # replace-semantics fields ONLY; notes never appear here
     title: str | None = None
     priority: str | None = None
     description: str | None = None
+    # The parent is single-valued, so a move belongs here with the other
+    # replace-semantics fields rather than on `dep add`, which only ever adds.
+    # bd's `update --parent` replaces the old parent-child edge outright, so
+    # one call moves the item with no window in which it has two parents.
+    parent: str | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/workcli/src/workcli/verbs/relations.py
+++ b/packages/workcli/src/workcli/verbs/relations.py
@@ -14,6 +14,85 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 
 _DEFAULT_DEP_TYPE = "blocks"
+_PARENT_DEP_TYPE = "parent-child"
+
+# bd's own documented edge vocabulary, read off `bd dep add --help` (bd 1.0.3)
+# and confirmed one type at a time against a scratch install. bd itself
+# enforces none of it: every string in that probe -- including a deliberate
+# nonsense one -- was stored verbatim as a real edge, so a typo'd `--type`
+# produces an edge that exists, renders, and participates in nothing. This
+# frozenset is the enforcement bd declines to do, and it gates `dep add` ONLY.
+#
+# `dep remove` stays open to any type on purpose: edges carrying an
+# unsanctioned type already exist in the wild, and a closed set on the removal
+# path would strand exactly the edges this check exists to stop being made.
+# `DepEdge.type` stays an open `str` for the same reason -- a read must be able
+# to report an edge type the write path would now refuse.
+DEP_TYPES = frozenset(
+    {
+        "blocks",
+        "tracks",
+        "related",
+        "parent-child",
+        "discovered-from",
+        "until",
+        "caused-by",
+        "validates",
+        "relates-to",
+        "supersedes",
+    }
+)
+
+
+def _dep_type_check(dep_type: str) -> None:
+    """Reject a type outside bd's documented vocabulary, before any backend call.
+
+    Pure: no read is needed to know the type is nonsense, so this runs first
+    and a rejected `dep add` costs zero bd invocations.
+    """
+    if dep_type in DEP_TYPES:
+        return
+    raise WorkError(
+        ErrorCode.USAGE,
+        f"unknown dep type {dep_type!r} (choose from {', '.join(sorted(DEP_TYPES))})",
+        detail={"field": "type", "dep_type": dep_type},
+    )
+
+
+def _parent_arity_check(backend: Backend, from_id: str, to_id: str, dep_type: str) -> None:
+    """Refuse a second parent for an item that already has one.
+
+    An item's parent is single-valued, but bd reports it from two sources that
+    a second `parent-child` edge drives apart: the `parent` scalar is bd's own
+    field, while `children` is derived from reverse edges. bd accepts the
+    second edge silently, so the item ends up with two parent-child edges and
+    one scalar -- and the field most readers check is the one that then omits a
+    parent the tree still walks from. Anything counting an epic's children
+    counts that item twice.
+
+    Redirecting to `work update --set-parent` (bd's own atomic `--parent`
+    reparent, verified to REPLACE the old edge rather than add beside it) is
+    what makes the recovery discoverable at the moment it is needed. Same
+    guard shape and error code as `update`'s append-only notes tripwire: a
+    write that would corrupt a single-valued field is refused by name, and
+    names the verb that expresses the intent properly.
+
+    Re-adding the parent an item ALREADY has is not a violation -- the
+    postcondition the caller asked for already holds, bd treats the repeat as a
+    no-op (verified against bd 1.0.3), and erroring would fail a correct
+    request and break retry-safety after a timeout.
+    """
+    if dep_type != _PARENT_DEP_TYPE:
+        return
+    child = backend.get(from_id)
+    if child.parent is None or child.parent == to_id:
+        return
+    raise WorkError(
+        ErrorCode.FIELD_CLOBBER_GUARD,
+        f"{from_id} is already a child of {child.parent}; an item has one parent. "
+        f"Use `work update {from_id} --set-parent {to_id}` to move it",
+        detail={"id": from_id, "parent": child.parent, "requested_parent": to_id},
+    )
 
 
 def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) -> None:
@@ -45,9 +124,11 @@ def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) 
 def dep(backend: Backend, args: Namespace) -> JsonValue:
     """`work dep {add,remove,list} ID [TARGET] [--type]`.
 
-    `dep add A B` = A depends on B. `list` maps bd's own inverted
-    `--direction` naming into `{depends_on, dependents}` (the ruling that
-    kills that ambiguity permanently -- see `model.DepListing`).
+    `dep add A B` = A depends on B. `add` is an add primitive and stays one:
+    it validates and refuses, and never silently relocates an edge to make a
+    request succeed. `list` maps bd's own inverted `--direction` naming into
+    `{depends_on, dependents}` (the ruling that kills that ambiguity
+    permanently -- see `model.DepListing`).
     """
     if args.action in ("add", "remove") and args.target is None:
         raise WorkError(ErrorCode.USAGE, f"dep {args.action} requires ID and TARGET")
@@ -64,6 +145,11 @@ def dep(backend: Backend, args: Namespace) -> JsonValue:
 
     dep_type = args.type if args.type is not None else _DEFAULT_DEP_TYPE
     if args.action == "add":
+        # Every pre-check raises before `dep_mutate` (the mutating bd call) is
+        # reached, cheapest first: the vocabulary check needs no read at all,
+        # and the two that do need one are mutually exclusive by type.
+        _dep_type_check(dep_type)
+        _parent_arity_check(backend, args.id, args.target, dep_type)
         _type_wall_check(backend, args.id, args.target, dep_type)
         backend.dep_mutate("add", args.id, args.target, dep_type)
     else:

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -43,13 +43,18 @@ def create_raw(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def update(backend: Backend, args: Namespace) -> JsonValue:
-    """`work update ID [--set-title] [--set-priority] [--set-description]`.
+    """`work update ID [--set-title] [--set-priority] [--set-description] [--set-parent]`.
 
     Replace semantics only; status never moves through this verb
-    (lifecycle verbs own claiming/status). `--set-notes` is recognized by
-    argparse only so it reaches this named clobber-guard rather than a
-    generic `E_USAGE` — notes only ever move through
-    `work note`. (Suppressed from `--help`; rationale at its
+    (lifecycle verbs own claiming/status). `--set-parent` is the move
+    operation: a parent is single-valued, which is exactly the contract this
+    verb already declares, and it maps to bd's own atomic reparent — the old
+    parent-child edge is replaced, never added beside. `dep add` refuses a
+    second parent and names this flag.
+
+    `--set-notes` is recognized by argparse only so it reaches this named
+    clobber-guard rather than a generic `E_USAGE` — notes only ever move
+    through `work note`. (Suppressed from `--help`; rationale at its
     `add_argument` site in `cli.py`.)
     """
     if args.set_notes is not None:
@@ -57,12 +62,28 @@ def update(backend: Backend, args: Namespace) -> JsonValue:
             ErrorCode.FIELD_CLOBBER_GUARD,
             "notes are append-only; use `work note ID TEXT` instead of --set-notes",
         )
-    if args.set_title is None and args.set_priority is None and args.set_description is None:
+    if args.set_parent is not None and not args.set_parent:
+        # bd reads an empty `--parent` as "remove the parent", and an
+        # unset shell variable expands to exactly that. Orphaning an item is
+        # not what anyone typing a move means, and this verb replaces a value
+        # with a value; detaching a parent is deliberately unexpressible here.
+        raise WorkError(
+            ErrorCode.USAGE,
+            "--set-parent requires an item id; it moves an item, it cannot detach one",
+            detail={"field": "parent"},
+        )
+    if (
+        args.set_title is None
+        and args.set_priority is None
+        and args.set_description is None
+        and args.set_parent is None
+    ):
         raise WorkError(ErrorCode.USAGE, "update requires at least one --set-* flag")
     fields = UpdateFields(
         title=args.set_title,
         priority=args.set_priority,
         description=args.set_description,
+        parent=args.set_parent,
     )
     backend.set_fields(args.id, fields)
     return None

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -198,6 +198,12 @@ class FakeBackend:
             rec.priority = fields.priority
         if fields.description is not None:
             rec.description = fields.description
+        if fields.parent is not None:
+            # Replace, matching bd: the old parent is gone, not kept beside
+            # the new one. `_children_of` derives children from this single
+            # field, so the fake cannot represent a double parent at all --
+            # which is the state the real backend now refuses to reach.
+            rec.parent = fields.parent
 
     def claim(self, item_id: str) -> None:
         self._require(item_id).status = "in_progress"

--- a/packages/workcli/tests/integration/test_parent_arity.py
+++ b/packages/workcli/tests/integration/test_parent_arity.py
@@ -1,0 +1,146 @@
+"""Parent arity and dep-type validation, against a real bd.
+
+This is the suite that matters for these two defects, because both are about
+what bd itself does with the calls the facade makes -- neither is visible
+against a fake that models an item's parent as one field and therefore cannot
+represent the corrupt state at all.
+
+Every assertion here reads BOTH descriptions of an item's place in the tree
+and requires them to agree: the `parent` scalar (bd's own field) and the
+`parent-child` edges from `dep list` (derived from edge rows). The defect was
+precisely that those two can disagree, so checking either alone proves nothing.
+"""
+
+from __future__ import annotations
+
+
+def _mk(driver, title: str, item_type: str = "task") -> str:
+    return driver(["create", "--raw", "--title", title, "--type", item_type, "--priority", "2"])[
+        "data"
+    ]["id"]
+
+
+def _parent_edges(driver, item_id: str) -> list[str]:
+    """The ids this item points at with a `parent-child` edge, from `dep list`."""
+    listing = driver(["dep", "list", item_id])
+    return [e["id"] for e in listing["data"]["depends_on"] if e["type"] == "parent-child"]
+
+
+def _children_edges(driver, item_id: str) -> list[str]:
+    """The ids pointing AT this item with a `parent-child` edge (the reverse side)."""
+    listing = driver(["dep", "list", item_id])
+    return [e["id"] for e in listing["data"]["dependents"] if e["type"] == "parent-child"]
+
+
+def _assert_parent_is(driver, item_id: str, expected: str) -> None:
+    """The scalar and the edges must agree, and there must be exactly one edge."""
+    assert driver(["show", item_id])["data"]["parent"] == expected
+    assert _parent_edges(driver, item_id) == [expected]
+
+
+def test_dep_add_second_parent_is_refused_and_leaves_the_tree_untouched(driver):
+    old_parent = _mk(driver, "pa-old", "epic")
+    new_parent = _mk(driver, "pa-new", "epic")
+    child = _mk(driver, "pa-child")
+    driver(["dep", "add", child, old_parent, "--type", "parent-child"])
+    _assert_parent_is(driver, child, old_parent)
+
+    env = driver(["dep", "add", child, new_parent, "--type", "parent-child"])
+
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_FIELD_CLOBBER_GUARD"
+    assert old_parent in env["error"]["message"]
+    assert "--set-parent" in env["error"]["message"]
+    # Nothing moved and nothing was added: this is the state the unguarded
+    # code left holding TWO parent-child edges against one scalar.
+    _assert_parent_is(driver, child, old_parent)
+    assert _children_edges(driver, new_parent) == []
+
+
+def test_dep_add_first_parent_leaves_the_scalar_and_the_edges_agreeing(driver):
+    parent = _mk(driver, "pa-first-parent", "epic")
+    child = _mk(driver, "pa-first-child")
+
+    assert driver(["dep", "add", child, parent, "--type", "parent-child"])["ok"] is True
+
+    _assert_parent_is(driver, child, parent)
+    assert _children_edges(driver, parent) == [child]
+
+
+def test_re_adding_the_parent_an_item_already_has_succeeds_and_adds_no_second_edge(driver):
+    parent = _mk(driver, "pa-idem-parent", "epic")
+    child = _mk(driver, "pa-idem-child")
+    driver(["dep", "add", child, parent, "--type", "parent-child"])
+
+    env = driver(["dep", "add", child, parent, "--type", "parent-child"])
+
+    assert env["ok"] is True
+    _assert_parent_is(driver, child, parent)
+
+
+def test_set_parent_moves_the_item_and_the_old_parent_child_edge_is_gone(driver):
+    old_parent = _mk(driver, "sp-old", "epic")
+    new_parent = _mk(driver, "sp-new", "epic")
+    child = _mk(driver, "sp-child")
+    driver(["dep", "add", child, old_parent, "--type", "parent-child"])
+    _assert_parent_is(driver, child, old_parent)
+
+    env = driver(["update", child, "--set-parent", new_parent])
+
+    assert env["ok"] is True
+    # The whole point of routing the move through bd's own `--parent`: the old
+    # edge is REPLACED. Asserting the scalar alone would pass even if the old
+    # edge survived, which is the exact failure being ruled out.
+    _assert_parent_is(driver, child, new_parent)
+    assert _children_edges(driver, old_parent) == []
+    assert _children_edges(driver, new_parent) == [child]
+
+
+def test_set_parent_to_a_missing_item_reports_not_found_and_changes_nothing(driver):
+    parent = _mk(driver, "sp-missing-parent", "epic")
+    child = _mk(driver, "sp-missing-child")
+    driver(["dep", "add", child, parent, "--type", "parent-child"])
+
+    env = driver(["update", child, "--set-parent", "itest-nosuchid"])
+
+    assert env["ok"] is False
+    # bd's reparent path words this differently from every other command; the
+    # facade must still call it what it is rather than E_BACKEND_DRIFT.
+    assert env["error"]["code"] == "E_NOT_FOUND"
+    _assert_parent_is(driver, child, parent)
+
+
+def test_an_unrecognized_dep_type_writes_no_edge_at_all(driver):
+    source = _mk(driver, "dt-source")
+    target = _mk(driver, "dt-target")
+
+    env = driver(["dep", "add", source, target, "--type", "bogus-type-probe"])
+
+    assert env["ok"] is False
+    assert env["error"]["code"] == "E_USAGE"
+    # Measured on the unguarded code, this stored a real edge typed
+    # `bogus-type-probe`. bd validates nothing here; the facade is the only
+    # layer that can refuse it.
+    assert driver(["dep", "list", source])["data"]["depends_on"] == []
+
+
+def test_every_type_in_the_closed_set_is_one_bd_accepts(driver):
+    # The set is transcribed from bd's own `dep add --help`. If bd's vocabulary
+    # drifts, this fails against the real binary rather than silently letting
+    # the facade advertise a type bd no longer honours.
+    from workcli.verbs.relations import DEP_TYPES
+
+    target = _mk(driver, "cs-target")
+    for index, dep_type in enumerate(sorted(DEP_TYPES)):
+        source = _mk(driver, f"cs-source-{index}", "epic" if dep_type == "blocks" else "task")
+        if dep_type == "blocks":
+            # The blocks wall needs both ends the same class; use two epics.
+            target_for_type = _mk(driver, f"cs-target-epic-{index}", "epic")
+        else:
+            target_for_type = target
+
+        env = driver(["dep", "add", source, target_for_type, "--type", dep_type])
+
+        assert env["ok"] is True, f"{dep_type} rejected: {env['error']}"
+        stored = [e["type"] for e in driver(["dep", "list", source])["data"]["depends_on"]]
+        assert stored == [dep_type], f"{dep_type} stored as {stored}"

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -525,6 +525,44 @@ def test_set_fields_sends_description_when_provided():
     assert runner.calls == [("update", "x.1", "--description", "New description")]
 
 
+def test_set_fields_sends_bds_own_reparent_flag_when_a_parent_is_provided():
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr=""))]
+    )
+    backend = BdBackend(runner)
+
+    backend.set_fields("x.1", UpdateFields(parent="p.2"))
+
+    # bd's `--parent` REPLACES the existing parent-child edge, so the move is
+    # this one call and never a remove-then-add with a window between them.
+    assert runner.calls == [("update", "x.1", "--parent", "p.2")]
+
+
+def test_set_fields_maps_bds_reparent_not_found_wording_to_not_found_error():
+    # The reparent path emits "not found: issue X", not the "no issue found
+    # matching X" every other command uses -- a second marker, or this lands
+    # in the unrecognized-failure bucket as E_BACKEND_DRIFT.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("update",),
+                BdResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="Error getting parent p.2: not found: issue p.2\n",
+                ),
+            )
+        ]
+    )
+    backend = BdBackend(runner)
+
+    try:
+        backend.set_fields("x.1", UpdateFields(parent="p.2"))
+        raise AssertionError("expected WorkError")
+    except WorkError as error:
+        assert error.code == ErrorCode.NOT_FOUND
+
+
 def test_set_fields_maps_no_issue_found_stderr_to_not_found_error():
     runner = ScriptedBdRunner(
         steps=[

--- a/packages/workcli/tests/unit/test_dep_add_validation.py
+++ b/packages/workcli/tests/unit/test_dep_add_validation.py
@@ -1,0 +1,208 @@
+"""`dep add`'s two pre-checks: the closed type vocabulary, and parent arity.
+
+Both refuse before `dep_mutate` is reached, so a rejected call costs zero
+mutating bd invocations -- the same property `test_dep_type_wall.py` holds for
+the `blocks` wall, asserted the same way, off the fake's call log.
+
+The parent-arity check is the one that matters most. bd accepts a second
+`parent-child` edge silently, and the item is then described by two sources
+that disagree: the `parent` scalar is bd's own field, `children` is derived
+from reverse edges. A caller who runs the add and verifies with `show` reads
+one parent and concludes nothing happened, while the tree still walks the item
+from both parents.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.conftest import run_cli, run_cli_with_runner
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.envelope import ErrorCode
+from workcli.verbs.relations import DEP_TYPES
+
+_OK = BdResult(returncode=0, stdout="", stderr="")
+
+# The two types whose pre-check reads bd; every other type reaches
+# `dep add` with no read at all.
+_READS_BOTH_ENDS = "blocks"
+_READS_THE_CHILD = "parent-child"
+
+
+def _show_result(item_id: str, *, parent: str | None = None, issue_type: str = "task") -> BdResult:
+    """A `bd show ID --json` response, with or without a parent."""
+    payload = [
+        {
+            "id": item_id,
+            "title": "t",
+            "issue_type": issue_type,
+            "status": "open",
+            "priority": 2,
+            "labels": [],
+            "parent": parent,
+            "dependencies": [],
+            "dependents": [],
+        }
+    ]
+    return BdResult(returncode=0, stdout=json.dumps(payload), stderr="")
+
+
+# ---- parent arity ----
+
+
+def test_dep_add_parent_child_onto_an_item_that_already_has_a_parent_never_mutates():
+    # The reproduction: on the unguarded code this call succeeded silently and
+    # left `child.1` carrying two parent-child edges against one parent scalar.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("show", "child.1", "--json"), _show_result("child.1", parent="old.1"))]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["dep", "add", "child.1", "new.1", "--type", "parent-child"], runner
+    )
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == str(ErrorCode.FIELD_CLOBBER_GUARD)
+    assert runner.calls == [("show", "child.1", "--json")]
+    assert not any(call[:2] == ("dep", "add") for call in runner.calls)
+
+
+def test_dep_add_parent_child_refusal_names_the_existing_parent_and_the_move_command():
+    # The recovery has to be discoverable from the error itself: the previous
+    # behaviour raised nothing at all, so nothing ever pointed at the fix.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("show", "child.1", "--json"), _show_result("child.1", parent="old.1"))]
+    )
+
+    _, envelope, _ = run_cli_with_runner(
+        ["dep", "add", "child.1", "new.1", "--type", "parent-child"], runner
+    )
+
+    error = envelope["error"]
+    assert "old.1" in error["message"]
+    assert "work update child.1 --set-parent new.1" in error["message"]
+    assert error["detail"] == {
+        "id": "child.1",
+        "parent": "old.1",
+        "requested_parent": "new.1",
+    }
+
+
+def test_dep_add_parent_child_onto_a_parentless_item_passes_through():
+    # Attaching a first parent is how a child is created; only a SECOND one is
+    # the violation.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("show", "orphan.1", "--json"), _show_result("orphan.1", parent=None)),
+            ScriptedStep(("dep", "add"), _OK),
+        ]
+    )
+
+    exit_code, _, _ = run_cli_with_runner(
+        ["dep", "add", "orphan.1", "new.1", "--type", "parent-child"], runner
+    )
+
+    assert exit_code == 0
+    assert runner.calls[-1] == ("dep", "add", "orphan.1", "new.1", "--type", "parent-child")
+
+
+def test_dep_add_re_adding_the_parent_an_item_already_has_stays_a_success():
+    # Judgment call, recorded: a re-add is a silent success, not an error. The
+    # postcondition the caller asked for already holds, bd treats the repeat as
+    # a no-op, and erroring here would fail a correct request -- and would make
+    # a retry after a timeout report failure on a call that had succeeded.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("show", "child.1", "--json"), _show_result("child.1", parent="same.1")),
+            ScriptedStep(("dep", "add"), _OK),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["dep", "add", "child.1", "same.1", "--type", "parent-child"], runner
+    )
+
+    assert exit_code == 0
+    assert envelope["error"] is None
+
+
+# ---- closed type vocabulary ----
+
+
+def test_dep_add_with_an_unrecognized_type_is_refused_without_calling_bd_at_all():
+    # Measured on the unguarded code: bd stored `bogus-type-probe` as a real
+    # edge. Nothing reads it, nothing acts on it, and it renders like any other
+    # edge -- a typo that produces a silently inert relationship.
+    exit_code, envelope, _ = run_cli(
+        ["dep", "add", "a.1", "b.1", "--type", "bogus-type-probe"], steps=[]
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert error["code"] == str(ErrorCode.USAGE)
+    assert error["detail"] == {"field": "type", "dep_type": "bogus-type-probe"}
+    # The accepted vocabulary is in the message, so the caller learns the set
+    # from the rejection rather than from bd's help.
+    assert "relates-to" in error["message"]
+
+
+def test_dep_add_refuses_the_near_miss_this_package_invented():
+    # `related-to` appeared in this package's own model comment and its tests
+    # and is in no bd vocabulary; `relates-to` and `related` are the real ones.
+    # The facade documenting a type its backend does not know is exactly the
+    # typo class the closed set exists to catch.
+    exit_code, envelope, _ = run_cli(["dep", "add", "a.1", "b.1", "--type", "related-to"], steps=[])
+
+    assert exit_code == 1
+    assert envelope["error"]["code"] == str(ErrorCode.USAGE)
+
+
+def test_every_type_in_the_closed_set_is_still_accepted():
+    for dep_type in sorted(DEP_TYPES):
+        if dep_type == _READS_BOTH_ENDS:
+            steps = [
+                ScriptedStep(
+                    ("show", "a.1", "b.1", "--json"),
+                    BdResult(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [
+                                json.loads(_show_result("a.1").stdout)[0],
+                                json.loads(_show_result("b.1").stdout)[0],
+                            ]
+                        ),
+                        stderr="",
+                    ),
+                ),
+                ScriptedStep(("dep", "add"), _OK),
+            ]
+        elif dep_type == _READS_THE_CHILD:
+            steps = [
+                ScriptedStep(("show", "a.1", "--json"), _show_result("a.1", parent=None)),
+                ScriptedStep(("dep", "add"), _OK),
+            ]
+        else:
+            steps = [ScriptedStep(("dep", "add"), _OK)]
+        runner = ScriptedBdRunner(steps=steps)
+
+        exit_code, envelope, _ = run_cli_with_runner(
+            ["dep", "add", "a.1", "b.1", "--type", dep_type], runner
+        )
+
+        assert exit_code == 0, f"{dep_type} was rejected: {envelope['error']}"
+        assert runner.calls[-1] == ("dep", "add", "a.1", "b.1", "--type", dep_type)
+
+
+def test_dep_remove_still_accepts_a_type_outside_the_closed_set():
+    # Deliberate asymmetry. Edges with an unsanctioned type already exist,
+    # written before this check landed; closing the set on removal too would
+    # strand precisely the edges that need cleaning up.
+    runner = ScriptedBdRunner(steps=[ScriptedStep(("dep", "remove"), _OK)])
+
+    exit_code, _, _ = run_cli_with_runner(
+        ["dep", "remove", "a.1", "b.1", "--type", "bogus-type-probe"], runner
+    )
+
+    assert exit_code == 0
+    assert runner.calls == [("dep", "remove", "a.1", "b.1")]

--- a/packages/workcli/tests/unit/test_dep_type_wall.py
+++ b/packages/workcli/tests/unit/test_dep_type_wall.py
@@ -169,16 +169,20 @@ def test_dep_add_epic_task_still_detects_the_wall_when_the_combined_show_returns
     assert error["detail"] == {"from": "epic.1", "to": "task.1", "dep_type": "blocks"}
 
 
-def test_dep_add_with_related_to_type_skips_the_wall_check_entirely():
+def test_dep_add_with_relates_to_type_skips_the_wall_check_entirely():
+    # `relates-to` is bd's own spelling. This test used to say `related-to`,
+    # which is in no vocabulary bd documents -- it was a string this package
+    # invented and only ever fed to its own fake, so nothing caught it.
     runner = ScriptedBdRunner(steps=[ScriptedStep(("dep", "add"), _OK)])
 
     exit_code, _, _ = run_cli_with_runner(
-        ["dep", "add", "epic.1", "task.1", "--type", "related-to"], runner
+        ["dep", "add", "epic.1", "task.1", "--type", "relates-to"], runner
     )
 
     assert exit_code == 0
-    # No `show` reads at all -- the pre-check never runs for a non-blocks type.
-    assert runner.calls == [("dep", "add", "epic.1", "task.1", "--type", "related-to")]
+    # No `show` reads at all -- neither pre-check reads for a type that is
+    # neither `blocks` nor `parent-child`.
+    assert runner.calls == [("dep", "add", "epic.1", "task.1", "--type", "relates-to")]
 
 
 def test_dep_remove_sends_exactly_one_bd_call_with_no_type_flag():

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -61,9 +61,18 @@ def test_protocol_wire_value_is_pinned() -> None:
     # test references PROTOCOL_VERSION. Bumping the protocol means updating
     # this one assertion deliberately.
     #
-    # 1.5 adds `unknown_relations` to every read item and stops emitting the
+    # 1.5 added `unknown_relations` to every read item and stopped emitting the
     # relationship fields it names. The removals keep the major: the fields
     # they drop were never populated on those reads, so no consumer can have
     # been reading a true value out of one, and the major is what every
     # consumer handshake pins on.
-    assert PROTOCOL_VERSION == "1.5"
+    #
+    # 1.6 adds `update --set-parent`, and starts refusing two inputs `dep add`
+    # used to accept: a `--type` outside bd's vocabulary, and a second parent
+    # for an item that already has one. The rule scopes MAJOR to breaking
+    # changes in the ENVELOPE or `data` shapes, and neither moves here -- a new
+    # flag is additive, and a newly-refused input yields the same typed failure
+    # envelope every other rejection already does. Both refusals only ever
+    # rejected a call whose success was the defect, so no consumer had correct
+    # behaviour to lose.
+    assert PROTOCOL_VERSION == "1.6"

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -254,7 +254,7 @@ def test_reconcile_ignores_a_non_placeholder_blocks_dependent_of_a_design():
 
 
 def test_reconcile_ignores_a_non_blocks_dependent_even_with_a_placeholder_marker():
-    # Only the blocks-edge links a design to its placeholder; a related-to
+    # Only the blocks-edge links a design to its placeholder; a relates-to
     # dependent (even one carrying a manifest marker) is not that relationship.
     backend = FakeBackend()
     backend.add("c", type="feature", labels=["shape-spec"])
@@ -263,8 +263,8 @@ def test_reconcile_ignores_a_non_blocks_dependent_even_with_a_placeholder_marker
         "relative",
         type="task",
         labels=["shape-feat"],
-        notes=_snapshot_note(_single()),  # marker present, but linked related-to, not blocks
-        deps=[DepEdge(id="d", type="related-to", status="in_progress")],
+        notes=_snapshot_note(_single()),  # marker present, but linked relates-to, not blocks
+        deps=[DepEdge(id="d", type="relates-to", status="in_progress")],
     )
 
     findings = _reconcile(backend)

--- a/packages/workcli/tests/unit/test_write_verbs.py
+++ b/packages/workcli/tests/unit/test_write_verbs.py
@@ -63,6 +63,79 @@ def test_update_with_no_set_flags_yields_usage_envelope():
     assert error["code"] == str(ErrorCode.USAGE)
 
 
+def test_update_set_parent_sends_one_bd_call_carrying_bds_own_reparent_flag():
+    # bd's `update --parent` REPLACES the parent-child edge (verified against
+    # bd 1.0.3), so the move is one call and never passes through a state where
+    # the item has two parents.
+    runner = ScriptedBdRunner(steps=[ScriptedStep(("update",), _OK)])
+
+    exit_code, _, _ = run_cli_with_runner(["update", "x.1", "--set-parent", "p.2"], runner)
+
+    assert exit_code == 0
+    assert runner.calls == [("update", "x.1", "--parent", "p.2")]
+
+
+def test_update_set_parent_alone_satisfies_the_at_least_one_flag_requirement():
+    runner = ScriptedBdRunner(steps=[ScriptedStep(("update",), _OK)])
+
+    exit_code, envelope, _ = run_cli_with_runner(["update", "x.1", "--set-parent", "p.2"], runner)
+
+    assert exit_code == 0
+    assert envelope["error"] is None
+
+
+def test_update_combines_set_parent_with_other_replace_fields_in_one_call():
+    runner = ScriptedBdRunner(steps=[ScriptedStep(("update",), _OK)])
+
+    exit_code, _, _ = run_cli_with_runner(
+        ["update", "x.1", "--set-title", "New title", "--set-parent", "p.2"], runner
+    )
+
+    assert exit_code == 0
+    assert runner.calls == [("update", "x.1", "--title", "New title", "--parent", "p.2")]
+
+
+def test_update_set_parent_with_an_empty_value_is_refused_before_any_bd_call():
+    # bd reads an empty `--parent` as "remove the parent", which is what an
+    # unset shell variable expands to. Silently orphaning an item is not what
+    # anyone typing a move means.
+    runner = ScriptedBdRunner(steps=[])
+
+    exit_code, envelope, _ = run_cli_with_runner(["update", "x.1", "--set-parent", ""], runner)
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.USAGE)
+    assert error["detail"] == {"field": "parent"}
+    assert runner.calls == []
+
+
+def test_update_set_parent_to_a_missing_item_reports_not_found_not_backend_drift():
+    # bd's reparent path uses a DIFFERENT not-found wording than every other
+    # command ("not found: issue X", not "no issue found matching X"). Without
+    # that second marker the likeliest `--set-parent` mistake reports
+    # E_BACKEND_DRIFT -- "bd's own model of itself broke" -- for a plain typo.
+    exit_code, envelope, _ = run_cli(
+        ["update", "x.1", "--set-parent", "nosuch.1"],
+        steps=[
+            ScriptedStep(
+                ("update",),
+                BdResult(
+                    returncode=1,
+                    stdout="",
+                    stderr="Error getting parent nosuch.1: not found: issue nosuch.1\n",
+                ),
+            )
+        ],
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.NOT_FOUND)
+
+
 def test_update_not_found_maps_to_not_found_envelope():
     exit_code, envelope, _ = run_cli(
         ["update", "bogus-id", "--set-title", "T"],


### PR DESCRIPTION
Closes the P0 `9k9.147` and the P3 `9k9.166` together, because they are one defect in one function wearing two hats: `work dep add` writing edges it cannot justify.

## What was broken

**No arity check on `parent-child`.** Run against an item that already had a parent, `dep add` succeeded silently and left two parent-child edges against one parent scalar. The scalar is what most readers check, so an agent that verified its own write read the unchanged value, concluded the move had failed, and either retried into a no-op or reported no change while the item was in fact double-parented. Anything walking the tree from the parent side counted that item twice.

**No vocabulary check at all.** `_type_wall_check` pre-checks `blocks` specifically and returns early for everything else, so an unrecognised `--type` did not fail the wall — it bypassed it. bd validates no type and stores whatever it is handed, so a typo produced an edge that exists, renders, and participates in nothing.

## What changed

Both checks run before any mutating call, cheapest first. `dep add` stays an add primitive and refuses rather than silently relocating an edge to make a request succeed; the refusal names the existing parent and the command that fixes it, so the recovery is discoverable at the moment it is needed. It reuses `E_FIELD_CLOBBER_GUARD` — the same shape as `update`'s append-only notes tripwire — rather than widening the error vocabulary.

The move is `work update --set-parent`, mapping to bd's own `--parent`.

## Two things measured rather than assumed

**bd's `--parent` genuinely replaces.** Verified against a scratch install: after a reparent the old parent-child edge is gone from *both* ends' `dep list`, not merely superseded in the scalar. So the non-atomic add-then-remove crash window recorded on the tracker item does not apply — one call moves the item, and the integration test asserts the old edge's absence rather than trusting the scalar.

**bd's apparent guard is a mirage.** A first probe was rejected with `cannot add dependency: X is already a child of Y` — which looks like bd already handles this. It does not: bd was inferring parentage from the hierarchical ID string, not from the edge, and named an item that was not the parent. With IDs that do not lexically nest, the second edge lands silently. The accidental protection covers only moves nobody needs.

## Deliberate asymmetry

The closed set is bd's documented ten, enforced **on write only**. `dep remove` and `DepEdge.type` stay open, because edges with an unsanctioned type already exist in the wild and closing the removal or read path would strand exactly what needs cleaning up. `related-to` — which appeared only in this package's own model comment and its own tests, and is in no bd vocabulary — is corrected to `relates-to`. That the facade was documenting a type its backend never knew is the same typo class the closed set now catches.

Re-adding the parent an item already has stays a success: the postcondition already holds, bd no-ops, and erroring would break retry-safety after a timeout.

## One adjacent fix

bd's reparent path words its not-found error differently from every other command (`not found: issue X`, not `no issue found matching X`). Unmapped, a typo'd `--set-parent` — the likeliest mistake anyone makes with a new flag — would have reported `E_BACKEND_DRIFT`. Mapped, so the flag does not ship with that defect attached.

## Protocol 1.5 → 1.6 (MINOR)

No envelope or `data` shape moves. Newly *rejecting* input is the judgment call, and it stays MINOR because the versioning rule scopes MAJOR to shape breaks, a rejection emits the same typed failure envelope as every other rejection, and the calls now refused are the ones whose success *was* the defect. `executor` pins MAJOR `1` and is unaffected; no package pins a MINOR.

## Verification

| Gate | Exit |
| --- | --- |
| `make ci` (whole repo) | 0 |
| `make ci-workcli` | 0 — 708 tests, 99.21% coverage |
| `make itest-workcli` (real bd) | 0 — 43 tests |

Each run standalone from the worktree root, exit status read directly. The new tests were mutation-checked: with the two guards removed, 7 of 8 unit tests in `test_dep_add_validation.py` fail, the eighth being the `dep remove` test that is unaffected by design.

## Known boundaries

- **Preventive only.** Items already carrying a double parent or a bogus-type edge from before this change are untouched and still need a sweep. `dep remove` stays open precisely so that sweep is possible.
- **`--set-parent ""` is refused** (`E_USAGE`). bd reads an empty `--parent` as "detach", which is what an unset shell variable expands to. Detaching stays unexpressible; it was not in scope.
- `discover.py` writes its provenance edge through `backend.dep_mutate` directly, bypassing the verb-layer check. Safe today — it passes an in-set constant, not user input — and left alone rather than guarded against a caller that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
