### PR TITLE
feat(9k9.47): price each artifact as the target loads it, not as the source claims

### DIFF
--- a/packages/installer/src/installer/content_lint_cli.py
+++ b/packages/installer/src/installer/content_lint_cli.py
@@ -44,8 +44,13 @@ def _report_budgets(result: ContentLintResult) -> None:
     """Print the measured always-on and per-skill numbers to stdout."""
     sys.stdout.write(f"content-lint: always-on surface (cap {ALWAYS_ON_TOKEN_CAP} tokens)\n")
     for surface in sorted(result.surfaces, key=lambda s: s.tool):
+        # The two components are split because they grow for different reasons:
+        # rules change rarely, and the catalog gains an entry with every skill
+        # admitted. A single total hides which one is moving.
         sys.stdout.write(
-            f"  {surface.tool:<10} {surface.tokens:>6} tokens  ({surface.rules} rule(s))\n"
+            f"  {surface.tool:<10} {surface.tokens:>6} tokens  "
+            f"({surface.rules} rule(s), {surface.catalog_entries} catalog entr"
+            f"{'y' if surface.catalog_entries == 1 else 'ies'})\n"
         )
 
     # Already one entry per artifact, grouped by the lint on the same identity
@@ -65,6 +70,22 @@ def _report_budgets(result: ContentLintResult) -> None:
         sys.stdout.write(
             f"  {body.tokens:>6} / {body.cap:<5} tokens  {body.where}  [{', '.join(body.tools)}]\n"
         )
+
+    # No cap on this block, and the header says so plainly: a number printed
+    # beside two ceilings would otherwise read as a third one. Sorted by the
+    # figure that decides anything — the largest single file, which is the unit
+    # a reader actually pays when they follow one pointer.
+    if result.payloads:
+        sys.stdout.write(
+            "content-lint: skill reference payloads (reported, no cap; non-prose is "
+            "executed or indexed, never loaded as context)\n"
+        )
+        for payload in result.payloads:
+            sys.stdout.write(
+                f"  {payload.prose_tokens:>6} prose in {payload.prose_files:>2} file(s), "
+                f"largest {payload.largest_tokens:>6} ({payload.largest_file or '-'}), "
+                f"{payload.other_tokens:>6} non-prose  {payload.label}\n"
+            )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/packages/installer/src/installer/core/capabilities.py
+++ b/packages/installer/src/installer/core/capabilities.py
@@ -28,10 +28,29 @@ Support is declared per key rather than per tool. A tool acquiring one of these
 capabilities is then a one-name edit, and a key nothing supports is visible as
 an empty set rather than as an absence from four lists.
 
-``disable-model-invocation`` carries a second consequence beyond projection: it
-is what decides which body cap measures the artifact (see ``surface_budget``).
-That reading is deliberately taken from the *source* front matter, before
-projection, so one artifact is measured against one cap on every tool.
+``disable-model-invocation`` carries two consequences beyond projection, and
+both are read from the **projected** front matter rather than from the source:
+it decides which cap measures the artifact's body, and whether the artifact's
+catalog entry is charged to the always-on budget (see ``surface_budget``).
+Reading the source would price a claim the author made instead of a fact about
+the target — a shared skill declaring itself user-invoked is fully
+model-invocable on every tool this projection strips the key for, so its
+description does load and its body arrives on the model's own judgement.
+
+Reading after projection makes one artifact's numbers depend on which tool is
+being staged. That is the intent: the number prices the target, and the targets
+differ. The *verdict* stays uniform, because the repo-side content lint stages
+every known tool unconditionally on every run — so an artifact is judged against
+every target it can reach, and a per-machine deploy can only be looser than the
+gate the repository has already passed.
+
+Codex is where the projected reading and the vendor's mechanism will eventually
+diverge: Codex honours a user-invoked declaration through a generated sidecar
+file beside the skill rather than through ``SKILL.md`` front matter, and this
+installer emits no such sidecar. So today every deployed skill is in Codex's
+catalog, which is exactly what the projected reading reports, because the key
+is stripped for Codex. The change that emits the sidecar is the change that
+must also make this module say so; nothing should be added for it beforehand.
 """
 
 from __future__ import annotations
@@ -53,6 +72,28 @@ CAPABILITY_SUPPORT: dict[str, frozenset[str]] = {
     "allowed-tools": frozenset({"claude"}),
     "argument-hint": frozenset({"claude"}),
 }
+
+
+#: Tools whose skill loading this project deliberately does not model, and which
+#: therefore contribute to neither skill measurement — no catalog charge, no body
+#: cap. Gemini is the only member: its CLI is deprecated, no vendor documentation
+#: establishes whether it reads a deployed skill at all, and a number invented for
+#: it would be a guess wearing a measurement's clothes. Silence is the honest
+#: report, because a guess is the thing a reader would act on.
+#:
+#: An entry leaves the day that tool's skill loading is established. The default
+#: is the safe direction: a tool absent from this set is modelled, so a newly
+#: registered tool is charged and capped rather than silently exempt.
+UNMODELLED_SKILL_LOADERS: frozenset[str] = frozenset({"gemini"})
+
+
+def models_skill_loading(tool: str) -> bool:
+    """True when this project models how ``tool``'s runtime loads a deployed skill.
+
+    False means neither the catalog charge nor the body cap is computed for that
+    tool — see ``UNMODELLED_SKILL_LOADERS``.
+    """
+    return tool not in UNMODELLED_SKILL_LOADERS
 
 
 def unsupported_keys(tool: str) -> frozenset[str]:

--- a/packages/installer/src/installer/core/content_lint.py
+++ b/packages/installer/src/installer/core/content_lint.py
@@ -9,10 +9,17 @@ with CI green.
 
 This module closes that hole. It stages the repo's own ``src/`` for **every**
 known tool with **every** discovered plugin, then hands the resulting plans to
-the same ``run_admission_gate`` the installer calls. It measures nothing itself:
-classification, sanitization, token counts, and the conflict audit are all the
-gate's, so the check and the installer cannot drift apart. Staging is pure and
-writes nothing — the installer is never invoked.
+the same ``run_admission_gate`` the installer calls. Every number the installer
+also computes is the gate's and not this module's — classification,
+sanitization, the always-on and skill-body token counts, and the conflict audit
+— so the check and the installer cannot drift apart about what deploys or what
+it weighs. Staging is pure and writes nothing; the installer is never invoked.
+
+The one measurement taken here is the one the installer does not make: a skill's
+reference payload (``_skill_payloads``). It has no failure condition, so it has
+no business in the deploy path, and a number only one side computes cannot drift
+from the other side's. The invariant that guards the shared measurements is
+therefore intact and narrower than it once read.
 
 Staging every tool with every plugin rather than whatever the current machine
 has installed is deliberate: the question the lint answers is "is this content
@@ -75,12 +82,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from installer.core import namespaces
+from installer.core.admission import DIR_RECORD_FILE
 from installer.core.content_tests import BUILD_DIRS
 from installer.core.deploy_gate import run_admission_gate
 from installer.core.installignore import InstallIgnore, load_installignore
 from installer.core.orchestrator import stage_and_transform
 from installer.core.staging import shared_source_dir
-from installer.core.surface_budget import SkillMeasure, SurfaceMeasure
+from installer.core.surface_budget import (
+    SkillMeasure,
+    SkillPayloadMeasure,
+    SurfaceMeasure,
+    measure_skill_payload,
+)
 from installer.plugins.registry import discover, is_plugin_dir
 from installer.tools.registry import get_adapter, known_tools
 
@@ -88,7 +101,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
     from installer.core.io_port import IOPort
-    from installer.core.model import StagingPlan, Tool
+    from installer.core.model import Contribution, StagingPlan, Tool
     from installer.plugins.base import PluginAdapter
 
 # The subtree the repo declares to be admitted content only, so a record-less
@@ -240,10 +253,11 @@ class SkillBody:
     """One admitted skill body's measured weight, in repo coordinates.
 
     ``where`` is the source file when the plan records one and the destination
-    otherwise. ``tools`` names every tool the body was measured for: a shared
-    skill stages into every plan, so ungrouped it reports the same number four
-    times. ``cap`` is the ceiling that measured it — a property of the source
-    front matter, so every tool in ``tools`` agrees on it.
+    otherwise. ``tools`` names every tool measured against the same ceiling: a
+    shared skill stages into every plan, so ungrouped it reports the same number
+    once per tool. ``cap`` is the ceiling that measured it, and it is a property
+    of the *target* rather than of the source — so one skill can produce two
+    entries, one per group of tools that agree about it.
     """
 
     where: str
@@ -267,6 +281,7 @@ class ContentLintResult:
     unadmitted: list[Unadmitted] = field(default_factory=list)
     surfaces: list[SurfaceMeasure] = field(default_factory=list)
     skills: list[SkillBody] = field(default_factory=list)
+    payloads: list[SkillPayloadMeasure] = field(default_factory=list)
 
     @property
     def fatal_unadmitted(self) -> list[Unadmitted]:
@@ -365,20 +380,67 @@ def _group_skill_bodies(
 
     ``tokens`` is part of the key rather than an attribute of the group because a
     per-tool transform can change one source's deployed weight, and one file
-    reporting two different numbers is precisely the thing worth seeing. The cap
-    is not: it is decided by the source front matter, which every tool staging
-    that artifact read, so the first measure in a group speaks for all of them.
+    reporting two different numbers is precisely the thing worth seeing. So is
+    ``cap``: the ceiling is chosen from the projected front matter, so a skill
+    declaring itself user-invoked is measured against the loose cap on the one
+    tool that honours the declaration and the strict cap everywhere else. Folding
+    those into one group would print whichever ceiling happened to arrive first
+    and hide the tools it does not apply to — the failure this grouping exists
+    to avoid, one column over.
     """
-    grouped: dict[tuple[str, int], tuple[int, list[str]]] = {}
+    grouped: dict[tuple[str, int, int], list[str]] = {}
     for measure in measures:
-        _cap, tools = grouped.setdefault(
-            (str(sources[measure.label]), measure.tokens), (measure.cap, [])
-        )
+        tools = grouped.setdefault((str(sources[measure.label]), measure.tokens, measure.cap), [])
         tools.append(measure.label.partition(":")[0])
     return [
         SkillBody(where=where, tokens=tokens, cap=cap, tools=tuple(sorted(set(tools))))
-        for (where, tokens), (cap, tools) in sorted(grouped.items())
+        for (where, tokens, cap), tools in sorted(grouped.items())
     ]
+
+
+def _skill_payloads(
+    plans: Mapping[Tool, StagingPlan], *, ignore: InstallIgnore
+) -> list[SkillPayloadMeasure]:
+    """Weigh what each admitted skill deploys beside its entry file.
+
+    The number with no ceiling, and the only one this module computes rather
+    than reads off the gate — a report has no failure condition, so it has no
+    business on the deploy path, where it would also widen the gate's disk
+    access from one entry file to a whole directory interior.
+
+    **What deploys, not what is authored.** The source tree is filtered through
+    the same manifest the copy filters with (``excludes_path``, the one
+    definition of that rule), then the tool's overrides are laid on top, exactly
+    as the sync writes them. The entry file is dropped: its body is already
+    weighed against the skill body cap.
+
+    One entry per skill *directory*, not per tool. A shared skill stages into
+    every plan out of one source tree, and the payload is a property of that
+    tree — so the trees are collected first and read once, and a plugin
+    extension's override files union in from whichever tools received them.
+    Skills with nothing beside their entry are left out entirely: a line reading
+    zero is noise in a report whose whole purpose is to show where the weight is.
+    """
+    trees: dict[Path, dict[Path, Contribution]] = {}
+    for plan in plans.values():
+        for dest, item in plan.items.items():
+            if item.namespace != "skills" or item.content is not None:
+                continue
+            trees.setdefault(item.source_path, {}).update(plan.dir_overrides.get(dest, {}))
+
+    payloads: list[SkillPayloadMeasure] = []
+    for root, overrides in sorted(trees.items()):
+        files = {
+            rel: path.read_bytes()
+            for path, rel in ((path, path.relative_to(root)) for path in sorted(root.rglob("*")))
+            if path.is_file() and not ignore.excludes_path(rel)
+        }
+        files.update({rel: part.content for rel, part in overrides.items()})
+        files.pop(Path(DIR_RECORD_FILE), None)
+        measure = measure_skill_payload(label=str(root), files=files)
+        if measure.prose_tokens or measure.other_tokens:
+            payloads.append(measure)
+    return sorted(payloads, key=lambda m: (-m.largest_tokens, m.label))
 
 
 def _is_admitted_only(source: Path, repo_root: Path) -> bool:
@@ -648,4 +710,7 @@ def lint_content(repo_root: Path, *, io: IOPort) -> ContentLintResult:
         unadmitted=unadmitted,
         surfaces=list(gate.surfaces),
         skills=_group_skill_bodies(gate.skills, sources=sources),
+        # The gate's filtered plans, so a skill the bar dropped is not weighed:
+        # a payload that never deploys is not a cost anyone pays.
+        payloads=_skill_payloads(gate.plans, ignore=staged.ignore),
     )

--- a/packages/installer/src/installer/core/content_lint.py
+++ b/packages/installer/src/installer/core/content_lint.py
@@ -416,16 +416,36 @@ def _skill_payloads(
 
     One entry per skill *directory*, not per tool. A shared skill stages into
     every plan out of one source tree, and the payload is a property of that
-    tree — so the trees are collected first and read once, and a plugin
-    extension's override files union in from whichever tools received them.
-    Skills with nothing beside their entry are left out entirely: a line reading
-    zero is noise in a report whose whole purpose is to show where the weight is.
+    tree — so the trees are collected first and read once, with each tool's
+    override files laid over the result. Skills with nothing beside their entry
+    are left out entirely: a line reading zero is noise in a report whose whole
+    purpose is to show where the weight is.
+
+    **That collection resolves rather than unions, and the difference is worth
+    stating.** Overrides accumulate per inner path, so a path one tool alone
+    receives is added and a path several tools receive identically is
+    idempotent — but a path two tools receive with *different* bytes takes
+    whichever plan is iterated last. Exactly one mechanism can produce that: a
+    tool-scoped extension patch against an inner file of a shared skill. A
+    carrier merge cannot, because it contributes one plugin's bytes to every
+    tool holding that plugin. No extension exists anywhere in the tree, so the
+    case has no occupant — and the one per-tool divergence that *is* live, the
+    entry file capability projection genuinely rewrites per target, is popped
+    below before anything is weighed.
+
+    When the first such extension lands, the repair is to report per tool rather
+    than to fold the tools together — the same shape ``_group_skill_bodies``
+    takes by keying on the cap. Taking a max across targets is the cheaper edit
+    and the wrong one: it would invent a number no target loads, which is the
+    error this whole measurement exists to end.
     """
     trees: dict[Path, dict[Path, Contribution]] = {}
     for plan in plans.values():
         for dest, item in plan.items.items():
             if item.namespace != "skills" or item.content is not None:
                 continue
+            # Per inner path, last plan wins on a collision. See the docstring
+            # for what could produce one and why nothing does.
             trees.setdefault(item.source_path, {}).update(plan.dir_overrides.get(dest, {}))
 
     payloads: list[SkillPayloadMeasure] = []

--- a/packages/installer/src/installer/core/deploy_gate.py
+++ b/packages/installer/src/installer/core/deploy_gate.py
@@ -12,9 +12,13 @@ is assembled and before any write. It:
    the target tool's loader does not define are projected out (see
    ``sanitize`` and ``capabilities``);
 3. measures the **surface budget** over the *rewritten admitted* content — the
-   always-on surface per tool and each admitted skill body. Measuring after the
-   rewrite is the point: the budget weighs what a reader actually loads, not
-   the governance metadata that enforces the budget;
+   always-on surface per tool, which now includes the catalog entry of every
+   skill that tool's runtime publishes to the model, and each admitted skill
+   body against the cap that fits the target it is deploying to. Measuring
+   after the rewrite is the point twice over: the budget weighs what a reader
+   actually loads rather than the governance metadata that enforces it, and it
+   reads the projected front matter rather than the source, so a declaration
+   the target's loader cannot honour prices nothing;
 4. runs the **conflict audit** over the admitted artifacts' claims.
 
 The unit judged is the **contributor**, not the destination. A rule destination
@@ -57,7 +61,7 @@ from installer.core.admission import (
     entry_file_text,
     is_gated,
 )
-from installer.core.capabilities import is_user_invoked
+from installer.core.capabilities import is_user_invoked, models_skill_loading
 from installer.core.conflict_audit import conflict_violations
 from installer.core.frontmatter import split_frontmatter
 from installer.core.installignore import InstallIgnore
@@ -167,6 +171,22 @@ def _skill_body(text: str) -> str:
     """The admitted skill's on-invoke body: its entry file minus front matter."""
     _mapping, body = split_frontmatter(text)
     return body
+
+
+def _catalog_entry(text: str) -> bytes:
+    """The bytes a tool's skill catalog carries for one admitted skill.
+
+    Its ``name`` and ``description``, which is what a runtime publishes to the
+    model before the user has typed anything. The exact framing each vendor
+    renders around them is not knowable from this repository, so the joined pair
+    is an approximation and the ``bytes / 4`` token estimate carries the slack
+    conservatively. What matters is that the two fields are charged at all: they
+    load into every session unconditionally, and until now nothing weighed them.
+    """
+    mapping, _body = split_frontmatter(text)
+    if mapping is None:
+        return b""
+    return f"{mapping.get('name', '')}: {mapping.get('description', '')}".encode()
 
 
 def _record_bearers(item: StagedItem, overrides: dict[Path, Contribution]) -> list[Contribution]:
@@ -322,11 +342,16 @@ def _judge(
     and sanitization read the same bytes: what the bar judged is what deploys,
     minus only the governance metadata the bar itself consumed.
 
-    The invocation mode is read from the SOURCE front matter, before the
-    projection removes the key for a tool that does not define it. Reading it
-    after would make one artifact's cap depend on which tool is being staged, so
-    the same repo would pass on a Claude-only machine and fail wherever a second
-    tool is detected.
+    The invocation mode is read from the DEPLOYED front matter, after the
+    projection has removed the key for a tool whose loader does not define it.
+    That makes one artifact's cap depend on which tool is being staged, and it
+    is the point: on a tool that strips the key the skill is model-invocable
+    whatever its author declared, so the strict cap is the one that fits and the
+    description does reach the catalog. The repository's verdict stays uniform
+    regardless, because the repo-side content lint stages every known tool on
+    every run — no artifact is ever judged against fewer targets than it can
+    reach, so a per-machine deploy can only be looser than the gate that
+    already passed.
     """
     text = contribution.content.decode("utf-8", errors="replace")
     verdict = classify(text)
@@ -334,12 +359,13 @@ def _judge(
         return None, None
     if verdict.outcome is AdmissionOutcome.MALFORMED:
         return None, f"{label}: incomplete admission record — {verdict.detail}"
+    deployed = project_capabilities(sanitize_text(text), tool=tool.value)
     return (
         _Admitted(
             source=contribution.source_path,
             label=label,
-            text=project_capabilities(sanitize_text(text), tool=tool.value),
-            user_invoked=is_user_invoked(text),
+            text=deployed,
+            user_invoked=is_user_invoked(deployed),
             claims=verdict.claims,
         ),
         None,
@@ -362,6 +388,9 @@ def run_admission_gate(
     sources: dict[str, Path] = {}
     claims_by_artifact: list[tuple[str, dict[str, str]]] = []
     skill_bodies: list[SkillBodySource] = []
+    # Per tool, because a catalog is a property of one runtime: the same skill
+    # is an entry on a tool that publishes it and nothing on a tool that hides it.
+    catalog: dict[Tool, list[bytes]] = {tool: [] for tool in plans}
 
     for tool, plan in plans.items():
         kept: dict[Path, StagedItem] = {}
@@ -440,7 +469,13 @@ def run_admission_gate(
                 )
             kept[dest] = item
 
-            if item.namespace == "skills":
+            # Only skills, and only on a tool whose skill loading is modelled.
+            # A commands namespace is charged nothing here and capped nowhere:
+            # the user types a command's name, so neither its description nor
+            # its body is a cost anyone was handed. An unmodelled tool is
+            # measured on neither count, which is the honest report when what
+            # its runtime does with a deployed skill is not established.
+            if item.namespace == "skills" and models_skill_loading(tool.value):
                 skill_bodies += [
                     SkillBodySource(
                         label=part.label,
@@ -448,6 +483,9 @@ def run_admission_gate(
                         user_invoked=part.user_invoked,
                     )
                     for part in admitted
+                ]
+                catalog[tool] += [
+                    _catalog_entry(part.text) for part in admitted if not part.user_invoked
                 ]
 
         # Drop override bytes for any item the gate removed, then lay each
@@ -465,11 +503,14 @@ def run_admission_gate(
             if it.namespace == "rules" and it.content is not None
         ]
         instruction = _instruction_bytes(plan)
+        entries = catalog[tool]
         surfaces.append(
-            measure_always_on(tool=tool.value, instruction=instruction, rules=rule_bytes)
+            measure_always_on(
+                tool=tool.value, instruction=instruction, rules=rule_bytes, catalog=entries
+            )
         )
         violations += always_on_violations(
-            tool=tool.value, instruction=instruction, rules=rule_bytes
+            tool=tool.value, instruction=instruction, rules=rule_bytes, catalog=entries
         )
     violations += skill_body_violations(skill_bodies)
     violations += conflict_violations(claims_by_artifact)

--- a/packages/installer/src/installer/core/surface_budget.py
+++ b/packages/installer/src/installer/core/surface_budget.py
@@ -3,18 +3,41 @@
 Two mechanical caps, each a hard failure that aborts the deploy before any
 write:
 
-- the **always-on surface** for a tool — the deployed instruction file plus
-  every admitted always-on rule — is capped at ``ALWAYS_ON_TOKEN_CAP``;
+- the **always-on surface** for a tool — the deployed instruction file, every
+  admitted always-on rule, and every skill catalog entry that tool's runtime
+  publishes to the model — is capped at ``ALWAYS_ON_TOKEN_CAP``;
 - each admitted **skill body** (the SKILL.md content after its front matter,
   the on-invoke payload) is capped at ``SKILL_BODY_TOKEN_CAP``, or at
-  ``USER_INVOKED_SKILL_BODY_TOKEN_CAP`` when the skill is user-invoked.
+  ``USER_INVOKED_SKILL_BODY_TOKEN_CAP`` when the target it deploys to keeps
+  that skill out of the model's reach.
 
-A model-invoked skill's body is loaded on the model's own judgement, mid-task,
-against whatever else the context is already carrying. A user-invoked one is
-reached only when the user names it, so the cost is asked for and lands at a
-moment chosen for it. That difference is what the second cap prices, and it is
-all it prices: the looser number is relief for a body that has already been
-split down, never permission to leave it whole.
+A ceiling prices bytes the reader cannot decline, and it prices them as the
+target actually loads them. A catalog entry is the unconditional case: a skill's
+name and description sit in the session before the user has typed anything,
+which is what puts them in the same aggregate as the instruction file instead of
+in a ceiling of their own. A model-invoked body is loaded on the model's own
+judgement, mid-task, against whatever else the context is already carrying; a
+body the model cannot reach is loaded only when the user names it, so the cost
+is asked for and lands at a moment chosen for it. That difference is what the
+second cap prices, and it is all it prices: the looser number is relief for a
+body that has already been split down, never permission to leave it whole.
+
+Both facts are per target, not per artifact, because the tools differ on whether
+a user-invoked declaration reaches their loader at all (see ``capabilities``).
+One skill is therefore charged on one tool and free on another, and measured
+against a different ceiling on each. Where a tool's skill loading is not modelled
+at all, it contributes to neither number.
+
+And one measurement with no ceiling: a skill's **reference payload**, the files
+that deploy beside its entry (``measure_skill_payload``). Reported, never
+enforced. The unit a reader pays is one file chosen mid-task, so the directory
+total is a quantity nobody is ever charged, and the largest readable file in the
+tree is a verbatim mirror of an upstream document that a cap could only truncate
+or delete. Readable means ``.md`` and ``.txt``; everything else is counted apart
+and costed at nothing, because executed scripts, schemas and fixtures are disk
+weight rather than context weight — charging them would price this repository's
+own "code over prose" principle as a cost, so the exclusion is a decision and
+not an oversight.
 
 Token count is the ``bytes / 4`` approximation (ceil): no tokenizer dependency
 is added. The cap carries >20x margin at the zero-base (~418 tokens vs
@@ -35,40 +58,71 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
 
 ALWAYS_ON_TOKEN_CAP = 10_000
 SKILL_BODY_TOKEN_CAP = 2_000
 USER_INVOKED_SKILL_BODY_TOKEN_CAP = 5_000
 
+#: Payload suffixes an agent reads into its context as prose. Everything else a
+#: skill ships is executed or indexed, and is reported apart at no cost.
+READABLE_SUFFIXES = frozenset({".md", ".txt"})
+
 
 @dataclass(frozen=True, slots=True)
 class SurfaceMeasure:
-    """One tool's always-on weight: the instruction file plus its rules.
+    """One tool's always-on weight: the instruction file, its rules, and the
+    skill catalog entries its runtime publishes.
 
-    ``rules`` is carried alongside ``tokens`` because the two move for different
-    reasons — a growing token count with a flat rule count is one rule bloating,
-    and both rising is the surface accreting.
+    ``rules`` and ``catalog_entries`` are carried alongside ``tokens`` because
+    the three move for different reasons — a growing token count with a flat
+    rule count is one rule bloating, both rising is the surface accreting, and a
+    rising entry count is the component that grows with every admission while
+    the rules stay still.
     """
 
     tool: str
     tokens: int
     rules: int
+    catalog_entries: int
 
 
 @dataclass(frozen=True, slots=True)
 class SkillBodySource:
     """One admitted skill body on its way to the scale.
 
-    ``user_invoked`` is read from the artifact's source front matter, so it is
-    a property of the skill rather than of any one deploy target: a tool whose
-    loader cannot honour the flag still measures the body against the cap the
-    author chose.
+    ``user_invoked`` is read from the artifact's **projected** front matter, so
+    it is a property of the deploy target rather than of the source: a tool
+    whose loader cannot honour the declaration measures the body against the
+    strict cap, because on that tool the model reaches the body on its own
+    judgement whatever the author wrote. One artifact can therefore carry two
+    numbers, one per target — the measurement telling the truth rather than
+    disagreeing with itself.
     """
 
     label: str
     body: str
     user_invoked: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SkillPayloadMeasure:
+    """What one skill deploys beside its body — reported, never capped.
+
+    ``prose_tokens`` and ``largest_tokens`` are the two numbers worth a reader's
+    attention: the whole tree if they followed every pointer, and the one file
+    they actually pay when they follow one. ``other_tokens`` is stated apart and
+    costed at nothing, so that a skill which moved work out of prose and into
+    code does not read as one that grew.
+    """
+
+    label: str
+    prose_tokens: int
+    prose_files: int
+    largest_file: str
+    largest_tokens: int
+    other_tokens: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,15 +149,22 @@ def approx_tokens(data: bytes | str) -> int:
 
 
 def measure_always_on(
-    *, tool: str, instruction: bytes | None, rules: list[bytes]
+    *, tool: str, instruction: bytes | None, rules: list[bytes], catalog: list[bytes]
 ) -> SurfaceMeasure:
-    """Weigh one tool's always-on surface: instruction-file bytes plus every
-    admitted rule's bytes. A tool with no instruction file (``instruction is
-    None``) contributes only its rules."""
+    """Weigh one tool's always-on surface: instruction-file bytes, every admitted
+    rule's bytes, and every skill catalog entry ``tool``'s runtime publishes to
+    the model. A tool with no instruction file (``instruction is None``)
+    contributes only the other two.
+
+    Which entries belong in ``catalog`` is the caller's judgement and cannot be
+    made here: this function sees bytes, not which skill produced them or what
+    the target does with it. An entry the target's runtime never publishes must
+    not be in the list.
+    """
     total = approx_tokens(instruction) if instruction is not None else 0
-    for rule in rules:
-        total += approx_tokens(rule)
-    return SurfaceMeasure(tool=tool, tokens=total, rules=len(rules))
+    for entry in (*rules, *catalog):
+        total += approx_tokens(entry)
+    return SurfaceMeasure(tool=tool, tokens=total, rules=len(rules), catalog_entries=len(catalog))
 
 
 def skill_body_cap(*, user_invoked: bool) -> int:
@@ -124,16 +185,50 @@ def measure_skill_bodies(bodies: Sequence[SkillBodySource]) -> list[SkillMeasure
     ]
 
 
-def always_on_violations(*, tool: str, instruction: bytes | None, rules: list[bytes]) -> list[str]:
+def always_on_violations(
+    *, tool: str, instruction: bytes | None, rules: list[bytes], catalog: list[bytes]
+) -> list[str]:
     """Violation messages if a tool's always-on surface exceeds the cap.
     Returns at most one message."""
-    measure = measure_always_on(tool=tool, instruction=instruction, rules=rules)
+    measure = measure_always_on(tool=tool, instruction=instruction, rules=rules, catalog=catalog)
     if measure.tokens > ALWAYS_ON_TOKEN_CAP:
         return [
             f"{tool}: always-on surface is {measure.tokens} tokens, over the "
             f"{ALWAYS_ON_TOKEN_CAP}-token cap"
         ]
     return []
+
+
+def measure_skill_payload(*, label: str, files: Mapping[Path, bytes]) -> SkillPayloadMeasure:
+    """Weigh one skill's payload — every file that deploys beside its entry.
+
+    ``files`` maps a path relative to the skill's directory to the bytes that
+    deploy at it, so which files those are is the caller's answer: nothing here
+    reads disk or knows what a deploy prunes. The entry file itself is not one
+    of them — its body is already weighed against the skill body cap, and
+    counting it here would charge it twice.
+
+    A skill with no payload measures zero against an empty ``largest_file``.
+    Ties for largest are broken by path order, so the answer does not depend on
+    the order the caller happened to read the tree in.
+    """
+    prose = {rel: data for rel, data in files.items() if rel.suffix in READABLE_SUFFIXES}
+    largest: Path | None = None
+    for rel in sorted(prose):
+        if largest is None or len(prose[rel]) > len(prose[largest]):
+            largest = rel
+    return SkillPayloadMeasure(
+        label=label,
+        prose_tokens=sum(approx_tokens(data) for data in prose.values()),
+        prose_files=len(prose),
+        largest_file=str(largest) if largest is not None else "",
+        largest_tokens=approx_tokens(prose[largest]) if largest is not None else 0,
+        other_tokens=sum(
+            approx_tokens(data)
+            for rel, data in files.items()
+            if rel.suffix not in READABLE_SUFFIXES
+        ),
+    )
 
 
 def skill_body_violations(bodies: Sequence[SkillBodySource]) -> list[str]:

--- a/packages/installer/tests/unit/test_capabilities.py
+++ b/packages/installer/tests/unit/test_capabilities.py
@@ -10,8 +10,10 @@ import pytest
 
 from installer.core.capabilities import (
     CAPABILITY_SUPPORT,
+    UNMODELLED_SKILL_LOADERS,
     USER_INVOKED_KEY,
     is_user_invoked,
+    models_skill_loading,
     unsupported_keys,
 )
 from installer.tools.registry import known_tools
@@ -51,3 +53,18 @@ def test_absent_or_missing_front_matter_reads_as_model_invoked() -> None:
     """The stricter cap is the one to fall back to when nothing says otherwise."""
     assert not is_user_invoked("---\nname: a\n---\nbody\n")
     assert not is_user_invoked("# no front matter\n")
+
+
+def test_every_unmodelled_loader_is_a_known_tool() -> None:
+    """An exemption naming a tool that does not exist grants nothing and hides
+    nothing, so it would sit here unfalsified until someone read the file."""
+    assert {tool.value for tool in known_tools()} >= UNMODELLED_SKILL_LOADERS
+
+
+def test_only_gemini_is_exempt_from_the_skill_measurements() -> None:
+    """The membership is pinned so that exempting a second tool arrives as a
+    reviewable diff. Silence about what a tool loads is a decision, not a default:
+    a tool absent from the set is charged and capped."""
+    assert not models_skill_loading("gemini")
+    assert all(models_skill_loading(tool) for tool in ["claude", "codex", "opencode"])
+    assert models_skill_loading("some-future-tool")

--- a/packages/installer/tests/unit/test_content_lint.py
+++ b/packages/installer/tests/unit/test_content_lint.py
@@ -12,10 +12,14 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from installer.core.capabilities import models_skill_loading
 from installer.core.content_lint import UNGATED_ROOTS, _staged_dirs, _unaccounted_dirs, lint_content
 from installer.core.installignore import load_installignore
 from installer.core.io_port import ScriptedIO
-from installer.core.surface_budget import SKILL_BODY_TOKEN_CAP
+from installer.core.surface_budget import (
+    SKILL_BODY_TOKEN_CAP,
+    USER_INVOKED_SKILL_BODY_TOKEN_CAP,
+)
 from installer.tools.registry import known_tools
 from tests.unit.plugin_double import RoutedPluginDouble
 
@@ -61,14 +65,18 @@ def _repo(
         skill_dir = shared / "skills" / name
         skill_dir.mkdir(parents=True, exist_ok=True)
         for filename, text in files.items():
-            (skill_dir / filename).write_text(text, encoding="utf-8")
+            target = skill_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
 
     for relpath, files in (plugin_skill_files or {}).items():
         plugin, name = relpath.split("/", 1)
         skill_dir = tmp_path / "src" / "plugins" / plugin / ".agents" / "skills" / name
         skill_dir.mkdir(parents=True, exist_ok=True)
         for filename, text in files.items():
-            (skill_dir / filename).write_text(text, encoding="utf-8")
+            target = skill_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
 
     for relpath, text in (plugin_rules or {}).items():
         plugin, filename = relpath.split("/", 1)
@@ -124,8 +132,9 @@ def test_over_cap_skill_body_in_real_src_is_a_violation(tmp_path: Path) -> None:
     """The regression this module exists for: an over-cap body reaching main with
     CI green because nothing measured the tree the installer would actually read.
 
-    Reported once for the one file, naming every tool it would have deployed to —
-    four lines and a count of four would read as four separate defects.
+    Reported once for the one file, naming every tool that measured it — a line
+    per tool and a count to match would read as several separate defects. Gemini
+    is not among them: its skill loading is not modelled, so it weighs no body.
     """
     oversize = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
     repo = _repo(tmp_path, skills={"bloated": _RECORD + oversize})
@@ -136,7 +145,8 @@ def test_over_cap_skill_body_in_real_src_is_a_violation(tmp_path: Path) -> None:
     assert "skills/bloated" in result.violations[0]
     assert "over the" in result.violations[0]
     for tool in known_tools():
-        assert tool.value in result.violations[0]
+        measured = tool.value in result.violations[0]
+        assert measured is models_skill_loading(tool.value)
 
 
 def test_a_violation_carrying_no_tool_prefix_passes_through_whole() -> None:
@@ -666,3 +676,73 @@ def test_an_admitted_skill_is_weighed_under_the_file_that_was_weighed(
     result = _lint(repo)
 
     assert [b.where for b in result.skills] == [str(repo / "src/user/.agents/skills/tidy/SKILL.md")]
+
+
+def test_the_payload_report_prints_on_a_pass_and_fails_nothing(tmp_path: Path) -> None:
+    """The number with no ceiling. A reader cannot otherwise see what a skill costs
+    when they follow one of its pointers, and the unit they pay is one file — so the
+    report names the largest and the verdict is untouched by it."""
+    repo = _repo(
+        tmp_path,
+        skills={"heavy": _RECORD + "short\n"},
+        shared_skill_files={
+            "heavy": {
+                "references/long.md": "p" * 4_000,
+                "references/short.md": "p" * 40,
+                "scripts/run.py": "c" * 8_000,
+            }
+        },
+    )
+    result = _lint(repo)
+
+    assert result.ok
+    assert [(p.prose_files, p.largest_file, p.largest_tokens) for p in result.payloads] == [
+        (2, "references/long.md", 1_000)
+    ]
+    # Executed code is counted apart and costed at nothing: it never enters a
+    # context window, and charging it would price code-over-prose as a cost.
+    assert [p.prose_tokens for p in result.payloads] == [1_010]
+    assert [p.other_tokens for p in result.payloads] == [2_000]
+
+
+def test_the_payload_walk_counts_what_deploys_not_what_is_authored(tmp_path: Path) -> None:
+    """A file the manifest prunes never reaches a user, so weighing it would report
+    a cost nobody pays. The manifest's own path rule answers this, rather than a
+    second copy of it here."""
+    repo = _repo(
+        tmp_path,
+        skills={"heavy": _RECORD + "short\n"},
+        shared_skill_files={"heavy": {"references/keep.md": "p" * 40, "README.md": "p" * 4_000}},
+    )
+    result = _lint(repo)
+
+    assert result.ok
+    assert [(p.prose_files, p.largest_file) for p in result.payloads] == [(1, "references/keep.md")]
+
+
+def test_a_skill_entry_file_is_not_charged_to_its_own_payload(tmp_path: Path) -> None:
+    """The body is already weighed against the skill body cap; counting it here
+    would charge one artifact's bytes to two different numbers."""
+    repo = _repo(
+        tmp_path,
+        skills={"lonely": _RECORD + "x" * 400},
+        shared_skill_files={"lonely": {"references/tiny.md": "p" * 4}},
+    )
+    result = _lint(repo)
+
+    assert [(p.prose_files, p.prose_tokens) for p in result.payloads] == [(1, 1)]
+
+
+def test_a_user_invoked_shared_skill_reports_one_line_per_ceiling(tmp_path: Path) -> None:
+    """Grouping folds a repeated finding into one line naming its tools, but the
+    ceiling now varies by target — so folding on the token count alone would print
+    whichever cap arrived first and hide the tools it does not apply to."""
+    flagged = _RECORD.replace("---\n", "---\ndisable-model-invocation: true\n", 1)
+    repo = _repo(tmp_path, skills={"quiet": flagged + "short\n"})
+    result = _lint(repo)
+
+    assert result.ok
+    assert [(body.cap, body.tools) for body in result.skills] == [
+        (SKILL_BODY_TOKEN_CAP, ("codex", "opencode")),
+        (USER_INVOKED_SKILL_BODY_TOKEN_CAP, ("claude",)),
+    ]

--- a/packages/installer/tests/unit/test_content_lint_cli.py
+++ b/packages/installer/tests/unit/test_content_lint_cli.py
@@ -22,11 +22,24 @@ from installer.core.surface_budget import (
 _RECORD = "---\nadmission:\n  prevents: p\n  cost: c\n  remove_when: r\n---\n"
 
 
-def _repo(tmp_path: Path, *, skill: str, name: str = "tidy") -> Path:
+def _repo(
+    tmp_path: Path,
+    *,
+    skill: str,
+    name: str = "tidy",
+    tree: str = ".agents",
+    payload: dict[str, str] | None = None,
+) -> Path:
+    """A repo root carrying one skill. ``tree`` picks the tool subdirectory, which
+    decides whether a user-invoked declaration survives the projection."""
     (tmp_path / ".installignore").write_text("AGENTS.md\n", encoding="utf-8")
-    skill_dir = tmp_path / "src" / "user" / ".agents" / "skills" / name
+    skill_dir = tmp_path / "src" / "user" / tree / "skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(skill, encoding="utf-8")
+    for filename, text in (payload or {}).items():
+        target = skill_dir / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
     return tmp_path
 
 
@@ -51,13 +64,50 @@ def test_a_user_invoked_skill_reports_against_the_raised_ceiling(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A body between the two caps deploys, and the trend line says which ceiling
-    let it through."""
+    let it through.
+
+    The Claude-only tree is the fixture because that is where the looser ceiling
+    is earned: the same declaration in the shared tree is stripped for three of
+    four tools, and the body is measured against the strict cap on each of them.
+    """
     body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
     flagged = _RECORD.replace("---\n", "---\ndisable-model-invocation: true\n", 1)
-    repo = _repo(tmp_path, skill=flagged + body)
+    repo = _repo(tmp_path, skill=flagged + body, tree=".claude")
 
     assert main([str(repo)]) == 0
     assert f"/ {USER_INVOKED_SKILL_BODY_TOKEN_CAP}" in capsys.readouterr().out
+
+
+def test_the_payload_block_prints_on_a_pass_and_changes_no_verdict(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A report, not a ceiling. It exists because a reader cannot otherwise see
+    what a skill costs when they follow one of its pointers — and its header says
+    there is no cap, so the number is not read as a third one."""
+    repo = _repo(
+        tmp_path,
+        skill=_RECORD + "short\n",
+        payload={"references/long.md": "p" * 40_000, "scripts/run.py": "c" * 4},
+    )
+
+    assert main([str(repo)]) == 0
+
+    out = capsys.readouterr().out
+    assert "no cap" in out
+    assert "10000 prose" in out
+    assert "references/long.md" in out
+    assert "1 non-prose" in out
+
+
+def test_a_skill_with_nothing_beside_its_body_prints_no_payload_line(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A line reading zero is noise in a report whose whole purpose is to show
+    where the weight is."""
+    repo = _repo(tmp_path, skill=_RECORD + "short\n")
+
+    assert main([str(repo)]) == 0
+    assert "reference payloads" not in capsys.readouterr().out
 
 
 def test_over_cap_body_exits_one_and_names_the_skill_on_stderr(

--- a/packages/installer/tests/unit/test_deploy_gate.py
+++ b/packages/installer/tests/unit/test_deploy_gate.py
@@ -396,11 +396,21 @@ def test_an_unflagged_body_over_the_standard_cap_still_fails(tmp_path: Path) -> 
     assert any(f"{SKILL_BODY_TOKEN_CAP}-token cap" in v for v in result.violations)
 
 
-@pytest.mark.parametrize("tool", list(Tool))
-def test_the_cap_is_the_artifact_s_and_not_the_tool_s(tmp_path: Path, tool: Tool) -> None:
-    """The flag is read from the source front matter, before the projection strips
-    it for a tool that cannot honour it. Reading it after would make one repo pass
-    on a Claude-only machine and fail wherever a second tool is detected."""
+@pytest.mark.parametrize(
+    ("tool", "cap"),
+    [
+        (Tool.CLAUDE, USER_INVOKED_SKILL_BODY_TOKEN_CAP),
+        (Tool.CODEX, SKILL_BODY_TOKEN_CAP),
+        (Tool.OPENCODE, SKILL_BODY_TOKEN_CAP),
+    ],
+)
+def test_the_cap_is_the_target_s_and_not_the_source_s_claim(
+    tmp_path: Path, tool: Tool, cap: int
+) -> None:
+    """One shared skill declaring itself user-invoked, measured against the loose
+    cap on the one tool whose loader honours the declaration and the strict cap on
+    the tools that strip it. On those the model reaches the body on its own
+    judgement whatever the author wrote, so the cost was never asked for."""
     body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
     item = _shared_skill(
         tmp_path,
@@ -409,8 +419,88 @@ def test_the_cap_is_the_artifact_s_and_not_the_tool_s(tmp_path: Path, tool: Tool
     )
     result = run_admission_gate({tool: _plan(_instruction(b"laws"), item, tool=tool)})
 
+    assert [m.cap for m in result.skills] == [cap]
+    assert result.ok is (cap == USER_INVOKED_SKILL_BODY_TOKEN_CAP)
+
+
+def test_a_user_invoked_skill_is_a_catalog_entry_only_where_the_key_is_stripped(
+    tmp_path: Path,
+) -> None:
+    """The same fact priced twice: Claude keeps the declaration and publishes
+    nothing, so the entry costs zero; Codex strips it and publishes the
+    description, so the entry is charged. A record claiming zero always-on cost
+    for a shared user-invoked skill is true on one tool and false on the others."""
+    item = _shared_skill(
+        tmp_path,
+        "quiet",
+        f"---\nname: quiet\ndescription: {'d' * 400}\n"
+        f"disable-model-invocation: true\n{_RECORD}---\nbody\n",
+    )
+    plans = {
+        tool: _plan(_instruction(b"laws"), item, tool=tool) for tool in (Tool.CLAUDE, Tool.CODEX)
+    }
+    result = run_admission_gate(plans)
+
+    charged = {s.tool: s.catalog_entries for s in result.surfaces}
+    assert charged == {"claude": 0, "codex": 1}
+    weights = {s.tool: s.tokens for s in result.surfaces}
+    assert weights["codex"] > weights["claude"]
+
+
+def test_an_oversized_skill_description_breaches_the_always_on_cap(tmp_path: Path) -> None:
+    """The catalog entry is charged against the ceiling that already exists, so a
+    description nobody can decline fails the deploy exactly as a rule would."""
+    item = _shared_skill(
+        tmp_path,
+        "verbose",
+        f"---\nname: verbose\ndescription: {'d' * (ALWAYS_ON_TOKEN_CAP * 4 + 8)}\n"
+        f"{_RECORD}---\nbody\n",
+    )
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), item)})
+
+    assert not result.ok
+    assert any("always-on surface" in v for v in result.violations)
+
+
+def test_a_command_description_is_charged_nothing(tmp_path: Path) -> None:
+    """A command is summoned by the user typing its name on every tool, so neither
+    its description nor its body is a cost anyone was handed. The regression guard
+    for that exemption, which nothing else in the gate states."""
+    command = StagedItem(
+        source_path=tmp_path / "commands" / "verbose.md",
+        dest_relpath=Path("commands") / "verbose.md",
+        kind=FileKind.NAMESPACED_MD,
+        namespace="commands",
+        provenance=Provenance(kind="tool", name="claude"),
+        content=(
+            f"---\nname: verbose\ndescription: {'d' * (ALWAYS_ON_TOKEN_CAP * 4 + 8)}\n"
+            f"{_RECORD}---\nbody\n"
+        ).encode(),
+    )
+    result = run_admission_gate({Tool.CLAUDE: _plan(_instruction(b"laws"), command)})
+
     assert result.ok, result.violations
-    assert [m.cap for m in result.skills] == [USER_INVOKED_SKILL_BODY_TOKEN_CAP]
+    assert [s.catalog_entries for s in result.surfaces] == [0]
+    assert result.skills == []
+
+
+def test_gemini_contributes_to_neither_skill_measurement(tmp_path: Path) -> None:
+    """Gemini's CLI is deprecated and nothing establishes what its runtime does
+    with a deployed skill, so this project models neither its catalog nor its body
+    cap. A number invented for it would be a guess a reader would act on."""
+    body = "x" * (SKILL_BODY_TOKEN_CAP * 4 + 4)
+    item = _shared_skill(
+        tmp_path,
+        "unmodelled",
+        f"---\nname: unmodelled\ndescription: {'d' * 400}\n{_RECORD}---\n{body}",
+    )
+    result = run_admission_gate({Tool.GEMINI: _plan(_instruction(b"laws"), item, tool=Tool.GEMINI)})
+
+    assert result.ok, result.violations
+    assert result.skills == []
+    assert [s.catalog_entries for s in result.surfaces] == [0]
+    # The skill still deploys — exempt from the measurements, not from the gate.
+    assert Path("skills/unmodelled") in result.plans[Tool.GEMINI].items
 
 
 def test_item_label_is_the_join_key_the_gate_reports_under() -> None:

--- a/packages/installer/tests/unit/test_surface_budget.py
+++ b/packages/installer/tests/unit/test_surface_budget.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
@@ -11,6 +13,7 @@ from installer.core.surface_budget import (
     approx_tokens,
     measure_always_on,
     measure_skill_bodies,
+    measure_skill_payload,
     skill_body_violations,
 )
 
@@ -29,14 +32,14 @@ def test_approx_tokens_is_ceil_of_bytes_over_four() -> None:
 
 def test_zero_base_surface_passes() -> None:
     # ~1670 bytes ≈ 418 tokens, far under the cap.
-    assert always_on_violations(tool="claude", instruction=b"x" * 1670, rules=[]) == []
+    assert always_on_violations(tool="claude", instruction=b"x" * 1670, rules=[], catalog=[]) == []
 
 
 def test_boundary_at_cap_passes_and_one_over_fails() -> None:
     at_cap = b"x" * (ALWAYS_ON_TOKEN_CAP * 4)  # exactly 10_000 tokens
-    assert always_on_violations(tool="claude", instruction=at_cap, rules=[]) == []
+    assert always_on_violations(tool="claude", instruction=at_cap, rules=[], catalog=[]) == []
     over = b"x" * (ALWAYS_ON_TOKEN_CAP * 4 + 1)  # 10_001 tokens (ceil)
-    violations = always_on_violations(tool="claude", instruction=over, rules=[])
+    violations = always_on_violations(tool="claude", instruction=over, rules=[], catalog=[])
     assert len(violations) == 1
     assert "claude" in violations[0]
     assert str(ALWAYS_ON_TOKEN_CAP) in violations[0]
@@ -44,12 +47,16 @@ def test_boundary_at_cap_passes_and_one_over_fails() -> None:
 
 def test_rules_count_toward_always_on_surface() -> None:
     half = b"x" * (ALWAYS_ON_TOKEN_CAP * 2)  # 5_000 tokens each
-    violations = always_on_violations(tool="codex", instruction=half, rules=[half, b"y" * 8])
+    violations = always_on_violations(
+        tool="codex", instruction=half, rules=[half, b"y" * 8], catalog=[]
+    )
     assert len(violations) == 1  # 5000 + 5000 + 2 > 10000
 
 
 def test_no_instruction_file_counts_only_rules() -> None:
-    assert always_on_violations(tool="gemini", instruction=None, rules=[b"x" * 16]) == []
+    assert (
+        always_on_violations(tool="gemini", instruction=None, rules=[b"x" * 16], catalog=[]) == []
+    )
 
 
 def test_skill_body_over_cap_is_named() -> None:
@@ -101,7 +108,9 @@ def test_measurement_carries_the_rule_count_beside_the_token_total() -> None:
     """Tokens and rule count move for different reasons — rising tokens against a
     flat rule count is one rule bloating, both rising is the surface accreting. A
     reader watching for drift needs to tell those apart."""
-    measure = measure_always_on(tool="claude", instruction=b"x" * 8, rules=[b"y" * 4, b"z" * 4])
+    measure = measure_always_on(
+        tool="claude", instruction=b"x" * 8, rules=[b"y" * 4, b"z" * 4], catalog=[]
+    )
     assert (measure.tool, measure.tokens, measure.rules) == ("claude", 4, 2)
 
 
@@ -109,8 +118,8 @@ def test_the_violation_verdict_is_the_measurement_it_reports() -> None:
     """The two callers must never disagree about what the surface weighs: the lint
     reports headroom from the same number the gate fails on."""
     over = b"x" * (ALWAYS_ON_TOKEN_CAP * 4 + 1)
-    measure = measure_always_on(tool="claude", instruction=over, rules=[])
-    violations = always_on_violations(tool="claude", instruction=over, rules=[])
+    measure = measure_always_on(tool="claude", instruction=over, rules=[], catalog=[])
+    violations = always_on_violations(tool="claude", instruction=over, rules=[], catalog=[])
     assert str(measure.tokens) in violations[0]
 
 
@@ -127,3 +136,59 @@ def test_skill_bodies_are_measured_whether_or_not_they_breach() -> None:
         ("claude:skills/small", 2),
         ("claude:skills/big", 1),
     ]
+
+
+def test_catalog_entries_are_charged_to_the_always_on_surface() -> None:
+    """A skill's name and description load before the user types, so they belong
+    in the same aggregate as the instruction file — the component that grows with
+    every admission, charged against the ceiling that already exists."""
+    entry = b"x" * 40  # 10 tokens
+    measure = measure_always_on(
+        tool="claude", instruction=b"y" * 8, rules=[], catalog=[entry, entry]
+    )
+    assert (measure.tokens, measure.catalog_entries) == (22, 2)
+
+
+def test_a_catalog_alone_can_breach_the_always_on_cap() -> None:
+    """No new ceiling: the entries are measured by the one that was already there,
+    over a domain that now includes them."""
+    over = b"x" * (ALWAYS_ON_TOKEN_CAP * 4 + 4)
+    violations = always_on_violations(tool="opencode", instruction=None, rules=[], catalog=[over])
+    assert len(violations) == 1
+    assert str(ALWAYS_ON_TOKEN_CAP) in violations[0]
+
+
+def test_the_payload_report_splits_prose_from_what_is_never_read() -> None:
+    """Executed code and indexed data are disk weight, not context weight. Folding
+    them into the prose total would report a skill that moved work into code as
+    one that grew, and price this repo's own code-over-prose principle as a cost."""
+    measure = measure_skill_payload(
+        label="skills/example",
+        files={
+            Path("references/a.md"): b"x" * 40,
+            Path("references/b.txt"): b"y" * 8,
+            Path("scripts/run.py"): b"z" * 400,
+            Path("evals/corpus.json"): b"w" * 4,
+        },
+    )
+    assert (measure.prose_tokens, measure.prose_files) == (12, 2)
+    assert measure.other_tokens == 101
+
+
+def test_the_payload_report_names_the_largest_single_readable_file() -> None:
+    """The unit a reader pays is one file chosen mid-task, never the tree — so the
+    number that would decide anything is the largest one file, not the total."""
+    measure = measure_skill_payload(
+        label="skills/example",
+        files={
+            Path("references/small.md"): b"x" * 4,
+            Path("references/big.md"): b"y" * 40,
+            Path("assets/huge.json"): b"z" * 4_000,
+        },
+    )
+    assert (measure.largest_file, measure.largest_tokens) == ("references/big.md", 10)
+
+
+def test_a_skill_with_no_payload_measures_zero() -> None:
+    measure = measure_skill_payload(label="skills/bare", files={})
+    assert (measure.prose_tokens, measure.other_tokens, measure.largest_file) == (0, 0, "")

--- a/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/src/user/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -4,7 +4,7 @@ description: Scan a codebase for deepening opportunities, present them as a visu
 disable-model-invocation: true
 admission:
   provides: A bounded architectural survey that ends in a decision — at most five deepening candidates, each with a before/after visualisation and a recommendation strength, then a grilling loop over the one the user picks. Unprompted, the model reviews the code in front of it; this reads commit history for hot spots, applies the deletion test, and refuses to propose interfaces before the user has chosen a candidate.
-  cost: Zero always-on tokens — user-invoked, so the description is absent from the session catalog. On invoke it costs the body, an HTML report, and one subagent walk of the codebase.
+  cost: A catalog entry of 39 always-on tokens on Codex and OpenCode, which strip the user-invoked declaration and publish the description regardless — zero on Claude, which honours it, and unmeasured on Gemini. On invoke it costs the body, an HTML report, and one subagent walk of the codebase.
   remove_when: A survey pass returns no candidate above Speculative in two consecutive runs, meaning the spec contract and the grilling path are catching architectural friction before it accumulates.
 ---
 

--- a/src/user/.agents/skills/retrospect/SKILL.md
+++ b/src/user/.agents/skills/retrospect/SKILL.md
@@ -4,7 +4,7 @@ description: Use when the user wants to reflect on the current session and make 
 disable-model-invocation: true
 admission:
   provides: The only pass that reads the session transcript for cause. Size and budget instruments measure artifacts; review gates measure a change; neither can see that a round-trip happened because context was buried, a tool went unused, or a request was under-specified. Produces a ranked set of fixes, each routed by root cause and each with a landing site that outlives the session.
-  cost: Zero always-on tokens — user-invoked, so the description is absent from the session catalog. On invoke it costs the body plus a pass over the conversation already in context.
+  cost: A catalog entry of 170 always-on tokens on Codex and OpenCode, which strip the user-invoked declaration and publish the description regardless — zero on Claude, which honours it, and unmeasured on Gemini. On invoke it costs the body plus a pass over the conversation already in context.
   remove_when: Two consecutive retrospectives produce no recommendation that changes a file, a gate, or a memory — the findings are all reinforcement, meaning the upstream causes are already being caught.
 ---
 

--- a/src/user/.agents/skills/to-tickets/SKILL.md
+++ b/src/user/.agents/skills/to-tickets/SKILL.md
@@ -4,7 +4,7 @@ description: Break a settled plan, spec, or the current conversation into build 
 disable-model-invocation: true
 admission:
   provides: A published set of vertical slices with real blocking edges on the tracker, each independently demoable and sized to one context window, from a spec or conversation that states an outcome and no sequence.
-  cost: A user-invoked catalog entry at zero always-on cost; per invocation, a decomposition pass, one round of approval with the user, and two tracker passes — mint, then wire.
+  cost: A catalog entry of 101 always-on tokens on Codex and OpenCode, which strip the user-invoked declaration and publish the description regardless — zero on Claude, which honours it, and unmeasured on Gemini. Per invocation, a decomposition pass, one round of approval with the user, and two tracker passes — mint, then wire.
   remove_when: The executor slices a spec into independently mergeable work and wires its dependency edges itself, so nothing invokes this.
 ---
 

--- a/src/user/.agents/skills/wait-what/SKILL.md
+++ b/src/user/.agents/skills/wait-what/SKILL.md
@@ -4,7 +4,7 @@ description: Stop. That last message did not land — re-pitch it.
 disable-model-invocation: true
 admission:
   prevents: A re-explanation delivered in the register that just failed — same jargon, no orienting context, terms that are not the project's. The default response to "I don't follow" is to restate it at greater length, which fails the same way and costs another round-trip.
-  cost: Nothing always-on — the skill is never model-invoked, so no description loads before the user types it. The body is 51 tokens, measured, paid only on invocation.
+  cost: A catalog entry of 16 always-on tokens on Codex and OpenCode, which strip the user-invoked declaration and publish the description regardless — zero on Claude, which honours it, and unmeasured on Gemini. The body is 51 tokens, measured, paid only on invocation.
   remove_when: Re-explanations land unprompted — the user stops needing a second turn after saying they are lost.
 ---
 

--- a/src/user/.agents/skills/wayfinder/SKILL.md
+++ b/src/user/.agents/skills/wayfinder/SKILL.md
@@ -4,7 +4,7 @@ description: Chart work too big for one agent session as a map of decision quest
 disable-model-invocation: true
 admission:
   provides: A durable map on the tracker for an effort larger than one agent session — the destination, the open decisions, their blocking edges, and what has been decided so far — so a fresh session orients from the tracker instead of from the previous session's context.
-  cost: A user-invoked catalog entry at zero always-on cost; per effort, one container plus one tracker item per decision, and a standing rule of one ticket resolved per session.
+  cost: A catalog entry of 103 always-on tokens on Codex and OpenCode, which strip the user-invoked declaration and publish the description regardless — zero on Claude, which honours it, and unmeasured on Gemini. Per effort, one container plus one tracker item per decision, and a standing rule of one ticket resolved per session.
   remove_when: A session's context reliably spans a whole effort, so the decisions and their order no longer need an artifact to outlive it.
 ---
 
@@ -12,7 +12,7 @@ admission:
 Source: skills/engineering/wayfinder/
 Upstream: https://github.com/mattpocock/skills @ 84fdeffd12f2ee307994d1eb6feb48173b6e0502
 Last sync: 2026-08-07
-Drift policy: local-fork — setup command and local-markdown fallback removed, tracker model rewritten onto work verbs, label scheme reduced to two, map body and ticket types split into references/; do not re-sync
+Drift policy: local-fork — setup command and local-markdown fallback removed, tracker model rewritten onto work verbs, label scheme reduced to two, map body, frontier-section rules, ticket types and tracker operations split into references/; do not re-sync
 -->
 
 # Wayfinder
@@ -33,31 +33,11 @@ Every map and ticket is a work item, so it has a **name** — its title. In ever
 
 ## The map on the tracker
 
-The map is a single container item labelled `wayfinder:map` — the canonical artifact. Its tickets are its children. `work` is the tracker, and there is no setup step: never stand up a parallel set of ticket files beside it.
+The map is a single container item labelled `wayfinder:map` — the canonical artifact. Its tickets are its children.
 
-The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
+The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links. What goes in its body is [references/map-body.md](references/map-body.md).
 
-| What | How |
-|---|---|
-| Create the map | `work create epic --title "<destination>" --label wayfinder:map (--parent <id> \| --orphan)`; the map body is `--description`. See [references/map-body.md](references/map-body.md). |
-| Create a ticket | `work create <noun> --title "<the question>" --parent <map-id> --description "<the question in full>"` |
-| The ticket's type | the noun: `spike` for research and prototype, `decision` for a grilling question, `chore` for a task |
-| An agent may resolve it alone | `--label wayfinder:afk`; without it, the ticket needs the human |
-| Blocking | `work dep add <blocked> <blocker>` — "the first depends on the second", wired in a second pass once both ids exist |
-| The ticket frontier | `work list --parent <map-id> --status open` — this map's live tickets, the closed and the claimed already out. The blocked are still in, and `work claim` is what rejects them, so the frontier is whatever claims: startable, which is not the same as answerable. Add `--label wayfinder:afk` for what a session can fan out without the human |
-| Claim | `work claim <id>` — refuses a blocked or closed ticket, so startability is enforced rather than assumed. On a ticket already in progress it no-ops instead of refusing, so it is not a lock against a concurrent session |
-| Resolve | `work close <id> --disposition "<the answer>"` — records the answer and closes, in one call |
-| Link an asset | `work note <id> "<pointer to the branch, file or document>"` |
-| Rule out of scope | `work close <id> --disposition "Out of scope: <why>"` |
-| Update the map | `work update <map-id> --set-description "<the whole new body>"` |
-
-Two of those carry a trap worth naming. `--set-description` **replaces**: re-read the map immediately before you write it back, or a concurrent session's line is lost. And a ticket is invalidated by **closing it with a disposition that says so**, never by deleting it — the facade has no delete, and the record of a route not taken is worth keeping anyway.
-
-`work ready` is absent from that table on purpose. It is global and takes no parent, so on a tracker carrying anything besides this effort it returns other work alongside this map's, and a session that takes its first result can claim and close a ticket belonging to something else entirely. Scope with `--parent`; let `claim` reject what is blocked.
-
-If tracks are configured and required, the facade refuses the map's create until you pass `--track <name>`, and the refusal lists the choices. Tickets minted under the map inherit its track and need no flag.
-
-**On labels.** Two survive, and only two. `wayfinder:map`, because enumerating maps — `work list --label wayfinder:map` — has no other expression, the container noun being shared with ordinary containers. `wayfinder:afk`, because whether a session may resolve a ticket without the human is the thing a session filters on when it fans out, and no field carries it. Everything else the label scheme once carried is now the noun, which is a first-class field; a label restating a field is duplication.
+Every verb — minting the map and its tickets, wiring blocking edges, walking the frontier, claiming, resolving, writing the map back — is in [references/tracker-operations.md](references/tracker-operations.md). Read it before touching the tracker: two of those calls carry a trap, and one query that looks exactly right returns work belonging to other efforts.
 
 ## Tickets
 
@@ -75,24 +55,9 @@ The answer isn't part of the description — it is recorded on resolution, as th
 
 ## Fog of war
 
-The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** — the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the destination is clear and no tickets remain.
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the live tickets lies the **fog of war** — decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the destination is clear and no tickets remain.
 
-The map's **Not yet specified** section is where that dim view is written down: the suspected question, the area to revisit later. It's the undiscovered frontier _toward_ the destination — everything here is in scope, just not sharp enough to ticket. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
-
-**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
-
-- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
-- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
-
-**Not yet specified** excludes what's already decided (Decisions so far), what's already a live ticket, and what's out of scope.
-
-## Out of scope
-
-Fog only ever gathers _toward_ the destination. The destination fixes the scope, so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in **Not yet specified**. It gets its own **Out of scope** section on the map: work you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it here.
-
-Out-of-scope work never graduates — the frontier stops at the destination — so it returns only if the destination is redrawn, and then as a fresh effort, not a resumption.
-
-Ruling something out of scope is a scoping act, not a step on the route. When a ticket that already exists turns out to sit past the destination — mis-scoped in while charting, or exposed by a resolution — **close it out of scope** and leave one line in the **Out of scope** section: the gist plus why, linking the closed ticket. It stays out of **Decisions so far**, which records the route actually walked — a scope boundary isn't a step on it.
+Fog is in scope and merely unsharp, so it lives in the map's **Not yet specified** section; the test for putting something there is whether you can state the question precisely now, _not_ whether you can answer it. Work you've consciously ruled beyond the destination is a different thing — **out of scope**, never fog — and it never graduates. Both sections, and how to rule an existing ticket out of scope, are in [references/map-body.md](references/map-body.md).
 
 ## Invocation
 

--- a/src/user/.agents/skills/wayfinder/references/map-body.md
+++ b/src/user/.agents/skills/wayfinder/references/map-body.md
@@ -28,6 +28,23 @@ Open tickets are **not** listed here — they are the map's open children, found
 <!-- work ruled beyond the destination; closed, never graduates -->
 ```
 
+## Not yet specified
+
+The dim view: the suspected question, the area to revisit later. It's the undiscovered frontier _toward_ the destination — everything here is in scope, just not sharp enough to ticket. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
+
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
+
+- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't pre-slice the fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
+
+This section excludes what's already decided, what's already a live ticket, and what's out of scope. Clear a patch from here as it graduates, so it lives only as its new tickets.
+
+## Out of scope
+
+Fog only ever gathers _toward_ the destination. The destination fixes the scope, so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in **Not yet specified**. Scope, not sharpness, lands it here, and it never graduates: the frontier stops at the destination, so it returns only if the destination is redrawn, and then as a fresh effort rather than a resumption.
+
+Ruling something out of scope is a scoping act, not a step on the route. When a ticket that already exists turns out to sit past the destination — mis-scoped in while charting, or exposed by a resolution — close it with a disposition saying so and leave one line here: the gist plus why, linking the closed ticket. It stays out of **Decisions so far**, which records the route actually walked.
+
 ## Writing it back
 
 `work update <map-id> --set-description "<body>"` **replaces** the description; there is no append. So the sequence is always read, edit, write:

--- a/src/user/.agents/skills/wayfinder/references/tracker-operations.md
+++ b/src/user/.agents/skills/wayfinder/references/tracker-operations.md
@@ -1,0 +1,29 @@
+# Tracker operations
+
+Every verb this skill uses against the tracker, plus the three that carry a trap. `work` is the tracker, and there is no setup step: never stand up a parallel set of ticket files beside it.
+
+| What | How |
+|---|---|
+| Create the map | `work create epic --title "<destination>" --label wayfinder:map (--parent <id> \| --orphan)`; the map body is `--description`. See [map-body.md](map-body.md). |
+| Create a ticket | `work create <noun> --title "<the question>" --parent <map-id> --description "<the question in full>"` |
+| The ticket's type | the noun: `spike` for research and prototype, `decision` for a grilling question, `chore` for a task |
+| An agent may resolve it alone | `--label wayfinder:afk`; without it, the ticket needs the human |
+| Blocking | `work dep add <blocked> <blocker>` — "the first depends on the second", wired in a second pass once both ids exist |
+| The ticket frontier | `work list --parent <map-id> --status open` — this map's live tickets, the closed and the claimed already out. The blocked are still in, and `work claim` is what rejects them, so the frontier is whatever claims: startable, which is not the same as answerable. Add `--label wayfinder:afk` for what a session can fan out without the human |
+| Claim | `work claim <id>` — refuses a blocked or closed ticket, so startability is enforced rather than assumed. On a ticket already in progress it no-ops instead of refusing, so it is not a lock against a concurrent session |
+| Resolve | `work close <id> --disposition "<the answer>"` — records the answer and closes, in one call |
+| Link an asset | `work note <id> "<pointer to the branch, file or document>"` |
+| Rule out of scope | `work close <id> --disposition "Out of scope: <why>"` |
+| Update the map | `work update <map-id> --set-description "<the whole new body>"` |
+
+**`--set-description` replaces.** Re-read the map immediately before you write it back, or a concurrent session's line is lost.
+
+**A ticket is invalidated by closing it with a disposition that says so**, never by deleting it — the facade has no delete, and the record of a route not taken is worth keeping anyway.
+
+**`work ready` is absent from that table on purpose.** It is global and takes no parent, so on a tracker carrying anything besides this effort it returns other work alongside this map's, and a session that takes its first result can claim and close a ticket belonging to something else entirely. Scope with `--parent`; let `claim` reject what is blocked.
+
+If tracks are configured and required, the facade refuses the map's create until you pass `--track <name>`, and the refusal lists the choices. Tickets minted under the map inherit its track and need no flag.
+
+## Labels
+
+Two survive, and only two. `wayfinder:map`, because enumerating maps — `work list --label wayfinder:map` — has no other expression, the container noun being shared with ordinary containers. `wayfinder:afk`, because whether a session may resolve a ticket without the human is the thing a session filters on when it fans out, and no field carries it. Everything else the label scheme once carried is now the noun, which is a first-class field; a label restating a field is duplication.


### PR DESCRIPTION
A ceiling prices bytes the reader cannot decline. This change makes three measurements price them **as the target actually loads them**, rather than as the source front matter claims they will be loaded.

## What changed

**Skill catalog entries are charged to the always-on budget.** A skill's `name` and `description` load into the model's catalog on every session before the user types, and were measured by nothing — outside the always-on cap and, by construction, outside the body cap. They now count toward `measure_always_on` against the **unchanged** 10,000-token ceiling. No new cap, no new constant: a correction to an existing measurement's domain.

The charge is per tool, because a catalog is a property of one runtime. Claude keeps `disable-model-invocation`, so a skill carrying it costs zero there. Codex and OpenCode strip the key at deploy — Codex reads a sidecar this installer does not emit, OpenCode has no user-invoked mechanism at all — so every skill is an entry on both.

| Tool | Before | After | Rules | Catalog entries |
|---|---:|---:|---:|---:|
| claude | 1,499 | **3,260** | 1 | 22 |
| codex | 840 | **2,512** | 0 | 22 |
| gemini | 840 | 840 | 0 | 0 |
| opencode | 840 | **2,512** | 0 | 22 |

The unmeasured component was larger than the measured one on every tool, and it is the one that grows with each admission. Headroom is now visible rather than guessed. No per-description sub-cap: the measured spread over 30 skills is 14–167 tokens with no outlier, so a ceiling there would have no nameable trigger.

**The body cap follows the target.** It was selected from the pre-projection text while the capability table grants `disable-model-invocation` to Claude alone, so six shared skills were measured against 5,000 on three tools that strip the key and leave them fully model-invocable. It is now read from the projected front matter.

This does make one artifact's number depend on which tool is staging — deliberately. The *verdict* stays uniform because the content lint stages every known tool unconditionally on every run, so a per-machine deploy can only be looser than the gate the repository already passed.

**Gemini is exempt from both.** Its CLI is deprecated and no vendor documentation establishes whether it reads a deployed skill at all. A number invented for it would be a guess a reader would act on.

**Reference payloads are reported, never capped** — prose total, largest single readable file, and non-prose counted apart at zero. In `content_lint` only: a report with no failure condition has no business in the deploy path. Readable is `.md`/`.txt`; over half the measured payload is `.py`, `.js`, `.json`, `.yaml`, `.css` and `.dot` that never enters a context window, and charging it would price this repo's own code-over-prose principle as a cost. The walk counts what deploys, reusing the manifest's own `excludes_path`.

## The one artifact this revealed

`wayfinder`'s body measured 2,873 against the 2,000 cap that fits three of its four targets — the point of the change, not a side effect. Its tracker verb table and the two frontier-section rules move into `references/`, a pattern the skill already carried. The body is now **1,813 tokens, measured by the gate**, and its provenance block records the wider split. The remaining tracker query in the body is still scoped by `--parent`.

Five admission records claimed zero always-on cost on the strength of the user-invoked flag while sitting in the shared tree. Their `cost:` lines now state the per-tool truth; the two Claude-only skills making the same claim truthfully are untouched.

## Verification

- `make ci` exits **0** from the worktree root.
- Deploy digest through the lint's staging seam and the gate, writing nothing: 274 → 278 files. The only changed hashes are `skills/wayfinder/{SKILL.md, references/map-body.md}` and the added `references/tracker-operations.md`, on each of the four tools. Everything else is byte-identical — including the four skills whose `cost:` line changed, which confirms the admission block is stripped from the deployed bytes.
- Tests pin each decision: an oversized description breaching the always-on cap; a command's description charged nothing; a user-invoked skill costing zero on Claude and non-zero where the key is stripped; the strict cap on a tool that cannot honour the flag and the loose cap on one that can; Gemini contributing to neither; the payload block printing on a pass and failing nothing.

Three docstrings that justified the reversed behaviour are rewritten rather than left to contradict the code: the capability module's, `SkillBodySource`'s, and `_judge`'s. `content_lint`'s "measures nothing itself" invariant is amended explicitly, narrowed to the measurements both sides make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017snRqijsEKmSS7mj5eHXne