### PR TITLE
feat(9k9.38): a gate authorizes every lens dispatch, and code reads what comes back

### DIFF
--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -30,7 +30,7 @@ Each panel mixes model tiers — hard-reasoning lenses on frontier models, mecha
 mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
 `tier` sets round 1; a declared `re_review_tier` sets every round after. Its declared `transport`
 carries the vendor-diversity claim, not the tier, so a reduced tier still spans both vendors — when
-it is down the lens fails over to the other transport, and the verdict records what ran it
+it is down the lens recovers onto another route, and the verdict records what ran it
 (`harvest.md`).
 
 Most lenses re-read the whole artifact every round. A lens marked `diff` reviews only the change
@@ -113,12 +113,13 @@ and model that *actually* produced the report, never the route `contracts.json` 
 Terminal-clean means a complete round that came out `clean`, with zero mechanical findings across
 every lens; a halted round is neither.
 
-A dispatch that returns no report is two different problems. A dead route — provider, auth, credit,
-connection — fails the lens over to the transport it was not declared on, and its single entry
-carries the substitution with that route's verbatim error; a failover that dies too halts the run,
-abandoning every remaining dispatch for a `halted` verdict naming the routes that ran out and
-everything they cost the round. A live route returning unusable output may instead be re-dispatched, and
-without a report the lens has no entry and the round is incomplete — fail closed. Every failover is
-reported to the operator, not merely recorded in the verdict. `harvest.md` holds the rest: how to
-tell those two failures apart, how tolerantly to read a report, what to do with a mechanical
-finding carrying no evidence, and the vendor-collapse count to make before the verdict is written.
+Every dispatch is authorized first by `dispatch_gate.py claim`, which records the attempt with the
+route that will run it, assigns the output path it writes to, and refuses the ones past the round's
+bounds — the bounds are that script's, not this prose's. Its refusal for a lens that ran out of
+routes carries halt guidance: the round is over, and the `halted` verdict names the routes that
+died and every dispatch abandoned behind them. `dispatch_gate.py ingest` reads what comes back
+through the tolerance ladder; without a report the lens has no entry and the round is incomplete —
+fail closed. Every failover is reported to the operator, not merely recorded in the verdict.
+`harvest.md` holds the rest: how to tell a dead route from a failed reviewer, what each refusal
+obliges, what to do with a mechanical finding carrying no evidence, and the vendor-collapse count
+to make before the verdict is written.

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -114,12 +114,11 @@ Terminal-clean means a complete round that came out `clean`, with zero mechanica
 every lens; a halted round is neither.
 
 Every dispatch is authorized first by `dispatch_gate.py claim`, which records the attempt with the
-route that will run it, assigns the output path it writes to, and refuses the ones past the round's
-bounds — the bounds are that script's, not this prose's. Its refusal for a lens that ran out of
-routes carries halt guidance: the round is over, and the `halted` verdict names the routes that
-died and every dispatch abandoned behind them. `dispatch_gate.py ingest` reads what comes back
-through the tolerance ladder; without a report the lens has no entry and the round is incomplete —
-fail closed. Every failover is reported to the operator, not merely recorded in the verdict.
-`harvest.md` holds the rest: how to tell a dead route from a failed reviewer, what each refusal
-obliges, what to do with a mechanical finding carrying no evidence, and the vendor-collapse count
-to make before the verdict is written.
+route running it, assigns its output path, and refuses the ones past the round's bounds — those
+bounds are the script's, not this prose's. A refusal for a lens out of routes carries halt
+guidance: the round is over, and the `halted` verdict names the dead routes and the dispatches
+abandoned behind them. `dispatch_gate.py ingest` reads the reply through the tolerance ladder;
+without a report the lens has no entry and the round is incomplete — fail closed. Every failover
+reaches the operator, not merely the verdict. `harvest.md` holds the rest: telling a dead route
+from a failed reviewer, what each refusal obliges, the mechanical finding carrying no evidence,
+and the vendor-collapse count before the verdict is written.

--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -33,7 +33,6 @@ EXIT_REFUSED = 2
 # ledger loses an attempt whenever two dispatches of one round overlap — which is
 # the normal shape of a panel, not an edge case.
 LEDGER_NAME = "attempts.json"
-ROUND_META_NAME = "round.json"
 
 # Three dispatches per lens per round, at most one of them recovering a reviewer
 # that produced unusable output. Recovery is a chain of attempts that each
@@ -163,9 +162,14 @@ def check_lens(raw: str | None) -> str:
 
 
 def check_route(transport: str | None, model: str | None) -> tuple[str, str]:
-    """Both halves, on every attempt. An attempt recorded without its model cannot
-    say which route is exhausted, and a dead vendor and a saturated model recover
-    in opposite directions."""
+    """Both halves, on every attempt, recorded exactly as declared.
+
+    An attempt recorded without its model cannot say which route is exhausted, and
+    a dead vendor and a saturated model recover in opposite directions. Which
+    route a lens deserves is not this gate's question: it counts attempts and
+    records what ran them, so a route it refused to record would be a dispatch it
+    could not bound.
+    """
     declared_transport, declared_model = (transport or "").strip(), (model or "").strip()
     if not declared_transport or not declared_model:
         raise Refusal(
@@ -212,27 +216,6 @@ def check_evidence(raw: str | None, reason: str) -> str:
     return raw or ""
 
 
-def declared_lenses(out_dir: str) -> frozenset[str] | None:
-    """The lens names this round's metadata declares, or None when it declares none.
-
-    A misspelled lens would otherwise open a second attempt chain under a name no
-    lens holds, spending dispatches against a bound that then guards nothing.
-    """
-    try:
-        meta = json.loads((Path(out_dir) / ROUND_META_NAME).read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None
-    entries = meta.get("lenses") if isinstance(meta, dict) else None
-    if not isinstance(entries, list):
-        return None
-    names = {
-        entry["lens"]
-        for entry in entries
-        if isinstance(entry, dict) and isinstance(entry.get("lens"), str)
-    }
-    return frozenset(names) or None
-
-
 def failed_routes(prior: list[dict], reason: str, evidence: str) -> list[dict[str, Any]]:
     """Every dispatched attempt paired with the failure the next claim reported for it.
 
@@ -276,12 +259,6 @@ def claim(args: argparse.Namespace) -> dict[str, Any]:
     """Authorize one dispatch of one lens, or refuse and say what closes the lens."""
     lens = check_lens(args.lens)
     transport, model = check_route(args.transport, args.model)
-    declared = declared_lenses(args.out_dir)
-    if declared is not None and lens not in declared:
-        raise Refusal(
-            "unknown-lens",
-            f"this round declares no lens {lens!r}; its lenses are " + ", ".join(sorted(declared)),
-        )
     path = ledger_path(args.out_dir)
     prior = claims_for(read_ledger(path), lens)
     attempt = len(prior) + 1

--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -122,12 +122,15 @@ def read_ledger(path: Path) -> list[dict]:
 
 
 def append_record(path: Path, record: dict[str, Any]) -> None:
-    """Append one record. The ledger is only ever opened for append, so no
-    invocation can rewrite what an earlier one wrote."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, sort_keys=True) + "\n")
+    """Append one record.
 
+    The ledger is opened in binary append mode and written as a single byte string so concurrent
+    processes don't risk interleaving partial JSON fragments.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = (json.dumps(record, sort_keys=True) + "\n").encode("utf-8")
+    with path.open("ab", buffering=0) as handle:
+        handle.write(line)
 
 def claims_for(records: list[dict], lens: str) -> list[dict]:
     return [r for r in records if r.get("kind") == "claim" and r.get("lens") == lens]

--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -32,7 +32,7 @@ EXIT_REFUSED = 2
 # bound is only as trustworthy as the history it counts, and a read-modify-write
 # ledger loses an attempt whenever two dispatches of one round overlap — which is
 # the normal shape of a panel, not an edge case.
-LEDGER_NAME = "attempts.json"
+LEDGER_NAME = "attempts.jsonl"
 
 # Three dispatches per lens per round, at most one of them recovering a reviewer
 # that produced unusable output. Recovery is a chain of attempts that each

--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Authorize every lens dispatch of a round, and parse what comes back.
+
+Usage: uv run dispatch_gate.py claim --lens <name> --transport <name> --model <name>
+           --reason initial|transport-error|unusable-output [--evidence <verbatim>]
+           [--out-dir <dir>]
+       uv run dispatch_gate.py ingest --output <path> [--out-dir <dir>]
+
+Stdout is JSON. Exit 0 on authorization or ingestion, 2 on refusal. Every
+authorized attempt is appended to the round's ledger before it runs, so a lens
+that has spent its dispatches cannot spend another by asking again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+EXIT_OK = 0
+EXIT_REFUSED = 2
+
+# The ledger holds one JSON record per line, appended and never rewritten. The
+# bound is only as trustworthy as the history it counts, and a read-modify-write
+# ledger loses an attempt whenever two dispatches of one round overlap — which is
+# the normal shape of a panel, not an edge case.
+LEDGER_NAME = "attempts.json"
+ROUND_META_NAME = "round.json"
+
+# Three dispatches per lens per round, at most one of them recovering a reviewer
+# that produced unusable output. Recovery is a chain of attempts that each
+# declare transport AND model, because a model can sit at capacity for the length
+# of a round while another model of the same vendor answers: a single transport
+# flip abandons a live vendor on one saturated model's say-so. A chain with no
+# end is the opposite failure — one lens spending the whole round's budget.
+MAX_ATTEMPTS = 3
+MAX_UNUSABLE_RECOVERIES = 1
+
+# Seconds to wait before a recovery dispatch, indexed by how many recoveries
+# precede it. A route that has failed twice is likelier saturated than flaking,
+# so the second wait is the longer one.
+BACKOFF_SECONDS = (15, 30)
+
+INITIAL = "initial"
+TRANSPORT_ERROR = "transport-error"
+UNUSABLE_OUTPUT = "unusable-output"
+REASONS = (INITIAL, TRANSPORT_ERROR, UNUSABLE_OUTPUT)
+
+# A lens name becomes a filename under the round directory, so it carries no
+# separator and no traversal.
+LENS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# A body that is nothing but one fenced block, language tag optional.
+FENCED_RE = re.compile(
+    r"\A\s*```[A-Za-z0-9_+-]*[ \t]*\r?\n(?P<body>.*?)\r?\n?```\s*\Z", re.DOTALL
+)
+
+HALT_GUIDANCE = (
+    "Every route this lens ran on died in transport. The round is over: abandon every dispatch "
+    "not yet made, write the verdict halted with these routes and their errors verbatim in the "
+    "halt block, and lead the operator report with them, ahead of any finding."
+)
+
+
+class Refusal(Exception):
+    """A typed refusal to authorize or to ingest; carries a stable machine-readable code."""
+
+    def __init__(self, code: str, message: str, halt: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.halt = halt
+
+    def as_dict(self) -> dict[str, str]:
+        return {"code": self.code, "message": self.message}
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def ledger_path(out_dir: str) -> Path:
+    return Path(out_dir) / LEDGER_NAME
+
+
+def read_ledger(path: Path) -> list[dict]:
+    """Every record appended to this round's ledger, oldest first."""
+    if not path.is_file():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise Refusal(
+            "unreadable-ledger", f"cannot read the attempt ledger {path}: {exc}"
+        ) from exc
+    records = []
+    for number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise Refusal(
+                "unreadable-ledger",
+                f"line {number} of the attempt ledger {path} is not a record: {exc}; a bound "
+                "cannot be enforced against a history that does not parse",
+            ) from exc
+        if not isinstance(record, dict):
+            raise Refusal(
+                "unreadable-ledger",
+                f"line {number} of the attempt ledger {path} is not a record object",
+            )
+        records.append(record)
+    return records
+
+
+def append_record(path: Path, record: dict[str, Any]) -> None:
+    """Append one record. The ledger is only ever opened for append, so no
+    invocation can rewrite what an earlier one wrote."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def claims_for(records: list[dict], lens: str) -> list[dict]:
+    return [r for r in records if r.get("kind") == "claim" and r.get("lens") == lens]
+
+
+def output_path_for(out_dir: str, lens: str, attempt: int) -> Path:
+    """Where this attempt writes its raw output — one path per (lens, attempt).
+
+    A fresh path per attempt is what makes an absent file mean something. A
+    transport that writes its output file only on success leaves the previous
+    attempt's file untouched when it fails, so a reused path hands the harvester
+    a stale report that reads as this attempt's.
+    """
+    return Path(out_dir).resolve() / f"{lens}.attempt-{attempt}.out"
+
+
+def backoff_for(attempt: int) -> int:
+    return BACKOFF_SECONDS[min(attempt - 2, len(BACKOFF_SECONDS) - 1)]
+
+
+def check_lens(raw: str | None) -> str:
+    if not (raw or "").strip():
+        raise Refusal("no-lens", "no --lens was named; this gate bounds dispatches per lens")
+    lens = (raw or "").strip()
+    if not LENS_RE.match(lens):
+        raise Refusal(
+            "no-lens",
+            f"lens name {lens!r} is not a plain name; a lens names its own output file, so it may "
+            "hold only letters, digits, dot, dash and underscore",
+        )
+    return lens
+
+
+def check_route(transport: str | None, model: str | None) -> tuple[str, str]:
+    """Both halves, on every attempt. An attempt recorded without its model cannot
+    say which route is exhausted, and a dead vendor and a saturated model recover
+    in opposite directions."""
+    declared_transport, declared_model = (transport or "").strip(), (model or "").strip()
+    if not declared_transport or not declared_model:
+        raise Refusal(
+            "no-route-declaration",
+            "every dispatch declares both --transport and --model; a route recorded without its "
+            "model leaves the next attempt no way to say what was already exhausted",
+        )
+    return declared_transport, declared_model
+
+
+def check_reason(raw: str | None, attempt: int) -> str:
+    if raw not in REASONS:
+        raise Refusal(
+            "unknown-reason",
+            f"reason {raw!r} is outside the closed set; a dispatch declares one of: "
+            + ", ".join(REASONS),
+        )
+    if attempt == 1 and raw != INITIAL:
+        raise Refusal(
+            "unknown-reason",
+            f"this is the first dispatch of the lens, so its reason is {INITIAL!r}; {raw!r} "
+            "describes a failure no attempt has recorded",
+        )
+    if attempt > 1 and raw == INITIAL:
+        raise Refusal(
+            "unknown-reason",
+            f"the lens has already been dispatched, so this attempt declares what failed: "
+            f"{TRANSPORT_ERROR!r} when the route died and the reviewer never ran, "
+            f"{UNUSABLE_OUTPUT!r} when the route worked and the body is unusable",
+        )
+    return raw
+
+
+def check_evidence(raw: str | None, reason: str) -> str:
+    if reason == INITIAL:
+        return ""
+    if not (raw or "").strip():
+        raise Refusal(
+            "no-failure-evidence",
+            "a recovery dispatch carries --evidence: the failed attempt's error or output, "
+            "verbatim. 'the route was unavailable' and '402 Insufficient credits' ask different "
+            "things of whoever reads the round, and only one of them can be acted on",
+        )
+    return raw or ""
+
+
+def declared_lenses(out_dir: str) -> frozenset[str] | None:
+    """The lens names this round's metadata declares, or None when it declares none.
+
+    A misspelled lens would otherwise open a second attempt chain under a name no
+    lens holds, spending dispatches against a bound that then guards nothing.
+    """
+    try:
+        meta = json.loads((Path(out_dir) / ROUND_META_NAME).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    entries = meta.get("lenses") if isinstance(meta, dict) else None
+    if not isinstance(entries, list):
+        return None
+    names = {
+        entry["lens"]
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("lens"), str)
+    }
+    return frozenset(names) or None
+
+
+def failed_routes(prior: list[dict], reason: str, evidence: str) -> list[dict[str, Any]]:
+    """Every dispatched attempt paired with the failure the next claim reported for it.
+
+    A claim describes the attempt before it, so the refused claim closes the
+    record: without it the failure that ran the lens out — the most recent one —
+    would be the one missing.
+    """
+    reported = [(r.get("reason"), r.get("evidence", "")) for r in prior[1:]] + [(reason, evidence)]
+    return [
+        {
+            "attempt": record.get("attempt"),
+            "transport": record.get("transport"),
+            "model": record.get("model"),
+            "reason": failure,
+            "error": error,
+        }
+        for record, (failure, error) in zip(prior, reported)
+    ]
+
+
+def exhausted(lens: str, why: str, routes: list[dict[str, Any]]) -> Refusal:
+    """The refusal for a dispatch past the bound, carrying halt guidance when every
+    recorded failure was transport-class.
+
+    A lens that ran out of routes and a lens whose reviewer kept producing garbage
+    end identically — no entry, an incomplete round — but only the first says
+    anything about the dispatches the round has not made yet.
+    """
+    transport_only = bool(routes) and all(route["reason"] == TRANSPORT_ERROR for route in routes)
+    if not transport_only:
+        return Refusal("attempts-exhausted", f"{lens}: {why}")
+    rendered = "; ".join(f"{r['transport']}/{r['model']}: {r['error']}" for r in routes)
+    return Refusal(
+        "attempts-exhausted",
+        f"{lens}: {why} Every route it ran on died in transport — {rendered}",
+        halt={"guidance": HALT_GUIDANCE, "exhausted_routes": routes},
+    )
+
+
+def claim(args: argparse.Namespace) -> dict[str, Any]:
+    """Authorize one dispatch of one lens, or refuse and say what closes the lens."""
+    lens = check_lens(args.lens)
+    transport, model = check_route(args.transport, args.model)
+    declared = declared_lenses(args.out_dir)
+    if declared is not None and lens not in declared:
+        raise Refusal(
+            "unknown-lens",
+            f"this round declares no lens {lens!r}; its lenses are " + ", ".join(sorted(declared)),
+        )
+    path = ledger_path(args.out_dir)
+    prior = claims_for(read_ledger(path), lens)
+    attempt = len(prior) + 1
+    reason = check_reason(args.reason, attempt)
+    evidence = check_evidence(args.evidence, reason)
+
+    refusal = None
+    if len(prior) >= MAX_ATTEMPTS:
+        refusal = exhausted(
+            lens,
+            f"{len(prior)} dispatches is the bound for one lens in one round.",
+            failed_routes(prior, reason, evidence),
+        )
+    elif (
+        reason == UNUSABLE_OUTPUT
+        and sum(1 for r in prior if r.get("reason") == UNUSABLE_OUTPUT) >= MAX_UNUSABLE_RECOVERIES
+    ):
+        refusal = exhausted(
+            lens,
+            "a reviewer that returns unusable output is re-dispatched once, then the lens fails "
+            "closed.",
+            failed_routes(prior, reason, evidence),
+        )
+    if refusal is not None:
+        # The refused claim carries the last failure's evidence, which exists
+        # nowhere else once this process exits.
+        append_record(
+            path,
+            {
+                "kind": "refusal",
+                "lens": lens,
+                "attempt": attempt,
+                "code": refusal.code,
+                "reason": reason,
+                "evidence": evidence,
+                "timestamp": now(),
+            },
+        )
+        raise refusal
+
+    record = {
+        "kind": "claim",
+        "lens": lens,
+        "attempt": attempt,
+        "transport": transport,
+        "model": model,
+        "cwd": str(Path.cwd()),
+        "reason": reason,
+        "output_path": str(output_path_for(args.out_dir, lens, attempt)),
+        "timestamp": now(),
+    }
+    if evidence:
+        record["evidence"] = evidence
+    if attempt > 1:
+        record["backoff_seconds"] = backoff_for(attempt)
+    append_record(path, record)
+    return {"authorized": True, **{k: v for k, v in record.items() if k != "kind"}}
+
+
+def _as_object(text: str) -> dict | None:
+    try:
+        value = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def parse_report(body: str) -> tuple[dict, str]:
+    """The tolerance ladder, in order; the first step that yields an object wins.
+
+    Models violate an exact-output contract in predictable, harmless ways: a
+    fence around the object, a sentence of preamble in front of it. Tolerance
+    stops at the end of this ladder on purpose — reconstructing a report from
+    prose makes the harvester the reviewer, and nothing downstream can tell the
+    difference.
+    """
+    document = _as_object(body)
+    if document is not None:
+        return document, "whole-body"
+    fenced = FENCED_RE.match(body)
+    if fenced is not None:
+        document = _as_object(fenced.group("body"))
+        if document is not None:
+            return document, "fenced-block"
+    start = body.find("{")
+    if start != -1:
+        try:
+            decoded, _ = json.JSONDecoder().raw_decode(body[start:])
+        except (json.JSONDecodeError, ValueError):
+            decoded = None
+        if isinstance(decoded, dict):
+            return decoded, "first-object"
+    raise Refusal(
+        "unparseable-output",
+        "the body is not a lens report: it is not JSON, not a single fenced object, and holds no "
+        "object to decode from its first brace. The lens has no entry and the round is incomplete "
+        "unless it is re-dispatched; a report assembled from the prose by hand is not a review",
+    )
+
+
+def _resolved(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:  # pragma: no cover - resolution of a plain path does not fail here
+        return str(path)
+
+
+def match_claim(records: list[dict], output: Path) -> dict | None:
+    """The claim that assigned this output path, or None if no claim did."""
+    target = _resolved(output)
+    for record in reversed(records):
+        if record.get("kind") != "claim":
+            continue
+        assigned = record.get("output_path")
+        if isinstance(assigned, str) and _resolved(Path(assigned)) == target:
+            return record
+    return None
+
+
+def outcome_record(claimed: dict, outcome: str, output: Path, **extra: Any) -> dict[str, Any]:
+    return {
+        "kind": "outcome",
+        "lens": claimed.get("lens"),
+        "attempt": claimed.get("attempt"),
+        "outcome": outcome,
+        "output_path": str(output),
+        "timestamp": now(),
+        **extra,
+    }
+
+
+def ingest(args: argparse.Namespace) -> dict[str, Any]:
+    """Read one lens's raw output through the tolerance ladder, and record what it was."""
+    if not (args.output or "").strip():
+        raise Refusal(
+            "no-output-path",
+            "no --output was supplied; ingest reads the file the claim assigned to this attempt",
+        )
+    output = Path((args.output or "").strip()).expanduser()
+    path = ledger_path(args.out_dir)
+    records = read_ledger(path)
+    claimed = match_claim(records, output)
+    if claimed is None:
+        append_record(
+            path,
+            {
+                "kind": "refusal",
+                "code": "unclaimed-attempt",
+                "output_path": str(output),
+                "timestamp": now(),
+            },
+        )
+        raise Refusal(
+            "unclaimed-attempt",
+            f"no claim in this round assigned the output path {output}; a dispatch made without "
+            "one leaves a hole in the ledger, and an unbounded lens is what the hole hides",
+        )
+    if not output.is_file():
+        append_record(path, outcome_record(claimed, "no-output", output))
+        raise Refusal(
+            "no-output",
+            f"the claimed output path {output} holds no file. Each attempt writes its own path, "
+            "so nothing there means the route wrote nothing and the reviewer never ran: claim "
+            f"again with reason {TRANSPORT_ERROR!r}, carrying the route's error as the evidence",
+        )
+    try:
+        body = output.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        append_record(path, outcome_record(claimed, "unparseable", output))
+        raise Refusal(
+            "unparseable-output", f"cannot read the claimed output {output} as text: {exc}"
+        ) from exc
+    try:
+        report, recovery = parse_report(body)
+    except Refusal:
+        append_record(path, outcome_record(claimed, "unparseable", output))
+        raise
+    append_record(path, outcome_record(claimed, "parsed", output, recovery=recovery))
+    return {
+        "ingested": True,
+        "lens": claimed.get("lens"),
+        "attempt": claimed.get("attempt"),
+        "recovery": recovery,
+        "report": report,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=True)
+    verbs = parser.add_subparsers(dest="verb", required=True)
+
+    claim_parser = verbs.add_parser("claim", help="authorize one dispatch of one lens")
+    claim_parser.add_argument("--out-dir", default=".")
+    claim_parser.add_argument("--lens")
+    claim_parser.add_argument("--transport")
+    claim_parser.add_argument("--model")
+    claim_parser.add_argument("--reason")
+    claim_parser.add_argument("--evidence")
+    claim_parser.set_defaults(run=claim)
+
+    ingest_parser = verbs.add_parser("ingest", help="read one lens's raw output")
+    ingest_parser.add_argument("--out-dir", default=".")
+    ingest_parser.add_argument("--output")
+    ingest_parser.set_defaults(run=ingest)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    verb = "authorized" if args.verb == "claim" else "ingested"
+    try:
+        result = args.run(args)
+    except Refusal as exc:
+        answer: dict[str, Any] = {verb: False, "errors": [exc.as_dict()]}
+        if exc.halt is not None:
+            answer["halt"] = exc.halt
+        print(json.dumps(answer, sort_keys=True))
+        return EXIT_REFUSED
+    except Exception as exc:  # noqa: BLE001 - stdout is a parsed contract; no traceback may escape
+        print(json.dumps(
+            {verb: False, "errors": [{"code": "gate-failure", "message": str(exc)}]},
+            sort_keys=True,
+        ))
+        return EXIT_REFUSED
+    print(json.dumps(result, sort_keys=True))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pytest>=8"]
+# ///
+"""Tests for the review-panel dispatch gate.
+
+Run: uv run dispatch_gate_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+GATE_PATH = HERE / "dispatch_gate.py"
+HARVEST_PATH = HERE / "harvest.md"
+SKILL_PATH = HERE / "SKILL.md"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("dispatch_gate", GATE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+
+REPORT = {"lens": "correctness", "verdict": "clean", "findings": []}
+
+
+@pytest.fixture
+def round_dir(tmp_path) -> Path:
+    path = tmp_path / "round-1"
+    path.mkdir()
+    return path
+
+
+def claim_argv(round_dir: Path, **overrides: Any) -> list[str]:
+    """The flags of one claim. An override of ``None`` drops its flag entirely."""
+    args: dict[str, Any] = {
+        "--out-dir": str(round_dir),
+        "--lens": "correctness",
+        "--transport": "codex",
+        "--model": "gpt-5.6-terra",
+        "--reason": "initial",
+    }
+    args.update(overrides)
+    flat = ["claim"]
+    for key, value in args.items():
+        if value is None:
+            continue
+        flat += [key, str(value)]
+    return flat
+
+
+def run(argv_list: list[str], capsys) -> tuple[int, dict]:
+    code = gate.main(argv_list)
+    return code, json.loads(capsys.readouterr().out)
+
+
+def authorize(round_dir: Path, capsys, **overrides: Any) -> dict:
+    code, answer = run(claim_argv(round_dir, **overrides), capsys)
+    assert code == gate.EXIT_OK, answer
+    return answer
+
+
+def refuse(argv_list: list[str], capsys) -> dict:
+    code, answer = run(argv_list, capsys)
+    assert code == gate.EXIT_REFUSED, answer
+    return answer
+
+
+def codes(answer: dict) -> list[str]:
+    return [error["code"] for error in answer["errors"]]
+
+
+def ledger(round_dir: Path) -> list[dict]:
+    return gate.read_ledger(round_dir / gate.LEDGER_NAME)
+
+
+def kinds(round_dir: Path, kind: str) -> list[dict]:
+    return [record for record in ledger(round_dir) if record["kind"] == kind]
+
+
+def write_output(answer: dict, body: str) -> Path:
+    path = Path(answer["output_path"])
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def transport_recovery(round_dir: Path, capsys, error: str, **overrides: Any) -> dict:
+    return authorize(
+        round_dir, capsys, **{"--reason": "transport-error", "--evidence": error, **overrides}
+    )
+
+
+class TestFirstClaim:
+    """AC1: the first dispatch is authorized, recorded in full, and never rewritten."""
+
+    def test_first_claim_is_authorized_with_a_full_attempt_record(self, round_dir, capsys):
+        answer = authorize(round_dir, capsys)
+        assert answer["authorized"] is True
+        assert answer["lens"] == "correctness"
+        assert answer["attempt"] == 1
+        assert answer["transport"] == "codex"
+        assert answer["model"] == "gpt-5.6-terra"
+        assert answer["reason"] == "initial"
+        assert answer["timestamp"].endswith("Z")
+        assert answer["cwd"]
+        assert answer["output_path"]
+
+    def test_the_attempt_lands_in_the_rounds_ledger(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        claims = kinds(round_dir, "claim")
+        assert (round_dir / "attempts.json").is_file()
+        assert len(claims) == 1
+        for field in ("lens", "attempt", "transport", "model", "cwd", "reason", "timestamp"):
+            assert field in claims[0], field
+        assert claims[0]["output_path"] == str(
+            round_dir.resolve() / "correctness.attempt-1.out"
+        )
+
+    def test_cwd_is_the_process_working_directory_not_a_declaration(
+        self, round_dir, capsys, tmp_path, monkeypatch
+    ):
+        """A dispatch run from the wrong tree reviews the wrong code, so the gate
+        measures the directory rather than accepting a claim about it."""
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        answer = authorize(round_dir, capsys)
+        assert Path(answer["cwd"]).resolve() == elsewhere.resolve()
+
+    def test_output_path_is_unique_per_lens_and_attempt(self, round_dir, capsys):
+        first = authorize(round_dir, capsys)
+        second = transport_recovery(round_dir, capsys, "503 upstream")
+        other_lens = authorize(round_dir, capsys, **{"--lens": "security"})
+        paths = [first["output_path"], second["output_path"], other_lens["output_path"]]
+        assert len(set(paths)) == 3
+        assert all(Path(p).parent == round_dir.resolve() for p in paths)
+
+    def test_the_ledger_is_append_only_across_invocations(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        after_first = (round_dir / "attempts.json").read_bytes()
+        transport_recovery(round_dir, capsys, "503 upstream")
+        after_second = (round_dir / "attempts.json").read_bytes()
+        assert after_second.startswith(after_first)
+        assert len(after_second) > len(after_first)
+
+    def test_a_refused_claim_rewrites_nothing_and_grants_no_attempt(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        after_first = (round_dir / "attempts.json").read_bytes()
+        refuse(claim_argv(round_dir, **{"--reason": "wishful"}), capsys)
+        assert (round_dir / "attempts.json").read_bytes().startswith(after_first)
+        assert len(kinds(round_dir, "claim")) == 1
+
+
+class TestRecoveryReason:
+    """AC2: a claim after the first declares a known reason and the prior failure."""
+
+    def test_a_missing_reason_is_refused(self, round_dir, capsys):
+        answer = refuse(claim_argv(round_dir, **{"--reason": None}), capsys)
+        assert codes(answer) == ["unknown-reason"]
+
+    def test_an_unknown_reason_is_refused(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "rate-limited", "--evidence": "429"}), capsys
+        )
+        assert codes(answer) == ["unknown-reason"]
+
+    def test_a_first_dispatch_may_not_declare_a_failure(self, round_dir, capsys):
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "transport-error", "--evidence": "503"}), capsys
+        )
+        assert codes(answer) == ["unknown-reason"]
+
+    def test_a_later_dispatch_may_not_declare_itself_initial(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        answer = refuse(claim_argv(round_dir, **{"--reason": "initial"}), capsys)
+        assert codes(answer) == ["unknown-reason"]
+
+    def test_a_recovery_without_evidence_is_refused(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        answer = refuse(claim_argv(round_dir, **{"--reason": "transport-error"}), capsys)
+        assert codes(answer) == ["no-failure-evidence"]
+
+    def test_blank_evidence_is_no_evidence(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "unusable-output", "--evidence": "   "}), capsys
+        )
+        assert codes(answer) == ["no-failure-evidence"]
+
+    def test_the_prior_failure_is_recorded_verbatim(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        transport_recovery(round_dir, capsys, "402 Insufficient credits")
+        assert kinds(round_dir, "claim")[1]["evidence"] == "402 Insufficient credits"
+
+
+class TestBounds:
+    """AC3/AC4/AC5/AC6: how far recovery goes, and what a refusal at the end says."""
+
+    def test_a_second_unusable_output_recovery_is_refused(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        authorize(
+            round_dir, capsys, **{"--reason": "unusable-output", "--evidence": "half a sentence"}
+        )
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "unusable-output", "--evidence": "prose again"}),
+            capsys,
+        )
+        assert codes(answer) == ["attempts-exhausted"]
+        assert len(kinds(round_dir, "claim")) == 2
+
+    def test_a_fourth_dispatch_is_refused_whatever_the_reason_mix(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        transport_recovery(round_dir, capsys, "503 upstream")
+        authorize(round_dir, capsys, **{"--reason": "unusable-output", "--evidence": "prose"})
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "transport-error", "--evidence": "503 again"}),
+            capsys,
+        )
+        assert codes(answer) == ["attempts-exhausted"]
+        assert len(kinds(round_dir, "claim")) == 3
+
+    def test_a_mixed_exhaustion_carries_no_halt_guidance(self, round_dir, capsys):
+        """Halting is a claim about the round's remaining dispatches; a reviewer
+        that produced garbage says nothing about the routes."""
+        authorize(round_dir, capsys)
+        authorize(round_dir, capsys, **{"--reason": "unusable-output", "--evidence": "prose"})
+        answer = refuse(
+            claim_argv(round_dir, **{"--reason": "unusable-output", "--evidence": "prose again"}),
+            capsys,
+        )
+        assert "halt" not in answer
+
+    def test_an_all_transport_exhaustion_names_every_route_and_its_error(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        transport_recovery(
+            round_dir,
+            capsys,
+            "402 Insufficient credits",
+            **{"--transport": "openrouter", "--model": "anthropic/claude-opus-5"},
+        )
+        transport_recovery(
+            round_dir,
+            capsys,
+            "503 upstream unavailable",
+            **{"--transport": "openrouter", "--model": "moonshotai/kimi-k2"},
+        )
+        answer = refuse(
+            claim_argv(
+                round_dir,
+                **{
+                    "--reason": "transport-error",
+                    "--evidence": "at capacity",
+                    "--transport": "codex",
+                    "--model": "gpt-5.6-terra",
+                },
+            ),
+            capsys,
+        )
+        routes = answer["halt"]["exhausted_routes"]
+        assert [(r["transport"], r["model"]) for r in routes] == [
+            ("codex", "gpt-5.6-terra"),
+            ("openrouter", "anthropic/claude-opus-5"),
+            ("openrouter", "moonshotai/kimi-k2"),
+        ]
+        assert [r["error"] for r in routes] == [
+            "402 Insufficient credits",
+            "503 upstream unavailable",
+            "at capacity",
+        ]
+        assert answer["halt"]["guidance"]
+
+    def test_the_last_failure_reaches_the_halt_guidance(self, round_dir, capsys):
+        """The refused claim carries the failure that ran the lens out; it exists
+        nowhere else, so the guidance would otherwise be one route short."""
+        authorize(round_dir, capsys)
+        transport_recovery(round_dir, capsys, "first error")
+        transport_recovery(round_dir, capsys, "second error")
+        answer = refuse(
+            claim_argv(
+                round_dir, **{"--reason": "transport-error", "--evidence": "third error"}
+            ),
+            capsys,
+        )
+        assert "third error" in answer["errors"][0]["message"]
+        assert kinds(round_dir, "refusal")[0]["evidence"] == "third error"
+
+    def test_every_authorized_recovery_carries_a_backoff_in_range(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        second = transport_recovery(round_dir, capsys, "503 upstream")
+        third = transport_recovery(round_dir, capsys, "503 again")
+        for answer in (second, third):
+            assert 15 <= answer["backoff_seconds"] <= 30
+
+    def test_a_first_dispatch_waits_for_nothing(self, round_dir, capsys):
+        assert "backoff_seconds" not in authorize(round_dir, capsys)
+
+    def test_the_bound_is_per_lens(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        transport_recovery(round_dir, capsys, "503 upstream")
+        transport_recovery(round_dir, capsys, "503 again")
+        assert authorize(round_dir, capsys, **{"--lens": "security"})["attempt"] == 1
+
+
+class TestIngest:
+    """AC7/AC8: the tolerance ladder in code, and output nobody claimed."""
+
+    def test_a_whole_body_object_is_the_first_rung(self, round_dir, capsys):
+        answer = authorize(round_dir, capsys)
+        output = write_output(answer, json.dumps(REPORT))
+        code, ingested = run(["ingest", "--out-dir", str(round_dir), "--output", str(output)],
+                             capsys)
+        assert code == gate.EXIT_OK
+        assert ingested["report"] == REPORT
+        assert ingested["recovery"] == "whole-body"
+        assert (ingested["lens"], ingested["attempt"]) == ("correctness", 1)
+
+    @pytest.mark.parametrize("fence", ["```json", "```"])
+    def test_a_single_fenced_object_is_the_second_rung(self, round_dir, capsys, fence):
+        answer = authorize(round_dir, capsys)
+        output = write_output(answer, f"{fence}\n{json.dumps(REPORT)}\n```\n")
+        code, ingested = run(["ingest", "--out-dir", str(round_dir), "--output", str(output)],
+                             capsys)
+        assert code == gate.EXIT_OK
+        assert ingested["report"] == REPORT
+        assert ingested["recovery"] == "fenced-block"
+
+    def test_an_object_behind_a_preamble_is_the_third_rung(self, round_dir, capsys):
+        answer = authorize(round_dir, capsys)
+        output = write_output(
+            answer, f"Here is my review:\n{json.dumps(REPORT)}\nHappy to expand on any of it.\n"
+        )
+        code, ingested = run(["ingest", "--out-dir", str(round_dir), "--output", str(output)],
+                             capsys)
+        assert code == gate.EXIT_OK
+        assert ingested["report"] == REPORT
+        assert ingested["recovery"] == "first-object"
+
+    def test_a_parsed_report_records_its_outcome_on_the_claimed_attempt(self, round_dir, capsys):
+        answer = authorize(round_dir, capsys)
+        output = write_output(answer, json.dumps(REPORT))
+        run(["ingest", "--out-dir", str(round_dir), "--output", str(output)], capsys)
+        outcome = kinds(round_dir, "outcome")[0]
+        assert (outcome["lens"], outcome["attempt"]) == ("correctness", 1)
+        assert outcome["outcome"] == "parsed"
+        assert outcome["recovery"] == "whole-body"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "The change looks fine to me, no findings.",
+            "",
+            '["correctness", "clean"]',
+            "```\nnot json at all\n```",
+        ],
+    )
+    def test_anything_past_the_ladder_is_unparseable(self, round_dir, capsys, body):
+        answer = authorize(round_dir, capsys)
+        output = write_output(answer, body)
+        refused = refuse(["ingest", "--out-dir", str(round_dir), "--output", str(output)], capsys)
+        assert codes(refused) == ["unparseable-output"]
+        assert "report" not in refused
+
+    def test_an_unparseable_body_records_its_outcome_too(self, round_dir, capsys):
+        answer = authorize(round_dir, capsys)
+        output = write_output(answer, "no report here")
+        refuse(["ingest", "--out-dir", str(round_dir), "--output", str(output)], capsys)
+        outcome = kinds(round_dir, "outcome")[0]
+        assert (outcome["lens"], outcome["outcome"]) == ("correctness", "unparseable")
+
+    def test_output_no_claim_assigned_is_refused(self, round_dir, capsys):
+        authorize(round_dir, capsys)
+        stray = round_dir / "correctness.out"
+        stray.write_text(json.dumps(REPORT), encoding="utf-8")
+        answer = refuse(["ingest", "--out-dir", str(round_dir), "--output", str(stray)], capsys)
+        assert codes(answer) == ["unclaimed-attempt"]
+
+    def test_an_unclaimed_ingest_is_itself_recorded(self, round_dir, capsys):
+        """The hole a bypassed dispatch leaves is the point; the ledger names it."""
+        authorize(round_dir, capsys)
+        stray = round_dir / "correctness.out"
+        stray.write_text(json.dumps(REPORT), encoding="utf-8")
+        refuse(["ingest", "--out-dir", str(round_dir), "--output", str(stray)], capsys)
+        assert kinds(round_dir, "refusal")[0]["code"] == "unclaimed-attempt"
+
+    def test_a_claimed_path_holding_no_file_is_a_transport_failure(self, round_dir, capsys):
+        """A transport that writes its file only on success writes nothing when it
+        fails, and the attempt's own path is empty rather than holding a stale
+        report from the attempt before it."""
+        answer = authorize(round_dir, capsys)
+        refused = refuse(
+            ["ingest", "--out-dir", str(round_dir), "--output", answer["output_path"]], capsys
+        )
+        assert codes(refused) == ["no-output"]
+        assert "transport-error" in refused["errors"][0]["message"]
+        assert kinds(round_dir, "outcome")[0]["outcome"] == "no-output"
+
+    def test_ingest_without_an_output_flag_is_refused(self, round_dir, capsys):
+        answer = refuse(["ingest", "--out-dir", str(round_dir)], capsys)
+        assert codes(answer) == ["no-output-path"]
+
+    def test_a_stale_report_cannot_be_ingested_as_a_later_attempt(self, round_dir, capsys):
+        """Attempt 1's file is not attempt 2's: the second attempt's own path is
+        what ingest reads, so last round's body cannot answer for this one."""
+        first = authorize(round_dir, capsys)
+        write_output(first, json.dumps(REPORT))
+        second = transport_recovery(round_dir, capsys, "503 upstream")
+        refused = refuse(
+            ["ingest", "--out-dir", str(round_dir), "--output", second["output_path"]], capsys
+        )
+        assert codes(refused) == ["no-output"]
+
+
+class TestGateSurface:
+    """Refusals for a malformed request, and the stdout contract they all keep."""
+
+    def test_a_missing_lens_is_refused(self, round_dir, capsys):
+        assert codes(refuse(claim_argv(round_dir, **{"--lens": None}), capsys)) == ["no-lens"]
+
+    def test_a_lens_name_that_is_a_path_is_refused(self, round_dir, capsys):
+        answer = refuse(claim_argv(round_dir, **{"--lens": "../escape"}), capsys)
+        assert codes(answer) == ["no-lens"]
+
+    @pytest.mark.parametrize("missing", ["--transport", "--model"])
+    def test_an_undeclared_route_is_refused(self, round_dir, capsys, missing):
+        answer = refuse(claim_argv(round_dir, **{missing: None}), capsys)
+        assert codes(answer) == ["no-route-declaration"]
+
+    def test_a_lens_the_round_does_not_declare_is_refused(self, round_dir, capsys):
+        (round_dir / "round.json").write_text(
+            json.dumps({"lenses": [{"lens": "correctness"}, {"lens": "security"}]}),
+            encoding="utf-8",
+        )
+        answer = refuse(claim_argv(round_dir, **{"--lens": "corectness"}), capsys)
+        assert codes(answer) == ["unknown-lens"]
+
+    def test_a_round_declaring_no_lenses_accepts_any_lens_name(self, round_dir, capsys):
+        (round_dir / "round.json").write_text("{not json", encoding="utf-8")
+        assert authorize(round_dir, capsys, **{"--lens": "house-lens"})["attempt"] == 1
+
+    @pytest.mark.parametrize(
+        "argv_tail",
+        [["claim", "--lens", "correctness", "--transport", "codex", "--model", "m",
+          "--reason", "initial"],
+         ["ingest", "--output", "somewhere.out"]],
+    )
+    def test_an_unparseable_ledger_stops_both_verbs(self, round_dir, capsys, argv_tail):
+        """A bound cannot be enforced against a history that does not parse, so
+        neither verb proceeds on one."""
+        (round_dir / "attempts.json").write_text("{}\nnot a record\n", encoding="utf-8")
+        answer = refuse([*argv_tail, "--out-dir", str(round_dir)], capsys)
+        assert codes(answer) == ["unreadable-ledger"]
+
+    def test_an_unexpected_fault_is_still_json(self, round_dir, capsys, monkeypatch):
+        def explode() -> str:
+            raise RuntimeError("clock unavailable")
+
+        monkeypatch.setattr(gate, "now", explode)
+        answer = refuse(claim_argv(round_dir), capsys)
+        assert codes(answer) == ["gate-failure"]
+        assert answer["authorized"] is False
+
+    def test_a_refusal_names_the_verb_it_refused(self, round_dir, capsys):
+        assert refuse(claim_argv(round_dir, **{"--lens": None}), capsys)["authorized"] is False
+        assert refuse(["ingest", "--out-dir", str(round_dir)], capsys)["ingested"] is False
+
+    def test_the_deployed_gate_carries_no_planning_jargon(self):
+        """The gate deploys into other projects, where this repo's planning
+        vocabulary names nothing."""
+        jargon = re.compile(r"\bD[0-9]|\bAC[0-9]|\bslice\b|\bcharter\b|\bmilestone\b",
+                            re.IGNORECASE)
+        for path in (GATE_PATH, HARVEST_PATH):
+            hits = [line for line in path.read_text(encoding="utf-8").splitlines()
+                    if jargon.search(line)]
+            assert not hits, f"{path.name}: {hits}"
+
+    def test_the_prose_routes_authorization_through_the_gate(self):
+        """AC10: the invoker is told to ask the gate, not to count attempts."""
+        harvest = HARVEST_PATH.read_text(encoding="utf-8")
+        for token in ("dispatch_gate.py", "claim", "ingest", "transport-error",
+                      "unusable-output"):
+            assert token in harvest, token
+        assert "dispatch_gate.py" in SKILL_PATH.read_text(encoding="utf-8")
+
+    def test_the_skill_body_stays_within_its_budget(self):
+        """The same four-characters-per-token proxy the rest of this skill is held to."""
+        body = SKILL_PATH.read_text(encoding="utf-8").split("---", 2)[2]
+        assert len(body) <= 8000, len(body)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -440,17 +440,25 @@ class TestGateSurface:
         answer = refuse(claim_argv(round_dir, **{missing: None}), capsys)
         assert codes(answer) == ["no-route-declaration"]
 
-    def test_a_lens_the_round_does_not_declare_is_refused(self, round_dir, capsys):
+    def test_the_declared_route_is_recorded_and_not_judged(self, round_dir, capsys):
+        """Which route a lens deserves is settled before the claim. The gate counts
+        attempts and records what ran them, whatever the round's metadata declares —
+        a route it refused to record would be a dispatch it could not bound."""
         (round_dir / "round.json").write_text(
-            json.dumps({"lenses": [{"lens": "correctness"}, {"lens": "security"}]}),
+            json.dumps({"lenses": [{"lens": "correctness", "transport": "codex"}]}),
             encoding="utf-8",
         )
-        answer = refuse(claim_argv(round_dir, **{"--lens": "corectness"}), capsys)
-        assert codes(answer) == ["unknown-lens"]
-
-    def test_a_round_declaring_no_lenses_accepts_any_lens_name(self, round_dir, capsys):
-        (round_dir / "round.json").write_text("{not json", encoding="utf-8")
-        assert authorize(round_dir, capsys, **{"--lens": "house-lens"})["attempt"] == 1
+        answer = authorize(
+            round_dir,
+            capsys,
+            **{
+                "--lens": "house-lens",
+                "--transport": "carrier-pigeon",
+                "--model": "unlisted/model-9",
+            },
+        )
+        assert (answer["transport"], answer["model"]) == ("carrier-pigeon", "unlisted/model-9")
+        assert kinds(round_dir, "claim")[0]["model"] == "unlisted/model-9"
 
     @pytest.mark.parametrize(
         "argv_tail",

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -122,7 +122,7 @@ class TestFirstClaim:
     def test_the_attempt_lands_in_the_rounds_ledger(self, round_dir, capsys):
         authorize(round_dir, capsys)
         claims = kinds(round_dir, "claim")
-        assert (round_dir / "attempts.json").is_file()
+        assert (round_dir / "attempts.jsonl").is_file()
         assert len(claims) == 1
         for field in ("lens", "attempt", "transport", "model", "cwd", "reason", "timestamp"):
             assert field in claims[0], field
@@ -151,17 +151,17 @@ class TestFirstClaim:
 
     def test_the_ledger_is_append_only_across_invocations(self, round_dir, capsys):
         authorize(round_dir, capsys)
-        after_first = (round_dir / "attempts.json").read_bytes()
+        after_first = (round_dir / "attempts.jsonl").read_bytes()
         transport_recovery(round_dir, capsys, "503 upstream")
-        after_second = (round_dir / "attempts.json").read_bytes()
+        after_second = (round_dir / "attempts.jsonl").read_bytes()
         assert after_second.startswith(after_first)
         assert len(after_second) > len(after_first)
 
     def test_a_refused_claim_rewrites_nothing_and_grants_no_attempt(self, round_dir, capsys):
         authorize(round_dir, capsys)
-        after_first = (round_dir / "attempts.json").read_bytes()
+        after_first = (round_dir / "attempts.jsonl").read_bytes()
         refuse(claim_argv(round_dir, **{"--reason": "wishful"}), capsys)
-        assert (round_dir / "attempts.json").read_bytes().startswith(after_first)
+        assert (round_dir / "attempts.jsonl").read_bytes().startswith(after_first)
         assert len(kinds(round_dir, "claim")) == 1
 
 
@@ -469,7 +469,7 @@ class TestGateSurface:
     def test_an_unparseable_ledger_stops_both_verbs(self, round_dir, capsys, argv_tail):
         """A bound cannot be enforced against a history that does not parse, so
         neither verb proceeds on one."""
-        (round_dir / "attempts.json").write_text("{}\nnot a record\n", encoding="utf-8")
+        (round_dir / "attempts.jsonl").write_text("{}\nnot a record\n", encoding="utf-8")
         answer = refuse([*argv_tail, "--out-dir", str(round_dir)], capsys)
         assert codes(answer) == ["unreadable-ledger"]
 

--- a/src/user/.claude/skills/review-panel/harvest.md
+++ b/src/user/.claude/skills/review-panel/harvest.md
@@ -25,7 +25,7 @@ this directory before every dispatch of a lens, the first one included:
 
 ```bash
 uv run dispatch_gate.py claim --out-dir /tmp/round-1 --lens correctness \
-  --transport codex --model gpt-5.6-terra --reason initial
+  --transport codex --model gpt-5.6-sol --reason initial
 ```
 
 An authorized answer carries the `output_path` this attempt writes its raw output to — one path
@@ -57,7 +57,7 @@ Either way, the next claim declares that reason and the failure verbatim:
 
 ```bash
 uv run dispatch_gate.py claim --out-dir /tmp/round-1 --lens correctness \
-  --transport openrouter --model anthropic/claude-opus-5 \
+  --transport openrouter --model moonshotai/kimi-k2.7-code \
   --reason transport-error --evidence "402 Insufficient credits"
 ```
 

--- a/src/user/.claude/skills/review-panel/harvest.md
+++ b/src/user/.claude/skills/review-panel/harvest.md
@@ -18,49 +18,70 @@ its declared entry, its verdict entry carries `substitution` with the declared t
 the reason, and — when the swap was forced rather than chosen — the dead route's error verbatim in
 `transport_error`. A round that lost diversity silently is indistinguishable from one that kept it.
 
+## Every dispatch is claimed first
+
+The gate authorizes each dispatch, records it, and refuses the ones past the bound. Run it from
+this directory before every dispatch of a lens, the first one included:
+
+```bash
+uv run dispatch_gate.py claim --out-dir /tmp/round-1 --lens correctness \
+  --transport codex --model gpt-5.6-terra --reason initial
+```
+
+An authorized answer carries the `output_path` this attempt writes its raw output to — one path
+per attempt, so an attempt that wrote nothing reads as nothing rather than as the previous
+attempt's report — and, for a recovery, the `backoff_seconds` to wait first. Run the claim from
+the directory the reviewer will read: the gate records the working directory it was invoked in,
+and a review of the wrong tree is the failure that leaves no trace of itself.
+
+A refusal (exit 2) ends that lens. However many attempts it took, a lens ends with exactly one
+entry, for the attempt that produced the report, carrying the `substitution` record above. Two
+entries for one lens is a validation error, not a fuller record: it double-counts coverage.
+
 ## A dispatch that came back with no report
 
-Two failures look alike from outside and are handled oppositely, so tell them apart first.
+Two failures look alike from outside and recover oppositely, so tell them apart before claiming
+again — the reason you declare is what the gate bounds.
 
-**The route died.** What came back describes the *transport*, not the review: an HTTP status, an
-authentication or credit error, a refused connection, a dead broker or session — or nothing at all.
-The reviewer never ran. Judge this on the body rather than the exit status: a dead route shows up
-as an exit 1 carrying a short provider error, and equally as an exit 0 carrying nothing.
+**The route died** (`transport-error`). What came back describes the *transport*, not the review:
+an HTTP status, an authentication or credit error, a refused connection, a dead broker or session
+— or nothing at all, including no output file where one was claimed. The reviewer never ran. Judge
+this on the body rather than the exit status: a dead route shows up as an exit 1 carrying a short
+provider error, and equally as an exit 0 carrying nothing.
 
-**The reviewer failed.** A body came back that is the model's own output, and it does not survive
-the tolerance ladder below — or the reviewer stalled mid-reasoning. The route worked; what came
-over it is unusable.
+**The reviewer failed** (`unusable-output`). A body came back that is the model's own output, and
+no report survives the ladder below — or the reviewer stalled mid-reasoning. The route worked;
+what came over it is unusable.
 
-### The route died: fail over, once
+Either way, the next claim declares that reason and the failure verbatim:
 
-Fail the lens over to the transport it was **not** declared on — Codex for a lens declared on
-OpenRouter, OpenRouter for a lens declared on Codex — on the same prompt, unchanged. This is not a
-judgement call, and not a retry on the same route: that route has just told you it is down.
+```bash
+uv run dispatch_gate.py claim --out-dir /tmp/round-1 --lens correctness \
+  --transport openrouter --model anthropic/claude-opus-5 \
+  --reason transport-error --evidence "402 Insufficient credits"
+```
 
-The lens ends with exactly one entry, for the attempt that produced the report, carrying the
-`substitution` record above. Two entries for one lens is a validation error, not a fuller record:
-it double-counts coverage.
+Declare a route that has not just failed. A model can sit at capacity for the length of a round
+while another model of the same vendor answers, so the alternative to a dead route is another
+transport **or** another model on it — and a retry of the route that just said it is down is
+neither.
 
-### Both routes died: stop the run
+### When the gate refuses
 
-If the failover also dies on a transport error — any error, any code, either vendor — the round is
-over. Abandon every dispatch not yet made. Do not retry, do not drop to a lesser model, and do not
-quietly finish the round with the lenses that happened to work.
-
-Write the verdict with `verdict: "halted"`, a `halt` block carrying every transport failure the
-round did not recover from — at minimum the declared route and the failover behind it, more when
-parallel dispatches ran out together — and every undispatched lens in `abandoned_lenses`. A failure
-some lens did recover from by failing over belongs on that lens's `substitution`, not here.
+A refusal whose every recorded failure was transport-class carries halt guidance naming each
+exhausted transport and model with its error. **The round is over.** Abandon every dispatch not
+yet made. Do not retry, do not drop to a lesser model, and do not quietly finish the round with
+the lenses that happened to work. Write the verdict with `verdict: "halted"`, a `halt` block
+carrying every transport failure the round did not recover from, and every undispatched lens in
+`abandoned_lenses`. A failure some lens did recover from by failing over belongs on that lens's
+`substitution`, not here.
 
 Stopping forfeits the budget already spent. Continuing forfeits that too, and buys a document that
 reads like a review of a change most of the panel never opened.
 
-### The reviewer failed: re-dispatch, then fail closed
-
-A lens whose reviewer returned unusable output **may be re-dispatched** inside the same round, on
-the same route or another. The round is not restarted and the other lenses are not re-run. If the
-re-dispatch fails too, the lens has **no** entry and the round is incomplete. That is the contract
-working. Fail closed — never write a `clean` entry for a lens that never reported.
+Any other refusal closes that lens alone: it has **no** entry and the round is incomplete. The
+round is not restarted and the other lenses are not re-run. That is the contract working. Fail
+closed — never write a `clean` entry for a lens that never reported.
 
 ## Say a failover out loud
 
@@ -79,17 +100,24 @@ transports died and what they said.
 
 ## Reading a lens report
 
-Models violate an exact-output contract in predictable, harmless ways. Read each report through
-this ladder, in order, and stop at the first step that yields an object:
+Models violate an exact-output contract in predictable, harmless ways, so a report is read through
+the gate rather than by eye:
 
-1. The whole body parses as JSON.
-2. The body is a single fenced code block; strip the fence and parse what is inside.
-3. Decode from the first `{` in the body and ignore any trailing text — this recovers a report
-   behind a prose preamble.
+```bash
+uv run dispatch_gate.py ingest --out-dir /tmp/round-1 \
+  --output /tmp/round-1/correctness.attempt-1.out
+```
 
-Anything else is **unparseable**: the lens has no entry and the round is incomplete unless you
-re-dispatch it. Tolerance stops here on purpose. Reconstructing a report by hand from prose makes
-the harvester the reviewer, and nothing downstream can tell the difference.
+It walks the tolerance ladder — the whole body as JSON, then a single fenced block, then the first
+object in the body with any trailing text ignored — and prints the report it recovered. Output
+from a dispatch it never authorized is refused rather than read, so a dispatch that went around
+the gate shows up as a hole in the ledger instead of as a lens entry. A claimed path holding no
+file at all is refused as a transport failure, not a reviewer one: the route wrote nothing.
+
+Past the ladder the output is **unparseable**: the lens has no entry and the round is incomplete
+unless it is re-dispatched with reason `unusable-output`. Tolerance stops there on purpose.
+Reconstructing a report by hand from prose makes the harvester the reviewer, and nothing
+downstream can tell the difference.
 
 ## A mechanical finding with no evidence
 


### PR DESCRIPTION
## What

Work item `agents-config-9k9.38`: review-panel's re-dispatch and failover bounds move from prose to code.

- **New `dispatch_gate.py`** beside the emitter, two verbs. `claim` authorizes every dispatch of a lens (the first included), appends the attempt — transport, model, cwd, reason, timestamp — to an append-only JSONL ledger (`attempts.jsonl`), assigns a per-attempt output path, and refuses past the bounds: 3 dispatches per lens per round, at most one recovery of a reviewer that returned unusable output. A refusal whose recorded failures are all transport-class carries halt guidance naming every exhausted route with its verbatim error. `ingest` reads a lens's raw output through the tolerance ladder in code and refuses output no claim assigned, so a dispatch that bypassed the gate is a visible ledger hole, not a lens entry.
- **`harvest.md`** — the failure sections route authority through the gate; recovery is a bounded chain of transport+model attempts (a model can sit at capacity while a same-vendor alternate answers, so a single transport flip under-recovers). No numeric bound is restated in prose.
- **`SKILL.md`** — the dispatch-failure paragraph names the gate; net −16 tokens, leaving the file at 1984/2000 against content-lint's cap post-#558.

Per-attempt output paths exist because a transport that writes its output file only on success leaves the previous attempt's stale report in place on failure — a reused path hands the harvester the wrong attempt's bytes.

## Seams

The gate is deliberately model-agnostic: it records the route the caller declares and validates nothing against `contracts.json` or `round.json` — routing policy is `9k9.17.14`'s seam. `claim` is the single pre-dispatch choke point where `9k9.17.15`'s key-headroom preflight lands.

## Evidence

- `make ci` exit 0 from the worktree root (13 content-test suites; `dispatch_gate_test.py` is 48 tests covering every refusal code, the append-only ledger, and the unique-output-path property)
- `make doc-lint` exit 0; `make content-lint` exit 0 with SKILL.md at 1984/2000
- Acceptance criteria AC1–AC10 recorded on the work item, each mapped to named tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDGU4TSr52GU5CrnnmhWjL