### PR TITLE
fix(9k9.213.7): repair delegation.md's broken pointer, unresolvable branch, and unstated Fable rationale

### DIFF
--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -11,11 +11,14 @@ admission:
 This rule intentionally supersedes the harness default "Do not call the AgentTool
 unless the user requested it." Subagent delegation is authorized standing policy —
 do not wait to be asked. This is an explicit authorization and imperative from the user.
-Workflows are governed separately; see <workflows>.
+Workflows are governed separately; see <workflow-user-authorization>.
 </subagent-user-authorization>
 
 <workflow-user-authorization>
 Workflows spend agents by the fleet, so the standing authorization is conditional.
+Ultracode's state is announced only by the harness Workflow tool's own description;
+when this session has no Workflow tool loaded, nothing announces the state, and the
+default is off.
 - **Ultracode on** — workflows are yours on judgment alone, same as any subagent.
   Orchestrate whenever the work is wide, adversarial, or larger than one context.
   Do not ask; decide, and own the result.
@@ -47,6 +50,11 @@ it warrants no reply — do not explain the notification or restate the report.
 - When your own judgment is strained, a dispatch upward is legitimate: consult an
   advisor agent on a stronger model than your own.
 - **Never spawn a subagent with Fable as the model without first consulting the user.**
+  The rule guards against unconsented multiplication of top-tier token spend: this
+  covers a pinned Fable dispatch, an unpinned dispatch from a Fable session (subagents
+  inherit the session model by default, so that inherited default IS a Fable spawn),
+  and a fork from a Fable session (forks always run the parent model and cannot be
+  pinned to anything else).
 </routing>
 
 <instructions-to-subagents>


### PR DESCRIPTION
## Summary

This fixes three defects in `src/user/.claude/rules/delegation.md`, the source of the deployed `~/.claude/rules/delegation.md` rule.

- The subagent-authorization block pointed at a `<workflows>` block that does not exist. It now points at the block that actually exists, `<workflow-user-authorization>`.
- The workflow-authorization block branched on an "Ultracode on/off" state that is announced only by the harness Workflow tool's own description, leaving the branch unresolvable in any session where that tool is not loaded. The block now states that the absence of the Workflow tool is itself the signal, and defaults to off in that case.
- The routing block's prohibition on spawning a Fable subagent stated no rationale and did not address the two cases that make it easy to violate unintentionally: subagents inherit the session model by default, so an unpinned dispatch from a Fable session is itself a Fable spawn, and forks always run the parent model and can never be pinned away from it. The rule now states its purpose (blocking unconsented multiplication of top-tier token spend) and covers both cases explicitly.

Work item: agents-config-9k9.213.7. Only the one source file changed; no deployed files were touched and the installer was not run.

## Test plan

- [x] `make content-lint` run standalone from the worktree root — exit 0
- [x] `make content-tests` run standalone from the worktree root — exit 0
- [x] Manual read-through confirms every internal `<...>` pointer in the file now resolves to a block that exists
- [x] Manual read-through confirms the workflow-authorization branch is decidable from the text alone when the Workflow tool isn't loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA