### PR TITLE
feat(9k9.17.14): review-panel routing carries a per-round tier policy

### DIFF
--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -8,9 +8,8 @@ admission:
 ---
 
 A round is a panel of single-lens reviewers. This skill routes: it maps the target to artifact
-classes, picks each class's lenses, fans out one reviewer per lens at the declared tier and
-transport, and assembles the reports into the round verdict. It holds no lens expertise itself —
-depth belongs to the reviewer.
+classes, picks each class's lenses, fans out one reviewer per lens, and assembles the reports into
+the round verdict. It holds no lens expertise itself — depth belongs to the reviewer.
 
 ## Artifact classes
 
@@ -29,8 +28,10 @@ contract explicitly or extend `contracts.json` — never improvise a lens set.
 
 Each panel mixes model tiers — hard-reasoning lenses on frontier models, mechanical walks on
 mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
-`transport` is that diversity claim, not a routing guarantee: when it is down the lens fails over to
-the other transport, and the verdict records what actually ran it (`harvest.md`).
+`tier` sets round 1; a declared `re_review_tier` sets every round after. Its declared `transport`
+carries the vendor-diversity claim, not the tier, so a reduced tier still spans both vendors — when
+it is down the lens fails over to the other transport, and the verdict records what ran it
+(`harvest.md`).
 
 Most lenses re-read the whole artifact every round. A lens marked `diff` reviews only the change
 since the head it last judged, and only when it returned green that round; anything judging

--- a/src/user/.claude/skills/review-panel/contracts.json
+++ b/src/user/.claude/skills/review-panel/contracts.json
@@ -14,6 +14,7 @@
         "mandate": "Judge whether this change can be made to act against the interests of the system that runs it, and say how an attacker gets there.",
         "acs_hint": "criteria describing trust boundaries, inputs, and permissions",
         "tier": "frontier",
+        "re_review_tier": "mid",
         "rescope": "full",
         "transport": "openrouter"
       },
@@ -58,6 +59,7 @@
         "mandate": "Judge whether each acceptance criterion can be converted into one or more tests that fail before the work and pass after it. Name the failing test that is impossible to write.",
         "acs_hint": "the criteria themselves, judged as testable claims",
         "tier": "frontier",
+        "re_review_tier": "mid",
         "rescope": "full",
         "transport": "openrouter"
       },
@@ -74,6 +76,7 @@
         "mandate": "Judge whether the proposed design holds together on its own terms and sits coherently in the architecture of the project and module around it. Read the surrounding structure, not only the document.",
         "acs_hint": "criteria describing the design's obligations to the surrounding system",
         "tier": "frontier",
+        "re_review_tier": "mid",
         "rescope": "full",
         "transport": "openrouter"
       },
@@ -102,6 +105,7 @@
         "mandate": "Judge whether the document fits the bigger picture: read the surrounding project material and report where the text contradicts, duplicates, or silently diverges from it.",
         "acs_hint": "criteria describing the document's obligations to its surroundings",
         "tier": "frontier",
+        "re_review_tier": "mid",
         "rescope": "full",
         "transport": "openrouter"
       },

--- a/src/user/.claude/skills/review-panel/emit_prompts.py
+++ b/src/user/.claude/skills/review-panel/emit_prompts.py
@@ -303,6 +303,14 @@ def lens_scope(lens: dict, round_no: int, verdicts: list[dict]) -> str:
     return "full"
 
 
+def lens_tier(lens: dict, round_no: int) -> str:
+    """Round 1 buys the declared tier; a re-review round buys the declared re_review_tier when
+    the lens names one, else the declared tier stays in force."""
+    if round_no < 2:
+        return lens["tier"]
+    return lens.get("re_review_tier", lens["tier"])
+
+
 def _render_findings(findings: list[dict], ledger: list[dict]) -> str:
     if not findings:
         return "None: this lens raised nothing in an earlier round.\n"
@@ -412,6 +420,7 @@ def emit(args: argparse.Namespace) -> dict[str, Any]:
 
     lenses = contracts[args.artifact_class]["lenses"]
     scopes = {lens["lens"]: lens_scope(lens, args.round, verdicts) for lens in lenses}
+    tiers = {lens["lens"]: lens_tier(lens, args.round) for lens in lenses}
     ctx = {
         "artifact_class": args.artifact_class, "round": args.round, "acs": acs,
         "target": args.target or "", "repo_root": args.repo_root or "",
@@ -431,8 +440,9 @@ def emit(args: argparse.Namespace) -> dict[str, Any]:
         "artifact_class": args.artifact_class, "claim_id": args.claim, "round": args.round,
         "base_sha": args.base_sha, "head_sha": args.head_sha, "retained_categories": retained,
         "lenses": [
-            {"lens": lens["lens"], "tier": lens["tier"], "rescope": lens["rescope"],
-             "transport": lens["transport"], "scope_this_round": scopes[lens["lens"]]}
+            {"lens": lens["lens"], "tier": lens["tier"], "tier_this_round": tiers[lens["lens"]],
+             "rescope": lens["rescope"], "transport": lens["transport"],
+             "scope_this_round": scopes[lens["lens"]]}
             for lens in lenses
         ],
         "prior_dispositions": ledger,

--- a/src/user/.claude/skills/review-panel/emit_prompts_test.py
+++ b/src/user/.claude/skills/review-panel/emit_prompts_test.py
@@ -319,6 +319,43 @@ class TestRoundsAndLedger:
             {"round": 1, "id": "f2", "lens": "security", "disposition": "advisory-deferred"},
         ]
 
+    def test_tier_round_one_always_resolves_declared_tier(self, repo, acs_file, tmp_path, capsys):
+        """Round 1 resolves each lens's declared tier, including a lens that also declares a
+        re_review_tier for later rounds."""
+        out_dir = tmp_path / "round-1"
+        run(argv(repo, acs_file, out_dir), capsys)
+        meta = json.loads((out_dir / "round.json").read_text(encoding="utf-8"))
+        by_lens = {entry["lens"]: entry for entry in meta["lenses"]}
+        assert by_lens["security"]["tier"] == "frontier"
+        assert by_lens["security"]["tier_this_round"] == "frontier"
+
+    def test_tier_round_two_resolves_declared_re_review_tier(self, repo, acs_file, tmp_path,
+                                                              capsys):
+        """Round 2 resolves the declared re_review_tier for a lens that declares one, while
+        round.json still carries the lens's unreduced declared tier."""
+        flat, out_dir = round2(tmp_path, repo, acs_file, [
+            {"round": 1, "id": "f1", "disposition": "fixed", "evidence": "regression test added"},
+            {"round": 1, "id": "f2", "disposition": "advisory-deferred"},
+        ])
+        run(flat, capsys)
+        meta = json.loads((out_dir / "round.json").read_text(encoding="utf-8"))
+        by_lens = {entry["lens"]: entry for entry in meta["lenses"]}
+        assert by_lens["security"]["tier"] == "frontier"
+        assert by_lens["security"]["tier_this_round"] == "mid"
+
+    def test_tier_round_two_without_declaration_keeps_declared_tier(self, repo, acs_file,
+                                                                     tmp_path, capsys):
+        """Round 2 keeps a lens's declared tier when the lens declares no re_review_tier."""
+        flat, out_dir = round2(tmp_path, repo, acs_file, [
+            {"round": 1, "id": "f1", "disposition": "fixed", "evidence": "regression test added"},
+            {"round": 1, "id": "f2", "disposition": "advisory-deferred"},
+        ])
+        run(flat, capsys)
+        meta = json.loads((out_dir / "round.json").read_text(encoding="utf-8"))
+        by_lens = {entry["lens"]: entry for entry in meta["lenses"]}
+        assert by_lens["correctness"]["tier"] == "frontier"
+        assert by_lens["correctness"]["tier_this_round"] == "frontier"
+
     def test_b4_unknown_disposition_value_is_refused(self, repo, acs_file, tmp_path, capsys):
         """S6-B4: a disposition outside the closed set cannot settle a mechanical finding."""
         flat, _ = round2(tmp_path, repo, acs_file, [


### PR DESCRIPTION
## What

`agents-config-9k9.17.14` — reserve the frontier openrouter seat for the first-round look instead of re-buying it every re-review round.

- `contracts.json`: the four openrouter-frontier lenses (typed-code/security, prose/global-consistency, spec/ac-testability, spec/architectural-fit) declare `"re_review_tier": "mid"`. No other entry changes.
- `emit_prompts.py`: `lens_tier()` resolves the effective tier per round — round 1 buys the declared tier, rounds ≥ 2 buy the declared `re_review_tier` when the lens names one. `round.json` lens entries carry both `tier` (declared) and `tier_this_round` (resolved), following the existing `rescope`/`scope_this_round` idiom.
- `SKILL.md`: states the per-round policy as current fact; the vendor-diversity claim is carried by the transport, not the price tier, so a reduced seat keeps the cross-vendor claim.

Model binding stays in the transport's routing table — no model names enter the skill. The qwen rebinding question this analysis surfaced is filed separately as `agents-config-9k9.17.17`; headroom preflight is `9k9.17.15`; failover mechanics are `9k9.38`.

## Evidence

- Red-green: the three new tier tests fail against the pre-change module (`KeyError: 'tier_this_round'`), pass after; the 33 pre-existing tests pass unmodified.
- `make ci` exits 0 from the worktree root (content-tests: 12 suites; content-lint: review-panel SKILL.md at 2000/2000 tokens — at the cap, not over it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA