### PR TITLE
chore(9k9.152): tdd and test-review, on one shared quality reference

### DIFF
--- a/src/user/.agents/skills/tdd/SKILL.md
+++ b/src/user/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: tdd
+description: The red-to-green loop and the discipline that keeps it honest. Use when implementing a feature or bugfix test-first, when failing tests have been handed over to be made green, when the user says "red-green-refactor" or "test-first", or when about to write production code that no test yet demands.
+admission:
+  prevents: The two model defaults that make a test suite prove nothing — writing the implementation first and back-filling tests that pass on arrival, and editing a handed-over failing test until it agrees with the code that was written instead of the contract it encodes.
+  cost: One model-invoked catalog line; a body paid only when an implementation cycle invokes it, plus a shared quality reference in a sibling skill, paid only when followed.
+  remove_when: The executor enforces the loop mechanically — refusing work whose tests did not fail before the implementation existed — so the discipline no longer has to be read to be obeyed.
+---
+
+<!--
+Amalgam of two upstreams, one Source/Upstream pair each. Every key stays at the
+start of its own line: the installer recognises a provenance header by matching
+`Source:`/`Upstream:` there, so folding these into prose or bullets would stop
+this block being stripped and ship repo-internal paths downstream.
+
+  Source: skills/engineering/tdd/
+  Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+
+  Source: skills/test-driven-development/
+  Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e949826bea9d7 (v5.1.0)
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation. This body lifts patterns from both
+upstreams rather than tracking either byte-for-byte, so it never resyncs
+wholesale. Three local decisions a resync would silently revert, and must not:
+
+  - The two-seat split. Both upstreams assume one agent writes the test and
+    then the code. Here the implementer seat, handed tests it did not write,
+    is first-class and is the seat the loop is stated for.
+  - The scoping of the one-slice-at-a-time rule. Upstream forbids writing all
+    tests before any implementation, unconditionally. Here that rule binds the
+    seat that writes the tests and explicitly permits a reviewed scaffold.
+  - The seam gate's unattended path. Upstream stops dead at an unconfirmed
+    seam; here an absent user is proceeded past on a recorded decision.
+
+The upstream companion files (tests.md, mocking.md, testing-anti-patterns.md)
+are not carried here. Their content was consolidated into the shared test
+quality reference so that one file, not four, answers a mocking question.
+-->
+
+# Test-driven development
+
+Red to green, one behaviour at a time. Which seat you are in decides who writes
+RED. Everything after that is the same.
+
+## Find your seat first
+
+**The tests already exist** — a scaffold, a spec's failing tests, a
+reproduction someone handed you. You are the implementer, and those tests are
+the contract.
+
+- Make them green **without changing the contract.** Do not edit a test, loosen
+  an assertion, rename a symbol it references, or change a signature it calls.
+- Run them before you write anything and watch them fail. A handed-over test
+  that is already green is a defect in the scaffold. Report it; do not
+  implement past it.
+- A test you believe is *wrong* is an escalation, not an edit. Name the test,
+  what it asserts, and what you think the contract should say instead. Then
+  wait.
+- Take them one at a time. Green the first, run the suite, green the next.
+
+**No tests exist** — you own both halves, and the loop below is yours end to
+end.
+
+## The iron law
+
+**No production code without a failing test first** — whoever wrote the test.
+
+Wrote code before a test existed? Delete it and implement fresh from the test.
+Not "keep it as reference", not "adapt it while writing the test": you will
+adapt it, and that is testing after. The hours already spent are gone either
+way; what you are choosing is whether to keep code that no test has ever caught
+a bug in.
+
+## The loop
+
+1. **RED** — one test, one behaviour, a name that says what the behaviour is.
+2. **Verify RED** — run it. It MUST fail, and fail *because the behaviour is
+   missing*, not because of a typo or a missing import. A test that passes on
+   arrival is pinning something that already works: fix the test. A test that
+   errors is not yet a test: fix the error and re-run until it fails cleanly.
+3. **GREEN** — the simplest code that passes it. No speculative parameters, no
+   options object, nothing the next test might want.
+4. **Verify GREEN** — run it, then run the rest of the suite. All green, output
+   clean. If it fails, fix the code, not the test.
+5. **REFACTOR** — only from green, and only to remove duplication or improve
+   names. No new behaviour. Stay green.
+
+Then the next behaviour.
+
+## One slice at a time — and what that rule is for
+
+Write one test, then its implementation, then the next test. Do not write five
+tests and then five implementations.
+
+The reason is the failure, not the ritual. Tests written in bulk against code
+that does not exist yet verify *imagined* behaviour: they pin the shape of
+things — signatures, data structures — rather than what a caller can observe,
+and they go insensitive to the changes that matter, because you committed to
+test structure before you understood the implementation.
+
+**This rule binds the seat that writes the tests. It does not forbid a
+scaffold.** A scaffold's tests are not imagined behaviour: they were written
+against a contract fixed before them, each one cites the criterion it pins, and
+someone other than their author reviewed them for exactly that. Those are the
+controls this rule stands in for when they are absent — where they are present,
+the rule has nothing left to prevent. In the implementer seat, take the given
+tests one at a time and leave them alone.
+
+## Seams — where the test goes
+
+A **seam** is the public boundary you observe behaviour through without
+reaching inside. Tests live at seams, never against internals.
+
+You cannot test everything, so decide where the effort lands before spending
+it:
+
+- **Tests were handed to you** — the seams are already settled; the tests are
+  sitting at them. Nothing to agree.
+- **You are writing the tests** — write down the seams you intend to test and
+  put that list to the user before writing test code. Domain knowledge re-ranks
+  it instantly, and it is the cheapest checkpoint in the cycle.
+- **The user is away** — proceed on your own list rather than stalling. Record
+  which seams you chose, and why, in the commit or change description. A seam
+  decision that is written down is reviewable and cheap to reverse; a stalled
+  cycle is neither.
+
+When the shape of the interface is itself the question — how deep the module
+is, where the seam belongs, what it should expose — the `codebase-design` skill
+carries that vocabulary.
+
+## Before you accept a test into the cycle
+
+Ask what coded decision it pins. If the answer is "the literal I just typed",
+or the language, or the standard library, it will pass forever and disagree
+with nothing. That filter, the refusal criteria for code too coupled to test,
+the fake-over-stub-over-spy-over-mock ordering, and skip hygiene are all in
+`../test-review/references/test-quality.md`. Read it when you are about to
+write a test double, when setup starts outgrowing the test, or when a test you
+just wrote could not fail.
+
+## Red flags — stop
+
+- Production code exists that no failing test asked for
+- The test passed the first time you ran it
+- You cannot say why the test failed
+- You are editing a handed-over test to match code you wrote
+- "I already tested it by hand"
+- "Tests after achieve the same thing" — they answer *what does this do*; a
+  test written first answers *what should this do*, which is the question that
+  finds the edge case
+- "It is too simple to break"
+- "Just this once"
+
+Hard to test means hard to use: when the test is painful to write, the design
+is what the test is telling you about. Take that finding to the code.

--- a/src/user/.agents/skills/test-review/SKILL.md
+++ b/src/user/.agents/skills/test-review/SKILL.md
@@ -76,11 +76,11 @@ you are judging a test double or a skip.
 
 - [ ] Fakes preferred to stubs, stubs to spies, spies to mocks
 - [ ] Every mock carries a one-sentence justification for existing
-- [ ] Mock data mirrors the complete real schema — a partial mock hides the
-      field downstream code will reach for
-- [ ] Nothing the unit under test owns is mocked
-- [ ] Mocked side effects are understood; no doubling "to be safe"
-- [ ] Five or more mocks in one test — the finding is against the production
+- [ ] A double's data mirrors the complete real schema — a partial double
+      hides the field downstream code will reach for
+- [ ] Nothing the unit under test owns is doubled
+- [ ] Doubled side effects are understood; nothing is doubled "to be safe"
+- [ ] Five or more doubles in one test — the finding is against the production
       code, not the test
 
 ### Isolation and structure
@@ -114,7 +114,7 @@ you are judging a test double or a skip.
 These say the design is the problem. Reporting them as test defects sends the
 author to fix the wrong file.
 
-- Five or more dependencies must be mocked to reach the code
+- Five or more dependencies need test doubles to reach the code
 - Setup exceeds twenty lines of configuration
 - The function under test has ten or more conditionals or early returns
 - Behaviour can only be verified by asserting on internal calls
@@ -140,12 +140,12 @@ and a concrete fix.
 
 | Smell | Signal | Fix |
 |---|---|---|
-| Asserting on a double | The assertion checks a mock is present | Unmock it, or assert on real behaviour |
+| Asserting on a double | The assertion checks a double is present | Drop the double, or assert on real behaviour |
 | Implementation testing | A "was called with" assertion is the main one | Assert on output or state |
 | Tautology | Expected value restates the implementation | Independent literal, worked example, or delete |
 | Test-only production method | The method has no caller outside tests | Move it to test utilities |
-| Partial mock | Response object omits fields real callers read | Mirror the complete schema |
-| Over-mocking | Five or more mocks; setup outweighs the test | Refactor the production code |
+| Partial double | Response object omits fields real callers read | Mirror the complete schema |
+| Too many doubles | Five or more doubles; setup outweighs the test | Refactor the production code |
 | Shared mutable state | Tests fail in isolation or in a different order | Fresh state per test |
 | Mystery skip | A skip with no reason or tracking reference | Document it or delete it |
 | Copy-paste tests | Near-identical blocks, one parameter apart | Parameterise |

--- a/src/user/.agents/skills/test-review/SKILL.md
+++ b/src/user/.agents/skills/test-review/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: test-review
+description: Judge whether a test suite would actually fail if the behaviour it covers broke. Use when reviewing test code in a change or pull request, auditing test quality across a package or codebase, investigating flaky or brittle tests, or when a test failure looks caused by the test's design rather than by a bug in the code under test.
+admission:
+  provides: A test-adequacy lens — the criteria that separate a test which would fail if the required behaviour broke from one that passes regardless, plus the smells whose remedy is the production code rather than the test. Produces findings ranked by severity, each naming the file, the line, and the concrete fix.
+  cost: One model-invoked catalog line; a body paid only when a review invokes it, plus a quality reference it hosts for itself and one other skill, paid only when followed.
+  remove_when: A mechanical check decides test adequacy — mutation testing gating the same claim — so the judgement no longer needs a reviewer.
+---
+
+<!--
+Source: skills/test-driven-development/testing-anti-patterns.md
+Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e949826bea9d7 (v5.1.0)
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation. Authored here; the mock and test-double
+anti-pattern catalog (asserting on a double's existence, test-only methods on
+production classes, partial mocks, mocking a side effect the test depends on)
+is lifted from the upstream file above and restated as review criteria rather
+than as authoring gates. It does not resync byte-for-byte.
+-->
+
+# Test review
+
+**Tests are production code for your safety net.** Review them with the rigour
+you would give the code they protect. A bad test is worse than no test: it
+reports confidence it has not earned, and it will be believed.
+
+The question every finding answers: **would this test fail if the behaviour it
+covers broke?** If not, the test is decoration, whatever its coverage number
+says.
+
+## Not this skill
+
+- Writing tests from scratch, or making a failing scaffold green — that is the
+  `tdd` loop.
+- A test failing because the code under test has a bug. That is a diagnosis
+  job; come back here once the cause is known and the question is whether the
+  test was the right test.
+- Throwaway spikes and prototypes. They are meant to be deleted.
+
+## Scope, then context
+
+| Reviewing | Take |
+|---|---|
+| Named test files | Those files |
+| A change or pull request | The test files in the diff |
+| A package or directory | Every test file under it |
+| A whole codebase | The diff against the trunk first, then widen |
+
+For a codebase-wide audit, order the work: recently changed tests, then tests
+covering critical paths, then the rest.
+
+**Read the production code the tests target before judging them.** You cannot
+tell whether an assertion pins the right thing without knowing what the right
+thing is. A review that only reads the test file grades style.
+
+`references/test-quality.md` holds the depth this checklist compresses — the
+tautology filter, the refusal criteria, the double hierarchy, and skip hygiene.
+Open it when a finding needs to say *why* rather than just *what*, and whenever
+you are judging a test double or a skip.
+
+## Checklist
+
+### Assertions and behaviour
+
+- [ ] Every assertion targets observable behaviour — a return value, a state
+      change, a visible side effect — not an internal call
+- [ ] No assertion on the mere existence of a test double
+- [ ] Test names describe the behaviour verified, not the method invoked
+- [ ] The test would survive an internal refactor that preserves behaviour
+- [ ] Expected values come from an independent source — a known literal, a
+      worked example, the spec — never recomputed the way the code computes them
+- [ ] Error paths and boundaries are covered, not only the happy path
+- [ ] Each test has one clear reason to fail
+
+### Doubles
+
+- [ ] Fakes preferred to stubs, stubs to spies, spies to mocks
+- [ ] Every mock carries a one-sentence justification for existing
+- [ ] Mock data mirrors the complete real schema — a partial mock hides the
+      field downstream code will reach for
+- [ ] Nothing the unit under test owns is mocked
+- [ ] Mocked side effects are understood; no doubling "to be safe"
+- [ ] Five or more mocks in one test — the finding is against the production
+      code, not the test
+
+### Isolation and structure
+
+- [ ] Each test sets up its own state and depends on no execution order
+- [ ] No shared mutable state across tests
+- [ ] Cleanup is complete and not duplicated
+- [ ] Deterministic — no wall-clock time, no unseeded randomness, no network
+- [ ] Setup and teardown blocks are minimal
+
+### Coverage and hygiene
+
+- [ ] Business logic and validation rules are tested; logging and metrics are not
+- [ ] Boundaries exercised: empty, null, maximum, off-by-one
+- [ ] Error cases assert the right error, not merely that nothing threw
+- [ ] Integration points use real implementations where that is feasible
+- [ ] Every skipped test has a reason, a tracking reference, and a re-enable
+      condition
+- [ ] No commented-out tests
+- [ ] No near-duplicate blocks varying one parameter — parameterise them
+
+### Readability
+
+- [ ] Setup is roughly ten lines or fewer per test
+- [ ] The intent is clear within five seconds of reading
+- [ ] Arrange-act-assert is evident
+- [ ] Helpers are named for what they set up
+
+## When the finding is against the production code
+
+These say the design is the problem. Reporting them as test defects sends the
+author to fix the wrong file.
+
+- Five or more dependencies must be mocked to reach the code
+- Setup exceeds twenty lines of configuration
+- The function under test has ten or more conditionals or early returns
+- Behaviour can only be verified by asserting on internal calls
+- Several tests need the same elaborate setup — a fixture or factory is missing
+- A method on a production class is called only from tests
+
+Say so explicitly: better production design is what makes these tests simple,
+and no amount of test rewriting substitutes for it.
+
+## Reporting
+
+Rank by severity and give every finding a file-and-line reference, the issue,
+and a concrete fix.
+
+- **CRITICAL** — tests that report false confidence: they pass while the code
+  is broken, or they assert on a double rather than on behaviour
+- **HIGH** — anti-patterns that will cost maintenance: brittle doubles,
+  implementation coupling, missing error and boundary cases
+- **SUGGESTION** — readability and structure
+- **POSITIVE** — tests worth naming as the pattern others should follow
+
+## Smell table
+
+| Smell | Signal | Fix |
+|---|---|---|
+| Asserting on a double | The assertion checks a mock is present | Unmock it, or assert on real behaviour |
+| Implementation testing | A "was called with" assertion is the main one | Assert on output or state |
+| Tautology | Expected value restates the implementation | Independent literal, worked example, or delete |
+| Test-only production method | The method has no caller outside tests | Move it to test utilities |
+| Partial mock | Response object omits fields real callers read | Mirror the complete schema |
+| Over-mocking | Five or more mocks; setup outweighs the test | Refactor the production code |
+| Shared mutable state | Tests fail in isolation or in a different order | Fresh state per test |
+| Mystery skip | A skip with no reason or tracking reference | Document it or delete it |
+| Copy-paste tests | Near-identical blocks, one parameter apart | Parameterise |
+| Incidental testing | Assertions on log calls or metric emissions | Delete; test the business rule |
+| Flaky timing | A sleep or fixed timeout inside the test | Wait on a condition |

--- a/src/user/.agents/skills/test-review/references/test-quality.md
+++ b/src/user/.agents/skills/test-review/references/test-quality.md
@@ -1,0 +1,254 @@
+# Test quality
+
+What separates a test worth keeping from one that costs more than it earns.
+Written for both seats: the agent about to write a test, and the agent judging
+one someone else wrote.
+
+## Contents
+
+- [The one question](#the-one-question) — the tautology filter
+- [Behaviour versus implementation](#behaviour-versus-implementation)
+- [Test doubles](#test-doubles) — fake over stub over spy over mock
+- [Where to mock, and how to design for it](#where-to-mock-and-how-to-design-for-it)
+- [Refusal criteria](#refusal-criteria) — when not to write the test at all
+- [Skip hygiene](#skip-hygiene)
+- [Worked examples](#worked-examples)
+
+## The one question
+
+Before accepting any test, ask: **what coded decision does this pin?**
+
+If the answer is "the literal I just typed" or "the language, the standard
+library, or the operating system", the test is a tautology. It passes by
+construction, it can never disagree with the code, and it will be maintained
+forever. Delete it.
+
+Three shapes to screen for.
+
+### 1. Language, compiler, standard library or OS behaviour
+
+A test that passes as long as the language is not broken is a comment with
+ceremony.
+
+| Reject | Why | Write instead |
+|---|---|---|
+| `isinstance(obj, SomeProtocol)` | Pins runtime name-matching, not your logic; the type checker already enforces the signature | A behaviour test through whatever consumes the object |
+| A frozen record raising on assignment | Pins the standard library's immutability machinery | Nothing — the type system enforces it |
+| A path helper returning false for a directory | Pins filesystem-library semantics, not your probe decision | "Given the config file is absent, auto-detect returns empty" — pins *your choice* of what to probe |
+
+### 2. Code with no caller yet
+
+If nothing in the current change invokes a function, a test for it pins the
+return-value literal you just typed. That is a snapshot of your own code, and
+it fails only when you edit the literal.
+
+Mark the uncalled code excluded from coverage with a note naming the change
+that will exercise it, and put the removal of that exclusion in that change's
+criteria. Do not write coverage theatre to satisfy a gate.
+
+### 3. Attribute and enum literals
+
+Asserting `adapter.name == "claude"` against an implementation that reads
+`name = "claude"` has exactly one failure mode: you changed the literal, and
+the linter told you first. Pin constants at the **consumer boundary** — flag
+parsing, config loading, the serialized output — where a wrong string breaks a
+visible contract.
+
+**Exception:** a public constant that forms part of a serialization contract
+(written to disk, sent over the wire) is pinned at the serialization boundary,
+not at its definition.
+
+## Behaviour versus implementation
+
+| | |
+|---|---|
+| **Good assertions** | Return values, observable state changes, side effects a caller can see |
+| **Bad assertions** | "Method X was called", internal execution order, call counts |
+
+A test coupled to implementation breaks when you refactor without changing
+behaviour. That is the tell, and it is the whole diagnosis.
+
+Do test: calculation correctness, validation rules, state transitions,
+business-rule enforcement, error types and messages.
+
+Do not test: logging calls, metric emissions, cache key formats, internal call
+order. Asserting that a logger was called pins a decision nobody made
+deliberately.
+
+Verify **through the interface**, never around it. A test that writes through
+the public API and then reads the database directly is testing two things and
+proving neither.
+
+## Test doubles
+
+Prefer them in this order, and reach further down the list only when the one
+above genuinely cannot work.
+
+| Type | What it does | When |
+|---|---|---|
+| **Fake** | A simple working implementation | The default. A database becomes an in-memory map |
+| **Stub** | Returns canned responses | External services with predictable responses |
+| **Spy** | Records calls against a real object | Verifying a side effect that has no other observable trace |
+| **Mock** | Asserts that specific calls happened | Almost never. Last resort |
+
+A mock asserts on *how*, which is the thing a test is supposed not to care
+about. Every mock in a test needs a one-sentence justification for why nothing
+above it in the table would do.
+
+**Mock the complete structure, not the fields your test happens to read.** A
+partial mock hides a structural assumption: downstream code reaches for a field
+you omitted, the test passes, and the integration fails. If you are mocking a
+response, you are claiming to understand the whole response.
+
+## Where to mock, and how to design for it
+
+Mock at **system boundaries** only: external APIs, time, randomness, sometimes
+the filesystem, sometimes the database — though a real test database usually
+beats mocking one.
+
+Do not mock your own classes, internal collaborators, or anything you control.
+Mocking something you own is a design signal, not a testing technique.
+
+Two habits make a boundary easy to double:
+
+**Accept dependencies, do not construct them.** A function handed a payment
+client is testable; one that builds a client from environment variables inside
+itself is not.
+
+**Prefer specific operations over one generic fetcher.** An interface with
+`getUser`, `getOrders` and `createOrder` gives each double one shape to return.
+A single `fetch(endpoint, options)` forces conditional logic inside the double,
+which is a second implementation you now have to debug.
+
+## Refusal criteria
+
+**Refuse to write the test** when any of these hold:
+
+- The function needs **five or more** dependencies mocked
+- The function has ten or more conditionals or early returns
+- Test setup would exceed twenty lines of double configuration
+- You would be asserting "did method X get called" rather than "did it produce
+  the right output"
+- You have not read the code under test — loose matchers like
+  `/completed|success|ok/i` are the tell
+
+**Say so, in these terms:** "This code is not testable in its current form.
+Let us decompose it into smaller units first, then test each one simply."
+
+Five is the line in both directions: five mocks is where a test stops being
+worth writing, and it is also the point at which the *production* code, not the
+test, is what needs to change.
+
+### When the refactor is blocked
+
+If a constraint forbids the refactor — a separate ticket, a frozen API, a
+pending review — and the code meets a refusal criterion:
+
+1. **Do not ship anti-pattern tests to satisfy a coverage gate.** Coverage from
+   a mock forest is theatre. It cements the design and buys permanent
+   maintenance cost.
+2. **Escalate.** File the blocker, ask for the refactor to be unblocked, or get
+   an explicit waiver from whoever owns the code.
+3. **Record the waiver where the reviewer will see it** — in the change
+   description, not buried in a test comment. They need to know they are
+   approving anti-pattern tests.
+
+"I will file a follow-up to fix it later" is not a waiver. Deferred cleanup is
+cleanup that does not happen.
+
+## Skip hygiene
+
+Treat every skip as debt that accrues interest.
+
+```
+Test is failing
+ └─ Do you understand why?
+     ├─ No  → investigate. Do not skip.
+     └─ Yes → Can you fix it now?
+               ├─ Yes → fix it
+               └─ No  → Environment-specific?
+                         ├─ Yes → exclude via config, and document where the
+                         │        project keeps its testing notes
+                         └─ No  → skip with a tracking reference and a deadline
+```
+
+Every skipped test carries three things: **a reason, a tracking reference, and
+the condition that re-enables it.** A skip with a comment saying only that it is
+skipped tells the next reader nothing about whether it is broken, obsolete, or
+platform-specific.
+
+| Red flag | What it usually means |
+|---|---|
+| Skip count rising over time | Tests are being abandoned, not fixed |
+| Skips with no explanation | Nobody knows whether they are still relevant |
+| Skips older than three months | Fix or delete; stale skips rot |
+| A skip added in the same change as the code | Possibly hiding a regression |
+| Skipping a "flaky" test | Often a real bug with a non-deterministic trigger |
+
+## Worked examples
+
+**Verify through the interface, not around it.**
+
+```typescript
+// BAD: bypasses the interface to check the result
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: the interface is both the action and the observation
+test("createUser makes the user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  expect((await getUser(user.id)).name).toBe("Alice");
+});
+```
+
+**The expected value comes from outside the implementation.**
+
+```typescript
+// BAD: expected value is recomputed the way the code computes it, so the
+// assertion agrees with the code no matter what either of them does
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  expect(calculateTotal(items)).toBe(items.reduce((s, i) => s + i.price, 0));
+});
+
+// GOOD: an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```
+
+**Assert on the output, not on the call.**
+
+```typescript
+// BAD: pins that a method was called. Breaks on any internal change and
+// proves nothing about correctness.
+it("calls validator.validate with the card", async () => {
+  await processor.processPayment(100, card);
+  expect(mockValidator.validate).toHaveBeenCalledWith(card);
+});
+
+// GOOD: pins a business rule
+it("caps commission at 50% of sales", () => {
+  expect(calculateCommission(1000, { rate: 0.8 })).toBe(500);
+});
+```
+
+**Each test owns its state.**
+
+```typescript
+// BAD: shared mutable state — test 2 fails, and only when test 1 ran first
+let counter = 0;
+beforeEach(() => { counter++; });
+it("test 1", () => { expect(counter).toBe(1); });
+it("test 2", () => { expect(counter).toBe(1); });
+
+// GOOD: fresh state per test
+it("increments from zero", () => {
+  const counter = createCounter();
+  counter.increment();
+  expect(counter.value).toBe(1);
+});
+```

--- a/src/user/.agents/skills/test-review/references/test-quality.md
+++ b/src/user/.agents/skills/test-review/references/test-quality.md
@@ -9,7 +9,7 @@ one someone else wrote.
 - [The one question](#the-one-question) — the tautology filter
 - [Behaviour versus implementation](#behaviour-versus-implementation)
 - [Test doubles](#test-doubles) — fake over stub over spy over mock
-- [Where to mock, and how to design for it](#where-to-mock-and-how-to-design-for-it)
+- [Where doubles belong, and how to design for them](#where-doubles-belong-and-how-to-design-for-them)
 - [Refusal criteria](#refusal-criteria) — when not to write the test at all
 - [Skip hygiene](#skip-hygiene)
 - [Worked examples](#worked-examples)
@@ -95,19 +95,20 @@ A mock asserts on *how*, which is the thing a test is supposed not to care
 about. Every mock in a test needs a one-sentence justification for why nothing
 above it in the table would do.
 
-**Mock the complete structure, not the fields your test happens to read.** A
-partial mock hides a structural assumption: downstream code reaches for a field
-you omitted, the test passes, and the integration fails. If you are mocking a
-response, you are claiming to understand the whole response.
+**Mirror the complete structure, not the fields your test happens to read.** A
+partial double hides a structural assumption: downstream code reaches for a
+field you omitted, the test passes, and the integration fails. If your double
+returns a response, you are claiming to understand the whole response.
 
-## Where to mock, and how to design for it
+## Where doubles belong, and how to design for them
 
-Mock at **system boundaries** only: external APIs, time, randomness, sometimes
-the filesystem, sometimes the database — though a real test database usually
-beats mocking one.
+Substitute at **system boundaries** only: external APIs, time, randomness,
+sometimes the filesystem, sometimes the database — though a real test database
+usually beats doubling one.
 
-Do not mock your own classes, internal collaborators, or anything you control.
-Mocking something you own is a design signal, not a testing technique.
+Do not double your own classes, internal collaborators, or anything you
+control. Substituting something you own is a design signal, not a testing
+technique.
 
 Two habits make a boundary easy to double:
 
@@ -124,7 +125,7 @@ which is a second implementation you now have to debug.
 
 **Refuse to write the test** when any of these hold:
 
-- The function needs **five or more** dependencies mocked
+- The function needs test doubles for **five or more** dependencies
 - The function has ten or more conditionals or early returns
 - Test setup would exceed twenty lines of double configuration
 - You would be asserting "did method X get called" rather than "did it produce
@@ -135,7 +136,7 @@ which is a second implementation you now have to debug.
 **Say so, in these terms:** "This code is not testable in its current form.
 Let us decompose it into smaller units first, then test each one simply."
 
-Five is the line in both directions: five mocks is where a test stops being
+Five is the line in both directions: five doubles is where a test stops being
 worth writing, and it is also the point at which the *production* code, not the
 test, is what needs to change.
 
@@ -145,7 +146,7 @@ If a constraint forbids the refactor — a separate ticket, a frozen API, a
 pending review — and the code meets a refusal criterion:
 
 1. **Do not ship anti-pattern tests to satisfy a coverage gate.** Coverage from
-   a mock forest is theatre. It cements the design and buys permanent
+   a forest of doubles is theatre. It cements the design and buys permanent
    maintenance cost.
 2. **Escalate.** File the blocker, ask for the refactor to be unblocked, or get
    an explicit waiver from whoever owns the code.


### PR DESCRIPTION
Three overlapping test skills collapse into two artifacts plus one shared reference. Discharges `9k9.1.15` (the TDD reframe) and `9k9.1.16` (writing-unit-tests). Neither retired name ships.

## The mock threshold was not the disagreement it was briefed as

It was framed as 4-versus-5 between two sources. Measured, it is not: `writing-unit-tests` says five in three places and never says four, while `test-review` contradicts **itself** — four in its checklist and quick reference, five in its own red-flag section. The self-consistent source wins.

The better reason is that the two numbers were doing different jobs. Five is a **refusal** threshold — stop, the production code is the problem. Four was a **signal**. Collapsing to one number means choosing which job it does, and a checkbox flagging at four beside a refusal firing at five would still be two artifacts disagreeing about when to stop. Five is now a refusal threshold in both skills and the shared reference; grep confirms four is gone.

## Conflict 1 — the loop versus D4, resolved by naming properties rather than exempting scaffolds

The anti-horizontal-slicing rule is a **proxy control**: its stated rationale is that bulk-written tests verify imagined behaviour, pin shape rather than observable behaviour, and commit to test structure before the implementation is understood. D4 defends all three directly, with controls the ad-hoc case lacks — the contract-only rule, the AC-to-test bijection checked by script, and authorship separation.

So the skill scopes the rule by naming the properties that earn the exemption:

> This rule binds the seat that writes the tests. It does not forbid a scaffold. A scaffold's tests are not imagined behaviour: they were written against a contract fixed before them, each one cites the criterion it pins, and someone other than their author reviewed them for exactly that.

That wording is load-bearing, because D4's controls are charter-prescribed and not all built yet. A scaffold lacking those properties does not get the exemption — the rule reasserts itself. "Scaffolds are exempt" would have handed an unreviewed bulk test dump a free pass.

## Conflict 2 — the seam gate now has a defined unattended path

Implementer seat: no gate at all, since the tests already sit at their seams and the human judgement was spent upstream at spec time. Author seat with the user present: write the seam list up before writing test code. Author seat alone: proceed on your own list and **record which seams you chose and why**.

The recording is what makes it safe rather than merely unblocked. A wrong seam produces implementation-coupled tests that pass while behaviour breaks — costly, but rework rather than damage, reviewable, and now caught by a shipped sibling whose whole job is that lens. A hard stop cost one human intervention per cycle against a failure mode with a downstream catcher.

## Where the shared reference lives

`test-review/references/test-quality.md`, reached from `tdd` one hop across. The decisive reason is lifetime: `tdd` carries the earlier removal condition — the executor enforcing the loop mechanically — so hosting the reference inside it would strand its co-consumer when that machinery arrives.

Staging confirmed positively, not by inspection: `content-lint` never descends into a skill's interior, so its silence proves nothing. Verified via the staging plan, the ignore filter, and the materialized fileset from the installer's own copytree callback.

## test-review and review-panel

It exists for the panel to reach; it is **not** wired in here. `9k9.39` nominates a `skill` field on the lens contract that does not exist, the `test-adequacy` lens has two transports needing two different mechanisms, and whether test craft counts as house context under D5/D7 needs an explicit ruling. All three belong to that item.

## Evidence

`tdd` **1,370**, `test-review` **1,536**, both against 2,000. Both gates exit 0 from the worktree root. Every pin verified by fetching the blob at the pinned SHA. One correction to the queue's own record: the tautology filter, refusal criteria, skip hygiene and double hierarchy are **not** upstream content — they were authored in-repo, so the rows pin only what is genuinely derived.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne