### PR TITLE
feat(9k9.172): an idea can be set aside without being called blocked

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -57,17 +57,29 @@ selected by whether a noun positional or `--raw` is given.
 | `work deliver ID [--spec PATH] [--pr REF] [--items ID,ID] [--trivial]` | on a design child: parses the merged spec's `## Continuations` manifest and reconciles the sibling placeholder; on a leaf: evidence-gated close |
 | `work plan ID (--done \| --undo) [--force]` | stamps/revokes the `planned` label (Planning-queue membership) |
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
+| `work defer ID [--note TEXT]` | sets an item aside as not-now → `deferred`; leaves `ready`, claims no obstruction, and never enters the parked staleness report |
+| `work undefer ID` | `deferred` → `open` |
 | `work reconcile [--dry-run]` | recovery sweep over the states the tracker can still observe: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
-Protocol is `"1.9"` — additive-only bumps (new `ErrorCode` members, the
+`defer`/`undefer` are deliberately not the park family (`work park
+--reason`/`redispatch`/`abandon`), which states why work that *was* started
+cannot merge and ages into a staleness report. A read envelope tells the two
+apart on `status` alone — `deferred` versus a parked item's `blocked` beside
+its `parked` label — so a consumer never parses a note to distinguish an idea
+from an obstruction. Both `defer` and `undefer` are idempotent on replay.
+
+Protocol is `"1.10"` — additive-only bumps (new `ErrorCode` members, the
 derived `Item.track` field and the `acceptance` field beside it, the
-capability-disposition model, `partial_progress` detail below, and `search`'s
-optional narrowing flags) never change an existing envelope or data shape. A
+capability-disposition model, `partial_progress` detail below, `search`'s
+optional narrowing flags, and the `defer`/`undefer` pair) never change an
+existing envelope or data shape. A
 bump can still widen what an unchanged call *answers*: 1.8 makes `search`
 read descriptions and notes as well as titles, stop excluding closed items,
 and stop stopping at the first page, so a query that used to return nothing
 may now return matches — and `create <noun>` refuses a title a closed item
-already carries. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+already carries. 1.10 is the same case in a smaller form: `status` can report
+`deferred` on an item the facade itself set aside, a value the backend always
+could hold and this contract always declared. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
 writes via `supports_dep_write` — `dep list` is never gated, even when
@@ -102,13 +114,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.9", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.10", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.9", "ok": false, "data": null,
+{"protocol": "1.10", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -142,7 +154,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.9", "ok": true, "data": {"protocol": "1.9"}, "error": null}
+{"protocol": "1.10", "ok": true, "data": {"protocol": "1.10"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -167,7 +179,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.9"}`.
+- `--protocol-version` → `{"protocol": "1.10"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.9"
+PROTOCOL_VERSION = "1.10"

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -174,6 +174,18 @@ def _add_transition_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentPa
     )
     abandon_parser.add_argument("id", metavar="ID")
 
+    defer_parser = subparsers.add_parser(
+        "defer",
+        help="set aside an item nobody has started; it leaves ready, with no obstruction implied",
+    )
+    defer_parser.add_argument("id", metavar="ID")
+    defer_parser.add_argument("--note", metavar="TEXT")
+
+    undefer_parser = subparsers.add_parser(
+        "undefer", help="bring a set-aside item back; back to ready"
+    )
+    undefer_parser.add_argument("id", metavar="ID")
+
     plan_parser = subparsers.add_parser("plan", help="add/remove an item from the Planning queue")
     plan_parser.add_argument("id", metavar="ID")
     plan_parser.add_argument("--done", action="store_true")

--- a/packages/workcli/src/workcli/lifecycle/defer.py
+++ b/packages/workcli/src/workcli/lifecycle/defer.py
@@ -1,0 +1,130 @@
+"""`defer`/`undefer` -- setting an idea aside, and picking it back up.
+
+An item nobody has chosen to start is not stuck. It has no obstruction to
+name, no attempt to count and nothing decaying while it waits, so the park
+family's machinery would all be lying about it: a typed failure reason, and a
+staleness report that nags forever about a cause that never existed.
+
+Deferring is therefore its own state and carries none of that. It moves the
+item to the `deferred` status and stops -- no handle label, no vocabulary, no
+clock. Two properties follow, and they are the whole reason the state is a
+status rather than another park reason. The item leaves `ready` on the
+backend's own semantics, and it stays invisible to both parked surfaces,
+which select on the park handle. And a read envelope tells the two apart on
+`status` alone: `deferred` for an idea, `blocked` beside the `parked` label
+for an obstruction, with no marker note read to decide it.
+
+An item may hold one of the two states, never both, so `defer` refuses a
+parked item outright rather than overwriting half of it.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from datetime import datetime
+
+from workcli.backend import Backend
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.park import PARKED_LABEL
+
+DEFERRED_STATUS = "deferred"
+DEFERRED_MARKER = "[work] deferred"  # full: "[work] deferred <ISO-8601>[: <text>]"
+UNDEFERRED_MARKER = "[work] undeferred"  # full: "[work] undeferred <ISO-8601>"
+
+# What a repaired marker says about itself. A repair can only ever record the
+# repairing call's instant -- the crashed defer's is unrecoverable -- so the
+# marker admits it, in the free text where no reader parses.
+REPAIR_TEXT = "marker repaired on re-defer; this timestamp is the repairing call's"
+
+
+def _marker(marker: str, now: datetime, text: str | None) -> str:
+    """One marker line: the kind, the instant, and the caller's free text.
+
+    Everything a reader interprets is the kind and the instant; the text
+    after the first `": "` is prose nothing parses.
+    """
+    head = f"{marker} {now.isoformat()}"
+    return f"{head}: {text}" if text else head
+
+
+def _last_marker(notes: str) -> str | None:
+    """Which of the two markers the LAST defer/undefer line is, or None.
+
+    Both transitions read it to decide whether the stint they are about to
+    record is already recorded. That is what makes each idempotent on replay:
+    a re-issued call converges on the one marker already written instead of
+    minting a second one stamped at a later instant. Scoped to the last line
+    of either kind, so a marker from an earlier defer/undefer cycle can never
+    stand in for the current stint's.
+    """
+    last: str | None = None
+    for line in notes.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{DEFERRED_MARKER} "):
+            last = DEFERRED_MARKER
+        elif stripped.startswith(f"{UNDEFERRED_MARKER} "):
+            last = UNDEFERRED_MARKER
+    return last
+
+
+def defer(backend: Backend, args: Namespace) -> JsonValue:
+    """`work defer ID [--note TEXT]` -- set an item aside as not-now.
+
+    Mutation order is `park`'s graceful-degradation order for the same
+    reason: the status lands FIRST, so a crash mid-defer leaves an item that
+    is at worst un-ready, never a claimable one that reports itself deferred.
+    That order also makes the marker the only thing a partial defer can be
+    missing, and re-deferring such an item repairs it.
+    """
+    item = backend.get(args.id)
+    if item.status == "closed":
+        raise WorkError(ErrorCode.USAGE, f"defer {args.id}: cannot defer a closed item")
+    if PARKED_LABEL in item.labels:
+        # Two different claims about one item -- an idea nobody started,
+        # versus work that started and stuck. Holding both would leave a read
+        # envelope saying deferred while the parked report still listed it,
+        # which is exactly the ambiguity this state exists to remove. Clearing
+        # the park is a decision, so it is made deliberately, by its own verb.
+        raise WorkError(
+            ErrorCode.USAGE,
+            f"defer {args.id}: parked, not idle; `work redispatch` or `work abandon` first",
+        )
+    if item.status == DEFERRED_STATUS:
+        # Idempotent replay: mint nothing -- unless this stint has no marker,
+        # which is what a defer that died between its two writes leaves. The
+        # status short-circuits every later defer, so this branch is the only
+        # one that can ever repair it.
+        if _last_marker(item.notes) != DEFERRED_MARKER:
+            text = f"{REPAIR_TEXT}; {args.note}" if args.note else REPAIR_TEXT
+            backend.append_note(args.id, _marker(DEFERRED_MARKER, args.now(), text))
+        return {"id": args.id, "status": DEFERRED_STATUS}
+
+    backend.set_status(args.id, DEFERRED_STATUS)
+    backend.append_note(args.id, _marker(DEFERRED_MARKER, args.now(), args.note))
+    return {"id": args.id, "status": DEFERRED_STATUS}
+
+
+def undefer(backend: Backend, args: Namespace) -> JsonValue:
+    """`work undefer ID` -- the idea's turn has come; back to ready.
+
+    Mutation order is the inverse of `defer`'s, from the same rule read the
+    other way. Here the status IS the handle a replay re-enters on, so it
+    drops STRICTLY LAST: the marker lands while the item is still deferred,
+    and every crash window therefore leaves an item that is still out of
+    `ready` and still reachable by this path. Clearing the status first would
+    strand the transition unrecorded, because the replay would meet an open
+    item and return the no-op. The dedup guard keeps that replay from minting
+    a second marker.
+    """
+    item = backend.get(args.id)
+    if item.status == "closed":
+        raise WorkError(ErrorCode.USAGE, f"undefer {args.id}: cannot undefer a closed item")
+    if item.status != DEFERRED_STATUS:
+        if item.status == "open":
+            return {"id": args.id, "status": "open"}  # idempotent no-op
+        raise WorkError(ErrorCode.USAGE, f"undefer {args.id}: not deferred (status {item.status})")
+
+    if _last_marker(item.notes) != UNDEFERRED_MARKER:
+        backend.append_note(args.id, _marker(UNDEFERRED_MARKER, args.now(), None))
+    backend.set_status(args.id, "open")
+    return {"id": args.id, "status": "open"}

--- a/packages/workcli/src/workcli/lifecycle/transitions.py
+++ b/packages/workcli/src/workcli/lifecycle/transitions.py
@@ -17,6 +17,7 @@ from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle import is_container
 from workcli.lifecycle.create import finalize_spec_instantiation
+from workcli.lifecycle.defer import DEFERRED_STATUS
 from workcli.lifecycle.nouns import CREATING_SPEC_LABEL, PLANNED_LABEL
 from workcli.lifecycle.park import PARKED_LABEL, parked_stale
 
@@ -50,6 +51,11 @@ def claim(backend: Backend, args: Namespace) -> JsonValue:
             ErrorCode.NOT_CLAIMABLE,
             f"{args.id}: parked; `work redispatch` or `work abandon` first",
         )
+    if item.status == DEFERRED_STATUS:
+        # Same reason as the branch above: a deferred item is absent from
+        # `ready`, so the generic refusal would send its caller hunting for a
+        # blocking dependency that does not exist.
+        raise WorkError(ErrorCode.NOT_CLAIMABLE, f"{args.id}: deferred; `work undefer` first")
 
     ready_ids = {ready_item.id for ready_item in backend.ready(None)}
     if args.id not in ready_ids:

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from workcli.backend import Backend, Capabilities, ReadySupport, SyncSupport
 from workcli.envelope import ErrorCode, JsonValue, WorkError
 from workcli.lifecycle.create import create_noun
+from workcli.lifecycle.defer import defer, undefer
 from workcli.lifecycle.deliver import deliver
 from workcli.lifecycle.discover import discover
 from workcli.lifecycle.park import abandon, park, parked, redispatch
@@ -102,6 +103,8 @@ VERBS: dict[str, Callable[[Backend, Namespace], JsonValue]] = {
     "redispatch": redispatch,
     "abandon": abandon,
     "parked": parked,
+    "defer": defer,
+    "undefer": undefer,
     "plan": plan,
     "promote": promote,
     "deliver": deliver,

--- a/packages/workcli/tests/integration/test_defer.py
+++ b/packages/workcli/tests/integration/test_defer.py
@@ -1,0 +1,88 @@
+"""defer / undefer against real backend state.
+
+The hermetic suite proves the verb layer's decisions against a fake. What it
+cannot prove is the claim the whole design rests on: that the backend itself
+drops a deferred item out of its ready set and takes it back on the return
+trip. That is a property of the real thing, so it is asserted here.
+"""
+
+from __future__ import annotations
+
+from tests.integration.conftest import ITEST_TRACK
+
+
+def _ready_ids(driver) -> list[str]:
+    return [item["id"] for item in driver(["ready"])["data"]["items"]]
+
+
+def _new_leaf(driver, title: str) -> str:
+    created = driver(
+        ["create", "feat", "--title", title, "--priority", "2", "--orphan", "--track", ITEST_TRACK]
+    )
+    assert created["ok"] is True, created
+    return created["data"]["id"]
+
+
+def test_defer_drops_a_real_item_out_of_ready_and_undefer_brings_it_back(driver):
+    item_id = _new_leaf(driver, "df-idea")
+    assert item_id in _ready_ids(driver)
+
+    deferred = driver(["defer", item_id, "--note", "nobody has picked this up"])
+    assert deferred["ok"] is True
+    assert deferred["data"] == {"id": item_id, "status": "deferred"}
+    assert driver(["show", item_id])["data"]["status"] == "deferred"
+    assert item_id not in _ready_ids(driver)
+
+    returned = driver(["undefer", item_id])
+    assert returned["ok"] is True
+    assert returned["data"] == {"id": item_id, "status": "open"}
+    assert driver(["show", item_id])["data"]["status"] == "open"
+    assert item_id in _ready_ids(driver)
+
+    # One marker per transition, and both survived the round trip.
+    notes = driver(["show", item_id])["data"]["notes"]
+    assert notes.count("[work] deferred") == 1
+    assert notes.count("[work] undeferred") == 1
+
+
+def test_a_deferred_item_raises_no_nag_and_refuses_a_claim(driver):
+    item_id = _new_leaf(driver, "df-nag")
+    driver(["defer", item_id])
+
+    assert driver(["parked"])["data"]["items"] == []
+    assert driver(["ready"])["data"]["parked_stale"] == []
+
+    refused = driver(["claim", item_id])
+    assert refused["ok"] is False
+    assert refused["error"]["code"] == "E_NOT_CLAIMABLE"
+    assert "undefer" in refused["error"]["message"]
+
+
+def test_a_read_envelope_tells_a_deferred_item_from_a_parked_one(driver):
+    idea = _new_leaf(driver, "df-idea-vs-obstruction")
+    stuck = _new_leaf(driver, "df-obstruction")
+    driver(["defer", idea])
+    assert driver(["claim", stuck])["ok"] is True
+    assert driver(["park", stuck, "--reason", "ci-failure"])["ok"] is True
+
+    idea_item = driver(["show", idea])["data"]
+    stuck_item = driver(["show", stuck])["data"]
+
+    assert idea_item["status"] == "deferred"
+    assert "parked" not in idea_item["labels"]
+    assert stuck_item["status"] == "blocked"
+    assert "parked" in stuck_item["labels"]
+
+
+def test_the_transitions_replay_idempotently_against_real_state(driver):
+    item_id = _new_leaf(driver, "df-replay")
+
+    first = driver(["defer", item_id])
+    second = driver(["defer", item_id])
+    assert first["data"] == second["data"] == {"id": item_id, "status": "deferred"}
+    assert driver(["show", item_id])["data"]["notes"].count("[work] deferred") == 1
+
+    third = driver(["undefer", item_id])
+    fourth = driver(["undefer", item_id])
+    assert third["data"] == fourth["data"] == {"id": item_id, "status": "open"}
+    assert driver(["show", item_id])["data"]["notes"].count("[work] undeferred") == 1

--- a/packages/workcli/tests/unit/test_defer.py
+++ b/packages/workcli/tests/unit/test_defer.py
@@ -1,0 +1,485 @@
+"""defer / undefer -- setting an idea aside, and picking it back up.
+
+Deferred = the backend's `deferred` status and nothing else: no label, no
+reason vocabulary, no staleness clock. The state is what tells an idea from
+an obstruction, so these tests hold two lines above all others -- a deferred
+item is absent from `ready` and from both parked surfaces, and a read
+envelope tells it from a parked item without any note being read.
+
+Idempotency is pinned on `park`/`redispatch`'s own terms: state is read
+first, an already-applied transition returns without writing, and a replay
+after a crash between the two writes converges on one marker rather than
+minting a second.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from datetime import UTC, datetime
+
+import pytest
+
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
+from workcli.envelope import ErrorCode, WorkError
+from workcli.lifecycle.defer import (
+    DEFERRED_MARKER,
+    DEFERRED_STATUS,
+    REPAIR_TEXT,
+    UNDEFERRED_MARKER,
+    defer,
+    undefer,
+)
+from workcli.lifecycle.park import PARKED_LABEL, park, parked
+from workcli.lifecycle.transitions import claim
+from workcli.verbs.read import list_, ready, show
+
+_NOW = datetime(2026, 8, 7, 12, 0, 0, tzinfo=UTC)
+_ISO = _NOW.isoformat()
+_LONG_AGO = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC).isoformat()
+
+
+def _defer_args(item_id: str, note: str | None = None) -> Namespace:
+    return Namespace(id=item_id, note=note, now=lambda: _NOW)
+
+
+def _id_args(item_id: str) -> Namespace:
+    return Namespace(id=item_id, now=lambda: _NOW)
+
+
+def _park_args(item_id: str, reason: str) -> Namespace:
+    return Namespace(id=item_id, reason=reason, note=None, now=lambda: _NOW)
+
+
+def _ready_args() -> Namespace:
+    return Namespace(label=None, now=lambda: _NOW)
+
+
+def _parked_args() -> Namespace:
+    return Namespace(stale_days=7, now=lambda: _NOW)
+
+
+# --- AC1: the two transitions -----------------------------------------------
+
+
+def test_defer_moves_an_open_item_to_deferred_and_records_a_marker():
+    backend = FakeBackend().add("w1", status="open")
+
+    data = defer(backend, _defer_args("w1", note="nobody has picked this up"))
+
+    item = backend.get("w1")
+    assert item.status == DEFERRED_STATUS
+    # No label and no reason code: the status carries the whole state, which
+    # is what keeps a deferral out of every surface keyed on the park handle.
+    assert item.labels == []
+    assert backend.note_lines("w1") == [f"{DEFERRED_MARKER} {_ISO}: nobody has picked this up"]
+    assert data == {"id": "w1", "status": "deferred"}
+
+
+def test_defer_without_a_note_records_a_bare_timestamped_marker():
+    backend = FakeBackend().add("w1", status="open")
+
+    defer(backend, _defer_args("w1"))
+
+    assert backend.note_lines("w1") == [f"{DEFERRED_MARKER} {_ISO}"]
+
+
+def test_defer_accepts_a_claimed_item():
+    """Setting down work already in hand is a deferral like any other.
+
+    `release` is the verb for handing a claim back, and requiring it first
+    would make "not now" a two-call sequence for the one case where the
+    caller has most obviously decided it.
+    """
+    backend = FakeBackend().add("w1", status="in_progress")
+
+    data = defer(backend, _defer_args("w1"))
+
+    assert backend.get("w1").status == DEFERRED_STATUS
+    assert data == {"id": "w1", "status": "deferred"}
+
+
+def test_undefer_returns_a_deferred_item_to_open_with_its_own_marker():
+    backend = FakeBackend().add("w1", status="open")
+    defer(backend, _defer_args("w1"))
+
+    data = undefer(backend, _id_args("w1"))
+
+    assert backend.get("w1").status == "open"
+    assert backend.note_lines("w1") == [
+        f"{DEFERRED_MARKER} {_ISO}",
+        f"{UNDEFERRED_MARKER} {_ISO}",
+    ]
+    assert data == {"id": "w1", "status": "open"}
+
+
+# --- AC2: out of `ready`, and no nag on either parked surface ----------------
+
+
+def test_a_deferred_item_leaves_the_ready_queue():
+    backend = FakeBackend().add("w1", status="open").add("w2", status="open")
+    before = ready(backend, _ready_args())
+    assert isinstance(before, dict)
+    assert {row["id"] for row in before["items"]} == {"w1", "w2"}
+
+    defer(backend, _defer_args("w1"))
+
+    after = ready(backend, _ready_args())
+    assert isinstance(after, dict)
+    assert {row["id"] for row in after["items"]} == {"w2"}
+
+
+def test_a_deferred_item_raises_no_staleness_nag_on_either_parked_surface():
+    backend = FakeBackend().add("w1", status="open")
+
+    defer(backend, _defer_args("w1"))
+
+    assert parked(backend, _parked_args()) == {"items": [], "stale_days": 7}
+    block = ready(backend, _ready_args())
+    assert isinstance(block, dict)
+    assert block["parked_stale"] == []
+
+
+def test_an_ancient_deferral_still_raises_no_nag():
+    """The nag is what a park earns and a deferral does not.
+
+    A park ages into a report because an obstruction left alone is a fact
+    someone must act on. An idea nobody has started is not decaying, so no
+    amount of elapsed time turns a deferral into something to surface -- and
+    both parked surfaces read the park handle, which a deferral never sets.
+    """
+    backend = ReadOnlyFakeBackend().add(
+        "w1", status=DEFERRED_STATUS, notes=f"{DEFERRED_MARKER} {_LONG_AGO}"
+    )
+
+    assert parked(backend, _parked_args()) == {"items": [], "stale_days": 7}
+    block = ready(backend, _ready_args())
+    assert isinstance(block, dict)
+    assert block["parked_stale"] == []
+
+
+# --- AC3: legible apart in a read envelope, with no prose parsed -------------
+
+
+def test_a_read_envelope_tells_a_deferred_item_from_a_parked_one():
+    backend = FakeBackend().add("idea", status="open").add("stuck", status="in_progress")
+
+    defer(backend, _defer_args("idea"))
+    park(backend, _park_args("stuck", "ci-failure"))
+
+    idea = show(backend, Namespace(ids=["idea"]))
+    stuck = show(backend, Namespace(ids=["stuck"]))
+    assert isinstance(idea, dict)
+    assert isinstance(stuck, dict)
+    assert idea["status"] == "deferred"
+    assert stuck["status"] == "blocked"
+    assert PARKED_LABEL not in idea["labels"]
+    assert PARKED_LABEL in stuck["labels"]
+
+
+def test_the_two_states_stay_legible_apart_with_every_note_removed():
+    """AC3's actual bar: a reader parses no prose to tell them apart.
+
+    The park family records its reason in a note marker, so a check that
+    read one would be reading the very prose this criterion rules out.
+    Both items here carry no notes at all, and the envelope still answers.
+    """
+    backend = ReadOnlyFakeBackend()
+    backend.add("idea", status=DEFERRED_STATUS, notes="")
+    backend.add("stuck", status="blocked", labels=[PARKED_LABEL], notes="")
+
+    idea = show(backend, Namespace(ids=["idea"]))
+    stuck = show(backend, Namespace(ids=["stuck"]))
+
+    assert isinstance(idea, dict)
+    assert isinstance(stuck, dict)
+    assert idea["notes"] == stuck["notes"] == ""
+    assert idea["status"] != stuck["status"]
+    assert (idea["status"], PARKED_LABEL in idea["labels"]) == ("deferred", False)
+    assert (stuck["status"], PARKED_LABEL in stuck["labels"]) == ("blocked", True)
+
+
+# --- AC4: idempotent on replay, on park's own terms --------------------------
+
+
+def test_defer_replay_is_a_noop_that_writes_nothing():
+    """A lost response makes the caller re-issue `defer`; the replay writes nothing.
+
+    Run against a backend that raises on every mutator, so "returned before
+    writing" is proven rather than inferred from a state comparison.
+    """
+    backend = FakeBackend().add("w1", status="open")
+    first = defer(backend, _defer_args("w1"))
+    settled = backend.get("w1")
+    replay_backend = ReadOnlyFakeBackend().add(
+        "w1", status=settled.status, labels=settled.labels, notes=settled.notes
+    )
+
+    second = defer(replay_backend, _defer_args("w1"))
+
+    assert first == second == {"id": "w1", "status": "deferred"}
+    assert replay_backend.note_lines("w1") == [f"{DEFERRED_MARKER} {_ISO}"]
+
+
+def test_defer_replay_repairs_the_marker_a_crashed_defer_never_wrote():
+    """The status lands first, so a crash between the two writes loses the marker.
+
+    The status then short-circuits every later defer, which makes this branch
+    the only one that can ever mint it. The repaired marker says so in its
+    free text: the instant it carries is the repairing call's, because the
+    crashed call's is unrecoverable.
+    """
+    backend = FakeBackend().add("w1", status=DEFERRED_STATUS)
+
+    data = defer(backend, _defer_args("w1", note="nobody has picked this up"))
+
+    assert backend.note_lines("w1") == [
+        f"{DEFERRED_MARKER} {_ISO}: {REPAIR_TEXT}; nobody has picked this up"
+    ]
+    assert data == {"id": "w1", "status": "deferred"}
+
+
+def test_undefer_replay_is_a_noop_that_writes_nothing():
+    backend = FakeBackend().add("w1", status="open")
+    defer(backend, _defer_args("w1"))
+    first = undefer(backend, _id_args("w1"))
+    settled = backend.get("w1")
+    replay_backend = ReadOnlyFakeBackend().add(
+        "w1", status=settled.status, labels=settled.labels, notes=settled.notes
+    )
+
+    second = undefer(replay_backend, _id_args("w1"))
+
+    assert first == second == {"id": "w1", "status": "open"}
+    lines = replay_backend.note_lines("w1")
+    assert sum(1 for line in lines if line.startswith(UNDEFERRED_MARKER)) == 1
+
+
+def test_undefer_replays_after_a_crash_between_its_two_writes_without_a_second_marker():
+    """`undefer` mints its marker first, so the crash window keeps the item deferred.
+
+    That is the point of the ordering: the status is the handle a replay
+    re-enters on, so a replay reaches this path again rather than the
+    already-open no-op, and the transition never ends up unrecorded. The
+    dedup guard is what stops it minting a second, later-stamped marker.
+    """
+    backend = FakeBackend().add(
+        "w1",
+        status=DEFERRED_STATUS,
+        notes=f"{DEFERRED_MARKER} {_LONG_AGO}\n{UNDEFERRED_MARKER} {_LONG_AGO}",
+    )
+
+    data = undefer(backend, _id_args("w1"))
+
+    assert backend.get("w1").status == "open"
+    assert backend.note_lines("w1") == [
+        f"{DEFERRED_MARKER} {_LONG_AGO}",
+        f"{UNDEFERRED_MARKER} {_LONG_AGO}",
+    ]
+    assert data == {"id": "w1", "status": "open"}
+
+
+def test_a_second_deferral_after_an_undefer_records_a_fresh_stint():
+    """Marker history accumulates; the last one is the current stint.
+
+    A re-deferred item must not be read as still carrying its first stint,
+    and the un-defer marker in between is what makes the second defer mint
+    rather than short-circuit.
+    """
+    backend = FakeBackend().add(
+        "w1",
+        status="open",
+        notes=f"{DEFERRED_MARKER} {_LONG_AGO}\n{UNDEFERRED_MARKER} {_LONG_AGO}",
+    )
+
+    defer(backend, _defer_args("w1"))
+
+    assert backend.note_lines("w1") == [
+        f"{DEFERRED_MARKER} {_LONG_AGO}",
+        f"{UNDEFERRED_MARKER} {_LONG_AGO}",
+        f"{DEFERRED_MARKER} {_ISO}",
+    ]
+
+
+def test_undefer_on_an_open_item_is_an_idempotent_noop():
+    backend = ReadOnlyFakeBackend().add("w1", status="open")
+
+    data = undefer(backend, _id_args("w1"))
+
+    assert data == {"id": "w1", "status": "open"}
+    assert backend.note_lines("w1") == []
+
+
+# --- refusals ---------------------------------------------------------------
+
+
+def test_defer_refuses_a_closed_item():
+    backend = FakeBackend().add("w1", status="closed")
+
+    with pytest.raises(WorkError) as excinfo:
+        defer(backend, _defer_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.USAGE
+
+
+def test_defer_refuses_a_parked_item_and_names_the_verbs_that_clear_it():
+    """The two axes are different claims, and one item may not hold both.
+
+    Overwriting `blocked` with `deferred` under a `parked` label would leave
+    an item the parked report still lists and a read envelope calls deferred
+    -- exactly the ambiguity the separate status exists to remove.
+    """
+    backend = FakeBackend().add("w1", status="in_progress")
+    park(backend, _park_args("w1", "ci-failure"))
+
+    with pytest.raises(WorkError) as excinfo:
+        defer(backend, _defer_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.USAGE
+    assert "redispatch" in excinfo.value.message
+    assert "abandon" in excinfo.value.message
+    # Refused before writing: the park is intact.
+    item = backend.get("w1")
+    assert item.status == "blocked"
+    assert PARKED_LABEL in item.labels
+
+
+def test_undefer_refuses_a_closed_item():
+    backend = FakeBackend().add("w1", status="closed")
+
+    with pytest.raises(WorkError) as excinfo:
+        undefer(backend, _id_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.USAGE
+
+
+def test_undefer_refuses_an_item_that_was_never_deferred():
+    backend = FakeBackend().add("w1", status="in_progress")
+
+    with pytest.raises(WorkError) as excinfo:
+        undefer(backend, _id_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.USAGE
+    assert "in_progress" in excinfo.value.message
+
+
+def test_a_deferred_item_is_not_claimable_and_the_refusal_names_undefer():
+    """The generic refusal would name a cause a deferred item does not have.
+
+    Without this branch the item falls through to "blocked by an open
+    dependency", sending its caller to look for a blocker that does not
+    exist -- the same reason the parked branch beside it was written.
+    """
+    backend = FakeBackend().add("w1", status="open")
+    defer(backend, _defer_args("w1"))
+
+    with pytest.raises(WorkError) as excinfo:
+        claim(backend, _id_args("w1"))
+
+    assert excinfo.value.code is ErrorCode.NOT_CLAIMABLE
+    assert "deferred" in excinfo.value.message
+    assert "undefer" in excinfo.value.message
+
+
+# --- CLI wiring (argparse surface, envelope, and mutation order) ------------
+
+
+def _show_step(status: str, labels: list[str], notes: str):
+    import json as _json
+
+    from tests.fakes import ScriptedStep
+    from workcli.adapters.bd.runner import BdResult
+
+    return ScriptedStep(
+        ("show",),
+        BdResult(
+            returncode=0,
+            stdout=_json.dumps(
+                [
+                    {
+                        "id": "w1",
+                        "title": "T",
+                        "issue_type": "task",
+                        "status": status,
+                        "priority": 2,
+                        "labels": labels,
+                        "parent": None,
+                        "notes": notes,
+                        "dependencies": [],
+                        "dependents": [],
+                    }
+                ]
+            ),
+            stderr="",
+        ),
+    )
+
+
+def test_cli_defer_wires_the_status_before_the_marker():
+    from tests.conftest import run_cli_with_runner
+    from tests.fakes import ScriptedBdRunner, ScriptedStep
+    from workcli.adapters.bd.runner import BdResult
+
+    ok = BdResult(returncode=0, stdout="", stderr="")
+    runner = ScriptedBdRunner(
+        steps=[
+            _show_step("open", [], ""),
+            ScriptedStep(("update", "w1", "--status", DEFERRED_STATUS), ok),
+            ScriptedStep(("update", "w1", "--append-notes"), ok),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["defer", "w1", "--note", "later"], runner)
+
+    assert exit_code == 0
+    assert envelope["data"] == {"id": "w1", "status": "deferred"}
+    assert [call[:2] for call in runner.calls] == [
+        ("show", "w1"),
+        ("update", "w1"),
+        ("update", "w1"),
+    ]
+
+
+def test_cli_undefer_records_the_marker_before_clearing_the_status():
+    from tests.conftest import run_cli_with_runner
+    from tests.fakes import ScriptedBdRunner, ScriptedStep
+    from workcli.adapters.bd.runner import BdResult
+
+    ok = BdResult(returncode=0, stdout="", stderr="")
+    runner = ScriptedBdRunner(
+        steps=[
+            _show_step(DEFERRED_STATUS, [], f"{DEFERRED_MARKER} {_LONG_AGO}"),
+            ScriptedStep(("update", "w1", "--append-notes"), ok),
+            ScriptedStep(("update", "w1", "--status", "open"), ok),
+        ]
+    )
+
+    exit_code, envelope, _ = run_cli_with_runner(["undefer", "w1"], runner)
+
+    assert exit_code == 0
+    assert envelope["data"] == {"id": "w1", "status": "open"}
+    assert [call[:2] for call in runner.calls] == [
+        ("show", "w1"),
+        ("update", "w1"),
+        ("update", "w1"),
+    ]
+
+
+def test_a_deferred_item_is_still_listed():
+    """Deferring takes an item out of the work queue, not out of the tracker.
+
+    `ready` answers "what may I pick up"; `list` answers "what exists". An
+    idea set aside has to stay findable, or setting it aside becomes a way
+    to lose it -- so a filter that also hid it from `list` would satisfy the
+    ready criterion by breaking the thing the state is for.
+    """
+    backend = FakeBackend().add("w1", status="open")
+    defer(backend, _defer_args("w1"))
+
+    listed = list_(
+        backend,
+        Namespace(status=None, label=None, parent=None, type=None, limit=None, track=None),
+    )
+
+    assert isinstance(listed, dict)
+    assert [row["id"] for row in listed["items"]] == ["w1"]
+    assert listed["items"][0]["status"] == "deferred"

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -104,7 +104,18 @@ def test_protocol_wire_value_is_pinned() -> None:
     # or shape, and one that ignores the key sees exactly what it saw before.
     # The field is always present, `null` where the item has none, so the
     # answer never arrives as a missing key a consumer would have to interpret.
-    assert PROTOCOL_VERSION == "1.9"
+    #
+    # 1.10 adds the `defer`/`undefer` verb pair, which sets an item aside as
+    # not-now and brings it back. Additive on both counts the rule scores: a
+    # new verb takes nothing away from an existing one, and its envelope is
+    # the `{"id", "status"}` shape the other transitions already answer with.
+    # What is new in a read envelope is that `status` can now hold `deferred`
+    # on an item the facade itself set aside -- but that was always a value
+    # the backend could hold and the item model already declared, so no
+    # consumer had a closed set of four to lose. `claim` additionally names
+    # the new state in its refusal instead of reporting a dependency that
+    # does not exist, which replaces a wrong answer rather than a right one.
+    assert PROTOCOL_VERSION == "1.10"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:


### PR DESCRIPTION
Closes work item `agents-config-9k9.172` (no facade path sets deferred status, so idea-parking is not expressible).

## The problem

An item nobody has chosen to start had two expressible fates through the facade, and both were wrong. Leave it open, and it pollutes every `ready`, `lint` and `triggers` report. Or `work park` it, which sets the backend's `blocked` status with a typed reason drawn from a vocabulary about work that is *stuck* — a statement about an obstruction, not about an idea — and puts it in the parked-staleness sweep, where it nags forever about a cause that does not exist.

## What changed

`work defer ID [--note TEXT]` sets an item aside as not-now; `work undefer ID` brings it back.

Deferred is a **status and nothing else** — no handle label, no reason vocabulary, no staleness clock. Two properties follow, and they are the reason the state is a status rather than a sixth park reason:

- The item leaves `ready` on the backend's own semantics, and stays invisible to both parked surfaces (`work parked` and the `parked_stale` block), which select on the park handle.
- A read envelope tells the two states apart on `status` alone — `deferred` versus a parked item's `blocked` beside its `parked` label — so a consumer never parses a marker note to tell an idea from an obstruction.

It still appears in `work list`: deferring takes work out of the queue, not out of the tracker.

## Why a status and not a park reason

The full decision, with the alternatives and why they were rejected, is recorded as a note on the tracker item. In short:

1. **A park reason cannot satisfy the legibility requirement.** A parked item's reason is recoverable only by parsing the `[work] parked` marker out of its notes, and `work show` would report an identical `blocked` + `parked` for an idea and an obstruction alike.
2. **It would contradict a cross-package contract's own stated scope.** `packages/contracts/park-reasons.toml` scopes itself in writing to "the FAILURE axis only — the reasons a work item's PR did not merge", and already records that grind carries a separate scheduling axis (`discovered-work`, `later-wave`, `deferred`) that "is grind-native, has no tracker counterpart, and is deliberately not listed here". Adding `deferred` there would deny the distinction that contract exists to draw, and by its own rule would be a three-package change.
3. **It would need an exemption to escape the staleness sweep** — machinery the status option needs none of.

## Idempotency

Both transitions are idempotent on replay on `park`/`redispatch`'s own terms: state is read first, an already-applied transition returns without writing, and a replay after a crash between the two writes converges on the one marker rather than minting a second.

The mutation orders are deliberately inverse to each other. `defer` lands the status first (a crash can then only lose the marker, and the next `defer` repairs it). `undefer` mints its marker while the item is still deferred and drops the status strictly last — there the status is the handle a replay re-enters on, so clearing it first would strand the transition unrecorded.

`defer` refuses a parked item, so no item can hold both states at once. `claim` now names the deferred state in its refusal instead of reporting a dependency that does not exist.

## Interaction with the close-walk (#508)

A deferred child **is not a closed one**. It holds its parent open on the walk's not-yet-exhausted branch, exactly as an open child does, and never reaches the new `held` report — which is for parents whose children *are* all closed and whose own scope is unfinished, a different claim. Reading `deferred` as "does not count" would auto-close a container with live work still in it, on the strength of a decision to postpone. Pinned by a test, and mutation-checked against exactly that change (`closewalk.py` patched to treat `deferred` as closed → the test goes red).

## Protocol

`1.10` → `1.11`. Derived against the **post-merge baseline**: #508 took 1.10 for the close-walk's `held` key. Both branches independently wrote `"1.10"`, so git auto-merged the constant with no conflict — two unrelated protocol changes would have shipped under one version, which is the drift the handshake pin and the README check exist to catch. Resolved by hand; 1.10's reasoning entry kept and 1.11's appended after it.

A new verb pair is additive: it answers the `{"id", "status"}` shape the other transitions already answer with, and no existing envelope or data shape moves.

## Verification

- `make ci-workcli` — **exit 0**, 832 tests, 99.23% branch coverage.
- `make itest-workcli` — **exit 0**, 58 tests against a real, isolated backend, including four new ones proving the round trip, the absent nag, the claim refusal, and idempotent replay against real state.
- Each new test of new behaviour was observed failing before the change and passing after. The two close-walk tests pin existing behaviour, so they were verified by mutation instead.

## Left open deliberately

`packages/executor/src/executor/rules.py` says of the scheduling axis that "The facade carries no vocabulary for it, which is why these rows issue zero tracker writes rather than a translated one." That is now false for `deferred`. Whether those rows should start issuing a tracker write is the executor's pairing-table decision, not this one's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
