### PR TITLE
fix(9k9.182): a listing carries every status, and only the caller narrows it

### DIFF
--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -118,8 +118,8 @@ backend returned unasked, which was live work only, so an id that exists
 could be absent from a complete-looking listing. It now carries every
 status, closed included, and `--status` is the only thing that narrows it.
 `ready` is unchanged — it answers the queue question, where closed work has
-no place, and a caller wanting the queue view of a listing asks `list
---status open` for it.
+no place, and a caller wanting the queue view of a listing asks
+`list --status open` for it.
 `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -28,7 +28,7 @@ change.
 | `work note ID TEXT` | append-only |
 | `work close IDS... [--disposition TEXT]` | disposition = one appended note per id |
 | `work reopen ID` | — |
-| `work list [--status S] [--label L] [--parent ID] [--type T] [--limit N]` | unbounded unless `--limit` |
+| `work list [--status S] [--label L] [--parent ID] [--type T] [--limit N]` | every status, closed included, and unbounded — `--status` and `--limit` are the only things that narrow either axis |
 | `work ready [--label L]` | unbounded |
 | `work dep {add,remove,list} ID [TARGET] [--type blocks]` | `dep add A B` = A depends on B |
 | `work label {add,remove,list} ID [LABELS...]` | multi-label in one call |
@@ -96,7 +96,7 @@ quote are criteria the replacement never reached. Once work has started the
 call additionally requires `--why`, which lands on the marker line beside the
 status the item was in. Setting the criteria already in force writes nothing.
 
-Protocol is `"1.12"` — additive-only bumps (new `ErrorCode` members, the
+Protocol is `"1.13"` — additive-only bumps (new `ErrorCode` members, the
 derived `Item.track` field and the `acceptance` field beside it, the
 capability-disposition model, `partial_progress` detail below, `search`'s
 optional narrowing flags, the close-walk's `held` key, the `defer`/`undefer`
@@ -112,7 +112,14 @@ named. 1.11 widens again, mildly: `status` can report `deferred` on an item
 the facade itself set aside, a value the backend always could hold and this
 contract always declared. 1.12 adds `acceptance set`, whose only visible mark
 on an existing shape is a facade-authored marker line in `notes`, beside the
-ones the park family and the `defer`/`undefer` pair already write.
+ones the park family and the `defer`/`undefer` pair already write. 1.13 is
+1.8's case again, on `list`: a listing used to carry whatever statuses the
+backend returned unasked, which was live work only, so an id that exists
+could be absent from a complete-looking listing. It now carries every
+status, closed included, and `--status` is the only thing that narrows it.
+`ready` is unchanged — it answers the queue question, where closed work has
+no place, and a caller wanting the queue view of a listing asks `list
+--status open` for it.
 `Capabilities` splits `ready` and `sync` into a `ReadySupport`/
 `SyncSupport` disposition each (`NATIVE` | `EMULATED`/`SERVER_AUTHORITATIVE`
 | `UNSUPPORTED`) instead of a single boolean, and `dep` gates only typed
@@ -148,13 +155,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.12", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "1.13", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.12", "ok": false, "data": null,
+{"protocol": "1.13", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -188,7 +195,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.12", "ok": true, "data": {"protocol": "1.12"}, "error": null}
+{"protocol": "1.13", "ok": true, "data": {"protocol": "1.13"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -226,7 +233,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.12"}`.
+- `--protocol-version` → `{"protocol": "1.13"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.12"
+PROTOCOL_VERSION = "1.13"

--- a/packages/workcli/src/workcli/adapters/bd/backend.py
+++ b/packages/workcli/src/workcli/adapters/bd/backend.py
@@ -129,8 +129,10 @@ class BdBackend:
 
     def query(self, filters: QueryFilters) -> list[Item]:
         argv = ["list", "--json"]
-        if filters.status is not None:
-            argv += ["--status", filters.status]
+        # The seam's "every status" is the absent filter; bd's listing spells
+        # it as a flag of its own, exactly as the description/notes search
+        # legs already ask for it.
+        argv += ["--all"] if filters.status is None else ["--status", filters.status]
         if filters.label is not None:
             argv += ["--label", filters.label]
         if filters.parent is not None:

--- a/packages/workcli/src/workcli/cli.py
+++ b/packages/workcli/src/workcli/cli.py
@@ -48,8 +48,12 @@ def _add_read_subparsers(subparsers: _SubParsersAction[_EnvelopeArgumentParser])
     show_parser = subparsers.add_parser("show", help="show one or more items by id")
     show_parser.add_argument("ids", nargs="+", metavar="ID")
 
-    list_parser = subparsers.add_parser("list", help="list items, unbounded unless --limit")
-    list_parser.add_argument("--status")
+    list_parser = subparsers.add_parser(
+        "list", help="list items: every status, unbounded unless narrowed"
+    )
+    list_parser.add_argument(
+        "--status", help="restrict to one status; default every status, closed included"
+    )
     list_parser.add_argument("--label")
     list_parser.add_argument("--parent")
     list_parser.add_argument("--type")

--- a/packages/workcli/src/workcli/lifecycle/park.py
+++ b/packages/workcli/src/workcli/lifecycle/park.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 
 from workcli.backend import Backend
 from workcli.envelope import ErrorCode, JsonValue, WorkError
-from workcli.model import Item, QueryFilters
+from workcli.model import Item, QueryFilters, not_closed
 
 PARKED_LABEL = "parked"
 PARKED_MARKER = "[work] parked"  # full: "[work] parked <ISO-8601> <code>: <text>"
@@ -237,8 +237,13 @@ def _read_parked_items(backend: Backend) -> list[Item]:
     re-read via one `batch_get` -- the same re-get seam `reconcile` uses on
     its candidates. Reads only; a caller of either surface issues no write on
     account of it (S9T1-P2).
+
+    A listing answers every status, so the handle alone is not the parked
+    set: an item can be closed with the label still on it, and closed work is
+    not stuck work. Nothing would ever clear such a row from the report,
+    which is the whole thing the report is for.
     """
-    lean = backend.query(QueryFilters(label=PARKED_LABEL))
+    lean = not_closed(backend.query(QueryFilters(label=PARKED_LABEL)))
     return backend.batch_get([entry.id for entry in lean])
 
 

--- a/packages/workcli/src/workcli/lifecycle/reconcile.py
+++ b/packages/workcli/src/workcli/lifecycle/reconcile.py
@@ -31,7 +31,7 @@ from workcli.lifecycle.nouns import (
     DESIGN_CHILD_LABEL,
     IMPL_PLACEHOLDER_LABEL,
 )
-from workcli.model import Item, QueryFilters
+from workcli.model import Item, QueryFilters, not_closed
 
 
 def _finding(item_id: str, kind: str, *, repaired: bool) -> dict[str, JsonValue]:
@@ -62,9 +62,13 @@ def _sweep_pending_placeholders(backend: Backend, *, dry_run: bool) -> list[Json
     surfaces as an attention finding without auto-repair. A corrupt snapshot is
     one poisoned item, reported as its own finding rather than aborting recovery
     of every healthy placeholder -- the typed drift `manifest_snapshot`
-    raises is caught per-item here."""
+    raises is caught per-item here.
+
+    A listing answers every status, so the candidates are narrowed to live
+    items: a closed placeholder is one this sweep would re-open work under,
+    and recovery repairs what was interrupted, never what was finished."""
     findings: list[JsonValue] = []
-    for candidate in backend.query(QueryFilters(label=IMPL_PLACEHOLDER_LABEL)):
+    for candidate in not_closed(backend.query(QueryFilters(label=IMPL_PLACEHOLDER_LABEL))):
         placeholder = backend.get(candidate.id)
         try:
             snapshot = manifest_snapshot(placeholder.notes)
@@ -136,9 +140,11 @@ def _sweep_interrupted_instantiations(backend: Backend, *, dry_run: bool) -> lis
     leaf is healed by stripping the leaked handle, never finalized as a
     container -- finalizing a leaf would mint grandchildren under it and stamp
     it `planned`. A second sweep over a healed tree finds no
-    handle -- idempotent."""
+    handle -- idempotent. Candidates are narrowed to live items for the same
+    reason the placeholder sweep above narrows its own: a closed container is
+    not an instantiation still in flight."""
     findings: list[JsonValue] = []
-    candidates = list(backend.query(QueryFilters(label=CREATING_SPEC_LABEL)))
+    candidates = not_closed(backend.query(QueryFilters(label=CREATING_SPEC_LABEL)))
     items = backend.batch_get([candidate.id for candidate in candidates])
     for item in items:
         if DESIGN_CHILD_LABEL in item.labels or IMPL_PLACEHOLDER_LABEL in item.labels:

--- a/packages/workcli/src/workcli/model.py
+++ b/packages/workcli/src/workcli/model.py
@@ -7,6 +7,7 @@ layer serializes into envelope `data` via `dataclasses.asdict`.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 # The three fields describing an item's place in the tree. Not every backend
@@ -106,11 +107,29 @@ class UpdateFields:  # replace-semantics fields ONLY; notes never appear here
 
 @dataclass(frozen=True)
 class QueryFilters:
+    # `None` is every status, closed included -- the same meaning it carries
+    # on `SearchFilters`, so one word means one thing across the seam. It used
+    # to mean "whatever the backend lists when nobody asks", which left the
+    # facade's answer defined by the backend rather than by the facade: a
+    # listing came back short and read exactly like a complete one. A caller
+    # that wants live work narrows for itself, which is what `not_closed` is
+    # for -- there is no single status meaning "not closed", so that narrowing
+    # cannot travel through this field.
     status: str | None = None
     label: str | None = None
     parent: str | None = None
     type: str | None = None
     limit: int | None = None
+
+
+def not_closed(items: Iterable[Item]) -> list[Item]:
+    """The live items of a listing -- everything the tracker has not closed.
+
+    A listing answers every status, so a sweep that acts on what it finds
+    says here that a closed item is not one of its candidates. Written once
+    because four sweeps need it and each would otherwise re-decide it.
+    """
+    return [item for item in items if item.status != "closed"]
 
 
 # The `Item` fields a search may read, in the order a result set reports them

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -59,6 +59,13 @@ def show(backend: Backend, args: Namespace) -> JsonValue:
 def list_(backend: Backend, args: Namespace) -> JsonValue:
     """`work list [--status --label --parent --type --limit --track]`.
 
+    Every status by default, closed included, for the same reason the bound
+    is unbounded by default: a listing narrowed by nobody comes back short
+    and reads exactly like a complete one, and a caller who has not read the
+    flag list has nothing to tell the two apart by. Every narrowing a listing
+    carries is therefore one the caller typed. The queue question -- what
+    should I work on -- is `ready`'s, and it keeps its own narrow view.
+
     `--track` filters on the DERIVED `Item.track` (never raw label presence),
     so filter and envelope field always agree: zero-or-multi-label items
     derive to null and match nothing. Validated against the

--- a/packages/workcli/src/workcli/verbs/report.py
+++ b/packages/workcli/src/workcli/verbs/report.py
@@ -15,16 +15,17 @@ from argparse import Namespace
 from workcli.backend import Backend
 from workcli.config import TrackLayerConfig
 from workcli.envelope import ErrorCode, JsonValue, WorkError
-from workcli.model import Item, QueryFilters
+from workcli.model import Item, QueryFilters, not_closed
 from workcli.tracks import TRACK_PREFIX, derive_track
 
 NO_MILESTONE_EXEMPT_LABEL = "lint-exempt:no-milestone"
 
 
 def _sweep(backend: Backend) -> list[Item]:
-    """All non-closed items. bd list already omits closed; the filter makes
-    the verb correct against any backend that returns them anyway."""
-    return [item for item in backend.query(QueryFilters()) if item.status != "closed"]
+    """All non-closed items. A listing answers every status, so what these
+    three verbs report on is the narrowing they state here: closed work
+    breaches no invariant and exerts no extraction pressure."""
+    return not_closed(backend.query(QueryFilters()))
 
 
 def _track_violations(non_milestone: list[Item], config: TrackLayerConfig) -> list[JsonValue]:

--- a/packages/workcli/tests/integration/test_list_status.py
+++ b/packages/workcli/tests/integration/test_list_status.py
@@ -1,0 +1,54 @@
+"""`work list` against a real backend: a default listing hides nothing.
+
+Only a real backend shows this. A scripted runner replays the rows it was
+scripted with, so it cannot drop a closed one -- which is how the narrow
+default survived so long: every hermetic test agreed with the facade's own
+model of the answer while the backend applied a filter nobody had asked for.
+
+One install, three listings: the default, one narrowed by status, and one
+narrowed on another axis. The contrast is the point -- what a caller can
+tell apart is a listing they narrowed from one that was narrowed for them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+_MARK = "ls-marked"
+
+
+def _create(driver: Callable[[Sequence[str]], dict], title: str, *label: str) -> str:
+    argv = ["create", "--raw", "--title", title, "--type", "task", "--priority", "2"]
+    for name in label:
+        argv += ["--label", name]
+    created = driver(argv)
+    assert created["ok"] is True, created
+    return created["data"]["id"]
+
+
+def _ids(envelope: dict) -> set[str]:
+    assert envelope["ok"] is True, envelope
+    return {item["id"] for item in envelope["data"]["items"]}
+
+
+def test_a_default_listing_carries_closed_work_and_a_narrowed_one_carries_what_was_asked(
+    driver,
+):
+    open_id = _create(driver, "ls-still-open")
+    closed_id = _create(driver, "ls-already-finished", _MARK)
+    assert driver(["close", closed_id])["ok"] is True
+
+    everything = driver(["list"])
+    by_status = driver(["list", "--status", "open"])
+    by_label = driver(["list", "--label", _MARK])
+
+    # A fresh install holds exactly these two items, so this is the whole
+    # database and not merely a superset check.
+    assert _ids(everything) == {open_id, closed_id}
+    closed = next(i for i in everything["data"]["items"] if i["id"] == closed_id)
+    assert closed["status"] == "closed"
+    # The only narrowing in a listing is the one the caller typed...
+    assert _ids(by_status) == {open_id}
+    # ...and narrowing on one axis does not quietly re-apply a status filter
+    # on another: this item matches the label and is closed.
+    assert _ids(by_label) == {closed_id}

--- a/packages/workcli/tests/unit/test_bd_backend.py
+++ b/packages/workcli/tests/unit/test_bd_backend.py
@@ -172,7 +172,7 @@ def test_query_defaults_to_limit_zero_meaning_unbounded():
     items = backend.query(QueryFilters())
 
     assert len(items) == 5
-    assert runner.calls == [("list", "--json", "--limit", "0")]
+    assert runner.calls == [("list", "--json", "--all", "--limit", "0")]
 
 
 def test_query_passes_through_a_positive_limit_and_the_status_filter():
@@ -208,6 +208,7 @@ def test_query_passes_through_the_label_parent_and_type_filters():
         (
             "list",
             "--json",
+            "--all",
             "--label",
             "tech-debt",
             "--parent",

--- a/packages/workcli/tests/unit/test_list_status_default.py
+++ b/packages/workcli/tests/unit/test_list_status_default.py
@@ -1,0 +1,45 @@
+"""`work list` answers every status unless the caller narrows it.
+
+The default used to be whatever set of statuses the backend listed when it
+was not asked, which is live work only: measured on this repository's own
+tracker, 89 items where 277 exist. A caller reading that envelope could not
+tell it from a complete listing -- the same failure the unbounded `--limit`
+already closed on the row-count axis, and `search` on this one.
+
+What the unit level can pin is the argv the adapter sends and the argv it
+does not send. A scripted runner returns whatever it was scripted with, so
+it can neither hide a closed row nor prove one comes back; that is the
+integration suite's job (`tests/integration/test_list_status.py`).
+"""
+
+from __future__ import annotations
+
+from tests.conftest import run_cli_with_runner
+from tests.fakes import ScriptedBdRunner, ScriptedStep
+from workcli.adapters.bd.runner import BdResult
+
+_EMPTY = BdResult(returncode=0, stdout="[]", stderr="")
+
+
+def _runner() -> ScriptedBdRunner:
+    return ScriptedBdRunner(steps=[ScriptedStep(("list",), _EMPTY)])
+
+
+def test_list_asks_for_every_status_when_the_caller_named_none():
+    runner = _runner()
+
+    exit_code, _, _ = run_cli_with_runner(["list"], runner)
+
+    assert exit_code == 0
+    assert runner.calls == [("list", "--json", "--all", "--limit", "0")]
+
+
+def test_list_asks_for_one_status_only_when_the_caller_named_one():
+    runner = _runner()
+
+    exit_code, _, _ = run_cli_with_runner(["list", "--status", "closed"], runner)
+
+    assert exit_code == 0
+    # The caller's narrowing REPLACES the wide ask rather than riding beside
+    # it: a listing carries either every status or the one that was named.
+    assert runner.calls == [("list", "--json", "--status", "closed", "--limit", "0")]

--- a/packages/workcli/tests/unit/test_list_unbounded.py
+++ b/packages/workcli/tests/unit/test_list_unbounded.py
@@ -49,7 +49,7 @@ def test_list_defaults_to_unbounded_and_every_row_surfaces():
     data = envelope["data"]
     assert isinstance(data, dict)
     assert len(data["items"]) == 60
-    assert runner.calls == [("list", "--json", "--limit", "0")]
+    assert runner.calls == [("list", "--json", "--all", "--limit", "0")]
 
 
 def test_list_limit_flag_passes_through_a_positive_limit():
@@ -60,7 +60,7 @@ def test_list_limit_flag_passes_through_a_positive_limit():
     exit_code, _, _ = run_cli_with_runner(["list", "--limit", "7"], runner)
 
     assert exit_code == 0
-    assert runner.calls == [("list", "--json", "--limit", "7")]
+    assert runner.calls == [("list", "--json", "--all", "--limit", "7")]
 
 
 def test_list_status_label_parent_type_filters_map_to_bd_flags():
@@ -120,7 +120,7 @@ def test_ready_defaults_to_unbounded_and_every_row_surfaces():
     assert isinstance(data, dict)
     assert len(data["items"]) == 120
     assert runner.calls == [
-        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("list", "--json", "--all", "--label", "parked", "--limit", "0"),
         ("ready", "--json", "--limit", "0"),
     ]
 
@@ -139,6 +139,6 @@ def test_ready_label_flag_passes_through():
     # `--label` reaches `bd ready` only; the parked read is never re-scoped by
     # it -- the surfacing is the whole parking lot regardless of the filter.
     assert runner.calls == [
-        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("list", "--json", "--all", "--label", "parked", "--limit", "0"),
         ("ready", "--json", "--label", "tech-debt", "--limit", "0"),
     ]

--- a/packages/workcli/tests/unit/test_park.py
+++ b/packages/workcli/tests/unit/test_park.py
@@ -333,6 +333,28 @@ def test_parked_report_lists_reason_category_staleness_read_only():  # S2-B7
     }
 
 
+def test_parked_report_omits_a_closed_item_that_still_carries_the_handle():
+    # The listing behind this report answers every status, so the label alone
+    # is not the parked set. A closed item is not stuck work, and nothing
+    # would ever clear such a row: `redispatch`/`abandon` are the only things
+    # that take the label off, and neither is reachable once the work is done.
+    backend = ReadOnlyFakeBackend()
+    _parked_item(backend, "still-stuck", parked_at=_ISO, reason="ci-failure")
+    backend.add(
+        "finished-anyway",
+        status="closed",
+        labels=[PARKED_LABEL],
+        notes=f"{PARKED_MARKER} {_ISO} ci-failure: CI red",
+    )
+
+    data = parked(backend, _parked_args())
+
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    assert [row["id"] for row in items if isinstance(row, dict)] == ["still-stuck"]
+
+
 def test_parked_report_degrades_an_unparseable_marker_to_nulls():  # S2-B7 (dep failure)
     backend = ReadOnlyFakeBackend()
     backend.add("w1", status="blocked", labels=[PARKED_LABEL], notes="hand-written note")
@@ -421,7 +443,7 @@ def test_cli_parked_with_no_parked_items_is_an_empty_report():
         ["parked"],
         steps=[
             ScriptedStep(
-                ("list", "--json", "--label", PARKED_LABEL),
+                ("list", "--json", "--all", "--label", PARKED_LABEL),
                 BdResult(returncode=0, stdout="[]", stderr=""),
             )
         ],

--- a/packages/workcli/tests/unit/test_parked_stale_block.py
+++ b/packages/workcli/tests/unit/test_parked_stale_block.py
@@ -169,7 +169,7 @@ def test_ready_bd_call_log_is_two_reads_and_nothing_else():  # S9T1-P2
     assert exit_code == 0
     assert envelope["data"] == {"items": [], "parked_stale": []}
     assert runner.calls == [
-        ("list", "--json", "--label", PARKED_LABEL, "--limit", "0"),
+        ("list", "--json", "--all", "--label", PARKED_LABEL, "--limit", "0"),
         ("ready", "--json", "--limit", "0"),
     ]
 
@@ -329,7 +329,7 @@ def test_ready_never_issues_its_own_listing_once_the_parked_read_fails():  # S9T
 
     assert exit_code == 1
     assert envelope["data"] is None
-    assert runner.calls == [("list", "--json", "--label", PARKED_LABEL, "--limit", "0")]
+    assert runner.calls == [("list", "--json", "--all", "--label", PARKED_LABEL, "--limit", "0")]
 
 
 # --- S9T1-P5: an unreadable marker surfaces, it does not exempt ------------

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -143,7 +143,16 @@ def test_protocol_wire_value_is_pinned() -> None:
     # whose criteria moved; `notes` has always carried facade-authored markers
     # (the park family's, the defer pair's), so this is one more of a kind
     # that already existed.
-    assert PROTOCOL_VERSION == "1.12"
+    #
+    # 1.13 widens what `list` answers: every status, closed included, where it
+    # used to carry whatever set the backend returned when nobody asked, which
+    # was live work only. That is 1.8's case on a second read verb and takes
+    # the same verdict -- the envelope and the `data` shape are untouched, the
+    # answer is wider and truer, and a consumer that acted on the absence of an
+    # item was acting on a listing that had been narrowed for it without being
+    # told. `ready` is deliberately untouched: it answers the queue question,
+    # and closed work is not in a queue.
+    assert PROTOCOL_VERSION == "1.13"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:

--- a/packages/workcli/tests/unit/test_recovery.py
+++ b/packages/workcli/tests/unit/test_recovery.py
@@ -306,6 +306,32 @@ def test_reconcile_dry_run_reports_findings_without_mutating():
     assert {"id": "p", "kind": "unreconciled_placeholder", "repaired": False} in findings
 
 
+def test_reconcile_ignores_closed_items_that_still_carry_a_completion_handle():
+    # The listing every sweep enumerates through answers each status, so a
+    # handle left on a CLOSED item is inside the candidate set the backend
+    # returns. Recovery repairs what was interrupted, and closed work was not:
+    # replaying either handle would mint children under, or stamp labels onto,
+    # an item somebody finished.
+    backend = FakeBackend()
+    backend.add(
+        "closed-placeholder",
+        type="feature",
+        status="closed",
+        labels=[IMPL_PLACEHOLDER_LABEL],
+        notes=_snapshot_note(_single()),
+    )
+    backend.add(
+        "closed-container",
+        type="feature",
+        status="closed",
+        labels=[CREATING_SPEC_LABEL],
+    )
+
+    assert _reconcile(backend) == []
+    assert IMPL_PLACEHOLDER_LABEL in backend.get("closed-placeholder").labels
+    assert CREATING_SPEC_LABEL in backend.get("closed-container").labels
+
+
 def test_reconcile_over_a_healed_tree_finds_nothing():
     backend = FakeBackend()
     _spec_tree(backend, design_status="in_progress", placeholder_notes=_snapshot_note(_single()))

--- a/packages/workcli/tests/unit/test_transitions.py
+++ b/packages/workcli/tests/unit/test_transitions.py
@@ -77,7 +77,7 @@ def test_claim_on_open_unblocked_leaf_sends_claim_and_returns_in_progress():
     assert runner.calls == [
         ("show", "x.1", "--json"),
         ("ready", "--json", "--limit", "0"),
-        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("list", "--json", "--all", "--label", "parked", "--limit", "0"),
         ("update", "x.1", "--claim"),
     ]
 
@@ -159,7 +159,7 @@ def test_claim_on_already_in_progress_is_a_noop_with_no_claim_call():
     assert envelope["data"] == {"id": "x.1", "status": "in_progress", "parked_stale": []}
     assert runner.calls == [
         ("show", "x.1", "--json"),
-        ("list", "--json", "--label", "parked", "--limit", "0"),
+        ("list", "--json", "--all", "--label", "parked", "--limit", "0"),
     ]
     assert not any(call[:1] == ("update",) for call in runner.calls)
 

--- a/scripts/track-backfill/verify.py
+++ b/scripts/track-backfill/verify.py
@@ -121,11 +121,19 @@ def main() -> int:
 
     lint = work(root, "lint")["data"]
     violations = {v["id"] for v in lint["track_violations"]}
-    items = work(root, "list", "--limit", "0")["data"]["items"]
+    # C1 audits live and closed items on different terms, so the two views are
+    # derived here rather than taken from whatever `work list` happens to
+    # return. That default MOVED: protocol 1.13 widened a bare `work list` to
+    # carry every status, where earlier versions omitted closed. This script
+    # runs against whichever `work` is on PATH, which is not necessarily the
+    # one in this checkout, so it must be correct under both — filtering a
+    # superset costs nothing and reading the default costs correctness.
+    listed = work(root, "list", "--limit", "0")["data"]["items"]
+    items = [item for item in listed if item["status"] != "closed"]
 
-    # Closed items are excluded from `work list` by default, which would make a
-    # stray write to a closed item invisible to C1 — and `work track set` has no
-    # status guard, so such a write is possible. Enumerate them explicitly.
+    # Closed items are asked for explicitly, and still must be: a stray write to
+    # a closed item would otherwise be invisible to C1, and `work track set` has
+    # no status guard, so such a write is possible.
     closed = work(root, "list", "--limit", "0", "--status", "closed")["data"]["items"]
 
     failures: list[str] = []


### PR DESCRIPTION
Closes work item `agents-config-9k9.182` (the `work list` closed-by-default bug).

## What was wrong

`work list` reported whatever set of statuses the backend returned when nobody asked, which is live work only. Measured on this repository's own tracker: **89 items returned where 277 exist** — every closed item invisible. The short answer arrived in the same envelope a complete one would, so a caller who had not read the flag list had nothing to tell the two apart. That is the failure the unbounded `--limit` already closed on the row-count axis, and the one `search` closed on this axis in 1.8.

## The decision, and the one rejected

**The default widens.** `work list` with no `--status` now answers every status, closed included; `--status` is the only thing that narrows it. `work ready` is deliberately untouched — it answers the queue question, where closed work has no place, and a caller who wants the queue view of a listing types `list --status open`.

Three pieces of evidence decided this rather than the `search` precedent alone:

- `list` is the general query verb, not the queue. The one queue-shaped caller in this repo (the wayfinder skill) already types `--status open` on every call, so the narrow default was not what queue callers depended on.
- Two in-repo callers were already paying for it. The `where-does-this-fit` skill asks `list --parent <epic>` for the sibling work surrounding an item and silently lost every finished sibling — exactly the context that question wants. `scripts/track-backfill/verify.py` had to issue a second `--status closed` call and merge the two, with a comment explaining the default.
- The only flag value that returns everything today, `--status all`, is documented nowhere in the facade and is not in the backend's own valid-status list either; it works by passing through. So "give me everything" was askable only by knowing an undeclared spelling.

**Rejected: keep the narrow default and disclose it** (an applied-filters key on the envelope). It documents a wrong answer instead of fixing it — the caller still gets 89 of 277 and must issue a second call. It would make the facade publish a default it did not choose, so a second adapter would disclose something different for the same call while the wide default stays portable. It resolves the same shape a third way, where `list`/`ready` already send an unbounded limit rather than disclosing a clip. And it spends a permanent envelope key every consumer must learn to read.

## The seam change underneath

`QueryFilters.status=None` now means "every status, closed included" — what it already meant on `SearchFilters`. It used to mean "whatever the backend lists unasked", which left the facade's answer defined by its backend rather than by the facade.

The four sweeps that act on what a listing returns now state their own live-only narrowing through `model.not_closed`: `lint`/`graph`/`triggers`, the parked staleness report, and `reconcile`'s placeholder and creating-spec sweeps. `verbs/report.py` had already written that filter and commented it against the day this changed. `parked`, `reconcile` and `ready` answer exactly what they answered before — pinned by new tests and mutation-checked by removing each filter and observing red.

## Protocol

**1.12 → 1.13**, MINOR on the same rule 1.8 took: unchanged envelope and `data` shapes, a wider and truer answer to an unchanged call. `packages/executor` is the only package that shells out to the facade; it calls `claim`/`park`/`redispatch`/`abandon`/`close`/`sync`/`parked`/`ready`, never `list`, and pins MAJOR only — nothing there moves.

## Evidence

- `make ci-workcli` — exit 0 (899 unit tests, branch coverage 99.25% against a 90% floor)
- `make itest-workcli` — exit 0 (62 tests against a real isolated backend, including the new listing test)
- The new unit test and the new integration test were both observed failing against the pre-change code; the two behaviour-preservation tests pass either way by nature and were mutation-checked instead.