### PR TITLE
chore(9k9.32, 9k9.33, 9k9.109, 9k9.110): four re-admissions, ported onto the work facade

### DIFF
--- a/src/user/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/src/user/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms (from the `/codebase-design` skill) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from the `/codebase-design` skill. Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in the `/codebase-design` glossary, reach for one that is before inventing a new one.

--- a/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: improve-codebase-architecture
+description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
+disable-model-invocation: true
+admission:
+  provides: A bounded architectural survey that ends in a decision — at most five deepening candidates, each with a before/after visualisation and a recommendation strength, then a grilling loop over the one the user picks. Unprompted, the model reviews the code in front of it; this reads commit history for hot spots, applies the deletion test, and refuses to propose interfaces before the user has chosen a candidate.
+  cost: Zero always-on tokens — user-invoked, so the description is absent from the session catalog. On invoke it costs the body, an HTML report, and one subagent walk of the codebase.
+  remove_when: A survey pass returns no candidate above Speculative in two consecutive runs, meaning the spec contract and the grilling path are catching architectural friction before it accumulates.
+---
+
+<!--
+Source: skills/engineering/improve-codebase-architecture/
+Upstream: https://github.com/mattpocock/skills @ e74f0061bb67222181640effa98c675bdb2fdaa7
+Last sync: 2026-05-23
+Drift policy: rewrite-and-divorce (project-extended fork)
+-->
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+This pass is _informed_ by the project's domain model and built on a shared design vocabulary:
+
+- Run the `codebase-design` skill for the architecture vocabulary (**module**, **interface**, **depth**, **seam**, **adapter**, **leverage**, **locality**) and its principles (the deletion test, "the interface is the test surface", "one adapter = hypothetical seam, two = real"). Use these terms exactly in every suggestion — don't drift into "component," "service," "API," or "boundary."
+- The domain language in `CONTEXT.md` gives names to good seams; ADRs record decisions this pass should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+**Scope before you scan — YAGNI.** Deepening a module pays off by making future changes to it easier, so put extra weight on the parts of the codebase that have recently changed. Decide *where* to look before you look:
+
+- If the user named a direction — a module, a subsystem, a pain point — take it, and skip the inference below.
+- Otherwise, walk back a good stretch of the commit history (`git log --oneline`) to find the codebase's hot spots — the files and areas that keep coming up — and let those paths pull your attention first. If the changes are scattered with no clear hot spot, widen the net.
+
+Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
+
+Then walk the codebase — delegate the walk to a subagent if your harness has them, since it keeps the raw file survey out of this context. Don't follow rigid heuristics; explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+**Take at most five candidates into the report.** More friction than that always exists, so an unbounded pass has no reason to stop and produces a list nobody acts on. Rank what you found by the deletion test and recommendation strength, carry the top five, and say in one line how many you set aside. If fewer than five clear the bar, report fewer — a short honest list beats a padded one.
+
+Ask the helper where the file goes, so nothing lands in the repo and the platform's opener is not re-derived:
+
+```bash
+uv run scripts/report_target.py            # prints a fresh absolute path
+# ... write the HTML there ...
+uv run scripts/report_target.py --open <path>
+```
+
+Tell the user the absolute path either way.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, render a card with:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and the `codebase-design` vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, run the `grilling` skill to walk the decision tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallise — run the `domain-modeling` skill to keep the domain model current as you go:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md`. Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones.
+- **Want to explore alternative interfaces for the deepened module?** Run the `codebase-design` skill and use its design-it-twice parallel sub-agent pattern.

--- a/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -49,12 +49,12 @@ Apply the **deletion test** to anything you suspect is shallow: would deleting i
 
 **Take at most five candidates into the report.** More friction than that always exists, so an unbounded pass has no reason to stop and produces a list nobody acts on. Rank what you found by the deletion test and recommendation strength, carry the top five, and say in one line how many you set aside. If fewer than five clear the bar, report fewer — a short honest list beats a padded one.
 
-Ask the helper where the file goes, so nothing lands in the repo and the platform's opener is not re-derived:
+Ask the helper where the file goes, so nothing lands in the repo and the platform's opener is not re-derived. Run it from this skill's `scripts` directory; the path it prints is absolute, so the report itself can be written from anywhere:
 
 ```bash
-uv run scripts/report_target.py            # prints a fresh absolute path
+uv run report_target.py            # prints a fresh absolute path
 # ... write the HTML there ...
-uv run scripts/report_target.py --open <path>
+uv run report_target.py --open <path>
 ```
 
 Tell the user the absolute path either way.

--- a/src/user/.agents/skills/improve-codebase-architecture/scripts/report_target.py
+++ b/src/user/.agents/skills/improve-codebase-architecture/scripts/report_target.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Where the architecture review is written, and how to open it.
+
+Two questions the model would otherwise re-derive on every run, and answer
+differently each time: which directory is the OS temp directory on this
+machine, and which command opens a file on this platform.
+
+Usage:
+  uv run report_target.py             print a fresh absolute path; creates nothing
+  uv run report_target.py --open PATH open PATH in the platform's default viewer
+
+Exit 0 on success, 2 on unusable input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# Second resolution plus a random tail. A timestamp alone collides when two runs
+# land in the same second, and the file is named before it is written -- so a
+# collision silently overwrites the previous run's report rather than failing.
+_STAMP_FORMAT = "%Y%m%dT%H%M%S"
+_SUFFIX_BYTES = 3
+
+
+def report_path(*, now: float | None = None) -> Path:
+    """A fresh absolute path for one run's report, inside the OS temp directory.
+
+    Nothing is created: the caller writes the HTML. ``tempfile.gettempdir()``
+    is what resolves TMPDIR / TEMP / TMP with the platform's own fallback, so
+    the environment-variable precedence is not restated here.
+    """
+    stamp = time.strftime(_STAMP_FORMAT, time.localtime(now))
+    tail = secrets.token_hex(_SUFFIX_BYTES)
+    return Path(tempfile.gettempdir()).resolve() / f"architecture-review-{stamp}-{tail}.html"
+
+
+def opener_argv(platform: str, path: str) -> tuple[str, ...]:
+    """The command that opens ``path`` in the default viewer for ``platform``.
+
+    ``platform`` is a ``sys.platform`` string.
+    """
+    if platform == "darwin":
+        return ("open", path)
+    if platform.startswith("win"):
+        # The empty string is `start`'s TITLE argument. Without it, `start`
+        # reads a quoted path as the window title and opens nothing.
+        return ("cmd", "/c", "start", "", path)
+    return ("xdg-open", path)
+
+
+def _open(target: str) -> int:
+    path = Path(target)
+    if not path.is_file():
+        # An opener handed a missing file fails quietly on some platforms, so
+        # the run would report success having shown the user nothing.
+        print(f"report_target: not a file: {target}", file=sys.stderr)
+        return 2
+    argv = opener_argv(sys.platform, str(path.resolve()))
+    try:
+        subprocess.run(argv, check=False)  # noqa: S603  # argv is built from the platform table
+    except FileNotFoundError:
+        print(f"report_target: no opener on PATH: {argv[0]}", file=sys.stderr)
+        return 2
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--open", dest="target", metavar="PATH")
+    args = parser.parse_args(argv)
+    if args.target is not None:
+        return _open(args.target)
+    print(report_path())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/user/.agents/skills/improve-codebase-architecture/scripts/report_target_test.py
+++ b/src/user/.agents/skills/improve-codebase-architecture/scripts/report_target_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest>=8"]
+# ///
+"""Tests for the architecture-review report target helper.
+
+Run: uv run report_target_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT_PATH = HERE / "report_target.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(SCRIPT_PATH.stem, SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+target = _load()
+
+
+def test_path_lands_in_the_resolved_temp_dir(tmp_path, monkeypatch):
+    """TMPDIR is honoured, so the report never lands in the repository.
+
+    ``tempfile`` memoises its answer on the first call, so the environment has
+    to be set *and* that cache cleared for an in-process test to see it. The
+    script is a one-shot CLI, so the cache never matters at run time.
+    """
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setenv("TEMP", str(tmp_path))
+    monkeypatch.setenv("TMP", str(tmp_path))
+    monkeypatch.setattr(tempfile, "tempdir", None)
+    path = target.report_path()
+    assert path.is_absolute()
+    assert path.parent == tmp_path.resolve()
+
+
+def test_path_creates_nothing():
+    """The helper names the file; the caller writes it."""
+    assert not target.report_path().exists()
+
+
+def test_each_call_is_a_fresh_file():
+    """Two runs in the same second must not name the same file.
+
+    A timestamp alone collides there, and because the name is chosen before the
+    file is written the second run would overwrite the first run's report.
+    """
+    names = {target.report_path().name for _ in range(50)}
+    assert len(names) == 50
+
+
+def test_name_shape_is_recognisable():
+    name = target.report_path().name
+    assert name.startswith("architecture-review-")
+    assert name.endswith(".html")
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [
+        ("darwin", ("open", "/tmp/r.html")),
+        ("linux", ("xdg-open", "/tmp/r.html")),
+        ("freebsd14", ("xdg-open", "/tmp/r.html")),
+    ],
+)
+def test_opener_per_platform(platform, expected):
+    assert target.opener_argv(platform, "/tmp/r.html") == expected
+
+
+def test_windows_opener_passes_an_empty_title():
+    """`start` reads a quoted path as the window title unless one precedes it."""
+    argv = target.opener_argv("win32", r"C:\Temp\r.html")
+    assert argv == ("cmd", "/c", "start", "", r"C:\Temp\r.html")
+
+
+def test_open_refuses_a_missing_file(tmp_path, capsys):
+    """An opener handed a missing path fails quietly on some platforms, so the
+    run would report success having shown the user nothing."""
+    assert target.main(["--open", str(tmp_path / "absent.html")]) == 2
+    assert "not a file" in capsys.readouterr().err
+
+
+def test_open_refuses_a_directory(tmp_path):
+    assert target.main(["--open", str(tmp_path)]) == 2
+
+
+def test_cli_prints_one_absolute_path(tmp_path):
+    """The documented invocation, driven as the skill drives it."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin", "TMPDIR": str(tmp_path)},
+    )
+    assert proc.returncode == 0
+    lines = proc.stdout.splitlines()
+    assert len(lines) == 1
+    assert Path(lines[0]).is_absolute()
+    assert Path(lines[0]).parent == tmp_path.resolve()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/src/user/.agents/skills/retrospect/SKILL.md
+++ b/src/user/.agents/skills/retrospect/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: retrospect
+description: Use when the user wants to reflect on the current session and make future ones better — a retrospective, retro, or post-mortem on how it went. Apply when they ask what slowed things down, wasted tokens, or caused round-trips, or what to improve about the agent's context (CLAUDE.md, AGENTS.md, memories, code or design docs), tool availability and selection, or how they prompt — and when they want what worked reinforced. Triggers on "retrospect", "retro", "post-mortem", "how did this session go", "how could this have gone smoother", "what should I change". Not for a single in-the-moment correction, and not for a retro on a project unrelated to this session.
+disable-model-invocation: true
+admission:
+  provides: The only pass that reads the session transcript for cause. Size and budget instruments measure artifacts; review gates measure a change; neither can see that a round-trip happened because context was buried, a tool went unused, or a request was under-specified. Produces a ranked set of fixes, each routed by root cause and each with a landing site that outlives the session.
+  cost: Zero always-on tokens — user-invoked, so the description is absent from the session catalog. On invoke it costs the body plus a pass over the conversation already in context.
+  remove_when: Two consecutive retrospectives produce no recommendation that changes a file, a gate, or a memory — the findings are all reinforcement, meaning the upstream causes are already being caught.
+---
+
+# Retrospect
+
+## Overview
+
+A retrospective turns one session's lived experience into durable improvements to
+the *environment* the agent works in — its context, its tools, and how it's
+prompted — not a recap of what happened.
+
+Core principle: **most of what slows a session down is fixable upstream.** Every
+avoidable round-trip, wasted search, or wrong turn traces to a cause in the agent's
+context, its tooling, or the prompt — and each cause has a *different* correct fix.
+The job is to find those causes, route each to the right fix, and rank them so the
+single highest-leverage change is unmistakable.
+
+A recommendation that ends as prose in a chat window is gone at the next session.
+Every one has to name where it lands.
+
+## When NOT to use
+
+- A single in-the-moment correction — apply it and move on.
+- A retrospective on a project or sprint unrelated to the current session.
+- A trivial session with nothing to learn — say so in one line rather than
+  manufacturing findings.
+
+## The distinction that makes recommendations correct
+
+Before recommending anything, classify each problem by its **root cause** — because
+the right fix differs for each, and the most common failure of a retrospective is
+"write another rule" for a problem more rules won't solve.
+
+| Root cause | Signal | Correct fix | Wrong fix |
+|---|---|---|---|
+| **Context gap** | Needed knowledge was missing, stale, or buried where it wasn't seen | Add, repair, or relocate the context (CLAUDE.md, AGENTS.md, a memory, code or design docs) | Putting the knowledge where it won't be seen at the decision point — right content, wrong home |
+| **Compliance failure** | The knowledge already existed and was ignored | A *mechanical* gate (hook, CI check, lint rule, script) that makes the mistake structurally impossible; or strengthen and relocate the existing rule so it's actually seen | Adding a second prose rule that says the same thing — rule bloat that degrades performance |
+| **Tooling gap** | No good tool existed for the job, or a better one was available but unused | Add or propose the tool or check; or document the better tool choice | A prose rule telling the agent to do the tool's job by hand from memory |
+| **Prompting gap** | The request was under-specified, ambiguous, or missing detail that caused rework | Suggest a concrete prompt pattern *to the user* — framed as their lever, not their fault | Silently absorbing it as an agent rule |
+
+**The dedup test:** before proposing any new rule, skill, or memory, check whether the
+lesson is *already* covered by existing context. If it is, the finding is a
+compliance failure, not a context gap — recommend enforcement, not duplication.
+
+## Process
+
+### 1. Scope it — honour the user's spotlight
+
+If the user named a focus area when invoking, make it the **spotlight**: analyse it
+deepest and lead the report with it. Still run the full sweep below — the spotlight
+is additive, never exclusive. If no focus was given, sweep everything.
+
+### 2. Reconstruct the session
+
+From the actual conversation in context (don't fabricate; if context was compacted,
+say so and work from what remains), establish:
+
+- **Goal** — what the user actually wanted.
+- **Path** — the route taken to get there.
+- **Outcome** — shipped, partial, or abandoned.
+- **Cost** — the *avoidable* part: correction round-trips, redundant searches, wrong
+  turns, token-heavy detours. Quantify where visible.
+
+### 3. Sweep the three improvement targets
+
+| Target | Ask |
+|---|---|
+| **Agent context** | Was needed context missing, stale, buried, or present-but-ignored? |
+| **Tool availability & selection** | Was the right tool *available*? Was it *chosen*? Would a mechanical check or a missing tool have prevented a problem? |
+| **Prompting** | Was the request clear, scoped, and complete up front? What upfront detail or phrasing would have removed a round-trip? |
+
+Efficiency is the cross-cutting lens: most findings surface first as wasted time or
+tokens. Trace each waste back to one of the three targets.
+
+### 4. Root-cause and route each finding
+
+For every problem, name the root cause from the table above, then the correct fix.
+Run the dedup test before proposing any rule, skill, or memory.
+
+### 5. Mark what went well — and why
+
+Identify practices, skills, or techniques that genuinely worked, and state **why**
+each worked, so the user repeats them with confidence. This is reinforcement, not
+praise — name only real wins, skip the filler. A retrospective that lists only
+problems trains the user away from what was working.
+
+### 6. Prioritise
+
+Score each recommendation by **impact** (time, tokens, and rework it saves) against
+**effort** (cost to land it), and sort. Lead with the top item.
+
+### 7. Give every recommendation a landing site
+
+A fix with no home is a fix that does not survive the session. Before presenting it,
+say where it lands:
+
+| Fix | Where it lands |
+|---|---|
+| Context repair | The file actually read at the decision point — the project's AGENTS.md/CLAUDE.md, a code or design doc. Right content in the wrong home is still a miss. |
+| A lesson that must outlive this session | Durable memory: one fact per entry, with why it matters and how to apply it. |
+| A mechanical gate | A hook, CI check, lint rule, or script — proposed as work to be done, never claimed as done. |
+| A new rule, skill, or command | The project's admission bar. State what it prevents or provides, what it costs, and what observation would remove it; default to declining. Run the dedup test first. |
+| A prompt pattern | Stated to the user as their lever. Nothing lands in the agent's context. |
+
+Then **offer** to action the approved items. Do not auto-apply; the user decides
+what lands.
+
+## Report structure
+
+See [references/deliverable-shape.md](references/deliverable-shape.md) for the
+section order, the recommendations table, and a worked example.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Recap instead of retrospective | Every finding must yield a fix or a reinforcement, not just a description |
+| "Write another rule" for a compliance failure | Recommend a mechanical gate; run the dedup test first |
+| A recommendation with no landing site | Name the file, the gate, or the memory — or it did not happen |
+| False praise in "what went well" | Name only genuine wins, each with a why — or say "nothing notable" |
+| Blaming the user for prompting gaps | Frame prompt findings as the user's lever, neutrally |
+| Findings with no priority | Always rank by impact vs effort; lead with the top one |
+| Fabricating session detail after compaction | Work only from what's in context; state the gap honestly |
+| Spotlight swallows the report | Honour the focus, but still sweep everything else briefly |

--- a/src/user/.agents/skills/retrospect/references/deliverable-shape.md
+++ b/src/user/.agents/skills/retrospect/references/deliverable-shape.md
@@ -1,0 +1,41 @@
+# Retrospective deliverable shape
+
+Section order and table shape for what a retrospective hands back.
+
+## Section order
+
+1. **Bottom line** — outcome, the avoidable cost, and the single highest-leverage
+   change, stated up front.
+2. **What went well** — wins worth repeating, each with its *why*.
+3. **What slowed us down** — findings, each tagged `[target / root-cause]` and traced
+   to its cause.
+4. **Recommendations** — the prioritised table:
+
+   | Recommendation | Target | Root cause | Lands in | Impact | Effort | Priority |
+   |---|---|---|---|---|---|---|
+
+   Every row carries a landing site. A row whose "Lands in" column reads "the
+   summary" is not a recommendation.
+5. **Apply?** — the offer to action approved items.
+
+## Worked example (condensed)
+
+> **Bottom line:** Feature shipped, but three correction round-trips did QA the
+> system should have done. Highest-leverage fix: convert the two most-violated prose
+> rules into mechanical gates.
+>
+> **What went well:** The todo list on the multi-step fix — *why:* it externalised
+> state so nothing got dropped mid-task. Keep requesting it for anything multi-step.
+>
+> **What slowed us down:** Skipped the project's AGENTS.md, so a documented "register
+> flags in two places" rule was missed `[Agent context / Compliance failure]` — the
+> rule existed and was ignored, so more prose won't help.
+>
+> | Recommendation | Target | Root cause | Lands in | Impact | Effort | Priority |
+> |---|---|---|---|---|---|---|
+> | Pre-edit hook blocking the first edit until AGENTS.md is read | Tool availability & selection | Compliance failure | A hook, proposed as work | High | Med | P0 |
+> | CI check: a flag must appear in both registration sites | Tool availability & selection | Compliance failure | The project's CI config, proposed as work | High | Low | P0 |
+> | Record the newly-seen test-tautology pattern in the existing testing guidance | Agent context | Context gap | The testing doc already read at that decision point | Med | Low | P1 |
+
+Note what the example does *not* contain: a fourth row proposing a new rule that
+restates the AGENTS.md rule already being ignored. That is the dedup test working.

--- a/src/user/.agents/skills/triaging-discovered-work/SKILL.md
+++ b/src/user/.agents/skills/triaging-discovered-work/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: triaging-discovered-work
+description: Use when a task, test, review, or implementation reveals new work requiring a scope, filing, or deferral decision, including bugs, missing requirements, scope expansions, and mid-task follow-ups that could be incorrectly filed, orphaned, or deferred.
+admission:
+  prevents: Discovered work used as a deferral channel for work already in scope, and discoveries filed where nothing will find them again — under the in-flight item, or with a provenance edge and no roadmap placement. The pressure at discovery time is a nearly-finished PR, and it bends every judgement the same way.
+  cost: One catalog description, always-on across every tool that installs it. The body and the adjudication are paid only when a discovery actually surfaces.
+  remove_when: Agents mid-task, with this skill unloaded, run the sibling test and name an escape hatch before filing in two consecutive sessions — or the tracker facade starts adjudicating scope rather than form.
+---
+
+# Triaging Discovered Work
+
+A mid-task discovery — a bug, a missing requirement, a scope expansion — forces one
+decision before anything else: fix it now, or file it. This skill owns that
+adjudication. `work discover` owns the filing and refuses a malformed one.
+
+## Iron Law
+
+**NO FILING OR DEFERMENT WITHOUT SCOPE ADJUDICATION.**
+
+Schedule pressure, a nearly-complete PR, or a request to "just create a work item"
+do not create an exception. A discovery is not a deferral channel for work already
+in scope.
+
+## Decide the scope
+
+Apply the **sibling test**: *would this have been on the current work item's
+original plan or spec?*
+
+### In scope — fix it in this session
+
+Do the work in the current session and PR. Deferral is permitted only when one of
+three named escape hatches applies:
+
+- **externally-blocked** — credentials, an upstream fix, or another PR must land first
+- **blast-radius** — the fix enters a subsystem or risk class outside this change
+- **own-cycle** — it needs its own design, tests and review, and would roughly double the diff
+
+File a permitted deferral as a **sibling** of the in-flight item, anchored at that
+item's parent:
+
+```bash
+work discover --noun bugfix --title "<title>" \
+  --scope in-scope-deferred:own-cycle --scope-why "<why this hatch>" \
+  --anchor <parent-of-in-flight> --anchor-why "<why here>" \
+  --priority P2 --priority-why "<why this priority>" \
+  --discovered-from <in-flight-id>
+```
+
+If the in-flight item has no parent, there is no sibling anchor to derive. File it
+out of scope instead and say so in the rationale.
+
+### Out of scope — file it anchored
+
+Find the best-fit epic beneath the milestone the work maps to. If no epic fits, use
+the milestone itself.
+
+```bash
+work discover --noun chore --title "<title>" \
+  --scope out-of-scope --scope-why "<why out of scope>" \
+  --anchor <epic-or-milestone-id> --anchor-why "<why this anchor>" \
+  --priority P3 --priority-why "<why this priority>" \
+  --discovered-from <current-work-id>
+```
+
+**Parentage is placement; `discovered-from` is provenance.** One call writes both
+edges. Neither substitutes for the other.
+
+An orphan is allowed only when no milestone fits: `--orphan --escalation-why "…"`
+in place of `--anchor`. That is a loud human escalation, not a quiet filing.
+
+Pass `--track NAME` when the anchor carries no track to inherit; the facade names
+the configured tracks when it refuses.
+
+## What the facade enforces, and what it does not
+
+`work discover` refuses to file without an anchor or an explicit `--orphan`, without
+a non-blank single-line rationale on every triage field, and — for an in-scope
+deferral — refuses any anchor that is not the exact parent of `--discovered-from`.
+That last refusal is the close-walk guard: a discovery filed as a *child* of the
+in-flight item can auto-close its parent when it closes.
+
+It enforces **form**. Scope correctness stays your judgement: whether the sibling
+test passes, whether a hatch genuinely applies, and which anchor is right.
+
+## Preserve close-walk safety
+
+Never close a newly filed discovery, or an out-of-scope item's new anchor chain, in
+the current session. Closing the last structural child can auto-close its parent
+while the in-flight work is still pending. If it happens, recover with
+`work reopen <parent>` and audit the propagated closes before continuing.
+
+## Completion reporting
+
+The `work discover` envelope carries a `manifest_row`. Put it in the completion
+report's manifest verbatim rather than re-describing the filing. When the envelope's
+`remaining_work` is true — every in-scope deferral — add an escalation line under
+**Remaining Work** naming the hatch. An orphan is escalated as
+`unanchored — needs your call`.
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "The PR is nearly done; I can file it later." | If it is in scope, fix it now unless a named escape hatch applies. |
+| "A provenance edge is enough." | Provenance is not placement; anchor it on the roadmap too. |
+| "It has no matching epic, so an orphan is fine." | Use the milestone when one fits; an orphan is a human escalation. |
+| "I can close the new item so the board stays tidy." | Closing it can close the in-flight parent through the close walk. |
+
+## Red flags — STOP
+
+- "Just make a work item."
+- "We can decide the anchor later."
+- "This was in scope, but it is discovered work now."
+- "Close it before wrapping up."
+- Reaching for `work discover` before the sibling test.
+
+Every one of these requires reapplying this skill before changing tracker state.

--- a/src/user/.agents/skills/triaging-discovered-work/evals/trigger-eval.json
+++ b/src/user/.agents/skills/triaging-discovered-work/evals/trigger-eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query": "While implementing the current work item I found a missing null check in the same request path. We are behind schedule; can I just file it for later?",
+    "should_trigger": true
+  },
+  {
+    "query": "The task is nearly done, but I found a retry defect in a subsystem this change does not touch. I need to decide whether to defer it or fix it now.",
+    "should_trigger": true
+  },
+  {
+    "query": "I discovered that the fix needs credentials for a vendor sandbox. Help me record the blocked work without losing its relationship to this task.",
+    "should_trigger": true
+  },
+  {
+    "query": "A code-review comment uncovered a separate documentation problem. Where should I file it on the roadmap and what evidence belongs with it?",
+    "should_trigger": true
+  },
+  {
+    "query": "I found extra validation that was clearly part of this work item's original acceptance criteria, but it would double the diff. Can I split it out?",
+    "should_trigger": true
+  },
+  {
+    "query": "The current work item has no parent and I uncovered unrelated configuration drift. How do I file the discovery safely?",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I close this work, I found a separate bug that maps to another milestone. Help me create the correctly anchored item and keep provenance.",
+    "should_trigger": true
+  },
+  {
+    "query": "I found work that does not fit any current milestone. Should I create an orphan and move on?",
+    "should_trigger": true
+  },
+  {
+    "query": "A test failure exposed additional work mid-task. I need to classify its scope, decide whether to defer it, and report it correctly.",
+    "should_trigger": true
+  },
+  {
+    "query": "The approved observability plan already assigns the dashboard task to its epic. Create that known child item now.",
+    "should_trigger": false
+  },
+  {
+    "query": "Last week's approved migration plan lists a post-release follow-up under the deployment epic. Create that already-adjudicated follow-up.",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the work items that are ready for implementation.",
+    "should_trigger": false
+  },
+  {
+    "query": "Close the completed child item and verify whether its parent epic also closed.",
+    "should_trigger": false
+  },
+  {
+    "query": "Triage the backlog for the next planning session and rank the open work.",
+    "should_trigger": false
+  },
+  {
+    "query": "Review pull request 250 and summarize the changes.",
+    "should_trigger": false
+  },
+  {
+    "query": "Why does work list --parent still return an item after I remove its dependency edge?",
+    "should_trigger": false
+  },
+  {
+    "query": "A previous completion report already classified the documentation cleanup as out of scope and named its anchor. Create the tracked item as specified.",
+    "should_trigger": false
+  },
+  {
+    "query": "Find the next milestone that has no blocking dependencies.",
+    "should_trigger": false
+  }
+]

--- a/src/user/.agents/skills/where-does-this-fit/SKILL.md
+++ b/src/user/.agents/skills/where-does-this-fit/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: where-does-this-fit
+description: Use when a user asks for the bigger picture for a context, or how a specific work item (task, epic, story, feature, bug, PR, issue — open, in-progress, or complete) fits into the broader project architecture, goals, or structural context, rather than just the narrow scope of the item itself.
+admission:
+  provides: A structural situating pass over one work item — which goal it serves, what container owns it, what sibling work surrounds it, what it touches, and what conflicts or stale assumptions a human has to resolve first. Produces the four-layer explanation and an explicit conflict callout, from the tracker and the project's own documents rather than from recall.
+  cost: One catalog description, always-on across every tool that installs it. The body plus two or three tracker reads, paid only when someone asks the question.
+  remove_when: Agents open a work item and volunteer its goal, its container, its siblings and its conflicts unprompted — or the tracker facade grows a verb that renders the same four layers.
+---
+
+# Where Does This Fit
+
+## Overview
+
+Explains where a specific work item sits in the project's larger architecture, goals, and feature structure. Surfaces conflicts, ambiguities, and inconsistencies the user may need to resolve before proceeding. Leaves both the user and the agent better-informed for brainstorming, deciding, and implementing.
+
+## Step 0: Pre-flight — is architecture documented?
+
+Before explaining anything, verify the project's goals and architecture are available and current.
+
+**Probe in order:**
+
+1. `AGENTS.md` / `CLAUDE.md` in the project root — does it carry high-level goals, active work, and an architecture overview?
+2. Referenced in-project docs — specs, ADRs, and architecture pages the orientation file points at.
+3. A knowledge graph, if the project builds one.
+
+```dot
+digraph preflight {
+    "Architecture documented?" [shape=diamond];
+    "Stale or incomplete?" [shape=diamond];
+    "Proceed to explanation" [shape=box];
+    "Flag staleness, reason from verifiable state" [shape=box];
+    "State gap honestly; offer to document" [shape=box];
+
+    "Architecture documented?" -> "Stale or incomplete?" [label="yes"];
+    "Architecture documented?" -> "State gap honestly; offer to document" [label="no"];
+    "Stale or incomplete?" -> "Flag staleness, reason from verifiable state" [label="yes"];
+    "Stale or incomplete?" -> "Proceed to explanation" [label="no"];
+}
+```
+
+**If documentation is insufficient:** do not fabricate context. State the problem clearly:
+
+> "The project's architecture and goals aren't documented clearly enough for me to give you a confident big-picture answer. Before proceeding, we should capture this — the right place is AGENTS.md. Want me to help draft a high-level goals and architecture section? That unlocks this skill for every future question."
+
+**If stale:** flag it, name the stale element, and reason only from what you can verify. Do not silently treat outdated milestones or closed epics as current.
+
+## Step 1: Gather the work item and its context
+
+```bash
+work show <id> <parent-id>    # the item and its container, in one call
+work list --parent <epic-id>  # the sibling work that surrounds it
+```
+
+Then read the project's own orientation file for its stated goals and architecture. Read what it says today rather than what you remember it saying — a project's structure section is exactly the prose that rots.
+
+A knowledge graph, where one exists, surfaces structural relationships grep cannot. Treat it as a **snapshot someone built at some past moment, not an index that follows the tree**: a graph built before a refactor still names the files that refactor deleted. Verify anything it reports against the working tree before asserting it, or rebuild it first.
+
+## Step 2: Construct the explanation
+
+Default audience: **someone familiar with the project in general but who has been away long enough that the structural context is no longer obvious.** That produces a few paragraphs — not a line, not a dissertation.
+
+Address these four layers in order:
+
+| Layer | Question to answer |
+|---|---|
+| **Project context** | Which goal or active milestone does this serve? Where is it on the roadmap? |
+| **Feature/epic context** | What parent container owns this? What sibling work surrounds it? |
+| **Functional impact** | Which system areas, subsystems, workflows, or user-facing behaviours does this touch or change? |
+| **Conflicts / ambiguities / inconsistencies** | What needs human attention before proceeding? |
+
+The fourth layer is not optional — it is often the most valuable part. Surface it even if there is nothing to flag (say so briefly).
+
+## Step 3: Calibrate detail level
+
+```dot
+digraph detail {
+    "User specifies level?" [shape=diamond];
+    "Use requested level" [shape=box];
+    "Default: away-for-a-while colleague" [shape=box];
+    "Follow-up: less?" [shape=diamond];
+    "Compress to 1-2 paragraphs" [shape=box];
+    "Follow-up: more?" [shape=diamond];
+    "Expand with subsystem and dependency analysis" [shape=box];
+    "Hold current level" [shape=box];
+
+    "User specifies level?" -> "Use requested level" [label="yes"];
+    "User specifies level?" -> "Default: away-for-a-while colleague" [label="no"];
+    "Default: away-for-a-while colleague" -> "Follow-up: less?" [label="user responds"];
+    "Follow-up: less?" -> "Compress to 1-2 paragraphs" [label="yes"];
+    "Follow-up: less?" -> "Follow-up: more?" [label="no"];
+    "Follow-up: more?" -> "Expand with subsystem and dependency analysis" [label="yes"];
+    "Follow-up: more?" -> "Hold current level" [label="no"];
+}
+```
+
+| Level | Shape |
+|---|---|
+| **Brief** | 1-2 paragraphs — just "what fits where" |
+| **Default** | 3-5 paragraphs covering all four layers |
+| **Deep dive** | Full structural analysis: dependency chains, subsystem interactions, risk surface, open sibling work |
+
+Adjust on follow-up without re-reading everything from scratch.
+
+If the session is running under a brevity or compression mode, apply it to the preamble, confirmations and wrap-up — **never to the explanation body or the conflict callouts.** A compressed big-picture explanation defeats its own purpose; clarity here requires complete sentences.
+
+## Conflict and ambiguity callouts
+
+Surface these separately, clearly labelled:
+
+> **Conflict:** [work item scope contradicts a stated project goal or milestone boundary]
+>
+> **Ambiguity:** [unclear how this work connects to the larger picture; multiple valid interpretations]
+>
+> **Inconsistency:** [parent container says one thing; work item implies another]
+>
+> **Staleness:** [referenced milestone, goal, or epic appears closed or superseded]
+
+If there is nothing to flag, close with one sentence: "No conflicts or ambiguities found in the current documentation."
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Fabricating architectural context when docs are sparse | State the gap; offer to document it — never invent what isn't there |
+| Starting from the item and staying there | Always start from the project goal and work DOWN to the item |
+| Skipping the conflict/ambiguity layer | It's the most useful part — always include it, even to say "none found" |
+| Treating a stale orientation file as ground truth | Verify container and milestone status with `work show`; flag discrepancies |
+| Trusting a knowledge graph that predates the tree | Check its claims against the working tree, or rebuild it |
+| Giving a deep dive by default | Default is "been away a while" — a few paragraphs, not an essay |


### PR DESCRIPTION
Four already-minted re-admission candidates, each with its tracker access rewritten onto `work` verbs and its dead citations removed.

## The port turned out to be a reshaping

`work discover` covers more than expected: it mechanically enforces the anchor, the whole triage block, the three-hatch vocabulary, the provenance edge, and the refusal to anchor an in-scope deferral at the in-flight item itself. So `triaging-discovered-work` now owns only what `discover`'s own docstring leaves to the caller — the sibling test, whether a hatch genuinely applies, which anchor is right. Five backend verbs collapse to one `work discover` plus `work reopen`.

Every flag was confirmed against `--help` and against the lifecycle source, plus two safe negative probes that created nothing. **No facade gap to record.**

## retrospect earned its admission on the reroute, not on its archived form

Its work item said to DECLINE if the existing instruments already surface what a retrospective would. They do not, and the gap is categorical: `content-lint` measures artifact size, the tracker's lint measures tracker hygiene, `review-panel` measures a change. **None observes a session** — and the prime directive is stated in interventions per merged PR, which only lives in the transcript.

The archived version would have earned a decline: its deliverable was a report and its one exit went to an agent D17 deleted. The reroute is what changes the answer — every recommendation must now name where it lands before it is presented (the file read at the decision point, durable memory, a mechanical gate proposed as work, or an admission bar defaulting to no). That plus its dedup test makes the default output *enforcement of something that already exists* rather than a new artifact. Removal condition recorded: two consecutive retros producing nothing that changes a file, a gate, or a memory.

## One acceptance criterion I got wrong

I required a provenance header and registry row on all four. Three of them — `retrospect`, `triaging-discovered-work`, `where-does-this-fit` — carry no header in the queue, none in the archive, and no upstream anywhere. They were authored in-repo, and the registry's own stated scope is OSS-derived artifacts only. The convention was applied rather than three OSS records fabricated in a table that file calls load-bearing.

## Also

`improve-codebase-architecture` moves its temp-dir resolution and platform opener out of prose into a script with an 11-test paired suite, and bounds a pass at five candidates — an unbounded improvement pass has no termination condition.

Worth knowing: the trigger-eval fixture ships downstream, no `.installignore` pattern prunes it, so scrubbing the backend nouns from it mattered beyond repo hygiene.

## Evidence

Backend-noun and repo-path greps over all four directories return nothing. `verify-checklist`, `docs/plans/`, `self-improving-agent` and `caveman` citations: gone, each replaced by something that resolves. `retrospect` 2,002 → **1,696** via a references split. Both gates exit 0 from the worktree root.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne