### PR TITLE
fix(9k9.170): every read returns the acceptance criteria, and says so when there are none

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -58,15 +58,15 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work reconcile [--dry-run]` | recovery sweep over the states the tracker can still observe: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol is `"1.8"` — additive-only bumps (new `ErrorCode` members, the
-derived `Item.track` field, the capability-disposition model,
-`partial_progress` detail below, and `search`'s optional narrowing flags)
-never change an existing envelope or data shape. A bump can still widen
-what an unchanged call *answers*: 1.8 makes `search` read descriptions and
-notes as well as titles, stop excluding closed items, and stop stopping at
-the first page, so a query that used to return nothing may now return
-matches — and `create <noun>` refuses a title a closed item already
-carries. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+Protocol is `"1.9"` — additive-only bumps (new `ErrorCode` members, the
+derived `Item.track` field and the `acceptance` field beside it, the
+capability-disposition model, `partial_progress` detail below, and `search`'s
+optional narrowing flags) never change an existing envelope or data shape. A
+bump can still widen what an unchanged call *answers*: 1.8 makes `search`
+read descriptions and notes as well as titles, stop excluding closed items,
+and stop stopping at the first page, so a query that used to return nothing
+may now return matches — and `create <noun>` refuses a title a closed item
+already carries. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
 writes via `supports_dep_write` — `dep list` is never gated, even when
@@ -101,13 +101,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.8", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.9", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.8", "ok": false, "data": null,
+{"protocol": "1.9", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -141,7 +141,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.8", "ok": true, "data": {"protocol": "1.8"}, "error": null}
+{"protocol": "1.9", "ok": true, "data": {"protocol": "1.9"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -153,6 +153,10 @@ are the same value, always.
 - `show` with one id → `data` IS the item object (never a single-element
   array). `show` with 2+ ids, `list`, `ready`, `search` → `data =
   {"items": [...]}`.
+- Every read item carries `acceptance`: the criteria the item was created
+  with, or `null` when it has none. The key is always present on `show`,
+  `list`, `ready` and `search` alike, so `null` reads as "this item has no
+  criteria" and never as "this verb did not fetch them".
 - `label list` → a bare `string[]` (never embedded objects).
 - `dep list` → `data = {"depends_on": [...], "dependents": [...]}` (bd's own
   inverted `--direction` naming is translated to these names).
@@ -162,7 +166,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.8"}`.
+- `--protocol-version` → `{"protocol": "1.9"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.8"
+PROTOCOL_VERSION = "1.9"

--- a/packages/workcli/src/workcli/adapters/bd/parse.py
+++ b/packages/workcli/src/workcli/adapters/bd/parse.py
@@ -256,6 +256,27 @@ def _string_field(
     return str(value)
 
 
+def _optional_string_field(raw: dict[str, JsonValue], key: str, item_id: str) -> str | None:
+    """Return `raw[key]` as a `str`, or `None` where the backend reports nothing.
+
+    The opposite discipline to `_string_field`, and for a field the normalized
+    model types as optional: absence is an answer here, not a gap. bd omits any
+    key whose value is empty, so an absent key, an explicit `null` and `""` are
+    one answer arriving three ways -- all normalize to `None`, because
+    publishing three spellings of "none" would make every consumer handle each.
+    A non-string value is still drift: the model types this as text.
+    """
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _drift(
+            f"the backend returned an item whose {key} field is not a string",
+            {"reason": "unexpected_field_type", "field": key, "id": item_id},
+        )
+    return value or None
+
+
 def _string_list_field(raw: dict[str, JsonValue], key: str, item_id: str) -> list[str]:
     """Return `raw[key]` as a `list[str]`, alarming on any non-string element.
 
@@ -368,6 +389,11 @@ def parse_item(raw: dict[str, JsonValue], *, unknown: frozenset[str] = frozenset
         notes=_string_field(raw, "notes", item_id, default=""),
         created=str(raw["created_at"]) if raw.get("created_at") is not None else None,
         updated=str(raw["updated_at"]) if raw.get("updated_at") is not None else None,
+        # Every read command carries this field (captured from bd 1.0.3
+        # against an isolated scratch install: show, list, ready and search
+        # all report it), so no read has to declare it unavailable the way
+        # the relationships below are declared -- see `_UNKNOWN_RELATIONS`.
+        acceptance=_optional_string_field(raw, "acceptance_criteria", item_id),
         # An unanswerable relationship is empty here AND travels declared, so
         # neither layer can mistake it for an answer: in-package callers reading
         # the Item see nothing to misread, and the verb layer drops the field

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -42,6 +42,13 @@ class Item:
     notes: str
     created: str | None  # ISO strings as bd emits them; no datetime parsing in v1
     updated: str | None
+    # The criteria a claim on this item is checked against. `None` is the
+    # backend's own answer -- this item carries none -- and is why the field
+    # takes no default: an item built without one would report "no criteria"
+    # for an item nobody asked about, which is the silence this field exists
+    # to end. Optional rather than `str` because "none" is a real state here,
+    # unlike `description`/`notes`, where the empty string says the same thing.
+    acceptance: str | None
     # Which of `RELATIONSHIP_FIELDS` the source read could not express. The
     # fields themselves hold their empty value when named here, and the verb
     # layer drops them from the envelope rather than publishing an empty

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -33,6 +33,11 @@ def _serialize_item(item: Item) -> dict[str, JsonValue]:
     for field in unknown:
         del serialized[field]
     serialized["unknown_relations"] = cast("list[JsonValue]", unknown)
+    # `acceptance` deliberately stays out of that mechanism. Every read the
+    # backend offers carries the criteria, so the field is always present and
+    # `null` says the item has none; an absent key would say this read never
+    # fetched them, which is a state no read is in. Same principle, different
+    # conclusion: the distinction is what matters, not the list.
     # Derived in the verb layer, config-free, so every read envelope carries
     # it regardless of config state (the 1.1 additive field).
     serialized["track"] = derive_track(item.labels)

--- a/packages/workcli/tests/fake_backend.py
+++ b/packages/workcli/tests/fake_backend.py
@@ -18,9 +18,10 @@ Fidelity choices that matter for recovery correctness:
   regression that trusts a query result's children is caught rather than
   masked. A fake that answered any of these from its own complete state would
   hide exactly the class of defect this seam exists to catch.
-- `Item` is frozen and carries no `acceptance` field, so `get()` rebuilds a
-  fresh snapshot per read, and acceptance -- which bd stores but the normalized
-  Item drops -- is exposed for assertions via `acceptance_of()`.
+- `Item` is frozen, so `get()` rebuilds a fresh snapshot per read. The record
+  holds acceptance the way bd stores it (`""` for an item that has none) and
+  the snapshot collapses that to `None`, exactly as the parser does;
+  `acceptance_of()` reads the stored text for write-path assertions.
 
 `add()`/`acceptance_of()`/`note_lines()` are test-facing scaffolding, not part
 of the `Backend` protocol; structural conformance to `Backend` is enforced by
@@ -146,6 +147,9 @@ class FakeBackend:
             notes=rec.notes,
             created=None,
             updated=None,
+            # Stored as the backend stores it, reported as the parser reports
+            # it: no criteria is `None` on the way out, never `""`.
+            acceptance=rec.acceptance or None,
             unknown_relations=unknown,
         )
 

--- a/packages/workcli/tests/fixtures/bd_list_acceptance.json
+++ b/packages/workcli/tests/fixtures/bd_list_acceptance.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "acp-wuq",
+    "title": "ac-none",
+    "description": "carries none",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:20Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:20Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  },
+  {
+    "id": "acp-gw6",
+    "title": "ac-one",
+    "description": "carries criteria",
+    "acceptance_criteria": "AC1 show returns this text.",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:19Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:19Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_ready_acceptance.json
+++ b/packages/workcli/tests/fixtures/bd_ready_acceptance.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "acp-wuq",
+    "title": "ac-none",
+    "description": "carries none",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:20Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:20Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  },
+  {
+    "id": "acp-gw6",
+    "title": "ac-one",
+    "description": "carries criteria",
+    "acceptance_criteria": "AC1 show returns this text.",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:19Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:19Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_search_acceptance.json
+++ b/packages/workcli/tests/fixtures/bd_search_acceptance.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "acp-wuq",
+    "title": "ac-none",
+    "description": "carries none",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:20Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:20Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  },
+  {
+    "id": "acp-gw6",
+    "title": "ac-one",
+    "description": "carries criteria",
+    "acceptance_criteria": "AC1 show returns this text.",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:19Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:19Z",
+    "dependency_count": 0,
+    "dependent_count": 0,
+    "comment_count": 0
+  }
+]

--- a/packages/workcli/tests/fixtures/bd_show_acceptance.json
+++ b/packages/workcli/tests/fixtures/bd_show_acceptance.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "acp-gw6",
+    "title": "ac-one",
+    "description": "carries criteria",
+    "acceptance_criteria": "AC1 show returns this text.",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:19Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:19Z"
+  },
+  {
+    "id": "acp-wuq",
+    "title": "ac-none",
+    "description": "carries none",
+    "status": "open",
+    "priority": 2,
+    "issue_type": "task",
+    "owner": "scotthamilton77@gmail.com",
+    "created_at": "2026-08-08T14:28:20Z",
+    "created_by": "Scott Hamilton",
+    "updated_at": "2026-08-08T14:28:20Z"
+  }
+]

--- a/packages/workcli/tests/integration/test_acceptance_roundtrip.py
+++ b/packages/workcli/tests/integration/test_acceptance_roundtrip.py
@@ -1,0 +1,70 @@
+"""Acceptance criteria survive create -> read against a real backend.
+
+The hermetic suite proves the facade reports what a captured payload holds.
+This proves the payload holds it: the criteria are written by a real `work
+create`, stored by a real backend, and read back through every verb that
+returns an item. A backend that stopped reporting them on one of its read
+commands would land here and nowhere else.
+"""
+
+from __future__ import annotations
+
+from tests.integration.conftest import ITEST_TRACK
+
+_CRITERIA = "AC1 the criteria come back through every read."
+
+
+def _create(driver, title: str, *argv: str) -> str:
+    created = driver(
+        [
+            "create",
+            "chore",
+            "--title",
+            title,
+            "--priority",
+            "2",
+            "--orphan",
+            "--track",
+            ITEST_TRACK,
+            *argv,
+        ]
+    )
+    assert created["ok"] is True, created
+    return created["data"]["id"]
+
+
+def test_show_returns_the_acceptance_the_item_was_created_with(driver):
+    item_id = _create(driver, "ac-roundtrip", "--acceptance", _CRITERIA)
+
+    shown = driver(["show", item_id])["data"]  # single-id show → item directly
+
+    assert shown["acceptance"] == _CRITERIA
+
+
+def test_an_item_created_without_acceptance_reports_none_rather_than_omitting_it(driver):
+    item_id = _create(driver, "ac-roundtrip-none")
+
+    shown = driver(["show", item_id])["data"]
+
+    assert "acceptance" in shown, "an absent key would say this read never fetched the criteria"
+    assert shown["acceptance"] is None
+
+
+def test_every_read_verb_reports_the_same_acceptance_show_does(driver):
+    with_criteria = _create(driver, "ac-listed", "--acceptance", _CRITERIA)
+    without_criteria = _create(driver, "ac-listed-none")
+    expected = {with_criteria: _CRITERIA, without_criteria: None}
+
+    reads = {
+        "list": driver(["list"]),
+        "ready": driver(["ready"]),
+        "search": driver(["search", "ac-listed"]),
+    }
+
+    for verb, envelope in reads.items():
+        assert envelope["ok"] is True, envelope
+        reported = {item["id"]: item for item in envelope["data"]["items"]}
+        for item_id, criteria in expected.items():
+            assert item_id in reported, f"{verb} did not report {item_id}"
+            assert "acceptance" in reported[item_id], f"{verb} omits acceptance for {item_id}"
+            assert reported[item_id]["acceptance"] == criteria, verb

--- a/packages/workcli/tests/unit/test_acceptance_read.py
+++ b/packages/workcli/tests/unit/test_acceptance_read.py
@@ -1,0 +1,296 @@
+"""Acceptance criteria on the read path -- the text a claim is checked against.
+
+`create --acceptance` always persisted the criteria; no read could return
+them, so every read reported a well-formed item with no acceptance key and a
+consumer read that as "this item has none".
+
+Two things are pinned here, and the second is what makes the first safe to
+build on:
+
+- the text round-trips (create, then show) and arrives from a real payload on
+  every read command;
+- the key is ALWAYS present on a read item. `null` is the backend's own answer
+  -- this item carries no criteria -- while an absent key would mean this read
+  never fetched them, and no read is in that state. They are different values,
+  so a consumer is never left guessing which one it holds: the same reason the
+  relationship fields are dropped-and-declared rather than published empty.
+
+The payloads are golden captures from an isolated scratch install (bd 1.0.3,
+off-repo temp dir, never this repository's tracker): two tasks, one created
+with `--acceptance` and one without, read back through each of the four
+commands the facade's reads are built on.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_cli
+from tests.fake_backend import FakeBackend
+from tests.fakes import ScriptedStep
+from workcli.adapters.bd.parse import parse_item
+from workcli.adapters.bd.runner import BdResult
+from workcli.config import TrackLayerConfig
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.create import create_noun
+from workcli.verbs.read import show
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+# The two seeded tasks: `ac-one` was created with `--acceptance`, `ac-none`
+# without it.
+_WITH_CRITERIA = "acp-gw6"
+_WITHOUT_CRITERIA = "acp-wuq"
+_CRITERIA = "AC1 show returns this text."
+
+_READ_COMMANDS = ("show", "list", "ready", "search")
+
+
+def _payload(name: str) -> str:
+    return (_FIXTURES / name).read_text()
+
+
+def _ok(stdout: str) -> BdResult:
+    return BdResult(returncode=0, stdout=stdout, stderr="")
+
+
+# `ready` reads the parked set first; `search` reads one leg per corpus field,
+# and only the title leg has a payload here.
+_READS = (
+    (
+        "show",
+        ["show", _WITH_CRITERIA, _WITHOUT_CRITERIA],
+        [ScriptedStep(("show",), _ok(_payload("bd_show_acceptance.json")))],
+    ),
+    (
+        "list",
+        ["list"],
+        [ScriptedStep(("list",), _ok(_payload("bd_list_acceptance.json")))],
+    ),
+    (
+        "ready",
+        ["ready"],
+        [
+            ScriptedStep(("list",), _ok("[]")),
+            ScriptedStep(("ready",), _ok(_payload("bd_ready_acceptance.json"))),
+        ],
+    ),
+    (
+        "search",
+        ["search", "ac-"],
+        [
+            ScriptedStep(("search",), _ok(_payload("bd_search_acceptance.json"))),
+            ScriptedStep(("list",), _ok("[]")),
+            ScriptedStep(("list",), _ok("[]")),
+        ],
+    ),
+)
+_READ_IDS = [read[0] for read in _READS]
+
+
+def _items_by_id(argv: list[str], steps: list[ScriptedStep]) -> dict[str, dict[str, JsonValue]]:
+    exit_code, envelope, _ = run_cli(argv, steps)
+
+    assert exit_code == 0, envelope
+    data = envelope["data"]
+    assert isinstance(data, dict)
+    rows = data["items"]
+    assert isinstance(rows, list)
+    by_id: dict[str, dict[str, JsonValue]] = {}
+    for row in rows:
+        assert isinstance(row, dict)
+        by_id[str(row["id"])] = row
+    return by_id
+
+
+# -- the round trip, over the in-memory backend -------------------------------
+
+
+def _unconfigured_track_layer() -> TrackLayerConfig:
+    # The track gate is not what this file is about; an unconfigured layer
+    # makes it a no-op without inventing a track vocabulary here.
+    raise WorkError(
+        ErrorCode.NOT_CONFIGURED,
+        "track layer not configured",
+        detail={"reason": "not-found"},
+    )
+
+
+def _create_args(*, acceptance: str | None) -> Namespace:
+    return Namespace(
+        noun="chore",
+        raw=False,
+        title="the created work",
+        description=None,
+        type=None,
+        priority=None,
+        parent=None,
+        label=[],
+        orphan=True,
+        spec=None,
+        trivial=False,
+        acceptance=acceptance,
+        track=None,
+        load_config=_unconfigured_track_layer,
+    )
+
+
+def _read_args(**overrides: object) -> Namespace:
+    base: dict[str, object] = {
+        "status": None,
+        "label": None,
+        "parent": None,
+        "type": None,
+        "limit": None,
+        "track": None,
+        "corpus": None,
+        "stale_days": 14,
+        "now": lambda: datetime(2026, 8, 8, 12, 0, tzinfo=UTC),
+        "load_config": lambda: None,
+    }
+    return Namespace(**{**base, **overrides})
+
+
+def _created(backend: FakeBackend, *, acceptance: str | None) -> str:
+    data = create_noun(backend, _create_args(acceptance=acceptance))
+    assert isinstance(data, dict)
+    new_id = data["id"]
+    assert isinstance(new_id, str)
+    return new_id
+
+
+def test_show_returns_the_acceptance_an_item_was_created_with() -> None:
+    # The defect in one assertion: the write path stored this text and no read
+    # could ever hand it back.
+    backend = FakeBackend()
+    new_id = _created(backend, acceptance=_CRITERIA)
+
+    shown = show(backend, _read_args(ids=[new_id]))
+
+    assert isinstance(shown, dict)
+    assert shown["acceptance"] == _CRITERIA
+
+
+def test_show_reports_null_for_an_item_created_without_acceptance() -> None:
+    backend = FakeBackend()
+    new_id = _created(backend, acceptance=None)
+
+    shown = show(backend, _read_args(ids=[new_id]))
+
+    assert isinstance(shown, dict)
+    assert "acceptance" in shown, (
+        "an absent key means this read did not fetch the criteria; an item that "
+        "has none must say so with a value"
+    )
+    assert shown["acceptance"] is None
+
+
+# -- every read verb, against real payloads -----------------------------------
+
+
+@pytest.mark.parametrize(("verb", "argv", "steps"), _READS, ids=_READ_IDS)
+def test_every_read_verb_returns_the_acceptance_text(
+    verb: str, argv: list[str], steps: list[ScriptedStep]
+) -> None:
+    reported = _items_by_id(argv, steps)
+
+    assert reported[_WITH_CRITERIA]["acceptance"] == _CRITERIA, (
+        f"{verb} does not report the criteria the backend holds for {_WITH_CRITERIA}"
+    )
+
+
+@pytest.mark.parametrize(("verb", "argv", "steps"), _READS, ids=_READ_IDS)
+def test_no_read_verb_omits_the_key_for_an_item_that_has_no_criteria(
+    verb: str, argv: list[str], steps: list[ScriptedStep]
+) -> None:
+    # Absent and null are the two answers a consumer must be able to tell
+    # apart, and only one of them is ever right here.
+    reported = _items_by_id(argv, steps)[_WITHOUT_CRITERIA]
+
+    assert "acceptance" in reported, f"{verb} omits acceptance rather than reporting none"
+    assert reported["acceptance"] is None
+
+
+def test_the_list_shaped_reads_agree_with_show_about_acceptance() -> None:
+    # Agreement is the contract, not availability: every read command's payload
+    # carries the field, so no read has a reason to differ from `show`.
+    show_argv, show_steps = _READS[0][1], _READS[0][2]
+    truth = _items_by_id(show_argv, show_steps)
+
+    for verb, argv, steps in _READS[1:]:
+        reported = _items_by_id(argv, steps)
+        for item_id, item in reported.items():
+            assert item["acceptance"] == truth[item_id]["acceptance"], (
+                f"{verb} reports acceptance={item['acceptance']!r} for {item_id} "
+                f"while show reports {truth[item_id]['acceptance']!r}"
+            )
+
+
+def test_the_captured_payloads_still_carry_acceptance_in_every_read_shape() -> None:
+    """The removal condition, made mechanical.
+
+    Both halves of the decision live in these payloads: every read command
+    reports the criteria when an item has them, and every one of them OMITS
+    the key when the item has none -- which is why an absent key normalizes to
+    `null` rather than alarming. If a later backend changes either half, this
+    fails, and the right response is to revisit the normalization rather than
+    relax the assertion.
+    """
+    for command in _READ_COMMANDS:
+        items = json.loads(_payload(f"bd_{command}_acceptance.json"))
+        by_id = {item["id"]: item for item in items}
+
+        assert by_id[_WITH_CRITERIA]["acceptance_criteria"] == _CRITERIA, command
+        assert "acceptance_criteria" not in by_id[_WITHOUT_CRITERIA], command
+
+
+# -- normalization at the parse boundary --------------------------------------
+
+
+def _raw_item(**overrides: object) -> dict[str, JsonValue]:
+    raw: dict[str, JsonValue] = {
+        "id": "raw-1",
+        "title": "T",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+    }
+    raw.update(overrides)  # type: ignore[arg-type]
+    return raw
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        pytest.param({}, None, id="absent"),
+        pytest.param({"acceptance_criteria": None}, None, id="null"),
+        pytest.param({"acceptance_criteria": ""}, None, id="empty-string"),
+        pytest.param({"acceptance_criteria": _CRITERIA}, _CRITERIA, id="text"),
+    ],
+)
+def test_the_parser_normalizes_every_backend_spelling_of_no_criteria(
+    overrides: dict[str, object], expected: str | None
+) -> None:
+    # The backend omits any key whose value is empty, so absent, null and ""
+    # are one answer arriving three ways. Keeping them apart would publish a
+    # distinction with nothing behind it, and each spelling would have to be
+    # handled by every consumer.
+    item = parse_item(_raw_item(**overrides))
+
+    assert item.acceptance == expected
+
+
+def test_the_parser_alarms_on_acceptance_that_is_not_text() -> None:
+    # The model types the criteria as text, so a non-string is the backend's
+    # model of itself breaking -- coercing it would publish "5" as an item's
+    # acceptance criteria and lose the only signal that anything was wrong.
+    with pytest.raises(WorkError) as exc_info:
+        parse_item(_raw_item(acceptance_criteria=5))
+
+    assert exc_info.value.code is ErrorCode.BACKEND_DRIFT
+    assert exc_info.value.detail["field"] == "acceptance_criteria"

--- a/packages/workcli/tests/unit/test_nouns.py
+++ b/packages/workcli/tests/unit/test_nouns.py
@@ -30,6 +30,7 @@ def _item(**overrides: object) -> Item:
         notes="",
         created=None,
         updated=None,
+        acceptance=None,
     )
     base.update(overrides)
     return Item(**base)  # type: ignore[arg-type]

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -96,7 +96,15 @@ def test_protocol_wire_value_is_pinned() -> None:
     # result was acting on a false negative. What changes is the answer, not
     # its shape, and a wider true answer is what the verb always claimed to
     # give.
-    assert PROTOCOL_VERSION == "1.8"
+    #
+    # 1.9 adds `acceptance` to every read item -- the criteria a claim on the
+    # item is checked against, which the write path has always stored and no
+    # read could return. A new key on an existing object is the same additive
+    # case as `track` in 1.1: nothing an existing consumer reads changes value
+    # or shape, and one that ignores the key sees exactly what it saw before.
+    # The field is always present, `null` where the item has none, so the
+    # answer never arrives as a missing key a consumer would have to interpret.
+    assert PROTOCOL_VERSION == "1.9"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:


### PR DESCRIPTION
Fixes `agents-config-9k9.170` (P1): acceptance criteria were write-only.

## The defect

`work create --acceptance TEXT` persisted the criteria and nothing could read them back. The normalized `Item` declared no such field, and `verbs/read.py` serializes `Item` via `dataclasses.asdict`, so `show`, `list`, `ready` and `search` all returned a well-formed item with no acceptance key at all. The failure was silent in the worst direction: a consumer read that as "this item has no criteria" rather than "this reader cannot see them" — and the charter makes those criteria the termination condition a claim is checked against.

## What changed

- `Item` carries `acceptance: str | None`, with no default, so no construction site can quietly report "no criteria" for an item nobody asked about.
- The adapter parses `acceptance_criteria` off the payload. The backend omits any key whose value is empty, so absent, `null` and `""` are one answer arriving three ways and all normalize to `None`; a non-string value is drift and alarms.
- Every read verb reports it, through the one serializer they already share. Protocol 1.8 → 1.9 (a new key on an existing object — additive on the same rule as the derived `track` field), README updated to match.

## Absent versus empty

The field is **always present**; `null` means the item has no criteria. An absent key would mean the read never fetched them, and no read is in that state: every read command reports the criteria, captured from bd 1.0.3 against an isolated scratch install (the four new fixtures, one per command). It deliberately does **not** join the `unknown_relations` mechanism — that names *relationships* a read cannot express, acceptance is not a relationship, and widening the list would either make its name lie or force a breaking rename. `graph` nodes and `parked` rows are unchanged: they are narrow projections that already omit description and notes, not item serializations.

## Editability after create

Answered in a note on the item, in short: yes in principle, not here, and never as another `update --set-*` field — a silent replace lets the criteria be rewritten to match whatever was built. Filed as `agents-config-9k9.184` (out-of-scope), which carries the design question the work actually turns on: what happens when the item is already claimed.

## Verification

- Every new test observed red against the pre-change code first, including the real-backend ones.
- `make ci-workcli` — exit 0 (795 unit tests, 99.24% branch coverage).
- `make itest-workcli` — exit 0 (54 tests against a real, isolated backend, ~3 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
