### PR TITLE
fix(9k9.213.4): the always-on core says what the charter admitted, and a gate holds it there

### DIFF
--- a/packages/installer/src/installer/content_lint_cli.py
+++ b/packages/installer/src/installer/content_lint_cli.py
@@ -21,6 +21,7 @@ from installer.core.merge.registry import UnknownMergeKeyError
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_CORE_TOKEN_CAP,
     USER_INVOKED_SKILL_BODY_TOKEN_CAP,
 )
 
@@ -42,14 +43,21 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _report_budgets(result: ContentLintResult) -> None:
     """Print the measured always-on and per-skill numbers to stdout."""
-    sys.stdout.write(f"content-lint: always-on surface (cap {ALWAYS_ON_TOKEN_CAP} tokens)\n")
+    sys.stdout.write(
+        f"content-lint: always-on surface (cap {ALWAYS_ON_TOKEN_CAP} tokens, "
+        f"core {USER_CORE_TOKEN_CAP})\n"
+    )
     for surface in sorted(result.surfaces, key=lambda s: s.tool):
-        # The two components are split because they grow for different reasons:
-        # rules change rarely, and the catalog gains an entry with every skill
-        # admitted. A single total hides which one is moving.
+        # The components are split because they grow for different reasons:
+        # rules change rarely, the catalog gains an entry with every skill
+        # admitted, and the core moves only when the shared zero-base or a tool's
+        # own template does. A single total hides which one is moving, and hides
+        # the core entirely — it is an eighth of the surface cap, so a core that
+        # has doubled still leaves the total looking comfortable.
         sys.stdout.write(
             f"  {surface.tool:<10} {surface.tokens:>6} tokens  "
-            f"({surface.rules} rule(s), {surface.catalog_entries} catalog entr"
+            f"(core {surface.core_tokens}, {surface.rules} rule(s), "
+            f"{surface.catalog_entries} catalog entr"
             f"{'y' if surface.catalog_entries == 1 else 'ies'})\n"
         )
 

--- a/packages/installer/src/installer/content_lint_cli.py
+++ b/packages/installer/src/installer/content_lint_cli.py
@@ -52,8 +52,8 @@ def _report_budgets(result: ContentLintResult) -> None:
         # rules change rarely, the catalog gains an entry with every skill
         # admitted, and the core moves only when the shared zero-base or a tool's
         # own template does. A single total hides which one is moving, and hides
-        # the core entirely — it is an eighth of the surface cap, so a core that
-        # has doubled still leaves the total looking comfortable.
+        # the core entirely — the surface cap is over twelve times the core's, so
+        # a core that has doubled still leaves the total looking comfortable.
         sys.stdout.write(
             f"  {surface.tool:<10} {surface.tokens:>6} tokens  "
             f"(core {surface.core_tokens}, {surface.rules} rule(s), "

--- a/packages/installer/src/installer/core/deploy_gate.py
+++ b/packages/installer/src/installer/core/deploy_gate.py
@@ -13,12 +13,13 @@ is assembled and before any write. It:
    ``sanitize`` and ``capabilities``);
 3. measures the **surface budget** over the *rewritten admitted* content — the
    always-on surface per tool, which now includes the catalog entry of every
-   skill that tool's runtime publishes to the model, and each admitted skill
-   body against the cap that fits the target it is deploying to. Measuring
-   after the rewrite is the point twice over: the budget weighs what a reader
-   actually loads rather than the governance metadata that enforces it, and it
-   reads the projected front matter rather than the source, so a declaration
-   the target's loader cannot honour prices nothing;
+   skill that tool's runtime publishes to the model, the instruction file alone
+   against the core sub-budget inside it, and each admitted skill body against
+   the cap that fits the target it is deploying to. Measuring after the rewrite
+   is the point twice over: the budget weighs what a reader actually loads
+   rather than the governance metadata that enforces it, and it reads the
+   projected front matter rather than the source, so a declaration the target's
+   loader cannot honour prices nothing;
 4. runs the **conflict audit** over the admitted artifacts' claims.
 
 The unit judged is the **contributor**, not the destination. A rule destination
@@ -77,6 +78,7 @@ from installer.core.surface_budget import (
     measure_always_on,
     measure_skill_bodies,
     skill_body_violations,
+    user_core_violations,
 )
 
 if TYPE_CHECKING:
@@ -536,6 +538,7 @@ def run_admission_gate(
         violations += always_on_violations(
             tool=tool.value, instruction=instruction, rules=rule_bytes, catalog=entries
         )
+        violations += user_core_violations(tool=tool.value, instruction=instruction)
     violations += skill_body_violations(skill_bodies)
     violations += conflict_violations(claims_by_artifact)
 

--- a/packages/installer/src/installer/core/surface_budget.py
+++ b/packages/installer/src/installer/core/surface_budget.py
@@ -1,15 +1,25 @@
 """The always-on surface budget.
 
-Two mechanical caps, each a hard failure that aborts the deploy before any
+Three mechanical caps, each a hard failure that aborts the deploy before any
 write:
 
 - the **always-on surface** for a tool — the deployed instruction file, every
   admitted always-on rule, and every skill catalog entry that tool's runtime
   publishes to the model — is capped at ``ALWAYS_ON_TOKEN_CAP``;
+- the **user core** inside that surface — the deployed instruction file alone,
+  which is the shared zero-based core after assembly — is capped at
+  ``USER_CORE_TOKEN_CAP``;
 - each admitted **skill body** (the SKILL.md content after its front matter,
   the on-invoke payload) is capped at ``SKILL_BODY_TOKEN_CAP``, or at
   ``USER_INVOKED_SKILL_BODY_TOKEN_CAP`` when the target it deploys to keeps
   that skill out of the model's reach.
+
+The core cap is a sub-budget rather than a second opinion about the same
+bytes. The surface cap prices what a session loads in total, and a surface
+under it can still be one bloated instruction file with nothing else admitted;
+the core cap prices the one component that no admission decision can remove,
+so a line only earns a place in it by being universal. Without it the core can
+grow by an order of magnitude and stay invisible under the wider ceiling.
 
 A ceiling prices bytes the reader cannot decline, and it prices them as the
 target actually loads them. A catalog entry is the unconditional case: a skill's
@@ -62,6 +72,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 ALWAYS_ON_TOKEN_CAP = 10_000
+USER_CORE_TOKEN_CAP = 800
 SKILL_BODY_TOKEN_CAP = 2_000
 USER_INVOKED_SKILL_BODY_TOKEN_CAP = 5_000
 
@@ -80,10 +91,15 @@ class SurfaceMeasure:
     rule count is one rule bloating, both rising is the surface accreting, and a
     rising entry count is the component that grows with every admission while
     the rules stay still.
+
+    ``core_tokens`` is the instruction file's own share of ``tokens``, carried
+    separately because it answers to a cap of its own and because it is the one
+    component a reader cannot decline by admitting less.
     """
 
     tool: str
     tokens: int
+    core_tokens: int
     rules: int
     catalog_entries: int
 
@@ -161,10 +177,17 @@ def measure_always_on(
     the target does with it. An entry the target's runtime never publishes must
     not be in the list.
     """
-    total = approx_tokens(instruction) if instruction is not None else 0
+    core = approx_tokens(instruction) if instruction is not None else 0
+    total = core
     for entry in (*rules, *catalog):
         total += approx_tokens(entry)
-    return SurfaceMeasure(tool=tool, tokens=total, rules=len(rules), catalog_entries=len(catalog))
+    return SurfaceMeasure(
+        tool=tool,
+        tokens=total,
+        core_tokens=core,
+        rules=len(rules),
+        catalog_entries=len(catalog),
+    )
 
 
 def skill_body_cap(*, user_invoked: bool) -> int:
@@ -195,6 +218,25 @@ def always_on_violations(
         return [
             f"{tool}: always-on surface is {measure.tokens} tokens, over the "
             f"{ALWAYS_ON_TOKEN_CAP}-token cap"
+        ]
+    return []
+
+
+def user_core_violations(*, tool: str, instruction: bytes | None) -> list[str]:
+    """Violation messages if a tool's deployed instruction file exceeds the core
+    cap. Returns at most one message.
+
+    Measured on the assembled file rather than on the shared source, because the
+    core a session pays is what a tool's template produced: a template that
+    includes the shared core and then adds to it has grown the core, whatever
+    the shared file weighs. A tool deploying no instruction file has no core.
+    """
+    if instruction is None:
+        return []
+    tokens = approx_tokens(instruction)
+    if tokens > USER_CORE_TOKEN_CAP:
+        return [
+            f"{tool}: always-on core is {tokens} tokens, over the {USER_CORE_TOKEN_CAP}-token cap"
         ]
     return []
 

--- a/packages/installer/src/installer/core/surface_budget.py
+++ b/packages/installer/src/installer/core/surface_budget.py
@@ -7,8 +7,8 @@ write:
   admitted always-on rule, and every skill catalog entry that tool's runtime
   publishes to the model — is capped at ``ALWAYS_ON_TOKEN_CAP``;
 - the **user core** inside that surface — the deployed instruction file alone,
-  which is the shared zero-based core after assembly — is capped at
-  ``USER_CORE_TOKEN_CAP``;
+  which is the shared zero-based core plus whatever the tool's own template
+  adds around it — is capped at ``USER_CORE_TOKEN_CAP``;
 - each admitted **skill body** (the SKILL.md content after its front matter,
   the on-invoke payload) is capped at ``SKILL_BODY_TOKEN_CAP``, or at
   ``USER_INVOKED_SKILL_BODY_TOKEN_CAP`` when the target it deploys to keeps

--- a/packages/installer/tests/unit/test_content_lint_cli.py
+++ b/packages/installer/tests/unit/test_content_lint_cli.py
@@ -53,9 +53,9 @@ def test_clean_tree_exits_zero_and_prints_the_budget_numbers(
 
     out = capsys.readouterr().out
     assert f"cap {ALWAYS_ON_TOKEN_CAP} tokens" in out
-    # The core is an eighth of the surface cap, so its own number and its own
-    # ceiling both have to print: a core that had doubled would otherwise leave
-    # the surface total looking comfortable.
+    # The core answers to a ceiling over twelve times tighter than the surface
+    # cap, so its own number and its own ceiling both have to print: a core that
+    # had doubled would otherwise leave the surface total looking comfortable.
     assert f"core {USER_CORE_TOKEN_CAP}" in out
     assert "(core 0," in out
     # Both ceilings on the header, and the one that applied on the body's own

--- a/packages/installer/tests/unit/test_content_lint_cli.py
+++ b/packages/installer/tests/unit/test_content_lint_cli.py
@@ -16,6 +16,7 @@ from installer.core.merge.base import CollisionError
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_CORE_TOKEN_CAP,
     USER_INVOKED_SKILL_BODY_TOKEN_CAP,
 )
 
@@ -43,7 +44,7 @@ def _repo(
     return tmp_path
 
 
-def test_clean_tree_exits_zero_and_prints_both_budgets(
+def test_clean_tree_exits_zero_and_prints_the_budget_numbers(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     repo = _repo(tmp_path, skill=_RECORD + "short\n")
@@ -52,6 +53,11 @@ def test_clean_tree_exits_zero_and_prints_both_budgets(
 
     out = capsys.readouterr().out
     assert f"cap {ALWAYS_ON_TOKEN_CAP} tokens" in out
+    # The core is an eighth of the surface cap, so its own number and its own
+    # ceiling both have to print: a core that had doubled would otherwise leave
+    # the surface total looking comfortable.
+    assert f"core {USER_CORE_TOKEN_CAP}" in out
+    assert "(core 0," in out
     # Both ceilings on the header, and the one that applied on the body's own
     # line: with two caps in play a lone number says nothing about headroom.
     assert f"cap {SKILL_BODY_TOKEN_CAP} tokens" in out

--- a/packages/installer/tests/unit/test_deploy_gate.py
+++ b/packages/installer/tests/unit/test_deploy_gate.py
@@ -26,6 +26,7 @@ from installer.core.model import (
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_CORE_TOKEN_CAP,
     USER_INVOKED_SKILL_BODY_TOKEN_CAP,
     approx_tokens,
 )
@@ -116,6 +117,26 @@ def test_admitted_surface_over_cap_fails() -> None:
     result = run_admission_gate(plans)
     assert not result.ok
     assert any("always-on surface" in v for v in result.violations)
+
+
+def test_an_oversized_instruction_file_fails_the_core_sub_budget() -> None:
+    """The gate weighs the instruction file twice: once inside the surface total,
+    and once against the core cap. This file breaches only the second, which is
+    the case the surface cap alone would deploy without comment."""
+    plans = {Tool.CLAUDE: _plan(_instruction(b"x" * (USER_CORE_TOKEN_CAP * 4 + 4)))}
+    result = run_admission_gate(plans)
+    assert not result.ok
+    assert any("always-on core" in v for v in result.violations)
+    assert not any("always-on surface" in v for v in result.violations)
+
+
+def test_the_gate_reports_the_core_beside_the_surface_total() -> None:
+    """Both numbers travel with the measurement, so the lint's trend report does
+    not have to re-derive a component the gate already weighed."""
+    plans = {Tool.CLAUDE: _plan(_instruction(b"x" * 400), _rule("a.md", _COMPLETE))}
+    result = run_admission_gate(plans)
+    assert result.ok, result.violations
+    assert [(s.tool, s.core_tokens) for s in result.surfaces] == [("claude", 100)]
 
 
 def test_conflicting_claims_across_admitted_items_fail() -> None:

--- a/packages/installer/tests/unit/test_surface_budget.py
+++ b/packages/installer/tests/unit/test_surface_budget.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from installer.core.surface_budget import (
     ALWAYS_ON_TOKEN_CAP,
     SKILL_BODY_TOKEN_CAP,
+    USER_CORE_TOKEN_CAP,
     USER_INVOKED_SKILL_BODY_TOKEN_CAP,
     SkillBodySource,
     always_on_violations,
@@ -15,6 +16,7 @@ from installer.core.surface_budget import (
     measure_skill_bodies,
     measure_skill_payload,
     skill_body_violations,
+    user_core_violations,
 )
 
 
@@ -57,6 +59,55 @@ def test_no_instruction_file_counts_only_rules() -> None:
     assert (
         always_on_violations(tool="gemini", instruction=None, rules=[b"x" * 16], catalog=[]) == []
     )
+
+
+def test_the_core_boundary_passes_at_the_cap_and_fails_one_over() -> None:
+    """The core sub-budget, pinned at both sides of its edge. The number is the
+    ceiling a line has to fit to earn always-on status, so a change to it is a
+    change to what the shared core may say."""
+    at_cap = b"x" * (USER_CORE_TOKEN_CAP * 4)
+    assert user_core_violations(tool="claude", instruction=at_cap) == []
+    over = b"x" * (USER_CORE_TOKEN_CAP * 4 + 1)
+    violations = user_core_violations(tool="claude", instruction=over)
+    assert len(violations) == 1
+    assert "claude" in violations[0]
+    assert str(USER_CORE_TOKEN_CAP) in violations[0]
+
+
+def test_a_core_many_times_over_its_cap_still_passes_the_surface_cap() -> None:
+    """Why the sub-budget exists at all. The surface ceiling is over ten times the
+    core's, so without a cap of its own the core can grow by an order of magnitude
+    and breach nothing."""
+    bloated = b"x" * (USER_CORE_TOKEN_CAP * 4 * 5)
+    assert always_on_violations(tool="claude", instruction=bloated, rules=[], catalog=[]) == []
+    assert len(user_core_violations(tool="claude", instruction=bloated)) == 1
+
+
+def test_rules_and_catalog_entries_are_not_charged_to_the_core() -> None:
+    """The core is the instruction file alone. Admitted rules and catalog entries
+    answer to the surface cap, and charging them here would fail a core that had
+    not moved — the one number a reader cannot reduce by admitting less."""
+    measure = measure_always_on(
+        tool="claude", instruction=b"x" * 400, rules=[b"y" * 4_000], catalog=[b"z" * 400]
+    )
+    assert (measure.core_tokens, measure.tokens) == (100, 1_200)
+
+
+def test_a_tool_with_no_instruction_file_has_no_core() -> None:
+    """Gemini's rules deploy without one, and a missing file is a core of zero
+    rather than a breach."""
+    assert user_core_violations(tool="gemini", instruction=None) == []
+    measure = measure_always_on(tool="gemini", instruction=None, rules=[b"x" * 16], catalog=[])
+    assert measure.core_tokens == 0
+
+
+def test_the_core_verdict_is_the_core_measurement_it_reports() -> None:
+    """Same contract as the surface cap: the lint reports headroom from the number
+    the gate fails on, so the two can never disagree about what the core weighs."""
+    over = b"x" * (USER_CORE_TOKEN_CAP * 4 + 1)
+    measure = measure_always_on(tool="claude", instruction=over, rules=[], catalog=[])
+    violations = user_core_violations(tool="claude", instruction=over)
+    assert str(measure.core_tokens) in violations[0]
 
 
 def test_skill_body_over_cap_is_named() -> None:

--- a/src/user/.agents/USER-CORE.md.template
+++ b/src/user/.agents/USER-CORE.md.template
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 <laws>
-Precedence: L0 > L1 > L2 > L3. Surface conflicts; never silently resolve them.
+Precedence: L0 > L1 > L2 > L3. Every block below is read under these laws: the decision rules resolve an unknown, the hard lines bound what an instruction can authorize, and the conventions are what L3 asks for in practice. Surface conflicts; never silently resolve them.
 - L0 Codebase: refuse changes that cause architectural drift, duplication, or design violations
 - L1 Safety: no vulnerabilities or bugs; challenge incorrect assumptions about the code — don't just agree
 - L2 Obey: follow instructions unless L0/L1 is violated — then propose alternatives
@@ -17,15 +17,10 @@ Facing an unknown, classify then act:
 Narrow "when in doubt, do the safe thing" rules (merge authorization, destructive git) override this matrix on their domain.
 </decisions>
 
-<reporting>
-- While delegated work is outstanding, report no partial findings and no per-agent play-by-play — nothing a later report might revise. A one-line status is fine.
-- When the last delegated result is in, deliver one answer: recommendation first, then only the facts that carry it, then an offer of detail on request. Fold corrections into it rather than spending a turn on them.
-</reporting>
-
 <hard-lines>
 - No hard resets, force pushes, amends, or `git clean -fd` without explicit approval.
 - Stage by explicit path. `git add -A`, `git add .` and `commit -a` sweep in untracked artifacts and other agents' in-flight files; read `git status` first and name what you are committing.
-- Creating a PR is not authorization to merge. Absent an explicit instruction or a configured rule-based policy, do not merge.
+- Creating a PR is not authorization to merge. Absent an explicit instruction, or a merge policy stated in writing in the project's own configuration, do not merge — branch protection, a green pipeline and an approving review are not one.
 - Before deleting or overwriting work you didn't create, look at it; surface contradictions instead of proceeding.
 </hard-lines>
 
@@ -34,16 +29,3 @@ Narrow "when in doubt, do the safe thing" rules (merge authorization, destructiv
 - Artifacts state the current decision, not its history — git is the changelog. This reaches code comments and docstrings as much as skills, rules, commands, AGENTS.md and README.md. Keep the refuted alternative — the plausible wrong design and what breaks under it — in the present tense; cut the episode, including who got it wrong and when. Exempt: changelogs, ADRs, plan or spec files that must state a before-state to plan the transition, and third-party content vendored at a pin along with its provenance header — a pinned copy has to reproduce its source, so it stands as written, and where it disagrees with these rules, these rules win.
 - If the repo has a CONTEXT.md glossary, use its terminology.
 </conventions>
-
-<communication>
-- Write prose for human readers: complete sentences in plain professional English — no telegraphic fragments, no arrow chains, no invented abbreviations (`impl`, `cfg`, `req`) unless the codebase already uses them.
-- Lead with the outcome or recommendation; supporting detail after.
-- Docs and specs state the decision, its rationale, and its prerequisites so a reader who was not present can follow — no reasoning transcripts, no padding.
-- Keep progress narration to a sentence; never mix it into the deliverable.
-</communication>
-
-<simplicity>
-- Guard only against conditions that can occur. Validate at trust boundaries (user input, network data, parsed files); do not re-validate what the type system or caller contract already guarantees.
-- No speculative abstraction layers, config flags, fallbacks, or compatibility shims for consumers that don't exist. If you cannot name the real trigger for a defensive construct, delete it.
-- Go beyond happy path plus standard error handling only when an observed failure or an explicit requirement demands it.
-</simplicity>


### PR DESCRIPTION
Resolves `agents-config-9k9.213.4`. The always-on user core (`src/user/.agents/USER-CORE.md.template`) had drifted to 2.4x the charter's zero-based draft, and the gate could not see it. This brings the deployed bytes back to what the charter admitted and gives the core a ceiling of its own.

**You ratify these decisions by merging.** The table below is the decision record the item's acceptance asks for — one line per block, kept or cut, with the reason.

## Per-block decisions

The charter is `docs/specs/2026-07-21-harness-rework-way-forward.md`. Appendix A (the zero-based draft) admits exactly four blocks: `<laws>`, `<decisions>`, `<hard-lines>`, `<conventions>`. D17 states the four-part admission test a line must pass — universal across projects, not model-default behaviour, not owned by pipeline code or contract, fits the ~800-token sub-budget — and its default verdict is DECLINE with no grandfathering.

| Block | Decision | Reason |
| --- | --- | --- |
| `<laws>` | **Keep** | Appendix A admits it verbatim; D17 names the L0–L3 laws as a survivor. |
| `<decisions>` | **Keep** | Appendix A admits it verbatim; D17 names the decision matrix (compressed) as a survivor. |
| `<reporting>` | **Cut** | Not in Appendix A. Every line is conditioned on delegated work being outstanding, which is a tool-specific capability — the shared tree takes only what works on every supported tool, so this is a tool-tree concern at best. Fails D17's universality test. |
| `<hard-lines>` | **Keep** | Appendix A admits it; D17 names git-safety hard lines as a survivor. |
| `<conventions>` | **Keep** | Appendix A admits it; D17 names state-the-decision-not-history as a survivor. |
| `<communication>` | **Cut** | Not in Appendix A. Substantially restates model-default prose behaviour (write in complete sentences, lead with the outcome, do not pad), which is precisely D17's not-a-model-default exclusion. |
| `<simplicity>` | **Cut** | Not in Appendix A. Good engineering practice rather than a universal always-on rule, and the specific judgements it makes (where to validate, when a defensive construct is speculative) are owned by a project's own code and contracts — D17's third exclusion. |

Two line-level decisions inside blocks that stay:

| Line | Decision | Reason |
| --- | --- | --- |
| `<hard-lines>` — "Stage by explicit path…" | **Keep** | Beyond Appendix A's draft, but admitted by D17's own survivor list ("git-safety hard lines"). It counters a habit rather than restating a default. |
| `<conventions>` — the expanded state-the-decision bullet, incl. the vendored-pin exemption | **Keep, untouched** | The pin-exemption sentence is owned by a separate pending ruling and is deliberately not reworded here. |

Nothing anywhere in `src/`, `docs/`, `packages/` or the READMEs referenced `<reporting>`, `<communication>` or `<simplicity>`, so no cross-reference breaks. `docs/guide/getting-started.md` already described the deployed core as the `<laws>`/`<decisions>`/`<hard-lines>`/`<conventions>` four — the template now agrees with the guide.

## Precedence reaches every remaining block

Precedence was declared among the L0–L3 laws only; the other blocks had no stated relationship to them. The `<laws>` header now says how each surviving block is read under the laws: the decision rules resolve an unknown, the hard lines bound what an instruction can authorize, and the conventions are what L3 asks for in practice.

## The merge escape hatch is now defined in deployed text

"Absent an explicit instruction or a configured rule-based policy, do not merge" used a term defined only inside this repository, which does not deploy. A downstream agent could reasonably match "configured rule-based policy" to branch protection, a green pipeline, or an approving review, and merge on its own. The clause now reads:

> Creating a PR is not authorization to merge. Absent an explicit instruction, or a merge policy stated in writing in the project's own configuration, do not merge — branch protection, a green pipeline and an approving review are not one.

The escape hatch survives (Appendix A carries it), but only a written policy in the project's own configuration can open it.

## The gate can now see core drift

`USER_CORE_TOKEN_CAP = 800` in `surface_budget.py`, enforced by `user_core_violations` on the assembled instruction file, wired into the same `run_admission_gate` pass that both the deploy gate and `make content-lint` run. Measured on the assembled file rather than the shared source, so a tool template that includes the core and then adds to it has grown the core.

Pinned by tests: the boundary (passes at 800, fails at 801, message names the tool and the cap), the reason it exists (a core five times over its own cap still clears the 10k surface cap), that rules and catalog entries are not charged to it, that a tool with no instruction file has no core, that the reported number is the number the gate fails on, and — at gate level — that an oversized instruction file fails while breaching nothing else.

`content-lint` now prints the core beside each tool's total, so regrowth reads as a trend rather than a cliff:

| | before | after |
| --- | --- | --- |
| core (every tool) | 983 | **685** |
| claude surface | 3403 | 3105 |
| codex / opencode surface | 2655 | 2357 |
| gemini surface | 983 | 685 |

The core is 610 words → 433 words; Appendix A's draft is 251 words, and the difference is almost entirely the expanded state-the-decision bullet, which is protected by the pending pin ruling.

## Open question for you: D16's flat 2k skill cap vs. the live 5k tier

The item asked me to conform the code to the charter here if the staged tree still passes. **It does pass** — every user-invoked skill is already under 2,000 tokens (largest: `wayfinder` 1813, `explain-diff` 1793, `retrospect` 1696) — but I did not make the change, because this is not drift and it is not mine to decide.

D16 states a flat 2k skill-body cap. `USER_INVOKED_SKILL_BODY_TOKEN_CAP = 5_000` was introduced deliberately by `a04f2867` / PR #474 (`9k9.149`, 2026-08-08), *after* the 2026-07-21 charter, with stated reasoning: a Claude skill carrying `disable-model-invocation: true` is kept out of the model's catalog entirely, so its body is paid only when the user names it. That decision is documented in `docs/primers/SKILLS_PRIMER.md` and recorded in the S5 spec. Reverting it here would undo a merged decision without your ruling and would falsify two documents outside this PR's scope.

Your options, whenever you want them:
1. **Keep the tier** — amend D16 in the charter to record it (the charter is read-only for me).
2. **Drop the tier** — a one-line constant change, mechanically free today; it also needs `SKILLS_PRIMER.md` §budget and the `admit-request` gate document updated.

Either way the number is free to move right now, which is the good time to decide it.

## Follow-up not taken

`docs/primers/RULES_PRIMER.md` documents `ALWAYS_ON_TOKEN_CAP` and does not yet mention the core sub-budget. It is not wrong, only incomplete, and it sits outside this PR's file scope with other agents active in the docs tree — worth one sentence in a docs pass.

## Verification

- `make ci` — exit 0, run standalone from the worktree root.
- `make content-lint` — exit 0, run standalone.
- `make test-installer` — 1252 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA
