### PR TITLE
docs(9k9.197): a pinned copy reproduces, and the house rules outrank it

### DIFF
--- a/src/user/.agents/USER-CORE.md.template
+++ b/src/user/.agents/USER-CORE.md.template
@@ -31,7 +31,7 @@ Narrow "when in doubt, do the safe thing" rules (merge authorization, destructiv
 
 <conventions>
 - Minimal, surgical edits: touch only what the task requires; nothing speculative.
-- Artifacts state the current decision, not its history — git is the changelog. This reaches code comments and docstrings as much as skills, rules, commands, AGENTS.md and README.md. Keep the refuted alternative — the plausible wrong design and what breaks under it — in the present tense; cut the episode, including who got it wrong and when. Exempt: changelogs, ADRs, plan or spec files that must state a before-state to plan the transition, and third-party provenance headers.
+- Artifacts state the current decision, not its history — git is the changelog. This reaches code comments and docstrings as much as skills, rules, commands, AGENTS.md and README.md. Keep the refuted alternative — the plausible wrong design and what breaks under it — in the present tense; cut the episode, including who got it wrong and when. Exempt: changelogs, ADRs, plan or spec files that must state a before-state to plan the transition, and third-party content vendored at a pin along with its provenance header — a pinned copy has to reproduce its source, so it stands as written, and where it disagrees with these rules, these rules win.
 - If the repo has a CONTEXT.md glossary, use its terminology.
 </conventions>
 


### PR DESCRIPTION
## What this does

The always-on authoring convention says artifacts state the current decision and not
its history, and it names skills among the classes it governs. A vendored reference
inside the `writing-skills` skill teaches the opposite: it shows a worked example of a
collapsed `## Old patterns` section holding a deprecated API version and concludes that
the section provides historical context without cluttering the main content. That file
deploys, so an agent authoring a skill can hold both instructions in one install with
nothing stating which outranks the other.

This settles it in the convention itself: **the convention governs what this repository
authors, not what it vendors, and where the two disagree the house rules win.**

## Why this shape and not the two alternatives

**Why not edit the vendored file.** The copy is pinned to an upstream commit, and the
point of a pin is that the copy reproduces. Rewriting a pinned body to house style
destroys its value as a citable snapshot, and the skill's drift policy exists precisely
so that a divergence is a deliberate, recorded act rather than a silent one.

**Why not annotate the divergence table.** That table sits inside the leading HTML
comment carrying the `Upstream:` marker, which the deploy-time sanitizer strips. A note
there is repo-side bookkeeping that no deployed agent can read, so it would resolve
nothing at the moment the conflict actually arises.

**Why precedence rather than a carve.** Stating precedence once covers every vendored
contradiction, including the ones nobody has found yet. Carving this passage out fixes
one site and leaves the next to be discovered by hand — an add operator with no
corresponding rule.

## Scope, measured

`grep -rn -i "old pattern" src/` returns four hits, all four inside the vendored
`references/anthropic-best-practices.md`. The six references split out of that skill's
body are house-authored and therefore in scope for the convention; none of them teaches
the pattern. So the contradiction is confined to vendored bytes and nothing house-side
needs a change.

No pointer was added to the skill body or the skills orientation, deliberately. The
orientation file does not deploy — `.installignore` names it — so a pointer there cannot
reach an agent authoring a skill in another project. The `writing-skills` body sits at
1967 of its 2000-token cap, so a pointer's real cost is evicting method content from a
body already pruned by a factor of 2.9 to fit. The benefit is close to zero either way:
the always-on core is loaded in every context by construction, so an agent reading the
vendored advice is already holding the rule that outranks it.

## Verification

| Check | Result |
| --- | --- |
| `content-lint` | exit 0 |
| `content-tests` | exit 0 |
| `doc-lint` | exit 0 |
| Vendored reference byte-unchanged | `git diff` against `main` empty |

The always-on surface is capped at 10000 tokens. This adds 42 to each tool: Claude
3361 → 3403, Codex 2613 → 2655, Gemini 941 → 983, OpenCode 2613 → 2655. The largest
surface is at 34% of cap.

One file, one line changed. No installer entry point was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky
