### PR TITLE
fix(9k9.163): read every file a skill directory deploys, not just its entry

### DIFF
--- a/packages/installer/src/installer/cli.py
+++ b/packages/installer/src/installer/cli.py
@@ -355,7 +355,7 @@ def _run(
     # a malformed record, an over-cap surface, or a claim conflict aborts the
     # whole deploy before any write. Runs on the user-home path only; the
     # --project fork returned above is ungated by design.
-    gate = run_admission_gate(plans)
+    gate = run_admission_gate(plans, ignore=ignore)
     for label in gate.skipped:
         io.info(f"admission: not admitted (no admission record): {label}", verbose=True)
     if gate.skipped:

--- a/packages/installer/src/installer/core/content_lint.py
+++ b/packages/installer/src/installer/core/content_lint.py
@@ -217,7 +217,8 @@ def deployed_asset_names(repo_root: Path, *, io: IOPort) -> dict[str, frozenset[
     different question (what is authored) and drift from this one silently, since
     nothing would ever compare the two.
     """
-    return admitted_asset_names(run_admission_gate(stage_src(repo_root, io=io).plans).plans)
+    staged = stage_src(repo_root, io=io)
+    return admitted_asset_names(run_admission_gate(staged.plans, ignore=staged.ignore).plans)
 
 
 @dataclass(frozen=True, slots=True)
@@ -600,7 +601,7 @@ def lint_content(repo_root: Path, *, io: IOPort) -> ContentLintResult:
     the caller surfaces, not something to swallow into a clean result.
     """
     staged = stage_src(repo_root, io=io)
-    gate = run_admission_gate(staged.plans)
+    gate = run_admission_gate(staged.plans, ignore=staged.ignore)
     sources = gate.sources
 
     # Bucketed on the source file: one authored file that four tools each staged

--- a/packages/installer/src/installer/core/deploy_gate.py
+++ b/packages/installer/src/installer/core/deploy_gate.py
@@ -27,6 +27,13 @@ reporting nothing against the file that actually lacked a record. So each
 contributor is classified and sanitized on its own, and the destination is
 reassembled from the survivors.
 
+One artifact is not one file either. A skill directory copies verbatim, so
+rewriting its entry file leaves every other file in it shipping as authored —
+including an ``admission`` block or a provenance comment, which is exactly what
+step 2 exists to keep out of a deploy. So the interior is scanned as well, down
+every level and through the overrides, and a file carrying that metadata is
+**reported rather than cleaned** (``_interior_violations`` states why).
+
 Any violation makes ``GateResult.ok`` false; the caller reports each and aborts
 with a non-zero exit *before* the write block, so a breach never half-deploys.
 The returned ``plans`` are the admission-filtered plans the caller installs —
@@ -53,9 +60,10 @@ from installer.core.admission import (
 from installer.core.capabilities import is_user_invoked
 from installer.core.conflict_audit import conflict_violations
 from installer.core.frontmatter import split_frontmatter
+from installer.core.installignore import InstallIgnore
 from installer.core.merge.strategies.append_rules import SEPARATOR
 from installer.core.model import Contribution, contributions_of
-from installer.core.sanitize import project_capabilities, sanitize_text
+from installer.core.sanitize import governance_findings, project_capabilities, sanitize_text
 from installer.core.surface_budget import (
     SkillBodySource,
     SkillMeasure,
@@ -67,11 +75,26 @@ from installer.core.surface_budget import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from installer.core.model import StagedItem, StagingPlan, Tool
 
 # The always-on instruction file each tool deploys (Claude/Codex/OpenCode emit
 # AGENTS.md; Gemini emits GEMINI.md). Used to weigh the surface budget.
 _INSTRUCTION_DESTS = (Path("AGENTS.md"), Path("GEMINI.md"))
+
+# Exclude nothing — the default for callers that have not loaded a manifest
+# (the unit tests, chiefly). It over-reports rather than under-reports: with no
+# manifest the interior scan reads files a real install would have pruned, so a
+# caller who forgets to pass one gets a finding too many, never a leak too few.
+_EMPTY_IGNORE = InstallIgnore()
+
+# The files inside a directory item the interior scan reads. Both shapes
+# ``governance_findings`` recognises are markdown conventions — a leading ``---``
+# YAML fence and a leading HTML comment — so a ``.py``, ``.sh``, ``.json`` or
+# ``.yaml`` sibling has nowhere to carry either, and scanning one would be
+# looking for a shape that cannot occur there.
+_SCANNED_SUFFIXES = frozenset({".md"})
 
 
 def item_label(tool: Tool, dest: Path) -> str:
@@ -182,6 +205,87 @@ def _record_bearers(item: StagedItem, overrides: dict[Path, Contribution]) -> li
     ]
 
 
+def _deployed_interior(
+    item: StagedItem, overrides: Mapping[Path, Contribution], ignore: InstallIgnore
+) -> dict[Path, Contribution]:
+    """Every file a directory item deploys *below* its entry file, by relative path.
+
+    The source tree filtered the way the copy filters it, then the overrides laid
+    on top — the same construction the sync's idempotency check makes, and for
+    the same reason: what matters is what reaches disk, not what is authored.
+    Overrides are deliberately not filtered, because the sync writes them
+    unconditionally after the filtered copy; a name the manifest excludes still
+    deploys when an override supplies its bytes.
+
+    The entry file is dropped at the top level only. It is the one file the gate
+    already reads and rewrites, so nothing is left in it to find; a ``SKILL.md``
+    nested deeper is a different file, which nothing reads and nothing strips.
+    """
+    interior = {
+        path.relative_to(item.source_path): Contribution(
+            source_path=path, content=path.read_bytes()
+        )
+        for path in sorted(item.source_path.rglob("*"))
+        if path.is_file() and not ignore.excludes_path(path.relative_to(item.source_path))
+    }
+    interior.update(overrides)
+    interior.pop(Path(DIR_RECORD_FILE), None)
+    return interior
+
+
+def _interior_violations(
+    item: StagedItem,
+    overrides: Mapping[Path, Contribution],
+    *,
+    tool: Tool,
+    dest: Path,
+    ignore: InstallIgnore,
+    sources: dict[str, Path],
+) -> list[str]:
+    """Report every file beside a directory item's entry that ships governance metadata.
+
+    A skill directory copies verbatim, so the gate reading exactly one file per
+    directory means every other file in it ships as authored — including the
+    ``admission`` block or the provenance comment the sanitizer exists to keep
+    out of a deploy. This is the scan that closes that, and it reads the same
+    interior the sync will write.
+
+    **Reported, never rewritten**, and the asymmetry with the entry file is the
+    decision rather than an omission. The entry file's record is *consumed*: the
+    bar reads it, then the sanitizer removes what it read, so the removal
+    completes a transaction. Nothing reads a record on any other file in the
+    directory, so stripping one would complete nothing — it would delete an
+    author's text and leave them believing a record there had done something. A
+    file asserting what the gate never asked is an authoring defect, and naming
+    it is the repair.
+
+    Rewriting would also be the more dangerous half. A references tree is where
+    a mirror of somebody else's document lives, and a mirror's whole value is
+    being byte-exact; a cleaner cannot tell one from a mistake. And the only
+    channel for rewritten interior bytes is ``dir_overrides``, which the sync
+    overlays *after* the filtered copy — so cleaning a file the manifest excludes
+    would deploy the file the manifest excluded. Reading and reporting can do
+    neither.
+    """
+    violations: list[str] = []
+    for rel, contribution in sorted(_deployed_interior(item, overrides, ignore).items()):
+        if rel.suffix not in _SCANNED_SUFFIXES:
+            continue
+        found = governance_findings(contribution.content.decode("utf-8", errors="replace"))
+        if not found:
+            continue
+        label = item_label(tool, dest / rel)
+        sources[label] = contribution.source_path
+        violations.append(
+            f"{label}: carries deploy-time metadata ({', '.join(found)}) that nothing "
+            "reads and nothing strips. Only the entry file's record is consumed and "
+            "removed, so on any other file in the directory this governs nothing and "
+            "reaches the installed copy as authored. Move it to the entry file, or "
+            "delete it from this one"
+        )
+    return violations
+
+
 @dataclass(frozen=True, slots=True)
 class _Admitted:
     """One contributor that cleared the bar, and the bytes it will deploy."""
@@ -228,8 +332,16 @@ def _judge(
     )
 
 
-def run_admission_gate(plans: dict[Tool, StagingPlan]) -> GateResult:
-    """Partition, budget, and conflict-audit ``plans`` in one pass."""
+def run_admission_gate(
+    plans: dict[Tool, StagingPlan], *, ignore: InstallIgnore = _EMPTY_IGNORE
+) -> GateResult:
+    """Partition, budget, and conflict-audit ``plans`` in one pass.
+
+    ``ignore`` is the ``.installignore`` manifest the same run stages with. The
+    gate needs it because a directory item's interior is scanned, and a file that
+    manifest prunes never deploys — reporting one would fail a deploy over bytes
+    nobody would have received.
+    """
     filtered: dict[Tool, StagingPlan] = {}
     skipped: list[str] = []
     violations: list[str] = []
@@ -304,6 +416,13 @@ def run_admission_gate(plans: dict[Tool, StagingPlan]) -> GateResult:
                 entry = admitted[0]
                 sanitized_entries[dest] = Contribution(
                     source_path=entry.source, content=entry.text.encode("utf-8")
+                )
+                # Only now, and only for a directory that is actually going to
+                # deploy. A record-less skill was dropped above, and its interior
+                # ships nothing — reporting it would fail a deploy over bytes no
+                # one receives.
+                violations += _interior_violations(
+                    item, overrides, tool=tool, dest=dest, ignore=ignore, sources=sources
                 )
             kept[dest] = item
 

--- a/packages/installer/src/installer/core/deploy_gate.py
+++ b/packages/installer/src/installer/core/deploy_gate.py
@@ -205,30 +205,46 @@ def _record_bearers(item: StagedItem, overrides: dict[Path, Contribution]) -> li
     ]
 
 
-def _deployed_interior(
+def _scanned_interior(
     item: StagedItem, overrides: Mapping[Path, Contribution], ignore: InstallIgnore
 ) -> dict[Path, Contribution]:
-    """Every file a directory item deploys *below* its entry file, by relative path.
+    """The files below a directory item's entry that the interior scan can read.
 
-    The source tree filtered the way the copy filters it, then the overrides laid
-    on top — the same construction the sync's idempotency check makes, and for
-    the same reason: what matters is what reaches disk, not what is authored.
-    Overrides are deliberately not filtered, because the sync writes them
+    Two filters, answering two different questions, and keeping them apart is
+    what makes this correct.
+
+    **What deploys** is the manifest's question. The source tree is filtered the
+    way the copy filters it, then the overrides are laid on top — the same
+    construction the sync's idempotency check makes, and for the same reason:
+    what matters is what reaches disk, not what is authored. Overrides are
+    deliberately *not* manifest-filtered, because the sync writes them
     unconditionally after the filtered copy; a name the manifest excludes still
     deploys when an override supplies its bytes.
+
+    **What can be read** is the scan's own question, and it applies to both
+    sides equally: a non-markdown override is as opaque to the scan as a
+    non-markdown file in the tree. It is applied *before* the bytes are read
+    rather than after, which is the whole reason this filter lives here instead
+    of at the call site. The interior carries implementation scripts, schemas
+    and fixtures — hundreds of kilobytes per gate run, on the deploy path — and
+    reading them to discard them unexamined is work done on a user's machine to
+    produce nothing.
 
     The entry file is dropped at the top level only. It is the one file the gate
     already reads and rewrites, so nothing is left in it to find; a ``SKILL.md``
     nested deeper is a different file, which nothing reads and nothing strips.
     """
     interior = {
-        path.relative_to(item.source_path): Contribution(
-            source_path=path, content=path.read_bytes()
+        rel: Contribution(source_path=path, content=path.read_bytes())
+        for path, rel in (
+            (path, path.relative_to(item.source_path))
+            for path in sorted(item.source_path.rglob("*"))
         )
-        for path in sorted(item.source_path.rglob("*"))
-        if path.is_file() and not ignore.excludes_path(path.relative_to(item.source_path))
+        if rel.suffix in _SCANNED_SUFFIXES and path.is_file() and not ignore.excludes_path(rel)
     }
-    interior.update(overrides)
+    interior.update(
+        {rel: part for rel, part in overrides.items() if rel.suffix in _SCANNED_SUFFIXES}
+    )
     interior.pop(Path(DIR_RECORD_FILE), None)
     return interior
 
@@ -247,8 +263,8 @@ def _interior_violations(
     A skill directory copies verbatim, so the gate reading exactly one file per
     directory means every other file in it ships as authored — including the
     ``admission`` block or the provenance comment the sanitizer exists to keep
-    out of a deploy. This is the scan that closes that, and it reads the same
-    interior the sync will write.
+    out of a deploy. This is the scan that closes that, over the part of the
+    interior the sync will write that this check can read (`_scanned_interior`).
 
     **Reported, never rewritten**, and the asymmetry with the entry file is the
     decision rather than an omission. The entry file's record is *consumed*: the
@@ -268,9 +284,7 @@ def _interior_violations(
     neither.
     """
     violations: list[str] = []
-    for rel, contribution in sorted(_deployed_interior(item, overrides, ignore).items()):
-        if rel.suffix not in _SCANNED_SUFFIXES:
-            continue
+    for rel, contribution in sorted(_scanned_interior(item, overrides, ignore).items()):
         found = governance_findings(contribution.content.decode("utf-8", errors="replace"))
         if not found:
             continue

--- a/packages/installer/src/installer/core/installignore.py
+++ b/packages/installer/src/installer/core/installignore.py
@@ -86,6 +86,27 @@ class InstallIgnore:
             for p in self.patterns
         )
 
+    def excludes_path(self, rel: Path) -> bool:
+        """Whether ``rel`` — a file path relative to a DIR item's root — is pruned.
+
+        The whole-path form of ``excludes``, for the one scope a DIR item has:
+        every component up to (not including) the file is tested as a directory
+        name, the file's own basename as a file name, all at nested scope. An
+        excluded directory therefore prunes everything beneath it, which is what
+        ``shutil.copytree``'s ``ignore=`` callback does for free by not recursing.
+
+        Two consumers need this same answer and must never disagree about it: the
+        sync's idempotency check, which re-derives from scratch what the filtered
+        copy placed at dest, and the deploy gate's scan of a directory item's
+        interior, which must not report a file that never deploys. Deriving it
+        once here is what keeps the pruning rule from being written twice.
+        """
+        parts = rel.parts
+        last = len(parts) - 1
+        return any(
+            self.excludes(part, is_dir=(i != last), at_root=False) for i, part in enumerate(parts)
+        )
+
 
 def load_installignore(path: Path) -> InstallIgnore:
     """Parse ``.installignore`` at ``path``; return an ``InstallIgnore``.

--- a/packages/installer/src/installer/core/sanitize.py
+++ b/packages/installer/src/installer/core/sanitize.py
@@ -26,6 +26,10 @@ a couple of keys. Dropping the keys' lines preserves the rest exactly.
 A provenance comment is recognized narrowly: an HTML comment standing before
 any prose, carrying a ``Source:`` or ``Upstream:`` line. An arbitrary leading
 comment is content and survives.
+
+The same two recognisers also answer the question without acting on it
+(``governance_findings``), for the files the gate reads but has no mandate to
+rewrite.
 """
 
 from __future__ import annotations
@@ -133,6 +137,36 @@ def _reassemble(text: str, kept: list[str], body: str) -> str:
         return body.lstrip("\r\n")
     newline = _line_ending(text)
     return f"{_FENCE}{newline}{''.join(kept)}{_FENCE}{newline}{body}"
+
+
+#: How :func:`governance_findings` names the provenance comment. The front-matter
+#: findings name themselves — they are the keys — so only this one needs a word.
+PROVENANCE_FINDING = "provenance comment"
+
+
+def governance_findings(text: str) -> tuple[str, ...]:
+    """Every piece of deploy-time metadata in ``text``, named.
+
+    The question :func:`sanitize_text` answers by removal, asked instead of
+    acted on — for the files the gate reads but does not rewrite, where the
+    answer is a finding to report rather than bytes to strip. Sharing the two
+    recognisers is the point: a second definition of "governance metadata" would
+    drift from the one that actually does the stripping, and the drift would show
+    up as a file reported clean and shipped dirty.
+
+    Deliberately *not* implemented as ``sanitize_text(text) != text``. That
+    compares bytes, so it also fires on the incidental normalisations reassembly
+    performs — a fence line carrying trailing whitespace, say — and would report
+    a formatting quirk under a message about governance metadata.
+
+    Empty means there is nothing here the installer consumes and the deployed
+    artifact does not want.
+    """
+    mapping, body = split_frontmatter(text)
+    found = [key for key in sorted(GOVERNANCE_KEYS) if mapping is not None and key in mapping]
+    if _strip_provenance(body) != body:
+        found.append(PROVENANCE_FINDING)
+    return tuple(found)
 
 
 def sanitize_text(text: str) -> str:

--- a/packages/installer/src/installer/core/sync.py
+++ b/packages/installer/src/installer/core/sync.py
@@ -435,24 +435,6 @@ def _copytree_ignore(ignore: InstallIgnore) -> Callable[[str, list[str]], set[st
     return _callback
 
 
-def _nested_path_is_excluded(rel: Path, ignore: InstallIgnore) -> bool:
-    """Whether any component of ``rel`` (a DIR item-relative file path) would be
-    pruned by ``ignore`` at nested (non-anchored) scope.
-
-    Mirrors what `_copytree_ignore` prunes during the real copy: every path
-    component up to (not including) the file itself is tested as a directory
-    name, the file's own basename as a file name. Needed because
-    ``Path.rglob`` — unlike ``copytree`` — does not stop descending into a
-    directory a caller has decided to exclude, so `_dir_is_unchanged`'s
-    expected-file walk must re-derive the same pruning from scratch.
-    """
-    parts = rel.parts
-    last = len(parts) - 1
-    return any(
-        ignore.excludes(part, is_dir=(i != last), at_root=False) for i, part in enumerate(parts)
-    )
-
-
 def _dir_is_unchanged(
     dest: Path, source_path: Path, overrides: Mapping[Path, bytes], ignore: InstallIgnore
 ) -> bool:
@@ -461,9 +443,11 @@ def _dir_is_unchanged(
 
     The expected file map is the source tree with ``overrides`` overlaid (override
     wins on a name collision — dump-time semantics), compared against the actual
-    dest tree. Files ``ignore`` excludes at nested scope (`_nested_path_is_excluded`)
+    dest tree. Files ``ignore`` excludes at nested scope (`InstallIgnore.excludes_path`)
     are dropped from the expected map at every depth, matching what
-    `_install_dir`'s filtered ``copytree`` actually places at dest — without
+    `_install_dir`'s filtered ``copytree`` actually places at dest — ``Path.rglob``,
+    unlike ``copytree``, does not stop descending into an excluded directory, so
+    the expected-file walk has to re-derive the same pruning. Without
     this, a skill carrying a test file would never compare equal and every
     re-install would back up and re-copy for no real change. Bytes are read
     through symlinks to match ``copytree``'s dereferencing; only files
@@ -471,7 +455,7 @@ def _dir_is_unchanged(
     expected = {
         p.relative_to(source_path): p.read_bytes()
         for p in source_path.rglob("*")
-        if p.is_file() and not _nested_path_is_excluded(p.relative_to(source_path), ignore)
+        if p.is_file() and not ignore.excludes_path(p.relative_to(source_path))
     }
     expected.update(overrides)
     actual = {p.relative_to(dest): p.read_bytes() for p in dest.rglob("*") if p.is_file()}

--- a/packages/installer/tests/unit/test_deploy_gate.py
+++ b/packages/installer/tests/unit/test_deploy_gate.py
@@ -7,6 +7,7 @@ run over the admitted set only.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -701,6 +702,43 @@ def test_a_non_markdown_sibling_is_not_scanned(tmp_path: Path) -> None:
     (item.source_path / "data.yaml").write_bytes(b"admission:\n  cost: c\n")
 
     result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert result.ok, result.violations
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root reads a mode-000 file, so nothing is proven")
+def test_a_file_the_scan_cannot_read_is_never_read(tmp_path: Path) -> None:
+    """The suffix filter runs before the bytes are read, not after.
+
+    The interior carries implementation scripts and fixtures the scan can have no
+    opinion about; reading them to discard them unexamined is work done on a
+    user's machine to produce nothing. Pinned without instrumenting file IO: an
+    unreadable file makes the read itself the observable event, so a gate that
+    passes here is a gate that did not attempt it."""
+    item = _skill_dir(tmp_path, "unread")
+    blocked = item.source_path / "big.py"
+    blocked.write_bytes(b"x" * 4096)
+    blocked.chmod(0o000)
+    try:
+        result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+        assert result.ok, result.violations
+    finally:
+        blocked.chmod(0o644)
+
+
+def test_an_override_the_scan_cannot_read_is_filtered_too(tmp_path: Path) -> None:
+    """The suffix filter is the scan's own question and applies to both sides. The
+    manifest exemption overrides carry is about what *deploys*, and it does not
+    extend to what this check can make sense of."""
+    item = _skill_dir(tmp_path, "binary-override")
+    plan = _plan(_instruction(b"laws"), item)
+    plan.dir_overrides[Path("skills/binary-override")] = {
+        Path("assets/data.json"): Contribution(
+            source_path=Path("/plugin/assets/data.json"), content=b'{"admission": 1}'
+        )
+    }
+
+    result = run_admission_gate({Tool.CLAUDE: plan})
 
     assert result.ok, result.violations
 

--- a/packages/installer/tests/unit/test_deploy_gate.py
+++ b/packages/installer/tests/unit/test_deploy_gate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from installer.core.deploy_gate import GateResult, item_label, run_admission_gate
+from installer.core.installignore import InstallIgnore, load_installignore
 from installer.core.merge.strategies.append_rules import AppendRulesStrategy
 from installer.core.model import (
     Contribution,
@@ -581,3 +582,155 @@ def test_what_deployed_is_exactly_what_the_contributions_say_contributed() -> No
         Path("/src/shared/a.md"),
         Path("/src/plugin/a.md"),
     ]
+
+
+# --- A skill directory's interior -------------------------------------------
+#
+# The gate reads and rewrites exactly one file per directory item; the copy takes
+# everything else verbatim. These pin that the rest of the interior is read too,
+# and that reading it is all the gate does to it.
+
+_SIBLING_RECORD = b"---\nadmission:\n  prevents: p\n  cost: c\n  remove_when: r\n---\nnotes\n"
+
+
+def _skill_dir(tmp_path: Path, name: str, entry: bytes = _COMPLETE) -> StagedItem:
+    skill = tmp_path / "skills" / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_bytes(entry)
+    return StagedItem(
+        source_path=skill,
+        dest_relpath=Path("skills") / name,
+        kind=FileKind.DIR,
+        namespace="skills",
+        provenance=Provenance(kind="tool", name="claude"),
+        content=None,
+    )
+
+
+def _ignore(tmp_path: Path, *patterns: str) -> InstallIgnore:
+    manifest = tmp_path / ".installignore"
+    manifest.write_text("".join(f"{p}\n" for p in patterns))
+    return load_installignore(manifest)
+
+
+def test_a_sibling_carrying_a_record_is_reported(tmp_path: Path) -> None:
+    """The entry file is not the artifact — the directory is. A record on any other
+    file in it is read by nothing and stripped by nothing, so left unreported it
+    reaches the installed copy exactly as authored."""
+    item = _skill_dir(tmp_path, "noted")
+    (item.source_path / "extra.md").write_bytes(_SIBLING_RECORD)
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert not result.ok
+    label = item_label(Tool.CLAUDE, Path("skills/noted/extra.md"))
+    assert [v for v in result.violations if v.startswith(f"{label}:")]
+    assert "admission" in result.violations[0]
+    # Reported against the file itself, so the lint can bucket it by source.
+    assert result.sources[label] == item.source_path / "extra.md"
+
+
+def test_a_sibling_below_the_top_level_is_reported(tmp_path: Path) -> None:
+    """The scan descends. A references tree is where the extra files actually are,
+    so a check that read only direct children would miss the common case."""
+    item = _skill_dir(tmp_path, "deep")
+    nested = item.source_path / "references" / "vendor"
+    nested.mkdir(parents=True)
+    (nested / "note.md").write_bytes(b"<!--\nSource: oss-snapshots/x/\n-->\n\nnotes\n")
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert not result.ok
+    label = item_label(Tool.CLAUDE, Path("skills/deep/references/vendor/note.md"))
+    assert [v for v in result.violations if v.startswith(f"{label}:")]
+    assert "provenance comment" in result.violations[0]
+
+
+def test_a_reported_sibling_is_not_rewritten(tmp_path: Path) -> None:
+    """Reported, not cleaned. The gate's only channel for interior bytes is
+    dir_overrides, and writing one here would both destroy an author's text and —
+    since the sync overlays overrides after the filtered copy — deploy files the
+    manifest excludes. So the scan adds nothing to what ships."""
+    item = _skill_dir(tmp_path, "untouched")
+    (item.source_path / "extra.md").write_bytes(_SIBLING_RECORD)
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    overrides = result.plans[Tool.CLAUDE].dir_overrides[Path("skills/untouched")]
+    assert set(overrides) == {Path("SKILL.md")}
+    assert (item.source_path / "extra.md").read_bytes() == _SIBLING_RECORD
+
+
+def test_an_excluded_sibling_is_not_reported(tmp_path: Path) -> None:
+    """A file .installignore prunes never deploys, so it cannot leak. Failing a
+    deploy over it would be failing over bytes nobody receives."""
+    item = _skill_dir(tmp_path, "pruned")
+    (item.source_path / "AGENTS.md").write_bytes(_SIBLING_RECORD)
+    docs = item.source_path / "scripts"
+    docs.mkdir()
+    (docs / "note.md").write_bytes(_SIBLING_RECORD)
+
+    result = run_admission_gate(
+        {Tool.CLAUDE: _plan(_instruction(b"laws"), item)},
+        ignore=_ignore(tmp_path, "AGENTS.md", "scripts/"),
+    )
+
+    assert result.ok, result.violations
+    assert result.plans[Tool.CLAUDE].dir_overrides[Path("skills/pruned")].keys() == {
+        Path("SKILL.md")
+    }
+
+
+def test_a_sibling_with_nothing_to_find_passes(tmp_path: Path) -> None:
+    """Front matter is not the defect — governance front matter is. A reference
+    file with its own metadata keeps it."""
+    item = _skill_dir(tmp_path, "clean")
+    (item.source_path / "extra.md").write_bytes(b"---\nname: extra\n---\n\nnotes\n")
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert result.ok, result.violations
+
+
+def test_a_non_markdown_sibling_is_not_scanned(tmp_path: Path) -> None:
+    """Both recognised shapes are markdown conventions — a leading `---` fence and
+    a leading HTML comment. A script cannot open with either, so a line in one that
+    merely reads like a record is its own content."""
+    item = _skill_dir(tmp_path, "scripted")
+    (item.source_path / "run.py").write_bytes(b"admission = {'cost': 'c'}\n")
+    (item.source_path / "data.yaml").write_bytes(b"admission:\n  cost: c\n")
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert result.ok, result.violations
+
+
+def test_a_sibling_arriving_as_an_override_is_scanned(tmp_path: Path) -> None:
+    """A plugin's carrier-merge contributes files the directory's own source tree
+    does not hold, and the sync writes them unconditionally. They deploy, so they
+    are read — and reported against the plugin file they came from."""
+    item = _skill_dir(tmp_path, "extended")
+    plan = _plan(_instruction(b"laws"), item)
+    origin = Path("/plugin/skills/extended/references/extra.md")
+    plan.dir_overrides[Path("skills/extended")] = {
+        Path("references/extra.md"): Contribution(source_path=origin, content=_SIBLING_RECORD)
+    }
+
+    result = run_admission_gate({Tool.CLAUDE: plan})
+
+    assert not result.ok
+    label = item_label(Tool.CLAUDE, Path("skills/extended/references/extra.md"))
+    assert [v for v in result.violations if v.startswith(f"{label}:")]
+    assert result.sources[label] == origin
+
+
+def test_the_interior_of_a_dropped_directory_is_not_scanned(tmp_path: Path) -> None:
+    """A record-less skill deploys nothing, so nothing in it can leak. Scanning it
+    would fail the deploy over a directory the gate had already thrown away."""
+    item = _skill_dir(tmp_path, "recordless", entry=b"---\nname: recordless\n---\nbody\n")
+    (item.source_path / "extra.md").write_bytes(_SIBLING_RECORD)
+
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert result.ok, result.violations
+    assert result.skipped == [item_label(Tool.CLAUDE, Path("skills/recordless"))]

--- a/packages/installer/tests/unit/test_installignore_invariant.py
+++ b/packages/installer/tests/unit/test_installignore_invariant.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from installer.core.installignore import load_installignore
 from installer.core.model import Tool
 from installer.core.staging import build_plan
-from installer.core.sync import _nested_path_is_excluded
 from installer.tools.registry import get_adapter
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -62,7 +61,7 @@ def test_marker_docs_are_excluded_at_every_depth_not_just_the_namespace_level() 
 
     for marker in sorted(_MARKER_BASENAMES):
         for rel in (Path(f"some-skill/{marker}"), Path(f"some-skill/references/{marker}")):
-            assert _nested_path_is_excluded(rel, ignore), (
+            assert ignore.excludes_path(rel), (
                 f"{rel} would deploy — {marker} is anchored in .installignore and must not be"
             )
 
@@ -76,5 +75,5 @@ def test_readme_stays_anchored_so_a_skill_can_ship_one() -> None:
     file, which is the failure mode the anchoring rule exists to prevent."""
     ignore = load_installignore(_REPO_ROOT / ".installignore")
 
-    assert not _nested_path_is_excluded(Path("some-skill/references/README.md"), ignore)
+    assert not ignore.excludes_path(Path("some-skill/references/README.md"))
     assert ignore.excludes("README.md", is_dir=False, at_root=True)

--- a/packages/installer/tests/unit/test_sanitize.py
+++ b/packages/installer/tests/unit/test_sanitize.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 import pytest
 
-from installer.core.sanitize import project_capabilities, sanitize_bytes, sanitize_text
+from installer.core.sanitize import (
+    governance_findings,
+    project_capabilities,
+    sanitize_bytes,
+    sanitize_text,
+)
 
 _RECORD = "admission:\n  prevents: p\n  cost: c\n  remove_when: r\n"
 _FLAGGED = "---\nname: handoff\ndisable-model-invocation: true\n---\nbody\n"
@@ -185,3 +190,39 @@ def test_projecting_twice_is_a_no_op() -> None:
 def test_projection_keeps_crlf_endings() -> None:
     text = "---\r\nname: a\r\ndisable-model-invocation: true\r\n---\r\nbody\r\n"
     assert project_capabilities(text, tool="gemini") == "---\r\nname: a\r\n---\r\nbody\r\n"
+
+
+# --- Naming the metadata instead of removing it ------------------------------
+#
+# The same two recognisers, asked rather than acted on — for the files the deploy
+# gate reads but has no mandate to rewrite.
+
+
+def test_findings_name_every_governance_key_present() -> None:
+    text = f"---\nname: a\n{_RECORD}claims:\n  k: v\n---\nbody\n"
+    assert governance_findings(text) == ("admission", "claims")
+
+
+def test_findings_name_a_provenance_comment_with_no_front_matter() -> None:
+    assert governance_findings("<!--\nSource: oss-snapshots/x/\n-->\n\nbody\n") == (
+        "provenance comment",
+    )
+
+
+def test_a_file_with_ordinary_front_matter_yields_no_findings() -> None:
+    assert governance_findings("---\nname: a\n---\n\n<!-- an ordinary note -->\nbody\n") == ()
+
+
+def test_findings_ignore_a_fence_quirk_that_reassembly_would_normalise() -> None:
+    """Not implemented as a byte-compare against `sanitize_text`. A fence carrying
+    trailing whitespace round-trips to a different byte string, and reporting that
+    under a message about governance metadata would name the wrong defect."""
+    text = "---  \nname: a\n---\nbody\n"
+    assert sanitize_text(text) != text
+    assert governance_findings(text) == ()
+
+
+def test_what_findings_name_is_what_sanitizing_removes() -> None:
+    text = f"---\nname: a\n{_RECORD}---\n\n<!--\nSource: x/\n-->\n\nbody\n"
+    assert governance_findings(text) == ("admission", "provenance comment")
+    assert governance_findings(sanitize_text(text)) == ()


### PR DESCRIPTION
Closes `agents-config-9k9.163`.

## The defect

A skill directory stages as one opaque `FileKind.DIR` item and syncs by `shutil.copytree`, pruned only by `.installignore`. The deploy gate read exactly one file per directory — `DIR_RECORD_FILE = "SKILL.md"` — sanitized it, and overlaid the result onto that one path. Every other file in the directory therefore shipped byte-for-byte as authored, including an `admission:` block or a `Source:`/`Upstream:` provenance comment naming repository-internal paths. That is precisely what the sanitizer exists to prevent, and no gate said a word.

This is the same disease as the per-contributor slice (#498), one level down: one sanitizer, a second blind spot. The fix sits inside that slice's structure — `Contribution`, `dir_overrides`, `_record_bearers` — rather than beside it.

Reproduced end to end before the change (gate + `sync_plan` against a synthetic home, no installer entry point):

```
gate.ok               = True
gate.violations       = []
deployed SKILL.md     = b'---\nname: mirror\n---\nbody\n'
deployed references/note.md = b'---\nadmission:\n  prevents: p\n  cost: c\n  remove_when: r\n---\nnotes\n'
sibling shipped verbatim    = True
```

After: the gate reports and the deploy aborts before any write.

## The three decisions

**Which files are in scope — markdown only.** Both shapes the sanitizer recognises are markdown conventions: a leading `---` YAML fence and a leading HTML comment. A `.py`, `.sh`, `.json` or `.yaml` sibling has nowhere to carry either, so scanning one would be looking for a shape that cannot occur there. A YAML file's top-level `admission:` key is its own content, and treating it as governance metadata would be a false positive on a file the installer never reads.

**Reported, not sanitized.** The asymmetry with the entry file is the decision rather than an omission. The entry file's record is *consumed* — the bar reads it, then the sanitizer removes what it read, so the removal completes a transaction. Nothing reads a record on any other file in the directory, so stripping one would complete nothing: it would delete an author's text and leave them believing a record there had done something. Two further consequences settle it. A references tree is where a mirror of somebody else's document lives, and a mirror's whole value is being byte-exact — a cleaner cannot tell one from a mistake. And the only channel for rewritten interior bytes is `dir_overrides`, which the sync overlays *after* the filtered copy, so cleaning a file `.installignore` excludes would deploy the file `.installignore` excluded. Reading and reporting can do neither.

**The walk lives in the deploy gate.** The property being protected — deployed bytes carry no repository-internal governance metadata — is a property of the deploy, so a check that only ran repo-side would not protect a user installing from a fork. And because `content_lint` runs this same gate, placing it here yields the repo-side check for free; placing it in `content_lint` would have yielded only one of the two.

## Supporting moves

- `sanitize.governance_findings` names what `sanitize_text` removes, so the reporter and the stripper share one definition of governance metadata. Deliberately not `sanitize_text(text) != text`, which also fires on reassembly's incidental normalisations (a fence line with trailing whitespace) and would report a formatting quirk under a message about governance metadata.
- The nested-exclusion walk moves from `sync._nested_path_is_excluded` onto `InstallIgnore.excludes_path`, where the gate's scan and the sync's idempotency check derive the pruning rule from one place instead of two.
- `run_admission_gate` takes the `.installignore` manifest. A file that manifest prunes never deploys, so reporting it would fail a deploy over bytes nobody receives. It defaults to exclude-nothing, which over-reports rather than under-reports — the safe direction for a gate.

## Evidence

- **Digest.** The staged plan built through `content_lint.stage_src` + `run_admission_gate` over the real `src/`, writing nothing, is byte-identical before and after: `bc0fe52e0c6574f33aab01a0ce6339ed01f068d64e56869d03fa52b54d350d46`. Zero intentional diff, and zero new violations — the gate's own verdict that the defect is latent here, not live.
- **Failing-before.** The three interior tests fail against `e9bc6245` on `assert not result.ok`; the `.installignore` test fails on the signature.
- **`.installignore` parity.** An excluded sibling is neither read nor reported, and nothing the scan reads is added to `dir_overrides` — so reading a file never deploys it.
- **`make ci`** exits 0 from the worktree root.

Out of scope by instruction and untouched: whether reference weight is charged to a token budget. Nothing here weighs anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne