### PR TITLE
feat(9k9.154, 9k9.107): admit the scoping chain onto the work facade

### DIFF
--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -192,6 +192,14 @@ enough to need no router is the goal), `wayfinder` (autopsy scheduled when
 the parent-spec path is designed), `triage`,
 `improve-codebase-architecture`. This discharges `wgclw.24`/`.25`.
 
+*Amended 2026-08-07:* `wayfinder` is admitted, user-invoked, with its tracker
+model rewritten onto `work` verbs and its setup command removed. The autopsy
+this decision deferred is superseded by that port: the objection was its
+tracker binding, and the binding is now the facade. Its open mechanical
+questions — the label scheme, the absence of a mechanical completion condition
+for a map, and whether a map is the retired prose-plan class under a new name —
+are carried by `agents-config-9k9.157`, not by this list.
+
 ### Measurement and sequencing
 
 **D19 — Instruments.** Bot App identity separates human from machine PR

--- a/src/user/.agents/skills/prototype/SKILL.md
+++ b/src/user/.agents/skills/prototype/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: prototype
+description: Build throwaway code that answers a design question — a driveable state model, or several structurally different UI variants to choose between. Use when a state machine, data shape, or interface has to be felt rather than argued about, and the discussion has stopped moving on prose alone.
+admission:
+  provides: A cheap concrete artifact to react to — a state model someone can click through, or variants that can be compared side by side — turning a design argument into an observation, plus the discipline that keeps the artifact out of main afterwards.
+  cost: One model-invoked catalog description, always on; per invocation, a throwaway artifact, the branch that keeps it out of main, and the pass that folds the validated decision into real code.
+  remove_when: Design questions about state models and interfaces are settled before implementation often enough that building something runnable stops changing the answer.
+---
+
+<!--
+Source: skills/engineering/prototype/
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: local-fork — LOGIC.md/UI.md relocated under references/ with links rewritten, capture step aimed at a work verb; do not re-sync
+-->
+
+# Prototype
+
+A prototype is **throwaway code that answers a question**. The question decides the shape.
+
+## Pick a branch
+
+Identify which question is being answered — from the user's prompt, the surrounding code, or by asking if the user is around:
+
+- **"Does this logic / state model feel right?"** → [references/logic.md](references/logic.md). Build a single shareable HTML file — free-play buttons plus tabbed guided walkthroughs — that pushes the state machine through cases that are hard to reason about on paper, and that a non-developer can drive.
+- **"What should this look like?"** → [references/ui.md](references/ui.md). Generate several radically different UI variations on a single route, switchable via a URL search param and a floating bottom bar.
+
+The two branches produce very different artifacts — getting this wrong wastes the whole prototype. If the question is genuinely ambiguous and the user isn't reachable, default to whichever branch better matches the surrounding code (a backend module → logic; a page or component → UI) and state the assumption at the top of the prototype.
+
+## Rules that apply to both
+
+1. **Throwaway from day one, and clearly marked as such.** Locate the prototype code close to where it will actually be used (next to the module or page it's prototyping for) so context is obvious — but name it so a casual reader can see it's a prototype, not production. For throwaway UI routes, obey whatever routing convention the project already uses; don't invent a new top-level structure.
+2. **Trivial to run.** A UI prototype starts from one command in the project's task runner — `pnpm <name>`, `python <path>`, `bun <path>`, etc. A logic demo is a single HTML file the user double-clicks. Either way, no thinking required to start it.
+3. **No persistence by default.** State lives in memory. Persistence is the thing the prototype is _checking_, not something it should depend on. If the question explicitly involves a database, hit a scratch DB or a local file with a clear "PROTOTYPE — wipe me" name.
+4. **Skip the polish.** No tests, no error handling beyond what makes the prototype _runnable_, no abstractions. The point is to learn something fast.
+5. **Surface the state.** After every action (logic) or on every variant switch (UI), print or render the full relevant state so the user can see what changed.
+6. **Capture it when done.** Fold the validated decision into the real code, then keep the prototype itself as a **primary source**: commit it to a throwaway branch, out of main. Record the verdict and the question it settled — `work note <id> "<verdict, and the branch holding the prototype>"` on the work item the prototype was answering for, or in the commit message if no item owns it. The main branch keeps only the validated decision.

--- a/src/user/.agents/skills/prototype/references/logic.md
+++ b/src/user/.agents/skills/prototype/references/logic.md
@@ -1,0 +1,67 @@
+# Logic Prototype
+
+A single, self-contained HTML file — a **shareable demo** — that lets anyone drive a state model by clicking buttons. Use this when the question is about **business logic, state transitions, or data shape** — the kind of thing that looks reasonable on paper but only feels wrong once you push it through real cases.
+
+Because it's one file with nothing to install, you can hand it to a non-developer — a designer, a PM, a domain expert — and let them feel the model for themselves. So it speaks their language, not the code's.
+
+## When this is the right shape
+
+- "I'm not sure if this state machine handles the edge case where X then Y."
+- "Does this data model actually let me represent the case where..."
+- "I want to feel out what the API should look like before writing it."
+- Anything where someone wants to **press buttons and watch state change**.
+
+If the question is "what should this look like" — wrong branch. Use [the UI branch](ui.md).
+
+## Process
+
+### 1. State the question
+
+Before writing code, write down what state model and what question you're prototyping. One paragraph, at the top of the demo (in a visible intro, not just a comment). A logic prototype that answers the wrong question is pure waste — make the question explicit so it can be checked later, whether the user is watching now or returning to it AFK.
+
+### 2. Isolate the logic in a portable module
+
+Put the actual logic — the bit that's answering the question — in a single `<script>` block written as a small, pure module that could be lifted out and dropped into the real codebase later. The page around it is throwaway; this module isn't.
+
+The right shape depends on the question:
+
+- **A pure reducer** — `(state, action) => state`. Good when actions are discrete events and state is a single value.
+- **A state machine** — explicit states and transitions. Good when "which actions are even legal right now" is part of the question.
+- **A small set of pure functions** over a plain data type. Good when there's no implicit current state — just transformations.
+- **A class or module with a clear method surface** when the logic genuinely owns ongoing internal state.
+
+Pick whichever shape best fits the question being asked, *not* whichever is easiest to wire to a page. Keep it pure: no DOM, no `document`, no button handlers reaching inside it. The page calls into it; nothing flows the other direction. This is what makes the prototype useful past its own lifetime: once the question's answered, the validated reducer / machine / function set lifts into the real module on its own.
+
+### 3. Build the shareable HTML file
+
+One file, plain HTML/CSS/JS — no framework, no bundler, no server, everything inline so it opens by double-click and survives being emailed around. Anyone should be able to run it by opening it.
+
+Write it for a non-developer. Every label is in **domain language**, not code — buttons and state read like the business, not the reducer. Explain in plain words what's happening.
+
+Lay it out with a clean hierarchy, top to bottom:
+
+1. **Title and one-line explanation** of what this demo lets you explore (the question from step 1).
+2. **Current state** — the full relevant state, rendered as a readable panel (labelled fields, not a raw JSON dump), re-rendered after every click so the change is visible. Where it helps a non-developer follow, call out what just changed.
+3. **Free-play buttons** — one button per action, always available, so anyone can poke at the model in any order. Each click dispatches its action and re-renders the state.
+4. **Guided walkthroughs** — a set of **scenarios**, one per tab. Each tab holds a short plain-language description of the scenario — the situation it sets up and what to watch for — and underneath it, the ordered **buttons to press** for that scenario. Each step is a real button: clicking it performs that action and moves to the next step. Starting a walkthrough resets to a known initial state so the scenario runs the same way every time.
+
+Choose scenarios that demonstrate the awkward cases — the happy path, a tricky edge case, an attempt at something that should be illegal — the ones hard to reason about on paper.
+
+Keep it beautiful but restrained: clean typography, generous spacing, one accent colour. No animations, no gimmicks — nothing that competes with the state and the buttons.
+
+### 4. Hand it over
+
+Send them the file, or open it for them. They'll click through the walkthroughs and free-play whenever they get to it; the interesting moments are when they say "wait, that shouldn't be possible" or "huh, I assumed X would be different" — those are the bugs in the _idea_, which is the whole point. If they want new actions or a new scenario, add them. Prototypes evolve.
+
+### 5. Capture the answer and the prototype
+
+Once the prototype has answered its question, capture the answer, then capture the prototype the way the [SKILL](../SKILL.md) describes. The logic-specific mapping: the validated reducer / machine / function set lifts into the real module (the decision, absorbed); the HTML shell rides along to the throwaway branch that keeps the prototype as a primary source — and being one self-contained file, it stays trivially re-runnable there.
+
+## Anti-patterns
+
+- **Don't add tests.** A prototype that needs tests is no longer a prototype.
+- **Don't wire it to the real database.** Use in-memory state unless the question is specifically about persistence.
+- **Don't generalise.** No "what if we wanted to support X later." The prototype answers one question.
+- **Don't blur the logic and the page together.** If the pure module references the DOM, `document`, or button handlers, it's no longer liftable. Keep the page as a thin shell over a pure module.
+- **Don't reach for a framework, bundler, or server.** One file the recipient double-clicks; a React app or a dev server defeats "shareable".
+- **Don't ship the HTML shell into production.** The page is optimised for being clicked through by hand. The logic module behind it is the bit worth keeping.

--- a/src/user/.agents/skills/prototype/references/ui.md
+++ b/src/user/.agents/skills/prototype/references/ui.md
@@ -1,0 +1,112 @@
+# UI Prototype
+
+Generate **several radically different UI variations** on a single route, switchable from a floating bottom bar. The user flips between variants in the browser, picks one (or steals bits from each), then throws the rest away.
+
+If the question is about logic/state rather than what something looks like — wrong branch. Use [the logic branch](logic.md).
+
+## When this is the right shape
+
+- "What should this page look like?"
+- "I want to see a few options for this dashboard before committing."
+- "Try a different layout for the settings screen."
+- Any time the user would otherwise spend a day picking between three vague mockups in their head.
+
+## Two sub-shapes — strongly prefer sub-shape A
+
+A UI prototype is much easier to judge when it's **butting up against the rest of the app** — real header, real sidebar, real data, real density. A throwaway route on its own is a vacuum: every variant looks fine in isolation. Default to sub-shape A whenever there's a plausible existing page to host the variants. Only reach for sub-shape B if the prototype genuinely has no nearby home.
+
+### Sub-shape A — adjustment to an existing page (preferred)
+
+The route already exists. Variants are rendered **on the same route**, gated by a `?variant=` URL search param. The existing data fetching, params, and auth all stay — only the rendering swaps. This is the default; pick it unless there's a specific reason not to.
+
+If the prototype is for something that doesn't yet have a page but *would naturally live inside one* (a new section of the dashboard, a new card on the settings screen, a new step in an existing flow) — that's still sub-shape A. Mount the variants inside the host page.
+
+### Sub-shape B — a new page (last resort)
+
+Only use this when the thing being prototyped genuinely has no existing page to live inside — e.g. an entirely new top-level surface, or a flow that can't be embedded anywhere sensible.
+
+Create a **throwaway route** following whatever routing convention the project already uses — don't invent a new top-level structure. Name it so it's obviously a prototype (e.g. include the word `prototype` in the path or filename). Same `?variant=` pattern.
+
+Before committing to sub-shape B, sanity-check: is there really no existing page this could be embedded in? An empty route hides design problems that a populated one would expose.
+
+In both sub-shapes the floating bottom bar is identical.
+
+## Process
+
+### 1. State the question and pick N
+
+Default to **3 variants**. More than 5 stops being radically different and starts being noise — cap there.
+
+Write down the plan in one line, in the prototype's location or a top-of-file comment:
+
+> "Three variants of the settings page, switchable via `?variant=`, on the existing `/settings` route."
+
+This works whether the user is here to push back or not.
+
+### 2. Generate radically different variants
+
+Draft each variant. Hold each one to:
+
+- The page's purpose and the data it has access to.
+- The project's component library / styling system (TailwindCSS, shadcn, MUI, plain CSS, whatever).
+- A clear exported component name, e.g. `VariantA`, `VariantB`, `VariantC`.
+
+Variants must be **structurally different** — different layout, different information hierarchy, different primary affordance, not just different colours. Three slightly-tweaked card grids isn't a UI prototype, it's wallpaper. If two drafts come out too similar, redo one with explicit "do not use a card grid" guidance.
+
+### 3. Wire them together
+
+Create a single switcher component on the route:
+
+```tsx
+// pseudo-code — adapt to the project's framework
+const variant = searchParams.get('variant') ?? 'A';
+return (
+  <>
+    {variant === 'A' && <VariantA {...data} />}
+    {variant === 'B' && <VariantB {...data} />}
+    {variant === 'C' && <VariantC {...data} />}
+    <PrototypeSwitcher variants={['A','B','C']} current={variant} />
+  </>
+);
+```
+
+For sub-shape A (existing page): keep all the existing data fetching above the switcher; only the rendered subtree changes per variant.
+
+For sub-shape B (new page): the throwaway route under `/prototype/<name>` mounts the same switcher.
+
+### 4. Build the floating switcher
+
+A small fixed-position bar at the bottom-centre of the screen with three pieces:
+
+- **Left arrow** — cycles to the previous variant (wraps around).
+- **Variant label** — shows the current variant key and, if the variant exports a name, that name too. e.g. `B — Sidebar layout`.
+- **Right arrow** — cycles forward (wraps around).
+
+Behaviour:
+
+- Clicking an arrow updates the URL search param (use the framework's router — `router.replace` on Next, `navigate` on React Router, etc) so the variant is shareable and reload-stable.
+- Keyboard: `←` and `→` arrow keys also cycle. Don't intercept arrow keys when an `<input>`, `<textarea>`, or `[contenteditable]` is focused.
+- Visually distinct from the page (e.g. high-contrast pill, subtle shadow) so it's obviously not part of the design being evaluated.
+- Hidden in production builds — gate on `process.env.NODE_ENV !== 'production'` or an equivalent check, so a stray prototype merge can't ship the bar to users.
+
+Put the switcher in a single shared component so both sub-shapes can reuse it. Locate it wherever shared UI lives in the project.
+
+### 5. Hand it over
+
+Surface the URL (and the `?variant=` keys). The user will flip through whenever they get to it. The interesting feedback is usually **"I want the header from B with the sidebar from C"** — that's the actual design they want.
+
+### 6. Capture the answer and clean up
+
+Once a variant has won, capture the answer — which variant and why — then capture the prototype the way the [SKILL](../SKILL.md) describes. Fold the winner into the real code and move the rest onto the throwaway branch, not into main:
+
+- **Sub-shape A** — fold the winner into the existing page; drop the losing variants and the switcher from main.
+- **Sub-shape B** — promote the winning variant to a real route; drop the throwaway route and the switcher from main.
+
+The full set of variants is the primary source, so it lands on the throwaway branch, not the bin — variant components and the switcher left in the main branch rot fast and confuse the next reader.
+
+## Anti-patterns
+
+- **Variants that differ only in colour or copy.** That's a tweak, not a prototype. Real variants disagree about structure.
+- **Sharing too much code between variants.** A shared `<Header>` is fine; a shared `<Layout>` defeats the point. Each variant should be free to throw out the layout.
+- **Wiring variants to real mutations.** Read-only prototypes are fine. If a variant needs to mutate, point it at a stub — the question is "what should this look like", not "does the backend work".
+- **Promoting the prototype directly to production.** The variant code was written under prototype constraints (no tests, minimal error handling). Rewrite it properly when you fold it in.

--- a/src/user/.agents/skills/research/SKILL.md
+++ b/src/user/.agents/skills/research/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: research
+description: Investigate a question against primary sources and leave the findings as a dated, cited note in the project's reference documentation. Use when a decision waits on an external fact — API behaviour, library semantics, specification details — that reading can settle and whose answer should outlive this session.
+admission:
+  provides: A cited note at a known path, traced to the documents that own each claim rather than to recall or a secondary write-up, which later sessions read instead of asking again.
+  cost: One model-invoked catalog description, always on; per invocation, a reading pass over primary sources and one committed file.
+  remove_when: Fact-finding routes to a retrieval tool that cites primary sources and persists its answer, so a hand-written note adds nothing.
+---
+
+<!--
+Source: skills/engineering/research/
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: local-fork — output artifact given a stated home, citation and open-question discipline added; do not re-sync
+-->
+
+# Research
+
+Answer the question from the sources that own it, and leave the answer behind in writing.
+
+Hand this to a background agent if you have one — the point is that you keep working while it reads.
+
+1. **Go to the primary source.** Official documentation, the library's own code, the specification, the first-party API. Not a blog post, not a summary, not memory. Follow every claim back to the artifact that defines it.
+2. **Cite each claim** precisely enough that a reader can re-check it: a URL, or a file and the symbol inside it.
+3. **Say what you could not settle.** A named open question is worth more than a confident guess, and it tells the next reader where to resume.
+4. **Write one Markdown file**, dated — `docs/reference/<YYYY-MM-DD>-<slug>.md`, unless the project already keeps notes like this somewhere else, in which case match that. Dated because the finding is true of the sources as they stood on the day they were read, and sources move.
+
+Report the answer in the conversation as well. The file is the durable copy, not the delivery.

--- a/src/user/.agents/skills/to-tickets/SKILL.md
+++ b/src/user/.agents/skills/to-tickets/SKILL.md
@@ -94,9 +94,9 @@ Read it as "the first depends on the second". One call per edge.
 
 Do NOT close or modify the container or any parent item.
 
-### 6. Hand off the frontier
+### 6. Hand off the ticket frontier
 
-`work ready` now returns the **frontier**: every ticket whose blockers are all closed and which nobody has claimed. For a purely linear chain that is top to bottom. Whoever picks one up takes it with `work claim <id>` first, so concurrent sessions don't collide.
+`work ready` now returns the **ticket frontier** — every ticket whose blockers are all closed and which nobody has claimed. This frontier is work that is startable, not questions that are answerable. For a purely linear chain it is top to bottom. Whoever picks one up takes it with `work claim <id>` first, so concurrent sessions don't collide.
 
 ## What goes in the ticket body
 

--- a/src/user/.agents/skills/to-tickets/SKILL.md
+++ b/src/user/.agents/skills/to-tickets/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: to-tickets
+description: Break a settled plan, spec, or the current conversation into build slices — tracer-bullet vertical tickets on the tracker, each sized to one context window and declaring the tickets that block it. Use when the decisions are already made and the work needs slicing, sequencing and publishing. Not for scoping open questions — a ticket here is resolved by shipping it, not by answering it.
+disable-model-invocation: true
+admission:
+  provides: A published set of vertical slices with real blocking edges on the tracker, each independently demoable and sized to one context window, from a spec or conversation that states an outcome and no sequence.
+  cost: A user-invoked catalog entry at zero always-on cost; per invocation, a decomposition pass, one round of approval with the user, and two tracker passes — mint, then wire.
+  remove_when: The executor slices a spec into independently mergeable work and wires its dependency edges itself, so nothing invokes this.
+---
+
+<!--
+Source: skills/engineering/to-tickets/
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: local-fork — local ticket store and triage label removed, publishing rewritten onto work verbs, ticket body reduced to what the facade carries no field for; do not re-sync
+-->
+
+# To Tickets
+
+Break a plan, spec, or conversation into **tickets** — tracer-bullet vertical slices, each declaring the tickets that **block** it.
+
+This is the step after the decisions are made. If what is in front of you is still a set of open questions rather than a set of things to build, this is the wrong skill: scope it first, and come back when there is a route to slice.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes a reference (a spec path, a work item id) as an argument, fetch it and read its full body and notes.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Ticket titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 3. Draft vertical slices
+
+Break the work into **tracer bullet** tickets.
+
+<vertical-slice-rules>
+
+- Each slice cuts a narrow but COMPLETE path through every layer (schema, API, UI, tests) — vertical, NOT a horizontal slice of one layer
+- A completed slice is demoable or verifiable on its own
+- Each slice is sized to fit in a single fresh context window
+- Any prefactoring should be done first
+
+</vertical-slice-rules>
+
+Give each ticket its **blocking edges** — the other tickets that must complete before it can start. A ticket with no blockers can start immediately.
+
+**Wide refactors are the exception to vertical slicing.** A **wide refactor** is one mechanical change — rename a column, retype a shared symbol — whose **blast radius** fans across the whole codebase, so a single edit breaks thousands of call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as **expand–contract**. First expand: add the new form beside the old so nothing breaks. Then migrate the call sites over in batches sized by blast radius (per package, per directory), each batch its own ticket blocked by the expand, keeping CI green batch to batch because the old form still exists. Finally contract: delete the old form once no caller remains, in a ticket blocked by every migrate batch. When even the batches can't stay green alone, keep the sequence but let them share an integration branch that all block a final integrate-and-verify ticket — green is promised only there.
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each ticket, show:
+
+- **Title**: short descriptive name
+- **Blocked by**: which other tickets (if any) must complete first
+- **What it delivers**: the end-to-end behaviour this ticket makes work
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the blocking edges correct — does each ticket only depend on tickets that genuinely gate it?
+- Should any tickets be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish through the `work` facade
+
+`work` is the tracker, and it needs no setup step. A ticket that is not on the tracker is not a ticket — never write a parallel set of ticket files instead.
+
+Publish in **two passes**, because a blocking edge needs both ids to exist before it can be drawn.
+
+**Pass one — mint the tickets**, in dependency order (blockers first):
+
+```
+work create <noun> --title "<title>" --parent <container-id> \
+  --description "<what to build>" --acceptance "<criteria>"
+```
+
+- `<noun>` is `feat` for new behaviour, `bugfix` for a defect, `chore` for mechanical work.
+- `--parent` is the container this effort already has — the spec or epic the slices belong to. If there is none, mint one first (`work create epic --title "<the effort>" --orphan`) and hang the slices off it. Scattering slices as orphans loses the set.
+- If the facade refuses the create for want of a track, it names the tracks the project has configured; pick one and pass `--track`. Slices minted under a tracked parent inherit its track and need no flag.
+- Record each id the facade returns — pass two needs them.
+
+**Pass two — wire the blocking edges:**
+
+```
+work dep add <blocked-ticket> <blocking-ticket>
+```
+
+Read it as "the first depends on the second". One call per edge.
+
+Do NOT close or modify the container or any parent item.
+
+### 6. Hand off the frontier
+
+`work ready` now returns the **frontier**: every ticket whose blockers are all closed and which nobody has claimed. For a purely linear chain that is top to bottom. Whoever picks one up takes it with `work claim <id>` first, so concurrent sessions don't collide.
+
+## What goes in the ticket body
+
+The facade carries most of the structure as fields, so the body only holds what has nowhere else to go:
+
+- The **parent** is the `--parent` edge, not a section of prose.
+- The **blocking edges** are `work dep` edges, not a "Blocked by" list.
+- The **acceptance criteria** are `--acceptance`, one criterion per line.
+
+That leaves `--description` to carry one thing: **the end-to-end behaviour this ticket makes work, from the user's perspective** — not a layer-by-layer implementation list.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.

--- a/src/user/.agents/skills/wayfinder/SKILL.md
+++ b/src/user/.agents/skills/wayfinder/SKILL.md
@@ -44,8 +44,8 @@ The map is an **index**, not a store. It lists the decisions made and points at 
 | The ticket's type | the noun: `spike` for research and prototype, `decision` for a grilling question, `chore` for a task |
 | An agent may resolve it alone | `--label wayfinder:afk`; without it, the ticket needs the human |
 | Blocking | `work dep add <blocked> <blocker>` — "the first depends on the second", wired in a second pass once both ids exist |
-| The ticket frontier | `work ready` — open, unblocked, unclaimed; tickets that are startable, not questions that are answerable. `work ready --label wayfinder:afk` is what a session can fan out without the human |
-| Claim | `work claim <id>` — refuses a blocked, closed, or already-claimed ticket, so the claim is enforced rather than a convention |
+| The ticket frontier | `work list --parent <map-id> --status open` — this map's live tickets, the closed and the claimed already out. The blocked are still in, and `work claim` is what rejects them, so the frontier is whatever claims: startable, which is not the same as answerable. Add `--label wayfinder:afk` for what a session can fan out without the human |
+| Claim | `work claim <id>` — refuses a blocked or closed ticket, so startability is enforced rather than assumed. On a ticket already in progress it no-ops instead of refusing, so it is not a lock against a concurrent session |
 | Resolve | `work close <id> --disposition "<the answer>"` — records the answer and closes, in one call |
 | Link an asset | `work note <id> "<pointer to the branch, file or document>"` |
 | Rule out of scope | `work close <id> --disposition "Out of scope: <why>"` |
@@ -53,7 +53,9 @@ The map is an **index**, not a store. It lists the decisions made and points at 
 
 Two of those carry a trap worth naming. `--set-description` **replaces**: re-read the map immediately before you write it back, or a concurrent session's line is lost. And a ticket is invalidated by **closing it with a disposition that says so**, never by deleting it — the facade has no delete, and the record of a route not taken is worth keeping anyway.
 
-If a track is configured, the facade refuses the map's create until you name one, and lists the choices. Tickets minted under the map inherit its track and need no flag.
+`work ready` is absent from that table on purpose. It is global and takes no parent, so on a tracker carrying anything besides this effort it returns other work alongside this map's, and a session that takes its first result can claim and close a ticket belonging to something else entirely. Scope with `--parent`; let `claim` reject what is blocked.
+
+If tracks are configured and required, the facade refuses the map's create until you pass `--track <name>`, and the refusal lists the choices. Tickets minted under the map inherit its track and need no flag.
 
 **On labels.** Two survive, and only two. `wayfinder:map`, because enumerating maps — `work list --label wayfinder:map` — has no other expression, the container noun being shared with ordinary containers. `wayfinder:afk`, because whether a session may resolve a ticket without the human is the thing a session filters on when it fans out, and no field carries it. Everything else the label scheme once carried is now the noun, which is a first-class field; a label restating a field is duplication.
 
@@ -112,7 +114,7 @@ User invokes with a loose idea.
 User invokes with a map. A ticket is **optional** — without one, you pick the next decision, not the user.
 
 1. Load the **map** — the low-res view, not every ticket body.
-2. Choose the ticket. If the user named one, use it. Otherwise take the first ticket `work ready` returns for this map. **Claim it** before any work.
+2. Choose the ticket. If the user named one, **claim it** before any work. Otherwise walk this map's open tickets — `work list --parent <map-id> --status open` — claiming each in turn until one is accepted; a refusal means that ticket is still blocked, so move to the next.
 3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the map's `## Notes` block names. If in doubt, use `grilling` and `domain-modeling`.
 4. Record the resolution: close the ticket with the answer as its disposition, then append a one-line gist and link to the map's Decisions-so-far.
 5. Add newly-surfaced tickets (create, then wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, rule it out of scope rather than resolving it on the route. If the decision invalidates other parts of the map, close those tickets with a disposition saying why.

--- a/src/user/.agents/skills/wayfinder/SKILL.md
+++ b/src/user/.agents/skills/wayfinder/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: wayfinder
+description: Chart work too big for one agent session as a map of decision questions on the tracker, then resolve them one at a time until the way to the destination is clear. Use when the destination is fogged and what to decide comes before what to build — a ticket here is resolved by answering it. Work whose decisions are already made and only needs slicing into build tickets goes to `to-tickets` instead.
+disable-model-invocation: true
+admission:
+  provides: A durable map on the tracker for an effort larger than one agent session — the destination, the open decisions, their blocking edges, and what has been decided so far — so a fresh session orients from the tracker instead of from the previous session's context.
+  cost: A user-invoked catalog entry at zero always-on cost; per effort, one container plus one tracker item per decision, and a standing rule of one ticket resolved per session.
+  remove_when: A session's context reliably spans a whole effort, so the decisions and their order no longer need an artifact to outlive it.
+---
+
+<!--
+Source: skills/engineering/wayfinder/
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: local-fork — setup command and local-markdown fallback removed, tracker model rewritten onto work verbs, label scheme reduced to two, map body and ticket types split into references/; do not re-sync
+-->
+
+# Wayfinder
+
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the way from here to the **destination** isn't visible yet. Wayfinding is about finding that way, not charging at the destination. This skill charts the way as a **shared map** on the tracker, then works its **decision tickets** — questions whose resolution is a decision, not slices of a build to execute — one at a time until the route is clear.
+
+The destination varies per effort, and naming it is the first act of charting — it shapes every ticket. It might be a spec to hand off and iterate on, a decision to lock before planning starts, or a change made in place like a data-structure migration. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+
+## Plan, don't do
+
+Wayfinder is **planning** by default: each ticket resolves a decision, and the map is done when the way is clear — nothing left to decide before someone goes and does the thing. The pull to just do the work is usually the signal you've reached the edge of the map and it's time to hand off. An effort can override this in its **Notes** — carrying execution into the map itself — but absent that, produce decisions, not deliverables.
+
+Handing off is the normal ending. When the map is clear, the build slices that follow are `to-tickets`' job, not this one.
+
+## Refer by name
+
+Every map and ticket is a work item, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far — refer to it by that name, never by a bare id. A wall of ids is illegible; names read at a glance. The id doesn't vanish — a name wraps its link — but it rides _inside_ the name, never stands in for it.
+
+## The map on the tracker
+
+The map is a single container item labelled `wayfinder:map` — the canonical artifact. Its tickets are its children. `work` is the tracker, and there is no setup step: never stand up a parallel set of ticket files beside it.
+
+The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
+
+| What | How |
+|---|---|
+| Create the map | `work create epic --title "<destination>" --label wayfinder:map (--parent <id> \| --orphan)`; the map body is `--description`. See [references/map-body.md](references/map-body.md). |
+| Create a ticket | `work create <noun> --title "<the question>" --parent <map-id> --description "<the question in full>"` |
+| The ticket's type | the noun: `spike` for research and prototype, `decision` for a grilling question, `chore` for a task |
+| An agent may resolve it alone | `--label wayfinder:afk`; without it, the ticket needs the human |
+| Blocking | `work dep add <blocked> <blocker>` — "the first depends on the second", wired in a second pass once both ids exist |
+| The frontier | `work ready` — open, unblocked, unclaimed. `work ready --label wayfinder:afk` is what a session can fan out without the human |
+| Claim | `work claim <id>` — refuses a blocked, closed, or already-claimed ticket, so the claim is enforced rather than a convention |
+| Resolve | `work close <id> --disposition "<the answer>"` — records the answer and closes, in one call |
+| Link an asset | `work note <id> "<pointer to the branch, file or document>"` |
+| Rule out of scope | `work close <id> --disposition "Out of scope: <why>"` |
+| Update the map | `work update <map-id> --set-description "<the whole new body>"` |
+
+Two of those carry a trap worth naming. `--set-description` **replaces**: re-read the map immediately before you write it back, or a concurrent session's line is lost. And a ticket is invalidated by **closing it with a disposition that says so**, never by deleting it — the facade has no delete, and the record of a route not taken is worth keeping anyway.
+
+If a track is configured, the facade refuses the map's create until you name one, and lists the choices. Tickets minted under the map inherit its track and need no flag.
+
+**On labels.** Two survive, and only two. `wayfinder:map`, because enumerating maps — `work list --label wayfinder:map` — has no other expression, the container noun being shared with ordinary containers. `wayfinder:afk`, because whether a session may resolve a ticket without the human is the thing a session filters on when it fans out, and no field carries it. Everything else the label scheme once carried is now the noun, which is a first-class field; a label restating a field is duplication.
+
+## Tickets
+
+Each ticket is a **child of the map**; its id is its identity. Its description is the question, sized to one agent session:
+
+```markdown
+## Question
+
+<the decision or investigation this ticket resolves>
+```
+
+Every ticket is either **HITL** — human in the loop, worked _with_ a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). AFK tickets carry `wayfinder:afk`. For which of the four kinds of ticket is which, and how each resolves, see [references/ticket-types.md](references/ticket-types.md).
+
+The answer isn't part of the description — it is recorded on resolution, as the closing disposition. Assets created while resolving a ticket are linked by note, not pasted in.
+
+## Fog of war
+
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** — the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the destination is clear and no tickets remain.
+
+The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. It's the undiscovered frontier _toward_ the destination — everything here is in scope, just not sharp enough to ticket. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
+
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
+
+- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
+
+**Not yet specified** excludes what's already decided (Decisions so far), what's already a live ticket, and what's out of scope.
+
+## Out of scope
+
+Fog only ever gathers _toward_ the destination. The destination fixes the scope, so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section on the map: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here.
+
+Out-of-scope work never graduates — the frontier stops at the destination — so it returns only if the destination is redrawn, and then as a fresh effort, not a resumption.
+
+Ruling something out of scope is a scoping act, not a step on the route. When a ticket that already exists turns out to sit past the destination — mis-scoped in while charting, or exposed by a resolution — **close it out of scope** and leave one line in the **Out of scope** section: the gist plus why, linking the closed ticket. It stays out of **Decisions so far**, which records the route actually walked — a scope boundary isn't a step on it.
+
+## Invocation
+
+Two modes. Either way, **never resolve more than one ticket per session** — with the exception of research tickets.
+
+### Chart the map
+
+User invokes with a loose idea.
+
+1. **Name the destination.** Run a `grilling` and `domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
+3. **Create the map**, with Destination and Notes filled in, Decisions-so-far empty, and the fog sketched into **Not yet specified**.
+4. **Create the tickets you can specify now** as children of the map, then wire blocking edges in a **second pass** — items need ids before they can reference each other. Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog.
+5. **Fire the research subagents.** For each research ticket you just created, delegate a `research` run to resolve it in parallel, and note the resulting artifact's location back onto the ticket.
+6. Stop — charting is one session's work; it hand-resolves nothing.
+
+### Work through the map
+
+User invokes with a map. A ticket is **optional** — without one, you pick the next decision, not the user.
+
+1. Load the **map** — the low-res view, not every ticket body.
+2. Choose the ticket. If the user named one, use it. Otherwise take the first ticket `work ready` returns for this map. **Claim it** before any work.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the map's `## Notes` block names. If in doubt, use `grilling` and `domain-modeling`.
+4. Record the resolution: close the ticket with the answer as its disposition, then append a one-line gist and link to the map's Decisions-so-far.
+5. Add newly-surfaced tickets (create, then wire); graduate any fog the answer has made specifiable, clearing each graduated patch from **Not yet specified** so it lives only as its new ticket. If the answer reveals a ticket — this one or another — sits beyond the destination, rule it out of scope rather than resolving it on the route. If the decision invalidates other parts of the map, close those tickets with a disposition saying why.
+
+The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.

--- a/src/user/.agents/skills/wayfinder/SKILL.md
+++ b/src/user/.agents/skills/wayfinder/SKILL.md
@@ -44,7 +44,7 @@ The map is an **index**, not a store. It lists the decisions made and points at 
 | The ticket's type | the noun: `spike` for research and prototype, `decision` for a grilling question, `chore` for a task |
 | An agent may resolve it alone | `--label wayfinder:afk`; without it, the ticket needs the human |
 | Blocking | `work dep add <blocked> <blocker>` — "the first depends on the second", wired in a second pass once both ids exist |
-| The frontier | `work ready` — open, unblocked, unclaimed. `work ready --label wayfinder:afk` is what a session can fan out without the human |
+| The ticket frontier | `work ready` — open, unblocked, unclaimed; tickets that are startable, not questions that are answerable. `work ready --label wayfinder:afk` is what a session can fan out without the human |
 | Claim | `work claim <id>` — refuses a blocked, closed, or already-claimed ticket, so the claim is enforced rather than a convention |
 | Resolve | `work close <id> --disposition "<the answer>"` — records the answer and closes, in one call |
 | Link an asset | `work note <id> "<pointer to the branch, file or document>"` |
@@ -103,7 +103,7 @@ User invokes with a loose idea.
 1. **Name the destination.** Run a `grilling` and `domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
 2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
 3. **Create the map**, with Destination and Notes filled in, Decisions-so-far empty, and the fog sketched into **Not yet specified**.
-4. **Create the tickets you can specify now** as children of the map, then wire blocking edges in a **second pass** — items need ids before they can reference each other. Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog.
+4. **Create the tickets you can specify now** as children of the map, then wire blocking edges in a **second pass** — items need ids before they can reference each other. Wiring sorts them into the ticket frontier and the blocked; everything you can't yet specify stays in the fog.
 5. **Fire the research subagents.** For each research ticket you just created, delegate a `research` run to resolve it in parallel, and note the resulting artifact's location back onto the ticket.
 6. Stop — charting is one session's work; it hand-resolves nothing.
 

--- a/src/user/.agents/skills/wayfinder/references/map-body.md
+++ b/src/user/.agents/skills/wayfinder/references/map-body.md
@@ -2,7 +2,7 @@
 
 The whole map at low resolution, loaded once per session. It goes in the map item's description, and is rewritten in place as the effort advances.
 
-Open tickets are **not** listed here — they are the map's open children, found by query (`work ready` for the frontier, `work list --parent <map-id> --status open` for all of them). Listing them in the body would mean maintaining a second copy that goes stale the moment a ticket closes.
+Open tickets are **not** listed here — they are the map's open children, found by query (`work ready` for the ticket frontier, `work list --parent <map-id> --status open` for all of them). Listing them in the body would mean maintaining a second copy that goes stale the moment a ticket closes.
 
 ```markdown
 ## Destination

--- a/src/user/.agents/skills/wayfinder/references/map-body.md
+++ b/src/user/.agents/skills/wayfinder/references/map-body.md
@@ -1,0 +1,39 @@
+# The map body
+
+The whole map at low resolution, loaded once per session. It goes in the map item's description, and is rewritten in place as the effort advances.
+
+Open tickets are **not** listed here — they are the map's open children, found by query (`work ready` for the frontier, `work list --parent <map-id> --status open` for all of them). Listing them in the body would mean maintaining a second copy that goes stale the moment a ticket closes.
+
+```markdown
+## Destination
+
+<what reaching the end of this map looks like — the spec, decision, or change this effort is finding its way to. One or two lines; every session orients to it before choosing a ticket.>
+
+## Notes
+
+<domain; skills every session should consult; standing preferences for this effort>
+
+## Decisions so far
+
+<!-- the index — one line per closed ticket: enough to judge relevance, then follow the link for the detail the ticket holds -->
+
+- [<closed ticket title>](<link or id>) — <one-line gist of the answer>
+
+## Not yet specified
+
+<!-- in-scope fog you can't ticket yet; graduates as the frontier advances -->
+
+## Out of scope
+
+<!-- work ruled beyond the destination; closed, never graduates -->
+```
+
+## Writing it back
+
+`work update <map-id> --set-description "<body>"` **replaces** the description; there is no append. So the sequence is always read, edit, write:
+
+1. `work show <map-id>` and take the current description.
+2. Make your edit to it.
+3. Write the whole edited body back.
+
+Do that immediately before writing, not at the start of the session. Other sessions may be working the same map in parallel, and a body composed against a stale read silently drops whatever they added in between.

--- a/src/user/.agents/skills/wayfinder/references/map-body.md
+++ b/src/user/.agents/skills/wayfinder/references/map-body.md
@@ -2,7 +2,7 @@
 
 The whole map at low resolution, loaded once per session. It goes in the map item's description, and is rewritten in place as the effort advances.
 
-Open tickets are **not** listed here — they are the map's open children, found by query (`work ready` for the ticket frontier, `work list --parent <map-id> --status open` for all of them). Listing them in the body would mean maintaining a second copy that goes stale the moment a ticket closes.
+Open tickets are **not** listed here — they are the map's open children, found by query: `work list --parent <map-id> --status open`. Listing them in the body would mean maintaining a second copy that goes stale the moment a ticket closes.
 
 ```markdown
 ## Destination

--- a/src/user/.agents/skills/wayfinder/references/ticket-types.md
+++ b/src/user/.agents/skills/wayfinder/references/ticket-types.md
@@ -9,7 +9,7 @@ Four kinds of ticket. The noun carries the shape; the `wayfinder:afk` label carr
 | Grilling | `decision` | HITL | conversation — `grilling` and `domain-modeling` |
 | Task | `chore` | either | doing the thing |
 
-A HITL ticket only resolves through a live exchange with a human who speaks for themselves. The agent never stands in for the human's side of it — a grilling agent that answers its own questions has broken this. Only AFK tickets carry `wayfinder:afk`, and `work ready --label wayfinder:afk` is what a session fans out when the human is away.
+A HITL ticket only resolves through a live exchange with a human who speaks for themselves. The agent never stands in for the human's side of it — a grilling agent that answers its own questions has broken this. Only AFK tickets carry `wayfinder:afk`, and `work list --parent <map-id> --status open --label wayfinder:afk` is what a session fans out when the human is away.
 
 **Research.** Reading documentation, third-party APIs, or local resources like a knowledge base, to surface a fact a decision waits on. Use when knowledge from outside the current working directory is required. These are the one exception to one-ticket-per-session: fire them in parallel.
 

--- a/src/user/.agents/skills/wayfinder/references/ticket-types.md
+++ b/src/user/.agents/skills/wayfinder/references/ticket-types.md
@@ -1,0 +1,24 @@
+# Ticket types
+
+Four kinds of ticket. The noun carries the shape; the `wayfinder:afk` label carries whether an agent may resolve it without the human.
+
+| Kind | Noun | Mode | Resolved by |
+|---|---|---|---|
+| Research | `spike` | AFK | a delegated `research` run |
+| Prototype | `spike` | HITL | the `prototype` skill, with the human reacting to what it builds |
+| Grilling | `decision` | HITL | conversation — `grilling` and `domain-modeling` |
+| Task | `chore` | either | doing the thing |
+
+A HITL ticket only resolves through a live exchange with a human who speaks for themselves. The agent never stands in for the human's side of it — a grilling agent that answers its own questions has broken this. Only AFK tickets carry `wayfinder:afk`, and `work ready --label wayfinder:afk` is what a session fans out when the human is away.
+
+**Research.** Reading documentation, third-party APIs, or local resources like a knowledge base, to surface a fact a decision waits on. Use when knowledge from outside the current working directory is required. These are the one exception to one-ticket-per-session: fire them in parallel.
+
+**Prototype.** Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code. Link the prototype from the ticket as an asset rather than pasting it in. Use when "how should it look" or "how should it behave" is the key question.
+
+**Grilling.** Conversation. The default case.
+
+**Task.** Manual work that must happen before a _decision_ can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that _does_ rather than decides, and it earns its place by unblocking a decision, not by delivering the destination. The agent drives it alone where it can; otherwise it hands the human a precise checklist. Resolved when the work is done, and the answer records what was done plus any resulting facts — where credentials live, new URLs, row counts — that later tickets depend on.
+
+## Spikes split two ways
+
+`spike` covers both research and prototype, because the facade has one investigation noun. The question itself tells them apart: a question settled by *reading* is research, and one settled by *building something to react to* is a prototype. The `wayfinder:afk` label follows from that — research runs unattended, a prototype needs someone to react.


### PR DESCRIPTION
Four skills for scoping and decomposing work — `to-tickets`, `research`, `wayfinder`, `prototype` — with their upstream tracker model rewritten onto `work` verbs.

## The wayfinder conditions, all four discharged

**The setup command is gone**, along with the default-to-local-markdown-tracker fallback — a self-invented ticket store the facade principle forbids. Upstream that command binds a tracker and a label vocabulary; here the binding is the facade and needs no setup step.

**The label scheme resolved to two labels, and the rest became the noun.** `wayfinder:map` stays, because enumerating maps has no other expression — `epic` is shared with ordinary containers. The four-value `wayfinder:<type>` scheme is replaced by `wayfinder:afk`: three of the four types are already a first-class facade field (a grilling ticket is a `decision`, a task a `chore`, research and prototype both `spike`), and a label restating a field is duplication. What the noun *cannot* express is whether an agent may resolve the ticket unattended — which is exactly what a session filters on when it fans out. Upstream's own text already makes HITL/AFK the primary classification, so this promotes the axis that was doing the work.

**The boundary against to-tickets is in both descriptions.** Wayfinder: a ticket here is resolved by answering it. To-tickets: resolved by shipping it, not by answering it. Two artifacts both claiming to break work into tracker items is the duplication the gate exists to catch.

**The charter is amended.** D18's disposition list filed `wayfinder` under skipped-and-re-admissible; a dated amendment records the admission and says why — the objection was its tracker binding, and the binding is now the facade. The original sentence is appended to, not rewritten.

## Two traps written into the skill because they will bite otherwise

`work update --set-description` **replaces**, so the map must be re-read immediately before writing it back or a concurrent session's line is lost — and upstream explicitly expects parallel sessions. And there is no delete verb, so an invalidated ticket is closed with a disposition saying why. That is arguably better than upstream: the route not taken stays on the record.

## The reference-file budget question from 9k9.107, answered

**Nothing charges reference files. They deploy in full, and no budget counts them.** The gate reads one file per skill and measures its body; the rest of the directory rides along inside an opaque copytree. Confirmed three ways behaviourally, not from the code alone — including that adding the provenance headers dropped all four measurements by exactly 7 tokens each, which is the sanitizer recognising the comment.

So `prototype`'s ~2,000 words of reference material cost nothing at any gate and ship to every tool. **The weight is real and uncharged**, which is the same shape `9k9.47` flags for descriptions. Filed separately as `9k9.167`.

## Provenance

Blob-verified, and the warning was well founded. At `ed37663c` — the commit the older registry rows used — `wayfinder` and `prototype` carry *different bytes* at the same paths. Pinning there would have named bytes we did not fork from. `wayfinder`'s content in fact postdates that commit.

## Evidence

`research` **267**, `prototype` **706**, `to-tickets` **1,421 / 5,000**, `wayfinder` **2,683 / 5,000** after splitting two lookup references. `content-lint`, `content-tests` and `make ci` all exit 0 from the worktree root.

## Follow-ups already filed

`9k9.156` (high priority) revises `to-spec` and `to-tickets` against the charter — both descend from an upstream design that treats the spec as a prose document. `9k9.157` carries wayfinder's remaining mechanical questions: whether a map has a completion condition, and whether it is the retired prose-plan class under a new name.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne