### PR TITLE
fix(9k9.171): the close-walk stops inferring a completion nobody checked

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -59,15 +59,18 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work reconcile [--dry-run]` | recovery sweep over the states the tracker can still observe: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol is `"1.9"` — additive-only bumps (new `ErrorCode` members, the
+Protocol is `"1.10"` — additive-only bumps (new `ErrorCode` members, the
 derived `Item.track` field and the `acceptance` field beside it, the
-capability-disposition model, `partial_progress` detail below, and `search`'s
-optional narrowing flags) never change an existing envelope or data shape. A
-bump can still widen what an unchanged call *answers*: 1.8 makes `search`
-read descriptions and notes as well as titles, stop excluding closed items,
-and stop stopping at the first page, so a query that used to return nothing
-may now return matches — and `create <noun>` refuses a title a closed item
-already carries. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+capability-disposition model, `partial_progress` detail below, `search`'s
+optional narrowing flags, and the close-walk's `held` key) never change an
+existing envelope or data shape. A bump can still change what an unchanged
+call *answers*, in either direction: 1.8 makes `search` read descriptions and
+notes as well as titles, stop excluding closed items, and stop stopping at
+the first page, so a query that used to return nothing may now return matches
+— and `create <noun>` refuses a title a closed item already carries. 1.10
+narrows instead: the close-walk stops closing a parent that carries scope of
+its own, so a parent that used to appear under `walked` now appears under
+`held` with what is unfinished named. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
 writes via `supports_dep_write` — `dep list` is never gated, even when
@@ -102,13 +105,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.9", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.10", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.9", "ok": false, "data": null,
+{"protocol": "1.10", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -142,7 +145,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.9", "ok": true, "data": {"protocol": "1.9"}, "error": null}
+{"protocol": "1.10", "ok": true, "data": {"protocol": "1.10"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -163,11 +166,20 @@ are the same value, always.
   inverted `--direction` naming is translated to these names).
 - `create --raw` → an object carrying the new item's `id` (see
   `verbs/write.py` for the exact shape).
-- `update` / `note` / `close` / `reopen` → `data: null` (no return payload).
+- `update` / `note` / `reopen` → `data: null` (no return payload).
+- `close` and `deliver` report the close-walk under two optional keys, each
+  present only when it has something to say (`close` → `data: null` when
+  neither does). `walked` is the ids the walk closed, in walk order. `held`
+  is the exhausted parents it declined to close because they carry scope of
+  their own — each entry carrying that item's `id`, `title`, `acceptance` (or
+  `null`), the `reason`, and the `resolve` naming the two ways out, so a
+  caller can act on the hold without re-reading the item. The ids a caller
+  names on `close` are closed unconditionally; the walk's rules govern only
+  what it infers.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.9"}`.
+- `--protocol-version` → `{"protocol": "1.10"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.9"
+PROTOCOL_VERSION = "1.10"

--- a/packages/workcli/src/workcli/lifecycle/closewalk.py
+++ b/packages/workcli/src/workcli/lifecycle/closewalk.py
@@ -2,28 +2,118 @@
 
 Close + close-walk + note happen as ONE facade call: a parent whose last open
 child closes is exhausted and closes with it, recursively, so a fully
-delivered tree never strands its containers open. Milestones are the walk
-boundary -- a milestone never auto-closes on child exhaustion; closing one is
-always a deliberate, explicit close call.
+delivered tree never strands its containers open.
+
+The walk closes a parent only where child exhaustion is the whole truth about
+that parent, and it has two boundaries. Milestones are the first -- a
+milestone never auto-closes on child exhaustion; closing one is always a
+deliberate, explicit close call. A parent carrying scope of its own is the
+second: closing its children establishes nothing about that scope, so the
+walk holds it open and reports what is unfinished rather than inferring a
+completion nobody checked. Neither boundary governs an id the caller names --
+a stated close is the caller's own claim, and it is never re-adjudicated here.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import cast
+
 from workcli.backend import Backend
+from workcli.envelope import JsonValue
+from workcli.lifecycle import DELIVERED_MARKER, has_marker, is_container
+from workcli.model import Item
 
 CLOSE_WALK_MARKER = "[work] close-walk: all children closed"
 
+HELD_REASON = "carries scope of its own, and no delivery is recorded against it"
 
-def close_walk(backend: Backend, ids: list[str]) -> list[str]:
+
+@dataclass(frozen=True)
+class HeldParent:
+    """One parent the walk declined to close, and why.
+
+    Carries the item's own title and criteria alongside the reason so a
+    caller can act on the hold as it stands: the criteria are the terms the
+    parent's completion is judged in, and re-reading the item to find them is
+    the round trip this record exists to spare.
+    """
+
+    id: str
+    title: str
+    reason: str
+    acceptance: str | None
+    resolve: str
+
+    def as_payload(self) -> dict[str, JsonValue]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "reason": self.reason,
+            "acceptance": self.acceptance,
+            "resolve": self.resolve,
+        }
+
+
+@dataclass(frozen=True)
+class WalkResult:
+    walked: list[str]  # auto-closed ids, in walk order
+    held: list[HeldParent]  # exhausted parents the walk refused to close
+
+
+def _own_scope_is_done(item: Item) -> bool:
+    """Whether nothing of `item`'s own remains before it can be called done.
+
+    Two ways that holds. A declared container has no scope of its own -- it
+    is structural, its children ARE its scope, so exhausting them completes
+    it. Anything else is a leaf that acquired children, and a leaf's own
+    scope is discharged by `deliver`, which records the delivery marker.
+    Declared state, never child count: same test `claim` and `deliver`
+    already dispatch on.
+
+    The marker case is narrow but real. `deliver` records it and then closes,
+    so a delivered parent is normally already closed when a walk reaches it;
+    the open-and-marked state is the crash window between those two writes,
+    which `deliver`'s own replay path exists for. Reading the marker is what
+    keeps this a statement about completion rather than about shape.
+    """
+    return is_container(item) or has_marker(item.notes, DELIVERED_MARKER)
+
+
+def _held(item: Item) -> HeldParent:
+    return HeldParent(
+        id=item.id,
+        title=item.title,
+        reason=HELD_REASON,
+        acceptance=item.acceptance,
+        resolve=(
+            f"deliver {item.id} with evidence once its own scope is done, or close "
+            f"{item.id} explicitly -- a close the caller names is never held"
+        ),
+    )
+
+
+def close_walk(backend: Backend, ids: list[str]) -> WalkResult:
     """Walk each closed id's parent chain, closing exhausted parents.
 
-    A parent closes iff it is not a milestone, not already closed, and every
-    child is closed; each auto-close appends `CLOSE_WALK_MARKER` and the walk
-    recurses upward. Returns the auto-closed ids in walk order. Closing
-    sibling ids in one call converges: the second sibling's walk meets the
-    already-closed parent and stops without a duplicate note (idempotency).
+    A parent closes iff it is not a milestone, not already closed, every
+    child is closed, and its own scope is done; each auto-close appends
+    `CLOSE_WALK_MARKER` and the walk recurses upward. An exhausted parent
+    whose own scope is not done is reported held instead, once per parent
+    however many of its children this call closes.
+
+    The three older stops stay silent, and deliberately so: a milestone is
+    the designed boundary, an already-closed parent is a no-op, and an open
+    sibling means the parent is simply not eligible yet. A hold is the one
+    stop where the tree looks finished and the walk declines anyway, which is
+    the only one a caller can be surprised by. Closing sibling ids in one
+    call converges on either outcome: the second sibling's walk meets the
+    already-closed parent, or the already-held one, and stops without a
+    duplicate note or a duplicate hold (idempotency).
     """
     walked: list[str] = []
+    held: list[HeldParent] = []
+    held_ids: set[str] = set()
     for start in backend.batch_get(ids):
         current = start
         while current.parent is not None:
@@ -33,8 +123,23 @@ def close_walk(backend: Backend, ids: list[str]) -> list[str]:
             children = backend.batch_get(parent.children)
             if any(child.status != "closed" for child in children):
                 break
+            if not _own_scope_is_done(parent):
+                if parent.id not in held_ids:
+                    held_ids.add(parent.id)
+                    held.append(_held(parent))
+                break
             backend.close([parent.id])
             backend.append_note(parent.id, CLOSE_WALK_MARKER)
             walked.append(parent.id)
             current = parent
-    return walked
+    return WalkResult(walked=walked, held=held)
+
+
+def walk_payload(result: WalkResult) -> dict[str, JsonValue]:
+    """`result` as envelope `data` keys -- each omitted when it has nothing to say."""
+    payload: dict[str, JsonValue] = {}
+    if result.walked:
+        payload["walked"] = cast("list[JsonValue]", list(result.walked))
+    if result.held:
+        payload["held"] = cast("list[JsonValue]", [entry.as_payload() for entry in result.held])
+    return payload

--- a/packages/workcli/src/workcli/lifecycle/deliver.py
+++ b/packages/workcli/src/workcli/lifecycle/deliver.py
@@ -14,7 +14,6 @@ on the `impl-placeholder` label's absence.
 from __future__ import annotations
 
 from argparse import Namespace
-from typing import cast
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
@@ -27,7 +26,7 @@ from workcli.lifecycle import (
     manifest_snapshot,
     spec_path,
 )
-from workcli.lifecycle.closewalk import close_walk
+from workcli.lifecycle.closewalk import close_walk, walk_payload
 from workcli.lifecycle.manifest import Manifest, parse_continuations, serialize_manifest
 from workcli.lifecycle.nouns import (
     CREATING_SPEC_LABEL,
@@ -189,14 +188,14 @@ def _leaf_evidence(backend: Backend, args: Namespace) -> str:
 def _walked_leaf_result(backend: Backend, item_id: str) -> JsonValue:
     """Close-walk from a closed leaf, then the leaf's `closed` envelope.
 
-    Same walk as `work close`: delivering the last open leaf
-    of a container closes the container -- this module's long-standing
-    "closes via close-walk" promise, now code.
+    Same walk as `work close` -- one implementation, so a parent held on one
+    path is held on the other: delivering the last open leaf of a container
+    closes the container (this module's long-standing "closes via close-walk"
+    promise, now code), and a parent carrying scope of its own is reported
+    held instead.
     """
-    walked = close_walk(backend, [item_id])
     result: dict[str, JsonValue] = {"id": item_id, "status": "closed"}
-    if walked:
-        result["walked"] = cast("list[JsonValue]", list(walked))
+    result.update(walk_payload(close_walk(backend, [item_id])))
     return result
 
 

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -9,11 +9,10 @@ envelope.
 from __future__ import annotations
 
 from argparse import Namespace
-from typing import cast
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
-from workcli.lifecycle.closewalk import close_walk
+from workcli.lifecycle.closewalk import close_walk, walk_payload
 from workcli.model import CreateFields, UpdateFields
 
 
@@ -102,17 +101,18 @@ def close(backend: Backend, args: Namespace) -> JsonValue:
     One batched `Backend.close` for all ids first, then one `append_note` per
     id carrying the disposition text (orchestrator ruling: the backend's own
     close-reason field is the wrong home; the disposition is an appended
-    note), then the close-walk: exhausted non-milestone parents close with a walk
-    note. `data` stays None when nothing walked (legacy envelope shape).
+    note), then the close-walk: exhausted parents close with a walk note, and
+    exhausted parents carrying scope of their own are reported held. The ids
+    named here are closed unconditionally -- the walk's rules govern what it
+    infers, not what the caller states. `data` stays None when the walk had
+    nothing to report (legacy envelope shape).
     """
     backend.close(args.ids)
     if args.disposition is not None:
         for item_id in args.ids:
             backend.append_note(item_id, args.disposition)
-    walked = close_walk(backend, list(args.ids))
-    if walked:
-        return {"walked": cast("list[JsonValue]", list(walked))}
-    return None
+    payload = walk_payload(close_walk(backend, list(args.ids)))
+    return payload or None
 
 
 def reopen(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/tests/unit/test_close_walk.py
+++ b/packages/workcli/tests/unit/test_close_walk.py
@@ -4,6 +4,8 @@ close + close-walk + note is ONE facade call: a non-milestone parent whose
 last open child closes is exhausted and closes with it, recursively, with a
 `[work] close-walk` note. Milestones are the boundary -- they never auto-close
 on child exhaustion; closing one is always a deliberate, explicit close call.
+A parent carrying scope of its own is the other boundary: exhausting its
+children says nothing about that scope, so the walk holds it and reports why.
 State-based against `FakeBackend`, driving the real `close` and `deliver`
 handlers.
 """
@@ -111,6 +113,167 @@ def test_sibling_batch_close_walks_the_parent_exactly_once():  # S2-C4 (repeated
     assert backend.get("E").status == "closed"
     assert backend.note_lines("E").count(CLOSE_WALK_MARKER) == 1
     assert data == {"walked": ["E"]}
+
+
+def test_parent_carrying_scope_of_its_own_is_held_open_though_every_child_closed():
+    """
+    Given a parent whose shape is a leaf's, with every child closed
+    When the last child closes
+    Then the parent stays open and the walk reports it as held.
+
+    The completion the walk infers is a claim about the parent, and a parent
+    that is not a declared container carries scope of its own that closing
+    its children says nothing about.
+    """
+    backend = (
+        FakeBackend()
+        .add("P", type="feature", labels=["shape-feat"], acceptance="AC1 the tool ships")
+        .add("c1", parent="P", status="closed")
+        .add("c2", parent="P", status="open")
+    )
+
+    data = _close(backend, ["c2"])
+
+    assert backend.get("P").status == "open"
+    assert backend.note_lines("P") == []
+    assert [entry["id"] for entry in data["held"]] == ["P"]
+    assert "walked" not in data
+
+
+def test_the_hold_names_the_item_its_criteria_and_the_two_ways_out():
+    """
+    Given a held parent carrying acceptance criteria
+    When the walk reports the hold
+    Then the entry carries what the caller needs to act without re-reading it.
+
+    The criteria are the terms the parent's own completion is judged in, so
+    they travel with the hold rather than costing a second read.
+    """
+    backend = (
+        FakeBackend()
+        .add("P", title="ship the thing", type="feature", labels=["shape-feat"], acceptance="AC1 x")
+        .add("c1", parent="P", status="open")
+    )
+
+    entry = _close(backend, ["c1"])["held"][0]
+
+    assert set(entry) == {"id", "title", "reason", "acceptance", "resolve"}
+    assert entry["id"] == "P"
+    assert entry["title"] == "ship the thing"
+    assert entry["acceptance"] == "AC1 x"
+    assert entry["reason"]
+    assert "deliver P" in entry["resolve"] and "close P" in entry["resolve"]
+
+
+def test_a_parent_whose_own_delivery_is_recorded_still_closes_on_exhaustion():
+    """
+    Given a leaf-shaped parent whose delivery is recorded but which never closed
+    When its last child closes
+    Then the walk closes it.
+
+    The delivery marker is the record that the parent's own scope is done, so
+    the hold lifts. This is the window `deliver` already replays through: the
+    marker is appended before the close, and a crash between the two leaves
+    exactly this state.
+    """
+    backend = (
+        FakeBackend()
+        .add("P", type="feature", labels=["shape-feat"], notes=f"{DELIVERED_MARKER} 42")
+        .add("c1", parent="P", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.get("P").status == "closed"
+    assert CLOSE_WALK_MARKER in backend.note_lines("P")
+    assert data == {"walked": ["P"]}
+
+
+def test_a_held_parent_stops_the_walk_below_its_own_parent():
+    """
+    Given a held parent under an exhausted container
+    When the walk reaches the hold
+    Then the container above it is neither closed nor reported.
+
+    A held parent is still open, so its own parent is not exhausted -- the
+    grandparent is simply not eligible, which is not a refusal to report.
+    """
+    backend = (
+        FakeBackend()
+        .add("G", type="epic", labels=["shape-epic"])
+        .add("P", type="feature", labels=["shape-feat"], parent="G")
+        .add("c1", parent="P", status="open")
+    )
+
+    data = _close(backend, ["c1"])
+
+    assert backend.get("G").status == "open"
+    assert backend.note_lines("G") == []
+    assert [entry["id"] for entry in data["held"]] == ["P"]
+
+
+def test_a_sibling_batch_reports_one_hold_per_parent():
+    """
+    Given two children of one held parent, closed in a single call
+    When both walks meet the same parent
+    Then it is reported held exactly once.
+
+    Same convergence the walked list already has, on the other outcome: a
+    caller reading two entries would think two items need attention.
+    """
+    backend = (
+        FakeBackend()
+        .add("P", type="feature", labels=["shape-feat"])
+        .add("c1", parent="P", status="open")
+        .add("c2", parent="P", status="open")
+    )
+
+    data = _close(backend, ["c1", "c2"])
+
+    assert [entry["id"] for entry in data["held"]] == ["P"]
+
+
+def test_naming_a_parent_on_close_is_the_discharge_and_is_never_held():
+    """
+    Given a parent the walk would hold
+    When the caller closes it by name
+    Then it closes, unexamined.
+
+    The rule governs what the walk infers, never what a caller states. That
+    boundary is what keeps the hold dischargeable in one command.
+    """
+    backend = FakeBackend().add("P", type="feature", labels=["shape-feat"])
+
+    data = _close(backend, ["P"])
+
+    assert backend.get("P").status == "closed"
+    assert data is None
+
+
+def test_deliver_reaches_the_same_hold_as_close():
+    """
+    Given a leaf under a parent carrying scope of its own
+    When the leaf is delivered rather than closed
+    Then the same parent is held, reported the same way.
+
+    Both verbs run one walk; a rule that held on one path and not the other
+    would be two rules.
+    """
+    backend = (
+        FakeBackend()
+        .add("P", type="feature", labels=["shape-feat"])
+        .add("L", parent="P", status="in_progress", labels=["shape-feat"])
+    )
+    args = Namespace(
+        id="L", spec=None, pr="42", items=None, trivial=False, read_file=fake_reader({})
+    )
+
+    data = deliver(backend, args)
+
+    assert backend.get("P").status == "open"
+    assert data["id"] == "L" and data["status"] == "closed"
+    assert [entry["id"] for entry in data["held"]] == ["P"]
+    assert "walked" not in data
 
 
 def test_deliver_leaf_triggers_the_same_walk():  # S2-C5

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -104,7 +104,19 @@ def test_protocol_wire_value_is_pinned() -> None:
     # or shape, and one that ignores the key sees exactly what it saw before.
     # The field is always present, `null` where the item has none, so the
     # answer never arrives as a missing key a consumer would have to interpret.
-    assert PROTOCOL_VERSION == "1.9"
+    #
+    # 1.10 stops the close-walk closing a parent that carries scope of its
+    # own, and gives `close` and `deliver` a `held` key naming each parent it
+    # declined and why. The key is the additive half and takes the same
+    # verdict as `acceptance` in 1.9. The behavioural half narrows `walked`:
+    # a consumer that saw a parent listed there now sees it under `held`
+    # instead. That is 1.8's case with the sign flipped -- `walked` has always
+    # claimed to list what the walk closed, and it now lists fewer because
+    # fewer should ever have closed. A consumer acting on the old entry was
+    # acting on a completion nothing had established, so there is no correct
+    # behaviour to lose, and the envelope and every `data` shape are
+    # untouched.
+    assert PROTOCOL_VERSION == "1.10"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:


### PR DESCRIPTION
Closes the defect filed as `agents-config-9k9.171`.

## What was wrong

`close_walk()` closed a parent when three conditions held: not a milestone,
not already closed, every child closed. Nothing asked whether the parent's
own scope had ever been done, and the walk recursed to the grandparent on
the same reasoning — so one leaf closing could silently close a chain, and a
parent carrying scope of its own got marked done on the strength of its
children alone.

This is not hypothetical. `agents-config-9k9.53` is a `shape-feat` with seven
children whose final note is `[work] close-walk: all children closed` and
whose note above it reads "NOT YET MINTED. Next action is to file the five
above."

## What changed

A parent's own scope is done when either holds, and the walk closes it only
then:

1. **Its shape says it has none** — a declared container (`is_container()`)
   is structural, so its children *are* its scope and exhausting them
   completes it. Declared state, never child count: the same test `claim` and
   `deliver` already dispatch on.
2. **Its own delivery is on the record** — a `[work] delivered:` note. Narrow
   but real: `deliver` records the marker and then closes, so open-and-marked
   is the crash window `deliver`'s own replay path exists for.

Anything else is a leaf that acquired children. The walk holds it open and
reports it under a new `held` key carrying that item's `id`, `title`,
`acceptance`, the `reason`, and a `resolve` naming the two ways out, so the
caller can act without re-reading the item.

The three older stops — milestone, already-closed, open sibling — are
untouched and stay silent. A milestone is the designed boundary, an
already-closed parent is a no-op, an open sibling means "not eligible yet".
The hold is the one stop where the tree looks finished and the walk declines
anyway, which is the only one a caller can be surprised by.

The rule governs what the walk **infers**, never what the caller **states**:
`work close P` closes P unexamined, which is the one-command discharge the
hold's own text names. `close` and `deliver` share the single walk
implementation, as before.

The decision, and the four alternatives rejected — acceptance-criteria
checking, an opt-in flag, non-empty description, `in_progress` status — are
recorded with their reasons in the tracker item's notes.

## Protocol

`1.9` → `1.10`. `held` is additive. The narrowing of `walked` takes 1.8's
verdict with the sign flipped: `walked` has always claimed to list what the
walk closed and now lists fewer, because fewer should ever have closed. The
reasoning is in `test_protocol_handshake.py`; the README is updated in the
five places it quotes the version, and its stale "`close` → `data: null`"
line now states the real shape.

## Verification

- `make ci-workcli` exits 0 from the worktree root, post-rebase — 802 tests,
  99.25% branch coverage.
- `make itest-workcli` exits 0 — 54 tests against a real, isolated backend.
- Each of the five new tests that could show red did, against the unchanged
  code, for the right reason. The two that pin behaviour the change must not
  break were mutation-checked instead: removing the delivery-marker half of
  the rule turns one red, and adjudicating the caller-named ids turns the
  other red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
