### PR TITLE
docs(9k9.215.2): the guide gives one tracker-setup answer, tree-verified

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Good reasons to open an issue:
 - You spotted a bug in `scripts/install.sh` or a drift in the docs.
 - You want to propose a new skill, agent, or command that has broad utility.
 - You want to add support for another AI coding assistant alongside Claude
-  Code, Codex CLI, and Gemini CLI.
+  Code, Codex CLI, Gemini CLI, and OpenCode.
 
 Personal-taste changes (rewording personas, swapping opinions in skills,
 changing the agent persona's personality) are usually better kept in your own

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,11 @@ the repo:
 ## Install & plugin prerequisites
 
 See the root [`README.md`](./README.md) for installation instructions and for
-what the installed content actually depends on. Neither plugin this file used
-to list as a prerequisite is one: `obra/superpowers` was dropped when the rules
-and skills referencing it were retired, and `steveyegge/beads` is needed only
-because the `work` CLI is a facade over `bd` — nothing in the installed
-instruction surface requires either.
+what the installed content actually depends on. Neither `obra/superpowers` nor
+`steveyegge/beads` is a hard prerequisite: nothing installed today calls into
+`superpowers`, and `beads` (via the `work` CLI, a facade over `bd`) is needed
+only by five deployed skills — `to-tickets`, `wayfinder`,
+`where-does-this-fit`, `triaging-discovered-work`, and `prototype` — each of
+which degrades to its own fallback without it. See
+[Getting Started](./docs/guide/getting-started.md#prerequisites) for what
+each fallback is.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ tool-scoped namespace with no shared variant:
 - `/clean-up-git [filter]` - Adjudicate which git worktrees and branches to
   delete: one dated table with each worktree paired to its branch and every
   deletion's cost stated, then a stop for your call before anything is touched
+- `/zoom-out [area]` - Map the code in view (or a named area) to the layer
+  above it: relevant modules, their callers, in the project's own glossary
+  vocabulary
 
 See [`src/user/.claude/commands/`](./src/user/.claude/commands/) for the
 authoritative set.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Where this README and the source tree disagree, believe the source tree.
 
 Nothing else is required. Two related tools are optional:
 
-- **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` tracker. The `work` CLI, which ships from its own repository and is a facade over `bd`, needs it to function; this repo installs neither, and nothing in the installed instruction surface requires either.
+- **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` tracker. The `work` CLI, which ships from its own repository and is a facade over `bd`, refuses every substantive verb until `bd` is installed and initialized; this repo installs neither. Five deployed skills reach for `work` and each degrades to its own fallback without a tracker instead of failing — see [Getting Started](./docs/guide/getting-started.md#prerequisites) for what each fallback is.
 - **[obra/superpowers](https://github.com/obra/superpowers)** — not a dependency. Nothing installed invokes its process skills.
 
 The `codex` plugin under `src/plugins/` is auto-detected when `~/.codex/` exists — a `codex` binary on PATH alone will not trigger it — and its skill assumes the [Codex CLI](https://github.com/openai/codex) is available.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -151,7 +151,8 @@ deferred. It needs no `bd` workspace to run and touches no backend, so you can
 run it before or independently of `bd init`.
 
 Five deployed skills are the reason to do any of this, and all five reach for
-`work` verbs directly:
+`work` verbs directly. Four ship to every detected tool; `wayfinder` is
+Claude Code only:
 
 - `to-tickets` and `wayfinder` fall back to writing their tickets or decision
   map as a local markdown file instead of tracker items.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -133,7 +133,8 @@ context compaction. This repo's tracker is [beads](https://github.com/steveyegge
 addressed through the `work` CLI — a facade over `bd` that ships from its own
 repository, [scotthamilton77/workcli](https://github.com/scotthamilton77/workcli),
 and is installed from there rather than by this repo's installer. You need `bd`
-installed and a `bd init` in your project for any of it to function.
+installed and a `bd init` in your project for any substantive `work` verb —
+anything but `init` and `guide` — to function.
 
 That `bd init` is a one-time, per-project setup step, and it is something
 `work` deliberately has no verb for: a workspace carries storage, remote and

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -138,10 +138,11 @@ installed and a `bd init` in your project for any of it to function.
 That `bd init` is a one-time, per-project setup step, and it is something
 `work` deliberately has no verb for: a workspace carries storage, remote and
 id-prefix decisions that belong to the tracker rather than to the facade over
-it. Run any `work` verb where no workspace has been created and it refuses with
-`E_NO_WORKSPACE`, telling you to run from a directory that already has one and
-pointing here for the rest. Running `bd init` at the root of your project is
-that rest — do it once, and every `work` verb below that root then resolves.
+it. Run a substantive `work` verb (anything but `init` and `guide`) where no
+workspace has been created and it refuses with `E_NO_WORKSPACE`, telling you
+to run from a directory that already has one and pointing here for the rest.
+Running `bd init` at the root of your project is that rest — do it once, and
+every `work` verb below that root then resolves.
 
 `work init` is the second setup step: it writes `.work/config.toml` at your
 project root, which is where `work` reads the vocabulary it validates but does
@@ -149,14 +150,21 @@ not author — your track names, your nouns, and the reasons work parks or is
 deferred. It needs no `bd` workspace to run and touches no backend, so you can
 run it before or independently of `bd init`.
 
-Three deployed skills are the reason to do any of this: `to-tickets`,
-`wayfinder`, and `where-does-this-fit` are built on `work` end to end.
-None of them hard-fails without a tracker — `to-tickets` and `wayfinder` fall
-back to writing their tickets or decision map as a local markdown file instead
-of tracker items, and `where-does-this-fit` falls back to fetching an item's
-container and siblings however the tracker in use exposes them, or asking you
-directly. Skip the setup above and these three degrade to that fallback;
-nothing else in the installed instruction surface reaches for `work`.
+Five deployed skills are the reason to do any of this, and all five reach for
+`work` verbs directly:
+
+- `to-tickets` and `wayfinder` fall back to writing their tickets or decision
+  map as a local markdown file instead of tracker items.
+- `where-does-this-fit` falls back to fetching an item's container and
+  siblings however the tracker in use exposes them, or asking you directly.
+- `triaging-discovered-work` falls back to a dated entry in a backlog file at
+  the repo root instead of a filed `work discover` item.
+- `prototype` falls back to recording its verdict in the commit message
+  instead of a `work note` on the tracker item.
+
+None of the five hard-fails without a tracker — skip the setup above and each
+degrades to its own fallback instead. Nothing else in the installed
+instruction surface reaches for `work`.
 
 Be aware of what does **not** ship: no installed rule or skill instructs your
 assistant to file an issue before writing code, to claim one when it starts, or

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -146,7 +146,17 @@ that rest — do it once, and every `work` verb below that root then resolves.
 `work init` is the second setup step: it writes `.work/config.toml` at your
 project root, which is where `work` reads the vocabulary it validates but does
 not author — your track names, your nouns, and the reasons work parks or is
-deferred.
+deferred. It needs no `bd` workspace to run and touches no backend, so you can
+run it before or independently of `bd init`.
+
+Three deployed skills are the reason to do any of this: `to-tickets`,
+`wayfinder`, and `where-does-this-fit` are built on `work` end to end.
+None of them hard-fails without a tracker — `to-tickets` and `wayfinder` fall
+back to writing their tickets or decision map as a local markdown file instead
+of tracker items, and `where-does-this-fit` falls back to fetching an item's
+container and siblings however the tracker in use exposes them, or asking you
+directly. Skip the setup above and these three degrade to that fallback;
+nothing else in the installed instruction surface reaches for `work`.
 
 Be aware of what does **not** ship: no installed rule or skill instructs your
 assistant to file an issue before writing code, to claim one when it starts, or

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -15,14 +15,15 @@ as prerequisites are now optional:
 - **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` work
   tracker. The `work` CLI, which ships from its own repository and is not
   installed by this one, is a facade over `bd`; every substantive `work` verb
-  refuses with `E_NO_WORKSPACE` until `bd` is installed and initialized. Three
-  deployed skills — `to-tickets`, `wayfinder`, and `where-does-this-fit` — are
-  built on `work` end to end, but each degrades gracefully without a tracker:
-  `to-tickets` and `wayfinder` fall back to a local markdown file, and
-  `where-does-this-fit` falls back to asking you directly. Nothing else in the
-  installed instruction surface reaches for `work`. Skip the tracker if you
-  don't want one; see [Configuration](./configuration.md) for setup once you
-  do.
+  refuses with `E_NO_WORKSPACE` until `bd` is installed and initialized. Five
+  deployed skills reach for `work`, and each degrades gracefully without a
+  tracker: `to-tickets` and `wayfinder` fall back to a local markdown file,
+  `where-does-this-fit` falls back to reading whatever tracker is actually in
+  use or asking you directly, `triaging-discovered-work` falls back to a dated
+  backlog-file entry, and `prototype` falls back to recording its verdict in
+  the commit message. Nothing else in the installed instruction surface
+  reaches for `work`. Skip the tracker if you don't want one; see
+  [Configuration](./configuration.md) for setup once you do.
 - **[obra/superpowers](https://github.com/obra/superpowers)** — no longer a
   dependency. The rules and skills that referenced its process skills have been
   retired; nothing that installs today calls into it.
@@ -77,7 +78,7 @@ The installer also puts this repo's CLIs on your PATH via `uv tool install`
 `executor` and `gitclean`; `CLI_PACKAGES` in
 `packages/installer/src/installer/core/clis.py` is the authoritative list. Of
 those four, `gitclean` is the one the installed skills actually reach for.
-`work`, the separate tracker CLI three other skills are built on (see above),
+`work`, the separate tracker CLI five other skills reach for (see above),
 ships and installs independently of this list.
 
 ## Verify the install

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,14 +16,16 @@ as prerequisites are now optional:
   tracker. The `work` CLI, which ships from its own repository and is not
   installed by this one, is a facade over `bd`; every substantive `work` verb
   refuses with `E_NO_WORKSPACE` until `bd` is installed and initialized. Five
-  deployed skills reach for `work`, and each degrades gracefully without a
-  tracker: `to-tickets` and `wayfinder` fall back to a local markdown file,
-  `where-does-this-fit` falls back to reading whatever tracker is actually in
-  use or asking you directly, `triaging-discovered-work` falls back to a dated
-  backlog-file entry, and `prototype` falls back to recording its verdict in
-  the commit message. Nothing else in the installed instruction surface
-  reaches for `work`. Skip the tracker if you don't want one; see
-  [Configuration](./configuration.md) for setup once you do.
+  deployed skills reach for `work`, four of them shipping to every detected
+  tool (`to-tickets`, `where-does-this-fit`, `triaging-discovered-work`,
+  `prototype`) and one Claude Code only (`wayfinder`). Each degrades
+  gracefully without a tracker: `to-tickets` and `wayfinder` fall back to a
+  local markdown file, `where-does-this-fit` falls back to reading whatever
+  tracker is actually in use or asking you directly, `triaging-discovered-work`
+  falls back to a dated backlog-file entry, and `prototype` falls back to
+  recording its verdict in the commit message. Nothing else in the installed
+  instruction surface reaches for `work`. Skip the tracker if you don't want
+  one; see [Configuration](./configuration.md) for setup once you do.
 - **[obra/superpowers](https://github.com/obra/superpowers)** — no longer a
   dependency. The rules and skills that referenced its process skills have been
   retired; nothing that installs today calls into it.
@@ -78,7 +80,7 @@ The installer also puts this repo's CLIs on your PATH via `uv tool install`
 `executor` and `gitclean`; `CLI_PACKAGES` in
 `packages/installer/src/installer/core/clis.py` is the authoritative list. Of
 those four, `gitclean` is the one the installed skills actually reach for.
-`work`, the separate tracker CLI five other skills reach for (see above),
+`work`, the separate tracker CLI that five other skills reach for (see above),
 ships and installs independently of this list.
 
 ## Verify the install

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -15,17 +15,18 @@ as prerequisites are now optional:
 - **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` work
   tracker. The `work` CLI, which ships from its own repository and is not
   installed by this one, is a facade over `bd`; every substantive `work` verb
-  refuses with `E_NO_WORKSPACE` until `bd` is installed and initialized. Five
-  deployed skills reach for `work`, four of them shipping to every detected
-  tool (`to-tickets`, `where-does-this-fit`, `triaging-discovered-work`,
-  `prototype`) and one Claude Code only (`wayfinder`). Each degrades
-  gracefully without a tracker: `to-tickets` and `wayfinder` fall back to a
-  local markdown file, `where-does-this-fit` falls back to reading whatever
-  tracker is actually in use or asking you directly, `triaging-discovered-work`
-  falls back to a dated backlog-file entry, and `prototype` falls back to
-  recording its verdict in the commit message. Nothing else in the installed
-  instruction surface reaches for `work`. Skip the tracker if you don't want
-  one; see [Configuration](./configuration.md) for setup once you do.
+  — anything but `init` and `guide` — refuses with `E_NO_WORKSPACE` until `bd`
+  is installed and initialized. Five deployed skills reach for `work`, four of
+  them shipping to every detected tool (`to-tickets`, `where-does-this-fit`,
+  `triaging-discovered-work`, `prototype`) and one Claude Code only
+  (`wayfinder`). Each degrades gracefully without a tracker: `to-tickets` and
+  `wayfinder` fall back to a local markdown file, `where-does-this-fit` falls
+  back to reading whatever tracker is actually in use or asking you directly,
+  `triaging-discovered-work` falls back to a dated backlog-file entry, and
+  `prototype` falls back to recording its verdict in the commit message.
+  Nothing else in the installed instruction surface reaches for `work`. Skip
+  the tracker if you don't want one; see [Configuration](./configuration.md)
+  for setup once you do.
 - **[obra/superpowers](https://github.com/obra/superpowers)** — no longer a
   dependency. The rules and skills that referenced its process skills have been
   retired; nothing that installs today calls into it.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,9 +14,15 @@ as prerequisites are now optional:
 
 - **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` work
   tracker. The `work` CLI, which ships from its own repository and is not
-  installed by this one, is a facade over `bd` and does nothing useful without
-  it. Nothing in the installed instruction surface requires either one, so skip
-  both if you do not want a tracker.
+  installed by this one, is a facade over `bd`; every substantive `work` verb
+  refuses with `E_NO_WORKSPACE` until `bd` is installed and initialized. Three
+  deployed skills — `to-tickets`, `wayfinder`, and `where-does-this-fit` — are
+  built on `work` end to end, but each degrades gracefully without a tracker:
+  `to-tickets` and `wayfinder` fall back to a local markdown file, and
+  `where-does-this-fit` falls back to asking you directly. Nothing else in the
+  installed instruction surface reaches for `work`. Skip the tracker if you
+  don't want one; see [Configuration](./configuration.md) for setup once you
+  do.
 - **[obra/superpowers](https://github.com/obra/superpowers)** — no longer a
   dependency. The rules and skills that referenced its process skills have been
   retired; nothing that installs today calls into it.
@@ -70,7 +76,9 @@ The installer also puts this repo's CLIs on your PATH via `uv tool install`
 (receipt-tracked, pruned on retirement). They are `prgroom`, `grind`,
 `executor` and `gitclean`; `CLI_PACKAGES` in
 `packages/installer/src/installer/core/clis.py` is the authoritative list. Of
-those, `gitclean` is the one the installed skills actually reach for.
+those four, `gitclean` is the one the installed skills actually reach for.
+`work`, the separate tracker CLI three other skills are built on (see above),
+ships and installs independently of this list.
 
 ## Verify the install
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,8 +9,7 @@
   suitable Python (≥3.11) on first run. `uv` ≥ 0.10.4 is required for the stage
   that puts this repo's CLIs on your PATH.
 
-Nothing else is required. Two things that earlier versions of this guide listed
-as prerequisites are now optional:
+Nothing else is required. Two more things are optional:
 
 - **[steveyegge/beads](https://github.com/steveyegge/beads)** — the `bd` work
   tracker. The `work` CLI, which ships from its own repository and is not

--- a/docs/guide/sdlc-workflow.md
+++ b/docs/guide/sdlc-workflow.md
@@ -59,9 +59,10 @@ setup:
 work create feat --title "..." --description "..." --priority P2 --parent <parent-id>
 ```
 
-`feat`, `bugfix`, and `chore` are this repo's item nouns (`work create --help`
-lists yours). A tracked parent supplies the track by inheritance; with no
-parent, use `--orphan --track <name>` instead.
+`feat` is one of this repo's item nouns — `work create --help` lists yours,
+and `.work/config.toml`'s `[taxonomy.nouns.*]` is the authority for this repo.
+A tracked parent supplies the track by inheritance; with no parent, use
+`--orphan --track <name>` instead.
 
 Tracked work carries dependencies and survives context compaction, so it
 resurfaces intact across sessions and agent handoffs. In-session step tracking is

--- a/docs/guide/sdlc-workflow.md
+++ b/docs/guide/sdlc-workflow.md
@@ -50,8 +50,10 @@ handing work to a subagent standing policy rather than something to ask about.
 ## 1. Capture — tooling, not enforcement
 
 Durable work belongs in a tracker that outlives the session. This repo uses
-[beads](https://github.com/steveyegge/beads) through the `work` CLI, which the
-installer puts on your PATH:
+[beads](https://github.com/steveyegge/beads) through the `work` CLI, which
+ships from its own repository and is installed separately — see
+[Configuration](./configuration.md#4-wire-up-work-tracking-optional) for
+setup:
 
 ```bash
 work create --raw --title "..." --description "..." --type feature --priority P2

--- a/docs/guide/sdlc-workflow.md
+++ b/docs/guide/sdlc-workflow.md
@@ -56,8 +56,12 @@ ships from its own repository and is installed separately — see
 setup:
 
 ```bash
-work create --raw --title "..." --description "..." --type feature --priority P2
+work create feat --title "..." --description "..." --priority P2 --parent <parent-id>
 ```
+
+`feat`, `bugfix`, and `chore` are this repo's item nouns (`work create --help`
+lists yours). A tracked parent supplies the track by inheritance; with no
+parent, use `--orphan --track <name>` instead.
 
 Tracked work carries dependencies and survives context compaction, so it
 resurfaces intact across sessions and agent handoffs. In-session step tracking is

--- a/src/user/.agents/skills/to-tickets/SKILL.md
+++ b/src/user/.agents/skills/to-tickets/SKILL.md
@@ -68,7 +68,7 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish through the `work` facade
 
-`work` is the tracker, and it needs no setup step. A ticket that is not on the tracker is not a ticket — never write a parallel set of ticket files beside a tracker that exists. If `work` is not installed, or the project has no tracker at all, publish the numbered breakdown from Step 4 as a single markdown file instead — one heading per ticket, blocking edges as a list — and say so in the handoff.
+`work` is the tracker, and once set up it needs no further setup step. A ticket that is not on the tracker is not a ticket — never write a parallel set of ticket files beside a tracker that exists. If `work` is not installed, or the project has no tracker at all, publish the numbered breakdown from Step 4 as a single markdown file instead — one heading per ticket, blocking edges as a list — and say so in the handoff.
 
 Publish in **two passes**, because a blocking edge needs both ids to exist before it can be drawn.
 

--- a/src/user/.claude/skills/wayfinder/references/tracker-operations.md
+++ b/src/user/.claude/skills/wayfinder/references/tracker-operations.md
@@ -1,6 +1,6 @@
 # Tracker operations
 
-Every verb this skill uses against the tracker, plus the three that carry a trap. `work` is the tracker, and there is no setup step: never stand up a parallel set of ticket files beside a tracker that exists — a second copy of what the tracker already holds only drifts. If `work` is not installed, or the project has no tracker, keep the map as a single local markdown file instead, with the same sections ([map-body.md](map-body.md)), and skip every verb below.
+Every verb this skill uses against the tracker, plus the three that carry a trap. `work` is the tracker, and once set up it needs no further setup step: never stand up a parallel set of ticket files beside a tracker that exists — a second copy of what the tracker already holds only drifts. If `work` is not installed, or the project has no tracker, keep the map as a single local markdown file instead, with the same sections ([map-body.md](map-body.md)), and skip every verb below.
 
 | What | How |
 |---|---|


### PR DESCRIPTION
## Summary

Fixes H1, L3, and L4 from the 2026-08-09 fresh-context recheck (repo-sanity-recheck-2026-08-09.md, agents-config-9k9.215.2), plus review rounds 1-5 (f1 rebutted and upheld by the team lead).

- `docs/guide/getting-started.md` claimed "nothing in the installed instruction surface requires" a tracker. False. Fixed to name the deployed skills built on `work`, their deployment breadth, and their fallbacks.
- `docs/guide/configuration.md` overclaimed "any of it" in two places — now scoped to substantive verbs throughout, consistent with getting-started.md.
- `docs/guide/sdlc-workflow.md` claimed the installer puts `work` on PATH — false, fixed; its only `work create` example also taught the non-public `--raw` adapter primitive — fixed to the public lifecycle-noun form; its noun enumeration undercounted the taxonomy — de-enumerated.
- `README.md`'s Commands section was missing `/zoom-out`; its own Prerequisites section separately repeated the same "nothing requires" falsehood — both fixed.
- `CONTRIBUTING.md` omitted OpenCode from the supported-tools list, and its plugin-prerequisites passage narrated history while repeating the same falsehood — all fixed, rewritten as present-tense fact.
- `src/user/.agents/skills/to-tickets/SKILL.md` and `src/user/.claude/skills/wayfinder/references/tracker-operations.md` both said "`work`... needs no setup step" — read bare against the guide's bd-install-and-init answer, this claimed no setup exists at all. Both hedged.

**CLI evidence for the tracker-setup answer** (run from a directory with no `.work/config.toml` and no `bd` workspace):
- `work show <id>` → `E_NO_WORKSPACE`: *"no tracker workspace is configured for this directory... Creating a workspace is a setup step outside this tool"*
- `work init` → succeeds (exit 0), writes `.work/config.toml`, touches no backend
- `work --protocol-version` / `work guide` → succeed with no workspace at all

## Review round 1 — findings disposition

- **f2 (fixed)** — configuration.md's "run any `work` verb... refuses with `E_NO_WORKSPACE`" overclaimed against the same section's own statement that `init`/`guide` need no workspace. Scoped to substantive verbs.
- **f3 (fixed)** — CONTRIBUTING.md narrated history instead of stating current truth, and separately carried the same now-fixed "nothing requires" falsehood. Rewritten present-tense.
- **f4 (fixed)** — the guide's "three skills" enumeration was incomplete. Uncapped sweep found the exhaustive list is **five**: `to-tickets`, `wayfinder`, `where-does-this-fit`, `triaging-discovered-work`, `prototype`. Corrected everywhere it appeared, plus two more drifted copies (README.md, CONTRIBUTING.md).
- **f1 (rebutted, upheld by team lead)** — wayfinder's SKILL.md drift-policy comment describes the original 2026-08-07 fork from upstream; the current fallback in `tracker-operations.md` was added deliberately by commit `01ecf7dc` (9k9.213.2) a day later, alongside four other skills' fallbacks. The guide's wayfinder claim matches the tree. Left unchanged.

## Copilot addendum (round 1) — deployment breadth + grammar

Both getting-started.md and configuration.md now state which of the five work-dependent skills ship to every tool versus Claude Code only (`wayfinder`), verified via `find`. Fixed a missing "that".

## Review round 2 — findings disposition

- **r2f1 (fixed)** — named `init`/`guide` locally in getting-started.md, matching configuration.md.
- **r2f2 (fixed)** — sdlc-workflow.md's `work create --raw --type feature` taught the non-public adapter primitive that bypasses this repo's required track enforcement. Replaced with the public lifecycle-noun form, verified against `work create --help` and `.work/config.toml`'s noun taxonomy.
- **r2f3, r2f4 (advisory, not mine)** — routed to the residue item and the primers PR respectively.

## Review round 3 — residue

configuration.md's opening sentence still carried the same unscoped "any" overclaim. Scoped identically. The round's other finding re-filed the already-rebutted wayfinder claim — dispositioned by the team lead directly.

## Review round 4 — skill-file clauses (scope widened to this PR)

`to-tickets/SKILL.md:71` and `wayfinder/references/tracker-operations.md:3` both said "`work`... needs no setup step" — read bare, contradicts the guide's bd-install-and-init answer. One-clause hedge in each: "once set up it needs no further setup step" — fallback clause in each file unchanged. Ran `content-lint`/`content-tests` standalone since these are deployed skill files (both exit 0).

## Review round 5 — residue (2 findings)

- **Narration (fixed)** — getting-started.md:12-13 said "Two things that earlier versions of this guide listed as prerequisites are now optional" — guide-history narration. Rewritten: "Nothing else is required. Two more things are optional:"
- **Noun undercount (fixed)** — sdlc-workflow.md:62 said "`feat`, `bugfix`, and `chore` are this repo's item nouns," undercounting against `.work/config.toml`'s `[taxonomy.nouns.*]` with `container=false`, which declares **five** leaf nouns (`spike`, `chore`, `decision`, `feat`, `bugfix`), not three. De-enumerated instead of re-listing a set that drifts: "`feat` is one of this repo's item nouns — `work create --help` lists yours, and `.work/config.toml`'s `[taxonomy.nouns.*]` is the authority for this repo."

## Consumer sweep (uncapped, case-insensitive, whole tree, run after every round)

- All old false phrasings — `"nothing in the installed instruction surface requires"`, `"skip both if you do not want a tracker"`, `"does nothing useful without it"`, `"which the installer puts on your PATH"`, `"three deployed skills"` / `"three other skills"`, `"used to list as a prerequisite"`, `"work create --raw --title"`, `"for any of it to function"`, `"no setup step"` (bare), `"earlier versions of this guide"`, `` "`feat`, `bugfix`, and `chore`" `` — zero remaining hits anywhere in the tracked tree (only the untracked recheck doc, which is evidence, not a consumer).
- Re-ran the full work-verb sweep after every round: still exactly five consumers throughout.
- `docs/guide/index.md`, `docs/guide/reference.md` — don't mention tracker/bd/work at all; no cross-reference risk.

## Test plan

- [x] `make doc-lint` — exit 0, standalone, every round (`doc-lint: read 122 tracked Markdown file(s)`, no errors).
- [x] `make content-lint` — exit 0, standalone (round 4: deployed-skill edits).
- [x] `make content-tests` — exit 0, standalone (round 4). 12 suites passed.
- [x] Verified the winning tracker-setup answer against `work`'s actual CLI behavior, not inferred from prose.
- [x] Verified all five skills' fallbacks and deployment trees by reading each skill's own file / running `find` directly.
- [x] Verified f1's rebuttal via `git log`/`git show` on the exact commits — upheld by the team lead independently.
- [x] Verified the r2f2 replacement example, and the round-5 noun-count finding, against `work create --help` and `.work/config.toml`'s actual taxonomy — not inferred or copied without checking.
- [x] Uncapped, case-insensitive consumer sweep after each round (see above).
- [ ] review-panel round 6 (if needed) per the epic's review contract — run by the team lead against this PR's final head (`1eb2758c`), not by this agent.

Not merging — per house policy, merge only on explicit human instruction.