### PR TITLE
docs(9k9.115): price a command at what it costs, which is nothing until it is typed

### DIFF
--- a/.claude/skills/admit-request/SKILL.md
+++ b/.claude/skills/admit-request/SKILL.md
@@ -110,13 +110,19 @@ Two surfaces, and an artifact is priced on the one it actually loads into.
 | Artifact | Always-on cost | On-invoke cost |
 |---|---|---|
 | Rule | its whole body — it is always loaded | — |
-| Skill / command / agent | its front-matter `description` only | its body, paid when invoked |
+| Skill / agent | its front-matter `description` only | its body, paid when invoked |
+| Command | none — it appears in no catalog | its body, paid when the user types it |
 
 **A skill's body is not always-on.** Until something invokes it, a skill costs
 its description line in the catalog and nothing else. So body size is a
 question of whether the body earns its cap *at the moment of use*, and
 description sprawl is the always-on concern — a vague description is worse than
 a long body, because it is paid every session and buys mis-invocation.
+
+**A command is not in any catalog at all.** Neither its body nor its
+description reaches a session until the user types it, so a command has no
+always-on figure to state and its whole cost is one the user asked for. Do not
+ask a command to justify a context cost it does not impose.
 
 Mechanical caps the installer enforces at deploy:
 


### PR DESCRIPTION
## What

The `admit-request` gate's budget table (check 4) charged commands an always-on cost they do not pay. It put **Skill / command / agent** on one row with an always-on column reading "its front-matter \`description\` only". Split into two rows, and added the sentence that says why.

| Artifact | Always-on cost | On-invoke cost |
|---|---|---|
| Skill / agent | its front-matter \`description\` only | its body, paid when invoked |
| Command | none — it appears in no catalog | its body, paid when the user types it |

## Why

A skill's and an agent's descriptions ride in catalogs the model reads before the user types anything. A command's do not: commands appear in no catalog, so neither the body nor the description reaches a session until the user invokes it. The old row asked someone proposing a command to justify a context cost the command does not impose — and, under check 2, to write a \`cost:\` field naming a surface it never loads into.

## The installer is right; the prose was wrong

No code change is needed. The budget path selects namespaces explicitly and commands are in neither selection:

- \`core/deploy_gate.py:201-205\` — the always-on surface is the instruction file plus \`it.namespace == "rules"\`.
- \`core/deploy_gate.py:183\` — the body cap collects only \`item.namespace == "skills"\`.
- \`core/surface_budget.py\` — 146 lines, zero occurrences of "command".

Commands *are* gated for their admission record (\`core/admission.py:46\`), which is a separate axis from the budget. So the exemption is deliberate and narrow, not an oversight.

## Verification

Prose-only, and the file is project-scoped (`.claude/`), outside every `make ci` target's scope — `content-lint` and `content-tests` read `src/`, `spec-lint` reads `docs/specs/`. The applicable gate is `doc-lint`, which reads tracked Markdown outside `docs/specs/`: it reports 3 unresolved citations, all in files this PR does not touch, and reports the identical 3 on `main`. No finding in the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)