### PR TITLE
chore(9k9.192): the zero-write on a scheduling park is a decision, not a missing vocabulary

### DIFF
--- a/packages/executor/AGENTS.md
+++ b/packages/executor/AGENTS.md
@@ -91,7 +91,9 @@ ports.py  →  state.py  →  rules.py  →  pairing.py  →  enact.py  →  cli
   runtime and the facade also emit; each of the three pins what it emits, and
   this package's copy is the literal its suite asserts `FAILURE_REASONS`
   against. The scheduling axis is runtime-native and issues zero tracker
-  writes — the facade deliberately has no vocabulary for it.
+  writes — a scheduling decision is run state the event log already records,
+  not item state; the facade's `work defer` covers durable deferral, and
+  pairing onto it would be a policy change, not a missing translation.
 
 ## The matrices
 

--- a/packages/executor/src/executor/rules.py
+++ b/packages/executor/src/executor/rules.py
@@ -68,8 +68,12 @@ FAILURE_REASONS: tuple[str, ...] = (
     "budget-exhausted",
 )
 # The scheduling axis is runtime-native: sequencing decisions about work that
-# never had a PR to fail. The facade carries no vocabulary for it, which is why
-# these rows issue zero tracker writes rather than a translated one.
+# never had a PR to fail. These rows issue zero tracker writes because a
+# scheduling decision is state of the run, not of the item -- the event log
+# already records it, and the item's tracker standing did not change. The
+# facade's `work defer` covers deferral that must outlive a run; pairing a
+# scheduling reason onto it would decide that run-internal sequencing is
+# durable state, which is a policy change, not a missing translation.
 SCHEDULING_REASONS: tuple[str, ...] = ("discovered-work", "later-wave", "deferred")
 
 # The reason an exhausted budget parks under, on both planes (S9T1-D12). A

--- a/packages/executor/tests/unit/test_commands.py
+++ b/packages/executor/tests/unit/test_commands.py
@@ -414,8 +414,8 @@ def test_a_scheduling_axis_park_issues_zero_tracker_calls(reason: str) -> None:
     not even a sync.
 
     The inverse of the failure-axis pair: these are sequencing decisions about
-    work that never had a PR to fail, and the facade deliberately carries no
-    vocabulary for them.
+    work that never had a PR to fail -- run state the event log records,
+    deliberately never written to the tracker.
     """
     runtime = FakeRuntime(run_state(item("it-1", work_id="w-1")))
     tracker = FakeTracker()

--- a/packages/executor/tests/unit/test_pairing_table.py
+++ b/packages/executor/tests/unit/test_pairing_table.py
@@ -203,8 +203,8 @@ def test_the_exhaustion_reason_is_on_the_axis_its_row_declares_a_tracker_verb_fo
 
     S9T1-D12 gives the exhaustion row a `work park --reason` rather than the
     scheduling axis's none, and that is only correct while the reason it uses
-    is a failure-axis member. Moving it to the other axis would leave the row
-    writing to a facade with no vocabulary for it.
+    is a failure-axis member. Moving it to the other axis would make the row a
+    zero-write, and an exhausted budget would stop being durable tracker state.
     """
     assert park_axis(BUDGET_EXHAUSTED) is Axis.FAILURE
     assert BUDGET_EXHAUSTED in _FAILURE_VOCABULARY


### PR DESCRIPTION
The comment above `SCHEDULING_REASONS` in executor's `rules.py` justified the scheduling axis's zero tracker writes by "the facade carries no vocabulary for it" — false since `work defer`/`work undefer` shipped. The zero-write behaviour is unchanged and correct; this restates its justification in the executor's own terms: a scheduling decision is state of the run (already in the event log), not of the item, and pairing a scheduling reason onto the facade's defer verb would be a policy decision to make run-internal sequencing durable, not a missing translation.

The same expired premise was repeated in the package AGENTS.md and two test docstrings (`test_pairing_table.py`, `test_commands.py`); all four sites now carry the same reasoning. Comment/docstring-only — no production behaviour changes. `make ci` exits 0 standalone from the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvcjhkpEum7zVHzx8CBBue