### PR TITLE
fix(9k9.174): work search answers "does this already exist?"

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -32,7 +32,7 @@ Twelve verbs; each is a subcommand of `work`.
 | `work ready [--label L]` | unbounded |
 | `work dep {add,remove,list} ID [TARGET] [--type blocks]` | `dep add A B` = A depends on B |
 | `work label {add,remove,list} ID [LABELS...]` | multi-label in one call |
-| `work search QUERY` | — |
+| `work search QUERY [--in FIELD] [--status S] [--limit N]` | reads title, description and notes, every status, unbounded — `--in` (repeatable) narrows the fields, `--status`/`--limit` the rest |
 | `work sync [--pull]` | — |
 | global | `--format {json,human}` (human renders to **stderr**; stdout envelope unchanged), `--protocol-version`, `--config PATH` (explicit `project-config.toml`; overrides the upward search — track-layer surfaces only, see below) |
 
@@ -58,10 +58,15 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work reconcile [--dry-run]` | recovery sweep over the states the tracker can still observe: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol is `"1.7"` — additive-only bumps (new `ErrorCode` members, the
-derived `Item.track` field, the capability-disposition model and
-`partial_progress` detail below) never change an existing envelope or data
-shape. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+Protocol is `"1.8"` — additive-only bumps (new `ErrorCode` members, the
+derived `Item.track` field, the capability-disposition model,
+`partial_progress` detail below, and `search`'s optional narrowing flags)
+never change an existing envelope or data shape. A bump can still widen
+what an unchanged call *answers*: 1.8 makes `search` read descriptions and
+notes as well as titles, stop excluding closed items, and stop stopping at
+the first page, so a query that used to return nothing may now return
+matches — and `create <noun>` refuses a title a closed item already
+carries. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
 writes via `supports_dep_write` — `dep list` is never gated, even when
@@ -96,13 +101,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.7", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.8", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.7", "ok": false, "data": null,
+{"protocol": "1.8", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -123,7 +128,7 @@ Failure:
 | `E_UNSUPPORTED_CAPABILITY` | the verb is not supported by the active backend's declared `Capabilities` |
 | `E_USAGE` | invalid CLI usage — bad flags, missing required args, or a rejected flag combination (e.g. `create` given neither `--raw` nor a noun; noun creation given `--type`/`--label`; `deliver` given flags for the wrong shape) |
 | `E_INTERNAL` | an unexpected internal fault — the envelope invariant holds even on facade bugs |
-| `E_DUPLICATE_TITLE` | `create <noun>` found an exact, case-sensitive title match before minting |
+| `E_DUPLICATE_TITLE` | `create <noun>` found an exact, case-sensitive title match before minting — in any status, closed included; `detail` carries the `id` and its `status` |
 | `E_NOT_CLAIMABLE` | `claim` refused a container, a blocked leaf, or a closed item |
 | `E_EVIDENCE` | `deliver` has no verifiable evidence (`--pr`/`--items`/`--trivial` missing, or `--items` didn't resolve) |
 | `E_MANIFEST` | a spec's `## Continuations` section is missing, empty, or fails the manifest grammar |
@@ -136,7 +141,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.7", "ok": true, "data": {"protocol": "1.7"}, "error": null}
+{"protocol": "1.8", "ok": true, "data": {"protocol": "1.8"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -157,7 +162,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.7"}`.
+- `--protocol-version` → `{"protocol": "1.8"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.7"
+PROTOCOL_VERSION = "1.8"

--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -38,7 +38,27 @@ from workcli.adapters.bd.retry import run_with_retry
 from workcli.adapters.bd.runner import BdRunner
 from workcli.backend import Capabilities, DepOp, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, JsonValue, StepProgress, WorkError, with_progress
-from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
+from workcli.model import (
+    SEARCH_FIELDS,
+    CreateFields,
+    DepListing,
+    Item,
+    QueryFilters,
+    SearchFilters,
+    SyncResult,
+    UpdateFields,
+)
+
+# The backend's substring filter for each searchable field other than the
+# title, which has a command of its own (see `BdBackend._search_legs`).
+_TEXT_FILTER_FLAGS = {"description": "--desc-contains", "notes": "--notes-contains"}
+
+# Every leg of one search is parsed at the disclosure the weakest leg can
+# support, so a single result set never mixes disclosure levels: a consumer
+# reading `unknown_relations` off the first item would otherwise generalize
+# it to the rest and take an unknown parent for an absent one. The leg that
+# reads titles reports no relationship at all, so it sets the floor.
+_SEARCH_DISCLOSURE = "search"
 
 # Exact stderr wording per an orchestrator ruling, not a golden capture
 # -- `bd dolt` is never run mutating against a real DB in this project. `bd
@@ -135,13 +155,48 @@ class BdBackend:
             raise map_bd_failure(result)
         return parse_items(result.stdout, command="ready")
 
-    def search(self, query: str) -> list[Item]:
-        argv = ["search", query, "--json"]
+    def _search_legs(self, filters: SearchFilters) -> list[list[str]]:
+        """One backend read per requested field, in `SEARCH_FIELDS` order.
 
-        result = run_with_retry(self._runner, argv, sleep=self._sleep)
-        if result.returncode != 0:
-            raise map_bd_failure(result)
-        return parse_items(result.stdout, command="search")
+        The backend has no single call that answers "title OR description":
+        its text filters intersect with its text query rather than union
+        with it, and the query itself only ever reads titles (and ids).
+        Composing the union is therefore this adapter's job -- a backend
+        that could answer it in one call would implement `search` in one.
+        Every leg is asked unbounded: the caller's bound belongs to the
+        merged set, and a bound applied here would clip each field's matches
+        before they were merged.
+        """
+        legs: list[list[str]] = []
+        for field in SEARCH_FIELDS:
+            if field not in filters.corpus:
+                continue
+            if field == "title":
+                # The text-query command, which also matches on id -- which
+                # is why this leg leads: an exact id is the sharpest thing a
+                # caller can type. Its own default drops closed items, so
+                # every status has to be asked for by name.
+                leg = ["search", filters.query, "--json"]
+                leg += ["--status", filters.status if filters.status is not None else "all"]
+            else:
+                # The listing command carries a substring filter per text
+                # field, and spells "every status" as its own flag.
+                leg = ["list", "--json", _TEXT_FILTER_FLAGS[field], filters.query]
+                leg += ["--all"] if filters.status is None else ["--status", filters.status]
+            legs.append([*leg, "--limit", "0"])
+        return legs
+
+    def search(self, filters: SearchFilters) -> list[Item]:
+        merged: dict[str, Item] = {}
+        for argv in self._search_legs(filters):
+            result = run_with_retry(self._runner, argv, sleep=self._sleep)
+            if result.returncode != 0:
+                raise map_bd_failure(result)
+            for item in parse_items(result.stdout, command=_SEARCH_DISCLOSURE):
+                # First field to match sets an item's rank; a later leg
+                # re-reporting it changes nothing.
+                merged.setdefault(item.id, item)
+        return list(merged.values())
 
     def create(self, fields: CreateFields) -> str:
         argv = ["create", "--json", "--title", fields.title]

--- a/packages/workcli/src/workcli/backend.py
+++ b/packages/workcli/src/workcli/backend.py
@@ -12,7 +12,15 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Literal, Protocol
 
-from workcli.model import CreateFields, DepListing, Item, QueryFilters, SyncResult, UpdateFields
+from workcli.model import (
+    CreateFields,
+    DepListing,
+    Item,
+    QueryFilters,
+    SearchFilters,
+    SyncResult,
+    UpdateFields,
+)
 
 DepOp = Literal["add", "remove"]
 
@@ -63,5 +71,12 @@ class Backend(Protocol):
         self, op: str, item_id: str, labels: Sequence[str]
     ) -> None: ...  # pragma: no cover
     def labels(self, item_id: str) -> list[str]: ...  # pragma: no cover
-    def search(self, query: str) -> list[Item]: ...  # pragma: no cover
+    def search(self, filters: SearchFilters) -> list[Item]:
+        """Return every item matching `filters`, unbounded, in `SEARCH_FIELDS` order.
+
+        Deduplicated by id: an item matched on two fields is reported once,
+        at the rank of the first field that matched it.
+        """
+        ...  # pragma: no cover
+
     def sync(self, pull: bool) -> SyncResult: ...  # pragma: no cover

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -26,6 +26,7 @@ from workcli.config import TrackLayerConfig, load_config
 from workcli.envelope import ErrorCode, JsonValue, WorkError, emit_failure, emit_success
 from workcli.lifecycle.nouns import LEAF_NOUNS, Noun
 from workcli.lifecycle.park import DEFAULT_STALE_DAYS
+from workcli.model import SEARCH_FIELDS
 from workcli.render import render_human
 from workcli.verbs import VERBS, missing_capability
 
@@ -58,8 +59,28 @@ def _add_read_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser])
     ready_parser = subparsers.add_parser("ready", help="list ready-to-work items, unbounded")
     ready_parser.add_argument("--label")
 
-    search_parser = subparsers.add_parser("search", help="search items by query text")
+    search_parser = subparsers.add_parser(
+        "search",
+        help="search items by query text: every field, every status, unbounded unless narrowed",
+    )
     search_parser.add_argument("query", metavar="QUERY")
+    search_parser.add_argument(
+        "--in",
+        dest="corpus",
+        action="append",
+        choices=SEARCH_FIELDS,
+        metavar="FIELD",
+        help=(
+            f"restrict the search to one field ({'|'.join(SEARCH_FIELDS)}); repeatable, "
+            "default all of them (an id match reports under 'title')"
+        ),
+    )
+    search_parser.add_argument(
+        "--status", help="restrict to one status; default every status, closed included"
+    )
+    search_parser.add_argument(
+        "--limit", type=int, default=None, help="cap the result count; default unbounded"
+    )
 
 
 def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -27,7 +27,7 @@ from workcli.lifecycle.nouns import (
 )
 from workcli.lifecycle.park import PARKED_LABEL
 from workcli.lifecycle.validate import combine_errors, validate_noun, validate_priority
-from workcli.model import CreateFields
+from workcli.model import CreateFields, SearchFilters
 from workcli.tracks import TRACK_PREFIX, derive_track, require_known_track, track_label
 
 # The reserved-namespace wall for additive `--label`: labels that
@@ -195,13 +195,31 @@ def _validate_usage(args: Namespace, noun: Noun) -> None:
 
 
 def _check_duplicate_title(backend: Backend, title: str) -> None:
-    matches = backend.search(title)
+    """Refuse a title some item already carries, whatever became of that item.
+
+    The guard states its own search rather than inheriting the verb's wide
+    defaults, because it asks a narrower question than a person searching
+    does. Two of the three axes are deliberate:
+
+    - **Titles alone.** Only an exact title match can collide, so a hit in a
+      description or a note could never satisfy the test below -- widening
+      the corpus would spend extra backend reads per create on rows this
+      discards.
+    - **Every status, closed included.** Work that was already done is still
+      prior art, and re-filing it under the same title is exactly the
+      duplicate this guard exists to prevent -- the more so because a closed
+      item is the one a caller is least likely to have found by hand. The
+      refusal carries the id and its status, so the caller can reopen it,
+      link to it, or retitle deliberately; genuinely recurring work gets a
+      title that distinguishes the occurrence.
+    """
+    matches = backend.search(SearchFilters(query=title, corpus=frozenset({"title"})))
     collision = next((item for item in matches if item.title == title), None)
     if collision is not None:
         raise WorkError(
             ErrorCode.DUPLICATE_TITLE,
-            f"an item titled {title!r} already exists: {collision.id}",
-            detail={"id": collision.id},
+            f"an item titled {title!r} already exists ({collision.status}): {collision.id}",
+            detail={"id": collision.id, "status": collision.status},
         )
 
 

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -102,3 +102,24 @@ class QueryFilters:
     parent: str | None = None
     type: str | None = None
     limit: int | None = None
+
+
+# The `Item` fields a search may read, in the order a result set reports them
+# -- a title match ranks above a description match, which ranks above a note.
+# Ordering is contract, not incidental: it is what a caller's `--limit` keeps.
+SEARCH_FIELDS = ("title", "description", "notes")
+
+
+@dataclass(frozen=True)
+class SearchFilters:
+    query: str
+    # Every field by default. The three narrowings this verb used to apply
+    # silently -- corpus, status, bound -- are each askable now, and each
+    # defaults to the wide answer: a narrowing nobody chose returns an empty
+    # result a caller cannot tell from a true "nothing like this exists".
+    corpus: frozenset[str] = frozenset(SEARCH_FIELDS)
+    status: str | None = None  # None = every status, closed included
+    # No limit here on purpose. A search spans several fields, and a bound
+    # pushed down per field would truncate each one before they are merged
+    # and undercount the union; the verb layer applies it to the merged set
+    # instead (same ordering `list --track` already enforces).

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -14,7 +14,7 @@ from typing import cast
 from workcli.backend import Backend
 from workcli.envelope import JsonValue
 from workcli.lifecycle.park import parked_stale
-from workcli.model import Item, QueryFilters
+from workcli.model import SEARCH_FIELDS, Item, QueryFilters, SearchFilters
 from workcli.tracks import derive_track, require_known_track
 
 
@@ -112,5 +112,21 @@ def ready(backend: Backend, args: Namespace) -> JsonValue:
 
 
 def search(backend: Backend, args: Namespace) -> JsonValue:
-    """`work search QUERY`."""
-    return _serialize_items(backend.search(args.query))
+    """`work search QUERY [--in FIELD] [--status S] [--limit N]`.
+
+    Wide by default on all three axes -- every searchable field, every
+    status, no bound -- because each narrowing turns a match into an empty
+    result indistinguishable from a true "nothing like this exists", and a
+    caller checking for prior art reads that as permission to file. Any of
+    the three can be asked for explicitly; none is applied unasked.
+
+    `--limit` slices the merged result, never the individual field reads:
+    bounding each field before the merge would undercount the union, the
+    same ordering `list --track` enforces on its own filter. Zero-or-negative
+    means unbounded, matching `list`.
+    """
+    corpus = frozenset(args.corpus or SEARCH_FIELDS)
+    items = backend.search(SearchFilters(query=args.query, corpus=corpus, status=args.status))
+    if args.limit is not None and args.limit > 0:
+        items = items[: args.limit]
+    return _serialize_items(items)

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -40,6 +40,7 @@ from workcli.model import (
     DepListing,
     Item,
     QueryFilters,
+    SearchFilters,
     SyncResult,
     UpdateFields,
 )
@@ -289,11 +290,20 @@ class FakeBackend:
     def labels(self, item_id: str) -> list[str]:
         return list(self._require(item_id).labels)
 
-    def search(self, query: str) -> list[Item]:
+    def search(self, filters: SearchFilters) -> list[Item]:
+        # Models the seam's contract, not one backend's text semantics: the
+        # corpus is whatever the caller asked for, closed items are in it
+        # unless a status narrows them out, and nothing is truncated.
+        def matches(rec: _Rec) -> bool:
+            if filters.status is not None and rec.status != filters.status:
+                return False
+            fields = {"title": rec.title, "description": rec.description, "notes": rec.notes}
+            return any(filters.query in fields[field] for field in filters.corpus)
+
         return [
             self._snapshot(rec, unknown=_SEARCH_UNKNOWN)
             for rec in self._items.values()
-            if query in rec.title
+            if matches(rec)
         ]
 
     def sync(self, pull: bool) -> SyncResult:

--- a/packages/workcli/tests/integration/test_search_corpus.py
+++ b/packages/workcli/tests/integration/test_search_corpus.py
@@ -1,0 +1,105 @@
+"""`work search` against a real backend holding more than one page of matches.
+
+The hermetic tests pin the argv the adapter sends. Only a real backend can
+show what that argv buys, and each of the three narrowings this fixture is
+built to catch is invisible to a fake: a scripted runner returns whatever it
+was scripted with, so it cannot truncate at a page boundary, cannot hide a
+closed row, and cannot decline to look at a description.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import pytest
+
+from tests.integration.conftest import _bd_init, _make_driver, _run_bd
+
+# One more than the backend's own default page, so a search that inherited
+# that default comes back visibly short.
+_PAGEFUL = 60
+_TITLE_WORD = "pagefulword"
+_DESCRIPTION_WORD = "descriptiononlyword"
+_NOTES_WORD = "notesonlyword"
+_CLOSED_WORD = "closedonlyword"
+
+
+def _seed_lines() -> list[dict[str, object]]:
+    lines: list[dict[str, object]] = [
+        {"title": f"{_TITLE_WORD} match {i}", "issue_type": "task", "priority": 2}
+        for i in range(_PAGEFUL)
+    ]
+    lines.append(
+        {
+            "title": "an item whose title says nothing",
+            "issue_type": "task",
+            "priority": 2,
+            "description": f"the word {_DESCRIPTION_WORD} lives only here",
+        }
+    )
+    lines.append({"title": "an item annotated later", "issue_type": "task", "priority": 2})
+    lines.append({"title": f"{_CLOSED_WORD} work already finished", "issue_type": "task"})
+    return lines
+
+
+@pytest.fixture(scope="module")
+def search_driver(bd_binary: str, tmp_path_factory: pytest.TempPathFactory):
+    """One seeded install for the whole module: 63 items is too slow per test."""
+    install = tmp_path_factory.mktemp("search_corpus_beads")
+    _bd_init(bd_binary, install)
+
+    seed = Path(install) / "seed.jsonl"
+    seed.write_text("\n".join(json.dumps(line) for line in _seed_lines()) + "\n", encoding="utf-8")
+    _run_bd(bd_binary, install, "import", str(seed))
+
+    listing = json.loads(_run_bd(bd_binary, install, "list", "--json", "--limit", "0").stdout)
+    by_title = {item["title"]: item["id"] for item in listing}
+    _run_bd(bd_binary, install, "close", by_title[f"{_CLOSED_WORD} work already finished"])
+    _run_bd(
+        bd_binary,
+        install,
+        "note",
+        by_title["an item annotated later"],
+        f"a note mentioning {_NOTES_WORD}",
+    )
+
+    return _make_driver(bd_binary, install)
+
+
+def _titles(driver: Callable[[Sequence[str]], dict], argv: Sequence[str]) -> list[str]:
+    envelope = driver(argv)
+    assert envelope["ok"] is True, envelope
+    return [item["title"] for item in envelope["data"]["items"]]
+
+
+def test_a_match_set_larger_than_one_page_arrives_whole(search_driver):
+    # The backend's own default caps this at 50 and says nothing about it.
+    assert len(_titles(search_driver, ["search", _TITLE_WORD])) == _PAGEFUL
+
+
+def test_a_word_only_in_a_description_finds_its_item(search_driver):
+    assert _titles(search_driver, ["search", _DESCRIPTION_WORD]) == [
+        "an item whose title says nothing"
+    ]
+
+
+def test_a_word_only_in_a_note_finds_its_item(search_driver):
+    assert _titles(search_driver, ["search", _NOTES_WORD]) == ["an item annotated later"]
+
+
+def test_a_closed_item_is_still_found(search_driver):
+    envelope = search_driver(["search", _CLOSED_WORD])
+
+    assert envelope["ok"] is True, envelope
+    assert [item["status"] for item in envelope["data"]["items"]] == ["closed"]
+
+
+def test_the_caller_can_narrow_all_three_axes(search_driver):
+    # Corpus: the description word is invisible to a title-only search.
+    assert _titles(search_driver, ["search", _DESCRIPTION_WORD, "--in", "title"]) == []
+    # Status: the closed item drops out of an open-only search.
+    assert _titles(search_driver, ["search", _CLOSED_WORD, "--status", "open"]) == []
+    # Bound: the caller's own cap is honored on the merged set.
+    assert len(_titles(search_driver, ["search", _TITLE_WORD, "--limit", "3"])) == 3

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -17,7 +17,7 @@ from workcli.adapters.bd.backend import BdBackend
 from workcli.adapters.bd.runner import BdResult
 from workcli.backend import ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, WorkError
-from workcli.model import CreateFields, DepEdge, QueryFilters, UpdateFields
+from workcli.model import CreateFields, DepEdge, QueryFilters, SearchFilters, UpdateFields
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
 
@@ -295,10 +295,10 @@ def test_search_sends_the_query_and_returns_normalized_items():
     )
     backend = BdBackend(runner)
 
-    items = backend.search("quarantine")
+    items = backend.search(SearchFilters(query="quarantine", corpus=frozenset({"title"})))
 
     assert len(items) == 5
-    assert runner.calls == [("search", "quarantine", "--json")]
+    assert runner.calls == [("search", "quarantine", "--json", "--status", "all", "--limit", "0")]
 
 
 def test_search_maps_an_unrecognized_nonzero_exit_to_backend_drift():
@@ -313,7 +313,7 @@ def test_search_maps_an_unrecognized_nonzero_exit_to_backend_drift():
     backend = BdBackend(runner)
 
     try:
-        backend.search("x")
+        backend.search(SearchFilters(query="x"))
         raise AssertionError("expected WorkError")
     except WorkError as error:
         assert error.code == ErrorCode.BACKEND_DRIFT

--- a/packages/workcli/tests/unit/test_create_noun.py
+++ b/packages/workcli/tests/unit/test_create_noun.py
@@ -43,12 +43,12 @@ def _search_result(*raw_items: dict[str, object]) -> BdResult:
     return BdResult(returncode=0, stdout=json.dumps(list(raw_items)), stderr="")
 
 
-def _item_raw(item_id: str, title: str) -> dict[str, object]:
+def _item_raw(item_id: str, title: str, *, status: str = "open") -> dict[str, object]:
     return {
         "id": item_id,
         "title": title,
         "issue_type": "task",
-        "status": "open",
+        "status": status,
         "priority": 2,
         "labels": [],
         "dependencies": [],
@@ -84,7 +84,7 @@ def test_create_spike_with_parent_sends_search_then_one_create_call():
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1"}
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -119,7 +119,7 @@ def test_create_chore_with_orphan_creates_with_no_parent_and_records_orphan_note
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1"}
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         ("create", "--json", "--title", "T", "--type", "chore", "--labels", "shape-chore"),
         ("update", "x.1", "--append-notes", ORPHAN_MARKER),
     ]
@@ -158,8 +158,53 @@ def test_create_duplicate_title_blocks_before_any_create_call():
     error = envelope["error"]
     assert isinstance(error, dict)
     assert error["code"] == str(ErrorCode.DUPLICATE_TITLE)
-    assert error["detail"] == {"id": "x.9"}
-    assert runner.calls == [("search", "T", "--json")]
+    assert error["detail"] == {"id": "x.9", "status": "open"}
+    assert runner.calls == [("search", "T", "--json", "--status", "all", "--limit", "0")]
+
+
+def test_duplicate_title_guard_reads_titles_alone_and_never_a_second_corpus():
+    # The guard keeps only an EXACT title match, so a hit in a description or
+    # a note could never satisfy it -- widening its corpus would spend two
+    # more backend reads per create on rows it then discards. One leg.
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(("search",), _search_result()),
+            ScriptedStep(("create",), _create_result("x.1")),
+            ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr="")),
+        ]
+    )
+
+    exit_code, _, _ = run_cli_with_runner(
+        ["create", "spike", "--title", "T", "--orphan"],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 0
+    assert runner.calls[0] == ("search", "T", "--json", "--status", "all", "--limit", "0")
+    assert [call[0] for call in runner.calls] == ["search", "create", "update"]
+
+
+def test_create_refuses_a_title_a_closed_item_already_carries():
+    # Prior art that was already finished is still prior art, and re-filing it
+    # under the same title is the duplicate this guard exists to prevent. The
+    # refusal names the id, so the caller can reopen it, link it, or retitle.
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("search",), _search_result(_item_raw("x.4", "T", status="closed")))]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["create", "spike", "--title", "T", "--orphan"],
+        runner,
+        config_loader=_not_found_config_loader,
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.DUPLICATE_TITLE)
+    assert error["detail"] == {"id": "x.4", "status": "closed"}
+    assert "closed" in error["message"]
 
 
 def test_create_feat_with_type_flag_is_usage_error_without_any_bd_call():
@@ -205,7 +250,7 @@ def test_create_feat_with_spec_evidence_adds_spec_ready_label():
 
     assert exit_code == 0
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -238,7 +283,7 @@ def test_create_feat_without_evidence_omits_spec_ready_label():
 
     assert exit_code == 0
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -271,7 +316,7 @@ def test_create_feat_with_trivial_adds_spec_ready_label():
 
     assert exit_code == 0
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -328,7 +373,7 @@ def test_create_epic_sends_one_create_with_epic_type_and_shape_label():
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1"}
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -375,7 +420,7 @@ def test_create_spec_mints_shape_with_creating_spec_handle_removed_last():
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1", "design_child": "x.2", "placeholder": "x.3"}
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -458,7 +503,7 @@ def test_create_spec_with_orphan_creates_container_with_no_parent_and_records_or
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1", "design_child": "x.2", "placeholder": "x.3"}
     assert runner.calls[:3] == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",

--- a/packages/workcli/tests/unit/test_create_noun_synonyms.py
+++ b/packages/workcli/tests/unit/test_create_noun_synonyms.py
@@ -107,7 +107,7 @@ def test_create_bug_alias_sends_the_identical_bd_call_as_bugfix() -> None:
     assert envelope_alias["data"] == envelope_canon["data"]
     assert runner_alias.calls == runner_canon.calls
     assert runner_canon.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",
@@ -159,7 +159,7 @@ def test_create_bare_priority_digit_normalizes_to_canonical_p_notation() -> None
     assert exit_code == 0
     assert envelope["data"] == {"id": "x.1"}
     assert runner.calls == [
-        ("search", "T", "--json"),
+        ("search", "T", "--json", "--status", "all", "--limit", "0"),
         (
             "create",
             "--json",

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -215,7 +215,12 @@ VERB_CASES: list[VerbCase] = [
     VerbCase(
         "search",
         ["search", "quarantine"],
-        [ScriptedStep(("search",), _EMPTY_ARRAY)],
+        # One step per corpus field: a default search reads them all.
+        [
+            ScriptedStep(("search",), _EMPTY_ARRAY),
+            ScriptedStep(("list",), _EMPTY_ARRAY),
+            ScriptedStep(("list",), _EMPTY_ARRAY),
+        ],
         ["search", "quarantine"],
         [ScriptedStep(("search",), _GARBAGE)],
     ),

--- a/packages/workcli/tests/unit/test_item_track_field.py
+++ b/packages/workcli/tests/unit/test_item_track_field.py
@@ -59,7 +59,9 @@ def test_show_zero_or_multi_track_labels_carry_null() -> None:
         # `ready` reads the parking lot first (the parked_stale block), so its
         # own listing is the SECOND bd call.
         (["ready"], (("list",),), ("ready",)),
-        (["search", "T"], (), ("search",)),
+        # Narrowed to one corpus field so this stays a one-call case like its
+        # siblings; the field a match came from has no bearing on the track.
+        (["search", "T", "--in", "title"], (), ("search",)),
     ],
 )
 def test_every_list_shaped_read_verb_carries_track(

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -84,7 +84,19 @@ def test_protocol_wire_value_is_pinned() -> None:
     # consumer branching on the drift alarm loses only a case it could not have
     # handled correctly anyway: it was being told the facade's model of its
     # backend had broken, when what was missing was a workspace.
-    assert PROTOCOL_VERSION == "1.7"
+    #
+    # 1.8 gives `search` optional narrowing flags and widens what it answers
+    # without them: descriptions and notes join the corpus, closed items stop
+    # being filtered out, and the result stops ending at the backend's own
+    # first page. `create <noun>` correspondingly refuses a title a CLOSED
+    # item already carries. Same rule as 1.6 and the same verdict: the
+    # envelope and the `data` shape are untouched -- `search` still answers
+    # `{"items": [...]}` of the same item objects, declaring the same
+    # relationships unknown -- and a consumer that acted on the old empty
+    # result was acting on a false negative. What changes is the answer, not
+    # its shape, and a wider true answer is what the verb always claimed to
+    # give.
+    assert PROTOCOL_VERSION == "1.8"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:

--- a/packages/workcli/tests/unit/test_read_relationship_contract.py
+++ b/packages/workcli/tests/unit/test_read_relationship_contract.py
@@ -49,7 +49,13 @@ def _ok(stdout: str) -> BdResult:
 
 
 _SHOW_STEPS = [ScriptedStep(("show",), _ok(_payload("bd_show_shape.json")))]
-_SEARCH_STEPS = [ScriptedStep(("search",), _ok(_payload("bd_search_shape.json")))]
+# A default search reads every corpus field; only the title leg matches
+# here, and the other two answer empty.
+_SEARCH_STEPS = [
+    ScriptedStep(("search",), _ok(_payload("bd_search_shape.json"))),
+    ScriptedStep(("list",), _ok("[]")),
+    ScriptedStep(("list",), _ok("[]")),
+]
 _LIST_STEPS = [ScriptedStep(("list",), _ok(_payload("bd_list_shape.json")))]
 # `ready` reads the parked set first (one `bd list --label parked`); no seeded
 # item carries the label, so the empty reply short-circuits the re-read.
@@ -219,6 +225,7 @@ def _read_args(**overrides: object) -> Namespace:
         "type": None,
         "limit": None,
         "track": None,
+        "corpus": None,
         "stale_days": 14,
         "now": lambda: datetime(2026, 8, 7, 12, 0, tzinfo=UTC),
         "load_config": lambda: None,

--- a/packages/workcli/tests/unit/test_search.py
+++ b/packages/workcli/tests/unit/test_search.py
@@ -1,4 +1,12 @@
-"""`work search QUERY` — behavioral test through the full CLI."""
+"""`work search QUERY` — the corpus, the statuses, and the bound.
+
+Three narrowings used to be wired in and none of them was askable: the verb
+read titles alone, skipped closed items, and stopped at the backend's own
+default page. Each one turns a match into an empty result that a caller
+cannot tell from a true negative, which is how a search for prior art
+becomes a duplicate filing. The tests here pin the wide default and the
+caller's ability to narrow it back down deliberately.
+"""
 
 from __future__ import annotations
 
@@ -8,31 +16,214 @@ from tests.conftest import run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.adapters.bd.runner import BdResult
 
+_EMPTY = BdResult(returncode=0, stdout="[]", stderr="")
 
-def test_search_sends_the_query_and_surfaces_matching_items():
-    raw = {
-        "id": "x.1",
-        "title": "quarantine bd behind a shim",
+
+def _raw(
+    item_id: str,
+    *,
+    title: str = "an item",
+    status: str = "open",
+    description: str = "",
+    notes: str = "",
+) -> dict[str, object]:
+    return {
+        "id": item_id,
+        "title": title,
         "issue_type": "task",
-        "status": "open",
-        "priority": 1,
+        "status": status,
+        "priority": 2,
         "labels": [],
+        "description": description,
+        "notes": notes,
         "dependencies": [],
         "dependents": [],
     }
+
+
+def _found(*raw_items: dict[str, object]) -> BdResult:
+    return BdResult(returncode=0, stdout=json.dumps(list(raw_items)), stderr="")
+
+
+def _legs(*results: BdResult) -> list[ScriptedStep]:
+    """Script one result per corpus leg, in the order the adapter reads them."""
+    prefixes = (("search",), ("list",), ("list",))
+    return [ScriptedStep(prefix, result) for prefix, result in zip(prefixes, results, strict=True)]
+
+
+def _ids(envelope: dict[str, object]) -> list[str]:
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    return [item["id"] for item in data["items"]]
+
+
+def test_search_reads_title_description_and_notes_by_default():
+    runner = ScriptedBdRunner(steps=_legs(_EMPTY, _EMPTY, _EMPTY))
+
+    exit_code, _, _ = run_cli_with_runner(["search", "quarantine"], runner)
+
+    assert exit_code == 0
+    assert runner.calls == [
+        ("search", "quarantine", "--json", "--status", "all", "--limit", "0"),
+        ("list", "--json", "--desc-contains", "quarantine", "--all", "--limit", "0"),
+        ("list", "--json", "--notes-contains", "quarantine", "--all", "--limit", "0"),
+    ]
+
+
+def test_search_returns_an_item_whose_only_match_is_in_its_description():
+    # The first narrowing: a word that appears only in a description used to
+    # return nothing at all.
     runner = ScriptedBdRunner(
-        steps=[
-            ScriptedStep(
-                ("search",),
-                BdResult(returncode=0, stdout=json.dumps([raw]), stderr=""),
-            )
-        ]
+        steps=_legs(
+            _EMPTY,
+            _found(_raw("x.7", title="unrelated title", description="mentions quarantine")),
+            _EMPTY,
+        )
     )
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "quarantine"], runner)
+
+    assert exit_code == 0
+    assert _ids(envelope) == ["x.7"]
+
+
+def test_search_returns_an_item_whose_only_match_is_in_its_notes():
+    runner = ScriptedBdRunner(
+        steps=_legs(
+            _EMPTY,
+            _EMPTY,
+            _found(_raw("x.8", title="unrelated title", notes="measured: quarantine holds")),
+        )
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "quarantine"], runner)
+
+    assert exit_code == 0
+    assert _ids(envelope) == ["x.8"]
+
+
+def test_search_returns_a_closed_item():
+    # The second narrowing: every leg asks for every status, so a match that
+    # was already done and closed still answers "yes, this exists".
+    runner = ScriptedBdRunner(
+        steps=_legs(_found(_raw("x.9", title="park re-park", status="closed")), _EMPTY, _EMPTY)
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "park"], runner)
+
+    assert exit_code == 0
+    assert _ids(envelope) == ["x.9"]
+    assert runner.calls[0] == ("search", "park", "--json", "--status", "all", "--limit", "0")
+
+
+def test_search_defaults_to_unbounded_and_every_row_surfaces():
+    # The third narrowing: the backend's own default page is 50, so a match
+    # set of 60 used to arrive clipped with nothing to say it had been.
+    matches = [_raw(f"x.{i}") for i in range(60)]
+    runner = ScriptedBdRunner(steps=_legs(_found(*matches), _EMPTY, _EMPTY))
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "item"], runner)
+
+    assert exit_code == 0
+    assert len(_ids(envelope)) == 60
+    # The bound is what the backend was actually asked for: a fake returns
+    # whatever it was scripted with, so only the argv can prove the page was
+    # lifted. `tests/integration/test_search_corpus.py` proves the effect
+    # against a real backend holding more than a page of matches.
+    assert [call[-2:] for call in runner.calls] == [("--limit", "0")] * 3
+
+
+def test_search_narrowed_to_titles_reads_one_leg_only():
+    runner = ScriptedBdRunner(steps=[ScriptedStep(("search",), _EMPTY)])
+
+    exit_code, _, _ = run_cli_with_runner(["search", "quarantine", "--in", "title"], runner)
+
+    assert exit_code == 0
+    assert runner.calls == [("search", "quarantine", "--json", "--status", "all", "--limit", "0")]
+
+
+def test_search_corpus_narrowing_is_repeatable_and_drops_the_field_not_named():
+    runner = ScriptedBdRunner(
+        steps=[ScriptedStep(("search",), _EMPTY), ScriptedStep(("list",), _EMPTY)]
+    )
+
+    exit_code, _, _ = run_cli_with_runner(
+        ["search", "quarantine", "--in", "title", "--in", "notes"], runner
+    )
+
+    assert exit_code == 0
+    assert runner.calls == [
+        ("search", "quarantine", "--json", "--status", "all", "--limit", "0"),
+        ("list", "--json", "--notes-contains", "quarantine", "--all", "--limit", "0"),
+    ]
+
+
+def test_search_status_narrowing_reaches_every_leg():
+    runner = ScriptedBdRunner(steps=_legs(_EMPTY, _EMPTY, _EMPTY))
+
+    exit_code, _, _ = run_cli_with_runner(["search", "park", "--status", "open"], runner)
+
+    assert exit_code == 0
+    assert runner.calls == [
+        ("search", "park", "--json", "--status", "open", "--limit", "0"),
+        ("list", "--json", "--desc-contains", "park", "--status", "open", "--limit", "0"),
+        ("list", "--json", "--notes-contains", "park", "--status", "open", "--limit", "0"),
+    ]
+
+
+def test_search_limit_slices_the_union_and_never_the_legs():
+    # A bound applied per leg would truncate each one before the merge and
+    # undercount the union -- the same ordering `list --track` already fixes.
+    # So every leg is asked unbounded and the cap applies to the merged set.
+    runner = ScriptedBdRunner(
+        steps=_legs(_found(_raw("x.1")), _found(_raw("x.2")), _found(_raw("x.3")))
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "item", "--limit", "2"], runner)
+
+    assert exit_code == 0
+    assert _ids(envelope) == ["x.1", "x.2"]
+    assert [call[-2:] for call in runner.calls] == [("--limit", "0")] * 3
+
+
+def test_search_unions_by_id_and_reports_a_twice_matched_item_once():
+    both = _raw("x.5", title="quarantine the backend", description="quarantine again")
+    runner = ScriptedBdRunner(steps=_legs(_found(both), _found(both), _EMPTY))
+
+    exit_code, envelope, _ = run_cli_with_runner(["search", "quarantine"], runner)
+
+    assert exit_code == 0
+    assert _ids(envelope) == ["x.5"]
+    assert len(runner.calls) == 3
+
+
+def test_search_declares_the_same_relationship_disclosure_whichever_leg_matched():
+    # One result set never mixes disclosure levels. The leg that reads titles
+    # can report no relationship at all, so that is the floor for all of them
+    # -- a consumer reading `unknown_relations` off the first item would
+    # otherwise generalize it to the rest and mistake an unknown parent for
+    # an absent one.
+    from_title = _raw("x.1", title="quarantine")
+    from_description = {**_raw("x.2", description="quarantine"), "parent": "x.0"}
+    runner = ScriptedBdRunner(steps=_legs(_found(from_title), _found(from_description), _EMPTY))
 
     exit_code, envelope, _ = run_cli_with_runner(["search", "quarantine"], runner)
 
     assert exit_code == 0
     data = envelope["data"]
     assert isinstance(data, dict)
-    assert [item["id"] for item in data["items"]] == ["x.1"]
-    assert runner.calls == [("search", "quarantine", "--json")]
+    assert _ids(envelope) == ["x.1", "x.2"]
+    for item in data["items"]:
+        assert item["unknown_relations"] == ["children", "deps", "parent"]
+        assert "parent" not in item
+
+
+def test_search_rejects_a_corpus_field_it_does_not_have():
+    exit_code, envelope, _ = run_cli_with_runner(
+        ["search", "quarantine", "--in", "acceptance"], ScriptedBdRunner(steps=[])
+    )
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "E_USAGE"


### PR DESCRIPTION
Closes the scope recorded on `agents-config-9k9.174` — whose notes say the filed premise ("silently truncates at 50") is too narrow, and that the truncation is the least of it.

## What was wrong

`work search` applied three narrowings, none of them askable and none disclosed:

1. **Titles only.** Descriptions and notes were invisible. `work search E_BACKEND_DRIFT` returned 0 against this repository's own tracker while six items carry the string.
2. **Open items only.** `work search "dep add"` returned 0 while a closed item's title contains that exact phrase.
3. **Capped at 50**, because the adapter sent no bound and the backend's own default is 50.

Each one turns a real match into an empty result indistinguishable from a true negative — which is how an agent checking for prior art is told "nothing here" and files a duplicate. One was filed and closed that way on 2026-08-07.

The verb is not only operator-facing: `create <noun>`'s duplicate-title guard runs through the same search, so it could not see a collision with a closed item.

## What changed

**`work search QUERY [--in FIELD] [--status S] [--limit N]`** — wide on all three axes by default, each narrowable:

- Corpus: title, description and notes. `--in` is repeatable; an id match still reports under `title`.
- Status: every status, closed included. `--status` narrows.
- Bound: unbounded, like `list` and `ready` already are. `--limit` caps.

The backend has no single call answering "title OR description" — its text filters intersect with its text query rather than union with it — so the adapter runs one read per requested field and merges by id, ranked by field order. `--limit` slices the merged set and never the individual reads: bounding each field before the merge would undercount the union, the same ordering `list --track` already enforces.

Every leg parses at the disclosure the title read can support, so a single result set never mixes disclosure levels; `search` declares exactly the relationships it declared before.

**The `create` guard states its own search** rather than inheriting the new defaults: titles alone (only an exact title match can collide, so a description hit could never satisfy it), but every status — work already done and closed is the prior art a caller is least likely to have found by hand, and re-filing it under the same title is the duplicate the guard exists to prevent. `E_DUPLICATE_TITLE` now carries the colliding item's `status` beside its `id`.

**Protocol 1.7 → 1.8 (MINOR).** Additive flags; the envelope and `data` shapes are untouched. What changes is the answer a call gives, not its shape. Decided against the post-rebase baseline: `main` reached 1.7 via the 9k9.177 lane while this branch was in flight, and publishing two independent protocol changes under one version is what the handshake pin exists to prevent.

## Verification

- `make ci-workcli` — exit 0, 776 unit tests, 99.23% coverage against a 90% branch floor. Re-run after rebasing onto `eb928f04`.
- `make itest-workcli` — exit 0, 51 tests against a real isolated backend, including a new module that seeds 60 same-token titles and proves an over-a-page match set arrives whole, that description-only and note-only matches are found, and that a closed item is still returned.
- Each of the three narrowings has a unit test observed failing against the previous code before the fix landed.
