### PR TITLE
docs(9k9.215.7): the charter records the rulings the tree already ships

### DIFF
--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -114,6 +114,16 @@ are surfaced at the start of any open-new-work interaction — reviewing stuck
 work is the price of pulling new work. The machine never acts on a parked
 item of its own accord; there is no automatic TTL action.
 
+*Amended 2026-08-09:* the park-reason vocabulary spans two axes, and every
+typed park sits on exactly one. The *failure* axis is the PR-bound set above,
+mirrored member for member by the `work` facade. The *scheduling* axis —
+`discovered-work`, `later-wave`, `deferred` — records a sequencing decision
+about work that never failed and may never have had a PR; it is native to the
+grind runtime, and the facade carries no reason for it. Machine-actionable
+versus human-required stays a statement about a park's cause, spent before the
+park: it is not a second axis, neither axis grants an exit, and every parked
+item is walked back by a human verb.
+
 ### Platform
 
 **D11 — workcli first; the harness never speaks bd.** The future harness
@@ -139,16 +149,19 @@ machinery (fixing is the work-loop's job). Never build `verify`/`sweep` —
 scaffold red tests superseded them. Add thin: verdict harvester (parse
 invoked-review output into the verdict artifact) and merge-eligibility
 evaluation. Absorb `abn9.8.33` (classic commit-status), `abn9.8.49` (5xx ≠
-auth failure), `j8pdq` (pagination). Delete the skills
+auth failure), `j8pdq` (pagination) — all three archive-era, resolvable in the
+private archive repository and not through `work`. Delete the skills
 `wait-for-pr-comments`, `reply-and-resolve-pr-threads`, `monitor-pr`, and the
 contradictory completion-gate text. The audits' "finish verify and cut over"
 verdict predates the review-medium decision and is superseded.
 
-**D14 — Grind runtime re-aimed.** `wgclw.30` (event-sourced grind runtime) is
-the one live M0 workstream pointed at the future: it becomes the executor loop
-of the new pipeline (dispatch scaffold→green workers, bounded budgets, typed
-park reasons), not an upgrade to the `orchestrated-grind` skill. Its fit is
-verified against its spec before slice scoping (open verification V1).
+**D14 — Grind runtime re-aimed.** `wgclw.30` (event-sourced grind runtime;
+archive-era, resolvable in the private archive repository and not through
+`work`) is the one live M0 workstream pointed at the future: it becomes the
+executor loop of the new pipeline (dispatch scaffold→green workers, bounded
+budgets, typed park reasons), not an upgrade to the `orchestrated-grind`
+skill. Its fit is verified against its spec before slice scoping (open
+verification V1).
 
 **D15 — Config homes.** Installer deploys to the standard homes only
 (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.config/opencode`), exactly one
@@ -170,6 +183,14 @@ case is first-class: a repeatable procedure earns admission on its own terms,
 and forcing it into failure language produces a fiction rather than a
 justification. Nothing enters by default or nostalgia.
 
+*Amended 2026-08-09:* the skill-body cap is two tiers, not one — **2k tokens**
+for a model-invoked body, **5k** for a user-invoked one. A model-invoked body
+loads on the model's own judgement, mid-task, against whatever the context is
+already carrying, which is what the tighter number prices; a user-invoked body
+is reached only when the user names it, a cost asked for at a moment chosen for
+it. The raised ceiling is relief for a body already split down to its residue,
+never permission to leave one whole.
+
 **D17 — User-scoped AGENTS.md is zero-based.** A line earns always-on status
 only if all four hold: universal across projects; not model-default behavior;
 not owned by pipeline code/contract; fits the ~800-token sub-budget.
@@ -190,7 +211,9 @@ shape (pattern feeds the verdict design, not adopted as a skill);
 design rules. Skipped, re-admissible later: `ask-matt` (a catalog small
 enough to need no router is the goal), `wayfinder` (autopsy scheduled when
 the parent-spec path is designed), `triage`,
-`improve-codebase-architecture`. This discharges `wgclw.24`/`.25`.
+`improve-codebase-architecture`. This discharges `wgclw.24`/`.25`
+(archive-era, resolvable in the private archive repository and not through
+`work`).
 
 *Amended 2026-08-07:* `wayfinder` is admitted, user-invoked, with its tracker
 model rewritten onto `work` verbs and its setup command removed. The autopsy
@@ -199,6 +222,15 @@ tracker binding, and the binding is now the facade. Its open mechanical
 questions — the label scheme, the absence of a mechanical completion condition
 for a map, and whether a map is the retired prose-plan class under a new name —
 are carried by `agents-config-9k9.157`, not by this list.
+
+*Amended 2026-08-09:* `improve-codebase-architecture` is admitted,
+user-invoked, in the Claude tree, with its grafts: the house `codebase-design`
+vocabulary in place of its own terms, a survey bounded at five candidates each
+carrying a recommendation strength, and a `grilling` loop over the one the user
+picks. The Claude-only placement is a condition of the admission rather than a
+convenience — an invocation writes an HTML report and opens it in the user's
+viewer before anything is asked, and only a host honouring
+`disable-model-invocation` can withhold that.
 
 ### Measurement and sequencing
 
@@ -235,6 +267,13 @@ ACs carry IDs; slice work cites them.
 - **AC5** `wait-for-pr-comments`, `reply-and-resolve-pr-threads`,
   `monitor-pr`, `writing-plans`, and the prgroom deleted modules are absent
   from `src/` and from every deploy target; no deployed text references them.
+
+*Amended 2026-08-09 (AC5):* the surface AC5 binds is the repo-owned one —
+`src/`, and everything this repo deploys — not everything a session can see.
+The admission gate has no reach over third-party marketplace plugins, and one
+installed plugin (`superpowers`, primary account only) ships its own
+`writing-plans` skill; that exposure is a known accepted gap outside AC5's
+jurisdiction rather than a breach of it.
 
 ### Outcome (against the 2026-07-20 baseline, over the termination window)
 

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -155,11 +155,11 @@ private archive repository and not through `work`. Delete the skills
 contradictory completion-gate text. The audits' "finish verify and cut over"
 verdict predates the review-medium decision and is superseded.
 
-**D14 — Grind runtime re-aimed.** `wgclw.30` (event-sourced grind runtime;
-archive-era, resolvable in the private archive repository and not through
-`work`) is the one live M0 workstream pointed at the future: it becomes the
-executor loop of the new pipeline (dispatch scaffold→green workers, bounded
-budgets, typed park reasons), not an upgrade to the `orchestrated-grind`
+**D14 — Grind runtime re-aimed.** The event-sourced grind runtime — `wgclw.30`,
+an archive-era ID that resolves in the private archive repository and not
+through `work` — is the one live M0 workstream pointed at the future: it
+becomes the executor loop of the new pipeline (dispatch scaffold→green workers,
+bounded budgets, typed park reasons), not an upgrade to the `orchestrated-grind`
 skill. Its fit is verified against its spec before slice scoping (open
 verification V1).
 

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -270,10 +270,10 @@ ACs carry IDs; slice work cites them.
 
 *Amended 2026-08-09 (AC5):* the surface AC5 binds is the repo-owned one —
 `src/`, and everything this repo deploys — not everything a session can see.
-The admission gate has no reach over third-party marketplace plugins, and one
-installed plugin (`superpowers`, primary account only) ships its own
-`writing-plans` skill; that exposure is a known accepted gap outside AC5's
-jurisdiction rather than a breach of it.
+Marketplace plugins install outside that surface and the admission gate has no
+reach over them: the `superpowers` plugin ships a `writing-plans` skill, so the
+retired artifact class can reach a session by a route the gate never sees. That
+exposure is a known gap outside AC5's jurisdiction rather than a breach of it.
 
 ### Outcome (against the 2026-07-20 baseline, over the termination window)
 


### PR DESCRIPTION
Implements the five human rulings recorded on `agents-config-9k9.215.7` (the
seven charter-vs-tree disagreements from the 2026-08-09 fresh-context recheck).
The charter is canonical, so none of these took a unilateral edit — each carries
a ruling made by the repository owner and quoted verbatim on the tracker item.

Charter prose only. Nothing else is in the diff.

## What changed

Each amendment follows the charter's existing convention: a dated
`*Amended YYYY-MM-DD:*` paragraph immediately after the decision it amends
(the 2026-08-07 `wayfinder` readmission is the precedent). No decision is
renumbered or rewritten.

| Ruling | Charter section | Amendment |
| --- | --- | --- |
| 2 — caps: "Amend: record the 5k tier" | D16 | Records both tiers: 2k model-invoked, 5k user-invoked, with the raised ceiling stated as relief rather than permission |
| 3 — readmission: "Backfill the amendment" | D18 | Dated readmission of `improve-codebase-architecture`, user-invoked, Claude tree, with its grafts and the placement condition |
| 4 — park reasons: "Amend: record both axes" | D10 | Records the failure axis (PR-bound, mirrored by the `work` facade) and the grind-native scheduling axis |
| 6 — dead tracker IDs: "Mark as archive-era" | D13, D14, D18 | Each citation marked archive-era, resolvable in the private archive repository and not through `work` |
| 7 — no-prose-plans surface: "Repo-owned surface only" | AC5 | Names the repo-owned surface AC5 binds, and records the marketplace exposure — `superpowers` ships a `writing-plans` skill — as a known gap outside that jurisdiction |

Two of the seven rulings produce no charter edit and are deliberately absent
here: ruling 1 (home2 conform — the charter is unchanged; execution is
`agents-config-9k9.215.19`) and ruling 5 (extend spec-lint to match AC4 — code
work routed to `agents-config-9k9.215.8`).

## Round 2 — review disposition

Round 1 returned five mechanical findings. Findings f1/f2/f3 were one defect and
are fixed in `98449dd4`: the AC5 amendment stated the marketplace exposure as
account-scoped machine state ("one installed plugin (`superpowers`, primary
account only)"), which no observation of this repository can settle and which
goes stale the moment that account changes. The amendment now states the same
ruling as a standing property — marketplace plugins install outside the
repo-owned surface, the admission gate has no reach over them, and the
`superpowers` plugin ships a `writing-plans` skill — so every clause is
settleable without inspecting a particular machine. The ruling's three parts are
intact: AC5 binds the repo-owned surface; the exposure is known and outside its
jurisdiction; `superpowers`/`writing-plans` is the named instance.

Findings f4 (archive-era annotations) and f5 (readmission amendment) are
rebutted in the round-2 disposition ledger rather than changed.

Copilot's three comments triaged alongside. One fixed in `baff4269`: D14 read
"`wgclw.30` (event-sourced grind runtime; archive-era, …) is the one live M0
workstream", colliding "archive-era" and "live" in one sentence with each
adjective on the wrong noun. The runtime now leads the sentence and keeps the
live claim, and the archive-era note attaches to the ID it describes. The other
two — rewrite D16's base 2k sentence, drop `improve-codebase-architecture` from
D18's base skipped list — are rebutted: the charter's own convention preserves
base text under a dated amendment that supersedes it, which is why the
2026-08-07 `wayfinder` amendment sits beneath a list still naming `wayfinder`
as skipped. Rewriting base decisions was out of scope of the rulings.

## Verification

All five disagreements were re-verified against the current tree before
amending; none had been resolved in the interim.

- **Caps** — `surface_budget.py` carries `SKILL_BODY_TOKEN_CAP = 2_000` and
  `USER_INVOKED_SKILL_BODY_TOKEN_CAP = 5_000`.
- **Readmission** — `src/user/.claude/skills/improve-codebase-architecture/`
  is present with a complete admission record and `disable-model-invocation`.
- **Park axes** — `PARK_REASONS` in `packages/grind/src/grind/model.py` maps
  every reason to `failure` or `scheduling`; `.work/config.toml`'s
  `[park.reasons]` carries the five failure-axis reasons only, which is why the
  amendment calls the scheduling axis grind-native.
- **Dead IDs** — `work show` returns `E_NOT_FOUND` for all six of
  `abn9.8.33`, `abn9.8.49`, `j8pdq`, `wgclw.30`, `wgclw.24`, `wgclw.25`.
- **AC5 surface** — zero hits for the retired names under `src/`. The
  `superpowers` plugin ships a `writing-plans` skill, which is the claim the
  amendment makes and is a property of the plugin rather than of any install.

Gates, re-run standalone from this worktree root after the round-1 fix:
`make spec-lint` exit 0, `make doc-lint` exit 0. No `packages/**` code changed,
so no package suite applies.

## Consumer sweep (uncapped)

Whole-repo greps, no `head` caps, excluding only `.git`, `.venv`,
`node_modules`, `__pycache__`, `.beads` and other worktrees. **No quoter was
edited** — the files below belong to other items.

**Skill-body caps.** Two child specs state the flat 2k without the tier, both
point-in-time documents that predate it (PR 474 / `9k9.149`):
`docs/specs/2026-07-22-installer-single-home-admission-s3.md:91` and
`docs/specs/2026-07-24-spec-contract-s5.md:25` (the same document states both
tiers correctly at `:220`). Already consistent with the amendment:
`.claude/skills/admit-request/SKILL.md:157-159` and
`docs/primers/SKILLS_PRIMER.md:139-141`.

**Park axes.** Every downstream artifact already carries both axes — the
amendment brings the charter to them, not the reverse:
`docs/specs/2026-07-25-executor-seam-s9-tier1.md:25`,
`docs/specs/2026-07-19-event-sourced-grind-runtime.md:179-200`, `CONTEXT.md:88-92`,
`packages/grind/AGENTS.md:174-181`, `packages/executor/src/executor/rules.py:58`.
`docs/specs/2026-07-22-workcli-completion-s2.md:45-46` lists failure-axis reasons
only, which remains correct for the facade.

**D18 / `improve-codebase-architecture`.** No stale quoter.
`src/user/.agents/skills/AGENTS.md:88` records it as a Claude-tree skill with its
provenance, and `docs/specs/2026-07-22-instruction-surface-teardown-s4.md:192`
cites its content as live — both consistent with the readmission.

**AC5.** No quoter contradicts the repo-owned reading.
`docs/specs/2026-07-24-review-contracts-s6.md:34` and
`docs/specs/2026-07-24-spec-contract-s5.md:4,162,185` all read on that surface.
One adjacent staleness, pre-existing and not induced here: the S6 line says the
retired skills are "held only under `archive/`", a tree that has since moved to
the private archive repository.

**Archive-era IDs.** No document quotes the charter's citations. The same
namespace appears as other specs' own bead headers
(`docs/specs/2026-07-19-event-sourced-grind-runtime.md:3`,
`docs/specs/2026-07-19-grind-dashboard-renderer.md:3`,
`docs/specs/2026-07-16-prgroom-runloop-state-derivation.md:5`), in the
grind-dashboard prototype fixtures, and in `scripts/track-backfill/applied.log`
— the same dead-namespace class, but each owned by its own document.

Closes `agents-config-9k9.215.7` on merge.

