### PR TITLE
fix(9k9.187): close the scrubber hole the backend's own singular noun walked through

### DIFF
--- a/packages/workcli/AGENTS.md
+++ b/packages/workcli/AGENTS.md
@@ -173,6 +173,23 @@ stderr markers. It reads the message argument of an error and nothing else,
 which is what keeps the first case above out of its reach by construction
 rather than by an exemption someone has to maintain.
 
+The redactor's own coverage is pinned separately, in
+`tests/unit/test_backend_redaction.py`, which names each spelling of the
+backend's identity one at a time and then measures the widened pattern against
+this package's captured backend output to show it eats nothing else. The
+singular noun is the spelling most easily left out — it names no file and no
+environment variable, so it reads as domain vocabulary rather than as a name.
+
+The scan over the layers above the adapter carries exactly one exemption, and
+it marks the one place the wall genuinely bends. The superseded spelling of a
+config key contains the backend's singular noun and cannot be renamed without
+silently ceasing to read `project-config.toml` files already on disk: its
+bytes are a value the facade matches a user's keys against, not vocabulary the
+facade chose. It is exempted by the name it is bound to rather than by its
+text, so no second literal inherits the exemption, and a companion check fails
+if the binding ever stops needing one. An exemption outliving its subject is
+how a scan like this goes quiet.
+
 ## Tests
 
 - Behavioural, not tautological — each test pins a coded decision (an

--- a/packages/workcli/src/workcli/adapters/bd/vocabulary.py
+++ b/packages/workcli/src/workcli/adapters/bd/vocabulary.py
@@ -25,12 +25,21 @@ from __future__ import annotations
 import re
 
 # The tokens that identify this backend: the binary, the project it belongs
-# to (which names its environment variable and its storage directory too), and
-# the storage engine underneath it. Word edges are spelled out rather than
-# left to `\b` so that `BEADS_DIR` and `.beads` are matched -- `_` and a
-# leading `.` are word characters to `\b`, which would let both through.
+# to (which names its environment variable and its storage directory too), the
+# singular noun it calls one item by, and the storage engine underneath it.
+# Word edges are spelled out rather than left to `\b` so that `BEADS_DIR` and
+# `.beads` are matched -- `_` and a leading `.` are word characters to `\b`,
+# which would let both through.
+#
+# The singular noun earns its place the same way the plural does, and is the
+# easiest of the four to leave out: it names no file and no environment
+# variable, so it reads as domain vocabulary rather than as a name. It is the
+# backend's word for an item, it is authored throughout the backend's own
+# user-facing prose, and removing it from this facade's vocabulary was the
+# whole of an earlier piece of work -- which a sentence carrying it back
+# outward would undo silently.
 _BACKEND_IDENTITY = re.compile(
-    r"(?<![A-Za-z0-9])\.?(?:beads|bd|dolt)(?![A-Za-z0-9])",
+    r"(?<![A-Za-z0-9])\.?(?:beads?|bd|dolt)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 

--- a/packages/workcli/tests/integration/test_error_paths.py
+++ b/packages/workcli/tests/integration/test_error_paths.py
@@ -145,7 +145,7 @@ def test_a_missing_workspace_is_a_configuration_failure_not_a_drift_alarm(bd_bin
     assert env["error"]["code"] == "E_NO_WORKSPACE"
     assert env["error"]["detail"] == {}
     published = json.dumps(env["error"])
-    for name in ("bd", "beads", "dolt", "BEADS_DIR"):
+    for name in ("bd", "bead", "beads", "dolt", "BEADS_DIR"):
         assert name not in published, f"the error envelope names the backend: {published}"
 
 
@@ -157,7 +157,7 @@ def test_a_real_backend_refusal_reaches_the_consumer_naming_no_backend(driver):
 
     assert env["ok"] is False
     published = json.dumps(env["error"])
-    for name in ("bd", "beads", "dolt", "BEADS_DIR"):
+    for name in ("bd", "bead", "beads", "dolt", "BEADS_DIR"):
         assert name not in published, f"the error envelope names the backend: {published}"
     assert "argv" not in env["error"]["detail"]
 

--- a/packages/workcli/tests/unit/test_backend_redaction.py
+++ b/packages/workcli/tests/unit/test_backend_redaction.py
@@ -1,0 +1,205 @@
+"""The scrubber: every spelling of the backend's identity it removes, and nothing else.
+
+`redact` is the only mechanical guard over the one text the prose rule and its
+AST scan cannot reach -- the sentences the backend writes at runtime, which no
+reviewer can read before they exist. What the guard misses it misses silently:
+the envelope leaves looking scrubbed either way, and the caller has no way to
+tell a clean sentence from one that was never matched.
+
+So the spellings are named here one at a time rather than checked by driving
+the pattern's own alternation. A test that read the pattern would ratify
+whatever the pattern happens to say and would go green the moment someone
+shortened it; naming each spelling is a second, independent statement of what
+this backend is called.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from workcli.adapters.bd.vocabulary import redact
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+# ── every spelling, named one at a time ──────────────────────────────────
+#
+# The placeholder is spelled out in each expectation rather than imported,
+# for the same reason the spellings are: an expectation built from the
+# module under test agrees with it by construction.
+#
+# Four names identify this backend: its binary, the plural noun that also
+# names its environment variable and its storage directory, the singular noun
+# it uses for one item, and the storage engine underneath. The singular was
+# the spelling the pattern missed -- and it is the one whose removal from the
+# facade's own vocabulary was a whole piece of earlier work, so a sentence
+# carrying it back out undoes that quietly.
+#
+# The sentences are the backend's, not invented: the first three are captured
+# failures this adapter has met, and the singular-noun cases are lifted
+# verbatim from the backend's own help output (`bd --help`, `bd create
+# --help`, `bd list --help` at version 1.0.3), which is where its user-facing
+# vocabulary is authored.
+@pytest.mark.parametrize(
+    ("backend_text", "expected"),
+    [
+        # -- the binary --
+        ("a bd error", "a [tracker] error"),
+        ("run 'bd init' to create a new database", "run '[tracker] init' to create a new database"),
+        # -- the plural noun, bare, dotted, and as an environment variable --
+        ("no beads database found", "no [tracker] database found"),
+        (
+            "set BEADS_DIR to point to your .beads directory",
+            "set [tracker]_DIR to point to your [tracker] directory",
+        ),
+        ("Back up your beads database", "Back up your [tracker] database"),
+        # -- the singular noun: the spelling this file was written for --
+        ("the bead was updated", "the [tracker] was updated"),
+        ("Promote a wisp to a permanent bead", "Promote a wisp to a permanent [tracker]"),
+        ("Entity URI or bead ID affected", "Entity URI or [tracker] ID affected"),
+        ("Filter to descendants of this bead/epic", "Filter to descendants of this [tracker]/epic"),
+        ("List child beads of a parent", "List child [tracker] of a parent"),
+        # -- the storage engine --
+        ("dolt push failed", "[tracker] push failed"),
+        (
+            "panic: dolt: runtime error at hash 0xdeadbeef",
+            "panic: [tracker]: runtime error at hash 0xdeadbeef",
+        ),
+        # -- case is not a hiding place --
+        ("Bead not found", "[tracker] not found"),
+        ("BD exited nonzero", "[tracker] exited nonzero"),
+        ("Beads is unreachable", "[tracker] is unreachable"),
+        ("Dolt refused the write", "[tracker] refused the write"),
+    ],
+)
+def test_every_spelling_of_the_backends_identity_is_scrubbed(
+    backend_text: str, expected: str
+) -> None:
+    """
+    Given a sentence the backend writes about itself
+    When it is scrubbed on its way into a published field
+    Then its name is gone and the diagnosis it carried is not.
+    """
+    assert redact(backend_text) == expected
+
+
+def test_the_scrub_removes_the_identity_and_leaves_the_diagnosis() -> None:
+    """
+    Given the multi-line failure that names the backend three ways at once
+    When it is scrubbed
+    Then nothing of the backend's identity survives and the advice still reads.
+
+    The missing-workspace report is the incident the scrubber was built for:
+    one sentence carrying the binary, the environment variable and the storage
+    directory. The scrub is deliberately narrow -- it takes the identity, not
+    the diagnosis -- so the caller must still learn that a database is missing
+    and that something can be run to create one.
+    """
+    scrubbed = redact(
+        "Error: no beads database found\n"
+        "Hint: run 'bd where' to inspect the resolved workspace, or 'bd init' to create a new "
+        "database\n      or set BEADS_DIR to point to your .beads directory\n"
+    )
+
+    assert "database" in scrubbed
+    assert "to create a new" in scrubbed
+    for spelling in ("bd", "bead", "beads", "dolt"):
+        assert spelling not in scrubbed.lower()
+
+
+# ── nothing but the identity is touched ──────────────────────────────────
+
+# The four names, lowercased: the closed set of things a redaction is allowed
+# to have eaten out of real backend text.
+_IDENTITY_SPELLINGS = frozenset({"bd", "bead", "beads", "dolt"})
+
+# A generic word splitter -- deliberately not the scrubber's pattern, which is
+# the thing under test. Word edges here are every non-alphanumeric character,
+# so `BEADS_DIR`, `.beads` and `bead's` each come apart into the name and the
+# characters around it.
+_WORD_PARTS = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _captured_backend_words() -> list[str]:
+    """Every distinct word in this package's real captured backend output.
+
+    The JSON fixtures are output captured verbatim from the live backend, and
+    they carry both the backend's own vocabulary and whatever prose users typed
+    into item titles, descriptions and notes -- which is the widest sample of
+    real text this package holds, and the sample a scrubber would mangle.
+    """
+    words: set[str] = set()
+    for fixture in sorted(FIXTURES.glob("*.json")):
+        words.update(
+            part for part in _WORD_PARTS.split(fixture.read_text(encoding="utf-8")) if part
+        )
+    return sorted(words)
+
+
+def test_the_corpus_is_big_enough_and_contains_the_spelling_at_issue() -> None:
+    """
+    Given the captured-output corpus the next test scans
+    When it is read
+    Then it is substantial and it does contain the singular noun.
+
+    The control. The scan below is an assertion over a comprehension and would
+    pass over an empty corpus, and it would pass just as quietly over a corpus
+    that never happened to contain the spelling this file exists for.
+    """
+    words = _captured_backend_words()
+
+    assert len(words) > 500
+    assert "bead" in words
+    assert "beads" in words
+
+
+def test_no_word_of_real_backend_text_is_mangled_by_the_scrub() -> None:
+    """
+    Given every word the backend has actually been captured emitting
+    When each one is scrubbed
+    Then the only ones that change are the backend's four names.
+
+    The widening risk runs the other way from the leak: an alternation loose
+    enough to catch the singular noun could also eat an ordinary English word,
+    and a diagnostic mangled into nonsense costs a caller the one thing an
+    unrecognised failure had left to give. Measured against real captured text
+    rather than argued about -- if the word edges ever slip, a word from this
+    corpus lands in `mangled` and names itself.
+    """
+    mangled = [
+        word
+        for word in _captured_backend_words()
+        if redact(word) != word and word.lower() not in _IDENTITY_SPELLINGS
+    ]
+
+    assert mangled == []
+
+
+@pytest.mark.parametrize(
+    "word",
+    [
+        "abdicate",  # the binary, mid-word
+        "subdivide",
+        "beadle",  # the singular noun, as a prefix
+        "beadwork",
+        "beaded",
+        "doltish",  # the storage engine, as a prefix
+        "embedded",
+        "wisp",  # a backend concept, not its identity
+    ],
+)
+def test_an_ordinary_word_that_merely_contains_a_name_survives(word: str) -> None:
+    """
+    Given an English word one of the backend's names sits inside
+    When it is scrubbed
+    Then it comes through untouched.
+
+    The word edges are what make the alternation safe to widen, so they are
+    asserted directly rather than left as a property of the corpus above --
+    the corpus contains what the backend happened to write, not the cases a
+    future widening would break.
+    """
+    assert redact(word) == word

--- a/packages/workcli/tests/unit/test_envelope_invariants.py
+++ b/packages/workcli/tests/unit/test_envelope_invariants.py
@@ -463,17 +463,24 @@ _ADAPTERS = _SRC / "adapters"
 
 # The names that would tell a consumer which tracker is behind the seam: the
 # binary, the project that names its environment variable and its storage
-# directory, and the storage engine under it. Word edges are spelled out
-# rather than left to `\b` so `BEADS_DIR` and `.beads` are caught — `_` and a
-# leading `.` are word characters, and `\b` would wave both through.
+# directory, the singular noun it calls one item by, and the storage engine
+# under it. Word edges are spelled out rather than left to `\b` so `BEADS_DIR`
+# and `.beads` are caught — `_` and a leading `.` are word characters, and
+# `\b` would wave both through.
 #
 # Restated here rather than imported from the adapter's own scrubber, on
 # purpose. The adapter's list is a claim about what it knows to hide; a test
 # that imported it would ratify that claim instead of checking it, and would
 # go green the moment someone shortened it. Two independent statements of the
 # same fact: narrow one without the other and this file turns red.
+#
+# Independent is not the same as narrower, though. This is the check that
+# reads the bytes that actually left the process, so a name the scrubber hides
+# and this pattern does not know is a name no behavioural test can catch
+# leaking on a path the scrubber was never applied to. Whatever the scrubber
+# covers, this covers.
 _BACKEND_IDENTITY = re.compile(
-    r"(?<![A-Za-z0-9])\.?(?:beads|bd|dolt)(?![A-Za-z0-9])",
+    r"(?<![A-Za-z0-9])\.?(?:beads?|bd|dolt)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 
@@ -564,6 +571,61 @@ def test_real_backend_stderr_never_reaches_a_consumer_intact(stderr: str) -> Non
 
     assert envelope["ok"] is False
     _assert_envelope_is_quarantined(envelope)
+
+
+# The one string above the seam that has to spell a backend name. It is the
+# superseded spelling of a config key, still read so that the
+# `project-config.toml` files already on disk keep working — its bytes are a
+# value the facade matches a user's keys against, not vocabulary the facade
+# chose, and renaming it would stop those files being read. Held to the rule
+# in the only way that costs nothing: it never travels alone, and the sentence
+# it does travel in tells the user to rename the key it names, which is a
+# sentence about their own file.
+#
+# Exempted by the name it is bound to rather than by its text, so a second
+# literal spelling a backend name still fails this scan.
+_SUPERSEDED_CONFIG_KEY_BINDING = "GROOM_STATE_KEY_SUPERSEDED"
+
+
+def test_a_failure_naming_one_item_in_the_backends_own_noun_is_scrubbed_too() -> None:
+    """
+    Given an unrecognised failure written in the backend's word for one item
+    When the facade turns it into an envelope
+    Then that word does not reach the consumer either.
+
+    Kept out of the captured corpus above, because it is not a capture: the
+    corpus is failures this adapter has actually met, and no captured failure
+    uses the singular noun. The vocabulary is the backend's, though — it is
+    how the backend's own help output at version 1.0.3 refers to one item
+    ("Promote a wisp to a permanent bead", "Entity URI or bead ID affected"),
+    so it is a sentence the backend can write, not one invented here.
+
+    That distinction is the whole reason this case is worth a test. The
+    singular noun is the spelling the scrubber is likeliest to be missing at
+    any given moment, precisely because nothing in the corpus forces it.
+    """
+    runner = ScriptedBdRunner(
+        steps=[
+            ScriptedStep(
+                ("show",),
+                BdResult(
+                    returncode=3,
+                    stdout="",
+                    stderr=(
+                        "Error: cannot promote a wisp to a permanent bead: storage is read-only\n"
+                    ),
+                ),
+            )
+        ]
+    )
+
+    _, envelope = _assert_stdout_is_exactly_one_envelope(runner, ["show", "x.1"])
+
+    assert envelope["ok"] is False
+    _assert_envelope_is_quarantined(envelope)
+    # The scrub is narrow by design, so the diagnosis has to survive it: an
+    # unrecognised failure has nothing to offer a caller except its sentence.
+    assert "storage is read-only" in json.dumps(envelope["error"])
 
 
 def _adapter_sources() -> list[Path]:
@@ -722,6 +784,8 @@ def test_nothing_above_the_adapter_names_the_backend_in_a_string() -> None:
     purpose: a comment is read by whoever maintains this package, while a
     string literal is liable to be printed, and `work --help` printing the
     backend's name is contract, not commentary.
+
+    One binding is exempt, for the reason recorded where it is named.
     """
     offenders = []
     for path in _generic_sources():
@@ -731,12 +795,55 @@ def test_nothing_above_the_adapter_names_the_backend_in_a_string() -> None:
             for node in ast.walk(tree)
             if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
         }
+        exempt = {
+            id(node.value)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == _SUPERSEDED_CONFIG_KEY_BINDING
+        }
         for node in ast.walk(tree):
             if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
                 continue
-            if id(node) in docstrings:
+            if id(node) in docstrings or id(node) in exempt:
                 continue
             if _BACKEND_IDENTITY.search(node.value):
                 offenders.append(f"{path.relative_to(_SRC)}:{node.lineno}: {node.value!r}")
 
     assert offenders == []
+
+
+def test_the_one_exempt_binding_still_exists_and_still_needs_exempting() -> None:
+    """
+    Given the single binding the scan above waves through
+    When the source is read for it
+    Then it is still there and its value still names the backend.
+
+    An exemption outliving what it exempts is how a scan like this goes quiet:
+    the entry stays, nobody rereads it, and the next literal to be waved
+    through is waved through by a rule nobody can still justify. The superseded
+    config key is expected to die once no `project-config.toml` on disk still
+    carries it — and on the day it does, this fails and the exemption goes with
+    it.
+    """
+    bindings = [
+        node.value.value
+        for path in _generic_sources()
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == _SUPERSEDED_CONFIG_KEY_BINDING
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    ]
+
+    assert len(bindings) == 1, (
+        f"{_SUPERSEDED_CONFIG_KEY_BINDING} is no longer a single string constant above the "
+        "seam; if it is gone, delete its exemption from the scan above"
+    )
+    assert _BACKEND_IDENTITY.search(bindings[0]), (
+        f"{_SUPERSEDED_CONFIG_KEY_BINDING} no longer names the backend, so the scan above "
+        "no longer needs to exempt it — delete the exemption"
+    )


### PR DESCRIPTION
Closes the last spelling of the backend's identity that could reach a consumer in runtime text. Tracker item: **agents-config-9k9.187** (P3).

## What was wrong

The adapter's redactor (`packages/workcli/src/workcli/adapters/bd/vocabulary.py`) removed the backend's plural noun, its binary name and its storage engine from backend-authored text on its way into a published field. It let the **singular noun** through — the backend's own word for one item, and the exact token whose removal from the facade's vocabulary was the whole of `agents-config-9k9.35`.

Measured against the unchanged pattern:

| input | before | after |
| --- | --- | --- |
| `no beads database found` | `no [tracker] database found` | unchanged |
| `a bd error` | `a [tracker] error` | unchanged |
| `dolt push failed` | `[tracker] push failed` | unchanged |
| `the bead was updated` | **UNCHANGED** | `the [tracker] was updated` |

The exposure was a hole in a guard rather than an observed leak — scrubbed text rides out only on the unrecognised-failure path, since a classified failure carries the facade's own message instead. It still matters, because this scrubber is the only mechanical guard over the one surface the prose rule and its AST scan cannot reach: sentences the backend writes at runtime, which no reviewer can read before they exist.

## Why widening is safe

Decided on evidence rather than intuition, because an alternation loose enough to catch the singular noun could also eat ordinary English.

- Across this package's real captured backend output (15 JSON fixtures) and 722 lines of the backend's own help text, **all 42 occurrences of the singular noun are the tracker's word for an item**. None is ordinary English.
- The backend authors that noun in its own user-facing prose — `Promote a wisp to a permanent bead`, `Entity URI or bead ID affected`, `Filter to descendants of this bead/epic` — so it is a word the backend can put in a failure sentence.
- The word edges already in the pattern do the containment: `beadle`, `beadwork`, `abdicate`, `subdivide`, `doltish` and `embedded` all survive untouched, and are asserted so.

A test observed the hole red before the fix: exactly five singular-noun cases failed, every other spelling passed.

## The restated denylist moves too

`tests/unit/test_envelope_invariants.py` deliberately restates the denylist rather than importing it, so the two cannot agree by construction. That restatement widens here as well. **Independent is not the same as narrower**: that check reads the bytes that actually left the process, so a name the scrubber hides and the check does not know is a name no behavioural test can catch leaking on a path the scrubber was never applied to.

Widening it exposed one string above the seam that must spell a backend name — the superseded config key `GROOM_STATE_KEY_SUPERSEDED`, whose bytes are matched against keys in `project-config.toml` files already on disk. Renaming it would stop those files being read, so it is exempted, **by the name it is bound to rather than by its text**, and a companion check fails if it ever stops needing the exemption. Both properties were verified by mutation.

One correction to the framing this work started from: that constant is not merely an unprintable value. It is interpolated into a deprecation string that the `groom` verb publishes into `data["warnings"]`. That is still correct behaviour — the sentence tells users to rename a key in their own file, which is the `data` exemption's own rationale — but it is printable, and the exemption is recorded on that basis rather than on "the scrubber never sees it".

## Protocol

Unchanged at **1.11**. No classification behaviour changed and the envelope shape is untouched.

## Gates

| gate | exit | result |
| --- | --- | --- |
| `make ci-workcli` | 0 | 861 passed, 99.23% branch coverage against a 90% floor |
| `make itest-workcli` | 0 | 58 passed against a real backend |

Both run standalone from the worktree root and read directly, never piped. The integration suite was run because the adapter executes the changed code on the drift path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1
