### PR TITLE
fix(9k9.213.3): exclude shell test suites by class and fix OpenCode skills-location docs

### DIFF
--- a/.installignore
+++ b/.installignore
@@ -68,19 +68,20 @@ GEMINI.md
 # unread directory as a defect, and without a declaration it would fail the build
 # for whoever follows that layout table.
 /rules-readmes/
-# Confirmed live leaker, not defensive coverage — but only because THIS ONE
-# sits at the depth an anchored pattern reaches (ruff-postedit_test.sh is a
-# direct child of the hooks/ namespace dir).
-/ruff-postedit_test.sh
 # Dev-only artifacts that must never deploy, at ANY depth — including inside a
 # DIR item's own interior (a skill's scripts/ subdir, most visibly). The
-# Python patterns mirror the repo gate's suite discovery (*_test.py or
-# test_*.py) deliberately: a file the gate runs as a repo-side suite must not
-# be a file the installer ships. Widening one without the other lets a suite
-# be both executed here and deployed downstream.
+# Python and shell patterns mirror the repo gate's suite discovery (*_test.<ext>
+# or test_*.<ext>) deliberately: a file the gate runs as a repo-side suite must
+# not be a file the installer ships. Widening one without the other lets a
+# suite be both executed here and deployed downstream. Confirmed live leakers:
+# ruff-postedit_test.sh and codex-broker-reaper_test.sh, both direct children
+# of the hooks/ namespace dir — caught by class (below) rather than by name,
+# so a future hook's own *_test.sh suite is covered without a new entry.
 *_test.py
 test_*.py
 *_test.js
+*_test.sh
+test_*.sh
 *.pyc
 __pycache__/
 .pytest_cache/

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -12,9 +12,10 @@ if TYPE_CHECKING:
 class OpenCodeAdapter:
     """Adapter for OpenCode. Two divergences from the dot-dir tools:
     it installs under the XDG config dir (~/.config/opencode/, not ~/.opencode/),
-    and it skips the shared agents/ namespace (frontmatter format differs;
-    see OPENCODE-EXTENSIONS.md). Detected when opencode is on PATH OR the XDG
-    config dir (~/.config/opencode) exists."""
+    and it skips the shared agents/ namespace (OpenCode's agent frontmatter uses
+    provider-prefixed model IDs plus mode:/permission: keys, unlike the shared
+    format). Detected when opencode is on PATH OR the XDG config dir
+    (~/.config/opencode) exists."""
 
     name: str = "opencode"
 
@@ -40,7 +41,8 @@ class OpenCodeAdapter:
 
     def should_install_namespace(self, namespace: str, source: str) -> bool:
         # Skip the shared agents/ namespace: OpenCode's agent frontmatter format
-        # differs from the shared format (see OPENCODE-EXTENSIONS.md).
+        # differs from the shared format (provider-prefixed model IDs plus
+        # mode:/permission: keys).
         return not (namespace == "agents" and source == "shared")
 
     def post_staging_transforms(

--- a/packages/installer/tests/unit/test_installignore_invariant.py
+++ b/packages/installer/tests/unit/test_installignore_invariant.py
@@ -76,3 +76,19 @@ def test_readme_stays_anchored_so_a_skill_can_ship_one() -> None:
 
     assert not ignore.excludes_path(Path("some-skill/references/README.md"))
     assert ignore.excludes("README.md", is_dir=False, at_root=True)
+
+
+def test_shell_test_suites_are_excluded_by_class_not_by_name() -> None:
+    """A hook's own ``*_test.sh`` suite must never deploy, using the REAL repo
+    ``.installignore`` and the REAL Claude hooks/ staging (hooks are Claude-only).
+
+    ``ruff-postedit_test.sh`` was once carried as a single named entry; a second
+    shell suite (``codex-broker-reaper_test.sh``) shipped anyway because nothing
+    excluded the class. Both must be caught the same way ``*_test.py`` catches
+    every Python suite, so a third hook's own suite needs no new manifest line."""
+    ignore = load_installignore(_REPO_ROOT / ".installignore")
+    plan = build_plan(get_adapter(Tool.CLAUDE), repo_root=_REPO_ROOT, ignore=ignore)
+
+    for leaker in ("ruff-postedit_test.sh", "codex-broker-reaper_test.sh"):
+        assert Path("hooks") / leaker not in plan.items, f"{leaker} leaked into the Claude plan"
+        assert ignore.excludes(leaker, is_dir=False, at_root=True)

--- a/packages/installer/tests/unit/test_opencode_skills_location.py
+++ b/packages/installer/tests/unit/test_opencode_skills_location.py
@@ -1,0 +1,46 @@
+"""Invariant guard: every statement about where OpenCode skills land agrees
+with where the installer actually stages them.
+
+Three surfaces make this claim independently — the runtime config template,
+and two source-side docs read by contributors — and nothing enforced that a
+change to one would keep the others honest. This test reads all three plus
+the real ``OpenCodeAdapter`` and requires them to agree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from installer.tools.opencode import OpenCodeAdapter
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_FAKE_HOME = Path("/home/u")
+
+
+def _real_skills_dir() -> Path:
+    """Where the installer actually stages OpenCode's shared skills/ namespace."""
+    return OpenCodeAdapter().dest_dir(_FAKE_HOME) / "skills"
+
+
+def test_jsonc_template_skills_paths_matches_real_staging_destination() -> None:
+    template = _REPO_ROOT / "src" / "user" / ".opencode" / "opencode.jsonc.template"
+    config = json.loads(template.read_text(encoding="utf-8"))
+    (configured,) = config["skills"]["paths"]
+
+    assert configured.startswith("~/")
+    expanded = _FAKE_HOME / configured.removeprefix("~/")
+    assert expanded == _real_skills_dir()
+
+
+def test_opencode_agents_md_names_the_real_skills_destination() -> None:
+    text = (_REPO_ROOT / "src" / "user" / ".opencode" / "AGENTS.md").read_text(encoding="utf-8")
+    assert "~/.config/opencode/skills/" in text
+    # The two prior wrong answers this doc gave, so a regression to either is caught.
+    assert "~/.claude/skills" not in text
+    assert "~/.agents/skills" not in text
+
+
+def test_shared_readme_names_the_real_opencode_skills_destination() -> None:
+    text = (_REPO_ROOT / "src" / "user" / ".agents" / "README.md").read_text(encoding="utf-8")
+    assert "~/.config/opencode/" in text

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -3,9 +3,10 @@ OpenCodeAdapter — this is where OpenCodeAdapter.should_install_namespace
 earns behavioural coverage.
 
 Pins the key OpenCode divergence from Claude/Codex: the shared agents/
-namespace is NOT staged (frontmatter format differs; see
-OPENCODE-EXTENSIONS.md), while shared skills/ and rules/ ARE staged
-(rules remain available for DYNAMIC-INCLUDE-ALL-RULES inlining).
+namespace is NOT staged (OpenCode's agent frontmatter uses provider-prefixed
+model IDs plus mode:/permission: keys, unlike the shared format), while shared
+skills/ and rules/ ARE staged (rules remain available for
+DYNAMIC-INCLUDE-ALL-RULES inlining).
 """
 
 from __future__ import annotations

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -20,9 +20,10 @@ resolution.
 
 ## Skills
 
-OpenCode scans `~/.claude/skills/**/SKILL.md` natively. Shared skills are
-available without duplication. Skills use bare names (e.g. `review-verdict`)
-and are installed from this repo's `src/` directory.
+Shared skills stage into `~/.config/opencode/skills/` the same way they stage
+into every other tool's tree (one directory per skill, bare names like
+`review-verdict`). `opencode.jsonc.template`'s `skills.paths` names that
+directory explicitly; OpenCode also scans it as a default location on its own.
 
 ## Agents and commands
 

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -22,8 +22,9 @@ resolution.
 
 Shared skills stage into `~/.config/opencode/skills/` the same way they stage
 into every other tool's tree (one directory per skill, bare names like
-`review-verdict`). `opencode.jsonc.template`'s `skills.paths` names that
-directory explicitly; OpenCode also scans it as a default location on its own.
+`review-verdict`). `opencode.jsonc.template`'s `skills.paths` points OpenCode
+at that same directory, so the installed config and the installed content
+agree on where to look.
 
 ## Agents and commands
 

--- a/src/user/.opencode/README.md
+++ b/src/user/.opencode/README.md
@@ -5,7 +5,6 @@ This directory contains source templates for OpenCode (`opencode`) support.
 ## Contents
 
 - `AGENTS.md.template` — Skeleton with dynamic-include markers for the flat instruction file
-- `OPENCODE-EXTENSIONS.md.template` — OpenCode-specific notes and conventions
 - `opencode.jsonc.template` — Settings (model, permissions, skills paths)
 
 ## How it works

--- a/src/user/.opencode/opencode.jsonc.template
+++ b/src/user/.opencode/opencode.jsonc.template
@@ -3,7 +3,7 @@
   "model": "moonshotai/kimi-k2.6",
   "skills": {
     "paths": [
-      "~/.agents/skills/"
+      "~/.config/opencode/skills/"
     ]
   },
   "permission": {


### PR DESCRIPTION
## Summary

- `.installignore` excluded Python and JS dev-only test suites by class (`*_test.py`, `test_*.py`, `*_test.js`) but only one shell suite by name (`/ruff-postedit_test.sh`). A second shell suite, `codex-broker-reaper_test.sh`, had no matching pattern and was shipping to `~/.claude/hooks/`. This adds `*_test.sh` and `test_*.sh` as class patterns (mirroring the Python precedent's dual convention) and drops the now-redundant named entry. A new test, `test_shell_test_suites_are_excluded_by_class_not_by_name`, proves both known shell suites are excluded against the real `.installignore`; it fails without this change.
- Three sources disagreed about where OpenCode's shared skills land: `opencode.jsonc.template` pointed `skills.paths` at `~/.agents/skills/` (a directory this installer never populates), `src/user/.opencode/AGENTS.md` claimed OpenCode "scans `~/.claude/skills/**/SKILL.md` natively", and only `src/user/.agents/README.md` had it right. Per the installer's staging code (`core/staging.py`'s `build_plan`, Phase 2), the shared `skills/` namespace stages into every active tool's own `dest_dir`, so OpenCode's copy lands at `~/.config/opencode/skills/`, same mechanism as every other tool. Corrected the template and the AGENTS.md prose to agree with `README.md`; added `test_opencode_skills_location.py`, which reads all three real files plus the real `OpenCodeAdapter` and fails without the fix.
- `src/user/.opencode/README.md` listed `OPENCODE-EXTENSIONS.md.template`, which does not exist anywhere in the repo. Removed the stale bullet, and fixed the same dangling reference in three other places that cited it (`OpenCodeAdapter`'s docstring x2, and `test_staging_opencode.py`'s docstring) — replaced with the actual fact each comment was gesturing at (OpenCode's agent frontmatter uses provider-prefixed model IDs plus `mode:`/`permission:` keys).

## Not included: prune's OpenCode-tree coverage

The work item (`agents-config-9k9.213.3`) also asked to make the installer's prune cover the OpenCode tree, evidenced by real debris in `~/.config/opencode/skills/` (retired bead-era skill directories, a stale `zoom-out` directory, and a leaked `AGENTS.md` file directly under `skills/`).

Investigation found the receipt-diff prune engine already covers this correctly and generically for OpenCode, including the multi-segment `.config/opencode` root and both directory- and file-kind orphans (verified with fake-home reproductions of both cases, matching sha256 included). The debris is explained by content that predates any receipt entry for it — either because it existed on disk from before OpenCode's receipt tracking or the most recent retirement, or from before the `.installignore` `AGENTS.md` exclusion landed (2026-07-31) — and pruning is deliberately, by design, never allowed to sweep undocumented content it merely finds on disk (pinned by the existing `test_hook_present_but_recorded_in_no_receipt_is_left_alone`). Making the current real-machine debris disappear via code alone would require either running a real install (to first record a baseline) or reversing that pinned "never touch untracked content" invariant — both are out of bounds per the task brief's own stop conditions. Full reasoning and reproduction steps are in the accompanying report.

## Test plan

- [x] `make ci` from the worktree root: exit 0 (installer, prgroom, workcli, grind, gitclean, executor package gates; lint-actions, spec-lint, content-lint, content-tests, doc-lint)
- [x] New/changed tests independently verified to fail on the pre-fix code via `git stash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA