### PR TITLE
fix(9k9.215.16): delegation.md models the running harness, not the superseded one

### DIFF
--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -8,17 +8,16 @@ admission:
 # Delegation
 
 <subagent-user-authorization>
-This rule intentionally supersedes the harness default "Do not call the AgentTool
-unless the user requested it." Subagent delegation is authorized standing policy —
-do not wait to be asked. This is an explicit authorization and imperative from the user.
-Workflows are governed separately; see <workflow-user-authorization>.
+Subagent delegation is authorized standing policy — do not wait to be asked, even if
+the harness would otherwise default to delegating only on request. This is an explicit
+authorization and imperative from the user. Workflows are governed separately; see
+<workflow-user-authorization>.
 </subagent-user-authorization>
 
 <workflow-user-authorization>
 Workflows spend agents by the fleet, so the standing authorization is conditional.
-Ultracode's state is announced only by the harness Workflow tool's own description;
-when this session has no Workflow tool loaded, nothing announces the state, and the
-default is off.
+Ultracode is on only when something in the session announces it; absent that
+announcement, the default is off.
 - **Ultracode on** — workflows are yours on judgment alone, same as any subagent.
   Orchestrate whenever the work is wide, adversarial, or larger than one context.
   Do not ask; decide, and own the result.

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -1,6 +1,6 @@
 ---
 admission:
-  provides: Standing authorization to delegate to subagents and workflows without being asked each time, the boundary between orchestrator work and delegated work, the pointer to the delegate-selection skill, a consult gate before spawning a Fable subagent, and the no-reply rule for post-report idle notifications.
+  provides: Standing authorization to delegate to subagents without being asked each time, a conditional authorization for workflows gated on the session announcing an elevated orchestration state, the boundary between orchestrator work and delegated work, the pointer to the delegate-selection skill, a consult gate before spawning a Fable subagent, and the no-reply rule for post-report idle notifications.
   cost: Biases toward spawning subagents, spending dispatch overhead on work the main loop could have done inline.
   remove_when: The harness stops shipping a built-in prohibition on unrequested delegation, and unaided sessions hold the orchestrator/delegated boundary without being told.
 ---
@@ -8,10 +8,9 @@ admission:
 # Delegation
 
 <subagent-user-authorization>
-Subagent delegation is authorized standing policy — do not wait to be asked, even if
-the harness would otherwise default to delegating only on request. This is an explicit
-authorization and imperative from the user. Workflows are governed separately; see
-<workflow-user-authorization>.
+Subagent delegation is authorized standing policy — do not wait to be asked. This is an
+explicit authorization and imperative from the user. Workflows are governed separately;
+see <workflow-user-authorization>.
 </subagent-user-authorization>
 
 <workflow-user-authorization>

--- a/src/user/.claude/rules/delegation.md
+++ b/src/user/.claude/rules/delegation.md
@@ -15,8 +15,9 @@ see <workflow-user-authorization>.
 
 <workflow-user-authorization>
 Workflows spend agents by the fleet, so the standing authorization is conditional.
-Ultracode is on only when something in the session announces it; absent that
-announcement, the default is off.
+Ultracode is on only when the session's loaded context, or the operator's own
+instruction, explicitly states so; absent an explicit statement either way, the
+default is off.
 - **Ultracode on** — workflows are yours on judgment alone, same as any subagent.
   Orchestrate whenever the work is wide, adversarial, or larger than one context.
   Do not ask; decide, and own the result.


### PR DESCRIPTION
## Summary
- `src/user/.claude/rules/delegation.md` quoted two harness-specific claims that the current harness contradicts: a "Do not call the AgentTool unless the user requested it." default (the current tool is named `Agent` and its description encourages delegation, not withholds it) and "Ultracode's state is announced only by the harness Workflow tool's own description" (this session has no `Workflow` tool loaded at all; the announcement vehicle observed in practice is session system-reminders).
- Reworded both to state the rule's own policy without naming or quoting harness internals this repo doesn't control, so the text doesn't re-rot on the next harness change. No policy obligation changed: subagent delegation is still standing-authorized without being asked; Ultracode is still off by default absent an in-session announcement.
- **Follow-up push:** a review-panel round (this repo's own, plus an independent one) caught two carryovers from the same defect class: the subagent-authorization sentence still hedged on a hypothetical harness default ("even if the harness would otherwise default to delegating only on request"), and the admission record's `provides` line claimed workflows are standing-authorized like subagents when the body gates them on Ultracode being announced on. Both fixed: the harness-default clause is dropped entirely, and the `provides` line now separates subagents (standing) from workflows (conditional), matching the body.

Verification performed:
- Confirmed via this session's live Agent tool description: no "AgentTool" name, no "ask first" default — it explicitly authorizes/encourages delegation.
- Confirmed via `ToolSearch` that no `Workflow`/`Ultracode` tool is loaded in this session, consistent with the claim that announcement (when present) rides system-reminders rather than a tool's own description.
- Repo-wide grep for the exact removed phrases (`AgentTool`, "announced only by", "harness Workflow tool's own description", "even if the harness would otherwise default") returns zero hits outside git history — no other document quotes the stale text.
- `docs/primers/AGENTS_PRIMER.md`, flagged in the dispatch as a possible citer of this file, does not actually quote or cite either changed claim (checked for `AgentTool`, `Ultracode`, `Fable`, the two XML tag names — zero hits). No update needed there.

## Consumer sweep (uncapped)
- `grep -rn "AgentTool"` (whole tree): only match was the line removed in the first commit.
- `grep -rn "announced only by\|harness Workflow tool's own description\|even if the harness would otherwise default"` (whole tree): zero hits after both edits.
- `grep -rln "delegation\.md"` (whole tree): two dated specs (`docs/specs/2026-07-24-spec-contract-s5.md`, `docs/specs/2026-06-21-w1qls.8.14-staging-merge-dispatch-design.md`) reference delegation.md, but both cite a since-removed "routes planning to X" line unrelated to this change — not consumers of the text touched here.

## Test plan
- [x] `make content-lint` — exit 0 (run standalone from this worktree root, both commits)
- [x] `make content-tests` — exit 0 (12 suites passed, both commits)
- [x] `make doc-lint` — exit 0
- [x] review-panel round (prose class, 3 lenses: internal-consistency, global-consistency, standalone-read) — round 1 found 2 mechanical findings on the internal-consistency lens, both fixed above; global-consistency and standalone-read returned clean in round 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Round 2 addendum:** review-panel round 2 (global-consistency + standalone-read) found the round-1 Ultracode clause harness-agnostic but undecidable — "something in the session announces it" names no test a reader can apply. Commit `fddf0c59` states the recognition rule directly: Ultracode is on only when the session's loaded context or the operator's own instruction explicitly says so; absent that, default-off decides. `internal-consistency` was clean this round. Content gates re-run standalone from the worktree root: `make content-lint` exit 0, `make content-tests` exit 0 (12 suites passed).
