### PR TITLE
docs(9k9.175): an anticipated section says what is missing, not that nothing exists

### DIFF
--- a/project-config.toml
+++ b/project-config.toml
@@ -34,9 +34,16 @@ name = "agents-config"
 # The agent merges only on an explicit in-session human instruction.
 merge-authorization = "explicit"
 
-# Anticipates future work: autonomous merge once the selected rule holds. Needs a
-# deployed rule evaluator and an approving review the branch ruleset accepts —
-# neither exists (agents-config-9k9.23, .28, .64).
+# Anticipates future work: autonomous merge once the selected rule holds. What is
+# missing is the approving review the branch ruleset accepts (agents-config-9k9.23);
+# reinstating the authorization itself is agents-config-9k9.64.
+#
+# An eligibility evaluator does ship, and it is not the one this anticipates:
+# `prgroom status --json` emits `auto_merge_eligible`, the AND of four gates
+# (packages/prgroom/src/prgroom/lifecycle/status.py). It is derived from prgroom's
+# own bot quiescence, which the charter supersedes, and no term in it consults a
+# review verdict. Read a true value there as a report on grooming, never as an
+# authorization to merge — nothing stands behind it as one.
 # merge-authorization = "rule-based"
 # merge-rule          = "bot-quiescence"
 
@@ -49,7 +56,9 @@ merge-authorization = "explicit"
 # key-path-env = "MERGE_GUARD_APPROVER_KEY_PATH"
 
 # Anticipates future work: which reviews to expect, and how many human approvals a
-# merge needs. Nothing polls for reviews today.
+# merge needs. Reviews are fetched today — `prgroom poll` queries gh for review
+# items, reviews and CI status — but nothing turns that into an expected-reviewer
+# set or an approval count, so these keys would have no reader if uncommented.
 # [review-expectations]
 # bot-review-expected      = true
 # bot-reviewers            = ["Copilot", "copilot-pull-request-reviewer[bot]", "chatgpt-codex-connector[bot]"]  # exact identities, never substrings


### PR DESCRIPTION
**Comments only.** No uncommented key added, removed or changed — verified by parsing the file and diffing every non-comment line, of which there are none.

## Context: what you decided, and what I got wrong

You asked for proof that the commented-out merge sections cause problems as they stand. **There is none**, and I've recorded that on `9k9.69` so it isn't re-litigated:

- All four blocks are commented out and each already annotates itself as inert.
- Three places already say a commented key is future work nothing reads: this file's header, root `AGENTS.md`, `docs/guide/configuration.md`.
- No gate reads the file; it's not in the always-on surface, so no token cost.
- **`9k9.69`'s own premise is historical** — the file no longer declares `merge-authorization = "rule-based"` in the present tense; the de-rot landed under `9k9.71`.
- Its `remove_when` has two disjuncts. Keeping the sections closes it by the *other* one ("an implementation is deployed"). My delete recommendation rested on reading the first disjunct as a rule rather than on measured harm.

**The sections stay.** What the harm test *did* turn up is two annotations that are factually false — and both understate what's deployed, which is the direction that hides a trap rather than creating one.

## Correction 1 — "neither exists"

An eligibility evaluator **ships**. `packages/prgroom/src/prgroom/lifecycle/status.py:99` computes `auto_merge_eligible` as the AND of four gates and emits it from `prgroom status --json`. `9k9.28`'s closing note says it outright: *"a merge-eligibility evaluator already ships in prgroom."* That item is also **closed**, so citing it beside two open ones read as though all three were pending.

This is worse than untidy. `9k9.69` already recorded the evaluator as a latent trap — *"an agent that runs `prgroom status --json` on its own initiative reads `auto_merge_eligible: true` as an authorization no gate stands behind."* Telling a reader no evaluator exists **makes that trap harder to find**, because it says there's nothing to look for.

The annotation now names the evaluator, notes it's derived from bot quiescence `D13` supersedes and consults no review verdict, and says to read a true value as a report on grooming rather than a permission to merge.

## Correction 2 — "Nothing polls for reviews today"

`prgroom poll` is a live verb on PATH. Its own `--help`:

> Query gh for new review items, reviews, and CI status; update state (read-only).

`lifecycle/poll.py` paginates the reviews response; `lifecycle/human_review.py` fetches reviews too. Reviews **are** fetched. What's missing is anything that turns them into an expected-reviewer set or an approval count — which is what the annotation now says.

## Verification

- `make ci` — **exit 0** from this worktree, captured standalone.
- `make doc-lint` — exit 2 on the **same three** unresolved findings in the same three files as `main` (`installer-design.md:216`, `BEADS_GITHOOKS_PRIMER.md:134`, `grind/AGENTS.md:157`). It now reads 99 tracked files rather than 94 because two skills landed on `main` meanwhile; the finding count is unchanged.
- `tomllib.load` — parses; `[merge-policy]`, `[tracks]`, `[operating-model]`, `[extraction.*]` all unchanged.

## Left alone deliberately

`[completion-gate]`'s four thresholds. Measured: `heavy_min_files` and `trivial_max_loc` appear **only** in this file — no spec, no tracker item, and the guide says there is no tier router. Deleting that block would destroy the only record of numbers somebody reasoned about. It also isn't a merge section, so `9k9.69` never covered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky