### PR TITLE
fix(9k9.215.4): config comments state what the reader does, not what it ignores

### DIFF
--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -129,7 +129,10 @@ Structured config at `packages/installer/installer.toml`, parsed by `core/instal
 
 ```toml
 [tools]
-# Optional per-tool dest-dir overrides — leave commented to use the built-in adapters.
+# Optional per-tool dest-dir overrides. Parsed into `tool_dest_overrides`
+# (installer_toml.py) but not yet consumed by anything — dest resolution
+# always goes through `adapter.dest_dir(home)`, so uncommenting this has no
+# effect today.
 # claude.dest = "~/.claude"
 ```
 

--- a/docs/architecture/installer/installer-design.md
+++ b/docs/architecture/installer/installer-design.md
@@ -142,7 +142,10 @@ Structured TOML at `packages/installer/installer.toml`, parsed by `core/installe
 
 ```toml
 [tools]
-# Optional per-tool dest-dir overrides — leave commented to use built-in adapters.
+# Optional per-tool dest-dir overrides. Parsed into `tool_dest_overrides`
+# (installer_toml.py) but not yet consumed by anything — dest resolution
+# always goes through `adapter.dest_dir(home)`, so uncommenting this has no
+# effect today.
 # claude.dest = "~/.claude"
 ```
 

--- a/packages/installer/installer.toml
+++ b/packages/installer/installer.toml
@@ -4,5 +4,8 @@
 # optional set of per-tool dest-dir overrides.
 
 [tools]
-# Optional per-tool dest-dir overrides — leave commented to use built-in adapters.
+# Optional per-tool dest-dir overrides. Parsed into `tool_dest_overrides`
+# (installer_toml.py) but not yet consumed by anything — dest resolution
+# always goes through `adapter.dest_dir(home)`, so uncommenting this has no
+# effect today.
 # claude.dest = "~/.claude"

--- a/profiles.toml
+++ b/profiles.toml
@@ -21,10 +21,11 @@ include = ["**"]
 
 # A deliberately tiny user install. Selectors must match the staged universe —
 # a dead selector fails the install loud — so this lists only what exists.
-# `rules/**`, `agents/**`, and `commands/**` are absent from the universe today:
-# every artifact in them was record-less and was retired out of the repository.
-# Re-add the selectors here in the same change that readmits content into those
-# namespaces.
+# `agents/**` is the only namespace absent from the universe today: nothing
+# stages into it. `rules/**` and `commands/**` are populated — this profile
+# just doesn't select them.
+# Re-add the `agents/**` selector here in the same change that readmits content
+# into that namespace.
 [profiles.minimal-user]
 include = ["instructions"]
 

--- a/profiles.toml
+++ b/profiles.toml
@@ -21,17 +21,16 @@ include = ["**"]
 
 # A deliberately tiny user install. Selectors must match the staged universe —
 # a dead selector fails the install loud — so this lists only what exists.
-# `agents/**` is the only namespace absent from the universe today: nothing
-# stages into it. `rules/**` and `commands/**` are populated — this profile
-# just doesn't select them.
+# `agents/**` and `workflows/**` are the namespaces absent from the universe
+# today: nothing stages into them. `rules/**` and `commands/**` are populated —
+# this profile just doesn't select them.
 # Re-add the `agents/**` selector here in the same change that readmits content
 # into that namespace.
 [profiles.minimal-user]
 include = ["instructions"]
 
-# The SDLC discipline content. `workflows/**` is absent from the universe today:
-# the last workflow (quality-gate.js) was retired out of the repository on 2026-07-25
-# (revisit tracked as agents-config-9k9.17.6). Re-add the selector here in the
-# same change that readmits content into that namespace.
+# The SDLC discipline content. `workflows/**` is absent from the universe
+# today: nothing stages into it. Re-add the selector here in the same change
+# that readmits content into that namespace.
 [profiles.sdlc]
 include = ["skills/**"]


### PR DESCRIPTION
## Summary

Fixes `agents-config-9k9.215.4` (findings H3 and M11 from `repo-sanity-recheck-2026-08-09.md`) — comment prose in two config files that invited actions their reading code ignores.

- **H3 — `profiles.toml:22-27`**: the `minimal-user` profile comment claimed `rules/**`, `agents/**`, and `commands/**` were all "absent from the universe today." False for two of three: `src/user/.claude/rules/delegation.md` and `src/user/.claude/commands/{clean-up-git,zoom-out}.md` exist on disk and carry admission records. `project_universe()` (`packages/installer/src/installer/core/profiles.py:250-267`) unions every tool plan's staged items, and `namespaces.py`'s `TOOL_SCOPED` view includes `rules`/`commands`/`agents`, so both stage today. Comment now names `agents/**` and `workflows/**` (see round 1 below) as absent.
- **M11 — `packages/installer/installer.toml:7`**: "leave commented to use built-in adapters" implied uncommenting `claude.dest = "..."` activates a redirect. `installer_toml.py:28-33`'s own docstring says `tool_dest_overrides` is "parsed and surfaced but NOT yet consumed... a declared override is currently inert." Comment now states that plainly, per the repo convention that a commented-out key nothing reads must say so. **Verified clean by the round-1 review panel, no follow-up.**

## Review round 1 — 2 mechanical findings, both fixed

Verdict: https://github.com/scotthamilton77/agents-config/pull/548#issuecomment-5233508623 (base `e7e2098`, head `8ef620c7`).

- **f1 (all three lenses hit this one)**: the corrected `profiles.toml:24` claimed `agents/**` was the *only* namespace absent from the universe — false, and it contradicted the file's own untouched `[profiles.sdlc]` comment (line 32), which separately named `workflows/**` absent too. Verified independently: no `workflows/` directory stages anywhere under `src/`, and `namespaces.py` keeps `workflows` in `ALL`/`TOOL_SCOPED`. **Fix**: the `minimal-user` comment now names both `agents/**` and `workflows/**` as absent; the two comments in the file now agree with each other and with the tree.
- **f2**: the `[profiles.sdlc]` comment (lines 32-35) narrated a retirement episode — a date (2026-07-25), the retired artifact's name (`quality-gate.js`), and a "revisit tracked as `agents-config-9k9.17.6`" pointer — instead of stating current truth. **Fix**: trimmed to "`workflows/**` is absent from the universe today: nothing stages into it," per the house convention that an artifact states its current decision, not its history; the episode is git's job.
- M11 was verified clean by the panel — no changes needed there in this round.

Both fixes are on the same branch (commit `dc652031`), comment-only, and `make ci` re-run standalone from the worktree root after the fix: **exit 0**.

## Consumer sweep (uncapped, whole-repo grep, no head caps)

Original sweep (round 0, before/after the first edit):

- `"every artifact in them was record-less"` / the old `rules/**`+`agents/**`+`commands/**` sentence — zero hits anywhere outside `profiles.toml` itself, before or after the edit. No other doc quoted the old profiles.toml comment.
- `"leave commented to use ... built-in adapters"` — found two verbatim reproductions of the old installer.toml comment inside fenced code blocks, both in evergreen architecture docs whose surrounding prose already correctly explains the override is inert (making the code-block reproduction the only stale part):
  - `docs/architecture/installer/installer-design.md:145` (§"Configuration — installer.toml")
  - `docs/architecture/installer/data-view.md:132` (§"installer.toml schema")

  Both updated in this PR to reproduce the corrected comment verbatim, keeping the quoted snippet in sync with its source. Re-ran the same grep post-edit: zero remaining hits of the old phrasing anywhere in the tree.
- Checked but left alone (no live-key or comment-prose claim, out of scope): `docs/specs/2026-07-06-profiles-scope-routing.md` and `docs/specs/2026-07-12-s2-project-scoped-install-design.md` reference `tool_dest_overrides` only in the context of a future S3 retirement plan — dated specs describing intent, already accurate about current (inert) state, no verbatim quote of either changed comment. `docs/architecture/installer/c4-l2-container.md` already paraphrases the M11 reality correctly ("Designed, parsed, not yet wired") without quoting the misleading comment text.

Round 1 sweep (after the f1/f2 fix, targeting the text that just changed):

- `"agents/** is the only namespace"` (the now-retracted "only" claim) — zero hits anywhere in the tree.
- `"quality-gate.js" was retired` / `9k9.17.6` (the trimmed retirement episode) — zero hits anywhere in the tree; nothing else quoted that narration.
- `minimal-user` / `profiles.sdlc` references elsewhere: `docs/specs/2026-07-06-profiles-scope-routing.md` and `packages/installer/tests/unit/test_profiles.py` reference the profile *names* only (as identifiers, e.g. `[("full",), ("minimal-user",), ("sdlc",)]` in a parametrized test), never the comment prose or the retirement narration — no change needed.

## Scope note

The dispatch that produced this PR initially named `project-config.toml` and `.critical-paths` as targets; the tracker item's own text explicitly excludes `project-config.toml` ("do not touch") and `.critical-paths` has no corresponding finding in the source recheck document. Confirmed with the task owner that the tracker item's actual scope (H3/M11 above) governs. Neither `project-config.toml` nor the `[tracks]` vocabulary is touched by this PR.

## What did NOT change

- No live TOML key added, removed, or changed value anywhere in the diff — `git diff` is comment/prose lines only (see diff).
- `project-config.toml` and `.critical-paths` untouched, per the item's explicit exclusion.

## Test plan

- [x] `make ci` run standalone from the worktree root, twice (once per commit) — **exit 0 both times** (includes `ci-installer`: ruff check/format, mypy --strict, pytest --cov branch 98%+, pip-audit; plus `spec-lint`, `content-lint`, `content-tests`, `doc-lint` for the repo-wide gate). Required because `installer.toml` sits under `packages/installer/`.
- [x] Manual verification of both readers cited above (`profiles.py::project_universe()`, `namespaces.py::TOOL_SCOPED`, `installer_toml.py`'s docstring) against the current tree.
- [x] Uncapped consumer sweep (above), before and after each edit.
- [x] Round-1 review-panel findings (f1, f2) independently re-verified against the tree before fixing (see above), then fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA
