### PR TITLE
fix(9k9.195): a test states the behaviour it pins, not a line number that moved

### DIFF
--- a/packages/installer/tests/unit/test_cli_deploy_wiring.py
+++ b/packages/installer/tests/unit/test_cli_deploy_wiring.py
@@ -163,12 +163,7 @@ def test_prune_only_drops_retired_cli_through_real_receipt_path(tmp_path: Path) 
     Then the deploy half never fires, the uninstall does, and the rewritten
     receipt no longer carries the entry.
 
-    Pins the --prune-only convergence rule. NOTE: requires a
-    nonzero RETIRED_CLIS in the test — monkeypatch installer.core.run's
-    retired source or pass through a seam; the implementer wires
-    prune_clis(retired=frozenset(RETIRED_CLIS)) in cli.py, so monkeypatch
-    installer.cli.RETIRED_CLIS (import it into cli.py namespace for
-    patchability).
+    Pins the --prune-only convergence rule.
     """
     repo = _hermetic_repo(tmp_path)
     home = tmp_path / "home"

--- a/packages/installer/tests/unit/test_cli_smoke.py
+++ b/packages/installer/tests/unit/test_cli_smoke.py
@@ -244,7 +244,7 @@ def test_main_autodetect_empty_home_dry_run_selects_claude_returns_zero(
     Then it returns 0 — auto-detect falls back to claude and proceeds.
 
     Pins: a bare home does not take a no-tools exit-2 guard; claude is the
-    auto-detect floor, matching install.sh's unconditional `TOOLS=(claude)`.
+    auto-detect floor, matching the bash installer's unconditional `TOOLS=(claude)`.
     """
     repo = _hermetic_repo(tmp_path)
     rc = main(["--dry-run"], home=tmp_path, io=ScriptedIO(interactive=False), repo_root=repo)
@@ -544,9 +544,9 @@ def test_explicit_plugins_override_warns_about_excluded_plugin(tmp_path: Path) -
     Then a warning naming 'widget' and the non-prune guidance is emitted.
 
     Pins: an explicit --plugins= override that drops a discovered plugin warns the
-    operator the already-installed files are NOT removed — bash
-    scripts/install.sh:325. Fails while the Python installer drops excluded plugins
-    silently (resolve_plugins returns the resolved set with no exclusion warning).
+    operator the already-installed files are NOT removed, matching bash. Fails while
+    the Python installer drops excluded plugins silently (resolve_plugins returns
+    the resolved set with no exclusion warning).
     """
     repo = _repo_with_widget_plugin(tmp_path)
     io = ScriptedIO(interactive=False)
@@ -570,7 +570,7 @@ def test_explicit_plugins_override_with_prune_warns_orphan_wording(tmp_path: Pat
     Given a discoverable 'widget' plugin excluded via --plugins= AND --prune-only
     When main runs
     Then the exclusion warning uses the prune wording (excluded files become
-    orphans and may be removed) — bash scripts/install.sh:323.
+    orphans and may be removed), matching bash.
 
     Pins: the wording branches on whether a prune phase is active. Fails if the
     warning is unconditional (always the non-prune text) or absent under --prune.
@@ -599,7 +599,7 @@ def test_autodetect_does_not_warn_about_excluded_plugins(tmp_path: Path) -> None
     Then NO exclusion warning is emitted.
 
     Pins: the exclusion warning fires only under an EXPLICIT --plugins= override
-    (bash gates it on PLUGINS_FLAG_SET, scripts/install.sh:308). Auto-detect
+    (bash gates it on PLUGINS_FLAG_SET). Auto-detect
     dropping an undetected plugin is normal, not warn-worthy. Fails if the warning
     keys on the discovered-vs-resolved delta regardless of how plugins were
     resolved.
@@ -703,7 +703,7 @@ def test_verbose_flag_constructs_terminal_io_verbose(
 
     Pins: args.verbose is parsed (both spellings) and threaded into the
     TerminalIO construction in main — the plumbing the bash installer's
-    VERBOSE=true wiring (scripts/install.sh:110) ports to. A spy on the lazily
+    VERBOSE=true wiring ports to. A spy on the lazily
     imported TerminalIO captures the kwarg without touching a real terminal.
     Fails while the flag is unparsed (argparse SystemExit) or constructed with a
     hard-coded verbose=False.
@@ -1074,7 +1074,7 @@ def test_main_quiet_reinstall_renders_all_up_to_date(tmp_path: Path) -> None:
     --tools=claude --yes (quiet)
     When main runs again
     Then it emits exactly the em-dash 'All files up to date — no changes made.'
-    line — every item is a skip, so nothing changed (scripts/install.sh:1863).
+    line — every item is a skip, so nothing changed.
 
     Pins: the all-zero quiet branch reaches the renderer from a real re-install.
     """
@@ -1145,9 +1145,9 @@ def test_main_dry_run_summary_reports_would_be_installs(tmp_path: Path) -> None:
     Given --tools=claude --dry-run against a hermetic repo (a claude create)
     When main runs in preview mode
     Then the summary still reports the would-be install — bash tallies counters
-    on a dry-run too (e.g. scripts/install.sh:1154-1160 increments
-    tool_installed inside the DRY_RUN branch) and renders the Summary
-    unconditionally at the end. The quiet 'claude: N installed' line appears.
+    on a dry-run too (it increments tool_installed inside the DRY_RUN branch) and
+    renders the Summary unconditionally at the end. The quiet
+    'claude: N installed' line appears.
 
     Pins: the summary renders on a dry-run with the previewed counts, matching
     bash — it is NOT gated to real writes only.

--- a/packages/installer/tests/unit/test_config.py
+++ b/packages/installer/tests/unit/test_config.py
@@ -52,7 +52,7 @@ def test_autodetect_includes_claude_when_settings_json_absent(
     Then the result is (Tool.CLAUDE,).
 
     Pins: claude is unconditionally selected under auto-detect, matching
-    install.sh's `TOOLS=(claude)` ("claude always; others if ~/.<tool>/").
+    the bash installer's `TOOLS=(claude)` ("claude always; others if ~/.<tool>/").
     A fresh machine with no ~/.claude/settings.json still installs claude.
     """
     assert resolve_tools(home=tmp_path, override_csv=None) == (Tool.CLAUDE,)

--- a/packages/installer/tests/unit/test_config_plugins.py
+++ b/packages/installer/tests/unit/test_config_plugins.py
@@ -57,7 +57,7 @@ def test_empty_override_installs_no_plugins(tmp_path: Path) -> None:
     Given an empty --plugins= value (and a whitespace-only value)
     When resolve_plugins is called
     Then the result is empty — the deliberate asymmetry with resolve_tools,
-    which raises on empty --tools= (install.sh:298-300).
+    which raises on empty --tools=.
     """
     root = _sources_with_two_plugins(tmp_path)
     home = tmp_path / "home"

--- a/packages/installer/tests/unit/test_gemini_frontmatter.py
+++ b/packages/installer/tests/unit/test_gemini_frontmatter.py
@@ -80,8 +80,8 @@ def test_description_block_scalar_preserved_while_stripping_and_wrapping() -> No
     # The headline parity guarantee: a `description: |-` block scalar survives
     # byte-for-byte even as color: is stripped and tools: is wrapped. The pyyaml
     # round-trip reflowed the block (quoting/spacing/style); the line port leaves
-    # every untouched line verbatim. Mirrors install.sh transform_gemini_agent_
-    # frontmatter (the surgical awk).
+    # every untouched line verbatim. Mirrors the bash installer's
+    # transform_gemini_agent_frontmatter (the surgical awk).
     block = "description: |-\n  Line one.\n\n  Line two with: a colon and  weird   spacing.\n"
     src = ("---\nname: a\n" + block + "tools: Read, Grep\ncolor: purple\n---\nbody\n").encode()
     out = transform_agent_frontmatter(src).decode("utf-8")

--- a/packages/installer/tests/unit/test_installignore_invariant.py
+++ b/packages/installer/tests/unit/test_installignore_invariant.py
@@ -4,8 +4,7 @@ Python installer's staged output, using the REAL repo-root .installignore.
 The leaker paths are HARDCODED here, deliberately NOT sourced from .installignore:
 a manifest-sourced check would go blind to the exact regression it must catch —
 someone deleting an entry from .installignore. This test goes red on a manifest
-mis-edit OR a staging-logic regression, and survives the parity gate (it tests
-Python, the permanent installer, not the bash↔python comparison)."""
+mis-edit OR a staging-logic regression."""
 
 from __future__ import annotations
 

--- a/packages/installer/tests/unit/test_prune_flow.py
+++ b/packages/installer/tests/unit/test_prune_flow.py
@@ -1,8 +1,8 @@
 """Unit tests for installer.core.prune_flow (G.4 — interactive prune flow).
 
 Each test pins a coded decision in ``run_prune``, the port of the bash
-``prune_orphans`` (``scripts/install.sh:1602-1687``). The engine is driven
-through ``ScriptedIO`` and asserted against real filesystem end-state plus the
+``prune_orphans``. The engine is driven through ``ScriptedIO`` and asserted
+against real filesystem end-state plus the
 returned per-target ``dict[str, Counters]`` (keyed by ``Orphan.tool``) — never
 against which IOPort method was called. A no-deletion path returns ``{}``; a
 deleting path returns one bucket per pruned orphan's tool.
@@ -323,7 +323,7 @@ def test_empty_orphan_list_is_noop() -> None:
     Then it returns pruned == 0 without consulting any prompt.
 
     Note: the empty fast-path sits AFTER the non-interactive guard (bash
-    ordering, scripts/install.sh:1603-1620), so this exercises the empty path
+    ordering), so this exercises the empty path
     only once the guard has been cleared — see
     test_non_interactive_prune_only_without_auth_raises for the guard-first case.
     """
@@ -342,7 +342,7 @@ def test_backup_precedes_delete_into_sibling_namespace_dir(tmp_path: Path) -> No
     and backed_up == 1.
 
     Pins the path-aware routing reuse: a scoped-namespace orphan's backup lands
-    in <grandparent>/<namespace>-backup/, not in-place (scripts/install.sh:369).
+    in <grandparent>/<namespace>-backup/, not in-place.
     """
     o1 = _file_orphan(tmp_path, "claude", "skills", "retired", body="precious")
     io = ScriptedIO(interactive=False)

--- a/packages/installer/tests/unit/test_receipt_pipeline.py
+++ b/packages/installer/tests/unit/test_receipt_pipeline.py
@@ -582,10 +582,12 @@ def test_cross_tree_relocation_prunes_stale_fanout_copies(tmp_path: Path) -> Non
     owner's desired keys, and root-valid, so all three are pruned; Claude's copy matches
     its desired key and is kept.
 
-    Pins the per-owner ``(owner, path)`` diff against a cross-tree relocation — the
-    receipt model's structural answer to the bash-era merged-source orphan gap (design
-    relocation scenario, case c). A regression here would mean a relocated-and-narrowed
-    skill leaves stale copies littering the tools it no longer ships to.
+    Pins the per-owner ``(owner, path)`` diff against a cross-tree relocation. A
+    merged-source install cannot attribute an orphan to its owner — the four copies
+    are one logical source, so a copy an owner no longer ships is indistinguishable
+    from one it still ships — which is why the receipt diff is keyed per owner. A
+    regression here would mean a relocated-and-narrowed skill leaves stale copies
+    littering the tools it no longer ships to.
     """
     home = tmp_path
     claude = home / ".claude" / "skills" / "zoom-out"

--- a/packages/installer/tests/unit/test_staging_build_plan.py
+++ b/packages/installer/tests/unit/test_staging_build_plan.py
@@ -75,7 +75,8 @@ def test_build_plan_stages_hooks_namespace_with_exec_bit(
     tmp_path: Path, ignore: InstallIgnore
 ) -> None:
     """The Claude installer stages src/user/.claude/hooks/ -> hooks/ and preserves
-    the +x bit on hook scripts (8.7 parity with install.sh's hooks/ support)."""
+    the +x bit on hook scripts (8.7 parity with the bash installer's hooks/
+    support)."""
     repo = _make_repo(tmp_path)
     plan = build_plan(ClaudeAdapter(), repo_root=repo, ignore=ignore)
     assert Path("hooks/ruff-postedit.py") in plan.items

--- a/packages/installer/tests/unit/test_staging_classify.py
+++ b/packages/installer/tests/unit/test_staging_classify.py
@@ -1,7 +1,7 @@
 """Unit tests for installer.core.staging.classify_file — C.1.
 
-Each test pins a row of the bash classify_file() truth table
-(scripts/install.sh:486-505) as mirrored onto FileKind.
+Each test pins a row of the bash classify_file() truth table as mirrored onto
+FileKind.
 """
 
 from __future__ import annotations

--- a/packages/installer/tests/unit/test_staging_shared_carrier.py
+++ b/packages/installer/tests/unit/test_staging_shared_carrier.py
@@ -1,7 +1,7 @@
 """build_plan Phase 2 marks shared skills/agents DIR items as carrier dirs.
 
 The ``shared_carrier`` flag is the in-memory replacement for the bash
-``.carrier-from-user-shared`` sentinel file (scripts/install.sh:517-529): it
+``.carrier-from-user-shared`` sentinel file: it
 records that a skills/agents directory was first staged from the shared carrier
 tree, so the Phase 6 plugin overlay can distinguish an allowed carrier-merge
 from a forbidden plugin-plugin directory collision. These tests pin *where*

--- a/packages/installer/tests/unit/test_summary.py
+++ b/packages/installer/tests/unit/test_summary.py
@@ -1,13 +1,13 @@
 """Unit tests for installer.core.summary.render_summary (8.18 — install summary).
 
-The renderer is the in-memory port of the bash install Summary
-(``scripts/install.sh:1801-1869``). It is pure: it takes the per-target merged
-``Counters``, the active tool/plugin lists, the ALL_* universes, and a verbose
-flag, and emits through the injected ``IOPort``. These tests drive it with
+The renderer is the in-memory port of the bash install Summary. It is pure: it
+takes the per-target merged ``Counters``, the active tool/plugin lists, the ALL_*
+universes, and a verbose flag, and emits through the injected ``IOPort``. These
+tests drive it with
 ``ScriptedIO`` and assert the recorded transcript STRINGS and the per-target
 grouping decisions — never which method fired, and never a Counters default.
 
-Covered decisions (bash spec line refs in each test):
+Covered decisions:
 - verbose per-tool block with the six fields in bash order,
 - the DIM '(not detected, skipped)' footer for an ALL_* target absent from the
   active/report set,
@@ -35,7 +35,7 @@ def test_verbose_block_lists_six_fields_in_bash_order() -> None:
     skipped spread, under verbose
     When render_summary runs
     Then its block lists the six fields in EXACT bash order — Installed, Updated,
-    Merged, Backed up, Pruned, Skipped (scripts/install.sh:1820-1825) — with
+    Merged, Backed up, Pruned, Skipped — with
     'Installed' sourced from Counters.created.
     """
     io = ScriptedIO()
@@ -72,8 +72,7 @@ def test_verbose_names_the_target_in_its_block_header() -> None:
     """
     Given an active tool, under verbose
     When render_summary runs
-    Then a header naming the tool ('-- claude --') is emitted before its fields
-    (scripts/install.sh:1819).
+    Then a header naming the tool ('-- claude --') is emitted before its fields.
     """
     io = ScriptedIO()
     render_summary(
@@ -95,7 +94,7 @@ def test_verbose_emits_not_detected_footer_for_inactive_all_tool() -> None:
     Given ALL_TOOLS={claude,codex} but only claude active, under verbose
     When render_summary runs
     Then a DIM '-- codex (not detected, skipped) --' footer is emitted for the
-    inactive tool (scripts/install.sh:1832-1834) and claude gets a real block.
+    inactive tool, and claude gets a real block.
     """
     io = ScriptedIO()
     render_summary(
@@ -120,8 +119,8 @@ def test_verbose_plugin_pruned_outside_active_set_gets_real_block_not_footer() -
     verbose
     When render_summary runs
     Then beads gets a real '-- beads --' block (its pruned tally), NOT a
-    '(not detected, skipped)' footer — bash AC#19 (scripts/install.sh:1808-1812,
-    keyed off REPORT_TARGETS so it is not double-printed).
+    '(not detected, skipped)' footer — bash AC#19, keyed off REPORT_TARGETS so it
+    is not double-printed.
     """
     io = ScriptedIO()
     render_summary(
@@ -146,7 +145,7 @@ def test_quiet_one_line_per_nonzero_target() -> None:
     under quiet (verbose=False)
     When render_summary runs
     Then claude gets a one-line summary naming its non-zero parts and codex is
-    omitted (scripts/install.sh:1847-1858).
+    omitted.
     """
     io = ScriptedIO()
     render_summary(
@@ -170,7 +169,7 @@ def test_quiet_all_zero_prints_up_to_date_em_dash_line() -> None:
     Given every active target all-zero (only skips), under quiet
     When render_summary runs
     Then it prints exactly 'All files up to date — no changes made.' (note the
-    em-dash) and no per-target lines (scripts/install.sh:1862-1863).
+    em-dash) and no per-target lines.
     """
     io = ScriptedIO()
     render_summary(
@@ -193,9 +192,9 @@ def test_quiet_skipped_is_not_a_change_but_verbose_still_prints_the_block() -> N
     Given an all-skips target, comparing quiet vs verbose
     When render_summary runs each way
     Then quiet omits it from the per-target lines (skips are not 'changes':
-    installed+updated+merged+pruned == 0, scripts/install.sh:1848) BUT verbose
-    still prints its full all-but-skipped block (scripts/install.sh:1818 iterates
-    every REPORT_TARGET regardless of activity).
+    installed+updated+merged+pruned == 0) BUT verbose still prints its full
+    all-but-skipped block — bash iterates every REPORT_TARGET regardless of
+    activity.
     """
     counters = {"claude": Counters(skipped=7)}
 
@@ -231,7 +230,7 @@ def test_quiet_reports_pruned_and_backed_up_parts() -> None:
     Given a target whose only activity is a prune (pruned + backed_up), under quiet
     When render_summary runs
     Then its one-line summary names 'pruned' and 'backed up' (pruned counts as a
-    change; scripts/install.sh:1855-1856) so a --prune run surfaces in the quiet
+    change) so a --prune run surfaces in the quiet
     summary.
     """
     io = ScriptedIO()
@@ -254,7 +253,7 @@ def test_verbose_summary_header_is_dash_wrapped_with_leading_blank() -> None:
     Given any verbose run
     When render_summary runs
     Then the 'Summary' header byte-matches bash header() — wrapped '-- Summary --'
-    (NOT bare 'Summary') and preceded by a blank line (scripts/install.sh:162,1816).
+    (NOT bare 'Summary') and preceded by a blank line.
     A bare 'Summary' or a missing leading blank is a parity regression.
     """
     io = ScriptedIO()
@@ -281,7 +280,7 @@ def test_verbose_block_and_footer_headers_are_dash_wrapped_with_leading_blank() 
     When render_summary runs
     Then each per-tool block header and each '(not detected, skipped)' footer is
     '-- ... --' wrapped and immediately preceded by a blank line, byte-matching
-    bash's leading-'\\n' printf (scripts/install.sh:1819,1833).
+    bash's leading-'\\n' printf.
     """
     io = ScriptedIO()
     render_summary(
@@ -307,7 +306,7 @@ def test_verbose_emits_blank_line_before_done() -> None:
     Given any verbose run
     When render_summary runs
     Then the final 'Done.' is immediately preceded by a blank line, matching
-    bash's ``echo ""`` before ``ok "Done."`` (scripts/install.sh:1844-1845).
+    bash's ``echo ""`` before ``ok "Done."``.
     """
     io = ScriptedIO()
     render_summary(
@@ -330,7 +329,7 @@ def test_quiet_emits_blank_line_before_outcome() -> None:
     Given a quiet run that changed nothing
     When render_summary runs
     Then a blank line precedes the 'up to date' line, matching bash's ``echo ""``
-    ahead of the quiet outcome branch (scripts/install.sh:1859).
+    ahead of the quiet outcome branch.
     """
     io = ScriptedIO()
     render_summary(

--- a/packages/installer/tests/unit/test_sync.py
+++ b/packages/installer/tests/unit/test_sync.py
@@ -370,12 +370,11 @@ def test_write_to_read_only_destination_surfaces_permission_error(tmp_path: Path
 # ─────────────────────── G.1: path-aware backup ───────────────────────
 #
 # These tests pin the path-aware backup contract ported from the bash
-# installer's backup() (scripts/install.sh:352-388): an existing
-# destination that is about to be overwritten is copied to a timestamped
-# backup BEFORE the write. The routing decision is coded — a scoped
-# namespace dir routes to a sibling <ns>-backup/, everything else gets an
-# in-place .backup-<ts> suffix — so each test pins that decision, not
-# Path/shutil semantics.
+# installer's backup(): an existing destination that is about to be
+# overwritten is copied to a timestamped backup BEFORE the write. The
+# routing decision is coded — a scoped namespace dir routes to a sibling
+# <ns>-backup/, everything else gets an in-place .backup-<ts> suffix — so
+# each test pins that decision, not Path/shutil semantics.
 
 _FIXED_TS = "20260613-120000"
 

--- a/packages/installer/tests/unit/test_sync_plan.py
+++ b/packages/installer/tests/unit/test_sync_plan.py
@@ -533,7 +533,7 @@ def test_unchanged_dir_item_is_skipped_without_backup(tmp_path: Path) -> None:
     When sync_plan re-runs into the same dest
     Then the unchanged dir is skipped — no backup is created and skipped is
     counted — mirroring bash sync_directory's ``src_hash == dest_hash`` "up to
-    date" branch (scripts/install.sh:1230) so a re-install is idempotent.
+    date" branch, so a re-install is idempotent.
     """
     src = tmp_path / "src_skill"
     (src / "sub").mkdir(parents=True)
@@ -936,11 +936,10 @@ def test_interactive_decline_keeps_existing_file_and_counts_skipped(tmp_path: Pa
 # ── 8.13: verbose per-file detail (bash parity) ──
 #
 # The bash installer emits per-file chatter via ``vok`` at the real-install
-# outcomes — "Installed X (new)" / "X is up to date" / "Updated X"
-# (scripts/install.sh:1158,1166,1180,1224,1237,1255). The Python port routes
-# these through the IOPort with ``verbose=True`` so ``TerminalIO`` suppresses
-# them unless constructed with ``verbose=True`` — matching ``vok``'s
-# silent-unless-``--verbose`` contract (scripts/install.sh:166-168). These tests
+# outcomes — "Installed X (new)" / "X is up to date" / "Updated X". The Python
+# port routes these through the IOPort with ``verbose=True`` so ``TerminalIO``
+# suppresses them unless constructed with ``verbose=True`` — matching ``vok``'s
+# silent-unless-``--verbose`` contract. These tests
 # assert the emission AND its ``verbose=True`` tag at the ScriptedIO transcript
 # boundary; the suppression direction itself is pinned in test_io_port.py.
 

--- a/packages/installer/tests/unit/test_sync_routes.py
+++ b/packages/installer/tests/unit/test_sync_routes.py
@@ -1,12 +1,11 @@
 """Unit tests for installer.core.sync.sync_routes (F.4 / G2 — plugin-route install).
 
 ``sync_routes`` is the in-memory port of the bash installer's
-``stage_and_install_beads`` (``scripts/install.sh:948-1124``): it walks a plugin's
-``PluginRoute`` set, globs each route's ``source_dir``, and installs the matched
-files at its ``dest_dir`` with the route's exec bit. Unlike the tool-file path, a
-route restores a *lost* exec bit on a hash-equal skip
-(``scripts/install.sh:1096``) — that restore is route-scoped, since bash carries
-no general executable-file mode reconcile.
+``stage_and_install_beads``: it walks a plugin's ``PluginRoute`` set, globs each
+route's ``source_dir``, and installs the matched files at its ``dest_dir`` with the
+route's exec bit. Unlike the tool-file path, a route restores a *lost* exec bit on a
+hash-equal skip — that restore is route-scoped, since bash carries no general
+executable-file mode reconcile.
 
 Each test pins a coded decision and drives the engine through ``ScriptedIO`` + the
 real filesystem under ``tmp_path``. ``PluginRoute`` carries absolute source/dest
@@ -80,7 +79,7 @@ def test_routes_install_only_glob_matches(tmp_path: Path) -> None:
     When sync_routes runs with glob *.toml
     Then only the .toml is installed; the README is left behind.
 
-    Pins: the route glob filters the source dir (install.sh:971 `for ... *.toml`),
+    Pins: the route glob filters the source dir (bash iterates `for ... *.toml`),
     so unrelated files in the plugin's route dir are not routed.
     """
     src = tmp_path / "src" / "formulas"
@@ -102,8 +101,8 @@ def test_route_with_missing_source_dir_installs_nothing(tmp_path: Path) -> None:
     When sync_routes runs
     Then nothing is installed, the dest is not created, and no error is raised.
 
-    Pins: bash guards each plugin's route dir with `[[ -d ... ]] || continue`
-    (install.sh:969,1056); a plugin without that subtree contributes no files.
+    Pins: bash guards each plugin's route dir with `[[ -d ... ]] || continue`;
+    a plugin without that subtree contributes no files.
     """
     src = tmp_path / "src" / "absent"
     dest = tmp_path / "home" / ".beads" / "formulas"
@@ -125,8 +124,9 @@ def test_route_unchanged_script_is_skipped_but_lost_exec_bit_is_restored(
     Then no rewrite/backup happens (content matches), but the exec bit is restored
     to 0o755 and the item counts as skipped.
 
-    Pins install.sh:1096 — "content matches but exec bit may have been lost;
-    restore it without a full copy" — route-scoped (bash has no general reconcile).
+    Pins the bash installer's rule — content matches but the exec bit may have been
+    lost, so restore it without a full copy — route-scoped (bash has no general
+    reconcile).
     """
     src = tmp_path / "src" / "scripts"
     dest = tmp_path / "home" / ".beads" / "scripts"
@@ -149,8 +149,8 @@ def test_route_lost_exec_restore_emits_verbose_detail_but_clean_skip_does_not(
     (0o644 -> repaired) and one whose dest already carries it (0o755 -> untouched)
     When sync_routes runs
     Then ONLY the repaired one emits a verbose-tagged "Restored +x" line — the
-    parity equivalent of bash ``vinfo "Restored +x on scripts/X"``
-    (scripts/install.sh:1096), which fires only when the repair actually happens.
+    parity equivalent of bash ``vinfo "Restored +x on scripts/X"``, which fires only
+    when the repair actually happens.
 
     Pins: the exec-bit repair on a hash-equal skip is announced under --verbose
     (and silent without it), and a skip that does no repair stays quiet on that
@@ -185,7 +185,7 @@ def test_route_restore_adds_exec_without_widening_existing_rw_bits(tmp_path: Pat
     a fixed 0o755 — bash's ``chmod +x`` preserves read/write bits and never widens
     group/other read.
 
-    Pins faithfulness to ``install.sh:1096`` ``chmod +x`` semantics (add exec,
+    Pins faithfulness to the bash installer's ``chmod +x`` semantics (add exec,
     preserve the rest), so a user-tightened file is not silently re-opened.
     """
     src = tmp_path / "src" / "scripts"
@@ -228,8 +228,8 @@ def test_route_skips_a_directory_that_matches_the_glob(tmp_path: Path) -> None:
     When sync_routes runs
     Then only the file is installed; the glob-matching directory is skipped.
 
-    Pins bash's `[[ -f "$formula" ]] || continue` (install.sh:972) — the glob can
-    match a directory, and only regular files are routed.
+    Pins bash's `[[ -f "$formula" ]] || continue` — the glob can match a directory,
+    and only regular files are routed.
     """
     src = tmp_path / "src" / "formulas"
     dest = tmp_path / "home" / ".beads" / "formulas"
@@ -274,8 +274,8 @@ def test_route_changed_file_is_backed_up_then_overwritten(tmp_path: Path) -> Non
     Then the original is backed up under <name>.backup-<ts>, the new bytes are
     written, the exec bit is set, and the item counts as an update + backup.
 
-    Pins: a changed route file is backed up before overwrite (install.sh:1109-1111
-    backup; cp; chmod +x), matching the tool-file overwrite contract.
+    Pins: a changed route file is backed up before overwrite (bash: backup; cp;
+    chmod +x), matching the tool-file overwrite contract.
     """
     src = tmp_path / "src" / "scripts"
     dest = tmp_path / "home" / ".beads" / "scripts"
@@ -298,7 +298,7 @@ def test_route_dry_run_previews_without_writing(tmp_path: Path) -> None:
     Then nothing is written to disk, but the would-be create is counted.
 
     Pins: dry_run previews and touches nothing, reusing the file installer's
-    dry-run contract (install.sh:1083 "Would install").
+    dry-run contract (bash's "Would install").
     """
     src = tmp_path / "src" / "scripts"
     dest = tmp_path / "home" / ".beads" / "scripts"
@@ -319,7 +319,7 @@ def test_route_dry_run_does_not_restore_a_lost_exec_bit(tmp_path: Path) -> None:
     Then the bit is NOT restored — a dry run mutates nothing, including mode.
 
     Pins the ``not dry_run`` term of the restore guard, mirroring bash's
-    ``[[ "$DRY_RUN" == true ]] ||`` on the line-1096 restore (install.sh:1096).
+    ``[[ "$DRY_RUN" == true ]] ||`` on the exec-bit restore.
     """
     src = tmp_path / "src" / "scripts"
     dest = tmp_path / "home" / ".beads" / "scripts"

--- a/packages/installer/tests/unit/test_sync_settings_union.py
+++ b/packages/installer/tests/unit/test_sync_settings_union.py
@@ -1,8 +1,8 @@
 """sync_plan unions a staged settings.json with the user's existing dest file.
 
-Ports the bash installer's ``sync_settings_file`` (``scripts/install.sh:1268-1335``):
-a settings.json install is not a blind overwrite — the staged template is
-union-merged into the user's current file so user values survive. A blind
+Ports the bash installer's ``sync_settings_file``: a settings.json install is not
+a blind overwrite — the staged template is union-merged into the user's current
+file so user values survive. A blind
 overwrite would leave the user's keys only in the backup; these tests pin the
 union semantics.
 """
@@ -82,7 +82,7 @@ def test_sync_settings_union_over_existing_counts_merged_not_updated(tmp_path: P
     """A settings.json union that changes an existing user file is tallied as a
     *merge*, not a plain update — bash increments ``tool_merged`` (not
     ``tool_updated``) when ``sync_settings_file`` applies a changed union over an
-    existing dest (``scripts/install.sh:1366``). The 'Merged' summary line counts
+    existing dest. The 'Merged' summary line counts
     exactly these. Pins: the changed-existing settings path increments
     ``Counters.merged`` and leaves created/updated at zero. Fails while the merge
     path tallies through ``_record_write`` (created/updated) and ``merged`` stays 0."""
@@ -105,8 +105,8 @@ def test_sync_settings_union_over_existing_counts_merged_not_updated(tmp_path: P
 
 def test_sync_fresh_settings_counts_created_not_merged(tmp_path: Path) -> None:
     """A first settings.json install (no existing dest) is a plain create, not a
-    merge — bash increments ``tool_installed`` on the new-file branch
-    (``scripts/install.sh:1303``), never ``tool_merged``. Pins: the no-existing-dest
+    merge — bash increments ``tool_installed`` on the new-file branch, never
+    ``tool_merged``. Pins: the no-existing-dest
     settings path increments ``created`` and leaves ``merged`` at zero. Fails if the
     merge tally fires on a fresh install (e.g. keyed on kind alone, not on an
     existing dest)."""
@@ -129,7 +129,7 @@ def test_sync_fresh_settings_counts_created_not_merged(tmp_path: Path) -> None:
 def test_sync_preserves_and_skips_invalid_existing_settings(tmp_path: Path) -> None:
     """An existing settings.json that is not valid JSON is left untouched and
     reported as an error, not overwritten — matching bash, which refuses to touch a
-    file it cannot parse (``scripts/install.sh:1299-1304``: err + skip + return, the
+    file it cannot parse (err + skip + return, the
     file left in place). Clobbering it with the template would leave the user's
     content only in a backup; these assertions pin the skip-and-preserve
     contract."""

--- a/packages/installer/tests/unit/test_templates.py
+++ b/packages/installer/tests/unit/test_templates.py
@@ -2,7 +2,7 @@
 
 Each test pins a behaviour the B.4 story contract requires
 (docs/specs/2026-05-31-w1qls.2.4-dynamic-include-file-form.md). The behavioural
-reference is the bash installer's flatten_agents_md (scripts/install.sh).
+reference is the bash installer's flatten_agents_md.
 """
 
 from __future__ import annotations

--- a/packages/installer/tests/unit/test_templates_flatten_plan.py
+++ b/packages/installer/tests/unit/test_templates_flatten_plan.py
@@ -1,6 +1,6 @@
 """Unit tests for installer.core.templates.flatten_plan_templates — the plan-level
 Phase 6.5/6.75 port: flatten the instruction templates in a StagingPlan, then drop
-the include-only templates they inline (bash install.sh:849-890).
+the include-only templates they inline.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What this does

Installer test docstrings pinned their assertions to the retired bash installer and cited
it by line number — `scripts/install.sh:1268-1335` and forty-five others. `scripts/install.sh`
is now a six-line `exec` stub, so a reader following a citation to learn why an assertion
holds arrives at nothing.

## The decision, and why it is not a deletion pass

**The retired implementation's behaviour is the specification these assertions pin. The
coordinate is the dangling part, not the behaviour.** A pass that deleted every mention of
the bash installer would strip the stated reason for the assertion sitting next to it —
which is the harm worth avoiding, since an assertion nobody can justify is an assertion
the next author deletes.

So each site got one of three treatments:

| Treatment | Sites |
| --- | --- |
| Coordinate stripped, behavioural statement kept | 22 |
| Whole clause cut — it carried nothing but the coordinate | 32 |
| Reason restated, because the citation was the only statement of it | 1 |
| **Total** | **55, across 18 files** |

That is larger than the item's estimate of roughly thirty-five across seven files. The
census was taken by grepping the whole test tree for `install.sh` and for bare line-range
coordinates, and it turned up three kinds the estimate missed: 46 dangling coordinates in
11 files, 5 bare artifact names with no coordinate, and 4 dead references that are not
coordinates at all.

## The four sites that needed a judgement rather than a rule

**`test_receipt_pipeline.py`** cited the merged-source orphan gap and was the only
statement of why the receipt diff is keyed per owner. Cutting it would orphan the
assertion from its reason. The reading was verified against `core/receipt_diff.py` —
`diff_orphans` takes `desired_keys: set[tuple[str, Path]]` and `live_roots_by_owner`, so
scope, desire and validation are all per-owner — and restated as a property: a
merged-source install cannot attribute an orphan to its owner, because the copies are one
logical source, so a copy an owner no longer ships is indistinguishable from one it still
ships.

**`test_installignore_invariant.py`** claimed the test "survives the parity gate". There is
no parity gate: zero case-insensitive hits for `parity` in the `Makefile`. The clause also
asserted the test is scoped to Python rather than a bash-versus-Python comparison, which
is now trivially true. Cut; the preceding sentence carries the guarantee.

**`test_cli_deploy_wiring.py`** carried a `NOTE` block instructing whoever was implementing
the feature how to wire it. The body already does what the note asked for, so nothing was
lost by deleting the scaffolding.

**`test_summary.py`** advertised "bash spec line refs in each test" in its module
docstring — a meta-claim that became false the moment the refs were stripped, and one the
item did not list. Reduced to the bare heading.

`test_sync_routes.py` cited one coordinate five times for four different behaviours. Each
now names its own behaviour locally — the exec-bit restore rule, add-not-clobber `chmod`
semantics, the announcement, the dry-run guard — rather than sharing one pointer.

## Left alone, deliberately

`test_doc_lint.py` and `test_doc_lint_cli.py` hold the only surviving `install.sh` and
`:NNN` strings, and all of them are executable — fixture writes and expected-value inputs
for the doc-lint rule itself. `scripts/install.sh` genuinely is still on disk and still an
entry point, so nothing there dangles. `test_overlay.py` turned out to carry no citation at
all despite being on the item's list. Planning-ID tags are a different defect class and are
untouched.

## Verification

**No executable line changed, and that is proven rather than asserted.** For every touched
Python file, the abstract syntax tree with docstrings and bare string expressions stripped
is identical to the same file on `main`: 18 files compared, 18 identical, zero differences.
This was checked independently of the authoring agent.

One precision, since the strip step does slightly more than "docstrings" suggests: it
removes every bare string-expression statement, which includes attribute-documentation
strings sitting under a name. Those are prose here and have no runtime effect, since the
compiler evaluates and discards them. So the claim is stronger than a docstring-only
comparison, not weaker.

| Gate | Result |
| --- | --- |
| `ci-installer` | exit 0 — 1245 passed, 2 skipped, coverage 97.90% against a 90% floor, `pip-audit` clean |
| `doc-lint` | exit 0 — 125 tracked Markdown files |
| AST identity | 18 / 18 identical |

Each gate was run standalone from the worktree root with its exit status read directly,
never piped, because a pipeline reports the last command's status and a red gate would read
as green. The gate's entry-verify step runs `--help` on the two entry points, which the
installer package documents as the sanctioned exception: it parses the argument table and
exits before anything is staged. No other installer route was touched and nothing was
deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HkuFNrwBjBpgwm5ojKGgky
