### PR TITLE
feat(9k9.154): grill a whole answerable frontier per round, and adopt /zoom-out

### DIFF
--- a/src/user/.agents/skills/grill-with-docs/SKILL.md
+++ b/src/user/.agents/skills/grill-with-docs/SKILL.md
@@ -3,29 +3,18 @@ name: grill-with-docs
 description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
 admission:
   prevents: An existing plan advancing to implementation while it still contradicts the project's glossary, ADRs, and code — the drift surfaces late as rework and human intervention.
-  cost: Adds a standalone deep session that cross-checks every claim against CONTEXT.md/ADR docs and holds the plan until its acceptance criteria are enumerated.
+  cost: Adds a deep session that runs the grilling interview with the domain model attached, cross-checking every claim against CONTEXT.md/ADR docs and holding the plan until its acceptance criteria are enumerated.
   remove_when: The readiness gate can mechanically detect glossary/ADR contradictions and prove enumerated red-test-convertible acceptance criteria without this session having run.
 ---
 
 <!--
 Source: skills/engineering/grill-with-docs/
-Upstream: https://github.com/mattpocock/skills @ ed37663cc5fbef691ddfecd080dff42f7e7e350d
-Last sync: 2026-05-23
-Drift policy: local-fork — grafted, do not re-sync
-Note: promoted from byte-identical local copy at <repo>/.claude/skills/grill-with-docs/.
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation — upstream's dispatcher shape is adopted, but the domain-model entry point and the docs cross-check on the exit criterion are local additions a byte-for-byte resync would revert. Take upstream changes selectively.
 -->
 
-<what-to-do>
-
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
-
-Ask the questions one at a time, waiting for feedback on each question before continuing.
-
-If a question can be answered by exploring the codebase, explore the codebase instead.
-
-</what-to-do>
-
-<supporting-info>
+Run a `grilling` session. The interview itself — the design tree, the rounds, the question frontier, and the acceptance-criteria exit criterion — lives in that skill, which this one composes rather than restates.
 
 ## Domain awareness
 
@@ -33,18 +22,6 @@ What separates this session from a plain grilling is that it maintains the proje
 
 **Invoke `domain-modeling` before you ask the first interview question.** Glossary entries and ADRs get written the moment a term or a decision crystallises rather than batched at the end, so the mechanics have to be in hand before the interview begins — not fetched partway through an answer.
 
-## Exit criterion
+## What this session adds to the exit criterion
 
-A deep session against the docs does not end at glossary agreement. It ends only when the plan's **acceptance criteria are enumerated with stable IDs**, each one stated so it is directly expressible as a *failing test* (red-test-convertible: a concrete observable — false today, true when the work is done — that a reader can check against the code and the docs).
-
-For every acceptance criterion, apply the edge-case taxonomy — surface and resolve, or explicitly rule out with a reason, each of:
-
-- **Inverse case** — the negative/failure path, not just the happy path.
-- **Empty / boundary input** — zero, empty, min, max, first, last.
-- **Dependency failure** — an upstream tool, file, service, or precondition is absent or errors.
-- **Repeated / concurrent invocation** — run twice, run in parallel, interleaved.
-- **Idempotency** — a second identical run changes nothing beyond the first.
-
-Cross-check each criterion against `CONTEXT.md` and the ADRs as you go: an AC that contradicts the recorded glossary or a documented decision is not done — resolve the contradiction (update the docs or revise the AC) before the session ends. If any AC lacks an ID, cannot be phrased as a failing test, or has an unaddressed taxonomy row, keep grilling until it can.
-
-</supporting-info>
+`grilling` already refuses to end until every acceptance criterion carries a stable ID, is expressible as a failing test, and has each edge-case taxonomy row resolved or ruled out. This session adds one condition to each of those criteria: cross-check it against `CONTEXT.md` and the ADRs as you go. A criterion that contradicts the recorded glossary or a documented decision is not done — resolve the contradiction, by updating the docs or by revising the criterion, before the session ends.

--- a/src/user/.agents/skills/grill-with-docs/SKILL.md
+++ b/src/user/.agents/skills/grill-with-docs/SKILL.md
@@ -14,7 +14,7 @@ Last sync: 2026-08-07
 Drift policy: selective-amalgamation — upstream's dispatcher shape is adopted, but the domain-model entry point and the docs cross-check on the exit criterion are local additions a byte-for-byte resync would revert. Take upstream changes selectively.
 -->
 
-Run a `grilling` session. The interview itself — the design tree, the rounds, the question frontier, and the acceptance-criteria exit criterion — lives in that skill, which this one composes rather than restates.
+**Invoke `grilling` at the start of this session.** The interview itself — the design tree, the rounds, the question frontier, and the acceptance-criteria exit criterion — lives in that skill, which this one composes rather than restates.
 
 ## Domain awareness
 

--- a/src/user/.agents/skills/grilling/SKILL.md
+++ b/src/user/.agents/skills/grilling/SKILL.md
@@ -3,30 +3,38 @@ name: grilling
 description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
 admission:
   prevents: Implementation starting from a goals-only idea whose decisions and edge cases were never resolved, forcing rework and human babysitting downstream.
-  cost: Front-loads a one-question-at-a-time interview and a terminal acceptance-criteria enumeration before any building begins.
+  cost: Front-loads a multi-round interview — one user round-trip per frontier, plus subagent fact-finding — and a terminal acceptance-criteria enumeration, before any building begins.
   remove_when: The readiness gate can mechanically prove a plan enumerates red-test-convertible acceptance criteria without this interview having run.
 ---
 
 <!--
 Source: skills/productivity/grilling/
-Upstream: https://github.com/mattpocock/skills @ ed37663cc5fbef691ddfecd080dff42f7e7e350d
-Last sync: 2026-07-24
-Drift policy: local-fork — grafted, do not re-sync
+Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
+Last sync: 2026-08-07
+Drift policy: selective-amalgamation — upstream's design-tree/round/frontier machinery is grafted onto a local exit criterion (acceptance-criteria IDs plus the edge-case taxonomy) that upstream does not carry. A byte-for-byte resync would revert the exit criterion; take upstream changes selectively.
 -->
 
-Interview me relentlessly about every aspect of this until we reach a shared understanding. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
 
-Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+Work the tree in **rounds**. The **question frontier** is every decision whose prerequisites are already settled — the questions you can ask *now* without guessing at answers you have not heard yet. Ask the whole question frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round. (The qualifier matters: this frontier is *questions that are answerable*, not work that is startable.)
 
-If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
+Format each question like this:
 
-Do not act on it until I confirm we have reached a shared understanding.
+```
+❓ **Q1** - **<question title>**: <question body, possibly several paragraphs, including any multiple choices>
+
+➡️ <your recommended answer>
+```
+
+Each round of answers reshapes the tree — settled decisions push the question frontier outward and unblock the questions that depended on them. Recompute it, then ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
+
+Finding *facts* is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, docs), dispatch a subagent to find it rather than asking the user for anything you could look up yourself. Do not block the round on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for that subagent to report — ask the rest of the question frontier now. The *decisions* are the user's: put each one to them and wait.
 
 ## Exit criterion
 
-The grilling session does not end until the plan's **acceptance criteria are enumerated with stable IDs**, and each one is stated so it is directly expressible as a *failing test* (red-test-convertible: a concrete observable that is false today and true when the work is done).
+An empty question frontier is necessary but not sufficient. The session does not end until the plan's **acceptance criteria are enumerated with stable IDs**, each one stated so it is directly expressible as a *failing test* (red-test-convertible: a concrete observable that is false today and true when the work is done).
 
-For every acceptance criterion, apply the edge-case taxonomy — surface and resolve, or explicitly rule out with a reason, each of:
+Those criteria are branches of the same tree, not a checklist bolted onto the end. For every acceptance criterion, each row of the edge-case taxonomy is itself a question on the frontier — resolve it, or explicitly rule it out with a reason:
 
 - **Inverse case** — the negative/failure path, not just the happy path.
 - **Empty / boundary input** — zero, empty, min, max, first, last.
@@ -34,4 +42,4 @@ For every acceptance criterion, apply the edge-case taxonomy — surface and res
 - **Repeated / concurrent invocation** — run twice, run in parallel, interleaved.
 - **Idempotency** — a second identical run changes nothing beyond the first.
 
-If any AC lacks an ID, cannot be phrased as a failing test, or has an unaddressed taxonomy row, the session is not done — keep grilling until it is.
+If any criterion lacks an ID, cannot be phrased as a failing test, or has an unaddressed taxonomy row, the frontier is not empty — keep grilling. Do not act on the plan until the user confirms you have reached a shared understanding.

--- a/src/user/.agents/skills/grilling/SKILL.md
+++ b/src/user/.agents/skills/grilling/SKILL.md
@@ -18,13 +18,11 @@ Interview the user relentlessly until you reach a shared understanding. Map this
 
 Work the tree in **rounds**. The **question frontier** is every decision whose prerequisites are already settled — the questions you can ask *now* without guessing at answers you have not heard yet. Ask the whole question frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round. (The qualifier matters: this frontier is *questions that are answerable*, not work that is startable.)
 
-Format each question like this:
+Format each question like this, as Markdown in your reply rather than inside a code block:
 
-```
-❓ **Q1** - **<question title>**: <question body, possibly several paragraphs, including any multiple choices>
+❓ **Q1** - **Question title**: question body, possibly several paragraphs, including any multiple choices.
 
-➡️ <your recommended answer>
-```
+➡️ Your recommended answer
 
 Each round of answers reshapes the tree — settled decisions push the question frontier outward and unblock the questions that depended on them. Recompute it, then ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
 

--- a/src/user/.claude/commands/zoom-out.md
+++ b/src/user/.claude/commands/zoom-out.md
@@ -1,0 +1,20 @@
+---
+description: Map the code in view to the layer above it — the relevant modules, their callers, and the project's own vocabulary for them. For when you do not know this part of the codebase.
+admission:
+  provides: A fixed request for the layer above the code in view. Invoking it produces a map of the relevant modules and their callers, named in the project's glossary vocabulary rather than in whatever terms the model reaches for first — so the altitude and the vocabulary are both settled by typing the command instead of being renegotiated in prose each time.
+  cost: One Claude-scoped command. Nothing is always-on — the two-line body is paid only when someone types it, and the exploration behind the map is paid then too.
+  remove_when: Asking about an unfamiliar area of code in plain words, with no command typed, already returns a module-and-caller map in the project's glossary vocabulary on two consecutive occasions.
+---
+
+<!--
+Source: skills/engineering/zoom-out/
+Upstream: https://github.com/mattpocock/skills @ e74f0061bb67222181640effa98c675bdb2fdaa7
+Last sync: 2026-08-07
+Drift policy: rewrite-and-divorce — upstream deleted this skill after the pinned commit, so there is nothing left to resync against. The pin is a historical origin for the utterance, which is verbatim upstream; the asset type (Claude command, not skill) and the record are ours.
+-->
+
+# /zoom-out
+
+`$ARGUMENTS` optionally names the area to map; empty means the code already in view.
+
+I don't know this area of code well. Go up a layer of abstraction. Give me a map of all the relevant modules and callers, using the project's domain glossary vocabulary.


### PR DESCRIPTION
Resyncs `grilling` with upstream's frontier machinery, stops `grill-with-docs` inlining a copy of it, and adopts `zoom-out` as a command.

## What the frontier machinery changes

Before: *"Ask the questions one at a time, waiting for feedback on each."* A plan with twenty decisions cost twenty user round-trips — which is the babysitting the prime directive exists to remove.

After, the session is a decision tree walked in rounds. Compute the **question frontier** — every decision whose prerequisites are settled — and ask that entire frontier in one message, numbered, each with a recommended answer. Answers reshape the tree and push the frontier outward.

**The round count becomes the depth of the tree rather than its size.** A question depending on another still open this round is deferred, which is what stops the batch being the bewildering pile the old rule guarded against: the guard survives as a dependency test rather than a blanket rule.

Fact-finding dispatches to a subagent and the round does not block on it — the running exploration is an unsettled prerequisite, so only questions downstream of it wait.

## The exit criterion composes rather than stacks

This was the stop-and-report risk. Upstream terminates on an empty frontier; ours terminates on every acceptance criterion having an ID, being red-test-convertible, and every taxonomy row discharged. Stacked as two independent conditions they can disagree. Instead **each unresolved taxonomy row is itself a question on the frontier**, so the two are one condition stated at both ends of the body. Nothing was dropped from the local addition.

## A second duplicate, beyond the one the work item named

`grill-with-docs` also carried its own copy of the exit criterion — the same stable-IDs paragraph and the same five-row taxonomy `grilling` states. Once it dispatches, that copy is hand-synced dead weight: the same defect, not a new one. Cut, keeping the genuinely additive clause — cross-check each criterion against `CONTEXT.md` and the ADRs.

The duplication was verified before cutting, not taken on faith: three sentences against three near-verbatim counterparts, differing only in "this" versus "this plan", "decision tree" versus "design tree", and one dropped clause. Upstream corroborates — its `grill-with-docs` is a single dispatch line with no interview block.

## The frontier word collision

`to-tickets` uses *frontier* for startable tickets; ours means answerable questions. Same graph shape, different node type. Resolved by **renaming ours to the question frontier** with an inline gloss, rather than cross-referencing the sibling — a cross-reference couples deployed prose to a branch that might not land, and a qualifier travels with every occurrence instead of sitting only at the definition. The sibling PR qualifies its own use symmetrically.

## Evidence

`grilling` 412 → **713** (it gains the machinery and keeps the entire local exit criterion). `grill-with-docs` 645 → **380**, continuing 1,154 → 645 → 380 across two PRs, a 67% cut. The pair went from 1,057 tokens to 1,093 for materially more behaviour and no duplicated text.

`/zoom-out`'s deployed body is ~67 tokens against the neighbouring command's ~2,319. It does not lean on the missing command budget (`9k9.115`) — it would pass the skill cap thirty times over.

**A control so the gate pass is not vacuous:** `content-lint` lists no commands, so a green run does not by itself prove it inspected the commands directory. A record-less throwaway command was planted there and the gate exited 2 naming it. Probe deleted, gate re-run to 0, tree clean.

Pins blob-verified. `zoom-out`'s removal from upstream verified too — present at the pin, absent from the recursive tree at head — which is why its drift policy is `rewrite-and-divorce`: there is nothing left to resync against.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne