### PR TITLE
chore(9k9.45): the generic layer states its contract, not one backend's behaviour

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -37,7 +37,8 @@ Twelve verbs; each is a subcommand of `work`.
 | global | `--format {json,human}` (human renders to **stderr**; stdout envelope unchanged), `--protocol-version`, `--config PATH` (explicit `project-config.toml`; overrides the upward search — track-layer surfaces only, see below) |
 
 `epic`/`stats`/`compact`/`delete` are deliberately out of scope for v1 — no
-programmatic consumer observed; use `bd` directly for those.
+programmatic consumer observed. A consumer that needs one adds it here; the
+facade does not expose a way around itself.
 
 ## Lifecycle verbs
 

--- a/packages/workcli/pyproject.toml
+++ b/packages/workcli/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "workcli"
 version = "0.1.0"
-description = "work — facade CLI quarantining the issue-tracker backend (bd) behind a stable contract."
+description = "work — facade CLI quarantining the issue-tracker backend behind a stable contract."
 requires-python = ">=3.11"
 dependencies = []
 

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -1,6 +1,6 @@
 """workcli — the `work` CLI transport layer.
 
-Quarantines the issue-tracker backend (bd) behind a stable, versioned JSON
+Quarantines the issue-tracker backend behind a stable, versioned JSON
 envelope contract. See ``docs/specs/2026-07-04-work-facade-cli-contract.md``
 for the behavioral spec this package implements.
 """

--- a/packages/workcli/src/workcli/backend.py
+++ b/packages/workcli/src/workcli/backend.py
@@ -1,8 +1,9 @@
 """The Backend seam: one protocol per the verb set's primitive needs.
 
 The verb layer owns normalization, typed errors, and retries; adapters own
-only backend I/O and concept mapping (spec section 6). v1 ships the bd
-adapter (`adapters/bd/backend.py`) alone.
+only backend I/O and concept mapping (spec section 6). v1 ships exactly one
+adapter (`adapters/bd/backend.py`); everything above this file is written so
+a second one needs no change here.
 """
 
 from __future__ import annotations
@@ -54,7 +55,7 @@ class Backend(Protocol):
 
     def create(self, fields: CreateFields) -> str: ...  # returns new item id  # pragma: no cover
     def set_fields(self, item_id: str, fields: UpdateFields) -> None: ...  # pragma: no cover
-    def claim(self, item_id: str) -> None: ...  # bd `update --claim`  # pragma: no cover
+    def claim(self, item_id: str) -> None: ...  # atomic; never set_status  # pragma: no cover
     def set_status(self, item_id: str, status: str) -> None: ...  # pragma: no cover
     def set_type(self, item_id: str, item_type: str) -> None: ...  # pragma: no cover
     def set_acceptance(self, item_id: str, text: str) -> None: ...  # pragma: no cover

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -1,7 +1,7 @@
 """workcli CLI — argparse wiring, protocol handshake, and the dispatch loop.
 
 `main()` is the single injectable entry point: every outside-world dependency
-(argv, the bd runner, stdout/stderr, sleep) arrives as an argument, never a
+(argv, the backend runner, stdout/stderr, sleep) arrives as an argument, never a
 module global. The `Backend` itself is constructed lazily, inside `main()`,
 only when a verb actually dispatches -- `--protocol-version` short-circuits
 before it and never touches the runner: the handshake is cheap and

--- a/packages/workcli/src/workcli/envelope.py
+++ b/packages/workcli/src/workcli/envelope.py
@@ -47,10 +47,11 @@ class StepProgress:
     """A `label_mutate`/`sync` mid-sequence failure's replayable progress.
 
     The seam's only two irreducibly multi-call `Backend` primitives
-    (`label_mutate` -- one `bd label` call per label; `sync` --
-    `dolt commit` then `dolt push`) can fail after some sub-steps already
-    applied. `with_progress` attaches this record to the raised `WorkError`
-    so a caller can tell "nothing applied" (no `partial_progress` key --
+    (`label_mutate` -- one backend call per label, where the backend takes
+    them one at a time; `sync` -- a commit followed by a push) can fail
+    after some sub-steps already applied. `with_progress` attaches this record
+    to the raised `WorkError` so a caller can tell "nothing applied"
+    (no `partial_progress` key --
     contract per decision "absence means atomic") from "these sub-steps
     already applied, retry from the top is safe" (this record present).
     """

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -312,10 +312,10 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     """`work create <noun> --title T (--parent ID | --orphan) [...]`.
 
     NOUN and --priority are validated together, before any backend call --
-    same precedence discover's aggregate holds, and the same reason: a caller
-    who gets both wrong learns about both from one invocation, and an invalid
-    NOUN never reaches the backend. `args.priority` is reassigned to the validated,
-    canonicalized value so every downstream read (here and in
+    the same precedence `discover`'s aggregate holds, and for the same reason:
+    a caller who gets both wrong learns about both from one invocation, and an
+    invalid NOUN never reaches the backend. `args.priority` is reassigned to
+    the validated, canonicalized value so every downstream read (here and in
     `_create_spec_container`) sees the same notation `discover` would have
     produced for the same input, without threading a second parameter through
     both call sites.

--- a/packages/workcli/src/workcli/lifecycle/create.py
+++ b/packages/workcli/src/workcli/lifecycle/create.py
@@ -285,7 +285,7 @@ def _create_spec_container(
         CreateFields(
             title=args.title,
             description=args.description,
-            type=template.bd_type,
+            type=template.item_type,
             priority=args.priority,
             parent=parent,
             labels=(template.shape_label, CREATING_SPEC_LABEL)
@@ -314,7 +314,7 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
     NOUN and --priority are validated together, before any backend call --
     same precedence discover's aggregate holds, and the same reason: a caller
     who gets both wrong learns about both from one invocation, and an invalid
-    NOUN never reaches bd. `args.priority` is reassigned to the validated,
+    NOUN never reaches the backend. `args.priority` is reassigned to the validated,
     canonicalized value so every downstream read (here and in
     `_create_spec_container`) sees the same notation `discover` would have
     produced for the same input, without threading a second parameter through
@@ -351,7 +351,7 @@ def create_noun(backend: Backend, args: Namespace) -> JsonValue:
         CreateFields(
             title=args.title,
             description=args.description,
-            type=template.bd_type,
+            type=template.item_type,
             priority=args.priority,
             parent=parent,
             labels=tuple(labels),

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -4,7 +4,7 @@ reconciliation.
 Dispatches on the `shape-design` label (CLI surface table): a design
 child's `deliver` parses the merged spec's `## Continuations` manifest and
 reconciles the sibling placeholder; a leaf's `deliver` verifies
-bd-observable evidence before recording the `[work] delivered:` marker and
+tracker-observable evidence before recording the `[work] delivered:` marker and
 closing. A container is refused outright -- it completes via close-walk when
 its children close, never through `deliver`. `reconcile_placeholder` is
 exported for reuse by `reconcile` -- it is short-circuit idempotent
@@ -158,7 +158,7 @@ def _deliver_design(backend: Backend, args: Namespace, design_item: Item) -> Jso
 def _leaf_evidence(backend: Backend, args: Namespace) -> str:
     """Verify + describe the evidence for a leaf `deliver`.
 
-    `--pr` is caller-attested (no bd verification); `--items` is verified
+    `--pr` is caller-attested (no backend verification); `--items` is verified
     via `batch_get` -- a miss surfaces `E_NOT_FOUND`, translated here to
     `E_EVIDENCE` because the items themselves ARE the evidence, not a lookup
     target; `--trivial` records a bare acknowledgement. Absent all three,
@@ -247,7 +247,7 @@ def _reconcile_single(backend: Backend, placeholder_id: str, manifest: Manifest)
     # its shape label yet already off the sweep's handle.
     item = manifest.items[0]
     template = NOUN_TEMPLATES[Noun(item.noun)]
-    backend.set_type(placeholder_id, template.bd_type)
+    backend.set_type(placeholder_id, template.item_type)
     backend.set_fields(placeholder_id, UpdateFields(title=item.title))
     backend.set_acceptance(placeholder_id, item.acceptance)
     backend.label_mutate("add", placeholder_id, [template.shape_label, SPEC_READY_LABEL])
@@ -255,7 +255,7 @@ def _reconcile_single(backend: Backend, placeholder_id: str, manifest: Manifest)
 
 def _reconcile_multi(backend: Backend, placeholder: Item, manifest: Manifest) -> None:
     # One order-preserving batch_get instead of an N+1 get()-per-child loop
-    # (empty children -> zero bd calls, per the batch_get empty-ids pin).
+    # (empty children -> zero backend calls, per the batch_get empty-ids pin).
     existing_titles = {child.title for child in backend.batch_get(list(placeholder.children))}
     for item in manifest.items:
         if item.title in existing_titles:
@@ -264,7 +264,7 @@ def _reconcile_multi(backend: Backend, placeholder: Item, manifest: Manifest) ->
         backend.create(
             CreateFields(
                 title=item.title,
-                type=template.bd_type,
+                type=template.item_type,
                 parent=placeholder.id,
                 labels=(template.shape_label,),
                 acceptance=item.acceptance,

--- a/packages/workcli/src/workcli/lifecycle/manifest.py
+++ b/packages/workcli/src/workcli/lifecycle/manifest.py
@@ -153,7 +153,7 @@ def serialize_manifest(manifest: Manifest) -> str:
     Recorded in-band as the `[work] manifest:` note's payload at first design
     `deliver`, so recovery replays toward this frozen target instead of
     re-reading the (mutable) spec file. Single-line (no literal newlines, even
-    across a multi-line title/AC — JSON escapes them) so it survives as one bd
+    across a multi-line title/AC — JSON escapes them) so it survives as one
     note line the marker parser reads.
     """
     payload = {
@@ -177,9 +177,9 @@ def _snapshot_drift(text: str) -> WorkError:
 def deserialize_manifest(text: str) -> Manifest:
     """Inverse of `serialize_manifest`: the recorded snapshot back to a `Manifest`.
 
-    The snapshot lives in a bd note -- shared, dolt-synced state a human or
-    another agent can hand-edit -- so a truncated, malformed, or tampered payload
-    is *expected* corruption, not an internal bug. It surfaces as a typed
+    The snapshot lives in a note -- shared state, replicated across machines,
+    that a human or another agent can hand-edit -- so a truncated, malformed,
+    or tampered payload is *expected* corruption, not an internal bug. It surfaces as a typed
     `E_BACKEND_DRIFT` carrying the offending text, so `reconcile` can report one
     poisoned placeholder as a single attention finding instead of a raw
     `JSONDecodeError`/`KeyError` aborting the whole sweep as `E_INTERNAL`.

--- a/packages/workcli/src/workcli/lifecycle/nouns.py
+++ b/packages/workcli/src/workcli/lifecycle/nouns.py
@@ -45,7 +45,7 @@ def resolve_noun(value: str) -> Noun | None:
 
 @dataclass(frozen=True)
 class NounTemplate:
-    bd_type: str  # bd --type value
+    item_type: str  # the `Item.type` this noun is stamped with at creation
     shape_label: str  # birth shape label, e.g. "shape-feat"
     is_container: bool  # True for spec/epic
     expects_evidence: bool  # True for feat/bugfix (evidence rule applies)

--- a/packages/workcli/src/workcli/lifecycle/park.py
+++ b/packages/workcli/src/workcli/lifecycle/park.py
@@ -2,7 +2,7 @@
 work.
 
 A work item whose PR won't merge parks with a typed reason and the machine
-disengages: parked is bd's `blocked` status (drops the item out of `ready`,
+disengages: parked is the backend's `blocked` status (drops it out of `ready`,
 so `claim` refuses it) + the `parked` label (the cheap queryable handle) + a
 timestamped `[work] parked` marker note carrying the reason. The two human
 verbs walk it back to `open` with distinct recorded intent -- recut is

--- a/packages/workcli/src/workcli/lifecycle/reconcile.py
+++ b/packages/workcli/src/workcli/lifecycle/reconcile.py
@@ -3,11 +3,11 @@
 Candidate sets are enumerated **only** through removable completion handles
 (labels), never inferred from external state such as a design child's status or
 a spec file's contents. Because `query()`/`list`-sourced Items always have
-`children == []` and no deps (bd `list` has no `dependents` key -- see
-`adapters/bd/parse.py`), every candidate is re-fetched via `get()` before its
-children/deps/notes are read. Recovery replays toward the in-band
-`[work] manifest:` snapshot recorded at first delivery, so the spec file is
-never re-read here. `--dry-run` performs zero mutating bd calls; repairs are
+`children == []` and no deps -- a listing carries less than a full read, and
+an adapter says so through `unknown_relations` -- every candidate is re-fetched
+via `get()` before its children/deps/notes are read. Recovery replays toward
+the in-band `[work] manifest:` snapshot recorded at first delivery, so the spec
+file is never re-read here. `--dry-run` performs zero mutating backend calls; repairs are
 idempotent (a second sweep over a healed tree finds nothing).
 """
 
@@ -131,8 +131,8 @@ def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> lis
     tail the write paths run, so a crashed `promote` gets its `shape-feat`->`shape-spec`
     swap reconstructed, not just create-spec's tail replayed. Each candidate is
     re-`get()`d for its labels first: a container's own design child /
-    placeholder can carry a LEAKED `creating-spec` (bd inherited the parent's
-    labels at mint, before the adapter's `--no-inherit-labels` opt-out); such a
+    placeholder can carry a LEAKED `creating-spec` (a child inherited the
+    parent's labels at mint, before the adapter opted out); such a
     leaf is healed by stripping the leaked handle, never finalized as a
     container -- finalizing a leaf would mint grandchildren under it and stamp
     it `planned`. A second sweep over a healed tree finds no

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -26,7 +26,7 @@ def _claimed(item_id: str, block: list[JsonValue]) -> JsonValue:
 
 
 def claim(backend: Backend, args: Namespace) -> JsonValue:
-    """`work claim ID` -- uses bd's own atomic `--claim`; detects stale claims.
+    """`work claim ID` -- uses the seam's atomic `claim`; detects stale claims.
 
     Every SUCCESS carries the read-only `parked_stale` block: taking new work
     is exactly the interaction that must show the stuck work first. A refusal

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -1,8 +1,8 @@
 """Shapes shared across the verb layer and every Backend adapter.
 
-Normalized, backend-agnostic dataclasses: `Item`/`DepEdge` are what the bd
-adapter's parser (`adapters/bd/parse.py`) produces from raw bd JSON, and what
-the verb layer serializes into envelope `data` via `dataclasses.asdict`.
+Normalized, backend-agnostic dataclasses: `Item`/`DepEdge` are what an
+adapter's parser produces from the backend's raw payload, and what the verb
+layer serializes into envelope `data` via `dataclasses.asdict`.
 """
 
 from __future__ import annotations
@@ -18,11 +18,11 @@ RELATIONSHIP_FIELDS = ("parent", "deps", "children")
 class DepEdge:
     id: str
     # An open `str`, deliberately, and NOT the closed set `dep add` enforces
-    # (`verbs/relations.py::DEP_TYPES`, bd's own documented vocabulary). bd
-    # validates no type at all and stores whatever it is handed, so edges
-    # carrying an unsanctioned type already exist; a read that could not
-    # express one would misreport the very edges the write-side check now
-    # exists to stop being made. Closed on write, open on read.
+    # (`verbs/relations.py::DEP_TYPES`). A backend need not validate the type
+    # it is handed -- bd stores whatever it is given -- so edges carrying an
+    # unsanctioned type already exist; a read that could not express one would
+    # misreport the very edges the write-side check now exists to stop being
+    # made. Closed on write, open on read.
     type: str
     status: str  # status of the item at the other end
 
@@ -40,7 +40,7 @@ class Item:
     children: list[str]
     description: str
     notes: str
-    created: str | None  # ISO strings as bd emits them; no datetime parsing in v1
+    created: str | None  # ISO strings as the backend emits them; no datetime parsing in v1
     updated: str | None
     # The criteria a claim on this item is checked against. `None` is the
     # backend's own answer -- this item carries none -- and is why the field
@@ -60,12 +60,13 @@ class Item:
 
 @dataclass(frozen=True)
 class DepListing:
-    # `bd dep list --direction` semantics read backward from intuition: the
-    # default ("down") lists what this item depends on; "up" lists what
-    # depends on this item. Naming the fields after bd's own directions
-    # would silently re-encode that ambiguity into every caller, so these
-    # are named for the relationship instead (verified against golden
-    # fixtures in adapters/bd/backend.py::BdBackend.dep_list).
+    # Named for the relationship, never for a backend's own direction words:
+    # "up" and "down" invert depending on who is speaking, and a field named
+    # after one would re-encode that ambiguity into every caller. bd is the
+    # case that established it -- its `dep list --direction` default ("down")
+    # lists what this item depends on, while "up" lists what depends on this
+    # item (verified against golden fixtures in
+    # adapters/bd/backend.py::BdBackend.dep_list).
     depends_on: list[DepEdge]
     dependents: list[DepEdge]
 
@@ -86,8 +87,8 @@ class CreateFields:
     priority: str | None = None
     parent: str | None = None
     labels: tuple[str, ...] = ()
-    acceptance: str | None = None  # NEW — bd `--acceptance`
-    blocked_by: str | None = None  # NEW — bd `--deps <id>` (bare; atomic blocks-edge at creation)
+    acceptance: str | None = None  # the criteria to stamp at creation
+    blocked_by: str | None = None  # one bare blocks-edge, applied atomically at creation
 
 
 @dataclass(frozen=True)
@@ -97,8 +98,9 @@ class UpdateFields:  # replace-semantics fields ONLY; notes never appear here
     description: str | None = None
     # The parent is single-valued, so a move belongs here with the other
     # replace-semantics fields rather than on `dep add`, which only ever adds.
-    # bd's `update --parent` replaces the old parent-child edge outright, so
-    # one call moves the item with no window in which it has two parents.
+    # Reparenting through the seam replaces the old parent-child edge outright
+    # (verified against bd's atomic `update --parent`), so one call moves the
+    # item with no window in which it has two parents.
     parent: str | None = None
 
 

--- a/packages/workcli/src/workcli/verbs/groom.py
+++ b/packages/workcli/src/workcli/verbs/groom.py
@@ -1,7 +1,7 @@
 """`work groom --done` / `work groom --status` -- Backlog Grooming state.
 
-Its own module, not `report.py`: `--done` MUTATES state (bd's own
-per-item state, on a note field) unlike the read-only aggregations
+Its own module, not `report.py`: `--done` MUTATES state (tracker state,
+on a note field) unlike the read-only aggregations
 `lint`/`graph`/`triggers` compute, so it's closer in shape to
 `verbs/tracks.py`'s single mutating verb than to the report family.
 
@@ -9,7 +9,7 @@ Persistence mechanism: the `Backend` protocol has no metadata primitive
 (only `get`/`append_note`), so state lives as a parseable note line
 (`backlog_last_groomed: <iso8601>`) on the designated
 `[operating-model].groom-state-item` -- the spec's named fallback. Notes are
-append-only (bd's `--append-notes`, same discipline as `work note`), so
+append-only (the seam's `append_note`, same discipline as `work note`), so
 `--done` never edits an existing line; `--status` selects the marker with
 the latest PARSED timestamp, not the physically last line -- concurrent
 `--done` calls can append out of chronological order.
@@ -27,7 +27,7 @@ from workcli.envelope import ErrorCode, JsonValue, WorkError
 
 _NOTE_LINE_PATTERN = re.compile(r"^backlog_last_groomed: (.*)$", re.MULTILINE)
 _TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-# backlog_last_groomed is dolt-synced across machines: ordinary
+# backlog_last_groomed is shared across machines: ordinary
 # NTP drift on a fast clock can leave a freshly-written marker slightly in
 # the future, and treating that as invalid would fail a groom that just
 # happened. A marker further in the future than this isn't drift -- it's
@@ -98,8 +98,8 @@ def _latest_marker(
 
 
 def _invalid_marker(groom_state_item: str, last_groomed: str, problem: str) -> WorkError:
-    """Notes are append-only and raw `bd note`/`bd label` writes stay possible
-    outside `work groom --done` -- any marker this module cannot trust must
+    """Notes are append-only and raw tracker writes stay possible outside
+    `work groom --done` -- any marker this module cannot trust must
     fail loud as a typed error here, never crash into E_INTERNAL (which would
     silently drop the nag rather than surfacing the broken state)."""
     return WorkError(
@@ -134,7 +134,7 @@ def _status(
         }
     last_groomed, parsed = latest
     # A small future skew (<= tolerance, already accepted by _latest_marker)
-    # is ordinary NTP drift on a fast clock across dolt-synced machines:
+    # is ordinary NTP drift on a fast clock across machines sharing the state:
     # clamp to 0 rather than reporting a negative days_since, so an honest
     # cross-machine groom never falsely reports breached=True.
     days_since = max((now - parsed).days, 0)

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -66,12 +66,12 @@ def list_(backend: Backend, args: Namespace) -> JsonValue:
     E_UNKNOWN_TRACK, not a silently-empty result. Ordering matters twice:
     config loads BEFORE the backend query (E_NOT_CONFIGURED must precede any
     backend error, and an unconfigured call must not read the tracker), and
-    --limit applies AFTER the track filter (a bd-side limit would truncate
-    the candidate set before filtering and undercount matches). `--limit 0`
-    is the existing unbounded sentinel (mirrored from the bd adapter, which
-    sends "0" for both an omitted limit and an explicit 0) -- it must not
-    slice the filtered set down to zero items. A negative limit is never
-    meaningful either -- unlike bd-side slicing, Python's `items[:n]` with a
+    --limit applies AFTER the track filter (a backend-side limit would
+    truncate the candidate set before filtering and undercount matches).
+    `--limit 0` is the existing unbounded sentinel (mirrored from the bd
+    adapter, which sends "0" for both an omitted limit and an explicit 0) --
+    it must not slice the filtered set down to zero items. A negative limit is
+    never meaningful either -- unlike backend-side slicing, `items[:n]` with a
     negative `n` silently drops trailing items rather than erroring, so
     zero-or-negative both mean unbounded here.
     """

--- a/packages/workcli/src/workcli/verbs/relations.py
+++ b/packages/workcli/src/workcli/verbs/relations.py
@@ -16,12 +16,13 @@ from workcli.envelope import ErrorCode, JsonValue, WorkError
 _DEFAULT_DEP_TYPE = "blocks"
 _PARENT_DEP_TYPE = "parent-child"
 
-# bd's own documented edge vocabulary, read off `bd dep add --help` (bd 1.0.3)
-# and confirmed one type at a time against a scratch install. bd itself
-# enforces none of it: every string in that probe -- including a deliberate
-# nonsense one -- was stored verbatim as a real edge, so a typo'd `--type`
-# produces an edge that exists, renders, and participates in nothing. This
-# frozenset is the enforcement bd declines to do, and it gates `dep add` ONLY.
+# The facade's own closed edge vocabulary, read off bd's documented set
+# (`bd dep add --help`, bd 1.0.3) and confirmed one type at a time against a
+# scratch install. A backend is not obliged to enforce it, and bd does not:
+# every string in that probe -- including a deliberate nonsense one -- was
+# stored verbatim as a real edge, so a typo'd type produces an edge that
+# exists, renders, and participates in nothing. This frozenset is where that
+# enforcement lives instead, and it gates `dep add` ONLY.
 #
 # `dep remove` stays open to any type on purpose: edges carrying an
 # unsanctioned type already exist in the wild, and a closed set on the removal
@@ -45,10 +46,10 @@ DEP_TYPES = frozenset(
 
 
 def _dep_type_check(dep_type: str) -> None:
-    """Reject a type outside bd's documented vocabulary, before any backend call.
+    """Reject a type outside `DEP_TYPES`, before any backend call.
 
     Pure: no read is needed to know the type is nonsense, so this runs first
-    and a rejected `dep add` costs zero bd invocations.
+    and a rejected `dep add` costs zero backend invocations.
     """
     if dep_type in DEP_TYPES:
         return
@@ -62,24 +63,25 @@ def _dep_type_check(dep_type: str) -> None:
 def _parent_arity_check(backend: Backend, from_id: str, to_id: str, dep_type: str) -> None:
     """Refuse a second parent for an item that already has one.
 
-    An item's parent is single-valued, but bd reports it from two sources that
-    a second `parent-child` edge drives apart: the `parent` scalar is bd's own
-    field, while `children` is derived from reverse edges. bd accepts the
-    second edge silently, so the item ends up with two parent-child edges and
-    one scalar -- and the field most readers check is the one that then omits a
-    parent the tree still walks from. Anything counting an epic's children
-    counts that item twice.
+    An item's parent is single-valued, but the backend reports it from two
+    sources that a second `parent-child` edge drives apart: the `parent`
+    scalar is the backend's own field, while `children` is derived from
+    reverse edges. A backend need not refuse the second edge -- bd accepts it
+    silently -- so the item ends up with two parent-child edges and one scalar,
+    and the field most readers check is the one that then omits a parent the
+    tree still walks from. Anything counting an epic's children counts that
+    item twice.
 
-    Redirecting to `work update --set-parent` (bd's own atomic `--parent`
-    reparent, verified to REPLACE the old edge rather than add beside it) is
+    Redirecting to `work update --set-parent` (the seam's atomic reparent,
+    verified to REPLACE the old edge rather than add beside it) is
     what makes the recovery discoverable at the moment it is needed. Same
     guard shape and error code as `update`'s append-only notes tripwire: a
     write that would corrupt a single-valued field is refused by name, and
     names the verb that expresses the intent properly.
 
     Re-adding the parent an item ALREADY has is not a violation -- the
-    postcondition the caller asked for already holds, bd treats the repeat as a
-    no-op (verified against bd 1.0.3), and erroring would fail a correct
+    postcondition the caller asked for already holds, a repeat is a no-op at
+    the backend (verified against bd 1.0.3), and erroring would fail a correct
     request and break retry-safety after a timeout.
     """
     if dep_type != _PARENT_DEP_TYPE:
@@ -101,7 +103,7 @@ def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) 
     `blocks` requires both items epic, or both non-epic (a milestone counts
     as non-epic). One order-preserving `Backend.batch_get` read pays for
     this certainty; a
-    violation raises before `dep_mutate` (the mutating bd call) is ever
+    violation raises before `dep_mutate` (the mutating backend call) is ever
     invoked -- the fake's call log must show zero `dep`-mutation
     invocations in that case.
     """
@@ -126,7 +128,7 @@ def dep(backend: Backend, args: Namespace) -> JsonValue:
 
     `dep add A B` = A depends on B. `add` is an add primitive and stays one:
     it validates and refuses, and never silently relocates an edge to make a
-    request succeed. `list` maps bd's own inverted `--direction` naming into
+    request succeed. `list` maps the backend's own direction vocabulary into
     `{depends_on, dependents}` (the ruling that kills that ambiguity
     permanently -- see `model.DepListing`).
     """
@@ -145,7 +147,7 @@ def dep(backend: Backend, args: Namespace) -> JsonValue:
 
     dep_type = args.type if args.type is not None else _DEFAULT_DEP_TYPE
     if args.action == "add":
-        # Every pre-check raises before `dep_mutate` (the mutating bd call) is
+        # Every pre-check raises before `dep_mutate` (the mutating backend call) is
         # reached, cheapest first: the vocabulary check needs no read at all,
         # and the two that do need one are mutually exclusive by type.
         _dep_type_check(dep_type)
@@ -166,11 +168,10 @@ def dep(backend: Backend, args: Namespace) -> JsonValue:
 def label(backend: Backend, args: Namespace) -> JsonValue:
     """`work label {add,remove,list} ID [LABELS...]`.
 
-    bd's own `label add`/`label remove` accept exactly one label per call
-    (orchestrator ruling) -- `add`/`remove` fan a multi-label request out
-    into one bd invocation per label, still one envelope. `list` returns
-    the flat `string[]` bd itself emits ("labels are always
-    `string[]`").
+    `add`/`remove` accept many labels and still emit one envelope: where the
+    backend takes exactly one label per call (bd does), the adapter fans the
+    request out into one invocation per label. `list` returns a flat
+    `string[]` -- the shape the seam promises, whatever the backend's own.
     """
     if args.action in ("add", "remove") and not args.labels:
         raise WorkError(ErrorCode.USAGE, f"label {args.action} requires at least one LABEL")

--- a/packages/workcli/src/workcli/verbs/relations.py
+++ b/packages/workcli/src/workcli/verbs/relations.py
@@ -102,10 +102,9 @@ def _type_wall_check(backend: Backend, from_id: str, to_id: str, dep_type: str) 
 
     `blocks` requires both items epic, or both non-epic (a milestone counts
     as non-epic). One order-preserving `Backend.batch_get` read pays for
-    this certainty; a
-    violation raises before `dep_mutate` (the mutating backend call) is ever
-    invoked -- the fake's call log must show zero `dep`-mutation
-    invocations in that case.
+    this certainty; a violation raises before `dep_mutate` (the mutating
+    backend call) is ever invoked -- the fake's call log must show zero
+    `dep`-mutation invocations in that case.
     """
     if dep_type != _DEFAULT_DEP_TYPE:
         return

--- a/packages/workcli/src/workcli/verbs/tracks.py
+++ b/packages/workcli/src/workcli/verbs/tracks.py
@@ -78,6 +78,6 @@ def track(backend: Backend, args: Namespace) -> JsonValue:
         "skipped": len(skipped),
         # list() wrap: a NAMED list[str] local is not assignable to a
         # JsonValue slot under mypy --strict (invariance); the constructor
-        # call re-infers from context. Same idiom as the bd adapter.
+        # call re-infers from context. Same idiom as the adapter layer.
         "skipped_ids": list(skipped),
     }

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -48,7 +48,7 @@ def update(backend: Backend, args: Namespace) -> JsonValue:
     Replace semantics only; status never moves through this verb
     (lifecycle verbs own claiming/status). `--set-parent` is the move
     operation: a parent is single-valued, which is exactly the contract this
-    verb already declares, and it maps to bd's own atomic reparent — the old
+    verb already declares, and it maps to the seam's atomic reparent — the old
     parent-child edge is replaced, never added beside. `dep add` refuses a
     second parent and names this flag.
 
@@ -63,7 +63,7 @@ def update(backend: Backend, args: Namespace) -> JsonValue:
             "notes are append-only; use `work note ID TEXT` instead of --set-notes",
         )
     if args.set_parent is not None and not args.set_parent:
-        # bd reads an empty `--parent` as "remove the parent", and an
+        # An empty parent reads as "remove the parent" at the backend, and an
         # unset shell variable expands to exactly that. Orphaning an item is
         # not what anyone typing a move means, and this verb replaces a value
         # with a value; detaching a parent is deliberately unexpressible here.
@@ -99,10 +99,10 @@ def close(backend: Backend, args: Namespace) -> JsonValue:
     """`work close IDS... [--disposition TEXT]` -- close + close-walk + note,
     one call.
 
-    Batch `bd close` for all ids first, then one `--append-notes` call per
-    id carrying the disposition text (orchestrator ruling: `bd close
-    --reason` lands in the wrong field; the disposition is an appended note),
-    then the close-walk: exhausted non-milestone parents close with a walk
+    One batched `Backend.close` for all ids first, then one `append_note` per
+    id carrying the disposition text (orchestrator ruling: the backend's own
+    close-reason field is the wrong home; the disposition is an appended
+    note), then the close-walk: exhausted non-milestone parents close with a walk
     note. `data` stays None when nothing walked (legacy envelope shape).
     """
     backend.close(args.ids)

--- a/packages/workcli/tests/integration/test_nouns.py
+++ b/packages/workcli/tests/integration/test_nouns.py
@@ -1,4 +1,4 @@
-"""Each `work create <noun>` template stamps the right bd type + shape label."""
+"""Each `work create <noun>` template stamps the right item type + shape label."""
 
 from __future__ import annotations
 
@@ -6,8 +6,8 @@ import pytest
 
 from tests.integration.conftest import ITEST_TRACK
 
-# (noun, expected bd type, expected shape label) — verified against
-# lifecycle/nouns.py NOUN_TEMPLATES (bd_type, shape_label). Exact contract.
+# (noun, expected item type, expected shape label) — verified against
+# lifecycle/nouns.py NOUN_TEMPLATES (item_type, shape_label). Exact contract.
 NOUN_EXPECTATIONS = [
     ("spike", "task", "shape-spike"),
     ("chore", "chore", "shape-chore"),
@@ -19,8 +19,8 @@ NOUN_EXPECTATIONS = [
 ]
 
 
-@pytest.mark.parametrize("noun,bd_type,shape_label", NOUN_EXPECTATIONS)
-def test_create_noun_stamps_type_and_shape_label(driver, noun, bd_type, shape_label):
+@pytest.mark.parametrize("noun,item_type,shape_label", NOUN_EXPECTATIONS)
+def test_create_noun_stamps_type_and_shape_label(driver, noun, item_type, shape_label):
     created = driver(
         [
             "create",
@@ -37,7 +37,7 @@ def test_create_noun_stamps_type_and_shape_label(driver, noun, bd_type, shape_la
     assert created["ok"] is True, created
     item_id = created["data"]["id"]  # create → {"id": ...}
     shown = driver(["show", item_id])["data"]  # single-id show → item directly
-    assert shown["type"] == bd_type  # Item field is `type`, not `issue_type`
+    assert shown["type"] == item_type  # Item field is `type`, not `issue_type`
     assert shape_label in shown["labels"]
     assert f"track:{ITEST_TRACK}" in shown["labels"]  # --track lands as the track label
 


### PR DESCRIPTION
Closes the sweep tracked as `agents-config-9k9.45` (workcli's generic layer names the bd tool in its comments).

## What was wrong

`workcli`'s backend-agnostic layer explained itself in terms of `bd`. Someone writing a second adapter would have read `model.py`, the `Backend` protocol, or the verb layer and found the first backend's observed behaviour presented as the seam's contract — "bd validates no type at all", "bd's `update --parent` replaces the old edge", "bd reports it from two sources". None of it was a user-facing surface, which is why this sat at P3; it misleads a future implementer rather than a user today.

## How each site was decided

The package rule this item was waiting on now exists, in `packages/workcli/AGENTS.md` under "What may name the backend, and where". Its test was applied site by site rather than substituting a word: **rewrite the sentence with a second, hypothetical adapter in its place.** If it stays true and still explains the code, the name was *evidence* and stays. If it goes false, the name was carrying *the contract*, and the contract belongs in the sentence with the product demoted to the observation that established it.

That test is what makes "kept" a real disposition rather than a miss. The rule governs by audience, and its downward prohibition ("nothing above `adapters/` may name the backend") is scoped to strings that can be printed — prose is held to the substitution test instead, at any layer.

**Census: 65 raw matches across 19 files in the generic layer.** Larger than the 42-site audit recorded on the item, because that audit predates three PRs that landed in this package the same day and because it scanned `.py` only.

- **~30 rewritten.** `# ISO strings as bd emits them` → `as the backend emits them`. `bd validates no type at all and stores whatever it is handed` → `A backend need not validate the type it is handed -- bd stores whatever it is given`. The `DepListing` comment now leads with the rule (fields are named for the relationship, never for a backend's direction words) and cites bd's `dep list --direction` as the case that established it.
- **13 kept as evidence.** Version-pinned probes (`read off bd's documented set (bd dep add --help, bd 1.0.3)`), explicit verification markers (`verified against bd 1.0.3`), and statements that stay true however many adapters exist (`"noop" is reserved for server-authoritative backends; the bd adapter never emits it` — that tells a second-adapter author the slot is theirs).
- **3 out of scope, unchanged.** Two adapter imports in `cli.py`, which is the composition root, and `GROOM_STATE_KEY_SUPERSEDED = "groom-state-bead"`, a superseded config key still accepted on read — renaming it would break existing project configs. It is a value, not prose.

## One identifier renamed

`NounTemplate.bd_type` → `item_type`, matching `Backend.set_type`'s own parameter name. This was the one leaked identifier in the generic layer and the one item here that could mislead a reader into thinking the field is backend-specific. Five call sites in `src/`, three in the integration suite; nothing outside `packages/workcli/` referenced it.

## Two surfaces earlier audits missed

Both fail the substitution test outright and are consumer-facing rather than commentary, which is why they are worth calling out separately:

- `README.md` told a consumer to "use `bd` directly" for the four out-of-scope verbs — documentation instructing a consumer to bypass the facade by name. It now says a consumer that needs one adds it here.
- `pyproject.toml`'s package description named the backend in the same sentence that claims to hide it. Package metadata is read by anyone deciding whether to depend on this.

## Verification

- `make ci-workcli` — **exit 0**, run standalone from the worktree root, before and after the rebase onto `origin/main`. 795 tests, 99.24% coverage.
- `make itest-workcli` — **exit 0**, 54 tests against a real isolated `bd`. Run because the rename touches the `create`/`deliver` paths the suite drives and because a file in that suite changed.
- The mechanical scan in `tests/unit/test_envelope_invariants.py` passes unmodified. None of its assertions went stale: it exempts docstrings and cannot see comments, which is exactly the surface this change covers.
- Behaviour unchanged. The diff's only executable edit is the rename; there is no control-flow change. Protocol stays at 1.9, as a prose sweep should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
