### PR TITLE
fix(9k9.215.11): shared-tree subagent orders hedge for tools that can't dispatch

### DIFF
--- a/src/user/.agents/skills/codebase-design/SKILL.md
+++ b/src/user/.agents/skills/codebase-design/SKILL.md
@@ -19,6 +19,11 @@ what this body serves and is not upstream's. This header and the admission recor
 are stripped at deploy.
 -->
 
+DESIGN-IT-TWICE.md and this file's body below are vendored at a pin: your
+standing instructions and the always-on decision rules win wherever they
+disagree — including their unconditional "spawn sub-agents" steps, on a
+harness without subagent dispatch.
+
 # Codebase Design
 
 Design **deep modules**: a lot of behaviour behind a small interface, placed at a clean seam, testable through that interface. Use this language and these principles wherever code is being designed or restructured. The aim is leverage for callers, locality for maintainers, and testability for everyone.

--- a/src/user/.agents/skills/grilling/SKILL.md
+++ b/src/user/.agents/skills/grilling/SKILL.md
@@ -26,7 +26,7 @@ Format each question like this, as Markdown in your reply rather than inside a c
 
 Each round of answers reshapes the tree — settled decisions push the question frontier outward and unblock the questions that depended on them. Recompute it, then ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
 
-Finding *facts* is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, docs), dispatch a subagent to find it rather than asking the user for anything you could look up yourself. Do not block the round on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for that subagent to report — ask the rest of the question frontier now. The *decisions* are the user's: put each one to them and wait.
+Finding *facts* is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, docs), dispatch a subagent to find it if your harness can spawn one, otherwise look it up yourself with the tools you have — either way, never ask the user for anything you could look up. Do not block the round on it: a running lookup is an unsettled prerequisite, so only the questions downstream of it wait for it to finish — ask the rest of the question frontier now. The *decisions* are the user's: put each one to them and wait.
 
 ## Exit criterion
 

--- a/src/user/.agents/skills/writing-skills/references/testing-methodology.md
+++ b/src/user/.agents/skills/writing-skills/references/testing-methodology.md
@@ -69,8 +69,10 @@ A bad query:
    ]
    ```
 2. For each query, dispatch a subagent in an environment with the skill
-   available; ask it whether it would invoke the skill, and why. Run each
-   query 3 times to get a reliable trigger rate (model output is stochastic).
+   available if your harness can spawn subagents; otherwise open a fresh
+   session with the skill available and run the query there yourself. Ask
+   whether the skill would trigger, and why. Run each query 3 times to get a
+   reliable trigger rate (model output is stochastic).
 3. Tabulate hit rates: true-positives (correctly triggered),
    false-negatives (should have triggered, didn't), true-negatives
    (correctly skipped), false-positives (incorrectly triggered).


### PR DESCRIPTION
## Summary

Fixes agents-config-9k9.215.11 (recheck finding M23, epic agents-config-9k9.215): the shared `src/user/.agents/` tree deploys to Claude, Codex, Gemini, and OpenCode, but three of its files ordered subagent dispatch unhedged — a capability only Claude Code has.

## Sites

- **`src/user/.agents/skills/grilling/SKILL.md:29`** (house-authored) — "dispatch a subagent to find it" now reads "dispatch a subagent to find it if your harness can spawn one, otherwise look it up yourself with the tools you have," with the downstream sentence adjusted so it no longer presumes an async subagent report.
- **`src/user/.agents/skills/writing-skills/references/testing-methodology.md:71`** (house-authored) — the trigger-eval step's "dispatch a subagent in an environment with the skill available" now hedges with "if your harness can spawn subagents; otherwise open a fresh session with the skill available and run the query there yourself."
- **`src/user/.agents/skills/codebase-design/DESIGN-IT-TWICE.md:19-21`** ("Spawn 3+ sub-agents") — **pinned bytes unedited; a subordination sentence added instead.** This file, and the codebase-design SKILL.md body from its `# Codebase Design` heading down, are vendored-pin bytes under the body-only pin ruling (9k9.213.12) and cannot be edited — confirmed by diffing the pinned span against `origin/main`, byte-identical.

  Per the house convention (`src/user/.agents/skills/AGENTS.md`: "Where a vendored body disagrees with its host skill or with the house rules, the host and the house rules win, and the host skill says so in one sentence rather than the body being edited" — precedent: `writing-skills/SKILL.md`'s `anthropic-best-practices.md` line), `codebase-design/SKILL.md` now carries that one sentence in the house-authored gap between its provenance comment and the pinned heading:

  > DESIGN-IT-TWICE.md and this file's body below are vendored at a pin: your standing instructions and the always-on decision rules win wherever they disagree — including their unconditional "spawn sub-agents" steps, on a harness without subagent dispatch.

  This deploys (only the front-matter `admission:` block and the HTML provenance comment are stripped at install; plain body text between the comment and the heading is not) and sits directly above the pinned body a Codex/Gemini/OpenCode agent reads, unlike the earlier disposition which lived only in the tracker note and this PR body. The substance is the same USER-CORE `<decisions>` precedence this repo already licenses ("In-scope choice … → decide and proceed"): an agent hitting "spawn sub-agents" without that capability produces the designs itself, sequentially, and proceeds rather than stalling. Full ranking is recorded on agents-config-9k9.215.11's notes.

## Sweep (uncapped, `src/user/.agents/**`, class = unhedged subagent-dispatch orders)

`grep -rniE "spawn|dispatch a subagent|dispatch subagent|dispatch.*agent|fan out|fan-out|parallel sub-?agents?|background agent"` plus a broader case-insensitive `subagent` pass, both swept manually against every hit:

- **Fixed:** the two sites above.
- **Already hedged, no action:** `research/SKILL.md:21` — "Hand this to a background agent if you have one."
- **Pinned, disposed above:** `codebase-design/DESIGN-IT-TWICE.md` and the pinned portion of `codebase-design/SKILL.md`.
- **Not actionable / not an unhedged order:**
  - `codebase-design/SKILL.md`'s `admission.cost` field — stripped at deploy, never reaches a deployed agent.
  - `writing-skills/references/testing-skills-with-subagents.md` — method-neutral throughout ("give agents a realistic task," "run scenarios"); never literally orders a subagent-dispatch mechanism.
  - `writing-skills/references/writing-for-agents.md:124` — already offers an alternate ("a hand-off *or* a subagent dispatch"), illustrative rather than a mandate.
  - `writing-skills/references/descriptions.md:24` — example text inside a "bad description" callout, not an instruction to this agent.
  - `instructing-subagents/SKILL.md` — already generic across delegate types ("a subagent, a workflow stage, a background worker, or a nested harness").

No other tool-specific procedural capability (hooks, AskUserQuestion, the Skill tool) was found ordered unhedged in the shared tree.

## Test plan

- [x] `make content-lint` — exit 0 (`codebase-design/SKILL.md` now 1609/2000 tokens, `grilling` 779/2000; both well under cap)
- [x] `make content-tests` — exit 0, 12/12 suites pass (writing-skills' own suites included)
- [x] `git diff origin/main -- src/user/.agents/skills/codebase-design/` restricted to the pinned span (`awk '/^# Codebase Design$/,0'`) — empty; pinned bytes untouched
- [ ] review-panel round to terminal-clean verdict (per epic 9k9.215's binding review contract) — one round already returned an advisory (addressed in this update); confirming terminal-clean is still open
