### PR TITLE
feat(9k9.184): criteria can be corrected, and the correction leaves a trail

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -24,7 +24,7 @@ Twelve verbs; each is a subcommand of `work`.
 |---|---|
 | `work show IDS...` | — |
 | `work create --raw --title T [--description D] [--type task] [--priority P2] [--parent ID] [--label L ...]` | `--label` repeatable |
-| `work update ID [--set-title T] [--set-priority P] [--set-description D]` | ≥1 `--set-*` required; `--set-notes` → `E_FIELD_CLOBBER_GUARD` (suppressed from `--help`) |
+| `work update ID [--set-title T] [--set-priority P] [--set-description D]` | ≥1 `--set-*` required; `--set-notes` and `--set-acceptance` → `E_FIELD_CLOBBER_GUARD` (both suppressed from `--help`) |
 | `work note ID TEXT` | append-only |
 | `work close IDS... [--disposition TEXT]` | disposition = one appended note per id |
 | `work reopen ID` | — |
@@ -59,6 +59,7 @@ selected by whether a noun positional or `--raw` is given.
 | `work promote ID` | a `shape-feat` leaf becomes a `shape-spec` container |
 | `work defer ID [--note TEXT]` | sets an item aside as not-now → `deferred`; leaves `ready`, claims no obstruction, and never enters the parked staleness report |
 | `work undefer ID` | `deferred` → `open` |
+| `work acceptance set ID TEXT [--why REASON]` | restates the criteria a claim is checked against; `--why` is required once work has started (any status but `open`/`deferred`) |
 | `work reconcile [--dry-run]` | recovery sweep over the states the tracker can still observe: interrupted delivers, unreconciled placeholders, interrupted expansions — idempotent, safe to run from any session or cron |
 
 `defer`/`undefer` are deliberately not the park family (`work park
@@ -71,11 +72,25 @@ deferred child is not a closed one: it holds its parent open in the
 close-walk exactly as an open child does, and never reaches the `held`
 report, which is for parents whose children *are* all closed.
 
-Protocol is `"1.11"` — additive-only bumps (new `ErrorCode` members, the
+`acceptance set` is the only way criteria move after create: `update` refuses
+`--set-acceptance` with `E_FIELD_CLOBBER_GUARD` and names this verb. The
+criteria are the termination condition a claim is checked against, so a silent
+replace would let a check pass because the contract moved rather than because
+the work met it — and the two things that stop that are the verb's whole
+content. The superseded text is quoted into a note (`> ` per line, under a
+`[work] acceptance restated <ISO-8601>` marker; `[work] acceptance first set`
+where the item carried none) and that note is written **before** the
+replacement, so a failure between the two writes can only leave a trail
+without a change, never a change without a trail — criteria still equal to the
+quote are criteria the replacement never reached. Once work has started the
+call additionally requires `--why`, which lands on the marker line beside the
+status the item was in. Setting the criteria already in force writes nothing.
+
+Protocol is `"1.12"` — additive-only bumps (new `ErrorCode` members, the
 derived `Item.track` field and the `acceptance` field beside it, the
 capability-disposition model, `partial_progress` detail below, `search`'s
-optional narrowing flags, the close-walk's `held` key, and the
-`defer`/`undefer` pair) never change an existing envelope or data shape. A
+optional narrowing flags, the close-walk's `held` key, the `defer`/`undefer`
+pair, and `acceptance set`) never change an existing envelope or data shape. A
 bump can still change what an unchanged call *answers*, in either direction:
 1.8 makes `search` read descriptions and notes as well as titles, stop
 excluding closed items, and stop stopping at the first page, so a query that
@@ -85,7 +100,10 @@ stops closing a parent that carries scope of its own, so a parent that used
 to appear under `walked` now appears under `held` with what is unfinished
 named. 1.11 widens again, mildly: `status` can report `deferred` on an item
 the facade itself set aside, a value the backend always could hold and this
-contract always declared. `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
+contract always declared. 1.12 adds `acceptance set`, whose only visible mark
+on an existing shape is a facade-authored marker line in `notes`, beside the
+ones the park family and the `defer`/`undefer` pair already write.
+`Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
 writes via `supports_dep_write` — `dep list` is never gated, even when
@@ -120,13 +138,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.11", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.12", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.11", "ok": false, "data": null,
+{"protocol": "1.12", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -138,7 +156,7 @@ Failure:
 | `E_NOT_FOUND` | the id(s) requested do not exist |
 | `E_TYPE_WALL` | a `blocks` dep between an epic and a non-epic (pre-checked before any mutation reaches the backend) |
 | `E_DEP_CYCLE` | the backend rejected a dep edge as a cycle |
-| `E_FIELD_CLOBBER_GUARD` | an attempt to replace notes via `update` instead of appending via `note` |
+| `E_FIELD_CLOBBER_GUARD` | a field-protecting guard refused the write: notes replaced via `update` instead of appended via `note`; acceptance criteria moved via `update --set-acceptance` instead of `acceptance set`; or `acceptance set` on an item work has started, with no `--why` — `detail` names the `field` and, for the last, the `status` |
 | `E_LOCK_CONTENTION` | backend lock contention survived the bounded retry — from `label_mutate`/`sync`, may carry `detail.partial_progress` |
 | `E_SYNC_BEHIND` | `sync --pull` with uncommitted local changes |
 | `E_OPEN_BLOCKERS` | `close` refused: items blocking this one are still open — `detail.blocked_by` names them |
@@ -160,7 +178,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.11", "ok": true, "data": {"protocol": "1.11"}, "error": null}
+{"protocol": "1.12", "ok": true, "data": {"protocol": "1.12"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -176,6 +194,10 @@ are the same value, always.
   with, or `null` when it has none. The key is always present on `show`,
   `list`, `ready` and `search` alike, so `null` reads as "this item has no
   criteria" and never as "this verb did not fetch them".
+- `acceptance set` → `{"id", "acceptance", "previous", "status"}`: the criteria
+  now in force, the ones superseded (`null` where the item had none), and the
+  status the item was in when they moved. `previous == acceptance` is the
+  no-op case — the criteria were already those, and nothing was written.
 - `label list` → a bare `string[]` (never embedded objects).
 - `dep list` → `data = {"depends_on": [...], "dependents": [...]}` (bd's own
   inverted `--direction` naming is translated to these names).
@@ -194,7 +216,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.11"}`.
+- `--protocol-version` → `{"protocol": "1.12"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.11"
+PROTOCOL_VERSION = "1.12"

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -132,6 +132,11 @@ def _add_write_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]
     # help=SUPPRESS hides it from --help entirely: it's a tripwire, not an
     # advertised option, so it never invites the attempt it then rejects.
     update_parser.add_argument("--set-notes", help=SUPPRESS)
+    # The same tripwire, for the same reason, over the criteria a claim is
+    # checked against: they move only through their own verb, which records
+    # what they were. A guess at this flag reaches that answer by name rather
+    # than an unknown-flag error that leaves the caller hunting.
+    update_parser.add_argument("--set-acceptance", help=SUPPRESS)
 
     note_parser = subparsers.add_parser("note", help="append a note (append-only)")
     note_parser.add_argument("id", metavar="ID")
@@ -257,6 +262,24 @@ def _add_relations_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentPar
     label_parser.add_argument("labels", nargs="*", metavar="LABELS")
 
 
+def _add_acceptance_subparser(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
+    acceptance_parser = subparsers.add_parser(
+        "acceptance",
+        help="restate the criteria a claim is checked against: acceptance set ID TEXT",
+    )
+    acceptance_parser.add_argument("action", choices=["set"])
+    acceptance_parser.add_argument("id", metavar="ID")
+    acceptance_parser.add_argument("text", metavar="TEXT")
+    acceptance_parser.add_argument(
+        "--why",
+        metavar="REASON",
+        help=(
+            "why the criteria change; required once work has started, and recorded "
+            "on the item beside the criteria it supersedes"
+        ),
+    )
+
+
 def _add_track_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser]) -> None:
     track_parser = subparsers.add_parser(
         "track", help="track assignment: track set ID NAME [--cascade]"
@@ -326,6 +349,7 @@ def _build_parser() -> _EnvelopeArgumentParser:
     _add_transition_subparsers(subparsers)
     _add_discover_subparser(subparsers)
     _add_relations_subparsers(subparsers)
+    _add_acceptance_subparser(subparsers)
     _add_track_subparsers(subparsers)
     _add_report_subparsers(subparsers)
     _add_sync_subparser(subparsers)

--- a/packages/workcli/src/workcli/verbs/__init__.py
+++ b/packages/workcli/src/workcli/verbs/__init__.py
@@ -25,6 +25,7 @@ from workcli.lifecycle.discover import discover
 from workcli.lifecycle.park import abandon, park, parked, redispatch
 from workcli.lifecycle.reconcile import reconcile
 from workcli.lifecycle.transitions import claim, plan, promote, release
+from workcli.verbs.acceptance import acceptance
 from workcli.verbs.groom import groom
 from workcli.verbs.read import list_, ready, search, show
 from workcli.verbs.relations import dep, label
@@ -112,6 +113,7 @@ VERBS: dict[str, Callable[[Backend, Namespace], JsonValue]] = {
     "discover": discover,
     "dep": dep,
     "label": label,
+    "acceptance": acceptance,
     "sync": sync,
     "track": track,
     "lint": lint,

--- a/packages/workcli/src/workcli/verbs/acceptance.py
+++ b/packages/workcli/src/workcli/verbs/acceptance.py
@@ -1,0 +1,137 @@
+"""`work acceptance set ID TEXT [--why REASON]` -- correcting the contract, on the record.
+
+Its own verb family for the same reason `track set` is: `update` is
+replace-semantics over scalar fields, and a silent replace is the one thing
+acceptance criteria must never have. They are the termination condition a
+claim is checked against, so criteria quietly rewritten to match whatever was
+built let the check pass because the contract moved rather than because the
+work met it. Everything here exists to keep that visible.
+
+THE TRAIL. The criteria being superseded are quoted into a note, and the note
+is written BEFORE the replacement. The order is the integrity argument: a
+failure between the two writes can only ever leave a trail without a change,
+never a change without a trail. Nothing extra is needed to tell those apart
+either -- the note quotes what it superseded, so criteria that still equal the
+quote are criteria the replacement never reached. A retry appends a second
+entry rather than deduplicating, because a second attempt is a second event
+and the history of the contract is the thing being preserved.
+
+THE GATE. Once anybody has started, the change needs a stated reason, and the
+note records that work was underway when the target moved. Refusing outright
+was the alternative and it is worse: `release` is one call away, leaves no
+trace of its own, and returns the item to a status this verb waves through --
+so a refusal would convert a recorded mid-flight change into an unrecorded
+one. What is required instead is the sentence a reviewer needs. "Started" is
+read as "not one of the two statuses meaning nobody has picked this up", so a
+parked item -- work that began and stuck -- takes the gate exactly as a claim
+in hand does.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from datetime import datetime
+
+from workcli.backend import Backend
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.lifecycle.defer import DEFERRED_STATUS
+
+# full: "[work] acceptance restated <ISO-8601>[ while <status>][: <why>]"
+RESTATED_MARKER = "[work] acceptance restated"
+# The same line for an item that carried no criteria at all. Two markers
+# rather than one, because "nothing was superseded" and "the quote is missing"
+# are different facts and a reader should not have to infer the first from the
+# second.
+FIRST_SET_MARKER = "[work] acceptance first set"
+QUOTE_PREFIX = "> "
+
+# The statuses meaning nobody has started: criteria move freely here, which is
+# the ordinary case this verb exists for. Every other status -- a claim in
+# hand, a parked item, a closed one -- requires a stated reason.
+_UNSTARTED_STATUSES = frozenset({"open", DEFERRED_STATUS})
+
+
+def _require_criteria(text: str) -> str:
+    """Refuse a blank restatement: this verb states a contract, never removes one.
+
+    An unset shell variable expands to exactly this, and emptying the criteria
+    a claim is checked against is not what anyone typing a correction means --
+    the same reason `update --set-parent` refuses an empty id.
+    """
+    if not text.strip():
+        raise WorkError(
+            ErrorCode.USAGE,
+            "acceptance set requires criteria; it restates them, it cannot remove them",
+            detail={"field": "acceptance"},
+        )
+    return text
+
+
+def _require_single_line_reason(why: str | None) -> str | None:
+    """The reason's shape rule: non-blank and single-line, or absent entirely.
+
+    It travels on the marker's own line, so a second line would land in the
+    note unquoted, beside the criteria the note preserves.
+    """
+    if why is None:
+        return None
+    stripped = why.strip()
+    if not stripped or "\n" in stripped or "\r" in stripped:
+        raise WorkError(
+            ErrorCode.USAGE,
+            "--why must be a non-blank, single-line reason",
+            detail={"field": "why"},
+        )
+    return stripped
+
+
+def _marker_line(previous: str | None, now: datetime, status: str, why: str | None) -> str:
+    head = FIRST_SET_MARKER if previous is None else RESTATED_MARKER
+    line = f"{head} {now.isoformat()}"
+    if status not in _UNSTARTED_STATUSES:
+        line += f" while {status}"
+    if why is not None:
+        line += f": {why}"
+    return line
+
+
+def _trail(previous: str | None, now: datetime, status: str, why: str | None) -> str:
+    """The whole note: the marker, then the superseded criteria, quoted line by line.
+
+    The quote prefix is what keeps a later note appended underneath from
+    reading as part of the criteria this one preserved.
+    """
+    line = _marker_line(previous, now, status, why)
+    if previous is None:
+        return line
+    return "\n".join([line, *(f"{QUOTE_PREFIX}{part}" for part in previous.splitlines())])
+
+
+def acceptance(backend: Backend, args: Namespace) -> JsonValue:
+    """Dispatch `work acceptance ACTION`; v1 ships `set` only (argparse pins choices)."""
+    text = _require_criteria(args.text)
+    why = _require_single_line_reason(args.why)
+    item = backend.get(args.id)
+
+    if item.status not in _UNSTARTED_STATUSES and why is None:
+        raise WorkError(
+            ErrorCode.FIELD_CLOBBER_GUARD,
+            f"{args.id}: work has started ({item.status}); moving the criteria a claim is "
+            "checked against now requires --why, which is recorded on the item",
+            detail={"field": "acceptance", "status": item.status},
+        )
+
+    payload: JsonValue = {
+        "id": args.id,
+        "acceptance": text,
+        "previous": item.acceptance,
+        "status": item.status,
+    }
+    if item.acceptance == text:
+        # Replay safety: converge on the state already there rather than mint a
+        # trail entry for a change nobody made.
+        return payload
+
+    backend.append_note(args.id, _trail(item.acceptance, args.now(), item.status, why))
+    backend.set_acceptance(args.id, text)
+    return payload

--- a/packages/workcli/src/workcli/verbs/acceptance.py
+++ b/packages/workcli/src/workcli/verbs/acceptance.py
@@ -113,14 +113,6 @@ def acceptance(backend: Backend, args: Namespace) -> JsonValue:
     why = _require_single_line_reason(args.why)
     item = backend.get(args.id)
 
-    if item.status not in _UNSTARTED_STATUSES and why is None:
-        raise WorkError(
-            ErrorCode.FIELD_CLOBBER_GUARD,
-            f"{args.id}: work has started ({item.status}); moving the criteria a claim is "
-            "checked against now requires --why, which is recorded on the item",
-            detail={"field": "acceptance", "status": item.status},
-        )
-
     payload: JsonValue = {
         "id": args.id,
         "acceptance": text,
@@ -129,8 +121,21 @@ def acceptance(backend: Backend, args: Namespace) -> JsonValue:
     }
     if item.acceptance == text:
         # Replay safety: converge on the state already there rather than mint a
-        # trail entry for a change nobody made.
+        # trail entry for a change nobody made. This is checked BEFORE the
+        # started-work gate below, and the order is the point: that gate exists
+        # to stop a contract moving unremarked, and a no-op moves nothing.
+        # Gating it would refuse the retry that follows a crash -- the one call
+        # a caller makes precisely because it does not know whether the first
+        # attempt landed, and the one that must be safe to repeat.
         return payload
+
+    if item.status not in _UNSTARTED_STATUSES and why is None:
+        raise WorkError(
+            ErrorCode.FIELD_CLOBBER_GUARD,
+            f"{args.id}: work has started ({item.status}); moving the criteria a claim is "
+            "checked against now requires --why, which is recorded on the item",
+            detail={"field": "acceptance", "status": item.status},
+        )
 
     backend.append_note(args.id, _trail(item.acceptance, args.now(), item.status, why))
     backend.set_acceptance(args.id, text)

--- a/packages/workcli/src/workcli/verbs/write.py
+++ b/packages/workcli/src/workcli/verbs/write.py
@@ -51,15 +51,25 @@ def update(backend: Backend, args: Namespace) -> JsonValue:
     parent-child edge is replaced, never added beside. `dep add` refuses a
     second parent and names this flag.
 
-    `--set-notes` is recognized by argparse only so it reaches this named
-    clobber-guard rather than a generic `E_USAGE` — notes only ever move
-    through `work note`. (Suppressed from `--help`; rationale at its
-    `add_argument` site in `cli.py`.)
+    `--set-notes` and `--set-acceptance` are recognized by argparse only so
+    they reach this named clobber-guard rather than a generic `E_USAGE`. Notes
+    only ever move through `work note`, and the criteria a claim is checked
+    against only through `work acceptance set`, which records what they were —
+    a replace here would leave neither the history nor the contract. (Both are
+    suppressed from `--help`; rationale at their `add_argument` sites in
+    `cli.py`.)
     """
     if args.set_notes is not None:
         raise WorkError(
             ErrorCode.FIELD_CLOBBER_GUARD,
             "notes are append-only; use `work note ID TEXT` instead of --set-notes",
+        )
+    if args.set_acceptance is not None:
+        raise WorkError(
+            ErrorCode.FIELD_CLOBBER_GUARD,
+            "acceptance criteria are the contract a claim is checked against; use "
+            "`work acceptance set ID TEXT` instead of --set-acceptance, which records "
+            "the criteria it supersedes",
         )
     if args.set_parent is not None and not args.set_parent:
         # An empty parent reads as "remove the parent" at the backend, and an

--- a/packages/workcli/tests/integration/test_acceptance_roundtrip.py
+++ b/packages/workcli/tests/integration/test_acceptance_roundtrip.py
@@ -1,10 +1,15 @@
-"""Acceptance criteria survive create -> read against a real backend.
+"""Acceptance criteria survive create -> read -> correction against a real backend.
 
 The hermetic suite proves the facade reports what a captured payload holds.
 This proves the payload holds it: the criteria are written by a real `work
 create`, stored by a real backend, and read back through every verb that
 returns an item. A backend that stopped reporting them on one of its read
 commands would land here and nowhere else.
+
+The correction path is here for the same reason. `acceptance set` rests on two
+properties of the real thing that no fake can establish — that the backend
+replaces the criteria outright rather than appending to them, and that a
+multi-line note carrying the superseded text survives the round trip intact.
 """
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ from __future__ import annotations
 from tests.integration.conftest import ITEST_TRACK
 
 _CRITERIA = "AC1 the criteria come back through every read."
+_CORRECTED = "AC1 the criteria come back, and can be corrected."
 
 
 def _create(driver, title: str, *argv: str) -> str:
@@ -68,3 +74,50 @@ def test_every_read_verb_reports_the_same_acceptance_show_does(driver):
             assert item_id in reported, f"{verb} did not report {item_id}"
             assert "acceptance" in reported[item_id], f"{verb} omits acceptance for {item_id}"
             assert reported[item_id]["acceptance"] == criteria, verb
+
+
+def test_a_correction_replaces_the_criteria_and_leaves_the_old_text_readable(driver):
+    # Replaces, never appends: the item ends up carrying the new criteria and
+    # nothing of the old ones, while the old ones stay readable in the notes.
+    item_id = _create(driver, "ac-corrected", "--acceptance", _CRITERIA)
+
+    corrected = driver(["acceptance", "set", item_id, _CORRECTED])
+
+    assert corrected["ok"] is True, corrected
+    assert corrected["data"]["previous"] == _CRITERIA
+    shown = driver(["show", item_id])["data"]
+    assert shown["acceptance"] == _CORRECTED
+    assert _CRITERIA not in shown["acceptance"]
+    assert f"> {_CRITERIA}" in shown["notes"]
+    assert "[work] acceptance restated" in shown["notes"]
+
+
+def test_multi_line_criteria_survive_the_round_trip_quoted_line_by_line(driver):
+    # The trail is a multi-line note, which is the shape most likely to be
+    # mangled somewhere between the facade and the stored item.
+    previous = "AC1 the first thing.\nAC2 the second thing."
+    item_id = _create(driver, "ac-multiline", "--acceptance", previous)
+
+    driver(["acceptance", "set", item_id, _CORRECTED])
+
+    notes = driver(["show", item_id])["data"]["notes"]
+    assert "> AC1 the first thing." in notes
+    assert "> AC2 the second thing." in notes
+
+
+def test_a_claimed_item_refuses_a_silent_correction_and_records_a_stated_one(driver):
+    item_id = _create(driver, "ac-claimed", "--acceptance", _CRITERIA)
+    assert driver(["claim", item_id])["ok"] is True
+
+    refused = driver(["acceptance", "set", item_id, _CORRECTED])
+
+    assert refused["ok"] is False
+    assert refused["error"]["code"] == "E_FIELD_CLOBBER_GUARD"
+    assert driver(["show", item_id])["data"]["acceptance"] == _CRITERIA
+
+    stated = driver(["acceptance", "set", item_id, _CORRECTED, "--why", "AC1 was ambiguous"])
+
+    assert stated["ok"] is True, stated
+    shown = driver(["show", item_id])["data"]
+    assert shown["acceptance"] == _CORRECTED
+    assert "while in_progress: AC1 was ambiguous" in shown["notes"]

--- a/packages/workcli/tests/unit/test_acceptance_set.py
+++ b/packages/workcli/tests/unit/test_acceptance_set.py
@@ -182,6 +182,23 @@ def test_a_started_item_refuses_a_restatement_that_states_no_reason(status: str)
 
 
 @pytest.mark.parametrize("status", ["in_progress", "blocked", "closed"])
+def test_a_started_item_replaying_the_criteria_already_in_force_needs_no_reason(
+    status: str,
+) -> None:
+    # The retry after a crash is the whole point: a caller re-issues the same
+    # command precisely because it does not know whether the first attempt
+    # landed. Gating the no-op behind --why would refuse that retry on every
+    # started item, so the one call that exists to be safely repeatable would
+    # be the one call that fails. The --why gate guards a contract MOVING;
+    # nothing moves here, and `ReadOnlyFakeBackend` proves nothing is written.
+    backend = ReadOnlyFakeBackend().add("w1", acceptance=_OLD, status=status)
+
+    data = acceptance(backend, _args("w1", _OLD))
+
+    assert data == {"id": "w1", "acceptance": _OLD, "previous": _OLD, "status": status}
+
+
+@pytest.mark.parametrize("status", ["in_progress", "blocked", "closed"])
 def test_a_started_item_takes_a_stated_restatement_and_the_note_says_so(status: str) -> None:
     backend = FakeBackend().add("w1", acceptance=_OLD, status=status)
 

--- a/packages/workcli/tests/unit/test_acceptance_set.py
+++ b/packages/workcli/tests/unit/test_acceptance_set.py
@@ -1,0 +1,329 @@
+"""Correcting acceptance criteria after create -- and what that costs.
+
+The criteria are the termination condition a claim is checked against, so the
+one thing this verb must never be is a silent replace: criteria rewritten to
+match whatever was built let a check pass because the contract moved rather
+than because the work met it. Three properties carry that, and they are what
+these tests hold.
+
+- The previous criteria stay recoverable. They are quoted into a note, so
+  whoever later checks a claim can see the contract moved and what it was.
+- The trail is written FIRST. A failure between the two writes can then only
+  leave a trail without a change, never a change without a trail -- and the
+  quote is what tells the two apart, because criteria that still equal it are
+  criteria the replacement never reached.
+- Once anybody has started, the change needs a stated reason, and the note
+  says work was underway. Refusing outright was the alternative, and it is
+  worse: `release` is one call away and leaves no trace at all, so the refusal
+  would convert a recorded mid-flight change into an unrecorded one.
+
+`update` is deliberately not a route to any of this: it recognises
+`--set-acceptance` only to refuse it by name.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import pytest
+
+from tests.conftest import run_cli, run_cli_with_runner
+from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+from workcli.cli import main
+from workcli.envelope import ErrorCode, JsonValue, WorkError
+from workcli.verbs.acceptance import (
+    FIRST_SET_MARKER,
+    QUOTE_PREFIX,
+    RESTATED_MARKER,
+    acceptance,
+)
+
+_NOW = datetime(2026, 8, 8, 12, 0, 0, tzinfo=UTC)
+_ISO = _NOW.isoformat()
+_OLD = "AC1 the item reports the criteria it was created with."
+_NEW = "AC1 the item reports the criteria it now carries."
+
+
+def _args(item_id: str, text: str, *, why: str | None = None) -> Namespace:
+    return Namespace(action="set", id=item_id, text=text, why=why, now=lambda: _NOW)
+
+
+def _quoted(text: str) -> list[str]:
+    return [f"{QUOTE_PREFIX}{line}" for line in text.splitlines()]
+
+
+# -- the correction itself ----------------------------------------------------
+
+
+def test_the_criteria_an_item_was_created_with_can_be_corrected() -> None:
+    # The whole gap in one assertion: before this verb, the criteria were
+    # settable exactly once and a typo had no repair short of recreating.
+    backend = FakeBackend().add("w1", acceptance=_OLD)
+
+    data = acceptance(backend, _args("w1", _NEW))
+
+    assert backend.acceptance_of("w1") == _NEW
+    assert data == {"id": "w1", "acceptance": _NEW, "previous": _OLD, "status": "open"}
+
+
+def test_the_previous_criteria_survive_the_change_as_a_quoted_note() -> None:
+    backend = FakeBackend().add("w1", acceptance=_OLD)
+
+    acceptance(backend, _args("w1", _NEW))
+
+    assert backend.note_lines("w1") == [f"{RESTATED_MARKER} {_ISO}", *_quoted(_OLD)]
+
+
+def test_multi_line_criteria_are_quoted_line_by_line() -> None:
+    # Every line carries the quote prefix, so a later note appended underneath
+    # can never be read as part of the criteria this one preserved.
+    previous = "AC1 the first thing.\nAC2 the second thing."
+    backend = FakeBackend().add("w1", acceptance=previous)
+
+    acceptance(backend, _args("w1", _NEW))
+
+    assert backend.note_lines("w1") == [
+        f"{RESTATED_MARKER} {_ISO}",
+        f"{QUOTE_PREFIX}AC1 the first thing.",
+        f"{QUOTE_PREFIX}AC2 the second thing.",
+    ]
+
+
+def test_an_item_that_had_no_criteria_records_a_first_set_and_quotes_nothing() -> None:
+    # Nothing was superseded, so there is nothing to preserve and the marker
+    # says which of the two happened rather than leaving a reader to infer it
+    # from an absent quote.
+    backend = FakeBackend().add("w1", acceptance="")
+
+    data = acceptance(backend, _args("w1", _NEW))
+
+    assert backend.note_lines("w1") == [f"{FIRST_SET_MARKER} {_ISO}"]
+    assert data == {"id": "w1", "acceptance": _NEW, "previous": None, "status": "open"}
+
+
+def test_a_reason_is_recorded_when_one_is_given() -> None:
+    backend = FakeBackend().add("w1", acceptance=_OLD)
+
+    acceptance(backend, _args("w1", _NEW, why="AC1 named the wrong verb"))
+
+    assert backend.note_lines("w1")[0] == f"{RESTATED_MARKER} {_ISO}: AC1 named the wrong verb"
+
+
+def test_setting_the_criteria_that_are_already_there_writes_nothing() -> None:
+    # Replay safety: a re-issued call converges on the state that is already
+    # there rather than minting a second trail entry for a change nobody made.
+    backend = FakeBackend().add("w1", acceptance=_OLD)
+
+    data = acceptance(backend, _args("w1", _OLD))
+
+    assert backend.note_lines("w1") == []
+    assert data == {"id": "w1", "acceptance": _OLD, "previous": _OLD, "status": "open"}
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n"], ids=["empty", "spaces", "newline"])
+def test_blank_criteria_are_refused_rather_than_emptying_the_contract(text: str) -> None:
+    # An unset shell variable expands to exactly this, and deleting the
+    # criteria a claim is checked against is not what anyone typing a
+    # correction means -- the same reason `--set-parent` refuses an empty id.
+    backend = FakeBackend().add("w1", acceptance=_OLD)
+
+    with pytest.raises(WorkError) as exc_info:
+        acceptance(backend, _args("w1", text))
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert backend.acceptance_of("w1") == _OLD
+
+
+@pytest.mark.parametrize(
+    "why", ["", "   ", "line one\nline two"], ids=["empty", "spaces", "multi-line"]
+)
+def test_a_blank_or_multi_line_reason_is_refused(why: str) -> None:
+    # The reason travels on the marker's own line; a second line would land
+    # unquoted beside the criteria the note preserves.
+    backend = FakeBackend().add("w1", acceptance=_OLD, status="in_progress")
+
+    with pytest.raises(WorkError) as exc_info:
+        acceptance(backend, _args("w1", _NEW, why=why))
+
+    assert exc_info.value.code is ErrorCode.USAGE
+    assert backend.acceptance_of("w1") == _OLD
+
+
+def test_a_missing_item_is_reported_before_anything_is_written() -> None:
+    backend = FakeBackend()
+
+    with pytest.raises(WorkError) as exc_info:
+        acceptance(backend, _args("nope", _NEW))
+
+    assert exc_info.value.code is ErrorCode.NOT_FOUND
+
+
+# -- the gate once work has started -------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["in_progress", "blocked", "closed"])
+def test_a_started_item_refuses_a_restatement_that_states_no_reason(status: str) -> None:
+    # `blocked` is a parked item: work that started and stuck, which is the
+    # same case as a claim in hand. The refusal is proved to write nothing at
+    # all rather than to leave a half-applied change behind.
+    backend = ReadOnlyFakeBackend().add("w1", acceptance=_OLD, status=status)
+
+    with pytest.raises(WorkError) as exc_info:
+        acceptance(backend, _args("w1", _NEW))
+
+    assert exc_info.value.code is ErrorCode.FIELD_CLOBBER_GUARD
+    assert exc_info.value.detail == {"field": "acceptance", "status": status}
+    assert "--why" in exc_info.value.message
+
+
+@pytest.mark.parametrize("status", ["in_progress", "blocked", "closed"])
+def test_a_started_item_takes_a_stated_restatement_and_the_note_says_so(status: str) -> None:
+    backend = FakeBackend().add("w1", acceptance=_OLD, status=status)
+
+    data = acceptance(backend, _args("w1", _NEW, why="the spec moved under it"))
+
+    assert backend.acceptance_of("w1") == _NEW
+    assert backend.note_lines("w1") == [
+        f"{RESTATED_MARKER} {_ISO} while {status}: the spec moved under it",
+        *_quoted(_OLD),
+    ]
+    assert data["status"] == status
+
+
+@pytest.mark.parametrize("status", ["open", "deferred"])
+def test_an_item_nobody_has_started_needs_no_reason(status: str) -> None:
+    # Sharpening criteria before anyone picks the work up is the ordinary
+    # case this verb exists for; ceremony there buys nothing.
+    backend = FakeBackend().add("w1", acceptance=_OLD, status=status)
+
+    acceptance(backend, _args("w1", _NEW))
+
+    assert backend.acceptance_of("w1") == _NEW
+    assert backend.note_lines("w1")[0] == f"{RESTATED_MARKER} {_ISO}"
+
+
+# -- the order the two writes go in -------------------------------------------
+
+
+def _raw_item(acceptance_criteria: str | None) -> dict[str, JsonValue]:
+    raw: dict[str, JsonValue] = {
+        "id": "x.1",
+        "title": "T",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "labels": [],
+        "dependencies": [],
+        "dependents": [],
+    }
+    if acceptance_criteria is not None:
+        raw["acceptance_criteria"] = acceptance_criteria
+    return raw
+
+
+def _show_step(acceptance_criteria: str | None) -> ScriptedStep:
+    return ScriptedStep(
+        ("show",),
+        BdResult(returncode=0, stdout=json.dumps([_raw_item(acceptance_criteria)]), stderr=""),
+    )
+
+
+def _ok_step() -> ScriptedStep:
+    return ScriptedStep(("update",), BdResult(returncode=0, stdout="", stderr=""))
+
+
+def _writes(calls: Sequence[tuple[str, ...]]) -> list[tuple[str, ...]]:
+    return [call for call in calls if call[0] == "update"]
+
+
+def test_the_trail_is_written_before_the_criteria_change() -> None:
+    """
+    Given an item whose criteria are about to be replaced
+    When the verb runs
+    Then the note preserving them reaches the backend before the replacement.
+
+    The order is the whole integrity argument. Reversed, a failure between the
+    two writes would leave criteria that moved with nothing recording it --
+    exactly the state the trail exists to make impossible.
+    """
+    runner = ScriptedBdRunner(steps=[_show_step(_OLD), _ok_step(), _ok_step()])
+
+    exit_code, envelope, _ = run_cli_with_runner(["acceptance", "set", "x.1", _NEW], runner)
+
+    assert exit_code == 0, envelope
+    trail, change = _writes(runner.calls)
+    assert "--append-notes" in trail
+    assert _OLD in " ".join(trail)
+    assert change == ("update", "x.1", "--acceptance", _NEW)
+
+
+def test_a_failed_replacement_leaves_a_trail_whose_quote_still_matches_the_item() -> None:
+    """
+    Given a backend that accepts the note and then refuses the replacement
+    When the verb runs
+    Then the trail is there, the criteria are untouched, and the two agree.
+
+    The half-failed write is legible without extra bookkeeping: the note
+    quotes what it superseded, so criteria still equal to the quote are
+    criteria the replacement never reached.
+    """
+
+    class _ReplacementFails(FakeBackend):
+        def set_acceptance(self, _item_id: str, _text: str) -> None:
+            raise WorkError(ErrorCode.TIMEOUT, "the tracker did not answer")
+
+    backend = _ReplacementFails().add("w1", acceptance=_OLD)
+
+    with pytest.raises(WorkError) as exc_info:
+        acceptance(backend, _args("w1", _NEW))
+
+    assert exc_info.value.code is ErrorCode.TIMEOUT
+    assert backend.note_lines("w1") == [f"{RESTATED_MARKER} {_ISO}", *_quoted(_OLD)]
+    assert backend.acceptance_of("w1") == _OLD
+
+
+# -- the CLI surface ----------------------------------------------------------
+
+
+def test_the_verb_is_reachable_from_the_command_line() -> None:
+    exit_code, envelope, _ = run_cli(
+        ["acceptance", "set", "x.1", _NEW, "--why", "AC1 named the wrong verb"],
+        [_show_step(_OLD), _ok_step(), _ok_step()],
+    )
+
+    assert exit_code == 0
+    assert envelope["data"] == {
+        "id": "x.1",
+        "acceptance": _NEW,
+        "previous": _OLD,
+        "status": "open",
+    }
+
+
+def test_update_refuses_to_move_the_criteria_and_names_the_verb_that_does() -> None:
+    # An empty script: a backend call on this path would exhaust it and fail
+    # loudly, which is how "refused before any write" is proved here.
+    exit_code, envelope, _ = run_cli(["update", "x.1", "--set-acceptance", _NEW], steps=[])
+
+    assert exit_code == 1
+    error = envelope["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == str(ErrorCode.FIELD_CLOBBER_GUARD)
+    assert "acceptance set" in str(error["message"])
+
+
+def test_update_help_does_not_advertise_set_acceptance(capsys: pytest.CaptureFixture[str]) -> None:
+    # A tripwire, not an advertised option: naming it in --help would invite
+    # the attempt it exists to reject.
+    with pytest.raises(SystemExit) as exc_info:
+        main(["update", "--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "--set-acceptance" not in captured.out
+    assert "--set-title" in captured.out

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -130,7 +130,20 @@ def test_protocol_wire_value_is_pinned() -> None:
     # Nothing here touches 1.10's close-walk narrowing: a deferred child is
     # not a closed one, so it stops the walk on the not-yet-exhausted branch
     # exactly as an open child does, and never reaches the `held` report.
-    assert PROTOCOL_VERSION == "1.11"
+    #
+    # 1.12 adds `acceptance set`, the first way a caller can correct the
+    # criteria an item was created with, and a refusal on `update
+    # --set-acceptance` that names it. A new verb is 1.11's case exactly: it
+    # takes nothing away from an existing one, and its envelope is a new
+    # `data` shape rather than a change to any existing one. The refusal is
+    # additive in the same sense the 1.6 refusals were -- the flag it rejects
+    # was never accepted, so it replaces an unknown-flag error with a named
+    # one and no consumer had correct behaviour to lose. What a reader of an
+    # existing shape can newly see is a note line the facade wrote, on an item
+    # whose criteria moved; `notes` has always carried facade-authored markers
+    # (the park family's, the defer pair's), so this is one more of a kind
+    # that already existed.
+    assert PROTOCOL_VERSION == "1.12"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:


### PR DESCRIPTION
Tracker item: `agents-config-9k9.184` — "Acceptance criteria are settable only at create, and update is the wrong place to change that".

## What changed

Acceptance criteria were settable exactly once, at create, through `create <noun> --acceptance`. A typo had no repair short of recreating the item, even though criteria are routinely sharpened between filing and claiming. `work acceptance set ID TEXT [--why REASON]` is the correction path.

It is its own verb rather than an `update --set-*` flag because the criteria are the termination condition a claim is checked against: a silent replace lets them be rewritten to match whatever was built, and the check then passes because the contract moved rather than because the work met it. `update` recognises `--set-acceptance` only to refuse it with `E_FIELD_CLOBBER_GUARD` and name the verb that records the change — the same tripwire shape `--set-notes` already uses, suppressed from `--help`.

## The audit trail

The superseded criteria are quoted into a note (one `> ` line each) under a `[work] acceptance restated <ISO-8601>` marker, or `[work] acceptance first set` where the item carried none. The note is written **before** the replacement, so the only reachable half-failure is a trail without a change, never a change without a trail. Nothing extra is needed to tell those apart: the note quotes what it superseded, so criteria still equal to the quote are criteria the replacement never reached. A test pins that half-failure directly.

## The already-started case

Any status other than `open`/`deferred` requires `--why`, which lands on the marker line beside the status (`… while in_progress: AC1 was ambiguous`). `blocked` (parked) and `closed` take the same gate.

Refusing outright was the tempting alternative and is worse: `work release` is one call away, leaves no trace of its own, and returns the item to a status this verb waves through — so a hard refusal would convert a recorded mid-flight change into an unrecorded one, defeating the trail exactly where it matters most. The decision, and the alternatives rejected on both halves, is recorded as a note on the tracker item.

Also: a blank `TEXT` is refused (the verb states a contract, it cannot remove one), `--why` must be non-blank and single-line, and setting the criteria already in force writes nothing.

## Protocol

1.11 → 1.12. A new verb takes nothing away from an existing one, and the refusal replaces an unknown-flag error on a flag that was never accepted. Reasoning is appended in `test_protocol_handshake.py`; the README is checked mechanically against the value the code emits.

## Verification

- `make ci-workcli` — exit 0 (858 tests, 99.25% branch coverage against the 90% floor).
- `make itest-workcli` — exit 0 (61 tests against a real isolated backend), including three new ones proving the backend replaces the criteria rather than appending, that a multi-line quoted trail survives the round trip, and that a claimed item refuses a silent correction and records a stated one.
- Each new test was observed failing against the pre-change code before the implementation landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1