### PR TITLE
docs(9k9.198): the installer architecture points at the registry instead of copying it

### DIFF
--- a/docs/architecture/installer/c4-l3-engine.md
+++ b/docs/architecture/installer/c4-l3-engine.md
@@ -23,7 +23,7 @@
 
 Open the `installer` process boundary and show its components. Answers: *what code inside the process actually does the work, how is the tool-agnostic core kept separate from tool/plugin specifics, and where are the seams a test substitutes a fake across?*
 
-This is the most-detailed structural artifact in the set. It is the L3 zoom an implementer reads alongside the story they are wiring (e.g. C.1 staging, E.* merge strategies, F.2 plugin overlay).
+This is the most-detailed structural artifact in the set. It is the L3 zoom to read alongside the module being changed — staging, a merge strategy, the plugin overlay.
 
 ## Diagram
 
@@ -48,8 +48,8 @@ C4Component
             Component(overlay, "overlay.py", "Python", "Phase 6: overlay_plugins — merges each active plugin's content onto the base plan, alphabetical plugin order. Carrier-merges a plugin's disjoint files into a shared_carrier skills/agents DIR; every other collision routes through the merge registry (DIR is fatal).")
             Component(sync, "sync.py", "Python", "Phase 7: require_consent guard -> hash-compare -> diff -> confirm -> path-aware backup -> write. Reports per-item InstallOutcome (WRITTEN / SKIPPED_IDENTICAL / DECLINED). Honours --dry-run.")
             Component(consent, "consent.py", "Python", "require_consent: hard-fails a non-interactive run (no TTY) that passes neither --yes nor --dry-run, before any write. Raises ConsentRequiredError, caught by cli.py as exit 1.")
-            Component(run, "run.py", "Python", "Run-level composition, called directly by cli.py after staging finishes for every tool: install_pipeline + install_plugin_routes (the plugin-route analog: the destinations an adapter claims outside any tool tree) + deploy_clis / prune_clis (the CLI-deploy stage: uv tool install/uninstall for the work + prgroom + grind console scripts) + prune_pipeline (diff -> partition -> run_prune) + record_receipt (mirrors disk, now including cli deploy/prune outcomes).")
-            Component(clis, "clis.py", "Python", "CLI_PACKAGES registry (workcli -> work, prgroom -> prgroom, grind -> grind) + RETIRED_CLIS allowlist; cli_source_digest (deployable-source hash); the CliDeployPort protocol + UvCliDeploy (real, the only module that shells out for CLI deploys) + ScriptedCliDeploy (test fake).")
+            Component(run, "run.py", "Python", "Run-level composition, called directly by cli.py after staging finishes for every tool: install_pipeline + install_plugin_routes (the plugin-route analog: the destinations an adapter claims outside any tool tree) + deploy_clis / prune_clis (the CLI-deploy stage: uv tool install/uninstall for every console script the CLI_PACKAGES registry names) + prune_pipeline (diff -> partition -> run_prune) + record_receipt (mirrors disk, now including cli deploy/prune outcomes).")
+            Component(clis, "clis.py", "Python", "CLI_PACKAGES registry, each entry pairing a uv tool name with the console script it provides, + RETIRED_CLIS allowlist; cli_source_digest (deployable-source hash); the CliDeployPort protocol + UvCliDeploy (real, the only module that shells out for CLI deploys) + ScriptedCliDeploy (test fake).")
             Component(receipt, "receipt.py + receipt_store.py + receipt_lock.py", "Python", "Receipt / ReceiptEntry model + canonical serialization + integrity digest; read (MISSING vs CORRUPT) / atomic write; single-writer advisory flock.")
             Component(rdiff, "receipt_diff.py + receipt_build.py", "Python", "scope_owners + validate_entry + diff_orphans -> Orphan list; desired_staged_keys / desired_route_keys, entry builders, merge_receipt.")
             Component(phash, "prune_hash.py", "Python", "is_prunable + partition_file_orphans: hash/type-aware prune-vs-relinquish, re-checked at the deletion boundary (TOCTOU guard).")
@@ -152,7 +152,7 @@ The engine knows nothing about any specific tool; it takes a `ToolAdapter` and a
 - **`io_port.py`** is the I/O chokepoint. `sync` and `prune` reach the terminal only through the `IOPort` protocol; tests inject `ScriptedIO` to drive every prompt deterministically.
 - **`templates.py`** does DYNAMIC-INCLUDE flattening. The file form inlines one fragment; the ALL-RULES form expands the staged rules collection sorted + `\n---\n`-joined. (The Gemini frontmatter conversion is invoked here in tests but **lives in `tools/gemini.py`** — the engine stays tool-agnostic.)
 - **`staging.py`** walks the source, strips the `.template` suffix, scopes files into namespaces, consults `.installignore`, builds `StagedItem`s into the `StagingPlan`, and calls the adapter's `post_staging_transforms`. It is parameterised by the `ToolAdapter`, never branching on a tool name itself. A same-dest collision within base staging (shared + per-tool content) routes through the merge registry, same as plugin overlay.
-- **`installignore.py`** loads `.installignore`, the shared exclusion manifest both `staging.py` and `overlay.py` consult while walking a namespace. A missing, unreadable, or non-UTF-8 file is a **hard error** (`cli.py` exit 2) — the manifest is load-bearing policy, not an optional default; a silent empty-exclusion fallback would re-leak namespace dev-docs identically on both installers, the failure mode the golden-master parity oracle can't see.
+- **`installignore.py`** loads `.installignore`, the shared exclusion manifest both `staging.py` and `overlay.py` consult while walking a namespace. A missing, unreadable, or non-UTF-8 file is a **hard error** (`cli.py` exit 2) — the manifest is load-bearing policy, not an optional default. A silent empty-exclusion fallback would deploy every namespace's development docs into every destination store, and a run doing that looks exactly like a correct one from the outside.
 - **`overlay.py`** (`overlay_plugins`, Phase 6) merges each active plugin's `.<tool>/` (tool scope) and shared `.agents/` content onto the base plan, in alphabetical plugin order so last-wins collisions resolve deterministically. A plugin directory colliding with a `shared_carrier` skills/agents `DIR` carrier-merges when the two directories' file sets are disjoint (recording the plugin's files in `StagingPlan.dir_overrides`); every other collision — including a second plugin landing on an already-merged carrier — routes through the merge registry, where `FileKind.DIR` is fatal.
 - **`sync.py`** is Phase 7: `require_consent` guards up front (hard-fails a non-interactive run with neither `--yes` nor `--dry-run`), then for each planned file, hash-compare against the destination; identical → skip; different → diff via `IOPort`, confirm, path-aware backup, write. It reports a per-item `InstallOutcome` (`WRITTEN` / `SKIPPED_IDENTICAL` / `DECLINED`, with the real `sha256`) so the receipt records only what was actually written as our bytes. `--dry-run` short-circuits before any write.
 - **`consent.py`** (`require_consent`) is the non-interactive consent guard: raises `ConsentRequiredError` before any write when stdin is not a TTY and neither `--yes` nor `--dry-run` was passed. Called from `sync.py`'s `sync_plan`/`sync_routes`; `cli.py` catches the exception and exits 1.
@@ -173,14 +173,14 @@ One module per tool behind the `ToolAdapter` protocol (`base.py`). Each adapter 
 
 ### `plugins/` — per-plugin adapters
 
-Plugins sit behind the `PluginAdapter` protocol (`base.py`), **string-keyed** in `registry.py` and discovered dynamically by scanning `src/plugins/` — adding a plugin requires no change to `model.py`. **`generic.py`** holds `GenericPluginAdapter`, the adapter every discovered plugin gets: it detects on the plugin's own `~/.<name>/` footprint and declares no bespoke routes, so its content reaches disk through the per-tool namespace overlay. A plugin needing behaviour that convention cannot express — a detection probe beyond the home footprint, or a destination outside every tool tree — registers a factory in `registry.py`'s specialized-adapter map, which is the named extension point and is empty. **`extensions.py`** (`apply_extensions()`, story F.5) applies plugin-declared YAML patches to base markdown assets post-staging, once per enabled tool against that tool's plan.
+Plugins sit behind the `PluginAdapter` protocol (`base.py`), **string-keyed** in `registry.py` and discovered dynamically by scanning `src/plugins/` — adding a plugin requires no change to `model.py`. **`generic.py`** holds `GenericPluginAdapter`, the adapter every discovered plugin gets: it detects on the plugin's own `~/.<name>/` footprint and declares no bespoke routes, so its content reaches disk through the per-tool namespace overlay. A plugin needing behaviour that convention cannot express — a detection probe beyond the home footprint, or a destination outside every tool tree — registers a factory in `registry.py`'s specialized-adapter map, which is the named extension point and is empty. **`extensions.py`** (`apply_extensions()`) applies plugin-declared YAML patches to base markdown assets post-staging, once per enabled tool against that tool's plan.
 
 ### The four protocol seams
 
 | Seam | Protocol module | What a test substitutes |
 |---|---|---|
 | Tool behaviour | `tools/base.py` `ToolAdapter` | `FakeToolAdapter` — exercises the core engine with no real tool |
-| Plugin overlay | `plugins/base.py` `PluginAdapter` | synthetic test-plugin fixture (story F.1) |
+| Plugin overlay | `plugins/base.py` `PluginAdapter` | synthetic test-plugin fixture |
 | Collision resolution | `core/merge/base.py` `MergeStrategy` | swap a registry entry to assert dispatch |
 | All I/O | `core/io_port.py` `IOPort` | `ScriptedIO` — drives prompts, records transcript |
 
@@ -190,7 +190,7 @@ Every cross-boundary dependency is one of these four protocols. That is the desi
 
 - **Execution order across the components** — detect → stage → overlay → merge → sync → prune is the subject of [`sequences.md`](sequences.md).
 - **The data shapes** the components pass around (`StagingPlan`, `StagedItem`, `Config`, …) and the merge-dispatch table — see [`data-view.md`](data-view.md).
-- **The per-strategy merge mechanics** (append separator placement, JSON deep-union rules, fatal message format) — specified in `installer-design.md` §"Test architecture" and per-strategy in the E.* stories.
+- **The per-strategy merge mechanics** (append separator placement, JSON deep-union rules, fatal message format) — specified in `installer-design.md` §"Test architecture".
 - **The container boundary + external stores at process granularity** — see [`c4-l2-container.md`](c4-l2-container.md).
 
 ## Cross-references

--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -32,7 +32,7 @@ The data view answers: *what shapes does the installer build in memory, what dri
 
 ## In-memory model ER diagram
 
-Field names mirror the target dataclasses in `packages/installer/src/installer/core/model.py` and `packages/installer/src/installer/config.py`. This represents target state, not necessarily current code — the ER is the design authority; implementation stories bring the code into alignment with it.
+This is the current entity model. Field names mirror the dataclasses in `packages/installer/src/installer/core/model.py` and `packages/installer/src/installer/config.py`, and the diagram is amended in step with them; a divergence between the two is a defect in whichever one moved without the other.
 
 ```mermaid
 erDiagram
@@ -109,7 +109,7 @@ erDiagram
 
 ## Merge-dispatch table — `(FileKind, namespace)` → `MergeStrategy`
 
-The collision matrix — the dispatch contract `core/merge/registry.py` implements (see `installer-design.md`). It keys on `(FileKind, namespace)`: `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key. The strategy names below are the design's; the modules land in Epic E.
+The collision matrix — the dispatch contract `core/merge/registry.py` implements (see `installer-design.md`). It keys on `(FileKind, namespace)`: `NAMESPACED_MD` is the only kind whose namespace changes the strategy; for every other kind the namespace component is unused and the lookup degenerates to a `FileKind`-only key. The strategy modules live under `core/merge/strategies/`, one class per module.
 
 | FileKind | Namespace | Strategy | Behaviour on collision |
 |---|---|---|---|
@@ -151,7 +151,7 @@ erDiagram
         string integrity       "sha256: digest over canonical (schema_version + roots + entries [+ clis when non-empty]); recomputed on read, mismatch -> CORRUPT"
         Roots  roots           "persisted install-root allowlist (prior | this run's live roots); retired-plugin root validation"
         Entry  entries         "the recorded wholesale-authored entries"
-        Cli    clis            "the recorded installer-deployed uv tools (workcli/prgroom/grind); empty on every pre-CLI-deploy receipt"
+        Cli    clis            "the recorded installer-deployed uv tools, one per registry entry; empty on every pre-CLI-deploy receipt"
     }
 
     ReceiptEntry {
@@ -163,8 +163,8 @@ erDiagram
     }
 
     CliReceiptEntry {
-        string name    "registry / uv tool name (workcli, prgroom, grind) — the diff key"
-        string binary  "console-script the tool provides (work, prgroom, grind)"
+        string name    "registry / uv tool name — the diff key"
+        string binary  "console-script the tool provides; need not match name (workcli provides work)"
         string digest  "cli_source_digest(package_dir) at deploy time — gates verify/heal/fresh"
     }
 ```
@@ -173,7 +173,7 @@ erDiagram
 - **`path` is the diff key, `owner` the scope tag.** Orphan detection is `{ e ∈ prior : e.owner ∈ scope ∧ (e.owner, e.path) ∉ desired_staged_keys ∧ validate_entry(e) }`. `desired_staged_keys` is the owned dest paths in this run's staging plan (built even under `--prune-only`) plus the active plugins' currently-shipped route files.
 - **`sha256` is ownership-drift protection.** A file orphan whose on-disk bytes no longer match the recorded digest is the user's now — it is relinquished, not deleted. `dir` entries carry `sha256: null` (recursive content-drift protection is a deliberate v1 limitation, deferred).
 - **`integrity` + `roots` make the receipt a trusted deletion-authority input.** `integrity` is recomputed on read; any accidental change fails closed (prune disabled, file untouched). `roots` is the persisted allowlist used to validate a *retired* plugin's recorded root (tool and discovered-plugin roots come from live code instead). See [`sequences.md`](sequences.md) §"Sequence 4 — Prune flow" for the full lifecycle.
-- **`clis` is additive and omitted-when-empty for integrity compatibility.** `canonical_bytes` serializes the `clis` key into the integrity payload only when `receipt.clis` is non-empty, so a receipt written before this field existed — or one where the CLI-deploy stage never ran — hashes byte-identically to today's code and its persisted `integrity` still validates on read (no forced re-hash, no downgrade caveat: an OLDER installer reading a NEWER receipt with a non-empty `clis` simply ignores the unknown key via its own dict-based parser, and ignores CLIs it never shipped). Merged by `merge_clis` (`receipt_build.py`): a registry name (`workcli`/`prgroom`/`grind`) keeps the run's freshly deployed entry when deployed, else its retained prior entry (skip/decline/failure); a non-registry (retired) name drops once its uninstall completes or it is relinquished as foreign, else it is retained so retirement retries next prune.
+- **`clis` is additive and omitted-when-empty for integrity compatibility.** `canonical_bytes` serializes the `clis` key into the integrity payload only when `receipt.clis` is non-empty, so a receipt written before this field existed — or one where the CLI-deploy stage never ran — hashes byte-identically to today's code and its persisted `integrity` still validates on read (no forced re-hash, no downgrade caveat: an OLDER installer reading a NEWER receipt with a non-empty `clis` simply ignores the unknown key via its own dict-based parser, and ignores CLIs it never shipped). Merged by `merge_clis` (`receipt_build.py`): a name still in the registry keeps the run's freshly deployed entry when deployed, else its retained prior entry (skip/decline/failure); a non-registry (retired) name drops once its uninstall completes or it is relinquished as foreign, else it is retained so retirement retries next prune.
 
 ## Canonical-ownership boundaries
 
@@ -238,8 +238,8 @@ flowchart LR
 
 - **The components that build / read these shapes** — see [`c4-l3-engine.md`](c4-l3-engine.md).
 - **The order** in which the shapes are built and flushed — see [`sequences.md`](sequences.md).
-- **The per-strategy merge mechanics** (deep-union algorithm, append separator placement) — specified per-strategy in the E.* stories and `installer-design.md` §"Test architecture".
-- **The golden-master / fixture data shapes** — test artifacts; see `installer-design.md` §"Fixture strategy".
+- **The per-strategy merge mechanics** (deep-union algorithm, append separator placement) — specified per-strategy in `installer-design.md` §"Test architecture".
+- **The fixture data shapes** — test artifacts; see `installer-design.md` §"Fixture strategy".
 
 ## Cross-references
 

--- a/docs/architecture/installer/index.md
+++ b/docs/architecture/installer/index.md
@@ -1,10 +1,9 @@
 # Python Installer — HLD Artifact Index
 
 > **Source bead**: `agents-config-w1qls.9`
-> **Subsystem**: Python installer rewrite (`agents-config-w1qls` feature)
+> **Subsystem**: the Python installer (`packages/installer`)
 > **Companion spec**: [`installer-design.md`](installer-design.md) — the design these artifacts visualise
 > **Glossary**: per-artifact short glossaries appear at the top of each file
-> **Status**: under construction
 
 ## Glossary (subsystem-wide terms used across this artifact set)
 
@@ -12,7 +11,7 @@
 |---|---|
 | HLD | High-Level Design — evergreen reference material describing how a subsystem is meant to be structured and behave. This folder *is* the HLD set for the installer. |
 | C4 | A model for visualising software architecture in four levels (Context, Container, Component, Code); see [c4model.com](https://c4model.com). This folder uses **L2** and **L3** only — see "Why no L1 / Deployment" below. |
-| Installer | The Python package at `packages/installer/` that replaces the 1788-line `scripts/install.sh`. A short-lived CLI: parse argv → stage in memory → merge → sync to disk → optional prune → exit. |
+| Installer | The Python package at `packages/installer/`, reached through `scripts/install.sh` — a thin `exec` stub that delegates to it. A short-lived CLI: parse argv → stage in memory → merge → sync to disk → optional prune → exit. |
 | Tool | One of the four supported AI coding assistants — **Claude Code**, **Codex CLI**, **Gemini CLI**, **OpenCode** — each with its own destination store and its own `ToolAdapter`. |
 | `ToolAdapter` | The protocol abstracting everything the engine needs to know about a tool: source dir, dest dir, detection, scoped namespaces, namespace filtering, post-staging transforms. Per-tool adapters live in `tools/`. |
 | `PluginAdapter` | The protocol for an optional plugin that overlays extra content onto the staging plan. Discovered dynamically by scanning `src/plugins/<name>/`; string-keyed (NOT enumerated). |
@@ -24,14 +23,12 @@
 | `IOPort` | The single injectable I/O abstraction (`info`/`warn`/`show_diff`/`confirm`/…). `TerminalIO` is real (via `rich`); `ScriptedIO` is the test fake. No module calls `print`/`input` directly. |
 | DYNAMIC-INCLUDE | The directive form (`<!-- DYNAMIC-INCLUDE: path -->` and the ALL-RULES variant) that flattens shared template fragments into assembled per-tool instruction files at staging time. |
 | Namespace | The managed sub-directory a file belongs to (`commands` / `skills` / `agents` / `rules` / `hooks` / `workflows`) — second component of the merge-dispatch key; drives append-vs-fatal collision behaviour. |
-| Parity gate | The point at which the golden-master suite proves the Python installer byte-matches `install.sh`, after which `install.sh` collapses to a `uv run` wrapper and deliberate divergence is allowed. |
-| Golden-master | The **transitional** bash-vs-python parity suite; retires once parity is confirmed and the cutover lands. |
 
 Each artifact file in this folder carries its **own short glossary** at the top, listing the terms used in that specific file.
 
 ## Purpose
 
-This folder is the **high-level design (HLD) artifact set** for the Python installer. It exists to fix the big-picture architecture in pictures — boundary, internals, runtime flow, data model — so the 34 implementation stories (A.1 … H.5) share one mental model of the system rather than each re-deriving it from 394 lines of spec prose.
+This folder is the **high-level design (HLD) artifact set** for the Python installer. It exists to fix the big-picture architecture in pictures — boundary, internals, runtime flow, data model — so that anyone changing the installer works from one mental model of the system rather than re-deriving it from the design prose.
 
 These artifacts are **evergreen reference material**: they describe how the installer is meant to be structured and behave, and are amended in place as the design evolves. They are NOT point-in-time proposals — those live in `docs/specs/` with date-prefixed filenames. The companion design here, `installer-design.md`, is itself the design-of-record (moved into this folder rather than dated because it is the living installer design, not a snapshot).
 
@@ -48,8 +45,7 @@ These artifacts are **evergreen reference material**: they describe how the inst
 
 - **Code-level (C4 L4) diagrams** — C4 itself recommends against drawing this level; the package layout in `installer-design.md` is sufficient at code granularity.
 - **The agent-config *content* itself** — what the skills/agents/rules/commands *say* is the subject of the rest of the repo, not of the installer's architecture.
-- **`install.sh`'s internal mechanics** beyond its role as the parity reference. The bash line-ranges that pin behaviour are catalogued in `installer-design.md` §"Critical files for implementation".
-- **The test architecture** (unit / integration / golden-master suites) — fully specified in `installer-design.md` §"Test architecture"; not re-drawn here.
+- **The test architecture** — specified in `installer-design.md` §"Test architecture"; not re-drawn here.
 
 ### Why no L1 (Context) or Deployment artifact
 
@@ -58,7 +54,7 @@ Both are **deliberately skipped**, not forgotten:
 - **C4 L1 (System Context)** would show one box (the installer) talking to a developer and a filesystem. The ecosystem is obvious and singular; an L1 page would carry no information the L2 container view doesn't already make plain. L2 is the natural entry point here.
 - **C4 Deployment** would show the installer running on the developer's own workstation, reading and writing the same local filesystem. There is no multi-host topology, no service, no scheduler — the deployment is "run a script in your repo." Nothing to diagram.
 
-prgroom and pdlc-orchestrator carry L1 + Deployment because each has a genuinely non-trivial ecosystem (GitHub, schedulers, agent subprocesses) or topology. The installer has neither.
+Either level earns its place in a subsystem with a genuinely non-trivial ecosystem (external services, schedulers, agent subprocesses) or a real topology. The installer has neither.
 
 ## Reading order
 
@@ -71,12 +67,12 @@ Newcomers should read in this order; deep contributors may navigate freely.
 
 ## Artifact synopsis
 
-| File | Status | Synopsis |
-|---|---|---|
-| [`c4-l2-container.md`](c4-l2-container.md) | drawn | **C4 Level 2** — the `installer` process, its read-only source tree + `installer.toml` inputs, its N destination stores + backup-dir outputs, and the four AI assistants that consume the deployed stores at their own runtime. The in-memory `StagingPlan` is explicitly NOT a container (it lives at L3 / data-view). |
-| [`c4-l3-engine.md`](c4-l3-engine.md) | drawn | **C4 Level 3** — components inside the installer process, grouped by sub-package: the tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `installignore`, `overlay`, `sync`, `consent`, `prune`, `merge/*`), the `tools/` adapters, the `plugins/` adapters, and the `cli`/`config`/`orchestrator` top layer — with the four protocol seams (`ToolAdapter`, `PluginAdapter`, `MergeStrategy`, `IOPort`) as the test-substitution points. `cli.py` is the real top-level driver (staging then sync as two separate whole-fleet passes); `orchestrator.py` covers staging only. |
-| [`sequences.md`](sequences.md) | drawn | **Four sequence diagrams**: (1) end-to-end install — detect → stage → overlay → merge → sync; (2) collision-merge dispatch — `(FileKind, namespace)` → strategy; (3) sync per-item decision — hash-skip vs diff → confirm → backup → write; (4) prune flow — orphan scan → interactive prune → backup + remove. |
-| [`data-view.md`](data-view.md) | drawn | **Data model**: ER for `Config` / `StagingPlan` / `StagedItem` / `Provenance` / `FileKind` / `IncludeDirective` / `Orphan` / `Counters`; the `(FileKind, namespace)` → `MergeStrategy` dispatch table; the `installer.toml` schema; and the source-vs-plan-vs-destination ownership boundaries. |
+| File | Synopsis |
+|---|---|
+| [`c4-l2-container.md`](c4-l2-container.md) | **C4 Level 2** — the `installer` process, its read-only source tree + `installer.toml` inputs, its N destination stores + backup-dir outputs, and the four AI assistants that consume the deployed stores at their own runtime. The in-memory `StagingPlan` is explicitly NOT a container (it lives at L3 / data-view). |
+| [`c4-l3-engine.md`](c4-l3-engine.md) | **C4 Level 3** — components inside the installer process, grouped by sub-package: the tool-agnostic `core/` engine (`model`, `io_port`, `templates`, `staging`, `installignore`, `overlay`, `sync`, `consent`, `prune`, `merge/*`), the `tools/` adapters, the `plugins/` adapters, and the `cli`/`config`/`orchestrator` top layer — with the four protocol seams (`ToolAdapter`, `PluginAdapter`, `MergeStrategy`, `IOPort`) as the test-substitution points. `cli.py` is the real top-level driver (staging then sync as two separate whole-fleet passes); `orchestrator.py` covers staging only. |
+| [`sequences.md`](sequences.md) | **Four sequence diagrams**: (1) end-to-end install — detect → stage → overlay → merge → sync; (2) collision-merge dispatch — `(FileKind, namespace)` → strategy; (3) sync per-item decision — hash-skip vs diff → confirm → backup → write; (4) prune flow — orphan scan → interactive prune → backup + remove. |
+| [`data-view.md`](data-view.md) | **Data model**: ER for `Config` / `StagingPlan` / `StagedItem` / `Provenance` / `FileKind` / `IncludeDirective` / `Orphan` / `Counters`; the `(FileKind, namespace)` → `MergeStrategy` dispatch table; the `installer.toml` schema; and the source-vs-plan-vs-destination ownership boundaries. |
 
 ## Conventions
 
@@ -91,7 +87,3 @@ Newcomers should read in this order; deep contributors may navigate freely.
 ## Source-spec coupling
 
 Diagrams in this folder are **derived artifacts**. The source of truth is [`installer-design.md`](installer-design.md). Diagrams cite the spec section they visualise (each file does so in its header / cross-references) and are amended in place when the spec changes. If the implementation diverges from these diagrams without a paired amendment, that is a drift signal — update both as one commit.
-
-## Provenance
-
-Filed as `agents-config-w1qls.9` under the `w1qls` feature (Python installer rewrite). This artifact set is the authoritative HLD for the installer; it is referenced from `installer-design.md` and will be cited from the implementation stories (A.1 … H.5) under `w1qls`.

--- a/docs/architecture/installer/installer-design.md
+++ b/docs/architecture/installer/installer-design.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-A `uv`-managed Python package (`packages/installer`) that installs agent configuration from this repo into AI coding assistant homes (`~/.claude/`, `~/.codex/`, `~/.gemini/`, OpenCode XDG). User-facing entry point is `scripts/install.sh`, a thin `exec uv run --project packages/installer python -m installer` stub. This repo is the first Python subproject in a modular monorepo; its layout is the template for future Python subprojects. On the user path, the same install run also deploys the `work` (`packages/workcli`), `prgroom` (`packages/prgroom`), and `grind` (`packages/grind`) CLIs onto PATH via `uv tool install` — a closed registry, receipt-tracked, healed/pruned on later runs — through the CLI-deploy stage (`core/clis.py` + `core/run.py`'s `deploy_clis`/`prune_clis`).
+A `uv`-managed Python package (`packages/installer`) that installs agent configuration from this repo into AI coding assistant homes (`~/.claude/`, `~/.codex/`, `~/.gemini/`, OpenCode XDG). User-facing entry point is `scripts/install.sh`, a thin `exec uv run --project packages/installer python -m installer` stub. This repo is the first Python subproject in a modular monorepo; its layout is the template for future Python subprojects. On the user path, the same install run also deploys every CLI named in `core/clis.py`'s `CLI_PACKAGES` registry onto PATH via `uv tool install` — a closed registry, receipt-tracked, healed/pruned on later runs — through the CLI-deploy stage (`core/clis.py` + `core/run.py`'s `deploy_clis`/`prune_clis`). The registry is the roster; a copy of it here would go stale the first time a package graduates.
 
 ## Architecture
 

--- a/docs/architecture/installer/sequences.md
+++ b/docs/architecture/installer/sequences.md
@@ -102,7 +102,7 @@ sequenceDiagram
         Note over CLI,Port: Phase 3 — CLI-deploy stage (still inside the receipt lock), via run.deploy_clis
         CLI->>CliDep: deploy_clis(CLI_PACKAGES, prior, deploy=cli_deploy)
         CliDep->>Port: uv_version() -- MIN_UV_VERSION guard
-        loop per registry CLI (workcli, then prgroom, then grind)
+        loop per CLI in CLI_PACKAGES, in registry order
             CliDep->>Port: shim_path / tool_list (PATH-independent decision signals)
             alt verify (digest unchanged, shim + provenance proven)
                 CliDep->>Port: smoke(shim, spec.smoke_args)
@@ -131,7 +131,7 @@ sequenceDiagram
 - **Tool order is the detection order; tools are independent within each pass.** Each tool gets its own plan and its own sync pass — there is no cross-tool state. A failure shaping one tool's plan does not corrupt another's.
 - **Collisions happen in both base staging and overlay.** Within a single tool's plan, shared + per-tool content can collide (base staging, `staging.py`); the more common case is plugin content landing on a base asset (`overlay.py`). Both route through the same merge registry (Sequence 2), never through `Sync`.
 - **`Config` is built between the two passes, not before the loop.** `resolve_tools` / `resolve_plugins` (pure functions in `config.py`) run once, up front; the frozen `Config` dataclass itself (`home`, `tools`, `auto_yes`) is constructed after staging finishes and before the sync pass begins. `installer.toml` plays no part in any of this — its loader is parsed but unwired (see [`data-view.md`](data-view.md)).
-- **The CLI-deploy stage runs third, still inside the receipt lock, and only on the user path.** `deploy_clis` walks the closed `CLI_PACKAGES` registry (`workcli` → `work`, `prgroom` → `prgroom`, `grind` → `grind`) in order, deciding verify/heal/fresh per CLI from PATH-independent signals (`shim_path`, `tool_list`) rather than trusting `PATH` itself — `which` is consulted only for the reachability invariant after a successful install. A `--project` run never constructs a `CliDeployPort` and never calls `deploy_clis`/`prune_clis` — the user-space CLI deploy is entirely out of scope for project-local installs. Its outcome merges into `record_receipt` via `merge_clis` alongside the file-install/prune outcomes (see [`data-view.md`](data-view.md) §"Install receipt").
+- **The CLI-deploy stage runs third, still inside the receipt lock, and only on the user path.** `deploy_clis` walks the closed `CLI_PACKAGES` registry in its declared order, deciding verify/heal/fresh per CLI from PATH-independent signals (`shim_path`, `tool_list`) rather than trusting `PATH` itself — `which` is consulted only for the reachability invariant after a successful install. A `--project` run never constructs a `CliDeployPort` and never calls `deploy_clis`/`prune_clis` — the user-space CLI deploy is entirely out of scope for project-local installs. Its outcome merges into `record_receipt` via `merge_clis` alongside the file-install/prune outcomes (see [`data-view.md`](data-view.md) §"Install receipt").
 
 ---
 
@@ -236,7 +236,7 @@ sequenceDiagram
 
 - **Hash-compare is the skip gate.** Unchanged files are never rewritten, so re-running the installer is cheap and quiet — the common case (most files identical) produces no prompts and no backups.
 - **Three modes govern the hashes-differ branch.** `--yes` (auto_yes): backup and write unconditionally, no diff or prompt. `--dry-run`: show diff, no write. Interactive: show diff, prompt, write only on confirmation.
-- **`--dry-run` short-circuits before every write but still shows diffs.** It is the preview mode: the operator sees exactly what *would* change (created / updated counts + diffs) without touching disk. This is also the parity-gate smoke-test surface (`install.py --dry-run` vs `install.sh --dry-run`).
+- **`--dry-run` short-circuits before every write but still shows diffs.** It is the preview mode: the operator sees exactly what *would* change (created / updated counts + diffs) without touching disk.
 - **Backup precedes overwrite, always** — including under `--yes`. No destination file is overwritten without first being copied to its path-aware backup location. The backup routing keeps namespaced backups out of the assistant's discovery walk.
 - **All prompting is through `IOPort`.** `show_diff` and `confirm` never call the terminal directly; `ScriptedIO` drives them in tests, so every branch above is unit-testable without a TTY.
 
@@ -334,7 +334,7 @@ sequenceDiagram
 - **The component structure** that executes these flows — see [`c4-l3-engine.md`](c4-l3-engine.md).
 - **The data shapes** (`StagingPlan`, `StagedItem`, `Orphan`, `Counters`, `Config`) the participants pass — see [`data-view.md`](data-view.md).
 - **DYNAMIC-INCLUDE flattening internals** (the three directive forms) and the **Gemini frontmatter transform** mechanics — referenced as steps here; specified in `installer-design.md`.
-- **The golden-master parity harness** (`install.sh` vs `install.py` diff) — a test artifact, not an install-time flow; see `installer-design.md` §"Test architecture".
+- **The test suites** — test artifacts, not install-time flows; see `installer-design.md` §"Test architecture".
 
 ## Cross-references
 


### PR DESCRIPTION
## What this does

An architecture set is what someone reads before touching the installer, and this one
named a CLI roster missing two of its five members, described a completed migration as
under construction, and hedged an accurate entity diagram as target state.

## The enumeration is removed, not refreshed

`CLI_PACKAGES` holds five entries: `workcli`, `prgroom`, `grind`, `executor`, `gitclean`.
Four documents enumerated three of them. Adding the two missing names would reproduce the
defect on the next commit that adds a CLI — and this roster has now gone stale for two
separate additions, which is the measurement that settles which fix to take.

The engine view had already solved this correctly in one bullet, and that bullet is the
model the rest now follow:

> **`clis.py`** is the CLI-deploy engine's pure/port half: the closed `CLI_PACKAGES`
> registry, which is its own authority — read it rather than an enumeration here, since a
> copy of the list goes stale the first time a package graduates.

Nine sites across five documents now point at the registry instead of copying it: the
engine view's `run.py` and `clis.py` components, four places in the data view, the
sequences view's loop label and CLI-deploy note, and the design-of-record's purpose
paragraph.

That last one was a fourth enumeration site not in the item's inventory. It matters more
than the others because it is the design the remaining four cite as their source, so
leaving it would have preserved the defect at its root.

One mention of a CLI survives, as an example rather than a roster: the receipt entry's
`binary` field exists precisely because the uv tool name and the console-script name can
differ, and `workcli` providing `work` is the pair that demonstrates it.

## The index describes a system, not a migration

Cut: the `Status: under construction` line; the count of 34 implementation stories and 394
lines of spec prose; the **Parity gate** and **Golden-master** glossary rows; a
`Status` column whose every value was "drawn"; a provenance section promising citations
from stories under a retired feature; and an out-of-scope bullet pointing at a section
name that no longer exists.

Restated rather than cut: the Installer glossary row now describes `scripts/install.sh` as
the thin `exec` stub it is. It deliberately does not substitute a new line count for the
old one, which would recreate the same class of staleness.

Kept: the domain glossary, the evergreen-versus-dated distinction, scope and non-scope,
the reading order, the synopses, the diagram conventions, and the spec coupling. All
accurate and all load-bearing for someone orienting.

**Cutting the parity definitions forced a small widening, and it was the right call.**
Three other places *used* those terms — a dry-run described as "the parity-gate smoke-test
surface", a "golden-master parity harness", and a failure mode "the golden-master parity
oracle can't see". Removing definitions while leaving uses would have been worse than
either state. The dead comparisons are gone and the exclusion-manifest bullet now states
its reasoning on its own terms, keeping the refuted alternative — a silent
empty-exclusion default — in the present tense.

Verified independently: zero case-insensitive `parity` hits in the `Makefile`, and
`packages/installer/tests/` contains only `unit/` and `fixtures/`, so there is no
golden-master suite to define a term for.

## The data view states current code

The entity diagram was hedged as target state, with implementation stories bringing the
code into alignment. The code exists and the diagram is maintained against it, so the
hedge read as a licence to distrust an accurate document. It now says the two are
maintained in step and a divergence is a defect in whichever one moved without the other.

Its merge-dispatch section also claimed the strategy modules were still to land. They are
under `core/merge/strategies/` — five modules, one class each, confirmed by directory
listing and class count.

## Also removed: dangling story citations

The same documents cited stories of a retired feature by identifier — `story F.5`,
`story F.1`, `E.* stories`, "the modules land in Epic E", "the story they are wiring".
Each is a pointer to a tracker item nobody can resolve, which is the same defect class as
the stale roster: a reader following it arrives nowhere. The uniform one-line
`Source bead` provenance header on each file is left in place, being provenance rather
than transition narration.

## Verification

| Check | Result |
| --- | --- |
| `doc-lint` | exit 0 — 125 tracked Markdown files |
| `spec-lint` | exit 0 |
| `prgroom` / `grind` in the architecture tree | no matches |
| `parity` / `golden` in the architecture tree | no matches |
| Nothing under `packages/` in the diff | empty |

Five documents, documentation only. `clis.py` was read, never executed, and no installer
entry point was run.

## Adjacent staleness found and deliberately not fixed

The design-of-record's test-architecture section claims three suites and documents an
integration suite at `tests/integration/`, which does not exist. A real defect, and a
different one from the three this addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky
