### PR TITLE
fix(9k9.143): work show answers one shape, whatever its argument count

### DIFF
--- a/packages/executor/src/executor/ports.py
+++ b/packages/executor/src/executor/ports.py
@@ -49,7 +49,7 @@ _NOT_FOUND = 127
 # mismatch rather than risk mis-parsing mid-run -- and for a mutating consumer
 # the timing is the point: checking a reply is too late, because an
 # incompatible facade may already have acted.
-_TRACKER_PROTOCOL_MAJOR = "1"
+_TRACKER_PROTOCOL_MAJOR = "2"
 # The one exit code that carries a verdict rather than an outcome: `grind
 # check` exits 1 on a stale grind while emitting `ok: true`.
 _STALE_EXIT = 1

--- a/packages/executor/tests/unit/test_ports.py
+++ b/packages/executor/tests/unit/test_ports.py
@@ -42,7 +42,7 @@ def _facade(answers: dict[tuple[str, ...], CommandResult]) -> ScriptedRunner:
     Every `WorkTracker` verb pins the protocol first, so a runner without this
     would fail on the handshake rather than on the behaviour under test.
     """
-    return ScriptedRunner({_HANDSHAKE: _ok({"ok": True, "data": {"protocol": "1.3"}}), **answers})
+    return ScriptedRunner({_HANDSHAKE: _ok({"ok": True, "data": {"protocol": "2.0"}}), **answers})
 
 
 def _state_reply() -> CommandResult:
@@ -266,7 +266,7 @@ def test_a_nonzero_exit_from_the_facade_is_a_failure_whatever_it_says() -> None:
     No facade verb carries a verdict in its exit code, so the tolerance never
     applies on this side at all.
     """
-    runner = _facade({("work", "claim"): _ok({"protocol": "1", "ok": True}, 1)})
+    runner = _facade({("work", "claim"): _ok({"protocol": "2.0", "ok": True}, 1)})
 
     with pytest.raises(ExecutorError) as raised:
         WorkTracker(runner).claim("w-1")
@@ -393,7 +393,7 @@ def test_each_tracker_verb_maps_to_its_facade_invocation(
     `work`, and a park's reason reaches `--reason` unchanged.
     """
     runner = _facade(
-        {argv[:2]: _ok({"protocol": "1", "ok": True, "data": {"reason": "ci-failure"}})}
+        {argv[:2]: _ok({"protocol": "2.0", "ok": True, "data": {"reason": "ci-failure"}})}
     )
 
     call(WorkTracker(runner))
@@ -708,8 +708,8 @@ def test_a_partially_applied_facade_failure_still_owes_its_sync() -> None:
 
 @pytest.mark.parametrize(
     "version",
-    ["2.0", "0.9", "", None, 1, "x.1"],
-    ids=["major-2", "major-0", "empty", "null", "int", "unparseable"],
+    ["1.13", "3.0", "", None, 1, "x.1"],
+    ids=["major-1", "major-3", "empty", "null", "int", "unparseable"],
 )
 def test_a_facade_speaking_another_protocol_major_is_refused_before_any_verb(
     version: object,

--- a/packages/workcli/README.md
+++ b/packages/workcli/README.md
@@ -96,12 +96,28 @@ quote are criteria the replacement never reached. Once work has started the
 call additionally requires `--why`, which lands on the marker line beside the
 status the item was in. Setting the criteria already in force writes nothing.
 
-Protocol is `"1.13"` — additive-only bumps (new `ErrorCode` members, the
-derived `Item.track` field and the `acceptance` field beside it, the
+Protocol is `"2.0"`. **MAJOR** is reserved for a breaking change to the
+envelope or to an existing `data` shape, and 2.0 is the first one: `show`
+answered a single id with the item object itself and two or more ids with
+`{"items": [...]}`, and it now answers `{"items": [...]}` for any number of
+ids. A consumer that read `data.id` off a one-id `show` reads
+`data.items[0].id` from 2.0 on, and one that already handled the multi-id
+reply needs no change at all. Nothing else moved: the item object is
+identical, and every other verb answers exactly what it did before. The shape
+had to move because the argument count is frequently not a literal at the call
+site — a script showing whatever ids a previous verb returned got one shape on
+a one-result day and another on a two-result day, and the singular case failed
+by iterating null in the consumer rather than at the source. Pinning the major
+is what makes the break survivable: a consumer refuses an unrecognised facade
+at adapter init rather than mis-parsing a reply mid-run.
+
+Every bump before it was a **MINOR** — additive-only (new `ErrorCode` members,
+the derived `Item.track` field and the `acceptance` field beside it, the
 capability-disposition model, `partial_progress` detail below, `search`'s
 optional narrowing flags, the close-walk's `held` key, the `defer`/`undefer`
-pair, and `acceptance set`) never change an existing envelope or data shape. A
-bump can still change what an unchanged call *answers*, in either direction:
+pair, and `acceptance set`), never changing an existing envelope or data
+shape. A minor can still change what an unchanged call *answers*, in either
+direction:
 1.8 makes `search` read descriptions and notes as well as titles, stop
 excluding closed items, and stop stopping at the first page, so a query that
 used to return nothing may now return matches — and `create <noun>` refuses a
@@ -155,13 +171,13 @@ second, human-readable rendering on stderr.
 Success:
 
 ```json
-{"protocol": "1.13", "ok": true, "data": {"id": "x.1", "title": "..."}, "error": null}
+{"protocol": "2.0", "ok": true, "data": {"items": [{"id": "x.1", "title": "..."}]}, "error": null}
 ```
 
 Failure:
 
 ```json
-{"protocol": "1.13", "ok": false, "data": null,
+{"protocol": "2.0", "ok": false, "data": null,
  "error": {"code": "E_TYPE_WALL", "message": "blocks: epic may not block task",
            "detail": {"from": "x.1", "to": "y.1", "dep_type": "blocks"}}}
 ```
@@ -195,7 +211,7 @@ component; refuse to run against a mismatched facade rather than risk
 mis-parsing mid-run:
 
 ```json
-{"protocol": "1.13", "ok": true, "data": {"protocol": "1.13"}, "error": null}
+{"protocol": "2.0", "ok": true, "data": {"protocol": "2.0"}, "error": null}
 ```
 
 Every other verb's envelope carries the same `protocol` field at the top
@@ -204,9 +220,9 @@ are the same value, always.
 
 ## Data-shape contract
 
-- `show` with one id → `data` IS the item object (never a single-element
-  array). `show` with 2+ ids, `list`, `ready`, `search` → `data =
-  {"items": [...]}`.
+- `show`, `list`, `ready`, `search` → `data = {"items": [...]}`. `show`
+  answers in that shape for one id and for many alike, so a single item is
+  `data.items[0]` and a consumer never branches on its own argument count.
 - Every read item carries `acceptance`: the criteria the item was created
   with, or `null` when it has none. The key is always present on `show`,
   `list`, `ready` and `search` alike, so `null` reads as "this item has no
@@ -233,7 +249,7 @@ are the same value, always.
 - `sync` → `{"synced": ..., "mode": "push" | "pull" | "noop"}`. `"noop"` is
   reserved for server-authoritative backends (the CLI contract spec §6's
   declared no-op); the bd adapter only ever emits `"push"` or `"pull"`.
-- `--protocol-version` → `{"protocol": "1.13"}`.
+- `--protocol-version` → `{"protocol": "2.0"}`.
 
 Human-readable output is opt-in only (`--format human`): it renders the
 envelope's `data` (or `error`) to **stderr**, for direct human use at a

--- a/packages/workcli/src/workcli/__init__.py
+++ b/packages/workcli/src/workcli/__init__.py
@@ -7,4 +7,4 @@ for the behavioral spec this package implements.
 
 from __future__ import annotations
 
-PROTOCOL_VERSION = "1.13"
+PROTOCOL_VERSION = "2.0"

--- a/packages/workcli/src/workcli/verbs/read.py
+++ b/packages/workcli/src/workcli/verbs/read.py
@@ -49,11 +49,16 @@ def _serialize_items(items: list[Item]) -> JsonValue:
 
 
 def show(backend: Backend, args: Namespace) -> JsonValue:
-    """`work show ID...` — one id -> object, 2+ ids -> `{"items": [...]}`."""
-    items = backend.batch_get(args.ids)
-    if len(items) == 1:
-        return _serialize_item(items[0])
-    return _serialize_items(items)
+    """`work show ID...` — always `{"items": [...]}`, one id or many.
+
+    One shape per verb, matching `list`, `ready` and `search`. The count of
+    ids is frequently not a literal at the call site, so a shape that
+    followed it made a consumer branch on its own argument list to parse the
+    reply -- and got the singular case wrong by iterating null rather than by
+    failing at the source. The single item stays reachable as `items[0]`;
+    nothing about the item object itself changed.
+    """
+    return _serialize_items(backend.batch_get(args.ids))
 
 
 def list_(backend: Backend, args: Namespace) -> JsonValue:

--- a/packages/workcli/tests/conftest.py
+++ b/packages/workcli/tests/conftest.py
@@ -40,6 +40,23 @@ def _no_config_loads(_explicit_path: str | None) -> TrackLayerConfig:
     raise AssertionError("config loader unexpectedly invoked; inject config_loader= explicitly")
 
 
+def only_item(data: JsonValue) -> dict[str, JsonValue]:
+    """The single row of a one-id `show` payload, with its arity asserted.
+
+    `show` answers `{"items": [...]}` whatever its argument count, so a test
+    that shows one id says so here rather than by indexing blind: a payload
+    that came back with a different number of rows fails on that fact instead
+    of on whatever the wrong row happens to hold.
+    """
+    assert isinstance(data, dict)
+    items = data["items"]
+    assert isinstance(items, list)
+    assert len(items) == 1, f"expected exactly one row, got {items!r}"
+    row = items[0]
+    assert isinstance(row, dict)
+    return row
+
+
 def run_cli(
     argv: Sequence[str],
     steps: Sequence[ScriptedStep],

--- a/packages/workcli/tests/integration/test_acceptance_roundtrip.py
+++ b/packages/workcli/tests/integration/test_acceptance_roundtrip.py
@@ -42,7 +42,7 @@ def _create(driver, title: str, *argv: str) -> str:
 def test_show_returns_the_acceptance_the_item_was_created_with(driver):
     item_id = _create(driver, "ac-roundtrip", "--acceptance", _CRITERIA)
 
-    shown = driver(["show", item_id])["data"]  # single-id show → item directly
+    shown = driver(["show", item_id])["data"]["items"][0]  # show → {"items": [...]}
 
     assert shown["acceptance"] == _CRITERIA
 
@@ -50,7 +50,7 @@ def test_show_returns_the_acceptance_the_item_was_created_with(driver):
 def test_an_item_created_without_acceptance_reports_none_rather_than_omitting_it(driver):
     item_id = _create(driver, "ac-roundtrip-none")
 
-    shown = driver(["show", item_id])["data"]
+    shown = driver(["show", item_id])["data"]["items"][0]
 
     assert "acceptance" in shown, "an absent key would say this read never fetched the criteria"
     assert shown["acceptance"] is None
@@ -85,7 +85,7 @@ def test_a_correction_replaces_the_criteria_and_leaves_the_old_text_readable(dri
 
     assert corrected["ok"] is True, corrected
     assert corrected["data"]["previous"] == _CRITERIA
-    shown = driver(["show", item_id])["data"]
+    shown = driver(["show", item_id])["data"]["items"][0]
     assert shown["acceptance"] == _CORRECTED
     assert _CRITERIA not in shown["acceptance"]
     assert f"> {_CRITERIA}" in shown["notes"]
@@ -100,7 +100,7 @@ def test_multi_line_criteria_survive_the_round_trip_quoted_line_by_line(driver):
 
     driver(["acceptance", "set", item_id, _CORRECTED])
 
-    notes = driver(["show", item_id])["data"]["notes"]
+    notes = driver(["show", item_id])["data"]["items"][0]["notes"]
     assert "> AC1 the first thing." in notes
     assert "> AC2 the second thing." in notes
 
@@ -113,11 +113,11 @@ def test_a_claimed_item_refuses_a_silent_correction_and_records_a_stated_one(dri
 
     assert refused["ok"] is False
     assert refused["error"]["code"] == "E_FIELD_CLOBBER_GUARD"
-    assert driver(["show", item_id])["data"]["acceptance"] == _CRITERIA
+    assert driver(["show", item_id])["data"]["items"][0]["acceptance"] == _CRITERIA
 
     stated = driver(["acceptance", "set", item_id, _CORRECTED, "--why", "AC1 was ambiguous"])
 
     assert stated["ok"] is True, stated
-    shown = driver(["show", item_id])["data"]
+    shown = driver(["show", item_id])["data"]["items"][0]
     assert shown["acceptance"] == _CORRECTED
     assert "while in_progress: AC1 was ambiguous" in shown["notes"]

--- a/packages/workcli/tests/integration/test_crash_recovery.py
+++ b/packages/workcli/tests/integration/test_crash_recovery.py
@@ -94,7 +94,7 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
     # in-band manifest snapshot the appends recorded before the fault is present
     # — that snapshot is what `reconcile` replays off, so its persistence proves
     # the fault landed after the appends and before the shape mutation.
-    mid = drive(["show", placeholder])["data"]
+    mid = drive(["show", placeholder])["data"]["items"][0]
     assert "impl-placeholder" in mid["labels"]
     assert "shape-feat" not in mid["labels"]
     assert "[work] manifest:" in mid["notes"]
@@ -108,21 +108,23 @@ def test_interrupted_deliver_is_healed_by_reconcile(fresh_install, bd_binary):
     # (delivery complete), spec-ready is stamped, and the placeholder keeps
     # its manifest-noun shape — the instantiation sweep must never re-finalize
     # it into a planned shape-spec container (wgclw.9.8).
-    healed = drive(["show", placeholder])["data"]
+    healed = drive(["show", placeholder])["data"]["items"][0]
     assert "impl-placeholder" not in healed["labels"]  # handle removed strictly last
     assert "spec-ready" in healed["labels"]
     assert "shape-feat" in healed["labels"]  # manifest-noun shape survives the sweep
     assert "creating-spec" not in healed["labels"]
     assert "planned" not in healed["labels"]
-    assert drive(["show", design_child])["data"]["status"] == "closed"
+    assert drive(["show", design_child])["data"]["items"][0]["status"] == "closed"
 
 
 def _design_and_placeholder(drive, container_id: str) -> tuple[str, str]:
     """Return (design_child_id, placeholder_id): the container's two children."""
-    children = drive(["show", container_id])["data"]["children"]  # single-id show
+    children = drive(["show", container_id])["data"]["items"][0][
+        "children"
+    ]  # show → {"items": [...]}
     design_child = placeholder = None
     for child_id in children:
-        labels = drive(["show", child_id])["data"]["labels"]
+        labels = drive(["show", child_id])["data"]["items"][0]["labels"]
         if "shape-design" in labels:
             design_child = child_id
         else:

--- a/packages/workcli/tests/integration/test_defer.py
+++ b/packages/workcli/tests/integration/test_defer.py
@@ -30,17 +30,17 @@ def test_defer_drops_a_real_item_out_of_ready_and_undefer_brings_it_back(driver)
     deferred = driver(["defer", item_id, "--note", "nobody has picked this up"])
     assert deferred["ok"] is True
     assert deferred["data"] == {"id": item_id, "status": "deferred"}
-    assert driver(["show", item_id])["data"]["status"] == "deferred"
+    assert driver(["show", item_id])["data"]["items"][0]["status"] == "deferred"
     assert item_id not in _ready_ids(driver)
 
     returned = driver(["undefer", item_id])
     assert returned["ok"] is True
     assert returned["data"] == {"id": item_id, "status": "open"}
-    assert driver(["show", item_id])["data"]["status"] == "open"
+    assert driver(["show", item_id])["data"]["items"][0]["status"] == "open"
     assert item_id in _ready_ids(driver)
 
     # One marker per transition, and both survived the round trip.
-    notes = driver(["show", item_id])["data"]["notes"]
+    notes = driver(["show", item_id])["data"]["items"][0]["notes"]
     assert notes.count("[work] deferred") == 1
     assert notes.count("[work] undeferred") == 1
 
@@ -65,8 +65,8 @@ def test_a_read_envelope_tells_a_deferred_item_from_a_parked_one(driver):
     assert driver(["claim", stuck])["ok"] is True
     assert driver(["park", stuck, "--reason", "ci-failure"])["ok"] is True
 
-    idea_item = driver(["show", idea])["data"]
-    stuck_item = driver(["show", stuck])["data"]
+    idea_item = driver(["show", idea])["data"]["items"][0]
+    stuck_item = driver(["show", stuck])["data"]["items"][0]
 
     assert idea_item["status"] == "deferred"
     assert "parked" not in idea_item["labels"]
@@ -80,9 +80,9 @@ def test_the_transitions_replay_idempotently_against_real_state(driver):
     first = driver(["defer", item_id])
     second = driver(["defer", item_id])
     assert first["data"] == second["data"] == {"id": item_id, "status": "deferred"}
-    assert driver(["show", item_id])["data"]["notes"].count("[work] deferred") == 1
+    assert driver(["show", item_id])["data"]["items"][0]["notes"].count("[work] deferred") == 1
 
     third = driver(["undefer", item_id])
     fourth = driver(["undefer", item_id])
     assert third["data"] == fourth["data"] == {"id": item_id, "status": "open"}
-    assert driver(["show", item_id])["data"]["notes"].count("[work] undeferred") == 1
+    assert driver(["show", item_id])["data"]["items"][0]["notes"].count("[work] undeferred") == 1

--- a/packages/workcli/tests/integration/test_lifecycle.py
+++ b/packages/workcli/tests/integration/test_lifecycle.py
@@ -27,7 +27,9 @@ def test_create_claim_deliver_trivial_then_reconcile_noop(driver):
     # A leaf delivery with trivial evidence closes it.
     delivered = driver(["deliver", item_id, "--trivial"])
     assert delivered["ok"] is True
-    assert driver(["show", item_id])["data"]["status"] == "closed"  # single-id show
+    assert (
+        driver(["show", item_id])["data"]["items"][0]["status"] == "closed"
+    )  # show → {"items": [...]}
     # reconcile with nothing recoverable is a clean no-op.
     swept = driver(["reconcile"])
     assert swept["ok"] is True
@@ -55,7 +57,7 @@ def test_plan_add_then_done(driver):
     added = driver(["plan", item_id, "--done"])
     assert added["ok"] is True
     assert added["data"]["planned"] is True
-    assert "planned" in driver(["show", item_id])["data"]["labels"]
+    assert "planned" in driver(["show", item_id])["data"]["items"][0]["labels"]
     # Idempotent replay: PLANNED_LABEL already present short-circuits to the
     # same result rather than erroring or double-adding the label.
     replayed = driver(["plan", item_id, "--done"])
@@ -82,4 +84,6 @@ def test_promote_leaf_to_spec_container(driver):
     promoted = driver(["promote", leaf])
     assert promoted["ok"] is True
     assert promoted["data"]["promoted"] == "spec"
-    assert "shape-spec" in driver(["show", leaf])["data"]["labels"]  # single-id show
+    assert (
+        "shape-spec" in driver(["show", leaf])["data"]["items"][0]["labels"]
+    )  # show → {"items": [...]}

--- a/packages/workcli/tests/integration/test_nouns.py
+++ b/packages/workcli/tests/integration/test_nouns.py
@@ -36,7 +36,7 @@ def test_create_noun_stamps_type_and_shape_label(driver, noun, item_type, shape_
     )
     assert created["ok"] is True, created
     item_id = created["data"]["id"]  # create → {"id": ...}
-    shown = driver(["show", item_id])["data"]  # single-id show → item directly
+    shown = driver(["show", item_id])["data"]["items"][0]  # show → {"items": [...]}
     assert shown["type"] == item_type  # Item field is `type`, not `issue_type`
     assert shape_label in shown["labels"]
     assert f"track:{ITEST_TRACK}" in shown["labels"]  # --track lands as the track label
@@ -63,8 +63,8 @@ def test_create_spec_children_carry_exactly_their_own_labels(driver):
         ]
     )
     assert created["ok"] is True, created
-    design = driver(["show", created["data"]["design_child"]])["data"]
-    placeholder = driver(["show", created["data"]["placeholder"]])["data"]
+    design = driver(["show", created["data"]["design_child"]])["data"]["items"][0]
+    placeholder = driver(["show", created["data"]["placeholder"]])["data"]["items"][0]
     # The container's track propagates to both children (create.py:
     # instantiate_spec_shape stamps track_label on each), so the exact sets are
     # the child's own label plus that track — and nothing inherited.

--- a/packages/workcli/tests/integration/test_parent_arity.py
+++ b/packages/workcli/tests/integration/test_parent_arity.py
@@ -34,7 +34,7 @@ def _children_edges(driver, item_id: str) -> list[str]:
 
 def _assert_parent_is(driver, item_id: str, expected: str) -> None:
     """The scalar and the edges must agree, and there must be exactly one edge."""
-    assert driver(["show", item_id])["data"]["parent"] == expected
+    assert driver(["show", item_id])["data"]["items"][0]["parent"] == expected
     assert _parent_edges(driver, item_id) == [expected]
 
 

--- a/packages/workcli/tests/integration/test_verbs_happy.py
+++ b/packages/workcli/tests/integration/test_verbs_happy.py
@@ -18,12 +18,31 @@ def test_show_returns_exact_seeded_fields(read_only_driver):
     alpha_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-alpha")
     env = read_only_driver(["show", alpha_id])
     assert env["ok"] is True
-    item = env["data"]  # single-id show → item object directly
+    item = env["data"]["items"][0]  # show → {"items": [...]}
     assert item["id"] == alpha_id
     assert item["title"] == "seed-alpha"
     assert item["status"] == "open"
     assert item["priority"] == "P2"  # priority is a string, not int
     assert "seed" in item["labels"]  # value-level: label round-trips
+
+
+def test_show_answers_one_id_in_the_same_shape_as_many(read_only_driver):
+    """The uniform-shape contract, on the wire against a real backend.
+
+    The hermetic suite pins the same thing over a scripted runner. This is the
+    half that scripting cannot vouch for: whatever the backend hands back for
+    one id versus several, the envelope a consumer parses is the same shape.
+    """
+    listing = read_only_driver(["list"])["data"]["items"]
+    alpha_id = next(i["id"] for i in listing if i["title"] == "seed-alpha")
+    child_id = next(i["id"] for i in listing if i["title"] == "seed-child")
+
+    singular = read_only_driver(["show", alpha_id])
+    plural = read_only_driver(["show", alpha_id, child_id])
+
+    assert list(singular["data"]) == list(plural["data"]) == ["items"]
+    assert [i["id"] for i in singular["data"]["items"]] == [alpha_id]
+    assert {i["id"] for i in plural["data"]["items"]} == {alpha_id, child_id}
 
 
 def test_list_filter_by_label(read_only_driver):
@@ -35,7 +54,7 @@ def test_list_filter_by_label(read_only_driver):
 def test_show_child_reports_seeded_parent(read_only_driver):
     listing = read_only_driver(["list"])
     child_id = next(i["id"] for i in listing["data"]["items"] if i["title"] == "seed-child")
-    item = read_only_driver(["show", child_id])["data"]  # single-id show → item directly
+    item = read_only_driver(["show", child_id])["data"]["items"][0]  # show → {"items": [...]}
     assert item["parent"] is not None  # value-level: parent edge survives
 
 
@@ -63,16 +82,16 @@ def test_create_raw_update_note_close_reopen_roundtrip(driver):
     item_id = created["data"]["id"]  # create → {"id": ...}
 
     driver(["update", item_id, "--set-title", "wv-one-renamed"])
-    assert driver(["show", item_id])["data"]["title"] == "wv-one-renamed"  # value-level
+    assert driver(["show", item_id])["data"]["items"][0]["title"] == "wv-one-renamed"  # value-level
 
     driver(["note", item_id, "a durable note"])
-    assert "a durable note" in driver(["show", item_id])["data"]["notes"]
+    assert "a durable note" in driver(["show", item_id])["data"]["items"][0]["notes"]
 
     assert driver(["close", item_id])["ok"] is True
-    assert driver(["show", item_id])["data"]["status"] == "closed"
+    assert driver(["show", item_id])["data"]["items"][0]["status"] == "closed"
 
     assert driver(["reopen", item_id])["ok"] is True
-    assert driver(["show", item_id])["data"]["status"] == "open"
+    assert driver(["show", item_id])["data"]["items"][0]["status"] == "open"
 
 
 def test_label_add_list_remove(driver):
@@ -104,5 +123,5 @@ def test_claim_and_release(driver):
         ["create", "--raw", "--title", "wv-claim", "--type", "task", "--priority", "2"]
     )["data"]["id"]
     assert driver(["claim", item_id])["ok"] is True
-    assert driver(["show", item_id])["data"]["status"] == "in_progress"
+    assert driver(["show", item_id])["data"]["items"][0]["status"] == "in_progress"
     assert driver(["release", item_id])["ok"] is True

--- a/packages/workcli/tests/unit/test_acceptance_read.py
+++ b/packages/workcli/tests/unit/test_acceptance_read.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import run_cli
+from tests.conftest import only_item, run_cli
 from tests.fake_backend import FakeBackend
 from tests.fakes import ScriptedStep
 from workcli.adapters.bd.parse import parse_item
@@ -170,9 +170,8 @@ def test_show_returns_the_acceptance_an_item_was_created_with() -> None:
     backend = FakeBackend()
     new_id = _created(backend, acceptance=_CRITERIA)
 
-    shown = show(backend, _read_args(ids=[new_id]))
+    shown = only_item(show(backend, _read_args(ids=[new_id])))
 
-    assert isinstance(shown, dict)
     assert shown["acceptance"] == _CRITERIA
 
 
@@ -180,9 +179,8 @@ def test_show_reports_null_for_an_item_created_without_acceptance() -> None:
     backend = FakeBackend()
     new_id = _created(backend, acceptance=None)
 
-    shown = show(backend, _read_args(ids=[new_id]))
+    shown = only_item(show(backend, _read_args(ids=[new_id])))
 
-    assert isinstance(shown, dict)
     assert "acceptance" in shown, (
         "an absent key means this read did not fetch the criteria; an item that "
         "has none must say so with a value"

--- a/packages/workcli/tests/unit/test_defer.py
+++ b/packages/workcli/tests/unit/test_defer.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from tests.conftest import only_item
 from tests.fake_backend import FakeBackend, ReadOnlyFakeBackend
 from workcli.envelope import ErrorCode, WorkError
 from workcli.lifecycle.defer import (
@@ -167,10 +168,8 @@ def test_a_read_envelope_tells_a_deferred_item_from_a_parked_one():
     defer(backend, _defer_args("idea"))
     park(backend, _park_args("stuck", "ci-failure"))
 
-    idea = show(backend, Namespace(ids=["idea"]))
-    stuck = show(backend, Namespace(ids=["stuck"]))
-    assert isinstance(idea, dict)
-    assert isinstance(stuck, dict)
+    idea = only_item(show(backend, Namespace(ids=["idea"])))
+    stuck = only_item(show(backend, Namespace(ids=["stuck"])))
     assert idea["status"] == "deferred"
     assert stuck["status"] == "blocked"
     assert PARKED_LABEL not in idea["labels"]
@@ -188,11 +187,9 @@ def test_the_two_states_stay_legible_apart_with_every_note_removed():
     backend.add("idea", status=DEFERRED_STATUS, notes="")
     backend.add("stuck", status="blocked", labels=[PARKED_LABEL], notes="")
 
-    idea = show(backend, Namespace(ids=["idea"]))
-    stuck = show(backend, Namespace(ids=["stuck"]))
+    idea = only_item(show(backend, Namespace(ids=["idea"])))
+    stuck = only_item(show(backend, Namespace(ids=["stuck"])))
 
-    assert isinstance(idea, dict)
-    assert isinstance(stuck, dict)
     assert idea["notes"] == stuck["notes"] == ""
     assert idea["status"] != stuck["status"]
     assert (idea["status"], PARKED_LABEL in idea["labels"]) == ("deferred", False)

--- a/packages/workcli/tests/unit/test_format_human.py
+++ b/packages/workcli/tests/unit/test_format_human.py
@@ -41,6 +41,20 @@ def test_format_human_stdout_is_byte_identical_to_json_default_and_stderr_is_non
     assert human_stderr != ""
 
 
+def test_a_one_id_show_renders_through_the_same_items_list_as_any_read() -> None:
+    # The renderer is deliberately generic: it walks whatever `data` holds and
+    # knows no verb names. So `show` moving to `{"items": [...]}` moves the
+    # human view with it, and a one-id show now reads like the listing verbs
+    # rather than like a special case. Teaching the renderer that `show` with
+    # one row should be flattened would put a verb's identity into a module
+    # that has none, and would make the human view disagree with the JSON
+    # envelope printed beside it.
+    _, _, stderr_text = _run(["--format", "human", "show", "x.1"])
+
+    assert stderr_text.splitlines()[:3] == ["ok", "items:", "  -"]
+    assert "    id: x.1" in stderr_text
+
+
 def test_format_json_default_never_writes_to_stderr() -> None:
     _, _, stderr_text = _run(["show", "x.1"])
 

--- a/packages/workcli/tests/unit/test_item_track_field.py
+++ b/packages/workcli/tests/unit/test_item_track_field.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from tests.conftest import run_cli
+from tests.conftest import only_item, run_cli
 from tests.fakes import ScriptedStep
 from workcli.adapters.bd.runner import BdResult
 
@@ -39,17 +39,13 @@ def test_show_carries_derived_track() -> None:
         ["show", "w-1"], [_show_step("w-1", ["track:installer", "planned"])]
     )
     assert exit_code == 0
-    data = envelope["data"]
-    assert isinstance(data, dict)
-    assert data["track"] == "installer"
+    assert only_item(envelope["data"])["track"] == "installer"
 
 
 def test_show_zero_or_multi_track_labels_carry_null() -> None:
     exit_code, envelope, _ = run_cli(["show", "w-1"], [_show_step("w-1", ["track:a", "track:b"])])
     assert exit_code == 0
-    data = envelope["data"]
-    assert isinstance(data, dict)
-    assert data["track"] is None
+    assert only_item(envelope["data"])["track"] is None
 
 
 @pytest.mark.parametrize(

--- a/packages/workcli/tests/unit/test_protocol_handshake.py
+++ b/packages/workcli/tests/unit/test_protocol_handshake.py
@@ -152,7 +152,22 @@ def test_protocol_wire_value_is_pinned() -> None:
     # item was acting on a listing that had been narrowed for it without being
     # told. `ready` is deliberately untouched: it answers the queue question,
     # and closed work is not in a queue.
-    assert PROTOCOL_VERSION == "1.13"
+    #
+    # 2.0 is the first MAJOR, and the first bump none of the notes above could
+    # have carried: `show` answered a single id with the item object and two or
+    # more with `{"items": [...]}`, and it now answers `{"items": [...]}` in
+    # both cases. That is a breaking change to an existing `data` shape -- the
+    # one thing the rule reserves the major for. Unlike every case from 1.5 on,
+    # there is correct behaviour to lose: the old singular answer was a true
+    # answer to the call, just a differently-shaped one, so a consumer reading
+    # `data.id` off a one-id `show` was right and now reads a key that is not
+    # there. It moves to `data.items[0]`. Why the shape had to move at all: the
+    # argument count is frequently not a literal at the call site, so a caller
+    # had to branch on its own arguments to parse the reply, and the singular
+    # case failed by iterating null rather than at the source. The major is
+    # what makes that survivable -- a consumer pinning it refuses an
+    # unrecognised facade at adapter init, before it mis-parses anything.
+    assert PROTOCOL_VERSION == "2.0"
 
 
 def test_the_readme_states_the_protocol_version_the_code_emits() -> None:

--- a/packages/workcli/tests/unit/test_read_relationship_contract.py
+++ b/packages/workcli/tests/unit/test_read_relationship_contract.py
@@ -250,8 +250,9 @@ def test_the_in_memory_backend_holds_the_same_contract_as_bd(verb: str) -> None:
     # verb-level regression that trusts a search result's parent fails here
     # without a real bd anywhere near it.
     backend = _tree()
-    shown = show(backend, _read_args(ids=["c-1"]))
-    assert isinstance(shown, dict)
+    # `show` answers in the same `{"items": [...]}` shape as the three verbs
+    # under test, so the one row-picker serves all four.
+    shown = _one(show(backend, _read_args(ids=["c-1"])), "c-1")
     reads = {
         "search": lambda: search(backend, _read_args(query="child")),
         "list": lambda: list_(backend, _read_args()),

--- a/packages/workcli/tests/unit/test_show_normalization.py
+++ b/packages/workcli/tests/unit/test_show_normalization.py
@@ -1,9 +1,8 @@
 """`show` verb normalization.
 
-A single id must yield an object (never a single-element array), with lean
-dep edges (`{id, type, status}`) and `string[]` labels. Multiple ids must
-yield `data == {"items": [...]}`. Both drive the real CLI end-to-end through
-`ScriptedBdRunner`.
+`data == {"items": [...]}` for one id and for many alike, and each row is a
+lean item: dep edges as `{id, type, status}`, labels as bare `string[]`.
+Every test here drives the real CLI end-to-end through `ScriptedBdRunner`.
 """
 
 from __future__ import annotations
@@ -11,7 +10,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from tests.conftest import run_cli, run_cli_with_runner
+from tests.conftest import only_item, run_cli, run_cli_with_runner
 from tests.fakes import ScriptedBdRunner, ScriptedStep
 from workcli.adapters.bd.runner import BdResult
 from workcli.envelope import ErrorCode
@@ -23,7 +22,7 @@ def _read(name: str) -> str:
     return (FIXTURES / name).read_text()
 
 
-def test_show_single_id_returns_a_lean_object_not_an_array():
+def test_show_single_id_returns_a_lean_item():
     exit_code, envelope, stderr_text = run_cli(
         ["show", "agents-config-wgclw.9.1"],
         steps=[
@@ -36,17 +35,16 @@ def test_show_single_id_returns_a_lean_object_not_an_array():
 
     assert exit_code == 0
     assert stderr_text == ""
-    data = envelope["data"]
-    assert isinstance(data, dict)
-    assert data["id"] == "agents-config-wgclw.9.1"
+    item = only_item(envelope["data"])
+    assert item["id"] == "agents-config-wgclw.9.1"
     # Lean labels: bare string[], not embedded objects.
-    assert data["labels"] == ["implementation-ready", "shape-feat", "vision-85-5-10"]
+    assert item["labels"] == ["implementation-ready", "shape-feat", "vision-85-5-10"]
     # The fixture's one `dependencies[]` entry is parent-child (filtered out
     # of `deps`, since it's the item's own parent edge, not a real
     # dependency); its one `dependents[]` entry is `dependency_type: blocks`,
     # not parent-child, so it is not a child either.
-    assert data["deps"] == []
-    assert data["children"] == []
+    assert item["deps"] == []
+    assert item["children"] == []
 
 
 def test_show_single_id_with_a_real_dependency_yields_a_lean_dep_edge():
@@ -67,11 +65,49 @@ def test_show_single_id_with_a_real_dependency_yields_a_lean_dep_edge():
 
     assert exit_code == 0
     assert stderr_text == ""
-    data = envelope["data"]
-    assert isinstance(data, dict)
-    assert data["deps"] == [
+    assert only_item(envelope["data"])["deps"] == [
         {"id": "agents-config-fca6.12", "type": "discovered-from", "status": "closed"}
     ]
+
+
+def test_show_answers_one_id_in_the_same_shape_it_answers_many():
+    # The uniform-shape contract, and the reason the two tests above read
+    # through `items[0]`. One id used to answer with the item itself and two
+    # or more with `{"items": [...]}`, so a consumer could not write one
+    # accessor for the verb -- and the argument count is frequently not a
+    # literal at the call site: a script showing whatever ids a previous verb
+    # returned got one shape on a one-result day and another on a two-result
+    # day. The two answers now differ in the length of `items` and in nothing
+    # else, which is what this asserts rather than the singular case alone.
+    raw = {
+        "id": "x.1",
+        "title": "First",
+        "issue_type": "task",
+        "status": "open",
+        "priority": 2,
+        "labels": [],
+        "dependencies": [],
+        "dependents": [],
+    }
+    singular = run_cli(
+        ["show", "x.1"],
+        steps=[
+            ScriptedStep(("show",), BdResult(returncode=0, stdout=json.dumps([raw]), stderr=""))
+        ],
+    )[1]
+    plural = run_cli(
+        ["show", "x.1", "x.2"],
+        steps=[
+            ScriptedStep(
+                ("show",),
+                BdResult(returncode=0, stdout=json.dumps([raw, {**raw, "id": "x.2"}]), stderr=""),
+            )
+        ],
+    )[1]
+
+    assert list(singular["data"].keys()) == list(plural["data"].keys()) == ["items"]
+    assert [item["id"] for item in singular["data"]["items"]] == ["x.1"]
+    assert [item["id"] for item in plural["data"]["items"]] == ["x.1", "x.2"]
 
 
 def test_show_two_ids_returns_an_items_array():

--- a/scripts/track-backfill/README.md
+++ b/scripts/track-backfill/README.md
@@ -62,7 +62,7 @@ which spans every run rather than resetting per migration.
 
 ## Tests
 
-    cd scripts/track-backfill && python3 -m unittest test_reconcile test_payload_keys test_apply_contract test_gen_expected_mismatches test_verify_c1
+    cd scripts/track-backfill && python3 -m unittest test_reconcile test_payload_keys test_apply_contract test_gen_expected_mismatches test_verify_c1 test_show_shape
 
 `test_apply_contract.py` pins `set_track`'s failure classification by substituting
 the backend. It exists because a regression shipped here: the shared `work()`
@@ -76,6 +76,15 @@ deliberately **non-empty** fixtures. That is not incidental: a wrong key was
 shipped and survived a live run precisely because the list it indexed was empty,
 so the loop body never executed. An empty fixture cannot tell a right key from a
 wrong one.
+
+`test_show_shape.py` pins that `context.show` reads **both** `work show` reply
+shapes. These scripts shell out to whichever `work` is on PATH, which is not
+necessarily the one built in the checkout they run from: protocol 2.0 made
+`work show ID` answer `{"items": [...]}` where earlier versions answered a
+single id with the item object directly, so a helper written for either shape
+alone breaks against half the installations in existence. The same hazard, one
+verb over, is what verify.py's C1 comment records about the `work list` status
+default.
 
 ## Recovery
 

--- a/scripts/track-backfill/anchor_orphans.py
+++ b/scripts/track-backfill/anchor_orphans.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from context import HERE, data, resolve_root
+from context import HERE, data, resolve_root, show
 
 # child -> intended parent. Each item's own description names this milestone.
 ANCHORS = {
@@ -45,7 +45,7 @@ LABEL = "lint-exempt:no-milestone"
 
 def anchor(root, apply: bool) -> None:
     for child, parent in ANCHORS.items():
-        item = data(root, "show", child)
+        item = show(root, child)["data"]
         if item["status"] == "closed":
             raise SystemExit(
                 f"ABORT {child}: closed since the artifact was generated — "
@@ -68,7 +68,7 @@ def anchor(root, apply: bool) -> None:
 
 def exempt(root, apply: bool) -> None:
     for item_id in EXEMPT:
-        item = data(root, "show", item_id)
+        item = show(root, item_id)["data"]
         if item["status"] == "closed":
             print(f"  SKIP {item_id}: closed since generation, no exemption needed")
             continue
@@ -86,11 +86,11 @@ def verify(root) -> None:
     """Assert the exact intended mapping — printing parents is not verifying."""
     failures: list[str] = []
     for child, parent in ANCHORS.items():
-        got = data(root, "show", child)["parent"]
+        got = show(root, child)["data"]["parent"]
         if got != parent:
             failures.append(f"{child} parent is {got}, expected {parent}")
     for item_id in EXEMPT:
-        item = data(root, "show", item_id)
+        item = show(root, item_id)["data"]
         if item["status"] != "closed" and LABEL not in item["labels"]:
             failures.append(f"{item_id} is live but not exempt")
     if failures:

--- a/scripts/track-backfill/context.py
+++ b/scripts/track-backfill/context.py
@@ -97,3 +97,30 @@ def work(root: pathlib.Path, *argv: str, require_ok: bool = True) -> dict:
 def data(root: pathlib.Path, *argv: str) -> dict:
     """`work(...)` unwrapped to its data payload."""
     return work(root, *argv)["data"]
+
+
+def show(root: pathlib.Path, item_id: str, *, require_ok: bool = True) -> dict:
+    """`work show ID`'s envelope, with `data` normalized to the item itself.
+
+    The verb answers `{"items": [...]}` from protocol 2.0 on, where every
+    earlier version answered a single id with the item object directly. These
+    scripts run against whichever `work` is on PATH, which is not necessarily
+    the one in this checkout, so both shapes must parse — the same hazard the
+    `work list` status default moved under, one verb over (see verify.py's C1).
+    An `items` key is the discriminator: an item object has no such field.
+
+    The unwrap is here rather than in `data()` because `data()` serves every
+    verb, and the list-shaped reads mean their `items` wrapper.
+    """
+    envelope = work(root, "show", item_id, require_ok=require_ok)
+    payload = envelope.get("data")
+    if isinstance(payload, dict) and "items" in payload:
+        items = payload["items"]
+        # A one-id show returns one row. Anything else means the reply is not
+        # what was asked for, and taking the first row would hide that.
+        if len(items) != 1:
+            raise SystemExit(
+                f"`work show {item_id}` returned {len(items)} item(s); expected exactly one"
+            )
+        envelope = {**envelope, "data": items[0]}
+    return envelope

--- a/scripts/track-backfill/test_show_shape.py
+++ b/scripts/track-backfill/test_show_shape.py
@@ -1,0 +1,71 @@
+"""Pin that both `work show` reply shapes still parse.
+
+These scripts shell out to whichever `work` is on PATH, which is not
+necessarily the one built in this checkout. Protocol 2.0 made `work show ID`
+answer `{"items": [...]}`, where every earlier version answered a single id
+with the item object directly — so a helper written for either shape alone
+breaks against half the installations that exist right now. `context.show`
+reads both, and that is the whole of what is tested here.
+
+The same hazard, one verb over, is recorded in verify.py's C1 comment: a
+default that MOVED between protocol versions, read by a script that does not
+control which version it gets.
+"""
+
+import unittest
+from unittest import mock
+
+import context
+
+_ITEM = {
+    "id": "agents-config-x1",
+    "status": "open",
+    "parent": None,
+    "labels": ["track:workcli"],
+    "track": "workcli",
+}
+
+_OLD_SHAPE = {"protocol": "1.13", "ok": True, "data": dict(_ITEM), "error": None}
+_NEW_SHAPE = {"protocol": "2.0", "ok": True, "data": {"items": [dict(_ITEM)]}, "error": None}
+_NOT_FOUND = {
+    "protocol": "2.0",
+    "ok": False,
+    "data": None,
+    "error": {"code": "E_NOT_FOUND", "message": "no such item", "detail": None},
+}
+
+
+class TestShowReadsBothShapes(unittest.TestCase):
+    def _shown(self, envelope, **kwargs):
+        with mock.patch.object(context, "work", return_value=envelope) as ran:
+            got = context.show("/repo", "agents-config-x1", **kwargs)
+        self.assertEqual(ran.call_args.args[1:], ("show", "agents-config-x1"))
+        return got
+
+    def test_the_pre_2_0_singular_shape_still_parses(self):
+        """The installed `work` may predate the bump; it must keep working."""
+        self.assertEqual(self._shown(_OLD_SHAPE)["data"], _ITEM)
+
+    def test_the_2_0_items_shape_parses_to_the_same_item(self):
+        self.assertEqual(self._shown(_NEW_SHAPE)["data"], _ITEM)
+
+    def test_both_shapes_hand_the_caller_the_identical_payload(self):
+        # The point of the helper: a caller reads one thing and never learns
+        # which facade answered it.
+        self.assertEqual(self._shown(_OLD_SHAPE), {**self._shown(_NEW_SHAPE), "protocol": "1.13"})
+
+    def test_a_failing_envelope_is_returned_intact_for_the_caller_to_read(self):
+        # verify.py's C6 asks whether the groom-state item exists at all, so a
+        # failure is its finding rather than an abort.
+        got = self._shown(_NOT_FOUND, require_ok=False)
+        self.assertIs(got["ok"], False)
+        self.assertIsNone(got["data"])
+
+    def test_a_reply_carrying_more_than_one_row_aborts_rather_than_taking_the_first(self):
+        many = {"protocol": "2.0", "ok": True, "data": {"items": [_ITEM, _ITEM]}, "error": None}
+        with self.assertRaises(SystemExit):
+            self._shown(many)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/track-backfill/test_show_shape.py
+++ b/scripts/track-backfill/test_show_shape.py
@@ -12,6 +12,7 @@ default that MOVED between protocol versions, read by a script that does not
 control which version it gets.
 """
 
+import pathlib
 import unittest
 from unittest import mock
 
@@ -38,7 +39,7 @@ _NOT_FOUND = {
 class TestShowReadsBothShapes(unittest.TestCase):
     def _shown(self, envelope, **kwargs):
         with mock.patch.object(context, "work", return_value=envelope) as ran:
-            got = context.show("/repo", "agents-config-x1", **kwargs)
+            got = context.show(pathlib.Path("/repo"), "agents-config-x1", **kwargs)
         self.assertEqual(ran.call_args.args[1:], ("show", "agents-config-x1"))
         return got
 

--- a/scripts/track-backfill/verify.py
+++ b/scripts/track-backfill/verify.py
@@ -10,7 +10,7 @@ import collections
 import json
 import tomllib
 
-from context import HERE, resolve_root, work
+from context import HERE, resolve_root, show, work
 
 RUNLOG = HERE / "applied.log"
 
@@ -236,7 +236,7 @@ def main() -> int:
     if not groom_item:
         failures.append("C6 groom-state-item empty")
     else:
-        got = work(root, "show", groom_item, require_ok=False)
+        got = show(root, groom_item, require_ok=False)
         if not got.get("ok"):
             failures.append(f"C6 groom-state-item {groom_item} does not exist")
         else:


### PR DESCRIPTION
Tracker item: `agents-config-9k9.143` — *work show returns two different envelope shapes depending on how many ids it is given*.

## What changed

`work show ID` returned the item object directly as `data`; `work show ID ID` returned `{"items": [...]}`. A consumer could not write one accessor for the verb: `.data.items[]` failed the singular call by iterating null, and `.data` returned a wrapper on the plural one. `show` now answers `{"items": [...]}` for any number of ids, matching `list`, `ready` and `search` — the plural shape was already the house norm and `show` was the outlier.

Why it mattered beyond tidiness: the argument count is frequently not a literal at the call site. A script showing whatever ids a previous verb returned got one shape on a one-result day and another on a two-result day, and the singular case failed by iterating null in the consumer rather than by erroring at the source.

## Why this is a MAJOR

Protocol moves **1.13 → 2.0**. Every bump since 1.0 argued itself into a minor on the same rule — additive, or a wider/narrower *answer* in an unchanged shape. This one breaks an existing `data` shape, which is the one thing the rule reserves the major for, and unlike those cases there is correct consumer behaviour to lose: reading `data.id` off a one-id `show` was right before and reads a missing key now. `packages/workcli/README.md` states the MAJOR/MINOR split and this bump's reasoning; `tests/unit/test_protocol_handshake.py` carries the per-bump record.

## What a consumer must do

- Reading a one-id `show`: move from `data.<field>` to `data.items[0].<field>`.
- Already handling the multi-id reply: nothing changes.
- Pinning the facade's major at adapter init (as the README asks): move the pin to `2`. `packages/executor` does exactly this and its pin moved in this PR.

## Consumers in this repository

- `packages/executor` never calls `show`, but pins the tracker's protocol major before it mutates anything. `_TRACKER_PROTOCOL_MAJOR` moves `"1"` → `"2"`; its handshake test fixtures move with it (the refusal case now scripts `1.13` as the mismatched major, which is the realistic one).
- `scripts/track-backfill/` has five single-id `show` calls. Those scripts shell out to whichever `work` is on PATH — **not** the build in this checkout — so they must parse both shapes. All five now route through one `context.show` helper that unwraps an `items` wrapper when it sees one and passes the pre-2.0 item through untouched. `test_show_shape.py` pins both paths, and both directions of the tolerance are mutation-checked.

## `--format human`

Deliberately unchanged. The renderer walks whatever `data` holds and knows no verb names, so a one-id `show` now renders under `items` exactly as a listing does. Special-casing it would put a verb's identity into a module that has none, and would make the human view disagree with the JSON envelope printed beside it. Pinned by a new test in `test_format_human.py`.

## Verification

- `make ci-workcli` — exit 0 (901 tests, 99.25% coverage)
- `make itest-workcli` — exit 0 (63 tests against a real isolated backend, including a new wire-level proof that one id and many answer the same shape)
- whole-repo `make ci` — exit 0
- every `scripts/track-backfill/test_*.py` run directly — all exit 0

Each new test was observed red before the change: the uniform-shape pin fails against today's `show`, and so does the human-rendering test. `context.show`'s both-shapes tolerance can only be red under mutation, so it was mutation-checked in both directions (new-shape-only, old-shape-only) — each mutation fails the test that covers the shape it dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfMM2sQZcDxAh1eFgD8u1