### PR TITLE
fix(9k9.215.15): bound instruction-file backup accumulation

### DIFF
--- a/docs/architecture/installer/data-view.md
+++ b/docs/architecture/installer/data-view.md
@@ -228,7 +228,7 @@ flowchart LR
 | `StagingPlan` / `StagedItem` | **Installer** | One invocation | In-memory; gone when the process exits. `--dump-stage` materialises a throwaway copy. |
 | `Counters` / `Orphan` list | **Installer** | One invocation | Surfaced in the exit summary; not persisted. |
 | Destination stores | **Installer** writes → **Tool** reads | Permanent on disk | Single writer at install time; consumed asynchronously at each tool's runtime. |
-| Backups | **Installer** | Permanent on disk | Write-only recovery; never read back by the installer. |
+| Backups | **Installer** | Newest 5 per target, then pruned | Write-only recovery; never read back by the installer. Older backups of the same target are deleted the moment a new one is written (`core/backup.py`). |
 | Install receipt (`install-receipt.json` + `.lock`) | **Installer** | Permanent on disk (between runs) | The installer's own persisted state — read at prune start, rewritten at run end (mirrors disk). Trusted state behind an `integrity` digest; held under a single-writer advisory lock. |
 
 ### Explicit non-ownership

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -64,7 +64,10 @@ exactly this reason.
 
 `*.md.template` files install with the `.template` suffix stripped (e.g.
 `AGENTS.md.template` → `AGENTS.md`). Existing files get a diff preview and a
-timestamped backup before any overwrite.
+timestamped backup before any overwrite. Backups are retained, not kept
+forever: each file's own dated backups beyond the newest 5 are deleted the
+moment a new one is written, so repeated installs don't accumulate an
+unbounded pile of near-identical siblings.
 
 The installer also puts this repo's CLIs on your PATH via `uv tool install`
 (receipt-tracked, pruned on retirement). They are `prgroom`, `grind`,

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -38,9 +38,7 @@ _TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
 _TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
 
 # Newest backups kept per target; every older one is deleted the moment a new
-# backup is written for that same target. Arbitrary but generous: enough
-# history to recover from a bad install without unbounded per-file
-# accumulation. Stated for operators in docs/guide/getting-started.md.
+# backup is written for that same target.
 BACKUP_RETENTION_COUNT = 5
 
 

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -21,7 +21,6 @@ never left without a recoverable copy.
 
 from __future__ import annotations
 
-import glob
 import re
 import shutil
 from datetime import datetime
@@ -70,23 +69,35 @@ def _backup_path_for(target: Path, timestamp: str) -> Path:
 
 
 def _existing_backups(target: Path, backup_dir: Path) -> list[Path]:
-    """Every backup of ``target`` already sitting in ``backup_dir``, oldest first.
+    """Every retention-eligible backup of ``target`` already sitting in
+    ``backup_dir``, oldest first.
 
-    Matched by filename prefix (``<name>.backup-``), not by directory
-    provenance, so this counts a target's backups regardless of whether they
-    landed in-place or in a routed ``<namespace>-backup/`` dir — whichever
-    ``backup_dir`` the caller resolved. The ``YYYYMMDD-HHMMSS`` suffix sorts
-    lexicographically in chronological order, so a plain name sort is enough.
+    A candidate must start with the literal prefix ``<name>.backup-`` *and*
+    have everything after it satisfy ``valid_timestamp`` — the same contract
+    ``back_up`` enforces on every timestamp it writes. Matching is plain
+    string comparison, not a glob pattern, so a target name carrying a glob
+    metacharacter (``*``, ``?``, ``[...]``) needs no escaping and cannot
+    cross-match another target's backups. The timestamp check additionally
+    rejects two things a looser ``<name>.backup-*`` match would wrongly
+    accept: a hand-placed file that merely resembles a backup name (e.g.
+    ``AGENTS.md.backup-notes``), and a nested-name collision where one
+    target's own name is another target's name plus a backup suffix (target
+    ``X``'s prefix would otherwise also match target ``X.backup-old``'s own
+    backups, named ``X.backup-old.backup-<ts>``).
 
-    ``target.name`` is escaped (``glob.escape``) before it becomes part of the
-    glob pattern: a target whose own name carries a glob metacharacter (``*``,
-    ``?``, ``[...]``) would otherwise have that character interpreted as a
-    wildcard, matching — and in ``_prune_old_backups``, deleting — a different
-    target's backups sharing the same ``backup_dir``. Only the trailing
-    ``.backup-*`` suffix is a deliberate wildcard, over the timestamp.
+    Counts a target's backups regardless of whether they landed in-place or
+    in a routed ``<namespace>-backup/`` dir — whichever ``backup_dir`` the
+    caller resolved. The ``YYYYMMDD-HHMMSS`` suffix sorts lexicographically in
+    chronological order, so a plain name sort is enough.
     """
-    pattern = f"{glob.escape(target.name)}.backup-*"
-    return sorted(backup_dir.glob(pattern))
+    if not backup_dir.is_dir():
+        return []
+    prefix = f"{target.name}.backup-"
+    return sorted(
+        entry
+        for entry in backup_dir.iterdir()
+        if entry.name.startswith(prefix) and valid_timestamp(entry.name[len(prefix) :])
+    )
 
 
 def _prune_old_backups(target: Path, backup_dir: Path, *, keep: int) -> None:

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -21,6 +21,7 @@ never left without a recoverable copy.
 
 from __future__ import annotations
 
+import glob
 import re
 import shutil
 from datetime import datetime
@@ -39,10 +40,8 @@ _TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
 
 # Newest backups kept per target; every older one is deleted the moment a new
 # backup is written for that same target. Arbitrary but generous: enough
-# history to recover from a bad install without the unbounded per-file
-# accumulation the deployed surface showed (some instruction files had
-# collected dozens of dated siblings). Stated for operators in
-# docs/guide/getting-started.md.
+# history to recover from a bad install without unbounded per-file
+# accumulation. Stated for operators in docs/guide/getting-started.md.
 BACKUP_RETENTION_COUNT = 5
 
 
@@ -78,8 +77,16 @@ def _existing_backups(target: Path, backup_dir: Path) -> list[Path]:
     landed in-place or in a routed ``<namespace>-backup/`` dir — whichever
     ``backup_dir`` the caller resolved. The ``YYYYMMDD-HHMMSS`` suffix sorts
     lexicographically in chronological order, so a plain name sort is enough.
+
+    ``target.name`` is escaped (``glob.escape``) before it becomes part of the
+    glob pattern: a target whose own name carries a glob metacharacter (``*``,
+    ``?``, ``[...]``) would otherwise have that character interpreted as a
+    wildcard, matching — and in ``_prune_old_backups``, deleting — a different
+    target's backups sharing the same ``backup_dir``. Only the trailing
+    ``.backup-*`` suffix is a deliberate wildcard, over the timestamp.
     """
-    return sorted(backup_dir.glob(f"{target.name}.backup-*"))
+    pattern = f"{glob.escape(target.name)}.backup-*"
+    return sorted(backup_dir.glob(pattern))
 
 
 def _prune_old_backups(target: Path, backup_dir: Path, *, keep: int) -> None:

--- a/packages/installer/src/installer/core/backup.py
+++ b/packages/installer/src/installer/core/backup.py
@@ -10,6 +10,13 @@ pass a value matching the ``YYYYMMDD-HHMMSS`` contract; ``new_timestamp``
 produces one and ``valid_timestamp`` validates a caller-supplied value before
 it reaches the filesystem (a value carrying ``../`` would otherwise escape the
 backup directory).
+
+Retention: every call to ``back_up`` prunes that target's own older backups
+down to the newest ``BACKUP_RETENTION_COUNT``, so repeated installs or prunes
+of the same file do not accumulate dated siblings without bound. The prune is
+per-target (keyed on the backup filename, which embeds the original name) and
+never removes the newest surviving backup, so a target backed up only once is
+never left without a recoverable copy.
 """
 
 from __future__ import annotations
@@ -29,6 +36,14 @@ _TIMESTAMP_FORMAT = "%Y%m%d-%H%M%S"
 # carrying path separators (``../``) would split into Path components and write
 # the backup outside the intended directory.
 _TIMESTAMP_RE = re.compile(r"^\d{8}-\d{6}$")
+
+# Newest backups kept per target; every older one is deleted the moment a new
+# backup is written for that same target. Arbitrary but generous: enough
+# history to recover from a bad install without the unbounded per-file
+# accumulation the deployed surface showed (some instruction files had
+# collected dozens of dated siblings). Stated for operators in
+# docs/guide/getting-started.md.
+BACKUP_RETENTION_COUNT = 5
 
 
 def new_timestamp() -> str:
@@ -55,6 +70,36 @@ def _backup_path_for(target: Path, timestamp: str) -> Path:
     return target.with_name(f"{target.name}.backup-{timestamp}")
 
 
+def _existing_backups(target: Path, backup_dir: Path) -> list[Path]:
+    """Every backup of ``target`` already sitting in ``backup_dir``, oldest first.
+
+    Matched by filename prefix (``<name>.backup-``), not by directory
+    provenance, so this counts a target's backups regardless of whether they
+    landed in-place or in a routed ``<namespace>-backup/`` dir — whichever
+    ``backup_dir`` the caller resolved. The ``YYYYMMDD-HHMMSS`` suffix sorts
+    lexicographically in chronological order, so a plain name sort is enough.
+    """
+    return sorted(backup_dir.glob(f"{target.name}.backup-*"))
+
+
+def _prune_old_backups(target: Path, backup_dir: Path, *, keep: int) -> None:
+    """Delete every backup of ``target`` in ``backup_dir`` beyond the newest ``keep``.
+
+    ``keep`` is floored at 1 so a misconfigured non-positive value can never
+    delete a target's last remaining backup. A no-op whenever there are ``keep``
+    or fewer backups to begin with.
+    """
+    keep = max(keep, 1)
+    existing = _existing_backups(target, backup_dir)
+    if len(existing) <= keep:
+        return
+    for stale in existing[: len(existing) - keep]:
+        if stale.is_dir():
+            shutil.rmtree(stale)
+        else:
+            stale.unlink()
+
+
 def back_up(target: Path, timestamp: str) -> Path:
     """Copy ``target`` (file or directory) to its timestamped backup; return the path.
 
@@ -67,6 +112,9 @@ def back_up(target: Path, timestamp: str) -> Path:
     ``<namespace>-backup/``; else in-place), creating the backup dir as needed.
     Directories are copied recursively (``shutil.copytree``), files via
     ``shutil.copy2``.
+
+    After the copy, prunes ``target``'s own older backups down to the newest
+    ``BACKUP_RETENTION_COUNT`` (the retention policy — see module docstring).
     """
     if not valid_timestamp(timestamp):
         raise ValueError(f"timestamp must be YYYYMMDD-HHMMSS: {timestamp!r}")  # noqa: TRY003  # single call-site
@@ -76,4 +124,5 @@ def back_up(target: Path, timestamp: str) -> Path:
         shutil.copytree(target, dest)
     else:
         shutil.copy2(target, dest)
+    _prune_old_backups(target, dest.parent, keep=BACKUP_RETENTION_COUNT)
     return dest

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -99,21 +99,26 @@ def test_back_up_retention_is_scoped_per_target_within_a_shared_backup_dir(
 ) -> None:
     """
     Given two different targets whose backups route to the same sibling
-    <namespace>-backup/ directory
+    <namespace>-backup/ directory, with one target's backups created in
+    REVERSE timestamp order (newest first, oldest last)
     When one target accumulates more backups than the retention count
-    Then only that target's own excess backups are pruned — the other
-    target's lone backup is untouched.
+    Then only that target's own excess backups are pruned, by timestamp
+    VALUE rather than creation order — the other target's lone backup is
+    untouched.
 
     Pins that pruning is keyed on the backed-up file's own name, not on
     everything sharing its backup directory (a routed backup dir like
     skills-backup/ holds many unrelated skills' backups side by side).
+    Reverse-order creation is deliberate, matching the in-place retention
+    test above: it distinguishes sorting by the filename-embedded timestamp
+    value (correct) from sorting by creation order (wrong).
     """
     busy = tmp_path / ".claude" / "skills" / "busy"
     quiet = tmp_path / ".claude" / "skills" / "quiet"
     busy.parent.mkdir(parents=True)
     quiet.write_text("quiet-v0")
 
-    for ts in _TIMESTAMPS:
+    for ts in reversed(_TIMESTAMPS):
         busy.write_text(f"busy-{ts}")
         back_up(busy, ts)
     back_up(quiet, _TIMESTAMPS[0])
@@ -250,6 +255,13 @@ def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
     target.write_text("v0")
 
     back_up(target, _TIMESTAMPS[0])
+
+    # The lone-backup case, pinned on its own before a second backup exists:
+    # a single backup must never be pruned away, regardless of what a
+    # misconfigured retention count says.
+    first_backup = tmp_path / f"AGENTS.md.backup-{_TIMESTAMPS[0]}"
+    assert list(tmp_path.glob("AGENTS.md.backup-*")) == [first_backup]
+
     target.write_text("v1")
     back_up(target, _TIMESTAMPS[1])
 
@@ -265,12 +277,6 @@ def test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet
     Given a backup_dir that has never been created
     When _existing_backups is asked for a target's backups in it
     Then it returns an empty list rather than raising.
-
-    ``back_up`` always creates the backup dir (``mkdir``) before calling this,
-    so the public API never exercises this branch on its own — but
-    ``_existing_backups`` uses ``Path.iterdir``, which raises
-    ``FileNotFoundError`` on a directory that doesn't exist, so this guard is
-    needed to keep the helper safe to call standalone.
     """
     target = tmp_path / "AGENTS.md"
     missing_backup_dir = tmp_path / "does-not-exist"

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -155,6 +155,71 @@ def test_back_up_treats_glob_metacharacters_in_a_target_name_literally(
     assert f"noteX.backup-{_TIMESTAMPS[0]}" in all_names
 
 
+def test_back_up_ignores_a_backup_shaped_file_with_a_non_timestamp_suffix(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a hand-placed file that merely resembles a backup name — the text
+    after ``.backup-`` is not a well-formed timestamp
+    When the real target accumulates enough real backups to trigger pruning
+    Then the hand-placed file is never counted toward retention and is never
+    pruned — it survives untouched.
+
+    Pins the timestamp-suffix check: a looser ``<name>.backup-*`` match would
+    treat a file like ``AGENTS.md.backup-notes`` as one of AGENTS.md's own
+    dated backups.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("v0")
+    decoy = tmp_path / "AGENTS.md.backup-notes"
+    decoy.write_text("hand-written notes, not a backup")
+
+    for ts in _TIMESTAMPS:
+        target.write_text(f"content-{ts}")
+        back_up(target, ts)
+
+    assert decoy.read_text() == "hand-written notes, not a backup"
+    all_backup_like = sorted(p.name for p in tmp_path.glob("AGENTS.md.backup-*"))
+    real_survivors = [n for n in all_backup_like if n != decoy.name]
+    expected = [f"AGENTS.md.backup-{ts}" for ts in _TIMESTAMPS[-BACKUP_RETENTION_COUNT:]]
+    assert real_survivors == expected
+    assert decoy.name in all_backup_like
+
+
+def test_back_up_does_not_cross_match_a_nested_name_collision(tmp_path: Path) -> None:
+    """
+    Given two distinct targets sharing a backup directory, where one target's
+    own name equals another target's name plus a backup suffix (targets
+    "note" and "note.backup-old")
+    When the shorter-named target accumulates enough backups to trigger
+    pruning
+    Then the longer-named target's own backups (named
+    "note.backup-old.backup-<ts>") are never counted toward "note"'s
+    retention and are never pruned by it.
+
+    Without the timestamp-suffix check, "note.backup-old.backup-<ts>" starts
+    with "note"'s own prefix ("note.backup-"), so an unconstrained prefix (or
+    escaped-glob) match would sweep it into "note"'s retention set.
+    """
+    note = tmp_path / ".claude" / "skills" / "note"
+    collider = tmp_path / ".claude" / "skills" / "note.backup-old"
+    note.parent.mkdir(parents=True)
+    collider.write_text("collider-v0")
+    back_up(collider, _TIMESTAMPS[0])
+
+    for ts in _TIMESTAMPS[1:]:
+        note.write_text(f"note-{ts}")
+        back_up(note, ts)
+
+    backup_dir = tmp_path / ".claude" / "skills-backup"
+    all_names = sorted(p.name for p in backup_dir.iterdir())
+    collider_backup = f"note.backup-old.backup-{_TIMESTAMPS[0]}"
+    expected_note_backups = [
+        f"note.backup-{ts}" for ts in _TIMESTAMPS[1:][-BACKUP_RETENTION_COUNT:]
+    ]
+    assert all_names == sorted([collider_backup, *expected_note_backups])
+
+
 @pytest.mark.parametrize("retention_count", [0, -1])
 def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, retention_count: int
@@ -184,6 +249,27 @@ def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
     survivors = list(tmp_path.glob("AGENTS.md.backup-*"))
     assert survivors == [tmp_path / f"AGENTS.md.backup-{_TIMESTAMPS[1]}"]
     assert survivors[0].read_text() == "v1"
+
+
+def test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a backup_dir that has never been created
+    When _existing_backups is asked for a target's backups in it
+    Then it returns an empty list rather than raising.
+
+    ``back_up`` always creates the backup dir (``mkdir``) before calling this,
+    so the public API never exercises this branch on its own — but the helper
+    is documented and used standalone by ``_prune_old_backups``, and must
+    match the previous glob-based implementation's behaviour on a missing
+    directory (``Path.glob`` never raised there either); ``Path.iterdir``
+    would raise ``FileNotFoundError`` without this guard.
+    """
+    target = tmp_path / "AGENTS.md"
+    missing_backup_dir = tmp_path / "does-not-exist"
+
+    assert backup_module._existing_backups(target, missing_backup_dir) == []
 
 
 def test_backup_retention_count_is_5() -> None:

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -99,29 +99,40 @@ def test_back_up_retention_is_scoped_per_target_within_a_shared_backup_dir(
 ) -> None:
     """
     Given two different targets whose backups route to the same sibling
-    <namespace>-backup/ directory, with one target's backups created in
-    REVERSE timestamp order (newest first, oldest last)
-    When one target accumulates more backups than the retention count
-    Then only that target's own excess backups are pruned, by timestamp
-    VALUE rather than creation order — the other target's lone backup is
-    untouched.
+    <namespace>-backup/ directory — quiet's lone backup (at the globally
+    OLDEST timestamp used anywhere in this test) already exists before busy
+    accumulates its own backups in REVERSE timestamp order (newest first,
+    oldest last)
+    When busy is pruned repeatedly as it accumulates more backups than the
+    retention count
+    Then only busy's own excess backups are pruned, by timestamp VALUE
+    rather than creation order — quiet's backup, present throughout every
+    one of busy's prune cycles and old enough to be an easy target, is
+    never touched.
 
     Pins that pruning is keyed on the backed-up file's own name, not on
     everything sharing its backup directory (a routed backup dir like
     skills-backup/ holds many unrelated skills' backups side by side).
-    Reverse-order creation is deliberate, matching the in-place retention
-    test above: it distinguishes sorting by the filename-embedded timestamp
-    value (correct) from sorting by creation order (wrong).
+    Quiet's backup is created FIRST specifically so it is exposed to every
+    one of busy's prune cycles, not created only after busy has finished
+    pruning — an implementation that scoped pruning to the shared directory
+    as a whole, rather than to the target's own name, would otherwise have
+    nothing else in the directory to wrongly sweep up when it ran. Giving
+    quiet the globally oldest timestamp makes it the first casualty such an
+    unscoped implementation would take. Reverse-order creation of busy's own
+    backups is separately deliberate: it distinguishes sorting by the
+    filename-embedded timestamp value (correct) from sorting by creation
+    order (wrong).
     """
     busy = tmp_path / ".claude" / "skills" / "busy"
     quiet = tmp_path / ".claude" / "skills" / "quiet"
     busy.parent.mkdir(parents=True)
     quiet.write_text("quiet-v0")
+    back_up(quiet, _TIMESTAMPS[0])
 
     for ts in reversed(_TIMESTAMPS):
         busy.write_text(f"busy-{ts}")
         back_up(busy, ts)
-    back_up(quiet, _TIMESTAMPS[0])
 
     backup_dir = tmp_path / ".claude" / "skills-backup"
     busy_survivors = sorted(p.name for p in backup_dir.glob("busy.backup-*"))

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -68,17 +68,24 @@ def test_back_up_with_valid_timestamp_writes_recoverable_copy(tmp_path: Path) ->
 
 def test_back_up_prunes_in_place_backups_beyond_retention_count(tmp_path: Path) -> None:
     """
-    Given a target whose backups land in-place (parent not a BACKUP namespace)
+    Given a target whose backups land in-place (parent not a BACKUP namespace),
+    created in REVERSE timestamp order (newest first, oldest last)
     When back_up is called more times than BACKUP_RETENTION_COUNT
-    Then only the newest BACKUP_RETENTION_COUNT backups survive.
+    Then only the backups with the newest BACKUP_RETENTION_COUNT timestamp
+    VALUES survive — regardless of the order they were created in.
 
     Pins the retention policy on the in-place branch — a flat instruction file
     like AGENTS.md must not accumulate one dated sibling per install forever.
+    Creating in reverse order is deliberate: it distinguishes sorting by the
+    filename-embedded timestamp value (correct) from sorting by directory
+    iteration or creation order (wrong) — under creation-order sorting, this
+    exact input would keep the OLDEST timestamps and discard the newest,
+    the opposite of what's asserted below.
     """
     target = tmp_path / "AGENTS.md"
     target.write_text("v0")
 
-    for ts in _TIMESTAMPS:
+    for ts in reversed(_TIMESTAMPS):
         target.write_text(f"content-{ts}")
         back_up(target, ts)
 
@@ -260,11 +267,10 @@ def test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet
     Then it returns an empty list rather than raising.
 
     ``back_up`` always creates the backup dir (``mkdir``) before calling this,
-    so the public API never exercises this branch on its own — but the helper
-    is documented and used standalone by ``_prune_old_backups``, and must
-    match the previous glob-based implementation's behaviour on a missing
-    directory (``Path.glob`` never raised there either); ``Path.iterdir``
-    would raise ``FileNotFoundError`` without this guard.
+    so the public API never exercises this branch on its own — but
+    ``_existing_backups`` uses ``Path.iterdir``, which raises
+    ``FileNotFoundError`` on a directory that doesn't exist, so this guard is
+    needed to keep the helper safe to call standalone.
     """
     target = tmp_path / "AGENTS.md"
     missing_backup_dir = tmp_path / "does-not-exist"

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -4,7 +4,9 @@ Each test pins a coded decision in ``back_up`` / ``valid_timestamp``, the shared
 path-aware backup placement used by both sync and prune. The focus here is the
 safe-by-default validation boundary: ``back_up`` rejects a malformed timestamp
 itself, so a caller cannot interpolate a path-traversing value into the backup
-path by forgetting to pre-validate.
+path by forgetting to pre-validate. The retention tests below pin the second
+coded decision: repeated backups of the same target do not accumulate without
+bound, and the newest backup of a target is never the one deleted.
 """
 
 from __future__ import annotations
@@ -13,9 +15,14 @@ from pathlib import Path
 
 import pytest
 
-from installer.core.backup import back_up
+from installer.core import backup as backup_module
+from installer.core.backup import BACKUP_RETENTION_COUNT, back_up
 
 _TS = "20250101-120000"
+
+# Ascending timestamps, one per second, well-formed against the
+# YYYYMMDD-HHMMSS contract so `back_up` accepts every one of them.
+_TIMESTAMPS = [f"20250101-1200{i:02d}" for i in range(BACKUP_RETENTION_COUNT + 3)]
 
 
 def test_back_up_rejects_malformed_timestamp_before_any_io(tmp_path: Path) -> None:
@@ -57,3 +64,110 @@ def test_back_up_with_valid_timestamp_writes_recoverable_copy(tmp_path: Path) ->
 
     assert dest == tmp_path / ".claude" / "skills-backup" / f"retired.backup-{_TS}"
     assert dest.read_text() == "precious"
+
+
+def test_back_up_prunes_in_place_backups_beyond_retention_count(tmp_path: Path) -> None:
+    """
+    Given a target whose backups land in-place (parent not a BACKUP namespace)
+    When back_up is called more times than BACKUP_RETENTION_COUNT
+    Then only the newest BACKUP_RETENTION_COUNT backups survive.
+
+    Pins the retention policy on the in-place branch — an instruction file like
+    a flat AGENTS.md, the exact shape the deployed-surface finding named, must
+    not accumulate one dated sibling per install forever.
+    """
+    target = tmp_path / "AGENTS.md"
+    target.write_text("v0")
+
+    for ts in _TIMESTAMPS:
+        target.write_text(f"content-{ts}")
+        back_up(target, ts)
+
+    survivors = sorted(p.name for p in tmp_path.glob("AGENTS.md.backup-*"))
+    expected = [f"AGENTS.md.backup-{ts}" for ts in _TIMESTAMPS[-BACKUP_RETENTION_COUNT:]]
+    assert survivors == expected
+
+
+def test_back_up_retention_is_scoped_per_target_within_a_shared_backup_dir(
+    tmp_path: Path,
+) -> None:
+    """
+    Given two different targets whose backups route to the same sibling
+    <namespace>-backup/ directory
+    When one target accumulates more backups than the retention count
+    Then only that target's own excess backups are pruned — the other
+    target's lone backup is untouched.
+
+    Pins that pruning is keyed on the backed-up file's own name, not on
+    everything sharing its backup directory (a routed backup dir like
+    skills-backup/ holds many unrelated skills' backups side by side).
+    """
+    busy = tmp_path / ".claude" / "skills" / "busy"
+    quiet = tmp_path / ".claude" / "skills" / "quiet"
+    busy.parent.mkdir(parents=True)
+    quiet.write_text("quiet-v0")
+
+    for ts in _TIMESTAMPS:
+        busy.write_text(f"busy-{ts}")
+        back_up(busy, ts)
+    back_up(quiet, _TIMESTAMPS[0])
+
+    backup_dir = tmp_path / ".claude" / "skills-backup"
+    busy_survivors = sorted(p.name for p in backup_dir.glob("busy.backup-*"))
+    expected = [f"busy.backup-{ts}" for ts in _TIMESTAMPS[-BACKUP_RETENTION_COUNT:]]
+    assert busy_survivors == expected
+    assert (backup_dir / f"quiet.backup-{_TIMESTAMPS[0]}").exists()
+
+
+def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Given a target with exactly one backup and a misconfigured non-positive
+    retention count
+    When back_up is called again for that same target
+    Then the newest backup still survives — the floor of 1 holds regardless of
+    the configured count.
+
+    Pins the safety floor: a target must never be left with zero recoverable
+    backups, even if BACKUP_RETENTION_COUNT were set to 0 or negative.
+    """
+    monkeypatch.setattr(backup_module, "BACKUP_RETENTION_COUNT", 0)
+    target = tmp_path / "AGENTS.md"
+    target.write_text("v0")
+
+    back_up(target, _TIMESTAMPS[0])
+    target.write_text("v1")
+    back_up(target, _TIMESTAMPS[1])
+
+    survivors = list(tmp_path.glob("AGENTS.md.backup-*"))
+    assert survivors == [tmp_path / f"AGENTS.md.backup-{_TIMESTAMPS[1]}"]
+    assert survivors[0].read_text() == "v1"
+
+
+def test_back_up_prunes_stale_directory_backups_recursively(tmp_path: Path) -> None:
+    """
+    Given a directory target backed up more times than BACKUP_RETENTION_COUNT
+    When back_up is called each time
+    Then a pruned directory backup is removed recursively (rmtree), not left
+    behind as an unremovable non-empty directory.
+
+    A directory backup (``shutil.copytree``) is a tree, not a file — pruning it
+    needs ``shutil.rmtree`` rather than ``Path.unlink``, which raises on a
+    directory. This pins that branch specifically, distinct from the file-target
+    retention tests above.
+    """
+    target = tmp_path / ".claude" / "skills" / "retired"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("v0")
+
+    for ts in _TIMESTAMPS:
+        (target / "SKILL.md").write_text(f"content-{ts}")
+        back_up(target, ts)
+
+    backup_dir = tmp_path / ".claude" / "skills-backup"
+    survivors = sorted(p.name for p in backup_dir.glob("retired.backup-*"))
+    expected = [f"retired.backup-{ts}" for ts in _TIMESTAMPS[-BACKUP_RETENTION_COUNT:]]
+    assert survivors == expected
+    # The pruned (oldest) backup is gone entirely, not left as an empty dir.
+    assert not (backup_dir / f"retired.backup-{_TIMESTAMPS[0]}").exists()

--- a/packages/installer/tests/unit/test_backup.py
+++ b/packages/installer/tests/unit/test_backup.py
@@ -4,9 +4,9 @@ Each test pins a coded decision in ``back_up`` / ``valid_timestamp``, the shared
 path-aware backup placement used by both sync and prune. The focus here is the
 safe-by-default validation boundary: ``back_up`` rejects a malformed timestamp
 itself, so a caller cannot interpolate a path-traversing value into the backup
-path by forgetting to pre-validate. The retention tests below pin the second
-coded decision: repeated backups of the same target do not accumulate without
-bound, and the newest backup of a target is never the one deleted.
+path by forgetting to pre-validate. The retention tests below pin retention
+itself: repeated backups of the same target do not accumulate without bound,
+and the newest backup of a target is never the one deleted.
 """
 
 from __future__ import annotations
@@ -72,9 +72,8 @@ def test_back_up_prunes_in_place_backups_beyond_retention_count(tmp_path: Path) 
     When back_up is called more times than BACKUP_RETENTION_COUNT
     Then only the newest BACKUP_RETENTION_COUNT backups survive.
 
-    Pins the retention policy on the in-place branch — an instruction file like
-    a flat AGENTS.md, the exact shape the deployed-surface finding named, must
-    not accumulate one dated sibling per install forever.
+    Pins the retention policy on the in-place branch — a flat instruction file
+    like AGENTS.md must not accumulate one dated sibling per install forever.
     """
     target = tmp_path / "AGENTS.md"
     target.write_text("v0")
@@ -119,20 +118,62 @@ def test_back_up_retention_is_scoped_per_target_within_a_shared_backup_dir(
     assert (backup_dir / f"quiet.backup-{_TIMESTAMPS[0]}").exists()
 
 
+def test_back_up_treats_glob_metacharacters_in_a_target_name_literally(
+    tmp_path: Path,
+) -> None:
+    """
+    Given a target whose own name contains a glob metacharacter (``*``),
+    sharing a backup directory with an unrelated target whose name that
+    wildcard would incorrectly also match
+    When the metacharacter-bearing target's backups are pruned
+    Then only its own literal name is matched — the unrelated target's
+    backup, which an unescaped ``*`` wildcard would sweep in as a false
+    match, survives untouched.
+
+    Not a hypothetical input: this repo ships a real file named
+    ``*.instructions.md`` (`.github/instructions/`). ``_existing_backups``
+    must treat ``target.name`` as a literal string, not a pattern.
+    """
+    weird = tmp_path / ".claude" / "skills" / "note*"
+    decoy = tmp_path / ".claude" / "skills" / "noteX"
+    weird.parent.mkdir(parents=True)
+    # An unescaped "note*.backup-*" pattern also matches "noteX.backup-<ts>",
+    # so the decoy must exist *before* weird's retention-triggering loop runs
+    # for the false match to have anything to sweep up.
+    decoy.write_text("decoy-v0")
+    back_up(decoy, _TIMESTAMPS[0])
+
+    for ts in _TIMESTAMPS[1:]:
+        weird.write_text(f"weird-{ts}")
+        back_up(weird, ts)
+
+    backup_dir = tmp_path / ".claude" / "skills-backup"
+    all_names = sorted(p.name for p in backup_dir.iterdir())
+    weird_survivors = [n for n in all_names if n.startswith("note*.backup-")]
+    expected = [f"note*.backup-{ts}" for ts in _TIMESTAMPS[1:][-BACKUP_RETENTION_COUNT:]]
+    assert weird_survivors == expected
+    assert f"noteX.backup-{_TIMESTAMPS[0]}" in all_names
+
+
+@pytest.mark.parametrize("retention_count", [0, -1])
 def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, retention_count: int
 ) -> None:
     """
     Given a target with exactly one backup and a misconfigured non-positive
-    retention count
+    retention count (zero, or negative)
     When back_up is called again for that same target
     Then the newest backup still survives — the floor of 1 holds regardless of
     the configured count.
 
-    Pins the safety floor: a target must never be left with zero recoverable
-    backups, even if BACKUP_RETENTION_COUNT were set to 0 or negative.
+    Pins the safety floor (``max(keep, 1)`` in ``_prune_old_backups``): a
+    target must never be left with zero recoverable backups, whether
+    ``BACKUP_RETENTION_COUNT`` were misconfigured to exactly 0 or to something
+    negative. Without the floor either value would prune every existing
+    backup (``len(existing) <= keep`` is false for both, so the loop would
+    run and take everything), so both are covered here rather than only 0.
     """
-    monkeypatch.setattr(backup_module, "BACKUP_RETENTION_COUNT", 0)
+    monkeypatch.setattr(backup_module, "BACKUP_RETENTION_COUNT", retention_count)
     target = tmp_path / "AGENTS.md"
     target.write_text("v0")
 
@@ -143,6 +184,16 @@ def test_back_up_never_deletes_the_only_backup_even_with_non_positive_retention(
     survivors = list(tmp_path.glob("AGENTS.md.backup-*"))
     assert survivors == [tmp_path / f"AGENTS.md.backup-{_TIMESTAMPS[1]}"]
     assert survivors[0].read_text() == "v1"
+
+
+def test_backup_retention_count_is_5() -> None:
+    """
+    Pins the retention policy's actual number. The other retention tests
+    derive their expected survivor counts from ``BACKUP_RETENTION_COUNT``
+    itself, so a change to that constant would pass them silently; this test
+    is the one place a change to the number is itself a visible pin.
+    """
+    assert BACKUP_RETENTION_COUNT == 5
 
 
 def test_back_up_prunes_stale_directory_backups_recursively(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `agents-config-9k9.215.15` (child of epic `agents-config-9k9.215`): the L16 recheck finding — `back_up()` and the prune flow capped nothing, so deployed trees accumulated dozens of near-identical dated `AGENTS.md.backup-*` siblings per file with no bound.
- Adds a retention policy directly to `installer.core.backup.back_up()` — the single function both `sync.py` (overwrite backups) and `prune_flow.py` (delete backups) route through — so every caller gets it automatically. After each write, a target's own older timestamped backups are pruned down to the newest `BACKUP_RETENTION_COUNT` (5), keyed by the backup filename so it works identically for the in-place `<name>.backup-<ts>` case and the routed `<namespace>-backup/` case.
- Floor of 1 (`max(keep, 1)`) guarantees a target is never left with zero recoverable backups, even under a misconfigured non-positive retention count.
- Documented in `docs/guide/getting-started.md` (the line already describing backup-on-overwrite behavior) and `docs/architecture/installer/data-view.md`'s ownership table (see addendum 1 below).

## Consumer sweep (uncapped)

`docs/guide/getting-started.md`'s backup sentence is the only text I changed initially. Grepped the whole tree (not just `docs/`) for paraphrases/quotes of "timestamped backup" / backup-on-overwrite behavior:

- `README.md:192` — "Creates timestamped backups before overwriting anything." Still accurate (backups are still created before every overwrite); it just doesn't state the retention count, matching the terse one-line-per-bullet style of the rest of that feature list. Left unchanged.
- `docs/architecture/installer/{c4-l2-container,c4-l3-engine,sequences,installer-design}.md` describe the backup *routing* mechanism (in-place vs `<namespace>-backup/`) at a level of abstraction that never mentioned a lifetime/count to begin with — no changes needed.
- `docs/architecture/installer/data-view.md` — **missed on the first pass, caught by review**: its ownership table asserted `Backups | **Installer** | Permanent on disk | ...` — a lifetime claim, not a count, so my original count-only grep didn't catch it. Now contradicted by the retention policy. Fixed (see addendum 1).
- No other prose or code comment quotes the edited sentences.

## Addendum 1 (review round 1: prose lenses)

Review flagged `data-view.md:231`'s "Permanent on disk" lifetime cell for Backups as now false. Fixed:

```diff
-| Backups | **Installer** | Permanent on disk | Write-only recovery; never read back by the installer. |
+| Backups | **Installer** | Newest 5 per target, then pruned | Write-only recovery; never read back by the installer. Older backups of the same target are deleted the moment a new one is written (`core/backup.py`). |
```

Checked the two neighboring rows (`Destination stores`, `Install receipt`) for the same class of claim — both describe genuinely permanent installer-owned state (deployed files, the receipt file) and are unaffected by this change. `doc-lint` run standalone after the fix: exit 0.

## Addendum 2 (review round 1: code lenses)

Five findings, one a real correctness bug:

1. **Bug, fixed.** `_existing_backups()` interpolated `target.name` into a glob pattern unescaped. A target name carrying a glob metacharacter (`*`, `?`, `[...]`) would have that character interpreted as a wildcard against everything else in the same routed `<namespace>-backup/` directory — cross-matching, and via `_prune_old_backups`, deleting an unrelated target's backups. Not hypothetical: this repo ships a real file named `*.instructions.md` (`.github/instructions/`). Fixed by escaping `target.name` with `glob.escape()` before building the pattern; only the trailing `.backup-*` suffix stays a deliberate wildcard. New test `test_back_up_treats_glob_metacharacters_in_a_target_name_literally` proves cross-target isolation — mutation-tested by reverting the escape locally and confirming the test fails without it.
2. **Test-adequacy, fixed.** The retention tests derived their expected survivor counts from `BACKUP_RETENTION_COUNT` itself, so a changed constant would pass them silently. Added `test_backup_retention_count_is_5`, which pins the literal value.
3. **Test-adequacy, fixed.** The non-positive-retention floor test covered only `0`. Parametrized it over `[0, -1]` — verified both values actually exercise the floor doing work (without `max(keep, 1)`, either would prune every existing backup, not just fail an unfloored check).
4. **Documentation-quality, fixed.** `backup.py`'s `BACKUP_RETENTION_COUNT` comment narrated the deployed-surface finding's specific numbers ("dozens of dated siblings"). Trimmed to state the current rationale (avoid unbounded accumulation) without the history.
5. **Documentation-quality, fixed.** `test_backup.py`'s module docstring and one test docstring referenced "the second coded decision" and "the exact shape the deployed-surface finding named" — episode language. Reworded to state what each pins directly.

## Addendum 3 (review round 1: security lens, refining addendum 2 finding 1)

The security lens went further on the same defect family: escaping `target.name` (addendum 2, finding 1) stops a metacharacter from cross-matching, but the trailing `.backup-*` wildcard still accepted **any** suffix, not just a real timestamp — so the prune set could still swallow:
- a hand-placed file merely shaped like a backup name (`AGENTS.md.backup-notes`, `X.backup-2025`), or
- a **nested-name collision**: target `X.backup-old`'s own backups (`X.backup-old.backup-<ts>`) match target `X`'s pattern too, since `X.backup-` is a literal prefix of that name.

Fixed by dropping the glob approach entirely. `_existing_backups` now matches by plain string prefix (`<name>.backup-`) and validates everything after it against `valid_timestamp` — the module's own pre-existing `YYYYMMDD-HHMMSS` contract (`_TIMESTAMP_RE`), reused rather than re-invented. This closes both gaps at once (no glob semantics left to exploit) and removes the `glob` import.

Added tests for both new cases — `test_back_up_ignores_a_backup_shaped_file_with_a_non_timestamp_suffix` and `test_back_up_does_not_cross_match_a_nested_name_collision` — and mutation-tested both against the addendum-2-only implementation to confirm they fail without this fix (they do; the collider file gets swept into the "note" target's retention count and one of the collider's own backups goes missing). Also added `test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet`, since switching from `Path.glob` (never raises on a missing dir) to `Path.iterdir` (raises `FileNotFoundError`) needed an explicit guard, and that guard was otherwise unreachable from the public `back_up()` API (which always `mkdir`s the backup dir first) — closing a coverage gap the switch introduced.

The guide's existing "dated backups" wording (`docs/guide/getting-started.md`) already matches this precisely now — no doc change needed there.

## Addendum 4 (review round 2)

Two fixes, one rebuttal:

1. **Test-adequacy, fixed.** `test_back_up_prunes_in_place_backups_beyond_retention_count` created backups in ascending timestamp order *and* creation/call order simultaneously, so an implementation that sorted by directory-iteration or creation order (instead of the filename-embedded timestamp value) would have passed it too. Changed the loop to create backups in **reverse** timestamp order (newest first, oldest last). Mutation-tested against a deliberately buggy creation-order sort (`key=lambda p: p.stat().st_ctime_ns`) — confirmed the test now fails against it (survivors come back as the *oldest* timestamps instead of the newest), then restored the correct implementation.
2. **Documentation-quality, fixed.** `test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet`'s docstring referenced "the previous glob-based implementation." Reworded to state the current contract only: `_existing_backups` uses `Path.iterdir`, which raises on a missing directory, so the guard is needed.

**Rebutted by the team lead, not mine to action:** the security lens's objection that any file matching `<name>.backup-<valid-timestamp>` is treated as that target's backup without provenance. The naming contract *is* the identity mechanism and is unchanged in kind from before this PR (and the deletion scope is now strictly narrower); a provenance manifest is out of this item's remit. Ledgered separately.

## Addendum 5 (review round 3 — terminal)

Two test-adequacy fixes, two doc-quality trims, one rebuttal:

1. **Test-adequacy, fixed.** The non-positive-retention floor test only ever asserted the end state after a *second* backup existed, so the lone-backup case it's named for was never observed in isolation. Added an assertion right after the first backup (before any second exists) that the lone backup survives, then continued into the existing two-backup flow.
2. **Test-adequacy, fixed.** `test_back_up_retention_is_scoped_per_target_within_a_shared_backup_dir` had the same creation-order weakness fixed in the in-place test back in addendum 4: the "busy" target's backups were created in ascending timestamp order, so a wrong creation-order-based sort would have passed it too. Creates in reverse order instead. Mutation-tested against the same buggy `st_ctime_ns` sort as before — confirmed the test now fails without value-based sorting, then restored the fix.
3. **Documentation-quality, fixed.** Trimmed `BACKUP_RETENTION_COUNT`'s comment: dropped "Arbitrary but generous" rationale-shopping and the `docs/guide/getting-started.md` cross-pointer, leaving just the policy statement.
4. **Documentation-quality, fixed.** Trimmed `test_existing_backups_returns_empty_for_a_backup_dir_that_does_not_exist_yet`'s docstring to the contract line only, dropping the `mkdir`/`iterdir` implementation walk.

**Rebutted by the team lead, not mine to action:** the symlink-following objection. The installer's standing trust model treats the user's config tree as the operator's own; `sync`/`prune` already follow symlinks throughout, and the `glob` → `iterdir` change in this PR introduced no new symlink-following. Installer-wide symlink hardening is its own item. Ledgered separately.

## Test plan

- [x] `packages/installer/tests/unit/test_backup.py` — 12 tests (13 with the `[0, -1]` parametrization): in-place retention pruning (creation-order-independent), retention scoped per-target within a shared routed backup dir (also creation-order-independent), glob-metacharacter cross-target isolation, non-timestamp-suffix rejection, nested-name-collision isolation, the missing-backup-dir guard, the floor-of-1 safety guarantee under 0 and negative misconfiguration observed both immediately and after a second write, the retention-count literal pin, and directory-backup pruning via `rmtree` (vs `unlink` for files).
- [x] `make ci-installer` — green (coverage 97.9%+, `backup.py` at 100%).
- [x] `make ci` (whole-repo gate) — exit 0, run standalone from this worktree root, after every round of fixes.
- [x] `doc-lint` (standalone, after the data-view.md fix) — exit 0.
- [x] `ruff check` / `ruff format --check` / `mypy --strict` on the touched files individually, in addition to the full gate.

Not merging — per repo policy, merge requires an explicit human instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
