### PR TITLE
feat(9k9.155, 9k9.1.13): one worktree skill, with the detection in code

### DIFF
--- a/src/user/.agents/skills/using-git-worktrees/SKILL.md
+++ b/src/user/.agents/skills/using-git-worktrees/SKILL.md
@@ -26,12 +26,14 @@ you are not, and committing to the user's branch.
 
 ## 1. Survey before you create
 
-Run `scripts/worktree_status.py` from anywhere in the project. It prints where
+Run this skill's bundled `scripts/worktree_status.py` — that path is inside the
+skill's own directory, not the project's. It reports on the working directory
+you run it from, so run it from anywhere inside the project: it prints where
 you are, what git thinks the workspace is, and whether the conventional
-directories are ignored. It resolves both git paths before comparing them and
-probes ignore rules with a path that answers correctly whether or not the
-directory exists — do not re-derive either check by hand, because both are
-wrong when taken the obvious way.
+directories are ignored. It resolves both git paths before comparing them, and
+probes ignore rules from the repository top level with a path that answers
+correctly whether or not the directory exists — do not re-derive either check
+by hand, because both are wrong when taken the obvious way.
 
 | `verdict:` | What it means | What to do |
 |---|---|---|

--- a/src/user/.agents/skills/using-git-worktrees/SKILL.md
+++ b/src/user/.agents/skills/using-git-worktrees/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: using-git-worktrees
+description: Create a git worktree, and find out which workspace you are already standing in before you create anything. Use before starting work that must not touch the branch currently checked out, when a task says to work in an isolated workspace, or when you are unsure whether you are already in one. Not for deleting a worktree or a branch once work has merged — that is post-merge-cleanup.
+admission:
+  prevents: Isolation being judged by eye and judged wrong. The obvious check — comparing what `git rev-parse --git-dir` and `--git-common-dir` print — reports "already isolated" from any subdirectory of an ordinary checkout, because git prints one absolute and one relative, so the work lands on the branch the user had open. The obvious ignore check, `git check-ignore -q .worktrees`, answers "not ignored" against the conventional `.worktrees/` pattern whenever the directory does not exist yet, which is the state you are in before the first worktree. Both reproduce on git 2.50, the second against this project's own .gitignore.
+  cost: One catalog description, always-on, on every tool that installs it. The body and one script run are paid on invoke.
+  remove_when: Every supported tool exposes a worktree primitive of its own that reports what it created, so no agent reaches `git worktree add` by hand.
+---
+
+<!--
+Source: skills/using-git-worktrees/
+Upstream: https://github.com/obra/superpowers @ f2cbfbefebbfef77321e4c9abc9e949826bea9d7 (v5.1.0)
+Last sync: 2026-08-07
+Drift policy: rewrite-and-divorce. The step order and the location convention come from upstream; the detection is now a shipped script that corrects two measurements upstream's prose gets wrong, and the consent prompt is deliberately removed. A resync would reintroduce both.
+-->
+
+# Using git worktrees
+
+A worktree is a second checkout of one repository, on its own branch, with its
+own index and HEAD. It lets work proceed without disturbing whatever the user
+has open.
+
+Creating one is cheap. Creating a second one because you could not tell you
+were already inside the first is not — nor is deciding you are isolated when
+you are not, and committing to the user's branch.
+
+## 1. Survey before you create
+
+Run `scripts/worktree_status.py` from anywhere in the project. It prints where
+you are, what git thinks the workspace is, and whether the conventional
+directories are ignored. It resolves both git paths before comparing them and
+probes ignore rules with a path that answers correctly whether or not the
+directory exists — do not re-derive either check by hand, because both are
+wrong when taken the obvious way.
+
+| `verdict:` | What it means | What to do |
+|---|---|---|
+| `linked-worktree` | Already isolated, on the branch reported | Nothing. Work here. Do not nest another. |
+| `main-checkout` | An ordinary checkout — the user's workspace | Step 2, if the task needs isolation. |
+| `submodule` | Inside a submodule of the project named on `submodule-of:` | Step 2 here isolates **the submodule**, not the project. Move to the superproject first unless the submodule is genuinely the target. |
+| `not-a-git-repository` | Nothing to isolate | Say so. Do not `git init`. |
+
+If `branch:` reads `(detached HEAD)`, you are isolated but have nowhere to
+commit; create a branch before writing anything.
+
+## 2. Create the worktree
+
+If your harness has its own worktree primitive — a tool or command that creates
+one and tells you where it put it — use that instead of this step. It owns
+placement and cleanup; going around it leaves state the harness cannot see.
+
+Otherwise, and only from a `main-checkout`:
+
+```bash
+git worktree list                      # where does this project already put them?
+git worktree add <dir>/<branch> -b <branch>
+```
+
+**Placement.** Match what `git worktree list` already shows — several agents
+may share this project, and one convention is what lets them find each other's
+work. With nothing to match, use `.worktrees/<branch>` at the top level.
+
+**The directory must be ignored before anything is created in it**, or the next
+`git add` sweeps an entire second checkout into the index. The survey's
+`candidate:` lines answer this already. If it reports `ignored=no`, add the
+directory to `.gitignore` and commit that first.
+
+**Branch names are exclusive.** One branch can be checked out in one worktree
+at a time; `git worktree add` refuses a branch another worktree holds, and
+names it. That refusal is information — go to that worktree rather than around
+it.
+
+If creation fails on permissions, the sandbox blocked it. Say so and work in
+place; do not retry variations.
+
+## 3. Working inside one
+
+**Absolute paths only.** `git worktree add` creates the directory and leaves
+you where you were. And because a worktree is a full second copy of the tree,
+a relative path like `src/thing.py` is valid in *both* copies: it does not
+error, it silently resolves against whichever tree the thing resolving it
+happens to be standing in. Build every path from the `toplevel:` the survey
+printed, and re-run the survey rather than assuming a `cd` reached everything.
+
+**One committer per worktree.** The index and HEAD are per-worktree, so
+separate worktrees never collide — but two things committing in the *same* one
+do: the second gets `Unable to create '.git/index.lock': File exists` and
+fails. If you delegate work into a worktree, one agent commits there.
+
+**Do not remove a worktree anything is still standing in.** Once the directory
+is gone, every command from a process whose working directory was inside it
+fails with `Unable to read current working directory`, and the shell stays
+broken until something moves it elsewhere. Leave first, then remove.
+
+## What this is not
+
+This skill creates worktrees and works inside them. Removing one, and deleting
+the branch it held once that work has merged, is `post-merge-cleanup` — a
+different question with a different failure mode, since proving a branch merged
+is what makes deleting it safe.

--- a/src/user/.agents/skills/using-git-worktrees/SKILL.md
+++ b/src/user/.agents/skills/using-git-worktrees/SKILL.md
@@ -89,10 +89,19 @@ error, it silently resolves against whichever tree the thing resolving it
 happens to be standing in. Build every path from the `toplevel:` the survey
 printed, and re-run the survey rather than assuming a `cd` reached everything.
 
-**One committer per worktree.** The index and HEAD are per-worktree, so
-separate worktrees never collide — but two things committing in the *same* one
-do: the second gets `Unable to create '.git/index.lock': File exists` and
-fails. If you delegate work into a worktree, one agent commits there.
+**One committer per worktree.** Two things committing in the same worktree
+collide: the second gets `Unable to create '.git/index.lock': File exists` and
+fails. Two worktrees do not collide **so long as they hold different
+branches** — which is what git enforces when it refuses to check one branch out
+twice. Force past that refusal and the protection is gone: each worktree's HEAD
+is a symref to the one shared branch ref, so a commit in one moves the other's
+HEAD, and the other's next commit is built on a stale index and silently drops
+the first one's files. Exit 0, no warning. Give each committer its own branch.
+
+**Delegate with an absolute path.** If you hand work that commits to another
+agent, give it the absolute path of the worktree. A delegate that starts
+somewhere else commits to whatever *that* place has checked out — which is
+usually the branch the user had open.
 
 **Do not remove a worktree anything is still standing in.** Once the directory
 is gone, every command from a process whose working directory was inside it

--- a/src/user/.agents/skills/using-git-worktrees/SKILL.md
+++ b/src/user/.agents/skills/using-git-worktrees/SKILL.md
@@ -49,7 +49,13 @@ If your harness has its own worktree primitive — a tool or command that create
 one and tells you where it put it — use that instead of this step. It owns
 placement and cleanup; going around it leaves state the harness cannot see.
 
-Otherwise, and only from a `main-checkout`:
+**A new worktree starts from the last commit, not from what is on disk.**
+Unstaged edits, staged-but-uncommitted files and untracked files all stay
+behind in the checkout you left. Run `git status` first: if the work you are
+about to isolate is sitting there uncommitted, commit or stash it, or you will
+arrive in the new worktree without it.
+
+Then, and only from a `main-checkout`:
 
 ```bash
 git worktree list                      # where does this project already put them?
@@ -58,7 +64,8 @@ git worktree add <dir>/<branch> -b <branch>
 
 **Placement.** Match what `git worktree list` already shows — several agents
 may share this project, and one convention is what lets them find each other's
-work. With nothing to match, use `.worktrees/<branch>` at the top level.
+work. Ignore any entry marked `prunable`: its directory is already gone. With
+nothing to match, use `.worktrees/<branch>` at the top level.
 
 **The directory must be ignored before anything is created in it**, or the next
 `git add` sweeps an entire second checkout into the index. The survey's

--- a/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status.py
+++ b/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Survey the git workspace you are standing in, before creating another one.
+
+Run with no arguments from anywhere inside the project. Prints one labelled
+fact per line and exits 0; exits 2 when the directory is not inside a git
+repository.
+
+Two of these measurements are wrong when taken the obvious way. Both were
+verified against git 2.50:
+
+* ``--git-dir`` and ``--git-common-dir`` are each printed relative to the
+  current directory *or* absolute, depending on where you stand. From a
+  subdirectory of an ordinary checkout they read ``/abs/repo/.git`` and
+  ``../../.git`` — two different strings naming one directory. Comparing the
+  printed strings therefore concludes "already isolated" in an ordinary
+  checkout, and the work lands on the branch the user had open. Both are
+  resolved against the current directory, and through symlinks, before they
+  are compared.
+
+* ``git check-ignore -q .worktrees`` answers "not ignored" while the
+  conventional ``.worktrees/`` pattern sits in ``.gitignore``, because a
+  pattern ending in a slash matches directories only and that directory does
+  not exist yet — which is exactly the state you are in before the first
+  worktree. A path *inside* the directory is tested instead, which answers
+  correctly whether or not the directory exists.
+
+A directory holding worktrees must be ignored before anything is created in
+it, or the next ``git add`` sweeps a whole second checkout into the index.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Where worktrees are conventionally kept, best first. The hidden name is the
+# default; a project that already has the visible one gets to keep it.
+CANDIDATE_DIRS = (".worktrees", "worktrees")
+
+
+def git(*args: str, cwd: str | None = None) -> str | None:
+    """Run a git command and return its stripped stdout, or None if it failed.
+
+    Failure and empty output are deliberately distinct: several of these
+    queries answer a question by printing nothing at all.
+    """
+    proc = subprocess.run(  # noqa: S603
+        ("git", *args), cwd=cwd, capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def resolve_git_path(printed: str, cwd: str) -> Path:
+    """Turn what git printed for a directory into one comparable absolute path.
+
+    ``Path(cwd) / printed`` keeps an already-absolute value unchanged, so this
+    covers both shapes git emits, and ``realpath`` settles symlinks so two
+    routes to one directory compare equal.
+    """
+    return Path(os.path.realpath(Path(cwd) / printed))
+
+
+def classify(git_dir: Path, common_dir: Path, superproject: str) -> str:
+    """Name the workspace: linked-worktree, submodule, or main-checkout.
+
+    The worktree test is asked first and answers for a linked worktree of a
+    submodule too, which reports no superproject of its own.
+    """
+    if git_dir != common_dir:
+        return "linked-worktree"
+    if superproject:
+        return "submodule"
+    return "main-checkout"
+
+
+def main_worktree(cwd: str) -> str | None:
+    """The path of the main checkout, which git lists first from anywhere."""
+    listing = git("worktree", "list", "--porcelain", cwd=cwd)
+    if listing is None:
+        return None
+    for line in listing.splitlines():
+        if line.startswith("worktree "):
+            return line[len("worktree ") :]
+    return None
+
+
+def is_ignored(directory: str, cwd: str) -> bool:
+    """Whether a directory of that name would be ignored if it existed."""
+    return git("check-ignore", "-q", f"{directory}/probe", cwd=cwd) is not None
+
+
+def yn(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def survey(cwd: str) -> list[str] | None:
+    """The whole report as labelled lines, or None outside a git repository."""
+    printed_git_dir = git("rev-parse", "--git-dir", cwd=cwd)
+    printed_common = git("rev-parse", "--git-common-dir", cwd=cwd)
+    if printed_git_dir is None or printed_common is None:
+        return None
+
+    git_dir = resolve_git_path(printed_git_dir, cwd)
+    common_dir = resolve_git_path(printed_common, cwd)
+    superproject = git("rev-parse", "--show-superproject-working-tree", cwd=cwd) or ""
+    verdict = classify(git_dir, common_dir, superproject)
+
+    toplevel = git("rev-parse", "--show-toplevel", cwd=cwd) or ""
+    branch = git("branch", "--show-current", cwd=cwd) or ""
+
+    lines = [
+        f"verdict: {verdict}",
+        f"toplevel: {toplevel}",
+        f"branch: {branch or '(detached HEAD)'}",
+        f"main-checkout: {main_worktree(cwd) or '(unknown)'}",
+        f"git-dir: {git_dir}",
+        f"git-common-dir: {common_dir}",
+        f"submodule-of: {superproject or '(none)'}",
+    ]
+
+    # Only the placement decision needs the ignore survey, and a linked
+    # worktree is not making one.
+    if verdict != "linked-worktree" and toplevel:
+        for name in CANDIDATE_DIRS:
+            exists = (Path(toplevel) / name).is_dir()
+            ignored = is_ignored(name, cwd)
+            lines.append(f"candidate: {name} exists={yn(exists)} ignored={yn(ignored)}")
+    return lines
+
+
+def run(cwd: str) -> int:
+    lines = survey(cwd)
+    if lines is None:
+        print("verdict: not-a-git-repository", file=sys.stderr)
+        return 2
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run(os.getcwd()))

--- a/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status.py
+++ b/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status.py
@@ -22,7 +22,10 @@ verified against git 2.50:
   pattern ending in a slash matches directories only and that directory does
   not exist yet — which is exactly the state you are in before the first
   worktree. A path *inside* the directory is tested instead, which answers
-  correctly whether or not the directory exists.
+  correctly whether or not the directory exists, and it is tested from the
+  repository top level, because the directory being judged is the top-level
+  one and ``check-ignore`` resolves a relative path against the directory it
+  runs in.
 
 A directory holding worktrees must be ignored before anything is created in
 it, or the next ``git add`` sweeps a whole second checkout into the index.
@@ -88,9 +91,17 @@ def main_worktree(cwd: str) -> str | None:
     return None
 
 
-def is_ignored(directory: str, cwd: str) -> bool:
-    """Whether a directory of that name would be ignored if it existed."""
-    return git("check-ignore", "-q", f"{directory}/probe", cwd=cwd) is not None
+def is_ignored(directory: str, toplevel: str) -> bool:
+    """Whether that top-level directory would be ignored if it existed.
+
+    The probe runs from ``toplevel`` and not from wherever the caller stands,
+    because ``check-ignore`` resolves a relative path against the directory it
+    runs in. Asked from a subdirectory it would answer for
+    ``<subdirectory>/<directory>`` — a different path, which a root-anchored
+    pattern does not match and a subdirectory's own ``.gitignore`` may match
+    when the top-level one does not.
+    """
+    return git("check-ignore", "-q", f"{directory}/probe", cwd=toplevel) is not None
 
 
 def yn(value: bool) -> str:
@@ -127,7 +138,7 @@ def survey(cwd: str) -> list[str] | None:
     if verdict != "linked-worktree" and toplevel:
         for name in CANDIDATE_DIRS:
             exists = (Path(toplevel) / name).is_dir()
-            ignored = is_ignored(name, cwd)
+            ignored = is_ignored(name, toplevel)
             lines.append(f"candidate: {name} exists={yn(exists)} ignored={yn(ignored)}")
     return lines
 

--- a/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status_test.py
+++ b/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status_test.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest>=8"]
+# ///
+"""Tests for worktree_status.py — the workspace survey behind using-git-worktrees.
+
+These build real repositories rather than faking git's output, because what
+the script exists to get right *is* git's output: the two measurements it
+corrects are wrong only against a live repository, and a fake would encode the
+same misunderstanding the script was written to fix. The two regression tests
+are `test_subdirectory_of_plain_checkout_is_not_a_worktree` and
+`test_dir_only_pattern_is_ignored_before_the_directory_exists`; the rest hold
+the surrounding behaviour still.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from worktree_status import (  # noqa: E402
+    classify,
+    is_ignored,
+    main_worktree,
+    resolve_git_path,
+    survey,
+)
+
+
+def run(cwd: Path, *args: str) -> None:
+    """A git command that must succeed for the fixture to be meaningful."""
+    subprocess.run(("git", *args), cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def make_repo(root: Path) -> Path:
+    """An ordinary checkout with one commit on one branch."""
+    root.mkdir(parents=True, exist_ok=True)
+    run(root, "init", "-q", "-b", "main")
+    run(root, "config", "user.email", "t@example.com")
+    run(root, "config", "user.name", "Test")
+    (root / "a.txt").write_text("a\n")
+    run(root, "add", "a.txt")
+    run(root, "commit", "-qm", "init")
+    return root
+
+
+def field(lines: list[str], key: str) -> str:
+    """The value of one `key: value` line from a survey report."""
+    for line in lines:
+        if line.startswith(f"{key}: "):
+            return line[len(key) + 2 :]
+    raise AssertionError(f"no {key!r} line in {lines!r}")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    return make_repo(tmp_path / "repo")
+
+
+# --- path resolution -------------------------------------------------------
+
+
+def test_relative_and_absolute_forms_resolve_to_one_path(tmp_path: Path) -> None:
+    # git prints --git-dir absolute and --git-common-dir relative from the same
+    # directory. Both spellings must land on the same Path or the worktree test
+    # compares two names for one thing and calls them different.
+    (tmp_path / "repo" / ".git").mkdir(parents=True)
+    deep = tmp_path / "repo" / "deep" / "nested"
+    deep.mkdir(parents=True)
+
+    absolute = resolve_git_path(str(tmp_path / "repo" / ".git"), str(deep))
+    relative = resolve_git_path("../../.git", str(deep))
+
+    assert absolute == relative
+
+
+# --- classification --------------------------------------------------------
+
+
+def test_classify_names_each_workspace() -> None:
+    assert classify(Path("/r/.git/worktrees/x"), Path("/r/.git"), "") == "linked-worktree"
+    assert classify(Path("/r/.git/modules/m"), Path("/r/.git/modules/m"), "/r") == "submodule"
+    assert classify(Path("/r/.git"), Path("/r/.git"), "") == "main-checkout"
+
+
+def test_a_linked_worktree_of_a_submodule_reads_as_a_worktree() -> None:
+    # git reports no superproject from inside such a worktree, so the worktree
+    # test has to be asked first for this case to answer at all.
+    assert classify(Path("/s/.git/modules/m/worktrees/w"), Path("/s/.git/modules/m"), "") == (
+        "linked-worktree"
+    )
+
+
+# --- the survey against real repositories ----------------------------------
+
+
+def test_plain_checkout_is_not_a_worktree(repo: Path) -> None:
+    lines = survey(str(repo))
+    assert lines is not None
+    assert field(lines, "verdict") == "main-checkout"
+    assert field(lines, "branch") == "main"
+
+
+def test_subdirectory_of_plain_checkout_is_not_a_worktree(repo: Path) -> None:
+    # The regression. From here git prints --git-dir absolute and
+    # --git-common-dir relative, so comparing the printed strings reports a
+    # worktree that does not exist and the agent works on the user's branch.
+    deep = repo / "deep" / "nested"
+    deep.mkdir(parents=True)
+
+    lines = survey(str(deep))
+
+    assert lines is not None
+    assert field(lines, "verdict") == "main-checkout"
+
+
+def test_linked_worktree_is_detected(repo: Path, tmp_path: Path) -> None:
+    linked = tmp_path / "linked"
+    run(repo, "worktree", "add", "-q", str(linked), "-b", "feature")
+
+    lines = survey(str(linked))
+
+    assert lines is not None
+    assert field(lines, "verdict") == "linked-worktree"
+    assert field(lines, "branch") == "feature"
+    # A linked worktree is not choosing a location, so the placement survey is
+    # not run and cannot mislead a caller into a second `.gitignore` entry.
+    assert not [line for line in lines if line.startswith("candidate: ")]
+
+
+def test_detached_head_is_reported_not_blank(repo: Path, tmp_path: Path) -> None:
+    linked = tmp_path / "detached"
+    run(repo, "worktree", "add", "-q", "--detach", str(linked))
+
+    lines = survey(str(linked))
+
+    assert lines is not None
+    assert field(lines, "branch") == "(detached HEAD)"
+
+
+def test_main_checkout_is_named_from_inside_a_worktree(repo: Path, tmp_path: Path) -> None:
+    linked = tmp_path / "linked"
+    run(repo, "worktree", "add", "-q", str(linked), "-b", "feature")
+
+    assert main_worktree(str(linked)) == str(repo.resolve())
+    assert field(survey(str(linked)) or [], "main-checkout") == str(repo.resolve())
+
+
+def test_submodule_is_told_apart_from_a_worktree(tmp_path: Path) -> None:
+    # Both live under the superproject's .git, and creating a worktree from
+    # inside one isolates the submodule rather than the project you meant.
+    lib = make_repo(tmp_path / "lib")
+    super_repo = make_repo(tmp_path / "super")
+    run(
+        super_repo,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        str(lib),
+        "vendor/lib",
+    )
+    run(super_repo, "commit", "-qm", "add submodule")
+
+    lines = survey(str(super_repo / "vendor" / "lib"))
+
+    assert lines is not None
+    assert field(lines, "verdict") == "submodule"
+    assert field(lines, "submodule-of") == str(super_repo.resolve())
+
+
+def test_outside_a_repository_there_is_nothing_to_report(tmp_path: Path) -> None:
+    bare = tmp_path / "not-a-repo"
+    bare.mkdir()
+    assert survey(str(bare)) is None
+
+
+# --- the ignore check ------------------------------------------------------
+
+
+def test_dir_only_pattern_is_ignored_before_the_directory_exists(repo: Path) -> None:
+    # The regression. `.worktrees/` matches directories only, and asking about
+    # `.worktrees` before creating it answers "not ignored" — the state you are
+    # in before the first worktree. Probing a path inside answers correctly.
+    (repo / ".gitignore").write_text(".worktrees/\n")
+
+    assert is_ignored(".worktrees", str(repo)) is True
+
+
+def test_an_unignored_directory_is_reported_as_such(repo: Path) -> None:
+    (repo / ".gitignore").write_text(".worktrees/\n")
+
+    assert is_ignored("worktrees", str(repo)) is False
+
+
+def test_survey_reports_both_candidates_with_their_ignore_state(repo: Path) -> None:
+    (repo / ".gitignore").write_text(".worktrees/\n")
+
+    lines = survey(str(repo)) or []
+
+    assert "candidate: .worktrees exists=no ignored=yes" in lines
+    assert "candidate: worktrees exists=no ignored=no" in lines
+
+
+def test_an_existing_candidate_directory_is_reported_as_existing(repo: Path) -> None:
+    (repo / ".gitignore").write_text(".worktrees/\n")
+    (repo / ".worktrees").mkdir()
+
+    lines = survey(str(repo)) or []
+
+    assert "candidate: .worktrees exists=yes ignored=yes" in lines
+
+
+if __name__ == "__main__":
+    sys.dont_write_bytecode = True
+    sys.exit(pytest.main([__file__, "-q", "-p", "no:cacheprovider"]))

--- a/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status_test.py
+++ b/src/user/.agents/skills/using-git-worktrees/scripts/worktree_status_test.py
@@ -218,6 +218,56 @@ def test_an_existing_candidate_directory_is_reported_as_existing(repo: Path) -> 
     assert "candidate: .worktrees exists=yes ignored=yes" in lines
 
 
+# --- the answer does not depend on where you stand -------------------------
+#
+# The survey reports on the *top-level* candidate directory — `exists` is
+# already measured there — but `check-ignore` resolves a relative path against
+# the directory it runs in. Probed from a subdirectory it answers for
+# `<subdirectory>/.worktrees`, a different path, and the two cases below are
+# where that different path gets a different answer.
+
+
+def test_root_anchored_pattern_is_ignored_from_a_subdirectory(repo: Path) -> None:
+    # A pattern anchored at the repository root matches the top-level
+    # directory only. Probed from a subdirectory it does not match, and the
+    # survey reports an ignored directory as unignored: the caller then adds a
+    # second, redundant `.gitignore` entry it was told to commit first.
+    (repo / ".gitignore").write_text("/.worktrees/\n")
+    deep = repo / "deep" / "nested"
+    deep.mkdir(parents=True)
+
+    lines = survey(str(deep)) or []
+
+    assert "candidate: .worktrees exists=no ignored=yes" in lines
+
+
+def test_a_subdirectorys_own_gitignore_does_not_answer_for_the_top_level(repo: Path) -> None:
+    # The dangerous direction. Nothing ignores the top-level `.worktrees`, but
+    # a `.gitignore` beside the caller matches the path the probe resolves to,
+    # so the survey reports `ignored=yes` and the caller creates an unignored
+    # second checkout that the next `git add` sweeps into the index.
+    (repo / ".gitignore").write_text("unrelated\n")
+    deep = repo / "deep" / "nested"
+    deep.mkdir(parents=True)
+    (deep / ".gitignore").write_text(".worktrees/\n")
+
+    lines = survey(str(deep)) or []
+
+    assert "candidate: .worktrees exists=no ignored=no" in lines
+
+
+def test_the_whole_survey_reads_the_same_from_anywhere_in_the_checkout(repo: Path) -> None:
+    # The invariant the two cases above are instances of, stated once: the
+    # skill tells the caller to run this from anywhere in the project, so
+    # every line of it has to be a fact about the project rather than about
+    # the directory the caller happened to be standing in.
+    (repo / ".gitignore").write_text("/.worktrees/\n")
+    deep = repo / "deep" / "nested"
+    deep.mkdir(parents=True)
+
+    assert survey(str(deep)) == survey(str(repo))
+
+
 if __name__ == "__main__":
     sys.dont_write_bytecode = True
     sys.exit(pytest.main([__file__, "-q", "-p", "no:cacheprovider"]))


### PR DESCRIPTION
Merges the archived `using-git-worktrees` skill with the two sibling rules `9k9.1.13` names, and puts the mechanical part in a tested script.

## The central claim reproduced, but inverted — and the real case is worse

Inside a worktree the two git paths do differ. The dangerous case is the opposite one: **from a subdirectory of an ordinary checkout, git prints one absolute path and one relative one** (`/abs/repo/.git` versus `../../.git`) — two strings, one directory. A naive `!=` therefore reports isolation that **does not exist**, and the agent commits to the branch the user had open.

The failure the archived skill described was misplaced state inside a worktree. The actual failure is believing you are isolated when you are in the user's workspace. Now a script with a regression test.

**The submodule guard was needed for a different reason than stated.** Inside a submodule the two paths are equal, so there is no false positive to suppress. The real hazard is that `git worktree add` from inside a submodule isolates the submodule. Guard kept, reasoning corrected.

**A second defect nobody had flagged:** the archived skill's own prescribed `git check-ignore -q .worktrees` answers "not ignored" whenever the pattern is `.worktrees/` and the directory does not exist yet — which is the state you are in before the first worktree. Following it adds a duplicate entry and commits it. Both defects have named regression tests.

## Checklist disposition — an unverifiable claim does not ship

**Kept, verified:** isolation-by-path (now the script), phantom cwd after premature removal, one committer per worktree.

**Kept, rationale corrected:** the one-committer rule. Its archived premise — a shared index — is false; index and HEAD files are per-worktree. The isolation actually comes from the branches differing, which git enforces *unless someone passes `--force`*. Measured with one branch in two worktrees: a commit in one moves the other's HEAD, and the other's next commit silently drops its files at exit 0. The rule's conclusion holds; the stated reason did not, and the corrected text names the condition rather than softening the claim.

**Dropped, premise false:** commit-banner SHA capture (HEAD is per-worktree, so a post-commit read cannot return a sibling's commit), and the locked-database copy hazard (worktrees do not share a database; it also named a specific backend, which deployed prose may not).

**Dropped on placement:** subagent cwd inheritance and the `isolation: worktree` bug. This is a four-tool shared skill and cannot assert one harness's behaviour. Both were measured anyway: `isolation: "worktree"` **works**, and subagents do **not** inherit their parent's worktree — they start in the session root, which is a live footgun and is why the skill now says to hand a delegate the absolute path.

**Out of scope:** `-D` after a squash merge is `post-merge-cleanup`'s question, and that skill already covers it.

## Boundary

`post-merge-cleanup` contains zero occurrences of "creat" or "add". Pure complement — that deletes, this creates. Stated in the description and again in a closing section.

## Evidence

Body **1,303 of 2,000**. `content-lint` and `content-tests` exit 0 from the worktree root, the latter including the new 14-test suite. Staging confirmed by driving the installer's own `stage_src`: the skill stages for all four tools, the script ships, the test suite does not.

Pin verified against upstream; the bytes differ from the archived copy, which is what makes `rewrite-and-divorce` honest. The archived `Source:` pointed at a vendored snapshot tree this repo deleted; corrected.

## Flagged

`9k9.1.13` says the mechanical parts go into the S9 executor's worktree code. They are in a script inside the skill, per the acceptance criteria. If the executor is meant to own worktree creation, this script is the thing to move and its tests move with it.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne