### PR TITLE
chore(9k9.153): one bug-diagnosis skill, built on the mechanical gate

### DIFF
--- a/src/user/.agents/skills/diagnosing-bugs/SKILL.md
+++ b/src/user/.agents/skills/diagnosing-bugs/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: diagnosing-bugs
+description: Diagnosis loop for hard bugs and performance regressions. Use when the user says "diagnose"/"debug this", or reports something broken/throwing/failing/slow.
+admission:
+  prevents: An agent reading code to build a theory before it holds a command that goes red on the reported bug, then shipping a fix nothing can falsify — and, when a fix fails, stacking further attempts on a hypothesis space the evidence has already exhausted.
+  cost: One model-invoked catalog line and a body paid on invocation, plus a hard stop before hypothesising that spends a loop-building pass even on bugs whose cause turns out to be obvious.
+  remove_when: The executor refuses a fix unaccompanied by a named command observed red before the change and green after, so the gate no longer has to be read to be applied.
+---
+
+<!--
+Amalgam of two upstreams, one Source/Upstream pair each. Keep every key at the
+start of its own line: the installer recognises a provenance header by matching
+`Source:`/`Upstream:` there, so folding these into bullets or prose would stop
+this block being stripped and ship these paths into every downstream install.
+
+  Source: skills/engineering/diagnosing-bugs/
+  Upstream: https://github.com/mattpocock/skills @ bda79a3c3ca23d19d9ca483808580b5b4cc3d8e2
+  (the six-phase spine, the Phase 1 completion criterion, and the loop-construction
+  reference; verified byte-identical to the copy taken on 2026-08-07)
+
+  Source: skills/systematic-debugging/
+  Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e949826bea9d7 (v5.1.0)
+  (two patterns only: multi-component boundary instrumentation, and the
+  three-failed-fixes architectural escalation)
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation. This copy is authoritative and diverges
+from both upstreams by construction, so a wholesale resync would revert the
+graft. Pocock supplies the spine; the two obra patterns are lifted into Phase 3
+and Phase 5; the parallel-evidence thread structure of Phase 3 is in-house and
+appears in neither upstream. Consult either upstream for pattern lifts only. To
+inspect drift, clone each at the SHA above and diff by hand.
+-->
+
+# Diagnosing Bugs
+
+A discipline for hard bugs. Skip phases only when explicitly justified. Read `CONTEXT.md` if the project has one, and check ADRs in the area you're touching.
+
+## Redact
+
+This skill has you show commands, outputs and captured artifacts. **Redact every secret first** — write `<REDACTED>` in its place. Build loops against env vars so credentials never enter what you show, and quote only signal-carrying lines out of captured artifacts, which carry auth headers. If the redacted output is not enough, say so and ask.
+
+## Phase 1 — Build a feedback loop
+
+**This is the skill**; everything else is mechanical. A **tight** signal that goes red on _this_ bug finds the cause for you — bisection, hypothesis-testing and instrumentation all just consume it. Without one, staring at code will not save you.
+
+Spend disproportionate effort here. **Be aggressive. Be creative. Refuse to give up.** `references/feedback-loops.md` ranks ten ways to construct a loop, in the order to try them, plus tightening, non-determinism, and what to ask for when no loop is possible.
+
+### Completion criterion — a tight loop that goes red
+
+Phase 1 is done when you can name **one command** — a script path, a test invocation, a curl — that you have **already run at least once** (show it and its output, redacted), and that is:
+
+- [ ] **Red-capable** — it drives the actual bug code path and asserts the **user's exact symptom**, so it goes red on this bug and green once fixed. Not "runs without erroring": it must catch _this specific bug_.
+- [ ] **Deterministic** — same verdict every run (flaky bugs: a pinned, high reproduction rate, per the reference).
+- [ ] **Fast** — seconds, not minutes.
+- [ ] **Agent-runnable** — you can run it unattended; a human enters the loop only through the reference's prompt-and-capture script.
+
+If you catch yourself reading code to build a theory before this command exists, **stop — jumping straight to a hypothesis is the exact failure this skill prevents.** No red-capable command, no Phase 2.
+
+**If you genuinely cannot build one**, say so, list what you tried, and ask for what the reference says to ask for. Never hypothesise without a loop.
+
+## Phase 2 — Reproduce + minimise
+
+Run the loop. Watch it go red.
+
+- [ ] It produces the failure the **user** described, not a different one nearby. Wrong bug, wrong fix.
+- [ ] It reproduces across runs (non-deterministic bugs: at a rate high enough to debug against).
+- [ ] You captured the exact symptom — error message, wrong output, slow timing — so later phases can check the fix addresses it.
+
+Then shrink the repro to the **smallest scenario that still goes red**, cutting inputs, callers, config, data and steps **one at a time** and re-running after each cut. It shrinks Phase 3's hypothesis space and becomes Phase 5's regression test. Done when **every remaining element is load-bearing** — removing any one turns the loop green. Do not proceed until both are done.
+
+## Phase 3 — Gather evidence in parallel, then hypothesise
+
+**No fix without parallel evidence.** One line of investigation anchors on the first plausible idea; three angles gathered independently catch what one misses.
+
+- **Thread 1 — Git archaeology.** The last ~20 commits touching the affected files: what changed, who changed it, which could have introduced this. The bug arrived with a change, and finding it often reveals the cause outright.
+- **Thread 2 — Reproduction.** Already discharged: the red loop from Phases 1–2 *is* this evidence, and the captured symptom is its finding.
+- **Thread 3 — Data-flow trace.** Entry point to failure point: what values enter, how they transform, where they could become invalid. If similar working code exists, list every difference from it, however small — do not assume any cannot matter.
+
+Run Threads 1 and 3 independently — in parallel if your harness can, sequentially if not. What matters is that neither steers the other, and that **both return before you rank anything**.
+
+**Multi-layer bugs — instrument the boundaries first.** When the bug spans components (client → gateway → worker), reading source is not enough: extend Thread 3 with the boundary logging in `references/instrumentation.md` and run it once. This is evidence gathering, not Phase 4's prediction-testing — it establishes *which layer* fails before you hypothesise about *why*, so you do not fix the first suspicious component when the break is one boundary earlier.
+
+### Then hypothesise
+
+Generate **3–5 ranked hypotheses** before testing any. Each must be **falsifiable**: "if <X> is the cause, then <changing Y> makes the bug disappear." No prediction means it is a vibe — discard or sharpen it.
+
+An inconclusive thread is a finding, not a gap to fill with speculation; "no relevant changes in the last 20 commits" is an answer. If the threads diverge and no cause emerges, document what each ruled out and escalate.
+
+**Show the ranked list to the user before testing.** They often re-rank it instantly ("we just deployed a change to #3"). Don't block — proceed with your ranking if the user is AFK.
+
+## Phase 4 — Instrument
+
+Each probe must map to a specific prediction from Phase 3. **Change one variable at a time.** Prefer a debugger or REPL over logs; place logs only where they distinguish hypotheses; never "log everything and grep".
+
+**Tag every debug log** with a unique prefix, e.g. `[DEBUG-a4f2]`, so Phase 6's cleanup is one grep: untagged logs survive, tagged logs die.
+
+**Perf branch.** For a performance regression logs are the wrong instrument — measure a baseline, then bisect against it. See `references/instrumentation.md`.
+
+## Phase 5 — Fix + regression test
+
+Write the regression test **before the fix** — but only if a **correct seam** exists: one where the test exercises the real bug pattern as it occurs at the call site. Too shallow a seam — a unit test that cannot replicate the chain that triggered the bug — gives false confidence.
+
+**If no correct seam exists, that itself is the finding** — the architecture is preventing the bug from being locked down. Note it and carry it to Phase 6.
+
+With a correct seam:
+
+1. Turn the minimised repro into a failing test at that seam, and watch it fail.
+2. Apply the fix — one focused change at the root cause, nothing bundled in.
+3. Watch the test pass, then run the full suite and confirm no regressions.
+4. Re-run the Phase 1 loop against the original, un-minimised scenario.
+
+### If the fix doesn't work
+
+Count the fixes attempted on this bug.
+
+- **Fewer than three:** return to Phase 3. The failed fix is new evidence — re-correlate the threads against it and form a new hypothesis. Do **not** stack a second fix on the first.
+- **Three or more:** stop and question the architecture. Three failed fixes is an **architectural** signal, not a hypothesis signal — the abstraction is wrong, not the theory. The tells: each fix surfaces shared state or coupling somewhere *different*; each needs "massive refactoring" to land; each creates new symptoms elsewhere; you think "one more attempt should do it".
+
+Escalate before attempt #4 with the failed attempts, the pattern, and the architectural question they raise.
+
+## Phase 6 — Cleanup + post-mortem
+
+Before declaring done:
+
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
+- [ ] Regression test passes, or the absent seam is documented
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix)
+- [ ] Throwaway prototypes deleted, or moved somewhere marked as debug
+- [ ] The correct hypothesis is stated in the commit or PR message, so the next debugger learns
+
+**Then ask what would have prevented this bug.** If the answer is architectural — no good test seam, tangled callers, hidden coupling — raise it as its own work item, **after** the fix is in: you know more now than when you started.

--- a/src/user/.agents/skills/diagnosing-bugs/references/feedback-loops.md
+++ b/src/user/.agents/skills/diagnosing-bugs/references/feedback-loops.md
@@ -1,0 +1,82 @@
+# Constructing and tightening a feedback loop
+
+Phase 1 material. Read this when you do not yet have a command that goes red on
+the bug, or when the one you have is slow, flaky, or vague.
+
+## Ways to construct one — try them in roughly this order
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
+5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
+7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
+8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
+9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
+10. **Human-in-the-loop script.** Last resort — see below.
+
+Build the right feedback loop, and the bug is 90% fixed.
+
+## Tighten the loop
+
+Treat the loop as a product. Once you have _a_ loop, **tighten** it:
+
+- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
+- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
+- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+
+A 30-second flaky loop is barely better than no loop; a 2-second deterministic one is tight — a debugging superpower.
+
+## Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100×, parallelise, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it is debuggable.
+
+## When you genuinely cannot build one
+
+Stop and say so explicitly, and list what you tried — the list is what lets the
+user judge which of these to give you. Ask for one of:
+
+- **access** to whatever environment reproduces it;
+- **a redacted captured artifact** — HAR file, log dump, core dump, or a screen
+  recording with timestamps;
+- **permission** to add temporary instrumentation to production.
+
+Do not proceed to hypothesise without a loop. An unfalsifiable fix shipped
+against a bug you could not reproduce cannot be told from no fix at all.
+
+## Human-in-the-loop script
+
+Only when a human must physically click something. Driving them from a script keeps the loop structured and keeps the captured output in a form you can read back. Save this, edit the steps, and run it:
+
+```bash
+#!/usr/bin/env bash
+# The agent runs the script; the user follows prompts in their terminal.
+#   step "<instruction>"       → show instruction, wait for Enter
+#   capture VAR "<question>"   → show question, read response into VAR
+# `capture` prints its value back to the terminal, where the agent reads it — so
+# capture observations, and leave signing in to the user as a `step`.
+set -euo pipefail
+
+step() {
+  printf '\n>>> %s\n' "$1"
+  read -r -p "    [Enter when done] " _
+}
+
+capture() {
+  local var="$1" question="$2" answer
+  printf '\n>>> %s\n' "$question"
+  read -r -p "    > " answer
+  printf -v "$var" '%s' "$answer"
+}
+
+# --- edit below ---------------------------------------------------------
+step "Open the app at http://localhost:3000 and sign in."
+capture ERRORED "Click the 'Export' button. Did it throw an error? (y/n)"
+capture ERROR_MSG "Paste the error message (or 'none'):"
+# --- edit above ---------------------------------------------------------
+
+printf '\n--- Captured ---\n'
+printf 'ERRORED=%s\n' "$ERRORED"
+printf 'ERROR_MSG=%s\n' "$ERROR_MSG"
+```

--- a/src/user/.agents/skills/diagnosing-bugs/references/instrumentation.md
+++ b/src/user/.agents/skills/diagnosing-bugs/references/instrumentation.md
@@ -1,0 +1,75 @@
+# Instrumentation
+
+Two different jobs, and confusing them is how a multi-layer bug gets fixed in
+the wrong component. Boundary instrumentation (Phase 3) runs *before* you have a
+hypothesis, to find out which layer fails. Probe instrumentation (Phase 4) runs
+*after*, to test one prediction at a time.
+
+## Boundary instrumentation — Phase 3, multi-layer bugs only
+
+The trigger is a bug that spans components: CI → build → signing, API → service
+→ database, client → gateway → worker. Reading the source of all of them is
+slower and less conclusive than one instrumented run.
+
+For each component boundary:
+
+- log what data **enters** the component;
+- log what data **exits** it;
+- verify environment and configuration actually propagated across the boundary;
+- capture state at the transition itself.
+
+Then run **once** and read the evidence before touching anything. The output
+tells you which boundary the data was still correct at and which one it was not,
+which is a different question from why.
+
+```bash
+# Layer 1: workflow
+echo "=== secrets visible in workflow ==="
+echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
+
+# Layer 2: build script
+echo "=== env in build script ==="
+env | grep IDENTITY || echo "IDENTITY not in environment"
+
+# Layer 3: signing script
+echo "=== keychain state ==="
+security find-identity -v
+```
+
+Only once the failing layer is identified do you investigate it in depth. The
+failure this prevents is fixing the first component that looks suspicious when
+the break is one boundary earlier — and every fix you make upstream of the real
+break creates a new symptom rather than removing one.
+
+## Probe instrumentation — Phase 4
+
+Each probe maps to one prediction from the ranked hypotheses. Change one
+variable at a time, in this order of preference:
+
+1. **Debugger / REPL inspection**, wherever the environment supports it. One
+   breakpoint that lets you inspect the whole frame beats ten log lines chosen
+   in advance by someone who did not yet know what mattered.
+2. **Targeted logs**, placed at the boundaries that actually distinguish the
+   competing hypotheses — not everywhere the value appears.
+3. Never "log everything and grep". The volume hides the signal, and the cleanup
+   is unbounded.
+
+**Tagging.** Give every debug log a unique prefix for this investigation, e.g.
+`[DEBUG-a4f2]`. Cleanup then becomes a single grep for that tag, which is what
+makes Phase 6's removal step mechanical rather than a memory exercise. Untagged
+debug logs survive into the commit; tagged ones die.
+
+## Performance regressions
+
+Logs are usually the wrong instrument. A regression is a change in a
+distribution, and a log line tells you an event happened, not how long it took
+relative to before.
+
+1. Establish a **baseline measurement** first: a timing harness, a profiler run,
+   an EXPLAIN/query plan, or the runtime's own high-resolution clock
+   (`performance.now()` and equivalents).
+2. Then **bisect** against that measurement — across commits, across input
+   sizes, or across the stages of the request — until one stage owns the delta.
+
+Measure first, fix second. A perf fix without a before-and-after measurement is
+indistinguishable from no fix.

--- a/src/user/.agents/skills/handoff/SKILL.md
+++ b/src/user/.agents/skills/handoff/SKILL.md
@@ -52,7 +52,7 @@ After writing, print the absolute file path on its own line so the user can pass
 5. **Open questions and blockers** — anything the next agent needs to resolve before progress
 6. **Next concrete steps** — ordered, actionable
 7. **References** — paths and URLs only; do NOT duplicate content from PRDs, plans, ADRs, issues/beads, commits, or diffs
-8. **Suggested skills** — skills the next agent should invoke (e.g. `grilling`, `diagnosing-bugs`)
+8. **Suggested skills** — skills the next agent should invoke (e.g. `grilling`, `prototype`, `diagnosing-bugs`)
 
 ## Constraints
 

--- a/src/user/.agents/skills/handoff/SKILL.md
+++ b/src/user/.agents/skills/handoff/SKILL.md
@@ -52,7 +52,7 @@ After writing, print the absolute file path on its own line so the user can pass
 5. **Open questions and blockers** — anything the next agent needs to resolve before progress
 6. **Next concrete steps** — ordered, actionable
 7. **References** — paths and URLs only; do NOT duplicate content from PRDs, plans, ADRs, issues/beads, commits, or diffs
-8. **Suggested skills** — skills the next agent should invoke (e.g. `grilling`, `prototype`, `bugfix`)
+8. **Suggested skills** — skills the next agent should invoke (e.g. `grilling`, `diagnosing-bugs`)
 
 ## Constraints
 


### PR DESCRIPTION
Collapses the archived `bugfix` into the Pocock `diagnosing-bugs`. One skill ships; nothing named `bugfix` does.

## Why this spine won

Its Phase 1 gate is mechanically checkable: name one command, already run at least once, that is red-capable, deterministic, fast and agent-runnable. That is this repository's mechanical-evidence commitment applied to diagnosis, and it survives whole — four checkboxes plus the binding precondition that the command was already run and its output shown.

`bugfix`'s Iron Law — no fix without parallel evidence — is a dispatch pattern rather than a diagnostic method, so it attaches to the existing phases rather than replacing them.

## Grafts, placed where the spine had holes

The three-thread evidence dispatch opens Phase 3 with the failing-test thread marked discharged by the red loop. Boundary instrumentation extends the data-flow thread. The three-strike rule — three failed fixes is an architectural signal, not a hypothesis signal — fills Phase 5, which had no failed-fix branch at all.

## Three deviations worth reviewing

**Two upstreams, not one.** `bugfix`'s own header says the three-strike rule and boundary instrumentation came from `obra/superpowers`; both verified there. Two Source/Upstream pairs, two registry rows.

**The HITL loop template ships as a fenced block, not a file.** `content-tests` requires a paired suite for every shipped `.sh`, and `.installignore` does not cover `*_test.sh` unanchored — the suite would have deployed downstream, which is the leak that manifest exists to stop.

**The dispatch is harness-neutral, and this is a real weakening.** `bugfix` said spawn three parallel subagents. Written that way the skill depends on subagent orchestration, and the placement rule would send it to the Claude tree. Phase 3 now requires only that the threads not steer each other and both return before ranking, however they are scheduled. The Iron Law's substance survives; the mechanism does not.

## Rejected outright

The `model:` and `effort:` front-matter pins — a deployed skill must not pin a downstream user's model tier — and a regression test for an unrelated defect in this repository's own tracker plugin, which fails anywhere else.

## Evidence

Body **1,980 of 2,000**, with the ranked loop-construction menu and instrumentation detail in `references/`. Twenty tokens of margin, flagged rather than pre-emptively cut, since the house guidance is explicit that headroom is not a target to fill. Next candidates to move are Phase 5's seam explanation and Phase 6's post-mortem paragraph.

`content-lint` and `content-tests` exit 0 from the worktree root. Pin blob-verified.

Also repoints `handoff`'s suggested-skills example off `bugfix`, a name this change retires.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne