### PR TITLE
chore(9k9.150): writing-skills gains its theory layer and a second seat

### DIFF
--- a/src/user/.agents/skills/writing-skills/SKILL.md
+++ b/src/user/.agents/skills/writing-skills/SKILL.md
@@ -68,7 +68,7 @@ Documented divergences since:
     "completion bound" to keep it distinct from a review's acceptance
     criteria. Its steps/reference split, invocation axis and pruning levers
     are the parts that reshaped this body.
-Internal cross-references use bare-name skill conventions (e.g., `test-driven-development`).
+Internal cross-references use bare-name skill conventions (e.g., `tdd`).
 If a cross-reference dangles in a deployment, verify the skill exists in your installation.
 -->
 
@@ -205,7 +205,7 @@ This binds **discipline** documents in full. For technique and reference the spi
 still applies — verify the document teaches what you think it teaches — but the test
 format is application or retrieval, not pressure compliance.
 
-The cycle is `test-driven-development` applied to documentation. **RED** runs the
+The cycle is `tdd` applied to documentation. **RED** runs the
 scenario WITHOUT the document, or with the OLD version, capturing verbatim what the
 agent chose and which queries missed; **GREEN** addresses only those failures;
 **REFACTOR** counters the rationalizations and near-misses that testing then

--- a/src/user/.agents/skills/writing-skills/SKILL.md
+++ b/src/user/.agents/skills/writing-skills/SKILL.md
@@ -28,10 +28,13 @@ this block being stripped and ship these paths into every downstream install.
   verified byte-identical at the 2026-07-17 repo-move refresh)
 
   Source: skills/productivity/writing-for-agents/
-  Upstream: https://github.com/mattpocock/skills @ f054defc3f694558dbd1f418cd9046057594283b
-  (SKILL.md and SKILL-MECHANICS.md were both verified byte-identical to this
-  commit's blobs by hash, and were still unchanged at upstream main on the
-  sync date below)
+  Upstream: https://github.com/mattpocock/skills @ 4aaccb58d40559d7e3c59a029b2290ae5ba538de
+  (all three files in that directory — SKILL.md, SKILL-MECHANICS.md and
+  agents/openai.yaml — were verified byte-identical to this commit's blobs by
+  hash. SKILL.md and SKILL-MECHANICS.md reached this content two commits
+  earlier at f054defc, but 4aaccb58 is the first commit at which the whole
+  source directory reproduces, so it is the pin. Only the first two were
+  grafted; agents/openai.yaml is upstream-specific and was not taken.)
 Last sync: 2026-08-07
 Drift policy: selective-amalgamation. The merged SKILL.md is the authoritative
 copy and diverges from every upstream by construction — specific patterns were

--- a/src/user/.agents/skills/writing-skills/SKILL.md
+++ b/src/user/.agents/skills/writing-skills/SKILL.md
@@ -1,14 +1,19 @@
 ---
 name: writing-skills
-description: Use when creating a new skill, editing an existing skill, or verifying a skill works before deploying it. Apply whenever the user mentions skills, SKILL.md, skill authoring, skill testing, skill triggering accuracy, capturing a workflow as a reusable skill, or wants to know whether a skill is ready to ship — even if they don't explicitly say "skill" and just describe wanting to "package this up" or "make this reusable."
+description: Use when creating or editing a skill, verifying a skill triggers before deploying it, or authoring or improving an AGENTS.md or CLAUDE.md. Apply whenever the user mentions skills, SKILL.md, skill authoring, or skill testing; whenever agent instructions, project rules, or a CLAUDE.md are being written, trimmed, or reorganised; and whenever a document an agent reads is too long, gets ignored, or fires at the wrong time — even if they don't say "skill" and just describe wanting to "package this up", "make this reusable", or "tighten up the agent instructions".
 admission:
-  provides: Mechanism for creating, editing and verifying skills for agents.
-  cost: Unknown
-  remove_when: Agents prove they can craft their own skills with high quality.
+  provides: A method for authoring any document an agent reads — a skill, or an
+    AGENTS.md/CLAUDE.md — producing a trigger tested against near-misses, a body
+    sized to its budget, and material disclosed to references by branch, instead
+    of prose written by imitation of whatever skill the author read last.
+  cost: ~1.9k tokens on invoke plus an always-on description, and a RED baseline
+    run before every skill edit, which is slower than editing the prose directly.
+  remove_when: Agents author skills and instruction files that trigger accurately
+    and stay within budget without being told the method.
 ---
 
 <!--
-Amalgam of two upstreams, one Source/Upstream pair each. Keep every key at the
+Amalgam of three upstreams, one Source/Upstream pair each. Keep every key at the
 start of its own line: the installer recognises a provenance header by matching
 `Source:`/`Upstream:` there, so folding these into bullets or prose would stop
 this block being stripped and ship these paths into every downstream install.
@@ -21,11 +26,18 @@ this block being stripped and ship these paths into every downstream install.
   (development continues at https://github.com/anthropics/claude-plugins-official;
   the pinned repository and commit both remain reachable, and content was
   verified byte-identical at the 2026-07-17 repo-move refresh)
-Last sync: 2026-05-17
-Drift policy: accept-periodic-resync. The merged SKILL.md is the authoritative
-copy and may diverge from either upstream. To inspect drift, clone each
-upstream at the SHA above and diff that against this copy. On a resync, bump
-both SHAs and the date in the same change.
+
+  Source: skills/productivity/writing-for-agents/
+  Upstream: https://github.com/mattpocock/skills @ f054defc3f694558dbd1f418cd9046057594283b
+  (SKILL.md and SKILL-MECHANICS.md were both verified byte-identical to this
+  commit's blobs by hash, and were still unchanged at upstream main on the
+  sync date below)
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation. The merged SKILL.md is the authoritative
+copy and diverges from every upstream by construction — specific patterns were
+lifted, not whole files, so a resync would revert the graft. To inspect drift,
+clone each upstream at the SHA above and diff that against this copy. On a
+resync, bump the SHAs and the date in the same change.
 
 Bundled resources (scripts/, references/, examples/) were byte-identical
 copies of the upstream artifacts at the SHAs above at initial import.
@@ -47,101 +59,128 @@ Documented divergences since:
     anti-patterns.md — leaving inline only what an agent needs in order to
     DECIDE how to proceed. Content preserved, not cut; the description is
     byte-unchanged, so triggering behaviour is unaffected.
+  - references/writing-for-agents.md — the third upstream's SKILL.md and
+    SKILL-MECHANICS.md, grafted as theory. Reordered into one file, its
+    pointers redirected here, and its "completion criterion" renamed
+    "completion bound" to keep it distinct from a review's acceptance
+    criteria. Its steps/reference split, invocation axis and pruning levers
+    are the parts that reshaped this body.
 Internal cross-references use bare-name skill conventions (e.g., `test-driven-development`).
 If a cross-reference dangles in a deployment, verify the skill exists in your installation.
 -->
 
-# Writing Skills
+# Writing Skills and Agent Instruction Files
 
-## Overview
+## Scope
 
-**Writing skills IS Test-Driven Development applied to process documentation.**
+One method, two documents: a **skill**, and an **`AGENTS.md` / `CLAUDE.md`** — plus
+any doc either points at. The packaging differs; the writing does not. A skill is a
+reference guide for reusable methods a future agent can find and apply, not a
+narrative about how you solved a problem once.
 
-**Core principle:** If you didn't watch an agent fail without the skill, you
-don't know if the skill teaches the right thing. If you didn't watch the
-description compete with realistic near-miss queries, you don't know if it
-will trigger when it should.
+**Core principle:** a document you didn't watch an agent work without is one you
+don't know teaches the right thing; a pointer you didn't watch compete against
+realistic near-miss queries is one you don't know will be read.
 
-**REQUIRED BACKGROUND:** You MUST understand `test-driven-development` before
-using this skill. That skill defines the RED-GREEN-REFACTOR cycle; this one
-adapts it to documentation.
+**Read `references/writing-for-agents.md`** when a rule below doesn't decide your
+case: you can't tell what to inline and what to disclose, a document is followed
+unreliably or ignored, a pointer misfires, or you are cutting a document down and
+need to know what is safe to cut.
 
-A **skill** is a reference guide for proven techniques, patterns, or tools —
-reusable methods a future agent can find and apply. A skill is NOT a narrative
-about how you solved a problem once.
+## Context pointers — the wording is the trigger
 
-## Three Skill Types and the Register Split
+A **context pointer** names out-of-context material and encodes the condition for
+reaching it. A skill's `description` is one; a line in `AGENTS.md` naming a doc is
+the same object. **The pointer's wording, not its target, decides whether the agent
+reaches the material.** A must-have target behind a weak pointer is a variance bug
+— sharpen the wording first, and inline the material only if that fails.
 
-The single most important design decision is what *kind* of skill you are
-writing. The type drives both the **register** (how MUST-y the prose is) and
-the **test approach**.
-
-| Type | Examples | Register | Test approach |
-|------|----------|----------|---------------|
-| **Discipline** | rules you must obey under pressure | Hard MUSTs, Iron Law, "no exceptions," rationalization tables, red-flag lists | Pressure scenarios combining time + sunk-cost + authority |
-| **Technique** | how-to guides for a method | Soft, explain-the-why, theory-of-mind framing, examples beat MUSTs | Application scenarios on a new problem |
-| **Reference** | API docs, schemas, library guides | Neutral, scan-optimized tables, no admonitions | Retrieval scenarios |
-
-**Why the split matters.** Discipline skills exist because the agent will
-rationalize, and soft prose loses to time pressure — the MUSTs *are* the
-skill. Technique skills exist because the agent doesn't know the method, and
-hard MUSTs make it rigid where explanation makes it capable. Reference skills
-just need to be scannable.
-
-**Pick the type first, then write to the register.** Mixing registers within
-one skill is a smell — usually it means the skill is doing two jobs and should
-be split.
-
-**One exception: mechanical constraints carry MUSTs regardless of type.** When
-the runtime enforces a rule (depth-1 discovery, `name:` matching the folder,
-1024-char frontmatter), use a MUST even in a technique skill. The register
-split governs *judgment-call* prose, not constraints the host rejects anyway.
-
-## Progressive Disclosure — the Budget You Are Writing Against
-
-Three loading levels, and the cost of each is why the split exists:
-
-1. **Metadata** (frontmatter `name` + `description`) — always in context,
-   every session, for every installed skill. The description alone decides
-   whether the body ever loads.
-2. **SKILL.md body** — loaded when the skill triggers, and charged against a
-   deployed per-skill token budget. Keep it to what the agent needs in order
-   to *decide* how to proceed.
-3. **Bundled resources** (`references/`, `scripts/`, `assets/`) — loaded on
-   demand, unbudgeted. Scripts can execute without their source entering
-   context at all.
-
-So heavy reference, full example sets, and step-by-step checklists belong in
-`references/`; principles and decision tables stay inline. When a body
-outgrows its budget, move sections out **verbatim** and leave a pointer —
-cutting content to fit is how a skill quietly stops teaching what it used to.
-
-**Depth-1 only.** Every immediate subdirectory of the skills root is exactly
-one skill. Skills MUST NOT be nested under organizational subfolders — all
-four major runtimes (Claude Code, Codex CLI, Gemini CLI, OpenCode) discover
-skills one level deep.
-
-Layout, frontmatter fields, body-section conventions, cross-referencing
-markers, and the two content constraints are in `references/anatomy.md`.
-
-## Writing the Description
-
-The description does two jobs that look contradictory: it must make the agent
-load the body when relevant, and it must not let the agent act on the
-description alone. These reconcile into one rule:
+One rule governs every pointer:
 
 > **Be pushy about WHEN, never about WHAT or HOW.**
 
-```yaml
-# ❌ BAD — summarizes workflow; the agent follows this and skips the body
-description: Use when executing plans — dispatches subagent per task with code review between tasks
+A description summarizing workflow gets acted on in place of the body; one piling up
+conditions loads the body at the right moment and does nothing else.
 
-# ✅ GOOD — trigger-dense, pushy, process-free
-description: Use when tests have race conditions, timing dependencies, or pass/fail inconsistently. Apply whenever the user mentions flakiness, hangs, timeouts, zombie processes, or "works locally but fails in CI" — even if they describe the symptom without naming async/timing as the cause.
-```
+A pointer lists the **branches** that should trigger it — one trigger per branch,
+front-loading the word that does the triggering. Synonyms renaming a single branch
+are one branch written twice. An always-loaded pointer is charged on every turn, so
+it earns harder pruning than the body it guards.
 
-Full guidance — the pushy and process-free checklists, keyword coverage,
-naming, and the complete example set — is in `references/descriptions.md`.
+Worked examples, checklists, keyword coverage and naming are in
+`references/descriptions.md`.
+
+## What to inline and what to disclose
+
+Two budgets are in play. **Context load** is what always-loaded material costs the
+agent every turn. **Cognitive load** is what the human pays to remember which
+documents exist — not a cost to minimise, but the price of human agency.
+
+A skill spends them across three loading levels: **metadata** (`name` +
+`description`) sits in context every session and decides whether anything else
+loads; the **body** loads on trigger, against a deployed per-skill token budget;
+**bundled resources** (`references/`, `scripts/`, `assets/`) load on demand,
+unbudgeted. Hold the body to what the agent needs in order to *decide* how to
+proceed.
+
+**Branching is the disclosure test: inline what every branch needs, push behind a
+pointer what only some branches reach.** Progressive disclosure is not primarily a
+token optimisation — it is how the top of the document stays legible.
+
+**Disclosing is not pruning.** Over budget, move sections out *verbatim* behind a
+pointer: the content travels, nothing is lost. Prune only lines failing on their own
+merits — a no-op the model already obeys, a duplicate, a stale line. Cutting content
+to fit a budget is how a skill quietly stops teaching what it used to.
+
+**Depth-1 only.** Every immediate subdirectory of the skills root is exactly one
+skill; skills MUST NOT nest under organizational subfolders. All four major runtimes
+(Claude Code, Codex CLI, Gemini CLI, OpenCode) discover one level deep and no more.
+
+Layout, frontmatter fields, body sections and cross-reference markers are in
+`references/anatomy.md`.
+
+## Invocation — decide this before writing the description
+
+Every skill is **model-invoked** or **user-invoked**, and the choice trades the two
+loads against each other.
+
+| | Model-invoked | User-invoked |
+|---|---|---|
+| Reachable by | the agent, other skills, and you | you only, by name |
+| Context load | its description, permanently | none |
+| `description` | model-facing, carries the trigger branches | human-facing one-liner |
+| Mechanics | omit `disable-model-invocation` | set it `true`, where the host supports it |
+
+**The rule: choose model-invoked only when the agent must reach the skill on its
+own, or another skill must. Otherwise make it user-invoked and pay no context
+load.** A description only ever *adds* agent discovery — it never removes your
+reach — so the question is never "do I want to type its name", only "must something
+other than me find this".
+
+## Three document types and the register split
+
+The type drives both the **register** (how MUST-y the prose is) and the test
+approach — pressure scenarios, application scenarios or retrieval scenarios
+respectively, laid out under those names in `references/testing-methodology.md`.
+
+| Type | Register |
+|------|----------|
+| **Discipline** — obeyed under pressure | Hard MUSTs, Iron Law, "no exceptions", rationalization tables, red flags |
+| **Technique** — a method the agent lacks | Explain the why; examples beat MUSTs |
+| **Reference** — looked up | Neutral, scannable tables, no admonitions |
+
+**Why the split matters.** Discipline documents exist because the agent will
+rationalize and soft prose loses to time pressure — the MUSTs *are* the document.
+Technique documents exist because the agent lacks the method, and hard MUSTs make it
+rigid where explanation makes it capable.
+
+**Pick the type first, then write to the register.** Mixed registers in one document
+usually mean it is doing two jobs and should be split.
+
+**Mechanical constraints carry MUSTs regardless of type.** Where the runtime enforces
+a rule (depth-1 discovery, `name:` matching the folder, the 1024-char frontmatter
+limit), use a MUST even in a technique document: the register split governs
+*judgment-call* prose, not constraints the host rejects anyway.
 
 ## The Iron Law
 
@@ -149,61 +188,43 @@ naming, and the complete example set — is in `references/descriptions.md`.
 NO SKILL WITHOUT A FAILING TEST FIRST
 ```
 
-This applies to NEW skills AND EDITS to existing skills.
+NEW skills AND EDITS to existing ones — and an instruction file is no exception.
+Wrote it before testing? Delete it, start over. Edited without testing? Same
+violation.
 
-Wrote skill before testing? Delete it. Start over. Edited without testing?
-Same violation.
-
-**No exceptions:** not for "simple additions," not for "just adding a
-section," not for "documentation updates." Don't keep untested changes as
-"reference." Don't "adapt" while running tests. Delete means delete.
+**No exceptions:** not "simple additions", not "just adding a section", not
+"documentation updates". Don't keep untested changes as "reference". Don't "adapt"
+while running tests. Delete means delete.
 
 **Violating the letter of the rules is violating the spirit of the rules.**
 
-This applies in full to **discipline-type** skills. For technique and
-reference skills the spirit still applies — verify the skill teaches what you
-think it teaches — but the test format is application or retrieval, not
-pressure compliance.
+This binds **discipline** documents in full. For technique and reference the spirit
+still applies — verify the document teaches what you think it teaches — but the test
+format is application or retrieval, not pressure compliance.
 
-## RED-GREEN-REFACTOR for Skills
+The cycle is `test-driven-development` applied to documentation. **RED** runs the
+scenario WITHOUT the document, or with the OLD version, capturing verbatim what the
+agent chose and which queries missed; **GREEN** addresses only those failures;
+**REFACTOR** counters the rationalizations and near-misses that testing then
+surfaces. Scenario design is in `references/testing-methodology.md`.
 
-| TDD Concept | Skill Creation |
-|-------------|----------------|
-| Test case | Pressure scenario, application scenario, or trigger-eval query |
-| Production code | SKILL.md |
-| Test fails (RED) | Agent violates rule, fumbles technique, or skill undertriggers |
-| Test passes (GREEN) | Agent complies, applies correctly, or triggers reliably |
-| Refactor | Close loopholes, tighten examples, tune description |
+After writing ANY document covered here you MUST STOP and work
+`references/checklist.md` before moving on. Deploying an untested skill is deploying
+untested code.
 
-**RED** — run the scenario WITHOUT the skill (or with the OLD version).
-Capture verbatim: what choices the agent made, what rationalizations it used,
-which queries failed to trigger.
-
-**GREEN** — address the specific failures observed in RED. Don't add content
-for hypothetical cases that never came up. Re-run WITH the skill.
-
-**REFACTOR** — the agent will find new rationalizations and near-miss
-failures. Add explicit counters. Re-test until bulletproof.
-
-## Bundled References
+## Bundled references
 
 | File | Read when |
 |------|-----------|
 | `checklist.md` | **Before shipping — always** |
-| `anatomy.md` | Laying out a skill; frontmatter; cross-references |
-| `descriptions.md` | Writing or tuning the description |
-| `testing-methodology.md` | Designing scenarios; the trigger-eval loop |
-| `testing-skills-with-subagents.md` | Running the full pressure-subagent method |
+| `writing-for-agents.md` | An inline-or-disclose call; a misfiring pointer; trimming |
+| `anatomy.md` | Layout; frontmatter; cross-references |
+| `descriptions.md` | Writing or tuning a description |
+| `testing-methodology.md` | Scenario design; the trigger-eval loop |
+| `testing-skills-with-subagents.md` | The full pressure-subagent method |
 | `bulletproofing.md` | Hardening a discipline skill |
 | `anti-patterns.md` | Reviewing; adding a flowchart or example |
 | `anthropic-best-practices.md` | Anthropic's longer-form guidance |
 | `persuasion-principles.md` | Why discipline prose sticks |
 | `schemas.md` | Eval or grading JSON |
 | `graphviz-conventions.dot` | Flowchart style |
-
-## The Bottom Line
-
-Creating skills IS TDD for process documentation. Same Iron Law: no skill
-without a failing test first. Same cycle: RED → GREEN → REFACTOR. After
-writing ANY skill you MUST STOP and work `references/checklist.md` before
-moving on — deploying untested skills is deploying untested code.

--- a/src/user/.agents/skills/writing-skills/references/anatomy.md
+++ b/src/user/.agents/skills/writing-skills/references/anatomy.md
@@ -70,10 +70,10 @@ Concrete results — only if you have them and they're load-bearing.
 
 Use the skill name with an explicit requirement marker:
 
-- ✅ `REQUIRED SUB-SKILL: Use test-driven-development`
+- ✅ `REQUIRED SUB-SKILL: Use tdd`
 - ✅ `REQUIRED BACKGROUND: You MUST understand bugfix`
-- ❌ `See skills/testing/test-driven-development` — unclear if required
-- ❌ `@skills/testing/test-driven-development/SKILL.md` — force-loads, burns
+- ❌ `See skills/testing/tdd` — unclear if required
+- ❌ `@skills/testing/tdd/SKILL.md` — force-loads, burns
   context
 
 ## Principle of Lack of Surprise

--- a/src/user/.agents/skills/writing-skills/references/anatomy.md
+++ b/src/user/.agents/skills/writing-skills/references/anatomy.md
@@ -71,7 +71,7 @@ Concrete results — only if you have them and they're load-bearing.
 Use the skill name with an explicit requirement marker:
 
 - ✅ `REQUIRED SUB-SKILL: Use tdd`
-- ✅ `REQUIRED BACKGROUND: You MUST understand bugfix`
+- ✅ `REQUIRED BACKGROUND: You MUST understand diagnosing-bugs`
 - ❌ `See skills/testing/tdd` — unclear if required
 - ❌ `@skills/testing/tdd/SKILL.md` — force-loads, burns
   context

--- a/src/user/.agents/skills/writing-skills/references/testing-skills-with-subagents.md
+++ b/src/user/.agents/skills/writing-skills/references/testing-skills-with-subagents.md
@@ -28,7 +28,7 @@ You run scenarios without the skill (RED - watch agent fail), write skill addres
 
 **Core principle:** If you didn't watch an agent fail without the skill, you don't know if the skill prevents the right failures.
 
-**REQUIRED BACKGROUND:** You MUST understand `test-driven-development` before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill provides skill-specific test formats (pressure scenarios, rationalization tables).
+**REQUIRED BACKGROUND:** You MUST understand `tdd` before using this skill. That skill defines the fundamental RED-GREEN-REFACTOR cycle. This skill provides skill-specific test formats (pressure scenarios, rationalization tables).
 
 **Complete worked example:** See ../examples/CLAUDE_MD_TESTING.md for a full test campaign testing CLAUDE.md documentation variants.
 

--- a/src/user/.agents/skills/writing-skills/references/writing-for-agents.md
+++ b/src/user/.agents/skills/writing-skills/references/writing-for-agents.md
@@ -1,0 +1,240 @@
+# Writing for Agents — the theory under the rules
+
+Why the rules in `SKILL.md` work, and the levers they leave implicit. Read this
+when a rule in the body is not deciding your case: you cannot tell what to
+inline and what to disclose, a document is followed unreliably or ignored, a
+pointer fires at the wrong time, or you are cutting a document down and need to
+know what is safe to cut.
+
+The scope is any document an agent consumes — a skill, an `AGENTS.md` /
+`CLAUDE.md`, a doc reached by a pointer. The packaging differs; the writing does
+not. The same levers make each one predictable: the agent taking the same
+*process* every run, not producing the same output.
+
+## Contents
+
+- [Context pointers](#context-pointers)
+- [The two loads](#the-two-loads)
+- [Information hierarchy](#information-hierarchy)
+- [Steps and completion bounds](#steps-and-completion-bounds)
+- [When to split](#when-to-split)
+- [Leading words](#leading-words)
+- [Pruning](#pruning)
+
+## Context pointers
+
+A **context pointer** is a reference held in the agent's context that names some
+out-of-context material and encodes the condition for reaching it. A skill's
+description is one; a line in `AGENTS.md` naming a doc is the same object. The
+pointer's *wording*, not its target, decides when the agent reaches the material
+— and how reliably. A must-have target behind a weakly worded pointer is a
+variance bug: sharpen the wording first, and inline the material only if
+sharpening fails.
+
+A pointer does two jobs — state what the material is, and list the **branches**
+that should trigger reaching it (a branch is a distinct case the document
+handles, so different runs take different paths through it). Every word of an
+always-loaded pointer costs on every turn, so it earns even harder pruning than
+the body:
+
+- **Front-load the leading word** — the pointer is where it does its triggering
+  work.
+- **One trigger per branch.** Synonyms that rename a single branch are one branch
+  written twice; collapse them and keep only genuinely distinct branches.
+- **Cut identity the body already carries.**
+
+## The two loads
+
+Every document and pointer you add spends one of two budgets:
+
+- **Context load** — the cost of always-loaded material on the agent's window: an
+  `AGENTS.md` line, a skill description, anything sitting in context every turn,
+  spending tokens and attention whether or not it fires.
+- **Cognitive load** — the cost on the human: which documents exist and when to
+  reach for each. The human is the index. Not a cost to minimise — it is the
+  price of human agency; spend it where human judgement matters, remove it where
+  it does not.
+
+Material reached only through a pointer escapes context load at the price of the
+pointer's own line; material with no pointer at all rides entirely on cognitive
+load.
+
+## Information hierarchy
+
+A document is built from two content types — **steps** (the ordered actions the
+agent performs) and **reference** (definitions, rules, facts consulted on demand)
+— that mix freely: all steps (a recipe), all reference (a review's rules, this
+file), or both. The core decision is where each piece sits on the **information
+hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-file step** — the primary tier: what the agent does, in order.
+2. **In-file reference** — consulted on demand. Often a legitimately flat
+   peer-set (every rule of a review on one rung) — a fine arrangement, not a
+   smell.
+3. **Disclosed reference** — pushed out into a separate file, reached by a
+   context pointer, loaded only when the pointer fires. Spans a sibling file in
+   the same folder through fully external reference that lives anywhere and any
+   document can point at.
+
+Push too little down and the top bloats; push too much and you hide material the
+agent actually needs. That tension is the whole decision.
+
+**Progressive disclosure** is the move down the ladder — out of the main file and
+behind a pointer — so the top stays legible. Not primarily a token optimisation:
+it is how the hierarchy is protected. Branching is the cleanest disclosure test:
+inline what every branch needs, and push behind a pointer what only some branches
+reach. When a document has steps, in-file reference that should be disclosed
+buries them and turns attending to them into a coin-flip — a variance lever, not
+just a legibility one.
+
+**Co-location** is the within-file companion: where the ladder decides *how far
+down* a piece sits, co-location decides *what sits beside it* once there. Keep a
+concept's definition, rules, and caveats under one heading rather than scattered,
+so reading one part brings its neighbours with it. The test: the document should
+read like documentation written for the agent — grouped material reads that way;
+scattered material does not. (Distinct from duplication: that repeats one meaning
+in two places; scattering fragments one meaning across many.)
+
+**Sprawl** is the failure mode here: a document simply too long, even when every
+line is live and unique. Attention thins across the excess, and every extra line
+is one more to keep relevant. The cure is the ladder: disclose reference behind
+pointers, and split by branch or sequence so each path carries only what it needs.
+
+## Steps and completion bounds
+
+Every step ends on a **completion bound** — the condition that tells the agent the
+work is done.
+
+> **Vocabulary.** A completion bound is not a review's *acceptance criteria*.
+> Acceptance criteria are the termination condition for a round of review over
+> finished work — they decide when reviewing stops. A completion bound is a
+> property of one step inside a document you are authoring — it tells the agent
+> running that step when to stop working. Same shape, different object; keep the
+> names apart, because a document that uses one term for both teaches neither.
+
+Two properties make the bound a lever:
+
+- **Clarity** — can the agent tell done from not-done? A vague bound
+  ("understanding reached") invites **premature completion**: ending the step
+  before it is genuinely done, attention slipping to *being done*. The visible
+  steps still ahead — the **post-completion steps** — supply the pull; the bound's
+  clarity is the resistance. Defend in order: **sharpen the bound first** (local
+  and cheap); only if it is irreducibly fuzzy *and* you observe the rush, hide the
+  later steps by splitting the sequence — and hiding only works across a real
+  context boundary (a hand-off or a subagent dispatch; an inline call leaves the
+  later steps in context and clears nothing).
+- **Demand** — how much it requires. "Every modified model accounted for" forces
+  thorough work where "produce a change list" does not. Demand drives **legwork** —
+  the digging the agent does within the work, latent in the wording rather than
+  written as its own step — and it is not step-bound: "every rule applied" binds a
+  body of flat reference just as "every step done" binds a sequence, which is how
+  an all-reference document still carries an exhaustiveness bar.
+
+The strongest bounds are both checkable and exhaustive.
+
+## When to split
+
+Splitting one document into two spends one of the two loads, so split only when
+the cut earns it:
+
+- **By sequence** — split a run of steps where the post-completion steps tempt the
+  agent to rush the one in front of it. Keeping them out of view drives more
+  legwork on the current task. Beware the reverse: merging sequences exposes each
+  step's later steps to what follows, inviting premature completion.
+- **By invocation** — skill-specific; the decision rule is in `SKILL.md`. Split off
+  a model-invoked skill when you have a distinct leading word that should trigger
+  it on its own — a trigger word you actually use in your prompts — or another
+  skill must reach it. You pay context load for the new always-loaded description,
+  so that independent reach has to be worth it.
+
+**Routers.** When user-invoked skills multiply past what you can remember, that
+piled-up cognitive load is cured by a **router skill**: one user-invoked skill
+naming the others and when to reach for each, so the human has one skill to
+remember instead of many. It can only hint, never fire them — with no description,
+nothing but the human can reach them.
+
+Shared reference that two user-invoked skills both need can live in neither, for
+the same reason. Push it to a plain file outside the skill system, or into a
+model-invoked reference skill that both can reach.
+
+## Leading words
+
+A **leading word** is a compact concept already living in the model's pretraining
+that the agent thinks with while running the document (*lesson*, *fog of war*,
+*tracer bullets*). Repeated as a token, never as a sentence, it accumulates a
+distributed definition and anchors a whole region of behaviour in the fewest
+tokens, by recruiting priors the model already holds. Coining your own works if
+you define it clearly, but a made-up word recruits no priors — you pay in
+definition tokens what a pretrained word gives free; reach for an existing word
+first.
+
+It anchors twice. In the body, *execution*: the agent reaches for the same
+behaviour every time the word appears, and inside flat reference it focuses
+attention on a class of thing to look for. In a pointer, *invocation*: when the
+same word lives in your prompts, your docs, and your codebase, the agent links
+that shared language to the material and reaches it more reliably.
+
+Hunt for opportunities to refactor with leading words. A triad spelled out at
+three sites, a pointer spending a sentence to gesture at one idea — each is a
+passage begging to collapse into a single token:
+
+- "fast, deterministic, low-overhead" → *tight* (a *tight* loop).
+- "a loop you believe in" → *red* — a fuzzy gate becomes a binary observable state
+  (the loop goes *red* on the bug, or it doesn't).
+
+You win twice: fewer tokens, and a sharper hook for the agent to hang its thinking
+on. Assume every document is carrying restatements that leading words retire — go
+find them.
+
+**Negation** is the failure mode beside this lever: steering by prohibition drags
+the forbidden behaviour into context and makes it *more* available, not less.
+*Don't think of an elephant*, and the elephant is all there is; the negation is a
+weak modifier the strongly-activated concept overruns, so the ban half-reads as an
+instruction to do the thing. Prompt the **positive** — state the target behaviour
+("write one-line comments") so the banned one is never spoken. A prohibition earns
+its place only as a hard guardrail you cannot phrase positively; even then, pair it
+with the positive target so attention lands on what to do.
+
+## Pruning
+
+- Keep each meaning in a **single source of truth**: one authoritative place, so
+  changing the behaviour is a one-place edit. **Duplication** — the same meaning in
+  more than one place — costs maintenance and tokens, and inflates a meaning's
+  prominence on the ladder past its real rank. (The accidental inverse of a leading
+  word, which repeats a token on purpose, never the meaning.)
+- The **environment** is a source of truth too — `package.json` scripts, config
+  files, the directory layout, `--help` output — and a document that restates it is
+  a **cache**: a copy of a lookup, earning its load only when the lookup is
+  expensive. Cache what the agent cannot find by looking: the unwritten convention,
+  the reason behind a choice, the gotcha no config confesses. Leave the one-file,
+  one-command lookups to the environment, where they cannot go stale.
+- Check every line for **relevance**: does it still bear on what the document
+  does? A line loses relevance by never bearing on the task (mere exposition, or a
+  branch that should be disclosed) or by going stale as the behaviour or world it
+  describes changes. Shorter documents are easier to keep relevant. Without a
+  pruning discipline the default fate is **sediment**: stale layers that settle
+  because adding feels safe and removing feels risky, until you must core down
+  through them to find what is still live.
+- Hunt **no-ops** sentence by sentence: an instruction the model already obeys by
+  default pays load to say nothing. The test — does it change behaviour versus the
+  default? — is model-relative, not reader-relative: two people disagreeing about a
+  no-op disagree about the default, and settle it by running the document, not by
+  debate. When a sentence fails, delete the whole sentence rather than trim words
+  from it. The test also grades leading words: a word too weak to beat the default
+  (*be thorough* when the agent is already thorough-ish) is a no-op, and the fix is
+  a stronger word (*relentless*), not a different technique.
+
+### Pruning is not disclosure
+
+Both remove lines from the file in front of you, and confusing them is how a
+document quietly stops teaching what it used to.
+
+- **Disclosure** moves material down the ladder. Nothing is lost — the content
+  travels verbatim into a pointed-to file. This is the answer when a document is
+  over its budget.
+- **Pruning** deletes. It is the answer when a line fails on its own merits: a
+  no-op, a duplicate, a cache of a cheap lookup, a line no longer relevant.
+
+Size pressure is a reason to disclose, never a licence to prune. A cut made to fit
+a budget, on a line that would have survived the relevance test, is a silent
+capability regression.


### PR DESCRIPTION
Grafts the OSS `writing-for-agents` skill into the live `writing-skills`, which was method without theory — it asserted progressive disclosure and description rules without saying why they work, so an author applied them by imitation.

## What it gains

Into `references/writing-for-agents.md`: context pointers (the pointer's wording, not its target, decides when the agent reaches the material); the two loads, context versus cognitive; the three-rung information hierarchy with branching as the disclosure test; leading words and their negation and no-op failure modes; the pruning discipline against sediment.

Into the body: the model-invoked versus user-invoked decision rule, which the charter's D18 names as an admission in its own right and which every other skill in this wave was decided against.

## The multiplier, which is the reason to do it this way

`writing-for-agents` covers three document types with one method — a skill, an `AGENTS.md`/`CLAUDE.md`, and any pointed-to doc. **Grafting it closes the AGENTS.md-authoring seat for zero new catalog lines**, and that is why all three `optimize-*` skills in the queue are declines rather than a gap.

## The vocabulary collision, resolved by renaming

Upstream's *completion criterion* is a property of one step inside a document being authored — when the agent running that step should stop. This repository's *acceptance criteria* are the termination condition for a round of review over finished work. Same head noun, different referent. It is **completion bound** throughout the reference now, using the source's own phrasing, with an explicit disambiguation block written portably — no citation of this repo's charter, since the reference deploys into other people's projects.

## Two seams reconciled rather than papered over

The live skill said move sections out verbatim, because cutting content to fit is how a skill quietly stops teaching what it used to. The graft says prune relentlessly. Not a contradiction — they answer different questions — but left unreconciled the amalgam reads incoherently. Both now name them as two operations: **size pressure is a reason to disclose, never a licence to prune.**

The Iron Law read as skill-only once the skill covers instruction files; it now says an instruction file is no exception.

## Evidence

Body 1,854 → **1,967 of 2,000**, measured by `content-lint`. That is 28 tokens of margin and it is a real risk: the next edit to this body will likely trip the gate and force another disclosure round. The honest lever if you want headroom is moving the register split or the Iron Law's rationalization counters into a reference — both defensible, neither taken unilaterally.

`content-lint` and `content-tests` exit 0, run standalone from the worktree root. The pin is blob-verified: `4aaccb58` is the first commit at which the **whole source directory** reproduces, not just the two files grafted.

## Not done

No trigger-eval was run on the new description. The skill's own Iron Law demands one, and the AGENTS.md-authoring trigger is therefore asserted by construction rather than measured. Per `9k9.118` that eval must run outside this repository to mean anything.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne