### PR TITLE
fix(9k9.213.6): a verdict written from the prose validates, and the panel documents what it emits

### DIFF
--- a/src/user/.agents/skills/review-verdict/SKILL.md
+++ b/src/user/.agents/skills/review-verdict/SKILL.md
@@ -13,7 +13,7 @@ still outstanding.
 
 ## Envelope
 
-All fields are required.
+All fields are required except `halt`.
 
 | Field | Type | Meaning |
 | --- | --- | --- |
@@ -23,7 +23,7 @@ All fields are required.
 | `base_sha` | 40-hex | Commit the reviewed diff was taken against. |
 | `head_sha` | 40-hex | Reviewed head commit. The verdict is valid only for this commit. |
 | `claim_id` | non-blank string | The completion claim this round adjudicates. |
-| `retained_categories` | array of strings | Categories carried forward from earlier rounds. May be empty, but must be present — an empty array asserts "nothing retained". |
+| `retained_categories` | array of strings | Categories carried forward from earlier rounds. Always present; an empty array asserts "nothing retained". |
 | `lenses` | array | One entry per lens the artifact class declares, green ones included, each recording what actually ran it. At least one, unless the round halted first. |
 | `prior_dispositions` | array | What happened to each earlier mechanical finding. May be empty on round 1. |
 | `verdict` | `"clean"`, `"findings"`, or `"halted"` | Round-level result. |
@@ -40,6 +40,7 @@ All fields are required.
                   "transport_error": "401 Missing bearer authentication"}}
 ```
 
+A lens's own `verdict` is `clean` or `findings` — only the round halts, never a single lens.
 `vendor`, `transport` and `model` record what **actually** produced the report, never what the
 lens registry declared for it. A lens reports exactly once: a lens re-dispatched after a failure
 carries one entry describing the attempt that produced the report it holds, and a second entry for
@@ -94,8 +95,13 @@ for `rebutted` — a rebuttal without evidence is just a disagreement.
  "abandoned_lenses": ["test-adequacy", "documentation-quality"]}
 ```
 
-A halted round ran out of transports: a dispatch died on its route and the failover to the other
-route died too. It is never clean and never complete, and `verdict` says so outright rather than
+Both keys are required. `failures` carries at least two entries — a dispatch died on its route and
+the failover to the other route died too — each naming its `lens`, `transport` and the verbatim
+`error`; a failure a successful failover recovered from belongs on that lens's `substitution`
+instead. `abandoned_lenses` names the declared lenses the round never dispatched, and is present
+even when empty.
+
+A halted round is never clean and never complete, and `verdict` says so outright rather than
 leaving it inferred from a missing lens entry — a silent check guarding the merge gate is one
 nobody notices passing. Its findings are real and still not a verdict on the change: most of it was
 never opened.
@@ -126,23 +132,17 @@ against the pull request:
    empty one meaning nothing was retained.
 3. **Live and authentic** — the verdict is schema-valid, App-posted, and its `head_sha` equals the
    current head.
-4. **Lens coverage** — `lenses` covers the full lens set the artifact class declares, green lenses
-   included, each carrying what ran it. Coverage is read off the artifact; silence never counts as
-   a clean lens, and a lens that died and was never re-dispatched leaves the round incomplete.
+4. **Lens coverage** — `lenses` covers the full set the artifact class declares. Coverage is read
+   off the artifact; silence never counts as a clean lens, and a lens that died and was never
+   re-dispatched leaves the round incomplete.
 5. **Ledger coverage** — `prior_dispositions` accounts for every `mechanical` finding from every
    prior round's posted verdict.
 
 **Terminal-clean** = a complete round whose `verdict` is `clean`, carrying zero `mechanical`
-findings. Advisory findings never block; they go to the backlog. A halted round is never
-terminal-clean, however few findings it holds.
+findings. A halted round is never terminal-clean, however few findings it holds.
 
-Completeness and diversity are separate: a round every lens reported on is complete even on one
-vendor — see above on reporting, not blocking, the collapse.
-
-The schema checks the shape of a single artifact. The five conditions above are cross-artifact —
-they compare the verdict against the pull request and against earlier verdicts — so today a person
-checks them by hand. The merge-eligibility evaluator in the pull-request grooming toolchain will
-consume this same schema and check them mechanically.
+The schema checks the shape of a single artifact; the five conditions above compare it against the
+pull request and against earlier verdicts, so a person checks them by hand today.
 
 ## Validating
 

--- a/src/user/.agents/skills/review-verdict/verdict.schema.json
+++ b/src/user/.agents/skills/review-verdict/verdict.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agents.local/schemas/review-verdict/1",
+  "$id": "https://agents.local/schemas/review-verdict/2",
   "title": "Review verdict",
   "description": "Typed result of one code-review round, keyed to the git head SHA it reviewed.",
   "type": "object",

--- a/src/user/.agents/skills/tdd/SKILL.md
+++ b/src/user/.agents/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: The red-to-green loop and the discipline that keeps it honest. Use when implementing a feature or bugfix test-first, when failing tests have been handed over to be made green, when the user says "red-green-refactor" or "test-first", or when about to write production code that no test yet demands.
+description: The red-to-green loop and the discipline that keeps it honest. Use when implementing a feature or bugfix test-first, when failing tests have been handed over to be made green, when the user says "red-green-refactor" or "test-first", or when about to write production code that no test yet demands. A handed-over test that looks wrong escalates here rather than being edited; `test-review` governs only when judging a suite is itself the job.
 admission:
   prevents: The two model defaults that make a test suite prove nothing — writing the implementation first and back-filling tests that pass on arrival, and editing a handed-over failing test until it agrees with the code that was written instead of the contract it encodes.
   cost: A hard stop that waits for the user whenever a handed-over test looks wrong, rather than editing it.
@@ -76,8 +76,9 @@ a bug in.
 1. **RED** — one test, one behaviour, a name that says what the behaviour is.
 2. **Verify RED** — run it. It MUST fail, and fail *because the behaviour is
    missing*, not because of a typo or a missing import. A test that passes on
-   arrival is pinning something that already works: fix the test. A test that
-   errors is not yet a test: fix the error and re-run until it fails cleanly.
+   arrival is pinning something that already works; a test that errors is not
+   yet a test. Fix either one only if you wrote it — a handed-over test is the
+   contract, so report it and wait.
 3. **GREEN** — the simplest code that passes it. No speculative parameters, no
    options object, nothing the next test might want.
 4. **Verify GREEN** — run it, then run the rest of the suite. All green, output

--- a/src/user/.agents/skills/test-review/SKILL.md
+++ b/src/user/.agents/skills/test-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-review
-description: Judge whether a test suite would actually fail if the behaviour it covers broke. Use when reviewing test code in a change or pull request, auditing test quality across a package or codebase, investigating flaky or brittle tests, or when a test failure looks caused by the test's design rather than by a bug in the code under test.
+description: Judge whether a test suite would actually fail if the behaviour it covers broke. Use when reviewing test code in a change or pull request, auditing test quality across a package or codebase, investigating flaky or brittle tests, or when a test failure looks caused by the test's design rather than by a bug in the code under test. `tdd` governs instead when you are implementing against the tests, where a suspect test escalates rather than being fixed.
 admission:
   provides: A test-adequacy lens — the criteria that separate a test which would fail if the required behaviour broke from one that passes regardless, plus the smells whose remedy is the production code rather than the test. Produces findings ranked by severity, each naming the file, the line, and the concrete fix.
   cost: A read of the production code behind the tests, widening from the named files to the package and, where the scope says so, to the whole codebase.

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -10,7 +10,7 @@ admission:
 A round is a panel of single-lens reviewers. This skill routes: it maps the target to artifact
 classes, picks each class's lenses, fans out one reviewer per lens at the declared grade and
 transport, and assembles the reports into the round verdict. It holds no lens expertise itself —
-depth belongs to the reviewer, and to a dedicated skill where a lens names one.
+depth belongs to the reviewer.
 
 ## Artifact classes
 
@@ -25,9 +25,7 @@ and transports are data in `contracts.json`:
 
 A target spanning classes gets one round per class, each judging the files of that class and
 carrying its own verdict. A target no class fits is refused (`unknown-class`): pick the nearest
-contract explicitly or extend `contracts.json` — never improvise a lens set. A lens entry may
-carry a `skill` field naming a skill the reviewer must apply; the mandate then only scopes the
-lens, and the named skill supplies the depth.
+contract explicitly or extend `contracts.json` — never improvise a lens set.
 
 Each panel mixes model tiers — hard-reasoning lenses on frontier models, mechanical walks on
 mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
@@ -88,6 +86,7 @@ The emitter refuses rather than producing a prompt it knows is unsound. Refusals
 | `bad-prior-verdict` | An earlier verdict is unreadable, fails the verdict schema, or is for another claim, class, or a non-earlier round. |
 | `ledger-gap` | An earlier mechanical finding has no disposition, or a disposition is outside the closed set. |
 | `unsupported-rebuttal` | A finding is marked rebutted with no evidence. A rebuttal without evidence is a disagreement. |
+| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a schema that will not parse. The message carries what broke; no prompt is written. |
 
 ## What a prompt contains
 
@@ -98,8 +97,10 @@ reviewed content, and the exact-JSON contract for one lens report. Supporting da
 the target pointer, retained categories, prior findings — follows inside a marked section the
 instructions declare to be data, not instructions. That section is context, never the whole
 review: the reviewer reads the target itself, and whatever surrounding material its scope
-requires, directly from the repository. No other lens's mandate appears, and no house rulebook
-text does either.
+requires, directly from the repository. No other lens's mandate appears, and no ambient house
+context does either — no laws, no decision matrix, no hard lines. A lens's own mandate is the only
+route by which a house-specific standard reaches the reviewer, because a lens that states no test
+has nothing decidable to judge against.
 
 ## Assembling the round verdict
 

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -86,7 +86,7 @@ The emitter refuses rather than producing a prompt it knows is unsound. Refusals
 | `bad-prior-verdict` | An earlier verdict is unreadable, fails the verdict schema, or is for another claim, class, or a non-earlier round. |
 | `ledger-gap` | An earlier mechanical finding has no disposition, or a disposition is outside the closed set. |
 | `unsupported-rebuttal` | A finding is marked rebutted with no evidence. A rebuttal without evidence is a disagreement. |
-| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a schema that will not parse. The message carries what broke; no prompt is written. |
+| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a contract entry missing a field a prompt needs, an unwritable output directory. Alone among these it can strike mid-write: the rest are decided before the output directory exists, while this one can leave it holding some `<lens>.md` files and no `round.json`. Clear it before retrying — a partial round reads as a smaller panel. |
 
 ## What a prompt contains
 


### PR DESCRIPTION
Four artifacts in the review stack disagreed with themselves or with each other. This change makes each of them state what its own mechanism does.

## review-verdict — the prose described a document the schema rejects

A verdict written from `SKILL.md` alone did not validate. Four defects, all confirmed by running the validator against documents built from the prose as it stood:

- `All fields are required.` contradicted the schema, which forbids `halt` on any round that is not halted. The line now reads `All fields are required except `halt``, which agrees with the table row already stating when `halt` appears.
- The lens `verdict` enum was never stated in prose. A reader following "green ones included" naturally writes `"verdict": "green"`, which the schema rejects. The lens-entry section now states that a lens reports `clean` or `findings` and that only the round halts.
- The halt section understated its own object. The schema requires both keys, requires at least two failure entries, and requires each entry to name its lens, transport and error. The prose now states all of that, along with the rule that a failure a successful failover recovered from belongs on that lens's `substitution` instead, and that `abandoned_lenses` is present even when empty.
- The schema `$id` ended `/review-verdict/1` while `schema_version` is `"2"` and the tests reject a v1 envelope. It now ends `/2`. Nothing else in the repository references the identifier.

The schema is the correct side of every one of these: `validate_verdict_test.py` pins each rule directly, so the prose moved rather than the schema. `SKILL.md` sat at 1999 of its 2000-token cap, so the additions are paid for in the same file by cutting a back-reference to the vendor-collapse rule, a restatement that advisory findings do not block, and a forward pointer to a mechanical checker nobody has written. It now measures 1988.

### Demonstration

A verdict and a halt were written following only the corrected prose and validated:

```
$ uv run validate_verdict.py prose-only-verdict.json
{"valid": true}                                        exit 0
$ uv run validate_verdict.py prose-only-halt.json
{"valid": true}                                        exit 0
```

The same two documents written from the prose as it stood fail, which is what makes the defect real rather than cosmetic:

```
'green' is not one of ['clean', 'findings']            /lenses/0/verdict
should not be valid under {'required': ['halt']}
'abandoned_lenses' is a required property              /halt
[{...one failure...}] is too short                     /halt/failures
```

## review-panel — documentation of things the emitter does not do

`SKILL.md` documented a per-lens `skill` field. `contracts.json` carries no such key on any lens and `emit_prompts.py` never reads one, so the paragraph is removed, along with the clause upstream that depended on it. The refusal table listed nine codes; the emitter can print ten, and `emitter-failure` is now documented. The table and the emitter are now exactly the same set of ten.

### Which route the rulebook claim took, and why

The claim that no house rulebook text reaches a reviewer prompt was false as written. The `documentation-quality` and `standalone-read` mandates state the house convention on narrated history, near-verbatim from the always-on conventions block, and a lens mandate is interpolated into the fixed-instruction section of every prompt.

**I made the claim honest rather than removing the interpolation**, on three grounds.

First, the interpolation is the lens's test, not ambient context. A documentation lens that states no standard has nothing decidable to judge against; every mandate in `contracts.json` embeds some house judgement, and stripping this one leaves a lens with a name and no criterion.

Second, removal is a measured regression. The discriminating half of the clause — a refuted alternative in the present tense is current rationale and stays — was added because the bare prohibition was tried against twelve real quoted sites and deleted the sentence naming the plausible wrong design. A reviewer told only "no narrated history" removes load-bearing rationale.

Third, what the charter's fresh-context requirement guards against is the reviewer judging the change against the plan, which is what ambient house context produces. The mechanical guard in `emit_prompts_test.py` already encodes that boundary — it bans laws, decision-matrix and hard-lines text from every emitted prompt — and it passes.

The claim now states the boundary the mechanism actually holds: no ambient house context, no laws, no decision matrix, no hard lines, and a lens's own mandate as the only route by which a house-specific standard reaches the reviewer. Verified against a real emitted prose-class prompt: the convention text appears exactly once, inside the `## Mandate` section.

Had the alternative been taken, making the claim literally true would have required stripping the whole history test from both mandates, reverting two shipped changes and reopening the items they closed.

## tdd — the loop authorised the defect the skill exists to prevent

Step 2 of the loop said that a test passing on arrival should be fixed. The loop binds both seats, and in the implementer seat the same document forbids editing a handed-over test, names that edit as a red flag, and records it in the admission block as the defect the skill prevents. Step 2 now fixes a test only if you wrote it, and reports a handed-over one — which is what the implementer-seat rules three sections above already said.

## tdd and test-review — a declared boundary

Both skills fire on a handed-over test that looks wrong, with opposite procedures: tdd stops and escalates, test-review produces a finding and a concrete fix. Neither description named the other, so routing was left to chance. Each description now carries one clause naming the other skill and the condition under which it governs.

## Verification

Both gates were run standalone from the worktree root and their exit statuses read directly, with no pipe and no `&&`:

- `make content-lint` — exit 0
- `make content-tests` — exit 0, 12 suites passed, including the review-verdict validator suite and the review-panel emitter suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA
