### PR TITLE
docs(9k9.215.3): source-tree docs match the installer's actual behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Purpose
 
-A versioned collection of skills, rules, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
+A versioned collection of skills, rules, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to every active tool — auto-detected, or explicitly selected via `--tools=`; tool-specific content goes only where it belongs.
 
 ## Harness Rework (active — read this first)
 
@@ -88,7 +88,7 @@ This project hosts agent configuration under `src/`, which the install script de
   - `src/user/.agents/` — shared content, staged into every active tool: `skills/`, `rules/`, and `USER-CORE.md.template` (the zero-based laws, decision matrix, hard lines, and conventions, D17). See `src/user/.agents/AGENTS.md` for the install model and the name-collision rules.
   - `src/user/.claude/` — Claude-only: `skills/`, `rules/`, `hooks/`, `AGENTS.md.template`, `CLAUDE.md.template`, `settings.json.template`
   - `src/user/.codex/`, `src/user/.gemini/`, `src/user/.opencode/` — per-tool instruction templates; OpenCode additionally carries `opencode.jsonc.template` and gets a flat, dynamically-built instruction file rather than `@` includes
-  - `src/plugins/` — optional plugin content, auto-detected by a directory scan. A plugin's content deploys only when its tool is detected **and** the artifact clears the admission gate.
+  - `src/plugins/` — optional plugin content, auto-detected by a directory scan. A plugin's content deploys only when its tool is active — auto-detected, or explicitly selected via `--tools=` — **and** the artifact clears the admission gate.
   - Each rules directory carries its own `AGENTS.md` stating what currently lives there; read it rather than inferring from the folder's contents.
 - `docs/`
   - `guide/` — user guide for people *running* the deployed assets: install, configure a project, run the agentic SDLC

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ src/
 │   ├── .codex/                     # Codex-specific (→ ~/.codex/)
 │   ├── .gemini/                    # Gemini-specific (→ ~/.gemini/)
 │   └── .opencode/                  # OpenCode-specific (→ ~/.config/opencode/), + opencode.jsonc.template
-└── plugins/                        # Optional plugin content (auto-discovered, installed when detected)
+└── plugins/                        # Optional plugin content (auto-discovered, active when detected or via `--plugins=`)
     └── codex/                      # codex plugin: model-routing skill for a Codex run (Claude-only)
 ```
 
 > Not everything under `src/` is a wrapper around a single tool: shared content
-> in `.agents/` installs to **all** detected tools; `.claude/`, `.codex/`,
+> in `.agents/` installs to **every active tool**; `.claude/`, `.codex/`,
 > `.gemini/`, and `.opencode/` add tool-specific pieces. The `packages/` are real
 > code, not installed configuration.
 
@@ -111,7 +111,7 @@ the authoritative inventory:
 | Claude-only skills | [`src/user/.claude/skills/`](./src/user/.claude/skills/) | `~/.claude/skills/` |
 | Claude-only rules | [`src/user/.claude/rules/`](./src/user/.claude/rules/) | `~/.claude/rules/` |
 | Slash commands | [`src/user/.claude/commands/`](./src/user/.claude/commands/) | `~/.claude/commands/` |
-| Plugin content | [`src/plugins/`](./src/plugins/) | matching tools, when detected |
+| Plugin content | [`src/plugins/`](./src/plugins/) | matching active tools |
 
 Each `rules/` directory carries its own `AGENTS.md` stating what currently lives
 there. For a walkthrough of what the installed set does and where the gaps are,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agents-config
 
-Versioned collection of skills, rules, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to all detected tools; tool-specific content goes only where it belongs.
+Versioned collection of skills, rules, commands, and templates for AI coding assistants. Supports **Claude Code**, **OpenAI Codex CLI**, **Google Gemini CLI**, and **OpenCode**. Shared content is installed to every active tool — auto-detected, or explicitly selected via `--tools=`; tool-specific content goes only where it belongs.
 
 > **New here and want to _use_ this?** Start with the **[User Guide](./docs/guide/index.md)** — install, configure a project, and run the opinionated agentic SDLC. This README is the project overview and installer reference.
 
@@ -68,7 +68,7 @@ docs/
 └── …                               # Plus reference material and prototypes
 src/
 ├── user/
-│   ├── .agents/                    # Shared content (copied into all detected tools)
+│   ├── .agents/                    # Shared content (copied into every active tool)
 │   │   ├── rules/                  # Shared always-on rules (empty today)
 │   │   ├── skills/                 # Methodology guides with examples
 │   │   └── USER-CORE.md.template   # Zero-based laws, decision matrix, hard lines, conventions
@@ -106,8 +106,8 @@ the authoritative inventory:
 
 | What | Where | Installs to |
 |------|-------|-------------|
-| Shared skills | [`src/user/.agents/skills/`](./src/user/.agents/skills/) | every detected tool |
-| Shared rules | [`src/user/.agents/rules/`](./src/user/.agents/rules/) | every detected tool |
+| Shared skills | [`src/user/.agents/skills/`](./src/user/.agents/skills/) | every active tool |
+| Shared rules | [`src/user/.agents/rules/`](./src/user/.agents/rules/) | every active tool |
 | Claude-only skills | [`src/user/.claude/skills/`](./src/user/.claude/skills/) | `~/.claude/skills/` |
 | Claude-only rules | [`src/user/.claude/rules/`](./src/user/.claude/rules/) | `~/.claude/rules/` |
 | Slash commands | [`src/user/.claude/commands/`](./src/user/.claude/commands/) | `~/.claude/commands/` |
@@ -180,7 +180,7 @@ the always-on surface is zero-based and carries no identity content.
 
 The installer (`scripts/install.sh`) is a thin exec stub backed by a uv-managed Python package (`packages/installer`). It:
 - Auto-detects installed tools (Claude Code, Codex CLI, Gemini CLI, OpenCode) or use `--tools=` to override
-- Copies shared content (`src/user/.agents/`) into all detected tools
+- Copies shared content (`src/user/.agents/`) into every active tool
 - Copies tool-specific content (e.g., `src/user/.claude/`) into the corresponding tool's config directory
 - Copies `*.md.template` files (stripping `.template` suffix), with diff preview and confirmation for existing files
 - Syncs `agents/`, `skills/`, `commands/`, and `rules/` directories using hash comparison per item, and a recursive digest to detect drift inside owned directories

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -66,10 +66,11 @@ _NAMED_RULES_SOURCE_DIR = Path("src/user/.claude/rules")
 # Tool-root instruction files that are flattened, keyed by their
 # ``.template``-stripped dest (how the plan stores them). The dest is per-tool,
 # so ``AGENTS.md`` covers Claude, Codex, AND OpenCode (each installs an
-# ``AGENTS.md``); ``GEMINI.md`` covers Gemini. No current template carries the
-# ALL-RULES marker — each of the four is a single DYNAMIC-INCLUDE of
-# USER-CORE.md.template — so every tool's rules currently survive; this list
-# is where a template would need to carry the marker for its rules to inline.
+# ``AGENTS.md``); ``GEMINI.md`` covers Gemini. No current template carries a
+# ``<!-- DYNAMIC-INCLUDE-ALL-RULES -->`` marker — each of the four is a single
+# file-form DYNAMIC-INCLUDE of USER-CORE.md.template — so every tool's rules
+# currently survive; this list is where a template would need to carry the
+# marker for its rules to inline.
 _FLATTENABLE_DESTS: tuple[Path, ...] = (Path("AGENTS.md"), Path("GEMINI.md"))
 
 
@@ -148,14 +149,16 @@ def flatten_plan_templates(plan: StagingPlan, *, repo_root: Path, io: IOPort) ->
 
     For each flattenable instruction file present in the plan (``AGENTS.md`` /
     ``GEMINI.md``), replace its content with the DYNAMIC-INCLUDE-flattened text —
-    file includes resolved from ``repo_root``, ALL-RULES from the plan's own
-    staged rules — then remove from the plan whatever that flattening inlined so it
-    is not also deployed standalone: the include-only file templates always, and —
-    for a tool whose instruction file carries an ALL-RULES marker — the loose
-    ``rules/`` items too. No current template carries that marker (Claude's
-    ``AGENTS.md`` reads a loose ``~/.claude/rules/`` tree natively, and the
-    other three are each a single DYNAMIC-INCLUDE of USER-CORE.md.template),
-    so every tool keeps its rules today. Mutates ``plan`` in place.
+    file includes resolved from ``repo_root``, ``<!-- DYNAMIC-INCLUDE-ALL-RULES -->``
+    content from the plan's own staged rules — then remove from the plan
+    whatever that flattening inlined so it is not also deployed standalone:
+    the include-only file templates always, and — for a tool whose
+    instruction file carries a ``<!-- DYNAMIC-INCLUDE-ALL-RULES -->`` marker —
+    the loose ``rules/`` items too. No current template carries that marker
+    (Claude's ``AGENTS.md`` reads a loose ``~/.claude/rules/`` tree natively,
+    and the other three are each a single DYNAMIC-INCLUDE of
+    USER-CORE.md.template), so every tool keeps its rules today. Mutates
+    ``plan`` in place.
     """
     include_only: set[Path] = set()
     inlines_rules = False

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -66,8 +66,10 @@ _NAMED_RULES_SOURCE_DIR = Path("src/user/.claude/rules")
 # Tool-root instruction files that are flattened, keyed by their
 # ``.template``-stripped dest (how the plan stores them). The dest is per-tool,
 # so ``AGENTS.md`` covers Claude, Codex, AND OpenCode (each installs an
-# ``AGENTS.md``); ``GEMINI.md`` covers Gemini. Only Codex/Gemini/OpenCode carry
-# the ALL-RULES marker — Claude's ``AGENTS.md`` does not, so its rules survive.
+# ``AGENTS.md``); ``GEMINI.md`` covers Gemini. No current template carries the
+# ALL-RULES marker — each of the four is a single DYNAMIC-INCLUDE of
+# USER-CORE.md.template — so every tool's rules currently survive; this list
+# is where a template would need to carry the marker for its rules to inline.
 _FLATTENABLE_DESTS: tuple[Path, ...] = (Path("AGENTS.md"), Path("GEMINI.md"))
 
 
@@ -149,10 +151,11 @@ def flatten_plan_templates(plan: StagingPlan, *, repo_root: Path, io: IOPort) ->
     file includes resolved from ``repo_root``, ALL-RULES from the plan's own
     staged rules — then remove from the plan whatever that flattening inlined so it
     is not also deployed standalone: the include-only file templates always, and —
-    when the instruction file carried an ALL-RULES marker — the loose ``rules/``
-    items too. A tool whose instruction file has no ALL-RULES marker (Claude reads
-    a loose ``~/.claude/rules/`` tree natively) keeps its rules. Mutates ``plan``
-    in place.
+    for a tool whose instruction file carries an ALL-RULES marker — the loose
+    ``rules/`` items too. No current template carries that marker (Claude's
+    ``AGENTS.md`` reads a loose ``~/.claude/rules/`` tree natively, and the
+    other three are each a single DYNAMIC-INCLUDE of USER-CORE.md.template),
+    so every tool keeps its rules today. Mutates ``plan`` in place.
     """
     include_only: set[Path] = set()
     inlines_rules = False

--- a/packages/installer/src/installer/core/templates.py
+++ b/packages/installer/src/installer/core/templates.py
@@ -212,10 +212,10 @@ def _text_inlines_rules(text: str) -> bool:
 def _flatten_with_plan_rules(text: str, *, plan: StagingPlan, repo_root: Path, io: IOPort) -> str:
     """Flatten ``text``, sourcing ALL-RULES from the plan's staged ``rules/``.
 
-    The on-disk staging tree is the source for ALL-RULES in the original design; the Python
-    installer stages in memory, so when (and only when) the template needs rules
-    they are materialised to a temp dir for ``flatten_template`` to read —
-    matching ``find $staging/rules -name '*.md' | sort``.
+    The Python installer stages in memory rather than to an on-disk tree, so
+    when (and only when) the template needs rules, the plan's staged
+    ``rules/`` items are materialised to a temp dir for ``flatten_template``
+    to read — matching ``find $staging/rules -name '*.md' | sort``.
     """
     if not _text_inlines_rules(text):
         return flatten_template(text, base_dir=repo_root, io=io, rules_dir=None)

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -54,12 +54,12 @@ class OpenCodeAdapter:
         shared rules/ namespace stages into ~/.config/opencode/rules/ the
         same as every other tool (build_plan Phase 2, namespaces.SHARED;
         should_install_namespace only excludes the shared agents/ namespace
-        here) — it is just empty today because the shared source has no rule
-        files yet. The loose rules/ drop that would apply once it isn't is
-        not OpenCode-specific either: flatten_plan_templates drops a plan's
-        standalone rules/ items only when its instruction file carries the
-        DYNAMIC-INCLUDE-ALL-RULES marker, and that runs earlier in
-        stage_and_transform. No current template carries that marker,
-        including OpenCode's, so nothing is dropped for any tool today.
-        Kept as a no-op only to satisfy the ToolAdapter protocol."""
+        here). It is empty today only because the shared rules/ source has
+        no files yet. Dropping standalone rules/ items once that source is
+        populated would not be OpenCode-specific either: flatten_plan_templates
+        drops a plan's standalone rules/ items only when its instruction file
+        carries the DYNAMIC-INCLUDE-ALL-RULES marker, and that runs earlier
+        in stage_and_transform. No current template carries that marker,
+        including OpenCode's, so nothing is dropped for any tool today. Kept
+        as a no-op only to satisfy the ToolAdapter protocol."""
         return plan

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -52,8 +52,8 @@ class OpenCodeAdapter:
     ) -> StagingPlan:
         """No-op. OpenCode has no standalone rules/ destination, but the loose
         rules/ drop is not OpenCode-specific: flatten_plan_templates drops
-        the inlined rules from EVERY plan whose instruction file carries the
-        DYNAMIC-INCLUDE-ALL-RULES marker (OpenCode's AGENTS.md does), and that runs
-        earlier in stage_and_transform. Kept as a no-op only to satisfy the
-        ToolAdapter protocol."""
+        the inlined rules from any plan whose instruction file carries the
+        DYNAMIC-INCLUDE-ALL-RULES marker (no current template does, including
+        OpenCode's), and that runs earlier in stage_and_transform. Kept as a
+        no-op only to satisfy the ToolAdapter protocol."""
         return plan

--- a/packages/installer/src/installer/tools/opencode.py
+++ b/packages/installer/src/installer/tools/opencode.py
@@ -50,10 +50,16 @@ class OpenCodeAdapter:
         plan: StagingPlan,
         io: IOPort,  # noqa: ARG002  # protocol parameter; OpenCode has no transform
     ) -> StagingPlan:
-        """No-op. OpenCode has no standalone rules/ destination, but the loose
-        rules/ drop is not OpenCode-specific: flatten_plan_templates drops
-        the inlined rules from any plan whose instruction file carries the
-        DYNAMIC-INCLUDE-ALL-RULES marker (no current template does, including
-        OpenCode's), and that runs earlier in stage_and_transform. Kept as a
-        no-op only to satisfy the ToolAdapter protocol."""
+        """No-op. OpenCode DOES get a standalone rules/ destination — the
+        shared rules/ namespace stages into ~/.config/opencode/rules/ the
+        same as every other tool (build_plan Phase 2, namespaces.SHARED;
+        should_install_namespace only excludes the shared agents/ namespace
+        here) — it is just empty today because the shared source has no rule
+        files yet. The loose rules/ drop that would apply once it isn't is
+        not OpenCode-specific either: flatten_plan_templates drops a plan's
+        standalone rules/ items only when its instruction file carries the
+        DYNAMIC-INCLUDE-ALL-RULES marker, and that runs earlier in
+        stage_and_transform. No current template carries that marker,
+        including OpenCode's, so nothing is dropped for any tool today.
+        Kept as a no-op only to satisfy the ToolAdapter protocol."""
         return plan

--- a/packages/installer/tests/unit/test_staging_opencode.py
+++ b/packages/installer/tests/unit/test_staging_opencode.py
@@ -35,8 +35,11 @@ def _make_opencode_repo(tmp_path: Path) -> Path:
     (shared / "INSTRUCTIONS.md.template").write_bytes(b"# shared root tmpl")
     # opencode tool root — templates + settings, no namespace subdirs
     opencode.mkdir(parents=True)
-    # Mirror the real OpenCode template: it carries the ALL-RULES marker, so
-    # flatten_plan_templates inlines the staged rules and drops the loose copies.
+    # Synthetic template exercising the ALL-RULES marker grammar: no current
+    # OpenCode template carries it (the real one is a single DYNAMIC-INCLUDE
+    # of USER-CORE.md.template) — this fixture is what a template WOULD need
+    # for flatten_plan_templates to inline the staged rules and drop the
+    # loose copies.
     (opencode / "AGENTS.md.template").write_bytes(
         b"# opencode root tmpl\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n"
     )
@@ -102,16 +105,22 @@ def test_opencode_build_plan_stages_jsonc_settings(tmp_path: Path, ignore: Insta
 
 def test_opencode_flatten_inlines_and_drops_rules(tmp_path: Path, ignore: InstallIgnore) -> None:
     """
-    Given an OpenCode plan that still carries shared rules/ items (build_plan keeps
-    them so the DYNAMIC-INCLUDE-ALL-RULES flatten can inline them)
+    Given an OpenCode plan built from this fixture's synthetic template (which
+    carries the ALL-RULES marker; no current real OpenCode template does) that
+    still carries shared rules/ items (build_plan keeps them so the
+    DYNAMIC-INCLUDE-ALL-RULES flatten can inline them)
     When flatten_plan_templates runs
     Then the rule is inlined into AGENTS.md and every rules/ item is dropped, while
     non-rules items (skills/, templates) survive.
 
-    Pins: OpenCode writes no standalone rules/ namespace — rules live only inline in
-    AGENTS.md. The loose-rules drop is owned by flatten_plan_templates (keyed on the
-    ALL-RULES marker OpenCode's AGENTS.md carries), NOT a per-adapter transform, so
-    the inliner still sees the rules but sync does not.
+    Pins: when a tool's instruction file carries the ALL-RULES marker, its
+    rules live only inline in AGENTS.md instead of a standalone rules/
+    namespace. The loose-rules drop is owned by flatten_plan_templates (keyed
+    on the marker a template carries), NOT a per-adapter transform, so the
+    inliner still sees the rules but sync does not. OpenCode's real rules/
+    destination isn't special-cased away by this mechanism — it's simply
+    unpopulated today because no current template carries the marker (see
+    OpenCodeAdapter.post_staging_transforms).
     """
     repo = _make_opencode_repo(tmp_path)
     plan = build_plan(OpenCodeAdapter(), repo_root=repo, ignore=ignore)

--- a/packages/installer/tests/unit/test_templates_flatten_plan.py
+++ b/packages/installer/tests/unit/test_templates_flatten_plan.py
@@ -109,10 +109,13 @@ def test_all_rules_inline_drops_loose_rules_from_plan(tmp_path: Path) -> None:
     """When the instruction file inlines every rule via ALL-RULES, the loose
     rules/ items are dropped from the plan.
 
-    A tool whose instruction file carries the ALL-RULES marker
-    (codex/gemini/opencode) gets every rule inlined into AGENTS.md/GEMINI.md, so
-    deploying the rules/ files standalone would write redundant copies the tool
-    does not read. They are removed exactly like include-only file templates."""
+    A tool whose instruction file carries the ALL-RULES marker gets every
+    rule inlined into AGENTS.md/GEMINI.md, so deploying the rules/ files
+    standalone would write redundant copies the tool does not read. No
+    current template (Claude/Codex/Gemini/OpenCode) carries this marker —
+    each is a single DYNAMIC-INCLUDE of USER-CORE.md.template — so this test
+    exercises the mechanism via a synthetic GEMINI.md fixture, not any real
+    template. They are removed exactly like include-only file templates."""
     gemini_md = _item(Path("GEMINI.md"), b"top\n<!-- DYNAMIC-INCLUDE-ALL-RULES -->\n")
     r1 = _item(Path("rules/a-first.md"), b"FIRST", namespace="rules")
     r2 = _item(Path("rules/b-second.md"), b"SECOND", namespace="rules")

--- a/src/plugins/AGENTS.md
+++ b/src/plugins/AGENTS.md
@@ -7,8 +7,8 @@ loose files like this `AGENTS.md` are skipped). Which discovered plugins are
 **activated** is resolved per run: by default each plugin's adapter
 auto-detects against `$HOME` (`is_detected`); `--plugins=<names>` overrides the
 set (naming an undiscovered plugin is a fast-fail error), and `--plugins=`
-(empty) installs none. A plugin's rules deploy only into the tools that are
-themselves detected.
+(empty) installs none. A plugin's rules deploy into every active tool —
+auto-detected, or explicitly selected via `--tools=` even if undetected.
 
 ## Plugin Structure
 

--- a/src/plugins/AGENTS.md
+++ b/src/plugins/AGENTS.md
@@ -7,8 +7,13 @@ loose files like this `AGENTS.md` are skipped). Which discovered plugins are
 **activated** is resolved per run: by default each plugin's adapter
 auto-detects against `$HOME` (`is_detected`); `--plugins=<names>` overrides the
 set (naming an undiscovered plugin is a fast-fail error), and `--plugins=`
-(empty) installs none. A plugin's rules deploy into every active tool —
-auto-detected, or explicitly selected via `--tools=` even if undetected.
+(empty) installs none. A plugin's two rule scopes route differently: shared
+`.agents/rules/` content deploys into every active tool — auto-detected, or
+explicitly selected via `--tools=` even if undetected — the same as base
+shared content; tool-scoped `.<tool>/rules/` content deploys only into that
+one matching tool (`overlay_plugins` stages a plugin's `.<adapter.name>/`
+tree once per active tool, so a `.codex/rules/` file is only ever staged
+into Codex's plan).
 
 ## Plugin Structure
 

--- a/src/user/.agents/AGENTS.md
+++ b/src/user/.agents/AGENTS.md
@@ -10,9 +10,8 @@ exists; or `--tools=` selects any of them).
 - `USER-CORE.md.template` — this directory's only top-level template, and
   include-only: each tool's own `AGENTS.md.template` (or `GEMINI.md.template`
   for Gemini) pulls it in with a `DYNAMIC-INCLUDE` marker, and the
-  installer's template-flattening phase (Phase 6.5/6.75) drops the
-  standalone copy during staging, so it never lands on its own as
-  `~/.<tool>/USER-CORE.md`.
+  installer's template-flattening step drops the standalone copy during
+  staging, so it never lands on its own as `~/.<tool>/USER-CORE.md`.
 - `skills/` — each top-level entry copied; **names must be unique** across the
   combined tree (shared + tool-specific + active plugins). Collisions are a
   **fatal install error**.

--- a/src/user/.agents/AGENTS.md
+++ b/src/user/.agents/AGENTS.md
@@ -2,7 +2,8 @@
 
 Tool-agnostic source content. `scripts/install.sh` stages everything here into
 **every active tool** (Claude always; Codex and Gemini when their `~/.<tool>/`
-dir exists or `--tools=` selects them).
+dir exists; OpenCode when `opencode` is on PATH or `~/.config/opencode/`
+exists; or `--tools=` selects any of them).
 
 ## Install model
 

--- a/src/user/.agents/AGENTS.md
+++ b/src/user/.agents/AGENTS.md
@@ -9,9 +9,10 @@ exists; or `--tools=` selects any of them).
 
 - `USER-CORE.md.template` — this directory's only top-level template, and
   include-only: each tool's own `AGENTS.md.template` (or `GEMINI.md.template`
-  for Gemini) pulls it in with a `DYNAMIC-INCLUDE` marker, and the installer
-  drops the standalone copy from the plan before staging, so it never lands
-  on its own as `~/.<tool>/USER-CORE.md`.
+  for Gemini) pulls it in with a `DYNAMIC-INCLUDE` marker, and the
+  installer's template-flattening phase (Phase 6.5/6.75) drops the
+  standalone copy during staging, so it never lands on its own as
+  `~/.<tool>/USER-CORE.md`.
 - `skills/` — each top-level entry copied; **names must be unique** across the
   combined tree (shared + tool-specific + active plugins). Collisions are a
   **fatal install error**.

--- a/src/user/.agents/AGENTS.md
+++ b/src/user/.agents/AGENTS.md
@@ -7,9 +7,11 @@ exists; or `--tools=` selects any of them).
 
 ## Install model
 
-- `*.md.template` — `.template` suffix stripped on copy; lands at
-  `~/.<tool>/<basename>.md` (e.g. `AGENTS.md.template` → `~/.claude/AGENTS.md`,
-  by DYNAMIC-INCLUDE into the per-tool assembled instruction file).
+- `USER-CORE.md.template` — this directory's only top-level template, and
+  include-only: each tool's own `AGENTS.md.template` (or `GEMINI.md.template`
+  for Gemini) pulls it in with a `DYNAMIC-INCLUDE` marker, and the installer
+  drops the standalone copy from the plan before staging, so it never lands
+  on its own as `~/.<tool>/USER-CORE.md`.
 - `skills/` — each top-level entry copied; **names must be unique** across the
   combined tree (shared + tool-specific + active plugins). Collisions are a
   **fatal install error**.
@@ -25,8 +27,9 @@ exists; or `--tools=` selects any of them).
 
 - These are **source templates**, not runtime config. Editing a file here
   changes what gets installed into users' real configs on next `install.sh` run.
-- Do not confuse a source file here with its installed copy under `~/.<tool>/` —
-  never edit the installed copy from this repo.
+- Do not confuse a source file here with its installed copy under `~/.<tool>/`
+  (`~/.config/opencode/` for OpenCode) — never edit the installed copy from
+  this repo.
 - Before adding a skill or rule, check for name collisions against
   `src/user/.claude/` and every `src/plugins/*/` — the installer aborts on
   duplicate names.

--- a/src/user/.agents/README.md
+++ b/src/user/.agents/README.md
@@ -1,8 +1,9 @@
 # src/user/.agents/ — Shared Content
 
-Tool-agnostic content that `scripts/install.sh` copies into **every detected
-AI coding assistant** (Claude Code, Codex CLI, Gemini CLI, OpenCode). If
-something here is useful to more than one tool, it lives here.
+Tool-agnostic content that `scripts/install.sh` copies into **every active
+tool** (Claude Code, Codex CLI, Gemini CLI, OpenCode — auto-detected, or
+explicitly selected via `--tools=`). If something here is useful to more than
+one tool, it lives here.
 
 ## What lives here
 
@@ -27,8 +28,9 @@ CLI `~/.codex/`, Gemini CLI `~/.gemini/`, OpenCode `~/.config/opencode/`.
 Skills land under `<config>/skills/`, rules under `<config>/rules/`, and the
 instruction text is assembled into each tool's own instruction file.
 
-The installer strips the `.template` suffix on copy and skips tools that aren't
-detected on the system.
+The installer strips the `.template` suffix on copy. Auto-detect skips tools
+that aren't detected on the system, but `--tools=` bypasses detection
+entirely and installs to any named tool regardless.
 
 ## Who it's for
 

--- a/src/user/.agents/README.md
+++ b/src/user/.agents/README.md
@@ -36,9 +36,9 @@ entirely and installs to any named tool regardless.
 ## Who it's for
 
 Fork-and-install users who want a ready-made set of skills and shared
-instruction text to drop into their `~/.<tool>/` config. Not a library for
-programmatic consumption — these are prose files meant to be read by an LLM at
-runtime.
+instruction text to drop into their tool's config (`~/.<tool>/`, or
+`~/.config/opencode/` for OpenCode). Not a library for programmatic
+consumption — these are prose files meant to be read by an LLM at runtime.
 
 See the [root README](../../../README.md) for install flow and customization
 pointers. Do not duplicate install instructions here.

--- a/src/user/.agents/README.md
+++ b/src/user/.agents/README.md
@@ -23,8 +23,9 @@ so confirm against the tool's own config directory rather than assuming.
 
 ## Where it installs
 
-Into every detected tool's config directory — Claude Code `~/.claude/`, Codex
-CLI `~/.codex/`, Gemini CLI `~/.gemini/`, OpenCode `~/.config/opencode/`.
+Into every active tool's config directory (auto-detected, or explicitly
+selected via `--tools=`) — Claude Code `~/.claude/`, Codex CLI `~/.codex/`,
+Gemini CLI `~/.gemini/`, OpenCode `~/.config/opencode/`.
 Skills land under `<config>/skills/`, rules under `<config>/rules/`, and the
 instruction text is assembled into each tool's own instruction file.
 

--- a/src/user/.agents/README.md
+++ b/src/user/.agents/README.md
@@ -8,9 +8,8 @@ something here is useful to more than one tool, it lives here.
 
 - `USER-CORE.md.template` — the zero-based shared laws, decision matrix, hard
   lines, and conventions (D17). Every tool's instruction template pulls this in
-  with a `DYNAMIC-INCLUDE` marker, so it is the one file whose text reaches all
-  four tools verbatim. It is currently hand-deployed to the standard homes;
-  `agents-config-9k9.10` tracks wiring it into automated per-tool assembly.
+  with a `DYNAMIC-INCLUDE` marker that the installer resolves at staging time,
+  so it is the one file whose text reaches all four tools verbatim.
 - `skills/` — methodology guides, one directory per skill with a `SKILL.md` and
   optional supporting scripts.
 - `rules/` — tool-agnostic always-on rules. Empty today.

--- a/src/user/.claude/AGENTS.md
+++ b/src/user/.claude/AGENTS.md
@@ -13,9 +13,13 @@ into `~/.claude/` (Claude is always an active tool; never auto-detected away).
   are a **fatal install error**.
 - `rules/*.md` — collisions are allowed: files with the same name are
   **appended** (base first, plugins alphabetically) with a `---` separator.
+- `hooks/` — Python scripts referenced by `settings.json.template`'s hook
+  commands (invoked as `python3 ~/.claude/hooks/<script>.py`); each script
+  ships a paired test.
 - `settings.json.template` — **union-merged** with any existing
-  `~/.claude/settings.json` via `jq` (user values preserved, arrays
-  deduplicated, new keys added).
+  `~/.claude/settings.json` by the installer's own deep-merge strategy (pure
+  Python, no `jq` dependency): dicts recurse, arrays concatenate and dedupe,
+  a scalar conflict keeps the existing value, and new keys are added.
 
 ## Agent warnings
 

--- a/src/user/.claude/README.md
+++ b/src/user/.claude/README.md
@@ -13,6 +13,9 @@ by default.
 - `rules/` — Claude-specific workflow rules, under that same gate. Each rules
   directory carries its own `AGENTS.md` saying what is currently in it; read
   that rather than counting files here.
+- `hooks/` — Python scripts invoked by `settings.json.template`'s hook
+  commands (e.g. `ruff-postedit.py`, `codex-broker-reaper.py`), each paired
+  with its own test script.
 - `AGENTS.md.template` — Top-level instruction file. It is a single
   `DYNAMIC-INCLUDE` of the shared zero-based core in
   `src/user/.agents/USER-CORE.md.template`, which the installer flattens in at

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -16,9 +16,10 @@ PATH or `~/.config/opencode/` exists, or selected via `--tools=opencode`).
 marker (today it pulls in `USER-CORE.md.template`), which the installer
 resolves at staging time, producing a flat `AGENTS.md` with no `@` references.
 This is required because OpenCode does not support `@` include resolution.
-The installer also supports an `ALL-RULES` marker and a named-`RULES` subset
-marker, but this template carries neither today, so no rules content is
-inlined into OpenCode's `AGENTS.md`.
+The installer also supports a `<!-- DYNAMIC-INCLUDE-ALL-RULES -->` marker and
+a named `<!-- DYNAMIC-INCLUDE-RULES: ruleA,ruleB -->` subset marker, but this
+template carries neither today, so no rules content is inlined into
+OpenCode's `AGENTS.md`.
 
 ## Skills
 

--- a/src/user/.opencode/AGENTS.md
+++ b/src/user/.opencode/AGENTS.md
@@ -12,11 +12,13 @@ PATH or `~/.config/opencode/` exists, or selected via `--tools=opencode`).
 
 ## Dynamic flattening
 
-`AGENTS.md.template` is special: it contains `<!-- DYNAMIC-INCLUDE: path -->` and
-`<!-- DYNAMIC-INCLUDE-ALL-RULES -->` markers that the installer
-resolves at staging time, producing a single flat `AGENTS.md` with no `@`
-references. This is required because OpenCode does not support `@` include
-resolution.
+`AGENTS.md.template` is special: it is a single `<!-- DYNAMIC-INCLUDE: path -->`
+marker (today it pulls in `USER-CORE.md.template`), which the installer
+resolves at staging time, producing a flat `AGENTS.md` with no `@` references.
+This is required because OpenCode does not support `@` include resolution.
+The installer also supports an `ALL-RULES` marker and a named-`RULES` subset
+marker, but this template carries neither today, so no rules content is
+inlined into OpenCode's `AGENTS.md`.
 
 ## Skills
 

--- a/src/user/.opencode/README.md
+++ b/src/user/.opencode/README.md
@@ -15,6 +15,7 @@ This directory contains source templates for OpenCode (`opencode`) support.
    `USER-CORE.md.template`'s content)
 3. Writing the result to `~/.config/opencode/AGENTS.md`
 
-The template carries no `ALL-RULES` or named-`RULES` marker today, so no rules
-content reaches OpenCode's `AGENTS.md`. This preserves DRY (content lives in
-one place) while producing a file OpenCode can use.
+The template carries no `<!-- DYNAMIC-INCLUDE-ALL-RULES -->` or
+`<!-- DYNAMIC-INCLUDE-RULES: ... -->` marker today, so no rules content
+reaches OpenCode's `AGENTS.md`. This preserves DRY (content lives in one
+place) while producing a file OpenCode can use.

--- a/src/user/.opencode/README.md
+++ b/src/user/.opencode/README.md
@@ -11,8 +11,10 @@ This directory contains source templates for OpenCode (`opencode`) support.
 
 `install.sh` builds a flat `AGENTS.md` at install time by:
 1. Reading `AGENTS.md.template`
-2. Resolving `<!-- DYNAMIC-INCLUDE: path -->` markers (inlines referenced file content)
-3. Resolving `<!-- DYNAMIC-INCLUDE-RULES: rule1,... -->` markers (inlines rules from `src/user/.claude/rules/`)
-4. Writing the result to `~/.config/opencode/AGENTS.md`
+2. Resolving its `<!-- DYNAMIC-INCLUDE: path -->` marker (inlines
+   `USER-CORE.md.template`'s content)
+3. Writing the result to `~/.config/opencode/AGENTS.md`
 
-This preserves DRY (content lives in one place) while producing a file OpenCode can use.
+The template carries no `ALL-RULES` or named-`RULES` marker today, so no rules
+content reaches OpenCode's `AGENTS.md`. This preserves DRY (content lives in
+one place) while producing a file OpenCode can use.


### PR DESCRIPTION
## Summary

Fixes the five verified findings on `agents-config-9k9.215.3` (recheck findings H4, H6, L5, M29, M5 from `repo-sanity-recheck-2026-08-09.md`): `src/user/**` prose that misdescribed the installer's actual staging/merge/marker behavior.

| Finding | File(s) | Was | Now |
|---|---|---|---|
| H4 | `src/user/.agents/README.md` | Said USER-CORE is "currently hand-deployed" pending `9k9.10` | All four tool templates (`.claude`, `.codex`, `.gemini`, `.opencode`) carry the `DYNAMIC-INCLUDE` marker and `templates.py` resolves it at staging time — the deploy is live, not hand-copied |
| H6 | `src/user/.opencode/AGENTS.md`, `src/user/.opencode/README.md` | Claimed an `ALL-RULES` marker (AGENTS.md) or named `DYNAMIC-INCLUDE-RULES:` markers sourcing `src/user/.claude/rules/` (README) — disagreeing with each other | The real `src/user/.opencode/AGENTS.md.template` is one line, a single `DYNAMIC-INCLUDE` of `USER-CORE.md.template`; neither marker is present, so no rules content reaches OpenCode's `AGENTS.md` today |
| L5 | `src/user/.agents/AGENTS.md` | Staging parenthetical named only Claude/Codex/Gemini, omitting OpenCode | Added OpenCode's actual detection condition (`opencode` on PATH or `~/.config/opencode/` exists), matching `OpenCodeAdapter.is_detected` and the tree's own later bullets |
| M5 | `src/user/.claude/AGENTS.md` | Said settings merge happens "via `jq`" | `merge/strategies/json_union.py` is pure Python; described the actual deep-merge rules (dict recurse, array concat+dedupe, scalar keeps existing) |
| M29 | `src/user/.claude/README.md`, `src/user/.claude/AGENTS.md` | Both "What lives here"/"Install model" listings omitted `hooks/` | Added a `hooks/` bullet to both — a real, deployed dir wired into `settings.json.template`'s hook commands |

Every claim was re-verified against the installer's current code before editing (see `templates.py`, `tools/opencode.py`, `tools/claude.py`, `merge/strategies/json_union.py`, `settings.json.template`) — cited in the task report, not restated here per this repo's "current decision, not history" prose convention.

### Round 2 — review-panel round 1 findings (f1–f5)

Round 1's review-panel verdict found the round-1 fix left orphaned paraphrasers of the same corrected claims — comments in `packages/installer/` and two more `src/user/.agents/` claims the first pass's sweep missed:

| Finding | File(s) | Was | Now |
|---|---|---|---|
| f1/f3 (mechanical) | `packages/installer/src/installer/tools/opencode.py:53-58`, `packages/installer/src/installer/core/templates.py:68-71,152-154` | Comments/docstrings still asserted non-Claude templates carry the `ALL-RULES` marker | Corrected to state no current template carries it — all four are a single `DYNAMIC-INCLUDE` of `USER-CORE.md.template` |
| f2 (mechanical) | `src/user/.agents/AGENTS.md:10-12,28-29` | Generalized template destinations and installed copies as `~/.<tool>/`, false for OpenCode | Added OpenCode's `~/.config/opencode/` path; rewrote the `*.md.template` bullet to name `USER-CORE.md.template` specifically (this directory's only template) |
| f4 (advisory) | `src/user/.agents/README.md:3-5,30-31` | Described staging as detection-only ("skips tools that aren't detected") | Added the `--tools=` override, which bypasses detection entirely (`config.py::resolve_tools`) |
| f5 (advisory) | `src/user/.agents/AGENTS.md:10-12` | The `*.md.template` bullet's "lands at `~/.<tool>/<basename>.md`" claim, with an `AGENTS.md.template` example that doesn't exist in this directory, was false for this directory's only template — `USER-CORE.md.template` is include-only and never lands standalone | Rewrote the bullet to describe the include-only mechanism (`templates.py::flatten_plan_templates` drops the standalone copy before staging) |

This round does touch code — three code comments/docstrings in `packages/installer/` corrected to match current behavior (no code *behavior* changed).

### Copilot addendum — exact marker strings

Copilot flagged that the corrected OpenCode docs described the markers as shorthand `ALL-RULES` / named-`RULES`, which reads as a different syntax than the installer's actual directive strings. Fixed both `src/user/.opencode/AGENTS.md` and `README.md` to use the literal `<!-- DYNAMIC-INCLUDE-ALL-RULES -->` and `<!-- DYNAMIC-INCLUDE-RULES: ... -->` forms (`templates.py`'s own vocabulary). Checked the same shorthand in the other files this claim touches: the `src/user/.agents` pair has no marker mentions at all (clean); the two `packages/installer/` comment blocks the round-2 fix touched (`templates.py:68-71,150-159`) used the same bare "ALL-RULES marker" shorthand, so applied the same exact-string convention there too, matching the RST double-backtick style already used elsewhere in that file. Left `opencode.py:53-58` alone — it already names the marker by its full identifier (`DYNAMIC-INCLUDE-ALL-RULES marker`), not the ambiguous bare shorthand, and left `templates.py`'s pre-existing untouched lines (e.g. `:62-63,81,114,119,177,...`) alone — they're outside this diff and follow the file's own established "define the literal form once in the module docstring, abbreviate consistently thereafter" convention, which is not the same defect as the docs' unanchored shorthand.

### Round 3 — review-panel round 2 findings (r2f1–r2f4)

Round 2's review-panel verdict found four more findings, all induced by round-2's fixes or reached by extending their sweep:

| Finding | File(s) | Was | Now |
|---|---|---|---|
| r2f1 (mechanical) | `packages/installer/src/installer/tools/opencode.py:53` | Docstring claimed "OpenCode has no standalone rules/ destination" | False as a mechanism claim: `build_plan` Phase 2 stages the shared `rules/` namespace for OpenCode the same as every other tool (`namespaces.SHARED` includes `"rules"`; `OpenCodeAdapter.should_install_namespace` only excludes the shared `agents/` namespace) — the destination exists, it's just empty today because `src/user/.agents/rules/` has no files yet. Rewrote the docstring to say so |
| r2f2 (mechanical) | `src/user/.agents/README.md` | Self-contradiction: `:3-5` (round 1) documents the `--tools=` override, but the "Where it installs" section (`:25-26`) still said "every detected tool's config directory" | Reconciled — "every active tool's config directory (auto-detected, or explicitly selected via `--tools=`)" |
| r2f3 (advisory) | `src/plugins/AGENTS.md:11` | "A plugin's rules deploy only into the tools that are themselves detected" — same detection-only defect one level up; `orchestrator.py`'s `stage_and_transform` overlays plugins per already-resolved tool, so an explicitly-`--tools=`-selected, undetected tool still gets plugin content | Added the same override language |
| r2f4 (advisory) | `src/user/.agents/AGENTS.md:13` | Said the installer "drops the standalone copy from the plan before staging" | The drop is itself a staging phase (`templates.py`'s own "Phase 6.5/6.75"), not something that happens before staging — reworded to name the phase and say "during staging," matching the sibling README's "at staging time" |

Commit `b242539b`. Files changed: `packages/installer/src/installer/tools/opencode.py`, `src/user/.agents/README.md`, `src/user/.agents/AGENTS.md`, `src/plugins/AGENTS.md` (unclaimed by any other PR at time of fix).

**Consumer sweep for round 3 surfaced two more instances of the same detection-only phrasing pattern, left unfixed as out of this item's scope:** root `README.md:109-110` ("every detected tool" for shared skills/rules) and `docs/primers/SKILLS_PRIMER.md:289` (near-verbatim "a plugin's content deploys only into tools that are themselves detected" — the same sentence r2f3 just corrected in `src/plugins/AGENTS.md`, but this location is a primer, a different findings cluster in the recheck). Neither is under `src/user/**`; root README.md's Commands section is explicitly named by a separate recheck finding (L3), suggesting it's already another child's territory. Flagging for the epic owner to route rather than fixing unilaterally.

### Round 4 — review-panel round 3 findings (top-level quotients, grammar, wording check)

Round 3's review-panel verdict (the codex lenses; the global-consistency lens still returning) settled three findings, all adjacent-reach residue of earlier rounds' corrections:

| Finding | File(s) | Was | Now |
|---|---|---|---|
| Root-surface quals (mechanical) | `README.md:3,71,109-110,183`, `AGENTS.md:7,91` | Root README.md and AGENTS.md were the last unqualified quoters of "installed/deploys to all detected tools" after every `src/user/**` occurrence was corrected in earlier rounds | Added the same `--tools=`-override qualifier to `:3`/`:7` (shared "Project Purpose" sentence, duplicated verbatim across both files) and `:91` (plugin content bullet); reworded `:71`,`:109-110`,`:183` to "every active tool," reached by extending the sweep within README.md itself (the opening-line fix at `:3` didn't reach these three later, independent occurrences of the same claim) |
| opencode.py grammar (mechanical) | `packages/installer/src/installer/tools/opencode.py:53` | "The loose rules/ drop that would apply once it isn't is not OpenCode-specific either" — dangling pronoun, "it" has no antecedent for a cold reader | Rewrote without the ambiguous pronoun: "Dropping standalone rules/ items once that source is populated would not be OpenCode-specific either" |
| Staging-vs-consumption wording check | all files touched this claim | Reviewer asked me to verify my staging-related wording never implies the rules are *read/consumed* by a tool (only Claude reads a loose `rules/` tree; Codex/Gemini/OpenCode would need the inlining markers, which no current template carries — `docs/primers/RULES_PRIMER.md:187-189`) | Checked: my wording consistently uses staging verbs only — "stages," "deploy," "lands," "reaches," "inlined into," "installed to" — never "read," "consume," or "apply." Confirmed staging-only; no rewording needed beyond the grammar fix above |

Commit `54d2d64b`.

### Round 5 — one exhaustive sweep, not more line-by-line misses

Round 4's review kept finding more copies of the same detection-only class in files already in this diff (round 2 fixed `src/user/.agents/README.md:3-5`, round 3 fixed `README.md:109-110`, round 4 fixed `README.md:3,71,183`/`AGENTS.md:7,91` — three separate rounds catching new instances in the same handful of files). Team lead's call: stop finding these one at a time. Grepped root `README.md`, `src/plugins/AGENTS.md`, and `src/user/.agents/README.md` exhaustively for `detect`/`detected` and the generic `~/.<tool>/` path, and dispositioned every hit — fixed, or recorded correct-as-is with a reason. Full counts and per-hit disposition in the task report; summary:

| File | `detect` hits | `~/.<tool>` hits | Fixed | Correct as-is |
|---|---|---|---|---|
| `README.md` | 8 | 0 (all already tool-specific) | `:86` (plugin activation), `:90-92` (all→every active), `:114` (table cell) | `:3` (already fixed), `:38` (Prerequisites convenience note), `:46` (off-limits, PR #543's hunk — also independently precise/scoped), `:182,204-205` (these define the override flags), `:186` (unrelated: file-drift detection) |
| `src/plugins/AGENTS.md` | 5 | 1 | `:10-11` rewritten to distinguish two rule scopes (see below) | `:8` (plugin-activation default, already qualified same line), `:62` (a specific adapter's footprint-check description), `:63` (same), `:81` (table header label) |
| `src/user/.agents/README.md` | 4 | 1 | `:39` (`~/.<tool>/` → tool's config, OpenCode exception named) | `:4,26,32-33` (already qualified in rounds 1-2) |

`src/plugins/AGENTS.md:10-11` needed more than a qualifier: verified against `overlay_plugins` (`packages/installer/src/installer/core/overlay.py:47-82`) that a plugin's two rule scopes route differently — shared `.agents/rules/` content deploys into every active tool (same as base shared content), but tool-scoped `.<tool>/rules/` content only stages when `overlay_plugins`'s per-tool call builds `tool_root = plugin.source_path / f".{adapter.name}"`, so a `.codex/rules/` file is only ever staged into Codex's plan. The old sentence collapsed both scopes into one blanket "every active tool" claim, wrong for the tool-scoped half. Rewrote to name both scopes and their different destinations.

**Consumer sweep for this round surfaced one more instance, left unfixed as out of scope:** `docs/guide/getting-started.md:55` has the identical "matching tools, when detected" table cell just fixed at `README.md:114` — `docs/guide/` is explicitly another item's territory per my original brief. Flagging for the epic owner.

Commit `8e40a91b`.

### Round 6 — one history-narration line

Round 6 review (ic/gc lenses clean) found one standalone-read finding:
`packages/installer/src/installer/core/templates.py:215`
(`_flatten_with_plan_rules`'s docstring) said "The on-disk staging tree is
the source for ALL-RULES in the original design; the Python installer
stages in memory..." — narrating a prior design as contrast rather than
stating the current mechanism, in a file this PR already edits. Rewrote to
state only what the staging tree is the source for today: "The Python
installer stages in memory rather than to an on-disk tree, so when (and
only when) the template needs rules, the plan's staged `rules/` items are
materialised to a temp dir for `flatten_template` to read." Commit
`850e8ff9`. `packages/installer/` changed, so ran `make ci` standalone —
exit 0.

### Round 7 — drop installer-internal phase numbering from deployed prose

Round 7 review (ic/gc clean) found one last standalone-read nit:
`src/user/.agents/AGENTS.md:13` cited "(Phase 6.5/6.75)" — installer-internal
staging-phase numbering that a deployed reader (someone with only their
`~/.<tool>/AGENTS.md` in front of them, not this repo) has no way to
resolve. Dropped the numbering, kept the concept: "the installer's
template-flattening step drops the standalone copy during staging." No
`packages/installer/` change this round, so ran the content gates
standalone (`make content-lint`/`make content-tests`/`make doc-lint`) —
exit 0 each. Commit `d956d6da`.

### Round 8 — test docstrings state what the fixture exercises, not a claim about real templates

Round 8 review (ic/sr clean; one real gc finding, distinguished from an earlier synthetic-fixture rebuttal): three test docstrings/comments asserted real tool templates carry the ALL-RULES marker — false for the same reason established throughout this PR (every current template is a single `DYNAMIC-INCLUDE` of `USER-CORE.md.template`):

| File | Was | Now |
|---|---|---|
| `packages/installer/tests/unit/test_staging_opencode.py:38` | Fixture comment: "Mirror the real OpenCode template: it carries the ALL-RULES marker" | "Synthetic template exercising the ALL-RULES marker grammar: no current OpenCode template carries it... this fixture is what a template WOULD need" |
| `packages/installer/tests/unit/test_staging_opencode.py:103-115` | Docstring: "OpenCode writes no standalone rules/ namespace" and "the ALL-RULES marker OpenCode's AGENTS.md carries" | Rewrote to name the fixture's synthetic template explicitly, generalize the pin to "when a tool's instruction file carries the marker," and state OpenCode's real rules/ destination isn't special-cased away — it's unpopulated today because no current template carries the marker |
| `packages/installer/tests/unit/test_templates_flatten_plan.py:112-113` | "(codex/gemini/opencode)" parenthetical, asserting these three currently carry the marker | Dropped the parenthetical; added that no current template (any of the four) carries it, and this test exercises the mechanism via a synthetic `GEMINI.md` fixture |

No test behaviour changed — docstring/comment text only. Swept the rest of `packages/installer/tests/` for the same pattern: `test_templates.py` and `test_profiles.py`'s `ALL-RULES` mentions test the marker grammar via literal strings/direct function calls without claiming any real template uses it — correct as-is, no change needed. `packages/installer/` changed, so ran `make ci` standalone — exit 0. Commit `25d9596b`.

## Consumer sweep

**Round 1:** Uncapped repo-wide sweep for each corrected claim (hand-deployed/9k9.10, jq, ALL-RULES/DYNAMIC-INCLUDE-RULES, the staging parenthetical, hooks/ listings) found no other `src/`-tree quoters needing the same fix. The only other occurrences are dated `docs/specs/` proposals describing historical/point-in-time design intent, out of this item's scope.

**Round 2:** Re-ran the sweep for the ALL-RULES claim across `packages/installer/src/` (not just `src/`) after the review-panel finding — found and fixed the three additional installer comments (f1/f3). Also swept `~/.<tool>/` generalizations and the "skips tools that aren't detected" phrasing repo-wide; no further quoters found. One remaining ALL-RULES mention, `packages/installer/src/installer/core/orchestrator.py:16`, describes the phase-ordering mechanism generically (what a marker *would* see, not a claim that any current template carries one) — not a stale paraphrase, left as is.

## Test plan

- [x] `make content-lint` — exit 0 (round 1, standalone from worktree root)
- [x] `make content-tests` — exit 0 (round 1, 12 suites passed)
- [x] `make doc-lint` — exit 0 (round 1)
- [x] `make ci` — exit 0 (round 2, standalone from worktree root; required once `packages/installer/` changed — 515 installer tests, 98.11% coverage, ruff/mypy/content-lint/content-tests/doc-lint all clean)
- [x] Uncapped consumer sweep for all changed quoted/paraphrased text — recorded above for both rounds
- [x] `make ci` — exit 0 (Copilot addendum round, standalone from worktree root; `packages/installer/` changed again)
- [x] `make ci` — exit 0 (round 3, standalone from worktree root; `packages/installer/` changed again)
- [x] `make ci` — exit 0 (round 4, standalone from worktree root; `packages/installer/` changed again — verified twice, once before and once after the two additional README.md sweep fixes)
- [x] `make content-lint` / `make content-tests` / `make doc-lint` — exit 0 each (round 5; no `packages/installer/` change this round, so `make ci` wasn't required)
- [x] `make ci` — exit 0 (round 6, standalone from worktree root; `packages/installer/` changed again)
- [x] `make content-lint` / `make content-tests` / `make doc-lint` — exit 0 each (round 7; no `packages/installer/` change this round)
- [x] `make ci` — exit 0 (round 8, standalone from worktree root; `packages/installer/` changed again — test docstrings/comments only, no behavior change)
- [ ] review-panel round 8 (re-review at new head `25d9596b`, per epic `agents-config-9k9.215` review contract) — expected terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA







