### PR TITLE
fix(9k9.18): a deleted hook stops firing, and an overwritten one is recoverable

### DIFF
--- a/packages/installer/src/installer/core/namespaces.py
+++ b/packages/installer/src/installer/core/namespaces.py
@@ -53,19 +53,18 @@ SHARED_CARRIER: frozenset[str] = frozenset({"skills", "agents"})
 PLUGIN_TOOL_SCOPED: tuple[str, ...] = ("commands", "skills", "agents", "rules")
 
 # Namespaces recorded in the install receipt (prune-eligible tool-tree content).
-# Excludes ``hooks``: it is staged and deployed (see :data:`TOOL_SCOPED`) but is
-# NOT currently receipt-tracked, so a removed-source hook survives forever in
-# ~/.claude/hooks/ — a suspected latent gap (the identical gap was deliberately
-# fixed for ``workflows``, which is why workflows IS here). Preserved as-is so
-# this consolidation changes no behavior; the prune-policy fix is tracked as
-# separate follow-up work. Excludes ``formulas``: plugin-routed content is pruned
-# via the plugin-route receipt path, not this tool-tree set.
-PRUNE: tuple[str, ...] = ("commands", "skills", "agents", "rules", "workflows")
+# Includes ``hooks``: it is staged and deployed (see :data:`TOOL_SCOPED`) and IS
+# receipt-tracked, so a removed-source hook is pruned from ~/.claude/hooks/ on
+# the next install — the identical fix already applied to ``workflows``.
+# Excludes ``formulas``: plugin-routed content is pruned via the plugin-route
+# receipt path, not this tool-tree set.
+PRUNE: tuple[str, ...] = ("commands", "skills", "agents", "rules", "hooks", "workflows")
 
 # Namespaces whose backups route to a sibling ``<namespace>-backup/`` dir rather
 # than an in-place ``<name>.backup-<ts>`` suffix. Includes ``formulas``: an
-# overwritten plugin-route file still gets a sibling-dir backup. Excludes
-# ``hooks`` (the same suspected gap as :data:`PRUNE`).
+# overwritten plugin-route file still gets a sibling-dir backup. Includes
+# ``hooks``: an overwritten hook script is backed up to ``hooks-backup/`` rather
+# than lost, since a hook is an executable in the user's home.
 BACKUP: frozenset[str] = frozenset(
-    {"commands", "skills", "agents", "rules", "formulas", "workflows"}
+    {"commands", "skills", "agents", "rules", "hooks", "formulas", "workflows"}
 )

--- a/packages/installer/src/installer/core/ownership.py
+++ b/packages/installer/src/installer/core/ownership.py
@@ -14,7 +14,7 @@ from installer.core.model import FileKind, StagedItem
 from installer.core.receipt import ReceiptEntry
 
 # The prune-eligible namespaces, sourced from the canonical vocabulary. Its
-# membership (notably the hooks/formulas exclusions) is documented at the
+# membership (notably the formulas exclusion) is documented at the
 # ``namespaces.PRUNE`` definition.
 PRUNE_NAMESPACES: tuple[str, ...] = namespaces.PRUNE
 

--- a/packages/installer/tests/unit/test_hooks_prune_and_backup.py
+++ b/packages/installer/tests/unit/test_hooks_prune_and_backup.py
@@ -1,0 +1,152 @@
+"""End-to-end pins for hooks joining the prune-tracked, sibling-backed-up
+namespaces (``namespaces.PRUNE`` / ``namespaces.BACKUP``).
+
+Before this fix, a hooks item was staged and deployed (``TOOL_SCOPED``) but
+never receipt-recorded and never sibling-backed-up: ``entries_from_outcomes``
+dropped every hooks write (namespace not in ``PRUNE_NAMESPACES``), so a
+removed-source hook had no receipt entry to trigger its deletion, and an
+overwritten hook's prior bytes landed as an in-place ``<name>.backup-<ts>``
+sibling instead of a recoverable ``hooks-backup/`` dir. Mirrors
+test_workflows_namespace.py, the reference fix for the identical gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from installer.core.backup import back_up
+from installer.core.hashing import sha256_file
+from installer.core.io_port import ScriptedIO
+from installer.core.model import InstallOutcome, Outcome, StagingPlan, Tool
+from installer.core.receipt import Receipt
+from installer.core.receipt_build import entries_from_outcomes
+from installer.core.run import prune_pipeline
+from installer.core.sync import sync
+from installer.tools.claude import ClaudeAdapter
+from installer.tools.registry import get_adapter
+
+_TS = "20250101-120000"
+
+
+def _claude_home(tmp_path: Path) -> Path:
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "settings.json").write_text("{}")
+    return tmp_path
+
+
+def test_hook_with_removed_source_is_pruned_on_next_install(tmp_path: Path) -> None:
+    """A hook recorded in a prior receipt, whose source has since been removed,
+    is pruned from the home on the next install.
+
+    Builds the prior receipt via ``entries_from_outcomes`` — the real recording
+    path a full install run uses — rather than hand-authoring a ``ReceiptEntry``,
+    so the test actually exercises the namespace-membership gate this fix closes.
+    Before the fix, ``entries_from_outcomes`` drops the hooks write (namespace
+    not in ``PRUNE_NAMESPACES``), so ``prior.entries`` never gets an entry for it,
+    no orphan is ever detected, and the hook survives; after the fix the entry is
+    recorded and the now-sourceless hook is diffed out and deleted.
+    """
+    home = _claude_home(tmp_path)
+    hook_path = home / ".claude" / "hooks" / "old-hook.py"
+    hook_path.parent.mkdir(parents=True)
+    hook_path.write_bytes(b"#!/usr/bin/env python3\n")
+
+    # The recorded sha256 must match the on-disk bytes: prune_hash's bytes-match
+    # guard relinquishes (keeps) a file orphan whose recorded hash disagrees with
+    # what is actually on disk, so a mismatched hash here would make this test
+    # pass for the wrong reason (relinquished, not pruned).
+    outcomes = [InstallOutcome(hook_path, Outcome.WRITTEN, sha256_file(hook_path).hex())]
+    entries = entries_from_outcomes(outcomes, tool="claude", dest_root=home / ".claude", home=home)
+    prior = Receipt(roots=(Path(".claude"),), entries=tuple(entries))
+
+    # Next install: the hook's source has been removed, so this run's plan no
+    # longer stages it.
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+
+    outcome = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        prior=prior,
+        home=home,
+        discovered_plugin_names=set(),
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert not hook_path.exists()
+    assert outcome.pruned_paths == {Path(".claude/hooks/old-hook.py")}
+
+
+def test_overwritten_hook_backs_up_to_sibling_hooks_backup_dir(tmp_path: Path) -> None:
+    """Overwriting a deployed hook places the previous content in a sibling
+    ``hooks-backup/`` directory rather than an in-place ``.backup-<ts>`` suffix
+    next to the live hook.
+    """
+    repo_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    source = repo_root / "src" / "user" / ".claude" / "hooks" / "ruff-postedit.py"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"new content\n")
+
+    dest = home / ".claude" / "hooks" / "ruff-postedit.py"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(b"old content\n")
+
+    counters = sync(
+        ClaudeAdapter(),
+        Path("hooks/ruff-postedit.py"),
+        repo_root=repo_root,
+        home=home,
+        io=ScriptedIO(),
+        timestamp=_TS,
+    )
+
+    backup = home / ".claude" / "hooks-backup" / f"ruff-postedit.py.backup-{_TS}"
+    assert backup.read_bytes() == b"old content\n"
+    assert dest.read_bytes() == b"new content\n"
+    assert counters.backed_up == 1
+
+
+def test_back_up_routes_a_hooks_target_to_the_sibling_dir(tmp_path: Path) -> None:
+    """Unit-level companion to the sync test above: ``back_up`` itself routes a
+    hooks-namespace target to the sibling ``hooks-backup/`` dir, exercised
+    directly (no sync/staging machinery) the way test_backup.py pins the other
+    backup-routed namespaces.
+    """
+    target = tmp_path / ".claude" / "hooks" / "retired.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("precious")
+
+    dest = back_up(target, _TS)
+
+    assert dest == tmp_path / ".claude" / "hooks-backup" / f"retired.py.backup-{_TS}"
+    assert dest.read_text() == "precious"
+
+
+def test_hook_present_but_recorded_in_no_receipt_is_left_alone(tmp_path: Path) -> None:
+    """A hook file that is physically present in the home, but recorded in no
+    receipt at all (hand-placed, or from before receipts existed), is never
+    swept up by hooks joining the prune-eligible namespaces — pruning only ever
+    acts on a recorded orphan, never on undocumented content it finds on disk.
+    """
+    home = _claude_home(tmp_path)
+    stray = home / ".claude" / "hooks" / "hand-placed.py"
+    stray.parent.mkdir(parents=True)
+    stray.write_bytes(b"#!/usr/bin/env python3\n")
+
+    plans = {Tool.CLAUDE: StagingPlan(items={}, tool=Tool.CLAUDE)}
+
+    outcome = prune_pipeline(
+        [get_adapter(Tool.CLAUDE)],
+        plans=plans,
+        prior=Receipt(),  # no receipt entries at all
+        home=home,
+        discovered_plugin_names=set(),
+        io=ScriptedIO(interactive=False),
+        auto_yes=True,
+        timestamp=_TS,
+    )
+
+    assert stray.exists()
+    assert outcome.pruned_paths == set()

--- a/packages/installer/tests/unit/test_namespaces.py
+++ b/packages/installer/tests/unit/test_namespaces.py
@@ -56,18 +56,19 @@ def test_plugin_tool_scoped_view() -> None:
 
 
 def test_prune_view() -> None:
-    # Receipt-recorded, prune-eligible tool-tree namespaces. hooks absent — see
-    # test_hooks_is_staged_but_not_pruned_or_backed_up. formulas absent: it is
+    # Receipt-recorded, prune-eligible tool-tree namespaces. hooks included — see
+    # test_hooks_is_staged_and_pruned_and_backed_up. formulas absent: it is
     # plugin-routed and tracked via the plugin-route receipt path, not this set.
-    assert namespaces.PRUNE == ("commands", "skills", "agents", "rules", "workflows")
+    assert namespaces.PRUNE == ("commands", "skills", "agents", "rules", "hooks", "workflows")
 
 
 def test_backup_view() -> None:
     # Namespaces whose backups route to a sibling <ns>-backup/ dir (else an
     # in-place suffix). formulas included — overwritten plugin-route content still
-    # gets a sibling-dir backup; hooks absent (same gap as PRUNE).
+    # gets a sibling-dir backup; hooks included — an overwritten hook is backed up
+    # too, not lost.
     assert (
-        frozenset({"commands", "skills", "agents", "rules", "formulas", "workflows"})
+        frozenset({"commands", "skills", "agents", "rules", "hooks", "formulas", "workflows"})
         == namespaces.BACKUP
     )
 
@@ -88,18 +89,18 @@ def test_shared_carrier_is_a_subset_of_shared() -> None:
     assert set(namespaces.SHARED) >= namespaces.SHARED_CARRIER
 
 
-def test_hooks_is_staged_but_not_pruned_or_backed_up() -> None:
+def test_hooks_is_staged_and_pruned_and_backed_up() -> None:
     """hooks is a tool-scoped, deployed namespace (src/user/.claude/hooks/ ->
-    ~/.claude/hooks/) that is NOT receipt-tracked or sibling-backed-up. A
-    removed-source hook therefore survives forever with no receipt entry to
-    trigger its deletion — the same survives-forever gap that was deliberately
-    fixed for ``workflows`` (see test_workflows_namespace). This pins the CURRENT
-    state that the consolidation preserves unchanged; the prune-policy decision is
-    tracked as separate follow-up work.
+    ~/.claude/hooks/) that IS receipt-tracked and sibling-backed-up: a
+    removed-source hook is pruned on the next install, and an overwritten hook
+    is backed up to a sibling ``hooks-backup/`` dir rather than lost — the
+    identical fix already applied to ``workflows`` (see test_workflows_namespace).
+    The full prune/backup behavior is pinned end-to-end in
+    test_hooks_prune_and_backup.py; this pins the vocabulary membership only.
     """
     assert "hooks" in namespaces.TOOL_SCOPED
-    assert "hooks" not in namespaces.PRUNE
-    assert "hooks" not in namespaces.BACKUP
+    assert "hooks" in namespaces.PRUNE
+    assert "hooks" in namespaces.BACKUP
 
 
 def test_formulas_is_plugin_routed_backup_only() -> None:


### PR DESCRIPTION
## What and why

The `hooks` namespace was staged and deployed but named in neither `PRUNE` nor `BACKUP`. Two consequences, both silent:

- **No prune.** Delete a hook from `src/user/.claude/hooks/` and the deployed copy survives in `~/.claude/hooks/` indefinitely, firing on every matching tool call with no source of truth behind it.
- **No backup.** An overwritten hook got an in-place `<name>.backup-<ts>` suffix beside the live hook instead of a sibling `hooks-backup/` directory.

The identical gap was deliberately fixed for `workflows`. `namespaces.py` documented the `hooks` case as a suspected latent gap and deferred the policy fix to follow-up work; this is that work.

Adding `hooks` to the two views is the **entire** behavioural change — both are consumed generically, so no call site needed a per-namespace branch. That is what the consolidated vocabulary module exists to make true.

## Why pruning hooks is safe

These are executables in the user's home, so this deserved proof rather than assertion. Two independent guards, both pre-existing and both namespace-agnostic:

1. An orphan must already be a **recorded receipt entry** (`core/receipt_diff.py`) — content the installer never deployed is invisible to the sweep.
2. A FILE orphan is pruned **only while its on-disk bytes still match the recorded hash** (`core/prune_hash.py`) — a hand-*edited* hook is relinquished, not deleted.

`test_hook_present_but_recorded_in_no_receipt_is_left_alone` pins the first directly.

## Verification

- `make ci-installer` — **exit 0**, run standalone from this worktree. 1184 passed, 2 skipped, **97.81%** branch coverage against a 90% floor.
- **RED confirmed independently of the authoring pass.** Reverting only the two list memberships: 3 of 4 tests fail. The one that still passes is the safety-invariant test above, which pins a property that held before and after — as intended.

Two ways these tests could have looked green while pinning nothing, both avoided deliberately and documented in the test docstrings:

- The prune test builds its prior receipt through the **real recording path** rather than hand-authoring a `ReceiptEntry`. A hand-authored entry passes even without the fix, because the orphan diff is namespace-agnostic — the real gate is upstream, at recording time.
- It routes the recorded hash through the **real hashing helper**. A placeholder would trip the bytes-match guard and pass for the wrong reason (relinquished, not pruned).

## One document contradicts this, and is superseded rather than overridden

`docs/specs/2026-06-13-ruff-postedit-hook-design.md:105` asks that the prune scan *"never treat `~/.<tool>/hooks/` entries as prunable orphans."* That reads as a direct conflict. It resolves on three counts:

- It is **`Status: draft (design — awaiting review)`** — never accepted.
- That requirement sits under the spec's **"Legacy `scripts/install.sh`"** heading, naming the bash implementation retired at Python parity.
- Its stated reason — *"the orphan scan excludes top-level non-namespace entries"* — describes **glob-driven** pruning, and cites a `core/prune.py` that no longer exists. Pruning is now receipt-based.

Under receipt-based pruning the hazard it guarded against cannot occur, and the property it actually wanted is now **pinned by a test** instead of bought by exempting the whole namespace. The spec is left unedited as a point-in-time proposal, per this repo's convention.

Closes `agents-config-9k9.18`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky