### PR TITLE
fix(9k9.215.13): model catalog drops dead pointers, names current roster

### DIFF
--- a/docs/reference/model-catalog.md
+++ b/docs/reference/model-catalog.md
@@ -6,6 +6,10 @@ Human-readable catalog of the AI model IDs this project routes to, their list
 prices, and the use-case tier each one serves. A decision aid for choosing
 routing tiers — **not** a runtime source of truth.
 
+IDs below are each vendor's canonical model ID. A harness invocation surface
+may accept its own aliases or flag forms for the same model (e.g. a CLI's
+`--model` short names); that surface's own docs govern those, not this table.
+
 > **Prices rot.** List prices here are point-in-time and versioned with the code
 > deliberately (they age alongside the routing decisions that cite them). For
 > OpenRouter-routed models specifically, a live user-maintained rate override

--- a/docs/reference/model-catalog.md
+++ b/docs/reference/model-catalog.md
@@ -7,11 +7,13 @@ prices, and the use-case tier each one serves. A decision aid for choosing
 routing tiers — **not** a runtime source of truth.
 
 > **Prices rot.** List prices here are point-in-time and versioned with the code
-> deliberately (they age alongside the routing decisions that cite them). At
-> runtime, per-model rates are **user-maintained in user-space config**
-> (`[providers.*.models.*].cost_per_mtok_*`) — that config is authoritative,
-> this doc is reference. When they disagree, trust the user config and update
-> this doc's date.
+> deliberately (they age alongside the routing decisions that cite them). For
+> OpenRouter-routed models specifically, a live user-maintained rate override
+> exists — `~/.config/agents-config/openrouter-model-registry.json`
+> (`input_per_m`/`output_per_m` keys; see the `openrouter-claude-subagent`
+> skill) — and takes precedence over this doc for those models. No equivalent
+> override exists for the other providers below; when a price here goes stale,
+> re-verify against the vendor and update this doc's date.
 
 Prices are USD per million tokens (input / output).
 
@@ -85,7 +87,7 @@ overage via the API sibling).
 |---|---|---|---|---|
 | Gemini CLI | `gemini-3-flash-preview` | 0.50 | — | Foreign-eyes review. |
 | Local | `ollama gemma4` | free | free | Cluster/classify baseline (never counts against budget ceiling). |
-| OpenRouter | `glm-5.2` | 0.60 | 2.20 | Metered peer rung (escalation-ladder example). |
+| OpenRouter | `glm-5.2` | 0.60 | 2.20 | Metered peer rung. |
 
 ---
 
@@ -134,7 +136,6 @@ Active sidekick profiles (from `llm.defaults.yaml`):
 - The `delegating-to-codex` skill — use-case → OpenAI model selection.
 - The `openrouter-claude-subagent` skill — OpenRouter-hosted model selection and rates.
 - `packages/prgroom/src/prgroom/agent/dispatcher.py` — `_DEFAULT_CHAINS`.
-- `project-config.toml` `[foreign-cli]` — per-stage Codex/Gemini model bindings.
 - `agents-config-uy5wx` — archive-era, resolvable in the private archive
   repository and not through `work`: proposed consolidating these duplicated
   model IDs into a single source of truth; this catalog is the human-readable

--- a/docs/reference/model-catalog.md
+++ b/docs/reference/model-catalog.md
@@ -36,9 +36,9 @@ dispatcher (`packages/prgroom/src/prgroom/agent/dispatcher.py`).
 
 ## OpenAI — Codex CLI
 
-Invoked via the Codex plugin (`codex-companion.mjs task --model <id>`). The
-`gpt-5.6-*` variants are the current review/impl tier; older `5.x` models remain
-available.
+Invoked by dispatching the `codex-rescue` agent (see the `delegating-to-codex`
+skill for the dispatch route and model choice). The `gpt-5.6-*` variants are
+the current review/impl tier; older `5.x` models remain available.
 
 | Model ID | In $/M | Out $/M | Tier / use |
 |---|---|---|---|
@@ -87,7 +87,7 @@ overage via the API sibling).
 |---|---|---|---|---|
 | Gemini CLI | `gemini-3-flash-preview` | 0.50 | — | Foreign-eyes review. |
 | Local | `ollama gemma4` | free | free | Cluster/classify baseline (never counts against budget ceiling). |
-| OpenRouter | `glm-5.2` | 0.60 | 2.20 | Metered peer rung. |
+| OpenRouter | `z-ai/glm-5.2` | 0.76 | 2.39 | Metered peer rung. |
 
 ---
 

--- a/docs/reference/model-catalog.md
+++ b/docs/reference/model-catalog.md
@@ -70,11 +70,12 @@ overage via the API sibling).
 | Opus 5 | `claude-opus-5` | TBD | TBD | Top judgment tier: architecture, impl, final synthesis. |
 | Sonnet 5 | `claude-sonnet-5` | TBD | TBD | Standard impl + review. |
 | Haiku 4.5 | `claude-haiku-4-5-20251001` | TBD | TBD | Mechanical / cheap fan-out. |
-| Fable 5 | `claude-fable-5` | TBD | TBD | Frontier-tier spec closure (fablize window work). |
+| Fable 5 | `claude-fable-5` | TBD | TBD | Frontier-tier spec closure. |
 
-> **TBD prices unverified.** Current Claude 5-era Anthropic list prices were
-> not confirmed at authoring time — fill from console.anthropic.com pricing
-> and re-date this doc. Do not guess.
+> **TBD prices unverified.** Current Claude 5-era Anthropic list prices stand
+> unverified against the vendor page. Re-verify using the route the roster
+> callout above names (console.anthropic.com) and re-date this doc. Do not
+> guess.
 
 ---
 
@@ -134,5 +135,7 @@ Active sidekick profiles (from `llm.defaults.yaml`):
 - The `openrouter-claude-subagent` skill — OpenRouter-hosted model selection and rates.
 - `packages/prgroom/src/prgroom/agent/dispatcher.py` — `_DEFAULT_CHAINS`.
 - `project-config.toml` `[foreign-cli]` — per-stage Codex/Gemini model bindings.
-- Bead `agents-config-uy5wx` — consolidate these duplicated model IDs into a
-  single source of truth; this catalog is the human-readable half of that effort.
+- `agents-config-uy5wx` — archive-era, resolvable in the private archive
+  repository and not through `work`: proposed consolidating these duplicated
+  model IDs into a single source of truth; this catalog is the human-readable
+  half of that effort.

--- a/docs/reference/model-catalog.md
+++ b/docs/reference/model-catalog.md
@@ -1,6 +1,6 @@
 # Model Catalog
 
-**Last updated: 2026-07-10**
+**Last updated: 2026-08-09**
 
 Human-readable catalog of the AI model IDs this project routes to, their list
 prices, and the use-case tier each one serves. A decision aid for choosing
@@ -9,9 +9,9 @@ routing tiers — **not** a runtime source of truth.
 > **Prices rot.** List prices here are point-in-time and versioned with the code
 > deliberately (they age alongside the routing decisions that cite them). At
 > runtime, per-model rates are **user-maintained in user-space config**
-> (`[providers.*.models.*].cost_per_mtok_*`, see the escalation-ladder spec) — that
-> config is authoritative, this doc is reference. When they disagree, trust the
-> user config and update this doc's date.
+> (`[providers.*.models.*].cost_per_mtok_*`) — that config is authoritative,
+> this doc is reference. When they disagree, trust the user config and update
+> this doc's date.
 
 Prices are USD per million tokens (input / output).
 
@@ -26,7 +26,7 @@ dispatcher (`packages/prgroom/src/prgroom/agent/dispatcher.py`).
 | Use case | OpenAI (Codex) | Anthropic (Claude) | Local / cheap |
 |---|---|---|---|
 | Mechanical / triage / classify / cluster / finder | `gpt-5.6-luna` | `haiku` (low–high) | `ollama gemma4` |
-| Standard review / implement / fix-chain / RALF cycle1 / merge-judge default | `gpt-5.6-terra` | `sonnet` / `opus` | — |
+| Standard review / implement / fix-chain / merge-judge default | `gpt-5.6-terra` | `sonnet` / `opus` | — |
 | Architecture / security / cross-subsystem / final pre-merge / deep adversarial review / spec-writer | `gpt-5.6-sol` | `opus` (high/xhigh) | — |
 | Deeply code-centric agentic (`--write`) | `gpt-5.3-codex` | — | — |
 
@@ -58,18 +58,23 @@ whatever reads this table rather than automatically.
 ## Anthropic — Claude Code CLI
 
 The subscription backbone (billed as subscription until exhausted, then metered
-overage via the API sibling). Model IDs from the Claude 5 / Opus 4.8 family.
+overage via the API sibling).
+
+> **Roster captured 2026-08-09** from the active session's own model
+> enumeration (the Claude Code harness's model list). Anthropic renames and
+> retires tiers without much notice — re-verify against the harness's current
+> model list or console.anthropic.com before routing anything cost-sensitive.
 
 | Name | Model ID | In $/M | Out $/M | Tier / use |
 |---|---|---|---|---|
-| Opus 4.8 | `claude-opus-4-8` | TBD | TBD | Top judgment tier: architecture, impl, final synthesis. |
+| Opus 5 | `claude-opus-5` | TBD | TBD | Top judgment tier: architecture, impl, final synthesis. |
 | Sonnet 5 | `claude-sonnet-5` | TBD | TBD | Standard impl + review. |
 | Haiku 4.5 | `claude-haiku-4-5-20251001` | TBD | TBD | Mechanical / cheap fan-out. |
 | Fable 5 | `claude-fable-5` | TBD | TBD | Frontier-tier spec closure (fablize window work). |
 
-> **TBD prices unverified.** Current Opus-4.8-era Anthropic list prices were not
-> confirmed at authoring time — fill from console.anthropic.com pricing and
-> re-date this doc. Do not guess.
+> **TBD prices unverified.** Current Claude 5-era Anthropic list prices were
+> not confirmed at authoring time — fill from console.anthropic.com pricing
+> and re-date this doc. Do not guess.
 
 ---
 
@@ -77,7 +82,7 @@ overage via the API sibling). Model IDs from the Claude 5 / Opus 4.8 family.
 
 | Provider | Model ID | In $/M | Out $/M | Use |
 |---|---|---|---|---|
-| Gemini CLI | `gemini-3-flash-preview` | 0.50 | — | RALF-IT iter2 foreign-eyes review. |
+| Gemini CLI | `gemini-3-flash-preview` | 0.50 | — | Foreign-eyes review. |
 | Local | `ollama gemma4` | free | free | Cluster/classify baseline (never counts against budget ceiling). |
 | OpenRouter | `glm-5.2` | 0.60 | 2.20 | Metered peer rung (escalation-ladder example). |
 
@@ -90,7 +95,7 @@ roster, sourced from its `llm.defaults.yaml`. OpenRouter-centric cheap models fo
 persona voice + creative generation, **not** the review/impl routing above.
 
 > **Source-dated 2025-11-09** (upstream `llm.defaults.yaml`). Stale relative to
-> this repo — e.g. it lists Opus/Sonnet 4.5, predating Opus 4.8 / Claude 5. Merged
+> this repo — e.g. it lists Opus/Sonnet 4.5, predating Claude 5. Merged
 > here verbatim for reference; reconcile on next sidekick sync.
 
 | Provider | Model | In $/M | Out $/M | Context | Notes |


### PR DESCRIPTION
## Summary

Fixes agents-config-9k9.215.13 (child of epic agents-config-9k9.215) — the model catalog (`docs/reference/model-catalog.md`) routed to a superseded roster through dead pointers.

- **M21**: The Anthropic section named "Claude 5 / Opus 4.8 family" with `claude-opus-4-8` as the top judgment tier and no Opus 5 row. Replaced with `claude-opus-5` (Opus 5) — verified as the current top Anthropic tier via cross-check against `claude-opus-5` already used in this repo's own test fixtures (`src/user/.agents/skills/review-verdict/validate_verdict_test.py`, `src/user/.claude/skills/review-panel/emit_prompts_test.py`) and the active session's own model enumeration. Added a "Roster captured 2026-08-09" note with a named re-verification route (harness model list / console.anthropic.com), mirroring the dated-snapshot convention already used by the `delegating-to-codex` and `openrouter-claude-subagent` sibling tables. Bumped the file's top-level "Last updated" date and reworded the now-stale "Opus-4.8-era" / "predating Opus 4.8" phrasing in the adjacent TBD-prices note and the Sidekick section for consistency.
- **L10**: Removed the dead "see the escalation-ladder spec" pointer (no such spec exists anywhere in `docs/specs/` or the repo) while keeping the substantive claim about user-space config it was attached to. Dropped the undefined "RALF cycle1" and "RALF-IT iter2" jargon from two routing rows (term is defined nowhere in the repo) rather than inventing a definition.

## Review round 1 fixes (post-open)

Three more standalone-read findings surfaced in PR review and are fixed on this branch:

- **"fablize" jargon**: the Fable 5 row's parenthetical "(fablize window work)" named a retired skill with no live definition anywhere under `src/`. Dropped the parenthetical rather than resurrecting archive content or inventing a definition; the row now reads "Frontier-tier spec closure."
- **Backend vocabulary + dead ID in Related section**: `Bead agents-config-uy5wx` used tracker-backend vocabulary and named an ID that doesn't resolve via `work show` or `work search`. It matches the archive-era short-code pattern the charter already documents and annotates elsewhere (`j8pdq`, `wgclw.30`, etc.) — applied the same phrasing: "archive-era, resolvable in the private archive repository and not through `work`," dropping "Bead."
- **Anthropic TBD-prices note**: reworded from an authoring-episode narration ("were not confirmed at authoring time — fill … later") to a current-fact statement ("stand unverified against the vendor page"), pointing at the re-verification route the roster callout above it already names.

## Review round 2 fixes (global-consistency lens)

Three more dead-pointer findings, same class this item exists to close:

- **Phantom config key**: the "Prices rot" callout cited `[providers.*.models.*].cost_per_mtok_*`, a key nothing in the tree reads, documents, or defines (repo-wide grep: only that one line). Pointed the sentence at the rate store that actually exists — `~/.config/agents-config/openrouter-model-registry.json` (`input_per_m`/`output_per_m` keys, documented in the `openrouter-claude-subagent` skill's `model-routing.md`) — and scoped the claim correctly: that registry covers OpenRouter-routed models only, and no equivalent override exists for the other providers in this doc.
- **"escalation-ladder example"**: this parenthetical on the `glm-5.2` row survived the earlier removal of the sibling "see the escalation-ladder spec" pointer and now resolved to nothing anywhere in the tree. Dropped.
- **Dead `project-config.toml [foreign-cli]` bullet**: the Related section cited a `[foreign-cli]` section that does not exist in `project-config.toml` (only a comment there stating foreign-CLI model selection is deliberately *not* configured in that file) and that the guide (`docs/guide/configuration.md:48`) documents as unread even when such sections are present. Dropped the bullet — the real per-stage binding already has its own correct bullet (the `delegating-to-codex` skill, cited two lines above).

## Review round 3 fixes (global lens, second pass)

Two more of the same dead-pointer class:

- **Phantom `codex-companion.mjs`**: the OpenAI section's invocation line named a file that exists nowhere in the tree (only a dated spec and this doc mentioned it). Repointed at the real route — dispatching the `codex-rescue` agent, per the `delegating-to-codex` skill already cited elsewhere in this file.
- **Stale `glm-5.2` ID and prices**: the catalog's own nominated OpenRouter reference (the `openrouter-claude-subagent` skill's `model-routing.md`) lists `z-ai/glm-5.2` at $0.76/$2.39; this file's bare `glm-5.2` at 0.60/2.20 had drifted from both the ID form and the prices. Aligned to the nominated reference.

## Review round 4 fix (scope clarification)

The global-consistency lens kept re-litigating a vendor-ID question round over round (prgroom dispatcher aliases like `opus[1m]`, `claude-fable-5` fixture coverage) by comparing this catalog's canonical vendor IDs against a different mechanism — harness invocation surfaces, which may accept their own aliases or flag forms for the same model. Rather than rebut the same class again, added one scoping line near the top of the file: this table lists each vendor's canonical model ID; a harness invocation surface's own docs govern its own alias/flag forms, not this table. No roster change — `claude-fable-5` stays (current vendor top-tier model; this catalog documents the roster, not per-tool invocation syntax).

## Consumer sweep (uncapped, all four rounds)

Grepped the full tree (excluding `.worktrees/`, the archive, and the dated recheck doc itself) for every string touched: `Opus 4.8` / `opus-4-8`, `RALF`, `escalation-ladder`, `model-catalog` (as a quoted/referenced filename), `fablize`, `agents-config-uy5wx`, `cost_per_mtok`, `[foreign-cli]` / `foreign-cli`, `codex-companion.mjs`, and `glm-5.2`. No other file in the repo references any of this changed text or the removed phantom identifiers — `model-catalog.md` has zero in-repo quoters, so no downstream edits were needed in any round. `codex-companion.mjs` still appears in one dated spec (`docs/specs/2026-07-24-review-contracts-s6.md`), left untouched — a historical reference outside this item's scope, not a live quoter of this catalog.

## Findings disposition

| Finding | Disposition |
|---|---|
| M21 | Fixed — Opus 5 / `claude-opus-5` now the top row, dated snapshot + re-verification route added |
| L10 | Fixed — escalation-ladder spec pointer removed, RALF/RALF-IT dropped from both rows |
| Review: "fablize" undefined jargon | Fixed — parenthetical dropped |
| Review: `agents-config-uy5wx` backend vocabulary + dead ID | Fixed — archive-era annotation, "Bead" dropped |
| Review: TBD-prices note narrates an authoring episode | Fixed — reworded to current-fact statement |
| Review: phantom `cost_per_mtok_*` config key | Fixed — pointed at the real OpenRouter registry, scoped correctly |
| Review: "escalation-ladder example" orphaned by round 1's fix | Fixed — dropped |
| Review: dead `project-config.toml [foreign-cli]` bullet | Fixed — bullet dropped |
| Review: phantom `codex-companion.mjs` invocation | Fixed — repointed at `codex-rescue` agent dispatch |
| Review: stale `glm-5.2` ID/prices | Fixed — aligned to the catalog's own nominated reference |
| Review: recurring vendor-ID-vs-invocation-alias re-litigation | Fixed — one scope line added; no roster change |

## Gates

- `make doc-lint` — exit 0 on all five rounds (206 pre-existing "not judged" citations elsewhere in the tree, unrelated to this change; no new citation issues from this diff)
- Prose-only change; no `packages/**` or `src/**` touched, so `make ci` / content gates don't apply

## Test plan

- [ ] Review-panel round per the epic's binding review contract (agents-config-9k9.215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


