### PR TITLE
docs(9k9.215.9): D9 records the PR-thread interim Scott ruled

### DIFF
--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -96,6 +96,17 @@ machine-posted comments and approvals use the bot App identity, never Scott's
 auth. The merge gate requires the verdict artifact — broken review machinery
 blocks merges rather than silently passing them.
 
+*Amended 2026-08-09:* until the replacement review path ships, PR comment
+threads remain a review medium, and machine-posted replies continue
+authenticating as Scott's identity rather than the bot App identity — an
+accepted, recorded interim cost, not the target state (the App-identity write
+path is unbuilt and remains unfiled scope; see
+`docs/specs/2026-07-25-agent-comment-authorship.md`). This interim settles only
+where a reply is read, not what one means: a reply rendering under Scott's
+identity is still never evidence of merge authorization, and D9's
+merge-eligibility clause — CI green, verdict artifact, approval — is
+unchanged.
+
 **D10 — Non-merging PRs park; the machine disengages.** Closed = merged, no
 exceptions (dependents key off merge). A work item whose PR won't merge enters
 a parked state with a typed reason:

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -96,14 +96,15 @@ machine-posted comments and approvals use the bot App identity, never Scott's
 auth. The merge gate requires the verdict artifact — broken review machinery
 blocks merges rather than silently passing them.
 
-*Amended 2026-08-09:* until the replacement review path ships, PR comment
-threads remain a review medium, and machine-posted replies continue
-authenticating as Scott's identity rather than the bot App identity — an
-accepted, recorded interim cost, not the target state (the App-identity write
-path is unbuilt and remains unfiled scope; see
-`docs/specs/2026-07-25-agent-comment-authorship.md`). This interim settles only
-where a reply is read, not what one means: a reply rendering under Scott's
-identity is still never evidence of merge authorization, and D9's
+*Amended 2026-08-09:* the two clauses end on different termini. PR comment
+threads remain a review medium until the replacement review path ships;
+machine-posted replies keep authenticating as Scott's identity, not the bot
+App identity, until the separate App-identity write path ships — its own,
+still-unfiled scope (`docs/specs/2026-07-25-agent-comment-authorship.md`),
+which the replacement review path does not itself close. Both are an
+accepted, recorded interim cost, not the target state. This interim settles
+only where a reply is read, not what one means: a reply rendering under
+Scott's identity is still never evidence of merge authorization, and D9's
 merge-eligibility clause — CI green, verdict artifact, approval — is
 unchanged.
 
@@ -254,8 +255,9 @@ mechanical churn requires an explicit override.
 
 *Amended 2026-08-09:* the separation is target state, not current fact — D9's
 2026-08-09 interim keeps non-verdict machine comments rendering under Scott's
-identity, so the interventions-per-PR proxy has no substrate to read from
-until that interim resolves.
+identity until the App-identity write path ships, a later and separate
+terminus than D9's review-medium clause, so the interventions-per-PR proxy
+has no substrate to read from until then.
 
 **D20 — Roadmap disposition.** M0 closes as superseded, not finished — its
 live surface almost entirely hardens machinery this spec deletes. M3 pauses

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -106,7 +106,9 @@ accepted, recorded interim cost, not the target state. This interim settles
 only where a reply is read, not what one means: a reply rendering under
 Scott's identity is still never evidence of merge authorization, and D9's
 merge-eligibility clause — CI green, verdict artifact, approval — is
-unchanged.
+unchanged. While clause (b) holds, AC7's bot-identity precondition is unmet
+for every PR, so the AC9 termination window does not open until the
+App-identity write path ships.
 
 **D10 — Non-merging PRs park; the machine disengages.** Closed = merged, no
 exceptions (dependents key off merge). A work item whose PR won't merge enters

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -252,6 +252,11 @@ counts, PR diff lines) are tracked as erosion tripwires — watched, never
 targeted. PR diff tripwire (initial, tunable): > 800 changed lines excluding
 mechanical churn requires an explicit override.
 
+*Amended 2026-08-09:* the separation is target state, not current fact — D9's
+2026-08-09 interim keeps non-verdict machine comments rendering under Scott's
+identity, so the interventions-per-PR proxy has no substrate to read from
+until that interim resolves.
+
 **D20 — Roadmap disposition.** M0 closes as superseded, not finished — its
 live surface almost entirely hardens machinery this spec deletes. M3 pauses
 until the minimal readiness gate (D1–D3) exists. The WIP cap of 2 is honored.

--- a/docs/specs/2026-07-21-harness-rework-way-forward.md
+++ b/docs/specs/2026-07-21-harness-rework-way-forward.md
@@ -99,16 +99,16 @@ blocks merges rather than silently passing them.
 *Amended 2026-08-09:* the two clauses end on different termini. PR comment
 threads remain a review medium until the replacement review path ships;
 machine-posted replies keep authenticating as Scott's identity, not the bot
-App identity, until the separate App-identity write path ships — its own,
-still-unfiled scope (`docs/specs/2026-07-25-agent-comment-authorship.md`),
-which the replacement review path does not itself close. Both are an
-accepted, recorded interim cost, not the target state. This interim settles
-only where a reply is read, not what one means: a reply rendering under
-Scott's identity is still never evidence of merge authorization, and D9's
-merge-eligibility clause — CI green, verdict artifact, approval — is
-unchanged. While clause (b) holds, AC7's bot-identity precondition is unmet
-for every PR, so the AC9 termination window does not open until the
-App-identity write path ships.
+App identity, until the separate App-identity write path ships — its own
+scope, filed and in progress as `agents-config-9k9.42`
+(`docs/specs/2026-07-25-agent-comment-authorship.md`), which the replacement
+review path does not itself close. Both are an accepted, recorded interim
+cost, not the target state. This interim settles only where a reply is read,
+not what one means: a reply rendering under Scott's identity is still never
+evidence of merge authorization, and D9's merge-eligibility clause — CI
+green, verdict artifact, approval — is unchanged. While clause (b) holds,
+AC7's bot-identity precondition is unmet for every PR, so the AC9 termination
+window does not open until the App-identity write path ships.
 
 **D10 — Non-merging PRs park; the machine disengages.** Closed = merged, no
 exceptions (dependents key off merge). A work item whose PR won't merge enters
@@ -257,9 +257,11 @@ mechanical churn requires an explicit override.
 
 *Amended 2026-08-09:* the separation is target state, not current fact — D9's
 2026-08-09 interim keeps non-verdict machine comments rendering under Scott's
-identity until the App-identity write path ships, a later and separate
-terminus than D9's review-medium clause, so the interventions-per-PR proxy
-has no substrate to read from until then.
+identity until the App-identity write path ships (`agents-config-9k9.42`), a
+later and separate terminus than D9's review-medium clause. Post-S6,
+App-posted verdict comments are already separable; what the
+interventions-per-PR proxy lacks until then is a reliable authorship signal
+on the owner-credentialed remainder.
 
 **D20 — Roadmap disposition.** M0 closes as superseded, not finished — its
 live surface almost entirely hardens machinery this spec deletes. M3 pauses


### PR DESCRIPTION
## Summary

Records the ruling on `agents-config-9k9.215.9` (parent epic `agents-config-9k9.215`) that resolved finding M7: root AGENTS.md's review step and charter D9 previously ordered opposite behavior on PR comment threads.

- Charter D9 gains a dated amendment with **two independent termini, one per clause**: (a) PR comment threads remain a review medium until the replacement review path (S6) ships; (b) machine-posted replies keep authenticating as Scott's identity until the separate App-identity write path ships, filed and in progress as `agents-config-9k9.42`. The two are kept apart deliberately — the S6 spec (`docs/specs/2026-07-24-review-contracts-s6.md`) states that non-verdict machine writes (grooming comments, review-thread replies) stay owner-credentialed even after S6 ships, so a single shared terminus would have expired clause (b) at S6-ship while owner-auth replies were still live, reviving D9's unamended "never Scott's auth" text against what actually ships.
- The amendment preserves the no-authorization nuance: a reply rendering under Scott's identity is still never evidence of merge authorization; D9's merge-eligibility clause (CI green + verdict artifact + approval) is unchanged.
- The amendment also states a sequencing consequence: while clause (b) holds, AC7's bot-identity precondition (every PR carries machine comments under the bot identity) is unmet for every PR, so **AC9's ten-consecutive-PR termination window cannot open until the App-identity write path ships**. AC7/AC9's own text is untouched — the sequencing is recorded once, inside the D9 amendment.
- Root AGENTS.md's review step (`4. Open a PR and address review to quiescence...only items that change the code get a reply on the PR`) already states the ruled contract — no edit was needed there; recorded as already-resolved.
- **From the spec-class review round:** D19 asserted "Bot App identity separates human from machine PR comments" as current fact, which the D9 interim now contradicts (non-verdict machine comments still render under Scott's identity). D19 gets a short dated rider pointing back at D9's clause (b) terminus (`agents-config-9k9.42`) rather than the interim as a whole, and states precisely what's missing until then: post-S6, App-posted verdict comments are already separable — what the interventions-per-PR proxy lacks is a reliable authorship signal on the owner-credentialed remainder, not "no substrate to read from" as an earlier draft overstated it.

Ruling quoted verbatim on `agents-config-9k9.215.9`: "Threads stay; your identity, interim." (a) PR comment threads remain a review medium until the charter's replacement review path ships. (b) Machine replies continue under Scott's GitHub identity as an accepted, recorded interim cost; App-identity work is not built here and remains unfiled scope. (c) Root AGENTS.md keeps review-to-quiescence with PR replies as the mechanism; the charter's D9 is amended to record the interim.

## Consumer sweep (uncapped)

Searched the whole tree (excluding `archive/`) for quotes/paraphrases of the amended D9 clause ("PR comments cease to be a review medium", "bot App identity, never Scott's auth", and the general phrase "review medium" / "PR comment threads"):

- `docs/specs/2026-07-24-review-contracts-s6.md:75` ("Human PR comments remain a non-medium (D9)") and `:424` (S6-D4) quote the **human-comment-as-intervention** half of D9, which this amendment does not touch. This spec is a dated point-in-time child spec, exempt from current-truth rewriting by the repo's own docs taxonomy — the charter is the canonical live document and now records the interim, so no edit was made here; the reviewing lead is dispositioning this in the review ledger.
- `docs/specs/2026-07-24-review-contracts-s6.md:187` ("Verdicts ride the existing bot identity...") already states that non-verdict machine writes stay owner-credentialed after S6 ships — this is in fact the evidence that motivated splitting D9's amendment into two termini (see Summary above), not a contradiction to fix.
- **D19** (same charter, ~line 250) asserted the target-state identity separation as current fact — fixed with a dated rider pointing at clause (b)'s own terminus.
- **AC7/AC9** (same charter): AC7 requires bot-identifiable machine comments per PR and AC9 gates milestone closure on 10 consecutive PRs meeting AC6-AC8; the D9 amendment now states explicitly that this window can't open while clause (b) holds, rather than leaving a reader to infer it.
- **`agents-config-9k9.42`** verified via `work show`: filed, `in_progress`, title "Agent-posted PR comments render as the owner, so agents misread them as human authorization" — cited by both D9 and D19 in place of the earlier, incorrect "still-unfiled scope" language.
- No other file in the tree references "review medium" or PR comment threads in this context.
- `D9` token also appears in `docs/specs/2026-07-25-executor-seam-s9-tier1.md` and `packages/executor/**` as `S9T1-D9`, an unrelated decision in a different spec (naming collision only, not a quoter).

## Gates

- `make spec-lint` — exit 0
- `make doc-lint` — exit 0 (122 tracked Markdown files read; 206 pre-existing citations "not judged" are unrelated to this diff)
- Diff touches exactly one file: `docs/specs/2026-07-21-harness-rework-way-forward.md` (D9 amendment + D19 rider only).

## Test plan

- [x] `make spec-lint` exits 0
- [x] `make doc-lint` exits 0
- [x] Diff scoped to the charter's D9 amendment and D19 rider only
- [x] review-panel spec-class round 1: D19 finding fixed; S6 finding rebutted (dated child spec, not current-truth surface)
- [x] review-panel spec-class round 1 (architectural-fit): single-terminus flaw in the D9 amendment fixed — clauses (a) and (b) now end on independent termini
- [x] review-panel spec-class round 2 (decidability): AC7/AC9 sequencing consequence of clause (b) now stated explicitly in the D9 amendment
- [x] review-panel spec-class round 4 (act/cvs): "still-unfiled scope" corrected to cite `agents-config-9k9.42` (filed, in progress); D19's "no substrate to read from" recast to name the missing reliable authorship signal precisely

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA