### PR TITLE
feat(9k9.17.15): dispatch_gate gains a preflight verb for the openrouter budget

### DIFF
--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -111,8 +111,8 @@ Terminal-clean means a complete round that came out `clean`, with zero mechanica
 every lens; a halted round is neither.
 
 Before the round's first claim, run `dispatch_gate.py preflight` once: it refuses loudly when the
-openrouter dispatches `round.json` plans would exceed the key's remaining credit, rather than a
-lens dying mid-round. Every dispatch is then authorized by `dispatch_gate.py claim`, which records
+openrouter dispatches planned in `round.json` would exceed the key's remaining credit, rather
+than a lens dying mid-round. Every dispatch is then authorized by `dispatch_gate.py claim`, which records
 the attempt with the route running it, assigns its output path, and refuses the ones past the
 round's bounds — those bounds are the script's, not this prose's. A refusal for a lens out of routes carries halt
 guidance: the round is over, and the `halted` verdict names the dead routes and the dispatches

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -85,7 +85,7 @@ The emitter refuses rather than producing a prompt it knows is unsound. Refusals
 | `bad-prior-verdict` | An earlier verdict is unreadable, fails the verdict schema, or is for another claim, class, or a non-earlier round. |
 | `ledger-gap` | An earlier mechanical finding has no disposition, or a disposition is outside the closed set. |
 | `unsupported-rebuttal` | A finding is marked rebutted with no evidence. A rebuttal without evidence is a disagreement. |
-| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a missing field, an unwritable output directory. Alone among these can strike mid-write, leaving some `<lens>.md` files but no `round.json`. Clear the directory before retrying — a partial round reads as a smaller panel. |
+| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a missing field, an unwritable output directory. Alone among these it can strike mid-write, leaving some `<lens>.md` files but no `round.json`. Clear the directory before retrying — a partial round reads as a smaller panel. |
 
 ## What a prompt contains
 

--- a/src/user/.claude/skills/review-panel/SKILL.md
+++ b/src/user/.claude/skills/review-panel/SKILL.md
@@ -30,8 +30,7 @@ Each panel mixes model tiers — hard-reasoning lenses on frontier models, mecha
 mid-tier — and spans two vendors, because blind spots correlate inside a vendor. A lens's declared
 `tier` sets round 1; a declared `re_review_tier` sets every round after. Its declared `transport`
 carries the vendor-diversity claim, not the tier, so a reduced tier still spans both vendors — when
-it is down the lens recovers onto another route, and the verdict records what ran it
-(`harvest.md`).
+it is down the lens recovers onto another route, and the verdict records what ran it.
 
 Most lenses re-read the whole artifact every round. A lens marked `diff` reviews only the change
 since the head it last judged, and only when it returned green that round; anything judging
@@ -52,8 +51,7 @@ uv run emit_prompts.py --class typed-code --claim <claim-id> --round 1 \
   --retained '[]' --out-dir /tmp/round-1
 ```
 
-If `uv` is not installed, install `jsonschema` yourself and run `python3 emit_prompts.py ...`
-instead — that dependency is the script's only one.
+Without `uv`, install `jsonschema` — its only dependency — and run `python3 emit_prompts.py ...`.
 
 `--acs` points at a file the invoker writes before round 1: the acceptance criteria the claim is
 judged against, gathered from wherever the claim is stated — the work item, the governing design
@@ -87,7 +85,7 @@ The emitter refuses rather than producing a prompt it knows is unsound. Refusals
 | `bad-prior-verdict` | An earlier verdict is unreadable, fails the verdict schema, or is for another claim, class, or a non-earlier round. |
 | `ledger-gap` | An earlier mechanical finding has no disposition, or a disposition is outside the closed set. |
 | `unsupported-rebuttal` | A finding is marked rebutted with no evidence. A rebuttal without evidence is a disagreement. |
-| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a contract entry missing a field a prompt needs, an unwritable output directory. Alone among these it can strike mid-write: the rest are decided before the output directory exists, while this one can leave it holding some `<lens>.md` files and no `round.json`. Clear it before retrying — a partial round reads as a smaller panel. |
+| `emitter-failure` | Any other fault while emitting — an unreadable contracts file, a missing field, an unwritable output directory. Alone among these can strike mid-write, leaving some `<lens>.md` files but no `round.json`. Clear the directory before retrying — a partial round reads as a smaller panel. |
 
 ## What a prompt contains
 
@@ -100,8 +98,7 @@ instructions declare to be data, not instructions. That section is context, neve
 review: the reviewer reads the target itself, and whatever surrounding material its scope
 requires, directly from the repository. No other lens's mandate appears, and no ambient house
 context does either — no laws, no decision matrix, no hard lines. A lens's own mandate is the only
-route by which a house-specific standard reaches the reviewer, because a lens that states no test
-has nothing decidable to judge against.
+route a house standard reaches the reviewer through.
 
 ## Assembling the round verdict
 
@@ -113,9 +110,11 @@ and model that *actually* produced the report, never the route `contracts.json` 
 Terminal-clean means a complete round that came out `clean`, with zero mechanical findings across
 every lens; a halted round is neither.
 
-Every dispatch is authorized first by `dispatch_gate.py claim`, which records the attempt with the
-route running it, assigns its output path, and refuses the ones past the round's bounds — those
-bounds are the script's, not this prose's. A refusal for a lens out of routes carries halt
+Before the round's first claim, run `dispatch_gate.py preflight` once: it refuses loudly when the
+openrouter dispatches `round.json` plans would exceed the key's remaining credit, rather than a
+lens dying mid-round. Every dispatch is then authorized by `dispatch_gate.py claim`, which records
+the attempt with the route running it, assigns its output path, and refuses the ones past the
+round's bounds — those bounds are the script's, not this prose's. A refusal for a lens out of routes carries halt
 guidance: the round is over, and the `halted` verdict names the dead routes and the dispatches
 abandoned behind them. `dispatch_gate.py ingest` reads the reply through the tolerance ladder;
 without a report the lens has no entry and the round is incomplete — fail closed. Every failover

--- a/src/user/.claude/skills/review-panel/dispatch_gate.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate.py
@@ -5,22 +5,30 @@
 # ///
 """Authorize every lens dispatch of a round, and parse what comes back.
 
-Usage: uv run dispatch_gate.py claim --lens <name> --transport <name> --model <name>
+Usage: uv run dispatch_gate.py preflight --out-dir <dir>
+       uv run dispatch_gate.py claim --lens <name> --transport <name> --model <name>
            --reason initial|transport-error|unusable-output [--evidence <verbatim>]
            [--out-dir <dir>]
        uv run dispatch_gate.py ingest --output <path> [--out-dir <dir>]
 
-Stdout is JSON. Exit 0 on authorization or ingestion, 2 on refusal. Every
-authorized attempt is appended to the round's ledger before it runs, so a lens
-that has spent its dispatches cannot spend another by asking again.
+Stdout is JSON. Exit 0 on authorization, ingestion, or an affordable or
+unanswerable preflight; 2 on refusal. Every authorized attempt is appended to
+the round's ledger before it runs, so a lens that has spent its dispatches
+cannot spend another by asking again. Run preflight once, before the round's
+first claim: it checks whether the openrouter dispatches round.json plans can
+be afforded, and refuses loudly on a shortfall instead of a lens dying
+mid-round.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -149,6 +157,176 @@ def output_path_for(out_dir: str, lens: str, attempt: int) -> Path:
 
 def backoff_for(attempt: int) -> int:
     return BACKOFF_SECONDS[min(attempt - 2, len(BACKOFF_SECONDS) - 1)]
+
+
+ROUND_META_NAME = "round.json"
+OPENROUTER_TRANSPORT = "openrouter"
+
+# The floor for one openrouter dispatch: a frontier model reserves its full
+# max_tokens against the key's balance up front, whatever it actually returns.
+# 32,768 max_tokens at ~$15 per million output tokens (frontier-tier pricing)
+# prices that reservation at ~$0.49; rounded up to the cent to keep the floor
+# conservative. Flat across lenses and models on purpose — this gate carries no
+# per-model pricing table and does not judge which model a lens deserves.
+RESERVATION_USD = 0.50
+
+KEY_URL = "https://openrouter.ai/api/v1/key"
+CREDITS_URL = "https://openrouter.ai/api/v1/credits"
+KEY_MANAGEMENT_URL = "https://openrouter.ai/settings/keys"
+
+
+def round_meta_path(out_dir: str) -> Path:
+    return Path(out_dir) / ROUND_META_NAME
+
+
+def read_round_meta(out_dir: str) -> dict[str, Any]:
+    """This round's plan, as emit_prompts.py wrote it: which lenses, on which transports.
+
+    Preflight runs after the round is planned and before its first dispatch, so
+    round.json already exists; one missing or unparseable means the round was
+    never emitted and there is nothing to check the budget of.
+    """
+    path = round_meta_path(out_dir)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise Refusal("no-round-meta", f"cannot read round metadata {path}: {exc}") from exc
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise Refusal("no-round-meta", f"round metadata {path} is not valid JSON: {exc}") from exc
+    if not isinstance(document, dict) or not isinstance(document.get("lenses"), list):
+        raise Refusal("no-round-meta", f"round metadata {path} carries no lens list")
+    return document
+
+
+def count_openrouter_lenses(round_meta: dict[str, Any]) -> int:
+    return sum(
+        1
+        for lens in round_meta["lenses"]
+        if isinstance(lens, dict) and lens.get("transport") == OPENROUTER_TRANSPORT
+    )
+
+
+def urllib_fetch(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+    """One live HTTP GET, returning its status and raw body.
+
+    An HTTPError still carries a status and a body — OpenRouter's 402/403
+    replies are JSON — so it is read rather than raised; only a request that
+    never reached a server (DNS, connection, timeout) surfaces as an OSError.
+    """
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
+            return response.status, response.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def _probe_endpoint(url: str, api_key: str) -> tuple[dict[str, Any] | None, str | None]:
+    """This endpoint's ``data`` object, or the reason it could not be read."""
+    try:
+        status, body = urllib_fetch(url, {"Authorization": f"Bearer {api_key}"})
+    except OSError as exc:
+        return None, str(exc)
+    if not 200 <= status < 300:
+        return None, f"HTTP {status}"
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None, "response body is not JSON"
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return None, "response carries no data object"
+    return data, None
+
+
+def probe_remaining_credit(api_key: str) -> tuple[float | None, list[str]]:
+    """The tightest of every credit bound the key answers, or none if neither did.
+
+    ``/key`` bounds what this specific key may still spend (null when the key
+    is uncapped); ``/credits`` bounds the account's whole balance but requires
+    a management key, so a regular key sees it answer 403 — that is one
+    endpoint failing to answer, not a shortfall. Either bound can be the
+    binding one, so the effective remaining credit is the smaller of whichever
+    endpoint actually answers.
+    """
+    bounds: list[float] = []
+    warnings: list[str] = []
+
+    key_data, key_error = _probe_endpoint(KEY_URL, api_key)
+    if key_error is not None:
+        warnings.append(f"{KEY_URL}: {key_error}")
+    else:
+        limit_remaining = key_data.get("limit_remaining")
+        if isinstance(limit_remaining, (int, float)):
+            bounds.append(float(limit_remaining))
+
+    credits_data, credits_error = _probe_endpoint(CREDITS_URL, api_key)
+    if credits_error is not None:
+        warnings.append(f"{CREDITS_URL}: {credits_error}")
+    else:
+        total, used = credits_data.get("total_credits"), credits_data.get("total_usage")
+        if isinstance(total, (int, float)) and isinstance(used, (int, float)):
+            bounds.append(float(total) - float(used))
+
+    if not bounds:
+        return None, warnings
+    return min(bounds), warnings
+
+
+def _preflight_record(outcome: str, count: int, demand: float, **extra: Any) -> dict[str, Any]:
+    return {
+        "kind": "preflight", "outcome": outcome, "openrouter_lenses": count,
+        "demand_usd": demand, "timestamp": now(), **extra,
+    }
+
+
+def preflight(args: argparse.Namespace) -> dict[str, Any]:
+    """Verify the round's planned openrouter dispatches can be afforded before the first claim."""
+    path = ledger_path(args.out_dir)
+    count = count_openrouter_lenses(read_round_meta(args.out_dir))
+    demand = round(count * RESERVATION_USD, 2)
+
+    if count == 0:
+        record = _preflight_record("pass", 0, 0.0)
+        append_record(path, record)
+        return {"preflight": True, **{k: v for k, v in record.items() if k != "kind"}}
+
+    api_key = (os.environ.get("OPENROUTER_API_KEY") or "").strip()
+    if not api_key:
+        refusal = Refusal(
+            "no-openrouter-key",
+            f"round.json plans {count} openrouter lens dispatch(es), demanding ${demand:.2f} in "
+            "reservation, but OPENROUTER_API_KEY is not set — those dispatches could not run "
+            f"without a key. Manage keys at {KEY_MANAGEMENT_URL}",
+        )
+        append_record(path, _preflight_record("refusal", count, demand, code=refusal.code))
+        raise refusal
+
+    remaining, warnings = probe_remaining_credit(api_key)
+    if remaining is None:
+        warning = "; ".join(warnings) if warnings else "the credit probe could not be answered"
+        record = _preflight_record("warn", count, demand, warning=warning)
+        append_record(path, record)
+        return {"preflight": True, **{k: v for k, v in record.items() if k != "kind"}}
+
+    if remaining < demand:
+        refusal = Refusal(
+            "insufficient-openrouter-credit",
+            f"round.json plans {count} openrouter lens dispatch(es), demanding ${demand:.2f} in "
+            f"reservation, but only ${remaining:.2f} remains on OPENROUTER_API_KEY — a lens would "
+            f"die mid-round. Manage keys at {KEY_MANAGEMENT_URL}",
+        )
+        append_record(
+            path,
+            _preflight_record("refusal", count, demand, remaining_usd=remaining, code=refusal.code),
+        )
+        raise refusal
+
+    record = _preflight_record("pass", count, demand, remaining_usd=remaining)
+    append_record(path, record)
+    return {"preflight": True, **{k: v for k, v in record.items() if k != "kind"}}
 
 
 def check_lens(raw: str | None) -> str:
@@ -453,6 +631,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(add_help=True)
     verbs = parser.add_subparsers(dest="verb", required=True)
 
+    preflight_parser = verbs.add_parser(
+        "preflight", help="verify the round's planned openrouter dispatches can be afforded"
+    )
+    preflight_parser.add_argument("--out-dir", default=".")
+    preflight_parser.set_defaults(run=preflight)
+
     claim_parser = verbs.add_parser("claim", help="authorize one dispatch of one lens")
     claim_parser.add_argument("--out-dir", default=".")
     claim_parser.add_argument("--lens")
@@ -469,9 +653,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+VERB_KEYS = {"claim": "authorized", "ingest": "ingested", "preflight": "preflight"}
+
+
 def main(argv: list[str]) -> int:
     args = build_parser().parse_args(argv)
-    verb = "authorized" if args.verb == "claim" else "ingested"
+    verb = VERB_KEYS[args.verb]
     try:
         result = args.run(args)
     except Refusal as exc:

--- a/src/user/.claude/skills/review-panel/dispatch_gate_test.py
+++ b/src/user/.claude/skills/review-panel/dispatch_gate_test.py
@@ -104,6 +104,41 @@ def transport_recovery(round_dir: Path, capsys, error: str, **overrides: Any) ->
     )
 
 
+def write_round_meta(round_dir: Path, lenses: list[dict]) -> None:
+    (round_dir / "round.json").write_text(json.dumps({"lenses": lenses}), encoding="utf-8")
+
+
+def preflight_argv(round_dir: Path) -> list[str]:
+    return ["preflight", "--out-dir", str(round_dir)]
+
+
+def make_fetch(
+    key_body: dict | None = None,
+    key_status: int = 200,
+    key_raises: Exception | None = None,
+    credits_body: dict | None = None,
+    credits_status: int = 200,
+    credits_raises: Exception | None = None,
+):
+    """A stub for ``dispatch_gate.urllib_fetch`` that answers only the two probe URLs."""
+
+    def fetch(url: str, headers: dict[str, str]) -> tuple[int, bytes]:
+        assert headers["Authorization"].startswith("Bearer ")
+        if url == gate.KEY_URL:
+            if key_raises is not None:
+                raise key_raises
+            return key_status, json.dumps(key_body if key_body is not None else {}).encode()
+        if url == gate.CREDITS_URL:
+            if credits_raises is not None:
+                raise credits_raises
+            return credits_status, json.dumps(
+                credits_body if credits_body is not None else {}
+            ).encode()
+        raise AssertionError(f"unexpected probe url {url}")
+
+    return fetch
+
+
 class TestFirstClaim:
     """AC1: the first dispatch is authorized, recorded in full, and never rewritten."""
 
@@ -163,6 +198,161 @@ class TestFirstClaim:
         refuse(claim_argv(round_dir, **{"--reason": "wishful"}), capsys)
         assert (round_dir / "attempts.jsonl").read_bytes().startswith(after_first)
         assert len(kinds(round_dir, "claim")) == 1
+
+
+class TestPreflight:
+    """The round-start credit check: refuses loudly before a lens dies mid-round."""
+
+    def test_zero_openrouter_lenses_passes_without_a_key_or_a_probe(
+        self, round_dir, capsys, monkeypatch
+    ):
+        write_round_meta(round_dir, [{"lens": "correctness", "transport": "codex"}])
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        def explode(url, headers):
+            raise AssertionError("a round with no openrouter lens must not probe")
+
+        monkeypatch.setattr(gate, "urllib_fetch", explode)
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["preflight"] is True
+        assert answer["outcome"] == "pass"
+        assert answer["openrouter_lenses"] == 0
+        assert answer["demand_usd"] == 0.0
+        assert kinds(round_dir, "preflight")[0]["outcome"] == "pass"
+
+    def test_missing_key_with_openrouter_lenses_planned_is_refused(
+        self, round_dir, capsys, monkeypatch
+    ):
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        answer = refuse(preflight_argv(round_dir), capsys)
+        assert codes(answer) == ["no-openrouter-key"]
+        assert gate.KEY_MANAGEMENT_URL in answer["errors"][0]["message"]
+        assert kinds(round_dir, "preflight")[0]["outcome"] == "refusal"
+
+    def test_a_definitive_shortfall_refuses_naming_remaining_demanded_and_the_url(
+        self, round_dir, capsys, monkeypatch
+    ):
+        write_round_meta(round_dir, [
+            {"lens": "security", "transport": "openrouter"},
+            {"lens": "ac-testability", "transport": "openrouter"},
+        ])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_body={"data": {"limit_remaining": 0.75}},
+                credits_status=403, credits_body={"error": "management key required"},
+            ),
+        )
+        answer = refuse(preflight_argv(round_dir), capsys)
+        assert codes(answer) == ["insufficient-openrouter-credit"]
+        message = answer["errors"][0]["message"]
+        assert "0.75" in message
+        assert "1.00" in message
+        assert gate.KEY_MANAGEMENT_URL in message
+        record = kinds(round_dir, "preflight")[0]
+        assert (record["outcome"], record["remaining_usd"], record["demand_usd"]) == (
+            "refusal", 0.75, 1.0
+        )
+
+    def test_sufficient_credit_passes_and_records_the_bound_it_checked(
+        self, round_dir, capsys, monkeypatch
+    ):
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_body={"data": {"limit_remaining": 5.0}},
+                credits_status=403, credits_body={"error": "management key required"},
+            ),
+        )
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["preflight"] is True
+        assert answer["outcome"] == "pass"
+        assert answer["remaining_usd"] == 5.0
+        assert answer["demand_usd"] == 0.5
+
+    def test_remaining_exactly_equal_to_demand_passes(self, round_dir, capsys, monkeypatch):
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_body={"data": {"limit_remaining": gate.RESERVATION_USD}},
+                credits_status=403, credits_body={"error": "management key required"},
+            ),
+        )
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["outcome"] == "pass"
+
+    def test_the_tightest_of_two_answered_bounds_governs(self, round_dir, capsys, monkeypatch):
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_body={"data": {"limit_remaining": 5.0}},
+                credits_body={"data": {"total_credits": 10.0, "total_usage": 8.7}},
+            ),
+        )
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["remaining_usd"] == pytest.approx(1.3)
+
+    def test_an_unanswerable_probe_fails_open_with_a_warning(
+        self, round_dir, capsys, monkeypatch
+    ):
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_raises=OSError("name resolution failed"),
+                credits_raises=OSError("name resolution failed"),
+            ),
+        )
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["preflight"] is True
+        assert answer["outcome"] == "warn"
+        assert answer["warning"]
+        assert kinds(round_dir, "preflight")[0]["outcome"] == "warn"
+
+    def test_an_uncapped_key_with_no_management_credentials_fails_open(
+        self, round_dir, capsys, monkeypatch
+    ):
+        """Neither endpoint answers a definitive bound: an uncapped key reports
+        ``limit_remaining: null`` and credits needs a management key this one
+        is not, so there is nothing to refuse against."""
+        write_round_meta(round_dir, [{"lens": "security", "transport": "openrouter"}])
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr(
+            gate, "urllib_fetch",
+            make_fetch(
+                key_body={"data": {"limit_remaining": None}},
+                credits_status=403, credits_body={"error": "management key required"},
+            ),
+        )
+        code, answer = run(preflight_argv(round_dir), capsys)
+        assert code == gate.EXIT_OK
+        assert answer["outcome"] == "warn"
+
+    def test_a_missing_round_meta_is_refused(self, round_dir, capsys):
+        answer = refuse(preflight_argv(round_dir), capsys)
+        assert codes(answer) == ["no-round-meta"]
+
+    def test_every_preflight_outcome_lands_in_the_ledger_ahead_of_the_first_claim(
+        self, round_dir, capsys
+    ):
+        write_round_meta(round_dir, [{"lens": "correctness", "transport": "codex"}])
+        run(preflight_argv(round_dir), capsys)
+        authorize(round_dir, capsys)
+        assert [record["kind"] for record in ledger(round_dir)] == ["preflight", "claim"]
 
 
 class TestRecoveryReason:


### PR DESCRIPTION
## What

`dispatch_gate.py` gains a third verb, `preflight`, run once at round start before the first claim. It reads `round.json`'s planned lens routes and, when openrouter-transport lenses are planned, checks the key's remaining credit against a flat worst-case reservation floor — refusing loudly with the shortfall and the key-management URL instead of a lens dying mid-round on a 402/403.

## Design

- **Round-start, whole-round check** — `claim` and `ingest` stay offline and behaviourally unchanged (zero existing test lines touched).
- **Flat worst-case floor** — demand = openrouter lens count × $0.50 (a 32k max_tokens reservation at frontier output pricing, rounded up). No per-model pricing table anywhere; the gate stays model-agnostic.
- **Fail-open on an unanswerable probe** — network failure, non-2xx, malformed body, or no resolvable bound: exit 0 with the warning in the JSON output. A definitive shortfall, or a missing `OPENROUTER_API_KEY` while openrouter lenses are planned: exit 2 refusal.
- **Every budget-check outcome in the ledger** — pass, warn, shortfall refusal, and missing-key refusal each append a typed `preflight` record to `attempts.jsonl`, so the round's history shows what the preflight knew. A preflight that finds no round to check (missing or unreadable `round.json`) refuses without touching a ledger, matching the gate's existing idiom for invocation-validity refusals — appending there would create a round-shaped artifact in a directory that isn't a round.
- Probe reads both `GET /api/v1/key` (`limit_remaining`; null when uncapped) and `GET /api/v1/credits` (management-key-only; a regular key's 403 there is one endpoint declining to answer, not a shortfall) and takes the tightest bound that resolves.

## Verification

- 10 new tests in `TestPreflight`; probe behind an injected seam (`urllib_fetch`), no network I/O in any test. Red-green: the new tests fail against the pre-change module (`invalid choice: 'preflight'`) while all 48 pre-existing tests still pass there.
- `make ci` exit 0 from the branch root; `SKILL.md` measures 1975/2000 tokens after naming the preflight in the dispatch sequence.

Work item: agents-config-9k9.17.15 (child of the 9k9.17 review-contracts epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PCYry2VZm5PGqixuDKmPA
