### PR TITLE
docs(9k9.101): a provenance block means external derivation, and the rule now says so from both sides

### DIFF
--- a/.claude/skills/admit-request/SKILL.md
+++ b/.claude/skills/admit-request/SKILL.md
@@ -197,13 +197,14 @@ source, it MUST carry the provenance header immediately after the front matter,
 using the literal audit keys (`Source:`, `Upstream:`, `Last sync:`,
 `Drift policy:`), and MUST get a row in the shared skills registry.
 
-An artifact we authored ourselves MUST NOT carry one. The block means one thing —
-there is an outside party, at a known commit, whose future changes could collide
-with ours — and a reader who has learned to read it that way has to open the
-upstream to discover that this instance meant something else. `Source: authored
-<date>` is not provenance; it is history, which git already holds. An artifact
-that is partly ours and partly derived keeps the block and scopes it, naming
-which files have an upstream and which do not.
+An artifact we authored ourselves MUST NOT carry a provenance header at all — no
+comment, and none of those keys. The header means one thing — there is an outside
+party, at a known commit, whose future changes could collide with ours — and a
+reader who has learned to read it that way has to open the upstream to discover
+that this instance meant something else. `Source: authored <date>` is not
+provenance; it is history, which git already holds. An artifact that is partly
+ours and partly derived keeps the header and scopes it, naming which files have
+an upstream and which do not.
 
 Set the drift policy deliberately. Any local graft that diverges from upstream
 flips the policy to a fork policy — a resync would silently revert the graft.

--- a/.claude/skills/admit-request/SKILL.md
+++ b/.claude/skills/admit-request/SKILL.md
@@ -197,6 +197,14 @@ source, it MUST carry the provenance header immediately after the front matter,
 using the literal audit keys (`Source:`, `Upstream:`, `Last sync:`,
 `Drift policy:`), and MUST get a row in the shared skills registry.
 
+An artifact we authored ourselves MUST NOT carry one. The block means one thing —
+there is an outside party, at a known commit, whose future changes could collide
+with ours — and a reader who has learned to read it that way has to open the
+upstream to discover that this instance meant something else. `Source: authored
+<date>` is not provenance; it is history, which git already holds. An artifact
+that is partly ours and partly derived keeps the block and scopes it, naming
+which files have an upstream and which do not.
+
 Set the drift policy deliberately. Any local graft that diverges from upstream
 flips the policy to a fork policy — a resync would silently revert the graft.
 

--- a/src/plugins/codex/.claude/skills/delegating-to-codex/SKILL.md
+++ b/src/plugins/codex/.claude/skills/delegating-to-codex/SKILL.md
@@ -7,10 +7,6 @@ admission:
   remove_when: The Codex plugin's runtime selects a model by task profile itself, so a caller that names nothing still gets the right tier.
 ---
 
-<!--
-Source: authored 2026-08-01.
--->
-
 # Delegating to Codex
 
 Reach Codex through the plugin's own runtime — the Codex rescue agent, or the

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -5,10 +5,6 @@ admission:
   remove_when: The harness stops shipping a built-in prohibition on unrequested delegation, and unaided sessions hold the orchestrator/delegated boundary without being told.
 ---
 
-<!--
-Source: authored 2026-07-26.
--->
-
 # Delegation
 
 <subagent-user-authorization>

--- a/src/user/.claude/skills/choosing-a-delegate/SKILL.md
+++ b/src/user/.claude/skills/choosing-a-delegate/SKILL.md
@@ -7,10 +7,6 @@ admission:
   remove_when: Sessions that were never given this reach cross-vendor on their own judgement when independence is what the task needs.
 ---
 
-<!--
-Source: authored 2026-08-02.
--->
-
 # Choosing a Delegate
 
 Independence comes from a different **vendor**, not a bigger model from the same one.

--- a/src/user/.claude/skills/instructing-subagents/SKILL.md
+++ b/src/user/.claude/skills/instructing-subagents/SKILL.md
@@ -7,10 +7,6 @@ admission:
   remove_when: A run of dispatches shows well-formed briefs — criteria, boundaries, delivered reports — written without loading this skill.
 ---
 
-<!--
-Source: authored 2026-07-31, replacing dispatching-subagents (archived).
--->
-
 # Instructing Subagents
 
 A subagent inherits none of your context, your conversation, or your intent. The brief is


### PR DESCRIPTION
## What and why

The provenance header means one thing: **there is an outside party, at a known commit, whose future changes could collide with ours.** Four artifacts we wrote ourselves carried one anyway, using the audit keys to record history instead:

| Artifact | Carried |
|---|---|
| `src/user/.claude/rules/delegation.md` | `Source: authored 2026-07-26.` |
| `src/user/.claude/skills/instructing-subagents/SKILL.md` | `Source: authored 2026-07-31, replacing dispatching-subagents (archived).` |
| `src/user/.claude/skills/choosing-a-delegate/SKILL.md` | `Source: authored 2026-08-02.` |
| `src/plugins/codex/.claude/skills/delegating-to-codex/SKILL.md` | `Source: authored 2026-08-01.` |

A reader who has learned to read the block as a collision signal then has to open the upstream to discover this instance meant nothing of the kind — exactly the cost the block exists to remove.

## The rule was only stated in one direction

`admit-request` check 6 said when a provenance block is **required** and never that anything forbids one. It now states the other side, including the mixed case: an artifact partly ours and partly derived **keeps** the block and scopes it, naming which files have an upstream and which do not.

That case is not hypothetical. `explain-diff` looks like a fifth offender to a naive grep — its first line reads `Source: authored in-repo 2026-07-10 … have no upstream` — but it is **correct**: its next line documents a genuine partial derivation (17 of an upstream's 48 persona files), and the first line exists to scope which assets are *not* derived. A rule stated in only one direction would have read as licensing its removal.

## The count was three; it is four

The extra is `choosing-a-delegate`, authored **2026-08-02** — one day after this defect was filed and measured, and it passed review.

The item said to *"decide whether anything mechanical should enforce it … prefer the cheaper answer absent evidence that review misses it."* That is the evidence. So the mechanical check is now **filed as follow-up work with the measurement attached**, rather than left as an open question. It is cheap to build: the installer's sanitizer already carries the exact marker regex a check would need (`sanitize.py:51`).

## Verification

- `make ci` — **exit 0**, run from this worktree's root.
- **Zero deployed bytes change, proven rather than asserted.** The installer's sanitizer strips any leading comment carrying a `Source:` or `Upstream:` key (`core/sanitize.py:51`, `_strip_provenance`), so these four never reached a downstream agent — the harm was repo-side only. I ran `sanitize_text` over each file's content before and after: **byte-identical in all four cases.**
- The **17** legitimate external blocks are untouched. Counted with the sanitizer's own marker regex, not a hand-written pattern — which matters, because two of my own earlier counts were wrong: `rg` skips hidden directories by default and this repo's entire deployed surface lives under them (`src/user/.claude/`, `src/user/.agents/`, `src/plugins/*/.claude/`), and `writing-skills` indents its keys so a `^Source:`-anchored pattern misses a legitimate block entirely.

Closes `agents-config-9k9.101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky