### PR TITLE
docs(9k9.196): the READMEs name the assets that exist and stop counting the ones that do

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ docs/
 ├── architecture/                   # Evergreen HLD artifacts (C4, sequence, state machines) per subsystem
 ├── primers/                        # Prose explainers for the discipline-layer primitives
 ├── specs/                          # Dated, point-in-time design proposals
-├── plans/                          # Dated implementation plans
-└── adr/                            # Architecture decision records
+├── adr/                            # Architecture decision records
+└── …                               # Plus reference material and prototypes
 src/
 ├── user/
 │   ├── .agents/                    # Shared content (copied into all detected tools)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The five load-bearing convictions behind this:
 
 ### Current state — mid-rebuild
 
-**The harness is being rebuilt, and much of what the vision above describes is not in the tree.** There is no completion gate, no merge guard, no PR-feedback skill and no role-based agent definition; their replacements are specified but mostly not built. What ships today is a much smaller set: the always-on instruction core (laws, decision matrix, hard lines), the design and spec-writing path (`grilling`, `to-spec`, `ac-attack`), the review contracts (`review-panel`, `review-verdict`), the delegation skills, and git cleanup.
+**The harness is being rebuilt, and much of what the vision above describes is not in the tree.** There is no completion gate, no merge guard, no PR-feedback skill and no role-based agent definition; their replacements are specified but mostly not built.
+
+What does ship spans the always-on instruction core (laws, decision matrix, hard lines, conventions); skills for design and spec-writing, review contracts, delegation, test-first implementation, diagnosis, codebase navigation and session handoff; a few slash commands; the Claude hooks; and the CLIs the installer puts on PATH. The inventory itself is the directories under [What actually deploys](#what-actually-deploys) — read those, because any list written here is wrong by the next commit that adds a skill.
 
 The plan of record is [`docs/specs/2026-07-21-harness-rework-way-forward.md`](./docs/specs/2026-07-21-harness-rework-way-forward.md) — decisions, acceptance criteria, and the ordered slice list. Read it before building on anything here. Live status lives in the tracker, not in this file.
 

--- a/src/user/.claude/README.md
+++ b/src/user/.claude/README.md
@@ -13,13 +13,12 @@ by default.
 - `rules/` — Claude-specific workflow rules, under that same gate. Each rules
   directory carries its own `AGENTS.md` saying what is currently in it; read
   that rather than counting files here.
-- `AGENTS.md.template` — Top-level instruction file that pulls in the shared
-  personas and session-primer, and `CLAUDE-EXTENSIONS.md`. Does not yet pull
-  in the shared zero-based `AGENTS.md.template` survivor — see that file's
-  entry in `src/user/.agents/README.md` (`agents-config-9k9.10`).
+- `AGENTS.md.template` — Top-level instruction file. It is a single
+  `DYNAMIC-INCLUDE` of the shared zero-based core in
+  `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at
+  deploy time; it carries no text of its own. Claude-specific workflow lives in
+  `rules/`.
 - `CLAUDE.md.template` — Thin wrapper pointing at `AGENTS.md`.
-- `CLAUDE-EXTENSIONS.md.template` — Stub header kept for compatibility;
-  Claude-specific workflow now lives in `rules/`.
 - `settings.json.template` — Permission allowlists, hooks, and experimental
   features. The installer union-merges this into any existing
   `~/.claude/settings.json`.
@@ -31,9 +30,10 @@ Into `~/.claude/` (user-scoped Claude Code config). The installer strips the
 
 ## Who it's for
 
-Claude Code users who want to adopt this repo's agents, skills, rules, and
-slash commands. Shared content from `src/user/.agents/` also installs into
-`~/.claude/` alongside the files in this folder.
+Claude Code users who want to adopt this repo's skills, rules, and slash
+commands. No agent definitions ship, so `~/.claude/agents/` gets nothing from
+here. Shared content from `src/user/.agents/` also installs into `~/.claude/`
+alongside the files in this folder.
 
 See the [root README](../../../README.md) for install flow and customization
 pointers.

--- a/src/user/.codex/README.md
+++ b/src/user/.codex/README.md
@@ -6,25 +6,26 @@ because `~/.codex/` already exists.
 
 ## What lives here
 
-- `AGENTS.md.template` — Top-level instruction file that pulls in the shared
-  personas, session-primer, and all rules; and `CODEX-EXTENSIONS.md`. Does not
-  yet pull in the shared zero-based `AGENTS.md.template` survivor — see that
-  file's entry in `src/user/.agents/README.md` (`agents-config-9k9.10`).
-- `CODEX-EXTENSIONS.md.template` — Placeholder for Codex-specific workflow
-  additions. Currently empty; populate as Codex-specific conventions emerge.
+- `AGENTS.md.template` — Top-level instruction file. It is a single
+  `DYNAMIC-INCLUDE` of the shared zero-based core in
+  `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at
+  deploy time; it carries no text of its own. There is no Codex-specific
+  instruction content, so this is the whole of the Codex tree's prose.
 
 ## Where it installs
 
 Into `~/.codex/` (user-scoped Codex CLI config). The installer strips the
 `.template` suffix on copy.
 
-Shared content from `src/user/.agents/` also installs into `~/.codex/`
-(agents, skills, personas).
+Shared content from `src/user/.agents/` also installs into `~/.codex/` — the
+skills, and the rules directory, which is empty today. No agent definitions and
+no persona templates exist to install: the always-on surface is zero-based and
+carries no identity content.
 
 ## Who it's for
 
-OpenAI Codex CLI users who want the same agents, skills, and persona setup
-they'd get under Claude Code, adapted to Codex's conventions.
+OpenAI Codex CLI users who want the same skills and the same shared instruction
+core they'd get under Claude Code.
 
 See the [root README](../../../README.md) for install flow and customization
 pointers.

--- a/src/user/.codex/README.md
+++ b/src/user/.codex/README.md
@@ -10,7 +10,7 @@ because `~/.codex/` already exists.
   `DYNAMIC-INCLUDE` of the shared zero-based core in
   `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at
   deploy time; it carries no text of its own. There is no Codex-specific
-  instruction content, so this is the whole of the Codex tree's prose.
+  instruction content.
 
 ## Where it installs
 

--- a/src/user/.gemini/README.md
+++ b/src/user/.gemini/README.md
@@ -24,8 +24,11 @@ carries no identity content.
 
 ## Who it's for
 
-Google Gemini CLI users who want the same skills and the same shared instruction
-core they'd get under Claude Code.
+Google Gemini CLI users who want the same shared instruction core they'd get
+under Claude Code. The skills stage here too, but whether the Gemini CLI reads a
+deployed skill at all is not established by any vendor documentation, so this
+project does not model its skill loading and reports no skill measurement for
+it — expect the instruction core to carry the weight.
 
 See the [root README](../../../README.md) for install flow and customization
 pointers.

--- a/src/user/.gemini/README.md
+++ b/src/user/.gemini/README.md
@@ -6,27 +6,26 @@ exists or when the user passes `--tools=gemini`.
 
 ## What lives here
 
-- `GEMINI.md.template` — Top-level instruction file that pulls in the shared
-  personas, session-primer, and all rules; and `GEMINI-EXTENSIONS.md`. Gemini
-  is the one tool where the shared zero-based `AGENTS.md.template` survivor
-  *could* wire in safely today (its dest is `GEMINI.md`, not `AGENTS.md`, so
-  no basename collision) — not done here to keep the four tools' behavior
-  consistent until `agents-config-9k9.10` fixes it for all of them at once.
-- `GEMINI-EXTENSIONS.md.template` — Placeholder for Gemini-specific workflow
-  additions. Currently empty; populate as Gemini-specific conventions emerge.
+- `GEMINI.md.template` — Top-level instruction file. It is a single
+  `DYNAMIC-INCLUDE` of the shared zero-based core in
+  `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at
+  deploy time; it carries no text of its own. There is no Gemini-specific
+  instruction content, so this is the whole of the Gemini tree's prose.
 
 ## Where it installs
 
 Into `~/.gemini/` (user-scoped Gemini CLI config). The installer strips the
 `.template` suffix on copy.
 
-Shared content from `src/user/.agents/` also installs into `~/.gemini/`
-(agents, skills, personas).
+Shared content from `src/user/.agents/` also installs into `~/.gemini/` — the
+skills, and the rules directory, which is empty today. No agent definitions and
+no persona templates exist to install: the always-on surface is zero-based and
+carries no identity content.
 
 ## Who it's for
 
-Google Gemini CLI users who want the same agents, skills, and persona setup
-they'd get under Claude Code, adapted to Gemini's conventions.
+Google Gemini CLI users who want the same skills and the same shared instruction
+core they'd get under Claude Code.
 
 See the [root README](../../../README.md) for install flow and customization
 pointers.

--- a/src/user/.gemini/README.md
+++ b/src/user/.gemini/README.md
@@ -10,7 +10,7 @@ exists or when the user passes `--tools=gemini`.
   `DYNAMIC-INCLUDE` of the shared zero-based core in
   `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at
   deploy time; it carries no text of its own. There is no Gemini-specific
-  instruction content, so this is the whole of the Gemini tree's prose.
+  instruction content.
 
 ## Where it installs
 


### PR DESCRIPTION
## What this does

These README files are what an author reads to learn what the deployed surface contains,
and they were false in four places. A reader trusting the root README believed five
skills ship; a reader trusting the Claude tree's README went looking for a file that is
not there.

## The four scoped sites

**1. The root README characterised the surface by size and then enumerated it** — "a much
smaller set" followed by a closed list of five things. The tree holds 22 shared skill
directories and 7 Claude-only ones, so both halves were wrong: the count and the framing.

The fix removes the enumeration rather than lengthening it. A list of 30 goes stale on the
next commit that adds a skill, which is the failure mode that recurs. What the paragraph
was actually trying to say is true and stays: specific capabilities the vision names are
absent — no completion gate, no merge guard, no PR-feedback skill, no role-based agent
definition. That is a claim about named absences, which is checkable and does not rot.
The inventory now defers to the directory table further down, which makes the section's
closing "believe the source tree" line load-bearing instead of decorative.

**2. The Claude tree's README described `CLAUDE-EXTENSIONS.md.template`** as a stub kept
for compatibility. No such file exists. The bullet is deleted rather than reworded into
confident present tense, which would launder the falsehood instead of removing it.

**3 and 4. The Codex and Gemini READMEs promised "the shared personas."** There are no
persona templates and the always-on surface is zero-based, which the root README already
states. Both now match it.

## Three more falsehoods in the same bullets

Correcting sites 3 and 4 meant rewriting lines that carried further false claims, and
leaving them in a line being rewritten was not defensible:

- `CODEX-EXTENSIONS.md.template` and `GEMINI-EXTENSIONS.md.template` are described as
  placeholder files and do not exist — site 2's defect, in the same bullets.
- All three READMEs claimed their template "does not yet pull in the shared zero-based
  `AGENTS.md.template` survivor." Each template is in fact a single `DYNAMIC-INCLUDE` of
  the shared instruction core and nothing else. The cross-reference attached to that claim
  also resolved to nothing.
- The docs tree diagram listed a `plans/` directory. `docs/` holds adr, architecture,
  guide, primers, prototypes, reference and specs, and the prose plan is retired as an
  artifact class. Replaced with the ellipsis row the same diagram already uses for
  `packages/`, so a new supporting directory will not falsify it.

## One finding that changed the fix itself

`content-lint` reports the Gemini surface with **zero** skill-catalog entries against 22
for the other three tools. `capabilities.py` explains it: Gemini is the sole member of
`UNMODELLED_SKILL_LOADERS`, because its CLI is deprecated and no vendor documentation
establishes whether it reads a deployed skill at all. The files stage, so the install
section stands — but a first-pass rewrite promising Gemini users "the same skills you'd
get under Claude Code" would have been a fresh over-promise of exactly the kind site 4
was about. The Gemini README now states the unmodelled loading plainly.

## Verification

Every claim was checked against the tree rather than read for plausibility.

| Claim | Check |
| --- | --- |
| Four named capabilities absent | `find src` for completion / merge-guard / pr-feedback patterns and for an `agents` directory returns nothing |
| No extensions templates | `find . -name '*-EXTENSIONS*'` returns nothing tree-wide |
| No persona templates | `find` for `USER-PERSONA*` / `AGENT-PERSONA*` / `*session-primer*` returns nothing; the only `src/` match is a skill asset |
| Categories named all real | 22 shared skills, 7 Claude-only, 2 commands, 2 hooks, five CLIs from `CLI_PACKAGES` |
| Anchor resolves | `#what-actually-deploys` → `### What actually deploys` |
| No `plans/` tree | `ls -d docs/*/` lists seven directories, none of them `plans` |

| Gate | Result |
| --- | --- |
| `content-lint` | exit 0 |
| `content-tests` | exit 0 — 12 suites |
| `doc-lint` | exit 0 — 125 tracked Markdown files |

Prose only. No installer entry point was run by any route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky
