### PR TITLE
fix(9k9.213.9): narrow choosing-a-delegate's firing condition to match delegation.md

### DIFF
--- a/src/user/.claude/skills/choosing-a-delegate/SKILL.md
+++ b/src/user/.claude/skills/choosing-a-delegate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: choosing-a-delegate
-description: Use when handing work to anyone but yourself — a second opinion, an independent review, an adversarial critique, or any task you are about to delegate. Apply whenever you think "find someone to look at this", "get another perspective", "poke holes in it", or "have someone check this before I commit", and whenever a judgement must be independent of whoever produced the work. Not for writing the brief once the delegate is known, and not for vendor CLI setup.
+description: Use before delegating to anything beyond the native Agent tool or Workflow — another vendor, another harness — for a second opinion, an independent review, an adversarial critique, or independent judgement. Apply when you think "find someone to look at this", "get another perspective", or "poke holes in it" and a native subagent won't supply that independence. Not for writing the brief once the delegate is known, and not for vendor CLI setup.
 admission:
   provides: The decision of who does delegated work, and standing permission to reach another vendor for it unasked. An orchestrator that is not told this treats a foreign-model dispatch as something the user must request by name, and answers "get me a second opinion" with a larger model from the same vendor as the work under review.
   cost: The vendor pointers need revisiting whenever a delegation route is added or retired.


### PR DESCRIPTION
## Summary

The delegation rule's routing block gates reading the `choosing-a-delegate` skill on delegating to a non-native substrate only — "before delegating to anything else — another vendor, another harness." The skill's own front-matter description instead fired on any delegation at all, "handing work to anyone but yourself... any task you are about to delegate," which included plain native subagent dispatches that the rule never intended to gate.

The narrow condition wins. The skill's body — the vendor-choice table ("Does this need another vendor?"), the vendor-permission section, and the vendor routing table — only ever helps decide among substrates and vendors once a delegation is already being considered outside the native Agent tool or Workflow. Nothing in the body offers guidance for a routine native-only dispatch beyond restating that native is the default, so gating every native delegation on reading this skill would add overhead without adding a decision the skill can inform.

This change narrows the description to state the same non-native-substrate condition as the rule's routing block, in matching language ("before delegating to anything beyond the native Agent tool or Workflow — another vendor, another harness"). `delegation.md` already names the `choosing-a-delegate` skill by name in its routing bullet, so the two artifacts cross-reference and a future edit to either firing condition should surface the mismatch against the other.

## Test plan

- [x] `make content-lint` run standalone from the worktree root — exit 0
- [x] `make content-tests` run standalone from the worktree root — exit 0
- [x] Manual read-through confirming the new description's condition text matches `src/user/.claude/rules/delegation.md`'s routing block wording
- [x] Confirmed the description stayed at or under its prior character count (446 vs. 460 chars) since Claude Code charges skill descriptions to always-on context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA