### PR TITLE
fix(9k9.215.1): root AGENTS.md names shipped review skills and matches the deployed merge quote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ This is the whole delivery contract:
 2. Implement on a worktree branch; never commit to the default branch.
 3. Verify mechanically before claiming anything. For `packages/**`, and for any skill under `src/` that ships its own tests, that is `make ci` — read the `ci` target in the `Makefile` for its current membership, and note that a single package's gate is not the whole-repo gate. Run it from the root of the tree you are working in: the `Makefile` `cd`s relative to the invoking directory, so a gate run from the main checkout while you are on a worktree branch reports green on code you did not change. Run the gate standalone and read its exit status — never pipe it into a `grep && commit` chain, where the pipeline's status is the grep's and a red gate ships. For prose-only changes, run `doc-lint` — the one gate that reads prose outside `docs/specs/`, checking that every backticked citation still resolves — and state what else you checked by hand.
 4. Open a PR and address review to quiescence. Every item gets a disposition in your own inventory; only items that change the code get a reply on the PR. Bookkeeping and meta comments are dispositioned silently — a thread of "no action required" replies is noise the next reader has to wade through.
-5. **Merge only on an explicit human instruction.** The shared hard-lines permit merging on an explicit instruction or a merge policy stated in writing in the project's own configuration. `project-config.toml`'s live `[merge-policy]` block is that writing, and it states `merge-authorization = "explicit"` — no rule-based policy is configured, and no implementation of one is deployed, so the written policy and this step agree: explicit human instruction only. The repository ruleset also requires an approving review that no configured reviewer submits — see `agents-config-9k9.23`. Read the commented-out `merge-authorization = "rule-based"` line as future work (`agents-config-9k9.64`), not as permission.
+5. **Merge only on an explicit human instruction.** The shared hard-lines state: "Creating a PR is not authorization to merge. Absent an explicit instruction, or a merge policy stated in writing in the project's own configuration, do not merge — branch protection, a green pipeline and an approving review are not one." `project-config.toml`'s live `[merge-policy]` block is that writing, and it states `merge-authorization = "explicit"` — no rule-based policy is configured, and no implementation of one is deployed, so the written policy and this hard line agree: explicit human instruction only. The repository ruleset also requires an approving review that no configured reviewer submits — see `agents-config-9k9.23`. Read the commented-out `merge-authorization = "rule-based"` line as future work (`agents-config-9k9.64`), not as permission.
 
 ### Why the charter decides as it does
 
@@ -59,7 +59,7 @@ The charter states its decisions without the reasoning underneath them. Four cla
 4. **Guardrail every completion claim with mechanical evidence**
 5. **Persist context** (work items, memories) so work survives compaction, agent handoff, and overnight runs
 
-Commitments 3 and 4 ship as the `review-panel`, `review-verdict`, and `ac-attack` skills, deployed in both homes with admission records. `review-panel`'s `contracts.json` routes lenses across models (Codex, OpenRouter) for commitment 3; `review-verdict` defines the terminal-clean state that "address review to quiescence" (above) means for commitment 4.
+Commitments 3 and 4 ship as the `review-panel`, `ac-attack`, and `review-verdict` skills — `review-panel` and `ac-attack` from `src/user/.claude/skills/` (Claude-only), `review-verdict` from `src/user/.agents/skills/` (shared to every tool), each carrying a repo-side admission record (stripped from deployed bytes, per above). `review-panel`'s `contracts.json` routes lenses across models (Codex, OpenRouter) for commitment 3; `review-verdict` defines the terminal-clean state that "address review to quiescence" (above) means for commitment 4.
 
 ### Design principles for this repo
 
@@ -130,8 +130,10 @@ most of the response on the main answer. When asked to explain something, give a
 summary unless an in-depth explanation is specifically requested. BLUF - bottom line up 
 front.  
 
-When a persona or voice hook is active, it shapes voice, not volume: these brevity
-and BLUF rules still govern length and structure in character exactly as out of it.
+A persona or voice hook shapes voice, not volume: it never adds length or
+overrides these brevity and BLUF rules. A user-invoked compression mode like
+`/caveman` is the user's own instruction, not the persona, and changes length
+by design.
 
 Don't assume the user will recognize work by work-id, document sections by section
 number, etc.  The user needs help connecting dots sometimes, so it's ok to use short

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ This is the whole delivery contract:
 
 1. Enter the work in the tracker via `work` verbs, as a child of `agents-config-9k9`, with an admission record **and a track**. Milestones are track-exempt, so a child of the milestone inherits nothing and `work create` fails closed with `E_TRACK_REQUIRED` unless you pass `--track NAME`. That failure names every configured track, so the vocabulary is one wrong create away rather than something to look up; the charters deciding which one an item takes are in the track-partition spec's §3. Nesting under a tracked parent instead inherits its track. Installer work also carries the `install` label; nest it under an install epic beneath the owning milestone.
 2. Implement on a worktree branch; never commit to the default branch.
-3. Verify mechanically before claiming anything. For `packages/**`, and for any skill under `src/` that ships its own tests, that is `make ci` — read the `ci` target in the `Makefile` for its current membership, and note that a single package's gate is not the whole-repo gate. Run it from the root of the tree you are working in: the `Makefile` `cd`s relative to the invoking directory, so a gate run from the main checkout while you are on a worktree branch reports green on code you did not change. Run the gate standalone and read its exit status — never pipe it into a `grep && commit` chain, where the pipeline's status is the grep's and a red gate ships. For prose-only changes, state what you checked and how.
+3. Verify mechanically before claiming anything. For `packages/**`, and for any skill under `src/` that ships its own tests, that is `make ci` — read the `ci` target in the `Makefile` for its current membership, and note that a single package's gate is not the whole-repo gate. Run it from the root of the tree you are working in: the `Makefile` `cd`s relative to the invoking directory, so a gate run from the main checkout while you are on a worktree branch reports green on code you did not change. Run the gate standalone and read its exit status — never pipe it into a `grep && commit` chain, where the pipeline's status is the grep's and a red gate ships. For prose-only changes, run `doc-lint` — the one gate that reads prose outside `docs/specs/`, checking that every backticked citation still resolves — and state what else you checked by hand.
 4. Open a PR and address review to quiescence. Every item gets a disposition in your own inventory; only items that change the code get a reply on the PR. Bookkeeping and meta comments are dispositioned silently — a thread of "no action required" replies is noise the next reader has to wade through.
-5. **Merge only on an explicit human instruction.** No rule-based merge policy is configured here, no implementation of one is deployed, and the repository ruleset requires an approving review that no configured reviewer submits — see `agents-config-9k9.23`. The shared hard-lines permit merging under "a configured rule-based policy"; that clause has nothing here to match. If you believe it does, read `project-config.toml`'s `[merge-policy]` before acting on it, and read anything commented out there as future work rather than permission.
+5. **Merge only on an explicit human instruction.** The shared hard-lines permit merging on an explicit instruction or a merge policy stated in writing in the project's own configuration. `project-config.toml`'s live `[merge-policy]` block is that writing, and it states `merge-authorization = "explicit"` — no rule-based policy is configured, and no implementation of one is deployed, so the written policy and this step agree: explicit human instruction only. The repository ruleset also requires an approving review that no configured reviewer submits — see `agents-config-9k9.23`. Read the commented-out `merge-authorization = "rule-based"` line as future work (`agents-config-9k9.64`), not as permission.
 
 ### Why the charter decides as it does
 
@@ -41,7 +41,7 @@ The charter states its decisions without the reasoning underneath them. Four cla
 - **Why acceptance criteria are load-bearing (D1/D3/D8).** An LLM reviewer is a findings generator: given any surface, it emits findings in proportion to that surface, indefinitely. Convergence needs a contract to check against, because taste is inexhaustible. Acceptance criteria are therefore not primarily a defect-prevention device — they are the termination condition that review otherwise lacks.
 - **Why every artifact carries a removal condition (D16).** Without one, the system has an add operator and no delete operator: every failure mints a permanent global rule, and nothing carries a budget, a scope bound, or an obligation to tear down what it replaces. Duplicate deploys, contradictory rules, and two live workflow generations are then one disease, not four.
 - **Why reviewer prompts must not carry the house rulebook (D5/D7).** A reviewer loaded with the full house context reviews the change against the plan — both in-house artifacts, sharing the author's blind spots. A fresh-context reviewer reviews the artifact against the world instead. Inconsistency between a document and the code is invisible to plan-conformance review precisely when the plan is the inconsistent document.
-- **Why a plan states signatures and not bodies (D4).** The signature is the decision and the implementation is its consequence. A plan that embeds bodies promotes consequences into decisions and freezes them before the evidence for them exists.
+- **Why the plan is a scaffold, not prose (D4).** D4 deletes the prose plan as an artifact class; a frontier model materializes the plan instead as compilable stubs and failing tests, and the contract-only rule limits those stubs to the spec's public signatures, never bodies. The signature is the decision the tests pin; embedding an implementation promotes a consequence into the decision before the evidence for it exists.
 
 ## Vision & Mission
 
@@ -59,7 +59,7 @@ The charter states its decisions without the reasoning underneath them. Four cla
 4. **Guardrail every completion claim with mechanical evidence**
 5. **Persist context** (work items, memories) so work survives compaction, agent handoff, and overnight runs
 
-Commitments 3 and 4 have no deployed implementation right now; the charter's slice plan owns what replaces them. Do not go looking for the retired one.
+Commitments 3 and 4 ship as the `review-panel`, `review-verdict`, and `ac-attack` skills, deployed in both homes with admission records. `review-panel`'s `contracts.json` routes lenses across models (Codex, OpenRouter) for commitment 3; `review-verdict` defines the terminal-clean state that "address review to quiescence" (above) means for commitment 4.
 
 ### Design principles for this repo
 
@@ -86,7 +86,7 @@ This project hosts agent configuration under `src/`, which the install script de
 - `scripts/` — installer entry points and maintenance scripts. `install.sh` is a thin exec stub delegating to the uv-managed Python installer in `packages/installer`; `install.py` is the Python entry point. See `scripts/AGENTS.md`.
 - `src/` — **the deployed surface.** Everything installed into user space is authored here.
   - `src/user/.agents/` — shared content, staged into every active tool: `skills/`, `rules/`, and `USER-CORE.md.template` (the zero-based laws, decision matrix, hard lines, and conventions, D17). See `src/user/.agents/AGENTS.md` for the install model and the name-collision rules.
-  - `src/user/.claude/` — Claude-only: `skills/`, `rules/`, `hooks/`, `AGENTS.md.template`, `CLAUDE.md.template`, `settings.json.template`
+  - `src/user/.claude/` — Claude-only: `skills/`, `rules/`, `commands/`, `hooks/`, `AGENTS.md.template`, `CLAUDE.md.template`, `settings.json.template`
   - `src/user/.codex/`, `src/user/.gemini/`, `src/user/.opencode/` — per-tool instruction templates; OpenCode additionally carries `opencode.jsonc.template` and gets a flat, dynamically-built instruction file rather than `@` includes
   - `src/plugins/` — optional plugin content, auto-detected by a directory scan. A plugin's content deploys only when its tool is detected **and** the artifact clears the admission gate.
   - Each rules directory carries its own `AGENTS.md` stating what currently lives there; read it rather than inferring from the folder's contents.
@@ -129,6 +129,9 @@ Keep responses focused, brief, and concise. Keep disclaimers and caveats short, 
 most of the response on the main answer. When asked to explain something, give a high-level 
 summary unless an in-depth explanation is specifically requested. BLUF - bottom line up 
 front.  
+
+When a persona or voice hook is active, it shapes voice, not volume: these brevity
+and BLUF rules still govern length and structure in character exactly as out of it.
 
 Don't assume the user will recognize work by work-id, document sections by section
 number, etc.  The user needs help connecting dots sometimes, so it's ok to use short

--- a/docs/guide/sdlc-workflow.md
+++ b/docs/guide/sdlc-workflow.md
@@ -177,7 +177,8 @@ and the `merge-guard` skill that enforced it has been retired.
 
 What remains is the contract itself, in the always-on hard lines: **creating a
 PR is not authorization to merge**, and absent an explicit instruction or a
-configured rule-based policy, the agent does not merge. When in doubt, treat the
+merge policy stated in writing in the project's own configuration, the agent
+does not merge. When in doubt, treat the
 PR as not authorized. This is a deliberate risk-asymmetric default: the cost of a
 wrong merge outweighs the cost of waiting. It now rests on the agent honouring a
 line in its instructions rather than on a mechanism, which is a weaker guarantee


### PR DESCRIPTION
## Summary

Fixes the root AGENTS.md findings from the 2026-08-09 fresh-context recheck (`repo-sanity-recheck-2026-08-09.md`), tracked as `agents-config-9k9.215.1` under epic `agents-config-9k9.215`. Every finding was re-verified against the current tree (not the recheck's 2026-08-09 snapshot) before editing. Round 2 incorporates the review-panel verdict on this PR (https://github.com/scotthamilton77/agents-config/pull/544#issuecomment-5233461895).

## Findings addressed — round 1

- **H2** (line ~62, fixed): "Commitments 3 and 4 have no deployed implementation right now ... Do not go looking for the retired one" was false — `review-panel`, `review-verdict`, and `ac-attack` exist with admission records in `src/`. Names the three skills and points to `review-verdict`'s terminal-clean definition and `review-panel/contracts.json`'s cross-model lens routing (Codex, OpenRouter). (Reworded again in round 2 — see below.)
- **M30** (line ~106, already-fixed): "calls `packages/contracts/` 'an earlier-stage package'" — this bullet no longer exists. `packages/contracts/` was deleted entirely in commit `e396c618` ("the work facade ships from its own repository...", 2026-08-09, same day as the recheck) along with the AGENTS.md bullet describing it. No action needed.
- **M8** (line ~35, fixed): AGENTS.md quoted the merge hard-line as "a configured rule-based policy" — the deployed `USER-CORE.md.template:23` reads "a merge policy stated in writing in the project's own configuration". Fixed the quote to match, reconciled the reasoning against `project-config.toml`'s live `[merge-policy]` block (`merge-authorization = "explicit"`), and corrected the future-work citation to `agents-config-9k9.64` (what `project-config.toml`'s own comment on that exact line cites). (Quote form corrected again in round 2 — see below.)
- **L2** (line ~89, fixed): `src/user/.claude/` listing omitted `commands/` while lines 22/24 treat commands as an admissible class. Added `commands/` (verified `src/user/.claude/commands/{clean-up-git,zoom-out}.md` exist).
- **L15** (line ~44, fixed): D4 was glossed as "a plan states signatures and not bodies," licensing a signature-only prose plan. D4 actually deletes the prose plan as an artifact class in favor of scaffold-as-plan. Rewrote the gloss to describe the scaffold mechanism.
- **L14 (partial)** (line ~33, fixed): the delivery contract answered prose-only verification with "state what you checked and how" without naming `doc-lint`. Now names it explicitly.
- **Scope addition** (Communication Style, Scott's verbatim direction): amended to state a persona or voice hook shapes voice, not volume. (Bounded to one direction in round 2 — see below.)

## Round 2 — review-panel findings fixed

- **f1+f2** (the commitments sentence, line ~62): claimed the three skills are "deployed in both homes with admission records." Both claims were wrong on the ground: `review-panel` and `ac-attack` are Claude-tree only — confirmed absent from `~/.codex/skills/`, `~/.gemini/skills/`, `~/.config/opencode/skills/`, which carry `review-verdict` alone. Deployed bytes carry **no** admission records — confirmed by diffing `~/.claude/skills/review-panel/SKILL.md` against `src/user/.claude/skills/review-panel/SKILL.md`: the deployed copy has no `admission:` block, matching this file's own admission-gate paragraph ("the `admission:`/`claims:` front matter ... [is] stripped from the deployed bytes"). Reworded to state which source tree each skill ships from (`review-panel`/`ac-attack` from `src/user/.claude/skills/`, `review-verdict` from `src/user/.agents/skills/`) and that admission records are repo-side — asserting no deployment state, consistent with this file's own rule that deployment is confirmed by listing the tool's config directory, not claimed in prose.
- **f3** (merge step, line ~35): the hard-line was paraphrased into a permissive form ("permit merging on..."). Fixed to quote `USER-CORE.md.template:23` verbatim in its negative form: "Creating a PR is not authorization to merge. Absent an explicit instruction, or a merge policy stated in writing in the project's own configuration, do not merge — branch protection, a green pipeline and an approving review are not one." The `project-config.toml` reasoning now stands on that verbatim quote.
- **f4** (`docs/guide/sdlc-workflow.md:178-180`): a live, amended-in-place guide page still stated the hard line as "a configured rule-based policy," contradicting the now-corrected AGENTS.md step 5. Updated to "a merge policy stated in writing in the project's own configuration" to match the deployed wording. Did not touch the other hunk at lines ~52-54 (different finding, different PR). **This supersedes the scope addition recorded on sibling item `agents-config-9k9.215.17`** (which captured this exact line from this PR's round-1 sweep) — that item's addition for `sdlc-workflow.md:180` is now already done and should be dropped or marked resolved rather than re-worked.
- **f5** (persona sentence, Communication Style, advisory — fixed): the round-1 wording ("these brevity and BLUF rules still govern length and structure in character exactly as out of it") is a universal that the deployed `caveman` skill falsifies — `caveman` is a user-invoked compression mode (`disable-model-invocation: true`, three intensity levels) whose entire point is changing length and structure. Reworded to bound the mandate to one direction: a persona/voice hook must never add length or override brevity/BLUF, but a user-invoked compression mode like `/caveman` is the user's own instruction, not the persona, and is unaffected.

## Consumer sweep (uncapped)

- `configured rule-based policy` (the old merge-hard-line phrasing): after this PR's round-2 fix, remaining hits are `docs/specs/2026-07-21-harness-rework-way-forward.md:342` (the charter — off-limits per this item's boundary, routes through the epic's decision items) and `docs/specs/2026-07-25-agent-comment-authorship.md:104,163` (a dated spec quoting historical wording as before-state material — exempt per the repo's before-state convention for specs). Neither fixed here.
- `Commitments 3 and 4` / old D4 gloss ("plan states signatures and not bodies") / "state what you checked" / `BLUF - bottom line up front` / the pre-fix `src/user/.claude/` listing line / "deployed in both homes with admission records" / "shapes voice, not volume" (round-1 wording): zero hits outside `AGENTS.md` for every passage, before and after each round's edit.

## Verification

- Root AGENTS.md and `docs/guide/sdlc-workflow.md` are both outside `src/` and `packages/`, so no code gate applies.
- Ran `doc-lint` standalone from the worktree root (`uv --project packages/installer run python -m installer.doc_lint_cli .`): exit 0 after every edit in both rounds, most recently after the round-2 commit.
- Verified every new/changed citation resolves: skill source-tree locations (`src/user/.claude/skills/{review-panel,ac-attack}`, `src/user/.agents/skills/review-verdict`); deployed-vs-source admission-block diff; `review-panel/contracts.json`'s `codex`/`openrouter` transports; `src/user/.claude/commands/`; `agents-config-9k9.64`/`9k9.23`/`9k9.215.17` via `work show`; `project-config.toml`'s `[merge-policy]` block; the verbatim `USER-CORE.md.template:23` hard-line text; the `caveman` skill's `disable-model-invocation`/compression-mode nature.

Not merging — per house policy, merge requires an explicit human instruction. Not replying to review comments per instruction.
